### PR TITLE
Added filter

### DIFF
--- a/Rules
+++ b/Rules
@@ -158,8 +158,8 @@ compile '*' do
 
     unless id.match('/api/')
       filter :header_links
+      filter :insert_common_links
     end
-
     case
 
     # when id.match('/ja/guides/basic_agent_usage/')

--- a/config.yaml
+++ b/config.yaml
@@ -85,3 +85,6 @@ redirects:
   - from:  /guides/billing/
     to:    https://help.datadoghq.com/hc/en-us/sections/200705969-Billing/
 
+commonfilters:
+  - phrase: 'info command'
+    link: /guides/basic_agent_usage/ubuntu/

--- a/lib/filters/insert_common_links.rb
+++ b/lib/filters/insert_common_links.rb
@@ -1,0 +1,16 @@
+class Insert_Common_Links < Nanoc::Filter
+  identifier :insert_common_links
+
+  def run(content, params = {})
+    if @config.key?(:commonfilters)
+      if !@config[:commonfilters].to_a.empty?
+        @config[:commonfilters].each do |commonfilter|
+          phrase = commonfilter[:phrase]
+          link = "<a href='#{commonfilter[:link]}'>#{commonfilter[:phrase]}</a>"
+          content = content.gsub(phrase,link)
+        end
+      end
+      content
+    end
+  end
+end


### PR DESCRIPTION
Update common filters in config file to get links added to phrases in the docs

So the config yaml file has a phrase "info command" and a link that points to the agent guide. Now every mention of info command in the docs will get replaced with a [info command](http://docs.datadoghq.com/guides/basic_agent_usage/ubuntu/). You can add as many other phrase/link combos as you like. info command was the reason for adding this.