### PR TITLE
Add description about docker image name to service discovery guide

### DIFF
--- a/content/guides/servicediscovery.md
+++ b/content/guides/servicediscovery.md
@@ -41,7 +41,26 @@ Here is the structure of a configuration template:
           - instances: [{instance_config}]
         ...
 
+### Docker Image Name
+About image name, specify **only** image name.
 
+
+    # DO
+    /datadog/
+      check_configs/
+        image_name/
+          - check_names: ["check_name_0"]
+          - init_configs: [{init_config}]
+          ...
+
+
+    # DO NOT
+    /datadog/
+      check_configs/
+        repo/user/image_name:tag/
+          - check_names: ["check_name_0"]
+          - init_configs: [{init_config}]
+          ...
 
 ### Setup NGINX
 


### PR DESCRIPTION
@remh @jhotta 

## What I change
I add more description about docker image name to service discovery guide.

## Why I change
When I tried service discovery feature for the first time, I was confused about which format should I use for "image name", `repo/user/name:tag` or just only image name. It will be more helpful if there is some examples or description about the format like below:

```yaml
# DO
/datadog/
  check_configs/
    image_name/

# DO NOT
/datadog/
  check_configs/
    repo/user/image_name:tag/
```

ps. @remh  I also sent you an email about some feedbacks about service discovery feature. I hope it will help you.