### PR TITLE
Fix mistake in the jmx example file

### DIFF
--- a/code_snippets/jmx-basic-conf.yaml
+++ b/code_snippets/jmx-basic-conf.yaml
@@ -2,7 +2,7 @@ conf:
     - include: 
        domain: domain_name
        type: bean_type
-       name: bean_name
+       bean: bean_name
        attribute:
             nameOfAttribute:
                 metric_type: counter


### PR DESCRIPTION
The correct attribute is bean, not "name"