### PR TITLE
Adding process monitoring with ansible KB

### DIFF
--- a/content/integrations/faq/_index.md
+++ b/content/integrations/faq/_index.md
@@ -40,6 +40,10 @@ kind: faq
 * [Issues with Apache Integration](/integrations/faq/issues-with-apache-integration)
 * [Apache SSL certificate issues](/integrations/faq/apache-ssl-certificate-issues)
 
+## Ansible
+
+* [Enabling Process Monitoring in Ansible](/integrations/faq/enabling-process-monitoring-with-ansible)
+
 ## Azure
 * [My Azure VM is powered down... why is it still listed in my infrastructure list?](/integrations/faq/my-azure-vm-is-powered-down-why-is-it-still-listed-in-my-infrastructure-list)
 * [Azure VMs are showing up in the App but not reporting metrics](/integrations/faq/azure-vms-are-showing-up-in-the-app-but-not-reporting-metrics)

--- a/content/integrations/faq/enabling-process-monitoring-with-ansible.md
+++ b/content/integrations/faq/enabling-process-monitoring-with-ansible.md
@@ -1,0 +1,34 @@
+---
+title: Enabling Process Monitoring in Ansible
+kind: faq
+---
+
+In the same directory as a playbook, create a file named `process_agent.yaml`with the following contents:
+
+```
+init_config:
+  enabled: true
+instances:
+  - {}
+```
+
+Sample playbook that copies the file to the appropriate directory and restarts the agent.
+
+```
+- hosts: all
+  become: yes
+  roles:
+    - { role: Datadog.datadog, become: yes } 
+  vars:
+    datadog_api_key: "API_KEY"
+    datadog_agent6: true
+    datadog_config:
+        process_agent_enabled: true
+  tasks:
+  - copy:
+      src: process_agent.yaml
+      dest: /etc/datadog-agent/conf.d/process_agent.yaml
+      mode: 0777
+  - name: Restart datadog-agent after copying config file
+    command: systemctl restart datadog-agent
+```


### PR DESCRIPTION
A customer couldn't get process agent to work for an Agent 6 beta deployment on ansible so a support member tested and created an ansible playbook that finally got it to work. The customer suggested it should be in our docs.