### PR TITLE
add guides/alerting/ to aliases

### DIFF
--- a/content/monitors/_index.md
+++ b/content/monitors/_index.md
@@ -4,6 +4,7 @@ kind: documentation
 aliases:
     - /guides/monitors/
     - /guides/monitoring/
+    - /guides/alerting/
 description: Create & manage your notifications
 ---
 


### PR DESCRIPTION
### What does this PR do?
adds missing alias for /guides/alerting

### Motivation
https://trello.com/c/bgs1uP4V/1974-broken-link-on-blog

### Preview link
https://docs-staging.datadoghq.com/michaelw/redirect-old-url/guides/alerting

### Additional Notes
<!-- Anything else we should know when reviewing?-->
