### PR TITLE
Redirect old service discovery guide

### DIFF
--- a/content/guides/autodiscovery.md
+++ b/content/guides/autodiscovery.md
@@ -2,6 +2,9 @@
 title: Using Autodiscovery with Docker
 kind: guide
 listorder: 15
+aliases:
+  - /guides/servicediscovery/
+
 ---
 
 <div class="alert alert-info">


### PR DESCRIPTION
The old link to https://docs.datadoghq.com/guides/servicediscovery still exists in a few places. Currently it 404s. This PR adds an alias to the newer autodiscovery guide to prevent those 404s and re-route people to the correct place.