### PR TITLE
changing with_source into with_sources

### DIFF
--- a/content/developers/faq/query-the-infrastructure-list-via-the-api.md
+++ b/content/developers/faq/query-the-infrastructure-list-via-the-api.md
@@ -18,7 +18,7 @@ By default, this endpoint queries all the data in your infrastructure list, whic
 * **hostnames[]**: list of strings. A list of those specific hostnames you want to query data from
 * **with_apps**: boolean. If true, displays the applications(integrations) that are associated with a given host.
 with_mute_status: boolean. If true, displays whether the host is muted by a downtime or not
-* **with_source**: boolean. If true, returns a list of sources from which metrics are reported for this host. For example, you might see 'aws', or 'agent', or 'azure' in this list.
+* **with_sources**: boolean. If true, returns a list of sources from which metrics are reported for this host. For example, you might see 'aws', or 'agent', or 'azure' in this list.
 * **with_aliases**: boolean. If true, displays aliases for this host. Here is information about aliases and what they are.
 * **with_meta**: boolean. If true, includes metadata about the host with things like disk information/ IP addresses/ etc
 


### PR DESCRIPTION

### What does this PR do?
https://docs.datadoghq.com/developers/faq/query-the-infrastructure-list-via-the-api/

On this doc page, the option "with_source" should be "with_sources" :

so this will return results:

curl -XGET "https://app.datadoghq.com/reports/v2/overview?api_key=${API_KEY}&application_key=${APP_KEY}&with_sources=true"
