### PR TITLE
Add note on TCP DNS support

### DIFF
--- a/content/agent/faq/forwarder-logs-contain-599-response-code.md
+++ b/content/agent/faq/forwarder-logs-contain-599-response-code.md
@@ -59,6 +59,7 @@ When DNS responses are more than 512 bytes, DNS is sent on TCP. If any TCP ports
 ```
 gaierror: (-2, ' Name of service not known ')
 ```
+If your system or network doesn't support DNS over TCP, disabling IPv6 may help to reduce DNS message sizes and allow the use of UDP.
 
 ### IVP6
 


### PR DESCRIPTION
### Motivation
TCP support is now required by the DNS protocol (https://tools.ietf.org/html/rfc5966) (https://tools.ietf.org/html/rfc7766) but some legacy systems may not support it:

>      DNS resolvers and recursive servers MUST support UDP, and SHOULD
>      support TCP, for sending (non-zone-transfer) queries.
>
>   However, some implementors have taken the text quoted above to mean
>   that TCP support is an optional feature of the DNS protocol

This PR adds a note that points out the existence of this issue and a possible workaround.

A user encountered this issue, prompting me to create this PR.

### Preview link
<!-- Impacted pages preview links-->


### Additional Notes
<!-- Anything else we should know when reviewing?-->
