### PR TITLE
stop sliding the api page and jump to section

### DIFF
--- a/src/js/datadog-docs.js
+++ b/src/js/datadog-docs.js
@@ -375,7 +375,7 @@ $(document).ready(function () {
     $('.api-nav .dropdown-menu .dropdown-item').on('click', function(e) {
         var href = $(this).attr('href');
         if(href.substr(0, 1) === '#') {
-            moveToAnchor(href.substr(1));
+            moveToAnchor(href.substr(1), false);
             /*var pop = document.getElementById('api-popper')
             if(pop) {
                 pop.style.display = (pop.style.display === 'none') ? 'block' : 'none';
@@ -385,10 +385,18 @@ $(document).ready(function () {
     });
 
     //
-    $('#TableOfContents a, .sidenav-api a').on('click', function(e) {
+    $('#TableOfContents a').on('click', function(e) {
         var href = $(this).attr('href');
         if(href.substr(0, 1) === '#') {
             moveToAnchor(href.substr(1));
+            return false;
+        }
+    });
+
+    $('.sidenav-api a').on('click', function(e) {
+        var href = $(this).attr('href');
+        if(href.substr(0, 1) === '#') {
+            moveToAnchor(href.substr(1), false);
             return false;
         }
     });
@@ -397,7 +405,7 @@ $(document).ready(function () {
     $('.api-select').on('change', function(e) {
         var href = $(this).val();
         if(href.substr(0, 1) === '#') {
-            moveToAnchor(href.substr(1));
+            moveToAnchor(href.substr(1), false);
             return false;
         }
     });


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Stops the api page from sliding up and down and does immediate jumps
https://docs-staging.datadoghq.com/david.jones/stop-api-sliding/api/

### Motivation
<!-- What inspired you to submit this pull request?-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
