### PR TITLE
Updated API docs and code samples for screenboards to use correct ags

### DIFF
--- a/code_snippets/api-screenboard-create.py
+++ b/code_snippets/api-screenboard-create.py
@@ -7,23 +7,22 @@ options = {
 
 initialize(**options)
 
-title = "My Screenboards"
+board_title = "My Screenboard"
 description = "An informative screenboard."
 width = 1024
-board = [{
+widgets = [{
   "type": "image",
   "height": 20,
   "width": 32,
   "y": 7,
   "x": 32,
   "url": "https://path/to/image.jpg"
-  }
-  ]
+  }]
 template_variables = [{
   "name": "host1",
   "prefix": "host",
   "default": "host:my-host"
 }]
 
-api.Screenboard.create(title=title, description=description, graphs=board,
-  template_variables=template_variables, width=width)
+api.Screenboard.create(board_title=board_title, description=description,
+  widgets=widgets, template_variables=template_variables, width=width)

--- a/code_snippets/api-screenboard-create.sh
+++ b/code_snippets/api-screenboard-create.sh
@@ -5,7 +5,7 @@ curl -X POST -H "Content-type: application/json" \
 -d '{
         "width": 1024,
         "height": 768,
-        "board_title": "dogapi tests",
+        "board_title": "dogapi test",
         "widgets": [
             {
               "type": "image",

--- a/code_snippets/results/result.api-screenboard-create.py
+++ b/code_snippets/results/result.api-screenboard-create.py
@@ -1,5 +1,5 @@
 {'description': 'An informative screenboard.',
- 'graphs': [{'height': 20,
+ 'widgets': [{'height': 20,
    'type': 'image',
    'url': 'https://path/to/image.jpg',
    'width': 32,
@@ -9,5 +9,5 @@
  'template_variables': [{'default': 'host:my-host',
    'name': 'host1',
    'prefix': 'host'}],
- 'title': 'My Screenboard',
+ 'board_title': 'My Screenboard',
  'width': 1024}

--- a/content/api/index.html
+++ b/content/api/index.html
@@ -1139,25 +1139,12 @@ kind: documentation
       <%= left_side_div %>
         <h5>Arguments</h5>
         <ul class="arguments">
-          <%= argument("title", 'The name of the dashboard.') %>
-          <%= argument("description", "A description of the dashboard\'s content.") %>
-          <%= argument("graphs", "A list of graph definitions. Graph definitions follow this form:") %>
-          <ul class="arguments">
-            <li>
-              <strong>title [required]</strong>
-              <div>The name of the graph.</div>
-            </li>
-            <li>
-              <strong>widgets [required]</strong>
-              <div>
-                The widget definition. See <a href="/api/screenboards/">here</a> for more examples.
-              </div>
-            </li>
-          </ul>
+          <%= argument("board_title", 'The name of the dashboard.') %>
+          <%= argument("description", "A description of the dashboard\'s content.", :default => "None") %>
+          <%= argument("widgets", "A list of widget definitions. See <a href='/api/screenboards/'>here</a> for more examples.") %>
           <%= argument("template_variables", "A list of template variables for using Dashboard templating.", :default => "None") %>
           <%= argument("width", "Screenboard width in pixels", :default => "None") %>
           <%= argument("height", "Height in pixels.", :default => "None") %>
-
         </ul>
       </div>
       <%= right_side_div %>


### PR DESCRIPTION
In screenboard API docs, changes `title` argument references to `board_title`, and `graphs` to `widgets`