### PR TITLE
Theming the browser's address bar to match our brand's colors

### DIFF
--- a/content/graphing/infrastructure/_index.md
+++ b/content/graphing/infrastructure/_index.md
@@ -76,7 +76,7 @@ The names collected by the Agent (detailed [above](#agent-host-names)) are added
 You can see a list of all the hosts in your account from the Infrastructure tab
 in Datadog. From the Inspect panel, you can see (among other things) the list of aliases associated with each host.
 
-{{< img src="graphing/infrastructure/index/host_aliases.png" responsive="true" popup="true" >}}
+{{< img src="graphing/infrastructure/index/host_aliases.png" alt="host aliases" responsive="true" popup="true" >}}
 
 ### Export your infrastructure list and Agent versions
 

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -41,3 +41,6 @@
 <meta property="og:description" content="{{ $meta_desc }}"/>
 <meta property="og:site_name" content="Datadog Infrastructure and Application Monitoring"/>
 <meta property="article:author" content="Datadog"/>
+
+<!-- Address Bar Matches Brand Colors -->
+<meta name="theme-color" content="#774aa4"/>


### PR DESCRIPTION
After running a lighthouse audit, we missed  the themed color
https://developers.google.com/web/tools/lighthouse/audits/address-bar