### PR TITLE
update image tag name

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,8 +10,6 @@ variables:
   LIVE_DOMAIN: "https://docs.datadoghq.com/"
   PREVIEW_DOMAIN: "https://docs-staging.datadoghq.com/"
 
-image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:latest
-
 # ================== copy scripts =============== #
 before_script:
   - find local/bin/ -type f -exec cp {} /usr/local/bin \;  # load scripts
@@ -20,6 +18,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
   tags:
     - "runner:main"
     - "size:large"


### PR DESCRIPTION
### What does this PR do?
updates the primary image name to `master` because of the way we build images in corp-ci.

### Preview link
https://docs-staging.datadoghq.com/michaelw/image-tag/

### Additional Notes
We will probably change the primary branch for corp-ci to `latest` in the near future to stick with tagging conventions. 