### PR TITLE
add link to screenboardupdate

### DIFF
--- a/content/api/index.html
+++ b/content/api/index.html
@@ -1276,7 +1276,7 @@ kind: documentation
       </div>
     </div>
 
-    <h4 id="screenboards-post">Update a Screenboard</h4>
+    <div class="int-anchor" id="screenboards-put"></div><a href="#screenboards-put"><h4>Update a Screenboard</h4></a>
     <div class="row">
       <%= left_side_div %>
         <h5>Arguments</h5>


### PR DESCRIPTION
The trello card refers to POST vs PUT, but looks like we fixed that already. It also mentioned that the link to the PUT was broken. so this fixes that issue