### PR TITLE
Adding link to conf option in k8

### DIFF
--- a/content/agent/basic_agent_usage/kubernetes.md
+++ b/content/agent/basic_agent_usage/kubernetes.md
@@ -108,7 +108,9 @@ spec:
           name: cgroups
 ```
 
-Replace `YOUR_API_KEY` with [your api key](https://app.datadoghq.com/account/settings#api) or use [Kubernetes secrets](https://kubernetes.io/docs/concepts/configuration/secret/) to set your API key [as an environement variable](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables).
+Replace `YOUR_API_KEY` with [your api key](https://app.datadoghq.com/account/settings#api) or use [Kubernetes secrets](https://kubernetes.io/docs/concepts/configuration/secret/) to set your API key [as an environement variable](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables).  
+
+[Consult our docker integration to discover all configuration options](/agent/basic_agent_usage/docker/#environment-variables)
 
 * Deploy the DaemonSet with the command:
   ```

--- a/content/agent/basic_agent_usage/kubernetes.md
+++ b/content/agent/basic_agent_usage/kubernetes.md
@@ -110,7 +110,7 @@ spec:
 
 Replace `YOUR_API_KEY` with [your api key](https://app.datadoghq.com/account/settings#api) or use [Kubernetes secrets](https://kubernetes.io/docs/concepts/configuration/secret/) to set your API key [as an environement variable](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables).  
 
-[Consult our docker integration to discover all configuration options](/agent/basic_agent_usage/docker/#environment-variables)
+[Consult our docker integration to discover all configuration options.](/agent/basic_agent_usage/docker/#environment-variables)
 
 * Deploy the DaemonSet with the command:
   ```


### PR DESCRIPTION
### What does this PR do?

Add link from k8 to docker in order to show all conf options

### Motivation

Customer trying to set up DD agent on kubernetes based on this guide (https://www.datadoghq.com/blog/monitor-kubernetes-docker/#send-custom-metrics-to-dogstatsd)
and couldn't get custom metrics to work.

### Preview link

* https://docs-staging.datadoghq.com/gus/docker-K8-variable/agent/basic_agent_usage/kubernetes/#log-collection-setup