### PR TITLE
Increase memory allocation to 256

### DIFF
--- a/content/integrations/awsbeanstalk.md
+++ b/content/integrations/awsbeanstalk.md
@@ -75,7 +75,7 @@ The following snippet illustrates a `Dockerrun.aws.json` declaring the Datadog a
               "value": "simple-tag-0, tag-key-1:tag-value-1"
             }
       ],
-      "memory": 128,
+      "memory": 256,
       "mountPoints": [
         {
           "sourceVolume": "docker_sock",


### PR DESCRIPTION
As per https://github.com/DataDog/docker-dd-agent/issues/219 the latest versions of the docker image require > 256mb of ram

### What does this PR do?
Increases the documentation's example to 256mb of RAM as is now required

### Motivation
Could not deploy based on this example, google revealed: https://github.com/DataDog/docker-dd-agent/issues/219

