### PR TITLE
Remove threshold and window from TCP Check

### DIFF
--- a/content/integrations/tcpcheck.md
+++ b/content/integrations/tcpcheck.md
@@ -49,8 +49,6 @@ Edit the `tcp_check.yaml` file in your agent's `conf.d` directory. The following
 * `host` (Required) - Host to be checked. This will be included as a tag: `url:<host>:<port>`.
 * `port` (Required) - Port to be checked. This will be included as a tag: `url:<host>:<port>`.
 * `timeout` (Optional) - Timeout for the check. Defaults to 10 seconds.
-* `threshold` (Optional) - Used in conjunction with `window`. An alert will trigger if the check fails `<threshold>` times in `<window>` attempts.
-* `window` (Optional) - Refer to 'threshold'.
 * `collect_response_time` (Optional) - Defaults to false. If this is not set to true, no response time metric will be collected. If it is set to true, the metric returned is `network.tcp.response_time`.
 * `skip_event` (Optional) - Defaults to false. Set to true to skip creating an event. This option will be removed in a future version and will default to true.
 * `tags` (Optional) - Tags to be assigned to the metric.


### PR DESCRIPTION
The `window` and `threshold` parameters are deprecated in favor of service checks, already removed from default TCP yaml file - https://github.com/DataDog/integrations-core/pull/478