### PR TITLE
[nodejs] Use hot-shots library in the example

### DIFF
--- a/content/integrations/nodejs.md
+++ b/content/integrations/nodejs.md
@@ -19,19 +19,20 @@ Connect your Node.js applications to Datadog to:
 ## Setup
 ### Configuration
 
-The Node.js integration enables you to monitor any custom metric by instrumenting a few lines of code. 
-For instance, you can have a metric that returns the number of page views or the time of any function call. 
-For additional information about the Node.js integration, please refer to this [guide on submitting metrics](https://docs.datadoghq.com/guides/metrics/)
-For advanced usage, please refer to the [documentation in the repository](https://github.com/joybro/node-dogstatsd)
+The Node.js integration enables you to monitor any custom metric by instrumenting a few lines of code.
+For instance, you can have a metric that returns the number of page views or the time of any function call.
+Instrumentation can be implemented using [hot-shots](https://github.com/brightcove/hot-shots),
+an open source DogStatsD client for node.js.
+ For additional information about the Node.js integration, please refer to this [guide on submitting metrics](https://docs.datadoghq.com/guides/metrics/)
 
-1. Install the library with npm:
+1. Install hot-shots with npm:
 ```
-npm install node-dogstatsd
+npm install hot-shots
 ```
 
 2. Start instrumenting your code:
 {{< highlight javascript>}}
-var StatsD = require('node-dogstatsd').StatsD;
+var StatsD = require('hot-shots');
 var dogstatsd = new StatsD();
 
 // Increment a counter.
@@ -39,4 +40,4 @@ dogstatsd.increment('page.views')
 {{< /highlight >}}
 
 ### Validation
-Go to the Metrics explorer page and see that it just works! 
+Go to the Metrics explorer page and see that it just works!


### PR DESCRIPTION
### What does this PR do?
Use `hot-shots` in the example about how to instrument a node.js application to send metrics.

### Motivation
The `node-dogstatsd` project isn't maintained anymore and the docs seem to imply that's a project owned by Datadog, which is incorrect.

Please let me know whether or not it's clear that `hot-shots` is not owned by Datadog.
