### PR TITLE
Added missing -e flag for DD_LOG_ENABLED env var.

### DIFF
--- a/content/logs/index.md
+++ b/content/logs/index.md
@@ -130,7 +130,7 @@ For containerized installation, here are the command related to log collection:
 * `-v /var/run/docker.sock:/var/run/docker.sock:ro`: Give access to docker api to collect container stdout and stderr
 * `-v /my/path/to/conf.d:/conf.d:ro`: mount configuration repository
 * `-v /my/file/to/tail:/tail.log:ro`: Foreach log file that should be tailed by the agent (not required if you only want to collect container stdout or stderr)
-* `DD_LOG_ENABLED=true`: Activate log collection (disable by default)
+* `-e DD_LOG_ENABLED=true`: Activate log collection (disable by default)
 * `-e DD_API_KEY=<YOUR_API_KEY>`: Set the api key
 
 To start collecting logs for a given container filtered by image or label, update the integration log section in its yaml file, or create a custom yaml file.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR fixes a typo in the 'log' documentation where a `-e` is missing for the DD_LOG_ENABLED environment variable.

### Motivation
I ran into this discrepancy while configuring 'logs' and noticed that the syntax was incorrect.

### Additional Notes
N/A
