### PR TITLE
Updated Go APM documentation

### DIFF
--- a/content/tracing/languages/go.md
+++ b/content/tracing/languages/go.md
@@ -37,11 +37,38 @@ For another example, see the [`example_test.go`](https://github.com/DataDog/dd-t
 
 ## Compatibility
 
-Currently, only Go 1.7 is supported. The following Go libraries are supported:
+Currently, only Go 1.7 is supported.
 
-- [Gin](https://github.com/gin-gonic/gin)
-- [Gorilla Mux](https://github.com/gorilla/mux)
-- [gRPC](https://github.com/grpc/grpc-go)
+### Framework Compatibility
+
+The ddtrace library includes support for a number of web frameworks, including:
+
+___
+
+{{% table responsive="true" %}}
+| Framework   | Framework Documentation               | GoDoc Datadog Documentation                                                        |
+|-------------|---------------------------------------|------------------------------------------------------------------------------------|
+| Gin         | https://gin-gonic.github.io/gin/      | https://godoc.org/github.com/DataDog/dd-trace-go/tracer/contrib/gin-gonic/gintrace |
+| Gorilla Mux | http://www.gorillatoolkit.org/pkg/mux | https://godoc.org/github.com/DataDog/dd-trace-go/tracer/contrib/gorilla/muxtrace   |
+| gRPC        | https://github.com/grpc/grpc-go       | https://godoc.org/github.com/DataDog/dd-trace-go/tracer/contrib/tracegrpc          |
+{{% /table %}}
+
+### Library Compatibility
+
+It also includes support for the following data stores and libraries:
+
+___
+
+
+{{% table responsive="true" %}}
+| Library           | Library Documentation                            | GoDoc Datadog Documentation                                                              |
+|-------------------|--------------------------------------------------|------------------------------------------------------------------------------------------|
+| Elasticsearch     | https://olivere.github.io/elastic/               | https://godoc.org/github.com/DataDog/dd-trace-go/tracer/contrib/elastictraced            |
+| Cassandra (gocql) | http://gocql.github.io/                          | https://godoc.org/github.com/DataDog/dd-trace-go/tracer/contrib/gocql                    |
+| Redis             | https://godoc.org/github.com/go-redis/redis      | https://godoc.org/github.com/DataDog/dd-trace-go/tracer/contrib/redigo                   |
+| MySQL             | https://godoc.org/github.com/go-sql-driver/mysql | https://godoc.org/github.com/DataDog/dd-trace-go/tracer/contrib/sqltraced/parsedsn/mysql |
+| Postgres (lib/pq) | https://godoc.org/github.com/lib/pq              | https://godoc.org/github.com/DataDog/dd-trace-go/tracer/contrib/sqltraced/parsedsn/pq    |
+{{% /table %}}
 
 ## Further Reading
 


### PR DESCRIPTION
### What does this PR do?

Updates Go APM documentation in a similar way to #1940, and #1952.

### Motivation

Upon my first read through the ruby/python/go documentation, I expected the links for the libraries and frameworks would link me to documentation related to integrating the ddtrace python package with the said library/framework - not to the language-specific documentation.

I think this table format is a little bit cleaner and more visible where the links go to (albeit more verbose).

### Preview link
https://docs-staging.datadoghq.com/andrew.mcburney/apm-docs-go/tracing/languages/go

### Additional Notes
N/A
