### PR TITLE
Added "ecs: StartTelemetrySession" to the IAM policy action.

### DIFF
--- a/content/integrations/ecs.md
+++ b/content/integrations/ecs.md
@@ -109,7 +109,8 @@ To monitor your ECS containers and tasks with Datadog, run the Agent as a contai
                     "ecs:DiscoverPollEndpoint",
                     "ecs:Submit*",
                     "ecs:Poll",
-                    "ecs:StartTask"
+                    "ecs:StartTask",
+                    "ecs:StartTelemetrySession"
                 ],
                 "Resource": [
                     "*"


### PR DESCRIPTION
Hi,

I've added "ecs: StartTelemetrySession" to the IAM policy action. This is because, in the collection of ECS CloudWatch metrics "ecs: StartTelemetrySession" is required.

Please check the following document.

http://docs.aws.amazon.com/ja_jp/AmazonECS/latest/developerguide/cloudwatch-metrics.html

> Your Amazon ECS container instances also require ecs:. StartTelemetrySession permission on the IAM role that you launch your container instances with If you created your Amazon ECS container instance role before CloudWatch metrics were available for Amazon ECS, then you might need to add this permission . For information on checking your Amazon ECS container instance role and attaching the managed IAM policy for container instances, see To check for the ecsInstanceRole in the IAM console.

It has been described as above.

Please confirm.

Thank you.
