### PR TITLE
[integrations] update system metrics source

### DIFF
--- a/content/integrations/disk.md
+++ b/content/integrations/disk.md
@@ -80,5 +80,5 @@ Checks
 
 ## Metrics
 
-{{< get-metrics-from-git "system" "system.disk system.fs">}}
+{{< get-metrics-from-git "disk">}}
 

--- a/content/integrations/network.md
+++ b/content/integrations/network.md
@@ -42,4 +42,4 @@ instances:
 {{< /highlight >}}
 ## Metrics
 
-{{< get-metrics-from-git "system" "system.net" >}}
+{{< get-metrics-from-git "network" >}}

--- a/content/integrations/ntp.md
+++ b/content/integrations/ntp.md
@@ -57,7 +57,7 @@ Checks
 
 ## Metrics
 
-{{< get-metrics-from-git "system" "ntp" >}}
+{{< get-metrics-from-git "ntp" >}}
 
 ## Events
 

--- a/content/integrations/process.md
+++ b/content/integrations/process.md
@@ -69,4 +69,4 @@ Each instance, regardless of the number of search strings used, counts for a sin
 
 Visit the Metrics Explorer to see the new metrics available. You will find all the metrics under `system.processes`.
 
-{{< get-metrics-from-git "system" "system.processes" >}}
+{{< get-metrics-from-git "processes" >}}


### PR DESCRIPTION
dogweb doesn't have separate system integrations, integrations-core does. this pr updates system integrations that have a dedicated metrics csv in integrations-core.

https://d2cx6t4ssmwdrv.cloudfront.net/michaelw/pull-network-metrics/integrations/network/
https://d2cx6t4ssmwdrv.cloudfront.net/michaelw/pull-network-metrics/integrations/process/
https://d2cx6t4ssmwdrv.cloudfront.net/michaelw/pull-network-metrics/integrations/disk/
https://d2cx6t4ssmwdrv.cloudfront.net/michaelw/pull-network-metrics/integrations/ntp/

