### PR TITLE
update agent 6 installation

### DIFF
--- a/content/logs/index.md
+++ b/content/logs/index.md
@@ -18,7 +18,7 @@ Datadog's Logs is currently available via private beta. You can apply for inclus
 ## Getting started with the Agent
 
 Log collection requires an Agent version >= 6.0. Older versions of the Agent do not include the `Log collection` interface that we'll be using.
-If you are not using it already, please follow the installation (or update) instructions [here](https://github.com/DataDog/datadog-agent/blob/master/docs/beta/upgrade.md).
+If you are not using it already, please follow the installation instructions [here](https://github.com/DataDog/datadog-agent/blob/master/docs/beta/upgrade.md). We highly recommend to do a fresh install instead of the upgrade. 
 
 Collecting logs is **disabled** by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
 


### PR DESCRIPTION
### What does this PR do?
Update the documentation to recommend a fresh install of the agent 6 instead of the upgrade.

### Motivation
Almost all raised issue by log users are linked to the upgrade of the agent 6

### Additional Notes
