### PR TITLE
Azure | improvement to the install script

### DIFF
--- a/content/guides/azure.html
+++ b/content/guides/azure.html
@@ -2,28 +2,62 @@
 title: Deploying the Datadog Agent to Azure
 ---
 
-This guide assumes you are deploying an Azure Cloud Service using a [cloud service package](http://www.windowsazure.com/en-us/manage/services/cloud-services/how-to-create-and-deploy-a-cloud-service/#deploy).
+This guide assumes you are deploying an Azure Cloud Service.
 Also, at the moment, the Agent install requires .net framework 2.0 or 3.5.
 
 ### Install the Agent on instance startup
 
 **Create** a file called `installDatadogAgent.cmd` with the following contents:
 
-    powershell -c "(New-Object System.Net.WebClient).DownloadFile(\"https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli.msi\", \"ddagent.msi\")"
-    msiexec /qn /i ddagent.msi APIKEY="YOUR_API_KEY"
 
-Be sure to replace `YOUR_API_KEY` with your API key found at [here](https://app.datadoghq.com/account/settings#api). 
-The created file will download and install the latest version of the Agent on application deploy.
+    set log=datadog-install.log
+    set api_key=%1
 
+    sc query | findstr DatadogAgent
+    if ERRORLEVEL 1 (
+        echo "Datadog Agent service not detected" >> %log%
+        echo "Starting the installation" >> %log%
+        reg query "HKLM\SOFTWARE\Microsoft\NET Framework Setup\NDP\v3.5"| findstr /c:"Install    REG_DWORD    0x1"
+
+        if ERRORLEVEL 1 (
+            echo "Installing .NET 3.5" >> %log%
+            powershell -Command "Import-Module ServerManager;Add-WindowsFeature -Name 'Net-Framework-Core'"
+        ) else (
+            echo ".NET 3.5 already installed" >> %log%
+        )
+
+        if exist ddagent.msi (
+            echo "Already has the installer" >> %log%
+        ) else (
+            echo "Fetching the Agent Installer" >> %log%
+            powershell -Command "(New-Object System.Net.WebClient).DownloadFile('https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli.msi', 'ddagent.msi')"
+        )
+
+        echo "Starting the installer" >>%log%
+        msiexec.exe /qn /i ddagent.msi APIKEY=%api_key% /L+ %log%
+    ) else (
+        echo "Agent already exists, skipping install" >>%log%
+    )
+
+    echo "Finished Install" >>%log%
+    exit 0
+
+If you are using Visual Studio, make sure that the file is included in the package: Set the *Copy to Output Directory* property of the file to *Copy Always* and make sure that the *Build Action* is *Content* .
 
 **Add** the installation task to your `ServiceDefinition.csdef` file by adding the following in the `<Startup>` section:
 
-    <Task commandLine="installDatadogAgent.cmd" executionContext="elevated" />
+    <Task commandLine="installDatadogAgent.cmdi YOUR_API_KEY" executionContext="elevated" />
 
+
+Be sure to replace `YOUR_API_KEY` with your API key found at [here](https://app.datadoghq.com/account/settings#api).
+
+
+The created file will download and install the latest version of the Agent on application deploy.
 
 ### Deploy your app
 
-You shold now repackage your app's cloud service package file (*.cspkg), making sure to include the `installDatadogAgent.cmd` file in the package.
+You should now repackage your app's cloud service package file (*.cspkg), making sure to include the `installDatadogAgent.cmd` file in the package.
+You can also directly upload from Visual Studio using the `Publish` button.
 
 On deploy you should see your new hosts appear on your infrastructure overview:
 

--- a/layouts/_header.html
+++ b/layouts/_header.html
@@ -18,6 +18,7 @@
                 <li><a href="/guides/agent_checks/">Writing an Agent Check</a></li>
                 <li><a href="/guides/services_checks/">Setting up Service Checks</a></li>
                 <li><a href="/guides/chef/">Deploying the Agent with Chef</a></li>
+                <li><a href="/guides/azure/">Deploying the Agent to Azure</a></li>
                 <li><a href="/guides/alerting/">Guide to Alerting</a></li>
                 <li><a href="/guides/templating/">Guide to Dashboard Templating</a></li>
                 <li><a href="/guides/saml/">Single Sign On With SAML</a></li>


### PR DESCRIPTION
The install script for Azure now handles the dependency on .NET3.5 and contains some basic logs to indicate the control flow taken.
It is also possible to run it several times without consequences.
