### PR TITLE
get rid of duplicate aliases

### DIFF
--- a/content/integrations/tcpcheck.ja.md
+++ b/content/integrations/tcpcheck.ja.md
@@ -1,6 +1,5 @@
 ---
 aliases:
-- /guides/network_checks
 - /ja/guides/network_checks
 integration_title: TCP Check
 kind: integration

--- a/content/integrations/tcpcheck.md
+++ b/content/integrations/tcpcheck.md
@@ -6,7 +6,6 @@ newhlevel: true
 update_for_agent: 5.8.5
 aliases:
   - /guides/network_checks
-  - /ja/guides/network_checks
 ---
 ## Overview
 


### PR DESCRIPTION
This fixes the default redirect to ja pages for `/guides/network_checks` url

----------------

https://d2cx6t4ssmwdrv.cloudfront.net/michaelw/fix-bad-redirects/guides/network_checks/
https://d2cx6t4ssmwdrv.cloudfront.net/michaelw/fix-bad-redirects/ja/guides/network_checks/