### PR TITLE
missing redirect

### DIFF
--- a/content/guides/monitors.md
+++ b/content/guides/monitors.md
@@ -4,6 +4,7 @@ kind: guide
 listorder: 13
 aliases:
   - /guides/monitoring
+  - /guides/alerting
 ---
 
 ***For more detail about monitors, review the [Monitoring Reference](/monitoring) page.***


### PR DESCRIPTION
adds an alias for /guides/alerting/ --> /guides/monitors/

testing:
https://d2cx6t4ssmwdrv.cloudfront.net/michaelw/update-missing-redirect/guides/alerting/