### PR TITLE
show integration title on integrations page

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     {{ partial "prefetch.html" . }}
     {{ partial "preload.html" . }}
-    <title>{{ .Title }}</title>
+    <title>{{ if isset .Params "integration_title" }}{{ .Params.integration_title }}{{ else }}{{ .Title }}{{ end }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {{ if .Params.external_redirect }} {{ partial "meta-http-equiv.html" . }} {{ end }}
     {{ if (or (eq .Params.beta true) (eq .Params.private true)) }} <meta name="robots" content="noindex"> {{ end }}


### PR DESCRIPTION
### What does this PR do?
This pr adds titles back to integration detail pages which don't have them e.g https://docs.datadoghq.com/integrations/slack/

### Motivation
A customer reported it

### Preview link
https://docs-staging.datadoghq.com/david.jones/integration-title-fix/integrations/slack/

### Additional Notes

