### PR TITLE
Update Agent 6 manual install to point to stable repos

### DIFF
--- a/content/agent/basic_agent_usage/amazonlinux.md
+++ b/content/agent/basic_agent_usage/amazonlinux.md
@@ -110,39 +110,39 @@ To install on a clean box (or have an existing agent 5 install from which you do
 #### Manual install
 1. Set up Datadog's Yum repo on your system by creating /etc/yum.repos.d/datadog.repo with the contents:
 
-```
-[datadog]
-name = Datadog, Inc.
-baseurl = https://yum.datadoghq.com/stable/6/x86_64/
-enabled=1
-gpgcheck=1
-gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-```
+    ```
+    [datadog]
+    name = Datadog, Inc.
+    baseurl = https://yum.datadoghq.com/stable/6/x86_64/
+    enabled=1
+    gpgcheck=1
+    gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+    ```
 
 2. Update your local yum repo and install the Agent:
 
-```
-sudo yum makecache
-sudo yum install datadog-agent
-```
+    ```
+    sudo yum makecache
+    sudo yum install datadog-agent
+    ```
 
 3. Copy the example config into place and plug in your API key:
 
-```
-sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
-```
+    ```
+    sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+    ```
 
 4. Re-start the Agent for Amazon linux 2.0:
 
-```
-sudo systemctl restart datadog-agent.service
-```
+    ```
+    sudo systemctl restart datadog-agent.service
+    ```
 
 5. Re-start the Agent for Amazon linux 1.0:
 
-```
-sudo initctl start datadog-agent
-```
+    ```
+    sudo initctl start datadog-agent
+    ```
 
 ### Downgrade to Agent v5
 

--- a/content/agent/basic_agent_usage/amazonlinux.md
+++ b/content/agent/basic_agent_usage/amazonlinux.md
@@ -108,26 +108,41 @@ To install on a clean box (or have an existing agent 5 install from which you do
 ```
 
 #### Manual install
-1. Set up apt so it can download through https
+1. Set up Datadog's Yum repo on your system by creating /etc/yum.repos.d/datadog.repo with the contents:
 
-    ```shell
-    sudo apt-get update
-    sudo apt-get install apt-transport-https
-    ```
+```
+[datadog]
+name = Datadog, Inc.
+baseurl = https://yum.datadoghq.com/stable/6/x86_64/
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+```
 
-2. Add the repository to your system and import the Datadog gpg key
+2. Update your local yum repo and install the Agent:
 
-    ```shell
-    echo 'deb https://apt.datadoghq.com/ beta main' | sudo tee /etc/apt/sources.list.d/datadog-beta.list
-    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
-    ```
+```
+sudo yum makecache
+sudo yum install datadog-agent
+```
 
-3. Update APT and Install the agent
+3. Copy the example config into place and plug in your API key:
 
-    ```shell
-    sudo apt-get update
-    sudo apt-get install datadog-agent
-    ```
+```
+sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+```
+
+4. Re-start the Agent for Amazon linux 2.0:
+
+```
+sudo systemctl restart datadog-agent.service
+```
+
+5. Re-start the Agent for Amazon linux 1.0:
+
+```
+sudo initctl start datadog-agent
+```
 
 ### Downgrade to Agent v5
 
@@ -137,10 +152,10 @@ To install on a clean box (or have an existing agent 5 install from which you do
     sudo apt-get install apt-transport-https
     ```
 
-2. Remove the repository and Ensure the stable repository is present
+2. Remove the Agent 6 repository and Ensure the stable repository is present
 
     ```shell
-    sudo rm /etc/apt/sources.list.d/datadog-beta.list [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
+    sudo rm /etc/yum.repos.d/datadog.repo [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
     sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
     ```
 

--- a/content/agent/basic_agent_usage/centos.md
+++ b/content/agent/basic_agent_usage/centos.md
@@ -111,26 +111,42 @@ To install on a clean box (or have an existing agent 5 install from which you do
 ```
 
 #### Manual install
-1. Set up apt so it can download through https
+1. Set up Datadog's Yum repo on your system by creating /etc/yum.repos.d/datadog.repo with the contents:
 
-    ```shell
-    sudo apt-get update
-    sudo apt-get install apt-transport-https
-    ```
+```
+[datadog]
+name = Datadog, Inc.
+baseurl = https://yum.datadoghq.com/stable/6/x86_64/
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+```
 
-2. Add the repository to your system and import the Datadog gpg key
+2. Update your local yum repo and install the Agent:
 
-    ```shell
-    echo 'deb https://apt.datadoghq.com/ beta main' | sudo tee /etc/apt/sources.list.d/datadog-beta.list
-    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
-    ```
+```
+sudo yum makecache
+sudo yum remove datadog-agent-base
+sudo yum install datadog-agent
+```
 
-3. Update APT and Install the agent
+3. Copy the example config into place and plug in your API key:
 
-    ```shell
-    sudo apt-get update
-    sudo apt-get install datadog-agent
-    ```
+```
+sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+```
+
+4. Re-start the Agent on Centos 7 and above:
+
+```
+sudo systemctl restart datadog-agent.service
+```
+
+5. Re-start the Agent on Centos 6:
+
+```
+sudo initctl start datadog-agent
+```
 
 ### Downgrade to Agent v5
 
@@ -140,10 +156,10 @@ To install on a clean box (or have an existing agent 5 install from which you do
     sudo apt-get install apt-transport-https
     ```
 
-2. Remove Beta Repo and Ensure the stable repo is present
+2. Remove Agent 6 Repo and Ensure the stable repo is present
 
     ```shell
-    sudo rm /etc/apt/sources.list.d/datadog-beta.list [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
+    sudo rm /etc/yum.repos.d/datadog.repo [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
     sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
     ```
 

--- a/content/agent/basic_agent_usage/centos.md
+++ b/content/agent/basic_agent_usage/centos.md
@@ -113,40 +113,40 @@ To install on a clean box (or have an existing agent 5 install from which you do
 #### Manual install
 1. Set up Datadog's Yum repo on your system by creating /etc/yum.repos.d/datadog.repo with the contents:
 
-```
-[datadog]
-name = Datadog, Inc.
-baseurl = https://yum.datadoghq.com/stable/6/x86_64/
-enabled=1
-gpgcheck=1
-gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-```
+    ```
+    [datadog]
+    name = Datadog, Inc.
+    baseurl = https://yum.datadoghq.com/stable/6/x86_64/
+    enabled=1
+    gpgcheck=1
+    gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+    ```
 
 2. Update your local yum repo and install the Agent:
 
-```
-sudo yum makecache
-sudo yum remove datadog-agent-base
-sudo yum install datadog-agent
-```
+    ```
+    sudo yum makecache
+    sudo yum remove datadog-agent-base
+    sudo yum install datadog-agent
+    ```
 
 3. Copy the example config into place and plug in your API key:
 
-```
-sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
-```
+    ```
+    sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+    ```
 
 4. Re-start the Agent on Centos 7 and above:
 
-```
-sudo systemctl restart datadog-agent.service
-```
+    ```
+    sudo systemctl restart datadog-agent.service
+    ```
 
 5. Re-start the Agent on Centos 6:
 
-```
-sudo initctl start datadog-agent
-```
+    ```
+    sudo initctl start datadog-agent
+    ```
 
 ### Downgrade to Agent v5
 

--- a/content/agent/basic_agent_usage/deb.md
+++ b/content/agent/basic_agent_usage/deb.md
@@ -112,38 +112,38 @@ To install on a clean box (or have an existing agent 5 install from which you do
 
 1. Set up apt so that it can download through https:
 
-```
-sudo apt-get update
-sudo apt-get install apt-transport-https
-```
+    ```
+    sudo apt-get update
+    sudo apt-get install apt-transport-https
+    ```
 
 2. Set up the Datadog deb repo on your system and import Datadog's apt key:
 
-```
-sudo sh -c "echo 'deb https://apt.datadoghq.com/ stable 6' > /etc/apt/sources.list.d/datadog.list"
-sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
-```
+    ```
+    sudo sh -c "echo 'deb https://apt.datadoghq.com/ stable 6' > /etc/apt/sources.list.d/datadog.list"
+    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
+    ```
 
-Note: You might need to install `dirmngr` to add Datadog's apt key.
+    Note: You might need to install `dirmngr` to add Datadog's apt key.
 
 3. Update your local apt repo and install the Agent:
 
-```
-sudo apt-get update
-sudo apt-get install datadog-agent
-```
+    ```
+    sudo apt-get update
+    sudo apt-get install datadog-agent
+    ```
 
 4. Copy the example config into place and plug in your API key:
 
-```
-sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
-```
+    ```
+    sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml" 
+    ```
 
 5. Start the Agent:
 
-```
-sudo systemctl restart datadog-agent.service
-```
+    ```
+    sudo systemctl restart datadog-agent.service
+    ```
 
 
 ### Downgrade to Agent v5

--- a/content/agent/basic_agent_usage/deb.md
+++ b/content/agent/basic_agent_usage/deb.md
@@ -109,26 +109,42 @@ To install on a clean box (or have an existing agent 5 install from which you do
 ```
 
 #### Manual install
-1. Set up apt so it can download through https
 
-    ```shell
-    sudo apt-get update
-    sudo apt-get install apt-transport-https
-    ```
+1. Set up apt so that it can download through https:
 
-2. Add the repository to your system and import the Datadog gpg key
+```
+sudo apt-get update
+sudo apt-get install apt-transport-https
+```
 
-    ```shell
-    echo 'deb https://apt.datadoghq.com/ beta main' | sudo tee /etc/apt/sources.list.d/datadog-beta.list
-    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
-    ```
+2. Set up the Datadog deb repo on your system and import Datadog's apt key:
 
-3. Update APT and Install the agent
+```
+sudo sh -c "echo 'deb https://apt.datadoghq.com/ stable 6' > /etc/apt/sources.list.d/datadog.list"
+sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
+```
 
-    ```shell
-    sudo apt-get update
-    sudo apt-get install datadog-agent
-    ```
+Note: You might need to install `dirmngr` to add Datadog's apt key.
+
+3. Update your local apt repo and install the Agent:
+
+```
+sudo apt-get update
+sudo apt-get install datadog-agent
+```
+
+4. Copy the example config into place and plug in your API key:
+
+```
+sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+```
+
+5. Start the Agent:
+
+```
+sudo systemctl restart datadog-agent.service
+```
+
 
 ### Downgrade to Agent v5
 
@@ -138,10 +154,10 @@ To install on a clean box (or have an existing agent 5 install from which you do
     sudo apt-get install apt-transport-https
     ```
 
-2. Remove Beta Repo and Ensure the stable repo is present
+2. Remove Agent 6 Repo and Ensure the stable repo is present
 
     ```shell
-    sudo rm /etc/apt/sources.list.d/datadog-beta.list [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
+    sudo rm /etc/apt/sources.list.d/datadog.list [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
     sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
     ```
 

--- a/content/agent/basic_agent_usage/fedora.md
+++ b/content/agent/basic_agent_usage/fedora.md
@@ -114,33 +114,33 @@ To install on a clean box (or have an existing agent 5 install from which you do
 #### Manual install
 1. Set up Datadog's Yum repo on your system by creating /etc/yum.repos.d/datadog.repo with the contents:
 
-```
-[datadog]
-name = Datadog, Inc.
-baseurl = https://yum.datadoghq.com/stable/6/x86_64/
-enabled=1
-gpgcheck=1
-gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-```
+    ```
+    [datadog]
+    name = Datadog, Inc.
+    baseurl = https://yum.datadoghq.com/stable/6/x86_64/
+    enabled=1
+    gpgcheck=1
+    gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+    ```
 
 2. Update your local yum cache and install/update the agent
 
-```shell
-sudo yum makecache
-sudo yum install datadog-agent
-```
+    ```
+    sudo yum makecache
+    sudo yum install datadog-agent
+    ```
 
 3. Import existing configuration (optional)
 
-```
-sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
-```
+    ```
+    sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+    ```
 
 5. Restart the agent
 
-```
-sudo systemctl restart datadog-agent.service
-```
+    ```
+    sudo systemctl restart datadog-agent.service
+    ```
 
 ### Downgrade to Agent v5
 

--- a/content/agent/basic_agent_usage/fedora.md
+++ b/content/agent/basic_agent_usage/fedora.md
@@ -112,67 +112,41 @@ To install on a clean box (or have an existing agent 5 install from which you do
 ```
 
 #### Manual install
-1. Set up Datadog's Yum repo on your system
+1. Set up Datadog's Yum repo on your system by creating /etc/yum.repos.d/datadog.repo with the contents:
 
-    ```
-    [datadog-beta]
-    name = Beta, Datadog, Inc.
-    baseurl = https://yum.datadoghq.com/beta/x86_64/
-    enabled=1
-    gpgcheck=1
-    priority=1
-    gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-    ```
-
-    use this command to do it directly:
-
-    ```shell
-    # Red Hat
-    echo -e '[datadog-beta]\nname = Beta, Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/beta/x86_64/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public\n       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public' | sudo tee /etc/yum.repos.d/datadog-beta.repo
-    ```
+```
+[datadog]
+name = Datadog, Inc.
+baseurl = https://yum.datadoghq.com/stable/6/x86_64/
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+```
 
 2. Update your local yum cache and install/update the agent
 
-    ```shell
-    sudo yum clean expire-cache
-    sudo yum install datadog-agent
-    ```
+```shell
+sudo yum makecache
+sudo yum install datadog-agent
+```
 
 3. Import existing configuration (optional)
 
-    If you ran the `install_script.sh` all agent and checks configuration should be already imported.
-
-    If you didn't you can run manually the import command:
-
-    ```shell
-    /opt/datadog-agent/bin/agent/agent import /etc/dd-agent /etc/datadog-agent
-    ```
-
-4. Enable desired custom checks (optional)
-
-    Since all custom checks might not work on Agent 6, we let you enable these manually. Copy them over to the `additional_checksd` location (defaults to `/etc/datadog-agent/checks.d/` for Agent 6):
-
-    ```shell
-    sudo -u dd-agent -- cp /etc/dd-agent/checks.d/<check>.py /etc/datadog-agent/checks.d/
-    ```
-
-    **Note:** custom checks now have a *lower* precedence than the checks bundled by default with the Agent. This affects your custom checks if they have the same name as a check in [integrations-core][https://github.com/DataDog/integrations-core].
+```
+sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+```
 
 5. Restart the agent
 
-    ```shell
-    # Systemd
-    sudo systemctl restart datadog-agent
-    # Upstart
-    sudo restart datadog-agent
-    ```
+```
+sudo systemctl restart datadog-agent.service
+```
 
 ### Downgrade to Agent v5
 
-1. Remove the Beta Yum repo from your system:
+1. Remove the Agent 6 Yum repo from your system:
     ```shell 
-    rm /etc/yum.repos.d/datadog-beta.repo [ ! -f /etc/yum.repos.d/datadog.repo ] && echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/rpm/x86_64/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public\n       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public' | sudo tee /etc/yum.repos.d/datadog.repo
+    rm  /etc/yum.repos.d/datadog.repo [ ! -f /etc/yum.repos.d/datadog.repo ] && echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/rpm/x86_64/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public\n       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public' | sudo tee /etc/yum.repos.d/datadog.repo
     ```
 
 2. Update your local yum cache and downgrade the agent

--- a/content/agent/basic_agent_usage/redhat.md
+++ b/content/agent/basic_agent_usage/redhat.md
@@ -104,67 +104,49 @@ To install on a clean box (or have an existing agent 5 install from which you do
 ```
 
 #### Manual install
-1. Set up Datadog's Yum repo on your system
 
-    ```
-    [datadog-beta]
-    name = Beta, Datadog, Inc.
-    baseurl = https://yum.datadoghq.com/beta/x86_64/
-    enabled=1
-    gpgcheck=1
-    priority=1
-    gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-    ```
+1. Set up Datadog's Yum repo on your system by creating /etc/yum.repos.d/datadog.repo with the contents:
 
-    use this command to do it directly:
+```
+[datadog]
+name = Datadog, Inc.
+baseurl = https://yum.datadoghq.com/stable/6/x86_64/
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+```
 
-    ```shell
-    # Red Hat
-    echo -e '[datadog-beta]\nname = Beta, Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/beta/x86_64/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public\n       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public' | sudo tee /etc/yum.repos.d/datadog-beta.repo
-    ```
+2. Update your local yum repo and install the Agent:
 
-2. Update your local yum cache and install/update the agent
+```
+sudo yum makecache
+sudo yum remove datadog-agent-base
+sudo yum install datadog-agent
+```
 
-    ```shell
-    sudo yum clean expire-cache
-    sudo yum install datadog-agent
-    ```
+3. Copy the example config into place and plug in your API key:
 
-3. Import existing configuration (optional)
+```
+sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+```
 
-    If you ran the `install_script.sh` all agent and checks configuration should be already imported.
+4. Re-start the Agent on Centos 7 and above:
 
-    If you didn't you can run manually the import command:
+```
+sudo systemctl restart datadog-agent.service
+```
 
-    ```shell
-    /opt/datadog-agent/bin/agent/agent import /etc/dd-agent /etc/datadog-agent
-    ```
+5. Re-start the Agent on Centos 6:
 
-4. Enable desired custom checks (optional)
-
-    Since all custom checks might not work on Agent 6, we let you enable these manually. Copy them over to the `additional_checksd` location (defaults to `/etc/datadog-agent/checks.d/` for Agent 6):
-
-    ```shell
-    sudo -u dd-agent -- cp /etc/dd-agent/checks.d/<check>.py /etc/datadog-agent/checks.d/
-    ```
-
-    **Note:** custom checks now have a *lower* precedence than the checks bundled by default with the Agent. This affects your custom checks if they have the same name as a check in [integrations-core][https://github.com/DataDog/integrations-core].
-
-5. Restart the agent
-
-    ```shell
-    # Systemd
-    sudo systemctl restart datadog-agent
-    # Upstart
-    sudo restart datadog-agent
-    ```
+```
+sudo initctl start datadog-agent
+```
 
 ### Downgrade to Agent v5
 
-1. Remove the Beta Yum repo from your system:
+1. Remove the Agent 6 Yum repo from your system:
     ```shell 
-    rm /etc/yum.repos.d/datadog-beta.repo [ ! -f /etc/yum.repos.d/datadog.repo ] && echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/rpm/x86_64/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public\n       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public' | sudo tee /etc/yum.repos.d/datadog.repo
+    rm /etc/yum.repos.d/datadog.repo [ ! -f /etc/yum.repos.d/datadog.repo ] && echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/rpm/x86_64/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public\n       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public' | sudo tee /etc/yum.repos.d/datadog.repo
     ```
 
 2. Update your local yum cache and downgrade the agent

--- a/content/agent/basic_agent_usage/redhat.md
+++ b/content/agent/basic_agent_usage/redhat.md
@@ -107,40 +107,40 @@ To install on a clean box (or have an existing agent 5 install from which you do
 
 1. Set up Datadog's Yum repo on your system by creating /etc/yum.repos.d/datadog.repo with the contents:
 
-```
-[datadog]
-name = Datadog, Inc.
-baseurl = https://yum.datadoghq.com/stable/6/x86_64/
-enabled=1
-gpgcheck=1
-gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-```
+    ```
+    [datadog]
+    name = Datadog, Inc.
+    baseurl = https://yum.datadoghq.com/stable/6/x86_64/
+    enabled=1
+    gpgcheck=1
+    gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+    ```
 
 2. Update your local yum repo and install the Agent:
 
-```
-sudo yum makecache
-sudo yum remove datadog-agent-base
-sudo yum install datadog-agent
-```
+    ```
+    sudo yum makecache
+    sudo yum remove datadog-agent-base
+    sudo yum install datadog-agent
+    ```
 
 3. Copy the example config into place and plug in your API key:
 
-```
-sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
-```
+    ```
+    sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+    ```
 
 4. Re-start the Agent on Centos 7 and above:
 
-```
-sudo systemctl restart datadog-agent.service
-```
+    ```
+    sudo systemctl restart datadog-agent.service
+    ```
 
 5. Re-start the Agent on Centos 6:
 
-```
-sudo initctl start datadog-agent
-```
+    ```
+    sudo initctl start datadog-agent
+    ```
 
 ### Downgrade to Agent v5
 

--- a/content/agent/basic_agent_usage/suse.md
+++ b/content/agent/basic_agent_usage/suse.md
@@ -75,32 +75,38 @@ Configuration files for [integrations](/integrations):
 
 ## Upgrade to Agent 6
 
-1. Set up Datadog's Yum repo on your system:
+1. Set up Datadog's Yum repo on your system by creating /etc/zypp/repos.d/datadog.repo with the contents:
 
-  ```
-  [datadog-beta]
-  name=Beta, Datadog, Inc.
-  enabled=1
-  baseurl=https://yum.datadoghq.com/suse/beta/6/x86_64
-  type=rpm-md
-  gpgcheck=1
-  repo_gpgcheck=0
-  gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-  ```
+```
+[datadog]
+name=Datadog, Inc.
+enabled=1
+baseurl=https://yum.datadoghq.com/suse/stable/6/x86_64
+type=rpm-md
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+```
 
-  or use this command to do it directly 
+2. Update your local zypper repo and install the Agent:
 
-  ```shell
-  echo -e '[datadog-beta]\nname = Beta, Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/suse/beta/6/x86_64/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public\ntype=rpm-md\nrepo_gpgcheck=0' | sudo tee /etc/zypp/repos.d/datadog-beta.repo
-  ```
+```
+sudo zypper refresh
+sudo rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+sudo zypper install datadog-agent
+```
 
-2. Update your local zypper cache and install/update the agent
-  
-  ```shell
-  sudo zypper refresh
-  sudo rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-  sudo zypper install datadog-agent
-  ```
+3. Copy the example config into place and plug in your API key:
+
+```
+sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+```
+
+4. Re-start the Agent:
+
+```
+sudo systemctl restart datadog-agent.service
+```
 
 ## Troubleshooting
 

--- a/content/agent/basic_agent_usage/suse.md
+++ b/content/agent/basic_agent_usage/suse.md
@@ -77,36 +77,36 @@ Configuration files for [integrations](/integrations):
 
 1. Set up Datadog's Yum repo on your system by creating /etc/zypp/repos.d/datadog.repo with the contents:
 
-```
-[datadog]
-name=Datadog, Inc.
-enabled=1
-baseurl=https://yum.datadoghq.com/suse/stable/6/x86_64
-type=rpm-md
-gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-```
+  ```
+  [datadog]
+  name=Datadog, Inc.
+  enabled=1
+  baseurl=https://yum.datadoghq.com/suse/stable/6/x86_64
+  type=rpm-md
+  gpgcheck=1
+  repo_gpgcheck=0
+  gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+  ```
 
 2. Update your local zypper repo and install the Agent:
 
-```
-sudo zypper refresh
-sudo rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-sudo zypper install datadog-agent
-```
+  ```
+  sudo zypper refresh
+  sudo rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+  sudo zypper install datadog-agent
+  ```
 
 3. Copy the example config into place and plug in your API key:
 
-```
-sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
-```
+  ```
+  sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+  ```
 
 4. Re-start the Agent:
 
-```
-sudo systemctl restart datadog-agent.service
-```
+  ```
+  sudo systemctl restart datadog-agent.service
+  ```
 
 ## Troubleshooting
 

--- a/content/agent/basic_agent_usage/ubuntu.md
+++ b/content/agent/basic_agent_usage/ubuntu.md
@@ -113,42 +113,42 @@ To install on a clean box (or have an existing agent 5 install from which you do
 #### Manual install
 1. Set up apt so it can download through https
 
-```shell
-sudo apt-get update
-sudo apt-get install apt-transport-https
-```
+    ```
+    sudo apt-get update
+    sudo apt-get install apt-transport-https
+    ```
 
 2. Set up the Datadog deb repo on your system and import Datadog's apt key:
 
-```
-sudo sh -c "echo 'deb https://apt.datadoghq.com/ stable 6' > /etc/apt/sources.list.d/datadog.list"
-sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
-```
+    ```
+    sudo sh -c "echo 'deb https://apt.datadoghq.com/ stable 6' > /etc/apt/sources.list.d/datadog.list"
+    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
+    ```
 
 3. Update your local apt repo and install the Agent:
 
-```
-sudo apt-get update
-sudo apt-get install datadog-agent
-```
+    ```
+    sudo apt-get update
+    sudo apt-get install datadog-agent
+    ```
 
 4. Copy the example config into place and plug in your API key:
 
-```
-sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
-```
+    ```
+    sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+    ```
 
 5. Start the Agent with Ubuntu 16.04 and higher:
 
-```
-sudo systemctl restart datadog-agent.service
-```
+    ```
+    sudo systemctl restart datadog-agent.service
+    ```
 
 6. Start the Agent with Ubuntu 14.04:
 
-```
-sudo initctl start datadog-agent
-```
+    ```
+    sudo initctl start datadog-agent
+    ```
 
 ### Downgrade to Agent v5
 

--- a/content/agent/basic_agent_usage/ubuntu.md
+++ b/content/agent/basic_agent_usage/ubuntu.md
@@ -113,24 +113,42 @@ To install on a clean box (or have an existing agent 5 install from which you do
 #### Manual install
 1. Set up apt so it can download through https
 
-    ```shell
-    sudo apt-get update
-    sudo apt-get install apt-transport-https
-    ```
+```shell
+sudo apt-get update
+sudo apt-get install apt-transport-https
+```
 
-2. Add the repository to your system and import the Datadog gpg key
+2. Set up the Datadog deb repo on your system and import Datadog's apt key:
 
-    ```shell
-    echo 'deb https://apt.datadoghq.com/ beta main' | sudo tee /etc/apt/sources.list.d/datadog-beta.list
-    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
-    ```
+```
+sudo sh -c "echo 'deb https://apt.datadoghq.com/ stable 6' > /etc/apt/sources.list.d/datadog.list"
+sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
+```
 
-3. Update APT and Install the agent
+3. Update your local apt repo and install the Agent:
 
-    ```shell
-    sudo apt-get update
-    sudo apt-get install datadog-agent
-    ```
+```
+sudo apt-get update
+sudo apt-get install datadog-agent
+```
+
+4. Copy the example config into place and plug in your API key:
+
+```
+sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+```
+
+5. Start the Agent with Ubuntu 16.04 and higher:
+
+```
+sudo systemctl restart datadog-agent.service
+```
+
+6. Start the Agent with Ubuntu 14.04:
+
+```
+sudo initctl start datadog-agent
+```
 
 ### Downgrade to Agent v5
 
@@ -140,10 +158,10 @@ To install on a clean box (or have an existing agent 5 install from which you do
     sudo apt-get install apt-transport-https
     ```
 
-2. Remove the repository and Ensure the stable repository is present
+2. Remove the Agent 6 repository and Ensure the stable repository is present
 
     ```shell
-    sudo rm /etc/apt/sources.list.d/datadog-beta.list [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
+    sudo rm /etc/apt/sources.list.d/datadog.list [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
     sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
     ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates the A6 manual install docs to point to the stable repo so users can download Agent 6.0.0

### Motivation
Current docs were out of date and led to installs of 6.0 RC4 from the beta branch. This keeps things in line with the in app install instructions.

### Preview link
https://docs-staging.datadoghq.com/nick/update_a6_to_stable/agent/basic_agent_usage/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
