### PR TITLE
add title

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     {{ partial "prefetch.html" . }}
-    <title>{{ .Params.title }}</title>
+    <title>{{ .Title }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {{ if .Params.external_redirect }} {{ partial "meta-http-equiv.html" . }} {{ end }}
     {{ if eq .Params.beta true }} <meta name="robots" content="noindex"> {{ end }}


### PR DESCRIPTION
`.Title` is the proper variable for getting the `title:` from front matter. Integration pages were missing this

https://d2cx6t4ssmwdrv.cloudfront.net/peter/add_title/videos/pagerduty/