### PR TITLE
Fix inaccurate documentation surrounding downtime expiration and monitor alerts

### DIFF
--- a/content/monitors/downtimes.md
+++ b/content/monitors/downtimes.md
@@ -20,15 +20,11 @@ You may occasionally need to shut systems down or take them off-line to perform 
 
 ## What happens to a monitor when it is muted (or has a downtime)?
 
-You can schedule downtimes and/or mute your Datadog monitors so that they do not alert at specific times when you do not want them to. You can read how to schedule downtimes here and here. 
+You can schedule downtimes and/or mute your Datadog monitors so that they do not alert at specific times when you do not want them to. You can read how to schedule downtimes here and here.
 
 Monitors trigger events when they change state between ALERT, WARNING (if enabled), RESOLVED, and NO DATA (if enabled). But if a monitor has been silenced either by a downtime or muting, then any transition from RESOLVED to another state won't trigger an event (nor the notification channels that the event would have set off).
 
 {{< img src="monitors/downtimes/downtime_on_alert.png" alt="downtime on alert" responsive="true" popup="true" style="width:80%;">}}
-
-If a monitor has a transition from the RESOLVED state to either ALERT or WARNING while it has been silenced, and if it then remains in that ALERT or WARNING state once the silence-time expires, then the monitor triggers an ALERT or WARNING event at the time that the silencing expires.
-
-{{< img src="monitors/downtimes/downtime_stop.png" alt="downtime stop" responsive="true" popup="true" style="width:80%;">}}
 
 By default, this is not true of NO DATA alerts: if a monitor has transitioned from the RESOLVED state to NO DATA while it has been silenced, and if it remains in a NO DATA state once the silence-time expires, then there is no NO DATA alert. But once data returns for that monitor scope, the monitor triggers a recovery event. 
 
@@ -50,9 +46,9 @@ To schedule downtime, click the "Schedule Downtime" button in the upper right.
 
 1. Choose what to silence.
   {{< img src="monitors/downtimes/downtime-silence.png" alt="downtime-silence" responsive="true" popup="true" style="width:80%;">}}
-  You can select a specific monitor to silence, or leave this field empty to silence all monitors. You can also select a scope to constrain your downtime to a specific host, device or arbitrary tag.  
-  Refer to the [scope section](/graphing/miscellaneous/graphingjson/#scope) of the Graphing Primer using JSON for further information about scope.  
-  If you choose to silence all monitors constrained by a scope, clicking the "Preview affected monitors" shows which monitors are currently affected. Any monitors within your scope that are created or edited after the downtime is schedule is also silenced.  
+  You can select a specific monitor to silence, or leave this field empty to silence all monitors. You can also select a scope to constrain your downtime to a specific host, device or arbitrary tag.
+  Refer to the [scope section](/graphing/miscellaneous/graphingjson/#scope) of the Graphing Primer using JSON for further information about scope.
+  If you choose to silence all monitors constrained by a scope, clicking the "Preview affected monitors" shows which monitors are currently affected. Any monitors within your scope that are created or edited after the downtime is schedule is also silenced.
   Note that if a multi alert is included, it is only silenced for systems covered by the scope. For example, if a downtime scope is set for `host:X` and a multi alert is triggered on both `host:X` and `host:Y`, Datadog generates a monitor notification for `host:Y`, but not `host:X`.
 
 2. Set a schedule.
@@ -63,6 +59,6 @@ To schedule downtime, click the "Schedule Downtime" button in the upper right.
   {{< img src="monitors/downtimes/downtime-notify.png" alt="downtime-notify" responsive="true" popup="true" style="width:80%;">}}
   Enter a message to notify your team about this downtime. The message field allows standard [markdown formatting](http://daringfireball.net/projects/markdown/syntax) as well as Datadog's @-notification syntax. The "Notify your team" field allows you to specify team members or send the message to a service [integration](https://app.datadoghq.com/account/settings#integrations).
 
-## Further Reading 
+## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
### What does this PR do?
remove inaccurate documentation about ALERT, WARN, NODATA transition notifications when downtimes expire, this currently does not exist

### Motivation
Fixing documentation for a feature that does not exist.

### Preview link

### Additional Notes

