### PR TITLE
Removed private beta text from usage api doc

### DIFF
--- a/layouts/section/api.html
+++ b/layouts/section/api.html
@@ -2270,7 +2270,7 @@
         <div class="int-anchor" id="usage_metering"></div><a href="#usage_metering"><h3>Usage Metering</h3></a>
         <div class="row">
           <div class="col-xs-12 col-md-6 api-left">
-            <p class="c">This API is currently in private beta.  Python and Ruby clients are not yet supported.</p>
+            <p class="c">This API is available to all customers. Python and Ruby clients are not yet supported.</p>
             <p>
               The usage metering end-point allows you to:
             </p>


### PR DESCRIPTION
This PR removes the private beta text for DD Usage Public API