### PR TITLE
Clarify that AWS Account IDs should be entered without dashes.

### DIFF
--- a/content/integrations/aws.md
+++ b/content/integrations/aws.md
@@ -128,7 +128,7 @@ Note: The GovCloud and China regions do not currently support IAM role delegatio
 
 1.  Open the [AWS Integration tile](https://app.datadoghq.com/account/settings#integrations/amazon_web_services).
 2.  Select the **Role Delegation** tab.
-3.  Enter your AWS Account ID which can be found in the ARN of the newly created role. Then enter the name of the role you just created. Finally enter the External ID you specified above.
+3.  Enter your AWS Account ID **without dashes**, e.g. 123456789012, not 1234-5678-9012. Your Account ID can be found in the ARN of the newly created role. Then enter the name of the role you just created. Finally enter the External ID you specified above.
 4.  Choose the services you want to collect metrics for on the left side of the dialog. You can optionally add tags to all hosts and metrics. Also if you want to only monitor a subset of EC2 instances on AWS, tag them and specify the tag in the limit textbox here.
 5.  Click **Install Integration**.
 


### PR DESCRIPTION
As pointed out in #1289, using dashes is no good.