### PR TITLE
fix 'dog' binary path for splunk integration

### DIFF
--- a/content/integrations/splunk.md
+++ b/content/integrations/splunk.md
@@ -30,7 +30,7 @@ Once it is done, [get your api key and an application key](https://app.datadoghq
     #!/bin/bash
     export API_KEY=YOURAPIKEYHERE
     export APP_KEY=YOURAPPKEYHERE
-    dog --api-key $API_KEY --application-key $APP_KEY event post \
+    /opt/datadog-agent/bin/dog --api-key $API_KEY --application-key $APP_KEY event post \
     "Found $SPLUNK_ARG_1 events in splunk" \
     "Matching $SPLUNK_ARG_2 based on $SPLUNK_ARG_5," \
     " from report $SPLUNK_ARG_4. More details at $SPLUNK_ARG_6." \
@@ -56,7 +56,7 @@ If the trace file include a Traceback that ends with ```pkg_resources.Distributi
     unset LD_LIBRARY_PATH
     export API_KEY=YOURAPIKEYHERE
     export APP_KEY=YOURAPPKEYHERE
-    dog --api-key $API_KEY --application-key $APP_KEY event post \
+    /opt/datadog-agent/bin/dog --api-key $API_KEY --application-key $APP_KEY event post \
     "Found $SPLUNK_ARG_1 events in splunk" \
     "Matching $SPLUNK_ARG_2 based on $SPLUNK_ARG_5," \
     " from report $SPLUNK_ARG_4. More details at $SPLUNK_ARG_6." \

--- a/content/ja/integrations/splunk.md
+++ b/content/ja/integrations/splunk.md
@@ -36,7 +36,7 @@ Once it is done, [get your api key and an application key](https://app.datadoghq
     #!/bin/bash
     API_KEY= your_api_key
     APP_KEY= your_application_key
-    dog --api-key $API_KEY --application-key $APP_KEY event post \
+    /opt/datadog-agent/bin/dog --api-key $API_KEY --application-key $APP_KEY event post \
     "Found $SPLUNK_ARG_1 events in splunk" \
     "Matching $SPLUNK_ARG_2 based on $SPLUNK_ARG_5, from report $SPLUNK_ARG_4. More details at $SPLUNK_ARG_6." \
     --aggregation_key $SPLUNK_ARG_3 --type splunk
@@ -61,7 +61,7 @@ You can now configure your splunk reports to exectue this script in order to get
         #!/bin/bash
         API_KEY= your_api_key
         APP_KEY= your_application_key
-        dog --api-key $API_KEY --application-key $APP_KEY event post \
+        /opt/datadog-agent/bin/dog --api-key $API_KEY --application-key $APP_KEY event post \
         "Found $SPLUNK_ARG_1 events in splunk" \
         "Matching $SPLUNK_ARG_2 based on $SPLUNK_ARG_5, from report $SPLUNK_ARG_4. More details at $SPLUNK_ARG_6." \
         --aggregation_key $SPLUNK_ARG_3 --type splunk


### PR DESCRIPTION
This documentation hasn't changed in two years so this is probably a result of that. 

The example script refers to `dog` directly while the current binary absolute path of `/opt/datadog-agent/bin/dog` should be called instead. This is probably because at some points `dog` was inside `/usr/local/bin/dog`, part of $PATH, or was symlinked but is no longer there (sorry I haven't been using Datadog that long to know about past releases). 