### PR TITLE
Update API doc: add some downtime parameters, add cancel by scope

### DIFF
--- a/code_snippets/api-monitor-cancel-downtime-by-scope.sh
+++ b/code_snippets/api-monitor-cancel-downtime-by-scope.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+api_key="9775a026f1ca7d1c6c5af9d94d9595a4"
+app_key="87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"
+
+curl -X POST -H "Content-type: application/json" -H "Accept: application/json" \
+-d "{
+      \"scope\": \"host:i-123\"
+   }" \
+   "https://app.datadoghq.com/api/v1/downtime/cancel/by_scope?api_key=${api_key}&application_key=${app_key}"

--- a/content/api/index.html
+++ b/content/api/index.html
@@ -1005,12 +1005,15 @@ kind: documentation
     <div class="row">
       <%= left_side_div %>
         <h5>Arguments</h5>
-          <%= argument 'scope', "The scope to which the downtime will apply, e.g.
-          'host:app2'." %>
-          <%= argument 'monitor_id', "A single monitor to which the downtime will apply.", :default=>"None" %>
-          <%= argument 'start', "POSIX timestamp to start the downtime. In the default case, the downtime will start immediately.", :default=>"None" %>
-          <%= argument 'end', "POSIX timestamp to end the downtime. In the
-          default case, the downtime will go until cancelled.",
+          <%= argument 'scope', "The scope(s) to which the downtime will apply, e.g.
+          'host:app2'. Provide multiple scopes as a comma-separated list, e.g. 'env:dev,env:prod'. The resulting downtime
+          applies to sources that matches ALL provided scopes (i.e. env:dev AND env:prod), NOT any of them." %>
+          <%= argument 'monitor_id', "A single monitor to which the downtime will apply. If no monitor_id is provided,
+          the downtime will apply to all monitors.", :default=>"None" %>
+          <%= argument 'start', "POSIX timestamp to start the downtime. If not provided, the downtime starts the moment
+          it is created.", :default=>"None" %>
+          <%= argument 'end', "POSIX timestamp to end the downtime. If not provided, the downtime will be active indefinitely
+          (or until cancelled).",
           :default => "None" %>
           <%= argument 'message', "A message to include with notifications for this downtime. Email notifications can be sent to specific users by using the same '@username' notation as events",
           :default => "None" %>
@@ -1062,12 +1065,15 @@ kind: documentation
         <h5>Arguments</h5>
           <%= argument 'id', "The integer id of the downtime to be updated" %>
           <%= argument 'scope', "The scope to which the downtime will apply, e.g.
-          'host:app2'.",
+          'host:app2'. Provide multiple scopes as a comma-separated list, e.g. 'env:dev,env:prod'. The resulting downtime
+          applies to anything that matches ALL scopes (i.e. scope1 && scope2..), not ANY scope (i.e. ||)",
           :default => "original scope" %>
-          <%= argument 'monitor_id', "A single monitor to which the downtime will apply.", :default=>"original monitor_id" %>
+          <%= argument 'monitor_id', "A single monitor to which the downtime will apply. If no monitor_id is provided,
+          the downtime will apply to all monitors.", :default=>"original monitor_id" %>
           <%= argument 'start', "POSIX timestamp to start the downtime",
           :default => "original start" %>
-          <%= argument 'end', "POSIX timestamp to end the downtime, or None if the downtime should continue until cancelled",
+          <%= argument 'end', "POSIX timestamp to end the downtime If not provided, the downtime will be active indefinitely
+          (or until cancelled).",
           :default => "original end" %>
           <%= argument 'message', "A message to include with notifications for this downtime. Email notifications can be sent to specific users by using the same '@username' notation as events",
           :default => "original message" %>
@@ -1136,7 +1142,7 @@ kind: documentation
     <div class="row">
       <%= left_side_div %>
         <h5>Arguments</h5>
-        <%= argument 'scope', "Cancel all downtimes with the given 'scope', where 'scope' may be a comma-separated list, e.g. 'role:db,db-slave'" %>
+        <%= argument 'scope', "Cancel all downtimes with the given scope(s), e.g. 'role:db,role:db-slave'." %>
       </div>
       <%= right_side_div %>
         <h5>Signature</h5>

--- a/content/api/index.html
+++ b/content/api/index.html
@@ -1005,8 +1005,9 @@ kind: documentation
     <div class="row">
       <%= left_side_div %>
         <h5>Arguments</h5>
-          <%= argument 'scope', "The scope to apply the downtime to, e.g.
-          'host:app2'" %>
+          <%= argument 'scope', "The scope to which the downtime will apply, e.g.
+          'host:app2'." %>
+          <%= argument 'monitor_id', "A single monitor to which the downtime will apply.", :default=>"None" %>
           <%= argument 'start', "POSIX timestamp to start the downtime. In the default case, the downtime will start immediately.", :default=>"None" %>
           <%= argument 'end', "POSIX timestamp to end the downtime. In the
           default case, the downtime will go until cancelled.",
@@ -1038,6 +1039,7 @@ kind: documentation
               </li>
             </ul>
           </li>
+          <%= argument 'timezone', "The timezone for the downtime.", :default => "UTC" %>
       </div>
       <%= right_side_div %>
         <h5>Signature</h5>
@@ -1059,9 +1061,10 @@ kind: documentation
       <%= left_side_div %>
         <h5>Arguments</h5>
           <%= argument 'id', "The integer id of the downtime to be updated" %>
-          <%= argument 'scope', "The scope to apply the downtime to, e.g.
-          'host:app2'",
+          <%= argument 'scope', "The scope to which the downtime will apply, e.g.
+          'host:app2'.",
           :default => "original scope" %>
+          <%= argument 'monitor_id', "A single monitor to which the downtime will apply.", :default=>"original monitor_id" %>
           <%= argument 'start', "POSIX timestamp to start the downtime",
           :default => "original start" %>
           <%= argument 'end', "POSIX timestamp to end the downtime, or None if the downtime should continue until cancelled",
@@ -1093,6 +1096,7 @@ kind: documentation
               </li>
             </ul>
           </li>
+          <%= argument 'timezone', "The timezone for the downtime.", :default => "original timezone" %>
       </div>
       <%= right_side_div %>
         <h5>Signature</h5>
@@ -1124,6 +1128,23 @@ kind: documentation
         <%= snippet_code_block "api-monitor-cancel-downtime.sh" %>
         <h5>Example Response</h5>
         <%= no_response %>
+      </div>
+    </div>
+
+    <!-- Cancel monitor downtime by scope -->
+    <div class="int-anchor" id="cancel-downtim-by-scope"></div><a href="#cancel-downtime-by-scope"><h4>Cancel monitor downtimes by scope</h4></a>
+    <div class="row">
+      <%= left_side_div %>
+        <h5>Arguments</h5>
+        <%= argument 'scope', "Cancel all downtimes with the given 'scope', where 'scope' may be a comma-separated list, e.g. 'role:db,db-slave'" %>
+      </div>
+      <%= right_side_div %>
+        <h5>Signature</h5>
+        <code>POST /api/v1/downtime/cancel/by_scope</code>
+        <h5>Example Request</h5>
+        <%= snippet_code_block "api-monitor-cancel-downtime-by-scope.sh" %>
+        <h5>Example Response</h5>
+        <code>{"cancelled_ids":[123456789,123456790]}</code>
       </div>
     </div>
 

--- a/content/api/index.html
+++ b/content/api/index.html
@@ -1008,11 +1008,11 @@ kind: documentation
           <%= argument 'scope', "The scope(s) to which the downtime will apply, e.g.
           'host:app2'. Provide multiple scopes as a comma-separated list, e.g. 'env:dev,env:prod'. The resulting downtime
           applies to sources that matches ALL provided scopes (i.e. env:dev AND env:prod), NOT any of them." %>
-          <%= argument 'monitor_id', "A single monitor to which the downtime will apply. If no monitor_id is provided,
+          <%= argument 'monitor_id', "A single monitor to which the downtime will apply. If not provided,
           the downtime will apply to all monitors.", :default=>"None" %>
           <%= argument 'start', "POSIX timestamp to start the downtime. If not provided, the downtime starts the moment
           it is created.", :default=>"None" %>
-          <%= argument 'end', "POSIX timestamp to end the downtime. If not provided, the downtime will be active indefinitely
+          <%= argument 'end', "POSIX timestamp to end the downtime. If not provided, the downtime will apply indefinitely
           (or until cancelled).",
           :default => "None" %>
           <%= argument 'message', "A message to include with notifications for this downtime. Email notifications can be sent to specific users by using the same '@username' notation as events",
@@ -1066,13 +1066,13 @@ kind: documentation
           <%= argument 'id', "The integer id of the downtime to be updated" %>
           <%= argument 'scope', "The scope to which the downtime will apply, e.g.
           'host:app2'. Provide multiple scopes as a comma-separated list, e.g. 'env:dev,env:prod'. The resulting downtime
-          applies to anything that matches ALL scopes (i.e. scope1 && scope2..), not ANY scope (i.e. ||)",
+          applies to sources that matches ALL provided scopes (i.e. env:dev AND env:prod), NOT any of them.",
           :default => "original scope" %>
-          <%= argument 'monitor_id', "A single monitor to which the downtime will apply. If no monitor_id is provided,
+          <%= argument 'monitor_id', "A single monitor to which the downtime will apply. If not provided,
           the downtime will apply to all monitors.", :default=>"original monitor_id" %>
-          <%= argument 'start', "POSIX timestamp to start the downtime",
+          <%= argument 'start', "POSIX timestamp to start the downtime.",
           :default => "original start" %>
-          <%= argument 'end', "POSIX timestamp to end the downtime If not provided, the downtime will be active indefinitely
+          <%= argument 'end', "POSIX timestamp to end the downtime. If not provided, the downtime will be active indefinitely
           (or until cancelled).",
           :default => "original end" %>
           <%= argument 'message', "A message to include with notifications for this downtime. Email notifications can be sent to specific users by using the same '@username' notation as events",

--- a/content/api/index.html
+++ b/content/api/index.html
@@ -1012,8 +1012,8 @@ kind: documentation
           the downtime will apply to all monitors.", :default=>"None" %>
           <%= argument 'start', "POSIX timestamp to start the downtime. If not provided, the downtime starts the moment
           it is created.", :default=>"None" %>
-          <%= argument 'end', "POSIX timestamp to end the downtime. If not provided, the downtime will apply indefinitely
-          (or until cancelled).",
+          <%= argument 'end', "POSIX timestamp to end the downtime. If not provided, the downtime will be in effect indefinitely
+          (i.e. until you cancel it).",
           :default => "None" %>
           <%= argument 'message', "A message to include with notifications for this downtime. Email notifications can be sent to specific users by using the same '@username' notation as events",
           :default => "None" %>
@@ -1072,8 +1072,8 @@ kind: documentation
           the downtime will apply to all monitors.", :default=>"original monitor_id" %>
           <%= argument 'start', "POSIX timestamp to start the downtime.",
           :default => "original start" %>
-          <%= argument 'end', "POSIX timestamp to end the downtime. If not provided, the downtime will be active indefinitely
-          (or until cancelled).",
+          <%= argument 'end', "POSIX timestamp to end the downtime. If not provided, the downtime will be in effect indefinitely
+          (i.e. until you cancel it).",
           :default => "original end" %>
           <%= argument 'message', "A message to include with notifications for this downtime. Email notifications can be sent to specific users by using the same '@username' notation as events",
           :default => "original message" %>


### PR DESCRIPTION
As requested in #1249. `evaluation_delay` is being added in #1253.

This also adds a newer endpoint `POST /api/v1/downtime/cancel/by_scope`, though I only have a shell example for it (our Python and Ruby libraries don't support it yet).