### PR TITLE
now dogweb metrics are cached locally speeding up compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ remote-compile.sh
 code_test
 tested.code
 .sass-cache
+github_metrics

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'rake/clean'
 
 
-CLEAN.include(%w(output tmp code_test tested.code))
+CLEAN.include(%w(output tmp code_test tested.code github_metrics))
 
 CODE_SNIPPETS = 'code_snippets'
 CODE_TEST = 'code_test'


### PR DESCRIPTION
Before, the compile would grab the metrics from every integration on github every compile. even when nothing changes, it grabs the metrics from gh. On my fast connection at home, this takes 70+ seconds every time. Now it grabs all the metrics all at once and caches them. Every other compile you do grabs from the cache until you do a rake clean. This means that for simple changes the compile goes back to ~4-10 seconds. Much better than 70.