### PR TITLE
Correct mistake where text doesnt match image

### DIFF
--- a/content/guides/tagging.md
+++ b/content/guides/tagging.md
@@ -118,7 +118,7 @@ After you have assigned tags at the host and integration level, you can start us
 
 ### Using tags in the Events List
 
-The Events List will show you all the events that have occured in your environment over the time period specified. This can be overwhelming so you can use tags to filter down the list based on the tags you have assigned. You can enter any text you want in the search box above the Event List and a full text search will be performed. You can also enter ```tags:``` followed by a tag to see all the events that come from a host or integration with that tag. The example in the image is the tag role:sobotka. So the search text is ```tags:role:sobotka```.
+The Events List will show you all the events that have occured in your environment over the time period specified. This can be overwhelming so you can use tags to filter down the list based on the tags you have assigned. You can enter any text you want in the search box above the Event List and a full text search will be performed. You can also enter ```tags:``` followed by a tag to see all the events that come from a host or integration with that tag. The example in the image is the tag role:cassandra. So the search text is ```tags:role:cassandra```.
 
 {{< img src="guides/tagging/eventtags.png" alt="Events List and Tags" >}}
 


### PR DESCRIPTION
The images shows `role:cassandra` and the text says `role:sobotka`. Corrected it so that the text would say `role:cassandra` too.