### PR TITLE
instruction added to avoid misleading

### DIFF
--- a/content/integrations/jenkins.md
+++ b/content/integrations/jenkins.md
@@ -32,11 +32,13 @@ _This plugin requires [Jenkins 1.580.1](http://updates.jenkins-ci.org/download/w
 
 4. To configure the plugin, navigate to the **Manage Jenkins** -> **Configure System** page, and find the *Datadog Plugin* section.
 
-5. Copy/Paste your API Key from the [API Keys](https://app.datadoghq.com/account/settings#api) page on your Datadog account, into the `API Key` textbox on the configuration screen.
+5. Restart Jenkins to get the plugin enabled.
 
-6. Before saving your configuration, test your API connection using the *Test Key* button, directly below the `API Key` textbox.
+6. Copy/Paste your API Key from the [API Keys](https://app.datadoghq.com/account/settings#api) page on your Datadog account, into the `API Key` textbox on the configuration screen.
 
-7. Optional: Set a custom Hostname
+7. Before saving your configuration, test your API connection using the *Test Key* button, directly below the `API Key` textbox.
+
+8. Optional: Set a custom Hostname
 You can set a custom hostname for your Jenkins host via the Hostname textbox on the same configuration screen. Note: Hostname must follow the [RFC 1123](https://tools.ietf.org/html/rfc1123#section-2) format.
 
 ## Configuration


### PR DESCRIPTION
The recently released new version of jenkins plugin - v0.6.1 and have several users reached out since they couldn't see any events / metrics coming into datadog after they installed the plugin.

The only thing is that they will need to restart jenkins to get the plugin enabled.It would be nice to add one more step in installation instructions to let user know they should restart jenkins.

https://docs.datadoghq.com/integrations/jenkins/