### PR TITLE
API fix typo Get Screenboard

### DIFF
--- a/code_snippets/results/result.api-screenboard-get.py
+++ b/code_snippets/results/result.api-screenboard-get.py
@@ -2,7 +2,7 @@
  'created': '2015-12-17T21:29:40.890824+00:00',
  'modified': '2015-12-17T21:39:20.770834+00:00',
  'read_only': False,
- 'graphs': [{'height': 20,
+ 'widgets': [{'height': 20,
    'type': 'image',
    'url': 'https://path/to/image.jpg',
    'width': 32,


### PR DESCRIPTION
Ticket https://datadog.zendesk.com/agent/tickets/82652 figured out this typo in the python code snippet. Here is the concerned code http://docs.datadoghq.com/api/#screenboards-get https://cl.ly/252G1n1D1o1m