### PR TITLE
removing tracing enable

### DIFF
--- a/content/tracing/index.md
+++ b/content/tracing/index.md
@@ -16,6 +16,10 @@ The Datadog APM is included in our Enterprise plan or as an upgrade to our Pro p
 
 Currently, tracing is only supported by version 5.11.0 (or above) of the Datadog Agent running on Linux and Docker.
 
+<div class="alert alert-info">
+Enabled by default after Datadog agent 5.13, tracing can be disabled by adding the parameter <br>`apm_enabled: no`<br> in your Datadog agent configuration file.
+</div>
+
 #### Installing the agent
 
 With our infrastructure monitoring, metrics are sent to the Datadog Agent, which then forwards them to Datadog. Similarly, tracing metrics are also sent to the Datadog agent. To enable tracing:

--- a/content/tracing/index.md
+++ b/content/tracing/index.md
@@ -20,16 +20,7 @@ Currently, tracing is only supported by version 5.11.0 (or above) of the Datadog
 
 With our infrastructure monitoring, metrics are sent to the Datadog Agent, which then forwards them to Datadog. Similarly, tracing metrics are also sent to the Datadog agent. To enable tracing:
 
-1.  Install the latest [Datadog Agent](https://app.datadoghq.com/account/settings#agent) (version 5.11.0 or above is required).
-1.  Enable the APM in the Datadog Agent configuration file
-
-    ~~~
-    [Main]
-    # Enable the trace agent.
-    apm_enabled: true
-    ~~~
-
-1.  [Restart the Agent](/guides/basic_agent_usage/)
+Install the latest [Datadog Agent](https://app.datadoghq.com/account/settings#agent) (version 5.11.0 or above is required).
 
 #### Running the agent in Docker
 


### PR DESCRIPTION
As of 5.13 its enabled by default and so step 2 on https://docs.datadoghq.com/tracing/#installing-the-agent could be misleading:

Enable the APM in the Datadog Agent configuration file

```
[Main]
# Enable the trace agent.
apm_enabled: true
```