### PR TITLE
forgot to switch to samples to query for python

### DIFF
--- a/content/api/index.html
+++ b/content/api/index.html
@@ -1466,10 +1466,10 @@ kind: documentation
         <h5>Signature</h5>
         <code>GET https://app.datadoghq.com/api/v1/query</code>
         <h5>Example Request</h5>
-        <%= snippet_code_block "api-search.py" %>
+        <%= snippet_code_block "api-query.py" %>
         <%= snippet_code_block "api-query.sh" %>
         <h5>Example Response</h5>
-        <%= snippet_result_code_block "api-search.py" %>
+        <%= snippet_result_code_block "api-query.py" %>
         <%= snippet_result_code_block "api-query.sh" %>
       </div>
     </div>


### PR DESCRIPTION
the code sample for python for the query section was still set to search

Signed-off-by: Technovangelist <m@technovangelist.com>