### PR TITLE
add cli instructions for ecs task instructions

### DIFF
--- a/content/integrations/ecs.md
+++ b/content/integrations/ecs.md
@@ -12,8 +12,8 @@ Amazon EC2 Container Service (ECS) is a highly scalable, high performance contai
 To monitor your ECS containers and tasks with Datadog, run the Agent as a container on every EC2 instance in your ECS cluster. As detailed below, there are a few setup steps:
 
 1. **Add an ECS Task**
-2. **Create or Modify your IAM Policy**
-3. **Create a new Instance with a User Script**
+1. **Create or Modify your IAM Policy**
+1. **Create a new Instance with a User Script**
 
 This documentation assume you already have a working EC2 Container Service cluster configured. If not, review the [Getting Started section in the ECS documentation](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_GetStarted.html).
 
@@ -33,36 +33,36 @@ You may either configure the task using the [AWS CLI tools](https://aws.amazon.c
 #### Web UI
 
 1. Log in to your AWS Console and navigate to the EC2 Container Service section.
-2. Click on the cluster you wish to add Datadog to.
-3. Click on **Task Definitions** on the left side and click the button **Create new Task Definition**.
-4. Enter a **Task Definition Name**, such as ```dd-agent-task```.
-5. Click on the **Add volume** link.
-6. For **Name** enter ```docker_sock```. For **Source Path**, enter ```/var/run/docker.sock```. Click **Add**.
-7. Add another volume with the name ```proc``` and source path of ```/proc/```.
-8. Add another volume with the name ```cgroup``` and source path of ```/cgroup/```.
-9. Click the large **Add container** button.
-10. For **Container name** enter ```dd-agent```.
-11. For **Image** enter ```datadog/docker-dd-agent:ecs```.
-12. For **Maximum memory** enter ```128```.
-13. Scroll down to the **Advanced container configuration** section and enter ```10``` in **CPU units**.
-14. For **Env Variables**, add a **Key** of ```API_KEY``` and enter your Datadog API Key in the value. *If you feel more comfortable storing secrets like this in s3, take a [look at the ECS Configuration guide](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html#ecs-config-s3).*
-15. Add another Environment Variable for any tags you want to add using the key ```TAGS```.
-16. Scroll down to the **Storage and Logging** section.
-17. In **Mount points** select the **docker_sock** source volume and enter ```/var/run/docker.sock``` in the Container path. Leave the **Read only** checkbox un-checked.
-18. Add another mount point for **proc** and enter ```/host/proc/``` in the Container path. Check the **Read only** checkbox.
-19. Add a third mount point for **cgroup** and enter ```/host/sys/fs/cgroup``` in the Container path. Check the **Read only** checkbox.
+1. Click on the cluster you wish to add Datadog to.
+1. Click on **Task Definitions** on the left side and click the button **Create new Task Definition**.
+1. Enter a **Task Definition Name**, such as ```dd-agent-task```.
+1. Click on the **Add volume** link.
+1. For **Name** enter ```docker_sock```. For **Source Path**, enter ```/var/run/docker.sock```. Click **Add**.
+1. Add another volume with the name ```proc``` and source path of ```/proc/```.
+1. Add another volume with the name ```cgroup``` and source path of ```/cgroup/```.
+1. Click the large **Add container** button.
+1. For **Container name** enter ```dd-agent```.
+1. For **Image** enter ```datadog/docker-dd-agent:ecs```.
+1. For **Maximum memory** enter ```128```.
+1. Scroll down to the **Advanced container configuration** section and enter ```10``` in **CPU units**.
+1. For **Env Variables**, add a **Key** of ```API_KEY``` and enter your Datadog API Key in the value. *If you feel more comfortable storing secrets like this in s3, take a [look at the ECS Configuration guide](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html#ecs-config-s3).*
+1. Add another Environment Variable for any tags you want to add using the key ```TAGS```.
+1. Scroll down to the **Storage and Logging** section.
+1. In **Mount points** select the **docker_sock** source volume and enter ```/var/run/docker.sock``` in the Container path. Leave the **Read only** checkbox un-checked.
+1. Add another mount point for **proc** and enter ```/host/proc/``` in the Container path. Check the **Read only** checkbox.
+1. Add a third mount point for **cgroup** and enter ```/host/sys/fs/cgroup``` in the Container path. Check the **Read only** checkbox.
 
 ### Create or Modify your IAM Policy
 
 If you are modifying the IAM Policy you created for your cluster, you may only need to add one Action: ```ecs:StartTask```.
 
 1. Using the Identity and Access Management (IAM) console, create a new role called ```dd-agent-ecs```.
-2. Select **Amazon EC2 Role for EC2 Container Service**. On the next screen do not check any checkboxes and click **Next Step**.
-3. Click **Create Role**.
-4. Click on the newly created role.
-5. Expand the **Inline Policies** section. Click the link to create a new inline policy.
-6. Choose **Custom Policy** and press the button.
-7. For **Policy Name** enter ```dd-agent-policy```. Copy the following text into the **Policy Document**:
+1. Select **Amazon EC2 Role for EC2 Container Service**. On the next screen do not check any checkboxes and click **Next Step**.
+1. Click **Create Role**.
+1. Click on the newly created role.
+1. Expand the **Inline Policies** section. Click the link to create a new inline policy.
+1. Choose **Custom Policy** and press the button.
+1. For **Policy Name** enter ```dd-agent-policy```. Copy the following text into the **Policy Document**:
 
 
        {
@@ -95,11 +95,11 @@ Ideally you want the Datadog agent to load on one container on each EC2 instance
 #### Create a new Amazon Linux instance
 
 1. Log in to the AWS console and navigate to the EC2 section.
-2. Create a new instance by clicking the **Launch Instance** button.
-3. Click on Community AMIs. Visit [this page to see a list of current ECS optimized instances](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_container_instance.html). Choose the appropriate AMI for your region and copy the ID into the search box. Choose the AMI that comes up as a result of the  search.
-4. Follow the prompts as you normally would when setting up an instance.
-5. On the third dialog, select the IAM role you created above.
-6. Expand the Advanced Details section and copy the following script into the User Data section. Change cluster name to your cluster's name and task definition to the name you gave your task definition.
+1. Create a new instance by clicking the **Launch Instance** button.
+1. Click on Community AMIs. Visit [this page to see a list of current ECS optimized instances](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_container_instance.html). Choose the appropriate AMI for your region and copy the ID into the search box. Choose the AMI that comes up as a result of the  search.
+1. Follow the prompts as you normally would when setting up an instance.
+1. On the third dialog, select the IAM role you created above.
+1. Expand the Advanced Details section and copy the following script into the User Data section. Change cluster name to your cluster's name and task definition to the name you gave your task definition.
 
        #!/bin/bash
        cluster="cluster_name"
@@ -127,9 +127,9 @@ Ideally you want the Datadog agent to load on one container on each EC2 instance
 #### Create a new CoreOS instance
 
 1. Log in to the AWS console and navigate to the EC2 section.
-2. Create a new instance  as described in the instructions for a simple CoreOS ECS instance [here](https://coreos.com/os/docs/latest/booting-on-ecs.html)).
-3. When you get to the Configure Instance Details step, select the IAM role you created above.
-4. Paste the following block in User Data under Advanced Details, replace `CLUSTER_NAME` and `YOUR_API_KEY` with the ECS cluster that instance will join and your Datadog API key. This block declares two units with cloud-config, one for the ecs-agent container, used by Amazon ECS to administrate the ECS instance, and one for the dd-agent container, used by Datadog to collect metrics about the system and the tasks running on this ECS instance. Of course it can be modified to include your own tasks as well.
+1. Create a new instance  as described in the instructions for a simple CoreOS ECS instance [here](https://coreos.com/os/docs/latest/booting-on-ecs.html)).
+1. When you get to the Configure Instance Details step, select the IAM role you created above.
+1. Paste the following block in User Data under Advanced Details, replace `CLUSTER_NAME` and `YOUR_API_KEY` with the ECS cluster that instance will join and your Datadog API key. This block declares two units with cloud-config, one for the ecs-agent container, used by Amazon ECS to administrate the ECS instance, and one for the dd-agent container, used by Datadog to collect metrics about the system and the tasks running on this ECS instance. Of course it can be modified to include your own tasks as well.
 
 
        #cloud-config

--- a/content/integrations/ecs.md
+++ b/content/integrations/ecs.md
@@ -21,6 +21,17 @@ This documentation assume you already have a working EC2 Container Service clust
 
 This task will launch the Datadog container. When you need to modify the configuration, you will update this Task Definition as described further down in this guide.
 
+You may either configure the task using the [AWS CLI tools](https://aws.amazon.com/cli/) or using the Amazon Web Console.
+
+#### AWS CLI
+
+1. Download [dd-agent-ecs.json](/static/dd-agent-ecs.json).
+1. Edit dd-agent-ecs.json and update it with the [API_KEY](https://app.datadoghq.com/account/settings#api) for your account.
+1. Execute the following command:
+       aws ecs register-task-definition --cli-input-json file://path/to/dd-agent-ecs.json
+
+#### Web UI
+
 1. Log in to your AWS Console and navigate to the EC2 Container Service section.
 2. Click on the cluster you wish to add Datadog to.
 3. Click on **Task Definitions** on the left side and click the button **Create new Task Definition**.

--- a/content/static/dd-agent-ecs.json
+++ b/content/static/dd-agent-ecs.json
@@ -1,0 +1,54 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "dd-agent",
+      "image": "datadog/docker-dd-agent:ecs",
+      "cpu": 10,
+      "memory": 128,
+      "essential": true,
+      "mountPoints": [
+        {
+          "containerPath": "/var/run/docker.sock",
+          "sourceVolume": "docker_sock"
+        },
+        {
+          "containerPath": "/host/sys/fs/cgroup",
+          "sourceVolume": "cgroup",
+          "readOnly": true
+        },
+        {
+          "containerPath": "/host/proc ",
+          "sourceVolume": "proc",
+          "readOnly": true
+        }
+      ],
+      "environment": [
+        {
+          "name": "API_KEY",
+          "value": "YOUR_API_KEY_GOES_HERE"
+        }
+      ]
+    }
+  ],
+  "volumes": [
+    {
+      "host": {
+        "sourcePath": "/var/run/docker.sock"
+      },
+      "name": "docker_sock"
+    },
+    {
+      "host": {
+        "sourcePath": "/proc/"
+      },
+      "name": "proc"
+    },
+    {
+      "host": {
+        "sourcePath": "/cgroup/"
+      },
+      "name": "cgroup"
+    }
+  ],
+  "family": "dd-agent-task"
+}


### PR DESCRIPTION
Creating an ECS task involves a lot of manual clicking in the webui.  This PR adds instructions for using the AWS CLI.
