### PR TITLE
no longer need to fix bad filename in dogweb

### DIFF
--- a/lib/helpers_.rb
+++ b/lib/helpers_.rb
@@ -67,12 +67,8 @@ def get_metrics_from_git
 
   if ENV.has_key?('github_personal_token')
     ititle = @item[:git_integration_title]
-    if ititle == 'system'
-      ititle2 = 'os'
-    else
-      ititle2 = ititle
-    end
-    itext = $client.contents('datadog/dogweb', :path => "integration/"+ititle+"/"+ititle2+"_metadata.csv").content
+
+    itext = $client.contents('datadog/dogweb', :path => "integration/"+ititle+"/"+ititle+"_metadata.csv").content
     # return Base64.decode64(client.contents('datadog/dogweb', :path => "integration/"+@item[:git_integration_title]+"/desc.mako"))
     # return Base64.decode64(itext) #.gsub!(/<%(inherit|include)[^>]*\/>|<%def[^>]*>[^<]*<\/%def>/, '')
     metric_string = "<table class='table'>"


### PR DESCRIPTION
had special logic in the git scraper stuff that looked for a different file in system integration. This was fixed in dogweb so no longer need this.