### PR TITLE
Disabling Bootstrap-affix for scrolling sidebar

### DIFF
--- a/content/static/css/style.css
+++ b/content/static/css/style.css
@@ -64,11 +64,6 @@ h1, h2, h3 {
     width: 220px;
 }
 
-.nav.sidebar.affix {
-    margin-top: 0;
-    top: 20px;
-}
-
 .nav.sidebar .nav-header:first-child {
       border-radius: 4px 4px 0 0;
 }

--- a/layouts/basic_agent_usage.html
+++ b/layouts/basic_agent_usage.html
@@ -18,7 +18,7 @@ to the basic agent usage guide of each platform
 
         <!-- SIDEBAR -->
         <div class="span3">
-        <ul class="nav nav-tabs nav-stacked sidebar" data-spy="affix" data-offset-top="150">
+        <ul class="nav nav-tabs nav-stacked sidebar">
 
           <!-- AGENT PLATFORM SELECTION -->
           <li class="nav-header">Agent Guides by Platform</li>

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -18,7 +18,7 @@ this layout provides a sidebar and main column.
         <!-- SIDEBAR -->
         <div class="span3" id="sidebarcolumn">
         <% if @item[:sidebar] && @item[:sidebar][:nav] %>
-          <ul class="nav nav-tabs nav-stacked sidebar" data-spy="affix" data-offset-top="140">
+          <ul class="nav nav-tabs nav-stacked sidebar">
           <% @item[:sidebar][:nav].each do |i| %>
             <% if i[:header] %>
               <li class="nav-header"><%= i[:header] %></li>


### PR DESCRIPTION
Tiny change to remove the affix data attributes. They were causing problems on viewports not tall enough to show the whole sidebar.
