### PR TITLE
Fix info command documentation

### DIFF
--- a/content/agent/faq/agent-commands.fr.md
+++ b/content/agent/faq/agent-commands.fr.md
@@ -67,7 +67,7 @@ Le `[OK]` dans le retour de l'Agent implique que la vérification a été config
 |:--------|:-----|:--------|
 |Linux|`sudo service datadog-agent info`|`sudo datadog-agent status`|
 |Docker|`sudo docker exec -it dd-agent /etc/init.d/datadog-agent info`|`sudo docker exec -it datadog-agent agent status`|
-|Docker (Alpine)|`docker exec -it dd-agent /opt/datadog-agent/bin/agent`|`n/a`|
+|Docker (Alpine)|`docker exec -it dd-agent /opt/datadog-agent/bin/agent info`|`n/a`|
 |MacOS x|`datadog-agent info`               | `datadog-agent status` or [web GUI](/agent/#using-the-gui)                    |
 |Source|`sudo ~/.datadog-agent/bin/info`|`sudo datadog-agent status`|
 |Windows|[Consult our dedicated windows doc](/agent/basic_agent_usage/windows/#status-and-information)|[Consult our dedicated windows doc](/agent/basic_agent_usage/windows/#status-and-information)|

--- a/content/agent/faq/agent-commands.md
+++ b/content/agent/faq/agent-commands.md
@@ -68,7 +68,7 @@ The `[OK]` in the Agent output implies that the check was configured/run correct
 |:--------|:-----|:--------|
 |Linux|`sudo service datadog-agent info`|`sudo datadog-agent status`|
 |Docker|`sudo docker exec -it dd-agent /etc/init.d/datadog-agent info`|`sudo docker exec -it datadog-agent agent status`|
-|Docker (Alpine)|`docker exec -it dd-agent /opt/datadog-agent/bin/agent`|`n/a`|
+|Docker (Alpine)|`docker exec -it dd-agent /opt/datadog-agent/bin/agent info`|`n/a`|
 |MacOS x|`datadog-agent info`               | `datadog-agent status` or [web GUI](/agent/#using-the-gui)                    |
 |Source|`sudo ~/.datadog-agent/bin/info`|`sudo datadog-agent status`|
 |Windows|[Consult our dedicated windows doc](/agent/basic_agent_usage/windows/#status-and-information)|[Consult our dedicated windows doc](/agent/basic_agent_usage/windows/#status-and-information)|


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

The documentation here https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information states that the info command to run on alpine is 

`/opt/datadog-agent/bin/agent`

but i think it should be 

`/opt/datadog-agent/bin/agent info`

@davidejones

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
I've corrected the documentation in english and french.

### Motivation
<!-- What inspired you to submit this pull request?-->


### Preview link
<!-- Impacted pages preview links-->


### Additional Notes
<!-- Anything else we should know when reviewing?-->
