### PR TITLE
Double quotes are sometimes transmitted to the requirements.txt file

### DIFF
--- a/content/integrations/gae.md
+++ b/content/integrations/gae.md
@@ -52,7 +52,7 @@ Ensure that Billing is enabled on your Google App Engine project to collect all 
 
 4. Add ```dogapi``` to the requirements.txt file.
 
-        echo "dogapi" >> requirements.txt
+        echo dogapi >> requirements.txt
 
 5. Ensure the requirements are installed.
 


### PR DESCRIPTION
Causing pip to fail installing dogapi, see: https://datadog.zendesk.com/agent/tickets/53136
The command without the double quotes avoids the problem.