### PR TITLE
Add option Further Reading section to Integration doc guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ Include a list of events if the integration provides any.
 
 Include a list of service checks if the integration provides any.
 
+### Further Reading
+**Optional**
+
+Include any links to Docs guides or Datadog blog articles that highlight the integration.
 
 # How to add a new Guide
 


### PR DESCRIPTION
Some of our docs reference Docs guides and Datadog blog posts related to the integration at hand, but these references are peppered throughout different sections of the READMEs in no orderly way.

What about adding an optional Further Reading section?