### PR TITLE
change table display and wrap in a scroll

### DIFF
--- a/layouts/shortcodes/classic-libraries-table.html
+++ b/layouts/shortcodes/classic-libraries-table.html
@@ -1,30 +1,32 @@
 <div class="table-responsive-container">
-  <table class="table table-responsive">
-  <thead>
-    <tr>
-      <th>Language</th>
-      <th>Library</th>
-      <th>Official</th>
-      <th>API</th>
-      <th>DogStatsD</th>
-      <th>Notes</th>
-    </tr>
-  </thead>
-  <tbody>
-    {{ range $e := $.Site.Data.libraries.Classic }}
-      {{ range $libName, $info := . }}
-          {{ range $i, $el := $info }}
-            <tr>
-              <td>{{ if eq $i 0}}<strong>{{ $libName }}</strong>{{ end }}</td>
-              <td><a href="{{ $el.link }}">{{ $el.name }}</a></td>
-              <td>{{ if $el.official}}<i class="icon-tick"></i>{{ end }}</td>
-              <td>{{ if $el.api}}<i class="icon-tick"></i>{{ end }}</td>
-              <td>{{ if $el.dogstatsd }}<i class="icon-tick"></i>{{ end }}</td>
-              <td>{{if $el.authors }}Written by {{ $el.authors }}{{ end }}{{ if $el.notes }}{{ $el.notes }}.{{ end }}</td>
-            </tr>
-          {{ end }}
+  <div class="table-scroll">
+    <table class="table table-responsive">
+    <thead>
+      <tr>
+        <th>Language</th>
+        <th>Library</th>
+        <th>Official</th>
+        <th>API</th>
+        <th>DogStatsD</th>
+        <th>Notes</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{ range $e := $.Site.Data.libraries.Classic }}
+        {{ range $libName, $info := . }}
+            {{ range $i, $el := $info }}
+              <tr>
+                <td>{{ if eq $i 0}}<strong>{{ $libName }}</strong>{{ end }}</td>
+                <td><a href="{{ $el.link }}">{{ $el.name }}</a></td>
+                <td>{{ if $el.official}}<i class="icon-tick"></i>{{ end }}</td>
+                <td>{{ if $el.api}}<i class="icon-tick"></i>{{ end }}</td>
+                <td>{{ if $el.dogstatsd }}<i class="icon-tick"></i>{{ end }}</td>
+                <td>{{if $el.authors }}Written by {{ $el.authors }}{{ end }}{{ if $el.notes }}{{ $el.notes }}.{{ end }}</td>
+              </tr>
+            {{ end }}
+        {{ end }}
       {{ end }}
-    {{ end }}
-  </tbody>
-</table>
+    </tbody>
+    </table>
+  </div>
 </div>

--- a/layouts/shortcodes/table.html
+++ b/layouts/shortcodes/table.html
@@ -1,1 +1,3 @@
-<div class="{{ if .Get "responsive"}}table-responsive-container{{ end }} {{ if .Get "wide" }}table-wide{{ end }} {{ if .Get "vertical-mobile" }}table-vertical-mobile{{ end }}">{{.Inner}}</div>
+<div class="{{ if .Get "responsive"}}table-responsive-container{{ end }} {{ if .Get "wide" }}table-wide{{ end }} {{ if .Get "vertical-mobile" }}table-vertical-mobile{{ end }}">
+{{ if .Get "responsive"}}<div class="table-scroll">{{.Inner}}</div>{{ else }}{{.Inner}}{{ end }}
+</div>

--- a/layouts/shortcodes/tracing-libraries-table.html
+++ b/layouts/shortcodes/tracing-libraries-table.html
@@ -1,27 +1,29 @@
 <div class="table-responsive-container">
-<table class="table table-responsive">
-  <thead>
-    <tr>
-      <th>Language</th>
-      <th>Library</th>
-      <th>Official</th>
-      <th>Notes</th>
-    </tr>
-  </thead>
+  <div class="table-scroll">
+    <table class="table table-responsive">
+      <thead>
+        <tr>
+          <th>Language</th>
+          <th>Library</th>
+          <th>Official</th>
+          <th>Notes</th>
+        </tr>
+      </thead>
 
-  <tbody>
-  {{ range $e := $.Site.Data.libraries.Tracing }}
-    {{ range $libName, $info := . }}
-        {{ range $i, $el := $info }}
-          <tr>
-            <td>{{ if eq $i 0}}<strong>{{ $libName }}</strong>{{ end }}</td>
-            <td><a href="{{ $el.link }}">{{ $el.name }}</a></td>
-            <td>{{ if $el.official}}<i class="icon-tick"></i>{{ end }}</td>
-            <td>{{if $el.authors }}Written by {{ $el.authors }}{{ end }}{{ if $el.notes }}{{ $el.notes }}.{{ end }}</td>
-          </tr>
+      <tbody>
+      {{ range $e := $.Site.Data.libraries.Tracing }}
+        {{ range $libName, $info := . }}
+            {{ range $i, $el := $info }}
+              <tr>
+                <td>{{ if eq $i 0}}<strong>{{ $libName }}</strong>{{ end }}</td>
+                <td><a href="{{ $el.link }}">{{ $el.name }}</a></td>
+                <td>{{ if $el.official}}<i class="icon-tick"></i>{{ end }}</td>
+                <td>{{if $el.authors }}Written by {{ $el.authors }}{{ end }}{{ if $el.notes }}{{ $el.notes }}.{{ end }}</td>
+              </tr>
+            {{ end }}
         {{ end }}
-    {{ end }}
-  {{ end }}
-  </tbody>
-</table>
+      {{ end }}
+      </tbody>
+    </table>
+  </div>
 </div>

--- a/src/scss/pages/_global.scss
+++ b/src/scss/pages/_global.scss
@@ -348,7 +348,7 @@ table, .table {
     top: -26px;
     background-image: linear-gradient(-179deg,hsla(0,0%,100%,0),#fff 77%);
     content: "";
-    display: inline-block;
+    display: none;
     width: 300px;
     position: absolute;
     right: 0;
@@ -359,7 +359,7 @@ table, .table {
     bottom: -26px;
     background-image: linear-gradient(1turn,hsla(0,0%,100%,0),#fff 77%);
     content: "";
-    display: inline-block;
+    display: none;
     width: 300px;
     position: absolute;
     right: 0;
@@ -422,6 +422,18 @@ table, .table {
     box-shadow: -5px 0 10px rgba(0,0,0,.25);
     content: "";
     display:none;
+  }
+  .table-scroll {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    -ms-overflow-style: -ms-autohiding-scrollbar;
+    margin-bottom:31px;
+  }
+  table {
+    display:table;
+    margin-bottom:0;
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
Some of the tables have a white space gap on the right. This pr corrects his by changing some of the css display and wrapping the table with another div.

### Motivation
https://trello.com/c/bO7I9gsR/149-responsive-table-looks-weird-when-there-is-no-enough-content-inside

### Preview link
(using libraries as an example, see additional notes for why)
https://docs-staging.datadoghq.com/david.jones/table-blank-space/developers/libraries/

### Additional Notes
The initial request was referring to this url on another preview site https://docs-staging.datadoghq.com/andrewmcburney/apm-docs-ruby/tracing/languages/ruby/#compatibility 
I have tested this as working with my changes and note that this page doesn't exist in my preview site as i branched from master.