### PR TITLE
FAQ markdown cleanup

### DIFF
--- a/content/faq.md
+++ b/content/faq.md
@@ -35,20 +35,22 @@ sidebar:
 -->
 
 ### Agent
-{: #agent}
 
 <!-- this is not currently true
-<h4 id="dogstatsd-flush-interval">Is the DogStatsD flush interval configurable?</h4>
-<p>
-Yes, it is!  You can change the flush interval by updating your agent’s configuration file called datadog.conf and replacing the value for the “dogstatsd_interval” key.  Use the following link, select your OS in the left column, and go to the Configuration section to find the location of your agent’s configuration file: <a href="http://docs.datadoghq.com/guides/basic_agent_usage/">http://docs.datadoghq.com/guides/basic_agent_usage/</a>
-</p>
+#### Is the DogStatsD flush interval configurable?
+{: #dogstatsd-flush-interval}
+
+Yes, it is!  You can change the flush interval by updating your agent’s configuration
+file called datadog.conf and replacing the value for the `dogstatsd_interval` key. Visit
+[our agent guide][agent-3], select your OS in the left column, and go to the Configuration
+section to find the location of your agent’s configuration file.
 -->
 
 #### Is the agent necessary to use Datadog?
 {: #agent-optional}
 
 * No, it is not. You don't have to install an agent if you only want to submit
-metrics via our API. You can read more about our API [here][api].
+metrics via our API. You can read more about our API [here][agent-1].
 * In general, most folks find a lot of value in installing an agent because
 they get system metrics for free and metrics on common software like mysql,
 postgres, etc. with just a little bit of configuration. Another advantage is
@@ -60,7 +62,7 @@ that there is a small statsd server built-in to the agent.
 
 Any StatsD client will work just fine, but using the Datadog DogStatsD client
 will give you a few extra features. You can read more about our clients extra
-features [here][dogstatsd].
+features [here][agent-2].
 
 
 #### How can I change the hostname
@@ -69,7 +71,7 @@ features [here][dogstatsd].
 You can change the hostname by updating your agent’s configuration file called
 datadog.conf and replacing the value for the “hostname” key.  Use the following
 link, select your OS in the left column, and go to
-the [Configuration section][basic_agent_usage] to find the location of your
+the [Configuration section][agent-3] to find the location of your
 agent’s configuration file.
 
 #### How do I uninstall the agent
@@ -84,12 +86,9 @@ agent’s configuration file.
   ~~~
 
 * Windows: You can uninstall the agent in Add/Remove Programs
-* Linux: ```$ sudo apt-get remove datadog-agent -y```
-* CentOS 5: ```$ sudo yum remove datadog-agent-base```
-* CentOS 6: ```$ sudo yum remove datadog-agent```
-
-
-
+* Linux: `$ sudo apt-get remove datadog-agent -y`
+* CentOS 5: `$ sudo yum remove datadog-agent-base`
+* CentOS 6: `$ sudo yum remove datadog-agent`
 
 #### I stopped my agent but I’m still seeing the host in my Datadog account. Why is that?
 {: #agent-stopped}
@@ -101,11 +100,12 @@ actually receiving data.
 #### Other Agent-related questions?
 {: #agent-other}
 
-Please refer to the [Basic Agent Usage Guide][basic_agent_usage].
+Please refer to the [Basic Agent Usage Guide][agent-3].
 
-[api]: /api/
-[dogstatsd]: /guides/dogstatsd/
-[basic_agent_usage]: /guides/basic_agent_usage/
+[agent-1]: /api/
+[agent-2]: /guides/dogstatsd/
+[agent-3]: /guides/basic_agent_usage/
+
 <!--
 ===============================================================================
     Alerts
@@ -113,7 +113,6 @@ Please refer to the [Basic Agent Usage Guide][basic_agent_usage].
 -->
 
 ### Alerts
-{: #alerts}
 
 #### I set up an alert with one of my integration metrics. Why am I getting so many No Data alerts?
 {: #no-data}
@@ -138,9 +137,10 @@ alert when at 80% or above:
   3. For set alert grouping, select "simple alert".
   4. Set alert conditions: Select Above and for the value put 0.8.
   5. Add a custom message for alert if you'd like.
-* You can read more about setting up monitors [here][monitoring].
+* You can read more about setting up monitors [here][alerts-1].
 
-[monitoring]: /guides/monitoring/
+[alerts-1]: /guides/monitoring/
+
 <!--
 ===============================================================================
     API
@@ -148,7 +148,6 @@ alert when at 80% or above:
 -->
 
 ### API
-{: #api}
 
 #### What are valid metric names?
 {: #api-metric-names}
@@ -156,10 +155,10 @@ alert when at 80% or above:
 Metric names must start with a letter, and after that may contain ascii alphanumerics, underscore and periods.
 Other characters will get converted to underscores. There is no max length. Unicode is not supported.
 We recommend avoiding spaces.
-Metrics reported by the Agent are in a pseudo-hierarchical dotted format (e.g. http.nginx.response_time).
+Metrics reported by the Agent are in a pseudo-hierarchical dotted format (e.g. `http.nginx.response_time`).
 We say pseudo-hierarchical because we’re not actually enforcing a hierarchy or doing anything with it,
 but we have aspirations to use it to infer things about servers (e.g. “hey, I see hostA and hostB are
-reporting ‘http.nginx.*’, those must be web frontends”).
+reporting `http.nginx.*`, those must be web frontends”).
 
 
 #### What are valid tags?
@@ -174,6 +173,7 @@ Note: An exception to this is with trailing underscores, which will be trimmed o
 
 #### I'm submitting points to the API- anything I should know?
 {: #api-else}
+
 We store metric points at the 1 second resolution, but we’d prefer if you only
 submitted points every 15 seconds. Any metrics with fractions of a second timestamps
 will get rounded to the nearest second, and if any points have the same timestamp,
@@ -189,7 +189,6 @@ defined as a unique combination of metric name and tag.
 -->
 
 ### Architecture
-{: #architecture}
 
 #### Is Datadog a cloud service or server application?
 {: #arch-cloud-or-server}
@@ -223,10 +222,9 @@ into Datadog, we'd probably say:
 <application>.requests.mean_90{http_method:<HTTP Method>, handler_class:<HTTP Method>, handler_method:<Handler Method>}
 ~~~
 
-
-Where ```<application>.requests.mean_90``` is the metric name, and
-  ```http_method:<HTTP Method>, handler_class:<HTTP Method>, handler_method:<Handler Method>```
-    are tags, so a concrete example might look like:
+Where `<application>.requests.mean_90` is the metric name, and
+`http_method:<HTTP Method>, handler_class:<HTTP Method>, handler_method:<Handler Method>`
+are tags, so a concrete example might look like:
 
 ~~~
 foo.requests.mean_90{http_method:GET, handler_class:ThingHandler, handler_method:list}
@@ -252,8 +250,8 @@ Which would graph stacked area series for each http_method value like GET, POST,
 {: #arch-hostnames}
 
 The hostnames are determined by what the Datadog Agent detects; this is fully
-documented [here][hostnames]. You can see all names being detected by the Agent by running the info command:
- ```/etc/init.d/datadog-agent info```
+documented [here][architecture-1]. You can see all names being detected by the Agent by running the info command:
+`/etc/init.d/datadog-agent info`
 
 
 #### Tell me about tagging!
@@ -283,6 +281,7 @@ With these tags you can then do:
 ~~~
 sum:page.views{domain:example.com}
 ~~~
+
 which should give the desired result.
 
 To get a breakdown by host, you can do:
@@ -291,16 +290,14 @@ To get a breakdown by host, you can do:
 sum:page.views{domain:example.com} by {host}
 ~~~
 
-Further tagging info can be found [here][tags].
+Further tagging info can be found [here][architecture-2].
 
-For information on AWS tagging, please see [here][integration-aws].
+For information on AWS tagging, please see [here][architecture-3].
 
 
-[hostnames]: /hostnames/
-[tags]: /guides/metrics/#tags
-[integration-aws]: /integrations/aws/
-
-<!-- ====================================================================== -->
+[architecture-1]: /hostnames/
+[architecture-2]: /guides/metrics/#tags
+[architecture-3]: /integrations/aws/
 
 <!--
 ===============================================================================
@@ -309,7 +306,6 @@ For information on AWS tagging, please see [here][integration-aws].
 -->
 
 ### AWS
-{: #aws}
 
 #### I just set up my AWS integration. Why am I seeing duplicate hosts?
 {: #duplicate-hosts}
@@ -320,14 +316,14 @@ meaningful host name provided by an internal DNS server or a config-managed host
 file (myhost.mydomain). Datadog creates aliases for host names when there are multiple
 uniquely identifiable names for a single host.  It takes about 10-20 minutes for the
 single host’s duplicate names to be aliased. You can read more about
-hostnames [here][hostnames].
+hostnames [here][architecture-1].
 
 
 #### What metrics will I get from the AWS integration?
 {: #aws-metrics}
 
 * Our crawlers use the Cloudwatch API, and we collect everything available from it.
-* You can read in detail about our AWS integration [here][integration-aws].
+* You can read in detail about our AWS integration [here][architecture-3].
 
 #### I can’t filter out my ELB instances - will I be charged for them?
 {: #aws-elb}
@@ -351,8 +347,8 @@ latency to view your metrics may be ~10-12 minutes.
 Yes you can! Follow the steps below to set this up:
 
 1. Install the agent on an ec2 instance that can connect to the RDS instance
-2. Use the RDS endpoint in <code>conf.d/postgres.yaml</code> (host and port)
-3. Add tags in postgres.yaml: <code>dbinstanceidentifier:(rds-instance-id), enginename:postgres</code>
+2. Use the RDS endpoint in `conf.d/postgres.yaml` (host and port)
+3. Add tags in postgres.yaml: `dbinstanceidentifier:(rds-instance-id), enginename:postgres`
 4. Restart the agent
 
 
@@ -363,29 +359,25 @@ Yes you can! Follow the steps below to set this up:
 ===============================================================================
 -->
 
-
 ### Billing
-{: #billing}
-
 
 #### How can I change the Billing contact?
 {: #billing-contact}
 
 You can set a specific email address to receive invoices, even if that address
-is not a team member within Datadog (invoices@yourcompany.com) [here][app-billing].
-
+is not a team member within Datadog (invoices@yourcompany.com) [here][billing-1].
 
 #### Where can I get a copy of the invoice?
 {: #billing-invoice}
 
-As an admin you can check out past invoices [here][app-billing-history].
+As an admin you can check out past invoices [here][billing-2].
 
+***You can read more about billing [here][billing-3].***
 
-***You can read more about billing [here][billing].***
+[billing-1]: https://app.datadoghq.com/account/billing
+[billing-2]: https://app.datadoghq.com/account/billing_history
+[billing-3]: /guides/billing/
 
-[app-billing]: https://app.datadoghq.com/account/billing
-[app-billing-history]: https://app.datadoghq.com/account/billing_history
-[billing]: /guides/billing/
 <!--
 ===============================================================================
     Graphing
@@ -398,8 +390,8 @@ As an admin you can check out past invoices [here][app-billing-history].
 #### How do I do arithmetic with grouped metrics?
 {: #graph-sum-grouped}
 
-To graph the sum of ```app.foo.bar{env:staging}``` and ```app.foo.baz{env:staging}```
-grouped ```by {host}```, write a graph query that looks like:
+To graph the sum of `app.foo.bar{env:staging}` and `app.foo.baz{env:staging}`
+grouped `by {host}`, write a graph query that looks like:
 
 ~~~
 metric.foo.bar{env:staging} by {host} + metric.foo.baz{env:staging} by {host}
@@ -429,27 +421,32 @@ to:
 You can apply smoothing averages to your series by droping to the JSON editor and
 adding ‘ewma’, for example:
 add any of ewma_x(…) where x can be 5, 10, 20 around your series, e.g.
-```ewma_20(exception.invalid{*})```.
+`ewma_20(exception.invalid{*})`.
 ewma stands for exponentially-moving average and the full list of functions
-you can apply is <a href="http://docs.datadoghq.com/graphing/#functions">here</a>.
+you can apply is [here][graphing-1].
 
 
-<h4>Can I stack CPU metrics on the same graph?</h4>
-<p>
-Check out our documentation on <a href="http://docs.datadoghq.com/graphing/">stacked series</a>.
+#### Can I stack CPU metrics on the same graph?
+{: #stack-cpu-metrics}
+
+Check out our documentation on [stacked series][graphing-2].
 The metric explorer just does one metric per graph, but you can see a stacked CPU graph
-on the overview page by clicking any host <a href="https://app.datadoghq.com/infrastructure">here</a>.
-</p>
+on the overview page by clicking any host [here][graphing-3].
 
 #### Is there a way to share graphs?
 {: #share-graphs}
 
 There are two ways to share a graph or screenboard
 
-<h4>How do I track cron jobs?</h4>
-* In a time board, pick a graph on a dashboard and click on the pencil to edit it. Under step 2, "Choose metrics and events," you’ll find the “share” tab that will generate an IFRAME of just that graph.
-* In a custom screenboard, click the settings cog in the upper right of the screen, then click the "Generate public URL" option. This will create a URL which gives live and read-only access to just the contents of that screenboard.
+* In a time board, pick a graph on a dashboard and click on the pencil to edit it.
+Under step 2, "Choose metrics and events," you’ll find the “share” tab that will
+generate an IFRAME of just that graph.
+* In a custom screenboard, click the settings cog in the upper right of the screen,
+then click the "Generate public URL" option. This will create a URL which gives
+live and read-only access to just the contents of that screenboard.
 
+#### How do I track cron jobs?
+{: #track-cron}
 
 Often, you set cron jobs that trigger some meaningful script that you want to monitor and
 correlate with other metrics. For example, you might have a cron'd script to vacuum a Postgres table every day:
@@ -458,48 +455,54 @@ correlate with other metrics. For example, you might have a cron'd script to vac
 
 Vacuum is particularly resource-intensive though, so you might want Datadog events for
 each time they run so you can correlate metrics and other events with vacuums.
-You can do this with the dogwrap command line tool provided by the <a href="https://github.com/DataDog/datadogpy">datadog python client library</a>:
+You can do this with the dogwrap command line tool provided by the [datadog python client library][graphing-4]:
 
     dogwrap -n "Vacuuming mytable" -k $API_KEY --submit_mode errors "psql -c 'vacuum verbose my_table'" 2>&1 /var/log/postgres_vacuums.log
 
 
 This will call the command at the end of the script and
-send Datadog events if it exits with a non-zero exit code (i.e. an error). <code>--submit_mode all</code>
+send Datadog events if it exits with a non-zero exit code (i.e. an error). `--submit_mode all`
 will send events on every run.
 
-(To get the python client lib you can install it with <code>easy_install datadog</code> or <code>pip install datadog</code>).
+(To get the python client lib you can install it with `easy_install datadog` or `pip install datadog`).
 
-
-<!-- ====================================================================== -->
-
+[graphing-1]: /graphing/#functions
+[graphing-2]: /graphing
+[graphing-3]: http://app.datadoghq.com/infrastructure
+[graphing-4]: https://github.com/DataDog/datadogpy
 
 <!--
 ===============================================================================
     Integrations
 ===============================================================================
 -->
-<h3><a name="integrations" href="#integrations">Integrations</a></h3>
 
-<h4 id="integration-metrics">I set up my integration. Why am I not seeing metrics?</h4>
-<p>
-There a several problems that could cause this.  Send a message to support (support@datadoghq.com) describing the issue and include the agent info, the logs, and the configuration file as attachments to that message.  You can find the location of these in the following link and selecting your OS: <a href="http://docs.datadoghq.com/guides/basic_agent_usage/">http://docs.datadoghq.com/guides/basic_agent_usage/</a>
-</p>
+### Integrations
 
-<h4 id="integration-data">How is Datadog retrieving my data?</h4>
-<p>
-<ul>
-<li>Traffic is always initiated by the agent to Datadog. No sessions are ever initiated from Datadog back to the agent.</li>
-<li>All traffic is sent over SSL.</li>
-<li>All communication to Datadog is via HTTPS.</li>
-<li>The full license agreement can be found <a href="https://app.datadoghq.com/policy/license">here</a>.</li>
-</ul>
-</p>
+#### I set up my integration. Why am I not seeing metrics?
+{: #integration-metrics}
 
-<h4 id="integration-edit">I’d like to tweak an integration or write up a new one. Do you accept pull requests?</h4>
-<p>
-Yes! The agent is entirely open source and can be found <a href="https://github.com/DataDog/dd-agent/">here</a>.
-</p>
+There a several problems that could cause this.  Send a message to support
+(support@datadoghq.com) describing the issue and include the agent info, the logs, and
+the configuration file as attachments to that message.  You can find the location of
+these in the following link and selecting your OS on our [agent usage guide][integrations-1]
 
+#### How is Datadog retrieving my data?
+{: #integration-data}
+
+* Traffic is always initiated by the agent to Datadog. No sessions are ever initiated from Datadog back to the agent.
+* All traffic is sent over SSL.
+* All communication to Datadog is via HTTPS.
+* The full license agreement can be found [here][integrations-2].
+
+#### I’d like to tweak an integration or write up a new one. Do you accept pull requests?
+{: #integration-edit}
+
+Yes! The agent is entirely open source and can be found on our [Github project page][integrations-3].
+
+[integrations-1]: /guides/basic_agent_usage
+[integrations-2]: https://app.datadoghq.com/policy/license
+[integrations-3]: https://github.com/DataDog/dd-agent
 
 <!--
 ===============================================================================
@@ -508,21 +511,20 @@ Yes! The agent is entirely open source and can be found <a href="https://github.
 -->
 
 ### Metrics
-{: #metrics}
 
 #### How do I submit custom metrics?
 
-You can submit your custom metrics with the DogStatsD client. You can read more about this [here][1].
+You can submit your custom metrics with the DogStatsD client. You can read more about this [here][metrics-1].
 
 
 #### Why is my counter metric showing decimal values?
 
-StatsD counters are normalized over the flush interval to report per-second units. You can read more about this [here][2].
+StatsD counters are normalized over the flush interval to report per-second units. You can read more about this [here][metrics-2].
 
 
 #### Is there a way to submit metrics from my log data?
 
-Yes there is! We detail log parsing [here][3].
+Yes there is! We detail log parsing [here][metrics-3].
 
 
 #### I’d like to add historical data to my account. Is there a way to do that?
@@ -533,27 +535,33 @@ Unfortunately, we do not allow adding historical data at this time.
 
 This depends on the medium you use to send metrics.
 
-  * For an Agent Check, see this [link][4].
-  * For DogStatsD, see this [link][5].
-  * For the API, see this [link][6].
+* For an Agent Check, see this [link][metrics-4].
+* For DogStatsD, see this [link][metrics-5].
+* For the API, see this [link][metrics-6].
 
 
 #### Is there a way I can get metric reports?
 
 We offer reporting in a variety of ways so far, which include:
 
-  * The ability to embed any chart anywhere. Pick a graph on a dashboard, click on the pencil to edit it and you’ll find the “share” tab that will generate an IFRAME.
-  * For certain sources (e.g. pagerduty), you’ll get a report in your mailbox once a week to go over past alerts.
-  * Metric alerts provide a way to report changes that are outside of what you define as “normal”.
+* The ability to embed any chart anywhere. Pick a graph on a dashboard, click on
+the pencil to edit it and you’ll find the “share” tab that will generate an IFRAME.
+* For certain sources (e.g. pagerduty), you’ll get a report in your mailbox once
+a week to go over past alerts.
+* Metric alerts provide a way to report changes that are outside of what you define
+as “normal”.
 
 #### How do I get disk usage as a percentage instead of in bytes?
 
-The Datadog Agent emits a metric named `system.disk.in_use` which will give you disk usage as a percentage.
+The Datadog Agent emits a metric named `system.disk.in_use` which will give you disk
+usage as a percentage.
 
 #### How is data aggregated in graphs
 {: #metric-aggregation}
 
-Within Datadog, a graph can only contain a set number of points and, as the timeframe over which a metric is viewed increases, aggregation between points will occur to stay below that set number.
+Within Datadog, a graph can only contain a set number of points and, as the timeframe
+over which a metric is viewed increases, aggregation between points will occur to
+stay below that set number.
 
 Thus, if you are querying for larger timeframes of data, the points
 returned will be more aggregated. The max granularity within Datadog
@@ -567,181 +575,146 @@ average,sum,  min, max, or count.
 #### What's the difference between system.load.1, system.load.5, and system.load.15?
 {: #systemload1-5-15}
 
-When you run uptime on a *nix system, the three numbers at the end represent system.load.1, system.load.5, and system.load.15. System.load.1 is the system load for the past 1 minute for a single core. Related to these is system.load.norm.1, which is the system.load for the past 1 minute on divided by the number of cores on that machine.
+When you run uptime on a *nix system, the three numbers at the end represent
+system.load.1, system.load.5, and system.load.15. System.load.1 is the system load
+for the past 1 minute for a single core. Related to these is system.load.norm.1, which
+is the system.load for the past 1 minute on divided by the number of cores on that
+machine.
 
-<h4 id="metric-other">Any other things about metrics?</h4>
-<p>
-When using the 'sum/min/max/avg' aggregator, we're looking across series, not at points within a single series. So if it is scoped to it's most granular level, it's possible that switching between those aggregators will not change the values you're seeing.
-</p>
-<p>
+#### Any other things about metrics?
+{: #metric-other}
+
+When using the 'sum/min/max/avg' aggregator, we're looking across series,
+not at points within a single series. So if it is scoped to it's most granular
+level, it's possible that switching between those aggregators will not change
+the values you're seeing.
+
 For example, let's say you break down used memory by host, you'll get one
 time series for each host. If you don't break down by host,
 by default you'll get the average across all hosts.
-</p>
 
+[metrics-1]: /guides/metrics/
+[metrics-2]: /guides/metrics/#counters
+[metrics-3]: /guides/logs/
+[metrics-4]: /guides/agent_checks/#sending-metrics
+[metrics-5]: /guides/dogstatsd/#metrics
+[metrics-6]: /api/#metrics-post
 
 <!--
 ===============================================================================
     Events
 ===============================================================================
 -->
-<h3><a name="events" href="#other">Events</a></h3>
 
-<h4 id="notify">What do @ notifications do in Datadog?</h4>
-<p>
-<ul>
-<li><code>@support-datadog</code> – this will reach Datadog support directly when posted in your stream.</li>
-<li><code>@all</code> – this will send a notification to all members of your organization.</li>
-<li><code>@yourname</code> – this will notify the specific user named ‘yourname’.</li>
-<li><code>@test@test.com</code> this will send an email to test@test.com.</li>
-<li>If you have HipChat, Slack, Webhooks, Pagerduty or VictorOps you can use:
-<ul>
-<li><code>@hipchat-[room-name]</code> or <code>@slack-[room-name]</code> – posts the event or graph to that chat room.</li>
-<li><code>@webhook</code> – alerts or triggers whatever is attached to that webhook. Check out
-<a target="_blanks" href="https://www.datadoghq.com/2014/07/send-alerts-sms-customizable-webhooks-twilio/">this blogpost</a> on Webhooks!</li>
-<li><code>@pagerduty</code>
-– sends an alert to Pagerduty. You can also use <code>@pagerduty-acknowledge</code> and <code>@pagerduty-resolve</code>.</li>
-</ul>
+### Events
 
-</li>
-</ul>
-</p>
+#### What do @ notifications do in Datadog?
+{: #notify}
 
-<h4>Searching Events Help</h4>
+* `@support-datadog` – this will reach Datadog support directly when posted in your stream.
+* `@all` – this will send a notification to all members of your organization.
+* `@yourname` – this will notify the specific user named ‘yourname’.
+* `@test@test.com` this will send an email to test@test.com.
+* If you have HipChat, Slack, Webhooks, Pagerduty or VictorOps you can use:
+    * `@hipchat-[room-name]` or `@slack-[room-name]` – posts the event or graph to that chat room.
+    * `@webhook` – alerts or triggers whatever is attached to that webhook. Check out [our blogpost on Webhooks][events-1]!
+    * `@pagerduty` – sends an alert to Pagerduty. You can also use `@pagerduty-acknowledge` and `@pagerduty-resolve`.
 
-<p>Your query runs a full text search of events and their comments.
-You can also target certain event properties, such as the event source or status, by using the following search prefixes:</p>
+#### Searching Events Help
 
-<ul>
-<li>
-<p>
-<code class="no-highlight"><strong>user:</strong>pup@datadoghq.com</code>
-Find all events with comments by pup@datadoghq.com. </p>
-</li>
+Your query runs a full text search of events and their comments. You can also
+target certain event properties, such as the event source or status, by using
+the following search prefixes:
 
-<li>
-<p>
-<code class="no-highlight"><strong>sources:</strong>github,chef</code>
-Show events from Github and Chef.</p>
-</li>
+* **`user:`**`pup@datadoghq.com` Find all events with comments by pup@datadoghq.com.
+* **`sources:`**`github,chef` Show events from Github and Chef.
+* **`tags:`**`env-prod,db` Show events tagged with #env-prod AND #db.
+* **`hosts:`**`db1.myapp.com,db2.myapp.com` Show events from db1.myapp.com OR db2.myapp.com.
+* **`status:`**`error` Show only error status events. (**supports:** 'error', 'warning', 'success')
+* **`priority:`**`low` Show only low-priority events. (**supports:** 'low' or 'normal'. defaults to 'all')
+* **`incident:`**`claimed` Show only claimed incidents. (**supports:** 'open', 'claimed', 'resolved', or 'all')
 
-<li>
-<p><code class="no-highlight"><strong>tags:</strong>env-prod,db</code>
-Show events tagged with #env-prod AND #db.</p>
-</li>
+Prefixes can easily be combined to make much more complex searches.  For example,
+if you wanted to find all open chef or nagios errors that mention cassandra, you'd
+have a search like:
 
-<li>
-<p><code class="no-highlight"><strong>hosts:</strong>db1.myapp.com,db2.myapp.com</code>
-Show events from db1.myapp.com OR db2.myapp.com.</p>
-</li>
+`sources:nagios,chef status:error cassandra`
 
-<li>
-<p><code class="no-highlight"><strong>status:</strong>error</code>
-Show only error status events. (<strong>supports:</strong> 'error', 'warning', 'success')</p>
-</li>
+Note: no spaces after the colon or commas in these lists and anything not attached
+to a prefix goes to full text search.
 
-<li>
-<p><code class="no-highlight"><strong>priority:</strong>low</code>
-Show only low-priority events. (<strong>supports:</strong> 'low' or 'normal'. defaults to 'all')</p>
-</li>
+#### Is it possible to submit events via email?
 
-<li>
-<p><code class="no-highlight"><strong>incident:</strong>claimed</code>
-Show only claimed incidents. (supports: 'open', 'claimed', 'resolved', or 'all')</p>
-</li>
-</ul>
-
-<p>Prefixes can easily be combined to make much more complex searches.
-For example, if you wanted to find all open chef or nagios errors that mention cassandra, you'd have a search like:
-</p>
-<p><code>sources:nagios,chef status:error cassandra </code>.</p>
-
-<p>
-Note: no spaces after the colon or commas in these lists and anything not attached to a prefix goes to full text search.
-</p>
-
-
-<h4>Is it possible to submit events via email?</h4>
-<p>
-Yes!
-To get started you need to go the API tab in the
-<a target="_blank" href="https://app.datadoghq.com/account/settings#api">settings page</a>,
+Yes! To get started you need to go the API tab in the [settings page][events-2],
 create one or more API emails.
-For a monitoring tool that does not allow you to edit the body of the email you need to create a plain-text email,
-and have that system or tool send alarms or notifications to this email.
-For systems that allow you to edit the content
-of the notification emails, you may use a JSON email. In the body of an email sent to a JSON API email you need
-to include a well formatted JSON event request as per our existing events API (which you can find more details
-about on <a target="_blank" href="http://docs.datadoghq.com/api/">here</a>).
-</p>
 
-<p>
+For a monitoring tool that does not allow you to edit the body of the email you
+need to create a plain-text email, and have that system or tool send alarms or
+notifications to this email.
+
+For systems that allow you to edit the content of the notification emails, you
+may use a JSON email. In the body of an email sent to a JSON API email you need
+to include a well formatted JSON event request as per our existing events API.
+For more details about our events API, visit our [API documentation][events-3].
+
 Here is an example:
-<pre><code>{
-"title": “Host CPU above 75% for 5 minutes",
-"text": "Host CPU has been above 75% for the last 5 minutes …etc",
-"priority": "normal",
-"tags": ["vsphere", "env:prod", "host:i-a4f761f0", "role:admin"],
-"alert_type": "error"
-}</code></pre>
-</p>
+
+~~~
+{
+  "title": “Host CPU above 75% for 5 minutes",
+  "text": "Host CPU has been above 75% for the last 5 minutes …etc",
+  "priority": "normal",
+  "tags": ["vsphere", "env:prod", "host:i-a4f761f0", "role:admin"],
+  "alert_type": "error"
+}
+~~~
 
 #### What formatting is available for event text?
 {: #eventformat}
 
-We have adopted Daring Fireball's Markdown throughout the site. To find out more about Markdown, visit the [Markdown docs](http://daringfireball.net/projects/markdown/syntax).
+We have adopted Daring Fireball's Markdown throughout the site. To find out more
+about Markdown, visit the [Markdown docs][events-4].
+
+[events-1]: https://www.datadoghq.com/2014/07/send-alerts-sms-customizable-webhooks-twilio
+[events-2]: https://app.datadoghq.com/account/settings#api
+[events-3]: /api#events
+[events-4]: http://daringfireball.net/projects/markdown/syntax
 
 <!--
 ===============================================================================
     Other
 ===============================================================================
 -->
-<h3><a name="other" href="#other">Other</a></h3>
 
-<h4 id="team">How do I setup my team in Datadog?</h4>
-<p>
+### Other
+
+#### How do I setup my team in Datadog?
+{: #team}
+
 The admin of the account should enter the email addresses of team members
-<a href="https://app.datadoghq.com/account/team">here</a>. Some team best practices are as follows:
-<ul>
-<li>When the team member receives the confirmation email, they will be provided
-with a link to log in directly. The user should not click ‘sign up’ during this process.</li>
-<li>If multiple users from the same organization sign up separately, this will
-register as different organizations in Datadog. Please reach out to support to
-have these merged, but please note that all information contained in the
-account getting merged will not be transferred over.</li>
-<li>The only access controls we have right now are around admin activities
-(adding/removing users, billing, etc.). As far as data goes (hosts, metrics, dashboards, etc.)
-all users have access to everything; more robust access controls are in our
-pipeline, but not something we’ve focused a lot of attention on yet.</li>
-<li>To remove a team member use the “disable” button on the same ‘team’ page (only available
-for admins). You cannot permanently remove users, just disable; disabled users will
-only be visible to admins on the team page and can’t log in and any session they have
-open is invalidated. We don’t fully delete them because they might own events,
-dashboards, etc. which are not supposed to be removed.</li>
-</ul>
-</p>
+[here][other-1]. Some team best practices are as follows:
+
+* When the team member receives the confirmation email, they will be provided with a link to log in directly. The user should not click ‘sign up’ during this process.
+* If multiple users from the same organization sign up separately, this will register as different organizations in Datadog. Please reach out to support to have these merged, but please note that all information contained in the account getting merged will not be transferred over.
+* The only access controls we have right now are around admin activities (adding/removing users, billing, etc.). As far as data goes (hosts, metrics, dashboards, etc.) all users have access to everything; more robust access controls are in our pipeline, but not something we’ve focused a lot of attention on yet.
+* To remove a team member use the “disable” button on the same ‘team’ page (only available for admins). You cannot permanently remove users, just disable; disabled users will only be visible to admins on the team page and can’t log in and any session they have open is invalidated. We don’t fully delete them because they might own events, dashboards, etc. which are not supposed to be removed.
 
 
-<h4 id="security">Are my data and credentials safe?</h4>
-<p>
-<ul>
-<li>Traffic is always initiated by the agent to Datadog. No sessions are ever initiated from Datadog back to the agent.</li>
-<li>All traffic is sent over SSL.</li>
-<li>All communication to Datadog is via HTTPS.</li>
-<li>The full license agreement can be found <a href="https://app.datadoghq.com/policy/license">here</a>.</li>
-<li>The agent is entirely open source and can be found <a href="https://github.com/DataDog/dd-agent/">here</a>.</li>
-<li>Some installations (for example, installing the agent on CentOS 5), will request your password. The password is needed because it's installing packages - Datadog does not retain it in anyway. You can also use the step-by-step directions if you prefer to see exactly what the script is doing.</li>
-</ul>
-</p>
+#### Are my data and credentials safe?
+{: #security}
 
-<h4 id="feature-request">I have a feature request. How can I submit it?</h4>
-<p>
+* Traffic is always initiated by the agent to Datadog. No sessions are ever initiated from Datadog back to the agent.
+* All traffic is sent over SSL.
+* All communication to Datadog is via HTTPS.
+* The full license agreement can be found [here][other-2].
+* The agent is entirely open source and can be found [here][other-3].
+* Some installations (for example, installing the agent on CentOS 5), will request your password. The password is needed because it's installing packages - Datadog does not retain it in anyway. You can also use the step-by-step directions if you prefer to see exactly what the script is doing.
+
+#### I have a feature request. How can I submit it?
+{: #feature-request}
+
 You can send the request to support@datadoghq.com and we will add it to our feature request log.
-</p>
 
-   [1]: http://docs.datadoghq.com/guides/metrics/
-   [2]: http://docs.datadoghq.com/guides/metrics/#counters
-   [3]: http://docs.datadoghq.com/guides/logs/
-   [4]: http://docs.datadoghq.com/guides/agent_checks/#sending-metrics
-   [5]: http://docs.datadoghq.com/guides/dogstatsd/#metrics
-   [6]: http://docs.datadoghq.com/api/#metrics-post
+[other-1]: https://app.datadoghq.com/account/team
+[other-2]: https://app.datadoghq.com/policy/license
+[other-3]: https://github.com/DataDog/dd-agent/

--- a/content/faq.md
+++ b/content/faq.md
@@ -1,31 +1,7 @@
 ---
 title: Frequently Asked Questions
 kind: documentation
-sidebar:
-  nav:
-    - header: FAQ Topics
-    - text: Agent
-      href: "/faq/#agent"
-    - text: Alerts
-      href: "/faq/#alerts"
-    - text: API
-      href: "/faq/#api"
-    - text: Architecture
-      href: "/faq/#architecture"
-    - text: AWS
-      href: "/faq/#aws"
-    - text: Billing
-      href: "/faq/#billing"
-    - text: Graphing
-      href: "/faq/#graph"
-    - text: Integrations
-      href: "/faq/#integrations"
-    - text: Metrics
-      href: "/faq/#metrics"
-    - text: Events
-      href: "/faq/#events"
-    - text: Other
-      href: "/faq/#other"
+autotocdepth: 1
 ---
 
 <!--


### PR DESCRIPTION
- removed html.
- renamed link references to [section-#] (e.g. `[agent-1]`) and placed them at the bottom of each section.
- converted triple backticks to singles (multi backticks are only necessary if you intend to have a literal backtick. see [here](https://daringfireball.net/projects/markdown/syntax#code)).
- tried to wrap lines as best as possible for easier reading.