### PR TITLE
Update log4net logging instruction

### DIFF
--- a/content/logs/languages/csharp.md
+++ b/content/logs/languages/csharp.md
@@ -233,13 +233,11 @@ If you have followed the instructions you should see in your file (for example `
 }
 ```
 
-If despite the benefits of logging in JSON you wish to remain in a raw string format, we recommend to update the `log4net convertion pattern` as follows:
+If despite the benefits of logging in JSON you wish to remain in a raw string format, we recommend to update the `log4net convertion pattern` to automatically parse your logs with the c# integration pipeline as follows:
 
 ```
 <param name="ConversionPattern" value="%date%d{yyyy-MM-dd HH:mm:ss.SSS} %level [%thread] %logger %method:%line - %message%n" />
 ```
-
-It will then automatically be parsed by the c# integration pipeline.
 
 ## Configure your Datadog agent
 

--- a/content/logs/languages/csharp.md
+++ b/content/logs/languages/csharp.md
@@ -233,6 +233,14 @@ If you have followed the instructions you should see in your file (for example `
 }
 ```
 
+If despite the benefits of logging in JSON you wish to remain in a raw string format, we recommend to update the `log4net convertion pattern` as follows:
+
+```
+<param name="ConversionPattern" value="%date%d{yyyy-MM-dd HH:mm:ss.SSS} %level [%thread] %logger %method:%line - %message%n" />
+```
+
+It will then automatically be parsed by the c# integration pipeline.
+
 ## Configure your Datadog agent
 
 Create a `csharp.d/conf.yaml` file in your `conf.d/` folder with the following content:


### PR DESCRIPTION
### What does this PR do?
Add the recommended logging format when using log4net if JSON is not an option.

### Motivation
Everyone is not always keen to log in JSON as the file becomes harder to read (even if the point of log management solution is not to have to look at the file anymore). Therefore we automatically support some format and it had to be documented.

### Preview link
<!-- Impacted pages preview links-->


### Additional Notes
<!-- Anything else we should know when reviewing?-->
