### PR TITLE
changing title to match slug

### DIFF
--- a/content/developers/metrics.md
+++ b/content/developers/metrics.md
@@ -1,5 +1,5 @@
 ---
-title: Sending Metrics with DogStatsD
+title: Metrics
 kind: documentation
 js_dd_docs_methods:
   - metricsGuidePage


### PR DESCRIPTION
### What does this PR do?

Change title of `/developers/metrics` page to match slug