### PR TITLE
make signup go to the app for now as modal doesn't have perms to iframe

### DIFF
--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -5,7 +5,7 @@
             <div class="col-12 col-md-3 col-lg-4 footer-side">
                 <div class="row">
                     <div class="col-12 col-lg-8">
-                        <button type="button" class="btn btn-block btn-outline-semi-trans" data-toggle="modal" data-target="#signupModal">Free Trial</button>
+                        <a type="button" class="btn btn-block btn-outline-semi-trans" href="https://app.datadoghq.com/signup">Free Trial</a>
                     </div>
                 </div>
                 <span class="copyright d-none d-md-block">&copy; Datadog {{ $date := now }} {{ $date.Format "2006"}}</span>

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -39,7 +39,7 @@
                         </li>
                     {{ end }}
                     <li class="nav-item nav-button">
-                        <a class="btn btn-outline-primary sign-up-trigger" href="#" data-toggle="modal" data-target="#signupModal">GET STARTED FREE</a>
+                        <a class="btn btn-outline-primary sign-up-trigger" href="https://app.datadoghq.com/signup">GET STARTED FREE</a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
makes modal signups link to app

### Motivation
because we don't have perms to iframe the app signup

### Additional Notes
<!-- Anything else we should know when reviewing?-->
