### PR TITLE
[faq] Add note about trailing underscores

### DIFF
--- a/content/faq.md
+++ b/content/faq.md
@@ -171,6 +171,8 @@ underscores, minuses, colons, periods and slashes. Other characters will get
 converted to underscores. Tags can be up to 200 characters long and support
 unicode. Tags will be converted to lowercase as well.
 
+Note: An exception to this is with trailing underscores, which will be trimmed off of tags (e.g. path:thing_ becomes path:thing).
+
 #### I'm submitting points to the API- anything I should know? 
 {: #api-else}
 We store metric points at the 1 second resolution, but we’d prefer if you only


### PR DESCRIPTION
An issue came up that exposed that we both trim trailing spaces from submitted tags, and that the documentation suggests otherwise. This adds a note to make sure it's documented.

(internal) https://trello.com/c/yXQz0bwl/632-trailing-underscores-in-tags