### PR TITLE
added way to specify platform specific metrics

### DIFF
--- a/content/integrations/disk.md
+++ b/content/integrations/disk.md
@@ -3,6 +3,11 @@ title: Datadog-Disk Integration
 integration_title: Disk Check
 kind: integration
 newhlevel: true
+platformmetrics:
+  system.disk.read_time_pct:
+    - Windows
+  system.disk.write_time_pct:
+    - Windows
 ---
 
 # Overview

--- a/content/integrations/network.md
+++ b/content/integrations/network.md
@@ -3,12 +3,25 @@ title: Network check
 integration_title: Network Check
 kind: integration
 newhlevel: true
+platformmetrics:
+  system.net.tcp.retrans_packs:
+    - BSD
+  system.net.tcp.sent_packs:
+    - BSD
+  system.net.tcp.rcv_packs:
+    - BSD
+  system.net.tcp.retrans_segs:
+    - Solaris
+  system.net.tcp.in_segs:
+    - Solaris
+  system.net.tcp.out_segs:
+    - Solaris
 ---
 # Overview
 
 ![Network Dashboard](/static/images/netdashboard.png)
 
-The network check collects TCP and IP network metrics from the agent's host. 
+The network check collects TCP and IP network metrics from the agent's host.
 
 
 # Configuration

--- a/lib/helpers_.rb
+++ b/lib/helpers_.rb
@@ -218,14 +218,35 @@ def get_metrics_from_git(itemintegration=@item[:git_integration_title], items_to
   return formatmetrics(selectedmetrics)
 end
 
+def arraytoenglishlist(inputarray)
+  outputstring = ""
+
+  if inputarray.size == 1
+    outputstring = inputarray[0]
+  elsif inputarray.size == 2
+    outputstring = "#{inputarray[0]} and #{inputarray[1]}"
+  elsif inputarray.size > 2
+    outputstring = "#{inputarray[0..-2].join(', ')}, and #{inputarray[-1]}"
+  end
+
+  return outputstring
+end
+
 def formatmetrics(selectedmetrics)
+  platformmetrics = @item.attributes.has_key?(:platformmetrics)?@item[:platformmetrics]:{}
   metrictable = "<table class='table'>"
   if $goodconnection
     selectedmetrics.each do |metric|
-      metrictable += "<tr><td><strong>#{metric[:name]}</strong><br/>(#{metric[:type]}"
+      platformexceptions = ""
+      if platformmetrics.has_key?(:"#{metric[:name]}")
+        platformexceptions = " <i>**#{arraytoenglishlist(platformmetrics[:"#{metric[:name]}"])} only</i>"
+      end
+
+      metrictable += "<tr><td><strong>#{metric[:name]}</strong>#{platformexceptions}<br/>(#{metric[:type]}"
       if metric[:interval]>0
         metrictable += " every #{metric[:interval]} seconds"
       end
+
       metrictable += ")</td><td>#{metric[:description].gsub '^', ' to the '}"
       metrictable += metric[:unit].length>0 ? "<br/><em>shown as #{metric[:unit]}" : "<em>"
       metrictable += metric[:per_unit].length>0 ? "/#{metric[:per_unit]}</em>" : "</em>"
@@ -235,6 +256,7 @@ def formatmetrics(selectedmetrics)
     metrictable += "<tr><td>Metrics would go here if you didn't type rake slow</td></tr>"
   end
   metrictable += "</table>"
+
   return metrictable.force_encoding("utf-8")
 end
 


### PR DESCRIPTION
add platformmetrics to the frontmatter and then the metric name followed by a list of platforms you can find that metric on and the metric name in the table will be followed by **platform only where platform is the name of the platform. If you specify Windows and Solaris, it will say  **Windows and Solaris only. If you have more than 2 platform, it puts the commas in the right way.

I added the metrics for disk and network that were mentioned in the card. But I am sure there are others.