### PR TITLE
Adding missing "-" to example YAML

### DIFF
--- a/content/integrations/postgresql.md
+++ b/content/integrations/postgresql.md
@@ -41,7 +41,7 @@ When it prompts for a password, enter the one used in the first command.
 init_config:
 
 instances:
-    host: localhost
+  - host: localhost
     port: 5432
 {{< /highlight >}}
 


### PR DESCRIPTION
Looks like a "-" was dropped from this doc's example yaml at some point, added it back.