### PR TITLE
Update main config file path for Windows Agent 6

### DIFF
--- a/content/agent/basic_agent_usage/_index.md
+++ b/content/agent/basic_agent_usage/_index.md
@@ -46,8 +46,8 @@ The configuration files and folders for the Agent are located at:
 | [Mac OS X](/agent/basic_agent_usage/osx)                                 | `~/.datadog-agent/datadog.conf`                                            | `~/.datadog-agent/datadog.yaml` |
 | [Linux](/agent/basic_agent_usage/ubuntu)                                 | `/etc/dd-agent/datadog.conf`                                               | `/etc/datadog-agent/datadog.yaml`                                |
 | [Source](/agent/basic_agent_usage/source)                                | `~/.datadog-agent/agent/datadog.conf`                                      | `/etc/datadog-agent/datadog.yaml`                                |
-| [Windows Server 2008, Vista and newer](/agent/basic_agent_usage/windows) | `\\ProgramData\Datadog\datadog.conf`                                       | `n/a`                                |
-| [Windows Server 2003, XP or older](/agent/basic_agent_usage/windows)     | `\\Documents and Settings\All Users\Application Data\Datadog\datadog.conf` | `n/a`                                |
+| [Windows Server 2008, Vista and newer](/agent/basic_agent_usage/windows) | `\\ProgramData\Datadog\datadog.conf`                                       | `\\ProgramData\Datadog\datadog.yaml` |
+| [Windows Server 2003, XP or older](/agent/basic_agent_usage/windows)     | `\\Documents and Settings\All Users\Application Data\Datadog\datadog.conf` | `n/a` _(unsupported OS)_        |
 {{% /table %}}
 
 ## Log location


### PR DESCRIPTION
### What does this PR do?

Updates path to `datadog.yaml` on Windows

### Motivation

Wrongly shown as `n/a` on supported Windows versions.

### Preview link

### Additional Notes
