### PR TITLE
Revert "Add AWS Elasticsearch list and describe permissions"

### DIFF
--- a/content/integrations/aws.md
+++ b/content/integrations/aws.md
@@ -95,8 +95,6 @@ Note: GovCloud does not support role based authentication.
                 "elasticloadbalancing:Describe*",
                 "elasticmapreduce:List*",
                 "elasticmapreduce:Describe*",
-                "es:List*",
-                "es:Describe*",
                 "kinesis:List*",
                 "kinesis:Describe*",
                 "logs:Get*",


### PR DESCRIPTION
Reverts DataDog/documentation#939

Permissions not required. This will be explained in the followup documentation on each permission.