### PR TITLE
Add Java to the list of languages supported on the /tracing page.

### DIFF
--- a/content/tracing/_index.md
+++ b/content/tracing/_index.md
@@ -39,10 +39,10 @@ For additional information, reference [the Docker page](/tracing/docker)
 
 To instrument your application, select one of the following supported languages.
 
-- [Go](/tracing/go)
+- [Go](/tracing/languages/go)
 - [Java](/tracing/languages/java)
-- [Python](/tracing/python)
-- [Ruby](/tracing/ruby)
+- [Python](/tracing/languages/python)
+- [Ruby](/tracing/languages/ruby)
 
 To instrument an application written in a language that does not yet have official library support, reference the [Tracing API](/api/?lang=console#traces).
 

--- a/content/tracing/_index.md
+++ b/content/tracing/_index.md
@@ -40,6 +40,7 @@ For additional information, reference [the Docker page](/tracing/docker)
 To instrument your application, select one of the following supported languages.
 
 - [Go](/tracing/go)
+- [Java](/tracing/languages/java)
 - [Python](/tracing/python)
 - [Ruby](/tracing/ruby)
 


### PR DESCRIPTION
### What does this PR do?
Add Java to the list of languages supported on the [`/tracing`](https://docs.datadoghq.com/tracing/) page.

### Preview link
https://docs-staging.datadoghq.com/andrew.mcburney/add-java-to-apm-list/tracing/