### PR TITLE
Removed linux-specific 'agent configuration file path' in APM documentation.

### DIFF
--- a/content/tracing/_index.md
+++ b/content/tracing/_index.md
@@ -12,9 +12,9 @@ Datadog's integrated APM tool eliminates the traditional separation between infr
 
 Datadog APM is offered as an upgrade to our Pro and Enterprise plans. A free 14-day trial is available.  Registered users can visit the [APM page of the Datadog application](https://app.datadoghq.com/apm/home) to get started.
 
-APM is available as part of the Datadog Agent with versions 5.11+ as part of the one line install for the Linux and Docker Agents. Currently, [Mac](https://github.com/DataDog/datadog-trace-agent#run-on-osx) and [Windows](https://github.com/DataDog/datadog-trace-agent#run-on-windows) users must perform a manual install of the APM Agent (aka Trace Agent) via a separate install process.  
+APM is available as part of the Datadog Agent with versions 5.11+ as part of the one line install for the Linux and Docker Agents. Currently, [Mac](https://github.com/DataDog/datadog-trace-agent#run-on-osx) and [Windows](https://github.com/DataDog/datadog-trace-agent#run-on-windows) users must perform a manual install of the APM Agent (aka Trace Agent) via a separate install process.
 
-The Agent can be enabled by including the following in your [Datadog agent configuration file](/agent/faq/where-is-the-configuration-file-for-the-agent): 
+The Agent can be enabled by including the following in your [Datadog agent configuration file](/agent/faq/where-is-the-configuration-file-for-the-agent):
 ```
 apm_enabled: yes
 ```
@@ -47,7 +47,8 @@ To instrument an application written in a language that does not yet have offici
 
 ## Configuration
 
-The Datadog Agent uses the `/etc/dd-agent/datadog.conf` file for both infrastructure monitoring and APM configuration options.  
+The Datadog Agent uses the [configuration file](/agent/faq/where-is-the-configuration-file-for-the-agent) for both infrastructure monitoring and APM configuration options.
+
 Additionally, some configuration options may be set as environment variables. Note that options set as environment variables overrides the settings defined in the configuration file.
 
 {{% table responsive="true" %}}


### PR DESCRIPTION
### What does this PR do?

The configuration file path `/etc/dd-agent/datadog.conf` is specific to Linux.  I changed it to be more general, by linking to the [Where is the configuration file for the Agent?](https://docs.datadoghq.com/agent/faq/where-is-the-configuration-file-for-the-agent/) page.

### Motivation

Makes the documentation more general so that the path to agent is not specific to linux.

### Preview link

**Before**

<img width="865" alt="screen shot 2018-01-12 at 11 16 01 am" src="https://user-images.githubusercontent.com/8942499/34884194-ff98b75e-f789-11e7-96e3-afafa560d90b.png">

**After**

<img width="854" alt="screen shot 2018-01-12 at 10 53 29 am" src="https://user-images.githubusercontent.com/8942499/34883268-218641b8-f787-11e7-8a99-b6513f80d54a.png">

### Additional Notes
<!-- Anything else we should know when reviewing?-->
