### PR TITLE
Fixing broken links to check.py

### DIFF
--- a/content/integrations/faq/haproxy-multi-process.md
+++ b/content/integrations/faq/haproxy-multi-process.md
@@ -23,5 +23,5 @@ Refreshing the page in your browser shows the stats from a different process tha
 
 If your HAproxy integration is not well configured, you may notice:
 
-* Missing points on HAProxy metrics that are reported as rate (can be checked here https://github.com/DataDog/integrations-core/blob/master/haproxy/check.py) and for which you should get a value each 20 seconds.
+* Missing points on HAProxy metrics that are reported as rate [can be checked here](https://github.com/DataDog/integrations-core/blob/master/haproxy/datadog_checks/haproxy/haproxy.py) and for which you should get a value each 20 seconds.
 * High values and high variations on metrics that are low in normal conditions such as 5xx code error responses.

--- a/ja/content/integrations/haproxy.md
+++ b/ja/content/integrations/haproxy.md
@@ -30,7 +30,7 @@ Capture HAProxy activity in Datadog to:
 Datadog Agentの設定ファイルサンプルとメトリクス取得プログラム:
 
 * [HAProxyインテグレーションの設定ファイルサンプル](https://github.com/DataDog/integrations-core/blob/master/haproxy/conf.yaml.example)
-* [HAProxyインテグレーション checks.d](https://github.com/DataDog/integrations-core/blob/master/haproxy/check.py)
+* [HAProxyインテグレーション checks.d](https://github.com/DataDog/integrations-core/blob/master/haproxy/datadog_checks/haproxy/haproxy.py)
 
 
 <!-- The following metrics are collected by default with the HAProxy integration:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fix this broken links: https://github.com/DataDog/integrations-core/blob/master/haproxy/check.py