### PR TITLE
Removing host_id mentions in the api docs

### DIFF
--- a/code_snippets/api-tags-add.rb
+++ b/code_snippets/api-tags-add.rb
@@ -3,8 +3,8 @@ require 'dogapi'
 
 api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
 app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
-host_id = '108816'
 
 dog = Dogapi::Client.new(api_key, app_key)
 
-dog.add_tags(host_id, ["role:database", "environment:production"])
+host_name = 'test.host'
+dog.add_tags(host_name, ["role:database", "environment:production"])

--- a/code_snippets/api-tags-get-host.rb
+++ b/code_snippets/api-tags-get-host.rb
@@ -6,4 +6,5 @@ app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
 
 dog = Dogapi::Client.new(api_key, app_key)
 
-dog.host_tags('108816')
+host_name = 'test.host'
+dog.host_tags(host_name)

--- a/code_snippets/api-tags-remove.rb
+++ b/code_snippets/api-tags-remove.rb
@@ -3,8 +3,8 @@ require 'dogapi'
 
 api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
 app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
-host_id = '108816'
 
 dog = Dogapi::Client.new(api_key, app_key)
 
-dog.detach_tags(host_id)
+host_name = 'test.host'
+dog.detach_tags(host_name)

--- a/code_snippets/api-tags-remove.sh
+++ b/code_snippets/api-tags-remove.sh
@@ -1,16 +1,15 @@
 api_key=9775a026f1ca7d1c6c5af9d94d9595a4
 app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
-host_id=111892
 
 # Find a host to remove a tag from
-host_id=$(curl -G "https://app.datadoghq.com/api/v1/search" \
+host_name=$(curl -G "https://app.datadoghq.com/api/v1/search" \
     -d "api_key=${api_key}" \
     -d "application_key=${app_key}" \
     -d "q=hosts:" | jq -r '.results.hosts[0]')
 # Add tags to the host
 curl  -X POST -H "Content-type: application/json" \
 -d "{\"tags\" : [\"environment:production\", \"role:webserver\"]}" \
-"https://app.datadoghq.com/api/v1/tags/hosts/${host_id}?api_key=${api_key}&application_key=${app_key}"
+"https://app.datadoghq.com/api/v1/tags/hosts/${host_name}?api_key=${api_key}&application_key=${app_key}"
 
 
-curl -X DELETE "https://app.datadoghq.com/api/v1/tags/hosts/${host_id}?api_key=${api_key}&application_key=${app_key}"
+curl -X DELETE "https://app.datadoghq.com/api/v1/tags/hosts/${host_name}?api_key=${api_key}&application_key=${app_key}"

--- a/code_snippets/api-tags-update.rb
+++ b/code_snippets/api-tags-update.rb
@@ -3,8 +3,8 @@ require 'dogapi'
 
 api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
 app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
-host_id = '108816'
 
 dog = Dogapi::Client.new(api_key, app_key)
 
-dog.update_tags(host_id, ["role:web", "environment:test"])
+host_name = 'test.host'
+dog.update_tags(host_name, ["role:web", "environment:test"])

--- a/code_snippets/api-tags-update.sh
+++ b/code_snippets/api-tags-update.sh
@@ -1,9 +1,9 @@
 api_key=9775a026f1ca7d1c6c5af9d94d9595a4
 app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
-host_id=111892
+host_name=test.host
 
 curl -X PUT -H "Content-type: application/json" \
 -d '{
       "tags" : ["environment:production", "role:webserver"]
     }' \
-"https://app.datadoghq.com/api/v1/tags/hosts/${host_id}?api_key=${api_key}&application_key=${app_key}"
+"https://app.datadoghq.com/api/v1/tags/hosts/${host_name}?api_key=${api_key}&application_key=${app_key}"

--- a/content/api/index.html
+++ b/content/api/index.html
@@ -1373,7 +1373,7 @@ kind: documentation
       </div>
       <%= right_side_div %>
         <h5>Signature</h5>
-        <code>GET /api/v1/tags/hosts/:host_id_or_host_name</code>
+        <code>GET /api/v1/tags/hosts/:host_name</code>
         <h5>Example Request</h5>
         <%= snippet_code_block "api-tags-get-host.py" %>
         <%= snippet_code_block "api-tags-get-host.rb" %>
@@ -1399,7 +1399,7 @@ kind: documentation
       </div>
       <%= right_side_div %>
         <h5>Signature</h5>
-        <code>POST /api/v1/tags/hosts/:host_id_or_host_name</code>
+        <code>POST /api/v1/tags/hosts/:host_name</code>
         <h5>Example Request</h5>
         <%= snippet_code_block "api-tags-add.py" %>
         <%= snippet_code_block "api-tags-add.sh" %>
@@ -1425,7 +1425,7 @@ kind: documentation
       </div>
       <%= right_side_div %>
         <h5>Signature</h5>
-        <code>PUT /api/v1/tags/hosts/:host_id_or_host_name</code>
+        <code>PUT /api/v1/tags/hosts/:host_name</code>
         <h5>Example Request</h5>
         <%= snippet_code_block "api-tags-update.py" %>
         <%= snippet_code_block "api-tags-update.sh" %>
@@ -1450,7 +1450,7 @@ kind: documentation
       </div>
       <%= right_side_div %>
         <h5>Signature</h5>
-        <code>DELETE /api/v1/tags/hosts/:host_id_or_host_name</code>
+        <code>DELETE /api/v1/tags/hosts/:host_name</code>
         <h5>Example Request</h5>
         <%= snippet_code_block "api-tags-remove.py" %>
         <%= snippet_code_block "api-tags-remove.sh" %>


### PR DESCRIPTION
following PR #465 and according to trello https://trello.com/c/ylgRWFZb/701-docs-api-mentions-host-id-which-is-not-exposed-to-customers

- `host_id` has been replaced with `host_name` for ruby and shell code snippets
- `host_id` has been removed from the signatures.