### PR TITLE
if we are missing a trailing slash in our config correct it for user

### DIFF
--- a/local/bin/py/update_pre_build.py
+++ b/local/bin/py/update_pre_build.py
@@ -117,6 +117,12 @@ class PreBuild:
     def __init__(self, opts):
         super().__init__()
         self.options = opts
+        if self.options.dogweb and not self.options.dogweb.endswith(sep):
+            self.options.dogweb = self.options.dogweb + sep
+        if self.options.integrations and not self.options.integrations.endswith(sep):
+            self.options.integrations = self.options.integrations + sep
+        if self.options.extras and not self.options.extras.endswith(sep):
+            self.options.extras = self.options.extras + sep
         self.tempdir = '/tmp' if platform.system() == 'Darwin' else tempfile.gettempdir()
         self.data_dir = '{0}{1}{2}'.format(abspath(normpath(options.source)), sep, 'data' + sep)
         self.content_dir = '{0}{1}{2}'.format(abspath(normpath(options.source)), sep, 'content' + sep)


### PR DESCRIPTION
### What does this PR do?
In the make file config you can specify a local directory for the integration repos, we noticed that there were some issues if you didn't have a trailing slash on those directory paths. 
This pr adds a trailing slash if there isn't one on the provided paths.

### Motivation
After troubleshooting Issues reported from Daniel Langer we discovered this issue.

### Preview link
Not much to see on a preview site as this deals with local build specifically. Although here is the link anyway https://docs-staging.datadoghq.com/david.jones/missing-trailing-slash/

### Additional Notes

