### PR TITLE
adding configmap custom integration doc

### DIFF
--- a/content/integrations/kubernetes.md
+++ b/content/integrations/kubernetes.md
@@ -120,6 +120,48 @@ instances:
 
 See the [example kubernetes.yaml](https://github.com/DataDog/integrations-core/blob/master/kubernetes/conf.yaml.example) for all available configuration options.
 
+#### Custom integration
+
+It is possible to leverage the ConfigMaps to configure or enable integrations.
+To do so, you only need to create a ConfigMap with the integration(s)'s configuration.
+Then, reference this ConfigMap among the volumes of your agent's manifest.
+
+For example, in the following case we customize the name, url and tags fields of the http check.
+To enable other integrations, just specify the correct yaml name and make sure it is properly formated.
+
+```
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: dd-agent-config
+  namespace: default
+data:
+  http-config: |-
+    init_config:
+    instances:
+    - name: My service
+      url: my.service:port/healthz
+      tags:
+        - service:critical
+---
+```
+And in the manifest of your agent (Daemonset/Deployment) add the following:
+```
+[...]
+        volumeMounts:
+        [...]
+          - name: dd-agent-config
+            mountPath: /conf.d
+      volumes:
+      [...]
+        - name: dd-agent-config
+          configMap:
+            name: dd-agent-config
+            items:
+            - key: http-config
+              path: http_check.yaml
+[...]
+```              
 ### Validation
 #### Container Running
 


### PR DESCRIPTION
### What does this PR do?
Example of how to enable an integration with a configmap.

### Motivation

More doc to better use the kubernetes integration.

### Additional Notes

Not sure if this should live here or in the `datadog-agent/Dockerfiles/agent/README.md` ?
