### PR TITLE
Remove trailing slash from base_url

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -62,7 +62,7 @@ data_sources:
   # notify_on_compilation_success: true
   # notify_on_compilation_failure: true
 
-base_url: http://docs.datadoghq.com/
+base_url: http://docs.datadoghq.com
 
 # redirects:
 #   - /overview:


### PR DESCRIPTION
  Per Docs at http://nanoc.ws/doc/reference/helpers/
  base_url should not have a trailing slash. The slash
  was causing the sitemap to have errant URLs with
  double slashes.