### PR TITLE
fix videos when a section

### DIFF
--- a/layouts/section/videos.html
+++ b/layouts/section/videos.html
@@ -4,8 +4,8 @@
 <section>
     <ul>
         {{ $data := .Data }}
-        {{ range $key, $value := .Data.Terms }}
-        {{ $link := absLangURL (print $data.Plural "/" ($key | urlize) "/") }}
+        {{ range $key, $value := index .Site.Taxonomies "videos" }}
+        {{ $link := absLangURL (print "videos/" ($key | urlize) "/") }}
         <li><a href="{{ $link }}">{{ $key }}</a> - ({{ len $value }})</li>
         {{ end }}
     </ul>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
videos page taxonomy terms isn't showing when its loading as a section

### Motivation
<!-- What inspired you to submit this pull request?-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
