### PR TITLE
Calculated dates are less confusing

### DIFF
--- a/code_snippets/api-checks-post.sh
+++ b/code_snippets/api-checks-post.sh
@@ -1,8 +1,9 @@
+currenttime=$(date +%s)
 curl  -X POST -H "Content-type: application/json" \
--d '{
-      "check": "app.is_ok",
-      "host_name": "app1",
-      "timestamp": "1416241199",
-      "status": 0
-  }' \
+-d "{
+      \"check\": \"app.is_ok\",
+      \"host_name\": \"app1\",
+      \"timestamp\": $currenttime,
+      \"status\": 0
+  }" \
 'https://app.datadoghq.com/api/v1/check_run?api_key=9775a026f1ca7d1c6c5af9d94d9595a4'

--- a/code_snippets/api-events-stream.py
+++ b/code_snippets/api-events-stream.py
@@ -1,4 +1,5 @@
 from datadog import initialize, api
+import time
 
 options = {
     'api_key': 'api_key',
@@ -8,7 +9,7 @@ options = {
 initialize(**options)
 
 
-start_time = 1419436850
-end_time = 1419436870
+start_time = time.time()
+end_time = time.time() + 100
 
 api.Event.query(start=start_time, end=end_time, priority="normal", tags=["application:web"])

--- a/code_snippets/api-events-stream.rb
+++ b/code_snippets/api-events-stream.rb
@@ -6,7 +6,7 @@ app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
 
 dog = Dogapi::Client.new(api_key, app_key)
 
-start_time = 1346272158
-end_time = 1346274158
+start_time = Time.now.to_i
+end_time = Time.now.to_i + 100
 
 dog.stream(start_time, end_time, :priority=>"normal", :tags=>["application:web"])

--- a/code_snippets/api-events-stream.sh
+++ b/code_snippets/api-events-stream.sh
@@ -1,8 +1,9 @@
 # Note: this end point only accepts form-encoded requests.
-
+currenttime=$(date +%s)
+currenttime2=$(date -d '+1 hour' +%s)
 curl -G -H "Content-type: application/json" \
-    -d "start=1346272158" \
-    -d "end=1346274158" \
+    -d "start=${currenttime}" \
+    -d "end=${currenttime2}" \
     -d "api_key=9775a026f1ca7d1c6c5af9d94d9595a4" \
     -d "application_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff" \
     'https://app.datadoghq.com/api/v1/events'

--- a/code_snippets/api-graph-snapshot.py
+++ b/code_snippets/api-graph-snapshot.py
@@ -1,4 +1,5 @@
 from datadog import initialize, api
+import time
 
 options = {
     'api_key': 'api_key',

--- a/code_snippets/api-graph-snapshot.sh
+++ b/code_snippets/api-graph-snapshot.sh
@@ -1,7 +1,9 @@
+currenttime=$(date +%s)
+currenttime2=$(date -d '+1 hour' +%s)
 curl -G -H "Content-type: application/json" \
     -d "metric_query=system.load.1{*}" \
-    -d "start=1346272158" \
-    -d "end=1346274158" \
+    -d "start=${currenttime}" \
+    -d "end=${currenttime2}" \
     -d "api_key=9775a026f1ca7d1c6c5af9d94d9595a4" \
     -d "application_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff" \
     'https://app.datadoghq.com/api/v1/graph/snapshot'

--- a/code_snippets/api-metrics-post.py
+++ b/code_snippets/api-metrics-post.py
@@ -1,9 +1,13 @@
 from datadog import initialize, api
+import time
 
 options = {
     'api_key': 'api_key',
     'app_key': 'app_key'
 }
+
+CurrentPosixTime = time.time()
+CurrentPosixTime10 = time.time() + 10
 
 initialize(**options)
 
@@ -11,10 +15,10 @@ initialize(**options)
 api.Metric.send(metric='page.views', points=1000)
 
 # Submit a point with a timestamp (must be ~current)
-api.Metric.send(metric='my.pair', points=(1317652676, 15))
+api.Metric.send(metric='my.pair', points=(CurrentPosixTime, 15))
 
 # Submit multiple points.
-api.Metric.send(metric='my.series', points=[(1317652676, 15), (1317652800, 16)])
+api.Metric.send(metric='my.series', points=[(CurrentPosixTime, 15), (CurrentPosixTime10, 16)])
 
 # Submit a point with a host and tags.
 api.Metric.send(metric='my.series', points=100, host="myhost.example.com", tags=["version:1"])

--- a/code_snippets/api-metrics-post.sh
+++ b/code_snippets/api-metrics-post.sh
@@ -1,10 +1,13 @@
+
+currenttime=$(date +%s)
 curl  -X POST -H "Content-type: application/json" \
--d '{ "series" :
-         [{"metric":"test.metric",
-          "points":[[1346340794, 20]],
-          "type":"gauge",
-          "host":"test.example.com",
-          "tags":["environment:test"]}
+-d "{ \"series\" :
+         [{\"metric\":\"test.metric\",
+          \"points\":[[$currenttime, 20]],
+          \"type\":\"gauge\",
+          \"host\":\"test.example.com\",
+          \"tags\":[\"environment:test\"]}
         ]
-    }' \
+    }" \
+
 'https://app.datadoghq.com/api/v1/series?api_key=9775a026f1ca7d1c6c5af9d94d9595a4'

--- a/code_snippets/api-monitor-schedule-downtime.sh
+++ b/code_snippets/api-monitor-schedule-downtime.sh
@@ -1,9 +1,11 @@
 api_key=9775a026f1ca7d1c6c5af9d94d9595a4
 app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
 
+currenttime=$(date +%s)
+
 curl -X POST -H "Content-type: application/json" \
 -d '{
       "scope": "env:prod",
-      "start": 1412809696
+      "start": $currenttime
     }' \
     "https://app.datadoghq.com/api/v1/downtime?api_key=${api_key}&application_key=${app_key}"


### PR DESCRIPTION
There have been a few support tickets caused by the old dates in the sample code being used as is. So an event or metric would be added x months ago and not be visible. The customer would think that either the api was broken or the code sample was.

Signed-off-by: Technovangelist <m@technovangelist.com>