### PR TITLE
redirect broken tracing API links

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -96,6 +96,8 @@ redirects:
     to:    /guides/autodiscovery/
   - from: /videos/setuprailsapm/
     to:   /videos/apmsetup-rails/
+  - from: /tracing-api/
+    to:   /tracing/api/
 commonfilters:
   - phrase: 'info command'
     link: /guides/basic_agent_usage/ubuntu/


### PR DESCRIPTION
/tracing-api/ seems to be in the google search results for some reason but 404s. The correct page is /tracing-api/.