### PR TITLE
refactor video and example index pages

### DIFF
--- a/Rules
+++ b/Rules
@@ -84,7 +84,7 @@ compile '*' do
       layout 'integration_layout'
     when id.match('/examples/') && @item[:kind] == 'example'
       layout 'examplelayout'
-    when id.match('/videos/') && @item[:kind] == 'video'
+    when id.match('/videos/') && @item[:kind] == 'video' && @item[:language] == 'en'
       layout 'videolayout'
     when id.match('/guides/') && @item[:kind] == 'guide'
       layout 'guide_layout'

--- a/content/examples.md
+++ b/content/examples.md
@@ -5,7 +5,7 @@ kind: Documentation
 In this section you will find examples of configurations from across the entire product. Each example may include screenshots, code, output, and/or data. If there is something missing you would like to see, let us know.
 
 <ul>
-<% tag_set(@items.select { |i| i[:kind] == "example" }).sort().each do |tag| %>
-<li><a href="/examples/<%= tag.downcase %>/"><%= tag %></a> - (<%=count_tags()[tag] %>)</li>
+<% tag_set(example_items).sort().each do |tag| %>
+<li><a href="/examples/<%= tag.downcase %>/"><%= tag %></a> - (<%=count_tags(example_items)[tag] %>)</li>
 <% end %>
 </ul>

--- a/content/videos/Install_in_8_minutes.md
+++ b/content/videos/Install_in_8_minutes.md
@@ -1,10 +1,12 @@
 ---
 title: Install Five Integrations in 8 Minutes
 kind: video
+language: en
 wistiaid: ira7wzi1d4
 tags:
     - Introduction
     - Installation
+    - blah
 summary: In about 8 minutes you can get Datadog setup and install integrations with PagerDuty, HipChat, AWS, RDS, and ElasticSearch.
 ---
 

--- a/content/videos/five_minute_intro.md
+++ b/content/videos/five_minute_intro.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction to Datadog in 5 Minutes
 kind: video
+language: en
 wistiaid: nrw4x798k3
 tags:
     - Introduction

--- a/content/videos/index.md
+++ b/content/videos/index.md
@@ -5,7 +5,7 @@ kind: Documentation
 In this section you will find videos we have created for every part of the product. If there is something missing you would like to see, let us know.
 
 <ul>
-<% tag_set(@items.select { |i| i[:kind] == "video" }).sort().each do |tag| %>
-<li><a href="/videos/<%= tag.downcase %>/"><%= tag %></a> - (<%=count_tags()[tag] %>)</li>
+<% tag_set(video_items).sort().each do |tag| %>
+<li><a href="/videos/<%= tag.downcase %>/"><%= tag %></a> - (<%=count_tags(video_items)[tag] %>)</li>
 <% end %>
 </ul>

--- a/layouts/tag.html.erb
+++ b/layouts/tag.html.erb
@@ -22,7 +22,7 @@ when id.match('/examples/') %>
 
   <div class="container">
   <% items_with_tag(tag, @items.select { |i| i[:kind] == "video" }).each do |video| %>
-    <% if video[:language] == nil %>
+    <% if video[:language] == 'en' %>
       <h2><%= link_to video[:title], video %></h2>
       <p><%= video[:summary] %></p>
 

--- a/lib/helpers_.rb
+++ b/lib/helpers_.rb
@@ -11,7 +11,7 @@ def example_items
 end
 
 def video_items
-  @items.select { |item| item[:kind] == 'video' && item[:language] == nil }
+  @items.select { |item| item[:kind] == 'video' && item[:language] == 'en' }
 end
 
 def integration_items


### PR DESCRIPTION
for both the video and example pages i was re evaluating a list multiple times. video_items and example_items is defined in libs so now the index pages just use that instead, reducing errors.

Signed-off-by: Technovangelist <m@technovangelist.com>