### PR TITLE
make sure there is no starting space on multiline code blocks

### DIFF
--- a/src/scss/pages/_global.scss
+++ b/src/scss/pages/_global.scss
@@ -121,6 +121,7 @@ pre {
     white-space: pre-wrap;
     background-color: transparent;
     border-radius: 0;
+    border:none;
     font-family: $font-family-monospace;
   }
 }


### PR DESCRIPTION
### What does this PR do?
This removes the starting space on multi line code blocks the spacing should only exist on single inline code.

### Motivation
https://trello.com/c/QQMhSh5I/144-there-is-a-space-at-the-beginning-of-all-code-blocks

### Preview link
https://docs-staging.datadoghq.com/david.jones/codespace/

### Additional Notes

