### PR TITLE
Updated API code samples to delete events

### DIFF
--- a/code_snippets/api-events-delete.py
+++ b/code_snippets/api-events-delete.py
@@ -1,2 +1,10 @@
-# Deleting events is not yet implemented in the Python
-# library. The docs will be updated when it has been implemented.
+from datadog import initialize, api
+
+options = {
+    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
+    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+}
+
+initialize(**options)
+
+api.Event.delete(2603387619536318140)

--- a/code_snippets/api-events-delete.rb
+++ b/code_snippets/api-events-delete.rb
@@ -1,2 +1,9 @@
-# Deleting events is not yet implemented in the Ruby
-# library. The docs will be updated when it has been implemented.
+require 'rubygems'
+require 'dogapi'
+
+api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
+app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+
+dog = Dogapi::Client.new(api_key, app_key)
+
+dog.delete_event(1375909614428331251)

--- a/code_snippets/results/result.api-events-delete.py
+++ b/code_snippets/results/result.api-events-delete.py
@@ -1,2 +1,1 @@
-## Deleting events is not yet implemented in the Python
-# library. The docs will be updated when it has been implemented.
+{"deleted_event_id": "2603387619536318140"}

--- a/code_snippets/results/result.api-events-delete.rb
+++ b/code_snippets/results/result.api-events-delete.rb
@@ -1,2 +1,1 @@
-# Deleting events is not yet implemented in the Ruby
-# library. The docs will be updated when it has been implemented.
+["200", {"deleted_event_id"=>"1375909614428331251"}]


### PR DESCRIPTION
https://trello.com/c/Ch2ssN0p/1087-update-api-docs-for-0-13-0-release-events-are-deletable