### PR TITLE
kube_state_metrics version to 1.2.0 from 1.1.0 so that hpa metrics ca…

### DIFF
--- a/content/integrations/kubernetes.md
+++ b/content/integrations/kubernetes.md
@@ -167,7 +167,7 @@ spec:
     spec:
       containers:
       - name: kube-state-metrics
-        image: gcr.io/google_containers/kube-state-metrics:v1.1.0
+        image: gcr.io/google_containers/kube-state-metrics:v1.2.0
         ports:
         - name: metrics
           containerPort: 8080


### PR DESCRIPTION
### What does this PR do?
Change kube_state_metrics version to latest: 1.2.0
### Motivation
Proposed config support hpa metrics
https://trello.com/c/OekOyDYo/258-kubernetes-state-integration-image-version-and-available-metrics-are-not-consistent