### PR TITLE
if integration title does not match the integration link, you can now…

### DIFF
--- a/content/integrations/kafka.md
+++ b/content/integrations/kafka.md
@@ -431,7 +431,7 @@ And edit conf.d/kafka_consumer.yaml
       #     my_consumer:
       #       my_topic: [0, 1, 4, 12]
 
-{{< insert-example-links check="none" >}}
+{{< insert-example-links integration="kafka" link_text="Apache Kafka" check="none" >}}
 {{< insert-example-links integration="Apache Kafka Consumer" conf="kafka_consumer" check="kafka_consumer" include_intro="false" >}}
 ## Validation
 
@@ -450,4 +450,3 @@ To validate that the integration is working, restart the agent and then run the 
 
 ## Metrics
 
-{{< get-metrics-from-git >}}

--- a/layouts/shortcodes/insert-example-links.html
+++ b/layouts/shortcodes/insert-example-links.html
@@ -1,6 +1,4 @@
-
 {{ $integration := ((.Get "integration") | default .Page.Params.integration_title) }}
-
 {{ $conf := (.Get "conf" | default (replace (lower $integration ) " " "_")) }}
 {{ $check := (.Get "check" | default (replace (lower $integration ) " " "_")) }}
 {{ $yaml_extension := "example" }}
@@ -40,22 +38,17 @@
 
 {{ $integrationwebroot := "https://github.com/Datadog/integrations-core/blob/master/" }}
 
+{{ $link_text := or (.Get "link_text") $integration }}
 {{ if ne ($.Scratch.Get "conf") "none" }}
-
   {{ $url := (printf "%s%s/conf.yaml.example" $integrationwebroot ($.Scratch.Get "conf") ) }}
-  {{ $yaml_example := (printf "<li><a href='%s'>%s YAML example</a></li>" $url $integration ) }}
+  {{ $yaml_example := (printf "<li><a href='%s'>%s YAML example</a></li>" $url $link_text ) }}
   {{ $.Scratch.Set "yaml_example" $yaml_example }}
-
 {{ end }}
 
 {{ if ne ($.Scratch.Get "check") "none" }}
-
   {{ $url := (printf "%s%s/check.py" $integrationwebroot $check) }}
-
-  {{ $checks_file := (printf "<li><a href=%s>%s checks.d</a></li>" $url $integration) }}
-
+  {{ $checks_file := (printf "<li><a href=%s>%s checks.d</a></li>" $url $link_text) }}
   {{ $.Scratch.Set "checks_file" $checks_file }}
-
 {{ end }}
 
 {{ $example_links := (printf "<ul>%s%s</ul>" ($.Scratch.Get "yaml_example" | default "") ($.Scratch.Get "checks_file" | default "") ) }}


### PR DESCRIPTION
this is a fix for the broken kafka integration example link

https://d2cx6t4ssmwdrv.cloudfront.net/michaelw/improved-example-links/integrations/kafka/#configuration

https://trello.com/c/ijTQSupk/1682-20170714-documentation-broken-links