### PR TITLE
rollback expensive loop

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -73,25 +73,11 @@
     {{ if eq .Params.Kind "integration" }}
       <li class="nav-header">{{ i18n "integrations_other_integrations" }}</li>
       <li class="integration"><a href="/integrations/">{{ i18n "integrations_back_to_overview" }}</a></li>
-
-      {{ $lower := sort $integrations "Params.integration_title" "asc" }}
-      {{ $.Scratch.Set "lower_titles" (slice) }}
-      {{ range $lower }}
-        {{ $.Scratch.Add "lower_titles" (lower .Params.integration_title) }}
-      {{ end }}
-
-      {{ range sort ($.Scratch.Get "lower_titles") }}
-        {{ $lower_int := . }}
-        {{ range $int := $integrations }}
-          {{ if eq $lower_int (lower $int.Params.integration_title) }}
-            <li class="integration">
-              <a href="{{.Permalink}}">
-                {{ if eq $lastUrlElement .File.TranslationBaseName }}&gt;{{ end }}
-                {{ .Params.integration_title }}
-              </a>
-            </li>
-          {{ end }}
-        {{ end }}
+      {{ range $integrations }}
+          <li class="integration"><a href="{{.Permalink}}">
+            {{ if eq $lastUrlElement .File.TranslationBaseName }}&gt;{{ end }}
+            {{ .Params.integration_title }}
+          </a></li>
       {{ end }}
 
     {{ else }}


### PR DESCRIPTION
This reverts a change from yesterday to improve sorting on the `Other Integrations` menu. The menu will not be correctly sorted after this, but hugo build times will return to normal. We are looking into a better solution for sorting this menu. 