### PR TITLE
adding link to okta doc for saml2.0

### DIFF
--- a/content/account_management/faq/how-do-i-configure-okta-as-a-saml-idp.md
+++ b/content/account_management/faq/how-do-i-configure-okta-as-a-saml-idp.md
@@ -12,6 +12,8 @@ further_reading:
 
 It's recommended that you set up Datadog as an Okta application manually, as opposed to using a 'pre-configured' configuration.
 
+[Consult the dedicated Okta documentation, to know how to Configure SAML 2.0 for Datadog](http://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-for-DataDog.html) 
+
 ## General Details
 
 * **Single Sign On URL**: https://app.datadoghq.com/account/saml/assertion 


### PR DESCRIPTION
### What does this PR do?

Adding link to okta doc for saml set-up

### Motivation

using the Okta one is very straight-forward. Custom caused issues to some of our customers

### Preview link
<!-- Impacted pages preview links-->

* https://docs-staging.datadoghq.com/gus/okta-update/account_management/faq/how-do-i-configure-okta-as-a-saml-idp/