### PR TITLE
Jmx tagging update

### DIFF
--- a/content/integrations/java.md
+++ b/content/integrations/java.md
@@ -23,7 +23,7 @@ Make sure you can open a [JMX remote connection](http://docs.oracle.com/javase/1
 
 ## Configuration
 
-1.  Configure the Agent to connect using JMX and edit it according to your needs. Here is a sample jmx.yaml file:
+Configure the Agent to connect using JMX and edit it according to your needs. Here is a sample jmx.yaml file:
 {{< highlight yaml>}}
 init_config:
   custom_jar_paths: # optional

--- a/content/integrations/java.md
+++ b/content/integrations/java.md
@@ -24,57 +24,57 @@ Make sure you can open a [JMX remote connection](http://docs.oracle.com/javase/1
 ## Configuration
 
 1.  Configure the Agent to connect using JMX and edit it according to your needs. Here is a sample jmx.yaml file:
+{{< highlight yaml>}}
+init_config:
+  custom_jar_paths: # optional
+    - /path/to/custom/jarfile.jar
+  #is_jmx: true
 
-        init_config:
-          custom_jar_paths: # optional
-            - /path/to/custom/jarfile.jar
-          #is_jmx: true
+instances:
+  - host: localhost
+    port: 7199
+    user: username
+    password: password
 
-        instances:
-          - host: localhost
-            port: 7199
-            user: username
-            password: password
+    jmx_url: "service:jmx:rmi:///jndi/rmi://myhost.host:9999/custompath" # optional
 
-            jmx_url: "service:jmx:rmi:///jndi/rmi://myhost.host:9999/custompath" # optional
+    name: jmx_instance  # optional
+    java_bin_path: /path/to/java
+    java_options: "-Xmx200m -Xms50m"
+    trust_store_path: /path/to/trustStore.jks
+    trust_store_password: password
 
-            name: jmx_instance  # optional
-            java_bin_path: /path/to/java
-            java_options: "-Xmx200m -Xms50m"
-            trust_store_path: /path/to/trustStore.jks
-            trust_store_password: password
+    process_name_regex: .*process_name.*
+    tools_jar_path: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar
+    refresh_beans: 600 # optional (in seconds)
+    tags:
+      env: stage
+      newTag: test
 
-            process_name_regex: .*process_name.*
-            tools_jar_path: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar
-            refresh_beans: 600 # optional (in seconds)
-            tags:
-              env: stage
-              newTag: test
-
-            conf:
-              - include:
-                  domain: my_domain
-                  bean:
-                    - my_bean
-                    - my_second_bean
-                  attribute:
-                    attribute1:
-                      metric_type: counter
-                      alias: jmx.my_metric_name
-                    attribute2:
-                      metric_type: gauge
-                      alias: jmx.my2ndattribute
-              - include:
-                  domain: 2nd_domain
-                exclude:
-                  bean:
-                    - excluded_bean
-              - include:
-                  domain_regex: regex_on_domain
-                exclude:
-                  bean_regex:
-                    - regex_on_excluded_bean
-
+    conf:
+      - include:
+          domain: my_domain
+          bean:
+            - my_bean
+            - my_second_bean
+          attribute:
+            attribute1:
+              metric_type: counter
+              alias: jmx.my_metric_name
+            attribute2:
+              metric_type: gauge
+              alias: jmx.my2ndattribute
+      - include:
+          domain: 2nd_domain
+        exclude:
+          bean:
+            - excluded_bean
+      - include:
+          domain_regex: regex_on_domain
+        exclude:
+          bean_regex:
+            - regex_on_excluded_bean
+{{< /highlight >}}
 
 ### Configuration Options
 
@@ -88,6 +88,7 @@ Make sure you can open a [JMX remote connection](http://docs.oracle.com/javase/1
 * `process_name_regex` - (Optional) - Instead of specifying a host and port or jmx_url, the agent can connect using the attach api. This requires the JDK to be installed and the path to tools.jar to be set.
 * `tools_jar_path` - (Optional) - To be set when process_name_regex is set.
 * `refresh_beans` - (Optional) - Refresh period for refreshing the matching MBeans list.  Default is 600 seconds.  Decreasing this value may result in increased CPU usage.
+* `tags` - (Optional) - Tags applied to each metric. The benefit here is that you are no longer limited to the tags assigned by the MBean developer
 
 The `conf` parameter is a list of dictionaries. Only 2 keys are allowed in this dictionary:
 
@@ -117,50 +118,53 @@ The regexes defined in `domain_regex` and `bean_regex` must conform to [Java's r
 The `domain_regex` and `bean_regex` filters were added in version 5.5.0.
 
 On top of these parameters, the filters support "custom" keys which means that you can filter by bean parameters. For example, if you want to collect metrics regarding the Cassandra cache, you could use the `type: - Caches` filter:
-
-    conf:
-    - include:
-        domain: org.apache.cassandra.db
-        type:
-          - Caches
+{{< highlight yaml>}}
+conf:
+- include:
+    domain: org.apache.cassandra.db
+    type:
+      - Caches
+{{< /highlight >}}
 
 ### The `attribute` filter
 
 The `attribute` filter can accept two types of values:
 
 *   A dictionary whose keys are attributes names:
+{{< highlight yaml>}}
 
-        conf:
-          - include:
-              attribute:
-                maxThreads:
-                  alias: tomcat.threads.max
-                  metric_type: gauge
-                currentThreadCount:
-                  alias: tomcat.threads.count
-                  metric_type: gauge
-                bytesReceived:
-                  alias: tomcat.bytes_rcvd
-                  metric_type: counter
+conf:
+- include:
+    attribute:
+      maxThreads:
+        alias: tomcat.threads.max
+        metric_type: gauge
+      currentThreadCount:
+        alias: tomcat.threads.count
+        metric_type: gauge
+      bytesReceived:
+        alias: tomcat.bytes_rcvd
+        metric_type: counter
+{{< /highlight >}}
 
 In that case you can specify an alias for the metric that will become the metric name in Datadog. You can also specify the metric type either a gauge or a counter. If you choose counter, a rate per second will be computed for this metric.
 
 *   A list of attributes names:
-
-        conf:
-          - include:
-              domain: org.apache.cassandra.db
-              attribute:
-                - BloomFilterDiskSpaceUsed
-                - BloomFilterFalsePositives
-                - BloomFilterFalseRatio
-                - Capacity
-                - CompressionRatio
-                - CompletedTasks
-                - ExceptionCount
-                - Hits
-                - RecentHitRate
-
+{{< highlight yaml>}}
+conf:
+  - include:
+      domain: org.apache.cassandra.db
+      attribute:
+        - BloomFilterDiskSpaceUsed
+        - BloomFilterFalsePositives
+        - BloomFilterFalseRatio
+        - Capacity
+        - CompressionRatio
+        - CompletedTasks
+        - ExceptionCount
+        - Hits
+        - RecentHitRate
+{{< /highlight >}}
 
 In that case:
 
@@ -168,46 +172,46 @@ In that case:
   * The metric name will be jmx.\[DOMAIN_NAME].\[ATTRIBUTE_NAME]
 
 Here is another filtering example:
+{{< highlight yaml>}}
+instances:
+  - host: 127.0.0.1
+    name: jmx_instance
+    port: 9999
 
-    instances:
-      - host: 127.0.0.1
-        name: jmx_instance
-        port: 9999
-
-    init_config:
-      conf:
-        - include:
-            bean: org.apache.cassandra.metrics:type=ClientRequest,scope=Write,name=Latency
-            attribute:
-              - OneMinuteRate
-              - 75thPercentile
-              - 95thPercentile
-              - 99thPercentile
-
+init_config:
+  conf:
+    - include:
+        bean: org.apache.cassandra.metrics:type=ClientRequest,scope=Write,name=Latency
+        attribute:
+          - OneMinuteRate
+          - 75thPercentile
+          - 95thPercentile
+          - 99thPercentile
+{{< /highlight >}}
 
 ### Note
 
 List of filters is only supported in Datadog Agent > 5.3.0. If you are using an older version, please use singletons and multiple `include` statements instead.
+{{< highlight yaml>}}
+# Datadog Agent > 5.3.0
+conf:
+  - include:
+    domain: domain_name
+    bean:
+      - first_bean_name
+      - second_bean_name
+...
 
-    # Datadog Agent > 5.3.0
-      conf:
-        - include:
-            domain: domain_name
-            bean:
-              - first_bean_name
-              - second_bean_name
-    ...
-
-
-    # Older Datadog Agent versions
-      conf:
-        - include:
-            domain: domain_name
-            bean: first_bean_name
-        - include:
-            domain: domain_name
-            bean: second_bean_name
-    ...
+# Older Datadog Agent versions
+conf:
+  - include:
+      domain: domain_name
+      bean: first_bean_name
+  - include:
+      domain: domain_name
+      bean: second_bean_name
+...
+  {{< /highlight >}}
 
 ### Commands to view the metrics that are available:
 
@@ -267,18 +271,15 @@ JBoss/WildFly applications expose JMX over a specific protocol (Remoting JMX) th
   1. Locate the `jboss-cli-client.jar` file on your JBoss/WildFly server (by default, its path should be `$JBOSS_HOME/bin/client/jboss-cli-client.jar`).
   2. If JMXFetch is running on a different host than the JBoss/WildFly application, copy `jboss-cli-client.jar` to a location on the host JMXFetch is running on.
   3. Add the path of the jar to the `init_config` section of your configuration:
-
-```
+{{< highlight yaml>}}
 # Datadog Agent >= 5.6.0
-
 init_config:
   custom_jar_paths:
     - /path/to/jboss-cli-client.jar
-```
+{{< /highlight >}}
 
   4. Specify a custom URL that JMXFetch will connect to, in the `instances` section of your configuration:
-
-```
+{{< highlight yaml>}}
 # Datadog Agent >= 5.6.0
 
 # The jmx_url may be different depending on the version of JBoss/WildFly you're using
@@ -288,8 +289,7 @@ instances:
   - jmx_url: "service:jmx:remoting-jmx://localhost:9999"
     name: jboss-application  # Mandatory, but can be set to any value,
                              # will be used to tag the metrics pulled from that instance
-```
-
+{{< /highlight >}}
 
   5. Restart the agent: `sudo /etc/init.d/datadog-agent`
 
@@ -302,19 +302,16 @@ If you're using Tomcat with JMX Remote Lifecycle Listener enabled (see the [Tomc
   1. Locate the `catalina-jmx-remote.jar` file on your Tomcat server (by default, its path should be `$CATALINA_HOME/lib`).
   2. If JMXFetch is running on a different host than the Tomcat application, copy `catalina-jmx-remote.jar` to a location on the host JMXFetch is running on.
   3. Add the path of the jar to the `init_config` section of your configuration:
-
-```
+{{< highlight yaml>}}
 # Datadog Agent >= 5.6.0
 
 init_config:
   custom_jar_paths:
     - /path/to/catalina-jmx-remote.jar
-```
-
+{{< /highlight >}}
 
   4. Specify a custom URL that JMXFetch will connect to, in the `instances` section of your configuration:
-
-```
+{{< highlight yaml>}}
 # Datadog Agent >= 5.6.0
 
 # The jmx_url may be different depending on the way you've set up JMX on your Tomcat server
@@ -322,9 +319,7 @@ instances:
   - jmx_url: "service:jmx:rmi://:10002/jndi/rmi://:10001/jmxrmi"
     name: tomcat-application  # Mandatory, but can be set to any arbitrary value,
                               # will be used to tag the metrics pulled from that instance
-```
-
-
+{{< /highlight >}}
   5. Restart the agent: `sudo /etc/init.d/datadog-agent`
 
 


### PR DESCRIPTION
This is to answer this issue: https://github.com/DataDog/documentation/issues/1225

More specifically, this page:
https://docs.datadoghq.com/integrations/java/

 is missing info about this change:
https://www.datadoghq.com/blog/introducing-jmx-custom-tagging/

Preview: https://d2cx6t4ssmwdrv.cloudfront.net/gus/jmx-tagging-update/integrations/java/