### PR TITLE
Updated Mark's github handle, added Dropbox reference

### DIFF
--- a/content/libraries.md
+++ b/content/libraries.md
@@ -94,7 +94,7 @@ Some great folks have written their own libraries to help interact with Datadog.
 
   * [ecsdog][74] - a standalone Go application that scrapes metrics and events from ECS, and sends them to statsd by [ejholmes][75]
   * [godspeed][63] - a feature-rich dogstatsd client written in Go by [PagerDuty][64].
-  * [go-datadog-api][30] - a Go wrapper for our API by [Mark Smith][31].
+  * [go-datadog-api][30] - a Go wrapper for our API by [Mark Smith][31] from [Dropbox][81].
   * [go-dogstatsd][32] - a dogstatsd client written in Go by [Ooyala][33].
   * [xstats][69] - a generic client for service instrumentation using dogstatsd in Go by [Olivier Poitrey][70].
 
@@ -227,8 +227,8 @@ If you've written a Datadog library, write us at [code@datadoghq.com][56] and we
    [27]: https://github.com/isra00/plesk_datadog_metrics
    [28]: http://www.parallels.com/products/plesk/
    [29]: https://github.com/isra00
-   [30]: https://github.com/xb95/go-datadog-api
-   [31]: https://github.com/xb95
+   [30]: https://github.com/zorkian/go-datadog-api
+   [31]: https://github.com/zorkian
    [32]: https://github.com/ooyala/go-dogstatsd/
    [33]: https://github.com/ooyala
    [34]: https://github.com/tbarbugli/scales_datadog
@@ -278,3 +278,4 @@ If you've written a Datadog library, write us at [code@datadoghq.com][56] and we
    [78]: https://github.com/Sjeanpierre
    [79]: https://github.com/mediba-system/lua-resty-dogstatsd
    [80]: http://www.mediba.jp/
+   [81]: https://www.dropbox.com/


### PR DESCRIPTION
https://trello.com/c/6uRSA6rI/1007-dropbox-go-library

So we already had it listed, but Mark's github handle changed. This commit updates that.
The card also mentions Dropbox, so I added them with a link at the end.