### PR TITLE
add the rds-specific permission to list tags

### DIFF
--- a/content/integrations/aws.html
+++ b/content/integrations/aws.html
@@ -61,6 +61,7 @@ specifications:
             "route53:Get*",
             "route53:List*",
             "rds:Describe*",
+            "rds:ListTagsForResource",
             "s3:List*",
             "sdb:GetAttributes",
             "sdb:List*",

--- a/content/ja/integrations/aws.html
+++ b/content/ja/integrations/aws.html
@@ -61,6 +61,7 @@ specifications:
             "route53:Get*",
             "route53:List*",
             "rds:Describe*",
+            "rds:ListTagsForResource",
             "s3:List*",
             "sdb:GetAttributes",
             "sdb:List*",


### PR DESCRIPTION
RDS resources can have a variety of tags, we need some extra permisisons
to list them. The functionality to crawl them has not yet been
implemented, but this permission is a step in that direction.
