### PR TITLE
fix typo in infrastructure/process doc page

### DIFF
--- a/content/infrastructure/process.md
+++ b/content/infrastructure/process.md
@@ -52,11 +52,11 @@ In the [dd-agent.yaml](https://app.datadoghq.com/account/settings#agent/kubernet
         value: /host/proc
       - name: HOST_SYS
         value: /host/sys
-    volumeMount:
+    volumeMounts:
       - name: passwd
         mountPath: /etc/passwd
         readOnly: true
-    volume:
+    volumes:
       - hostPath:
           path: /etc/passwd
         name: passwd    


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fix typos in page: https://docs.datadoghq.com/infrastructure/process/#kubernetes-daemonset 
in the example we gave, the field "volume" should be "volumes", "volumeMount" should be "volumeMounts". 
### Motivation
Typos reported in this card: 
https://trello.com/c/Rjy7th1t/587-typo-in-kubernetes-daemonset-doc-page

