### PR TITLE
[forecasts] list functions that can't be used with forecasts

### DIFF
--- a/content/guides/forecasts.md
+++ b/content/guides/forecasts.md
@@ -96,4 +96,4 @@ The start and end times to specify when using the API are the start and end time
 
 ### Limitations
 
-Not all functions may be nested inside of forecast. In particular, you may not include any of the following functions in a forecast monitor or dashboard query: `anomalies()`, `cumsum()`, `default()`, `integral()`, `outliers()`, `piecewise_constant()`, `robust_trend()`, or `trend_line()`
+Not all functions may be nested inside of calls to the `forecast()` function. In particular, you may not include any of the following functions in a forecast monitor or dashboard query: `anomalies()`, `cumsum()`, `default()`, `integral()`, `outliers()`, `piecewise_constant()`, `robust_trend()`, or `trend_line()`

--- a/content/guides/forecasts.md
+++ b/content/guides/forecasts.md
@@ -93,3 +93,7 @@ For Linear: `forecast(metric_name, ‘linear’, 1, interval='60m', history='1w'
 For Seasonal: `forecast(metric_name, 'seasonal', 1, interval='60m', seasonality='weekly')`, where the options for `seasonality` are: `hourly`, `daily`, and `weekly`.
 
 The start and end times to specify when using the API are the start and end times of the forecast itself. If you want the forecast for the next day you would specify the start to be `now` and the end to be `1 day ahead`.
+
+### Limitations
+
+Not all functions may be nested inside of forecast. In particular, you may not include any of the following functions in a forecast monitor or dashboard query: `anomalies()`, `cumsum()`, `default()`, `integral()`, `outliers()`, `piecewise_constant()`, `robust_trend()`, or `trend_line()`

--- a/content/guides/forecasts.md
+++ b/content/guides/forecasts.md
@@ -96,4 +96,4 @@ The start and end times to specify when using the API are the start and end time
 
 ### Things to Note
 
-Not all functions may be nested inside of calls to the `forecast()` function. In particular, you may not include any of the following functions in a forecast monitor or dashboard query: `anomalies()`, `cumsum()`, `default()`, `integral()`, `outliers()`, `piecewise_constant()`, `robust_trend()`, or `trend_line()`
+Not all functions may be nested inside of calls to the `forecast()` function. In particular, you may not include any of the following functions in a forecast monitor or dashboard query: `anomalies()`, `cumsum()`, `integral()`, `outliers()`, `piecewise_constant()`, `robust_trend()`, or `trend_line()`

--- a/content/guides/forecasts.md
+++ b/content/guides/forecasts.md
@@ -94,6 +94,6 @@ For Seasonal: `forecast(metric_name, 'seasonal', 1, interval='60m', seasonality=
 
 The start and end times to specify when using the API are the start and end times of the forecast itself. If you want the forecast for the next day you would specify the start to be `now` and the end to be `1 day ahead`.
 
-### Limitations
+### Things to Note
 
 Not all functions may be nested inside of calls to the `forecast()` function. In particular, you may not include any of the following functions in a forecast monitor or dashboard query: `anomalies()`, `cumsum()`, `default()`, `integral()`, `outliers()`, `piecewise_constant()`, `robust_trend()`, or `trend_line()`


### PR DESCRIPTION
### What does this PR do?

Forecasts don't work with certain functions which limit the data queried for the original query window or output specially decorated query results. List these functions to make it explicit that forecasts are not expected to work with them.

cc @githomin @rachelwin 