### PR TITLE
exclude the ja folder from indexing

### DIFF
--- a/local/bin/py/index_algolia.py
+++ b/local/bin/py/index_algolia.py
@@ -19,7 +19,7 @@ def content_location():
 
 
 def index_algolia(app_id, api_key, content_path=None):
-    dirs_exclude = ['js', 'images', 'fonts', 'en', 'css', 'search', 'json', 'error', 'matts quick tips', 'videos']
+    dirs_exclude = ['js', 'images', 'fonts', 'en', 'css', 'search', 'json', 'error', 'matts quick tips', 'videos', 'ja']
     languages = ['fr']
 
     files_to_exclude = ['404.html']


### PR DESCRIPTION
### What does this PR do?
This makes sure we don't index the ja site

### Motivation
We didn't index it before after freezing the site so we shouldn't be now

### Preview link
None indexing only happens on merge to master

### Additional Notes

