### PR TITLE
Adding confirmation steps for flare prior upload

### DIFF
--- a/content/agent/faq/send-logs-and-configs-to-datadog-via-flare-command.md
+++ b/content/agent/faq/send-logs-and-configs-to-datadog-via-flare-command.md
@@ -12,7 +12,7 @@ further_reading:
 If you are running the 5.3 version (or higher) of the agent, you're able to send all necessary troubleshooting information to our Support Team, with one flare command!
 
 `flare` gathers all of the agent's configuration files and logs into an archive file. It removes sensitive information including passwords, API keys, Proxy credentials, and SNMP community strings.  
-**Confirm the upload of the archive to immediately sent it to Datadog support**.  
+**Confirm the upload of the archive to immediately send it to Datadog support**.  
 Since the Datadog Agent is completely open source, you can [verify the code's behavior](https://github.com/DataDog/dd-agent/blob/master/utils/flare.py). You can also review the archive prior to sending as the flare prompts a confirmation before uploading it.  
 
 In the commands below, replace `<CASE_ID>` with your Datadog support case ID, if you don't specify a case ID, the command asks for an email address that is used to login in your organization and creates a new support case.

--- a/content/agent/faq/send-logs-and-configs-to-datadog-via-flare-command.md
+++ b/content/agent/faq/send-logs-and-configs-to-datadog-via-flare-command.md
@@ -11,7 +11,9 @@ further_reading:
 
 If you are running the 5.3 version (or higher) of the agent, you're able to send all necessary troubleshooting information to our Support Team, with one flare command!
 
-`flare` gathers all of the agent's configuration files and logs, removes sensitive information including passwords, API keys, Proxy credentials, and SNMP community strings and uploads it to Datadog as an archive. Since the Datadog Agent is completely open source, you can [verify the code's behavior](https://github.com/DataDog/dd-agent/blob/master/utils/flare.py).
+`flare` gathers all of the agent's configuration files and logs into an archive file. It removes sensitive information including passwords, API keys, Proxy credentials, and SNMP community strings.  
+**Confirm the upload of the archive to immediately sent it to Datadog support**.  
+Since the Datadog Agent is completely open source, you can [verify the code's behavior](https://github.com/DataDog/dd-agent/blob/master/utils/flare.py). You can also review the archive prior to sending as the flare prompts a confirmation before uploading it.  
 
 In the commands below, replace `<CASE_ID>` with your Datadog support case ID, if you don't specify a case ID, the command asks for an email address that is used to login in your organization and creates a new support case.
 
@@ -91,7 +93,7 @@ or cmd.exe:
 C:\Program Files\Datadog\Datadog Agent\embedded\python.exe" "C:\Program Files\Datadog\Datadog Agent\agent\agent.py" flare <CASE_ID>
 ```
 
-## Flare Fails to Upload
+#### Flare Fails to Upload
 
 On Linux and Mac OSX, the output of the flare command tells you where the compressed flare archive is saved. In case the file fails to upload to Datadog, you can retrieve it from this directory and manually add as an attachment to an email.  
 


### PR DESCRIPTION
### What does this PR do?

Add info about the confirmation steps prior to upload for flare command

### Motivation


The datadog-agent prompts a confirmation before uploading the flare to Datadog support. This is not documented and some users forget to confirm so their flare doesn't get updated.

### Preview link
<!-- Impacted pages preview links-->
