### PR TITLE
Set default image for CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,7 @@ variables:
   LIVE_DOMAIN: "https://docs.datadoghq.com/"
   PREVIEW_DOMAIN: "https://docs-staging.datadoghq.com/"
 
+image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/corp-ci:latest
 
 # ================== copy scripts =============== #
 before_script:

--- a/content/integrations/jenkins.md
+++ b/content/integrations/jenkins.md
@@ -58,7 +58,7 @@ You will start to see Jenkins events in the Event Stream when the plugin is up a
 
 ## Metrics
 
-{{< get-metrics-from-git >}}
+The Jenkins check does not include any metric at this time.
 
 ## Events
 


### PR DESCRIPTION
We recently removed the capability to set the default image in our Gitlab CI