### PR TITLE
Update correct container identifier label

### DIFF
--- a/content/guides/autodiscovery.md
+++ b/content/guides/autodiscovery.md
@@ -332,9 +332,9 @@ You can also add a network name suffix to the `%%host%%` variable—`%%host_brid
 
 ### Alternate Container Identifier: Labels
 
-You can identify containers by label rather than container name or image. Just label any container `com.datadoghq.ad.check.id: <SOME_LABEL>`, and then put `<SOME_LABEL>` anywhere you'd normally put a container name or image. For example, if you label a container `com.datadoghq.ad.check.id: special-container`, Autodiscovery will apply to that container any auto-conf template that contains `special-container` in its `docker_images` list.
+You can identify containers by label rather than container name or image. Just label any container `com.datadoghq.sd.check.id: <SOME_LABEL>`, and then put `<SOME_LABEL>` anywhere you'd normally put a container name or image. For example, if you label a container `com.datadoghq.sd.check.id: special-container`, Autodiscovery will apply to that container any auto-conf template that contains `special-container` in its `docker_images` list.
 
-Autodiscovery can only identify each container by label OR image/name—not both—and labels take precedence. For a container that has a `com.datadoghq.ad.check.id: special-nginx` label and runs the `nginx` image, the Agent will NOT apply templates that include only `nginx` as a container identifier.
+Autodiscovery can only identify each container by label OR image/name—not both—and labels take precedence. For a container that has a `com.datadoghq.sd.check.id: special-nginx` label and runs the `nginx` image, the Agent will NOT apply templates that include only `nginx` as a container identifier.
 
 ### Template Source Precedence
 


### PR DESCRIPTION
The `com.datadoghq.ad.check.id` label is incorrect for the check container identifier label. The correct one is `com.datadoghq.sd.check.id` (even though the other labels are prefixed com.datadoghq.ad).

### What does this PR do?
Updates documentation for the correct alternative container check identifier label (`com.datadoghq.sd.check.id`). The current one is incorrect.

### Motivation
Wasting many hours debugging why `com.datadoghq.ad.check.id` label was not working.

### Additional Notes
The code in the agent should probably be updated eventually so that the prefix matches the rest of the labels. Everything else appears to be prefixed as `com.datadoghq.ad` except for the container check identifier label.
