### PR TITLE
Auto populates ja directory with files that have no translation

### DIFF
--- a/Rules
+++ b/Rules
@@ -15,9 +15,11 @@
 #   because “*” matches zero or more characters.
 
 require './lib/rule_helper'
+require './lib/generate_ja_pages'
 require 'octokit'
 preprocess do
   create_redirect_pages
+  generate_ja_pages
   # def rchomp(sep = $/)
   #   self.start_with?(sep) ? self[sep.size..-1] : self
   # end

--- a/lib/generate_ja_pages.rb
+++ b/lib/generate_ja_pages.rb
@@ -1,0 +1,42 @@
+require 'pp'
+
+def generate_ja_pages
+  english_pages = (@items.select { |item| !(item.identifier.match('/ja')) && !(item.identifier.match('tipuesearch')) && !(item.identifier.match('/static')) && !(item.identifier.match('images'))}).collect { |item| item.identifier}
+  english_pages = english_pages - @config[:redirects].collect{|redirect| redirect[:from]}
+  japanese_pages = (@items.select { |item| (item.identifier.match('/ja')) && !(item.identifier.match('/static')) && !(item.identifier.match('images'))}).collect { |item| item.identifier.sub('/ja', '')}
+
+  missingpages = english_pages-japanese_pages
+
+
+
+  japanese_prefix = "<div class='alert alert-info'><strong>NOTICE:</strong> The following content has not yet been translated from English.</div>\n\n"
+  missingpages.each do |page|
+    newitem = @items[page]
+    content = newitem.raw_content
+    newtitle = newitem[:title]
+    # puts "************************************************"
+    # puts rawcontent
+    # puts "************************************************"
+    # newitem["language"] = "ja"
+    # newitem["translation_status"] = 'original'
+    # newitem.identifier = "/ja"+newitem.identifier
+    @items << Nanoc::Item.new(
+        japanese_prefix + content,
+        {
+          :translation_status => "original",
+          :title => newitem[:title],
+          :language => "ja",
+          :kind => newitem[:kind],
+          :listorder => newitem[:listorder],
+          :integration_title => newitem[:integration_title],
+          :git_integration_title => newitem[:git_integration_title],
+          :wistiaid => newitem[:wistiaid],
+          :tags => newitem[:tags],
+          :summary => newitem[:summary],
+          :binary => false,
+          :extension => newitem[:extension]
+        },
+        "/ja"+newitem.identifier
+      )
+  end
+end

--- a/lib/generate_ja_pages.rb
+++ b/lib/generate_ja_pages.rb
@@ -9,7 +9,7 @@ def generate_ja_pages
 
 
 
-  japanese_prefix = "<div class='alert alert-info'><strong>NOTICE:</strong> The following content has not yet been translated from English.</div>\n\n"
+  japanese_prefix = "<div class='alert alert-info'><strong>NOTICE:</strong> アクセスいただきありがとうございます。こちらのページは現在英語のみのご用意となっております。引き続き日本語化の範囲を広げてまいりますので、皆様のご理解のほどよろしくお願いいたします。</div>\n\n"
   missingpages.each do |page|
     newitem = @items[page]
     content = newitem.raw_content


### PR DESCRIPTION
function looks for all english pages, all japanese pages, and creates a list of pages that don't exist in japanese that do in english. Then it adds an item to the @items array that is the same as the english version except that the language metadata is 'ja' and it has a info block that says this is a translation.