### PR TITLE
Added "change" option for time_aggr

### DIFF
--- a/content/api/index.html
+++ b/content/api/index.html
@@ -379,7 +379,7 @@ kind: documentation
 
             <code>time_aggr(window):space_aggr:metric{tags} [by {key}] operator #</code>
             <ul class="arguments">
-              <li><code>time_aggr</code> avg, sum, max, or min</li>
+              <li><code>time_aggr</code> avg, sum, max, min, or change</li>
               <li><code>time_window</code> last_#m (5, 10, 15, or 30),
               last_#h (1, 2, or 4), or last_1d</li>
               <li><code>space_aggr</code> avg, sum, min, or max</li>


### PR DESCRIPTION
Metric alerts can be based on the delta of a metric, but it was left out of the options listed.