### PR TITLE
Fix the sudo chown command that was missing

### DIFF
--- a/content/agent/faq/how-to-solve-permission-denied-errors.md
+++ b/content/agent/faq/how-to-solve-permission-denied-errors.md
@@ -35,7 +35,7 @@ total 52300
 If those files are not owned by the dd-agent user, change the ownership with:
 
 ```
-If those files are not owned by the dd-agent user, change the ownership with:
+sudo chown -R dd-agent:dd-agent /var/log/datadog/
 ```
 
 Then [restart the agent](/agent/faq/start-stop-restart-the-datadog-agent). 


### PR DESCRIPTION
### What does this PR do?
The `sudo chown` command was missing in the original doc. "If those files are not owned by the dd-agent user, change the ownership with:" was duplicated.

### Motivation
Mandatory fix as per the above note.

### Additional Notes
N/A
