### PR TITLE
update image on zookeeper docs

### DIFF
--- a/content/integrations/zk.md
+++ b/content/integrations/zk.md
@@ -9,7 +9,7 @@ aliases:
 description: "{{< get-desc-from-git >}}"
 ---
 
-{{< img src="images/integrations/zookeeper/zookeepergraph.png" alt="Zendesk Dashboard" >}}
+{{< img src="integrations/zookeeper/zookeepergraph.png" alt="Zendesk Dashboard" >}}
 
 ## Overview
 

--- a/content/integrations/zk.md
+++ b/content/integrations/zk.md
@@ -9,7 +9,7 @@ aliases:
 description: "{{< get-desc-from-git >}}"
 ---
 
-{{< img src="integrations/zendesk/zendesk_dash.png" alt="Zendesk Dashboard" >}}
+{{< img src="images/integrations/zookeeper/zookeepergraph.png" alt="Zendesk Dashboard" >}}
 
 ## Overview
 


### PR DESCRIPTION
Zookeeper docs were previously showing the Zendesk screenboard. This commit updates the docs to show a graph of ZK metrics.

Preview URL:
https://d2cx6t4ssmwdrv.cloudfront.net/ilan/zookeeper-image/integrations/zk/