### PR TITLE
[Java] Wording update

### DIFF
--- a/content/integrations/java.md
+++ b/content/integrations/java.md
@@ -19,7 +19,7 @@ JMX Checks have a limit of 350 metrics per instance which should be enough to sa
 
 ## Installation
 
-Make sure you can open a [JMX remote connection](http://docs.oracle.com/javase/1.5.0/docs/guide/management/agent.html).
+Enable your local [JMX agent](http://docs.oracle.com/javase/1.5.0/docs/guide/management/agent.html).
 
 ## Configuration
 

--- a/content/integrations/java.md
+++ b/content/integrations/java.md
@@ -19,7 +19,7 @@ JMX Checks have a limit of 350 metrics per instance which should be enough to sa
 
 ## Installation
 
-Enable your local [JMX agent](http://docs.oracle.com/javase/1.5.0/docs/guide/management/agent.html).
+Enable your local JMX agent, and test if you can open a [JMX connection](http://docs.oracle.com/javase/1.5.0/docs/guide/management/agent.html)
 
 ## Configuration
 


### PR DESCRIPTION
When we say be sure you can ‘open a JMX remote connection’, we just mean enable the local JMX agent. 