### PR TITLE
[statsD] wording update

### DIFF
--- a/content/guides/dogstatsd.md
+++ b/content/guides/dogstatsd.md
@@ -32,7 +32,7 @@ sidebar:
 This page explains what DogStatsD is, how it works, and what data it accepts.
 </p>
 
-The easiest way to get your custom application metrics into Datadog is to send them to DogStatsD, a metrics aggregation service bundled with the Datadog Agent. DogStatsD implements the [StatsD](https://github.com/etsy/statsd) protocol and adds a few Datadog-specific extensions:
+The easiest way to get your custom application metrics into Datadog is to send them to DogStatsD, a metrics aggregation service bundled with the Datadog Agent. DogStatsD implements most of the [StatsD](https://github.com/etsy/statsd) protocol and adds a few Datadog-specific extensions:
 
 * Histogram metric type
 * Service checks and Events

--- a/content/guides/dogstatsd.md
+++ b/content/guides/dogstatsd.md
@@ -32,11 +32,16 @@ sidebar:
 This page explains what DogStatsD is, how it works, and what data it accepts.
 </p>
 
-The easiest way to get your custom application metrics into Datadog is to send them to DogStatsD, a metrics aggregation service bundled with the Datadog Agent. DogStatsD implements most of the [StatsD](https://github.com/etsy/statsd) protocol and adds a few Datadog-specific extensions:
+The easiest way to get your custom application metrics into Datadog is to send them to DogStatsD, a metrics aggregation service bundled with the Datadog Agent. DogStatsD implements the [StatsD](https://github.com/etsy/statsd) protocol and adds a few Datadog-specific extensions:
 
 * Histogram metric type
 * Service checks and Events
 * Tagging
+
+**Note**: dogstatsD doesn't exactly follow the statsd implementation:
+
+* It does not support Gauge delta ([Learn more about this](https://github.com/DataDog/dd-agent/pull/2104))
+* It does not support the timing type on custom metrics. ([Learn more about this](#timers))
 
 ## How It Works
 

--- a/content/guides/dogstatsd.md
+++ b/content/guides/dogstatsd.md
@@ -38,10 +38,10 @@ The easiest way to get your custom application metrics into Datadog is to send t
 * Service checks and Events
 * Tagging
 
-**Note**: dogstatsD doesn't exactly follow the statsd implementation:
+**Note**: DogStatsD does NOT implement the following from StatsD:
 
-* It does not support Gauge delta ([Learn more about this](https://github.com/DataDog/dd-agent/pull/2104))
-* It does not support the timing type on custom metrics. ([Learn more about this](#timers))
+* Gauge deltas (see [this issue](https://github.com/DataDog/dd-agent/pull/2104))
+* Timers as a native metric type (though it [does support them via histograms](#timers))
 
 ## How It Works
 


### PR DESCRIPTION
a customer had an issue with metric metadata not getting set on our end (we don't have the `timing` type on custom metrics) so he wasn't seeing units.   
He thought this should be the case because in Etsy's StatsD docs https://github.com/etsy/statsd/blob/master/docs/metric_types.md#timing it mentions certain protocol that we don't follow.