### PR TITLE
Adding list of supported OS version for agent  5 and 6

### DIFF
--- a/content/agent/faq/_index.md
+++ b/content/agent/faq/_index.md
@@ -50,3 +50,4 @@ private: true
 * [How do I change the frequency of an agent check?](/agent/faq/how-do-i-change-the-frequency-of-an-agent-check)
 * [How does Datadog determine the agent hostname](/agent/faq/how-does-datadog-determine-the-agent-hostname)
 * [Agent check directory structure](/agent/faq/agent-check-directory-structure)
+* [Datadog Agent supported OS versions](/agent/faq/supported-os-versions)

--- a/content/agent/faq/supported-os-versions.md
+++ b/content/agent/faq/supported-os-versions.md
@@ -9,30 +9,34 @@ further_reading:
 ---
 
 ### Agent 5+
-
+](/agent/basic_agent_usage/deb)
 |OS| Supported versions|
 |:----|:----|
-|Debian x86_64 | Debian 7 (wheezy) and above (we do not support SysVinit)|
-|Ubuntu x86_64 | Ubuntu 12.04 and above|
-|RedHat/CentOS x86_64| RedHat/CentOS 6 and above |
-|SUSE Enterprise Linux x86_64 | SUSE 11 SP4 and above (we do not support SysVinit)| 
-|Fedora| Fedora 25 and above |
-|MacOS| OSX 10.10 and above|
-|Windows server 64-bit| Windows server 2008r2 or above|
-|Windows 64-bit| Windows 7 or above|
+|[Debian x86_64](/agent/basic_agent_usage/deb) | Debian 7 (wheezy) and above |
+|[Ubuntu x86_64](/agent/basic_agent_usage/ubuntu) | Ubuntu 12.04 and above|
+|[RedHat/CentOS x86_64](/agent/basic_agent_usage/redhat)| RedHat/CentOS 6 and above |
+|[SUSE Enterprise Linux x86_64](/agent/basic_agent_usage/suse) | SUSE 11 SP4 and above| 
+|[Fedora x86_64](/agent/basic_agent_usage/fedora)| Fedora 26 and above |
+|[MacOS](/agent/basic_agent_usage/osx)| OSX 10.10 and above|
+|[Windows server 64-bit](/agent/basic_agent_usage/windows)| Windows server 2008r2 or above|
+|[Windows 64-bit](/agent/basic_agent_usage/windows)| Windows 7 or above|
+
+**Note**: Source install may work on operating systems not listed here and is supported on a best effort basis.
 
 ### Agent 6+ (Beta)
 
 |OS| Supported versions|
 |:----|:----|
-|Debian x86_64 | Debian 7 (wheezy) and above (we do not support SysVinit)|
-|Ubuntu x86_64 | Ubuntu 12.04 and above|
-|RedHat/CentOS x86_64| RedHat/CentOS 6 and above |
-|SUSE Enterprise Linux x86_64 | SUSE 11 SP4 and above (we do not support SysVinit)| 
-|Fedora| Fedora 25 and above |
-|MacOS| OSX 10.10 and above|
-|Windows server 64-bit| Windows server 2008r2 or above|
-|Windows 64-bit| Windows 7 or above|
+|[Debian x86_64](/agent/basic_agent_usage/deb) | Debian 7 (wheezy) and above (we do not support SysVinit)|
+|[Ubuntu x86_64](/agent/basic_agent_usage/ubuntu) | Ubuntu 14.04 and above|
+|[RedHat/CentOS x86_64](/agent/basic_agent_usage/redhat)| RedHat/CentOS 6 and above |
+|[SUSE Enterprise Linux x86_64](/agent/basic_agent_usage/suse) | SUSE 11 SP4 and above (we do not support SysVinit)| 
+|[Fedora x86_64](/agent/basic_agent_usage/fedora) | Fedora 26 and above |
+|[MacOS](/agent/basic_agent_usage/osx)| OSX 10.10 and above|
+|[Windows server 64-bit](/agent/basic_agent_usage/windows)| Windows server 2008r2 or above|
+|[Windows 64-bit](/agent/basic_agent_usage/windows)| Windows 7 or above|
+
+**Note**: Source install may work on operating systems not listed here and is supported on a best effort basis.
 
 ### Further Reading
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/agent/faq/supported-os-versions.md
+++ b/content/agent/faq/supported-os-versions.md
@@ -1,6 +1,7 @@
 ---
 title: Datadog Agent supported OS versions
 kind: faq
+disable_toc: true
 further_reading:
 - link: "/agent/"
   tag: "Documentation"

--- a/content/agent/faq/supported-os-versions.md
+++ b/content/agent/faq/supported-os-versions.md
@@ -1,0 +1,37 @@
+---
+title: Datadog Agent supported OS versions
+kind: faq
+further_reading:
+- link: "/agent/"
+  tag: "Documentation"
+  text: Learn more about the Datadog Agent
+---
+
+### Agent 5+
+
+|OS| Supported versions|
+|:----|:----|
+|Debian x86_64 | Debian 7 (wheezy) and above (we do not support SysVinit)|
+|Ubuntu x86_64 | Ubuntu 12.04 and above|
+|RedHat/CentOS x86_64| RedHat/CentOS 6 and above |
+|SUSE Enterprise Linux x86_64 | SUSE 11 SP4 and above (we do not support SysVinit)| 
+|Fedora| Fedora 25 and above |
+|MacOS| OSX 10.10 and above|
+|Windows server 64-bit| Windows server 2008r2 or above|
+|Windows 64-bit| Windows 7 or above|
+
+### Agent 6+ (Beta)
+
+|OS| Supported versions|
+|:----|:----|
+|Debian x86_64 | Debian 7 (wheezy) and above (we do not support SysVinit)|
+|Ubuntu x86_64 | Ubuntu 12.04 and above|
+|RedHat/CentOS x86_64| RedHat/CentOS 6 and above |
+|SUSE Enterprise Linux x86_64 | SUSE 11 SP4 and above (we do not support SysVinit)| 
+|Fedora| Fedora 25 and above |
+|MacOS| OSX 10.10 and above|
+|Windows server 64-bit| Windows server 2008r2 or above|
+|Windows 64-bit| Windows 7 or above|
+
+### Further Reading
+{{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
### What does this PR do?

Adding list of supported OS version for agent  5 and 6

### Motivation

Support received lots of questions regarding this topic, and we didn't have a KB centralizing all those info

### Preview link
<!-- Impacted pages preview links-->
* https://docs-staging.datadoghq.com/gus/agent-os-version-kb/agent/faq/supported-os-versions/