### PR TITLE
all links get little link icon

### DIFF
--- a/Rules
+++ b/Rules
@@ -150,6 +150,10 @@ compile '*' do
 
     id = @item.identifier
 
+    unless id.match('/api/')
+      filter :header_links
+    end
+
     case
 
     # when id.match('/ja/guides/basic_agent_usage/')

--- a/content/static/css/style.scss
+++ b/content/static/css/style.scss
@@ -503,3 +503,52 @@ dt {
     max-width: 300px;
   }
 }
+
+
+/*!
+ *  Font Awesome 4.1.0 by @davegandy - http://fontawesome.io - @fontawesome
+ *  License - http://fontawesome.io/license (Font: SIL OFL 1.1, CSS: MIT License)
+ */
+.fa {
+  display: inline-block;
+  font-family: FontAwesome;
+  font-style: normal;
+  font-weight: normal;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+.fa-link:before {
+  content: "\f0c1";
+}
+/*
+ * This code is courtesy Ben Balter, modified by Parker Moore for jekyllrb.com
+ * http://ben.balter.com/2014/03/13/pages-anchor-links/
+ */
+.header-link {
+  position: relative;
+  left: -0.5em;
+  opacity: 0;
+  font-size: 0.8em;
+
+  -webkit-transition: opacity 0.2s ease-in-out 0.1s;
+  -moz-transition: opacity 0.2s ease-in-out 0.1s;
+  -ms-transition: opacity 0.2s ease-in-out 0.1s;
+}
+h1.linked-header,
+h2.linked-header,
+h3.linked-header,
+h4.linked-header,
+h5.linked-header,
+h6.linked-header{
+  margin-left: -22px;
+}
+
+h1:hover .header-link,
+h2:hover .header-link,
+h3:hover .header-link,
+h4:hover .header-link,
+h5:hover .header-link,
+h6:hover .header-link {
+  opacity: 1;
+}

--- a/layouts/_head.html
+++ b/layouts/_head.html
@@ -29,4 +29,5 @@
       })();
 
     </script>
+    <script src="https://use.fontawesome.com/700fac0342.js"></script>
   </head>

--- a/lib/filters/header_links.rb
+++ b/lib/filters/header_links.rb
@@ -1,0 +1,34 @@
+# encoding: utf-8
+require 'nokogiri'
+
+class Header_Links < Nanoc::Filter
+  identifier :header_links
+
+  def run(content, params={})
+    doc = Nokogiri::HTML(content)
+    
+    # Find comments.
+    # doc.xpath("//comment()").each do |comment|
+    #     # Check it's not a conditional comment.
+    #     if (comment.content !~ /\A(\[if|\<\!\[endif)/)
+    #         comment.remove()
+    #     end
+    # end
+
+    doc.css("h1, h2, h3, h4, h5, h6").each do |heading|
+      if heading['id']!= 'pagetitle'
+        heading.add_css_class('linked-header')
+        heading.inner_html = "<a class='header-link' href=\"##{heading['id']}\"><i class='fa fa-link'></i></a>#{heading.inner_html}"
+      end
+    end
+
+    doc.to_html
+  end
+end
+
+class Nokogiri::XML::Node
+  def add_css_class( *classes )
+    existing = (self['class'] || "").split(/\s+/)
+    self['class'] = existing.concat(classes).uniq.join(" ")
+  end
+end


### PR DESCRIPTION
You know how when you look at a readme on github, there is a little link icon to the left of each heading that appears on hover? well this adds that to our docs for everything except the top page title and the api page. 
![example](https://s3.amazonaws.com/f.cl.ly/items/0d1M2m0L0J3T3Q2m0w0q/Screen%20Recording%202016-07-20%20at%2006.28%20PM.gif?v=6d639385)