### PR TITLE
Adds sources and tags parameters to the event stream query example to…

### DIFF
--- a/code_snippets/api-events-stream.sh
+++ b/code_snippets/api-events-stream.sh
@@ -4,6 +4,8 @@ currenttime2=$(date --date='1 day ago' +%s)
 curl -G -H "Content-type: application/json" \
     -d "start=${currenttime2}" \
     -d "end=${currenttime}" \
+    -d "sources=My Apps" \
+    -d "tags=application:web,version:1" \
     -d "api_key=9775a026f1ca7d1c6c5af9d94d9595a4" \
     -d "application_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff" \
     'https://app.datadoghq.com/api/v1/events'


### PR DESCRIPTION
… demonstrate how these are used.

Both events in the example response match this source and these tags, so the example response doesn't need to be updated.