### PR TITLE
the api page doesn't use the class main

### DIFF
--- a/layouts/_default/api-baseof.html
+++ b/layouts/_default/api-baseof.html
@@ -26,7 +26,7 @@
             <div class="d-none d-lg-flex col-sm-3 side">
                 {{ partial "sidenav/sidenav-api.html" . }}
             </div>
-            <div class="col-12 col-lg-9">
+            <div class="col-12 col-lg-9 main-api">
                 {{ block "main" . }}{{ end }}
             </div>
         </div>

--- a/local/bin/py/index_algolia.py
+++ b/local/bin/py/index_algolia.py
@@ -70,7 +70,10 @@ def index_algolia(app_id, api_key, content_path=None):
                                     [tag.extract() for tag in html.findAll("div", {"class": "whatsnext"})]
 
                                     # description
-                                    main = html.find("div", {'main'}).prettify()[:7000]
+                                    main = html.find("div", {'main'})
+                                    if not main:
+                                        main = html.find("div", {'main-api'})
+                                    main = main.prettify()[:7000]
 
                                     fm_description = html.findAll(attrs={"itemprop": "description"})[0]['content']
                                     if fm_description != default_description and '{{' not in fm_description:


### PR DESCRIPTION
### What does this PR do?
The api page is missing from the search results this pr aims to restore this and other pages effected by the same issue.

The cause of the issue is that our algolia index script searches for a class of "main" in the built html but that doesn't exist on api pages.

### Motivation
https://trello.com/c/qTzYgZOR/143-cant-get-to-api-via-search

### Preview link
https://docs-staging.datadoghq.com/david.jones/search-missing-api/

### Additional Notes
The script index algolia doesn't get run on preview sites, so check the code carefully in review
