### PR TITLE
Corrected User invitation URL, to match example request

### DIFF
--- a/content/api/index.html
+++ b/content/api/index.html
@@ -959,7 +959,7 @@ title: API Reference
       </div>
       <%= right_side_div %>
         <h5>Signature</h5>
-        <code>POST api/v1/account/invite</code>
+        <code>POST api/v1/invite_users</code>
         <h5>Example Request</h5>
         <%= snippet_code_block "api-user-invite.py" %>
         <%= snippet_code_block "api-user-invite.rb" %>


### PR DESCRIPTION
I was wondering why I was getting 404 errors when trying to utilize this code, when I noticed the example request URL is different (and it works). Updated the endpoint URL to match what's in the example request.
