### PR TITLE
the carrot causes problems with nokogiri

### DIFF
--- a/content/integrations/mongodb.md
+++ b/content/integrations/mongodb.md
@@ -8,8 +8,8 @@ git_integration_title: mongodb
 
 Connect MongoDB to Datadog in order to:
 
-  * Visualize key MongoDB metrics.
-  * Correlate MongoDB performance with the rest of your applications.
+* Visualize key MongoDB metrics.
+* Correlate MongoDB performance with the rest of your applications.
 
 From the open-source Agent:
 
@@ -20,7 +20,9 @@ The user set in `mongo.yaml` must have the `clusterMonitor` role.
 
 ### Metrics
 
-<%= get_metrics_from_git()%> Note: many of these metrics are described in the [MongoDB Manual 3.0](https://docs.mongodb.org/manual/reference/command/dbStats/)
+<%= get_metrics_from_git()%>
+
+Note: many of these metrics are described in the [MongoDB Manual 3.0](https://docs.mongodb.org/manual/reference/command/dbStats/)
 
 [1]: https://github.com/DataDog/dd-agent/blob/master/conf.d/mongo.yaml.example
 [2]: https://github.com/DataDog/dd-agent/blob/master/checks.d/mongo.py

--- a/lib/helpers_.rb
+++ b/lib/helpers_.rb
@@ -78,7 +78,7 @@ def get_metrics_from_git
         if row['interval'] != nil
           metric_string += " every #{row['interval']} seconds"
         end
-        metric_string += ")</td><td>#{row['description']}"
+        metric_string += ")</td><td>#{row['description'].gsub '^', ' to the '}"
         if row['unit_name'] != nil
           metric_string += "<br/>shown as #{row['unit_name']}"
           if row['per_unit_name'] != nil


### PR DESCRIPTION
in the text pulled from github from dogweb metrics, 2^30 causes an issue with how nokogiri parses a file. Tried escaping it, but that didnt work, so replace any instance of '^' with ' to the '. this seems to work.