### PR TITLE
markdown link was wrapped in li tags

### DIFF
--- a/content/integrations/java.md
+++ b/content/integrations/java.md
@@ -228,7 +228,7 @@ The `datadog-agent jmx` command was added in version 4.1.0.
 
 For more details about configuring this integration refer to the following file(s) on GitHub:
 
-<li> [Java/JMX YAML example](https://github.com/DataDog/dd-agent/blob/master/conf.d/jmx.yaml.example) </li>
+* [Java/JMX YAML example](https://github.com/DataDog/dd-agent/blob/master/conf.d/jmx.yaml.example)
 
 <!-- <%= insert_example_links(conf: "jmx", check: "none")%> -->
 


### PR DESCRIPTION
markdown in html is not converted unless overridden