### PR TITLE
remove iframe default borders

### DIFF
--- a/src/scss/pages/_global.scss
+++ b/src/scss/pages/_global.scss
@@ -30,6 +30,10 @@ body {
   word-wrap: break-word;
 }
 
+iframe {
+  border:none;
+}
+
 .banner body {
   padding-top:159px;
 }


### PR DESCRIPTION
### What does this PR do?
This removes the default border on iframes

### Motivation
A video that is iframed looks strange on the logs page

### Preview link
https://docs-staging.datadoghq.com/david.jones/no-iframe-border/logs/

### Additional Notes

