### PR TITLE
Fix "applications" typo in python.md

### DIFF
--- a/content/tracing/setup/python.md
+++ b/content/tracing/setup/python.md
@@ -17,7 +17,7 @@ further_reading:
 ---
 
 <div class="alert alert-info">
-For Python applciations, note that tracing is disabled when your application is launched in <code>DEBUG</code> mode. Find more <a href="http://pypi.datadoghq.com/trace/docs/#module-ddtrace.contrib.django">here</a>.
+For Python applications, note that tracing is disabled when your application is launched in <code>DEBUG</code> mode. Find more <a href="http://pypi.datadoghq.com/trace/docs/#module-ddtrace.contrib.django">here</a>.
 </div>
 
 ## Installation

--- a/ja/content/tracing/python.md
+++ b/ja/content/tracing/python.md
@@ -24,7 +24,7 @@ pip install ddtrace
 Finally, import the tracer and instrument your code!
 
 <div class="alert alert-info">
-For Python applciations, please note that tracing is disabled when your application is launched in <b>DEBUG</b> mode. Find more <a href="http://pypi.datadoghq.com/trace/docs/#module-ddtrace.contrib.django">here</a>
+For Python applications, please note that tracing is disabled when your application is launched in <b>DEBUG</b> mode. Find more <a href="http://pypi.datadoghq.com/trace/docs/#module-ddtrace.contrib.django">here</a>
 </div>
 
 ### Example


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
applciations  -> applications

### Motivation
Typos make me itchy
