### PR TITLE
Running rake now checks for broken links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,5 @@ group :development do
   gem 'guard-rack'
   gem 'rack-contrib'
   gem 'rack-livereload'
+  gem 'guard-rake'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,9 @@ GEM
       libnotify
       rb-inotify
       spoon
+    guard-rake (1.0.0)
+      guard
+      rake
     hitimes (1.2.2)
     http_parser.rb (0.6.0)
     jsmin (1.0.1)
@@ -100,6 +103,7 @@ DEPENDENCIES
   guard-livereload
   guard-nanoc
   guard-rack
+  guard-rake
   kramdown
   nanoc
   nanoc-toolbox

--- a/Guardfile
+++ b/Guardfile
@@ -11,4 +11,8 @@ guard 'livereload' do
   watch(%r{^output/.+\.(css|js|html)})
 end
 
+guard 'rake', :task => 'checks' do
+  watch(%r{^output/.+\.(css|js|html)})
+end
+
 guard 'rack', port: '3000'

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,11 @@ CLEAN.include(%w(output tmp))
 
 CODE_SNIPPETS = 'code_snippets'
 
+desc 'Check site links'
+task :checks do
+  sh 'bundle exec nanoc check ilinks stale'
+end
+
 desc 'Build documentation site'
 task :compile do
   sh 'bundle exec nanoc compile'

--- a/content/faq.md
+++ b/content/faq.md
@@ -141,7 +141,7 @@ alert when at 80% or above:
   5. Add a custom message for alert if you'd like.
 * You can read more about setting up alerts [here][alerting].
 
-[alerting]: guides/alerting/
+[alerting]: /guides/alerting/
 <!--
 ===============================================================================
     API

--- a/content/hostnames.md
+++ b/content/hostnames.md
@@ -69,7 +69,7 @@ internal DNS server or a config-managed hosts file (`myhost.mydomain`). Datadog
 creates aliases for host names when there are multiple uniquely identifiable
 names for a single host.
 
-The names collected by the Agent (detailed <a href="agent">above</a>) are
+The names collected by the Agent (detailed <a href="#agent">above</a>) are
 added as aliases for the chosen canonical name.
 
 You can see a list of all the hosts in your account from the Infrastructure tab

--- a/content/ja/libraries.md
+++ b/content/ja/libraries.md
@@ -212,7 +212,7 @@ Datadog APIを操作するために、コミュニティーのメンバーが開
 
 - [java-dogstatsd-client](https://github.com/indeedeng/java-dogstatsd-client) - Jave向けDogStatsDクライエント by [Indeed](http://www.indeed.com/).
 - [metrics-datadog](https://github.com/coursera/metrics-datadog) - codahale'の[metrics](https://github.com/coursera/metrics-datadog)ライブラーリのバックエンド by [Coursera](https://github.com/coursera).
-- [Lassie](href="https://github.com/bazaarvoice/lassie) - Jave向け screenboard APIクライエント by [Bazaarvoice](http://www.bazaarvoice.com/).
+- [Lassie](https://github.com/bazaarvoice/lassie) - Jave向け screenboard APIクライエント by [Bazaarvoice](http://www.bazaarvoice.com/).
 
 #### Node.js {#community-node}
 


### PR DESCRIPTION
Every now and then there are issues brought up for broken links. Now, when you run rake, it compiles, refreshes the browser, AND checks for broken links...which resulted in finding about 5 broken links no one had reported yet

Signed-off-by: Technovangelist <m@technovangelist.com>