### PR TITLE
Renamed contact_info.html to _contact_info.html

### DIFF
--- a/content/api.html
+++ b/content/api.html
@@ -292,7 +292,7 @@ title: API Reference
     <div class="row-fluid">
       <%= left_side_div %>
         <p>
-          The Dashboards end point allow you to programmatically create, update
+          The Dashboards end point allows you to programmatically create, update
           delete and query dashboards.
         </p>
       </div>

--- a/content/guides/basic_agent_usage/deb.html
+++ b/content/guides/basic_agent_usage/deb.html
@@ -94,5 +94,5 @@ Logs for the subsystems are in the following files:
 If you're still having trouble, our support team will be glad to provide further assistance.
 You can contact them in one of the following ways:
 
-<%= render 'contact_info', :heading_size => 5, :hide_datadog => true %>
+<%= render '_contact_info', :heading_size => 5, :hide_datadog => true %>
 

--- a/content/guides/basic_agent_usage/osx.html
+++ b/content/guides/basic_agent_usage/osx.html
@@ -99,5 +99,5 @@ Logs for the subsystems are in the following files:
 If you're still having trouble, our support team will be glad to provide further assistance.
 You can contact them in one of the following ways:
 
-<%= render 'contact_info', :heading_size => 5, :hide_datadog => true %>
+<%= render '_contact_info', :heading_size => 5, :hide_datadog => true %>
 

--- a/content/guides/basic_agent_usage/redhat.html
+++ b/content/guides/basic_agent_usage/redhat.html
@@ -94,5 +94,5 @@ Logs for the subsystems are in the following files:
 If you're still having trouble, our support team will be glad to provide further assistance.
 You can contact them in one of the following ways:
 
-<%= render 'contact_info', :heading_size => 5, :hide_datadog => true %>
+<%= render '_contact_info', :heading_size => 5, :hide_datadog => true %>
 

--- a/content/guides/basic_agent_usage/smartos.html
+++ b/content/guides/basic_agent_usage/smartos.html
@@ -94,5 +94,5 @@ Logs for the subsystems are in the following files:
 If you're still having trouble, our support team will be glad to provide further assistance.
 You can contact them in one of the following ways:
 
-<%= render 'contact_info', :heading_size => 5, :hide_datadog => true %>
+<%= render '_contact_info', :heading_size => 5, :hide_datadog => true %>
 

--- a/content/guides/basic_agent_usage/source.html
+++ b/content/guides/basic_agent_usage/source.html
@@ -99,5 +99,5 @@ Logs for the subsystems are in the following files:
 If you're still having trouble, our support team will be glad to provide further assistance.
 You can contact them in one of the following ways:
 
-<%= render 'contact_info', :heading_size => 5, :hide_datadog => true %>
+<%= render '_contact_info', :heading_size => 5, :hide_datadog => true %>
 

--- a/content/guides/basic_agent_usage/windows.html
+++ b/content/guides/basic_agent_usage/windows.html
@@ -92,5 +92,5 @@ Logs for the subsystems are available in Event Viewer, under Windows Logs &rarr;
 If you're still having trouble, our support team will be glad to provide further assistance.
 You can contact them in one of the following ways:
 
-<%= render 'contact_info', :heading_size => 5, :hide_datadog => true %>
+<%= render '_contact_info', :heading_size => 5, :hide_datadog => true %>
 

--- a/content/help.html
+++ b/content/help.html
@@ -18,4 +18,4 @@ If you have any questions about Datadog, we'd love to hear from you. Here's how
 you get in touch:
 </p>
 
-<%= render 'contact_info', :heading_size => 3 %>
+<%= render '_contact_info', :heading_size => 3 %>

--- a/layouts/_contact_info.html
+++ b/layouts/_contact_info.html
@@ -21,5 +21,5 @@ where we'll be happy to answer any questions you might have. (There's a
 web chat client, too</a>.)
 
 <<%= @heading %> id="desk">Post a Question</<%= @heading %>>
-<a href="https://datadog.desk.com/customer/portal/questions/new">Post a public question!</a>
+<a href="https://datadog.desk.com/customer/portal/questions/new">Post a public question</a> on our support website!
 


### PR DESCRIPTION
This gives us a consistent naming scheme for partials/includes. Also
took the opportunity to clarify the support question link and fix
a typo.
