### PR TITLE
[splunk] 'dogapi' -> 'datadog'

### DIFF
--- a/content/integrations/splunk.html
+++ b/content/integrations/splunk.html
@@ -18,8 +18,8 @@ Connect your Splunk log monitoring to be able to:
 </div>
 
 
-<p>To receive your reports from Splunk into Datadog, you need to have <code>dogapi</code> installed</p>
-<p><pre class="linux"><code>pip install dogapi</code></pre></p>
+<p>To receive your reports from Splunk into Datadog, you need to have <code>datadog</code> installed</p>
+<p><pre class="linux"><code>pip install datadog</code></pre></p>
 
 <p>Once it is done, <a href="https://app.datadoghq.com/account/settings#api">get your api key and an application key </a>and drop the following
  <code>dog-splunk.sh</code> script into $SPLUNK_HOME/bin/scripts</p>


### PR DESCRIPTION
Splunk integration is now promoting 'datadog' usage instead of 'dogapi'.