### PR TITLE
Add Lambda permissions for AWS integration

### DIFF
--- a/content/integrations/aws.md
+++ b/content/integrations/aws.md
@@ -94,6 +94,8 @@ Note: The GovCloud and China regions do not currently support IAM role delegatio
                 "es:DescribeElasticsearchDomains",
                 "kinesis:List*",
                 "kinesis:Describe*",
+                "lambda:ListFunctions",
+                "lambda:ListTags",
                 "logs:Get*",
                 "logs:Describe*",
                 "logs:FilterLogEvents",


### PR DESCRIPTION
Lambda permissions are required for Lambda integration to work properly

Fixes #1393 