### PR TITLE
Api section monitors link fix

### DIFF
--- a/content/api/index.html
+++ b/content/api/index.html
@@ -349,7 +349,7 @@ kind: documentation
       <%= left_side_div %>
         <p>Monitors allow you to watch a metric or check that you care about,
         notifying your team when some defined threshold is exceeded. Please
-        refer to the <a href="/guides/monitors">Guide to Monitoring</a> for more
+        refer to the <a href="/guides/monitoring">Guide to Monitoring</a> for more
         information on creating monitors.</p>
       </div>
     </div>


### PR DESCRIPTION
There was a bad link in the api section that pointed to guides/monitors. fixed to guides/monitoring