### PR TITLE
Update Sudo Example

### DIFF
--- a/content/integrations/postfix.md
+++ b/content/integrations/postfix.md
@@ -26,7 +26,9 @@ Get metrics from Postfix in real time to monitor the messages pending in your Po
         # command to run the postfix check.  Here's an example:
         #
         # example /etc/sudoers entry:
-        #          dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/incoming -type f
+        #  dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/incoming -type f
+        #  dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/active -type f
+        #  dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/deferred -type f
         #
         # Redhat/CentOS/Amazon Linux flavours will need to add:
         #          Defaults:dd-agent !requiretty

--- a/content/integrations/postfix.md
+++ b/content/integrations/postfix.md
@@ -26,13 +26,7 @@ Get metrics from Postfix in real time to monitor the messages pending in your Po
         # command to run the postfix check.  Here's an example:
         #
         # example /etc/sudoers entry:
-        #          dd-agent ALL=(ALL) NOPASSWD:/usr/bin/find
-
-        # The user running dd-agent must have passwordless sudo access for the find
-        # command to run the postfix check.  Here's an example:
-        #
-        # example /etc/sudoers entry:
-        #          dd-agent ALL=(ALL) NOPASSWD:/usr/bin/find
+        #          dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/incoming -type f
         #
         # Redhat/CentOS/Amazon Linux flavours will need to add:
         #          Defaults:dd-agent !requiretty


### PR DESCRIPTION
This updates the sudoers example to be narrower. The current example is basically granting full root access. This now matches https://github.com/DataDog/integrations-core/blob/master/postfix/conf.yaml.example

Also remove the duplication, this looked like a cut and paste error.