### PR TITLE
Adding disclaimer for JSON keys case sensitive

### DIFF
--- a/content/api/troubleshooting/troubleshooting.md
+++ b/content/api/troubleshooting/troubleshooting.md
@@ -24,3 +24,5 @@ This output the current system’s date, and then make a request to our endpoint
 There are also certain fields which are not mandatory for submission, but do require a valid input. For example, in submitting an event the `priority` field must be one of the four given options.  
 
 Any other text results in a 202 'success' but no event showing up. Having an invalid `source_type_name` don't prevent the event from showing up, but that field is dropped upon submission.
+
+**Note**: Our API is keys case-sensitive, all your JSON attributes for POST endpoints should be in lowercase.

--- a/content/api/troubleshooting/troubleshooting.md
+++ b/content/api/troubleshooting/troubleshooting.md
@@ -25,4 +25,4 @@ There are also certain fields which are not mandatory for submission, but do req
 
 Any other text results in a 202 'success' but no event showing up. Having an invalid `source_type_name` don't prevent the event from showing up, but that field is dropped upon submission.
 
-**Note**: Our API is keys case-sensitive, all your JSON attributes for POST endpoints should be in lowercase.
+**Note**: Our API keys are case-sensitive. All your JSON attributes for POST endpoints should be in lowercase.


### PR DESCRIPTION
### What does this PR do?

Adding disclaimer for POST API endpoints that are now case-sensitive.

### Motivation

Customer was using the API call as seen below to post metrics, which randomly stopped working around Dec 12. It looks like there were some updates to use a faster JSON parser that now doesn't allow capital letters in the JSON keys. 

Call that used to work, but is now broken:

```
curl  -X POST -H "Content-type: application/json" \
-d "{ \"Series\" :[{\"Metric\":\"test.metric\",\"Points\":[[1516146157, 1]],\"Type\":\"gauge\",\"Host\":\"test.example.com\",\"Tags\":[\"environment:test\"]}]}" \
'https://app.datadoghq.com/api/v1/series?api_key=<API KEY>'
```

Call that works:

```
curl  -X POST -H "Content-type: application/json" \
-d "{ \"series\" :[{\"metric\":\"test.metric.lower\",\"points\":[[1516146157, 1]],\"type\":\"gauge\",\"host\":\"test.example.com\",\"tags\":[\"environment:test\"]}]}" \
'https://app.datadoghq.com/api/v1/series?api_key=<API KEY>'
```


### Preview link
<!-- Impacted pages preview links-->

* https://docs-staging.datadoghq.com/gus/api-case-sensitive/api/?lang=python#troubleshooting