### PR TITLE
make sure we exclude integrations in the json as well as the markup

### DIFF
--- a/layouts/partials/integrations/integrations.html
+++ b/layouts/partials/integrations/integrations.html
@@ -21,7 +21,12 @@
     {{ range $i, $e := $v.Params.categories }}
         {{ $.Scratch.Add "curr_categories" (print "cat-" (replace $e "/" "" | urlize)) }}
     {{ end }}
-    {{ $.Scratch.Add "ints" (dict "id" $k "name" $v.Params.name "tags" ($.Scratch.Get "curr_categories") "item_class" "" "redirect" $v.Params.doc_link "blurb" $v.Params.short_description "public_title" $v.Params.public_title) }}
+    {{ $urlname := $v.File.TranslationBaseName }}
+    {{ $src := (print "integrations_logos/" ($urlname | lower) ".png")}}
+    {{ $indx := (index .Site.Data.manifests.images $src )}}
+    {{ if $indx }}
+        {{ $.Scratch.Add "ints" (dict "id" $k "name" $v.Params.name "tags" ($.Scratch.Get "curr_categories") "item_class" "" "redirect" $v.Params.doc_link "blurb" $v.Params.short_description "public_title" $v.Params.public_title) }}
+    {{ end }}
 {{ end }}
 
 {{ $json := $.Scratch.Get "ints" | jsonify }}
@@ -65,7 +70,6 @@
         {{ $formatname := $.Scratch.Get "formatname" }}
 
         {{ $urlname := $v.File.TranslationBaseName }}
-
         {{ $src := (print "integrations_logos/" ($urlname | lower) ".png")}}
         {{ $indx := (index .Site.Data.manifests.images $src )}}
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes the sorting/filtering of integration tiles on the integrations page. It looks like this bug was introduced when i hid the integration tiles that had no images, the json also needed to be updated. 

### Motivation
Found the issue myself, here is the trello card i created
https://trello.com/c/FuxO4TAg/156-the-integrations-page-clicking-filters-is-no-longer-working

### Preview link
https://docs-staging.datadoghq.com/david.jones/fix-integration-sorting/integrations/

### Additional Notes
