### PR TITLE
Add service check dogstatsd datagram.

### DIFF
--- a/content/guides/dogstatsd.md
+++ b/content/guides/dogstatsd.md
@@ -313,6 +313,25 @@ the packets:
   - `|#tag1:value1,tag2,tag3:value3` — default: None. <strong><em><br/>
   Note: The `:` in tags is part of the tag list string and has no parsing purpose like for the other parameters.</em></strong>
 
+### Service Checks
+
+If you want to send service checks to DogStatsD, here is the format of the packets:
+
+`_sc|name|status|metadata`
+
+#### Fields
+- Mandatory:
+  - `name` — service check name string, shouldn't contain any `|`
+  - `status` — digit corresponding to the status you're reporting (OK = 0, WARNING = 1, CRITICAL = 2, UNKNOWN = 3)
+- Optional metadata `|metadata`:
+It's either nothing, or a combination of those suffixes:
+  - `|m:service_check_message` — A message describing the current state of the service check.
+  - `|d:timestamp` — Assign a timestamp to the check. Default is the current Unix epoch timestamp when not supplied.
+  - `|h:hostname` — default: None — Assign a hostname to the event.
+  - `|#tag1:value1,tag2,tag3:value3` — default: None. <strong><em><br/>
+  Note: The `:` in tags is part of the tag list string and has no parsing purpose like for the other parameters.</em></strong>
+
+
 
 ## Source
 


### PR DESCRIPTION
It's been released in the agent for a while, and it's rolled out in
a growing part of our client libraries.
Can be useful if people want to port their own or use more
close-to-the-metal dogstatsd clients.

cc @wang-arthur 