### PR TITLE
fix top dropdown links in nav not being clickable

### DIFF
--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -6,7 +6,7 @@
                 <ul class="nav navbar-left">
                     {{ range $dot.Page.Site.Data.partials.header.left }}
                         <li class="nav-item {{ if .children }}dropdown{{ end }}">
-                            <a class="nav-link {{ if .children }}dropdown-toggle{{ end }}" {{ if .children }}data-toggle="dropdown"{{ end }} href="{{ if in .link "http"}}{{ .link }}{{ else }}{{.Site.BaseURL}}/{{ .link }}{{ end }}">{{ .title }}</a>
+                            <a class="nav-link {{ if .children }}dropdown-toggle{{ end }}" href="{{ if in .link "http"}}{{ .link }}{{ else }}{{.Site.BaseURL}}/{{ .link }}{{ end }}">{{ .title }}</a>
                             {{ if .children }}
                                 <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                                     {{ range .children }}
@@ -28,7 +28,7 @@
                 <ul class="nav navbar-right float-right">
                     {{ range $dot.Page.Site.Data.partials.header.right }}
                         <li class="nav-item {{ if .children }}dropdown{{ end }}">
-                            <a class="nav-link {{ if .children }}dropdown-toggle{{ end }}" {{ if .children }}data-toggle="dropdown"{{ end }} href="{{ if in .link "http"}}{{ .link }}{{ else }}{{.Site.BaseURL}}/{{ .link }}{{ end }}">{{ .title }}</a>
+                            <a class="nav-link {{ if .children }}dropdown-toggle{{ end }}" href="{{ if in .link "http"}}{{ .link }}{{ else }}{{.Site.BaseURL}}/{{ .link }}{{ end }}">{{ .title }}</a>
                             {{ if .children }}
                             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                                 {{ range .children }}


### PR DESCRIPTION
### What does this PR do?
The navigation top level links that are drop downs do not click and go to their own urls. This pr fixes this.

### Motivation
https://trello.com/c/bwINKwec/150-top-nav-links-dont-work-if-they-have-dropdowns

### Preview link
https://docs-staging.datadoghq.com/david.jones/top-links-fix/

### Additional Notes
I removed the data-toggle dropdown as we display the dropdown on hover with css not with bootstrap click. This allowed the click event to work again as normal.
