### PR TITLE
AWS add emr authorisation

### DIFF
--- a/content/integrations/aws.md
+++ b/content/integrations/aws.md
@@ -88,6 +88,7 @@ There are two integration methods that can be used to allow Datadog to monitor y
                 "elasticache:Describe*",
                 "elasticache:List*",
                 "elasticloadbalancing:Describe*",
+                "elasticmapreduce:List*",
                 "iam:Get*",
                 "iam:List*",
                 "kinesis:Get*",


### PR DESCRIPTION
Fix for [this](https://app.datadoghq.com/metric/explorer?live=true&page=0&is_auto=false&tile_size=m&exp_metric=dd.crawler.aws.uncaughtBotoError&exp_scope=error_code%3Aaccessdeniedexception%2Cnamespace%3Aaws_emr&exp_agg=sum&exp_row_type=metric)

Log example (org 1074)

```log
2016-05-17 13:01:32,819 INFO [dd.base_crawler] [27448] [core.py:270] - Crawling orgs: [1074]
2016-05-17 13:01:32,843 INFO [dd.base_crawler] [27448] [core.py:353] - Running the crawler...
2016-05-17 13:01:32,861 INFO [dd.aws] [27448] [crawler.py:41] - crawling EMR for org 1074 after 2016-05-16 13:01:32, key 774013277495 region us-east-1
2016-05-17 13:01:33,000 WARNING [dd.integration.amazon_web_services.crawler.common] [27448] [common.py:71] - [accessdeniedexception] User: arn:aws:sts::774013277495:assumed-role/datadog-role-DatadogRole-L7ZEI0EFOFDY/DatadogAWSIntegration is not authorized to perform: elasticmapreduce:ListClusters
2016-05-17 13:01:33,005 INFO [dd.aws] [27448] [crawler.py:41] - crawling EMR for org 1074 after 2016-05-16 13:01:32, key 549050352176 region us-west-2
2016-05-17 13:01:33,437 WARNING [dd.integration.amazon_web_services.crawler.common] [27448] [common.py:71] - [accessdeniedexception] User: arn:aws:sts::549050352176:assumed-role/datadog-role-DatadogRole-3QFB103MP0UD/DatadogAWSIntegration is not authorized to perform: elasticmapreduce:ListClusters
2016-05-17 13:01:33,442 INFO [dd.aws] [27448] [crawler.py:41] - crawling EMR for org 1074 after 2016-05-16 13:01:32, key 468552248569 region us-west-2
2016-05-17 13:01:33,866 WARNING [dd.integration.amazon_web_services.crawler.common] [27448] [common.py:71] - [accessdeniedexception] User: arn:aws:sts::468552248569:assumed-role/datadog-role-DatadogRole-IMVL9I79GWL5/DatadogAWSIntegration is not authorized to perform: elasticmapreduce:ListClusters
2016-05-17 13:01:33,870 INFO [dd.base_crawler] [27448] [core.py:359] - Crawler ended
2016-05-17 13:01:33,871 INFO [dd.delancie.worker] [27448] [worker_impl.py:257] - Great success
```
