### PR TITLE
Remove mentions to the kubernetes docker tag

### DIFF
--- a/content/guides/servicediscovery.md
+++ b/content/guides/servicediscovery.md
@@ -74,12 +74,7 @@ The above settings can be passed to the dd-agent container through the following
     SD_BACKEND_PORT <-> sd_backend_port
     SD_TEMPLATE_DIR <-> sd_template_dir
 
-Available tags:
-
-    datadog/docker-dd-agent:latest (has the Docker check preconfigured)
-    datadog/docker-dd-agent:kubernetes (has the Docker and Kubernetes checks preconfigured)
-
-example:
+examples:
 
     docker run -d --name dd-agent \
      -v /var/run/docker.sock:/var/run/docker.sock \
@@ -87,7 +82,18 @@ example:
      -e API_KEY=[YOUR_API_KEY] -e SD_CONFIG_BACKEND=etcd \
      -e SD_BACKEND=docker -e SD_BACKEND_HOST=[YOUR_ETCD_IP] \
      -e SD_BACKEND_PORT=[YOUR_ETCD_PORT] \
-     datadog/docker-dd-agent:kubernetes
+     datadog/docker-dd-agent:latest
+
+or with the Kubernetes check preconfigured:
+
+    docker run -d --name dd-agent \
+     -v /var/run/docker.sock:/var/run/docker.sock \
+     -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
+     -e API_KEY=[YOUR_API_KEY] -e KUBERNETES=true \
+     -e SD_CONFIG_BACKEND=etcd \
+     -e SD_BACKEND=docker -e SD_BACKEND_HOST=[YOUR_ETCD_IP] \
+     -e SD_BACKEND_PORT=[YOUR_ETCD_PORT] \
+     datadog/docker-dd-agent:latest
 
 
 ### Example: setting up NGINX monitoring

--- a/content/integrations/kubernetes.md
+++ b/content/integrations/kubernetes.md
@@ -36,7 +36,7 @@ If DaemonSets are not an option for your Kubernetes cluster, you will need to in
     docker run -d --name dd-agent -h `hostname` \
       -v /var/run/docker.sock:/var/run/docker.sock \
       -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-      -e API_KEY='YOUR_API_KEY_HERE' datadog/docker-dd-agent:kubernetes
+      -e API_KEY='YOUR_API_KEY_HERE' -e KUBERNETES=yes datadog/docker-dd-agent:latest
 
 # Configuration
 


### PR DESCRIPTION
The tag will soon be deprecated and its replacement is already available. Let's prepare a smooth transition.