### PR TITLE
[ecs] enable autodiscovery in our example template

### DIFF
--- a/static/json/dd-agent-ecs.json
+++ b/static/json/dd-agent-ecs.json
@@ -26,6 +26,10 @@
         {
           "name": "API_KEY",
           "value": "INSERT_API_KEY"
+        },
+        {
+      	  "name": "SD_BACKEND",
+	  "value": "docker"
         }
       ]
     }


### PR DESCRIPTION
### What does this PR do?

Default to having autodiscovery enabled as we do for other orchestrator instructions and examples.

### Motivation

Everyone expects autodiscovery out of the box.
