### PR TITLE
Updated Python APM documentation

### DIFF
--- a/content/tracing/languages/python.md
+++ b/content/tracing/languages/python.md
@@ -20,7 +20,7 @@ Finally, import the tracer and instrument your code!
 ## Example
 
 <div class="alert alert-info">
-For Python applciations, note that tracing is disabled when your application is launched in <b>DEBUG</b> mode. Find more <a href="http://pypi.datadoghq.com/trace/docs/#module-ddtrace.contrib.django">here</a>
+For Python applciations, note that tracing is disabled when your application is launched in <b>DEBUG</b> mode. Find more <a href="http://pypi.datadoghq.com/trace/docs/#module-ddtrace.contrib.django">here</a>.
 </div>
 
 ```python
@@ -35,31 +35,43 @@ For more examples, see the [Getting Started section of library documentation](ht
 
 ## Compatibility
 
+### Framework Compatibility
+
 The ddtrace library includes support for a number of web frameworks, including:
 
-- [Bottle](https://bottlepy.org/)
-- [Django](https://www.djangoproject.com/)
-- [Falcon](https://falconframework.org/)
-- [Flask](http://flask.pocoo.org/)
-- [Pylons](http://pylonsproject.org/)
-- [Pyramid](https://trypyramid.com/)
+___
 
-To learn how to instrument these frameworks, reference [the library documentation](http://pypi.datadoghq.com/trace/docs/#web-frameworks)
+{{% table responsive="true" %}}
+| Framework | Framework Documentation        | PyPi Datadog Documentation                    |
+|-----------|--------------------------------|-----------------------------------------------|
+| Bottle    | https://bottlepy.org/          | http://pypi.datadoghq.com/trace/docs/#bottle  |
+| Django    | https://www.djangoproject.com/ | http://pypi.datadoghq.com/trace/docs/#django  |
+| Falcon    | https://falconframework.org/   | http://pypi.datadoghq.com/trace/docs/#falcon  |
+| Flask     | http://flask.pocoo.org/        | http://pypi.datadoghq.com/trace/docs/#flask   |
+| Pylons    | http://pylonsproject.org/      | http://pypi.datadoghq.com/trace/docs/#pylons  |
+| Pyramid   | https://trypyramid.com/        | http://pypi.datadoghq.com/trace/docs/#pyramid |
+{{% /table %}}
+
+### Library Compatibility
 
 It also includes support for the following data stores and libraries:
 
-- [Cassandra](http://cassandra.apache.org/)
-- [Elasticsearch](https://www.elastic.co/products/elasticsearch)
-- [Flask Cache](https://pythonhosted.org/Flask-Cache/)
-- [MongoDB](https://www.mongodb.com/what-is-mongodb)
-- [Memcached](https://memcached.org/)
-- [MySQL](https://www.mysql.com/)
-- [Postgres](https://www.postgresql.org/)
-- [Redis](https://redis.io/)
-- [SQLAlchemy](http://www.sqlalchemy.org/)
-- [SQLite](https://www.sqlite.org/)
+___
 
-To instrument these libraries, see [the library documentation](http://pypi.datadoghq.com/trace/docs/#other-libraries)
+{{% table responsive="true" %}}
+| Library       | Library Documentation                         | PyPi Datadog Documentation                          |
+|---------------|-----------------------------------------------|-----------------------------------------------------|
+| Cassandra     | http://cassandra.apache.org/                  | http://pypi.datadoghq.com/trace/docs/#cassandra     |
+| Elasticsearch | https://www.elastic.co/products/elasticsearch | http://pypi.datadoghq.com/trace/docs/#elasticsearch |
+| Flask Cache   | https://pythonhosted.org/Flask-Cache/         | http://pypi.datadoghq.com/trace/docs/#flask-cache   |
+| MongoDB       | https://www.mongodb.com/what-is-mongodb       | http://pypi.datadoghq.com/trace/docs/#mongodb       |
+| Memcached     | https://memcached.org/                        | http://pypi.datadoghq.com/trace/docs/#memcached     |
+| MySQL         | https://www.mysql.com/                        | http://pypi.datadoghq.com/trace/docs/#mysql         |
+| Postgres      | https://www.postgresql.org/                   | http://pypi.datadoghq.com/trace/docs/#postgres      |
+| Redis         | https://redis.io/                             | http://pypi.datadoghq.com/trace/docs/#redis         |
+| SQLAlchemy    | http://www.sqlalchemy.org/                    | http://pypi.datadoghq.com/trace/docs/#sqlalchemy    |
+| SQLite        | https://www.sqlite.org/                       | http://pypi.datadoghq.com/trace/docs/#sqlite        |
+{{% /table %}}
 
 ## Further Reading
 


### PR DESCRIPTION
### What does this PR do?

Updates python APM documentation in a similar way to #1940.

### Motivation

Upon my first read through the python documentation, I expected the links for the libraries and frameworks would link me to documentation related to integrating the ddtrace python package with the said library/framework - not to the language-specific documentation.

I think this table format is a little bit cleaner and more visible where the links go to (albeit more verbose).

### Preview link

https://docs-staging.datadoghq.com/andrew.mcburney/apm-docs-python/tracing/languages/python/

### Additional Notes
N/A
