### PR TITLE
Remove Kubernetes validation from Kube State Metrics section

### DIFF
--- a/content/integrations/kubernetes.md
+++ b/content/integrations/kubernetes.md
@@ -51,20 +51,10 @@ To gather your kube-state metrics:
   kubectl apply -f <NAME_OF_THE_KUBE_STATE_MANIFESTS_FOLDER>
   ```
 
-### Validation
-To verify the Datadog Agent is running in your environment as a daemonset, execute:
-
-    kubectl get daemonset
-
-If the Agent is deployed you will see similar output to the text below, where desired and current are equal to the number of running nodes in your cluster.
-
-    NAME       DESIRED   CURRENT   NODE-SELECTOR   AGE
-    datadog-agent   3         3         <none>          11h
-
 ## Setup Kubernetes DNS
 ### Configuration
 
-Since [agent v6](/agent/), Kubernetes DNS integration works automatically with the [Autodiscovery](/agent/autodiscovery). 
+Since [agent v6](/agent/), Kubernetes DNS integration works automatically with the [Autodiscovery](/agent/autodiscovery).
 
 ## Data Collected
 ### Metrics


### PR DESCRIPTION
### What does this PR do?
Removes the instructions for validating the Datadog Kubernetes integration from the Kube State Metrics section of the doc. The Kubernetes setup page already includes the validation info.

### Motivation
The validation is misleading and makes it seem like installing KSM will install the Datadog integration.

### Preview link
https://docs-staging.datadoghq.com/jyee/k8s_clarification/integrations/kubernetes/

