### PR TITLE
add datadog-agent-ecs.json ECS task manifest

### DIFF
--- a/static/json/datadog-agent-ecs.json
+++ b/static/json/datadog-agent-ecs.json
@@ -1,0 +1,58 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "datadog-agent",
+      "image": "datadog/agent:latest",
+      "cpu": 10,
+      "memory": 256,
+      "essential": true,
+      "mountPoints": [
+        {
+          "containerPath": "/var/run/docker.sock",
+          "sourceVolume": "docker_sock"
+        },
+        {
+          "containerPath": "/host/sys/fs/cgroup",
+          "sourceVolume": "cgroup",
+          "readOnly": true
+        },
+        {
+          "containerPath": "/host/proc",
+          "sourceVolume": "proc",
+          "readOnly": true
+        }
+      ],
+      "environment": [
+        {
+          "name": "DD_API_KEY",
+          "value": "INSERT_API_KEY"
+        },
+        {
+      	  "name": "SD_BACKEND",
+	  "value": "docker"
+        }
+      ]
+    }
+  ],
+  "volumes": [
+    {
+      "host": {
+        "sourcePath": "/var/run/docker.sock"
+      },
+      "name": "docker_sock"
+    },
+    {
+      "host": {
+        "sourcePath": "/proc/"
+      },
+      "name": "proc"
+    },
+    {
+      "host": {
+        "sourcePath": "/cgroup/"
+      },
+      "name": "cgroup"
+    }
+  ],
+  "family": "datadog-agent-task"
+}


### PR DESCRIPTION
add datadog-agent-ecs.json ECS task manifest
to go with ECS update for agent6 https://github.com/DataDog/dogweb/pull/24458