### PR TITLE
Auto redirect based on japanese

### DIFF
--- a/content/static/datadog-docs.js
+++ b/content/static/datadog-docs.js
@@ -46,4 +46,15 @@
 
     // Export to global scope.
     window.DD_docs = DD_docs;
+
+    var language = navigator.languages ? navigator.languages[0] : (navigator.language || navigator.userLanguage)
+    var noOverride = window.location.href.indexOf("overridelang") == -1;
+    if (noOverride) {
+        if (language.indexOf('ja') > -1 && window.location.pathname.indexOf('/ja/') != 0) {
+            document.location.href = '/ja' + window.location.pathname;
+        } else if (language.indexOf('ja') == -1 && window.location.pathname.indexOf('/ja/') == 0) {
+            document.location.href = window.location.pathname.substring(3);
+        }
+    }
+
 })();


### PR DESCRIPTION
If a user has their browser pref set to japanese and they are not on a ja page they will be redirected to the same url with ja at the beginning. If they are not using japanese and they are on a ja page, they will be redirected to the same url minus the ja.

If you are not using ja and want to see japanese version, then add ?overridelang to the url. The logic to redirect will be ignored. Same goes if using ja and want to see english version.

Signed-off-by: Technovangelist <m@technovangelist.com>