### PR TITLE
Document that logs from greater than 18 hours in the past are dropped

### DIFF
--- a/content/logs/_index.md
+++ b/content/logs/_index.md
@@ -16,7 +16,7 @@ Datadog's Logs is currently available via public beta. You can apply for inclusi
 
 Log collection requires an Agent version >= 6.0. Older versions of the Agent do not include the `Log collection` interface that is used for log collection.
 
-If you are not using it already, please follow [the agent installation instruction](https://github.com/DataDog/datadog-agent/blob/beta/docs/beta/upgrade.md).
+If you are not using it already, please follow [the agent installation instruction](https://github.com/DataDog/datadog-agent/blob/beta/docs/agent/upgrade).
 
 Collecting logs is **disabled** by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
 
@@ -267,7 +267,7 @@ However, if a JSON formatted log file includes one of the following attributes, 
 
 You can also specify alternate attributes to use as the source of a log's date by setting a [log date remapper processor](/logs/processing/#log-date-remapper)
 
-Note that if you use one of the above attributes or remap an alternate attribute as the official date of your log, Datadog rejects the log if that attribute is more than 18 hours in the past.
+**Note**: Datadog rejects a log entry if its official date is older than 18 hours in the past.
 
 <div class="alert alert-info">
 The recognized date formats are: <a href="https://www.iso.org/iso-8601-date-and-time-format.html">ISO8601</a>, <a href="https://en.wikipedia.org/wiki/Unix_time">UNIX (the milliseconds EPOCH format)</a>  and <a href="https://www.ietf.org/rfc/rfc3164.txt">RFC3164</a>.

--- a/content/logs/_index.md
+++ b/content/logs/_index.md
@@ -267,6 +267,8 @@ However, if a JSON formatted log file includes one of the following attributes, 
 
 You can also specify alternate attributes to use as the source of a log's date by setting a [log date remapper processor](/logs/processing/#log-date-remapper)
 
+Note that if you use one of the above attributes or remap an alternate attribute as the official date of your log, Datadog rejects the log if that attribute is more than 18 hours in the past.
+
 <div class="alert alert-info">
 The recognized date formats are: <a href="https://www.iso.org/iso-8601-date-and-time-format.html">ISO8601</a>, <a href="https://en.wikipedia.org/wiki/Unix_time">UNIX (the milliseconds EPOCH format)</a>  and <a href="https://www.ietf.org/rfc/rfc3164.txt">RFC3164</a>.
 </div>

--- a/content/logs/parsing.md
+++ b/content/logs/parsing.md
@@ -157,7 +157,8 @@ The date matcher transforms your timestamp in the EPOCH format.
 |Thu Jun 16 08:29:03 2016 | `%{date("EEE MMM dd HH:mm:ss yyyy","Europe/Paris"):date}` |{"date": 1466058543000}|
 |2007-08-31 19:22:22.427 ADT|`%{date("yyyy-MM-dd HH:mm:ss.SSS z"):date}`|{"date": 1188675889244}|
 {{% /table %}}
-Parsing a date **doesn't** set its value as the log official date, for this you need to use the Log Date Remapper [Log Date Remapper](/logs/processing/#log-date-remapper) in a subsequent processor.
+Parsing a date **doesn't** set its value as the log official date, for this you need to use the Log Date Remapper [Log Date Remapper](/logs/processing/#log-date-remapper) in a subsequent processor.  Note that if your log's official date is more than 18 hours in the past, Datadog rejects the log.
+
 
 ### Conditional pattern
 

--- a/content/logs/parsing.md
+++ b/content/logs/parsing.md
@@ -157,7 +157,8 @@ The date matcher transforms your timestamp in the EPOCH format.
 |Thu Jun 16 08:29:03 2016 | `%{date("EEE MMM dd HH:mm:ss yyyy","Europe/Paris"):date}` |{"date": 1466058543000}|
 |2007-08-31 19:22:22.427 ADT|`%{date("yyyy-MM-dd HH:mm:ss.SSS z"):date}`|{"date": 1188675889244}|
 {{% /table %}}
-Parsing a date **doesn't** set its value as the log official date, for this you need to use the Log Date Remapper [Log Date Remapper](/logs/processing/#log-date-remapper) in a subsequent processor.  Note that if your log's official date is more than 18 hours in the past, Datadog rejects the log.
+
+**Note**: Parsing a date **doesn't** set its value as the log official date, for this use the Log Date Remapper [Log Date Remapper](/logs/processing/#log-date-remapper) in a subsequent processor.
 
 
 ### Conditional pattern

--- a/content/logs/processing.md
+++ b/content/logs/processing.md
@@ -94,7 +94,7 @@ If your logs put their dates in an attribute not in this list, use the log date 
 
 {{< img src="logs/processing/log_date_remapper.png" alt="Log date Remapper" responsive="true" popup="true">}}
 
-If your logs don't contain any of the default attributes and you haven't defined your own date attribute, Datadog timestamps the logs with the date it received them.
+If your logs don't contain any of the default attributes and you haven't defined your own date attribute, Datadog timestamps the logs with the date it received them.  If the log's official timestamp is from one of the default attributes or an attribute of your choosing, Datadog rejects the log if the date is more than 18 hours in the past.
 
 ### Log Severity Remapper
 

--- a/content/logs/processing.md
+++ b/content/logs/processing.md
@@ -94,7 +94,8 @@ If your logs put their dates in an attribute not in this list, use the log date 
 
 {{< img src="logs/processing/log_date_remapper.png" alt="Log date Remapper" responsive="true" popup="true">}}
 
-If your logs don't contain any of the default attributes and you haven't defined your own date attribute, Datadog timestamps the logs with the date it received them.  If the log's official timestamp is from one of the default attributes or an attribute of your choosing, Datadog rejects the log if the date is more than 18 hours in the past.
+If your logs don't contain any of the default attributes and you haven't defined your own date attribute, Datadog timestamps the logs with the date it received them.  
+If the log's official timestamp is from one of the default attributes or [an attribute of your choosing](/logs/processing/#log-date-remapper), Datadog rejects the log if the date is more than 18 hours in the past.
 
 ### Log Severity Remapper
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a note to /logs/, /logs/parsing, and /logs/processing that logs with an official timestamp more than 18 hours in the past are rejected.

### Motivation
Steve Lechner requested that this point be presented clearly in the docoumentation

### Preview link
<!-- Impacted pages preview links-->


### Additional Notes
<!-- Anything else we should know when reviewing?-->
