### PR TITLE
adding KB for Process open file descriptors metric collection

### DIFF
--- a/content/integrations/faq/_index.md
+++ b/content/integrations/faq/_index.md
@@ -116,6 +116,10 @@ kind: faq
 ## Postgres
 * [Postgres custom metric collection explained](/integrations/faq/postgres-custom-metric-collection-explained)
 
+## Process
+
+* [Process open file descriptors metric collection](/integraitons/faq/open-file-descriptors-metric-collection)
+
 ## RabbitMQ
 
 * [Tagging RabbitMQ queues by tag family](/integrations/faq/tagging-rabbitmq-queues-by-tag-family)

--- a/content/integrations/faq/_index.md
+++ b/content/integrations/faq/_index.md
@@ -118,7 +118,7 @@ kind: faq
 
 ## Process
 
-* [Process open file descriptors metric collection](/integraitons/faq/open-file-descriptors-metric-collection)
+* [Process open file descriptors metric collection](/integrations/faq/open-file-descriptors-metric-collection)
 
 ## RabbitMQ
 

--- a/content/integrations/faq/open-file-descriptors-metric-collection.md
+++ b/content/integrations/faq/open-file-descriptors-metric-collection.md
@@ -1,0 +1,35 @@
+---
+title: Process open file descriptors metric collection
+kind: faq
+further_reading:
+- link: "/integrations/process"
+  tag: "Documentation"
+  text: Learn more about the Datadog Process integrations
+---
+
+For the [Datadog - process integration](/integrations/process/) `system.processes.open_file_descriptors` metric is only available for processes running as the same user as the agent (dd-agent).
+
+If you wish to collect this metric, a workaround may be to run a small Python script as root that uses psutil to read this metric and sends it to the Datadog Agent using [DogStatsD](/developers/dogstatsd).
+
+```python
+#!/opt/datadog-agent/embedded/bin/python
+
+import psutil
+import socket
+import sys
+
+process_filter = sys.argv[1]
+
+for proc in psutil.process_iter():
+    if process_filter in proc.name():
+        payload = "open_file_descriptors:{0}|g|#process_name:{1},pid:{2}".format(
+            proc.num_fds(), proc.name(), proc.pid)
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) # UDP
+        sock.sendto(payload, ("localhost", 8125))
+```
+
+This script takes a single argument which is a string that's used to filter processes, e.g.:  
+
+```
+sample_num_fd.py trace-agent
+```


### PR DESCRIPTION
### What does this PR do?

It's a follow up on https://github.com/DataDog/integrations-core/pull/1074

If a user wants to collect `system.processes.open_file_descriptors` even if it's from a process not launched by the same user as the agent, there is a workaround with a small python script
