### PR TITLE
Correct custom checks.d directory path

### DIFF
--- a/content/agent/faq/agent-check-directory-structure.md
+++ b/content/agent/faq/agent-check-directory-structure.md
@@ -9,13 +9,9 @@ For all Linux systems, find it at:
 
     /etc/dd-agent/checks.d/
 
-For Windows Server >= 2008, find it at:
+For Windows Server, find it at:
 
-    C:\Program Files (x86)\Datadog\Agent\checks.d\
-
-OR
-
-    C:\Program Files\Datadog\Agent\checks.d\
+    c:\programdata\datadog\checks.d\
 
 For Mac OS X and source installations, find it at:
 

--- a/ja/content/guides/agent_checks.md
+++ b/ja/content/guides/agent_checks.md
@@ -364,13 +364,9 @@ Linux系のシステムは、以下のディレクトリになります:
 
     /etc/dd-agent/checks.d/
 
-Windows Server > = 2008の場合は、以下のディレクトリになります:
+Windows Server の場合は、以下のディレクトリになります:
 
-    C:\Program Files (x86)\Datadog\Agent\checks.d\
-
-    OR
-
-    C:\Program Files\Datadog\Agent\checks.d\
+    c:\programdata\datadog\checks.d\
 
 Mac OS Xと、ソースからインストールした場合は、以下のディレクトリになります:
 


### PR DESCRIPTION
### What does this PR do?
Fixes the path recommended to put windows agent custom checks. 

### Motivation
We released a PR that removes the path that used to be listed. 

### Preview link

### Additional Notes
Confirmed with Croissant a
