### PR TITLE
Make it very obvious that JSON-formatted logs are parsed automatically

### DIFF
--- a/content/logs/_index.md
+++ b/content/logs/_index.md
@@ -55,9 +55,9 @@ During the beta phase of Datadog Logs, not all integrations include log configur
 * Nginx: [nginx.d/conf.yaml.example](https://github.com/DataDog/integrations-core/blob/nils/Logs-integration-beta/nginx/conf.yaml.example)
 * PostgreSQL: [postgres.d/conf.yaml.example](https://github.com/DataDog/integrations-core/blob/nils/Logs-integration-beta/postgres/conf.yaml.example)
 
-## The Advantage of Collecting JSON-formatted logs
+### The Advantage of Collecting JSON-formatted logs
 
-Datadog automatically parses JSON-formattted logs. For this reason, when you have control over the format of the logs you send to Datadog, we encourage you to format them as JSON to avoid the need for custom parsing rules.
+Datadog automatically parses JSON-formattted logs. For this reason, when you have control over the log format you send to Datadog, we encourage you to format them as JSON to avoid the need for custom parsing rules.
 
 ## Custom log collection
 

--- a/content/logs/_index.md
+++ b/content/logs/_index.md
@@ -55,6 +55,10 @@ During the beta phase of Datadog Logs, not all integrations include log configur
 * Nginx: [nginx.d/conf.yaml.example](https://github.com/DataDog/integrations-core/blob/nils/Logs-integration-beta/nginx/conf.yaml.example)
 * PostgreSQL: [postgres.d/conf.yaml.example](https://github.com/DataDog/integrations-core/blob/nils/Logs-integration-beta/postgres/conf.yaml.example)
 
+## The Advantage of Collecting JSON-formatted logs
+
+Datadog automatically parses JSON-formattted logs. For this reason, when you have control over the format of the logs you send to Datadog, we encourage you to format them as JSON to avoid the need for custom parsing rules.
+
 ## Custom log collection
 
 The Datadog Agent can collect logs from files or the network (TCP or UDP) and forward them to Datadog. To configure this, create a new repository and yaml file named after your log source  in the Agent's **conf.d** directory ( `conf.d/python.d/conf.yaml` for python logs, ...) and set these options:

--- a/content/logs/parsing.md
+++ b/content/logs/parsing.md
@@ -20,7 +20,7 @@ Datadog's Logs is currently available via public beta. You can apply for inclusi
 
 ## Overview 
 
-The Grok syntax provides an easier way to parse logs than pure regular expressions. 
+The Grok syntax provides an easier way to parse logs than pure regular expressions. If your logs are JSON-formatted, Datadog automatically parses them, but for other formats, Datadog allows you to enrich your logs with the help of Grok parsers. 
 The main usage of the Grok Parser is to extract attributes from semi-structured text messages.
 
 Grok comes with a lot of reusable patterns to parse integers, ip addresses, hostnames, etc...

--- a/content/logs/parsing.md
+++ b/content/logs/parsing.md
@@ -20,7 +20,8 @@ Datadog's Logs is currently available via public beta. You can apply for inclusi
 
 ## Overview 
 
-The Grok syntax provides an easier way to parse logs than pure regular expressions. If your logs are JSON-formatted, Datadog automatically parses them, but for other formats, Datadog allows you to enrich your logs with the help of Grok parsers. 
+If your logs are JSON-formatted, Datadog automatically parses them, but for other formats, Datadog allows you to enrich your logs with the help of Grok Parser.    
+The Grok syntax provides an easier way to parse logs than pure regular expressions.  
 The main usage of the Grok Parser is to extract attributes from semi-structured text messages.
 
 Grok comes with a lot of reusable patterns to parse integers, ip addresses, hostnames, etc...

--- a/content/logs/processing.md
+++ b/content/logs/processing.md
@@ -1,7 +1,7 @@
 ---
 title: Pipelines
 kind: documentation
-description: "Parse & Enrich your logs so you can create valuable facets & metrics in the Logs Explorer."
+description: "Parse & Enrich your logs to create valuable facets & metrics in the Logs Explorer."
 further_reading:
 - link: "/logs/parsing"
   tag: "Documentation"
@@ -31,7 +31,7 @@ To access the processing panel use the upper left menu:
 
 Datadog automatically parses JSON-formatted logs. When your logs are not JSON-formatted, Datadog enables you to add value to your raw logs by sending them through a processing pipeline.
 
-With pipelines, you can parse and enrich your logs by chaining them sequentially through [processors](#processors). This lets you extract meaningful information or attributes from semi-structured text to reuse them as [facets](/logs/explore/#facets).
+With pipelines, you parse and enrich your logs by chaining them sequentially through [processors](#processors). This lets you extract meaningful information or attributes from semi-structured text to reuse them as [facets](/logs/explore/#facets).
 
 Each log that comes through the pipelines is tested against every pipeline filter. If it matches one then all the [processors](#processors) are applied sequentially before moving to the next pipeline.
 
@@ -47,7 +47,7 @@ With one single pipeline:
 
 {{< img src="logs/processing/pipeline_example.png" alt="Pipelines example" responsive="true" popup="true" style="width:75%;">}}
 
-Pipelines can take logs from a wide variety of formats and translate them all into a common format in Datadog.
+Pipelines take logs from a wide variety of formats and translate them all into a common format in Datadog.
 
 ### Pipeline filters
 

--- a/content/logs/processing.md
+++ b/content/logs/processing.md
@@ -29,6 +29,8 @@ To access the processing panel use the upper left menu:
 
 **A processing pipeline takes a filtered subset of incoming logs and applies over them a list of sequential processors.**
 
+Datadog automatically parses JSON-formatted logs. When your logs are not JSON-formatted, Datadog enables you to add value to your raw logs by sending them through a processing pipeline.
+
 With pipelines, you can parse and enrich your logs by chaining them sequentially through [processors](#processors). This lets you extract meaningful information or attributes from semi-structured text to reuse them as [facets](/logs/explore/#facets).
 
 Each log that comes through the pipelines is tested against every pipeline filter. If it matches one then all the [processors](#processors) are applied sequentially before moving to the next pipeline.

--- a/content/logs/processing.md
+++ b/content/logs/processing.md
@@ -24,8 +24,8 @@ To access the processing panel use the upper left menu:
 
 {{< img src="logs/processing/processing_panel.png" alt="Pipelines panel" responsive="true" popup="true" style="width:50%;" >}}
 
-## Processing Pipelines 
-### Pipelines Goal 
+## Processing Pipelines
+### Pipelines Goal
 
 **A processing pipeline takes a filtered subset of incoming logs and applies over them a list of sequential processors.**
 
@@ -39,7 +39,7 @@ So for instance a processing pipeline can transform this log:
 
 {{< img src="logs/processing/original_log.png" alt="original log" responsive="true" popup="true" style="width:50%;">}}
 
-into this log: 
+into this log:
 
 {{< img src="logs/processing/log_post_severity.png" alt=" Log post severity " responsive="true" popup="true" style="width:50%;">}}
 
@@ -47,7 +47,7 @@ With one single pipeline:
 
 {{< img src="logs/processing/pipeline_example.png" alt="Pipelines example" responsive="true" popup="true" style="width:75%;">}}
 
-Pipelines take logs from a wide variety of formats and translate them all into a common format in Datadog.
+Pipelines take logs from a wide variety of formats and translate them into a common format in Datadog.
 
 ### Pipeline filters
 
@@ -55,7 +55,7 @@ Filters let you limit what kinds of logs a pipeline applies to.
 
 The filter syntax is the same as the [search bar](/logs/explore/#search-bar).
 
-**Be aware that the pipeline filtering is applied before any pipeline processing, hence you cannot filter on an attribute that does not exist** 
+**Be aware that the pipeline filtering is applied before any pipeline processing, hence you cannot filter on an attribute that does not exist**
 
 The logstream shows which logs your pipeline applies to:
 
@@ -81,7 +81,7 @@ Create custom grok rules to parse the full message or a specific attribute of yo
 
 Read more about this in the [parsing section](/logs/parsing)
 
-### Log Date Remapper 
+### Log Date Remapper
 
 As Datadog receives logs, it timestamps them using the value(s) from any of these default attributes:
 
@@ -138,7 +138,7 @@ It transforms this log:
 Into this log:
 {{< img src="logs/processing/attribute_post_remapping.png" alt="attribute post remapping " responsive="true" popup="true" style="width:40%;">}}
 
-### URL Parser 
+### URL Parser
 
 This processor extracts query parameters and other important parameters from a URL. To use it, just enter the source attribute of your url:
 
@@ -151,7 +151,7 @@ It recognizes major bots like the Google Bot, Yahoo Slurp, Bing and others.
 
 If your logs contain encoded useragents (as, for example, IIS logs do), configure this processor to **decode the URL** before parsing it.
 
-These settings: 
+These settings:
 {{< img src="logs/processing/useragent_processor_tile.png" alt="Useragent processor tile" responsive="true" popup="true">}}
 
 Give the following results:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds information that JSON-formatted logs are automatically parsed to the /logs, /logs/processing, and /logs/parsing documentation pages.

### Motivation
Steve wants it to be over-documented / very obvious to customers that if they submit JSON-formatted logs, they will get parsed automatically.

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
Request from Steve Lechner