### PR TITLE
Args for metric metadata UPDATE are optional

### DIFF
--- a/content/api/index.html
+++ b/content/api/index.html
@@ -324,12 +324,12 @@ kind: documentation
 
         <h5>Arguments</h5>
         <ul class="arguments">
-          <%= argument("type", "metric type such as 'gauge' or 'rate'") %>
-          <%= argument("description", "string description of the metric") %>
-          <%= argument("short_name", "short name string of the metric") %>
-          <%= argument("unit", "primary unit of the metric such as 'byte' or 'operation'") %>
-          <%= argument("per_unit", "'per' unit of the metric such as 'second' in 'bytes per second'") %>
-          <%= argument("statsd_interval", "if applicable, statds flush interval in seconds for the metric") %>
+          <%= argument("type", "metric type such as 'gauge' or 'rate'", {:default => 'None'}) %>
+          <%= argument("description", "string description of the metric", {:default => 'None'}) %>
+          <%= argument("short_name", "short name string of the metric", {:default => 'None'}) %>
+          <%= argument("unit", "primary unit of the metric such as 'byte' or 'operation'", {:default => 'None'}) %>
+          <%= argument("per_unit", "'per' unit of the metric such as 'second' in 'bytes per second'", {:default => 'None'}) %>
+          <%= argument("statsd_interval", "if applicable, statds flush interval in seconds for the metric", {:default => 'None'}) %>
         </ul>
       </div>
       <%= right_side_div %>


### PR DESCRIPTION
Not passing a default value makes them required which isn't the case.
It would be nice to be able to mark args as optional w/out specifying a default value since this can be misleading.