### PR TITLE
Adding serverless dd metrics lib

### DIFF
--- a/data/libraries.yaml
+++ b/data/libraries.yaml
@@ -88,6 +88,12 @@ Classic:
       link: https://github.com/chonton/dogstatd-client
       dogstatsd: true
       authors: Chas Honton
+  - Lambda:
+    - name: serverless-datadog-metrics
+      link: https://github.com/DanteInc/serverless-datadog-metrics
+      api: true
+      authors: Dante Consulting, Inc.
+      notes: This library logs useful metrics from AWS Lambda functions, so that they can be accumulated via Datadog's AWS Lambda integration
   - NiFi:
     - name: DataDogReportingTask
       link: https://nifi.apache.org/docs/nifi-docs/components/org.apache.nifi/nifi-datadog-nar/1.5.0/org.apache.nifi.reporting.datadog.DataDogReportingTask/index.html


### PR DESCRIPTION
### What does this PR do?

Adding https://github.com/DanteInc/serverless-datadog-metrics to the list of lib