### PR TITLE
user suggested adding a wait here

### DIFF
--- a/code_snippets/api-events-post.py
+++ b/code_snippets/api-events-post.py
@@ -12,3 +12,7 @@ text = 'And let me tell you all about it here!'
 tags = ['version:1', 'application:web']
 
 api.Event.create(title=title, text=text, tags=tags)
+
+# If you are programmatically adding a comment to this new event
+# you might want to insert a pause of .5 - 1 second to allow the
+# event to be available.

--- a/code_snippets/api-events-post.rb
+++ b/code_snippets/api-events-post.rb
@@ -11,3 +11,7 @@ dog = Dogapi::Client.new(api_key, app_key)
 dog = Dogapi::Client.new(api_key)
 
 dog.emit_event(Dogapi::Event.new('msg_text', :msg_title => 'Title'))
+
+# If you are programmatically adding a comment to this new event
+# you might want to insert a pause of .5 - 1 second to allow the
+# event to be available.


### PR DESCRIPTION
sometimes if you programmatically create a comment immediately after creating the event, the event won't be there in time to run the comment line.

Signed-off-by: Technovangelist <m@technovangelist.com>