### PR TITLE
fixing redirect to lead to agent index

### DIFF
--- a/content/agent/_index.md
+++ b/content/agent/_index.md
@@ -2,6 +2,8 @@
 title: Agent
 kind: documentation
 description: Install & configure the Agent to collect data
+aliases:
+    - /guides/basic_agent_usage/
 ---
 
 {{< partial name="platforms/platforms.html" >}}

--- a/content/agent/basic_agent_usage/_index.md
+++ b/content/agent/basic_agent_usage/_index.md
@@ -1,6 +1,4 @@
 ---
 title: Basic Agent Usage
 external_redirect: /agent/basic_agent_usage/amazonlinux/
-aliases:
-    - /guides/basic_agent_usage/
 ---


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Point alias into agent index page instead of amazon linux agent page
