### PR TITLE
add language entry for search and fix issue with toc on initial load

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -218,5 +218,9 @@
 
   "questions": {
     "other": "Questions?"
+  },
+
+  "search": {
+    "other": "Search"
   }
 }

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -218,5 +218,9 @@
 
   "questions": {
     "other": "Questions?"
+  },
+
+  "search": {
+    "other": "Search"
   }
 }

--- a/layouts/partials/sidenav/sidenav.html
+++ b/layouts/partials/sidenav/sidenav.html
@@ -21,46 +21,10 @@
             <a href="{{ "" | absLangURL }}"><h4>{{ i18n "datadog_docs" }}</h4></a>
             <form class="sidenav-search" action="{{ absLangURL "search/" }}">
                 <div class="input-group">
-                    <input type="text" class="form-control" name="s" placeholder="Search" aria-label="Search"/>
+                    <input type="text" class="form-control" name="s" placeholder="{{ i18n "search" }}" aria-label="Search"/>
                     <span class="input-group-addon">{{ partial "img.html" (dict "root" . "src" "icons/nav_search.png" "alt" "search" "width" "21") }}</span>
                 </div>
             </form>
-
-            <!--<ul class="list-unstyled">
-                {{ range $index, $element := $.Site.Data.sidenav.general.nav }}
-                    {{ $split_urls := split $dot.RelPermalink "/" }}
-                    {{ $url_first := print "/" (index $split_urls 1) "/" }}
-                    {{ $active_page := (or (and (eq $url_first $element.link) (ne $element.link "/")) (eq $dot.RelPermalink $element.link)) }}
-                    {{ if not $element.hide }}
-                    <li>
-                        <a href="{{ $element.link }}" {{if $active_page }}class="active"{{ end }}>
-                            {{ partial "img.html" (dict "root" $dot "src" (print "icons/" ($element.image)) "class" "static" "width" "21") }}
-                            {{ partial "img.html" (dict "root" $dot "src" (print "icons/" ($element.image_hover)) "class" "hover" "width" "21" ) }}
-                            <span>{{ $element.display_name }}</span>
-                        </a>
-                        {{ if (and $active_page (not $element.toc_disable)) }}
-                        {{ if $dot.Params.integration_title }}<span class="toctitle">{{ $dot.Params.integration_title | upper }}</span>{{ end }}
-                        {{ if $dot.Params.platform }}<span class="toctitle">{{ $dot.Params.platform | upper }}</span>{{ end }}
-                        {{ $dot.TableOfContents }}
-                        {{ end }}
-                        {{/* comments here {{ if (and (in ($element.display_name | lower) "integrations") (in $dot.RelPermalink "integrations") ) }}
-                        <nav id="TableOfContents">
-                            <ul>
-                                <li>
-                                    <ul>
-                                        <li><a data-ref="filter" data-filter="all" href="#all" class="">ALL</a></li>
-                                        {{ range $i, $e := (sort ($.Scratch.Get "filters")) }}
-                                        <li><a data-ref="filter" data-filter=".cat-{{ replace $e "/" "" | urlize }}" href="#cat-{{ replace $e "/" "" | urlize }}" class="">{{ $e }}</a></li>
-                                        {{ end }}
-                                    </ul>
-                                </li>
-                            </ul>
-                        </nav>
-                        {{ end }}*/}}
-                    </li>
-                    {{ end }}
-                {{ end }}
-            </ul>-->
             <div class="sidenav-nav">
                 {{ partial "sidenav/recursive-nav.html" (dict "context" $dot "data" .Site.Menus.main) }}
             </div>

--- a/layouts/partials/table-of-contents/table-of-contents.js
+++ b/layouts/partials/table-of-contents/table-of-contents.js
@@ -98,6 +98,7 @@ $(document).ready(function () {
                 $('.toc-container').toggleClass('mobile-open').toggleClass('d-none');
             }
             $(this).find('i').toggleClass('icon-small-x').toggleClass('icon-small-bookmark');
+            $( document ).trigger( "headerResize", [ parseInt($('body > header').height()) ] );
         });
 
         $(document).on( "moveToAnchor", function() {


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue with the table of contents appearing under the header on page load. It also adds in a language string for "search"

### Motivation
I found the visual bug with the toc while testing
I also saw that the search placeholder text wasn't a string translation so added it

### Preview link
https://docs-staging.datadoghq.com/david.jones/minor-fixes/

### Additional Notes
Visit https://docs-staging.datadoghq.com/david.jones/minor-fixes/getting_started/ when the page has loaded click the book icon in the top right to toggle the table of contents. You will see it shows correctly. If you follow the same actions on production you will see that it appears slightly under the header but will correct itself when you scroll down.
