### PR TITLE
Update api-tags-add.sh

### DIFF
--- a/code_snippets/api-tags-add.sh
+++ b/code_snippets/api-tags-add.sh
@@ -1,15 +1,15 @@
 api_key=9775a026f1ca7d1c6c5af9d94d9595a4
 app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
-host_id=111892
+host=YourHostName
 
 # Find a host to add a tag to
-host_id=$(curl -G "https://app.datadoghq.com/api/v1/search" \
+host_name=$(curl -G "https://app.datadoghq.com/api/v1/search" \
     -d "api_key=${api_key}" \
     -d "application_key=${app_key}" \
-    -d "q=hosts:" | jq -r '.results.hosts[0]')
+    -d "q=hosts:$host" | cut -d'"' -f6)
 
 curl  -X POST -H "Content-type: application/json" \
 -d "{
       \"tags\" : [\"environment:production\", \"role:webserver\"]
     }" \
-"https://app.datadoghq.com/api/v1/tags/hosts/${host_id}?api_key=${api_key}&application_key=${app_key}"
+"https://app.datadoghq.com/api/v1/tags/hosts/${host_name}?api_key=${api_key}&application_key=${app_key}"


### PR DESCRIPTION
Removed dependency on 'jq' for parsing json output and switched to 'cut' for parsing (assumed not all hosts have jq installed).  Changed all instances of host_id to host_name for consistency and to match similar pull request (https://github.com/DataDog/documentation/pull/461) for get-tags method. I also changed line 3 to just "host" instead of "host_name" since it would then be superseded by the variable defintion on line 6.  On line 9, I added the "$host" param being passed to the query so that way the correct host was found. Previously, this did not have a value and would then add the tags to the first host found in the account.