### PR TITLE
don't popup on gifs

### DIFF
--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -84,7 +84,7 @@
 
 {{ else }}
 
-    {{- if .Get "popup" -}}
+    {{- if (and (.Get "popup") (ne $image_ext "gif")) -}}
       <a href="{{ print $img $pop_param | relURL }}" class="pop" data-toggle="modal" data-target="#popupImageModal">
     {{- else if .Get "href" -}}
       <a href="{{- with .Get "href" -}}{{- . -}}{{- end -}}"
@@ -132,7 +132,7 @@
 
     {{ end }}
 
-    {{- if .Get "popup" -}}
+    {{- if (and (.Get "popup") (ne $image_ext "gif")) -}}
       </a>
     {{- else if .Get "href" -}}
       </a>


### PR DESCRIPTION
### What does this PR do?
After enabling animated gifs the popups on those take forever to load because they are much larger. This PR disables the popups for the animated gifs only.

### Motivation
https://trello.com/c/11WKeXAB/170-zoom-feature-does-not-work-on-gifs

### Preview link
https://docs-staging.datadoghq.com/david.jones/animate-gif-zoom/developers/faq/using-postman-with-datadog-apis/#api-put-post-calls

### Additional Notes
In the future we will replace animated gifs for videos anyway as a better experience.
