### PR TITLE
bug fix: In some case, formatmetrics() returens non UTF-8 codec.

### DIFF
--- a/lib/helpers_.rb
+++ b/lib/helpers_.rb
@@ -235,7 +235,7 @@ def formatmetrics(selectedmetrics)
     metrictable += "<tr><td>Metrics would go here if you didn't type rake slow</td></tr>"
   end
   metrictable += "</table>"
-  return metrictable
+  return metrictable.force_encoding("utf-8")
 end
 
 def get_units_from_git


### PR DESCRIPTION
And HTML compilation stops.

Issue#: 1207
Stops compilation, if I add "<%= get_metrics_from_git() %>" to a translated md file. #1207