### PR TITLE
Updated blog links from YYYY/MM/slug to blog/slug

### DIFF
--- a/content/faq.md
+++ b/content/faq.md
@@ -422,7 +422,7 @@ Here is an example:
 We have adopted Daring Fireball's Markdown throughout the site. To find out more
 about Markdown, visit the [Markdown docs][events-4].
 
-[events-1]: https://www.datadoghq.com/2014/07/send-alerts-sms-customizable-webhooks-twilio
+[events-1]: https://www.datadoghq.com/blog/send-alerts-sms-customizable-webhooks-twilio
 [events-2]: https://app.datadoghq.com/account/settings#api
 [events-3]: /api#events
 [events-4]: http://daringfireball.net/projects/markdown/syntax

--- a/content/graphingjson.md
+++ b/content/graphingjson.md
@@ -97,7 +97,7 @@ For other metrics, including gauges submitted by statsd, <code>.as_count()</code
 <code>.as_rate()</code> will have no effect.
 
 For more on <code>.as_count()</code> please see our blog post
-<a target="_blank" href="https://www.datadoghq.com/2014/05/visualize-statsd-metrics-counts-graphing/">here</a>.
+<a target="_blank" href="https://www.datadoghq.com/blog/visualize-statsd-metrics-counts-graphing/">here</a>.
 
 #### Aggregation Method
 {: #aggregation}

--- a/content/guides/overview.md
+++ b/content/guides/overview.md
@@ -72,7 +72,7 @@ The Event Stream is based on the same conventions as a blog:
 
 * Every event in the stream can be commented on.
 * Great for distributed <a target="_blank" href="/faq/#team">teams</a> and maintaining the focus of an investigation
-* You can <a target="_blank" href="https://www.datadoghq.com/2014/05/filter-datadog-events-stream-pinpoint-events-infrastructure/">filter</a>
+* You can <a target="_blank" href="https://www.datadoghq.com/blog/filter-datadog-events-stream-pinpoint-events-infrastructure/">filter</a>
 by: user, source, tag, host, status, priority, incident
 
 ![](/static/images/event_stream_post_incident_history.png){: style="width:100%; border:1px solid #777777"}
@@ -102,7 +102,7 @@ Dashboards contain <a target="_blank" href="/graphing/">graphs</a> with real-tim
 * As you hover over the graph the event stream moves with you.
 * Display by zone, host, or total usage.
 * We expose the JSON editor of the graph allowing for <a target="_blank" href="http://docs.datadoghq.com/graphing/#functions">arithmetic</a> and
-<a target="_blank" href="https://www.datadoghq.com/2014/04/rank-filter-performance-monitoring-metrics-top-function/">functions</a> to be applied to metrics.
+<a target="_blank" href="https://www.datadoghq.com/blog/rank-filter-performance-monitoring-metrics-top-function/">functions</a> to be applied to metrics.
 * Share a graph snapshot that will appear in the stream; clicking on
 that snapshot returns you to the original dashboard (via the camera in the upper right of a graph).
 * Graphs can be embedded in an iframe, giving a 3rd party a live graph

--- a/content/integrations/aws.md
+++ b/content/integrations/aws.md
@@ -334,4 +334,4 @@ When installing the agent on an aws host, you might see duplicated hosts on the 
    [2]: https://app.datadoghq.com/account/settings#integrations/amazon_web_services
 
    [6]: mailto:support@datadoghq.com
-   [7]: http://www.datadoghq.com/2013/10/dont-fear-the-agent
+   [7]: http://www.datadoghq.com/blog/dont-fear-the-agent

--- a/content/integrations/bitbucket.md
+++ b/content/integrations/bitbucket.md
@@ -42,5 +42,5 @@ Each entry in the integration tile is validated when you enter it. There is noth
 
 
 
-[1]: https://www.datadoghq.com/2014/06/understand-code-changes-impact-system-performance-bitbucket-datadog/
+[1]: https://www.datadoghq.com/blog/understand-code-changes-impact-system-performance-bitbucket-datadog/
 [2]: https://app.datadoghq.com/account/settings#integrations/bitbucket

--- a/content/integrations/desk.md
+++ b/content/integrations/desk.md
@@ -25,7 +25,7 @@ Hit the install button, and then you're all set! You will soon be able to select
    [1]: /static/images/desk_config.png
    [2]: https://app.datadoghq.com/account/settings#integrations/desk
    [3]: https://app.datadoghq.com/screen/integration/desk
-   [4]: https://www.datadoghq.com/2015/02/keep-support-team-page-salesforce-desk-integration/
+   [4]: https://www.datadoghq.com/blog/keep-support-team-page-salesforce-desk-integration/
 
 
 ## Metrics

--- a/content/integrations/docker.md
+++ b/content/integrations/docker.md
@@ -108,5 +108,5 @@ We've written several in depth blog posts on Datadog and Docker::
 * [How to Collect Docker Metrics](https://www.datadoghq.com/blog/how-to-collect-docker-metrics/)
 * [8 Surprising Facts about Real Docker Adoption](https://www.datadoghq.com/docker-adoption/)
 * [Monitor Docker on AWS ECS](https://www.datadoghq.com/blog/monitor-docker-on-aws-ecs/)
-* [Dockerize Datadog](https://www.datadoghq.com/2014/06/docker-ize-datadog/)
-* [Monitor Docker with Datadog](https://www.datadoghq.com/2014/06/monitor-docker-datadog/)
+* [Dockerize Datadog](https://www.datadoghq.com/blog/docker-performance-datadog/)
+* [Monitor Docker with Datadog](https://www.datadoghq.com/blog/monitor-docker-datadog/)

--- a/content/integrations/vmware.md
+++ b/content/integrations/vmware.md
@@ -87,5 +87,5 @@ The base pricing is $15 per virtual machine per month. For general info on Datad
 
 
 
-[1]: https://www.datadoghq.com/2014/08/unified-vsphere-app-monitoring-datadog/
+[1]: https://www.datadoghq.com/blog/unified-vsphere-app-monitoring-datadog/
 [4]: http://docs.datadoghq.com/guides/billing/

--- a/content/ja/faq.md
+++ b/content/ja/faq.md
@@ -955,7 +955,7 @@ by default you'll get the average across all hosts. -->
 <ul>
 <li><code>@hipchat-[room-name]</code> or <code>@slack-[room-name]</code> – posts the event or graph to that chat room.</li>
 <li><code>@webhook</code> – alerts or triggers whatever is attached to that webhook. Check out
-<a target="_blanks" href="https://www.datadoghq.com/2014/07/send-alerts-sms-customizable-webhooks-twilio/">this blogpost</a> on Webhooks!</li>
+<a target="_blanks" href="https://www.datadoghq.com/blog/send-alerts-sms-customizable-webhooks-twilio/">this blogpost</a> on Webhooks!</li>
 <li><code>@pagerduty</code> or <code>@oncall</code>
 – sends an alert to Pagerduty. You can also use <code>@pagerduty-acknowledge</code> and <code>@pagerduty-resolve</code>.</li>
 </ul>
@@ -974,7 +974,7 @@ by default you'll get the average across all hosts. -->
 -	`@test@test.com` test@test.comに電子メールを送信します。
 -	HipChat, Slack, Webhooks, Pagerduty, VictorOpsの使っている場合は、次のことができます。
 	-	`@hipchat-\[ルーム名\]`または`@slack-[ルーム名]` - \[ルーム名\]で指定したチャットルームに、イベントやグラフをポストすることができます。
-	-	`@webhook-[webhook名]` - アラートなどwebhookをつなげたものなら全て。例に関しては、[Send alerts by SMS with customizable WebHooks and Twilio](https://www.datadoghq.com/2014/07/send-alerts-sms-customizable-webhooks-twilio/)のblogポストを参照してください。この機能を使うためのIntegarationの基本は、[Datadog-Webhooks Integration](/ja/integrations/webhooks/)のページと、ダッシュボードの[Integration](https://app.datadoghq.com/account/settings)タブからwebhooksのタイルを選択し`configuration`タブを参照してください。
+	-	`@webhook-[webhook名]` - アラートなどwebhookをつなげたものなら全て。例に関しては、[Send alerts by SMS with customizable WebHooks and Twilio](https://www.datadoghq.com/blog/send-alerts-sms-customizable-webhooks-twilio/)のblogポストを参照してください。この機能を使うためのIntegarationの基本は、[Datadog-Webhooks Integration](/ja/integrations/webhooks/)のページと、ダッシュボードの[Integration](https://app.datadoghq.com/account/settings)タブからwebhooksのタイルを選択し`configuration`タブを参照してください。
 	-	`@pagerduty`または`@oncall` - Pagerdutyにアラートを送信します。 更に、`@pagerduty-acknowledge` や `@pagerduty-resolve`を使って通知することもできます。
 
 <!--<h4>Searching Events Help</h4>

--- a/content/ja/graphingjson.md
+++ b/content/ja/graphingjson.md
@@ -152,7 +152,7 @@ For other metrics, including gauges submitted by statsd, <code>.as_count()</code
 We strongly recommend not using <code>.rollup()</code> and <code>.as_count()</code> within the same query.
 We will also be building these functions fully into the graph editor in the near
 future. For more on <code>.as_count()</code> please see our blog post
-<a target="_blank" href="https://www.datadoghq.com/2014/05/visualize-statsd-metrics-counts-graphing/">here</a>.
+<a target="_blank" href="https://www.datadoghq.com/blog/visualize-statsd-metrics-counts-graphing/">here</a>.
 -->
 
 この他にも、クエリ結果に適用する上級者向けの関数が幾つかあります。
@@ -169,7 +169,7 @@ future. For more on <code>.as_count()</code> please see our blog post
 
 ``.rollup()``と``.as_count（）``を同じクエリで使用しないでください。
 また、将来的にはこれらの関数は、グラフエディターで簡単に操作できるようになる予定です(``.rollup()``は利用可能です)。
-``as_count()``に関する詳しい情報は、["Visualize StatsD metrics with Counts Graphing"](https://www.datadoghq.com/2014/05/visualize-statsd-metrics-counts-graphing/)のブログを参照してください。
+``as_count()``に関する詳しい情報は、["Visualize StatsD metrics with Counts Graphing"](https://www.datadoghq.com/blog/visualize-statsd-metrics-counts-graphing/)のブログを参照してください。
 
 <!-- #### Aggregation Method -->
 #### データポイントの集計

--- a/content/ja/guides/overview.md
+++ b/content/ja/guides/overview.md
@@ -127,7 +127,7 @@ The Event Stream is based on the same conventions as a blog:
 <ul>
 <li>Every event in the stream can be commented on.</li>
 <li>Great for distributed <a target="_blank" href="/faq/#team">teams</a> and maintaining the focus of an investigation</li>
-<li>You can <a target="_blank" href="https://www.datadoghq.com/2014/05/filter-datadog-events-stream-pinpoint-events-infrastructure/">filter</a>
+<li>You can <a target="_blank" href="https://www.datadoghq.com/blog/filter-datadog-events-stream-pinpoint-events-infrastructure/">filter</a>
 by: user, source, tag, host, status, priority, incident</li>
 </ul>
 
@@ -156,7 +156,7 @@ Eventの掲載は、ブログと同じ規則に基づいています:
 <ul>
 <li>ストリーム内のすべてのEventにはコメントを付けることができます。</li>
 <li>分散した<a target="_blank" href="/ja/faq/#team">チーム</a>や、問題の調査時に問題点をフォーカスするのに便利です。</li>
-<li>by: user, source, tag, host, status, priority, incident 等の項目で、<a target="_blank" href="https://www.datadoghq.com/2014/05/filter-datadog-events-stream-pinpoint-events-infrastructure/">フィルタリング</a>することができます。</li>
+<li>by: user, source, tag, host, status, priority, incident 等の項目で、<a target="_blank" href="https://www.datadoghq.com/blog/filter-datadog-events-stream-pinpoint-events-infrastructure/">フィルタリング</a>することができます。</li>
 </ul>
 
 <img src="/static/images/event_stream_post_incident_history.png" style="width:100%; border:1px solid #777777"/>
@@ -186,7 +186,7 @@ Dashboards contain <a target="_blank" href="/graphing/">graphs</a> with real-tim
 <li>As you hover over the graph the event stream moves with you.</li>
 <li>Display by zone, host, or total usage.</li>
 <li>We expose the JSON editor of the graph allowing for <a target="_blank" href="http://docs.datadoghq.com/graphing/#functions">arithmetic</a> and
-<a target="_blank" href="https://www.datadoghq.com/2014/04/rank-filter-performance-monitoring-metrics-top-function/">functions</a> to be applied to metrics.</li>
+<a target="_blank" href="https://www.datadoghq.com/blog/rank-filter-performance-monitoring-metrics-top-function/">functions</a> to be applied to metrics.</li>
 <li>Share a graph snapshot that will appear in the stream; clicking on
 that snapshot returns you to the original dashboard (via the camera in the upper right of a graph).</li>
 <li>Graphs can be embedded in an iframe, giving a 3rd party a live graph
@@ -205,7 +205,7 @@ without access to your data or any other information (via the pencil in the uppe
 <li>グラフ上で"Click & drag"することによって、時間軸を変更することができます。</li>
 <li>グラフ上でカーソルを移動することによって、Eventストリームの表示も該当箇所へ自動的に移動していきます。</li>
 <li>zone, host, total usageで、表示することができます。</li>
-<li>グラフ内に表示するメトリクスの<a target="_blank" href="/ja/graphing/#functions">計算</a>や<a target="_blank" href="https://www.datadoghq.com/2014/04/rank-filter-performance-monitoring-metrics-top-function/">統計</a>を可能にするために、JSON editorを画面上に設置しています。</li>
+<li>グラフ内に表示するメトリクスの<a target="_blank" href="/ja/graphing/#functions">計算</a>や<a target="_blank" href="https://www.datadoghq.com/blog/rank-filter-performance-monitoring-metrics-top-function/">統計</a>を可能にするために、JSON editorを画面上に設置しています。</li>
 <li>グラフのスナップショットをEventストリームで共有することができます。Eventストリームに掲載されたスナップショットを"Click"すると、そのグラフが表示されているダッシュボードに移動することができます。(グラフ右上のカメラマークから)</li>
 <li>グラフは、iframeに挿入することができます。この機能を使い、基礎データや他の情報を隠蔽したまま、第３者に<!-- ライブな -->グラフを公開することができます。(グラフ右上の鉛筆マークから)</li>
 </ul>

--- a/content/ja/integrations/aws.md
+++ b/content/ja/integrations/aws.md
@@ -211,4 +211,4 @@ When installing the agent on an aws host, you might see duplicated hosts on the 
    [2]: https://app.datadoghq.com/account/settings#integrations/amazon_web_services
 
    [6]: mailto:support@datadoghq.com
-   [7]: http://www.datadoghq.com/2013/10/dont-fear-the-agent
+   [7]: http://www.datadoghq.com/blog/dont-fear-the-agent

--- a/content/ja/integrations/bitbucket.md
+++ b/content/ja/integrations/bitbucket.md
@@ -28,6 +28,6 @@ doclevel: basic
 - コードの変更に関し、Datadogのイベントストリーム上でチャット可能にします
 
 
-<!-- We've written extensively about the Bitbuck integration on our [blog](https://www.datadoghq.com/2014/06/understand-code-changes-impact-system-performance-bitbucket-datadog/). -->
+<!-- We've written extensively about the Bitbuck integration on our [blog](https://www.datadoghq.com/blog/understand-code-changes-impact-system-performance-bitbucket-datadog/). -->
 
-Datadog blogの[「Understand how code changes impact system performance with Bitbucket and Datadog」](https://www.datadoghq.com/2014/06/understand-code-changes-impact-system-performance-bitbucket-datadog/)に於いても、Bitbucketインテグレーションに関して詳しく記述しています。こちらも合わせてご参照下さい。
+Datadog blogの[「Understand how code changes impact system performance with Bitbucket and Datadog」](https://www.datadoghq.com/blog/understand-code-changes-impact-system-performance-bitbucket-datadog/)に於いても、Bitbucketインテグレーションに関して詳しく記述しています。こちらも合わせてご参照下さい。

--- a/content/ja/integrations/desk.md
+++ b/content/ja/integrations/desk.md
@@ -38,7 +38,7 @@ Fill out the form as shown, leaving the latter two URL fields blank. Desk should
 
 Then from your Datadog account, enter the corresponding information on the [Desk tile](https://app.datadoghq.com/account/settings#integrations/desk). You will also need to enter your company's unique Desk domain name.
 
-Hit the install button, and then you're all set! You will soon be able to select desk.* metrics on a custom dashboard or view them on the provided [Desk dashboard](https://app.datadoghq.com/screen/integration/desk). (You can also read about this integration on [our blog](https://www.datadoghq.com/2015/02/keep-support-team-page-salesforce-desk-integration/).) -->
+Hit the install button, and then you're all set! You will soon be able to select desk.* metrics on a custom dashboard or view them on the provided [Desk dashboard](https://app.datadoghq.com/screen/integration/desk). (You can also read about this integration on [our blog](https://www.datadoghq.com/blog/keep-support-team-page-salesforce-desk-integration/).) -->
 
 ### 設定
 {:#int-configuration}
@@ -54,4 +54,4 @@ Deskのアカウントにログインし、`Setting` -> `API` -> `My Application
 
 最後に、`install`ボタンをクリックすると設定は終了です。しばらくすると、Deskから取得したメトリクス( desk.* )をカスタムダッシュボードで選択出来るようになります。又、予めDeskインテグレーションに備え付けられた[ダッシュボード](https://app.datadoghq.com/screen/integration/desk)でも、メトリクスが表示されるようになります。
 
-Deskのインテグレーションに関しては、blog記事[「Keep support on the same page with the Salesforce Desk integration」](https://www.datadoghq.com/2015/02/keep-support-team-page-salesforce-desk-integration/)でも紹介しています。
+Deskのインテグレーションに関しては、blog記事[「Keep support on the same page with the Salesforce Desk integration」](https://www.datadoghq.com/blog/keep-support-team-page-salesforce-desk-integration/)でも紹介しています。

--- a/content/ja/integrations/docker.md
+++ b/content/ja/integrations/docker.md
@@ -29,16 +29,16 @@ Dockerからリアルタイムにメトリクスを取得する目的は:
 
 <!-- We've written two in depth blog posts on Datadog and Docker::
 
-* <a target="_blank" href="https://www.datadoghq.com/2014/06/docker-ize-datadog/">
+* <a target="_blank" href="https://www.datadoghq.com/blog/docker-performance-datadog/">
 Dockerize Datadog</a>
-* <a target="_blank" href="https://www.datadoghq.com/2014/06/monitor-docker-datadog/">
+* <a target="_blank" href="https://www.datadoghq.com/blog/monitor-docker-datadog/">
 Monitor Docker with Datadog</a> -->
 
 DatadogとDockerについて詳しく書いたブログを掲載しています:
 
-* <a target="_blank" href="https://www.datadoghq.com/2014/06/docker-ize-datadog/">
+* <a target="_blank" href="https://www.datadoghq.com/blog/docker-performance-datadog/">
 Dockerize Datadog</a>
-* <a target="_blank" href="https://www.datadoghq.com/2014/06/monitor-docker-datadog/">
+* <a target="_blank" href="https://www.datadoghq.com/blog/monitor-docker-datadog/">
 Monitor Docker with Datadog</a>
 
 ブログの日本語訳:

--- a/content/ja/integrations/vmware.md
+++ b/content/ja/integrations/vmware.md
@@ -27,8 +27,8 @@ Install the Datadog VMware vSphere integration to:
 - vSphereメトリクスにつてイベントストーリーやグラフ上でチームメンバーで検討し、作業を進める
 
 
-<!-- We also have an awesome blog post on vSphere which can be seen [here](https://www.datadoghq.com/2014/08/unified-vsphere-app-monitoring-datadog/). -->
-vSphereに関するblog記事を準備しています。[「Unified vSphere and app monitoring with Datadog」](https://www.datadoghq.com/2014/08/unified-vsphere-app-monitoring-datadog/)も一読してみてください。
+<!-- We also have an awesome blog post on vSphere which can be seen [here](https://www.datadoghq.com/blog/unified-vsphere-app-monitoring-datadog/). -->
+vSphereに関するblog記事を準備しています。[「Unified vSphere and app monitoring with Datadog」](https://www.datadoghq.com/blog/unified-vsphere-app-monitoring-datadog/)も一読してみてください。
 
 <!-- The following metrics are collected by default with the VMware integration (for more info, please see [here](https://github.com/DataDog/dd-agent/blob/v5.0.2/checks/libs/vmware/basic_metrics.py)):
 

--- a/content/ja/overview.md
+++ b/content/ja/overview.md
@@ -128,7 +128,7 @@ The Event Stream is based on the same conventions as a blog:
 <ul>
 <li>Every event in the stream can be commented on.</li>
 <li>Great for distributed <a target="_blank" href="/faq/#team">teams</a> and maintaining the focus of an investigation</li>
-<li>You can <a target="_blank" href="https://www.datadoghq.com/2014/05/filter-datadog-events-stream-pinpoint-events-infrastructure/">filter</a>
+<li>You can <a target="_blank" href="https://www.datadoghq.com/blog/filter-datadog-events-stream-pinpoint-events-infrastructure/">filter</a>
 by: user, source, tag, host, status, priority, incident</li>
 </ul>
 
@@ -156,7 +156,7 @@ Eventの掲載は、ブログと同じ規則に基づいています:
 <ul>
 <li>ストリーム内のすべてのEventにはコメントを付けることができます。</li>
 <li>分散した<a target="_blank" href="/ja/faq/#team">チーム</a>や、問題の調査時に問題点をフォーカスするのに便利です。</li>
-<li>by: user, source, tag, host, status, priority, incident 等の項目で、<a target="_blank" href="https://www.datadoghq.com/2014/05/filter-datadog-events-stream-pinpoint-events-infrastructure/">フィルタリング</a>することができます。</li>
+<li>by: user, source, tag, host, status, priority, incident 等の項目で、<a target="_blank" href="https://www.datadoghq.com/blog/filter-datadog-events-stream-pinpoint-events-infrastructure/">フィルタリング</a>することができます。</li>
 </ul>
 
 <img src="/static/images/event_stream_post_incident_history.png" style="width:100%; border:1px solid #777777"/>
@@ -186,7 +186,7 @@ Dashboards contain <a target="_blank" href="/graphing/">graphs</a> with real-tim
 <li>As you hover over the graph the event stream moves with you.</li>
 <li>Display by zone, host, or total usage.</li>
 <li>We expose the JSON editor of the graph allowing for <a target="_blank" href="http://docs.datadoghq.com/graphing/#functions">arithmetic</a> and
-<a target="_blank" href="https://www.datadoghq.com/2014/04/rank-filter-performance-monitoring-metrics-top-function/">functions</a> to be applied to metrics.</li>
+<a target="_blank" href="https://www.datadoghq.com/blog/rank-filter-performance-monitoring-metrics-top-function/">functions</a> to be applied to metrics.</li>
 <li>Share a graph snapshot that will appear in the stream; clicking on
 that snapshot returns you to the original dashboard (via the camera in the upper right of a graph).</li>
 <li>Graphs can be embedded in an iframe, giving a 3rd party a live graph
@@ -204,7 +204,7 @@ without access to your data or any other information (via the pencil in the uppe
 <li>グラフ上で"Click & drag"することによって、時間軸を変更することができます。</li>
 <li>グラフ上でカーソルを移動することによって、Eventストリームの表示も該当箇所へ自動的に移動していきます。</li>
 <li>zone, host, total usageで、表示することができます。</li>
-<li>グラフ内に表示するメトリクスの<a target="_blank" href="/ja/graphing/#functions">計算</a>や<a target="_blank" href="https://www.datadoghq.com/2014/04/rank-filter-performance-monitoring-metrics-top-function/">統計</a>を可能にするために、JSON editorを画面上に設置しています。</li>
+<li>グラフ内に表示するメトリクスの<a target="_blank" href="/ja/graphing/#functions">計算</a>や<a target="_blank" href="https://www.datadoghq.com/blog/rank-filter-performance-monitoring-metrics-top-function/">統計</a>を可能にするために、JSON editorを画面上に設置しています。</li>
 <li>グラフのスナップショットをEventストリームで共有することができます。Eventストリームに掲載されたスナップショットを"Click"すると、そのグラフが表示されているダッシュボードに移動することができます。(グラフ右上のカメラマークから)</li>
 <li>グラフは、iframeに挿入することができます。この機能を使い、基礎データや他の情報を隠蔽したまま、第３者に<!-- ライブな -->グラフを公開することができます。(グラフ右上の鉛筆マークから)</li>
 </ul>

--- a/content/partials/graphingfunctions.md
+++ b/content/partials/graphingfunctions.md
@@ -39,7 +39,7 @@ Function               | Category      | Description
 
 **`.as_count()` & `.as_rate()`**
 
-These functions are only intended for metrics submitted as rates or counters via statsd. These functions will have no effect for other metric types. For more on details about how to use `.as_count()` and `.as_rate()` please see [our blog post](https://www.datadoghq.com/2014/05/visualize-statsd-metrics-counts-graphing/).
+These functions are only intended for metrics submitted as rates or counters via statsd. These functions will have no effect for other metric types. For more on details about how to use `.as_count()` and `.as_rate()` please see [our blog post](https://www.datadoghq.com/blog/visualize-statsd-metrics-counts-graphing/).
 
 **Rollup**
 


### PR DESCRIPTION
https://trello.com/c/cICEVRPU/1240-fyi-broken-link-http-docs-datadoghq-com-guides-overview-dashboards-line-we-expose-the-json-editor-of-the-graph-allowing-for-arit

Old style blog links led to 404 page.