### PR TITLE
Remove inverse class, add color to mobile menu

### DIFF
--- a/content/static/css/style.scss
+++ b/content/static/css/style.scss
@@ -150,9 +150,13 @@ ol.outline {
     width: 215px;
   }
 }
-.navbar-toggle{
+.navbar-toggle {
   margin-top: 8px;
   margin-bottom:0;
+  border-color: $gray;
+  .icon-bar {
+    background-color: $gray;
+  }
 }
 .nav {
   .search {

--- a/layouts/_header-ja.html
+++ b/layouts/_header-ja.html
@@ -1,5 +1,5 @@
 <!-- HEADER -->
-<div class="navbar navbar-inverse navbar-static-top">
+<div class="navbar navbar-static-top">
   <div class="container">
     <div class="<% unless @fluid %>row<% else %>row<% end %>">
       <div class="navbar-header">

--- a/layouts/_header.html
+++ b/layouts/_header.html
@@ -1,5 +1,5 @@
 <!-- HEADER -->
-<div class="navbar navbar-inverse navbar-static-top">
+<div class="navbar navbar-static-top">
   <div class="container">
     <div class="navbar-header">
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#topmenu" aria-expanded="false">


### PR DESCRIPTION
It appears the .navbar-inverse class was added to the menu in order to get the hamburger icon to appear when the site is in the narrowest breakpoint. This leads to the nav items going white on white. I've removed the class and simply styled the hamburger to be grey.

See https://trello.com/c/X1J7FKjG/1294-fix-css-menu-colors