### PR TITLE
update slug

### DIFF
--- a/content/integrations/elastic.md
+++ b/content/integrations/elastic.md
@@ -5,7 +5,7 @@ kind: integration
 newhlevel: true
 git_integration_title: elastic
 updated_for_agent: 5.8.5
-slug: /integrations/elasticsearch
+slug: elasticsearch
 description: "{{< get-desc-from-git >}}"
 ---
 


### PR DESCRIPTION
we use the setting `canonifyURLs` to convert all urls to absolute, so we don't need to specify path here. 