### PR TITLE
fixing python example with correct function

### DIFF
--- a/content/api/metrics/code_snippets/api-metric-metadata-get.py
+++ b/content/api/metrics/code_snippets/api-metric-metadata-get.py
@@ -9,4 +9,4 @@ initialize(**options)
 
 metric = 'system.cpu.idle'
 
-api.metric.list(metric_name=metric)
+api.Metadata.get(metric_name=metric)


### PR DESCRIPTION
[View Metric metadata](https://docs.datadoghq.com/api/?lang=python#view-metric-metadata)

The python code is incorrect: api.metric.list(metric_name=metric)
https://cl.ly/0o2P0u1g2k3T

Returns:

```
Traceback (most recent call last):
  File "metricmeta.py", line 12, in <module>
    api.metric.list(metric_name=metric)
AttributeError: 'module' object has no attribute 'metric'
```

This pr Replace _api.metric.list(metric_name=metric)_  with _api.Metadata.get(metric_name=metric)