### PR TITLE
Switching between search results pages creates browser history entries

### DIFF
--- a/src/js/datadog-docs.js
+++ b/src/js/datadog-docs.js
@@ -155,6 +155,7 @@ $(document).ready(function () {
                             if(current_page < page_nums[0]) {
                                 less(null);
                             } else {
+                                addHistory(current_page);
                                 changePage(current_page);
                             }
                         }
@@ -166,6 +167,7 @@ $(document).ready(function () {
                             if(current_page > page_nums[page_nums.length-1]) {
                                 more(null);
                             } else {
+                                addHistory(current_page);
                                 changePage(current_page);
                             }
                         }
@@ -181,6 +183,7 @@ $(document).ready(function () {
                             page_nums.push(i);
                         }
                         current_page = page_nums[page_nums.length-1];
+                        addHistory(current_page);
                         changePage(current_page);
                         return false;
                     }
@@ -197,6 +200,7 @@ $(document).ready(function () {
                             page_nums.push(i);
                         }
                         current_page = page_nums[0];
+                        addHistory(current_page);
                         changePage(current_page);
                         return false;
                     }
@@ -239,6 +243,7 @@ $(document).ready(function () {
                             page = 1;
                         }
                         current_page = page;
+                        addHistory(current_page);
                         changePage(current_page);
                         return false;
                     }
@@ -281,6 +286,19 @@ $(document).ready(function () {
                         html += '<a class="mr-1 btn btn-sm-tag btn-outline-secondary" href="#" id="btn_next">Next</a>';
                         page_navigation.innerHTML = html;
                         setHandlers();
+                    }
+
+                    window.onpopstate = function (event) {
+                        if (event.state.page) {
+                            current_page = event.state.page;
+                            changePage(current_page);
+                        } 
+                    };
+
+                    function addHistory(page) {
+                        var pageName = '?s=' + query;
+                        if (page !== 1) pageName += '&p=' + page;
+                        history.pushState({ page: page }, '', pageName);
                     }
 
                     function changePage(page)
@@ -330,8 +348,12 @@ $(document).ready(function () {
 
                     // init page nums
                     initPageNums();
-                    // set first page
-                    changePage(1);
+
+                    // set initial page
+                    var searchParams = new URLSearchParams(window.location.search);
+                    if (searchParams.get('p') !== null) current_page = parseInt(searchParams.get('p'));
+                    history.replaceState({ page: current_page }, '', '');
+                    changePage(current_page);
                 }
 
             }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Switching to a new page in the search results creates a new entry in the browser's history, and appends a query parameter to the url corresponding to the page, allowing users to link to specific search result pages.

Before:
* User enters a search query from docs homepage
* User is on page 1 of results
* User navigates to page 5
* User hits back button
* User is on docs homepage

After:
* User enters a search query from docs homepage
* User is on page 1 of results
* User navigates to page 5
* User hits back button
* User is on page 1 of results

### Motivation
<!-- What inspired you to submit this pull request?-->
Switching between pages in search results currently does not create new history entries, so if a user 
changes pages and hits the back button on the browser, they're taken to the page visited before the search results. This makes navigation within search results harder, and can be very disorienting for users.

### Preview link
<!-- Impacted pages preview links-->
All search results pages
