### PR TITLE
Adding disclaimer for the Kubernetes support updating rbac

### DIFF
--- a/content/agent/basic_agent_usage/kubernetes.md
+++ b/content/agent/basic_agent_usage/kubernetes.md
@@ -12,7 +12,7 @@ aliases:
     - /integrations/faq/gathering-kubernetes-events
 ---
 
-**Disclaimer**: The agent 6 only supports versions of Kubernetes higher than 1.7.6.
+**Note**: The agent v6 only supports versions of Kubernetes higher than 1.7.6, for prior version, use agent v5.
 
 There are two installation processes available to gather metrics, traces and logs from your Kubernetes Clusters:
 

--- a/content/agent/basic_agent_usage/kubernetes.md
+++ b/content/agent/basic_agent_usage/kubernetes.md
@@ -12,7 +12,7 @@ aliases:
     - /integrations/faq/gathering-kubernetes-events
 ---
 
-**Note**: The agent v6 only supports versions of Kubernetes higher than 1.7.6, for prior versions, use agent v5.
+**Note**: Agent version 6.0 and greater only support versions of Kubernetes higher than 1.7.6. For prior versions of Kubernetes, you must use Agent 5.x.
 
 There are two installation processes available to gather metrics, traces and logs from your Kubernetes Clusters:
 
@@ -24,7 +24,7 @@ Installing the agent on the host as opposed to in a pod as part of a Deployment 
 It could however help give visibility over the start of the Kubernetes ecosystem and health thereof.
 Similarly, one would not be restricted to monitoring applications belonging to the Kubernetes eco system.
 
-To discover all data collected automatically from the Kubernetes integration, refer to the dedicated [Kubernetes Integration Documentation](/integrations/kubernetes).  
+To discover all data collected automatically from the Kubernetes integration, refer to the dedicated [Kubernetes Integration Documentation](/integrations/kubernetes).
 
 This documentation is for agent v6 only, if you are still using agent v5, [follow this installation process](/agent/faq/agent-5-kubernetes-basic-agent-usage)
 
@@ -110,7 +110,7 @@ spec:
           name: cgroups
 ```
 
-Replace `YOUR_API_KEY` with [your api key](https://app.datadoghq.com/account/settings#api) or use [Kubernetes secrets](https://kubernetes.io/docs/concepts/configuration/secret/) to set your API key [as an environement variable](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables).  
+Replace `YOUR_API_KEY` with [your api key](https://app.datadoghq.com/account/settings#api) or use [Kubernetes secrets](https://kubernetes.io/docs/concepts/configuration/secret/) to set your API key [as an environement variable](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables).
 
 [Consult our docker integration to discover all configuration options.](/agent/basic_agent_usage/docker/#environment-variables)
 
@@ -126,10 +126,10 @@ Replace `YOUR_API_KEY` with [your api key](https://app.datadoghq.com/account/set
 To enable [Log collection](/logs) with your DaemonSet:
 
 1. Set the `DD_LOGS_ENABLED` variable to true in your *env* section:
-    
+
     ```
     (...)
-      env: 
+      env:
         (...)
         - name: DD_LOGS_ENABLED
             value: "true"
@@ -154,7 +154,7 @@ To enable [Log collection](/logs) with your DaemonSet:
     (...)
   ```
 
-Learn more about this in [the Docker log collection documentation](/logs/docker/#configuration-file-example). 
+Learn more about this in [the Docker log collection documentation](/logs/docker/#configuration-file-example).
 
 ### RBAC
 
@@ -225,10 +225,10 @@ data:
     logs:
       - type: docker
         service: docker
-        source: kubernetes 
+        source: kubernetes
 ```
 
-Learn more about this in [the Docker log collection documentation](/logs/docker/#configuration-file-example). 
+Learn more about this in [the Docker log collection documentation](/logs/docker/#configuration-file-example).
 
 ##### Annotations
 

--- a/content/agent/basic_agent_usage/kubernetes.md
+++ b/content/agent/basic_agent_usage/kubernetes.md
@@ -12,6 +12,8 @@ aliases:
     - /integrations/faq/gathering-kubernetes-events
 ---
 
+**Disclaimer**: The agent 6 only supports versions of Kubernetes higher than 1.7.6.
+
 There are two installation processes available to gather metrics, traces and logs from your Kubernetes Clusters:
 
 * [Container installation](#container-installation) - recommended

--- a/content/agent/basic_agent_usage/kubernetes.md
+++ b/content/agent/basic_agent_usage/kubernetes.md
@@ -12,7 +12,7 @@ aliases:
     - /integrations/faq/gathering-kubernetes-events
 ---
 
-**Note**: The agent v6 only supports versions of Kubernetes higher than 1.7.6, for prior version, use agent v5.
+**Note**: The agent v6 only supports versions of Kubernetes higher than 1.7.6, for prior versions, use agent v5.
 
 There are two installation processes available to gather metrics, traces and logs from your Kubernetes Clusters:
 

--- a/content/integrations/faq/using-rbac-permission-with-your-kubernetes-integration.md
+++ b/content/integrations/faq/using-rbac-permission-with-your-kubernetes-integration.md
@@ -19,18 +19,26 @@ Use these Kubernetes RBAC entities to configure permissions for your Datadog Age
     resources:
       - "nodes"
       - "namespaces"  #
-      - "events"      # Cluster events + kube_service cache invalidation
+      - "events"      # Cluster events 
       - "services"    # kube_service tag
+      - "pods"
+      - "endpoints"   # kube_service tag
+      - "componentstatuses"
     verbs: ["get", "list"]
   - apiGroups: [""]
     resources:
       - "configmaps"
-    resourceNames: ["datadog-leader-elector"]
-    verbs: ["get", "delete", "update"]
+    resourceNames: ["datadog-leader-election"]
+    verbs: ["get", "list", "create", "delete", "update"]
   - apiGroups: [""]
     resources:
       - "configmaps"
     verbs: ["create"]
+  - apiGroups: [""]
+    resources:
+      - "configmaps"
+    resourceNames: ["datadogtoken"]
+    verbs: ["get", "update"]    
   ---
   # You need to use that account for your dd-agent DaemonSet
   apiVersion: v1


### PR DESCRIPTION
### What does this PR do?

Update the RBAC to document the requirement to collect pods, component statuses, endpoints to have the kubeapiserver work out of the box.
Adding a disclaimer for the support of 1.7.6 minimum.

### Motivation
Make sure the agent works with the documented RBAC.
Give more exposure to the support.

### Preview link
https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/

https://docs.datadoghq.com/integrations/faq/using-rbac-permission-with-your-kubernetes-integration/
