### PR TITLE
added beta meta to remove from toc and search

### DIFF
--- a/content/guides/anomalies.md
+++ b/content/guides/anomalies.md
@@ -1,6 +1,8 @@
 ---
 title: Anomaly Detection (BETA)
-kind: documentation
+kind: guide
+listorder: 16
+beta: true
 sidebar:
   nav:
     - header: Anomaly Detection
@@ -9,6 +11,7 @@ sidebar:
     - text: Alert on Anomalies
       href: "#alerts"
 ---
+
 
 Anomaly detection is an algorithmic feature that allows you to identify when a metric is behaving differently than it has in the past, taking into account day-of-week and time-of-day patterns. It's well suited for metrics with recurring patterns that are hard or impossible to monitor with threshold-based alerting. For example, anomaly detection can help you discover when your web traffic is unusually low on a weekday afternoon - even though that same level of traffic would be perfectly normal later in the evening.
 

--- a/content/tipuesearch/tipuesearch_content.erb
+++ b/content/tipuesearch/tipuesearch_content.erb
@@ -1,6 +1,6 @@
 <%
 # for now we are using path exclusion scheme
-pages = @items.select{ |item| ((%w{article page documentation integration guide}.include? item[:kind]) && !(item.identifier.match('/ja/'))) }.collect{ |item|
+pages = @items.select{ |item| ((%w{article page documentation integration guide}.include? item[:kind]) && (item[:beta]!=true) && !(item.identifier.match('/ja/'))) }.collect{ |item|
   {
     "title" => item[:title],
     "text" => Nokogiri::HTML(item.compiled_content).at('body').inner_text,

--- a/lib/helpers_.rb
+++ b/lib/helpers_.rb
@@ -13,13 +13,13 @@ def collect_video_items
 end
 
 def collect_integration_items
-  integrations = @items.select { |item| item[:kind] == 'integration' && !(item.identifier.match('/ja/')) }
+  integrations = @items.select { |item| item[:kind] == 'integration' && (item[:beta]!=true) && !(item.identifier.match('/ja/')) }
   integrations.sort_by { |i| i[:integration_title].downcase }
   # $all_itegration_items = integrations
 end
 
 def collect_guide_items
-  guides = @items.select{ |item| item[:kind] == 'guide' && item[:listorder] != nil && !(item.identifier.match('/ja/')) }
+  guides = @items.select{ |item| item[:kind] == 'guide' && item[:listorder] != nil && (item[:beta]!=true) && !(item.identifier.match('/ja/')) }
   guides.sort_by { |item| item[:listorder] }
 end
 
@@ -38,12 +38,12 @@ def collect_ja_integration_items
 end
 
 def collect_ja_guide_items
-  guides = @items.select{ |item| item[:kind] == 'guide' && item[:listorder] != nil && item[:language] == 'ja' && item[:translation_status] == "complete" && item.identifier.match('/ja/') }
+  guides = @items.select{ |item| item[:kind] == 'guide' && item[:listorder] != nil && (item[:beta]!=true) && item[:language] == 'ja' && item[:translation_status] == "complete" && item.identifier.match('/ja/') }
   guides.sort_by { |item| item[:listorder] }
 end
 
 def ja_guide_items_yet
-  guides = @items.select{ |item| item[:kind] == 'guide' && item[:listorder] != nil && item[:language] == nil }
+  guides = @items.select{ |item| item[:kind] == 'guide' && item[:listorder] != nil && (item[:beta]!=true) && item[:language] == nil }
   guides_translated = @items.select{ |item| item[:kind] == 'guide' && item[:listorder] != nil && item[:language] == 'ja' && item[:translation_status] == "complete" && item.identifier.match('/ja/') }
 
   guides_translated.each do |jp_content|


### PR DESCRIPTION
Recently a guide was added to the site before the feature was added. It did not show up in the TOC but did in the search. The problem there was that the kind metadata was not set to guide. But set the meta correct and now it shows in the TOC and the search. This PR adds a meta field called beta. Set beta to true and the guide will be added to the site but not get included in the TOC or the search. If you change the value from true to false (or no value), you will need to 'rake clean' to get the changes to take effect. The other way will work though without a clean. 

Although the branch is called "betaguides", it works with integrations as well. 