### PR TITLE
signature consistency

### DIFF
--- a/content/api/checks/checks_post_code.md
+++ b/content/api/checks/checks_post_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#post-a-check-run
 ---
 
 ##### Signature
-`POST /api/v1/check_run`
+`POST https://app.datadoghq.com/api/v1/check_run`
 ##### Example Request
 {{< code-snippets basename="api-checks-post" >}}
 

--- a/content/api/comments/comments_create_code.md
+++ b/content/api/comments/comments_create_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#create-a-comment
 ---
 
 ##### Signature
-`POST api/v1/comments`
+`POST https://app.datadoghq.com/api/v1/comments`
 ##### Example Request
 {{< code-snippets basename="api-comment-create" >}}
 ##### Example Response

--- a/content/api/comments/comments_delete_code.md
+++ b/content/api/comments/comments_delete_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#delete-a-comment
 ---
 
 ##### Signature
-`DELETE api/v1/comments/:comment_id`
+`DELETE https://app.datadoghq.com/api/v1/comments/:comment_id`
 ##### Example Request
 {{< code-snippets basename="api-comment-delete" >}}
 ##### Example Response

--- a/content/api/comments/comments_edit_code.md
+++ b/content/api/comments/comments_edit_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#edit-a-comment
 ---
 
 ##### Signature
-`PUT api/v1/comments/:comment_id`
+`PUT https://app.datadoghq.com/api/v1/comments/:comment_id`
 ##### Example Request
 {{< code-snippets basename="api-comment-edit" >}}
 ##### Example Response

--- a/content/api/downtimes/downtimes_cancel_code.md
+++ b/content/api/downtimes/downtimes_cancel_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#cancel-monitor-downtime
 ---
 
 ##### Signature
-`DELETE /api/v1/downtime/:downtime_id`
+`DELETE https://app.datadoghq.com/api/v1/downtime/:downtime_id`
 ##### Example Request
 {{< code-snippets basename="api-monitor-cancel-downtime" >}}
 ##### Example Response

--- a/content/api/downtimes/downtimes_cancel_scope_code.md
+++ b/content/api/downtimes/downtimes_cancel_scope_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#cancel-monitor-downtime-by-scope
 ---
 
 ##### Signature
-`POST /api/v1/downtime/cancel/by_scope`
+`POST https://app.datadoghq.com/api/v1/downtime/cancel/by_scope`
 ##### Example Request
 {{< code-snippets basename="api-monitor-cancel-downtime-by-scope" >}}
 ##### Example Response

--- a/content/api/downtimes/downtimes_get_code.md
+++ b/content/api/downtimes/downtimes_get_code.md
@@ -5,7 +5,7 @@ order: 8.5
 external_redirect: /api/#get-a-monitor-downtime
 ---
 ##### Signature
-`GET /api/v1/downtime/:downtime_id`
+`GET https://app.datadoghq.com/api/v1/downtime/:downtime_id`
 ##### Example Request
 {{< code-snippets basename="api-monitor-get-downtime" >}}
 ##### Example Response

--- a/content/api/downtimes/downtimes_getall_code.md
+++ b/content/api/downtimes/downtimes_getall_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#get-all-monitor-downtimes
 ---
 
 ##### Signature
-`GET /api/v1/downtime`
+`GET https://app.datadoghq.com/api/v1/downtime`
 ##### Example Request
 {{< code-snippets basename="api-monitor-get-downtimes" >}}
 ##### Example Response

--- a/content/api/downtimes/downtimes_schedule_code.md
+++ b/content/api/downtimes/downtimes_schedule_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#schedule-monitor-downtime
 ---
 
 ##### Signature
-`POST /api/v1/downtime`
+`POST https://app.datadoghq.com/api/v1/downtime`
 ##### Example Request
 {{< code-snippets basename="api-monitor-schedule-downtime" >}}
 ##### Example Response

--- a/content/api/downtimes/downtimes_update_code.md
+++ b/content/api/downtimes/downtimes_update_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#update-monitor-downtime
 ---
 
 ##### Signature
-`PUT /api/v1/downtime/:downtime_id`
+`PUT https://app.datadoghq.com/api/v1/downtime/:downtime_id`
 ##### Example Request
 {{< code-snippets basename="api-monitor-update-downtime" >}}
 ##### Example Response

--- a/content/api/embeds/embeds_create_code.md
+++ b/content/api/embeds/embeds_create_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#create-embed
 ---
 
 ##### Signature
-`POST api/v1/graph/embed`
+`POST https://app.datadoghq.com/api/v1/graph/embed`
 ##### Example Request
 {{< code-snippets basename="api-embeds-create" >}}
 ##### Example Response

--- a/content/api/embeds/embeds_enable_code.md
+++ b/content/api/embeds/embeds_enable_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#enable-embed
 ---
 
 ##### Signature
-`GET api/v1/graph/embed/:embed_id/enable`
+`GET https://app.datadoghq.com/api/v1/graph/embed/:embed_id/enable`
 ##### Example Request
 {{< code-snippets basename="api-embeds-enable" >}}
 ##### Example Response

--- a/content/api/embeds/embeds_get_code.md
+++ b/content/api/embeds/embeds_get_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#get-specific-embed
 ---
 
 ##### Signature
-`GET api/v1/graph/embed/:embed_id`
+`GET https://app.datadoghq.com/api/v1/graph/embed/:embed_id`
 ##### Example Request
 {{< code-snippets basename="api-embeds-get" >}}
 ##### Example Response

--- a/content/api/embeds/embeds_getall_code.md
+++ b/content/api/embeds/embeds_getall_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#get-all-embeds
 ---
 
 ##### Signature
-`GET api/v1/graph/embed`
+`GET https://app.datadoghq.com/api/v1/graph/embed`
 ##### Example Request
 {{< code-snippets basename="api-embeds-get-all" >}}
 ##### Example Response

--- a/content/api/embeds/embeds_revoke_code.md
+++ b/content/api/embeds/embeds_revoke_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#revoke-embed
 ---
 
 ##### Signature
-`GET api/v1/graph/embed/:embed_id/revoke`
+`GET https://app.datadoghq.com/api/v1/graph/embed/:embed_id/revoke`
 ##### Example Request
 {{< code-snippets basename="api-embeds-revoke" >}}
 ##### Example Response

--- a/content/api/events/events_delete_code.md
+++ b/content/api/events/events_delete_code.md
@@ -5,7 +5,7 @@ order: 10.3
 external_redirect: /api/#delete-an-event
 ---
 ##### Signature
-`DELETE /api/v1/events/:event_id`
+`DELETE https://app.datadoghq.com/api/v1/events/:event_id`
 ##### Example Request
 {{< code-snippets basename="api-events-delete" >}}
 ##### Example Response

--- a/content/api/events/events_get_code.md
+++ b/content/api/events/events_get_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#get-an-event
 ---
 
 ##### Signature
-`GET /api/v1/events/:event_id`
+`GET https://app.datadoghq.com/api/v1/events/:event_id`
 ##### Example Request
 {{< code-snippets basename="api-events-get" >}}
 ##### Example Response

--- a/content/api/events/events_post_code.md
+++ b/content/api/events/events_post_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#post-an-event
 ---
 
 ##### Signature
-`POST /api/v1/events`
+`POST https://app.datadoghq.com/api/v1/events`
 ##### Example Request
 {{< code-snippets basename="api-events-post" >}}
 ##### Example Response

--- a/content/api/events/events_query_code.md
+++ b/content/api/events/events_query_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#query-the-event-stream
 ---
 
 ##### Signature
-`GET /api/v1/events`
+`GET https://app.datadoghq.com/api/v1/events`
 ##### Example Request
 {{< code-snippets basename="api-events-stream" >}}
 ##### Example Response

--- a/content/api/graphs/graphs_snapshot_code.md
+++ b/content/api/graphs/graphs_snapshot_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#graph-snapshot
 ---
 
 ##### Signature
-`GET api/v1/graph/snapshot`
+`GET https://app.datadoghq.com/api/v1/graph/snapshot`
 ##### Example Request
 {{< code-snippets basename="api-graph-snapshot" >}}
 ##### Example Response

--- a/content/api/hosts/hosts_mute_code.md
+++ b/content/api/hosts/hosts_mute_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#mute-a-host
 ---
 
 ##### Signature
-`POST /api/v1/host/:hostname/mute`
+`POST https://app.datadoghq.com/api/v1/host/:hostname/mute`
 ##### Example Request
 {{< code-snippets basename="api-host-mute" >}}
 ##### Example Response

--- a/content/api/hosts/hosts_unmute_code.md
+++ b/content/api/hosts/hosts_unmute_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#unmute-a-host
 ---
 
 ##### Signature
-`POST /api/v1/host/:hostname/unmute`
+`POST https://app.datadoghq.com/api/v1/host/:hostname/unmute`
 ##### Example Request
 {{< code-snippets basename="api-host-unmute" >}}
 ##### Example Response

--- a/content/api/metrics/metrics_editmetadata_code.md
+++ b/content/api/metrics/metrics_editmetadata_code.md
@@ -5,7 +5,7 @@ order: 14.5
 external_redirect: /api/#edit-metric-metadata
 ---
 ##### Signature
-`PUT /api/v1/metrics/:metric_name`
+`PUT https://app.datadoghq.com/api/v1/metrics/:metric_name`
 ##### Example Request
 {{< code-snippets basename="api-metric-metadata-update" >}}
 ##### Example Response

--- a/content/api/metrics/metrics_viewmetadata_code.md
+++ b/content/api/metrics/metrics_viewmetadata_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#view-metric-metadata
 ---
 
 ##### Signature
-`GET /api/v1/metrics/:metric_name`
+`GET https://app.datadoghq.com/api/v1/metrics/:metric_name`
 ##### Example Request
 {{< code-snippets basename="api-metric-metadata-get" >}}
 ##### Example Response

--- a/content/api/monitors/monitors_create_code.md
+++ b/content/api/monitors/monitors_create_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#create-a-monitor
 ---
 
 ##### Signature
-`POST /api/v1/monitor`
+`POST https://app.datadoghq.com/api/v1/monitor`
 ##### Example Request
 {{< code-snippets basename="api-monitor-create" >}}
 ##### Example Response

--- a/content/api/monitors/monitors_delete_code.md
+++ b/content/api/monitors/monitors_delete_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#delete-a-monitor
 ---
 
 ##### Signature
-`DELETE /api/v1/monitor/:monitor_id`
+`DELETE https://app.datadoghq.com/api/v1/monitor/:monitor_id`
 ##### Example Request
 {{< code-snippets basename="api-monitor-delete" >}}
 ##### Example Response

--- a/content/api/monitors/monitors_edit_code.md
+++ b/content/api/monitors/monitors_edit_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#edit-a-monitor
 ---
 
 ##### Signature
-`PUT /api/v1/monitor/:monitor_id`
+`PUT https://app.datadoghq.com/api/v1/monitor/:monitor_id`
 ##### Example Request
 {{< code-snippets basename="api-monitor-edit" >}}
 ##### Example Response

--- a/content/api/monitors/monitors_get_code.md
+++ b/content/api/monitors/monitors_get_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#get-a-monitor-s-details
 ---
 
 ##### Signature
-`GET /api/v1/monitor/:monitor_id`
+`GET https://app.datadoghq.com/api/v1/monitor/:monitor_id`
 ##### Example Request
 {{< code-snippets basename="api-monitor-show" >}}
 ##### Example Response

--- a/content/api/monitors/monitors_mute_code.md
+++ b/content/api/monitors/monitors_mute_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#mute-a-monitor
 ---
 
 ##### Signature
-`POST /api/v1/monitor/:monitor_id/mute`
+`POST https://app.datadoghq.com/api/v1/monitor/:monitor_id/mute`
 ##### Example Request
 {{< code-snippets basename="api-monitor-mute" >}}
 ##### Example Response

--- a/content/api/monitors/monitors_muteall_code.md
+++ b/content/api/monitors/monitors_muteall_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#mute-all-monitors
 ---
 
 ##### Signature
-`POST /api/v1/monitor/mute_all`
+`POST https://app.datadoghq.com/api/v1/monitor/mute_all`
 ##### Example Request
 {{< code-snippets basename="api-monitor-mute-all" >}}
 ##### Example Response

--- a/content/api/monitors/monitors_resolve_code.md
+++ b/content/api/monitors/monitors_resolve_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#resolve-monitor
 ---
 
 ##### Signature
-`POST /monitor/bulk_resolve`
+`POST https://app.datadoghq.com/monitor/bulk_resolve`
 ##### Example Request
 {{< code-snippets basename="api-monitor-bulk-resolve" >}}
 ##### Example Response

--- a/content/api/monitors/monitors_showall_code.md
+++ b/content/api/monitors/monitors_showall_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#get-all-monitor-details
 ---
 
 ##### Signature
-`GET /api/v1/monitor`
+`GET https://app.datadoghq.com/api/v1/monitor`
 ##### Example Request
 {{< code-snippets basename="api-monitor-show-all" >}}
 ##### Example Response

--- a/content/api/monitors/monitors_unmute_code.md
+++ b/content/api/monitors/monitors_unmute_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#unmute-a-monitor
 ---
 
 ##### Signature
-`POST /api/v1/monitor/:monitor_id/unmute`
+`POST https://app.datadoghq.com/api/v1/monitor/:monitor_id/unmute`
 ##### Example Request
 {{< code-snippets basename="api-monitor-unmute" >}}
 ##### Example Response

--- a/content/api/monitors/monitors_unmuteall_code.md
+++ b/content/api/monitors/monitors_unmuteall_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#unmute-all-monitors
 ---
 
 ##### Signature
-`POST /api/v1/monitor/unmute_all`
+`POST https://app.datadoghq.com/api/v1/monitor/unmute_all`
 ##### Example Request
 {{< code-snippets basename="api-monitor-unmute-all" >}}
 ##### Example Response

--- a/content/api/org/idp_update_code.md
+++ b/content/api/org/idp_update_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#upload-idp-metadata
 ---
 
 ##### Signature
-`POST api/v1/org/:public_id/idp_metadata`
+`POST https://app.datadoghq.com/api/v1/org/:public_id/idp_metadata`
 ##### Example Request
 {{< code-snippets basename="api-org-update" >}}
 ##### Example Response

--- a/content/api/org/org_create_code.md
+++ b/content/api/org/org_create_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#create-child-organization
 ---
 
 ##### Signature
-`POST api/v1/org`
+`POST https://app.datadoghq.com/api/v1/org`
 ##### Example Request
 {{< code-snippets basename="api-org-create" >}}
 ##### Example Response

--- a/content/api/org/org_get_code.md
+++ b/content/api/org/org_get_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#get-organization
 ---
 
 ##### Signature
-`GET api/v1/org/:public_id`
+`GET https://app.datadoghq.com/api/v1/org/:public_id`
 ##### Example Request
 {{< code-snippets basename="api-org-get" >}}
 ##### Example Response

--- a/content/api/org/org_update_code.md
+++ b/content/api/org/org_update_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#update-organization
 ---
 
 ##### Signature
-`PUT api/v1/org/:public_id`
+`PUT https://app.datadoghq.com/api/v1/org/:public_id`
 ##### Example Request
 {{< code-snippets basename="api-org-update" >}}
 ##### Example Response

--- a/content/api/screenboards/screenboards_create_code.md
+++ b/content/api/screenboards/screenboards_create_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#create-a-screenboard
 ---
 
 ##### Signature
-`POST /api/v1/screen`
+`POST https://app.datadoghq.com/api/v1/screen`
 ##### Example Request
 {{< code-snippets basename="api-screenboard-create" >}}
 ##### Example Response

--- a/content/api/screenboards/screenboards_delete_code.md
+++ b/content/api/screenboards/screenboards_delete_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#delete-a-screenboard
 ---
 
 ##### Signature
-`DELETE /api/v1/screen/:board_id`
+`DELETE https://app.datadoghq.com/api/v1/screen/:board_id`
 ##### Example Request
 {{< code-snippets basename="api-screenboard-delete" >}}
 ##### Example Response

--- a/content/api/screenboards/screenboards_get_code.md
+++ b/content/api/screenboards/screenboards_get_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#get-a-screenboard
 ---
 
 ##### Signature
-`GET /api/v1/screen/:board_id`
+`GET https://app.datadoghq.com/api/v1/screen/:board_id`
 ##### Example Request
 {{< code-snippets basename="api-screenboard-get" >}}
 ##### Example Response

--- a/content/api/screenboards/screenboards_getall_code.md
+++ b/content/api/screenboards/screenboards_getall_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#get-all-screenboards
 ---
 
 ##### Signature
-`GET /api/v1/screen`
+`GET https://app.datadoghq.com/api/v1/screen`
 ##### Example Request
 {{< code-snippets basename="api-screenboard-get-all" >}}
 ##### Example Response

--- a/content/api/screenboards/screenboards_revoke_code.md
+++ b/content/api/screenboards/screenboards_revoke_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#revoke-a-shared-a-screenboard
 ---
 
 ##### Signature
-`DELETE /api/v1/screen/share/:board_id`
+`DELETE https://app.datadoghq.com/api/v1/screen/share/:board_id`
 ##### Example Request
 {{< code-snippets basename="api-screenboard-revoke" >}}
 ##### Example Response

--- a/content/api/screenboards/screenboards_share_code.md
+++ b/content/api/screenboards/screenboards_share_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#share-a-screenboard
 ---
 
 ##### Signature
-`POST /api/v1/screen/share/:board_id`
+`POST https://app.datadoghq.com/api/v1/screen/share/:board_id`
 ##### Example Request
 {{< code-snippets basename="api-screenboard-share" >}}
 ##### Example Response

--- a/content/api/screenboards/screenboards_update_code.md
+++ b/content/api/screenboards/screenboards_update_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#update-a-screenboard
 ---
 
 ##### Signature
-`PUT /api/v1/screen/:board_id`
+`PUT https://app.datadoghq.com/api/v1/screen/:board_id`
 ##### Example Request
 {{< code-snippets basename="api-screenboard-update" >}}
 ##### Example Response

--- a/content/api/search/search_code.md
+++ b/content/api/search/search_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#search
 ---
 
 ##### Signature
-`GET /api/v1/search`
+`GET https://app.datadoghq.com/api/v1/search`
 ##### Example Request
 {{< code-snippets basename="api-search" >}}
 ##### Example Response

--- a/content/api/tags/tags_add_code.md
+++ b/content/api/tags/tags_add_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#add-tags-to-a-host
 ---
 
 ##### Signature
-`POST /api/v1/tags/hosts/:host_name`
+`POST https://app.datadoghq.com/api/v1/tags/hosts/:host_name`
 ##### Example Request
 {{< code-snippets basename="api-tags-add" >}}
 ##### Example Response

--- a/content/api/tags/tags_delete_code.md
+++ b/content/api/tags/tags_delete_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#remove-host-tags
 ---
 
 ##### Signature
-`DELETE /api/v1/tags/hosts/:host_name`
+`DELETE https://app.datadoghq.com/api/v1/tags/hosts/:host_name`
 ##### Example Request
 {{< code-snippets basename="api-tags-remove" >}}
 ##### Example Response

--- a/content/api/tags/tags_get_code.md
+++ b/content/api/tags/tags_get_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#get-tags
 ---
 
 ##### Signature
-`GET /api/v1/tags/hosts`
+`GET https://app.datadoghq.com/api/v1/tags/hosts`
 ##### Example Request
 {{< code-snippets basename="api-tags-get" >}}
 ##### Example Response

--- a/content/api/tags/tags_get_host_code.md
+++ b/content/api/tags/tags_get_host_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#get-host-tags
 ---
 
 ##### Signature
-`GET /api/v1/tags/hosts/:host_name`
+`GET https://app.datadoghq.com/api/v1/tags/hosts/:host_name`
 ##### Example Request
 {{< code-snippets basename="api-tags-get-host" >}}
 ##### Example Response

--- a/content/api/tags/tags_update_code.md
+++ b/content/api/tags/tags_update_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#update-host-tags
 ---
 
 ##### Signature
-`PUT /api/v1/tags/hosts/:host_name`
+`PUT https://app.datadoghq.com/api/v1/tags/hosts/:host_name`
 ##### Example Request
 {{< code-snippets basename="api-tags-update" >}}
 ##### Example Response

--- a/content/api/timeboards/timeboards_create_code.md
+++ b/content/api/timeboards/timeboards_create_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#create-a-timeboard
 ---
 
 ##### Signature
-`POST /api/v1/dash`
+`POST https://app.datadoghq.com/api/v1/dash`
 ##### Example Request
 {{< code-snippets basename="api-dashboard-create" >}}
 ##### Example Response

--- a/content/api/timeboards/timeboards_delete_code.md
+++ b/content/api/timeboards/timeboards_delete_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#delete-a-timeboard
 ---
 
 ##### Signature
-`DELETE /api/v1/dash/:dash_id`
+`DELETE https://app.datadoghq.com/api/v1/dash/:dash_id`
 ##### Example Request
 {{< code-snippets basename="api-dashboard-delete" >}}
 ##### Example Response

--- a/content/api/timeboards/timeboards_get_code.md
+++ b/content/api/timeboards/timeboards_get_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#get-a-timeboard
 ---
 
 ##### Signature
-`GET /api/v1/dash/:dash_id`
+`GET https://app.datadoghq.com/api/v1/dash/:dash_id`
 ##### Example Request
 {{< code-snippets basename="api-dashboard-get" >}}
 ##### Example Response

--- a/content/api/timeboards/timeboards_getall_code.md
+++ b/content/api/timeboards/timeboards_getall_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#get-all-timeboards
 ---
 
 ##### Signature
-`GET /api/v1/dash`
+`GET https://app.datadoghq.com/api/v1/dash`
 ##### Example Request
 {{< code-snippets basename="api-dashboard-get-all" >}}
 ##### Example Response

--- a/content/api/timeboards/timeboards_update_code.md
+++ b/content/api/timeboards/timeboards_update_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#update-a-timeboard
 ---
 
 ##### Signature
-`PUT /api/v1/dash/:dash_id`
+`PUT https://app.datadoghq.com/api/v1/dash/:dash_id`
 ##### Example Request
 {{< code-snippets basename="api-dashboard-update" >}}
 ##### Example Response

--- a/content/api/users/users_create_code.md
+++ b/content/api/users/users_create_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#create-user
 ---
 
 ##### Signature
-`POST api/v1/user`
+`POST https://app.datadoghq.com/api/v1/user`
 ##### Example Request
 {{< code-snippets basename="api-user-create" >}}
 ##### Example Response

--- a/content/api/users/users_delete_code.md
+++ b/content/api/users/users_delete_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#disable-user
 ---
 
 ##### Signature
-`DELETE api/v1/user/:handle`
+`DELETE https://app.datadoghq.com/api/v1/user/:handle`
 ##### Example Request
 {{< code-snippets basename="api-user-disable" >}}
 ##### Example Response

--- a/content/api/users/users_get_code.md
+++ b/content/api/users/users_get_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#get-user
 ---
 
 ##### Signature
-`GET api/v1/user/:handle`
+`GET https://app.datadoghq.com/api/v1/user/:handle`
 ##### Example Request
 {{< code-snippets basename="api-user-get" >}}
 ##### Example Response

--- a/content/api/users/users_getall_code.md
+++ b/content/api/users/users_getall_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#get-all-users
 ---
 
 ##### Signature
-`GET api/v1/user`
+`GET https://app.datadoghq.com/api/v1/user`
 ##### Example Request
 {{< code-snippets basename="api-user-get-all" >}}
 ##### Example Response

--- a/content/api/users/users_update_code.md
+++ b/content/api/users/users_update_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#update-user
 ---
 
 ##### Signature
-`PUT api/v1/user/:handle`
+`PUT https://app.datadoghq.com/api/v1/user/:handle`
 ##### Example Request
 {{< code-snippets basename="api-user-update" >}}
 ##### Example Response


### PR DESCRIPTION
### What does this PR do?

Upgrade the consistency of API signatures

### Motivation

Some API signature endpoints missed the leading /.

Example: api/v1/dash instead of /api/v1/dash
