### PR TITLE
add jira meta description

### DIFF
--- a/content/integrations/jira.md
+++ b/content/integrations/jira.md
@@ -4,6 +4,7 @@ integration_title: Jira
 kind: integration
 doclevel: basic
 newhlevel: true
+description: "This integration allows you to create tickets from triggered alerts in Datadog, and update existing tickets with new information as it arises. Additionally, you can see JIRA ticket creations as events within Datadog to overlay with all of your metrics."
 ---
 
 ## Overview

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -39,5 +39,5 @@
 <meta property="og:url" content="{{ $.Permalink }}"/>
 {{ if $meta_image}}<meta property="og:image" content="{{.Site.Params.img_url}}images{{ $meta_image }}"/>{{ end }}
 <meta property="og:description" content="{{ $meta_desc }}"/>
-<meta property="og:site_name" content="Datadog Instrastructure Monitoring"/>
+<meta property="og:site_name" content="Datadog Instrastructure and Application Monitoring"/>
 <meta property="article:author" content="Datadog"/>

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -39,5 +39,5 @@
 <meta property="og:url" content="{{ $.Permalink }}"/>
 {{ if $meta_image}}<meta property="og:image" content="{{.Site.Params.img_url}}images{{ $meta_image }}"/>{{ end }}
 <meta property="og:description" content="{{ $meta_desc }}"/>
-<meta property="og:site_name" content="Datadog Instrastructure and Application Monitoring"/>
+<meta property="og:site_name" content="Datadog Infrastructure and Application Monitoring"/>
 <meta property="article:author" content="Datadog"/>


### PR DESCRIPTION
@l0k0ms - here is an example of how to create accurate page descriptions/previews now using front-matter. Feel free to merge or close this PR.
add the jira meta description; update the site description

https://d2cx6t4ssmwdrv.cloudfront.net/michaelw/update-jira-page-desc/integrations/jira/

<img width="680" alt="screen shot 2017-08-01 at 6 49 51 pm" src="https://user-images.githubusercontent.com/20482473/28850379-417c0336-76ea-11e7-8548-24f7e1d3bfa0.png">
