### PR TITLE
adding float disclaimer

### DIFF
--- a/content/integrations/faq/how-to-collect-metrics-from-custom-mysql-queries.md
+++ b/content/integrations/faq/how-to-collect-metrics-from-custom-mysql-queries.md
@@ -5,6 +5,12 @@ kind: faq
 
 You can configure your MySQL integration to collect metrics from custom queries of your MySQL database by following the configuration syntax [in these lines](https://github.com/DataDog/dd-agent/blob/5.10.x/conf.d/mysql.yaml.example#L50-L66) of our `mysql.yaml.example` file. While you do this, there are a few things you want to keep in mind...
 
+
+<div class="alert alert-warning">
+Custom metrics queried via custom_proc must have type <code>FLOAT</code> and not <code>INT</code>
+</div>
+
+
 ## Qualifying your databases
 
 When you add your custom query, you have to be careful to make sure each table you reference has its database qualified. This can be done by prepending the table with its database name in the following format:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adding a disclaimer for mysql custom proc
### Motivation
<!-- What inspired you to submit this pull request?-->
Custom_proc flow in SQLServer configs is a bit weird.
One requirement it looks like is that metrics generated must be in FLOAT rather than INT otherwise the flow will not work
### Preview link
<!-- Anything else we should know when reviewing?-->
https://docs-staging.datadoghq.com/gus/mysql/integrations/faq/how-to-collect-metrics-from-custom-mysql-queries/