### PR TITLE
Updating links to new contrib repo

### DIFF
--- a/content/tracing/languages/go.md
+++ b/content/tracing/languages/go.md
@@ -62,13 +62,16 @@ ___
 
 
 {{% table responsive="true" %}}
-| Library           | Library Documentation                            | GoDoc Datadog Documentation                                                              |
+| Library| Library Documentation| GoDoc Datadog Documentation |
 |-------------------|--------------------------------------------------|------------------------------------------------------------------------------------------|
-| Elasticsearch     | https://olivere.github.io/elastic/               | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/olivere/elastic            |
-| Cassandra (gocql) | http://gocql.github.io/                          | https://godoc.org/github.com/gocql/gocql
-| Redis             | https://godoc.org/github.com/go-redis/redis      | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/go-redis/redis                   |
-| MySQL             | https://godoc.org/github.com/go-sql-driver/mysql | https://godoc.org/github.com/go-sql-driver/mysql |
-| Postgres (lib/pq) | https://godoc.org/github.com/lib/pq              | https://godoc.org/github.com/lib/pq    |
+|Elasticsearch | https://github.com/olivere/elastic | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/olivere/elastic |
+|gocql| https://github.com/gocql/gocql | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/gocql/gocql |
+|Go Redis| https://github.com/go-redis/redis |https://godoc.org/github.com/DataDog/dd-trace-go/contrib/go-redis/redis |
+|HTTP | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/net/http | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/net/http |
+|HTTP router|https://github.com/julienschmidt/httprouter| https://godoc.org/github.com/DataDog/dd-trace-go/contrib/julienschmidt/httprouter |
+|Redigo Redis| https://github.com/garyburd/redigo | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/garyburd/redigo |
+|SQL| https://godoc.org/github.com/DataDog/dd-trace-go/contrib/database/sql |https://godoc.org/github.com/DataDog/dd-trace-go/contrib/database/sql |
+|SQLx | https://github.com/jmoiron/sqlx | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/jmoiron/sqlx |
 {{% /table %}}
 
 ## Further Reading

--- a/content/tracing/languages/go.md
+++ b/content/tracing/languages/go.md
@@ -48,9 +48,10 @@ ___
 {{% table responsive="true" %}}
 | Framework   | Framework Documentation               | GoDoc Datadog Documentation                                                        |
 |-------------|---------------------------------------|------------------------------------------------------------------------------------|
-| Gin         | https://gin-gonic.github.io/gin/      | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/gin-gonic/gintrace |
-| Gorilla Mux | http://www.gorillatoolkit.org/pkg/mux | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/gorilla/muxtrace   |
-| gRPC        | https://github.com/grpc/grpc-go       | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/tracegrpc          |
+| Gin         | https://gin-gonic.github.io/gin/      | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/gin-gonic/gin |
+| Gorilla Mux | http://www.gorillatoolkit.org/pkg/mux | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/gorilla/mux   |
+| gRPC        | https://github.com/grpc/grpc-go       | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/google.golang.org/grpc         |
+|gRPC v1.2 | https://github.com/grpc/grpc-go | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/google.golang.org/grpc.v12 |
 {{% /table %}}
 
 ### Library Compatibility
@@ -63,11 +64,11 @@ ___
 {{% table responsive="true" %}}
 | Library           | Library Documentation                            | GoDoc Datadog Documentation                                                              |
 |-------------------|--------------------------------------------------|------------------------------------------------------------------------------------------|
-| Elasticsearch     | https://olivere.github.io/elastic/               | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/elastictraced            |
-| Cassandra (gocql) | http://gocql.github.io/                          | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/gocql                    |
-| Redis             | https://godoc.org/github.com/go-redis/redis      | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/redigo                   |
-| MySQL             | https://godoc.org/github.com/go-sql-driver/mysql | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/sqltraced/parsedsn/mysql |
-| Postgres (lib/pq) | https://godoc.org/github.com/lib/pq              | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/sqltraced/parsedsn/pq    |
+| Elasticsearch     | https://olivere.github.io/elastic/               | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/olivere/elastic            |
+| Cassandra (gocql) | http://gocql.github.io/                          | https://godoc.org/github.com/gocql/gocql
+| Redis             | https://godoc.org/github.com/go-redis/redis      | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/go-redis/redis                   |
+| MySQL             | https://godoc.org/github.com/go-sql-driver/mysql | https://godoc.org/github.com/go-sql-driver/mysql |
+| Postgres (lib/pq) | https://godoc.org/github.com/lib/pq              | https://godoc.org/github.com/lib/pq    |
 {{% /table %}}
 
 ## Further Reading

--- a/content/tracing/languages/go.md
+++ b/content/tracing/languages/go.md
@@ -48,9 +48,9 @@ ___
 {{% table responsive="true" %}}
 | Framework   | Framework Documentation               | GoDoc Datadog Documentation                                                        |
 |-------------|---------------------------------------|------------------------------------------------------------------------------------|
-| Gin         | https://gin-gonic.github.io/gin/      | https://godoc.org/github.com/DataDog/dd-trace-go/tracer/contrib/gin-gonic/gintrace |
-| Gorilla Mux | http://www.gorillatoolkit.org/pkg/mux | https://godoc.org/github.com/DataDog/dd-trace-go/tracer/contrib/gorilla/muxtrace   |
-| gRPC        | https://github.com/grpc/grpc-go       | https://godoc.org/github.com/DataDog/dd-trace-go/tracer/contrib/tracegrpc          |
+| Gin         | https://gin-gonic.github.io/gin/      | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/gin-gonic/gintrace |
+| Gorilla Mux | http://www.gorillatoolkit.org/pkg/mux | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/gorilla/muxtrace   |
+| gRPC        | https://github.com/grpc/grpc-go       | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/tracegrpc          |
 {{% /table %}}
 
 ### Library Compatibility
@@ -63,11 +63,11 @@ ___
 {{% table responsive="true" %}}
 | Library           | Library Documentation                            | GoDoc Datadog Documentation                                                              |
 |-------------------|--------------------------------------------------|------------------------------------------------------------------------------------------|
-| Elasticsearch     | https://olivere.github.io/elastic/               | https://godoc.org/github.com/DataDog/dd-trace-go/tracer/contrib/elastictraced            |
-| Cassandra (gocql) | http://gocql.github.io/                          | https://godoc.org/github.com/DataDog/dd-trace-go/tracer/contrib/gocql                    |
-| Redis             | https://godoc.org/github.com/go-redis/redis      | https://godoc.org/github.com/DataDog/dd-trace-go/tracer/contrib/redigo                   |
-| MySQL             | https://godoc.org/github.com/go-sql-driver/mysql | https://godoc.org/github.com/DataDog/dd-trace-go/tracer/contrib/sqltraced/parsedsn/mysql |
-| Postgres (lib/pq) | https://godoc.org/github.com/lib/pq              | https://godoc.org/github.com/DataDog/dd-trace-go/tracer/contrib/sqltraced/parsedsn/pq    |
+| Elasticsearch     | https://olivere.github.io/elastic/               | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/elastictraced            |
+| Cassandra (gocql) | http://gocql.github.io/                          | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/gocql                    |
+| Redis             | https://godoc.org/github.com/go-redis/redis      | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/redigo                   |
+| MySQL             | https://godoc.org/github.com/go-sql-driver/mysql | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/sqltraced/parsedsn/mysql |
+| Postgres (lib/pq) | https://godoc.org/github.com/lib/pq              | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/sqltraced/parsedsn/pq    |
 {{% /table %}}
 
 ## Further Reading


### PR DESCRIPTION
### What does this PR do?

Update links for go lib contrib now located at https://godoc.org/github.com/DataDog/dd-trace-go/contrib

### Motivation

The previous link was outdated: https://godoc.org/github.com/DataDog/dd-trace-go/tracer/contrib

### Preview link
<!-- Impacted pages preview links-->

* https://docs-staging.datadoghq.com/gus/link-fix-4/tracing/languages/go/#compatibility