### PR TITLE
Add docker to language pages

### DIFF
--- a/content/tracing/setup/go.md
+++ b/content/tracing/setup/go.md
@@ -18,7 +18,7 @@ further_reading:
 
 ## Installation
 
-To begin tracing applications written in Go, first [install and configure the Datadog Agent](/tracing/setup).
+To begin tracing applications written in Go, first [install and configure the Datadog Agent](/tracing/setup) (see additional documentation for [tracing Docker applications](/tracing/setup/docker/)).
 
 Next, install the Go Tracer from the Github repository:
 

--- a/content/tracing/setup/java.md
+++ b/content/tracing/setup/java.md
@@ -27,7 +27,7 @@ To improve visibility into applications using unsupported frameworks, consider:
 
 ## Installation and Getting Started
 
-To begin tracing applications written in any language, first [install and configure the Datadog Agent](https://docs.datadoghq.com/tracing/setup).
+To begin tracing applications written in any language, first [install and configure the Datadog Agent](https://docs.datadoghq.com/tracing/setup) (see additional documentation for [tracing Docker applications](/tracing/setup/docker/)).
 
 Next, download `dd-java-agent.jar` that contains the agent class files:
 

--- a/content/tracing/setup/python.md
+++ b/content/tracing/setup/python.md
@@ -22,7 +22,7 @@ For Python applciations, note that tracing is disabled when your application is 
 
 ## Installation
 
-To begin tracing applications written in Python, first [install and configure the Datadog Agent](/tracing/setup).
+To begin tracing applications written in Python, first [install and configure the Datadog Agent](/tracing/setup) (see additional documentation for [tracing Docker applications](/tracing/setup/docker/)).
 
 Next, install the Datadog Tracing library using pip:
 

--- a/content/tracing/setup/ruby.md
+++ b/content/tracing/setup/ruby.md
@@ -18,7 +18,7 @@ further_reading:
 
 ## Installation
 
-To begin tracing applications written in Ruby, first [install and configure the Datadog Agent](/tracing/setup).
+To begin tracing applications written in Ruby, first [install and configure the Datadog Agent](/tracing/setup) (see additional documentation for [tracing Docker applications](/tracing/setup/docker/)).
 
 Next, install the ddtrace gem:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add links in the individual APM language pages for setting up the agent in docker .


### Motivation
<!-- What inspired you to submit this pull request?-->
Requested by support.

