### PR TITLE
hide integration tiles with no image for now

### DIFF
--- a/layouts/partials/integrations/integrations.html
+++ b/layouts/partials/integrations/integrations.html
@@ -66,46 +66,49 @@
 
         {{ $urlname := $v.File.TranslationBaseName }}
 
-        {{ if $formatname }}
-        <div id="mixid_{{$i}}" class="col-6 col-sm-4 col-md-3 col-lg-3 col-xl-2-4 mix text-center {{ range $i, $e := $v.Params.categories }} cat-{{ replace $e "/" "" | urlize }} {{ end }}" data-id="{{ $i }}" data-ref="item">
-            <div class="card">
-                <a class="card-img" href="{{ $dot.Site.BaseURL }}integrations/{{$urlname | lower}}/">
-                    {{ $src := (print "integrations_logos/" ($urlname | lower) ".png")}}
-                    {{ $indx := (index .Site.Data.manifests.images $src )}}
-                    {{ $.Scratch.Set "url" ""}}
-                    {{ if $indx }}
-                        {{ $.Scratch.Set "url" (print (.Site.Params.img_url) "images/" $indx "?auto=format") | safeURL }}
-                    {{ else }}
-                        {{ $.Scratch.Set "url" (print (.Site.Params.img_url) "images/" (index .Site.Data.manifests.images "integrations_logos/dd-noimage.png") "?auto=format") | safeURL }}
-                    {{ end }}
-                    {{ $url := $.Scratch.Get "url" }}
-                    <picture class="mx-auto">
-                        <source srcset="{{ $url }}&w=144 1x, {{ $url }}&w=144&dpr=2 2x" media="(min-width: 530px)">
-                        <source srcset="{{ $url }}&w=200 1x, {{ $url }}&w=200&dpr=2 2x" media="(min-width: 0px)">
-                        <img class="img-fluid mx-auto"
-                             srcset="{{ $url }}&w=144"
-                             alt="integration">
-                    </picture>
-                </a>
-                <a class="card-img-gray" href="{{ $dot.Site.BaseURL }}integrations/{{$urlname | lower}}/">
-                    <picture class="mx-auto">
-                        <source srcset="{{ $url }}&w=144&sat=-100 1x, {{ $url }}&w=144&sat=-100&dpr=2 2x" media="(min-width: 530px)">
-                        <source srcset="{{ $url }}&w=200&sat=-100 1x, {{ $url }}&w=400&sat=-100&dpr=2 2x" media="(min-width: 0px)">
-                        <img class="img-fluid mx-auto"
-                             srcset="{{ $url }}&w=144&sat=-100"
-                             alt="integration">
-                    </picture>
-                </a>
-                <div class="text-center title" style="display: none;">{{ $formatname }}</div>
-                <div class="card-body">
-                    <a class="card-button" href="{{ $dot.Site.BaseURL }}integrations/{{$urlname | lower}}/">
-                        <h4 class="card-title">{{ $formatname }}</h4>
-                        <p class="card-text">{{ $v.Params.short_description }}</p>
-                        <div class="btn-container"><button type="button" class="btn btn-sm btn-outline-primary btn-block">GO</button></div>
+        {{ $src := (print "integrations_logos/" ($urlname | lower) ".png")}}
+        {{ $indx := (index .Site.Data.manifests.images $src )}}
+
+        {{ if $indx }}
+            {{ if $formatname }}
+            <div id="mixid_{{$i}}" class="col-6 col-sm-4 col-md-3 col-lg-3 col-xl-2-4 mix text-center {{ range $i, $e := $v.Params.categories }} cat-{{ replace $e "/" "" | urlize }} {{ end }}" data-id="{{ $i }}" data-ref="item">
+                <div class="card">
+                    <a class="card-img" href="{{ $dot.Site.BaseURL }}integrations/{{$urlname | lower}}/">
+                        {{ $.Scratch.Set "url" ""}}
+                        {{ if $indx }}
+                            {{ $.Scratch.Set "url" (print (.Site.Params.img_url) "images/" $indx "?auto=format") | safeURL }}
+                        {{ else }}
+                            {{ $.Scratch.Set "url" (print (.Site.Params.img_url) "images/" (index .Site.Data.manifests.images "integrations_logos/dd-noimage.png") "?auto=format") | safeURL }}
+                        {{ end }}
+                        {{ $url := $.Scratch.Get "url" }}
+                        <picture class="mx-auto">
+                            <source srcset="{{ $url }}&w=144 1x, {{ $url }}&w=144&dpr=2 2x" media="(min-width: 530px)">
+                            <source srcset="{{ $url }}&w=200 1x, {{ $url }}&w=200&dpr=2 2x" media="(min-width: 0px)">
+                            <img class="img-fluid mx-auto"
+                                 srcset="{{ $url }}&w=144"
+                                 alt="integration">
+                        </picture>
                     </a>
+                    <a class="card-img-gray" href="{{ $dot.Site.BaseURL }}integrations/{{$urlname | lower}}/">
+                        <picture class="mx-auto">
+                            <source srcset="{{ $url }}&w=144&sat=-100 1x, {{ $url }}&w=144&sat=-100&dpr=2 2x" media="(min-width: 530px)">
+                            <source srcset="{{ $url }}&w=200&sat=-100 1x, {{ $url }}&w=400&sat=-100&dpr=2 2x" media="(min-width: 0px)">
+                            <img class="img-fluid mx-auto"
+                                 srcset="{{ $url }}&w=144&sat=-100"
+                                 alt="integration">
+                        </picture>
+                    </a>
+                    <div class="text-center title" style="display: none;">{{ $formatname }}</div>
+                    <div class="card-body">
+                        <a class="card-button" href="{{ $dot.Site.BaseURL }}integrations/{{$urlname | lower}}/">
+                            <h4 class="card-title">{{ $formatname }}</h4>
+                            <p class="card-text">{{ $v.Params.short_description }}</p>
+                            <div class="btn-container"><button type="button" class="btn btn-sm btn-outline-primary btn-block">GO</button></div>
+                        </a>
+                    </div>
                 </div>
             </div>
-        </div>
+            {{ end }}
         {{ end }}
     {{ end }}
 </div>


### PR DESCRIPTION
### What does this PR do?
Skip the integration tile if there is no image for now

### Motivation
Too many missing images makes the site look broken since adding integrations-extras

### Preview link
https://docs-staging.datadoghq.com/david.jones/hide-noimg-integrations/integrations/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
