### PR TITLE
Add doc for the `DELETE /api/v1/screen/share/:board_id` endpoint

### DIFF
--- a/code_snippets/api-screenboard-revoke.sh
+++ b/code_snippets/api-screenboard-revoke.sh
@@ -1,0 +1,30 @@
+api_key=9775a026f1ca7d1c6c5af9d94d9595a4
+app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+board_id=6334
+
+# Create a screenboard to share
+board_id=$(curl -X POST -H "Content-type: application/json" \
+-d '{
+        "width": 1024,
+        "height": 768,
+        "board_title": "dogapi tests",
+        "widgets": [
+            {
+              "type": "image",
+              "height": 20,
+              "width": 32,
+              "y": 7,
+              "x": 32,
+              "url": "https://path/to/image.jpg"
+            }
+        ]
+    }' \
+"https://app.datadoghq.com/api/v1/screen?api_key=${api_key}&application_key=${app_key}" | jq '.id')
+
+# Share it
+curl -X GET \
+"https://app.datadoghq.com/api/v1/screen/share/${board_id}?api_key=${api_key}&application_key=${app_key}"
+
+# Revoke the sharing
+curl -X DELETE \
+"https://app.datadoghq.com/api/v1/screen/share/${board_id}?api_key=${api_key}&application_key=${app_key}"

--- a/content/api/index.html
+++ b/content/api/index.html
@@ -1178,6 +1178,24 @@ kind: documentation
       </div>
     </div>
 
+    <!-- revoke a screenboard -->
+    <h4 id="screenboards-revoke">Revoke a shared a Screenboard</h4>
+    <div class="row-fluid">
+      <%= left_side_div %>
+        <p>Revoke a currently shared screenboard's.</p>
+        <h5>Arguments</h5>
+        <%= no_args %>
+      </div>
+      <%= right_side_div %>
+        <h5>Signature</h5>
+        <code>DELETE /api/v1/screen/share/:board_id</code>
+        <h5>Example Request</h5>
+        <%= snippet_code_block "api-screenboard-revoke.sh" %>
+        <h5>Example Response</h5>
+        <%= no_response %>
+      </div>
+    </div>
+
 
     <!--
    =====================================================================

--- a/content/api/screenboards.md
+++ b/content/api/screenboards.md
@@ -35,6 +35,7 @@ Endpoints
 - update: `PUT /api/v1/screen/{board_id}`
 - delete: `DELETE /api/v1/screen/{board_id}`
 - sharing `GET /api/v1/screen/share/{board_id}`
+- revoke sharing `DELETE /api/v1/screen/share/{board_id}`
 
 For `create`/`read`/`update` endpoints, the body is one JSON payload describing the Screenboard.
 


### PR DESCRIPTION
Documentation for https://github.com/DataDog/dogweb/pull/7832

:warning: Ruby and Python examples are missing because this endpoint has not yet been implemented in the Ruby/Python libs