### PR TITLE
make api headers clickable as anchors again

### DIFF
--- a/src/js/datadog-docs.js
+++ b/src/js/datadog-docs.js
@@ -438,6 +438,14 @@ $(document).ready(function () {
         });
     });
 
+    $('.api-content h2[id]').each(function() {
+        var id = $(this).attr('id');
+        $(this).wrapInner('<a href="#'+id+'"></a>').on('click', function(e) {
+            moveToAnchor(id, false);
+            return false;
+        });
+    });
+
     // sticky polyfill trigger
     var elements = document.querySelectorAll('.sticky');
     Stickyfill.add(elements);

--- a/src/scss/pages/_api.scss
+++ b/src/scss/pages/_api.scss
@@ -17,6 +17,12 @@
         }
       }
     }
+    h2 a {
+      &:hover {
+        color:#000;
+        border-bottom: 1px solid #000;
+      }
+    }
   }
 
   .api-code {


### PR DESCRIPTION
### What does this PR do?
This pr will make the headers on the api page clickable anchor links again.

### Motivation
https://trello.com/c/IcWQW0Fm/126-endpoint-anchor-are-broken-on-api-page

### Preview link
https://docs-staging.datadoghq.com/david.jones/api-anchors/api/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
