### PR TITLE
adding info on local enpoint for tracing API

### DIFF
--- a/content/api/tracing/send_service_code.md
+++ b/content/api/tracing/send_service_code.md
@@ -5,7 +5,7 @@ order: 20.2
 ---
 
 ##### Signature
-`PUT /v0.3/services`
+`PUT  http://localhost:8126/v0.3/traces`
 
 ##### Example Request
 {{< code-snippets basename="send_service" >}}

--- a/content/api/tracing/send_trace_code.md
+++ b/content/api/tracing/send_trace_code.md
@@ -5,7 +5,7 @@ order: 20.1
 ---
 
 ##### Signature
-`PUT /v0.3/traces`
+`PUT  http://localhost:8126/v0.3/traces`
 
 ##### Example Request
 

--- a/content/api/tracing/tracing.md
+++ b/content/api/tracing/tracing.md
@@ -6,3 +6,5 @@ order: 20
 
 ## Tracing
 Learn more about [tracing with Datadog](/tracing) and [the APM terminology](/tracing/terminology)
+
+The tracing API is an agent API rather than a service side API. Submit your traces to the `http://localhost:8126/v0.3/traces` local endpoint so your Agent can forward them to Datadog.


### PR DESCRIPTION
### What does this PR do?
Adding info that tracing API has a local enpoint

### Motivation
The tracing API is an agent API rather than a service side API. It used to be in its own section, but was intentionally merged into a single page as part of the redesign. We clarify here on the api docs where the end point is and how to use it.

### Preview link
https://docs-staging.datadoghq.com/gus/trace-api-update/api/?lang=python#tracing