### PR TITLE
Add units documentation page

### DIFF
--- a/content/units.md
+++ b/content/units.md
@@ -1,0 +1,8 @@
+---
+title: Metric Units
+kind: documentation
+---
+
+The following units may be associated with metrics submitted to datadog.
+
+<%= get_units_from_git()%>

--- a/lib/helpers_.rb
+++ b/lib/helpers_.rb
@@ -97,6 +97,41 @@ def get_metrics_from_git
 return output
 end
 
+def get_units_from_git
+  require 'octokit'
+  require 'base64'
+  require 'csv'
+
+  if ENV.has_key?('github_personal_token')
+    itext = $client.contents('datadog/dogweb', :path => "integration/system/units_catalog.csv").content
+    unit_string = ""
+    units_by_family = Hash.new([])
+    CSV.parse(Base64.decode64(itext), :headers => true) do |row|
+      # row.each do |unit_id, family, name, plural, short_name, scale_factor|
+      if units_by_family.has_key?(row['family'])
+        units_by_family[row['family']].push(row['name'])
+      else
+        units_by_family[row['family']] = [row['name']]
+      end
+
+    end
+
+    units_by_family.keys.each do |family|
+      unit_string += "<h2>#{family}</h2>"
+      units_by_family[family].each do |unit_name|
+        unit_string += "<ul>"
+        unit_string += "<li>#{unit_name}</li>"
+        unit_string += "</ul>"
+      end
+    end
+    output = unit_string
+  else
+    raise "Github personal token required"
+  end
+
+return output
+end
+
 def get_cache_bust_fingerprints
   cbfingerprints = Hash.new()
   @items.each do |item|


### PR DESCRIPTION
Dynamically populate a documentation page from the [dogweb repo units csv file](https://github.com/DataDog/dogweb/blob/prod/integration/system/units_catalog.csv).

I did not add any links to this page yet. Currently we don't document the fact that people can specify metric units via the API and Dogstatsd. It will probably be a month or so before we finish building out our handling of units on the intake - and at that point we'll make that feature visible in the docs. This page is still worth creating now because some users have figured out on their own that they can submit units, and are submitting invalid ones. We can point such users to this documentation page.

# Screenshot
![screen shot 2015-12-14 at 10 36 28 am](https://cloud.githubusercontent.com/assets/2548712/11785191/8caba0e0-a24e-11e5-84da-936d9802d8dd.png)