### PR TITLE
Added OpenTracing setup documentation for Golang tracing page.

### DIFF
--- a/content/tracing/setup/go.md
+++ b/content/tracing/setup/go.md
@@ -82,6 +82,47 @@ ___
 |SQLx | https://github.com/jmoiron/sqlx | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/jmoiron/sqlx |
 {{% /table %}}
 
+### OpenTracing API
+
+Datadog APM client that implements an [OpenTracing](http://opentracing.io) Tracer.
+
+**Initialization**
+
+To start using the Datadog Tracer with the OpenTracing API, you should first initialize the tracer with a proper `Configuration` object:
+
+```go
+import (
+    // ddtrace namespace is suggested
+    ddtrace "github.com/DataDog/dd-trace-go/opentracing"
+    opentracing "github.com/opentracing/opentracing-go"
+)
+
+func main() {
+    // create a Tracer configuration
+    config := ddtrace.NewConfiguration()
+    config.ServiceName = "api-intake"
+    config.AgentHostname = "ddagent.consul.local"
+
+    // initialize a Tracer and ensure a graceful shutdown
+    // using the `closer.Close()`
+    tracer, closer, err := ddtrace.NewTracer(config)
+    if err != nil {
+        // handle the configuration error
+    }
+    defer closer.Close()
+
+    // set the Datadog tracer as a GlobalTracer
+    opentracing.SetGlobalTracer(tracer)
+    startWebServer()
+}
+```
+
+Function `NewTracer(config)` returns an `io.Closer` instance that can be used to gracefully shutdown the `tracer`. It's recommended to always call the `closer.Close(), otherwise internal buffers are not flushed and you may lose some traces.
+
+**Usage**
+
+See [Opentracing documentation](https://github.com/opentracing/opentracing-go) for some usage patterns. Legacy documentation is available in [GoDoc format](https://godoc.org/github.com/DataDog/dd-trace-go/tracer).
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
### What does this PR do?
Adds OpenTracing setup documentation to Golang tracing page. 

### Motivation
The documentation is in the README.md for the [dd-trace-go](https://github.com/DataDog/dd-trace-go) repo, but not in the docs page.

### Preview link
https://docs-staging.datadoghq.com/andrew.mcburney/apm-tracing-documentation/tracing/setup/go/#opentracing-api
