### PR TITLE
Updating agent commands

### DIFF
--- a/content/agent/faq/agent-commands.md
+++ b/content/agent/faq/agent-commands.md
@@ -40,8 +40,8 @@ aliases:
 |Platform|Agent v5 |Agent v6|
 |:--------|:-----|:--------|
 |Linux|`sudo service datadog-agent status`|`sudo datadog-agent status`|
-|Docker (Debian)|`sudo docker exec -it dd-agent /etc/init.d/datadog-agent status`|`sudo docker exec -it agent s6-svstat /var/run/s6/services/agent/`|
-|Docker (Alpine)|`sudo docker exec -it dd-agent supervisorctl -c /opt/datadog-agent/agent/supervisor.conf status`|`n/a`|
+|Docker (Debian)|`sudo docker exec -it <container_name> /etc/init.d/datadog-agent status`|`sudo docker exec -it agent s6-svstat /var/run/s6/services/agent/`|
+|Docker (Alpine)|`sudo docker exec -it <container_name> supervisorctl -c /opt/datadog-agent/agent/supervisor.conf status`|`n/a`|
 |MacOS x|`datadog-agent status`             | `launchctl list com.datadoghq.agent` or systray app|
 |Source|`sudo ~/.datadog-agent/bin/agent status`|`sudo service datadog-agent status`|
 |Windows|[Consult our dedicated windows doc](/agent/basic_agent_usage/windows/#status-and-information)|[Consult our dedicated windows doc](/agent/basic_agent_usage/windows/#status-and-information)|
@@ -67,8 +67,8 @@ The `[OK]` in the Agent output implies that the check was configured/run correct
 |Platform|Agent v5 |Agent v6|
 |:--------|:-----|:--------|
 |Linux|`sudo service datadog-agent info`|`sudo datadog-agent status`|
-|Docker|`sudo docker exec -it dd-agent /etc/init.d/datadog-agent info`|`sudo docker exec -it datadog-agent agent status`|
-|Docker (Alpine)|`docker exec -it dd-agent /opt/datadog-agent/bin/agent info`|`n/a`|
+|Docker|`sudo docker exec -it <container_name> /etc/init.d/datadog-agent info`|`sudo docker exec -it <container_name> agent status`|
+|Docker (Alpine)|`docker exec -it <container_name> /opt/datadog-agent/bin/agent info`|`n/a`|
 |MacOS x|`datadog-agent info`               | `datadog-agent status` or [web GUI](/agent/#using-the-gui)                    |
 |Source|`sudo ~/.datadog-agent/bin/info`|`sudo datadog-agent status`|
 |Windows|[Consult our dedicated windows doc](/agent/basic_agent_usage/windows/#status-and-information)|[Consult our dedicated windows doc](/agent/basic_agent_usage/windows/#status-and-information)|

--- a/content/agent/faq/agent-commands.md
+++ b/content/agent/faq/agent-commands.md
@@ -40,7 +40,7 @@ aliases:
 |Platform|Agent v5 |Agent v6|
 |:--------|:-----|:--------|
 |Linux|`sudo service datadog-agent status`|`sudo datadog-agent status`|
-|Docker (Debian)|`sudo docker exec -it <container_name> /etc/init.d/datadog-agent status`|`sudo docker exec -it agent s6-svstat /var/run/s6/services/agent/`|
+|Docker (Debian)|`sudo docker exec -it <container_name> /etc/init.d/datadog-agent status`|`sudo docker exec -it <container_name> s6-svstat /var/run/s6/services/agent/`|
 |Docker (Alpine)|`sudo docker exec -it <container_name> supervisorctl -c /opt/datadog-agent/agent/supervisor.conf status`|`n/a`|
 |MacOS x|`datadog-agent status`             | `launchctl list com.datadoghq.agent` or systray app|
 |Source|`sudo ~/.datadog-agent/bin/agent status`|`sudo service datadog-agent status`|


### PR DESCRIPTION
### What does this PR do?
A customer pointed out that the command for checking the docker agent status was incorrect. He offered a solution and I confirmed that it works correctly:

https://docs-staging.datadoghq.com/gus/agent-command-update/agent/faq/agent-commands/#agent-status-and-information