### PR TITLE
Updates Apache + HTTP check examples to clarify what the HTTP check does

### DIFF
--- a/content/guides/autodiscovery.md
+++ b/content/guides/autodiscovery.md
@@ -196,9 +196,9 @@ Notice that each of the three values is a list. Autodiscovery assembles list ite
 
 Unlike auto-conf files, **key-value stores may use the short OR long image name as container identifiers**, e.g. `httpd` OR `library/httpd:latest`. The next example uses a long name.
 
-#### Example: Apache and HTTP checks
+#### Example: Apache check with website availability monitoring
 
-The following etcd commands create the same Apache template and add an [HTTP check](https://github.com/DataDog/integrations-core/blob/master/http_check/conf.yaml.example) template:
+The following etcd commands create the same Apache template and add an [HTTP check](https://github.com/DataDog/integrations-core/blob/master/http_check/conf.yaml.example) template to monitor whether the website created by the Apache container is available:
 
 ~~~
 etcdctl set /datadog/check_configs/library/httpd:latest/check_names '["apache", "http_check"]'
@@ -228,7 +228,7 @@ The format is similar to that for key-value stores. The differences are:
 
 If you define your Kubernetes Pods directly (i.e. `kind: Pod`), add each Pod's annotations directly under its `metadata` section (see the first example below). If you define Pods _indirectly_ via Replication Controllers, Replica Sets, or Deployments, add Pod annotations under `.spec.templates.metadata` (see the second example below).
 
-#### Pod Example: Apache and HTTP checks
+#### Pod Example: Apache check with website availability monitoring
 
 The following Pod annotation defines two templates—equivalent to those from the end of the previous section—for `apache` containers:
 


### PR DESCRIPTION
On some systems Apache is named httpd. Indeed the container in this example is named httpd. Thus, a user may assume that the HTTP check monitors Apache and be confused why there are two checks. This commit clarifies what the HTTP check does.