### PR TITLE
standardize links to example conf and check files for local integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ The installation section should cover anything that needs to be installed on the
 
 The configuration section should cover anything that you can configure in the Datadog interface or the agent configuration files. In almost every case this section should be included since there is almost always something to configure. To be a complete integration, either an installation section or a configuration section must be included.
 
+At the end of the configuration section include a link to the example configuration files. This should be done by adding `<%= insert_example_links%>`. This method takes a few optional parameters: `conf` is the name of the example YAML file, minus the extension; `check` is the name of the check file, minus the .py extension; setting either `check` or `conf` to `"none"` will hide that line; `include_intro` set to false will show only the list minus the sentence at the top; normally the integration title in the links will come from the pages frontmatter, but setting `integration` will override that, `yaml_extension` will change the extension from example to something else (like "default").
+
+
 ### Validation
 **Required**
 

--- a/content/integrations/activemq.md
+++ b/content/integrations/activemq.md
@@ -99,6 +99,8 @@ Get metrics from ActiveMQ in real time to
         else echo -e "\e[031mAgent is not running\e[0m"; fi
     {:.language-shell}
 
+<%= insert_example_links(check: "none")%>
+
 ## Metrics
 
 <%= get_metrics_from_git()%>

--- a/content/integrations/apache.md
+++ b/content/integrations/apache.md
@@ -8,16 +8,11 @@ git_integration_title: apache
 
 # Overview
 
-Get metrics from Apache in real time; graph them and correlate them with other relevant system metrics and events.
+Get metrics from Apache in real timex; graph them and correlate them with other relevant system metrics and events.
 
   * Visualize your web server performance
   * Correlate the performance of Apache with the rest of your applications
 
-
-From the open-source Agent:
-
-  * [Apache YAML example][1]
-  * [Apache checks.d][2]
 
 # Installation
 
@@ -43,6 +38,8 @@ Make sure that [`mod_status`][3] is installed on your Apache server with `Extend
 2. Restart the agent
 
         sudo datadog-agent restart
+
+<%= insert_example_links %>
 
 # Validation
 

--- a/content/integrations/btrfs.md
+++ b/content/integrations/btrfs.md
@@ -11,6 +11,8 @@ Capture Btrfs metrics into Datadog to:
 * Visualize your file system performance.
 * Correlate the performance of Btrfs file system with the rest of your applications.
 
+<%= insert_example_links%>
+
 ## Metrics
 
 <%= get_metrics_from_git()  %>

--- a/content/integrations/cacti.md
+++ b/content/integrations/cacti.md
@@ -12,13 +12,8 @@ Connect Cacti to Datadog to:
 * Visualize Cacti metrics in Datadog.
 * Correlate metrics captured by Cacti with the rest of your applications.
 
-From the open-source Agent:
+<%= insert_example_links%>
 
-* [ Cacti YAML example][1]
-* [ Cacti checks.d][2]
-
-[1]: https://github.com/DataDog/dd-agent/blob/master/conf.d/cacti.yaml.example
-[2]: https://github.com/DataDog/dd-agent/blob/master/checks.d/cacti.py
 
 
 

--- a/content/integrations/cassandra.md
+++ b/content/integrations/cassandra.md
@@ -12,6 +12,8 @@ Learn more about how to monitor Cassandra performance metrics thanks to [our ser
 
 For information on JMX Checks, please see <a href="http://docs.datadoghq.com/integrations/java/">here</a>.
 
+<%= insert_example_links(check: "none")%>
+
 ## Metrics
 
 <%= get_metrics_from_git() %>

--- a/content/integrations/ceph.md
+++ b/content/integrations/ceph.md
@@ -8,9 +8,11 @@ newhlevel: true
 # Overview
 
 Enable the Datadog-Ceph integration to:
+
   * Track disk usage across storage pools
   * Receive service checks in case of issues
   * Monitor I/O performance metrics
+
 
 # Installation
 
@@ -22,7 +24,7 @@ Adjust the configuration file to match your environment. By default the check wi
 
 Any extra tags specific to the cluster can be specified under `tags`, as usual.
 
-  * [Ceph YAML example][1]
+<%= insert_example_links%>
 
 # Validation
 
@@ -39,5 +41,3 @@ Execute the info command `/etc/init.d/datadog-agent info` and verify that the in
               - Collected 19 metrics, 0 events & 2 service checks
 
 
-
-[1]: https://github.com/DataDog/dd-agent/blob/master/conf.d/ceph.yaml.example

--- a/content/integrations/consul.md
+++ b/content/integrations/consul.md
@@ -13,12 +13,7 @@ Connect Consul to Datadog in order to:
 * Correlate the performance of Consul with the rest of your applications
 * Monitor the health of your Consul cluster
 
-
-
-From the open-source Agent:
-
-* [Consul YAML Example][1]
-* [Consul checks.d][2]
+<%= insert_example_links%>
 
 
 # Metrics
@@ -30,5 +25,3 @@ Finally, we perform a service check `consul.check` that will report on the state
 
 The other consul metrics collected are not service bound but node bound, and only `consul.peers` is tagged with `mode:leader` or `mode:follower`.
 
-[1]: https://github.com/DataDog/dd-agent/blob/master/conf.d/consul.yaml.example
-[2]: https://github.com/DataDog/dd-agent/blob/master/checks.d/consul.py

--- a/content/integrations/couchbase.md
+++ b/content/integrations/couchbase.md
@@ -6,12 +6,15 @@ doclevel: basic
 git_integration_title: couchbase
 ---
 
+### Overview
 
 Get metrics from Couchbase in real time to
 
 * Visualize key Couchbase metrics
 * Correlate Couchbase performance with the rest of your applications
 
-## Metrics
+<%= insert_example_links%>
+
+### Metrics
 
 <%= get_metrics_from_git() %>

--- a/content/integrations/couchdb.md
+++ b/content/integrations/couchdb.md
@@ -12,14 +12,7 @@ Capture CouchDB data in Datadog to:
 * Visualize key CouchDB metrics.
 * Correlate CouchDB performance with the rest of your applications.
 
-From the open-source Agent:
-
-* [ CouchDB YAML example][1]
-* [ CouchDB checks.d][2]
-
-
-[1]: https://github.com/DataDog/dd-agent/blob/master/conf.d/couch.yaml.example
-[2]: https://github.com/DataDog/dd-agent/blob/master/checks.d/couch.py
+<%= insert_example_links(conf: "couch", check: "couch")%>
 
 
 ## Metrics

--- a/content/integrations/directory.md
+++ b/content/integrations/directory.md
@@ -15,11 +15,6 @@ Capture metrics from the files in given directories:
   * age of the creation
 
 
-From the Agent:
-
-* [Directory check script][1]
-* [Directory check configuration example][2]
-
 
 # Configuration
 {:#int-configuration}
@@ -48,6 +43,8 @@ From the Agent:
 
 4.  Restart the Agent
 
+<%= insert_example_links(conf: "directory", check: "directory")%>
+
 # Validation
 
 To validate that the check has passed run the agent info command. The output of the command should contain a section similar to the following:
@@ -62,6 +59,3 @@ To validate that the check has passed run the agent info command. The output of 
         - instance #0 [OK]
         - Collected 8 metrics & 0 events
 
-
-[1]: https://github.com/DataDog/dd-agent/blob/master/checks.d/directory.py
-[2]: https://github.com/DataDog/dd-agent/blob/master/conf.d/directory.yaml.example

--- a/content/integrations/dnscheck.md
+++ b/content/integrations/dnscheck.md
@@ -22,6 +22,8 @@ To configure the DNS Service Check, edit the dns_check.yaml file in your conf.d 
         nameserver: 127.0.0.1
         timeout: 8
 
+<%= insert_example_links(conf: "dns_check", check: "dns_check")%>
+
 # Validation
 
 To validate that the DNS Service Check is working, run `datadog-agent info`. You should see something like the following:

--- a/content/integrations/docker.md
+++ b/content/integrations/docker.md
@@ -21,6 +21,8 @@ Learn more about how to monitor Docker performance metrics thanks to [our series
 
 There are three ways to setup the Docker integration: install the agent on the host, on a single priviledged container, and on each individual container.
 
+<%= insert_example_links(conf: "docker_daemon", check: "docker_daemon")%>
+
 **Note:** docker_daemon replaces the older docker integration going forward.
 
 ### Installation

--- a/content/integrations/elasticsearch.md
+++ b/content/integrations/elasticsearch.md
@@ -14,10 +14,6 @@ Connect ElasticSearch to Datadog in order to:
 * Correlate ElasticSearch performance with the rest of your applications.
 
 
-From the open-source Agent:
-
-* [ ElasticSearch YAML example][1]
-* [ ElasticSearch checks.d][2]
 
 # Installation
 
@@ -34,6 +30,8 @@ No installation steps are required for this integration
             # The format for the url entry is url: http://servername:port
 
 2.  Restart the agent
+
+<%= insert_example_links(conf: "elastic", check: "elastic")%>
 
 # Validation
 
@@ -61,6 +59,3 @@ To validate that the integration is working, run ```datadog-agent info```. You s
 <%= get_metrics_from_git()%>
 
 
-
-[1]: https://github.com/DataDog/dd-agent/blob/master/conf.d/elastic.yaml.example
-[2]: https://github.com/DataDog/dd-agent/blob/master/checks.d/elastic.py

--- a/content/integrations/etcd.md
+++ b/content/integrations/etcd.md
@@ -13,12 +13,7 @@ Capture etcd metrics in Datadog to:
 * Know when host configurations may be out of sync.
 * Correlate the performance of etcd with the rest of your applications.
 
-From the open-source Agent:
-
-* [ etcd YAML example][1]
-* [ etcd checks.d][2]
-
-
+<%= insert_example_links%>
 
 ## Metrics
 
@@ -26,6 +21,3 @@ From the open-source Agent:
 %>
 
 Furthermore, etcd metrics are tagged with `etcd_state:leader` or `etcd_state:follower`, depending on the node status, so you can easily aggregate metrics by status.
-
-[1]: https://github.com/DataDog/dd-agent/blob/master/conf.d/etcd.yaml.example
-[2]: https://github.com/DataDog/dd-agent/blob/master/checks.d/etcd.py

--- a/content/integrations/eventviewer.md
+++ b/content/integrations/eventviewer.md
@@ -11,10 +11,6 @@ Connect Event Viewer to Datadog in order to:
 * Track system and application events in Datadog.
 * Correlate system and application events with the rest of your application.
 
-From the open-source Agent:
-
-* [ Event Viewer YAML example][1]
-* [ Event Viewer checks.d][2]
 
 ### Configuration
 
@@ -37,5 +33,4 @@ to capture the same kind of events.
 GUI may slightly differ from `Get-WmiObject`, so we recommend you to double-check your filters' values
 with `Get-WmiObject` if the integration does not capture the events you set up.
 
-[1]: https://github.com/DataDog/dd-agent/blob/master/conf.d/win32_event_log.yaml.example
-[2]: https://github.com/DataDog/dd-agent/blob/master/checks.d/win32_event_log.py
+<%= insert_example_links(conf: "win32_event_log", check: "win32_event_log")%>

--- a/content/integrations/fluentd.md
+++ b/content/integrations/fluentd.md
@@ -16,6 +16,7 @@ Get metrics from Fluentd in real time to
 
 ![Fluentd Dashboard](/static/images/snapshot-fluentd.png)
 
+
 # Installation
 
 Configure your fluentd to use a monitor agent and plugin id (see doc), for instance:
@@ -55,6 +56,8 @@ Edit conf.d/fluentd.yaml
            plugin_ids:
              - plg1
              - plg2
+
+<%= insert_example_links%>
 
 # Validation
 

--- a/content/integrations/gearman.md
+++ b/content/integrations/gearman.md
@@ -13,17 +13,8 @@ Bring Gearman metrics to Datadog to:
 * Know how many tasks are queued or running.
 * Correlate the performance of Gearman with the rest of your applications.
 
-From the open-source Agent:
-
-* [ Gearman YAML example][1]
-* [ Gearman checks.d][2]
-
+<%= insert_example_links(conf: "gearmand", check: "gearmand")%>
 
 ### Metrics
 
 <%= get_metrics_from_git() %>
-
-
-
-[1]: https://github.com/DataDog/dd-agent/blob/master/conf.d/gearmand.yaml.example
-[2]: https://github.com/DataDog/dd-agent/blob/master/checks.d/gearmand.py

--- a/content/integrations/goexpvar.md
+++ b/content/integrations/goexpvar.md
@@ -7,12 +7,13 @@ git_integration_title: go_expvar
 ---
 
 
-
 Use the Datadog Expvar Agent check to:
 
 * Get information and monitor into your application memory usage
 * Instrument your own metrics
 * An example configration file for GO Expvar can be found [here](https://github.com/DataDog/dd-agent/blob/master/conf.d/go_expvar.yaml.example)
+
+<%= insert_example_links(conf: "go_expvar", check: "go_expvar")%>
 
 ## Metrics
 

--- a/content/integrations/gunicorn.md
+++ b/content/integrations/gunicorn.md
@@ -5,6 +5,17 @@ kind: integration
 git_integration_title: gunicorn
 ---
 
+### Overview
+
+Capture Gunicorn metrics in Datadog to:
+
+* Visualize your web server performance
+* Correlate the performance of Gunicorn with the rest of your applications
+
+
+
+### Configuration
+
 To capture Gunicorn metrics you need to install the Datadog Agent.
 
 1. If you are using the Datadog Agent < 5.0.0, please look at the old documentation for more detailed instructions. The following instructions are for the Datadog Agent >= 5.0.0
@@ -32,6 +43,8 @@ Edit conf.d/gunicorn.yaml
 
 Not sure how to execute the last two steps? Visit the Agent Usage Guide for more detailed instructions.
 
-## Metrics
+<%= insert_example_links%>
+
+### Metrics
 
 <%= get_metrics_from_git() %>

--- a/content/integrations/haproxy.md
+++ b/content/integrations/haproxy.md
@@ -17,19 +17,9 @@ Capture HAProxy activity in Datadog to:
 
 Learn more about how to monitor HAProxy performance metrics thanks to [our series of posts](https://www.datadoghq.com/blog/monitoring-haproxy-performance-metrics/). We detail the key performance metrics, how to collect them, and how to use Datadog to monitor HAProxy.
 
+<%= insert_example_links%>
 
-From the open-source Agent:
-
-* [ HAProxy YAML example][1]
-* [ HAProxy checks.d][2]
-
-
-
-## Metrics
+### Metrics
 
 <%= get_metrics_from_git() %>
-
-[1]: https://github.com/DataDog/dd-agent/blob/master/conf.d/haproxy.yaml.example
-[2]: https://github.com/DataDog/dd-agent/blob/master/checks.d/haproxy.py
-
 

--- a/content/integrations/hdfs.md
+++ b/content/integrations/hdfs.md
@@ -48,6 +48,9 @@ Capture NameNode and DataNode HDFS metrics in Datadog to:
 
 3.  Restart the Agent
 
+<%= insert_example_links(integration: "HDFS NameNode")%>
+<%= insert_example_links(integration: "HDFS DataNode", include_intro: false)%>
+
 # Validation
 
 Execute the info command and verify that the integration check has passed. The output of the command should contain a section similar to the following:

--- a/content/integrations/httpcheck.md
+++ b/content/integrations/httpcheck.md
@@ -34,6 +34,7 @@ Edit the `http_check.yaml` file in your agent's `conf.d` directory. The followin
 
 There are many other choices available in the example yaml file that deal with specific SSL options.
 
+<%= insert_example_links%>
 
 # Validation
 

--- a/content/integrations/iis.md
+++ b/content/integrations/iis.md
@@ -2,6 +2,7 @@
 title: Datadog-IIS Integration
 integration_title: IIS
 kind: integration
+doclevel: basic
 git_integration_title: iis
 ---
 ### Overview
@@ -11,19 +12,11 @@ Connect IIS to Datadog in order to:
 * Visualize your web server performance.
 * Correlate the performance of IIS with the rest of your applications.
 
-From the open-source Agent:
-
-* [ IIS YAML example][1]
-* [ IIS checks.d][2]
+<%= insert_example_links%>
 
 ### Metrics
 
 <%= get_metrics_from_git() %>
-
-
-[1]: https://github.com/DataDog/dd-agent/blob/master/conf.d/iis.yaml.example
-[2]: https://github.com/DataDog/dd-agent/blob/master/checks.d/iis.py
-[3]: http://msdn.microsoft.com/en-us/library/aa394298(v=vs.85).aspx
 
 
 

--- a/content/integrations/java.md
+++ b/content/integrations/java.md
@@ -190,7 +190,7 @@ The `datadog-agent jmx` command was added in version 4.1.0.
 `sudo /etc/init.d/datadog-agent jmx collect`
 
 
-
+<%= insert_example_links(conf: "jmx", check: "none")%>
 
 # Validation
 

--- a/content/integrations/jenkins.md
+++ b/content/integrations/jenkins.md
@@ -13,6 +13,7 @@ From the open-source Jenkins plugin:
 
 * [ Jenkins Datadog Plugin][1]
 
+
 ## Metrics
 
 <%= get_metrics_from_git() %>

--- a/content/integrations/kafka.md
+++ b/content/integrations/kafka.md
@@ -431,6 +431,8 @@ And edit conf.d/kafka_consumer.yaml
       #     my_consumer:
       #       my_topic: [0, 1, 4, 12]
 
+<%= insert_example_links(check: "none")%>
+<%= insert_example_links(integration: "Apache Kafka Consumer", conf: "kafka_consumer", check: "kafka_consumer",  include_intro: false)%>
 # Validation
 
 To validate that the integration is working, restart the agent and then run the info command (For help on these steps, see [Getting Started with the Agent](/guides/basic_agent_usage/).  The output should contain a section similar to the following:

--- a/content/integrations/kong.md
+++ b/content/integrations/kong.md
@@ -2,6 +2,7 @@
 title: Datadog-Kong Integration
 integration_title: Kong
 kind: integration
+doclevel: basic
 git_integration_title: kong
 newhlevel: true
 ---
@@ -32,6 +33,7 @@ Configure the Agent to connect to Kong. Edit conf.d/kong.yaml
         tags:
             -   instance:bar
 
+<%= insert_example_links%>
 
 # Validation
 

--- a/content/integrations/kubernetes.md
+++ b/content/integrations/kubernetes.md
@@ -36,6 +36,8 @@ If DaemonSets are not an option for your Kubernetes cluster, you will need to in
 
 If you would like to customize your Agent configuration, please refer to the Agent [container documentation](https://github.com/DataDog/docker-dd-agent).
 
+<%= insert_example_links%>
+
 # Validation
 
 To verify the Datadog agent is running in your environment as a daemonset, execeute:

--- a/content/integrations/kyototycoon.md
+++ b/content/integrations/kyototycoon.md
@@ -11,3 +11,5 @@ Capture Kyoto Tycoon metrics in Datadog to:
 
 * Visualize your database server performance
 * Correlate the performance of Kyoto Tycoon with the rest of your applications
+
+<%= insert_example_links(conf: "kyototycoon", check: "kyototycoon")%>

--- a/content/integrations/lighttpd.md
+++ b/content/integrations/lighttpd.md
@@ -2,6 +2,7 @@
 title: Datadog-Lighttpd Integration
 integration_title: Lighttpd
 kind: integration
+doclevel: basic
 git_integration_title: lighttpd
 ---
 ### Overview
@@ -11,15 +12,9 @@ Bring Lighttpd metrics to Datadog to:
 * Visualize your web server performance.
 * Correlate the performance of Ligttpd with the rest of your applications.
 
-From the open-source Agent:
+<%= insert_example_links%>
 
-* [ Lighttpd YAML example][1]
-* [ Lighttpd checks.d][2]
-
-## Metrics
+### Metrics
 
 <%= get_metrics_from_git() %>
 
-
-[1]: https://github.com/DataDog/dd-agent/blob/master/conf.d/lighttpd.yaml.example
-[2]: https://github.com/DataDog/dd-agent/blob/master/checks.d/lighttpd.py

--- a/content/integrations/mapreduce.md
+++ b/content/integrations/mapreduce.md
@@ -44,6 +44,7 @@ Capture MapReduce metrics to:
 
 2.  Restart the Agent
 
+<%= insert_example_links(conf:"mapreduce", check:"mapreduce")%>
 
 # Validation
 

--- a/content/integrations/marathon.md
+++ b/content/integrations/marathon.md
@@ -11,6 +11,8 @@ Connects Marathon to Datadog in order to:
 * Visualize your Marathon framework's performance
 * Correlate the performance of Marathon with the rest of your Mesos applications
 
+<%= insert_example_links%>
+
 ## Metrics
 
 <%= get_metrics_from_git() %>

--- a/content/integrations/memcached.md
+++ b/content/integrations/memcached.md
@@ -11,10 +11,7 @@ Connect Memcached to Datadog in order to:
   * Visualize its performance
   * Correlate the performance of Memcached with the rest of your applications
 
-From the open-source Agent:
-
-* [ Memcache YAML example][1]
-* [ Memcache checks.d][2]
+<%= insert_example_links(conf:"mcache", check:"mcache")%>
 
 ## Metrics
 

--- a/content/integrations/mesos.md
+++ b/content/integrations/mesos.md
@@ -13,6 +13,10 @@ Connects Mesos to Datadog in order to:
 * Visualize your Mesos cluster performance
 * Correlate the performance of Mesos with the rest of your applications
 
+<%= insert_example_links%>
+<%= insert_example_links(integration:"Mesos Master", include_intro:false)%>
+<%= insert_example_links(integration:"Mesos Slave", include_intro:false)%>
+
 ## Metrics
 
 <%= get_metrics_from_git() %>

--- a/content/integrations/mongodb.md
+++ b/content/integrations/mongodb.md
@@ -12,11 +12,6 @@ Connect MongoDB to Datadog in order to:
 * Visualize key MongoDB metrics.
 * Correlate MongoDB performance with the rest of your applications.
 
-From the open-source Agent:
-
-* [ MongoDB YAML example][1]
-* [ Code for the MongoDB check][2]
-
 
 # Installation
 
@@ -47,6 +42,8 @@ From the open-source Agent:
               - top
 
 2.  Restart the agent
+
+<%= insert_example_links(conf:"mongo", check:"mongo")%>
 
 # Validation
 

--- a/content/integrations/mysql.md
+++ b/content/integrations/mysql.md
@@ -61,7 +61,7 @@ Connect MySQL to Datadog in order to:
     See the metrics section below to see a list of the new metrics provided by each of the metric options.
 
 
-
+<%= insert_example_links%>
 
 # Validation
 

--- a/content/integrations/nagios.md
+++ b/content/integrations/nagios.md
@@ -2,6 +2,7 @@
 title: Datadog-Nagios Integration
 integration_title: Nagios
 kind: integration
+doclevel: basic
 ---
 
 ### Overview
@@ -13,6 +14,8 @@ Capture Nagios activity in Datadog to:
   * Discuss service failures with your team.
 
 Set up information collection for Nagios by editing the given YAML configuration file [nagios.yaml.example][1] and renaming it as nagios.yaml After having Nagios reporting to Datadog for a week, an interactive report on alerting checks can be found [here][2]. To integrate with the Icinga fork of Nagios, you should be able to use the Nagios integration to pull in Icinga events. Just link to the Icinga configuration instead of the Nagios one.
+
+<%= insert_example_links%>
 
    [1]: https://github.com/DataDog/dd-agent/blob/master/conf.d/nagios.yaml.example
    [2]: https://app.datadoghq.com/report/nagios

--- a/content/integrations/nginx.md
+++ b/content/integrations/nginx.md
@@ -37,8 +37,9 @@ If you see some output with `configure arguments:` and lots of options, then you
       }
     }
 
-For more information on configuration, read the [stub status docs](http://nginx.org/en/docs/http/ngx_http_stub_status_module.html).  For some more insight into configuring the agent, check out the [NGINX example YAML config](https://github.com/DataDog/dd-agent/blob/master/conf.d/nginx.yaml.example) or take a look at the [NGINX agent plugin](https://github.com/DataDog/dd-agent/blob/master/checks.d/nginx.py).
+For more information on configuration, read the [stub status docs](http://nginx.org/en/docs/http/ngx_http_stub_status_module.html).
 
+<%= insert_example_links%>
 
 **All metrics collected for NGINX and NGINX Plus**
 

--- a/content/integrations/openstack.md
+++ b/content/integrations/openstack.md
@@ -2,7 +2,6 @@
 title: Datadog-OpenStack Integration
 integration_title: OpenStack
 kind: integration
-doclevel: basic
 git_integration_title: openstack
 ---
 
@@ -86,6 +85,9 @@ To capture OpenStack metrics you need to install the Datadog Agent on your hosts
           ---------
               - instance #0 [OK]
               - Collected 8 metrics & 0 events
-## Metrics
+
+<%= insert_example_links%>
+
+### Metrics
 
 <%= get_metrics_from_git() %>

--- a/content/integrations/pgbouncer.md
+++ b/content/integrations/pgbouncer.md
@@ -12,6 +12,8 @@ Connect your PGBouncer to Datadog in order to:
 * Visualize your pools of connections.
 * Monitor the traffic between PostgreSQL and your applications.
 
+<%= insert_example_links%>
+
 ### Metrics
 
 <%= get_metrics_from_git() %>

--- a/content/integrations/postfix.md
+++ b/content/integrations/postfix.md
@@ -9,6 +9,8 @@ git_integration_title: postfix
 
 Get metrics from Postfix in real time to monitor the messages pending in your Postfix mail queues.
 
+<%= insert_example_links%>
+
 ## Metrics
 
 <%= get_metrics_from_git() %>

--- a/content/integrations/postgresql.md
+++ b/content/integrations/postgresql.md
@@ -15,20 +15,20 @@ Connect PostgreSQL to Datadog in order to:
 
 ### Metrics
 
-<%= get_metrics_from_git()%> 
+<%= get_metrics_from_git()%>
 
 You can learn more about how we collect these metrics by looking at the source [here](https://github.com/DataDog/dd-agent/blob/master/checks.d/postgres.py).
 
 ### Prerequisites
 To get started with the PostgreSQL integration, create at least a read-only datadog user with proper access to your PostgreSQL Server. Start psql on your PostgreSQL database and run:
 
-    create user datadog with password '<PASSWORD>'; 
+    create user datadog with password '<PASSWORD>';
     grant SELECT ON pg_stat_database to datadog;
 
 To verify the correct permissions you can run the following command:
 
-    psql -h localhost -U datadog postgres -c "select * from pg_stat_database LIMIT(1);"  
-    && echo -e "\e[0;32mPostgres connection - OK\e[0m" || \ ||  
+    psql -h localhost -U datadog postgres -c "select * from pg_stat_database LIMIT(1);"
+    && echo -e "\e[0;32mPostgres connection - OK\e[0m" || \ ||
     echo -e "\e[0;31mCannot connect to Postgres\e[0m"
 
 When it prompts for a password, enter the one used in the first command.
@@ -57,25 +57,25 @@ Go to the datadog conf.d directory (if you aren't sure where this is, refer to [
     #      - my_other_table
 
 
-    # Custom metrics 
-    # Below are some examples of commonly used metrics, 
-    # which are implemented as custom metrics. Uncomment them 
-    # if you want to use them as is, or use as an example for 
-    # creating your own custom metrics. The format for describing 
-    # custom metrics is identical with the one used for common 
-    # metrics in postgres.py 
-    # 
-    # Be extra careful with ensuring proper custom metrics 
-    # description format. If your custom metric does not work 
-    # after an agent restart, look for errors in the output 
-    # of "/etc/init.d/datadog-agent info" command, as well as 
-    # /var/log/datadog/collector.log file. 
+    # Custom metrics
+    # Below are some examples of commonly used metrics,
+    # which are implemented as custom metrics. Uncomment them
+    # if you want to use them as is, or use as an example for
+    # creating your own custom metrics. The format for describing
+    # custom metrics is identical with the one used for common
+    # metrics in postgres.py
+    #
+    # Be extra careful with ensuring proper custom metrics
+    # description format. If your custom metric does not work
+    # after an agent restart, look for errors in the output
+    # of "/etc/init.d/datadog-agent info" command, as well as
+    # /var/log/datadog/collector.log file.
     #
     #    custom_metrics:
-    #    - # Londiste 3 replication lag 
-    #      descriptors: 
+    #    - # Londiste 3 replication lag
+    #      descriptors:
     #        - [consumer_name, consumer_name]
-    #      metrics: 
+    #      metrics:
     #         GREATEST(0, EXTRACT(EPOCH FROM lag)) as lag: [postgresql.londiste_lag, GAUGE]
     #         GREATEST(0, EXTRACT(EPOCH FROM lag)) as last_seen: [postgresql.londiste_last_seen, GAUGE]
     #         pending_events: [postgresql.londiste_pending_events, GAUGE]
@@ -95,4 +95,5 @@ After you restart the agent, you should be able to run the ```info``` command wh
           - Collected 8 metrics & 0 events
 
 
+<%= insert_example_links(conf:"postgres", check:"postgres")%>
 

--- a/content/integrations/process.md
+++ b/content/integrations/process.md
@@ -38,6 +38,8 @@ Refer to the comments in the [process.yaml.example](https://github.com/DataDog/d
 
 After the Agent has sent data to Datadog you can visit the [New Monitor section of the application](https://app.datadoghq.com/monitors#create/process) to set up a Monitor. If you only see information on how to configure the process check in the Agent, Datadog has not yet received any process information from the Agent. Use the instructions below to validate whether the Agent has been configured correctly.
 
+<%= insert_example_links(conf:"process", check:"process")%>
+
 ### Validation
 
 1.  Execute the info command

--- a/content/integrations/rabbitmq.md
+++ b/content/integrations/rabbitmq.md
@@ -12,12 +12,9 @@ Connect RabbitMQ to Datadog in order to:
   * Visualize RabbitMQ performance and utilization.
   * Correlate the performance of RabbitMQ with the rest of your applications.
 
-From the open-source Agent:
+<%= insert_example_links%>
 
-* [ RabbitMQ YAML example][1]
-* [ RabbitMQ checks.d][2]
-
-## Metrics
+### Metrics
 
 <%= get_metrics_from_git() %>
 
@@ -25,8 +22,6 @@ From the open-source Agent:
 
 By default, `queue` metrics are tagged by queue and `node` metrics are tagged by node. If you have a Datadog account you can see the integration installation instructions [here][3].
 
-   [1]: https://github.com/DataDog/dd-agent/blob/master/conf.d/rabbitmq.yaml.example
-   [2]: https://github.com/DataDog/dd-agent/blob/master/checks.d/rabbitmq.py
    [3]: https://app.datadoghq.com/account/settings#integrations/rabbitmq
 
 

--- a/content/integrations/redis.md
+++ b/content/integrations/redis.md
@@ -14,6 +14,8 @@ Track and graph your Redis activity and performance metrics with slice-and-dice 
 
 Learn more about how to monitor Redis performance metrics thanks to [our series of posts](https://www.datadoghq.com/blog/how-to-monitor-redis-performance-metrics/). We detail the key performance metrics, how to collect them, and how to use Datadog to monitor Redis.
 
+<%= insert_example_links(conf:"redisdb", check:"redisdb")%>
+
 ###  Troubleshooting and Questions
 
 **Q:** How do I filter to look at the stats for a particular DB in a particular environment?

--- a/content/integrations/riak.md
+++ b/content/integrations/riak.md
@@ -3,6 +3,7 @@ title: Datadog-Riak Integration
 integration_title: Riak
 git_integration_title: riak
 kind: integration
+doclevel: basic
 ---
 
 ### Overview
@@ -12,19 +13,10 @@ Connect Riak to Datadog in order to:
   * Visualize Riak performance and utilization.
   * Correlate the performance of Riak with the rest of your applications.
 
-From the open-source Agent:
-
-* [ Riak YAML example][1]
-* [ Riak checks.d][2]
+<%= insert_example_links%>
 
 ## Metrics
 
 <%= get_metrics_from_git() %>
 
 
-
-
-
-
-[1]: https://github.com/DataDog/dd-agent/blob/master/conf.d/riak.yaml.example
-[2]: https://github.com/DataDog/dd-agent/blob/master/checks.d/riak.py

--- a/content/integrations/riakcs.md
+++ b/content/integrations/riakcs.md
@@ -27,6 +27,8 @@ To configure the RiakCS integration, copy riakcs.yaml.example if the conf.d dire
         #port: 8080 # port used by your riakcs node
         #s3_root: s3.amazonaws.com #
 
+<%= insert_example_links%>
+
 ### Metrics
 
 <%= get_metrics_from_git() %>

--- a/content/integrations/snmp.md
+++ b/content/integrations/snmp.md
@@ -13,10 +13,6 @@ Use the SNMP Agent Check to:
 * Monitor all your network devices
 * Correlate their performance with the rest of your applications
 
-From the open-source Agent:
-
-* [SNMP YAML example](https://github.com/DataDog/dd-agent/blob/master/conf.d/snmp.yaml.example)
-* [SNMP checks.d](https://github.com/DataDog/dd-agent/blob/master/checks.d/snmp.py)
 
 # Configuration
 
@@ -49,6 +45,8 @@ To use the SNMP checks, edit the **snmp.yaml** file in your **conf.d** directory
 
 
 For each device that you want to monitor, you need to specify at least an ip_address and an authentication method. If not specified, a default port of 161 will be assumed.
+
+<%= insert_example_links%>
 
 # Usage
 

--- a/content/integrations/solr.md
+++ b/content/integrations/solr.md
@@ -3,9 +3,12 @@ title: Datadog-Solr Integration
 integration_title: Solr
 git_integration_title: solr
 kind: integration
+doclevel: basic
 ---
 
 For information on Solr, please see <a href="http://docs.datadoghq.com/integrations/java/">here</a>.
+
+<%= insert_example_links(check:"none")%>
 
 ## Metrics
 

--- a/content/integrations/spark.md
+++ b/content/integrations/spark.md
@@ -47,6 +47,7 @@ Get metrics from your app in real time to
             #   - optional_tag1
             #   - optional_tag2
 
+<%= insert_example_links%>
 
 # Validation
 

--- a/content/integrations/sqlserver.md
+++ b/content/integrations/sqlserver.md
@@ -3,6 +3,7 @@ title: Datadog-SQL Server Integration
 integration_title: SQL Server
 git_integration_title: sql_server
 kind: integration
+doclevel: basic
 ---
 
 ### Overview
@@ -13,18 +14,11 @@ Connect SQL Server to Datadog in order to:
   * Correlate the performance of SQL Server with the rest of your applications.
 
 
+<%= insert_example_links%>
 
-From the open-source Agent:
-
-* [ SQL Server YAML example][1]
-* [ SQL Server checks.d][2]
 
 ## Metrics
 
 <%= get_metrics_from_git() %>
-
-
-[1]: https://github.com/DataDog/dd-agent/blob/master/conf.d/sqlserver.yaml.example
-[2]: https://github.com/DataDog/dd-agent/blob/master/checks.d/sqlserver.py
 
 

--- a/content/integrations/ssh.md
+++ b/content/integrations/ssh.md
@@ -13,6 +13,8 @@ Capture SSH activity into Datadog to:
 * Visualize your SSH performance in real-time
 * Detect any protocol failure or network outage
 
+<%= insert_example_links(conf:"ssh_check", check:"ssh_check")%>
+
 ## Metrics
 
 <%= get_metrics_from_git() %>

--- a/content/integrations/statsd.md
+++ b/content/integrations/statsd.md
@@ -30,6 +30,8 @@ An example configuration can be found at [statsd.yaml.example](https://github.co
 
 **PORT**: The admin port of the StatsD server being monitored.
 
+<%= insert_example_links%>
+
 # Validation
 
 Execute the [info command](http://docs.datadoghq.com/guides/basic_agent_usage/) (`/etc/init.d/datadog-agent info` on *NIX) and verify that the integration check was successful.

--- a/content/integrations/supervisor.md
+++ b/content/integrations/supervisor.md
@@ -10,6 +10,8 @@ git_integration_title: supervisord
 
 Enable the supervisord check to monitor the states of your processes running under supervisord.
 
+<%= insert_example_links(conf:"supervisord", check: "supervisord")%>
+
 
 
 ## Metrics

--- a/content/integrations/system.md
+++ b/content/integrations/system.md
@@ -18,6 +18,12 @@ Get metrics from your system directories and processes. Check links below to see
 * <a href="/integrations/directory/">Directory check</a> - Capture metrics from the files in given directories.
 * <a href="/integrations/process/">Process check</a> - Capture metrics from specific running processes on a system.
 
+<%= insert_example_links(integration:"System Core")%>
+<%= insert_example_links(integration:"System Swap", include_intro:false)%>
+<%= insert_example_links(integration:"Directory", include_intro:false)%>
+<%= insert_example_links(integration:"Process", include_intro:false)%>
+
+
 ### Metrics
 
-<%= get_metrics_from_git()%> 
+<%= get_metrics_from_git()%>

--- a/content/integrations/tcprtt.md
+++ b/content/integrations/tcprtt.md
@@ -51,6 +51,8 @@ Edit the ```go-metro.yaml``` file in your agent's ```conf.d``` directory. The fo
           - app.datadoghq.com
 
 
+<%= insert_example_links(conf:"go-metro", check:"none")%>
+
 # Validation
 
 To validate that the check is running correctly, you should see `system.net.tcp.rtt` metrics showing in the Datadog interface. Also, if you run `sudo /etc/init.d/datadog-agent status`, you should see something similar to the following:

--- a/content/integrations/teamcity.md
+++ b/content/integrations/teamcity.md
@@ -11,3 +11,5 @@ Connect TeamCity to Datadog in order to:
 
 * Monitor your builds and deployments
 * Collect stats and bind tags to every step of your integration
+
+<%= insert_example_links%>

--- a/content/integrations/tokumx.md
+++ b/content/integrations/tokumx.md
@@ -63,6 +63,8 @@ Configure the Agent to connect to your TokuMX instance using your new Datadog us
 
 2.  Restart the Agent.
 
+<%= insert_example_links%>
+
 ### Validation
 
 1.  To validate that your integration is working run the Agent's info command. You should see output similar to the following:

--- a/content/integrations/tomcat.md
+++ b/content/integrations/tomcat.md
@@ -10,6 +10,8 @@ For information on Tomcat, please see [here][1].
 
    [1]: http://docs.datadoghq.com/integrations/java/
 
+<%= insert_example_links(check:"none")%>
+
 
 ## Metrics
 

--- a/content/integrations/varnish.md
+++ b/content/integrations/varnish.md
@@ -2,7 +2,7 @@
 title: Datadog-Varnish Integration
 integration_title: Varnish
 git_integration_title: varnish
-
+doclevel: basic
 kind: integration
 ---
 
@@ -17,10 +17,8 @@ Connect Varnish to Datadog in order to:
 
 Learn more about how to monitor Varnish performance metrics thanks to [our series of posts](https://www.datadoghq.com/blog/top-varnish-performance-metrics/). We detail the key performance metrics, how to collect them, and how to use Datadog to monitor Varnish.
 
-From the open-source Agent:
+<%= insert_example_links%>
 
-* [ Varnish YAML example][1]
-* [ Varnish checks.d][2]
 
 The following metrics are collected by default with the Varnish integration.
 

--- a/content/integrations/vmware.md
+++ b/content/integrations/vmware.md
@@ -3,6 +3,7 @@ title: Datadog-VMware Integration
 integration_title: VMware
 git_integration_title: vsphere
 kind: integration
+doclevel: basic
 ---
 
 #### _Overview_
@@ -14,6 +15,8 @@ Install the Datadog VMware vSphere integration to:
 * Interact with your teams on dashboards and the event stream, showing all vSphere data at one glance.
 
 We also have an awesome blog post on vSphere which can be seen [here][1].
+
+<%= insert_example_links(conf:"vsphere", check:"vsphere")%>
 
 ## Metrics
 

--- a/content/integrations/winservices.md
+++ b/content/integrations/winservices.md
@@ -56,3 +56,5 @@ After you restart the agent, Check the info page in the Agent Manager and verify
 	  ---------------
 	      - instance #0 [OK]
 	      - Collected 8 metrics & 0 events
+
+<%= insert_example_links(conf:"windows_service", check:"windows_service")%>

--- a/content/integrations/wmi.md
+++ b/content/integrations/wmi.md
@@ -11,3 +11,5 @@ Get metrics from your Windows applications/servers with Windows Management Instr
 
 * Visualize their performance.
 * Correlate their activity with the rest of your applications.
+
+<%= insert_example_links(conf:"wmi_check", check:"wmi_check")%>

--- a/content/integrations/yarn.md
+++ b/content/integrations/yarn.md
@@ -27,6 +27,7 @@ Capture Yarn metrics to:
 
 2.  Restart the Agent
 
+<%= insert_example_links(conf:"yarn", check:"yarn")%>
 
 
 # Validation

--- a/content/integrations/zookeeper.md
+++ b/content/integrations/zookeeper.md
@@ -13,15 +13,7 @@ Connect ZooKeeper to Datadog in order to:
   * Visualize ZooKeeper performance and utilization.
   * Correlate the performance of ZooKeeper with the rest of your applications.
 
-From the open-source Agent:
-
-* [ ZooKeeper YAML example][1]
-* [ ZooKeeper checks.d][2]
-
-   [1]: https://github.com/DataDog/dd-agent/blob/master/conf.d/zk.yaml.example
-   [2]: https://github.com/DataDog/dd-agent/blob/master/checks.d/zk.py
-
-
+<%= insert_example_links(conf:"zk", check:"zk")%>
 
 ## Metrics
 

--- a/lib/helpers_.rb
+++ b/lib/helpers_.rb
@@ -118,6 +118,14 @@ def serialize_github_metrics(items)
   end
 end
 
+def insert_example_links(integration: item[:integration_title], conf:  integration.downcase.tr(" ", "_"), check: integration.downcase.tr(" ", "_"), yaml_extension: "example", include_intro: true)
+  example_links = include_intro ? "For more details about configuring this integration refer to the following file(s) on GitHub:\n" : ""
+  yaml_example = conf!="none" ? "<li><a href='https://github.com/DataDog/dd-agent/blob/master/conf.d/" + conf + ".yaml."+yaml_extension+"'> "+ integration + " YAML example</a></li>" : ""
+  checks_file =  check!="none" ? "<li><a href='https://github.com/DataDog/dd-agent/blob/master/checks.d/" + check + ".py'>" + integration + " checks.d</a></li>" : ""
+
+  example_links += "<ul>" + yaml_example + checks_file + "</ul>\n"
+  return example_links
+end
 
 def get_metrics_from_git
   require 'octokit'


### PR DESCRIPTION
Many of the local integrations used different text to include links to the example config and check files. And many others didn't include any links and it's been a request from a number of support folks for a while. This update standardizes the text and adds it to every integration that runs at the agent. If we want to change the text, it's easy to do for the entire set of integrations at once