### PR TITLE
clarify measure is in seconds and not ms

### DIFF
--- a/content/api/index.html
+++ b/content/api/index.html
@@ -180,7 +180,7 @@ kind: documentation
                   <div>
                   <code>[[POSIX_timestamp, numeric_value], ...]</code>
                   </div>
-                  Note that the timestamp must be current, and the numeric value is a 32bit float gauge-type value.
+                  Note that the timestamp should be in seconds, must be current, and the numeric value is a 32bit float gauge-type value.
               </div>
           </li>
           <%= argument('host', 'The name of the host that produced the metric.', :default => 'None' ) %>

--- a/content/guides/dogstatsd.md
+++ b/content/guides/dogstatsd.md
@@ -231,7 +231,7 @@ eof
   - Event title.
   - Event text. Supports line breaks.
 - Optional:
-  - `date_happened` (Time, None) — default: None — Assign a timestamp to the event. Default is now when none.
+  - `date_happened` (Time, None) — default: None — Assign a POSIX timestamp in seconds to the event. Default is now when none.
   - `hostname` (String, None) — default: None — Assign a hostname to the event.
   - `aggregation_key` (String, None) — default: None — Assign an aggregation key to the event, to group it with some others.
   - `priority` (String, None) — default: 'normal' — Can be 'normal' or 'low'.


### PR DESCRIPTION
#756 suggested we clarify that we require timestamps be in seconds and not milliseconds.