### PR TITLE
make the header and footer links to docs language specific

### DIFF
--- a/data/partials/footer.fr.yaml
+++ b/data/partials/footer.fr.yaml
@@ -12,14 +12,14 @@ col1:
     link: 'https://www.datadoghq.com/alerts/'
     title: Alertes
   - name: api
-    link: 'https://docs.datadoghq.com/api/'
+    link: 'api/'
     title: API
   - name: pricing
     link: 'https://www.datadoghq.com/pricing/'
     title: Prix
 col2:
   - name: documentation
-    link: 'http://docs.datadoghq.com/'
+    link: ''
     title: Documentation
   - name: support
     link: 'https://www.datadoghq.com/support/'

--- a/data/partials/footer.yaml
+++ b/data/partials/footer.yaml
@@ -12,14 +12,14 @@ col1:
     link: "https://www.datadoghq.com/alerts/"
     title: "Alerts"
   - name: api
-    link: "https://docs.datadoghq.com/api/"
+    link: "api/"
     title: "API"
   - name: pricing
     link: "https://www.datadoghq.com/pricing/"
     title: "Pricing"
 col2:
   - name: documentation
-    link: "http://docs.datadoghq.com/"
+    link: ""
     title: "Documentation"
   - name: support
     link: "https://www.datadoghq.com/support/"

--- a/data/partials/header.yaml
+++ b/data/partials/header.yaml
@@ -19,10 +19,10 @@ left:
             link: "https://www.datadoghq.com/alerts/"
             title: "Alerts"
           - name: product_api
-            link: "https://docs.datadoghq.com/api"
+            link: "api"
             title: "API"
   - name: docs
-    link: "https://docs.datadoghq.com/"
+    link: ""
     title: "Docs"
   - name: pricing
     link: "https://www.datadoghq.com/pricing/"


### PR DESCRIPTION
### What does this PR do?
By settings these links to blank this allows "absLangURL" to correctly link the docs pages to the language we may already be on. e.g on the fr site clicking docs link will stay on fr

### Motivation
Clicking header of footer links was taking you away from the french version to the english always. Which wasn't a great experience.

### Preview link
https://docs-staging.datadoghq.com/david.jones/headfoot-links/fr/
Try clicking documentation or api in the footer or header notice you will stay on french site

### Additional Notes
