### PR TITLE
Update saml steps desc for google

### DIFF
--- a/content/account_management/faq/how-do-i-configure-google-as-a-saml-idp.md
+++ b/content/account_management/faq/how-do-i-configure-google-as-a-saml-idp.md
@@ -20,8 +20,8 @@ further_reading:
 
 * **Application Name**: Can be anything
 * **Description**: Can be anything
-* **ACS URL**: Use the url shown under "Assertion Consumer Service URL" on https://app.datadoghq.com/saml/saml_setup (the one containing `/id/<COMPAGNY_ID>`). If there is more than one value shown for Assertion Consumer Service URL, only enter one of them here.
-* **Entity ID**:  `<COMPAGNY_ID>` from ACS URL
+* **ACS URL**: Use the url shown under "Assertion Consumer Service URL" on https://app.datadoghq.com/saml/saml_setup (the one containing `/id/<COMPANY_ID>`). If there is more than one value shown for Assertion Consumer Service URL, only enter one of them here.
+* **Entity ID**:  `<COMPANY_ID>` from ACS URL
 * **Start URL**: Can be blank, or use the "Single Sign On Login URL" listed on https://app.datadoghq.com/saml/saml_setup and https://app.datadoghq.com/account/team
 * **Signed Response**: Leave unchecked
 * **Name ID**: "Basic Information" "Primary Email"

--- a/content/account_management/faq/how-do-i-configure-google-as-a-saml-idp.md
+++ b/content/account_management/faq/how-do-i-configure-google-as-a-saml-idp.md
@@ -16,10 +16,12 @@ further_reading:
 
 ## For the "Service Provider Details"
 
+**Pre-requisite**: IDP initiated SSO must be checked on DataDog SAML Configuration page
+
 * **Application Name**: Can be anything
 * **Description**: Can be anything
-* **ACS URL**: use the value shown under "Assertion Consumer Service URL" on https://app.datadoghq.com/saml/saml_setup. (e.g. https://app.datadoghq.com/account/saml/assertion). If there is more than one value shown for Assertion Consumer Service URL, only enter one of them here.
-* **Entity ID**: https://app.datadoghq.com/account/saml/metadata.xml
+* **ACS URL**: Use the url shown under "Assertion Consumer Service URL" on https://app.datadoghq.com/saml/saml_setup (the one containing `/id/<COMPAGNY_ID>`). If there is more than one value shown for Assertion Consumer Service URL, only enter one of them here.
+* **Entity ID**:  `<COMPAGNY_ID>` from ACS URL
 * **Start URL**: Can be blank, or use the "Single Sign On Login URL" listed on https://app.datadoghq.com/saml/saml_setup and https://app.datadoghq.com/account/team
 * **Signed Response**: Leave unchecked
 * **Name ID**: "Basic Information" "Primary Email"


### PR DESCRIPTION
### What does this PR do?

Update set-up steps for google saml

### Motivation

Feedback from customer:

From customer:

```
 I finally managed to get the SSO working from G-Suite applications. 
The guide (here)[https://help.datadoghq.com/hc/en-us/articles/208139913-How-do-I-configure-Google-as-a-SAML-IdP-] is not up to date.

Here below the good way to parameter the SAML applications from Google Admin Console : 
Pre-requisite : IDP initiated SSO must be checked on DataDog SAML Configuration page

- Go to Applications 
- Go to SAML Applications 
- Create a new one : 
-> Name : Can be anything 
-> Description : can be anything 
-> ACS URL : ACS URL from DataDog's SAML configuration page, the one containing /id/*companyid* 
-> Entity id : /id/*companyid* : From ACS URL 
-> Single Sign On URL : SSO URL from DataDog's SAML configuration

The rest of the guide is OK.
```

### Preview link
<!-- Impacted pages preview links-->

https://docs-staging.datadoghq.com/gus/saml-google-update/account_management/faq/how-do-i-configure-google-as-a-saml-idp/