### PR TITLE
changes 18 hours to 6 hours for how old logs can be when submitted

### DIFF
--- a/content/logs/_index.fr.md
+++ b/content/logs/_index.fr.md
@@ -261,7 +261,7 @@ Toutefois, si un fichier de log au format JSON inclut l'un des attributs suivant
 
 Vous pouvez également spécifier d'autres attributs à utiliser comme source de la date d'un log en définissant un processor [log date remapper](/logs/processing/#log-date-remapper)
 
-**Note**: Datadog rejette un log si sa date officielle est antérieure à 18 heures.
+**Note**: Datadog rejette un log si sa date officielle est antérieure à 6 heures.
 
 <div class="alert alert-info">
 Les formats de date reconnus sont: <a href="https://www.iso.org/iso-8601-date-and-time-format.html">ISO8601</a>, <a href="https://en.wikipedia.org/wiki/Unix_time">UNIX (le format milliseconds EPOCH)</a>  and <a href="https://www.ietf.org/rfc/rfc3164.txt">RFC3164</a>.

--- a/content/logs/_index.md
+++ b/content/logs/_index.md
@@ -261,7 +261,7 @@ However, if a JSON formatted log file includes one of the following attributes, 
 
 You can also specify alternate attributes to use as the source of a log's date by setting a [log date remapper processor](/logs/processing/#log-date-remapper)
 
-**Note**: Datadog rejects a log entry if its official date is older than 18 hours in the past.
+**Note**: Datadog rejects a log entry if its official date is older than 6 hours in the past.
 
 <div class="alert alert-info">
 The recognized date formats are: <a href="https://www.iso.org/iso-8601-date-and-time-format.html">ISO8601</a>, <a href="https://en.wikipedia.org/wiki/Unix_time">UNIX (the milliseconds EPOCH format)</a>  and <a href="https://www.ietf.org/rfc/rfc3164.txt">RFC3164</a>.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Changes
"Datadog rejects a log entry if its official date is older than 18 hours in the past."
To
"Datadog rejects a log entry if its official date is older than 6 hours in the past."

### Motivation
Discussion with Steve

### Preview link
<!-- Impacted pages preview links-->


### Additional Notes
