### PR TITLE
[AWS beanstalk] update installation process

### DIFF
--- a/content/integrations/awsbeanstalk.md
+++ b/content/integrations/awsbeanstalk.md
@@ -15,6 +15,10 @@ AWS Elastic Beanstalk is an easy-to-use service for deploying and scaling web ap
 
 If you haven't already, set up the [Amazon Web Services integration first](/integrations/aws).
 
+Receiving Elastic Beanstalk metrics requires also to [enable the Enhanced Health Reporting](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced.html) feature for your environment, and to configure your environment to [publish enhanced health metrics to CloudWatch](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced-cloudwatch.html#health-enhanced-cloudwatch-console)
+
+**Note**: This will increase your CloudWatch custom metric charges.
+
 ### Configuration
 
 #### Monitor Elastic Beanstalk environments with the Datadog agent container


### PR DESCRIPTION
The following setup steps are missing from the [Elastic Beanstalk integration](https://docs.datadoghq.com/integrations/awsbeanstalk/) setup instructions:

Receiving Elastic Beanstalk metrics requires [Enhanced Health Reporting and Monitoring](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced.html) and [publishing this data to CloudWatch](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced-cloudwatch.html#health-enhanced-cloudwatch-console) (note that this will incur CloudWatch custom metric charges).

Preview: https://d2cx6t4ssmwdrv.cloudfront.net/gus/aws-elastic-beanstalk-update/integrations/awsbeanstalk/