### PR TITLE
Updated Ruby APM documentation

### DIFF
--- a/content/tracing/languages/ruby.md
+++ b/content/tracing/languages/ruby.md
@@ -33,20 +33,44 @@ For more examples, see the [RubyDoc Gem documentation](http://www.rubydoc.info/g
 
 ## Compatibility
 
+### Framework Compatibility
+
 The ddtrace library includes support for the following web frameworks:
 
-*  [Ruby on Rails](http://rubyonrails.org/).
-*  [Sinatra](http://www.sinatrarb.com/).
+___
 
-To learn how to instrument these frameworks, reference [the RubyDoc documentation](http://www.rubydoc.info/gems/ddtrace)
+{{% table responsive="true" %}}
+| Framework     | Framework Documentation    | DataDog Instrumentation Documentation               |
+|---------------|----------------------------|-----------------------------------------------------|
+| Ruby on Rails | http://rubyonrails.org/    | http://www.rubydoc.info/gems/ddtrace/#Ruby_on_Rails |
+| Sinatra       | http://www.sinatrarb.com/  | http://www.rubydoc.info/gems/ddtrace/#Sinatra       |
+| Grape         | http://www.ruby-grape.org/ | http://www.rubydoc.info/gems/ddtrace#Grape          |
+{{% /table %}}
+
+### Library Compatibility
 
 It also includes support for the following libraries:
 
-* [Elasticsearch](https://www.elastic.co/products/elasticsearch)
-* [Net/HTTP](https://ruby-doc.org/stdlib-2.4.0/libdoc/net/http/rdoc/Net/HTTP.html)
-* [Redis](https://redis.io/)
+___
 
-For information on tracing these libraries, see [the RubyDoc documentation](http://www.rubydoc.info/gems/ddtrace#Other_libraries)
+
+
+{{% table responsive="true" %}}
+| Library       | Library Documentation                                                | DataDog Instrumentation Documentation               |
+|---------------|----------------------------------------------------------------------|-----------------------------------------------------|
+| Rack          | https://rack.github.io/                                              | www.rubydoc.info/gems/ddtrace#Rack                  |
+| ActiveRecord  | https://github.com/rails/rails/tree/master/activerecord              | http://www.rubydoc.info/gems/ddtrace#Active_Record  |
+| Elasticsearch | https://www.elastic.co/products/elasticsearch                        | http://www.rubydoc.info/gems/ddtrace#Elastic_Search |
+| MongoDB       | http://api.mongodb.com/ruby/current/                                 | http://www.rubydoc.info/gems/ddtrace#MongoDB        |
+| Faraday       | https://github.com/lostisland/faraday                                | http://www.rubydoc.info/gems/ddtrace#Faraday        |
+| AWS           | https://aws.amazon.com/sdk-for-ruby/                                 | http://www.rubydoc.info/gems/ddtrace#AWS            |
+| Dalli         | https://github.com/petergoldstein/dalli                              | http://www.rubydoc.info/gems/ddtrace#Dalli          |
+| Sidekiq       | https://sidekiq.org/                                                 | http://www.rubydoc.info/gems/ddtrace#Sidekiq        |
+| Resque        | https://github.com/resque/resque                                     | http://www.rubydoc.info/gems/ddtrace#Resque         |
+| SuckerPunch   | https://github.com/brandonhilkert/sucker_punch                       | http://www.rubydoc.info/gems/ddtrace#Sucker_Punch   |
+| Net/HTTP      | https://ruby-doc.org/stdlib-2.4.0/libdoc/net/http/rdoc/Net/HTTP.html | http://www.rubydoc.info/gems/ddtrace#Net_HTTP       |
+| Redis         | https://github.com/redis/redis-rb                                    | http://www.rubydoc.info/gems/ddtrace#Redis          |
+{{% /table %}}
 
 ## Further Reading
 


### PR DESCRIPTION
### What does this PR do?

1) Updates ruby language specific APM documentation to include table listing of frameworks and libraries supported by the `ddtrace` gem.

2) Adds libraries included in the RubyDoc documentation that was not included in the DataDog documentation.

**Frameworks Added:** Grape

_NOTE: In the RubyDoc documentation it lists 'Grape' as under 'Other Libraries' - yet it is a web framework._

**Libraries Added:** ActiveRecord, MongoDB, Faraday, AWS, Dalli, Redis, Sidekiq, Resque, SuckerPunch

### Motivation

Upon my first read, I expected the links for the libraries and frameworks would link me to documentation related to using integrating the `ddtrace` gem with the said library/framework - not to the language-specific documentation.

I think this table format is a little bit cleaner and more visible where the links go to (albeit more verbose).

### Preview link

<img width="909" alt="screen shot 2018-01-12 at 10 31 57 am" src="https://user-images.githubusercontent.com/8942499/34882276-122e0532-f784-11e7-929b-a1aac94f412b.png">
<img width="901" alt="screen shot 2018-01-12 at 10 32 06 am" src="https://user-images.githubusercontent.com/8942499/34882277-13984dba-f784-11e7-9972-5297328894e2.png">

### Additional Notes

- I was planning on doing similar changes to both the Python and Go language documentation pages (adding a tabular form similar to this). Please let me know if this is a good approach, or if you'd like something different.
- Would it be possible for me to get access to update the RubyDoc documentation? I'm not 100% sure what it would entail for me to get access, but there are suggestions I have for how to improve that documentation too.
