### PR TITLE
Typo on troubleshooting.md

### DIFF
--- a/content/agent/troubleshooting.md
+++ b/content/agent/troubleshooting.md
@@ -26,7 +26,7 @@ If you're still unsure about the issue, you may reach out to [Datadog support te
 
 To enable the full debug mode:
 
-1. Modify your local `datadog.yaml` file (see [this page](/agent/#configuration-file) to locate this configuration file on your instance)
+1. Modify your local `datadog.yaml` file (see [this page](/agent/#configuration-files) to locate this configuration file on your instance)
 
 2. Replace `# log_level: INFO` with `log_level: DEBUG` (make sure to get rid of # to uncomment the line)
 


### PR DESCRIPTION
Configuration file link missing an s.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes broken link.

### Motivation
Looking for info in the documentation, stumbled upon broken link.

### Preview link
<!-- Impacted pages preview links-->


### Additional Notes
<!-- Anything else we should know when reviewing?-->
