### PR TITLE
remove extra beta content

### DIFF
--- a/content/guides/process.ja.md
+++ b/content/guides/process.ja.md
@@ -9,8 +9,6 @@ title: Datadog Process Monitoring
 <div class='alert alert-info'><strong>NOTICE:</strong>アクセスいただきありがとうございます。こちらのページは現在英語のみのご用意となっております。引き続き日本語化の範囲を広げてまいりますので、皆様のご理解のほどよろしくお願いいたします。</div>
 
 
-**Beta - For support or to report any issues, contact [process-support@datadoghq.com](mailto:process-support@datadoghq.com).**
-
 ### Introduction
 
 The new Datadog Process Monitor allows for real time process-level visibility. After installing a small secondary agent, information from a host’s /proc file system will be streamed into Datadog and presented in a table at [https://app.datadoghq.com/process](https://app.datadoghq.com/process).

--- a/content/guides/process.md
+++ b/content/guides/process.md
@@ -4,7 +4,6 @@ kind: guide
 listorder: 16
 beta: true
 ---
-**Beta - For support or to report any issues, contact [process-support@datadoghq.com](mailto:process-support@datadoghq.com).**
 
 ### Introduction
 

--- a/layouts/guides/single.html
+++ b/layouts/guides/single.html
@@ -8,7 +8,7 @@
     <div class="col-xs-12 col-sm-9 col-md-9 main">
       <h1 id="pagetitle">{{ .Title }}</h1>
       {{ if .Params.beta }}
-      <p><strong>Beta - For support or to report any issues, contact <a href="mailto:process-support@datadoghq.com">process-support@datadoghq.com</a>.</strong></p>
+      <p><strong>Beta - For support or to report any issues, contact <a href="mailto:support@datadoghq.com">support@datadoghq.com</a>.</strong></p>
       {{ end }}
       {{.Content}}
     </div>

--- a/layouts/partials/meta-http-equiv.html
+++ b/layouts/partials/meta-http-equiv.html
@@ -1,3 +1,1 @@
 <meta http-equiv="refresh" content="0;url={{ .Params.external_redirect }}">
-
-Beta - For support or to report any issues, contact process-support@datadoghq.com.


### PR DESCRIPTION
Remove duplicate beta disclaimers

testing:
https://d2cx6t4ssmwdrv.cloudfront.net/michaelw/remove-duplicate-beta/guides/process/
vs
https://docs.datadoghq.com/guides/process/