### PR TITLE
Updated APM tracing documentation from Gus' refactor branch.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -56,7 +56,7 @@ languages:
           url: "/agent/"
           pre: "nav_agent"
           weight: 40
-          
+
         # AGENT - Subnav start
         - identifier: customnav_agentnav_basic_usage
           name: "Basic Agent Usage"
@@ -379,7 +379,7 @@ languages:
           url: "/tracing/docker/"
           weight: 10
           parent: menu_references_tracing
-        # Tracing languages  
+        # Tracing languages
         - identifier: customnav_tracingnav_langs
           name: "Languages"
           url: "/tracing/languages/"
@@ -411,26 +411,6 @@ languages:
           url: "/tracing/services/"
           weight: 30
           parent: menu_references_tracing
-        - identifier: customnav_tracingnav_cache
-          name: "Service: Cache"
-          url: "/tracing/services/cache"
-          weight: 310
-          parent: customnav_tracingnav_services
-        - identifier: customnav_tracingnav_custom
-          name: "Service: Custom"
-          url: "/tracing/services/custom"
-          weight: 320
-          parent: customnav_tracingnav_services
-        - identifier: customnav_tracingnav_db
-          name: "Service: DB"
-          url: "/tracing/services/DB"
-          weight: 330
-          parent: customnav_tracingnav_services
-        - identifier: customnav_tracingnav_web
-          name: "Service: Web"
-          url: "/tracing/services/web"
-          weight: 340
-          parent: customnav_tracingnav_services
         # Tracing micellaneous
         - identifier: customnav_tracingnav_miscellaneous
           name: "Miscellaneous"

--- a/content/tracing/_index.md
+++ b/content/tracing/_index.md
@@ -17,11 +17,11 @@ With our infrastructure monitoring, metrics are sent to the Datadog Agent, which
 
 **1. Install the Datadog Agent**
 
-Install and configure the latest [Datadog Agent](https://app.datadoghq.com/account/settings#agent) (version 5.11.0 or above is required). For additional information, reference the [getting started guide](/tracing/getting_started)
+Install and configure the latest [Datadog Agent](https://app.datadoghq.com/account/settings#agent) (version 5.11.0 or above is required). For additional information, reference the [getting started guide](/tracing/getting_started).
 
 **2. Install the Trace Agent**
 
-If you are running MacOS or Windows, you will need to install and run the [Trace Agent](https://github.com/DataDog/datadog-trace-agent) in addition to the DataDog agent. On Linux, the Trace Agent is packaged with the standard Datadog Agent, so no extra configuration is required.
+If you are running MacOS or Windows, you will need to install and run the [Trace Agent](https://github.com/DataDog/datadog-trace-agent) in addition to the DataDog agent. On Linux, the Trace Agent is packaged with the standard Datadog Agent, so no extra configuration is needed.
 
 - [MacOS Trace Agent Configuration](https://github.com/DataDog/datadog-trace-agent#run-on-osx)
 - [Windows Trace Agent Configuration](https://github.com/DataDog/datadog-trace-agent#run-on-windows)

--- a/content/tracing/_index.md
+++ b/content/tracing/_index.md
@@ -8,23 +8,34 @@ description: Instrument your code to improve performance
 
 Datadog's integrated APM tool eliminates the traditional separation between infrastructure and application performance monitoring. This not only provides greater visibility, but also allows you to see the relationship between application code and the underlying infrastructure.
 
-Datadog APM is offered as an upgrade to our Pro and Enterprise plans. A free 14-day trial is available.  
+Datadog APM is offered as an upgrade to our Pro and Enterprise plans. A free 14-day trial is available.
 Registered users can visit the [APM page of the Datadog application](https://app.datadoghq.com/apm/home).
 
 ## Instrument your application
 
 With our infrastructure monitoring, metrics are sent to the Datadog Agent, which then forwards them to Datadog. Similarly, tracing metrics are also sent to the Datadog agent. To start tracing your application:
 
-1. Install and configure the latest [Datadog Agent](https://app.datadoghq.com/account/settings#agent) (version 5.11.0 or above is required). For additional information, reference the [getting started guide](/tracing/getting_started)
+**1. Install the Datadog Agent**
 
-2. Instrument your application, select one of the following supported languages:
+Install and configure the latest [Datadog Agent](https://app.datadoghq.com/account/settings#agent) (version 5.11.0 or above is required). For additional information, reference the [getting started guide](/tracing/getting_started)
+
+**2. Install the Trace Agent**
+
+If you are running MacOS or Windows, you will need to install and run the [Trace Agent](https://github.com/DataDog/datadog-trace-agent) in addition to the DataDog agent. On Linux, the Trace Agent is packaged with the standard Datadog Agent, so no extra configuration is required.
+
+- [MacOS Trace Agent Configuration](https://github.com/DataDog/datadog-trace-agent#run-on-osx)
+- [Windows Trace Agent Configuration](https://github.com/DataDog/datadog-trace-agent#run-on-windows)
+
+**3. Instrument your application**
+
+Instrument your application, select one of the following supported languages:
 
 - [Go](/tracing/languages/go)
 - [Java](/tracing/languages/java)
 - [Python](/tracing/languages/python)
 - [Ruby](/tracing/languages/ruby)
 
-To instrument an application written in a language that does not yet have official library support, reference the [Tracing API](/api/?lang=console#traces).
+To instrument an application written in a language that does not yet have official library support, reference the [Tracing API](/api/?lang=console#traces), or visit our list of [community tracing libraries](/developers/libraries/#community-tracing-apm-libraries).
 
 ### Running the agent in Docker
 
@@ -32,44 +43,8 @@ To trace applications in Docker containers, you can use the [docker-dd-agent](ht
 
 For additional information, reference [the Docker page](/tracing/docker)
 
-
-## How long is tracing data stored?
-
-Individual traces are stored for up to 6 months but to determine how long a particular trace will be stored, the Agent makes a sampling decision early in the trace's lifetime. In Datadog backend, sampled traces are retained according to time buckets:
-
-
-|Retention bucket|% of stream kept|
-|:-----|:--------|
-|6 hours|100%|
-|Current day (UTC time)|25%|
-|6 days|10%|
-|6 months|1%|
-
-
-That is to say, on a given day you would see in the UI:
-
-* **100%** of sampled traces from the last 6 hours
-* **25%** of those from the previous hours of the current calendar day (starting at 00:00 UTC)
-* **10%** from the previous six calendar days
-* **1%** of those from the previous six months (starting from the first day of the month six months ago)
-* **0%** of traces older than 6 months
-
-
-For example, at `9:00am UTC Wed, 12/20` you would see:
-
-* **100%** of traces sampled on `Wed 12/20 03:00 - 09:00`
-* **25%** of traces sampled on `Wed 12/20 00:00` - `Wed 12/20 02:59`
-* **10%** of traces sampled on `Thurs 12/14 00:00` - `Tue 12/19 23:59`
-* **1%** of traces sampled on `7/1 00:00` - `12/13 23:59`
-* **0%** of traces before `7/1 00:00`
-
-
-Once a trace has been viewed, it continues to be available by using its trace ID in the URL: `https://app.datadoghq.com/apm/trace/<trace_id>` This is true even if it “expires” from the UI. This behavior is independent of the UI retention time buckets.
-
-{{< img src="tracing/trace_id.png" alt="Trace ID" responsive="true" popup="true">}}
-
 ## Additional resources
 
-For additional help from Datadog staff and other Datadog community members, join the [*apm* channel](https://datadoghq.slack.com/messages/apm) in our Datadog Slack. Visit [http://chat.datadoghq.com](http://chat.datadoghq.com) to join the Slack. We maintain a list of [community tracing libraries](/developers/libraries/#community-tracing-apm-libraries).
+For additional help from Datadog staff and other Datadog community members, join the [*apm* channel](https://datadoghq.slack.com/messages/apm) in our Datadog Slack. Visit [http://chat.datadoghq.com](http://chat.datadoghq.com) to join the Slack.
 
 You can also reach our APM team via email at [tracehelp@datadoghq.com](mailto:tracehelp@datadoghq.com).

--- a/content/tracing/faq/_index.md
+++ b/content/tracing/faq/_index.md
@@ -4,6 +4,7 @@ kind: faq
 private: true
 ---
 {{< whatsnext desc="List of Frequently Asked Questions:">}}
+    {{< nextlink href="/tracing/faq/how-long-is-tracing-data-stored" >}}How long is tracing data stored?{{< /nextlink >}}
     {{< nextlink href="/tracing/faq/what-are-the-naming-criteria-for-services-resources" >}}What are the naming criteria for services, resources, etc?{{< /nextlink >}}
     {{< nextlink href="/tracing/faq/how-often-does-the-trace-agent-send-stats" >}}How often does the trace agent send stats?{{< /nextlink >}}
     {{< nextlink href="/tracing/faq/why-am-i-getting-errno-111-connection-refused-errors-in-my-application-logs" >}}Why am I getting [Errno 111] Connection refused errors{{< /nextlink >}}

--- a/content/tracing/faq/how-long-is-tracing-data-stored.md
+++ b/content/tracing/faq/how-long-is-tracing-data-stored.md
@@ -1,0 +1,37 @@
+---
+title: How long is tracing data stored?
+kind: faq
+---
+
+Individual traces are stored for up to 6 months but to determine how long a particular trace will be stored, the Agent makes a sampling decision early in the trace's lifetime. In Datadog backend, sampled traces are retained according to time buckets:
+
+
+| Retention bucket       |  % of stream kept |
+| :--------------------- | :---------------- |
+| 6 hours                |              100% |
+| Current day (UTC time) |               25% |
+| 6 days                 |               10% |
+| 6 months               |                1% |
+
+
+That is to say, on a given day you would see in the UI:
+
+* **100%** of sampled traces from the last 6 hours
+* **25%** of those from the previous hours of the current calendar day (starting at `00:00 UTC`)
+* **10%** from the previous six calendar days
+* **1%** of those from the previous six months (starting from the first day of the month six months ago)
+* **0%** of traces older than 6 months
+
+
+For example, at `9:00am UTC Wed, 12/20` you would see:
+
+* **100%** of traces sampled on `Wed 12/20 03:00 - 09:00`
+* **25%** of traces sampled on `Wed 12/20 00:00` - `Wed 12/20 02:59`
+* **10%** of traces sampled on `Thurs 12/14 00:00` - `Tue 12/19 23:59`
+* **1%** of traces sampled on `7/1 00:00` - `12/13 23:59`
+* **0%** of traces before `7/1 00:00`
+
+
+Once a trace has been viewed, it continues to be available by using its trace ID in the URL: `https://app.datadoghq.com/apm/trace/<trace_id>` This is true even if it “expires” from the UI. This behavior is independent of the UI retention time buckets.
+
+{{< img src="tracing/trace_id.png" alt="Trace ID" responsive="true" popup="true">}}

--- a/content/tracing/getting_started.md
+++ b/content/tracing/getting_started.md
@@ -35,18 +35,18 @@ The Datadog Agent uses the [configuration file](/agent/faq/where-is-the-configur
 Additionally, some configuration options may be set as environment variables. Note that options set as environment variables overrides the settings defined in the configuration file.
 
 {{% table responsive="true" %}}
-| File setting | Environment variable | Description |
-|---|---|---|
-| **main** |
-| `apm_enabled` | `DD_APM_ENABLED` | The Datadog Agent accepts trace metrics when the value is set to `true`. The default value is `true`. |
-| **trace.sampler** |
-| `extra_sample_rate` | - | Use this setting to adjust the trace sample rate. The value should be a float between `0` (no sampling) and `1` (normal sampling rate). The default value is `1` |
-| `max_traces_per_second` | - | The maximum number of traces to sample per second. To disable the limit (*not recommended*), set to `0`. The default value is `10`.|
-| **trace.receiver** |
-| `receiver_port` | `DD_RECEIVER_PORT` | The port that the Datadog Agent's trace receiver should listen on. The default value is `8126`. |
-| `connection_limit` | - | The number of unique client connections to allow during one 30 second lease period. The default value is `2000`. |
-| **trace.ignore** |
-| `resource` | `DD_IGNORE_RESOURCE` | A blacklist of regular expressions to filter out Traces by their Resource name. |
+| File setting            | Environment variable | Description                                                                                                                                                      |
+|-------------------------|----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **main**                |                      |                                                                                                                                                                  |
+| `apm_enabled`           | `DD_APM_ENABLED`     | The Datadog Agent accepts trace metrics when the value is set to `true`. The default value is `true`.                                                            |
+| **trace.sampler**       |                      |                                                                                                                                                                  |
+| `extra_sample_rate`     | -                    | Use this setting to adjust the trace sample rate. The value should be a float between `0` (no sampling) and `1` (normal sampling rate). The default value is `1` |
+| `max_traces_per_second` | -                    | The maximum number of traces to sample per second. To disable the limit (*not recommended*), set to `0`. The default value is `10`.                              |
+| **trace.receiver**      |                      |                                                                                                                                                                  |
+| `receiver_port`         | `DD_RECEIVER_PORT`   | The port that the Datadog Agent's trace receiver should listen on. The default value is `8126`.                                                                  |
+| `connection_limit`      | -                    | The number of unique client connections to allow during one 30 second lease period. The default value is `2000`.                                                 |
+| **trace.ignore**        |                      |                                                                                                                                                                  |
+| `resource`              | `DD_IGNORE_RESOURCE` | A blacklist of regular expressions to filter out Traces by their Resource name.                                                                                  |
 {{% /table %}}
 
 For more information about the Datadog Agent, see the [dedicated doc page](/agent/) or refer to the [`datadog.conf.example` file](https://github.com/DataDog/dd-agent/blob/master/datadog.conf.example).

--- a/content/tracing/miscellaneous/_index.md
+++ b/content/tracing/miscellaneous/_index.md
@@ -4,6 +4,9 @@ kind: documentation
 ---
 
 {{< whatsnext desc="Enclosed in this section are other articles that may be of interest:">}}
+    {{< nextlink href="/api/?lang=python#tracing" >}} Learn more about our Trace API {{< /nextlink >}}
     {{< nextlink href="/tracing/miscellaneous/environments" >}} Learn more about the environment dimension {{< /nextlink >}}
+    {{< nextlink href="/monitors/monitor_types/apm/" >}} Learn more about monitors with APM {{< /nextlink >}}
+    {{< nextlink href="/graphing/dashboards/widgets/#service-summary" >}} Learn more about the dashboards widgets {{< /nextlink >}}
     {{< nextlink href="/tracing/miscellaneous/terminology" >}} Learn more about Datadog tracing terminology {{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/tracing/services/_index.md
+++ b/content/tracing/services/_index.md
@@ -22,7 +22,7 @@ The service list can be filtered depending on:
 
 Every Service monitored by your application is associated with a "Type". This type is automatically determined by Datadog and is applied for you. The "Type" specified the name of the application/framework the Datadog Agent is Integrating with.
 
-For example, if you are using the official Flask Integration, the "Type" is set to "Web". If you are monitoring a custom application, this appears as "Custom".
+For example, if you are using the official Flask Integration, the "Type" is set to "Web". If you are monitoring a custom application, the "Type" appears as "Custom".
 
 The type of the service can be one of:
 

--- a/content/tracing/services/_index.md
+++ b/content/tracing/services/_index.md
@@ -10,7 +10,7 @@ After having [instrumented your application](/tracing/languages), your reporting
 
 ## Filtering the services list
 
-The service list can be filtered depending of:
+The service list can be filtered depending on:
 
 * [Your environment](/tracing/miscellaneous/environments).
 * [Your service type](/tracing/miscellaneous/terminology/#type)
@@ -20,12 +20,13 @@ The service list can be filtered depending of:
 
 ## Services types
 
-Every Service being monitored by your application is associated with a "Type". This type is automatically determined by Datadog and is applied for you. The "Type" specified the name of the application/framework the Datadog Agent is Integrating with.  
-If you are monitoring a custom application, this appears as "Custom". For example, if you are using the official Flask Integration, the "Type" is set to "Web".
+Every Service monitored by your application is associated with a "Type". This type is automatically determined by Datadog and is applied for you. The "Type" specified the name of the application/framework the Datadog Agent is Integrating with.
 
-The type can be one of:
+For example, if you are using the official Flask Integration, the "Type" is set to "Web". If you are monitoring a custom application, this appears as "Custom".
 
-*  [Cache](/tracing/services/cache)
-*  [Custom](/tracing/services/custom)
-*  [DB](/tracing/services/db)
-*  [Web](/tracing/services/web)
+The type of the service can be one of:
+
+*  Cache
+*  Custom
+*  DB
+*  Web

--- a/content/tracing/services/cache.md
+++ b/content/tracing/services/cache.md
@@ -1,6 +1,0 @@
----
-title: Cache
-kind: Documentation
----
-
-wip

--- a/content/tracing/services/custom.md
+++ b/content/tracing/services/custom.md
@@ -1,6 +1,0 @@
----
-title: Custom
-kind: Documentation
----
-
-wip

--- a/content/tracing/services/db.md
+++ b/content/tracing/services/db.md
@@ -1,6 +1,0 @@
----
-title: DB
-kind: Documentation
----
-
-wip

--- a/content/tracing/services/web.md
+++ b/content/tracing/services/web.md
@@ -1,6 +1,0 @@
----
-title: Web
-kind: Documentation
----
-
-wip

--- a/data/libraries.yaml
+++ b/data/libraries.yaml
@@ -191,6 +191,11 @@ Tracing:
       authors: Matt Ho
       notes: OpenTracing Tracer implementation for Datadog in Go
   - Java:
+    - name: dd-trace-java
+      link: https://github.com/DataDog/dd-trace-java
+      official: true
+      authors: Datadog
+      notes: Java package 'tracer'
     - name: apm-client
       link: https://github.com/chonton/apm-client
       authors: Chas Honton

--- a/ja/data/libraries.yaml
+++ b/ja/data/libraries.yaml
@@ -160,6 +160,11 @@ Tracing:
       link: https://github.com/gchaincl/dd-go-opentracing
       notes: OpenTracing Tracer implementation for Datadog in Go
   - Java:
+    - name: dd-trace-java
+      link: https://github.com/DataDog/dd-trace-java
+      official: true
+      authors: Datadog
+      notes: Java package 'tracer'
     - name: apm-client
       link: https://github.com/chonton/apm-client
   - Javascript:


### PR DESCRIPTION
### What does this PR do?

I added my own changes to @l0k0ms's APM documentation refactor branch.

### Preview links

#### Tracing
- https://docs-staging.datadoghq.com/andrew.mcburney/apm-tracing-doc/tracing/
- https://docs-staging.datadoghq.com/andrew.mcburney/apm-tracing-doc/tracing/miscellaneous/

#### FAQ
- https://docs-staging.datadoghq.com/andrew.mcburney/apm-tracing-doc/tracing/faq  
- https://docs-staging.datadoghq.com/andrew.mcburney/apm-tracing-doc/tracing/faq/how-long-is-tracing-data-stored/

### Additional Notes

#### Services subpages
- I removed the services subpages because I don't think they're necessary. I figured it might be information overload to have a separate page for each service type. Thoughts on this @l0k0ms?

#### Client libraries
- I added the new [`dd-trace-java`](https://github.com/DataDog/dd-trace-java) Java client to the list of client APM libraries on the [community libraries page](https://docs-staging.datadoghq.com/andrew.mcburney/apm-tracing-doc/developers/libraries/#community-tracing-apm-libraries).

#### FAQs
- I moved the "How long is tracing data stored" on the [main APM tracing documentation page](https://docs-staging.datadoghq.com/andrew.mcburney/apm-tracing-doc/tracing/) to a separate [FAQ page](https://docs-staging.datadoghq.com/andrew.mcburney/apm-tracing-doc/tracing/faq/how-long-is-tracing-data-stored/).