### PR TITLE
[timeboards] Description is not optional

### DIFF
--- a/content/api/timeboards/timeboards_create.fr.md
+++ b/content/api/timeboards/timeboards_create.fr.md
@@ -10,7 +10,7 @@ external_redirect: /api/#create-a-timeboard
 
 * **`title`** [*obligatoire*]:  
     Le nom du dashboard.
-* **`description`** [*optionnel*, *defaut*=**None**]:  
+* **`description`** [*obligatoire*]:  
     Une description du contenu du dashboard.
 * **`graphs`** [*optionnel*, *defaut*=**None**]:  
     Une liste de définitions de graphique. Les définitions de graphique suivent cette forme:

--- a/content/api/timeboards/timeboards_create.md
+++ b/content/api/timeboards/timeboards_create.md
@@ -10,7 +10,7 @@ external_redirect: /api/#create-a-timeboard
 
 * **`title`** [*required*]:  
     The name of the dashboard.
-* **`description`** [*optional*, *default*=**None**]:  
+* **`description`** [*required*]:  
     A description of the dashboard's content.
 * **`graphs`** [*optional*, *default*=**None**]:  
     A list of graph definitions. Graph definitions follow this form:

--- a/content/api/timeboards/timeboards_update.fr.md
+++ b/content/api/timeboards/timeboards_update.fr.md
@@ -11,7 +11,7 @@ external_redirect: /api/#update-a-timeboard
 
 * **`title`** [*obligatoire*]:  
     Le nom du dashboard.
-* **`description`** [*optionnel*]:  
+* **`description`** [*obligatoire*]:  
     Une description du contenu du dashboard.
 * **`graphs`** [*optionnel*]:  
     Une liste de définitions de graphique. Les définitions de graphique suivent cette forme:

--- a/content/api/timeboards/timeboards_update.md
+++ b/content/api/timeboards/timeboards_update.md
@@ -13,7 +13,7 @@ external_redirect: /api/#update-a-timeboard
     The name of the dashboard.
 * **`description`** [*optional*]:  
     A description of the dashboard's contents.
-* **`graphs`** [*optional*]:  
+* **`graphs`** [*required*]:  
     A list of graph definitions. Graph definitions follow this form:
     * **`title`** [*required*]:  
         The name of the graph.


### PR DESCRIPTION
### What does this PR do?

Updates the timeboard description field optionality constraint.

### Motivation

Descriptions on timeboards are not optional.

https://trello.com/c/ks4MuZEk/674-timeboard-update-via-api-requires-description-field-but-is-documented-optional

### Preview link

![screen shot 2018-03-23 at 10 50 45 am](https://user-images.githubusercontent.com/1924983/37836106-15799afe-2e88-11e8-958a-ace72365c307.png)

### Additional Notes

N/A
