### PR TITLE
Fixed some issues with code samples provided for Datadog Java tracing.

### DIFF
--- a/content/tracing/languages/java.md
+++ b/content/tracing/languages/java.md
@@ -52,9 +52,9 @@ The tracer is configured using System Properties and Environment Variables as fo
 
 **Note**: If the same key type is set for both, the system property configuration takes priority.
 
-## Manual Instrumentation 
+## Manual Instrumentation
 
-Before instrumenting your application, review Datadog’s [APM Terminology](/tracing/terminology/) and familiarize yourself with the core concepts of Datadog APM. If you aren't using a [supported framework instrumentation](#integrations), or you would like additional depth in your application’s traces, you may want to to manually instrument your code.  
+Before instrumenting your application, review Datadog’s [APM Terminology](/tracing/terminology/) and familiarize yourself with the core concepts of Datadog APM. If you aren't using a [supported framework instrumentation](#integrations), or you would like additional depth in your application’s traces, you may want to to manually instrument your code.
 Do this either using the [Trace annotation](#trace-annotation) for simple method call tracing or with the [OpenTracing API](#opentracing-api) for complex tracing.
 
 ### Trace Annotation
@@ -118,19 +118,23 @@ compile group: 'com.datadoghq', name: 'dd-trace-ot', version: "${dd-trace-java.v
 
 Configure your application using environment variables or system properties as discussed in the [configuration](#configuration) section.
 
-#### Custom Instrumentation Examples 
+#### Custom Instrumentation Examples
 
 Use a combination of these if the automatic instrumentation isn’t providing you enough depth or detail.
 
 Using try-finally:
 
 ```java
+import datadog.trace.api.DDTags;
+
+import io.opentracing.Scope;
+import io.opentracing.Tracer;
 import io.opentracing.util.GlobalTracer;
 
 class InstrumentedClass {
 
     void method0() {
-        /* 
+        /*
          * 1. Configure your application using environment variables or system properties
          * 2. Using dd-java-agent (-javaagent:/path/to/dd-java-agent.jar),
          *    GlobalTracer is automatically instantiated.
@@ -145,7 +149,7 @@ class InstrumentedClass {
             Thread.sleep(1000);
 
         // If you don't call close(), the span data will NOT make it to Datadog!
-        finally {
+        } finally {
             scope.close();
         }
     }
@@ -155,6 +159,10 @@ class InstrumentedClass {
 Alternatively, wrap the code you want to trace in a `try-with-resources` statement:
 
 ```java
+import datadog.trace.api.DDTags;
+
+import io.opentracing.Scope;
+import io.opentracing.Tracer;
 import io.opentracing.util.GlobalTracer;
 
 class InstrumentedClass {
@@ -176,8 +184,11 @@ If you’re not using `dd-trace-java.jar`, you must register a configured tracer
 
 ```java
 import datadog.opentracing.DDTracer;
-import io.opentracing.util.GlobalTracer;
 import datadog.trace.api.sampling.AllSampler;
+import datadog.trace.common.writer.DDAgentWriter;
+
+import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
 
 public class Application {
 
@@ -279,7 +290,7 @@ Don't see your desired networking framework? We're continually adding additional
 *  Apache Derby
 *  Firebird SQL
 *  H2 Database Engine
-*  HSQLDB 
+*  HSQLDB
 *  IBM DB2
 *  MSSQL (Microsoft SQL Server)
 *  MySQL


### PR DESCRIPTION
### What does this PR do?
Minor fixes to Java code samples using Java tracing library.

### Motivation
I was going through setting up a JVM (Scala) project with the Datadog tracer and found some issues in the code samples provided.

### Preview link
https://docs-staging.datadoghq.com/andrew.mcburney/java-apm-updates/tracing/languages/java/

### Additional Notes
N/A
