### PR TITLE
Update java doc with multi line processor in log config

### DIFF
--- a/content/logs/languages/csharp.md
+++ b/content/logs/languages/csharp.md
@@ -254,6 +254,11 @@ logs:
     service: csharp
     source: csharp
     sourcecategory: sourcecode
+    # For multiline logs, if they start by the date with the format yyyy-mm-dd uncomment the following processing rule
+    #log_processing_rules:
+    #  - type: multi_line
+    #    name: new_log_start_with_date
+    #    pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
 ```
 
 That's it! Now, all your logs are going to be in proper JSON automatically understood by your Datadog application.

--- a/content/logs/languages/go.md
+++ b/content/logs/languages/go.md
@@ -98,6 +98,7 @@ logs:
     service: go
     source: go
     sourcecategory: sourcecode
+    # For multiline logs, if they start by the date with the format yyyy-mm-dd uncomment the following processing rule
 ```
 
 ## Getting Further

--- a/content/logs/languages/go.md
+++ b/content/logs/languages/go.md
@@ -98,7 +98,6 @@ logs:
     service: go
     source: go
     sourcecategory: sourcecode
-    # For multiline logs, if they start by the date with the format yyyy-mm-dd uncomment the following processing rule
 ```
 
 ## Getting Further

--- a/content/logs/languages/java.md
+++ b/content/logs/languages/java.md
@@ -116,6 +116,11 @@ logs:
     service: java
     source: java
     sourcecategory: sourcecode
+    # For multiline logs, if they start by the date with the format yyyy-mm-dd uncomment the following processing rule
+    #log_processing_rules:
+    #  - type: multi_line
+    #    name: new_log_start_with_date
+    #    pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
 ```
 
 ## Getting further

--- a/content/logs/languages/python.md
+++ b/content/logs/languages/python.md
@@ -130,6 +130,11 @@ logs:
     service: myapplication
     source: python
     sourcecategory: sourcecode
+    # For multiline logs, if they start by the date with the format yyyy-mm-dd uncomment the following processing rule
+    #log_processing_rules:
+    #  - type: multi_line
+    #    name: new_log_start_with_date
+    #    pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
 ```
 
 Then [Restart the Agent](/agent/faq/start-stop-restart-the-datadog-agent) to apply the configuration change.

--- a/content/logs/languages/ruby.md
+++ b/content/logs/languages/ruby.md
@@ -136,6 +136,11 @@ logs:
     service: ruby
     source: ruby
     sourcecategory: sourcecode
+    # For multiline logs, if they start by the date with the format yyyy-mm-dd uncomment the following processing rule
+    #log_processing_rules:
+    #  - type: multi_line
+    #    name: new_log_start_with_date
+    #    pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
 ```
 
 That's it! Now, all the rails calls are going to be in proper JSON automatically understood by your Datadog application.


### PR DESCRIPTION
### What does this PR do?
Add multiline configuration in the Java log collection documentation

### Motivation
Java logs contain stack traces and they need to be wrapped as a single log

### Preview link
<!-- Impacted pages preview links-->


### Additional Notes
<!-- Anything else we should know when reviewing?-->
