### PR TITLE
moving docker KBs to doc

### DIFF
--- a/content/integrations/faq/_index.md
+++ b/content/integrations/faq/_index.md
@@ -48,6 +48,11 @@ kind: faq
 ## Dyn
 * [Why is my dyn.qps metric delayed?](/integrations/faq/why-is-my-dyn-qps-metric-delayed)
 
+## Docker
+
+* [Compose and the Datadog Agent](/integrations/faq/compose-and-the-datadog-agent)
+* [DogStatsD and Docker](/integrations/faq/dogstatsd-and-docker)
+
 ## Elasticsearch 
 
 * [Why isn't Elasticsearch sending all my metrics?](/integrations/faq/why-isn-t-elasticsearch-sending-all-my-metrics)

--- a/content/integrations/faq/compose-and-the-datadog-agent.md
+++ b/content/integrations/faq/compose-and-the-datadog-agent.md
@@ -1,0 +1,57 @@
+---
+title: Compose and the Datadog Agent
+kind: faq
+---
+
+[Compose](https://docs.docker.com/compose/overview/) is a Docker tool that simplifies building applications on Docker by allowing you to define, build and run multiple containers as a single application.
+
+While the [Single Container Installation instructions](/integrations/docker_daemon) gets the stock Datadog Agent container running, you will most likely want to enable integrations for other containerized services that are part of your Compose application.  
+To do this, you'll need to combine integration YAML files with the base Datadog Agent image to create your Datadog Agent container. Then you'll need to add your container to the Compose YAML.
+
+##### Example: Monitoring Redis
+
+Let's look at how you would monitor a Redis container using Compose. Our example file structure is:
+
+    |- docker-compose.yml
+    |- datadog
+        |- Dockerfile
+        |- conf.d
+           |-redisdb.yaml
+
+First we'll take a look at the `docker-compose.yml` that describes how our containers work together and sets some of the configuration details for the containers.
+
+```yaml
+version: "2"
+services:
+  # Redis container
+  redis:
+    image: redis
+  # Agent container
+  datadog:
+    build: datadog
+    links:
+     - redis # Ensures datadog container can connect to redis container
+    environment:
+     - API_KEY=__your_datadog_api_key_here__
+    volumes:
+     - /var/run/docker.sock:/var/run/docker.sock
+     - /proc/mounts:/host/proc/mounts:ro
+     - /sys/fs/cgroup:/host/sys/fs/cgroup:ro
+```
+
+In this file, we can see that Compose will run the Docker image `redis` and it will also build and run a `datadog` container. By default it will look for a matching directory called `datadog` and run the `Dockerfile` in that directory.
+
+Our `Dockerfile` simply takes the standard [Datadog docker image](https://hub.docker.com/r/datadog/docker-dd-agent/) and places a copy of the `redisdb.yaml` integration configuration into the appropriate directory:
+
+    FROM datadog/docker-dd-agent
+    ADD conf.d/redisdb.yaml /etc/dd-agent/conf.d/redisdb.yaml
+
+Finally our `redisdb.yaml` is patterned after the [redisdb.yaml.example file](https://github.com/DataDog/integrations-core/blob/master/redisdb/conf.yaml.example) and tells the Datadog Agent to look for Redis on the host named `redis` (defined in our `docker-compose.yaml` above) and the standard Redis port 6379:
+
+    init_config:
+
+    instances:
+      - host: redis
+        port: 6379
+
+For a more complete example, please see our [Docker Compose example project on Github](https://github.com/DataDog/docker-compose-example).

--- a/content/integrations/faq/dogstatsd-and-docker.md
+++ b/content/integrations/faq/dogstatsd-and-docker.md
@@ -1,0 +1,46 @@
+---
+title: Compose and the Datadog Agent
+kind: faq
+---
+
+Datadog has a huge number of [integrations with common applications](/integrations/), but it can also be used to instrument your custom applications. This is typically using one of the many [Datadog libraries](/developers/libraries/).
+
+Libraries that communicate over HTTP using the [Datadog API](/api/) don't require any special configuration with regard to Docker. However, applications using libraries that integrate with DogStatsD or StatsD will need to configure the library to connect to the Agent. Note that each library will handle this configuration differently, so please refer to the individual library's documentation for more details.
+
+After your code is configured you can run your custom application container using [the `--link` option](https://docs.docker.com/engine/reference/run/#/expose-incoming-ports) to create a network connection between your application container and the Datadog Agent container.
+
+##### Example: Monitoring a basic Python application
+
+To start monitoring our application, we first need to run the Datadog container using the [Single Container Installation](#single-container-installation) instructions above. Note that the `docker run` command sets the name of the container to `dd-agent`.
+
+Next, we'll need to instrument our code. Here's a basic Flask-based web application:
+
+```python
+from flask import Flask
+from datadog import initialize, statsd
+
+# Initialize DogStatsD and set the host.
+initialize(statsd_host = 'dd-agent')
+
+app = Flask(__name__)
+
+@app.route('/')
+def hello():
+    # Increment a Datadog counter.
+    statsd.increment('my_webapp.page.views')
+
+    return "Hello World!"
+
+if __name__ == "__main__"
+    app.run()
+```
+
+In our example code above, we set the DogStatsD host to match the Datadog Agent container name, `dd-agent`.
+
+After we build our web application container, we can run it and use the `--link` argument to setup a network connection to the Datadog Agent container:
+
+    docker run -d --name my-web-app \
+      --link dd-agent:dd-agent
+      my-web-app
+
+For another example using DogStatsD, see our [Docker Compose example project on Github](https://github.com/DataDog/docker-compose-example).


### PR DESCRIPTION
### What does this PR do?

Moving Docker KB doc from integrations core repo to documentation
[PR for integrations core](https://github.com/DataDog/integrations-core/pull/985)

### Motivation

Reduce size of docker readme on integrations core repo

### Preview link

* https://docs-staging.datadoghq.com/gus/docker-faq/integrations/faq/compose-and-the-datadog-agent/
* https://docs-staging.datadoghq.com/gus/docker-faq/integrations/faq/dogstatsd-and-docker/
 