### PR TITLE
Add extra whitespace in kafka docs

### DIFF
--- a/content/integrations/kafka.md
+++ b/content/integrations/kafka.md
@@ -165,7 +165,9 @@ Edit conf.d/kafka.yaml
                     MeanRate:
                         metric_type: counter
                         alias: kafka.log.flush_rate
+
 And edit conf.d/kafka_consumer.yaml
+
     init_config:
 
     instances:


### PR DESCRIPTION
It seems the markdown engine for the docs is a bit different for github and datadog, the suggestion to edit `conf.d/kafka_consumer.yaml` gets put in the code block