### PR TITLE
Refactoring Notification doc page

### DIFF
--- a/content/monitors/notifications.md
+++ b/content/monitors/notifications.md
@@ -27,24 +27,82 @@ right people get notified so the problem can be resolved as soon as possible.
    explanation of the monitor so a notified team member can quickly understand
    what is going on.
 
-2. Enter a **message** for the monitor. This field allows standard
-   [markdown formatting](http://daringfireball.net/projects/markdown/syntax)
-   as well as Datadog's @-notification syntax. Note: you can notify any
-   non-Datadog users via email by adding `@their-email` to the
-   message. A common use-case for the monitor message is to include a step-by-step way to resolve the problem. For example if you are monitoring a database then you might want to include steps for failing over to a standby node. All in all, you should attempt to give as much context to the monitor as possible.
+2. Enter a **message** for the monitor. This field allows standard [markdown formatting](http://daringfireball.net/projects/markdown/syntax) as well as Datadog's @-notification syntax.  
+  Note: you can notify any non-Datadog users via email by adding `@their-email` to the message. A common use-case for the monitor message is to include a step-by-step way to resolve the problem.  
+  For example if you are monitoring a database then you might want to include steps for failing over to a standby node. All in all, you should attempt to give as much context to the monitor as possible.
 
 3. Optionally enable **monitor renotification**. This option is useful to remind your team that a problem is not solved until the monitor is marked as resolved. If enabled, you can configure an escalation message to be sent anytime the monitor renotifies. The original message is included as well.
 
-## Message template variables
+
+## Say what's happening
+### Message template variables
 
 Message template variables can be used to customize your monitor notifications.
 This feature is supported in all monitor types. There are two primary use cases
-for template variables: 1) displaying a different message depending on the
-notification type (e.g. triggered, recovered, no data) and 2) incorporating the
-triggering scope into the message of multi alerts.
+for template variables: 
 
-### Conditional variables for different notification types
-You can have a monitor event display a different message depending on whether the event is a trigger, warning, recovery, or no data notification. These variables use simple if-else logic with the following syntax:
+1. Displaying a different message depending on the
+notification type (e.g. triggered, recovered, no data)
+2. Incorporating the triggering scope into the message of multi alerts.
+
+#### Tag variables
+
+When your monitor is a multi alert, instead of having a generic message (and finding the triggering tag scope in the alert query definition), a variable can be used in the message for explicitly identifying the triggering scope.
+
+Here is an example of how you can use template variables for a multi alert:
+
+{{< img src="monitors/notifications/templatevareditor.png" alt="template var editor" responsive="true" popup="true" >}}
+
+and the corresponding event notification:
+
+{{< img src="monitors/notifications/templatevar.png" alt="template var" responsive="true" popup="true" >}}
+
+**Note**:  
+
+* The tag template variables available depend on the tag group selected in Step 1 of the monitor editor. The possible options automatically populate at the bottom of the "Use message template variables" help box in Step 3 of the editor.  
+
+* Template variable content is escaped by default. If your variable
+contains JSON or code that you would NOT like to be escaped, use triple braces instead of double braces (e.g. `{{{event.text}}}`).
+
+* See a complete list of contextual template variables available to your monitor by clicking the "Use message template variables" link or in the list of suggestions that appears when you type `{{` to begin a template variable name.
+
+* The tag template variables can also be used in the monitor titles (names), but the variables are only populated in the text of Datadog child events (not the parent, which displays an aggregation summary). 
+
+* Some tags identifying your triggering scope are automatically inserted into the title of your multi alert. If your scope is defined by a lot of tags, your alert title may end up being undesirably long.
+
+#### {{comparator}} template variables
+
+The `{{comparator}}` template variable's value is always a relational operator. It correlates to the relational value selected in the monitor's "Set alert conditions" section:
+{{< img src="monitors/notifications/comparator_alert.png" alt="comparator_alert" responsive="true" popup="true" >}}
+
+For example, when an alert set to trigger when a value rises "above" 50, this syntax:
+```
+  {{value}} {{comparator}} {{threshold}}
+```
+would yield a notification message like the following:
+```
+    51.47 > 50
+```
+
+### Conditional variables
+Use conditional variables to display a different notification content depending of the context of your notification.
+
+The conditional variables available are:
+
+* `{{is_alert}}`, 
+* `{{is_alert_recovery}}`,
+* `{{is_warning}}`, 
+* `{{is_warning_recovery}}`, 
+* `{{is_recovery}}`, 
+* `{{is_no_data}}`,
+* `{{is_match}}`.
+
+These can also be seen in the "Use message template variables" help box in
+Step 3 of the monitor editor.
+
+#### `{{is_alert}}` & `{{is_warning}}`
+
+These variables use simple if-else logic to display a different message depending on whether the event is a trigger, warning, recovery, or no data notification with the following syntax:
 
 {{< img src="monitors/notifications/conditionalvars.png" alt="conditional vars" responsive="true" popup="true" >}}
 
@@ -60,49 +118,24 @@ and the recovery notification:
 
 {{< img src="monitors/notifications/templateconditionalrecover.png" alt="template conditional recover" responsive="true" popup="true" >}}
 
-The conditional variables available are:
+#### `{{is_recovery}}` or `{{is_alert_recovery}}` 
 
-* `is_alert`, 
-* `is_alert_recovery`,
-* `is_warning`, 
-* `is_warning_recovery`, 
-* `is_recovery`, 
-* `is_no_data`.
+* `{{is_recovery}}` triggers and a monitor recovers indifferently either from a **WARNING** state or an **ALERT** state. 
+* `{{is_alert_recovery}}` triggers when a monitor recovers directly from an **ALERT** state to **OK** state. 
+* `{{is_warning_recovery}}` triggers when a monitor recovers from a **WARNING** state to **OK** state
 
-These can also be seen in the "Use message template variables" help box in
-Step 3 of the monitor editor.
+This means that if the monitor switches from ALERT to WARNING then OK state:
 
-### Tag variables for multi alerts
-When your monitor is a multi alert, instead of having a generic message (and finding the triggering tag scope in the alert query definition), a variable can be used in the message for explicitly identifying the triggering scope.
+* the `{{is_recovery}}` would trigger
+* the `{{is_alert_recovery}}` wouldn't trigger 
+* the `{{is_warning_recovery}}` would trigger. 
 
-Here is an example of how you can use template variables for a multi alert:
+The @ notification inside the template variables follows the same rules. 
 
-{{< img src="monitors/notifications/templatevareditor.png" alt="template var editor" responsive="true" popup="true" >}}
+#### `{{is_match}}`
 
-and the corresponding event notification:
-
-{{< img src="monitors/notifications/templatevar.png" alt="template var" responsive="true" popup="true" >}}
-
-The tag template variables available depend on the tag group selected in Step 1 of the monitor editor. The possible options automatically populate at the bottom of the "Use message template variables" help box in Step 3 of the editor.
-These variables can also be used in the monitor titles (names), but note that the variables are only populated in the text of Datadog child events (not the parent, which displays an aggregation summary).
-
-Some tags identifying your triggering scope are automatically inserted into the title of your multi alert. If your scope is defined by a lot of tags, your alert title may end up being undesirably long. If you've used template tag variables to include this information in the body of your alert, you can uncheck
-
-### Include triggering tags in notification title
-
-In order to save some space, you can Include triggering tags in notification title. This makes your notification title look like this:
-
-{{< img src="monitors/notifications/templatevar_short.png" alt="template var short" responsive="true" popup="true" >}}
-
-Note that template variable content is escaped by default. If your variable
-contains JSON or code that you would NOT like to be escaped, then use triple braces instead of double braces (e.g. `{{{event.text}}}`).
-
-### Conditional variables for different triggering scopes
-You can have a monitor event display a different message depending on the group that's causing a notification.  
-
-The `{{is_match}}` conditional lets you match the triggering context to some
-string. For example, you might want to notify your db team if a triggering
-host has `role:db` but notify your app team if the host has `role:app`.
+The `{{is_match}}` conditional allows you to match the triggering context to some string to display a different message.  
+For example, you might want to notify your db team if a triggering host has `role:db` but notify your app team if the host has `role:app`.
 
 You can use any of the available tag variables in your condition. A match
 is made if the comparison string is anywhere in the resolved variable.
@@ -126,8 +159,7 @@ Here is an example of how you can give a different message depending on the trig
   {{/is_match}}
   ```
 
-
-## Variable availability
+### Variable availability
 
 We provide a number of different types of monitors and not all variables are available for each type of monitor. Integration monitor variables are largely dependent on the specific integration and monitor configuration.  
   
@@ -164,48 +196,8 @@ We provide a number of different types of monitors and not all variables are ava
   }
 </style>
 
-Note that some monitors offer addtional contextual variables based on what you are monitoring. For example, host monitors may provide variables for `host.availability-zone` and `host.cloud_provider`. You can see a complete list of contextual template variables available to your monitor by clicking the "Use message template variables" link or in the list of suggestions that appears when you type `{{` to begin a template variable name.
-## Monitor Template Variable Explained 
-### {{comparator}}
-
-The {{comparator}} template variable's value is always a relational operator. It correlates to the relational value selected in the monitor's "Set alert conditions" section:
-{{< img src="monitors/notifications/comparator_alert.png" alt="comparator_alert" responsive="true" popup="true" >}}
-
-For example, when an alert set to trigger when a value rises "above" 50, this syntax:
-```
-  {{value}} {{comparator}} {{threshold}}
-```
-would yield a notification message like the following:
-```
-    51.47 > 50
-```
-
-### {{is_match}}
-
-This template variable allows you to trigger an alert based on the tags defined in your scope.
-
- The variable uses the following format:
-```
-{{#is_match "tag_variable" "comparison_string"}}
-This shows if comparison_string is in tag_variable.
-{{/is_match}}
-```
-
-### {{is_recovery}} or {{is_alert_recovery}} 
-
-* `{{is_recovery}}` triggers and a monitor recovers indifferently either from a **WARNING** state or an **ALERT** state. 
-* `{{is_alert_recovery}}` triggers when a monitor recovers directly from an **ALERT** state to **OK** state. 
-* `{{is_warning_recovery}}` triggers when a monitor recovers from a **WARNING** state to **OK** state
-
-This means that if the monitor switches from ALERT to WARNING then OK state:
-
-* the `{{is_recovery}}` would trigger
-* the `{{is_alert_recovery}}` wouldn't trigger 
-* the `{{is_warning_recovery}}` would trigger. 
-
-The @ notification inside the template variables follows the same rules. 
-
-## Include links to appropriate dashboards in your Monitor Notifications
+## Advanced notification configuration
+### Include links to appropriate dashboards
 
 Many organizations today would like to include additional context to their Alerts.  Quick links to relevant dashboards as a part of the Alert has proven to reduce the overall time it takes during the break fix process to reduce time to resolution.  
 
@@ -221,55 +213,59 @@ https://app.datadoghq.com/dash/integration/system_overview?tpl_var_scope=host:{{
 
 As you can see, `{{host.name}}` is replaced with the offending host of the monitor in question. 
 
-{{< img src="monitors/notifications/system_dashboard_url.png" alt="system_dashboard_url" responsive="true" popup="true" >}}
+{{< img src="monitors/notifications/system_dashboard_url.png" alt="system_dashboard_url" responsive="true" popup="true" style="width:70%;" >}}
 
 Find below additional examples of links that could be added to Monitors to provide Datadog Users quick access to common pages leveraged during the break fix and triage process.
 
 * **Hostmaps** - If you would like to include a HostMap to compare metrics with other similar hosts, you can use a link like below to be included in your Monitor: 
-```
-https://app.datadoghq.com/infrastructure/map?fillby=avg%3Acpuutilization&sizeby=avg%3Anometric&filter=cassandra 
-```
-The above link has more customizable options than your standard System Dashboard.  Here you have additional variables to define.  Most common variables passed into this URL are the following: 
+  ```
+  https://app.datadoghq.com/infrastructure/map?fillby=avg%3Acpuutilization&sizeby=avg%3Anometric&filter=cassandra 
+  ```
+  The above link has more customizable options than your standard System Dashboard.  Here you have additional variables to define.  Most common variables passed into this URL are the following **Fillby, sizeby, filter**: 
 
-**Fillby, sizeby, filter**: Fill by can be defined by adding fillby:avg:<MetricName>.  Size by can be defined by adding sizeby:avg:<SecondMetricName>.  Filter can be used to specify a specific integration (i.e. Cassandra, mysql, apache, snmp, etc) by adding filter=<integration_name>
-{{< img src="monitors/notifications/hostmap_url.png" alt="hostmap_url" responsive="true" popup="true" >}}
+  * `fillby` is defined by adding `fillby:avg:<MetricName>`.  
+  * `sizeby` is defined by adding `sizeby:avg:<SecondMetricName>`.
+  * `filter` is used to specify a specific integration (i.e. Cassandra, mysql, apache, snmp, etc) by adding `filter=<integration_name>`
+  {{< img src="monitors/notifications/hostmap_url.png" alt="hostmap_url" responsive="true" popup="true" style="width:70%;">}}
+  The above colors fill the hexagons by `system.cpu.system`, it sizes the hexagons by `system.cpu.stolen` and add a filter to only include Cassandra hosts.  
+  
 
-The above colors fill the hexagons by `system.cpu.system`, it sizes the hexagons by `system.cpu.stolen` and add a filter to only include Cassandra hosts. 
+*  **Integration Dashboards**- If you are building Application or Integration specific Monitors, link to that specific Integration Dashboard as well as adding a scope for the host that triggered the monitor.  
+  In the example below all that is necessary to populate is the `<integration_name>` section for something like Cassandra, apache, SNMP, etc as well as providing the scope for the offending host:
+  ```
+  https://app.datadoghq.com/dash/integration/<integration_name>?tpl_var_scope=host:{{host.name}}
+  ```
+  {{< img src="monitors/notifications/integration_url.png" alt="integration_url" responsive="true" popup="true" style="width:70%;">}}
 
-**Integration Dashboards**- If you are building Application or Integration specific Monitors, you can link to that specific Integration Dashboard as well as adding a scope for the host that triggered the monitor.  In the example below all that is necessary to populate is the *<integration_name> section for something like Cassandra, apache, SNMP, etc as well as providing the scope for the offending host:
+* **Manage Monitors Page** – To link to a Manage monitors page that displays all of the monitors for the host in question, define a link like below:  
+  ```
+  https://app.datadoghq.com/monitors/manage?q=scope:host:{{host.name}}
+  ```
+  The above links to all monitors for this host. You have other options available to further refine the link.  
+  For example, if you would only like monitors that are in an Alert State, you can add the following `status:Alert` (other statuses that can be leveraged are WARN, NO%20DATA, OK and MUTED).  Below is an example link:
+  ```
+  https://app.datadoghq.com/monitors/manage?q=scope:host:{{host.name}}&status:Alert
+  ```
+  {{< img src="monitors/notifications/monitor_url.png" alt="monitor_url" responsive="true" popup="true" style="width:70%;">}}
+  If you would like all monitors for a specific application or integration,  add the following query to the URL `q=<integration_name> `: 
+  ```
+  https://app.datadoghq.com/monitors/manage?q=cassandra
+  ```
 
-```
-https://app.datadoghq.com/dash/integration/<integration_name>?tpl_var_scope=host:{{host.name}}
-```
-{{< img src="monitors/notifications/integration_url.png" alt="integration_url" responsive="true" popup="true" >}}
+### Slack integration
 
-**Manage Monitors Page** – If you would like to link to a Manage monitors page that displays all of the monitors for the host in question, you can define a link like below:  
-```
-https://app.datadoghq.com/monitors/manage?q=scope:host:{{host.name}}
-```
+#### @-mentions in Slack from monitor alert
 
-The above links to all monitors for this host.  You have other options available to further refine the link.  For example, if you would only like monitors that are in an Alert State, you can add the following status:Alert (other statuses that can be leveraged are WARN, NO%20DATA, OK and MUTED).  Below is an example link:
-```
-https://app.datadoghq.com/monitors/manage?q=scope:host:{{host.name}}&status:Alert
-```
-{{< img src="monitors/notifications/monitor_url.png" alt="monitor_url" responsive="true" popup="true" >}}
+Wrap the `@username` in `< >` as seen below in your monitors message template to **@ notify** the defined user within slack notifications.  
+For example this configuration: 
 
-If you would like all monitors for a specific application or integration, you can add the following query to the URL q=<integration_name> : 
-```
-https://app.datadoghq.com/monitors/manage?q=cassandra
-```
+{{< img src="monitors/notifications/notification_template.png" alt="notification_template" responsive="true" popup="true" style="width:50%;" >}}
 
-## Slack integration
+Would produce this slack message:
 
-### @-mentions in Slack from monitor alert
+{{< img src="monitors/notifications/notification_slack_preview.png" alt="notification_slack_preview" responsive="true" popup="true" style="width:50%;" >}}
 
-Wrap the `@username` in `< >` as seen below in your monitors message template to **@ notify** the defined user within slack notifications.
-
-{{< img src="monitors/notifications/notification_template.png" alt="notification_template" responsive="true" popup="true" >}}
-
-{{< img src="monitors/notifications/notification_slack_preview.png" alt="notification_slack_preview" responsive="true" popup="true" >}}
-
-### Using message template variables to dynamically create @-mentions 
+#### Using message template variables to dynamically create @-mentions 
 
 Use message template variables within a monitor message to dynamically build **@-mentions**.  
 

--- a/content/monitors/notifications.md
+++ b/content/monitors/notifications.md
@@ -98,7 +98,7 @@ Note that template variable content is escaped by default. If your variable
 contains JSON or code that you would NOT like to be escaped, then use triple braces instead of double braces (e.g. `{{{event.text}}}`).
 
 ### Conditional variables for different triggering scopes
-You can have a monitor event display a different message depending on the group that's causing a notification.
+You can have a monitor event display a different message depending on the group that's causing a notification.  
 
 The `{{is_match}}` conditional lets you match the triggering context to some
 string. For example, you might want to notify your db team if a triggering
@@ -109,14 +109,23 @@ is made if the comparison string is anywhere in the resolved variable.
 
 The variable uses the following format:
 ```
-  {{#is_match "tag_variable" "comparison_string"}}
+{{#is_match "tag_variable" "comparison_string"}}
   This shows if comparison_string is in tag_variable.
-  {{/is_match}}
+{{/is_match}}
 ```
 
 Here is an example of how you can give a different message depending on the triggering context:
 
 {{< img src="monitors/notifications/scope_match_editor.png" alt="scope match editor" responsive="true" popup="true">}}
+
+**Note**: To use `{{is_match}}` conditional to check if a `tag_variable` is **NOT** empty, append `.name` after your tag name, for instance:  
+  
+  ```
+  {{#is_match "tag_variable.name" ""}}
+    This shows if tag_variable is not empty.
+  {{/is_match}}
+  ```
+
 
 ## Variable availability
 

--- a/content/monitors/notifications.md
+++ b/content/monitors/notifications.md
@@ -72,10 +72,10 @@ contains JSON or code that you would NOT like to be escaped, use triple braces i
 
 #### {{comparator}} template variables
 
-The `{{comparator}}` template variable's value is always a relational operator. It correlates to the relational value selected in the monitor's "Set alert conditions" section:
+The `{{comparator}}` template variable's value is always a relational operator. It corresponds to the relational value selected in the monitor's "Set alert conditions" section:
 {{< img src="monitors/notifications/comparator_alert.png" alt="comparator_alert" responsive="true" popup="true" >}}
 
-For example, when an alert set to trigger when a value rises "above" 50, this syntax:
+For example, when an alert is set to trigger when a value rises "above" 50, the following syntax:
 ```
   {{value}} {{comparator}} {{threshold}}
 ```
@@ -102,7 +102,7 @@ Step 3 of the monitor editor.
 
 #### `{{is_alert}}` & `{{is_warning}}`
 
-These variables use simple if-else logic to display a different message depending on whether the event is a trigger, warning, recovery, or no data notification with the following syntax:
+These variables use simple `if-else` logic to display a different message depending on the event type (*warning*, *recovery*, *no data*...)
 
 {{< img src="monitors/notifications/conditionalvars.png" alt="conditional vars" responsive="true" popup="true" >}}
 
@@ -121,10 +121,10 @@ and the recovery notification:
 #### `{{is_recovery}}` or `{{is_alert_recovery}}` 
 
 * `{{is_recovery}}` triggers and a monitor recovers indifferently either from a **WARNING** state or an **ALERT** state. 
-* `{{is_alert_recovery}}` triggers when a monitor recovers directly from an **ALERT** state to **OK** state. 
-* `{{is_warning_recovery}}` triggers when a monitor recovers from a **WARNING** state to **OK** state
+* `{{is_alert_recovery}}` triggers when a monitor recovers directly from an **ALERT** state to an **OK** state. 
+* `{{is_warning_recovery}}` triggers when a monitor recovers from a **WARNING** state to an **OK** state
 
-This means that if the monitor switches from ALERT to WARNING then OK state:
+This means that if the monitor switches from an **ALERT** to a **WARNING** to an **OK** state:
 
 * the `{{is_recovery}}` would trigger
 * the `{{is_alert_recovery}}` wouldn't trigger 
@@ -151,7 +151,7 @@ Here is an example of how you can give a different message depending on the trig
 
 {{< img src="monitors/notifications/scope_match_editor.png" alt="scope match editor" responsive="true" popup="true">}}
 
-**Note**: To use `{{is_match}}` conditional to check if a `tag_variable` is **NOT** empty, append `.name` after your tag name, for instance:  
+**Note**: To use the `{{is_match}}` conditional to check if a `tag_variable` is **NOT** empty, append `.name` after your tag name, for instance:  
   
   ```
   {{#is_match "tag_variable.name" ""}}
@@ -221,13 +221,13 @@ Find below additional examples of links that could be added to Monitors to provi
   ```
   https://app.datadoghq.com/infrastructure/map?fillby=avg%3Acpuutilization&sizeby=avg%3Anometric&filter=cassandra 
   ```
-  The above link has more customizable options than your standard System Dashboard.  Here you have additional variables to define.  Most common variables passed into this URL are the following **Fillby, sizeby, filter**: 
+  The above link has more customizable options than your standard System Dashboard.  Here you have additional variables to define.  Most common variables passed into this URL are the following **fillby, sizeby, filter**: 
 
   * `fillby` is defined by adding `fillby:avg:<MetricName>`.  
   * `sizeby` is defined by adding `sizeby:avg:<SecondMetricName>`.
   * `filter` is used to specify a specific integration (i.e. Cassandra, mysql, apache, snmp, etc) by adding `filter=<integration_name>`
   {{< img src="monitors/notifications/hostmap_url.png" alt="hostmap_url" responsive="true" popup="true" style="width:70%;">}}
-  The above colors fill the hexagons by `system.cpu.system`, it sizes the hexagons by `system.cpu.stolen` and add a filter to only include Cassandra hosts.  
+  The above colors fill the hexagons by `system.cpu.system`, it sizes the hexagons by `system.cpu.stolen` and add a filter to only include Cassandra hosts.   
   
 
 *  **Integration Dashboards**- If you are building Application or Integration specific Monitors, link to that specific Integration Dashboard as well as adding a scope for the host that triggered the monitor.  
@@ -241,7 +241,7 @@ Find below additional examples of links that could be added to Monitors to provi
   ```
   https://app.datadoghq.com/monitors/manage?q=scope:host:{{host.name}}
   ```
-  The above links to all monitors for this host. You have other options available to further refine the link.  
+  The above link links to all monitors for this host. You have other options available to further refine the link.  
   For example, if you would only like monitors that are in an Alert State, you can add the following `status:Alert` (other statuses that can be leveraged are WARN, NO%20DATA, OK and MUTED).  Below is an example link:
   ```
   https://app.datadoghq.com/monitors/manage?q=scope:host:{{host.name}}&status:Alert


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

* Refactor notification doc page to make it easier to understand
* Adding disclaimer concerning the fact that when using "is_match" you need to specify ".name" at the end of the tag to make it work.

### Motivation
<!-- What inspired you to submit this pull request?-->

It was missing

### Preview link
<!-- Impacted pages preview links-->

* https://docs-staging.datadoghq.com/gus/is_match_update/monitors/notifications/