### PR TITLE
adding metric token inlining

### DIFF
--- a/content/integrations/activemq.md
+++ b/content/integrations/activemq.md
@@ -15,17 +15,7 @@ description: "{{< get-desc-from-git >}}"
 //get-setup-from-git//
 
 ## Data Collected
-### Metrics
-
-{{< get-metrics-from-git >}}
-
-### Events
-
-The ActiveMQ check does not emit any events.
-
-### Service Checks
-
-The ActiveMQ check does not submit any service checks.
+//get-data-collected-from-git//
 
 ## Further Reading
 //get-further-reading-from-git//

--- a/local/bin/py/update_pre_build.py
+++ b/local/bin/py/update_pre_build.py
@@ -34,6 +34,10 @@ TROUBLESHOOTING_PATTERN= r'## Troubleshooting((?s).*)## Further Reading'
 
 FURTHER_READING_TOKEN = "//get-further-reading-from-git//"
 FURTHER_READING_PATTERN= r'## Further Reading((?s).*)'
+
+METRIC_TOKEN = "{{< get-metrics-from-git >}}"
+METRIC_PATERN= r'See \[metadata\.csv\].*provided by this integration.'
+
 """
 Functions
 """
@@ -189,7 +193,13 @@ def readme_get_section(from_path,key_name):
 
         result = re.search(DATA_COLLECTED_PATTERN, filedata)
         if result:
-            data_array.append([DATA_COLLECTED_TOKEN,result.group(1)])
+            try:
+                #Inlining metric token to display metric array
+                result = re.sub(METRIC_PATERN,METRIC_TOKEN, result.group(1))
+            except Exception as error:
+                print(error)
+                pass
+            data_array.append([DATA_COLLECTED_TOKEN,result])
         else:
             print("unable to find the pattern {} in file {}{}".format(DATA_COLLECTED_PATTERN,from_path, key_name))
 


### PR DESCRIPTION
We need to inline the get-metric-from-git token instead of the metadata.csv file link that is in the integration core repo.

This is not really robust, but if we fail to inline the token we will still have the link to the metadata.csv file so it's fine :)