### PR TITLE
Tracing doc update

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -388,7 +388,7 @@ languages:
           weight: 80
         # TRACING/APM - Subnav start
         - identifier: customnav_tracingnav_setup
-          name: "Setup"
+          name: "Setup APM"
           url: "/tracing/setup/"
           weight: 10
           parent: menu_references_tracing
@@ -431,7 +431,7 @@ languages:
 
         # Using the APM UI
         - identifier: customnav_tracingnav_visualization
-          name: "Using the APM UI"
+          name: "Use the APM UI"
           url: "/tracing/visualization/"
           weight: 20
           parent: menu_references_tracing

--- a/content/integrations/faq/list-of-api-source-attribute-value.md
+++ b/content/integrations/faq/list-of-api-source-attribute-value.md
@@ -74,7 +74,7 @@ kind: faq
 |Chef|CHEF|
 |Cloud Foundry|CLOUDFOUNDRY|
 |Cloudhealth|CLOUDHEALTH|
-|Cloud Service Health|CLOUDSERVICEHEALTH|
+|Cloudnetworkhealth|CLOUDNETWORKHEALTH|
 |Consul|CONSUL|
 |Couchbase|COUCHBASE|
 |Couchdb|COUCHDB|

--- a/content/tracing/setup/_index.md
+++ b/content/tracing/setup/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Setup
+title: Setup APM
 kind: Documentation
 aliases:
   - /tracing/languages/

--- a/content/tracing/setup/environment.md
+++ b/content/tracing/setup/environment.md
@@ -61,10 +61,33 @@ There are several ways to specify an environment when reporting data:
 3. Per trace:  
   When submitting a single trace, specify an environment by tagging one of its spans with the metadata key `env`. This overrides the agent configuration and the host tags value (if any).  
 
+  * **Go**:
     ```
-    # in code this looks like
-    span.set_tag('env', 'prod')
+    tracer.SetMeta(“env”, “prod”)
     ```
+  For OpenTracing use the “GlobalTags” field in the “opentracing.Configuration” structure.
+
+  * **Java**:  
+      Via sysprop: 
+      ```
+      -Ddd.trace.span.tags=”env:prod”
+      ```
+      Via env var:
+      ```
+      DD_TRACE_SPAN_TAGS=”env:prod”
+      ```
+
+  * **Ruby**:
+  ```
+  Datadog.tracer.set_tags(‘env’ => ‘prod’)
+  ```
+
+  * **Python**:
+    ```
+    from ddtrace import tracer
+    tracer.set_tags('env', 'prod')
+    ```
+
 
 ## Further Reading
 

--- a/content/tracing/setup/java.md
+++ b/content/tracing/setup/java.md
@@ -257,6 +257,8 @@ public class MyClass {
 ```
 
 
+## Debug
+
 To return debug level application logs, enable debug mode with the flag `-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug` when starting the JVM.
 
 ## Integrations

--- a/content/tracing/setup/java.md
+++ b/content/tracing/setup/java.md
@@ -256,6 +256,9 @@ public class MyClass {
 }
 ```
 
+
+To return debug level application logs, enable debug mode with the flag `-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug` when starting the JVM.
+
 ## Integrations
 
 ### Web Frameworks


### PR DESCRIPTION
### What does this PR do?

1. Change title of Tracing setup section
2. Add debug info to /tracing/setup/java
3.  more clear examples to the #3 in the evironment Setup section

### Motivation

1.  the “APM Setup” page is called “Setup” https://docs.datadoghq.com/tracing/setup/, let's bring some consistency
2. PM request
3. PM request

### Preview link

1. https://docs-staging.datadoghq.com/gus/tracing-java-update/tracing/setup/
2. https://docs-staging.datadoghq.com/gus/tracing-java-update/tracing/setup/java/#debug
3. https://docs-staging.datadoghq.com/gus/tracing-java-update/tracing/setup/environment/#setup
