### PR TITLE
Split release/deploy tasks into prod/staging jobs.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,12 +19,24 @@ task :view do
   sh 'bundle exec nanoc view'
 end
 
-desc 'Build and release the site to s3'
-task release: [:clean, :compile, :deploy]
+namespace :release do
+  desc 'Build and release the site to prod (http://docs.datadoghq.com)'
+  task prod: [:clean, :compile, :"deploy:prod"]
 
-desc 'Deploy to S3; Should be used by `rake release`'
-task :deploy do
-  sh('cd output && s3cmd -c ~/.s3cfg.prod sync . s3://docs.datadoghq.com')
+  desc 'Build and release the site to staging (http://docs-staging.datadoghq.com)'
+  task staging: [:clean, :compile, :"deploy:staging"]
+end
+
+namespace :deploy do
+  desc 'Deploy to prod S3 bucket; Should be used by `rake release:prod`'
+  task :prod do
+    sh('cd output && s3cmd -c ~/.s3cfg.prod sync . s3://docs.datadoghq.com')
+  end
+
+  desc 'Deploy to staging S3 bucket; Should be used by `rake release:staging`'
+  task :staging do
+    sh('cd output && s3cmd -c ~/.s3cfg.prod sync . s3://docs-staging.datadoghq.com')
+  end
 end
 
 desc 'test the code snippets'


### PR DESCRIPTION
Will allow us to view documentation before a full release. Staging site will be http://docs-staging.datadoghq.com
