### PR TITLE
Add Python and Ruby examples for the revoke screenboard feature

### DIFF
--- a/code_snippets/api-screenboard-revoke.py
+++ b/code_snippets/api-screenboard-revoke.py
@@ -1,0 +1,15 @@
+from datadog import initialize, api
+
+
+options = {
+    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
+    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+}
+
+initialize(**options)
+
+# Share it
+api.Screenboard.share(812)
+
+# Revoke the sharing
+api.Screenboard.revoke(812)

--- a/code_snippets/api-screenboard-revoke.rb
+++ b/code_snippets/api-screenboard-revoke.rb
@@ -1,0 +1,15 @@
+require 'rubygems'
+require 'dogapi'
+
+api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
+app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+
+dog = Dogapi::Client.new(api_key, app_key)
+
+board_id = '6334'
+
+# Share it
+dog.share_screenboard(board_id)
+
+# Revoke the sharing
+dog.revoke_screenboard(board_id)

--- a/content/api/index.html
+++ b/content/api/index.html
@@ -1230,6 +1230,8 @@ kind: documentation
         <h5>Signature</h5>
         <code>DELETE /api/v1/screen/share/:board_id</code>
         <h5>Example Request</h5>
+        <%= snippet_code_block "api-screenboard-revoke.py" %>
+        <%= snippet_code_block "api-screenboard-revoke.rb" %>
         <%= snippet_code_block "api-screenboard-revoke.sh" %>
         <h5>Example Response</h5>
         <%= no_response %>


### PR DESCRIPTION
cf https://github.com/DataDog/documentation/pull/395