### PR TITLE
Readme scraper

### DIFF
--- a/content/integrations/activemq.md
+++ b/content/integrations/activemq.md
@@ -21,11 +21,11 @@ description: "{{< get-desc-from-git >}}"
 
 ### Events
 
-The Activemq check does not include any event at this time.
+The ActiveMQ check does not emit any events.
 
 ### Service Checks
 
-The Activemq check does not include any service check at this time.
+The ActiveMQ check does not submit any service checks.
 
 ## Further Reading
 //get-further-reading-from-git//

--- a/content/integrations/activemq.md
+++ b/content/integrations/activemq.md
@@ -10,102 +10,12 @@ description: "{{< get-desc-from-git >}}"
 
 ## Overview
 
-Get metrics from ActiveMQ in real time to
-
-* Visualize your web ActiveMQ server performance
-* Correlate the performance of ActiveMQ with the rest of your applications
+{{< get-overview-from-git >}}
 
 ## Setup
-### Configuration
-
-
-***This integration requires Linux or Mac OS X.***
-
-*To capture ActiveMQ metrics you need to install the Datadog agent. Metrics will be captured using a JMX connection. **We recommend the use of Oracle's JDK for this integration.***
-
-1. **Make sure that [ JMX Remote is enabled][1] on your ActiveMQ server.**
-2. Configure the agent to connect to ActiveMQ. Edit `${confd_help('`conf.d/activemq.yaml`')}`
-{{< highlight yaml >}}
-instances:
-  - host: localhost
-    port: 7199
-    user: username
-    password: password
-    name: activemq_instance
-# List of metrics to be collected by the integration
-# You should not have to modify this.
-init_config:
-  conf:
-    - include:
-      Type: Queue
-      attribute:
-        AverageEnqueueTime:
-          alias: activemq.queue.avg_enqueue_time
-          metric_type: gauge
-        ConsumerCount:
-          alias: activemq.queue.consumer_count
-          metric_type: gauge
-        ProducerCount:
-          alias: activemq.queue.producer_count
-          metric_type: gauge
-        MaxEnqueueTime:
-          alias: activemq.queue.max_enqueue_time
-          metric_type: gauge
-        MinEnqueueTime:
-          alias: activemq.queue.min_enqueue_time
-          metric_type: gauge
-        MemoryPercentUsage:
-          alias: activemq.queue.memory_pct
-          metric_type: gauge
-        QueueSize:
-          alias: activemq.queue.size
-          metric_type: gauge
-        DequeueCount:
-          alias: activemq.queue.dequeue_count
-          metric_type: counter
-        DispatchCount:
-          alias: activemq.queue.dispatch_count
-          metric_type: counter
-        EnqueueCount:
-          alias: activemq.queue.enqueue_count
-          metric_type: counter
-        ExpiredCount:
-          alias: activemq.queue.expired_count
-          type: counter
-        InFlightCount:
-          alias: activemq.queue.in_flight_count
-          metric_type: counter
-
-    - include:
-      Type: Broker
-      attribute:
-        StorePercentUsage:
-          alias: activemq.broker.store_pct
-          metric_type: gauge
-        TempPercentUsage:
-          alias: activemq.broker.temp_pct
-          metric_type: gauge
-        MemoryPercentUsage:
-          alias: activemq.broker.memory_pct
-          metric_type: gauge
-{{< /highlight >}}
-
-3. Restart the agent
-{{< highlight shell >}}
-sudo /etc/init.d/datadog-agent restart
-
-
-if [ $(sudo supervisorctl status | egrep "datadog-agent.*RUNNING" | wc -l) == 3 ]; \
-then echo -e "\e[0;32mAgent is running\e[0m"; \
-else echo -e "\e[031mAgent is not running\e[0m"; fi
-{{< /highlight >}}
-
-{{< insert-example-links check="none" >}}
+{{< get-setup-from-git >}}
 
 ## Data Collected
 ### Metrics
 
 {{< get-metrics-from-git "activemq_xml" >}}
-
-
-[1]: http://activemq.apache.org/jmx.html

--- a/content/integrations/activemq.md
+++ b/content/integrations/activemq.md
@@ -9,7 +9,6 @@ description: "{{< get-desc-from-git >}}"
 ---
 
 ## Overview
-
 {{< get-overview-from-git >}}
 
 ## Setup
@@ -19,3 +18,14 @@ description: "{{< get-desc-from-git >}}"
 ### Metrics
 
 {{< get-metrics-from-git "activemq_xml" >}}
+
+### Events
+
+The Activemq check does not include any event at this time.
+
+### Service Checks
+
+The Activemq check does not include any service check at this time.
+
+## Further Reading
+{{< get-further-reading-from-git >}}

--- a/content/integrations/activemq.md
+++ b/content/integrations/activemq.md
@@ -9,10 +9,10 @@ description: "{{< get-desc-from-git >}}"
 ---
 
 ## Overview
-{{< get-overview-from-git >}}
+//get-overview-from-git//
 
 ## Setup
-{{< get-setup-from-git >}}
+//get-setup-from-git//
 
 ## Data Collected
 ### Metrics
@@ -28,4 +28,4 @@ The Activemq check does not include any event at this time.
 The Activemq check does not include any service check at this time.
 
 ## Further Reading
-{{< get-further-reading-from-git >}}
+//get-further-reading-from-git//

--- a/local/bin/py/update_pre_build.py
+++ b/local/bin/py/update_pre_build.py
@@ -207,7 +207,7 @@ def update_integration_pre_build(from_path=None, to_path=None):
             key_name = basename(file_name.replace('_manifest.json', ''))
             
             ## Scraping all sections that we can found
-            data_array = readme_get_section(to_path, key_name)
+            data_array = readme_get_section(from_path, key_name)
 
             """
             Gathering the manifest short description and adding the right token

--- a/local/bin/py/update_pre_build.py
+++ b/local/bin/py/update_pre_build.py
@@ -10,6 +10,7 @@ import csv
 import glob
 import fileinput
 import json
+import re
 
 """
 Variables
@@ -18,6 +19,21 @@ DESC_TOKEN = "{{< get-desc-from-git >}}"
 DESC_ATTRIBUTE = "short_description"
 INTEGRATION_FOLDER = "content/integrations/"
 
+OVERVIEW_TOKEN = "{{< get-overview-from-git >}}"
+OVERVIEW_PATTERN = r'## Overview((?s).*)## Setup'
+
+SETUP_TOKEN = "{{< get-setup-from-git >}}"
+SETUP_PATTERN = r'## Setup((?s).*)## Data Collected'
+
+DATA_COLLECTED_TOKEN= "{{< get-data-collected-from-git >}}"
+DATA_COLLECTED_PATTERN= r'## Data Collected((?s).*)## Troubleshooting'
+
+
+TROUBLESHOOTING_TOKEN ="{{< get-troubleshooting-from-git >}}"
+TROUBLESHOOTING_PATTERN= r'## Troubleshooting((?s).*)## Further Reading'
+
+FURTHER_READING_TOKEN = "{{< get-further-reading-from-git >}}"
+FURTHER_READING_PATTERN= r'## Overview((?s).*)'
 """
 Functions
 """
@@ -56,6 +72,24 @@ def download_github_files(token, org, repo, branch, to_path, is_dogweb=False):
     else:
         print('There was an error ({}) listing {}/{} contents..'.format(response.status_code, repo, branch))
         exit(1)
+
+    """
+    Donwloading manifest.json for integrations core repo only
+    """
+    if response.status_code == requests.codes.ok:
+        if not is_dogweb:
+            for obj in tqdm(response.json()):
+                name = obj.get('name', '')
+                if not name.startswith('.') and not splitext(name)[1] and name not in excludes:
+                    to_manifest = '{}/README.md'.format(name)
+                    response_manifest = requests.get('https://raw.githubusercontent.com/{0}/{1}/{2}/{3}'.format(org, repo, branch, to_manifest), headers=headers)
+                    if response_manifest.status_code == requests.codes.ok:
+                        with open('{}{}_readme.md'.format(to_path, name), mode='wb+') as f:
+                            f.write(response_manifest.content)
+    else:
+        print('There was an error ({}) listing {}/{} contents..'.format(response.status_code, repo, branch))
+        exit(1)
+
 
 def replace_token(to_path, key_name, content_token, data):
     """
@@ -121,6 +155,44 @@ def parse_args(args=None):
     parser.add_option("-s", "--source", help="location of src files", default=curdir)
     return parser.parse_args(args)
 
+
+def readme_get_section(from_path,key_name):
+    data_array=[]
+    with open('{}{}_readme.md'.format(from_path, key_name)) as readme:
+        filedata = readme.read()
+
+        result = re.search(OVERVIEW_PATTERN, filedata)
+        if result:
+            data_array.append([OVERVIEW_TOKEN,result.group(1)])
+        else:
+            print("unable to find the pattern {} in file {}{}".format(OVERVIEW_PATTERN,from_path, key_name))
+
+        result = re.search(SETUP_PATTERN, filedata)
+        if result:
+            data_array.append([SETUP_TOKEN,result.group(1)])
+        else:
+            print("unable to find the pattern {} in file {}{}".format(SETUP_PATTERN,from_path, key_name))
+
+        result = re.search(DATA_COLLECTED_PATTERN, filedata)
+        if result:
+            data_array.append([DATA_COLLECTED_TOKEN,result.group(1)])
+        else:
+            print("unable to find the pattern {} in file {}{}".format(DATA_COLLECTED_PATTERN,from_path, key_name))
+
+        result = re.search(TROUBLESHOOTING_PATTERN, filedata)
+        if result:
+            data_array.append([TROUBLESHOOTING_TOKEN,result.group(1)])
+        else:
+            print("unable to find the pattern {} in file {}{}".format(TROUBLESHOOTING_PATTERN,from_path, key_name))
+
+        result = re.search(FURTHER_READING_PATTERN, filedata)
+        if result:
+            data_array.append([FURTHER_READING_TOKEN,result.group(1)])
+        else:
+            print("unable to find the pattern {} in file {}{}".format(FURTHER_READING_PATTERN,from_path, key_name))
+
+    return data_array
+
 def update_integration_pre_build(from_path=None, to_path=None):
     """
     All modifications that may happen to a integration content are here
@@ -134,10 +206,13 @@ def update_integration_pre_build(from_path=None, to_path=None):
         for file_name in tqdm(sorted(glob.glob('{}{}'.format(from_path, pattern), recursive=True))):
             key_name = basename(file_name.replace('_manifest.json', ''))
             
+            ## Scraping all sections that we can found
+            data_array = readme_get_section(to_path, key_name)
+
             """
             Gathering the manifest short description and adding the right token
             """
-            data_array=[]
+
             data_array.append([DESC_TOKEN,manifest_get_data(from_path,key_name,DESC_ATTRIBUTE)])
 
             """

--- a/local/bin/py/update_pre_build.py
+++ b/local/bin/py/update_pre_build.py
@@ -57,7 +57,7 @@ def download_github_files(token, org, repo, branch, to_path, is_dogweb=False):
     response = requests.get(url, headers=headers)
     
     """
-    Donwloading manifest.json for integrations core repo only
+    Downloading manifest.json for integrations core repo only
     """
     if response.status_code == requests.codes.ok:
         if not is_dogweb:
@@ -74,7 +74,7 @@ def download_github_files(token, org, repo, branch, to_path, is_dogweb=False):
         exit(1)
 
     """
-    Donwloading readme.md for integrations core repo only
+    Downloading readme.md for integrations core repo only
     """
     if response.status_code == requests.codes.ok:
         if not is_dogweb:
@@ -159,7 +159,7 @@ def parse_args(args=None):
 
 def readme_get_section(from_path,key_name):
     """
-    Takes an integration readme file, extract all sections following this pattern:
+    Take an integration readme file, extract all sections following this pattern:
         ## Overview
         ## Setup
         ## Data Collected

--- a/local/bin/py/update_pre_build.py
+++ b/local/bin/py/update_pre_build.py
@@ -74,7 +74,7 @@ def download_github_files(token, org, repo, branch, to_path, is_dogweb=False):
         exit(1)
 
     """
-    Donwloading manifest.json for integrations core repo only
+    Donwloading readme.md for integrations core repo only
     """
     if response.status_code == requests.codes.ok:
         if not is_dogweb:
@@ -113,7 +113,7 @@ def replace_token(to_path, key_name, content_token, data):
             file.write(filedata)
 
     except Exception as error: 
-        print(error)
+        #print(error)
         pass
 
 
@@ -136,6 +136,7 @@ def manifest_get_data(to_path,key_name,attribute):
     :param to_path:     the output path to integration md files
     :param key_name:    integration key name for root object
     :param attribute:   attribute to get data from
+    :return: manifest.json attribute
     """ 
     with open('{}{}_manifest.json'.format(to_path, key_name)) as manifest:
         manifest_json = json.load(manifest)
@@ -157,6 +158,19 @@ def parse_args(args=None):
 
 
 def readme_get_section(from_path,key_name):
+    """
+    Takes an integration readme file, extract all sections following this pattern:
+        ## Overview
+        ## Setup
+        ## Data Collected
+        ## Troubleshooting
+        ## Further Reading
+
+    :param: from_path: folder where the integration readme is
+    :param key_name:    integration key name for root object
+    :return: an array of [TOKEN, section_scraped ] 
+    """
+
     data_array=[]
     with open('{}{}_readme.md'.format(from_path, key_name)) as readme:
         filedata = readme.read()
@@ -206,7 +220,9 @@ def update_integration_pre_build(from_path=None, to_path=None):
         for file_name in tqdm(sorted(glob.glob('{}{}'.format(from_path, pattern), recursive=True))):
             key_name = basename(file_name.replace('_manifest.json', ''))
             
-            ## Scraping all sections that we can found
+            """
+            Scraping all sections that we can found
+            """
             data_array = readme_get_section(from_path, key_name)
 
             """
@@ -216,7 +232,7 @@ def update_integration_pre_build(from_path=None, to_path=None):
             data_array.append([DESC_TOKEN,manifest_get_data(from_path,key_name,DESC_ATTRIBUTE)])
 
             """
-            Inlining the data in the description param for a given integration
+            Inlining the data in the doc file
             """
             file_update_content(to_path, key_name, data_array)
     else:

--- a/local/bin/py/update_pre_build.py
+++ b/local/bin/py/update_pre_build.py
@@ -33,7 +33,7 @@ TROUBLESHOOTING_TOKEN ="{{< get-troubleshooting-from-git >}}"
 TROUBLESHOOTING_PATTERN= r'## Troubleshooting((?s).*)## Further Reading'
 
 FURTHER_READING_TOKEN = "{{< get-further-reading-from-git >}}"
-FURTHER_READING_PATTERN= r'## Overview((?s).*)'
+FURTHER_READING_PATTERN= r'## Further Reading((?s).*)'
 """
 Functions
 """

--- a/local/bin/py/update_pre_build.py
+++ b/local/bin/py/update_pre_build.py
@@ -19,20 +19,20 @@ DESC_TOKEN = "{{< get-desc-from-git >}}"
 DESC_ATTRIBUTE = "short_description"
 INTEGRATION_FOLDER = "content/integrations/"
 
-OVERVIEW_TOKEN = "{{< get-overview-from-git >}}"
+OVERVIEW_TOKEN = "//get-overview-from-git//"
 OVERVIEW_PATTERN = r'## Overview((?s).*)## Setup'
 
-SETUP_TOKEN = "{{< get-setup-from-git >}}"
+SETUP_TOKEN = "//get-setup-from-git//"
 SETUP_PATTERN = r'## Setup((?s).*)## Data Collected'
 
-DATA_COLLECTED_TOKEN= "{{< get-data-collected-from-git >}}"
+DATA_COLLECTED_TOKEN= "//get-data-collected-from-git//"
 DATA_COLLECTED_PATTERN= r'## Data Collected((?s).*)## Troubleshooting'
 
 
-TROUBLESHOOTING_TOKEN ="{{< get-troubleshooting-from-git >}}"
+TROUBLESHOOTING_TOKEN ="//get-troubleshooting-from-git//"
 TROUBLESHOOTING_PATTERN= r'## Troubleshooting((?s).*)## Further Reading'
 
-FURTHER_READING_TOKEN = "{{< get-further-reading-from-git >}}"
+FURTHER_READING_TOKEN = "//get-further-reading-from-git//"
 FURTHER_READING_PATTERN= r'## Further Reading((?s).*)'
 """
 Functions


### PR DESCRIPTION
Overview
----

To reduce duplicated content, all integrations related content should be in their specific integrations-core/dogweb repo readme.

This is directly inspired from the process `{{<get-metrics-from-git>}}` 

** For now this only works for integration core repo, but this will be extended to dogweb repo at some point **

Integration's Readme have all the following sections:

```
## Overview
### Setup
#### Installation 
#### Configuration
#### Validation

## Data Collected
### Service checks
### Events
### Metrics

## Troubleshooting
### faq_1 ?
### faq_2 ?

## Further Reading 
### KB 
### Blog Article 
```

The idea here is to have a macro like:
`{{< get-SECTION-from-git >}}` that inline the corresponding content from the readme file in the doc page.
