### PR TITLE
Add '%%tags%%' to distinguish metrics by Kubernetes Pod metadata

### DIFF
--- a/content/guides/autodiscovery.md
+++ b/content/guides/autodiscovery.md
@@ -240,7 +240,7 @@ metadata:
   annotations:
     service-discovery.datadoghq.com/apache.check_names: '["apache","http_check"]'
     service-discovery.datadoghq.com/apache.init_configs: '[{},{}]'
-    service-discovery.datadoghq.com/apache.instances: '[{"apache_status_url": "http://%%host%%/server-status?auto"},{"name": "My service", "url": "http://%%host%%", timeout: 1}]'
+    service-discovery.datadoghq.com/apache.instances: '[{"apache_status_url": "http://%%host%%/server-status?auto", "tags": ["%%tags%%"]},{"name": "My service", "url": "http://%%host%%", timeout: 1}]'
   labels:
     name: apache
 spec:
@@ -269,7 +269,7 @@ spec:
       annotations:
         service-discovery.datadoghq.com/apache.check_names: '["apache","http_check"]'
         service-discovery.datadoghq.com/apache.init_configs: '[{},{}]'
-        service-discovery.datadoghq.com/apache.instances: '[{"apache_status_url": "http://%%host%%/server-status?auto"},{"name": "My service", "url": "http://%%host%%", timeout: 1}]'
+        service-discovery.datadoghq.com/apache.instances: '[{"apache_status_url": "http://%%host%%/server-status?auto", "tags": ["%%tags%%"]},{"name": "My service", "url": "http://%%host%%", timeout: 1}]'
     spec:
       containers:
       - name: apache # use this as the container identifier in your annotations


### PR DESCRIPTION
### What does this PR do?

Add undocumented template variable `%%tags%%` to Kubernetes Annotations-based Autodiscovery example.

### Motivation

Metrics collected by Autodiscovery on Kubernetes does not have any metadata of Deployment and Pod in default.
This in incovenient in the following points:

- We cannot distinguish the metrics by Deployment / Pod name.
- If two or more the same microservice's Pods are running on the same node, dd-agent fails to send their metrics. It seems these are treated as duplicated metrics.

I looked up the solution for the above, then I found that `%%tags%%` adds Pod metadata or Pod spec.
https://github.com/DataDog/dd-agent/blob/425de487204bfe7aefdd72e5895a33db90ee6f1a/utils/service_discovery/sd_docker_backend.py#L107