### PR TITLE
[api] wrong argument metric_type -> type

### DIFF
--- a/content/api/index.html
+++ b/content/api/index.html
@@ -183,7 +183,7 @@ kind: documentation
           </li>
           <%= argument('host', 'The name of the host that produced the metric.', :default => 'None' ) %>
           <%= argument('tags', 'A list of tags associated with the metric.', :default => 'None' ) %>
-          <%= argument('metric_type', 'The type of the metric - <code>gauge</code>
+          <%= argument('type', 'The type of the metric - <code>gauge</code>
             or <code>counter</code> (counter data is expected as a rate). Gauges are
                 32bit floats while counters are 64bit integers.', :default => 'gauge' ) %>
           </ul>


### PR DESCRIPTION
Our python lib was using `metric_type` instead of `type`, but it's the second one which is correct. Our Ruby and Shell scripts are already correct, and our python script didn't use it.