### PR TITLE
Fix monitor downtime update bash example (API)

### DIFF
--- a/code_snippets/api-monitor-update-downtime.sh
+++ b/code_snippets/api-monitor-update-downtime.sh
@@ -2,7 +2,7 @@ api_key=9775a026f1ca7d1c6c5af9d94d9595a4
 app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
 downtime_id=4336
 
-# Create a downtime to delete
+# Create a downtime to update
 currenttime=$(date +%s)
 downtime_id=$(curl -X POST -H "Content-type: application/json" \
 -d "{


### PR DESCRIPTION
# Problem

The bash example, which updates a monitor downtime contains a bad comment. It creates a downtime which is then updated, but the comment line is referring to delete:

`# Create a downtime to delete`

# Solution

Update the comment in the example to 

`# Create a downtime to update`
