### PR TITLE
Cécile/update haproxy apm

### DIFF
--- a/content/agent/proxy.md
+++ b/content/agent/proxy.md
@@ -168,9 +168,10 @@ Then edit each agent to point to HAProxy by setting its `dd_url` to the address 
 
 If you want to send traces through the proxy, you need to setup the following in `datadog.conf`:
 
-`[trace.api]
-
- endpoint = https://haproxy.example.com:3835`
+```
+[trace.api]
+endpoint = https://haproxy.example.com:3835
+ ```
 
 Before you [restart the agent](/agent/faq/agent-commands) Edit your supervisor configuration to disable SSL certificate verification. This is needed to prevent python from complaining about the discrepancy between the hostname on the SSL certificate (app.datadoghq.com) and your HAProxy hostname.
 

--- a/content/agent/proxy.md
+++ b/content/agent/proxy.md
@@ -168,7 +168,8 @@ Then edit each agent to point to HAProxy by setting its `dd_url` to the address 
 
 If you want to send traces through the proxy, you need to setup the following in `datadog.conf`:
 
-`[trace.api] 
+`[trace.api]
+
  endpoint = https://haproxy.example.com:3835`
 
 Before you [restart the agent](/agent/faq/agent-commands) Edit your supervisor configuration to disable SSL certificate verification. This is needed to prevent python from complaining about the discrepancy between the hostname on the SSL certificate (app.datadoghq.com) and your HAProxy hostname.

--- a/content/agent/proxy.md
+++ b/content/agent/proxy.md
@@ -122,7 +122,7 @@ defaults
 # You do not need credentials to view this page and you can
 # turn it off once you are done with setup.
 listen stats
-    bind *:3835
+    bind *:3833
     mode http
     stats enable
     stats uri /
@@ -165,6 +165,11 @@ Once the HAProxy configuration is in place, you can reload it or restart HAProxy
 Then edit each agent to point to HAProxy by setting its `dd_url` to the address of HAProxy (e.g. haproxy.example.com). This `dd_url` setting can be found in `datadog.conf`.
 
 `dd_url: https://haproxy.example.com:3834`
+
+If you want to send traces through the proxy, you need to setup the following in `datadog.conf`:
+
+`[trace.api] 
+ endpoint = https://haproxy.example.com:3835`
 
 Before you [restart the agent](/agent/faq/agent-commands) Edit your supervisor configuration to disable SSL certificate verification. This is needed to prevent python from complaining about the discrepancy between the hostname on the SSL certificate (app.datadoghq.com) and your HAProxy hostname.
 


### PR DESCRIPTION
### What does this PR do?
1. change port of haproxy stats so we don't give an example where the 3835 port is used for exposing stats AND receiving traces
2. add how to setup haproxy for traces (datadog.cong part)

### Motivation
https://datadog.zendesk.com/agent/tickets/129490

### Preview link

### Additional Notes

