### PR TITLE
fix anchor offset on non api pages

### DIFF
--- a/src/js/datadog-docs.js
+++ b/src/js/datadog-docs.js
@@ -73,6 +73,10 @@ $(document).ready(function () {
 
             return false;
         });
+    } else {
+        if(window.location.hash) {
+            moveToAnchor(window.location.hash.substr(1), false);
+        }
     }
 
     // algolia


### PR DESCRIPTION
### What does this PR do?
Because the site has a fixed header when using links to anchors on the page the browser cannot account for the header offset so we have to manually do this ourselves with javascript.

### Motivation
https://trello.com/c/2K0fVLzx/157-linking-to-an-anchor-does-not-display-the-anchor

### Preview link
https://docs-staging.datadoghq.com/david.jones/anchor-offset/logs/
Try clicking on one of the links like "Varnish" from this page it should take you to "log collection" without that title being obscured by the header.

### Additional Notes
