### PR TITLE
Ilan/fix kube description

### DIFF
--- a/content/integrations/kubernetes.md
+++ b/content/integrations/kubernetes.md
@@ -7,6 +7,9 @@ newhlevel: true
 updated_for_agent: 5.8.5
 description: "Monitor the health of your Kubernetes cluster and the applications running on it. Capture Pod scheduling events, track the status of your Kubelets, and more."
 is_public: true
+aliases:
+    - /tracing/api/
+    - /integrations/kubernetes_state/
 ---
 
 {{< img src="integrations/kubernetes/k8sdashboard.png" alt="Kubernetes Dashboard" responsive="true" popup="true">}}

--- a/content/integrations/kubernetes.md
+++ b/content/integrations/kubernetes.md
@@ -5,7 +5,7 @@ kind: integration
 git_integration_title: kubernetes
 newhlevel: true
 updated_for_agent: 5.8.5
-description: "{{< get-desc-from-git >}}"
+description: "Monitor the health of your Kubernetes cluster and the applications running on it. Capture Pod scheduling events, track the status of your Kubelets, and more."
 is_public: true
 ---
 


### PR DESCRIPTION
### What does this PR do?

Clean up kubernetes a bit.  Redirect from kube-state-metrics to k8s.  
Fix the description to include text from integrations-core

### Motivation

Google juice going to the wrong places.

### Preview link
See metadata tags at: https://docs-staging.datadoghq.com/ilan/fix_kube_description/integrations/kubernetes/

See redirect at:
https://docs-staging.datadoghq.com/ilan/fix_kube_description/integrations/kubernetes_state/
