### PR TITLE
Adding example for agent 6 proxy

### DIFF
--- a/content/agent/proxy.md
+++ b/content/agent/proxy.md
@@ -56,8 +56,24 @@ to
 
 ## Using a Web Proxy as Proxy
 
-Traditional web proxies are supported natively by the agent. 
-Edit `datadog.conf` with your proxy information.
+Traditional web proxies are supported natively by the agent. If you need a proxy to connect to the Internet, edit your Agent configuration file.
+
+### Agent v6
+
+Edit the `datadog.yaml` file with your proxy information. Use the `no_proxy` list to specify hosts that should bypass the proxy. 
+
+```
+proxy:
+    http: http(s)://user:password@proxy_for_http:port
+    https: http(s)://user:password@proxy_for_https:port
+#   no_proxy:
+#     - host1
+#     - host2
+```
+
+### Agent v5
+
+Edit the `datadog.conf` file with your proxy information:
 
 ```
 # If you need a proxy to connect to the Internet, provide the settings here

--- a/content/agent/proxy.md
+++ b/content/agent/proxy.md
@@ -56,7 +56,7 @@ to
 
 ## Using a Web Proxy as Proxy
 
-Traditional web proxies are supported natively by the agent. If you need a proxy to connect to the Internet, edit your Agent configuration file.
+Traditional web proxies are supported natively by the agent. If you need to connect to the Internet through a proxy, edit your Agent configuration file.
 
 ### Agent v6
 

--- a/content/agent/proxy.md
+++ b/content/agent/proxy.md
@@ -56,7 +56,7 @@ to
 
 ## Using a Web Proxy as Proxy
 
-Traditional web proxies are supported natively by the Agent. If you need a proxy to connect to the Internet, edit your Agent configuration file.
+Traditional web proxies are supported natively by the agent. If you need to connect to the Internet through a proxy, edit your Agent configuration file.
 
 ### Agent v6
 


### PR DESCRIPTION
### What does this PR do?

Update the docs to include an example for a proxy configuration for Agent 6, according to the template of datadog.yaml (https://github.com/DataDog/datadog-agent/blob/8321ace809f959806bb1539653da825862e8db3d/pkg/config/config_template.yaml#L15)

### Motivation

It's changed compared to Agent 5 and can lead to the Agent not being able to send data

### Preview link
<!-- Impacted pages preview links-->

https://docs-staging.datadoghq.com/gus/agent-proxy/agent/proxy/#using-a-web-proxy-as-proxy