### PR TITLE
Clarified group_states, added usage to example code

### DIFF
--- a/code_snippets/api-monitor-show.py
+++ b/code_snippets/api-monitor-show.py
@@ -8,4 +8,4 @@ options = {
 initialize(**options)
 
 # Get a monitor's details
-api.Monitor.get(2081)
+api.Monitor.get(2081, group_states='all')

--- a/code_snippets/api-monitor-show.rb
+++ b/code_snippets/api-monitor-show.rb
@@ -7,4 +7,4 @@ app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
 dog = Dogapi::Client.new(api_key, app_key)
 
 # Get a monitors's details
-dog.get_monitor(91879)
+dog.get_monitor(91879, :group_states => 'all')

--- a/code_snippets/api-monitor-show.sh
+++ b/code_snippets/api-monitor-show.sh
@@ -14,4 +14,5 @@ monitor_id=$(curl -X POST -H "Content-type: application/json" \
 
 curl -G "https://app.datadoghq.com/api/v1/monitor/${monitor_id}" \
      -d "api_key=${api_key}" \
-     -d "application_key=${app_key}"
+     -d "application_key=${app_key}" \
+     -d "group_states=all"

--- a/code_snippets/results/result.api-monitor-show.py
+++ b/code_snippets/results/result.api-monitor-show.py
@@ -1,15 +1,35 @@
-{'id': 2081,
- 'message': 'We may need to add web hosts if this is consistently high.',
- 'name': 'Bytes received on host0',
- 'options': {'no_data_timeframe': 20,
-  'notify_audit': False,
-  'notify_no_data': True,
-  'silenced': {}},
- 'org_id': 2,
- 'overall_state': 'No Data',
- 'query': 'avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 100',
- 'type': 'metric alert',
- 'multi': False,
- 'created': '2015-12-18T16:34:14.014039+00:00',
- 'modified': '2015-12-18T16:34:14.014039+00:00'
+{
+  'id': 2081,
+  'message': 'We may need to add web hosts if this is consistently high.',
+  'name': 'Bytes received on host0',
+  'options': {
+    'no_data_timeframe': 20,
+    'notify_audit': False,
+    'notify_no_data': True,
+    'silenced': {}
+  },
+  'org_id': 2,
+  'overall_state': 'No Data',
+  'query': 'avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 100',
+  'type': 'metric alert',
+  'multi': False,
+  'created': '2015-12-18T16:34:14.014039+00:00',
+  'modified': '2015-12-18T16:34:14.014039+00:00',
+  "state": {
+    "groups": {
+      "host:host0": {
+        "last_nodata_ts": null,
+        "last_notified_ts": 1481909160,
+        "last_resolved_ts": 1481908200,
+        "last_triggered_ts": 1481909160,
+        "name": "host:host0",
+        "status": "Alert",
+        "triggering_value": {
+          "from_ts": 1481909037,
+          "to_ts": 1481909097,
+          "value": 1000
+        }
+      }
+    }
+  }
 }

--- a/code_snippets/results/result.api-monitor-show.rb
+++ b/code_snippets/results/result.api-monitor-show.rb
@@ -1,11 +1,36 @@
 ["200",
- {"name"=>"Bytes received on host0",
-  "org_id"=>1499,
-  "options"=>{"notify_no_data"=>false, "notify_audit"=>false, "silenced"=>{}},
-  "query"=>"avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 100",
-  "message"=>"We may need to add web hosts if this is consistently high.",
-  "type"=>"metric alert",
-  "id"=>91879,
-  "multi"=>false,
-  "created"=>"2015-12-18T16:34:14.014039+00:00",
-  "modified"=>"2015-12-18T16:34:14.014039+00:00"}]
+  {
+    "name"=>"Bytes received on host0",
+    "org_id"=>1499,
+    "options"=>{
+      "no_data_timeframe"=>20,
+      "notify_no_data"=>false,
+      "notify_audit"=>false,
+      "silenced"=>{}
+    },
+    "query"=>"avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 100",
+    "message"=>"We may need to add web hosts if this is consistently high.",
+    "type"=>"metric alert",
+    "id"=>91879,
+    "multi"=>false,
+    "created"=>"2015-12-18T16:34:14.014039+00:00",
+    "modified"=>"2015-12-18T16:34:14.014039+00:00",
+    "state"=>{
+      "groups"=>{
+        "host:host0"=>{
+          "last_nodata_ts"=>null,
+          "last_notified_ts"=>1481909160,
+          "last_resolved_ts"=>1481908200,
+          "last_triggered_ts"=>1481909160,
+          "name"=>"host:host0",
+          "status"=>"Alert",
+          "triggering_value"=>{
+            "from_ts"=>1481909037,
+            "to_ts"=>1481909097,
+            "value"=>1000
+          }
+        }
+      }
+    }
+  }
+]

--- a/code_snippets/results/result.api-monitor-show.sh
+++ b/code_snippets/results/result.api-monitor-show.sh
@@ -1,16 +1,34 @@
 {
-    "id": 91879,
-    "message": "We may need to add web hosts if this is consistently high.",
-    "name": "Bytes received on host0",
-    "options": {
-        "notify_audit": false,
-        "notify_no_data": false,
-        "silenced": {}
-    },
-    "org_id": 1499,
-    "query": "avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 100",
-    "type": "metric alert",
-    "multi": false,
-    "created": "2015-12-18T16:34:14.014039+00:00",
-    "modified": "2015-12-18T16:34:14.014039+00:00"
+  "id": 91879,
+  "message": "We may need to add web hosts if this is consistently high.",
+  "name": "Bytes received on host0",
+  "options": {
+    'no_data_timeframe': 20,
+    "notify_audit": false,
+    "notify_no_data": false,
+    "silenced": {}
+  },
+  "org_id": 1499,
+  "query": "avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 100",
+  "type": "metric alert",
+  "multi": false,
+  "created": "2015-12-18T16:34:14.014039+00:00",
+  "modified": "2015-12-18T16:34:14.014039+00:00",
+  "state": {
+    "groups": {
+      "host:host0": {
+        "last_nodata_ts": null,
+        "last_notified_ts": 1481909160,
+        "last_resolved_ts": 1481908200,
+        "last_triggered_ts": 1481909160,
+        "name": "host:host0",
+        "status": "Alert",
+        "triggering_value": {
+          "from_ts": 1481909037,
+          "to_ts": 1481909097,
+          "value": 1000
+        }
+      }
+    }
+  }
 }

--- a/content/api/index.html
+++ b/content/api/index.html
@@ -710,9 +710,14 @@ kind: documentation
       <%= left_side_div %>
         <h5>Arguments</h5>
         <ul class="arguments">
-          <%= argument 'group_states', "A comma-separated string indicating
-          what, if any, group states to include. Choose from one or more from
-          'all', 'alert', 'warn', or 'no data'. Example: 'alert,warn'",
+          <%= argument 'group_states', "If this argument is
+          set, the returned data will include additional information (if
+          available) regarding the specified group states, including the
+          last notification timestamp, last resolution timestamp and
+          details about the last time the monitor was triggered. The
+          argument should include a string list indicating what, if any,
+          group states to include. Choose one or more from 'all', 'alert',
+          'warn', or 'no data'. Example: 'alert,warn'",
           :default => "None" %>
         </ul>
       </div>
@@ -791,9 +796,14 @@ kind: documentation
       <%= left_side_div %>
         <h5>Arguments</h5>
         <ul class="arguments">
-          <%= argument 'group_states', "A string list indicating
-          what, if any, group states to include. Choose from one or more from
-          'all', 'alert', 'warn', or 'no data'. Example: 'alert,warn'",
+          <%= argument 'group_states', "If this argument is
+          set, the returned data will include additional information (if
+          available) regarding the specified group states, including the
+          last notification timestamp, last resolution timestamp and
+          details about the last time the monitor was triggered. The
+          argument should include a string list indicating what, if any,
+          group states to include. Choose one or more from 'all', 'alert',
+          'warn', or 'no data'. Example: 'alert,warn'",
           :default => "None" %>
           <%= argument 'name', "A string to filter monitors by name",
           :default => "None" %>


### PR DESCRIPTION
https://trello.com/c/vpaR4DLe/1208-update-get-all-monitors-function-arguments-definition-in-ruby

Because group_states isn't clear (and a bit hard to describe), I updated the argument description (both get_monitor and get_all_monitors) and added it to the example in the get_monitor function.