### PR TITLE
Describe how to add tags manually to metrics obtained from JMX MBeans

### DIFF
--- a/content/integrations/java.md
+++ b/content/integrations/java.md
@@ -54,6 +54,10 @@ Make sure you can open a [JMX remote connection](http://docs.oracle.com/javase/1
             conf:
               - include:
                   domain: my_domain
+                  tags:
+                      simple: $attr0
+                      raw_value: my_chosen_value
+                      multiple: $attr0-$attr1
                   bean:
                     - my_bean
                     - my_second_bean
@@ -94,11 +98,11 @@ The `conf` parameter is a list of dictionaries. Only 2 keys are allowed in this 
 * `include` (**mandatory**): Dictionary of filters, any attribute that matches these filters will be collected unless it also matches the "exclude" filters (see below)
 * `exclude` (**optional**): Another dictionary of filters. Attributes that match these filters won't be collected
 
-For a given bean, metrics get tagged in the following manner:
+Tags are automatically added to the metrics based on the MBean actual name and you can also explicitly specify supplementary tags. For example, assuming the following MBean is exposed by the application you're monitoring: 
 
     mydomain:attr0=val0,attr1=val1
 
-Your metric will be mydomain (or some variation depending on the attribute inside the bean) and have the tags `attr0:val0, attr1:val1, domain:mydomain`.
+The example configuration above would create a metric called `mydomain` (or some variation depending on the attribute inside the bean) and have the tags `attr0:val0, attr1:val1, domain:mydomain, simple:val0, raw_value:my_chosen_value, multiple:val0-val1`. 
 
 If you specify an alias in an `include` key that is formatted as *camel case*, it will be converted to *snake case*. For example, `MyMetricName` will be shown in Datadog as `my_metric_name`.
 

--- a/content/integrations/java.md
+++ b/content/integrations/java.md
@@ -98,11 +98,12 @@ The `conf` parameter is a list of dictionaries. Only 2 keys are allowed in this 
 * `include` (**mandatory**): Dictionary of filters, any attribute that matches these filters will be collected unless it also matches the "exclude" filters (see below)
 * `exclude` (**optional**): Another dictionary of filters. Attributes that match these filters won't be collected
 
-Tags are automatically added to the metrics based on the MBean actual name and you can also explicitly specify supplementary tags. For example, assuming the following MBean is exposed by the application you're monitoring: 
+Tags are automatically added to metrics based on the actual MBean name. 
+You can explicitly specify supplementary tags. For instance, assuming the following MBean is exposed by your monitored application: 
 
     mydomain:attr0=val0,attr1=val1
 
-The example configuration above would create a metric called `mydomain` (or some variation depending on the attribute inside the bean) and have the tags `attr0:val0, attr1:val1, domain:mydomain, simple:val0, raw_value:my_chosen_value, multiple:val0-val1`. 
+It would create a metric called `mydomain` (or some variation depending on the attribute inside the bean) with tags: `attr0:val0, attr1:val1, domain:mydomain, simple:val0, raw_value:my_chosen_value, multiple:val0-val1`. 
 
 If you specify an alias in an `include` key that is formatted as *camel case*, it will be converted to *snake case*. For example, `MyMetricName` will be shown in Datadog as `my_metric_name`.
 

--- a/content/integrations/java.md
+++ b/content/integrations/java.md
@@ -103,7 +103,7 @@ You can explicitly specify supplementary tags. For instance, assuming the follow
 
     mydomain:attr0=val0,attr1=val1
 
-It would create a metric called `mydomain` (or some variation depending on the attribute inside the bean) with tags: `attr0:val0, attr1:val1, domain:mydomain, simple:val0, raw_value:my_chosen_value, multiple:val0-val1`. 
+It would create a metric called `mydomain` (or some variation depending on the attribute inside the bean) with tags: `attr0:val0, attr1:val1, domain:mydomain`
 
 If you specify an alias in an `include` key that is formatted as *camel case*, it will be converted to *snake case*. For example, `MyMetricName` will be shown in Datadog as `my_metric_name`.
 

--- a/content/integrations/java.md
+++ b/content/integrations/java.md
@@ -103,7 +103,7 @@ You can explicitly specify supplementary tags. For instance, assuming the follow
 
     mydomain:attr0=val0,attr1=val1
 
-It would create a metric called `mydomain` (or some variation depending on the attribute inside the bean) with tags: `attr0:val0, attr1:val1, domain:mydomain`
+It would create a metric called `mydomain` (or some variation depending on the attribute inside the bean) with tags: `attr0:val0, attr1:val1, domain:mydomain`.
 
 If you specify an alias in an `include` key that is formatted as *camel case*, it will be converted to *snake case*. For example, `MyMetricName` will be shown in Datadog as `my_metric_name`.
 

--- a/content/integrations/java.md
+++ b/content/integrations/java.md
@@ -103,7 +103,7 @@ You can explicitly specify supplementary tags. For instance, assuming the follow
 
     mydomain:attr0=val0,attr1=val1
 
-It would create a metric called `mydomain` (or some variation depending on the attribute inside the bean) with tags: `attr0:val0, attr1:val1, domain:mydomain`.
+It would create a metric called `mydomain` (or some variation depending on the attribute inside the bean) with tags: `attr0:val0, attr1:val1, domain:mydomain, simple:val0, raw_value:my_chosen_value, multiple:val0-val1`.
 
 If you specify an alias in an `include` key that is formatted as *camel case*, it will be converted to *snake case*. For example, `MyMetricName` will be shown in Datadog as `my_metric_name`.
 


### PR DESCRIPTION
- the optional 'tags' entry was added to the configuration of jmxfetch in release 0.14 (see this PR: https://github.com/DataDog/jmxfetch/pull/117)
- this commit adds to the java integration how to use this new 'tags' option to append new tags manually to a metric
- the documented example is directly inspired from the unit test of the  feature: https://github.com/DataDog/jmxfetch/blob/21069333fa9c04df3a09e79211f36827935ddc2c/src/test/resources/jmx_additional_tags.yml