### PR TITLE
Update schedule downtime docs to make the start argument optional

### DIFF
--- a/code_snippets/api-monitor-schedule-downtime.py
+++ b/code_snippets/api-monitor-schedule-downtime.py
@@ -5,4 +5,4 @@ api.api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
 api.application_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
 
 # Schedule downtime
-api.schedule_downtime('env:staging', int(time.time()))
+api.schedule_downtime('env:staging', start=int(time.time()))

--- a/code_snippets/api-monitor-schedule-downtime.rb
+++ b/code_snippets/api-monitor-schedule-downtime.rb
@@ -7,4 +7,4 @@ app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
 dog = Dogapi::Client.new(api_key, app_key)
 
 # Schedule downtime
-dog.schedule_downtime('env:testing', Time.now.to_i)
+dog.schedule_downtime('env:testing', :start => Time.now.to_i)

--- a/content/api/index.html
+++ b/content/api/index.html
@@ -701,7 +701,7 @@ kind: documentation
         <h5>Arguments</h5>
           <%= argument 'scope', "The scope to apply the downtime to, e.g.
           'host:app2'" %>
-          <%= argument 'start', "POSIX timestamp to start the downtime." %>
+          <%= argument 'start', "POSIX timestamp to start the downtime. In the default case, the downtime will start immediately.", :default=>"None" %>
           <%= argument 'end', "POSIX timestamp to end the downtime. In the
           default case, the downtime will go until cancelled.",
           :default => "None" %>


### PR DESCRIPTION
See:
- https://github.com/DataDog/dogapi/pull/124
- https://github.com/DataDog/dogapi-rb/pull/60