### PR TITLE
Added update to setup for Mac OS 10.11 & OpenSSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ gem install bundler # and set up your shell / shell profile for it
 rbenv exec bundle install
 ```
 
+As of OS X 10.11 (El Capitan), OpenSSL headers are no longer provided. You will need to install OpenSSL prior to running the bundle install.
+
+```
+brew install openssl
+brew link openssl --force
+```
+
 # Working on Docs
 
 ```


### PR DESCRIPTION
While running through the setup, bundle install threw a fatal error when trying to install the `eventmachine` gem. Event Machine requires the openssl/ssh header (see below for full error).

Installing OpenSSL and linking it resolves the error.

Error while installing bundle:

```
Installing eventmachine 1.0.8 with native extensions

Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/jasonyee/vendor/bundle/gems/eventmachine-1.0.8/ext
/Users/jasonyee/.rbenv/versions/2.3.0/bin/ruby -r ./siteconf20160601-14781-ywq4sd.rb extconf.rb
checking for rb_trap_immediate in ruby.h,rubysig.h... no
checking for rb_thread_blocking_region()... no
checking for ruby/thread.h... yes
checking for rb_thread_call_without_gvl() in ruby/thread.h... yes
checking for inotify_init() in sys/inotify.h... no
checking for __NR_inotify_init in sys/syscall.h... no
checking for writev() in sys/uio.h... yes
checking for rb_thread_fd_select()... yes
checking for rb_fdset_t in ruby/intern.h... yes
checking for pipe2() in unistd.h... no
checking for accept4() in sys/socket.h... no
checking for SOCK_CLOEXEC in sys/socket.h... no
checking for rb_wait_for_single_fd()... yes
checking for rb_enable_interrupt()... no
checking for rb_time_new()... yes
checking for sys/event.h... yes
checking for sys/queue.h... yes
CFLAGS= -O3 -Wno-error=shorten-64-to-32  -pipe  -Wall -Wextra -Wno-deprecated-declarations -Wno-ignored-qualifiers -Wno-unused-result
CPPFLAGS=-I/Users/jasonyee/.rbenv/versions/2.3.0/include  -D_XOPEN_SOURCE -D_DARWIN_C_SOURCE -D_DARWIN_UNLIMITED_SELECT -D_REENTRANT $(DEFS) $(cppflags) -Wall -Wextra -Wno-deprecated-declarations -Wno-ignored-qualifiers -Wno-unused-result
checking for clock_gettime()... no
checking for gethrtime()... no
creating Makefile

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /Users/jasonyee/vendor/bundle/extensions/x86_64-darwin-15/2.3.0-static/eventmachine-1.0.8/mkmf.log

current directory: /Users/jasonyee/vendor/bundle/gems/eventmachine-1.0.8/ext
make "DESTDIR=" clean

current directory: /Users/jasonyee/vendor/bundle/gems/eventmachine-1.0.8/ext
make "DESTDIR="
compiling binder.cpp
In file included from binder.cpp:20:
./project.h:116:10: fatal error: 'openssl/ssl.h' file not found
#include <openssl/ssl.h>
         ^
1 error generated.
make: *** [binder.o] Error 1

make failed, exit code 2

Gem files will remain installed in /Users/jasonyee/vendor/bundle/gems/eventmachine-1.0.8 for inspection.
Results logged to /Users/jasonyee/vendor/bundle/extensions/x86_64-darwin-15/2.3.0-static/eventmachine-1.0.8/gem_make.out
```