### PR TITLE
fixing issue about creating unwanted files when running `rake` command

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -128,4 +128,26 @@ task :slow do
   Rake::Task[:guard].invoke
 end
 
+desc 'Enabing Japanese lang-assitant on'
+task :jp do
+  ENV['JPASSIST'] = "true"
+  Rake::Task[:guard].invoke
+end
+
+desc 'This is a slow connection, dont collect remote stuff with Japanese lang-assitant files'
+task :slowjp do
+  ENV['NANOCRUNSLOW'] = "true"
+  ENV['JPASSIST'] = "true"
+  Rake::Task[:guard].invoke
+end
+
+desc 'Removing Japanese lang-assitant files'
+task :rmjpfiles do
+  sh("rm -f updated_files.txt")
+  sh("rm -f autogen_files.log")
+end
+
+desc 'Clean and remove Japanese lang-assitant files'
+task cleanjp: [:clean, :rmjpfiles]
+
 task default: :guard

--- a/Rules
+++ b/Rules
@@ -19,7 +19,14 @@ require './lib/generate_ja_pages'
 require 'octokit'
 preprocess do
   create_redirect_pages
-  list_update_pages
+
+  if ENV.has_key?('JPASSIST')
+    $jpassist = true
+    list_update_pages
+  else
+    $jpassist = false
+  end
+
   generate_ja_pages
   # def rchomp(sep = $/)
   #   self.start_with?(sep) ? self[sep.size..-1] : self

--- a/lib/generate_ja_pages.rb
+++ b/lib/generate_ja_pages.rb
@@ -7,8 +7,10 @@ def generate_ja_pages
 
   missingpages = english_pages-japanese_pages
 
-  File.open("autogen_files.log", "w") do |f|
-    f.puts(missingpages)
+  if $jpassist then
+    File.open("autogen_files.log", "w") do |f|
+      f.puts(missingpages)
+    end
   end
 
   japanese_prefix = "<div class='alert alert-info'><strong>NOTICE:</strong> アクセスいただきありがとうございます。こちらのページは現在英語のみのご用意となっております。引き続き日本語化の範囲を広げてまいりますので、皆様のご理解のほどよろしくお願いいたします。</div>\n\n"


### PR DESCRIPTION
removed code block that generates Japanese lang-assistant files.
Generation block runs on `rake jp` and `rake slowjp` commands.
Cleaning up Japanese lang-assistant files with output dir is `rake cleanjp`.

related PR:
https://github.com/DataDog/documentation/pull/1114
https://github.com/DataDog/documentation/pull/1115