### PR TITLE
if no navigation specified, all articles get a toc

### DIFF
--- a/layouts/default.html
+++ b/layouts/default.html
@@ -6,7 +6,6 @@ this layout provides a sidebar and main column.
 <html lang="en">
   <%= render "_head" %>
   <body>
-
     <%= render "_header" %>
     <div class="container">
       <div class="row">
@@ -22,15 +21,7 @@ this layout provides a sidebar and main column.
               </form>
             </li>
             <% end %>
-            <% if @item[:sidebar] && @item[:sidebar][:nav] %>
-              <% @item[:sidebar][:nav].each do |i| %>
-                <% if i[:header] %>
-                  <li class="nav-header"><%= i[:header] %></li>
-                <% else %>
-                  <li><a href="<%= i[:href]%>" onclick="$('#<%= i[:collapseid] %>').collapse('show')"><%= i[:text] %></a></li>
-                <% end %>
-              <% end %>
-            <% end %>
+            <%=show_table_of_contents%>
               <li class="nav-header"><%= @item["menu_guides"] %> </li>
               <% this_guide_items = @item["language"] != "ja" ? $guide_items : $ja_guide_items %>
             <% this_guide_items.each do |i| %>

--- a/layouts/integration_layout.html
+++ b/layouts/integration_layout.html
@@ -20,15 +20,7 @@ this layout provides a sidebar and main column.
               </form>
             </li>
             <% end %>
-            <% if @item[:sidebar] && @item[:sidebar][:nav] %>
-              <% @item[:sidebar][:nav].each do |i| %>
-                <% if i[:header] %>
-                  <li class="nav-header hidden-xs"><%= i[:header] %></li>
-                <% else %>
-                  <li class="hidden-xs"><a href="<%= i[:href]%>"><%= i[:text] %></a></li>
-                <% end %>
-              <% end %>
-            <% end %>
+            <%= show_table_of_contents %>
 
             <li class="nav-header auto"><%= @item["integrations_other_integrations"] %> <span class="toggle visible-xs-inline">(<a href="#toggleIntegrations" data-toggle="collapse"><%= @item["integrations_toggle_to_show_integrations"] %></a>)<br></span></li>
             <div class="collapse div-collapse" id="toggleIntegrations">


### PR DESCRIPTION
If you have a sidebar and nav defined in the meta, then you get a table of contents in the sidebar. If you don't then you get nothing. This PR changes that. If you have nothing, you get an indented table of contents that shows each h1, h2, h3,etc. Specify navigation in the meta and the auto toc is overridden, though they all have the header Table of Contents to keep things consistent.