### PR TITLE
change cmd + f on tiles to add class then use css for display changes

### DIFF
--- a/layouts/partials/integrations/integrations.html
+++ b/layouts/partials/integrations/integrations.html
@@ -102,7 +102,7 @@
                                  alt="integration">
                         </picture>
                     </a>
-                    <div class="text-center title" style="display: none;">{{ $formatname }}</div>
+                    <div class="text-center title">{{ $formatname }}</div>
                     <div class="card-body">
                         <a class="card-button" href="{{ $dot.Site.BaseURL }}integrations/{{$urlname | lower}}/">
                             <h4 class="card-title">{{ $formatname }}</h4>

--- a/layouts/partials/integrations/integrations.js
+++ b/layouts/partials/integrations/integrations.js
@@ -1,23 +1,17 @@
 $(document).ready(function () {
     var finder_state = 0;  // closed
-    var titles = document.getElementsByClassName('title');
+    var container = document.querySelector('[data-ref="container"]');
 
     $(window).on('focus', function () {
         if (finder_state) {
-            $.each(titles, function (e, v) {
-                v.style.display = 'none';
-            });
-            $('.integration-row').removeClass('find');
+            container.classList.remove('find');
             finder_state = 0;
         }
     });
 
     Mousetrap.bind(['command+f', 'control+f'], function (e) {
         if (!finder_state) {
-            $.each(titles, function (e, v) {
-                v.style.display = 'block';
-            });
-            $('.integration-row').addClass('find');
+            container.classList.add('find');
             finder_state = 1;
         }
     });

--- a/layouts/partials/integrations/integrations.scss
+++ b/layouts/partials/integrations/integrations.scss
@@ -115,7 +115,15 @@ $ddpurple:    #774DA2;
 // do card hovers at desktop only
 @media (min-width: 576px) {
   .integration-tiles {
+    &.find {
+      .card .title {
+        display:block;
+      }
+    }
     .card {
+      .title {
+        display:none;
+      }
       &:hover {
         border-color: $ddpurple;
         & > .card-img,
@@ -124,6 +132,9 @@ $ddpurple:    #774DA2;
         }
         & > .card-body {
           display: block;
+        }
+        .title {
+          display:none;
         }
       }
     }


### PR DESCRIPTION
### What does this PR do?
So when pressing cmd + f on the integrations page the tiles change to have a searchable title on them. Whilst in this mode if you hover over a tile the content is pushed down or cropped off. This pr fixes the styling on hover in this situation.

### Motivation
https://trello.com/c/oEetzEjK/155-content-in-integration-modal-is-croped

### Preview link
https://docs-staging.datadoghq.com/david.jones/integration-tile-content/integrations/

### Additional Notes
