### PR TITLE
adding missing alias

### DIFF
--- a/content/monitors/_index.md
+++ b/content/monitors/_index.md
@@ -3,6 +3,7 @@ title: Alerting
 kind: documentation
 aliases:
     - /guides/monitors/
+    - /guides/monitoring/
 description: Create & manage your notifications
 ---
 


### PR DESCRIPTION
### What does this PR do?
Adding an alias to monitor page to handle old link from DD app

### Motivation

It leads to a 404 otherwise
