### PR TITLE
Changing handle param to id

### DIFF
--- a/content/api/users/code_snippets/api-user-create.py
+++ b/content/api/users/code_snippets/api-user-create.py
@@ -8,4 +8,4 @@ options = {
 initialize(**options)
 
 # Create user
-api.User.create(handle='test@datadoghq.com', name='test user')
+api.User.create(id='test@datadoghq.com', name='test user')

--- a/content/api/users/code_snippets/api-user-create.rb
+++ b/content/api/users/code_snippets/api-user-create.rb
@@ -6,4 +6,4 @@ app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
 
 dog = Dogapi::Client.new(api_key, app_key)
 
-dog.create_user(: handle => 'test@datadoghq.com', : name => 'test user')
+dog.create_user(: id => 'test@datadoghq.com', : name => 'test user')

--- a/content/api/users/code_snippets/api-user-create.rb
+++ b/content/api/users/code_snippets/api-user-create.rb
@@ -6,4 +6,4 @@ app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
 
 dog = Dogapi::Client.new(api_key, app_key)
 
-dog.create_user(: id => 'test@datadoghq.com', : name => 'test user')
+dog.create_user(id: 'test@datadoghq.com', name: 'test user')

--- a/content/api/users/code_snippets/api-user-create.sh
+++ b/content/api/users/code_snippets/api-user-create.sh
@@ -2,7 +2,7 @@ api_key=9775a026f1ca7d1c6c5af9d94d9595a4
 app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
 
 curl -X POST -H "Content-type: application/json" \
-    -d '{"handle":"test@datadoghq.com","name":"test user"}' \
+    -d '{"id":"test@datadoghq.com","name":"test user"}' \
     "https://app.datadoghq.com/api/v1/user?api_key=${api_key}&application_key=${app_key}"
 
 

--- a/content/api/users/users_create.md
+++ b/content/api/users/users_create.md
@@ -8,7 +8,7 @@ external_redirect: /api/#create-user
 ## Create user
 ##### ARGUMENTS
 
-* **`handle`** [*required*]:  
+* **`id`** [*required*]:  
     The user handle, must be a valid email.
 * **`name`** [*optional*, *default*=**None**]:  
     The name of the user.

--- a/content/api/users/users_delete.md
+++ b/content/api/users/users_delete.md
@@ -9,5 +9,5 @@ external_redirect: /api/#disable-user
 Can only be used with application keys belonging to administrators.
 
 ##### ARGUMENTS
-* **`handle`** [*required*]:  
+* **`id`** [*required*]:  
     The handle of the user.

--- a/content/api/users/users_get.md
+++ b/content/api/users/users_get.md
@@ -7,5 +7,5 @@ external_redirect: /api/#get-user
 
 ## Get user
 ##### ARGUMENTS
-* **`handle`** [*required*]:  
+* **`id`** [*required*]:  
     The handle of the user.

--- a/content/api/users/users_update.md
+++ b/content/api/users/users_update.md
@@ -9,7 +9,7 @@ external_redirect: /api/#update-user
 Can only be used with application keys belonging to administrators.
 
 ##### ARGUMENTS
-* **`handle`** [*required*]:  
+* **`id`** [*required*]:  
     The handle of the user.
 * **`name`** [*optional*, *default*=**None**]:  
     The new name of the user.


### PR DESCRIPTION
### What does this PR do?

Change each 'handle' mention on api docs to 'id'.

### Motivation


When user explicitly specifies the 'handle' argument for any of the user API python methods, the call fails.

Error if including 'handle=' in API call:
Traceback (most recent call last):
File "test.py", line 11, in <module>
print(api.User.get(handle='sroman@gmail.com'))
TypeError: get() missing 1 required positional argument: 'id'

Every link that may be useful: 
potentially related source code

https://github.com/DataDog/datadogpy/blob/master/datadog/api/users.py

https://github.com/DataDog/datadogpy/blob/master/datadog/api/resources.py

https://github.com/DataDog/dogweb/blob/prod/dogweb/model/user.py


### Preview link
* https://docs-staging.datadoghq.com/gus/user-api-param-update/api/?lang=python#users