### PR TITLE
Update agent installation link in the log section

### DIFF
--- a/content/logs/_index.md
+++ b/content/logs/_index.md
@@ -16,7 +16,7 @@ Datadog's Logs is currently available via public beta. You can apply for inclusi
 
 Log collection requires an Agent version >= 6.0. Older versions of the Agent do not include the `Log collection` interface that is used for log collection.
 
-If you are not using it already, please follow [the agent installation instruction](https://github.com/DataDog/datadog-agent/blob/beta/docs/agent/upgrade.md).
+If you are not using it already, please follow [the agent installation instruction](https://github.com/DataDog/datadog-agent/blob/master/docs/agent/upgrade.md).
 
 Collecting logs is **disabled** by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
 


### PR DESCRIPTION
Update the agent installation link in the log section.
Please check if there are other places where this link should be modified 
Came from a client
Ticket: https://datadog.zendesk.com/agent/tickets/124596
