### PR TITLE
add border to content images

### DIFF
--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -59,11 +59,7 @@
 {{ $figure_class :=  .Get "figure_class" }}
 
 <span class="shortcode-wrapper shortcode-img expand {{ if $wide }}wide-parent{{ end }} text-center">
-  <figure class="{{ if $wide }} wide {{ end }} {{ $figure_class }}"
-  {{ if .Get "figure_style" }}
-     style="{{ with .Get "figure_style" }}{{ . | safeCSS }}{{end}}"
-  {{ end }}
-  >
+  <figure class="{{ if $wide }} wide {{ end }} {{ $figure_class }}" {{ if .Get "figure_style" }}style="{{ with .Get "figure_style" }}{{ . | safeCSS }}{{end}}"{{ end }}>
 
 {{ if $video }}
 
@@ -96,7 +92,7 @@
       {{ if eq $image_ext "gif" }}
         <img class="img-fluid" src="{{ (print $img "?fm=gif" | relURL | safeURL) }}"
             {{ if .Get "style" }}style="{{ with .Get "style" }}{{ . | safeCSS }}{{end}}"{{ end }}
-            alt="{{ with .Get "alt"}}{{.}}{{end}}">
+            alt="{{ with .Get "alt"}}{{.}}{{end}}" />
       {{ else }}
           <picture {{ if .Get "style" }}
             style="{{ with .Get "style" }}{{ . | safeCSS }}{{end}}"
@@ -105,8 +101,7 @@
                {{ if .Get "style" }}
                 style="{{ with .Get "style" }}{{ . | safeCSS }}{{end}}"
               {{ end }}
-              alt="{{ with .Get "alt"}}{{.}}{{end}}"
-          >
+              alt="{{ with .Get "alt"}}{{.}}{{end}}" />
         </picture>
       {{ end }}
 
@@ -115,7 +110,7 @@
         {{ if eq $image_ext "gif" }}
             <img class="img-fluid" src="{{ (print $img "?fm=gif" | relURL | safeURL) }}"
               {{ if .Get "style" }}style="{{ with .Get "style" }}{{ . | safeCSS }}{{end}}"{{ end }}
-              alt="{{ with .Get "alt"}}{{.}}{{end}}">
+              alt="{{ with .Get "alt"}}{{.}}{{end}}" />
         {{ else }}
               <picture {{ if .Get "style" }}
                 style="{{ with .Get "style" }}{{ . | safeCSS }}{{end}}"
@@ -124,8 +119,7 @@
               {{ if .Get "style" }}
                     style="{{ with .Get "style" }}{{ . | safeCSS }}{{end}}"
                   {{ end }}
-                  alt="{{ with .Get "alt"}}{{.}}{{end}}"
-              >
+                  alt="{{ with .Get "alt"}}{{.}}{{end}}" />
             </picture>
         {{ end }}
 

--- a/src/scss/pages/_global.scss
+++ b/src/scss/pages/_global.scss
@@ -289,7 +289,7 @@ h2 {
 
 //content images
 .shortcode-img img {
-  border: 2px solid #ddd;
+  border: 1px solid #ddd;
 }
 
 // popup images

--- a/src/scss/pages/_global.scss
+++ b/src/scss/pages/_global.scss
@@ -287,6 +287,10 @@ h2 {
   }
 }
 
+//content images
+.shortcode-img img {
+  border: 2px solid #ddd;
+}
 
 // popup images
 .pop {

--- a/src/scss/pages/_global.scss
+++ b/src/scss/pages/_global.scss
@@ -289,7 +289,7 @@ h2 {
 
 //content images
 .shortcode-img img {
-  border: 1px solid #ddd;
+  border: 1px solid #d6d6d6;
 }
 
 // popup images


### PR DESCRIPTION
### What does this PR do?
This PR adds borders around images to help clarify what is an image and what is part of the page.

### Motivation
https://trello.com/c/cOUhtrp5/171-add-border-to-doc-images

### Preview link
https://docs-staging.datadoghq.com/david.jones/border-images/

### Additional Notes

