### PR TITLE
[integration_sdk] Add details on unit and mock tests

### DIFF
--- a/content/guides/integration_sdk.md
+++ b/content/guides/integration_sdk.md
@@ -226,14 +226,14 @@ As you build your check and test code, you can use the following to run your tes
 
 Travis CI will automatically run tests when you create a pull request. Please ensure that you have thorough test coverage and that you are passing all tests prior to submitting pull requests.
 
-Please use the `@attr(requires='my_integration')` annotation on the test classes or methods that require a full docker testing environment (i.e. "integration" tests, see section below). Your unit and mock tests should not be annotated with this annotation, and will be run by `rake ci:run[default]`.
+Add the `@attr(requires='my_integration')` annotation on the test classes or methods that require a full docker testing environment (see next section).
+Don't add this annotation to your unit and mock tests ; those run via `rake ci:run[default]` on Travis CI.
 
 To iterate quickly on your unit and mock tests, instead of running all the tests with `rake ci:run[default]`, you can simply run:
 
 ~~~
-# shell
-source venv/bin/activate  # activate the python venv, you only need to run this once per shell
-bundle exec rake exec["nosetests my_integration/test_*.py -A 'not requires'"]   # run unit and mock tests
+# run unit and mock tests, in the virtualenv
+$ bundle exec rake exec["nosetests my_integration/test_*.py -A 'not requires'"]
 ~~~
 
 #### Docker test environments

--- a/content/guides/integration_sdk.md
+++ b/content/guides/integration_sdk.md
@@ -221,10 +221,20 @@ The [Datadog Agent](https://github.com/DataDog/dd-agent) provides a number of us
 As you build your check and test code, you can use the following to run your tests:
 
 - `rake lint`: Lint your code for potential errors
-- `rake ci:run[my_integration]`: Run the tests that you have created in your `test_my_integration.py` file.
-- `rake ci:run[default]`: Run the tests you have written in addition to some additional generic tests we have written.
+- `rake ci:run[my_integration]`: Run the tests that you have written in your `test_my_integration.py` file and that have an `@attr(requires='my_integration')` annotation.
+- `rake ci:run[default]`: Run the tests you have written written in your `test_my_integration.py` file (without the `@attr(requires='my_integration')` annotation) in addition to some additional generic tests we have written.
 
 Travis CI will automatically run tests when you create a pull request. Please ensure that you have thorough test coverage and that you are passing all tests prior to submitting pull requests.
+
+Please use the `@attr(requires='my_integration')` annotation on the test classes or methods that require a full docker testing environment (i.e. "integration" tests, see section below). Your unit and mock tests should not be annotated with this annotation, and will be run by `rake ci:run[default]`.
+
+To iterate quickly on your unit and mock tests, instead of running all the tests with `rake ci:run[default]`, you can simply run:
+
+~~~
+# shell
+source venv/bin/activate  # activate the python venv, you only need to run this once per shell
+bundle exec rake exec["nosetests my_integration/test_*.py -A 'not requires'"]   # run unit and mock tests
+~~~
 
 #### Docker test environments
 


### PR DESCRIPTION
Document the usage of the new `rake exec` command to run unit and mock tests quickly, and add details on the difference between integration tests and unit/mock tests (along with how they're being run in the CI).

We might improve this test workflow later, but for now `rake exec` should allow contributors to run their unit and mock tests quickly without all the overhead of `rake ci`.