### PR TITLE
[dogstatsd] Mention that the message field in SC should be last

### DIFF
--- a/content/guides/dogstatsd.md
+++ b/content/guides/dogstatsd.md
@@ -325,11 +325,12 @@ If you want to send service checks to DogStatsD, here is the format of the packe
   - `status` — digit corresponding to the status you're reporting (OK = 0, WARNING = 1, CRITICAL = 2, UNKNOWN = 3)
 - Optional metadata `|metadata`:
 It's either nothing, or a combination of those suffixes:
-  - `|m:service_check_message` — A message describing the current state of the service check.
   - `|d:timestamp` — Assign a timestamp to the check. Default is the current Unix epoch timestamp when not supplied.
   - `|h:hostname` — default: None — Assign a hostname to the event.
-  - `|#tag1:value1,tag2,tag3:value3` — default: None. <strong><em><br/>
-  Note: The `:` in tags is part of the tag list string and has no parsing purpose like for the other parameters.</em></strong>
+  - `|#tag1:value1,tag2,tag3:value3` — default: None. <strong><em><br />Note: The `:` in tags is part of the tag list string and
+  has no parsing purpose like for the other parameters.</em></strong>
+  - `|m:service_check_message` — A message describing the current state of the service check. <em>This field should always be
+positioned last among the metadata fields.</em>
 
 
 


### PR DESCRIPTION
So that the docs are consistent with the way we parse service check
packets in the agent's dogstatsd server.

See also https://github.com/DataDog/dd-agent/issues/1927