### PR TITLE
Update No Data timeframe default for monitor API

### DIFF
--- a/content/api/index.html
+++ b/content/api/index.html
@@ -605,9 +605,9 @@ kind: documentation
 
               <li><code>no_data_timeframe</code> the number of minutes before a
               monitor will notify when data stops reporting. Must be at least
-              2x the monitor timeframe for metric alerts or 2 minutes for
+              1x the monitor timeframe for metric alerts or 2 minutes for
               service checks.
-              <p>Default: <code>2x timeframe for metric alerts, 2 minutes for
+              <p>Default: <code>1x timeframe for metric alerts, 2 minutes for
               service checks</code></p></li>
 
               <li><code>timeout_h</code> the number of hours of the monitor not


### PR DESCRIPTION
Currently if a monitor is created without the no_data_timeframe option, it defaults to 1x the alert timeframe, rather than 2x