### PR TITLE
duplicate no-indexing code, consolidate and and make it noindex when …

### DIFF
--- a/layouts/_default/404-baseof.html
+++ b/layouts/_default/404-baseof.html
@@ -7,7 +7,7 @@
     <title>{{ .Title }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {{ if .Params.external_redirect }} {{ partial "meta-http-equiv.html" . }} {{ end }}
-    {{ if (or (eq .Params.beta true) (eq .Params.private true)) }} <meta name="robots" content="noindex"> {{ end }}
+    {{- partial "noindex.html" . -}}
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <link rel="icon" type="image/png" href="https://docs.datadoghq.com/favicon.ico">
     <link rel="stylesheet" href="{{ .Site.BaseURL }}css/{{ (index .Site.Data.manifests.css "main-dd.css" ) }}">

--- a/layouts/_default/api-baseof.html
+++ b/layouts/_default/api-baseof.html
@@ -7,7 +7,7 @@
     <title>{{ .Title }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {{ if .Params.external_redirect }} {{ partial "meta-http-equiv.html" . }} {{ end }}
-    {{ if (or (eq .Params.beta true) (eq .Params.private true)) }} <meta name="robots" content="noindex"> {{ end }}
+    {{- partial "noindex.html" . -}}
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <link rel="icon" type="image/png" href="https://docs.datadoghq.com/favicon.ico">
     <link rel="stylesheet" href="{{ .Site.BaseURL }}css/{{ (index .Site.Data.manifests.css "main-dd.css" ) }}">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,7 +7,7 @@
     <title>{{ if isset .Params "integration_title" }}{{ .Params.integration_title }}{{ else }}{{ .Title }}{{ end }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {{ if .Params.external_redirect }} {{ partial "meta-http-equiv.html" . }} {{ end }}
-    {{ if (or (eq .Params.beta true) (eq .Params.private true)) }} <meta name="robots" content="noindex"> {{ end }}
+    {{- partial "noindex.html" . -}}
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <link rel="icon" type="image/png" href="https://docs.datadoghq.com/favicon.ico">
     <link rel="stylesheet" href="{{ .Site.BaseURL }}css/{{ (index .Site.Data.manifests.css "main-dd.css" ) }}">

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -19,9 +19,6 @@
 {{ end }}
 {{ $meta_desc := $.Scratch.Get "meta_desc" }}
 
-{{- if (or (eq $.Params.noindex true) (eq $.Params.private true) (eq .Site.Params.environment "preview")) -}}
-    <meta name="robots" content="noindex, nofollow">
-{{- end -}}
 
 <!-- Schema.org markup for Google+ -->
 <meta itemprop="name" content="{{ $meta_title | safeHTML }}">

--- a/layouts/partials/noindex.html
+++ b/layouts/partials/noindex.html
@@ -1,0 +1,3 @@
+{{ if (or (eq .Params.beta true) (eq .Params.private true) (eq .Params.placeholder true) (eq .Site.Params.environment "preview") (eq .Params.noindex true) ) }}
+<meta name="robots" content="noindex, nofollow">
+{{ end }}


### PR DESCRIPTION
### What does this PR do?
This pr will consolidate the noindex calls to one new partial called "noindex.html" 
This meta tag will now be included if any of the following is true

- front matter param beta is true
- front matter param private is true
- front matter param placeholder is true
- front matter param noindex is true
- site config environment is preview

### Motivation
For seo reasons so that we aren't indexing fr pages that are placeholders and have english content which is a duplicate of the english site. Also to make maintenance a little easier next time.

### Preview link
https://docs-staging.datadoghq.com/david.jones/no-index/

### Additional Notes

