### PR TITLE
update config directory

### DIFF
--- a/content/guides/basic_agent_usage/osx.md
+++ b/content/guides/basic_agent_usage/osx.md
@@ -3,7 +3,7 @@ title: Basic Agent Usage for OS X
 kind: documentation
 servicename: /usr/local/bin/datadog-agent
 serviceinfoname: /usr/local/bin/datadog-agent info
-configdirectory: ~/.datadog-agent/
+configdirectory: /opt/datadog-agent/etc/
 logdirectory: /var/log/datadog/
 supervisorlog: /var/log/datadog/supervisord.log
 os: osx


### PR DESCRIPTION
this should also be changed, but i'm not sure if that is true for all `BasicAgentUsage-nix`

> Configuration
> The configuration file for the Agent is located at ~/.datadog-agent/datadog.conf
>
> Configuration files for integrations are located in ~/.datadog-agent/conf.d/