### PR TITLE
Removing wrong param on examples

### DIFF
--- a/content/api/metrics/code_snippets/api-metrics-post.rb
+++ b/content/api/metrics/code_snippets/api-metrics-post.rb
@@ -19,5 +19,5 @@ dog.emit_points('some.metric.name', points, : tags => ["version:1"])
 # Emit differents metrics in a single request to be more efficient
 dog.batch_metrics do
   dog.emit_point('test.api.test_metric',10)
-  dog.emit_point('test.api.this_other_metric', 1, :type => 'counter')
+  dog.emit_point('test.api.this_other_metric', 1)
 end

--- a/content/api/metrics/code_snippets/api-metrics-post.sh
+++ b/content/api/metrics/code_snippets/api-metrics-post.sh
@@ -8,7 +8,6 @@ curl  -X POST -H "Content-type: application/json" \
 -d "{ \"series\" :
          [{\"metric\":\"test.metric\",
           \"points\":[[$currenttime, 20]],
-          \"type\":\"gauge\",
           \"host\":\"test.example.com\",
           \"tags\":[\"environment:test\"]}
         ]

--- a/content/api/metrics/metrics_timeseries.md
+++ b/content/api/metrics/metrics_timeseries.md
@@ -18,7 +18,7 @@ The metrics end-point allows you to post time-series data that can be graphed on
     * `points` [*required*]:  
         A JSON array of points. Each point is of the form:  
         `[[POSIX_timestamp, numeric_value], ...]`  
-        **Note**: that the timestamp should be in seconds, must be current, and the numeric value is a 32bit float gauge-type value.
+        **Note**: The timestamp should be in seconds, current, and its format should be a 32bit float gauge-type value.
         Current is defined as not more than 10 minutes in the future or more than 1 hour in the past.
     * `host` [*required*]:  
         The name of the host that produced the metric.


### PR DESCRIPTION
### What does this PR do?

The cURL sample has a type: gauge argument added, while the Python doesn't.
A Client complained that the doc is not clear enough as what types are supported.

According to [this](https://docs.datadoghq.com/developers/metrics/) and [this doco](https://help.datadoghq.com/hc/en-us/articles/206955236-Metric-types-in-Datadog) we only support _gauge_ type.