### PR TITLE
replace deprecated DogApi library with datadogpy

### DIFF
--- a/content/libraries.md
+++ b/content/libraries.md
@@ -50,7 +50,7 @@ There are many libraries available to help you interact with the Datadog API.
 
 #### Python
 
-  * [DogApi][1] - A Python Datadog API wrapper.
+  * [datadogpy][1] - A Python Datadog API wrapper and DogStatsD client.
   * [dogstatsd-python][2] - A Python DogStatsD client.
 
 #### Ruby
@@ -168,7 +168,7 @@ Some great folks have written their own libraries to help interact with Datadog.
 
 If you've written a Datadog library, write us at [code@datadoghq.com][56] and we'll be happy to add it to the list. 
 
-   [1]: https://github.com/DataDog/dogapi
+   [1]: https://github.com/DataDog/datadogpy
    [2]: https://github.com/DataDog/dogstatsd-python
    [3]: https://github.com/DataDog/dogapi-rb
    [4]: https://github.com/DataDog/dogstatsd-ruby


### PR DESCRIPTION
according to https://github.com/DataDog/dogapi it is deprecated and people should be using https://github.com/DataDog/datadogpy instead, so I replaced the dogapi reference on the libraries page with the new one.

however, looking back at it, probably should have kept dogapi and just listed as deprecated and added datadogpy?