### PR TITLE
link correction

### DIFF
--- a/content/integrations/new_relic.md
+++ b/content/integrations/new_relic.md
@@ -21,7 +21,7 @@ Connect to New Relic to:
 #### New Relic Alerts in Event Stream
 
 1.  On the Webhook tab of New Relic's alerting notification settings page, enter the following webhook URL:
-`https://app.datadoghq.com/intake/webhooknewrelic?api_key={YOUR_DATADOG_API_KEY}`
+`https://app.datadoghq.com/intake/webhook/newrelic?api_key={YOUR_DATADOG_API_KEY}`
 
 2.  For 'Custom Payload'(s), select JSON 'Payload Type'.
 


### PR DESCRIPTION
Hi,

There is a typo in one of the urls in the docs here: 
https://docs.datadoghq.com/integrations/new_relic/#new-relic-alerts-in-event-stream

The url for setting up the webhook while integrating with new relic is given as 

https://app.datadoghq.com/intake/webhooknewrelic?api_key={YOUR_DATADOG_API_KEY} 

while it should be 

https://app.datadoghq.com/intake/webhook/newrelic?api_key={YOUR_DATADOG_API_KEY}

I spent a couple of hours to figure it out. So hoping no one else has to do that again.

Feedback from Preethi