### PR TITLE
updating json configuration

### DIFF
--- a/content/integrations/ecs.md
+++ b/content/integrations/ecs.md
@@ -29,7 +29,9 @@ You may either configure the task using the [AWS CLI tools](https://aws.amazon.c
 1. Download [dd-agent-ecs.json](/json/dd-agent-ecs.json).
 1. Edit dd-agent-ecs.json and update it with the [API_KEY](https://app.datadoghq.com/account/settings#api) for your account.
 1. Execute the following command:
-       aws ecs register-task-definition --cli-input-json file://path/to/dd-agent-ecs.json
+```
+aws ecs register-task-definition --cli-input-json file://path/to/dd-agent-ecs.json
+```
 
 ##### Web UI
 

--- a/static/json/dd-agent-ecs.json
+++ b/static/json/dd-agent-ecs.json
@@ -4,7 +4,7 @@
       "name": "dd-agent",
       "image": "datadog/docker-dd-agent:latest",
       "cpu": 10,
-      "memory": 128,
+      "memory": 256,
       "essential": true,
       "mountPoints": [
         {


### PR DESCRIPTION
Customer pointed out two changes that need to be made to docs:

1) Wrong type of dash used
From https://docs.datadoghq.com/integrations/ecs/:

The doc site has the wrong dash at the beginning of the command line, so it's not just a copy/past - however the dashes in the middle of the command line flag are the right type:

"aws ecs register-task-definition –cli-input-json" should be aws ecs register-task-definition --cli-input-json

https://cl.ly/3S311M3u2P41

Though I think the longer dash is the "--"...

2) Need to make this consistent:

The memory value in the JSON (128) file doesn't match up with the by-hand configuration instructions (256) - I got an OOM on the datadog agent container before updating this value.

In dd-agent-ecs.json:
https://cl.ly/3m1H0Y412t1N

From https://docs.datadoghq.com/integrations/ecs/:
https://cl.ly/3O1E0f0Y1l3F