### PR TITLE
Fix timeboard get_all output for the Python library.

### DIFF
--- a/code_snippets/results/result.api-dashboard-get-all.py
+++ b/code_snippets/results/result.api-dashboard-get-all.py
@@ -1,4 +1,4 @@
-[{'description': 'This has all the new hotness.',
+{'dashes': [{'description': 'This has all the new hotness.',
   'id': '2551',
   'resource': '/api/v1/dash/2551',
   'title': 'New and Improved Dashboard',
@@ -11,4 +11,4 @@
   'created': '2015-12-17T21:29:40.890824+00:00',
   'modified': '2015-12-17T21:39:20.770834+00:00',
   'read_only': True}
-]
+]}


### PR DESCRIPTION
Instead of returning just a list, we send back a dict with a `dashes` key that
has a list of dashboards. This also matches the outputs from other languages
(rb, sh).