### PR TITLE
adding create function for hdfs usecase

### DIFF
--- a/local/bin/py/update_pre_build.py
+++ b/local/bin/py/update_pre_build.py
@@ -140,7 +140,7 @@ class PreBuild:
         self.datafile_json = []
         self.pool_size = 5
         self.integration_mutations = OrderedDict({
-            'hdfs': {'action': 'truncate', 'target': 'hdfs', 'remove_header': False},
+            'hdfs': {'action': 'create', 'target': 'hdfs', 'remove_header': False},
             'mesos': {'action': 'truncate', 'target': 'mesos', 'remove_header': False},
             'activemq_xml': {'action': 'merge', 'target': 'activemq', 'remove_header': False},
             'cassandra_nodetool': {'action': 'merge', 'target': 'cassandra', 'remove_header': False},
@@ -272,6 +272,9 @@ class PreBuild:
                         open(output_file, 'w').close()
                 elif action == 'discard':
                     remove(input_file)
+                elif action == 'create':
+                    open(output_file, 'w+').close()
+
 
     def process_source_attribute(self, file_name):
         """

--- a/local/bin/py/update_pre_build.py
+++ b/local/bin/py/update_pre_build.py
@@ -145,7 +145,7 @@ class PreBuild:
             'activemq_xml': {'action': 'merge', 'target': 'activemq', 'remove_header': False},
             'cassandra_nodetool': {'action': 'merge', 'target': 'cassandra', 'remove_header': False},
             'gitlab_runner': {'action': 'merge', 'target': 'gitlab', 'remove_header': False},
-            'hdfs_datanode': {'action': 'merge', 'target': 'hdfs', 'remove_header': True},
+            'hdfs_datanode': {'action': 'merge', 'target': 'hdfs', 'remove_header': False},
             'hdfs_namenode': {'action': 'merge', 'target': 'hdfs', 'remove_header': False},
             'mesos_master': {'action': 'merge', 'target': 'mesos', 'remove_header': True},
             'mesos_slave': {'action': 'merge', 'target': 'mesos', 'remove_header': False},


### PR DESCRIPTION
### What does this PR do?

Add a new `action` in integrations build: "create"

Allowing to create an empty file to which we can append other content

### Motivation

HDFS main file is deleted by this PR:
https://github.com/DataDog/integrations-core/pull/1102

### Preview link
<!-- Impacted pages preview links-->

* https://docs-staging.datadoghq.com/gus/hdfs_integration_fix/integrations/hdfs/