### PR TITLE
Add better messaging when a metadata CSV cannot be read

### DIFF
--- a/lib/helpers_.rb
+++ b/lib/helpers_.rb
@@ -139,23 +139,27 @@ def get_all_metrics_from_github
           if intdircontent[:type] == "file" && intdircontent[:name].end_with?("metadata.csv")
             csvcontent = Base64.decode64($client.contents(repo, :path => "integration/#{intdir[:name]}/#{intdircontent[:name]}").content)
             metrics = []
-            CSV.parse(csvcontent, {:headers => true, :converters => :all}) do |row|
-              description = row['description'].nil? ? '' : row['description']
-              metric_name = row['metric_name']
-              metric_type = row['metric_type']
-              metric_unit = row['unit_name'].nil? ? '' : row['unit_name']
-              metric_per_unit = row['per_unit_name'].nil? ? '' : row['per_unit_name']
-              metric_interval = row['interval'].nil? ? 0 : row['interval'].to_i
-              metrics << {
-                :name => metric_name,
-                :type => metric_type,
-                :interval => metric_interval,
-                :description => description,
-                :unit => metric_unit,
-                :per_unit => metric_per_unit
-                }
+            begin
+              CSV.parse(csvcontent, {:headers => true, :converters => :all}) do |row|
+                description = row['description'].nil? ? '' : row['description']
+                metric_name = row['metric_name']
+                metric_type = row['metric_type']
+                metric_unit = row['unit_name'].nil? ? '' : row['unit_name']
+                metric_per_unit = row['per_unit_name'].nil? ? '' : row['per_unit_name']
+                metric_interval = row['interval'].nil? ? 0 : row['interval'].to_i
+                metrics << {
+                  :name => metric_name,
+                  :type => metric_type,
+                  :interval => metric_interval,
+                  :description => description,
+                  :unit => metric_unit,
+                  :per_unit => metric_per_unit
+                  }
+              end
+              $allmetrics[intdir['name']] = metrics
+            rescue
+              pp "An error occured while trying to parse the csv file " + intdircontent[:name] + " from dogweb integrations!"
             end
-            $allmetrics[intdir['name']] = metrics
           end
         }
       end


### PR DESCRIPTION
Add better messaging when a metadata CSV cannot be read to help identify bad files from dogweb.
