### PR TITLE
David.jones/dogstatsd links

### DIFF
--- a/content/guides/dogstatsd.md
+++ b/content/guides/dogstatsd.md
@@ -7,21 +7,25 @@ sidebar:
     - text: How It Works
       href: "#how-it-works"
     - text: Set Up
-      href: "#set-up"
+      href: "#setup"
+    - text: Data Types
+      href: "#data-types"
     - text: Metrics
       href: "#metrics"
     - text: Sample Rates
-      href: "#sample-rates"
-    - text: Tags
-      href: "#tags"
+      href: "#metric-option-sample-rates"
     - text: Events
       href: "#events"
-    - text: Configuration
-      href: "#configuration"
+    - text: Service Checks
+      href: "#service-checks"
+    - text: Tagging
+      href: "#tagging"
     - text: Datagram Format
       href: "#datagram-format"
-    - text: Source
-      href: "#source"
+    - text: Service Checks
+      href: "#service-checks-1"
+    - text: Related Reading
+      href: "#related-reading"
 ---
 
 <p class="aside">

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -46,7 +46,7 @@
           <!-- this is an anchor link, absLangURL wipes it out so build manually -->
           <li><a href="{{ $dot.RelPermalink | absLangURL }}{{ $v.href }}">{{ $v.text }}</a></li>
         {{ else }}
-          <!-- this is not an anchor link --->
+          <!-- this is not an anchor link -->
           <li><a href="{{ $v.href | absLangURL }}">{{ $v.text }}</a></li>
         {{ end }}
 

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -4,6 +4,7 @@
 {{ $integrations := ( where .Site.Pages "Params.kind" "integration" ) }}
 {{ $currentURL := .URL }}
 {{ $lastUrlElement := index (last 1 (split (delimit (split .URL "/") "," "") ",")) 0 }}
+{{ $dot := . }}
 
 <ul class="nav nav-tabs nav-stacked sidebar">
 
@@ -41,8 +42,13 @@
     {{ range $k, $v := $.Params.sidebar.nav }}
 
       {{ if not $v.header }}
-
-        <li><a href="{{ $v.href | absLangURL }}">{{ $v.text }}</a></li>
+        {{ if eq (slicestr $v.href 0 1) "#" }}
+          <!-- this is an anchor link, absLangURL wipes it out so build manually -->
+          <li><a href="{{ $dot.RelPermalink | absLangURL }}{{ $v.href }}">{{ $v.text }}</a></li>
+        {{ else }}
+          <!-- this is not an anchor link --->
+          <li><a href="{{ $v.href | absLangURL }}">{{ $v.text }}</a></li>
+        {{ end }}
 
       {{ end }}
 


### PR DESCRIPTION
This PR fixes a bug on https://docs.datadoghq.com/guides/dogstatsd/ where the links in the table of contents section all link to the domain instead of to the anchor sections they mention. It also updates the links to match the content.