### PR TITLE
fix nginx table

### DIFF
--- a/content/integrations/nginx.md
+++ b/content/integrations/nginx.md
@@ -76,6 +76,8 @@ These metrics do not have a directly related metric, but here are close translat
 <br/>
 Finally, these metrics have no good translation:
 
+|||
+|-------------------|-------------------|
 | nginx.net.reading | The current number of connections where nginx is reading the request header. |
 | nginx.net.writing | The current number of connections where nginx is writing the response back to the client. |
 


### PR DESCRIPTION
swept the whole site and found one more broken table at the bottom of https://docs.datadoghq.com/integrations/nginx/

fixed:
https://d2cx6t4ssmwdrv.cloudfront.net/michaelw/fix-broken-tables/integrations/nginx/