### PR TITLE
exit build for integrations sync issues

### DIFF
--- a/layouts/shortcodes/get-metrics-from-git.html
+++ b/layouts/shortcodes/get-metrics-from-git.html
@@ -14,7 +14,7 @@
 
 {{ $integration := $.Scratch.Get "integration" }}
 
-{{ if $.Page.Site.Data.integrations }}
+{{ if or (not (eq $.Page.Site.Params.environment "local")) ($.Page.Site.Data.integrations) }}
 
   {{ $data := index $.Page.Site.Data.integrations $integration }}
 

--- a/local/bin/py/integrations_sync.py
+++ b/local/bin/py/integrations_sync.py
@@ -39,7 +39,7 @@ def download_github_files(token, org, repo, branch, to_path, is_dogweb=False):
     :param is_dogweb: if dogweb repo we need to get nested data
     """
     directory = 'integration' if is_dogweb else ''
-    url = 'https://api.github.com/repos/{0}/{1}/{2}/contents/{3}'.format(org, repo, branch, directory)
+    url = 'https://api.github.com/repos/{0}/{1}/contents/{3}?ref={2}'.format(org, repo, branch, directory)
     headers = {'Authorization': 'token {}'.format(token)} if token else {}
     excludes = ['LICENSE', 'Rakefile', 'Gemfile']
     print('Downloading files from {}/{}..'.format(repo, branch))

--- a/local/bin/py/integrations_sync.py
+++ b/local/bin/py/integrations_sync.py
@@ -58,8 +58,8 @@ def download_github_files(token, org, repo, branch, to_path, is_dogweb=False):
                     with open('{}{}.csv'.format(to_path, name), mode='wb+') as f:
                         f.write(response_csv.content)
                 else:
-                    print('There was an error ({}) listing {}/{} contents..'.format(response_csv.status_code, repo,
-                                                                                    branch))
+                    print('There was an error ({}) downloading {}/{}/{}'.format(response_csv.status_code, repo,
+                                                                                    branch, name))
                     exit(1)
     else:
         print('There was an error ({}) listing {}/{} contents..'.format(response.status_code, repo, branch))

--- a/local/bin/py/integrations_sync.py
+++ b/local/bin/py/integrations_sync.py
@@ -48,7 +48,8 @@ def download_github_files(token, org, repo, branch, to_path, is_dogweb=False):
         for obj in tqdm(response.json()):
             name = obj.get('name', '')
             if not name.startswith('.') and not splitext(name)[1] and name not in excludes:
-                to_csv = '{0}/{1}/{1}_metadata.csv'.format(directory, name) if is_dogweb else '{}/metadata.csv'.format(name)
+                to_csv = '{0}/{1}/{1}_metadata.csv'.format(directory, name) if is_dogweb else '{}/metadata.csv'.format(
+                    name)
                 response_csv = requests.get(
                     'https://raw.githubusercontent.com/{0}/{1}/{2}/{3}'.format(org, repo, branch, to_csv),
                     headers=headers
@@ -56,8 +57,13 @@ def download_github_files(token, org, repo, branch, to_path, is_dogweb=False):
                 if response_csv.status_code == requests.codes.ok:
                     with open('{}{}.csv'.format(to_path, name), mode='wb+') as f:
                         f.write(response_csv.content)
+                else:
+                    print('There was an error ({}) listing {}/{} contents..'.format(response_csv.status_code, repo,
+                                                                                    branch))
+                    exit(1)
     else:
         print('There was an error ({}) listing {}/{} contents..'.format(response.status_code, repo, branch))
+        exit(1)
 
 
 def sync_from_dir(from_path=None, to_path=None, is_dogweb=False):
@@ -82,6 +88,7 @@ def sync_from_dir(from_path=None, to_path=None, is_dogweb=False):
             csv_to_yaml(key_name, file_name, new_file_name)
     else:
         print('Path does not exist: {}'.format(from_path))
+        exit(1)
 
 
 def parse_args(args=None):
@@ -142,6 +149,7 @@ def sync(*args):
             download_github_files(options.token, 'DataDog', 'dogweb', 'prod', options.dogweb + 'integration' + sep, True)
         else:
             print('No Github token.. dogweb retrieval failed')
+            exit(1)
     if options.dogweb:
         sync_from_dir(options.dogweb, dest_dir, True)
 

--- a/local/bin/py/integrations_sync.py
+++ b/local/bin/py/integrations_sync.py
@@ -39,7 +39,7 @@ def download_github_files(token, org, repo, branch, to_path, is_dogweb=False):
     :param is_dogweb: if dogweb repo we need to get nested data
     """
     directory = 'integration' if is_dogweb else ''
-    url = 'https://api.github.com/repos/{0}/{1}/contents/{2}'.format(org, repo, directory)
+    url = 'https://api.github.com/repos/{0}/{1}/{2}/contents/{3}'.format(org, repo, branch, directory)
     headers = {'Authorization': 'token {}'.format(token)} if token else {}
     excludes = ['LICENSE', 'Rakefile', 'Gemfile']
     print('Downloading files from {}/{}..'.format(repo, branch))
@@ -57,10 +57,7 @@ def download_github_files(token, org, repo, branch, to_path, is_dogweb=False):
                 if response_csv.status_code == requests.codes.ok:
                     with open('{}{}.csv'.format(to_path, name), mode='wb+') as f:
                         f.write(response_csv.content)
-                else:
-                    print('There was an error ({}) downloading {}/{}/{}'.format(response_csv.status_code, repo,
-                                                                                    branch, name))
-                    exit(1)
+
     else:
         print('There was an error ({}) listing {}/{} contents..'.format(response.status_code, repo, branch))
         exit(1)


### PR DESCRIPTION
* integrations_sync.py: be explicit with which branch we are using for both listing and downloading integrations
* integrations_sync.py: exit(1) anywhere we don't get expected behavior
* get-metrics-from-git.html: allow local dev to build without integrations, but allow hugo errors to break builds for preview and master pipelines.