### PR TITLE
Deleted extra space that would cause 400 error if copy/pasted

### DIFF
--- a/code_snippets/api-dashboard-get-all.sh
+++ b/code_snippets/api-dashboard-get-all.sh
@@ -1,4 +1,4 @@
 api_key=9775a026f1ca7d1c6c5af9d94d9595a4
 app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
 
-curl "https://app.datadoghq.com/api/v1/dash?api_key=${api_key}&application_key=${app_key} "
+curl "https://app.datadoghq.com/api/v1/dash?api_key=${api_key}&application_key=${app_key}"


### PR DESCRIPTION
The example curl command has a trailing space inside the quotes that causes the request to result in a 400 BAD REQUEST