### PR TITLE
Flare kb update

### DIFF
--- a/content/agent/faq/send-logs-and-configs-to-datadog-via-flare-command.md
+++ b/content/agent/faq/send-logs-and-configs-to-datadog-via-flare-command.md
@@ -18,16 +18,15 @@ In the commands below, replace `<CASE_ID>` with your Datadog support case ID, if
 ## Flare commands
 ### Debian, Ubuntu, Centos
 
-For Agent 5.3 or higher:
-```
-sudo /etc/init.d/datadog-agent flare <CASE_ID>
-```
+* For **Agent 5.3** or higher:
+    ```
+    sudo /etc/init.d/datadog-agent flare <CASE_ID>
+    ```
 
-For Agent v6 currently in beta:
-
-```
-$ sudo -u dd-agent -- datadog-agent flare <CASE_ID>
-```
+* For **Agent v6** (beta):
+    ```
+    $ sudo -u dd-agent -- datadog-agent flare <CASE_ID>
+    ```
 
 ### Agent installed from source
 
@@ -78,7 +77,7 @@ To send Datadog support a copy of your Windows logs and configurations, do the f
 
 That's it, you're done!
 
-{{< img src="agent/faq/windows_flare.jpg" alt="Windows Flare" responsive="true" popup="true">}}
+{{< img src="agent/faq/windows_flare.jpg" alt="Windows Flare" responsive="true" popup="true" style="width:75%;">}}
 
 It's also possible to run the flare command using Powershell:
 
@@ -92,7 +91,15 @@ C:\Program Files\Datadog\Datadog Agent\embedded\python.exe" "C:\Program Files\Da
 
 ## Flare Fails to Upload
 
-On Linux and Mac OSX, the output of the flare command tells you where the compressed flare archive is saved. In case the file fails to upload to Datadog, you can retrieve it from this directory and manually add as an attachment to an email. For Windows, you can find the location of this file by running the following from the agent's python command prompt (C:\Program Files\Datadog\Datadog Agent\dist\shell.exe since Agent v5.12, C:\Program Files (x86)\Datadog\Datadog Agent\files\shell.exe on older installations):
+On Linux and Mac OSX, the output of the flare command tells you where the compressed flare archive is saved. In case the file fails to upload to Datadog, you can retrieve it from this directory and manually add as an attachment to an email.  
+
+For Windows, you can find the location of this file by running the following from the agent's python command prompt:
+
+* Since Agent v5.12:  
+    `C:\Program Files\Datadog\Datadog Agent\dist\shell.exe since`
+
+* On older Agent version:  
+    `C:\Program Files (x86)\Datadog\Datadog Agent\files\shell.exe`
 
 ```
 import tempfile
@@ -101,7 +108,7 @@ print tempfile.gettempdir()
 
 Example : 
 
-{{< img src="agent/faq/flare_fail.png" alt="Flare Fail" responsive="true" popup="true">}}
+{{< img src="agent/faq/flare_fail.png" alt="Flare Fail" responsive="true" popup="true" style="width:75%;">}}
 
 ## Further Reading
 

--- a/content/agent/faq/send-logs-and-configs-to-datadog-via-flare-command.md
+++ b/content/agent/faq/send-logs-and-configs-to-datadog-via-flare-command.md
@@ -19,13 +19,15 @@ In the commands below, replace `<CASE_ID>` with your Datadog support case ID, if
 ### Debian, Ubuntu, Centos
 
 * For **Agent 5.3** or higher:
+
     ```
     sudo /etc/init.d/datadog-agent flare <CASE_ID>
     ```
 
 * For **Agent v6** (beta):
+
     ```
-    $ sudo -u dd-agent -- datadog-agent flare <CASE_ID>
+    sudo -u dd-agent -- datadog-agent flare <CASE_ID>
     ```
 
 ### Agent installed from source
@@ -72,7 +74,7 @@ To send Datadog support a copy of your Windows logs and configurations, do the f
 1. Open the Datadog Agent Manager
 2. Select Actions
 3. Select Flare
-4. Enter your ticket number - if you don't have one leave the value as zero
+4. Enter your ticket number (`<CASE_ID>`)- if you don't have one leave the value as zero
 5. Lastly, enter the email address you use to log into Datadog
 
 That's it, you're done!
@@ -82,11 +84,11 @@ That's it, you're done!
 It's also possible to run the flare command using Powershell:
 
 ```
-C:\Program Files\Datadog\Datadog Agent\embedded\python.exe" "C:\Program Files\Datadog\Datadog Agent\agent\agent.py" flare
+C:\Program Files\Datadog\Datadog Agent\embedded\python.exe" "C:\Program Files\Datadog\Datadog Agent\agent\agent.py" flare <CASE_ID>
 ```
 or cmd.exe:
 ```
-C:\Program Files\Datadog\Datadog Agent\embedded\python.exe" "C:\Program Files\Datadog\Datadog Agent\agent\agent.py" flare
+C:\Program Files\Datadog\Datadog Agent\embedded\python.exe" "C:\Program Files\Datadog\Datadog Agent\agent\agent.py" flare <CASE_ID>
 ```
 
 ## Flare Fails to Upload

--- a/content/agent/faq/send-logs-and-configs-to-datadog-via-flare-command.md
+++ b/content/agent/faq/send-logs-and-configs-to-datadog-via-flare-command.md
@@ -41,6 +41,13 @@ sudo ~/.datadog-agent/bin/agent flare <CASE_ID>
 docker exec -it dd-agent /etc/init.d/datadog-agent flare <CASE_ID>
 ```
 
+For an agent running in a container behind a proxy use:
+
+```
+sudo docker exec -it dd-agent /bin/bash
+sed -i 's/# skip_ssl_validation: no/skip_ssl_validation: yes/' /etc/dd-agent/datadog.conf /etc/init.d/datadog-agent flare <CASE_ID>
+```
+
 ### Alpine based docker
 
 ```


### PR DESCRIPTION
### What does this PR do?

Enhance flare KB to include docker proxy usage

### Motivation

It was missing

### Preview link
<!-- Impacted pages preview links-->

* https://docs-staging.datadoghq.com/gus/flare-kb-update/agent/faq/send-logs-and-configs-to-datadog-via-flare-command/
