### PR TITLE
Adding new apt key

### DIFF
--- a/content/agent/basic_agent_usage/amazonlinux.md
+++ b/content/agent/basic_agent_usage/amazonlinux.md
@@ -156,7 +156,7 @@ To install on a clean box (or have an existing agent 5 install from which you do
 
     ```shell
     sudo rm /etc/yum.repos.d/datadog.repo [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
-    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
+    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE
     ```
 
 3. Update apt and downgrade the agent

--- a/content/agent/basic_agent_usage/centos.md
+++ b/content/agent/basic_agent_usage/centos.md
@@ -160,7 +160,7 @@ To install on a clean box (or have an existing agent 5 install from which you do
 
     ```shell
     sudo rm /etc/yum.repos.d/datadog.repo [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
-    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
+    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE
     ```
 
 3. Update apt and downgrade the agent

--- a/content/agent/basic_agent_usage/deb.md
+++ b/content/agent/basic_agent_usage/deb.md
@@ -122,7 +122,7 @@ To install on a clean box (or have an existing agent 5 install from which you do
 
     ```
     sudo sh -c "echo 'deb https://apt.datadoghq.com/ stable 6' > /etc/apt/sources.list.d/datadog.list"
-    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
+    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE
     ```
 
     Note: You might need to install `dirmngr` to add Datadog's apt key.
@@ -159,7 +159,7 @@ To install on a clean box (or have an existing agent 5 install from which you do
 
     ```shell
     sudo rm /etc/apt/sources.list.d/datadog.list [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
-    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
+    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE
     ```
 
 3. Update apt and downgrade the agent

--- a/content/agent/basic_agent_usage/ubuntu.md
+++ b/content/agent/basic_agent_usage/ubuntu.md
@@ -122,7 +122,7 @@ To install on a clean box (or have an existing agent 5 install from which you do
 
     ```
     sudo sh -c "echo 'deb https://apt.datadoghq.com/ stable 6' > /etc/apt/sources.list.d/datadog.list"
-    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
+    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE
     ```
 
 3. Update your local apt repo and install the Agent:
@@ -162,7 +162,7 @@ To install on a clean box (or have an existing agent 5 install from which you do
 
     ```shell
     sudo rm /etc/apt/sources.list.d/datadog.list [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
-    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
+    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE
     ```
 
 3. Update apt and downgrade the agent

--- a/ja/content/install_debian_5.md
+++ b/ja/content/install_debian_5.md
@@ -19,7 +19,7 @@ If you prefer, the Agent can also be installed by following our step-by-step ins
 Set up the Datadog deb repo on your system and import Datadog's apt key:
 
     sudo sh -c "echo 'deb http://apt.datadoghq.com/ unstable main' > /etc/apt/sources.list.d/datadog.list"
-    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C7A7DA52
+    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 382E94DE
 
 Update your local apt repo and install the Agent:
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
GPG key here: https://docs.datadoghq.com/agent/basic_agent_usage/ubuntu/#manual-install reflects the old key, not the one that we're rotating to: https://help.datadoghq.com/hc/en-us/articles/360000886852.

We've had a few people reach out on this already
### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->


### Additional Notes
<!-- Anything else we should know when reviewing?-->
