### PR TITLE
when indexing the html remove the div with whatsnext class

### DIFF
--- a/local/bin/py/index_algolia.py
+++ b/local/bin/py/index_algolia.py
@@ -66,6 +66,9 @@ def index_algolia(app_id, api_key, content_path=None):
                                     title = html.select('h1')[0].text.strip()
 
                                 if title and '://' not in title:
+                                    # strip specific html
+                                    [tag.extract() for tag in html.findAll("div", {"class": "whatsnext"})]
+
                                     # description
                                     main = html.find("div", {'main'}).prettify()[:7000]
 


### PR DESCRIPTION
### What does this PR do?
This should remove the whats next / further reading section from the bottom of the search results.

### Motivation
https://trello.com/c/KKrX8ksW/141-search-displays-partials

### Preview link
https://docs-staging.datadoghq.com/david.jones/search-remove-whatsnext/

### Additional Notes
These changes don't get run on a preview site, i have tested locally and it works but please inspect the changes carefully and check the build is passing before merging.
