### PR TITLE
noindex preview sites and update robots for prod to allow logs

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -19,6 +19,9 @@
 {{ end }}
 {{ $meta_desc := $.Scratch.Get "meta_desc" }}
 
+{{- if (or (eq $.Params.noindex true) (eq $.Params.private true) (eq .Site.Params.environment "preview")) -}}
+    <meta name="robots" content="noindex, nofollow">
+{{- end -}}
 
 <!-- Schema.org markup for Google+ -->
 <meta itemprop="name" content="{{ $meta_title | safeHTML }}">

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,3 +1,1 @@
 User-agent: *
-Disallow: /logs
-Disallow: /logs/


### PR DESCRIPTION
### What does this PR do?
This pr does 2 things
- Makes the production robots.txt not disallow the logs dir anymore
- Makes all preview site pages noindex

### Motivation
https://trello.com/c/x7kWNZix/165-update-robotstxt

### Preview link
https://docs-staging.datadoghq.com/david.jones/indexing/
view the source you can see the meta tag noindex

### Additional Notes
We only have one robots.txt in the project and its used by both preview sites and production. This pr makes it so we follow the same process as corp site. Allow all in robots but no index each page on preview sites.
