### PR TITLE
Drop python-dogstatsd from libraries page as it's deprecated

### DIFF
--- a/content/libraries.md
+++ b/content/libraries.md
@@ -73,42 +73,42 @@ There are many libraries available to help you interact with the Datadog API.
 
 ### Community Libraries
 
-Some great folks have written their own libraries to help interact with Datadog. Check them out: 
+Some great folks have written their own libraries to help interact with Datadog. Check them out:
 
 #### Java
 {: #community-java}
 
-  * [java-dogstatsd-client][7] - a DogStatsD Client for Java written by [Indeed][8]. 
-  * [metrics-datadog][9] - a backend to yammers's [metrics][9] library written by [Coursera][10]. 
-  * [metrics-datadog][11] - a backend to codahale's [metrics][11] library extended by [Bazaarvoice][12]. 
-  * [Lassie][13] - a Java screenboard API client by [Bazaarvoice][12]. 
+  * [java-dogstatsd-client][7] - a DogStatsD Client for Java written by [Indeed][8].
+  * [metrics-datadog][9] - a backend to yammers's [metrics][9] library written by [Coursera][10].
+  * [metrics-datadog][11] - a backend to codahale's [metrics][11] library extended by [Bazaarvoice][12].
+  * [Lassie][13] - a Java screenboard API client by [Bazaarvoice][12].
   * [java-dogstatsd-client] [59] - DogStatsD Client for Java to submit both Events and Metrics written by [arnabk] [60].
 
 #### Node.js
 {: #community-node}
 
-  * [node-datadog][14] - a Node.js API client, contributed by [HashGo][15]. 
-  * [node-dogstatsd][16] - a Node.js DogStatsD client, contributed by [Young Han Lee][17]. 
-  * [node-dogapi][18] - a Node.js API client, contributed by [Brett Langdon][19]. 
+  * [node-datadog][14] - a Node.js API client, contributed by [HashGo][15].
+  * [node-dogstatsd][16] - a Node.js DogStatsD client, contributed by [Young Han Lee][17].
+  * [node-dogapi][18] - a Node.js API client, contributed by [Brett Langdon][19].
   * [datadog-metrics][57] - Node.js API client, contributed by [Daniel Bader][58].
 
 #### Perl
 {: #community-perl}
 
-  * [webservice-datadog][20] - a Perl API client, contributed by [Jennifer Pinkham][21]. 
-  * [dogstatsd-perl][22] - a Perl DogStatsD client, contributed by [Stefan Goethals][23]. 
+  * [webservice-datadog][20] - a Perl API client, contributed by [Jennifer Pinkham][21].
+  * [dogstatsd-perl][22] - a Perl DogStatsD client, contributed by [Stefan Goethals][23].
 
 #### Ruby
 {: #community-ruby}
 
-  * [metricks-dogstatsd][24] - a backend for the popular [Metriks][25] gem, written by [Mavenlink][26]. 
+  * [metricks-dogstatsd][24] - a backend for the popular [Metriks][25] gem, written by [Mavenlink][26].
   * [hotdog][61] - A command-line interface contributed by [Yuu Yamashita][62].
 
 #### PHP
 {: #community-php}
 
   * [php-datadogstatsd][5] - An extremely simple PHP DogStatsD client written by Alex Corley
-  * [plesk_metrics_datadog][27] - a PHP script to collect metrics from [Plesk][28] by [Israel Viana][29]. 
+  * [plesk_metrics_datadog][27] - a PHP script to collect metrics from [Plesk][28] by [Israel Viana][29].
 
 #### Go
 {: #community-go}
@@ -121,20 +121,20 @@ Some great folks have written their own libraries to help interact with Datadog.
 #### Python
 {: #community-python}
 
-  * [scales_datadog][34] - a Datadog backend for the [Scales][35] library, written by [Tommaso Barbugli][36]. 
+  * [scales_datadog][34] - a Datadog backend for the [Scales][35] library, written by [Tommaso Barbugli][36].
 
 #### Scala
 {: #community-scala}
 
-  * [datadgog-scala][37] - a Scala API client, written by [Cory Watson][38]. 
+  * [datadgog-scala][37] - a Scala API client, written by [Cory Watson][38].
 
 #### Elixir
 {: #community-elixir}
 
-  * [ExStatsD][39] - an Elixir DogStatsD library by [CargoSense][40]. 
-  * [dogstatsd-elixir][41] - a dogstatsd client in Elixir by [Adam Kittelson][42]. 
+  * [ExStatsD][39] - an Elixir DogStatsD library by [CargoSense][40].
+  * [dogstatsd-elixir][41] - a dogstatsd client in Elixir by [Adam Kittelson][42].
   * [mtx][65] - an Elixir Datadog client by [synrc][66].
-  
+
 #### C\#
 {: #community-c-sharp}
 
@@ -151,7 +151,7 @@ Some great folks have written their own libraries to help interact with Datadog.
 {: #community-integration-saltstack}
 
   * [Datadog Saltstack Formula][43]
-  * [Datadog Saltstack][44] written by [Luca Cipriani][45]. 
+  * [Datadog Saltstack][44] written by [Luca Cipriani][45].
 
 #### Ansible
 {: #community-integration-ansible}
@@ -161,26 +161,26 @@ Some great folks have written their own libraries to help interact with Datadog.
 #### FreeSwitch
 {: #community-integration-freeswitch}
 
-  * This is for a [FreeSwitch ESL ][48] application to export statistics to DataDog using the dogstatsd API and is written by [WiMacTel][49]. 
+  * This is for a [FreeSwitch ESL ][48] application to export statistics to DataDog using the dogstatsd API and is written by [WiMacTel][49].
 
 #### Google Analytics
 {: #community-integration-google-analytics}
 
-  * You can get data into Datadog from Google Analytics using our API with [this library][50]. 
+  * You can get data into Datadog from Google Analytics using our API with [this library][50].
 
 #### Pid-stats
 {: #community-integration-pid-stats}
 
-  * This [library][51] will allow you to generate process information from StatsD, given pid files. It was created by [GitterHQ][52]. 
+  * This [library][51] will allow you to generate process information from StatsD, given pid files. It was created by [GitterHQ][52].
 
 
 #### Reverse Color Scheme
 
-  * To get a darker background than default, you can use [this CSS library][55] to flip the colors. 
-  
+  * To get a darker background than default, you can use [this CSS library][55] to flip the colors.
 
 
-If you've written a Datadog library, write us at [code@datadoghq.com][56] and we'll be happy to add it to the list. 
+
+If you've written a Datadog library, write us at [code@datadoghq.com][56] and we'll be happy to add it to the list.
 
    [1]: https://github.com/DataDog/datadogpy
    [2]: https://github.com/DataDog/dogstatsd-python

--- a/content/libraries.md
+++ b/content/libraries.md
@@ -55,7 +55,6 @@ There are many libraries available to help you interact with the Datadog API.
 #### Python
 
   * [datadogpy][1] - A Python Datadog API wrapper and DogStatsD client.
-  * [dogstatsd-python][2] - A Python DogStatsD client.
 
 #### Ruby
 
@@ -183,7 +182,6 @@ Some great folks have written their own libraries to help interact with Datadog.
 If you've written a Datadog library, write us at [code@datadoghq.com][56] and we'll be happy to add it to the list.
 
    [1]: https://github.com/DataDog/datadogpy
-   [2]: https://github.com/DataDog/dogstatsd-python
    [3]: https://github.com/DataDog/dogapi-rb
    [4]: https://github.com/DataDog/dogstatsd-ruby
    [5]: https://github.com/DataDog/php-datadogstatsd


### PR DESCRIPTION
You can perform all functionality in the `datadogpy` library now. The README also shows the library as deprecated when you visit the repo.