### PR TITLE
Updating link to point at dedicated integrations log doc

### DIFF
--- a/content/logs/_index.md
+++ b/content/logs/_index.md
@@ -57,6 +57,7 @@ During the beta phase of Datadog Logs, not all integrations include log configur
 * [MySQL](/integrations/mysql/#log-collection)
 * [Nginx](/integrations/nginx/#log-collection)
 * [PostgreSQL](/integrations/postgres/#log-collection)
+* [Varnish](/integrations/varnish/#log-collection)
 
 ### The Advantage of Collecting JSON-formatted logs
 

--- a/content/logs/_index.md
+++ b/content/logs/_index.md
@@ -50,12 +50,13 @@ During the beta phase of Datadog Logs, not all integrations include log configur
 
 ### Agent checks
 
-* Apache: [apache.d/conf.yaml.example](https://github.com/DataDog/integrations-core/blob/nils/Logs-integration-beta/apache/conf.yaml.example)
-* Haproxy: [haproxy.d/conf.yaml.example](https://github.com/DataDog/integrations-core/blob/nils/Logs-integration-beta/haproxy/conf.yaml.example)
-* IIS: [iis.d/conf.yaml.example](https://github.com/DataDog/integrations-core/blob/nils/Logs-integration-beta/iis/conf.yaml.example)
-* Mongo: [mongo.d/conf.yaml.example](https://github.com/DataDog/integrations-core/blob/nils/Logs-integration-beta/mongo/conf.yaml.example)
-* Nginx: [nginx.d/conf.yaml.example](https://github.com/DataDog/integrations-core/blob/nils/Logs-integration-beta/nginx/conf.yaml.example)
-* PostgreSQL: [postgres.d/conf.yaml.example](https://github.com/DataDog/integrations-core/blob/nils/Logs-integration-beta/postgres/conf.yaml.example)
+* [Apache](/integrations/apache/#log-collection)
+* [Haproxy](/integrations/haproxy/#log-collection)
+* [IIS](/integrations/iis/#log-collection)
+* [Mongo](/integrations/mongo/#log-collection)
+* [MySQL](/integrations/mysql/#log-collection)
+* [Nginx](/integrations/nginx/#log-collection)
+* [PostgreSQL](/integrations/postgres/#log-collection)
 
 ### The Advantage of Collecting JSON-formatted logs
 


### PR DESCRIPTION
### What does this PR do?

Update links to point at dedicated `log collection` section in integrations doc

### Motivation

https://github.com/DataDog/integrations-core/pull/996

### Preview link
<!-- Impacted pages preview links-->

* https://docs-staging.datadoghq.com/gus/log-doc/logs/#agent-checks