### PR TITLE
Adding ecs/docker/kubernetes event KB

### DIFF
--- a/content/integrations/faq/_index.md
+++ b/content/integrations/faq/_index.md
@@ -52,6 +52,7 @@ kind: faq
 
 * [Compose and the Datadog Agent](/integrations/faq/compose-and-the-datadog-agent)
 * [DogStatsD and Docker](/integrations/faq/dogstatsd-and-docker)
+* [Docker, ECS, & Kubernetes Events](/integrations/faq/docker-ecs-kubernetes-events)
 
 ## Elasticsearch 
 

--- a/content/integrations/faq/docker-ecs-kubernetes-events.md
+++ b/content/integrations/faq/docker-ecs-kubernetes-events.md
@@ -1,0 +1,82 @@
+---
+title: Docker, ECS, & Kubernetes Events
+kind: faq
+---
+
+### Container Integration Events
+
+When monitoring containers and orchestrators (Docker, ECS & Kubernetes) you are familiar with the events that are available once an integration has been enabled and respective configuration steps followed.
+
+As your containerized environment grows, containers and orchestrators start emitting a high volume of events that leads to more noise in the [events stream](/graphing/event_stream), [monitors](/monitors) and overlays.
+
+To ensure that you don't have to worry about the eventual noise, events provided by default are limited to only severe and important events listed below.  
+
+If further access is needed to any other events in a specific integration, please [reach out to us](/help) to have these events enabled for your organization.
+
+## Docker, ECS & Kubernetes Integration Details
+
+The events below will be available per integration:
+
+### Docker
+
+* Delete Image
+* Die
+* Error
+* Fail
+* Kill
+* Out of memory (oom)
+* Pause
+* Restart container
+* Restart Daemon
+* Update
+
+[Learn more about Datadog-Docker integration](/integrations/docker_daemon/)
+
+### ECS
+
+* Drain
+* Error
+* Fail
+* Out of memory
+* Pending
+* Reboot
+* Terminate
+
+[Learn more about Datadog-AWS ECS integration](/integrations/amazon_ecs/)
+
+### Kubernetes
+
+* Backoff
+* Conflict
+* Delete
+* DeletingAllPods
+* Didn't have enough resource
+* Error
+* Failed
+* FailedCreate
+* FailedDelete
+* FailedMount
+* FailedSync
+* Failedvalidation
+* FreeDiskSpaceFailed
+* HostPortConflict
+* InsufficientFreeCPU
+* InsufficientFreeMemory
+* InvalidDiskCapacity
+* Killing
+* KubeletsetupFailed
+* NodeNotReady
+* NodeoutofDisk
+* OutofDisk
+* Rebooted
+* TerminatedAllPods
+* Unable
+* Unhealthy
+
+[Learn more about Datadog-Kubernetes integration](/integrations/kubernetes/)
+
+To access and utilize these events in Datadog, you can use the following three methods:
+
+* [Events stream](/graphing/event_stream)
+* [Monitors](/monitors)
+* [Event overlays on graphs](/graphing/dashboards/#event-correlation-at-view-time)

--- a/content/integrations/faq/docker-ecs-kubernetes-events.md
+++ b/content/integrations/faq/docker-ecs-kubernetes-events.md
@@ -5,15 +5,15 @@ kind: faq
 
 ### Container Integration Events
 
-When monitoring containers and orchestrators (Docker, ECS & Kubernetes) you are familiar with the events that are available once an integration has been enabled and respective configuration steps followed.
+When monitoring containers and orchestrators (Docker, ECS, and Kubernetes) you are familiar with the events that are available once an integration has been enabled and respective configuration steps followed.
 
-As your containerized environment grows, containers and orchestrators start emitting a high volume of events that leads to more noise in the [events stream](/graphing/event_stream), [monitors](/monitors) and overlays.
+As your containerized environment grows, containers and orchestrators start emitting a high volume of events that leads to more noise in the [events stream](/graphing/event_stream), [monitors](/monitors), and overlays.
 
 To ensure that you don't have to worry about the eventual noise, events provided by default are limited to only severe and important events listed below.  
 
 If further access is needed to any other events in a specific integration, please [reach out to us](/help) to have these events enabled for your organization.
 
-## Docker, ECS & Kubernetes Integration Details
+## Docker, ECS, and Kubernetes Integration Details
 
 The events below will be available per integration:
 
@@ -75,7 +75,7 @@ The events below will be available per integration:
 
 [Learn more about Datadog-Kubernetes integration](/integrations/kubernetes/)
 
-To access and utilize these events in Datadog, you can use the following three methods:
+To access and utilize these events in Datadog, use the following three methods:
 
 * [Events stream](/graphing/event_stream)
 * [Monitors](/monitors)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Migrating a KB from zendesk to the doc

### Motivation
<!-- What inspired you to submit this pull request?-->
We're getting rids of KBs in favor of docs

https://help.datadoghq.com/hc/en-us/articles/115004125863-Docker-ECS-Kubernetes-Events

is partially covered by https://docs.datadoghq.com/integrations/kubernetes/#events

but we'd actually need a FAQ article since:

* the KB is about Kubernetes and Docker and ECS
* there is a flag support can activate to get all events from docker.

### Preview link

* https://docs-staging.datadoghq.com/gus/docker-k8-event-kb/integrations/faq/docker-ecs-kubernetes-events/
  