### PR TITLE
Now build auto checks for api keys used in the docs

### DIFF
--- a/Checks
+++ b/Checks
@@ -1,0 +1,8 @@
+
+check :no_api_keys do
+  self.output_filenames.each do |fn|
+    if match=File.read(fn).force_encoding("ISO-8859-1").encode("utf-8", replace: nil).match(/\b([0-9a-f]){32}(?<!9775a026f1ca7d1c6c5af9d94d9595a4)(?![0-9a-f])/)
+      self.add_issue("API Key in here!! - #{match}\nPlease use 9775a026f1ca7d1c6c5af9d94d9595a4 as the API Key", :subject => fn)
+    end
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ CODE_SNIPPETS = 'code_snippets'
 
 desc 'Check site links'
 task :checks do
-  sh 'bundle exec nanoc check ilinks stale'
+  sh 'bundle exec nanoc check ilinks stale no_api_keys'
 end
 
 desc 'Build documentation site'


### PR DESCRIPTION
Its so easy to add a real api key to the docs. This checks for anything other than the standard one we use and alerts the user to the mistake.

Signed-off-by: Technovangelist <m@technovangelist.com>