### PR TITLE
Remove fetch tags by id: line 1327

### DIFF
--- a/content/api/index.html
+++ b/content/api/index.html
@@ -1324,8 +1324,7 @@ kind: documentation
           All metrics sent from a host will have its tags applied.
 
           When fetching and applying tags to a particular host, you can refer
-          to hosts by name (<code>yourhost.example.com</code>) or id
-          (<code>12345</code>).
+          to hosts by name (<code>yourhost.example.com</code>).
         </p>
         <p>
         The component of your infrastructure responsible for a tag is identified by


### PR DESCRIPTION
Per an inquiry with the support team, a host_id is not exposed to customers, and cannot be used to make queries for host tags. A pull request for the shell script get-tags api code snippet has been submitted that also corresponds to this change (https://github.com/DataDog/documentation/pull/461) and been merged.