### PR TITLE
Don't collect beta pages into sitemap.xml

### DIFF
--- a/content/sitemap.xml
+++ b/content/sitemap.xml
@@ -1,1 +1,1 @@
-<%= xml_sitemap %>
+<%= xml_sitemap :items => @items.reject{ |i| i[:beta] } %>

--- a/lib/generate_ja_pages.rb
+++ b/lib/generate_ja_pages.rb
@@ -1,7 +1,7 @@
 require 'pp'
 
 def generate_ja_pages
-  english_pages = (@items.select { |item| !(item.identifier.match('/ja')) && !(item.identifier.match('tipuesearch')) && !(item.identifier.match('/static')) && !(item.identifier.match('images'))}).collect { |item| item.identifier}
+  english_pages = (@items.select { |item| !(item.identifier.match('/ja')) && !(item.identifier.match('tipuesearch')) && !(item.identifier.match('/static')) && !(item.identifier.match('images')) && !item[:beta]}).collect { |item| item.identifier}
   english_pages = english_pages - @config[:redirects].collect{|redirect| redirect[:from]}
   japanese_pages = (@items.select { |item| (item.identifier.match('/ja')) && !(item.identifier.match('/static')) && !(item.identifier.match('images')) && !(item.identifier.match('/java'))}).collect { |item| item.identifier.sub('/ja', '')}
 


### PR DESCRIPTION
- Ignore beta pages when generating sitemap.xml file.
- Also skip beta pages from ja generation so the /ja page doesn't make
it in sitemap.xml either.