### PR TITLE
Update to reflect non-working proxy feature in logs.

### DIFF
--- a/content/logs/_index.md
+++ b/content/logs/_index.md
@@ -20,10 +20,6 @@ logs_enabled: true
 
 The Datadog agent sends its logs to Datadog over TLS-encrypted TCP. This requires outbound communication over port `10516`.
 
-## Using a Proxy for Logs
-
-This is unavailable at this time using the `proxy` setting in the `datadog.yaml` configuration file. 
-
 ## Enabling log collection from integrations
 To start collecting logs for a given integration, uncomment the logs section in that integration's yaml file, and configure it for your environment.  
 
@@ -236,6 +232,10 @@ logs:
 ```
 
 **Note**: that the agent requires the read and execute permission (5) on the directory to be able to list all the available files in it.
+
+## Using a Proxy for Logs
+
+The log agent does not presently respect the the proxy setting in the datadog.yaml configuration file. This feature will be available in a future release.
 
 ### The Advantage of Collecting JSON-formatted logs
 

--- a/content/logs/_index.md
+++ b/content/logs/_index.md
@@ -20,6 +20,10 @@ logs_enabled: true
 
 The Datadog agent sends its logs to Datadog over TLS-encrypted TCP. This requires outbound communication over port `10516`.
 
+## Using a Proxy for Logs
+
+This is unavailable at this time using the `proxy` setting in the `datadog.yaml` configuration file. 
+
 ## Enabling log collection from integrations
 To start collecting logs for a given integration, uncomment the logs section in that integration's yaml file, and configure it for your environment.  
 

--- a/content/logs/_index.md
+++ b/content/logs/_index.md
@@ -233,7 +233,7 @@ logs:
 
 **Note**: that the agent requires the read and execute permission (5) on the directory to be able to list all the available files in it.
 
-## Using a Proxy for Logs
+### Using a Proxy for Logs
 
 The log agent does not presently respect the the proxy setting in the datadog.yaml configuration file. This feature will be available in a future release.
 


### PR DESCRIPTION
Updating the logs configuration file as several customers are trying to proxy log files and we don't support this as of now.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fixes a common misconception among customers about proxy features working for logs.

### Motivation
<!-- What inspired you to submit this pull request?-->
Unhappy customers.

### Preview link
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/logs/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
