### PR TITLE
fix error in disk check doc

### DIFF
--- a/content/integrations/disk.md
+++ b/content/integrations/disk.md
@@ -1,5 +1,6 @@
 ---
 title: Datadog-Disk Integration
+integration_title: Disk Check
 kind: integration
 newhlevel: true
 ---
@@ -17,40 +18,40 @@ Included by default with the Datadog agent installation.
 
 This configuration does not require any explicit configuration to begin monititoring your storage devices.  One however can override the default settings to adjust how disks are monitored.
 
-        init_config:
+    init_config:
 
-        instances:
-          # The use_mount parameter will instruct the check to collect disk
-          # and fs metrics using mount points instead of volumes
-          - use_mount: no
-            # The (optional) excluded_filesystems parameter will instruct the check to
-            # ignore disks using these filesystems
-            # excluded_filesystems:
-            #   - tmpfs
+    instances:
+      # The use_mount parameter will instruct the check to collect disk
+      # and fs metrics using mount points instead of volumes
+      - use_mount: no
+      # The (optional) excluded_filesystems parameter will instruct the check to
+      # ignore disks using these filesystems
+      # excluded_filesystems:
+      #   - tmpfs
 
-            # The (optional) excluded_disks parameter will instruct the check to
-            # ignore this list of disks
-            # excluded_disks:
-            #   - /dev/sda1
-            #   - /dev/sda2
-            #
-            # The (optional) excluded_disk_re parameter will instruct the check to
-            # ignore all disks matching this regex
-            # excluded_disk_re: /dev/sde.*
-            #
-            # The (optional) tag_by_filesystem parameter will instruct the check to
-            # tag all disks with their filesystem (for ex: filesystem:nfs)
-            # tag_by_filesystem: no
-            #
-            # The (optional) excluded_mountpoint_re parameter will instruct the check to
-            # ignore all mountpoints matching this regex
-            # excluded_mountpoint_re: /mnt/somebody-elses-problem.*
-            #
-            # The (optional) all_partitions parameter will instruct the check to
-            # get metrics for all partitions. use_mount should be set to yes (to avoid
-            # collecting empty device names) when using this option.
-            # all_partitions: no
-    {:.language-yaml}
+      # The (optional) excluded_disks parameter will instruct the check to
+      # ignore this list of disks
+      # excluded_disks:
+      #   - /dev/sda1
+      #   - /dev/sda2
+      #
+      # The (optional) excluded_disk_re parameter will instruct the check to
+      # ignore all disks matching this regex
+      # excluded_disk_re: /dev/sde.*
+      #
+      # The (optional) tag_by_filesystem parameter will instruct the check to
+      # tag all disks with their filesystem (for ex: filesystem:nfs)
+      # tag_by_filesystem: no
+      #
+      # The (optional) excluded_mountpoint_re parameter will instruct the check to
+      # ignore all mountpoints matching this regex
+      # excluded_mountpoint_re: /mnt/somebody-elses-problem.*
+      #
+      # The (optional) all_partitions parameter will instruct the check to
+      # get metrics for all partitions. use_mount should be set to yes (to avoid
+      # collecting empty device names) when using this option.
+      # all_partitions: no
+{:.language-yaml}
 
 # Validation
 
@@ -73,3 +74,4 @@ You should see something similar to the following if everything is working corre
 
 # Metrics
 
+For details on the metrics collected by the disk check, refer to the metrics in [System check](/integrations/system) that start with `system.disk` and `system.fs`.


### PR DESCRIPTION
The disk check doc didn't include a integration_title which all integrations require. This results in a crashing compile. Also the metrics section was empty. Also the config section was not indented properly: too much space in front of the text and the language was shown at the bottom. all fixed now.