### PR TITLE
Fix spacing to be consistent in Golang tracing documentation.

### DIFF
--- a/content/tracing/setup/go.md
+++ b/content/tracing/setup/go.md
@@ -92,28 +92,28 @@ To start using the Datadog Tracer with the OpenTracing API, you should first ini
 
 ```go
 import (
-    // ddtrace namespace is suggested
-    ddtrace "github.com/DataDog/dd-trace-go/opentracing"
-    opentracing "github.com/opentracing/opentracing-go"
+  // ddtrace namespace is suggested
+  ddtrace "github.com/DataDog/dd-trace-go/opentracing"
+  opentracing "github.com/opentracing/opentracing-go"
 )
 
 func main() {
-    // create a Tracer configuration
-    config := ddtrace.NewConfiguration()
-    config.ServiceName = "api-intake"
-    config.AgentHostname = "ddagent.consul.local"
+  // create a Tracer configuration
+  config := ddtrace.NewConfiguration()
+  config.ServiceName = "api-intake"
+  config.AgentHostname = "ddagent.consul.local"
 
-    // initialize a Tracer and ensure a graceful shutdown
-    // using the `closer.Close()`
-    tracer, closer, err := ddtrace.NewTracer(config)
-    if err != nil {
-        // handle the configuration error
-    }
-    defer closer.Close()
+  // initialize a Tracer and ensure a graceful shutdown
+  // using the `closer.Close()`
+  tracer, closer, err := ddtrace.NewTracer(config)
+  if err != nil {
+    // handle the configuration error
+  }
+  defer closer.Close()
 
-    // set the Datadog tracer as a GlobalTracer
-    opentracing.SetGlobalTracer(tracer)
-    startWebServer()
+  // set the Datadog tracer as a GlobalTracer
+  opentracing.SetGlobalTracer(tracer)
+  startWebServer()
 }
 ```
 


### PR DESCRIPTION
### What does this PR do?
Changes the OpenTracing setup documentation to use 2 spaces instead of 4.

### Motivation
The spacing in the code I introduced was inconsistent with the current code on the page.

### Preview link
https://docs-staging.datadoghq.com/andrew.mcburney/apm-tracing-documentation/tracing/setup/go/#opentracing-api