### PR TITLE
Integration guides

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -20,6 +20,8 @@ sidebar:
       href: "/graphing/"
     - text: Host Names
       href: "/hostnames/"
+    - text: Integrations
+      href: "/integrations/"
     - text: Help
       href: "/help/"
 ---

--- a/content/integrations/aws.html
+++ b/content/integrations/aws.html
@@ -1,11 +1,15 @@
 ---
 title: Datadog-AWS Cloudwatch Integration
+sidebar:
+  nav:
+    - header: Integrations
+    - text: Back to Overview
+      href: "/integrations/"
 ---
 
 The recommended way to configure Cloudwatch in Datadog is to create a
-new user via the Amazon [IAM
-Console](https://console.aws.amazon.com/iam/home#s=Home) and grant
-that user (or group of user) Amazon EC2 and Cloudwatch *read-only*
+new user via the <a target="_blank" href="https://console.aws.amazon.com/iam/home#s=Home">IAM Console</a>
+and grant that user (or group of user) Amazon EC2 and Cloudwatch *read-only*
 access.
 
 These can be set via policy templates in the console.
@@ -17,51 +21,52 @@ specifications:
 
     {
       "Statement": [
-	{
-	  "Action": [
-	    "autoscaling:Describe*",
-	    "cloudformation:DescribeStacks",
-	    "cloudformation:DescribeStackEvents",
-	    "cloudformation:DescribeStackResources",
-	    "cloudformation:GetTemplate",
-	    "cloudfront:Get*",
-	    "cloudfront:List*",
-	    "cloudwatch:Describe*",
-	    "cloudwatch:Get*",
-	    "cloudwatch:List*",
-	    "dynamodb:GetItem",
-	    "dynamodb:BatchGetItem",
-	    "dynamodb:Query",
-	    "dynamodb:Scan",
-	    "dynamodb:DescribeTable",
-	    "dynamodb:ListTables",
-	    "ec2:Describe*",
-	    "elasticache:Describe*",
-	    "elasticbeanstalk:Check*",
-	    "elasticbeanstalk:Describe*",
-	    "elasticbeanstalk:List*",
-	    "elasticbeanstalk:RequestEnvironmentInfo",
-	    "elasticbeanstalk:RetrieveEnvironmentInfo",
-	    "elasticloadbalancing:Describe*",
-	    "iam:List*",
-	    "iam:Get*",
-	    "route53:Get*",
-	    "route53:List*",
-	    "rds:Describe*",
-	    "s3:List*",
-	    "sdb:GetAttributes",
-	    "sdb:List*",
-	    "sdb:Select*",
-	    "ses:Get*",
-	    "ses:List*",
-	    "sns:Get*",
-	    "sns:List*",
-	    "sqs:GetQueueAttributes",
-	    "sqs:ListQueues",
-	    "sqs:ReceiveMessage"
-	  ],
-	  "Effect": "Allow",
-	  "Resource": "*"
-	}
+        {
+          "Action": [
+            "autoscaling:Describe*",
+            "cloudformation:DescribeStacks",
+            "cloudformation:DescribeStackEvents",
+            "cloudformation:DescribeStackResources",
+            "cloudformation:GetTemplate",
+            "cloudfront:Get*",
+            "cloudfront:List*",
+            "cloudwatch:Describe*",
+            "cloudwatch:Get*",
+            "cloudwatch:List*",
+            "dynamodb:GetItem",
+            "dynamodb:BatchGetItem",
+            "dynamodb:Query",
+            "dynamodb:Scan",
+            "dynamodb:DescribeTable",
+            "dynamodb:ListTables",
+            "ec2:Describe*",
+            "elasticache:Describe*",
+            "elasticbeanstalk:Check*",
+            "elasticbeanstalk:Describe*",
+            "elasticbeanstalk:List*",
+            "elasticbeanstalk:RequestEnvironmentInfo",
+            "elasticbeanstalk:RetrieveEnvironmentInfo",
+            "elasticloadbalancing:Describe*",
+            "iam:List*",
+            "iam:Get*",
+            "route53:Get*",
+            "route53:List*",
+            "rds:Describe*",
+            "s3:List*",
+            "sdb:GetAttributes",
+            "sdb:List*",
+            "sdb:Select*",
+            "ses:Get*",
+            "ses:List*",
+            "sns:Get*",
+            "sns:List*",
+            "sqs:GetQueueAttributes",
+            "sqs:ListQueues",
+            "sqs:ReceiveMessage"
+          ],
+          "Effect": "Allow",
+          "Resource": "*"
+        }
       ]
     }
+

--- a/content/integrations/index.html
+++ b/content/integrations/index.html
@@ -1,0 +1,15 @@
+---
+title: Datadog Integrations
+sidebar:
+  nav:
+     - header: Integrations
+     - text: Amazon Web Services
+       href: "/integrations/aws/"
+---
+
+This section contains reference guides to configure the most common
+Datadog integrations.
+
+## SaaS Integrations
+
+* <a href="/integrations/aws/">Amazon Web Services</a>


### PR DESCRIPTION
We will populate integration guides in the case where they don't fit in the integration tile. The first one to go is the AWS integration guide, ported from tender. Once this is done, and once dogweb 1677 is fixed, we can turn tender off.
