### PR TITLE
Switching host parameter to optional

### DIFF
--- a/content/api/metrics/metrics_timeseries.md
+++ b/content/api/metrics/metrics_timeseries.md
@@ -20,7 +20,7 @@ The metrics end-point allows you to post time-series data that can be graphed on
         `[[POSIX_timestamp, numeric_value], ...]`  
         **Note**: The timestamp should be in seconds, current, and its format should be a 32bit float gauge-type value.
         Current is defined as not more than 10 minutes in the future or more than 1 hour in the past.
-    * **`host`** [*required*]:  
+    * **`host`** [*optional*]:  
         The name of the host that produced the metric.
     * **`tags`** [*optional*, *default*=**None**]:  
         A list of tags associated with the metric.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
switch host parameter to optional

### Motivation

The documentation it says that the `host` parameter is required whereas in the source code (https://github.com/DataDog/datadogpy/blob/master/datadog/api/metrics.py#L139) it looks like only the `points` parameter is required. Plus, the examples given on the right panel don’t always mention the host, so it does not appear to be required.
