### PR TITLE
Adding source parameter in the URL

### DIFF
--- a/content/api/tags/code_snippets/api-tags-add.sh
+++ b/content/api/tags/code_snippets/api-tags-add.sh
@@ -14,4 +14,4 @@ curl  -X POST -H "Content-type: application/json" \
 -d "{
       \"tags\" : [\"environment:production\", \"role:webserver\"]
 }" \
-"https://app.datadoghq.com/api/v1/tags/hosts/${host_name}?api_key=${api_key}&application_key=${app_key}&source=$source"
+"https://app.datadoghq.com/api/v1/tags/hosts/${host_name}?api_key=${api_key}&application_key=${app_key}&source=${source}"

--- a/content/api/tags/code_snippets/api-tags-add.sh
+++ b/content/api/tags/code_snippets/api-tags-add.sh
@@ -1,6 +1,8 @@
 api_key=9775a026f1ca7d1c6c5af9d94d9595a4
 app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+
 host=YourHostName
+source=YourSource
 
 # Find a host to add a tag to
 host_name=$(curl -G "https://app.datadoghq.com/api/v1/search" \
@@ -12,4 +14,4 @@ curl  -X POST -H "Content-type: application/json" \
 -d "{
       \"tags\" : [\"environment:production\", \"role:webserver\"]
 }" \
-"https://app.datadoghq.com/api/v1/tags/hosts/${host_name}?api_key=${api_key}&application_key=${app_key}"
+"https://app.datadoghq.com/api/v1/tags/hosts/${host_name}?api_key=${api_key}&application_key=${app_key}&source=$source"


### PR DESCRIPTION
### What does this PR do?

Add source parameter in the url directly

### Motivation
The `source` should be a URL parameter, not part of the json payload, in order to signify that the tags are from a certain source. Not setting the `source` URL parameter will always default to `user` in the UI.

### Preview link

https://docs-staging.datadoghq.com/gus/add-tag-api-update/api/?lang=bash#add-tags-to-a-host
