### PR TITLE
Add note that k8s service discovery format starts with 5.11

### DIFF
--- a/content/guides/servicediscovery.md
+++ b/content/guides/servicediscovery.md
@@ -171,7 +171,7 @@ For example, if a container has this label configured as `com.datadoghq.sd.check
 
 ## Configuration templates with Kubernetes annotations
 
-If you're using Kubernetes to orchestrate your containers, you can use Kubernetes pod annotations to store your configuration templates. The basic format looks similar to the structure used in the key-value store configuration above, but for Kubernetes it takes the form:
+As of version 5.11 of the Datadog Agent, you can use Kubernetes pod annotations to store your configuration templates. Follow the [Kubernetes integration instructions](/integrations/kubernetes/), then add annotations to your pod definitions. The basic format looks similar to the structure used in the key-value store configuration above, but for Kubernetes it takes the form:
 
     annotations:
       service-discovery.datadoghq.com.<Kubernetes Container Name>.check_names: '["check_name_0"]'


### PR DESCRIPTION
https://trello.com/c/F7qTWQOy/1261-add-clarification-around-agent-version-5-11-and-sd-env-vars-in-k8s-section-of-sd-docs