### PR TITLE
doh uppercase o

### DIFF
--- a/Rules
+++ b/Rules
@@ -15,7 +15,7 @@
 #   because “*” matches zero or more characters.
 
 require './lib/rule_helper'
-require 'Octokit'
+require 'octokit'
 preprocess do
 
   # def rchomp(sep = $/)


### PR DESCRIPTION
Could it be as simple as an uppercase O? I required 'Octokit' which worked on my mac and may need to require 'octokit'