### PR TITLE
Update api-tags-get-host.sh to use hostname parameter

### DIFF
--- a/code_snippets/api-tags-get-host.sh
+++ b/code_snippets/api-tags-get-host.sh
@@ -1,11 +1,13 @@
 api_key=9775a026f1ca7d1c6c5af9d94d9595a4
 app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
-host_id=111892
 
+# pass a single hostname as an argument to search for the specified host
+host=$1
+ 
 # Find a host to add a tag to
-host_id=$(curl -G "https://app.datadoghq.com/api/v1/search" \
+host_name=$(curl -G "https://app.datadoghq.com/api/v1/search" \
     -d "api_key=${api_key}" \
     -d "application_key=${app_key}" \
-    -d "q=hosts:" | jq -r '.results.hosts[0]')
-
-curl "https://app.datadoghq.com/api/v1/tags/hosts/${host_id}?api_key=${api_key}&application_key=${app_key}"
+	-d "q=hosts:$host" | cut -d'"' -f6)
+ 
+curl "https://app.datadoghq.com/api/v1/tags/hosts/${host_name}?api_key=${api_key}&application_key=${app_key}"


### PR DESCRIPTION
The existing shell script example utilizes host_id which is not a field that Datadog users can see (confirmed with Datadog Support).  Instead, this script example makes use of the "host_name" field which allows the user to pass in a hostname as a single argument to get host tags.  This updated example also eliminates the dependency on jq for parsing out the results returned in the initial host query.