### PR TITLE
Tell s3cmd to not use libmagic to determine file type

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,12 +34,12 @@ end
 namespace :deploy do
   desc 'Deploy to prod S3 bucket; Should be used by `rake release:prod`'
   task :prod do
-    sh('cd output && s3cmd -c ~/.s3cfg.prod sync --delete-removed --no-mime-magic --gues-mime-type . s3://docs.datadoghq.com')
+    sh('cd output && s3cmd -c ~/.s3cfg.prod sync --delete-removed --no-mime-magic --guess-mime-type . s3://docs.datadoghq.com')
   end
 
   desc 'Deploy to staging S3 bucket; Should be used by `rake release:staging`'
   task :staging do
-    sh('cd output && s3cmd -c ~/.s3cfg.prod sync --delete-removed --no-mime-magic --gues-mime-type . s3://docs-staging.datadoghq.com')
+    sh('cd output && s3cmd -c ~/.s3cfg.prod sync --delete-removed --no-mime-magic --guess-mime-type . s3://docs-staging.datadoghq.com')
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -34,12 +34,12 @@ end
 namespace :deploy do
   desc 'Deploy to prod S3 bucket; Should be used by `rake release:prod`'
   task :prod do
-    sh('cd output && s3cmd -c ~/.s3cfg.prod sync --delete-removed . s3://docs.datadoghq.com')
+    sh('cd output && s3cmd -c ~/.s3cfg.prod sync --delete-removed --no-mime-magic --gues-mime-type . s3://docs.datadoghq.com')
   end
 
   desc 'Deploy to staging S3 bucket; Should be used by `rake release:staging`'
   task :staging do
-    sh('cd output && s3cmd -c ~/.s3cfg.prod sync --delete-removed . s3://docs-staging.datadoghq.com')
+    sh('cd output && s3cmd -c ~/.s3cfg.prod sync --delete-removed --no-mime-magic --gues-mime-type . s3://docs-staging.datadoghq.com')
   end
 end
 


### PR DESCRIPTION
A bug exist where s3cmd will try to use existing file type libraries to set type. This pushes the detection back into s3cmd responsibility.