### PR TITLE
Adding configuration file for windows

### DIFF
--- a/content/agent/troubleshooting.fr.md
+++ b/content/agent/troubleshooting.fr.md
@@ -25,7 +25,7 @@ Si vous n'êtes toujours pas sûr du problème, vous pouvez contacter [l'équipe
 
 Pour activer le mode debug complet:
 
-1. Modifiez votre fichier `datadog.yaml` local (consultez [cette page](/agent/#configuration-files) pour localiser ce fichier de configuration sur votre instance)
+1. Modifiez votre fichier `datadog.yaml` local (consultez [cette page](/agent/basic_agent_usage/#configuration-files) pour localiser ce fichier de configuration sur votre instance)
 
 2. Remplacez `# log_level: INFO` par` log_level: DEBUG` (assurez-vous de vous débarrasser de # pour décommenter la ligne)
 

--- a/content/agent/troubleshooting.md
+++ b/content/agent/troubleshooting.md
@@ -26,7 +26,7 @@ If you're still unsure about the issue, you may reach out to [Datadog support te
 
 To enable the full debug mode:
 
-1. Modify your local `datadog.yaml` file (see [this page](/agent/#configuration-files) to locate this configuration file on your instance)
+1. Modify your local `datadog.yaml` file (see [this page](/agent/basic_agent_usage/#configuration-files) to locate this configuration file on your instance)
 
 2. Replace `# log_level: INFO` with `log_level: DEBUG` (make sure to get rid of # to uncomment the line)
 

--- a/content/graphing/infrastructure/process.md
+++ b/content/graphing/infrastructure/process.md
@@ -31,11 +31,16 @@ The following installation processes are for [agent v6 only](/agent), if you are
 
 The process agent is shipped by default with Agent 6 in Linux packages only. Refer to the instructions for standard [Agent installation](https://app.datadoghq.com/account/settings#agent) for platform-specific details.
 
-Once the Datadog Agent is installed, enable Live Processes collection by editing the [configuration file](/agent/#configuration-file) at :
+Once the Datadog Agent is installed, enable Live Processes collection by editing the [configuration file](/agent/basic_agent_usage/#configuration-file) at:
 
-```
-/etc/datadog-agent/datadog.yaml
-```
+* Linux
+  ```
+  /etc/datadog-agent/datadog.yaml
+  ```
+* Windows:
+  ```
+  \\ProgramData\Datadog\datadog.yaml
+  ```
 
 by adding the following:
 


### PR DESCRIPTION
The documentation at:

https://docs.datadoghq.com/graphing/infrastructure/process/#process-agent

doesn't give enough informations for Windows users to install the process agent. A customer had difficulty configuring the process agent on Windows.

