### PR TITLE
update integration names for missing metrics

### DIFF
--- a/content/integrations/activemq.md
+++ b/content/integrations/activemq.md
@@ -104,7 +104,7 @@ else echo -e "\e[031mAgent is not running\e[0m"; fi
 ## Data Collected
 ### Metrics
 
-{{< get-metrics-from-git >}}
+{{< get-metrics-from-git "activemq_xml" >}}
 
 
 [1]: http://activemq.apache.org/jmx.html

--- a/content/integrations/couchdb.md
+++ b/content/integrations/couchdb.md
@@ -53,7 +53,7 @@ Checks
 ## Data Collected
 ### Metrics
 
-{{< get-metrics-from-git >}}
+{{< get-metrics-from-git "couch" >}}
 
 ### Service Checks
 

--- a/content/integrations/docker.md
+++ b/content/integrations/docker.md
@@ -123,7 +123,7 @@ Checks
 ## Data Collected
 ### Metrics
 
-{{< get-metrics-from-git >}}
+{{< get-metrics-from-git "docker" >}}
 
 ### Deprecated metrics
 

--- a/content/integrations/docker.md
+++ b/content/integrations/docker.md
@@ -123,7 +123,7 @@ Checks
 ## Data Collected
 ### Metrics
 
-{{< get-metrics-from-git "docker" >}}
+{{< get-metrics-from-git "docker_daemon" >}}
 
 ### Deprecated metrics
 

--- a/content/integrations/elasticsearch.md
+++ b/content/integrations/elasticsearch.md
@@ -61,5 +61,5 @@ Checks
 ## Data Collected
 ### Metrics
 
-{{< get-metrics-from-git >}}
+{{< get-metrics-from-git "elastic" >}}
 

--- a/content/integrations/gearman.md
+++ b/content/integrations/gearman.md
@@ -53,7 +53,7 @@ Checks
 ## Data Collected
 ### Metrics
 
-{{< get-metrics-from-git >}}
+{{< get-metrics-from-git "gearmand" >}}
 
 ### Service Checks
 

--- a/content/integrations/hdfs.md
+++ b/content/integrations/hdfs.md
@@ -77,6 +77,8 @@ Checks
 
 The metrics available are collected using df from Spotify's Snakebite. hdfs.in_use is calculated by dividing used by capacity.
 
-{{< get-metrics-from-git >}}
+{{< get-metrics-from-git "hdfs_datanode" >}}
+
+{{< get-metrics-from-git "hdfs_namenode" >}}
 
 You may experience reduced functionality if using hadoop before v2.2.0. For earlier versions, we need to use Snakebite v1.3.9. If using HA Mode, you may want to upgrade.

--- a/content/integrations/memcached.md
+++ b/content/integrations/memcached.md
@@ -52,7 +52,7 @@ Execute the info command and verify that the integration check has passed. The o
 ## Data Collected
 ### Metrics
 
-{{< get-metrics-from-git >}}
+{{< get-metrics-from-git "mcache" >}}
 
 To learn more details about the different metrics, go to [this blog entry](http://www.pal-blog.de/entwicklung/perl/memcached-statistics-stats-command.html).
 

--- a/content/integrations/mongodb.md
+++ b/content/integrations/mongodb.md
@@ -79,7 +79,7 @@ Checks
 ## Data Collected
 ### Metrics
 
-{{< get-metrics-from-git >}}
+{{< get-metrics-from-git "mongo" >}}
 
 Note: many of these metrics are described in the [MongoDB Manual 3.0](https://docs.mongodb.org/manual/reference/command/dbStats/)
 

--- a/content/integrations/process.md
+++ b/content/integrations/process.md
@@ -71,4 +71,4 @@ Each instance, regardless of the number of search strings used, counts for a sin
 
 Visit the Metrics Explorer to see the new metrics available. You will find all the metrics under `system.processes`.
 
-{{< get-metrics-from-git "processes" >}}
+{{< get-metrics-from-git "process" >}}

--- a/content/integrations/ssh.md
+++ b/content/integrations/ssh.md
@@ -57,7 +57,7 @@ ssh_check
 ## Data Collected
 ### Metrics
 
-{{< get-metrics-from-git >}}
+{{< get-metrics-from-git "ssh_check" >}}
 
 ### Service checks
 

--- a/content/integrations/teamcity.md
+++ b/content/integrations/teamcity.md
@@ -76,8 +76,5 @@ Checks
 {{< /highlight >}}
 
 ## Data Collected
-### Metrics
-
-{{< get-metrics-from-git >}}
 
 This integration only create events. It will not return any metrics.

--- a/content/integrations/zookeeper.md
+++ b/content/integrations/zookeeper.md
@@ -48,4 +48,4 @@ Checks
 {{< /highlight >}}
 # Metrics
 
-{{< get-metrics-from-git >}}
+{{< get-metrics-from-git "zk" >}}

--- a/layouts/shortcodes/get-metrics-from-git.html
+++ b/layouts/shortcodes/get-metrics-from-git.html
@@ -18,7 +18,6 @@
 
   {{ $data := index $.Page.Site.Data.integrations $integration }}
 
-  {{ if and ($integration) ($data) }} {{/* An integration is set and datafile exists */}}
 
     {{ if (index $params 1 ) }} {{/* Custom metrics set in shortcode param index 1 (second position) */}}
 
@@ -72,6 +71,5 @@
 
     {{ end }}
 
-  {{ end }}
 
 {{ end }}


### PR DESCRIPTION
integration names differ between integrations-core and dogweb. Integration names can also be updated in integrations-core; this causes missing metrics on the docs site. 

1. update broken metrics by updating integration names in shortcodes
2. break builds if shortcode is called but the file is empty or missing