### PR TITLE
Update api-events-stream.sh

### DIFF
--- a/code_snippets/api-events-stream.sh
+++ b/code_snippets/api-events-stream.sh
@@ -1,9 +1,9 @@
 # Note: this end point only accepts form-encoded requests.
 currenttime=$(date +%s)
-currenttime2=$(date -v -1d +%s)
+currenttime2=$(date --date='1 day ago' +%s)
 curl -G -H "Content-type: application/json" \
-    -d "start=${currenttime}" \
-    -d "end=${currenttime2}" \
+    -d "start=${currenttime2}" \
+    -d "end=${currenttime}" \
     -d "api_key=9775a026f1ca7d1c6c5af9d94d9595a4" \
     -d "application_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff" \
     'https://app.datadoghq.com/api/v1/events'


### PR DESCRIPTION
$currenttime2 was using -v which is returning an invalid param in bash and tsch.  

Also swapped the variables "$currenttime/$currenttime2" for the start and end params being passed to cURL.  In the existing documentation, the end time is '1 day' prior to the start time, resulting in the query always returning an empty JSON string (cannot have events for negative days, and the start time should be prior to end).