### PR TITLE
Add multi-alert tags info

### DIFF
--- a/content/guides/tagging.md
+++ b/content/guides/tagging.md
@@ -159,7 +159,7 @@ When creating a monitor:
 
 * Use tags in the ```avg by``` textbox transform your monitor into a multi-alert monitor on each value of this tags.
 {{< img src="guides/tagging/monitortags_2.png" alt="excluding textbox tags in Monitors" >}}
- Please note that the tags on these events will be the tags related to the ```avg by:``` value. In order to have host-related tags (such as AWS integration tags), you will need to use ```avg by: host```
+Tags on these events are related to the ```avg by:``` value. In order to have host-related tags (such as AWS integration tags), use ```avg by: host```
 
 
 [tagsapi]: /api#tags

--- a/content/guides/tagging.md
+++ b/content/guides/tagging.md
@@ -159,6 +159,7 @@ When creating a monitor:
 
 * Use tags in the ```avg by``` textbox transform your monitor into a multi-alert monitor on each value of this tags.
 {{< img src="guides/tagging/monitortags_2.png" alt="excluding textbox tags in Monitors" >}}
+ Please note that the tags on these events will be the tags related to the ```avg by:``` value. In order to have host-related tags (such as AWS integration tags), you will need to use ```avg by: host```
 
 
 [tagsapi]: /api#tags


### PR DESCRIPTION
When using `avg by: <anything else than host>`, none of the host tags (AWS integration, DD tags, ...) will appear on the events. This was confusing for at least one user, so I thought it should be in the documentation.