### PR TITLE
add rake command for slow connections

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -122,4 +122,10 @@ task :guard do
   sh 'bundle exec guard'
 end
 
+desc 'This is a slow connection, dont collect remote stuff'
+task :slow do
+  ENV['NANOCRUNSLOW'] = "true"
+  Rake::Task[:guard].invoke
+end
+
 task default: :guard

--- a/Rules
+++ b/Rules
@@ -38,7 +38,13 @@ preprocess do
   #   end
   # end
 
-  if ENV.has_key?('github_personal_token')
+  if ENV.has_key?('NANOCRUNSLOW')
+    $goodconnection = false
+  else
+    $goodconnection = true
+  end
+
+  if ENV.has_key?('github_personal_token') && $goodconnection
     $client = $client ||= Octokit::Client.new(:access_token => ENV['github_personal_token'])
     $client.user.login
   end

--- a/lib/helpers_.rb
+++ b/lib/helpers_.rb
@@ -127,7 +127,7 @@ def get_all_metrics_from_github
   require 'csv'
 
   $allmetrics = {}
-  if ENV.has_key?('github_personal_token')
+  if ENV.has_key?('github_personal_token') && $goodconnection
     pp "Getting all metrics from github after a \'rake clean\'. This takes about 20-60 seconds on a good connection"
     repo='datadog/dogweb'
     reporootdir = $client.contents(repo, :path => "integration/")
@@ -191,7 +191,7 @@ def get_metrics_from_git(itemintegration=@item[:git_integration_title], items_to
   end
   selectedmetrics = []
   allmetricsforintegration = $allmetrics[itemintegration]
-  if items_to_include.count > 0
+  if items_to_include.count > 0 && $goodconnection
     items_to_include.each do |item_to_include|
       selectedmetrics = selectedmetrics + allmetricsforintegration.select {|metric| metric[:name].include?(item_to_include)}
     end
@@ -203,15 +203,19 @@ end
 
 def formatmetrics(selectedmetrics)
   metrictable = "<table class='table'>"
-  selectedmetrics.each do |metric|
-    metrictable += "<tr><td><strong>#{metric[:name]}</strong><br/>(#{metric[:type]}"
-    if metric[:interval]>0
-      metrictable += " every #{metric[:interval]} seconds"
+  if $goodconnection
+    selectedmetrics.each do |metric|
+      metrictable += "<tr><td><strong>#{metric[:name]}</strong><br/>(#{metric[:type]}"
+      if metric[:interval]>0
+        metrictable += " every #{metric[:interval]} seconds"
+      end
+      metrictable += ")</td><td>#{metric[:description].gsub '^', ' to the '}"
+      metrictable += metric[:unit].length>0 ? "<br/><em>shown as #{metric[:unit]}" : "<em>"
+      metrictable += metric[:per_unit].length>0 ? "/#{metric[:per_unit]}</em>" : "</em>"
+      metrictable += "</td></tr>"
     end
-    metrictable += ")</td><td>#{metric[:description].gsub '^', ' to the '}"
-    metrictable += metric[:unit].length>0 ? "<br/><em>shown as #{metric[:unit]}" : "<em>"
-    metrictable += metric[:per_unit].length>0 ? "/#{metric[:per_unit]}</em>" : "</em>"
-    metrictable += "</td></tr>"
+  else
+    metrictable += "<tr><td>Metrics would go here if you didn't type rake slow</td></tr>"
   end
   metrictable += "</table>"
   return metrictable
@@ -222,7 +226,7 @@ def get_units_from_git
   require 'base64'
   require 'csv'
 
-  if ENV.has_key?('github_personal_token')
+  if ENV.has_key?('github_personal_token') && $goodconnection
     itext = $client.contents('datadog/dogweb', :path => "integration/system/units_catalog.csv").content
     unit_string = ""
     units_by_family = Hash.new([])


### PR DESCRIPTION
If you are on a train or a plane with a slow internet connection, or you are on a beach with no connection, then building the docs will be painful. You might, in fact, be tempted to do nothing instead. But now there is a new rake option: `rake slow`. This new command is the same as running just `rake` but it sets an environment variable that gets checked every time nanoc goes to grab content from GitHub for metrics and units. Boom!! Say hello to your newfound productivity while in transit!!!