### PR TITLE
Add TLS setup for syslog-ng

### DIFF
--- a/content/logs/faq/how-to-send-logs-to-datadog-via-external-log-shippers.md
+++ b/content/logs/faq/how-to-send-logs-to-datadog-via-external-log-shippers.md
@@ -246,16 +246,17 @@ filter {
     ```
     
 4. (Optional) TLS Encryption 
+    To activate TLS encryption:
+    
+    1. Download our [certificate](https://gist.githubusercontent.com/estib/8762bc1a2a5bda781a6e55cca40235f2/raw/665b6b2906a728027f508ea067f01cdf3cf72b49/intake.logs.datadoghq.com.crt) and save it to `/etc/syslog-ng/certs.d/datadoghq.crt`. 
 
-To activate TLS encryption, you firstly need to download our [certificate](https://gist.githubusercontent.com/estib/8762bc1a2a5bda781a6e55cca40235f2/raw/665b6b2906a728027f508ea067f01cdf3cf72b49/intake.logs.datadoghq.com.crt). Save it to `/etc/syslog-ng/certs.d/datadoghq.crt`. 
+    2. Change the definition of the destination to the following:
 
-Then change the definition of the destination to the following:
+        ```
+        destination d_datadog { tcp("intake.logs.datadoghq.com" port(10516)     tls(peer-verify(required-untrusted) ca_dir('/opt/syslog-ng/certs.d/')) template(DatadogFormat)); };
+        ```
 
-```
-destination d_datadog { tcp("intake.logs.datadoghq.com" port(10516)     tls(peer-verify(required-untrusted) ca_dir('/opt/syslog-ng/certs.d/')) template(DatadogFormat)); };
-```
-
-More information about the TLS parameters and possibilities for syslog-ng available in their [official documentation](https://syslog-ng.com/documents/html/syslog-ng-ose-latest-guides/en/syslog-ng-ose-guide-admin/html/tlsoptions.html).
+    More information about the TLS parameters and possibilities for syslog-ng available in their [official documentation](https://syslog-ng.com/documents/html/syslog-ng-ose-latest-guides/en/syslog-ng-ose-guide-admin/html/tlsoptions.html).
 
 5. Restart syslog-ng 
 

--- a/content/logs/faq/how-to-send-logs-to-datadog-via-external-log-shippers.md
+++ b/content/logs/faq/how-to-send-logs-to-datadog-via-external-log-shippers.md
@@ -244,8 +244,20 @@ filter {
 
     log { source(s_src); source(s_files); destination(d_datadog); };
     ```
+    
+4. (Optional) TLS Encryption 
 
-4. Restart syslog-ng 
+To activate TLS encryption, you firstly need to download our [certificate](https://gist.githubusercontent.com/estib/8762bc1a2a5bda781a6e55cca40235f2/raw/665b6b2906a728027f508ea067f01cdf3cf72b49/intake.logs.datadoghq.com.crt). Save it to `/etc/syslog-ng/certs.d/datadoghq.crt`. 
+
+Then change the definition of the destination to the following:
+
+```
+destination d_datadog { tcp("intake.logs.datadoghq.com" port(10516)     tls(peer-verify(required-untrusted) ca_dir('/opt/syslog-ng/certs.d/')) template(DatadogFormat)); };
+```
+
+More information about the TLS parameters and possibilities for syslog-ng available in their [official documentation](https://syslog-ng.com/documents/html/syslog-ng-ose-latest-guides/en/syslog-ng-ose-guide-admin/html/tlsoptions.html).
+
+5. Restart syslog-ng 
 
 
 ## NXLog


### PR DESCRIPTION
### What does this PR do?
Add TLS setup instruction for syslog-ng

### Motivation
Using a secure transmission is always better when it is available.

### Preview link

### Additional Notes
<!-- Anything else we should know when reviewing?-->
