### PR TITLE
Updated date_happened field to include the time limit on past events

### DIFF
--- a/content/api/events/events_post.md
+++ b/content/api/events/events_post.md
@@ -17,7 +17,7 @@ This end point allows you to post events to the stream. Tag them, set priority a
     The text supports [markdown](/graphing/event_stream/#markdown-events\).
     Use `msg_text` with [the Datadog Ruby library](https://github.com/DataDog/dogapi-rb)
 * **`date_happened`** [*optional*, *default* = **now**]:  
-    POSIX timestamp of the event.
+    POSIX timestamp of the event. Must be sent as an integer (i.e. no quotes). *Limited to events no older than 1 year, 24 days (389 days)*
 * **`priority`** [*optional*, *default* = **normal**]:  
     The priority of the event: **normal** or **low**.
 * **`host`** [*optional*, *default*=**None**]:  
@@ -25,7 +25,7 @@ This end point allows you to post events to the stream. Tag them, set priority a
 * **`tags`** [*optional*, *default*=**None**]:  
     A list of tags to apply to the event.
 * **`alert_type`** [*optional*, *default* = **info**]:  
-    If its an alert event, set its type between: **error**, **warning**, **info**, and **success**.
+    If it's an alert event, set its type between: **error**, **warning**, **info**, and **success**.
 * **`aggregation_key`** [*optional*, *default*=**None**]:  
     An arbitrary string to use for aggregation. *Limited to 100 characters.*  
     If you specify a key, all events using that key are grouped together in the Event Stream.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds documentation of the exact limit for creating events in the past.

### Motivation
I stumbled over the past event limit when running some unit tests I built long ago, which had a hardcoded timestamp.  The test failed with “Event too far in the past", so I kept testing until I found the boundary of allowed dates.

### Preview link
<!-- Impacted pages preview links-->


### Additional Notes
<!-- Anything else we should know when reviewing?-->
