### PR TITLE
Clarified Go Compatability - from v1.7 to v1.7+

### DIFF
--- a/content/tracing/setup/go.md
+++ b/content/tracing/setup/go.md
@@ -48,7 +48,7 @@ For another example, see the [`example_test.go`](https://github.com/DataDog/dd-t
 
 ## Compatibility
 
-Currently, only Go 1.7 is supported.
+Currently, only Go 1.7+ is supported.
 
 ### Framework Compatibility
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
I'm just adding a subtle clarification.  We support go versions of 1.7 and above.

### Motivation
I had to ask for clarification from Raclette when responding to a support ticket
