### PR TITLE
move the place-holding to after sync steps

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,9 +38,9 @@ build_preview:
   script:
     - post_dd_event "documentation deploy ${CI_COMMIT_REF_NAME} started" "${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}" "info"
     - version_static_assets
-    - placehold_translations
     - sync_integration_descriptions
     - sync_integration_metrics
+    - placehold_translations
     - build_hugo_site
     - minify_html
     - collect_static_assets

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,9 +100,9 @@ build_live:
     - post_dd_event "documentation deploy ${CI_COMMIT_REF_NAME} started" "${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}" "info"
     - notify_slack "<https://github.com/DataDog/documentation/commit/${CI_COMMIT_SHA}|${CI_COMMIT_SHA:0:8}> sent to gitlab for production deployment. <${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}|details>" "#FFD700"
     - version_static_assets
-    - placehold_translations
     - sync_integration_descriptions
     - sync_integration_metrics
+    - placehold_translations
     - build_hugo_site
     - minify_html
     - collect_static_assets


### PR DESCRIPTION
sync steps replace markdown or html prior to hugo build. We want this to happen prior to i18n placeholder page generation. 