### PR TITLE
Added query endpoint for sh and py

### DIFF
--- a/code_snippets/api-query.py
+++ b/code_snippets/api-query.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+from datadog import initialize, api
+from datadog.api.base import HTTPClient
+import time
+
+options = {
+    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
+    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+}
+
+initialize(**options)
+
+start = int(time.time()) - 3600
+end = start + 3600
+# query for idle CPU for all machines tagged with speed:4000
+query = 'system.cpu.idle{*}by{host}'
+
+results = HTTPClient.request('GET', '/query', **{'from': start, 'to': end, 'query': query})
+print results

--- a/code_snippets/api-query.sh
+++ b/code_snippets/api-query.sh
@@ -1,0 +1,12 @@
+api_key=9775a026f1ca7d1c6c5af9d94d9595a4
+app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+to_time=$(date +%s)
+from_time=$(date -v -1d +%s)
+
+curl -G \
+    "https://app.datadoghq.com/api/v1/query" \
+    -d "api_key=${api_key}" \
+    -d "application_key=${app_key}" \
+    -d "from=${from_time}" \
+    -d "to=${to_time}" \
+    -d "query=system.cpu.idle{*}by{host}"

--- a/code_snippets/results/result.api-query.py
+++ b/code_snippets/results/result.api-query.py
@@ -1,0 +1,35 @@
+{
+  'status': 'ok',
+  'res_type': 'time_series',
+  'series': [{
+    'end': 1430313599000,
+    'metric': 'system.cpu.idle',
+    'interval': 30,
+    'start': 1430312070000,
+    'length': 10,
+    'aggr': None,
+    'attributes': {},
+    'pointlist': [
+      [1430312070000.0, 75.08000183105469],
+      [1430312100000.0, 99.33000183105469],
+      [1430312130000.0, 99.83499908447266],
+      [1430312160000.0, 100.0],
+      [1430312190000.0, 99.66999816894531],
+      [1430312220000.0, 100.0],
+      [1430312250000.0, 99.83499908447266],
+      [1430312280000.0, 99.66999816894531],
+      [1430312310000.0, 99.83499908447266],
+      [1430312340000.0, 99.66999816894531]
+    ],
+    'expression': 'system.cpu.idle{host:vagrant-ubuntu-trusty-64}',
+    'scope': 'host:vagrant-ubuntu-trusty-64',
+    'unit': None,
+    'display_name':
+    'system.cpu.idle'
+  }],
+  'from_date': 1430309983000,
+  'group_by': ['host'],
+  'to_date': 1430313583000,
+  'query': 'system.cpu.idle{*}by{host}',
+  'message': u''
+}

--- a/code_snippets/results/result.api-query.sh
+++ b/code_snippets/results/result.api-query.sh
@@ -1,0 +1,36 @@
+{
+  "status": "ok",
+  "res_type": "time_series",
+  "series": [
+    {
+      "metric": "system.cpu.idle",
+      "attributes": {},
+      "display_name": "system.cpu.idle",
+      "unit": null,
+      "pointlist": [
+        [
+          1430311800000,
+          98.19375610351562
+        ],
+        [
+          1430312400000,
+          99.85856628417969
+        ]
+      ],
+      "end": 1430312999000,
+      "interval": 600,
+      "start": 1430311800000,
+      "length": 2,
+      "aggr": null,
+      "scope": "host:vagrant-ubuntu-trusty-64",
+      "expression": "system.cpu.idle{host:vagrant-ubuntu-trusty-64}"
+    }
+  ],
+  "from_date": 1430226140000,
+  "group_by": [
+    "host"
+  ],
+  "to_date": 1430312540000,
+  "query": "system.cpu.idle{*}by{host}",
+  "message": ""
+}

--- a/content/api/index.html
+++ b/content/api/index.html
@@ -31,6 +31,7 @@ kind: documentation
         <a class="btn" href="#hosts">Hosts</a>
         <a class="btn" href="#tags">Tags</a>
         <a class="btn" href="#search">Search</a>
+        <a class="btn" href="#query">Query</a>
         <a class="btn" href="#comments">Comments</a>
         <a class="btn" href="#users">Users</a>
         <a class="btn" href="#graphs">Graphs</a>
@@ -1430,6 +1431,48 @@ kind: documentation
       </div>
     </div>
 
+
+    <!--
+   =====================================================================
+    Query
+    ====================================================================
+    -->
+
+    <h3 id="query">Query</h3>
+    <div class="row-fluid">
+      <%= left_side_div %>
+        <p>
+          This end point allows you to query for metrics from any time period.
+        </p>
+        <p>
+          As occurs within the Datadog UI, a graph can only contain a set number of points and as the timeframe over which a metric is viewed increases, aggregation between points will occur to stay below that set number.
+        </p>
+        <p>
+          Thus, if you are querying for larger timeframes of data, the points returned will be more aggregated. The max granularity within Datadog is one point per second, so if you had submitted points at that interval and requested a very small interval from the query API (in this case, probably less than 100 seconds), you could end up getting all of those points back. Otherwise, our algorithm tries to return about 150 points per any given time window, so you'll see coarser and coarser granularity as the amount of time requested increases. We do this time aggregation via averages.
+        </p>
+        <h5>Arguments</h5>
+        <ul class="arguments">
+          <%= argument("from", "seconds since the unix epoch") %>
+          <%= argument("to", "seconds since the unix epoch") %>
+          <%= argument("query", "The query string") %>
+        </ul>
+        <h5>Query Language</h5>
+        <p>
+          Any query used for a graph can be used here. See <a href="/graphing/">here</a> for more details. The time between from and to should be less than 24 hours. If it is longer, you will receive points with less granularity.
+        </p>
+
+      </div>
+      <%= right_side_div %>
+        <h5>Signature</h5>
+        <code>GET https://app.datadoghq.com/api/v1/query</code>
+        <h5>Example Request</h5>
+        <%= snippet_code_block "api-search.py" %>
+        <%= snippet_code_block "api-query.sh" %>
+        <h5>Example Response</h5>
+        <%= snippet_result_code_block "api-search.py" %>
+        <%= snippet_result_code_block "api-query.sh" %>
+      </div>
+    </div>
     <!--
    =====================================================================
     Comments


### PR DESCRIPTION
As per request from alq and dustin, the query endpoint doc has been added. So far this is only for sh and py. rb to come later.

Signed-off-by: Technovangelist <m@technovangelist.com>