### PR TITLE
Replace severity references to status

### DIFF
--- a/content/logs/_index.md
+++ b/content/logs/_index.md
@@ -298,13 +298,15 @@ The recognized date formats are: <a href="https://www.iso.org/iso-8601-date-and-
 
 By default, Datadog ingests the value of message as the body of the log entry. That value is then highlighted and display in the [logstream](/logs/explore/#logstream), where it is indexed for [full text search](/logs/explore/#search-bar).
 
-### *severity* attribute
+### *status* attribute
 
-Each log entry may specify a severity level which is made available for faceted search within Datadog. However, if a JSON formatted log file includes one of the following attributes, Datadog interprets its value as the the log’s official severity:
+Each log entry may specify a status level which is made available for faceted search within Datadog. However, if a JSON formatted log file includes one of the following attributes, Datadog interprets its value as the the log’s official status:
 
+* `severity`
+* `level`
 * `syslog.severity`
 
-If you would like to remap some severities existing in the `severity` attribute, you can do so with the [log severity remapper](/logs/processing/#log-severity-remapper)
+If you would like to remap some status existing in the `status` attribute, you can do so with the [log status remapper](/logs/processing/#log-status-remapper)
 
 ### *host* attribute
 
@@ -320,7 +322,7 @@ Using the Datadog Agent or the RFC5424 format automatically set the service valu
 
 ### Edit reserved attributes
 
-You can now control the global hostname, service, timestamp, and severity main mapping that are applied before the processing pipelines. This is particularly helpful if logs are sent in JSON or from an external agent.
+You can now control the global hostname, service, timestamp, and status main mapping that are applied before the processing pipelines. This is particularly helpful if logs are sent in JSON or from an external agent.
 
 {{< img src="logs/index/reserved_attribute.png" alt="Reserved Attribute" responsive="true" popup="true">}}
 

--- a/content/logs/_index.md
+++ b/content/logs/_index.md
@@ -267,7 +267,7 @@ logs:
    source: go
 ```
 
-Note that the agent requires the reand and execute permission (5) on the directory to be able to list all the available files in it.
+**Note**: that the agent requires the read and execute permission (5) on the directory to be able to list all the available files in it.
 
 ## Reserved attributes 
 

--- a/content/logs/_index.md
+++ b/content/logs/_index.md
@@ -171,9 +171,9 @@ logs:
 ```
 
 
-### Search and replace content in your logs
+### Scrub sensitive data in your logs
 
-If your logs contain sensitive information that you wish you redact, configure the Datadog Agent to mask sensitive sequences by using the `log_processing_rules` parameter in your configuration file with the **mask_sequences** `type`.
+If your logs contain sensitive information that you wish to redact, configure the Datadog Agent to scrub sensitive sequences by using the `log_processing_rules` parameter in your configuration file with the **mask_sequences** `type`.
 
 This replaces all matched groups with `replace_placeholder` parameter value.
 Example: Redact credit card numbers
@@ -267,6 +267,7 @@ logs:
    source: go
 ```
 
+Note that the agent requires the reand and execute permission (5) on the directory to be able to list all the available files in it.
 
 ## Reserved attributes 
 

--- a/content/logs/processing.md
+++ b/content/logs/processing.md
@@ -99,9 +99,9 @@ If your logs put their dates in an attribute not in this list, use the log date 
 If your logs don't contain any of the default attributes and you haven't defined your own date attribute, Datadog timestamps the logs with the date it received them.  
 If the log's official timestamp is from one of the default attributes or [an attribute of your choosing](/logs/processing/#log-date-remapper), Datadog rejects the log if the date is more than 18 hours in the past.
 
-### Log Severity Remapper
+### Log Status Remapper
 
-Use this processor if you want to assign some attributes as the official severity, just enter the attribute path in the processor tile as follow:
+Use this processor if you want to assign some attributes as the official status, just enter the attribute path in the processor tile as follow:
 
 {{< img src="logs/processing/severity_remapper_processor_tile.png" alt="Severity Remapper processor tile" responsive="true" popup="true">}}
 
@@ -113,7 +113,7 @@ Into this log:
 
 {{< img src="logs/processing/log_post_severity_bis.png" alt=" Log post severity bis" responsive="true" popup="true" style="width:40%;" >}}
 
-However, beware that each incoming severity value is mapped as follows:
+However, beware that each incoming status value is mapped as follows:
 
 * Integers from 0 to 7 map to the [Syslog severity standards](https://en.wikipedia.org/wiki/Syslog#Severity_level)
 * Strings beginning with **emerg** or **f** (case unsensitive) map to **emerg (0)**
@@ -124,6 +124,7 @@ However, beware that each incoming severity value is mapped as follows:
 * Strings beginning with **n** (case unsensitive) map to **notice (5)**
 * Strings beginning with **i** (case unsensitive) map to **info (6)**
 * Strings beginning with **d**, **trace** or **verbose** (case unsensitive) map to **debug (7)**
+* Strings matching **OK** or **Sucess** (case unsensitive) map to **OK (-1 and 8)**
 * All others map to **info (6)**
 
 ### Attribute Remapper

--- a/content/logs/processing.md
+++ b/content/logs/processing.md
@@ -124,7 +124,7 @@ However, beware that each incoming status value is mapped as follows:
 * Strings beginning with **n** (case unsensitive) map to **notice (5)**
 * Strings beginning with **i** (case unsensitive) map to **info (6)**
 * Strings beginning with **d**, **trace** or **verbose** (case unsensitive) map to **debug (7)**
-* Strings matching **OK** or **Sucess** (case unsensitive) map to **OK (-1 and 8)**
+* Strings matching **OK** or **Sucess** (case unsensitive) map to **OK**
 * All others map to **info (6)**
 
 ### Attribute Remapper


### PR DESCRIPTION
### What does this PR do?
Replace all reference to severity by the new status attribute

### Motivation
https://trello.com/c/317qes5p/865-reserved-attribute-rename-attribute-severity-into-status

### Preview link
<!-- Impacted pages preview links-->


### Additional Notes
<!-- Anything else we should know when reviewing?-->
