### PR TITLE
update trace port to 8126 in code snippets

### DIFF
--- a/code_snippets/trace-api-services.sh
+++ b/code_snippets/trace-api-services.sh
@@ -8,4 +8,4 @@ curl -X PUT -H "Content-type: application/json" \
       \"app_type\": \"web\"
     }
   }" \
-  http://localhost:7777/v0.3/services
+  http://localhost:8126/v0.3/services

--- a/code_snippets/trace-api-traces.sh
+++ b/code_snippets/trace-api-traces.sh
@@ -25,4 +25,4 @@ curl -X PUT -H "Content-type: application/json" \
     \"start\": $START,
     \"duration\": $DURATION
   }]]" \
-  http://localhost:7777/v0.3/traces
+  http://localhost:8126/v0.3/traces


### PR DESCRIPTION
The tracing api port was switched from 7777 to 8126 after the beta.