### PR TITLE
Replacing api & app keys with placeholder

### DIFF
--- a/content/api/authentication/code_snippets/api-auth.py
+++ b/content/api/authentication/code_snippets/api-auth.py
@@ -1,6 +1,6 @@
 from datadog import initialize, api
 
-options = {'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-           'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'}
+options = {'api_key': '<YOUR_API_KEY>',
+           'app_key': '<YOUR_APP_KEY>'}
 
 initialize(**options)

--- a/content/api/authentication/code_snippets/api-auth.rb
+++ b/content/api/authentication/code_snippets/api-auth.rb
@@ -1,4 +1,4 @@
 require 'rubygems'
 require 'dogapi'
 
-dog = Dogapi::Client.new('9775a026f1ca7d1c6c5af9d94d9595a4', '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff')
+dog = Dogapi::Client.new('<YOUR_API_KEY>', '<YOUR_APP_KEY>')

--- a/content/api/authentication/code_snippets/api-auth.sh
+++ b/content/api/authentication/code_snippets/api-auth.sh
@@ -1,6 +1,6 @@
 
 
 
-curl "https://api.datadoghq.com/api/v1/validate?api_key=9775a026f1ca7d1c6c5af9d94d9595a4"
+curl "https://api.datadoghq.com/api/v1/validate?api_key=<YOUR_API_KEY>"
 
 

--- a/content/api/checks/code_snippets/api-checks-post.py
+++ b/content/api/checks/code_snippets/api-checks-post.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 from datadog.api.constants import CheckStatus
 
-options = {'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-           'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'}
+options = {'api_key': '<YOUR_API_KEY>',
+           'app_key': '<YOUR_APP_KEY>'}
 
 initialize(**options)
 

--- a/content/api/checks/code_snippets/api-checks-post.rb
+++ b/content/api/checks/code_snippets/api-checks-post.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/checks/code_snippets/api-checks-post.sh
+++ b/content/api/checks/code_snippets/api-checks-post.sh
@@ -9,5 +9,5 @@ curl  -X POST -H "Content-type: application/json" \
       \"timestamp\": $currenttime,
       \"status\": 0
 }" \
-'https://api.datadoghq.com/api/v1/check_run?api_key=9775a026f1ca7d1c6c5af9d94d9595a4'
+'https://api.datadoghq.com/api/v1/check_run?api_key=<YOUR_API_KEY>'
 

--- a/content/api/comments/code_snippets/api-comment-create.py
+++ b/content/api/comments/code_snippets/api-comment-create.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/comments/code_snippets/api-comment-create.rb
+++ b/content/api/comments/code_snippets/api-comment-create.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/comments/code_snippets/api-comment-create.sh
+++ b/content/api/comments/code_snippets/api-comment-create.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl  -X POST -H "Content-type: application/json" \
 -d '{

--- a/content/api/comments/code_snippets/api-comment-delete.py
+++ b/content/api/comments/code_snippets/api-comment-delete.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/comments/code_snippets/api-comment-delete.rb
+++ b/content/api/comments/code_snippets/api-comment-delete.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/comments/code_snippets/api-comment-delete.sh
+++ b/content/api/comments/code_snippets/api-comment-delete.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 # comment_id=1382559936236196216
 
 # Create a comment to delete. Use jq (http://stedolan.github.io/jq/download/) to get the comment id.

--- a/content/api/comments/code_snippets/api-comment-edit.py
+++ b/content/api/comments/code_snippets/api-comment-edit.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 from time import sleep
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/comments/code_snippets/api-comment-edit.rb
+++ b/content/api/comments/code_snippets/api-comment-edit.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 comment_id = "1382579089039712607"
 
 dog = Dogapi::Client.new(api_key, app_key)

--- a/content/api/comments/code_snippets/api-comment-edit.sh
+++ b/content/api/comments/code_snippets/api-comment-edit.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 comment_id=1382557387240472966
 
 # Create a comment to edit. Use jq (http://stedolan.github.io/jq/download/) to get the comment id.

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-add-items.py
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-add-items.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-add-items.rb
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-add-items.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-add-items.sh
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-add-items.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 list_id=4741
 

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-create.py
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-create.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-create.rb
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-create.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-create.sh
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-create.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -X POST -H "Content-type: application/json" \
 -d '{

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-delete-items.py
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-delete-items.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-delete-items.rb
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-delete-items.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-delete-items.sh
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-delete-items.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 list_id=4741
 

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-delete.py
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-delete.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-delete.rb
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-delete.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-delete.sh
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-delete.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 list_id=4741
 

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-get-all.py
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-get-all.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-get-all.rb
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-get-all.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-get-all.sh
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-get-all.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -X GET \
 "https://api.datadoghq.com/api/v1/dashboard/lists/manual?api_key=${api_key}&application_key=${app_key}"

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-get-items.py
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-get-items.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-get-items.rb
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-get-items.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-get-items.sh
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-get-items.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 list_id=4741
 

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-get.py
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-get.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-get.rb
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-get.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-get.sh
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-get.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 list_id=4741
 

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-update-items.py
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-update-items.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-update-items.rb
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-update-items.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-update-items.sh
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-update-items.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 list_id=4741
 

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-update.py
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-update.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-update.rb
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-update.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/dashboard_lists/code_snippets/api-dashboard-list-update.sh
+++ b/content/api/dashboard_lists/code_snippets/api-dashboard-list-update.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 list_id=4741
 

--- a/content/api/downtimes/code_snippets/api-monitor-cancel-downtime-by-scope.sh
+++ b/content/api/downtimes/code_snippets/api-monitor-cancel-downtime-by-scope.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-api_key="9775a026f1ca7d1c6c5af9d94d9595a4"
-app_key="87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"
+api_key="<YOUR_API_KEY>"
+app_key="<YOUR_APP_KEY>"
 
 curl -X POST -H "Content-type: application/json" -H "Accept: application/json" \
 -d "{

--- a/content/api/downtimes/code_snippets/api-monitor-cancel-downtime.py
+++ b/content/api/downtimes/code_snippets/api-monitor-cancel-downtime.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/downtimes/code_snippets/api-monitor-cancel-downtime.rb
+++ b/content/api/downtimes/code_snippets/api-monitor-cancel-downtime.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/downtimes/code_snippets/api-monitor-cancel-downtime.sh
+++ b/content/api/downtimes/code_snippets/api-monitor-cancel-downtime.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 downtime_id=1656
 
 # Create a downtime to delete

--- a/content/api/downtimes/code_snippets/api-monitor-get-downtime.py
+++ b/content/api/downtimes/code_snippets/api-monitor-get-downtime.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/downtimes/code_snippets/api-monitor-get-downtime.sh
+++ b/content/api/downtimes/code_snippets/api-monitor-get-downtime.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 downtime_id=2473
 

--- a/content/api/downtimes/code_snippets/api-monitor-get-downtimes.py
+++ b/content/api/downtimes/code_snippets/api-monitor-get-downtimes.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/downtimes/code_snippets/api-monitor-get-downtimes.rb
+++ b/content/api/downtimes/code_snippets/api-monitor-get-downtimes.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/downtimes/code_snippets/api-monitor-get-downtimes.sh
+++ b/content/api/downtimes/code_snippets/api-monitor-get-downtimes.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 
 curl -G "https://api.datadoghq.com/api/v1/downtime" \

--- a/content/api/downtimes/code_snippets/api-monitor-schedule-downtime.py
+++ b/content/api/downtimes/code_snippets/api-monitor-schedule-downtime.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 import time
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/downtimes/code_snippets/api-monitor-schedule-downtime.rb
+++ b/content/api/downtimes/code_snippets/api-monitor-schedule-downtime.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/downtimes/code_snippets/api-monitor-schedule-downtime.sh
+++ b/content/api/downtimes/code_snippets/api-monitor-schedule-downtime.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 
 start=$(date +%s)

--- a/content/api/downtimes/code_snippets/api-monitor-update-downtime.py
+++ b/content/api/downtimes/code_snippets/api-monitor-update-downtime.py
@@ -3,8 +3,8 @@ import time
 
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/downtimes/code_snippets/api-monitor-update-downtime.rb
+++ b/content/api/downtimes/code_snippets/api-monitor-update-downtime.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/downtimes/code_snippets/api-monitor-update-downtime.sh
+++ b/content/api/downtimes/code_snippets/api-monitor-update-downtime.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 downtime_id=4336
 
 # Create a downtime to update

--- a/content/api/embeds/code_snippets/api-embeds-create.py
+++ b/content/api/embeds/code_snippets/api-embeds-create.py
@@ -3,8 +3,8 @@ import json
 
 # Intialize request parameters including API/APP key
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/embeds/code_snippets/api-embeds-create.rb
+++ b/content/api/embeds/code_snippets/api-embeds-create.rb
@@ -2,8 +2,8 @@ require 'rubygems'
 require 'dogapi'
 
 # Initialize API Client
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/embeds/code_snippets/api-embeds-create.sh
+++ b/content/api/embeds/code_snippets/api-embeds-create.sh
@@ -1,5 +1,5 @@
-api_key="9775a026f1ca7d1c6c5af9d94d9595a4"
-app_key="87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"
+api_key="<YOUR_API_KEY>"
+app_key="<YOUR_APP_KEY>"
 
 
 

--- a/content/api/embeds/code_snippets/api-embeds-enable.py
+++ b/content/api/embeds/code_snippets/api-embeds-enable.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 
 # Intialize request parameters including API/APP key
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/embeds/code_snippets/api-embeds-enable.rb
+++ b/content/api/embeds/code_snippets/api-embeds-enable.rb
@@ -2,8 +2,8 @@ require 'rubygems'
 require 'dogapi'
 
 # Initialize API Client
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/embeds/code_snippets/api-embeds-enable.sh
+++ b/content/api/embeds/code_snippets/api-embeds-enable.sh
@@ -1,5 +1,5 @@
-api_key="9775a026f1ca7d1c6c5af9d94d9595a4"
-app_key="87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"
+api_key="<YOUR_API_KEY>"
+app_key="<YOUR_APP_KEY>"
 embed_id="5f585b01c81b12ecdf5f40df0382738d0919170639985d3df5e2fc4232865b0c"
 
 

--- a/content/api/embeds/code_snippets/api-embeds-get-all.py
+++ b/content/api/embeds/code_snippets/api-embeds-get-all.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 
 # Intialize request parameters including API/APP key
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/embeds/code_snippets/api-embeds-get-all.rb
+++ b/content/api/embeds/code_snippets/api-embeds-get-all.rb
@@ -2,8 +2,8 @@ require 'rubygems'
 require 'dogapi'
 
 # Initialize API Client
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/embeds/code_snippets/api-embeds-get-all.sh
+++ b/content/api/embeds/code_snippets/api-embeds-get-all.sh
@@ -1,5 +1,5 @@
-api_key="9775a026f1ca7d1c6c5af9d94d9595a4"
-app_key="87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"
+api_key="<YOUR_API_KEY>"
+app_key="<YOUR_APP_KEY>"
 
 
 

--- a/content/api/embeds/code_snippets/api-embeds-get.py
+++ b/content/api/embeds/code_snippets/api-embeds-get.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 
 # Intialize request parameters including API/APP key
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/embeds/code_snippets/api-embeds-get.rb
+++ b/content/api/embeds/code_snippets/api-embeds-get.rb
@@ -2,8 +2,8 @@ require 'rubygems'
 require 'dogapi'
 
 # Initialize API Client
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/embeds/code_snippets/api-embeds-get.sh
+++ b/content/api/embeds/code_snippets/api-embeds-get.sh
@@ -1,5 +1,5 @@
-api_key="9775a026f1ca7d1c6c5af9d94d9595a4"
-app_key="87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"
+api_key="<YOUR_API_KEY>"
+app_key="<YOUR_APP_KEY>"
 
 
 embed_id="5f585b01c81b12ecdf5f40df0382738d0919170639985d3df5e2fc4232865b0c"

--- a/content/api/embeds/code_snippets/api-embeds-revoke.py
+++ b/content/api/embeds/code_snippets/api-embeds-revoke.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 
 # Intialize request parameters including API/APP key
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/embeds/code_snippets/api-embeds-revoke.rb
+++ b/content/api/embeds/code_snippets/api-embeds-revoke.rb
@@ -2,8 +2,8 @@ require 'rubygems'
 require 'dogapi'
 
 # Initialize API Client
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/embeds/code_snippets/api-embeds-revoke.sh
+++ b/content/api/embeds/code_snippets/api-embeds-revoke.sh
@@ -1,5 +1,5 @@
-api_key="9775a026f1ca7d1c6c5af9d94d9595a4"
-app_key="87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"
+api_key="<YOUR_API_KEY>"
+app_key="<YOUR_APP_KEY>"
 
 
 

--- a/content/api/events/code_snippets/api-events-delete.py
+++ b/content/api/events/code_snippets/api-events-delete.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/events/code_snippets/api-events-delete.rb
+++ b/content/api/events/code_snippets/api-events-delete.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/events/code_snippets/api-events-delete.sh
+++ b/content/api/events/code_snippets/api-events-delete.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 
 event_id=1377281704830403917

--- a/content/api/events/code_snippets/api-events-get.py
+++ b/content/api/events/code_snippets/api-events-get.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/events/code_snippets/api-events-get.rb
+++ b/content/api/events/code_snippets/api-events-get.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/events/code_snippets/api-events-get.sh
+++ b/content/api/events/code_snippets/api-events-get.sh
@@ -1,9 +1,9 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 event_id=1377281704830403917
 
 # Create an event to get
-event_id=$(curl  -X POST -H "Content-type: application/json" -d "{\"title\": \"Did you hear the news today?\"}" "https://api.datadoghq.com/api/v1/events?api_key=9775a026f1ca7d1c6c5af9d94d9595a4" | jq -r '.event.url|ltrimstr("https://app.datadoghq.com/event/event?id=")')
+event_id=$(curl  -X POST -H "Content-type: application/json" -d "{\"title\": \"Did you hear the news today?\"}" "https://api.datadoghq.com/api/v1/events?api_key=<YOUR_API_KEY>" | jq -r '.event.url|ltrimstr("https://app.datadoghq.com/event/event?id=")')
 sleep 5
 
 curl "https://api.datadoghq.com/api/v1/events/${event_id}?api_key=${api_key}&application_key=${app_key}"

--- a/content/api/events/code_snippets/api-events-post.py
+++ b/content/api/events/code_snippets/api-events-post.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/events/code_snippets/api-events-post.rb
+++ b/content/api/events/code_snippets/api-events-post.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/events/code_snippets/api-events-post.sh
+++ b/content/api/events/code_snippets/api-events-post.sh
@@ -10,7 +10,7 @@ curl  -X POST -H "Content-type: application/json" \
       "tags": ["environment:test"],
       "alert_type": "info"
 }' \
-'https://api.datadoghq.com/api/v1/events?api_key=9775a026f1ca7d1c6c5af9d94d9595a4'
+'https://api.datadoghq.com/api/v1/events?api_key=<YOUR_API_KEY>'
 
 
 

--- a/content/api/events/code_snippets/api-events-stream.py
+++ b/content/api/events/code_snippets/api-events-stream.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 import time
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/events/code_snippets/api-events-stream.rb
+++ b/content/api/events/code_snippets/api-events-stream.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/events/code_snippets/api-events-stream.sh
+++ b/content/api/events/code_snippets/api-events-stream.sh
@@ -7,6 +7,6 @@ curl -G -H "Content-type: application/json" \
     -d "end=${currenttime}" \
     -d "sources=My Apps" \
     -d "tags=application:web,version:1" \
-    -d "api_key=9775a026f1ca7d1c6c5af9d94d9595a4" \
-    -d "application_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff" \
+    -d "api_key=<YOUR_API_KEY>" \
+    -d "application_key=<YOUR_APP_KEY>" \
     'https://api.datadoghq.com/api/v1/events'

--- a/content/api/graphs/code_snippets/api-graph-snapshot.py
+++ b/content/api/graphs/code_snippets/api-graph-snapshot.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 import time
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/graphs/code_snippets/api-graph-snapshot.rb
+++ b/content/api/graphs/code_snippets/api-graph-snapshot.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/graphs/code_snippets/api-graph-snapshot.sh
+++ b/content/api/graphs/code_snippets/api-graph-snapshot.sh
@@ -6,7 +6,7 @@ curl -G -H "Content-type: application/json" \
     -d "metric_query=system.load.1{*}" \
     -d "start=${currenttime2}" \
     -d "end=${currenttime}" \
-    -d "api_key=9775a026f1ca7d1c6c5af9d94d9595a4" \
-    -d "application_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff" \
+    -d "api_key=<YOUR_API_KEY>" \
+    -d "application_key=<YOUR_APP_KEY>" \
     'https://api.datadoghq.com/api/v1/graph/snapshot'
 

--- a/content/api/hosts/code_snippets/api-host-mute.py
+++ b/content/api/hosts/code_snippets/api-host-mute.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/hosts/code_snippets/api-host-mute.rb
+++ b/content/api/hosts/code_snippets/api-host-mute.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/hosts/code_snippets/api-host-mute.sh
+++ b/content/api/hosts/code_snippets/api-host-mute.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 
 

--- a/content/api/hosts/code_snippets/api-host-unmute.py
+++ b/content/api/hosts/code_snippets/api-host-unmute.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/hosts/code_snippets/api-host-unmute.rb
+++ b/content/api/hosts/code_snippets/api-host-unmute.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/hosts/code_snippets/api-host-unmute.sh
+++ b/content/api/hosts/code_snippets/api-host-unmute.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 
 

--- a/content/api/metrics/code_snippets/api-metric-metadata-get.py
+++ b/content/api/metrics/code_snippets/api-metric-metadata-get.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/metrics/code_snippets/api-metric-metadata-get.rb
+++ b/content/api/metrics/code_snippets/api-metric-metadata-get.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = "9775a026f1ca7d1c6c5af9d94d9595a4"
+api_key = "<YOUR_API_KEY>"
 
 
 dog = Dogapi::Client.new(api_key)

--- a/content/api/metrics/code_snippets/api-metric-metadata-get.sh
+++ b/content/api/metrics/code_snippets/api-metric-metadata-get.sh
@@ -1,6 +1,6 @@
 
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 
 metric_name="system.net.bytes_sent"

--- a/content/api/metrics/code_snippets/api-metric-metadata-update.py
+++ b/content/api/metrics/code_snippets/api-metric-metadata-update.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/metrics/code_snippets/api-metric-metadata-update.rb
+++ b/content/api/metrics/code_snippets/api-metric-metadata-update.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = "9775a026f1ca7d1c6c5af9d94d9595a4"
+api_key = "<YOUR_API_KEY>"
 
 dog = Dogapi::Client.new(api_key)
 

--- a/content/api/metrics/code_snippets/api-metric-metadata-update.sh
+++ b/content/api/metrics/code_snippets/api-metric-metadata-update.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 
 metric_name="system.net.bytes_sent"

--- a/content/api/metrics/code_snippets/api-metrics-list.py
+++ b/content/api/metrics/code_snippets/api-metrics-list.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 import time
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/metrics/code_snippets/api-metrics-list.sh
+++ b/content/api/metrics/code_snippets/api-metrics-list.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 from_time=$(date -v -1d +%s)
 

--- a/content/api/metrics/code_snippets/api-metrics-post.py
+++ b/content/api/metrics/code_snippets/api-metrics-post.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 import time
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/metrics/code_snippets/api-metrics-post.rb
+++ b/content/api/metrics/code_snippets/api-metrics-post.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = "9775a026f1ca7d1c6c5af9d94d9595a4"
+api_key = "<YOUR_API_KEY>"
 
 dog = Dogapi::Client.new(api_key)
 

--- a/content/api/metrics/code_snippets/api-metrics-post.sh
+++ b/content/api/metrics/code_snippets/api-metrics-post.sh
@@ -12,7 +12,7 @@ curl  -X POST -H "Content-type: application/json" \
           \"tags\":[\"environment:test\"]}
         ]
 }" \
-'https://api.datadoghq.com/api/v1/series?api_key=9775a026f1ca7d1c6c5af9d94d9595a4'
+'https://api.datadoghq.com/api/v1/series?api_key=<YOUR_API_KEY>'
 
 
 

--- a/content/api/metrics/code_snippets/api-metrics-query.py
+++ b/content/api/metrics/code_snippets/api-metrics-query.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 import time
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/metrics/code_snippets/api-metrics-query.rb
+++ b/content/api/metrics/code_snippets/api-metrics-query.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = "9775a026f1ca7d1c6c5af9d94d9595a4"
-application_key = "87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"
+api_key = "<YOUR_API_KEY>"
+application_key = "<YOUR_APP_KEY>"
 
 dog = Dogapi::Client.new(api_key, application_key)
 

--- a/content/api/metrics/code_snippets/api-metrics-query.sh
+++ b/content/api/metrics/code_snippets/api-metrics-query.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 to_time=$(date +%s)
 from_time=$(date -v -1d +%s)
 

--- a/content/api/monitors/code_snippets/api-monitor-bulk-resolve.sh
+++ b/content/api/monitors/code_snippets/api-monitor-bulk-resolve.sh
@@ -2,8 +2,8 @@
 # Replace the API and/or APP key below
 # with the ones for your account
 
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 monitor_id= <YOUR_MONITOR_ID>
 group_1=<YOUR_FIRST_GROUP>

--- a/content/api/monitors/code_snippets/api-monitor-create.py
+++ b/content/api/monitors/code_snippets/api-monitor-create.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/monitors/code_snippets/api-monitor-create.rb
+++ b/content/api/monitors/code_snippets/api-monitor-create.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/monitors/code_snippets/api-monitor-create.sh
+++ b/content/api/monitors/code_snippets/api-monitor-create.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -X POST -H "Content-type: application/json" \
 -d '{

--- a/content/api/monitors/code_snippets/api-monitor-delete.py
+++ b/content/api/monitors/code_snippets/api-monitor-delete.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/monitors/code_snippets/api-monitor-delete.rb
+++ b/content/api/monitors/code_snippets/api-monitor-delete.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/monitors/code_snippets/api-monitor-delete.sh
+++ b/content/api/monitors/code_snippets/api-monitor-delete.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 monitor_id=59409
 
 # Create a monitor to delete

--- a/content/api/monitors/code_snippets/api-monitor-edit.py
+++ b/content/api/monitors/code_snippets/api-monitor-edit.py
@@ -1,8 +1,8 @@
 from datadog import initialize,  api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/monitors/code_snippets/api-monitor-edit.rb
+++ b/content/api/monitors/code_snippets/api-monitor-edit.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/monitors/code_snippets/api-monitor-edit.sh
+++ b/content/api/monitors/code_snippets/api-monitor-edit.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 monitor_id=91879
 
 # Create a monitor to edit

--- a/content/api/monitors/code_snippets/api-monitor-mute-all.py
+++ b/content/api/monitors/code_snippets/api-monitor-mute-all.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/monitors/code_snippets/api-monitor-mute-all.rb
+++ b/content/api/monitors/code_snippets/api-monitor-mute-all.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/monitors/code_snippets/api-monitor-mute-all.sh
+++ b/content/api/monitors/code_snippets/api-monitor-mute-all.sh
@@ -1,6 +1,6 @@
 
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 
 curl -X POST "https://api.datadoghq.com/api/v1/monitor/mute_all?api_key=${api_key}&application_key=${app_key}"

--- a/content/api/monitors/code_snippets/api-monitor-mute.py
+++ b/content/api/monitors/code_snippets/api-monitor-mute.py
@@ -2,8 +2,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 

--- a/content/api/monitors/code_snippets/api-monitor-mute.rb
+++ b/content/api/monitors/code_snippets/api-monitor-mute.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/monitors/code_snippets/api-monitor-mute.sh
+++ b/content/api/monitors/code_snippets/api-monitor-mute.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 monitor_id=62628
 
 # Create a monitor to mute

--- a/content/api/monitors/code_snippets/api-monitor-show-all.py
+++ b/content/api/monitors/code_snippets/api-monitor-show-all.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/monitors/code_snippets/api-monitor-show-all.rb
+++ b/content/api/monitors/code_snippets/api-monitor-show-all.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/monitors/code_snippets/api-monitor-show-all.sh
+++ b/content/api/monitors/code_snippets/api-monitor-show-all.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 
 curl -G "https://api.datadoghq.com/api/v1/monitor" \

--- a/content/api/monitors/code_snippets/api-monitor-show.py
+++ b/content/api/monitors/code_snippets/api-monitor-show.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 

--- a/content/api/monitors/code_snippets/api-monitor-show.rb
+++ b/content/api/monitors/code_snippets/api-monitor-show.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/monitors/code_snippets/api-monitor-show.sh
+++ b/content/api/monitors/code_snippets/api-monitor-show.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 monitor_id=91879
 
 # Create a monitor to show

--- a/content/api/monitors/code_snippets/api-monitor-unmute-all.py
+++ b/content/api/monitors/code_snippets/api-monitor-unmute-all.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/monitors/code_snippets/api-monitor-unmute-all.rb
+++ b/content/api/monitors/code_snippets/api-monitor-unmute-all.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/monitors/code_snippets/api-monitor-unmute-all.sh
+++ b/content/api/monitors/code_snippets/api-monitor-unmute-all.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 
 curl -X POST "https://api.datadoghq.com/api/v1/monitor/unmute_all?api_key=${api_key}&application_key=${app_key}"

--- a/content/api/monitors/code_snippets/api-monitor-unmute.py
+++ b/content/api/monitors/code_snippets/api-monitor-unmute.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 

--- a/content/api/monitors/code_snippets/api-monitor-unmute.rb
+++ b/content/api/monitors/code_snippets/api-monitor-unmute.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/monitors/code_snippets/api-monitor-unmute.sh
+++ b/content/api/monitors/code_snippets/api-monitor-unmute.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 monitor_id=62628
 
 # Create a monitor to unmute

--- a/content/api/org/code_snippets/api-idp-upload.sh
+++ b/content/api/org/code_snippets/api-idp-upload.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 public_id=axd2s
 
 curl -X POST -H "Content-Type: multipart/form-data" -F "idp_file=@metadata.xml" \

--- a/content/api/org/code_snippets/api-org-create.sh
+++ b/content/api/org/code_snippets/api-org-create.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -X POST -H "Content-type: application/json" \
     -d '{

--- a/content/api/org/code_snippets/api-org-get.sh
+++ b/content/api/org/code_snippets/api-org-get.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 public_id=axd2s
 
 curl -X GET "https://api.datadoghq.com/api/v1/org/${public_id}?api_key=${api_key}&application_key=${app_key}"

--- a/content/api/org/code_snippets/api-org-update.sh
+++ b/content/api/org/code_snippets/api-org-update.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 public_id=axd2s
 
 curl -X PUT -H "Content-type: application/json" \

--- a/content/api/screenboards/code_snippets/api-screenboard-create.py
+++ b/content/api/screenboards/code_snippets/api-screenboard-create.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/screenboards/code_snippets/api-screenboard-create.rb
+++ b/content/api/screenboards/code_snippets/api-screenboard-create.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/screenboards/code_snippets/api-screenboard-create.sh
+++ b/content/api/screenboards/code_snippets/api-screenboard-create.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -X POST -H "Content-type: application/json" \
 -d '{

--- a/content/api/screenboards/code_snippets/api-screenboard-delete.py
+++ b/content/api/screenboards/code_snippets/api-screenboard-delete.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/screenboards/code_snippets/api-screenboard-delete.rb
+++ b/content/api/screenboards/code_snippets/api-screenboard-delete.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/screenboards/code_snippets/api-screenboard-delete.sh
+++ b/content/api/screenboards/code_snippets/api-screenboard-delete.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 board_id=2471
 
 # Create a screenboard to delete

--- a/content/api/screenboards/code_snippets/api-screenboard-get-all.py
+++ b/content/api/screenboards/code_snippets/api-screenboard-get-all.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/screenboards/code_snippets/api-screenboard-get-all.rb
+++ b/content/api/screenboards/code_snippets/api-screenboard-get-all.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/screenboards/code_snippets/api-screenboard-get-all.sh
+++ b/content/api/screenboards/code_snippets/api-screenboard-get-all.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 
 

--- a/content/api/screenboards/code_snippets/api-screenboard-get.py
+++ b/content/api/screenboards/code_snippets/api-screenboard-get.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/screenboards/code_snippets/api-screenboard-get.rb
+++ b/content/api/screenboards/code_snippets/api-screenboard-get.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/screenboards/code_snippets/api-screenboard-get.sh
+++ b/content/api/screenboards/code_snippets/api-screenboard-get.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 board_id=6334
 
 # Create a screenboard to get

--- a/content/api/screenboards/code_snippets/api-screenboard-revoke.py
+++ b/content/api/screenboards/code_snippets/api-screenboard-revoke.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/screenboards/code_snippets/api-screenboard-revoke.rb
+++ b/content/api/screenboards/code_snippets/api-screenboard-revoke.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/screenboards/code_snippets/api-screenboard-revoke.sh
+++ b/content/api/screenboards/code_snippets/api-screenboard-revoke.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 board_id=6334
 
 # Create a screenboard to share

--- a/content/api/screenboards/code_snippets/api-screenboard-share.py
+++ b/content/api/screenboards/code_snippets/api-screenboard-share.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/screenboards/code_snippets/api-screenboard-share.rb
+++ b/content/api/screenboards/code_snippets/api-screenboard-share.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/screenboards/code_snippets/api-screenboard-share.sh
+++ b/content/api/screenboards/code_snippets/api-screenboard-share.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 board_id=6334
 
 # Create a screenboard to share

--- a/content/api/screenboards/code_snippets/api-screenboard-update.py
+++ b/content/api/screenboards/code_snippets/api-screenboard-update.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/screenboards/code_snippets/api-screenboard-update.rb
+++ b/content/api/screenboards/code_snippets/api-screenboard-update.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/screenboards/code_snippets/api-screenboard-update.sh
+++ b/content/api/screenboards/code_snippets/api-screenboard-update.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -X PUT -H "Content-type: application/json" \
 -d '{

--- a/content/api/search/code_snippets/api-search.py
+++ b/content/api/search/code_snippets/api-search.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/search/code_snippets/api-search.rb
+++ b/content/api/search/code_snippets/api-search.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/search/code_snippets/api-search.sh
+++ b/content/api/search/code_snippets/api-search.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -G "https://api.datadoghq.com/api/v1/search" \
     -d "api_key=${api_key}" \

--- a/content/api/tags/code_snippets/api-tags-add.py
+++ b/content/api/tags/code_snippets/api-tags-add.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/tags/code_snippets/api-tags-add.rb
+++ b/content/api/tags/code_snippets/api-tags-add.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/tags/code_snippets/api-tags-add.sh
+++ b/content/api/tags/code_snippets/api-tags-add.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 host=YourHostName
 source=YourSource

--- a/content/api/tags/code_snippets/api-tags-get-host.py
+++ b/content/api/tags/code_snippets/api-tags-get-host.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/tags/code_snippets/api-tags-get-host.rb
+++ b/content/api/tags/code_snippets/api-tags-get-host.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/tags/code_snippets/api-tags-get-host.sh
+++ b/content/api/tags/code_snippets/api-tags-get-host.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 # pass a single hostname as an argument to search for the specified host
 host=$1

--- a/content/api/tags/code_snippets/api-tags-get.py
+++ b/content/api/tags/code_snippets/api-tags-get.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/tags/code_snippets/api-tags-get.rb
+++ b/content/api/tags/code_snippets/api-tags-get.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/tags/code_snippets/api-tags-get.sh
+++ b/content/api/tags/code_snippets/api-tags-get.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl "https://api.datadoghq.com/api/v1/tags/hosts?api_key=${api_key}&application_key=${app_key}"
 

--- a/content/api/tags/code_snippets/api-tags-remove.py
+++ b/content/api/tags/code_snippets/api-tags-remove.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/tags/code_snippets/api-tags-remove.rb
+++ b/content/api/tags/code_snippets/api-tags-remove.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/tags/code_snippets/api-tags-remove.sh
+++ b/content/api/tags/code_snippets/api-tags-remove.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 # Find a host to remove a tag from
 host_name=$(curl -G "https://api.datadoghq.com/api/v1/search" \

--- a/content/api/tags/code_snippets/api-tags-update.py
+++ b/content/api/tags/code_snippets/api-tags-update.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/tags/code_snippets/api-tags-update.rb
+++ b/content/api/tags/code_snippets/api-tags-update.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/tags/code_snippets/api-tags-update.sh
+++ b/content/api/tags/code_snippets/api-tags-update.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 host_name=test.host
 
 curl -X PUT -H "Content-type: application/json" \

--- a/content/api/timeboards/code_snippets/api-dashboard-create.py
+++ b/content/api/timeboards/code_snippets/api-dashboard-create.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/timeboards/code_snippets/api-dashboard-create.rb
+++ b/content/api/timeboards/code_snippets/api-dashboard-create.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/timeboards/code_snippets/api-dashboard-create.sh
+++ b/content/api/timeboards/code_snippets/api-dashboard-create.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 
 

--- a/content/api/timeboards/code_snippets/api-dashboard-delete.py
+++ b/content/api/timeboards/code_snippets/api-dashboard-delete.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/timeboards/code_snippets/api-dashboard-delete.rb
+++ b/content/api/timeboards/code_snippets/api-dashboard-delete.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/timeboards/code_snippets/api-dashboard-delete.sh
+++ b/content/api/timeboards/code_snippets/api-dashboard-delete.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 dash_id=2471
 
 # Create a dashboard to delete. Use jq (http://stedolan.github.io/jq/download/) to get the dash id.

--- a/content/api/timeboards/code_snippets/api-dashboard-get-all.py
+++ b/content/api/timeboards/code_snippets/api-dashboard-get-all.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/timeboards/code_snippets/api-dashboard-get-all.rb
+++ b/content/api/timeboards/code_snippets/api-dashboard-get-all.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/timeboards/code_snippets/api-dashboard-get-all.sh
+++ b/content/api/timeboards/code_snippets/api-dashboard-get-all.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl "https://api.datadoghq.com/api/v1/dash?api_key=${api_key}&application_key=${app_key}"
 

--- a/content/api/timeboards/code_snippets/api-dashboard-get.py
+++ b/content/api/timeboards/code_snippets/api-dashboard-get.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/timeboards/code_snippets/api-dashboard-get.rb
+++ b/content/api/timeboards/code_snippets/api-dashboard-get.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/timeboards/code_snippets/api-dashboard-get.sh
+++ b/content/api/timeboards/code_snippets/api-dashboard-get.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 dash_id=2473
 
 # Create a dashboard to get. Use jq (http://stedolan.github.io/jq/download/) to get the dash id.

--- a/content/api/timeboards/code_snippets/api-dashboard-update.py
+++ b/content/api/timeboards/code_snippets/api-dashboard-update.py
@@ -1,7 +1,7 @@
 from datadog import initialize, api
 
-options = {'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-           'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'}
+options = {'api_key': '<YOUR_API_KEY>',
+           'app_key': '<YOUR_APP_KEY>'}
 
 initialize(**options)
 

--- a/content/api/timeboards/code_snippets/api-dashboard-update.rb
+++ b/content/api/timeboards/code_snippets/api-dashboard-update.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/timeboards/code_snippets/api-dashboard-update.sh
+++ b/content/api/timeboards/code_snippets/api-dashboard-update.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 dash_id=2532
 
 # Create a dashboard to get. Use jq (http://stedolan.github.io/jq/download/) to get the dash id.

--- a/content/api/usage/code_snippets/api-billing-usage-hosts.sh
+++ b/content/api/usage/code_snippets/api-billing-usage-hosts.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 start_hr=$(date -v -10d +%Y-%m-%dT%H)
 end_hr=$(date +%Y-%m-%dT%H)

--- a/content/api/usage/code_snippets/api-billing-usage-summary.sh
+++ b/content/api/usage/code_snippets/api-billing-usage-summary.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 start_month=$(date -v -60d +%Y-%m)
 end_month=$(date +%Y-%m)

--- a/content/api/usage/code_snippets/api-billing-usage-timeseries.sh
+++ b/content/api/usage/code_snippets/api-billing-usage-timeseries.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 start_hr=$(date -v -10d +%Y-%m-%dT%H)
 end_hr=$(date +%Y-%m-%dT%H)

--- a/content/api/usage/code_snippets/api-billing-usage-top-avg-metrics.sh
+++ b/content/api/usage/code_snippets/api-billing-usage-top-avg-metrics.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 month=$(date +%Y-%m)
 

--- a/content/api/users/code_snippets/api-user-create.py
+++ b/content/api/users/code_snippets/api-user-create.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/users/code_snippets/api-user-create.rb
+++ b/content/api/users/code_snippets/api-user-create.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/users/code_snippets/api-user-create.sh
+++ b/content/api/users/code_snippets/api-user-create.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -X POST -H "Content-type: application/json" \
     -d '{"handle":"test@datadoghq.com","name":"test user"}' \

--- a/content/api/users/code_snippets/api-user-disable.py
+++ b/content/api/users/code_snippets/api-user-disable.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/users/code_snippets/api-user-disable.rb
+++ b/content/api/users/code_snippets/api-user-disable.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/users/code_snippets/api-user-disable.sh
+++ b/content/api/users/code_snippets/api-user-disable.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 user_id=test@datadoghq.com
 
 curl -X DELETE "https://api.datadoghq.com/api/v1/user/${user_id}?api_key=${api_key}&application_key=${app_key}"

--- a/content/api/users/code_snippets/api-user-get-all.py
+++ b/content/api/users/code_snippets/api-user-get-all.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/users/code_snippets/api-user-get-all.rb
+++ b/content/api/users/code_snippets/api-user-get-all.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/users/code_snippets/api-user-get-all.sh
+++ b/content/api/users/code_snippets/api-user-get-all.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -X GET "https://api.datadoghq.com/api/v1/user?api_key=${api_key}&application_key=${app_key}"
 

--- a/content/api/users/code_snippets/api-user-get.py
+++ b/content/api/users/code_snippets/api-user-get.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/users/code_snippets/api-user-get.rb
+++ b/content/api/users/code_snippets/api-user-get.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/users/code_snippets/api-user-get.sh
+++ b/content/api/users/code_snippets/api-user-get.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 user_id=test@datadoghq.com
 
 curl -X GET "https://api.datadoghq.com/api/v1/user/${user_id}?api_key=${api_key}&application_key=${app_key}"

--- a/content/api/users/code_snippets/api-user-update.py
+++ b/content/api/users/code_snippets/api-user-update.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/content/api/users/code_snippets/api-user-update.rb
+++ b/content/api/users/code_snippets/api-user-update.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = '9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key = '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/content/api/users/code_snippets/api-user-update.sh
+++ b/content/api/users/code_snippets/api-user-update.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 user_id=test@datadoghq.com
 
 curl -X PUT -H "Content-type: application/json" \

--- a/content/developers/faq/powershell-api-examples.md
+++ b/content/developers/faq/powershell-api-examples.md
@@ -27,8 +27,8 @@ $http_request.responseText
 
 1. Replace the api/app key with yours
 ```
-$api_key = "9775a026f1ca7d1c6c5af9d94d9595a4" 
-$app_key = "87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"
+$api_key = "<YOUR_API_KEY>" 
+$app_key = "<YOUR_APP_KEY>"
 ```
 
 2. Set up your parameters according to [description in the host API](/api/#hosts), shell tab
@@ -50,8 +50,8 @@ $parameters = "{
 
 1. Replace the api/app key with yours
 ```
-$api_key = "9775a026f1ca7d1c6c5af9d94d9595a4" 
-$app_key = "87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"
+$api_key = "<YOUR_API_KEY>" 
+$app_key = "<YOUR_APP_KEY>"
 ```
 
 3. Set up parameters according to [description in the metrics API](/api/#metrics), shell tab

--- a/content/monitors/faq/how-do-i-add-custom-template-variables-to-my-monitor-message.md
+++ b/content/monitors/faq/how-do-i-add-custom-template-variables-to-my-monitor-message.md
@@ -45,8 +45,8 @@ You can also set up multi alert monitors using the Datadog API. The following ex
 #!/bin/sh
 # Make sure you replace the API and APP keys below
 # with the ones for your account
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -X POST -H "Content-type: application/json" \
 -d '{

--- a/ja/code_snippets/api-auth.py
+++ b/ja/code_snippets/api-auth.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-auth.rb
+++ b/ja/code_snippets/api-auth.rb
@@ -1,4 +1,4 @@
 require 'rubygems'
 require 'dogapi'
 
-dog = Dogapi::Client.new('9775a026f1ca7d1c6c5af9d94d9595a4', '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff')
+dog = Dogapi::Client.new('<YOUR_API_KEY>', '<YOUR_APP_KEY>')

--- a/ja/code_snippets/api-auth.sh
+++ b/ja/code_snippets/api-auth.sh
@@ -1,2 +1,2 @@
-curl "https://api.datadoghq.com/api/v1/validate?api_key=9775a026f1ca7d1c6c5af9d94d9595a4"
+curl "https://api.datadoghq.com/api/v1/validate?api_key=<YOUR_API_KEY>"
 

--- a/ja/code_snippets/api-billing-usage-hosts.sh
+++ b/ja/code_snippets/api-billing-usage-hosts.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 start_hr=$(date -v -10d +%Y-%m-%dT%H)
 end_hr=$(date +%Y-%m-%dT%H)

--- a/ja/code_snippets/api-billing-usage-timeseries.sh
+++ b/ja/code_snippets/api-billing-usage-timeseries.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 start_hr=$(date -v -10d +%Y-%m-%dT%H)
 end_hr=$(date +%Y-%m-%dT%H)

--- a/ja/code_snippets/api-billing-usage-top-avg-metrics.sh
+++ b/ja/code_snippets/api-billing-usage-top-avg-metrics.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 month=$(date +%Y-%m)
 

--- a/ja/code_snippets/api-checks-post.py
+++ b/ja/code_snippets/api-checks-post.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 from datadog.api.constants import CheckStatus
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-checks-post.rb
+++ b/ja/code_snippets/api-checks-post.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-checks-post.sh
+++ b/ja/code_snippets/api-checks-post.sh
@@ -6,4 +6,4 @@ curl  -X POST -H "Content-type: application/json" \
       \"timestamp\": $currenttime,
       \"status\": 0
   }" \
-'https://api.datadoghq.com/api/v1/check_run?api_key=9775a026f1ca7d1c6c5af9d94d9595a4'
+'https://api.datadoghq.com/api/v1/check_run?api_key=<YOUR_API_KEY>'

--- a/ja/code_snippets/api-comment-create.py
+++ b/ja/code_snippets/api-comment-create.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-comment-create.rb
+++ b/ja/code_snippets/api-comment-create.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-comment-create.sh
+++ b/ja/code_snippets/api-comment-create.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl  -X POST -H "Content-type: application/json" \
 -d '{

--- a/ja/code_snippets/api-comment-delete.py
+++ b/ja/code_snippets/api-comment-delete.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-comment-delete.rb
+++ b/ja/code_snippets/api-comment-delete.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-comment-delete.sh
+++ b/ja/code_snippets/api-comment-delete.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 # comment_id=1382559936236196216
 
 # Create a comment to delete. Use jq (http://stedolan.github.io/jq/download/) to get the comment id.

--- a/ja/code_snippets/api-comment-edit.py
+++ b/ja/code_snippets/api-comment-edit.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 from time import sleep
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 

--- a/ja/code_snippets/api-comment-edit.rb
+++ b/ja/code_snippets/api-comment-edit.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 comment_id="1382579089039712607"
 
 dog = Dogapi::Client.new(api_key, app_key)

--- a/ja/code_snippets/api-comment-edit.sh
+++ b/ja/code_snippets/api-comment-edit.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 comment_id=1382557387240472966
 
 # Create a comment to edit. Use jq (http://stedolan.github.io/jq/download/) to get the comment id.

--- a/ja/code_snippets/api-dashboard-create.py
+++ b/ja/code_snippets/api-dashboard-create.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-dashboard-create.rb
+++ b/ja/code_snippets/api-dashboard-create.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-dashboard-create.sh
+++ b/ja/code_snippets/api-dashboard-create.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl  -X POST -H "Content-type: application/json" \
 -d '{

--- a/ja/code_snippets/api-dashboard-delete.py
+++ b/ja/code_snippets/api-dashboard-delete.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-dashboard-delete.rb
+++ b/ja/code_snippets/api-dashboard-delete.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-dashboard-delete.sh
+++ b/ja/code_snippets/api-dashboard-delete.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 dash_id=2471
 
 # Create a dashboard to delete. Use jq (http://stedolan.github.io/jq/download/) to get the dash id.

--- a/ja/code_snippets/api-dashboard-get-all.py
+++ b/ja/code_snippets/api-dashboard-get-all.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-dashboard-get-all.rb
+++ b/ja/code_snippets/api-dashboard-get-all.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-dashboard-get-all.sh
+++ b/ja/code_snippets/api-dashboard-get-all.sh
@@ -1,4 +1,4 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl "https://api.datadoghq.com/api/v1/dash?api_key=${api_key}&application_key=${app_key}"

--- a/ja/code_snippets/api-dashboard-get.py
+++ b/ja/code_snippets/api-dashboard-get.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-dashboard-get.rb
+++ b/ja/code_snippets/api-dashboard-get.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-dashboard-get.sh
+++ b/ja/code_snippets/api-dashboard-get.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 dash_id=2473
 
 # Create a dashboard to get. Use jq (http://stedolan.github.io/jq/download/) to get the dash id.

--- a/ja/code_snippets/api-dashboard-update.py
+++ b/ja/code_snippets/api-dashboard-update.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-dashboard-update.rb
+++ b/ja/code_snippets/api-dashboard-update.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-dashboard-update.sh
+++ b/ja/code_snippets/api-dashboard-update.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 dash_id=2532
 
 # Create a dashboard to get. Use jq (http://stedolan.github.io/jq/download/) to get the dash id.

--- a/ja/code_snippets/api-embeds-create.py
+++ b/ja/code_snippets/api-embeds-create.py
@@ -3,8 +3,8 @@ import json
 
 # Intialize request parameters including API/APP key
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-embeds-create.rb
+++ b/ja/code_snippets/api-embeds-create.rb
@@ -2,8 +2,8 @@ require 'rubygems'
 require 'dogapi'
 
 # Initialize API Client
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-embeds-create.sh
+++ b/ja/code_snippets/api-embeds-create.sh
@@ -1,5 +1,5 @@
-api_key="9775a026f1ca7d1c6c5af9d94d9595a4"
-app_key="87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"
+api_key="<YOUR_API_KEY>"
+app_key="<YOUR_APP_KEY>"
 
 curl -POST \
     -d 'graph_json={"requests":[{"q":"avg:system.load.1{*}"}],"viz":"timeseries","events":[]}' \

--- a/ja/code_snippets/api-embeds-enable.py
+++ b/ja/code_snippets/api-embeds-enable.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 
 # Intialize request parameters including API/APP key
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-embeds-enable.rb
+++ b/ja/code_snippets/api-embeds-enable.rb
@@ -2,8 +2,8 @@ require 'rubygems'
 require 'dogapi'
 
 # Initialize API Client
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-embeds-enable.sh
+++ b/ja/code_snippets/api-embeds-enable.sh
@@ -1,5 +1,5 @@
-api_key="9775a026f1ca7d1c6c5af9d94d9595a4"
-app_key="87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"
+api_key="<YOUR_API_KEY>"
+app_key="<YOUR_APP_KEY>"
 embed_id="5f585b01c81b12ecdf5f40df0382738d0919170639985d3df5e2fc4232865b0c"
 
 curl -X GET "https://api.datadoghq.com/api/v1/graph/embed/${embed_id}/enable?api_key=${api_key}&application_key=${app_key}"

--- a/ja/code_snippets/api-embeds-get-all.py
+++ b/ja/code_snippets/api-embeds-get-all.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 
 # Intialize request parameters including API/APP key
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-embeds-get-all.rb
+++ b/ja/code_snippets/api-embeds-get-all.rb
@@ -2,8 +2,8 @@ require 'rubygems'
 require 'dogapi'
 
 # Initialize API Client
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-embeds-get-all.sh
+++ b/ja/code_snippets/api-embeds-get-all.sh
@@ -1,4 +1,4 @@
-api_key="9775a026f1ca7d1c6c5af9d94d9595a4"
-app_key="87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"
+api_key="<YOUR_API_KEY>"
+app_key="<YOUR_APP_KEY>"
 
 curl -X GET "https://api.datadoghq.com/api/v1/graph/embed?api_key=${api_key}&application_key=${app_key}"

--- a/ja/code_snippets/api-embeds-get.py
+++ b/ja/code_snippets/api-embeds-get.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 
 # Intialize request parameters including API/APP key
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-embeds-get.rb
+++ b/ja/code_snippets/api-embeds-get.rb
@@ -2,8 +2,8 @@ require 'rubygems'
 require 'dogapi'
 
 # Initialize API Client
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-embeds-get.sh
+++ b/ja/code_snippets/api-embeds-get.sh
@@ -1,5 +1,5 @@
-api_key="9775a026f1ca7d1c6c5af9d94d9595a4"
-app_key="87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"
+api_key="<YOUR_API_KEY>"
+app_key="<YOUR_APP_KEY>"
 embed_id="5f585b01c81b12ecdf5f40df0382738d0919170639985d3df5e2fc4232865b0c"
 
 curl -X GET "https://api.datadoghq.com/api/v1/graph/embed/${embed_id}?api_key=${api_key}&application_key=${app_key}"

--- a/ja/code_snippets/api-embeds-revoke.py
+++ b/ja/code_snippets/api-embeds-revoke.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 
 # Intialize request parameters including API/APP key
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-embeds-revoke.rb
+++ b/ja/code_snippets/api-embeds-revoke.rb
@@ -2,8 +2,8 @@ require 'rubygems'
 require 'dogapi'
 
 # Initialize API Client
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-embeds-revoke.sh
+++ b/ja/code_snippets/api-embeds-revoke.sh
@@ -1,5 +1,5 @@
-api_key="9775a026f1ca7d1c6c5af9d94d9595a4"
-app_key="87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"
+api_key="<YOUR_API_KEY>"
+app_key="<YOUR_APP_KEY>"
 embed_id="5f585b01c81b12ecdf5f40df0382738d0919170639985d3df5e2fc4232865b0c"
 
 curl -X GET "https://api.datadoghq.com/api/v1/graph/embed/${embed_id}/revoke?api_key=${api_key}&application_key=${app_key}"

--- a/ja/code_snippets/api-events-delete.py
+++ b/ja/code_snippets/api-events-delete.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-events-delete.rb
+++ b/ja/code_snippets/api-events-delete.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-events-delete.sh
+++ b/ja/code_snippets/api-events-delete.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 event_id=1377281704830403917
 
 curl -X DELETE "https://api.datadoghq.com/api/v1/events/${event_id}?api_key=${api_key}&application_key=${app_key}"

--- a/ja/code_snippets/api-events-get.py
+++ b/ja/code_snippets/api-events-get.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-events-get.rb
+++ b/ja/code_snippets/api-events-get.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-events-get.sh
+++ b/ja/code_snippets/api-events-get.sh
@@ -1,9 +1,9 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 event_id=1377281704830403917
 
 # Create an event to get
-event_id=$(curl  -X POST -H "Content-type: application/json" -d "{\"title\": \"Did you hear the news today?\"}" "https://api.datadoghq.com/api/v1/events?api_key=9775a026f1ca7d1c6c5af9d94d9595a4" | jq -r '.event.url|ltrimstr("https://app.datadoghq.com/event/event?id=")')
+event_id=$(curl  -X POST -H "Content-type: application/json" -d "{\"title\": \"Did you hear the news today?\"}" "https://api.datadoghq.com/api/v1/events?api_key=<YOUR_API_KEY>" | jq -r '.event.url|ltrimstr("https://app.datadoghq.com/event/event?id=")')
 sleep 5
 
 curl "https://api.datadoghq.com/api/v1/events/${event_id}?api_key=${api_key}&application_key=${app_key}"

--- a/ja/code_snippets/api-events-post.py
+++ b/ja/code_snippets/api-events-post.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-events-post.rb
+++ b/ja/code_snippets/api-events-post.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-events-post.sh
+++ b/ja/code_snippets/api-events-post.sh
@@ -6,4 +6,4 @@ curl  -X POST -H "Content-type: application/json" \
       "tags": ["environment:test"],
       "alert_type": "info"
   }' \
-'https://api.datadoghq.com/api/v1/events?api_key=9775a026f1ca7d1c6c5af9d94d9595a4'
+'https://api.datadoghq.com/api/v1/events?api_key=<YOUR_API_KEY>'

--- a/ja/code_snippets/api-events-stream.py
+++ b/ja/code_snippets/api-events-stream.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 import time
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-events-stream.rb
+++ b/ja/code_snippets/api-events-stream.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-events-stream.sh
+++ b/ja/code_snippets/api-events-stream.sh
@@ -6,6 +6,6 @@ curl -G -H "Content-type: application/json" \
     -d "end=${currenttime}" \
     -d "sources=My Apps" \
     -d "tags=application:web,version:1" \
-    -d "api_key=9775a026f1ca7d1c6c5af9d94d9595a4" \
-    -d "application_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff" \
+    -d "api_key=<YOUR_API_KEY>" \
+    -d "application_key=<YOUR_APP_KEY>" \
     'https://api.datadoghq.com/api/v1/events'

--- a/ja/code_snippets/api-graph-snapshot.py
+++ b/ja/code_snippets/api-graph-snapshot.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 import time
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-graph-snapshot.rb
+++ b/ja/code_snippets/api-graph-snapshot.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-graph-snapshot.sh
+++ b/ja/code_snippets/api-graph-snapshot.sh
@@ -4,6 +4,6 @@ curl -G -H "Content-type: application/json" \
     -d "metric_query=system.load.1{*}" \
     -d "start=${currenttime2}" \
     -d "end=${currenttime}" \
-    -d "api_key=9775a026f1ca7d1c6c5af9d94d9595a4" \
-    -d "application_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff" \
+    -d "api_key=<YOUR_API_KEY>" \
+    -d "application_key=<YOUR_APP_KEY>" \
     'https://api.datadoghq.com/api/v1/graph/snapshot'

--- a/ja/code_snippets/api-host-mute.py
+++ b/ja/code_snippets/api-host-mute.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-host-mute.rb
+++ b/ja/code_snippets/api-host-mute.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-host-mute.sh
+++ b/ja/code_snippets/api-host-mute.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -X POST -H "Content-type: application/json" \
 -d '{

--- a/ja/code_snippets/api-host-unmute.py
+++ b/ja/code_snippets/api-host-unmute.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-host-unmute.rb
+++ b/ja/code_snippets/api-host-unmute.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-host-unmute.sh
+++ b/ja/code_snippets/api-host-unmute.sh
@@ -1,4 +1,4 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -X POST -H "Content-type: application/json" "https://api.datadoghq.com/api/v1/host/test.host/unmute?api_key=${api_key}&application_key=${app_key}"

--- a/ja/code_snippets/api-metric-metadata-get.py
+++ b/ja/code_snippets/api-metric-metadata-get.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-metric-metadata-get.rb
+++ b/ja/code_snippets/api-metric-metadata-get.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = "9775a026f1ca7d1c6c5af9d94d9595a4"
+api_key = "<YOUR_API_KEY>"
 
 dog = Dogapi::Client.new(api_key)
 

--- a/ja/code_snippets/api-metric-metadata-get.sh
+++ b/ja/code_snippets/api-metric-metadata-get.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 metric_name="system.net.bytes_sent"
 
 curl "https://api.datadoghq.com/api/v1/metrics/${metric_name}?api_key=${api_key}&application_key=${app_key}"

--- a/ja/code_snippets/api-metric-metadata-update.py
+++ b/ja/code_snippets/api-metric-metadata-update.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-metric-metadata-update.rb
+++ b/ja/code_snippets/api-metric-metadata-update.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = "9775a026f1ca7d1c6c5af9d94d9595a4"
+api_key = "<YOUR_API_KEY>"
 
 dog = Dogapi::Client.new(api_key)
 

--- a/ja/code_snippets/api-metric-metadata-update.sh
+++ b/ja/code_snippets/api-metric-metadata-update.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 metric_name="system.net.bytes_sent"
 
 curl -X PUT -H "Content-type: application/json" \

--- a/ja/code_snippets/api-metrics-list.sh
+++ b/ja/code_snippets/api-metrics-list.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 from_time=$(date -v -1d +%s)
 

--- a/ja/code_snippets/api-metrics-post.py
+++ b/ja/code_snippets/api-metrics-post.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 import time
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-metrics-post.rb
+++ b/ja/code_snippets/api-metrics-post.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = "9775a026f1ca7d1c6c5af9d94d9595a4"
+api_key = "<YOUR_API_KEY>"
 
 dog = Dogapi::Client.new(api_key)
 

--- a/ja/code_snippets/api-metrics-post.sh
+++ b/ja/code_snippets/api-metrics-post.sh
@@ -9,4 +9,4 @@ curl  -X POST -H "Content-type: application/json" \
           \"tags\":[\"environment:test\"]}
         ]
     }" \
-'https://api.datadoghq.com/api/v1/series?api_key=9775a026f1ca7d1c6c5af9d94d9595a4'
+'https://api.datadoghq.com/api/v1/series?api_key=<YOUR_API_KEY>'

--- a/ja/code_snippets/api-metrics-query.py
+++ b/ja/code_snippets/api-metrics-query.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 import time
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-metrics-query.rb
+++ b/ja/code_snippets/api-metrics-query.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key = "9775a026f1ca7d1c6c5af9d94d9595a4"
-application_key = "87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"
+api_key = "<YOUR_API_KEY>"
+application_key = "<YOUR_APP_KEY>"
 
 dog = Dogapi::Client.new(api_key, application_key)
 

--- a/ja/code_snippets/api-metrics-query.sh
+++ b/ja/code_snippets/api-metrics-query.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 to_time=$(date +%s)
 from_time=$(date -v -1d +%s)
 

--- a/ja/code_snippets/api-monitor-bulk-resolve.sh
+++ b/ja/code_snippets/api-monitor-bulk-resolve.sh
@@ -2,8 +2,8 @@
 # Make sure you replace the API and/or APP key below
 # with the ones for your account
 
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 monitor_id= <YOUR_MONITOR_ID>
 group_1=<YOUR_FIRST_GROUP>

--- a/ja/code_snippets/api-monitor-cancel-downtime-by-scope.sh
+++ b/ja/code_snippets/api-monitor-cancel-downtime-by-scope.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-api_key="9775a026f1ca7d1c6c5af9d94d9595a4"
-app_key="87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"
+api_key="<YOUR_API_KEY>"
+app_key="<YOUR_APP_KEY>"
 
 curl -X POST -H "Content-type: application/json" -H "Accept: application/json" \
 -d "{

--- a/ja/code_snippets/api-monitor-cancel-downtime.py
+++ b/ja/code_snippets/api-monitor-cancel-downtime.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-monitor-cancel-downtime.rb
+++ b/ja/code_snippets/api-monitor-cancel-downtime.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-monitor-cancel-downtime.sh
+++ b/ja/code_snippets/api-monitor-cancel-downtime.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 downtime_id=1656
 
 # Create a downtime to delete

--- a/ja/code_snippets/api-monitor-create.py
+++ b/ja/code_snippets/api-monitor-create.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-monitor-create.rb
+++ b/ja/code_snippets/api-monitor-create.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-monitor-create.sh
+++ b/ja/code_snippets/api-monitor-create.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -X POST -H "Content-type: application/json" \
 -d '{

--- a/ja/code_snippets/api-monitor-delete.py
+++ b/ja/code_snippets/api-monitor-delete.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-monitor-delete.rb
+++ b/ja/code_snippets/api-monitor-delete.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-monitor-delete.sh
+++ b/ja/code_snippets/api-monitor-delete.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 monitor_id=59409
 
 # Create a monitor to delete

--- a/ja/code_snippets/api-monitor-edit.py
+++ b/ja/code_snippets/api-monitor-edit.py
@@ -1,8 +1,8 @@
 from datadog import initialize,  api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-monitor-edit.rb
+++ b/ja/code_snippets/api-monitor-edit.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-monitor-edit.sh
+++ b/ja/code_snippets/api-monitor-edit.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 monitor_id=91879
 
 # Create a monitor to edit

--- a/ja/code_snippets/api-monitor-get-downtime.py
+++ b/ja/code_snippets/api-monitor-get-downtime.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-monitor-get-downtime.sh
+++ b/ja/code_snippets/api-monitor-get-downtime.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 downtime_id=2473
 
 curl "https://api.datadoghq.com/api/v1/downtime/${downtime_id}?api_key=${api_key}&application_key=${app_key}"

--- a/ja/code_snippets/api-monitor-get-downtimes.py
+++ b/ja/code_snippets/api-monitor-get-downtimes.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-monitor-get-downtimes.rb
+++ b/ja/code_snippets/api-monitor-get-downtimes.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-monitor-get-downtimes.sh
+++ b/ja/code_snippets/api-monitor-get-downtimes.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -G "https://api.datadoghq.com/api/v1/downtime" \
      -d "api_key=${api_key}" \

--- a/ja/code_snippets/api-monitor-mute-all.py
+++ b/ja/code_snippets/api-monitor-mute-all.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-monitor-mute-all.rb
+++ b/ja/code_snippets/api-monitor-mute-all.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-monitor-mute-all.sh
+++ b/ja/code_snippets/api-monitor-mute-all.sh
@@ -1,4 +1,4 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -X POST "https://api.datadoghq.com/api/v1/monitor/mute_all?api_key=${api_key}&application_key=${app_key}"

--- a/ja/code_snippets/api-monitor-mute.py
+++ b/ja/code_snippets/api-monitor-mute.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-monitor-mute.rb
+++ b/ja/code_snippets/api-monitor-mute.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-monitor-mute.sh
+++ b/ja/code_snippets/api-monitor-mute.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 monitor_id=62628
 
 # Create a monitor to mute

--- a/ja/code_snippets/api-monitor-schedule-downtime.py
+++ b/ja/code_snippets/api-monitor-schedule-downtime.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 import time
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-monitor-schedule-downtime.rb
+++ b/ja/code_snippets/api-monitor-schedule-downtime.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-monitor-schedule-downtime.sh
+++ b/ja/code_snippets/api-monitor-schedule-downtime.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 start=$(date +%s)
 end=$(date -v+3H +%s)

--- a/ja/code_snippets/api-monitor-show-all.py
+++ b/ja/code_snippets/api-monitor-show-all.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-monitor-show-all.rb
+++ b/ja/code_snippets/api-monitor-show-all.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-monitor-show-all.sh
+++ b/ja/code_snippets/api-monitor-show-all.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -G "https://api.datadoghq.com/api/v1/monitor" \
      -d "api_key=${api_key}" \

--- a/ja/code_snippets/api-monitor-show.py
+++ b/ja/code_snippets/api-monitor-show.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-monitor-show.rb
+++ b/ja/code_snippets/api-monitor-show.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-monitor-show.sh
+++ b/ja/code_snippets/api-monitor-show.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 monitor_id=91879
 
 # Create a monitor to show

--- a/ja/code_snippets/api-monitor-unmute-all.py
+++ b/ja/code_snippets/api-monitor-unmute-all.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-monitor-unmute-all.rb
+++ b/ja/code_snippets/api-monitor-unmute-all.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-monitor-unmute-all.sh
+++ b/ja/code_snippets/api-monitor-unmute-all.sh
@@ -1,4 +1,4 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -X POST "https://api.datadoghq.com/api/v1/monitor/unmute_all?api_key=${api_key}&application_key=${app_key}"

--- a/ja/code_snippets/api-monitor-unmute.py
+++ b/ja/code_snippets/api-monitor-unmute.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-monitor-unmute.rb
+++ b/ja/code_snippets/api-monitor-unmute.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-monitor-unmute.sh
+++ b/ja/code_snippets/api-monitor-unmute.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 monitor_id=62628
 
 # Create a monitor to unmute

--- a/ja/code_snippets/api-monitor-update-downtime.py
+++ b/ja/code_snippets/api-monitor-update-downtime.py
@@ -3,8 +3,8 @@ import time
 
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-monitor-update-downtime.rb
+++ b/ja/code_snippets/api-monitor-update-downtime.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-monitor-update-downtime.sh
+++ b/ja/code_snippets/api-monitor-update-downtime.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 downtime_id=4336
 
 # Create a downtime to update

--- a/ja/code_snippets/api-screenboard-create.py
+++ b/ja/code_snippets/api-screenboard-create.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-screenboard-create.rb
+++ b/ja/code_snippets/api-screenboard-create.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-screenboard-create.sh
+++ b/ja/code_snippets/api-screenboard-create.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -X POST -H "Content-type: application/json" \
 -d '{

--- a/ja/code_snippets/api-screenboard-delete.py
+++ b/ja/code_snippets/api-screenboard-delete.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-screenboard-delete.rb
+++ b/ja/code_snippets/api-screenboard-delete.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-screenboard-delete.sh
+++ b/ja/code_snippets/api-screenboard-delete.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 board_id=2471
 
 # Create a screenboard to delete

--- a/ja/code_snippets/api-screenboard-get-all.py
+++ b/ja/code_snippets/api-screenboard-get-all.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-screenboard-get-all.rb
+++ b/ja/code_snippets/api-screenboard-get-all.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-screenboard-get-all.sh
+++ b/ja/code_snippets/api-screenboard-get-all.sh
@@ -1,4 +1,4 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -X GET "https://api.datadoghq.com/api/v1/screen?api_key=${api_key}&application_key=${app_key}"

--- a/ja/code_snippets/api-screenboard-get.py
+++ b/ja/code_snippets/api-screenboard-get.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-screenboard-get.rb
+++ b/ja/code_snippets/api-screenboard-get.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-screenboard-get.sh
+++ b/ja/code_snippets/api-screenboard-get.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 board_id=6334
 
 # Create a screenboard to get

--- a/ja/code_snippets/api-screenboard-revoke.py
+++ b/ja/code_snippets/api-screenboard-revoke.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-screenboard-revoke.rb
+++ b/ja/code_snippets/api-screenboard-revoke.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-screenboard-revoke.sh
+++ b/ja/code_snippets/api-screenboard-revoke.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 board_id=6334
 
 # Create a screenboard to share

--- a/ja/code_snippets/api-screenboard-share.py
+++ b/ja/code_snippets/api-screenboard-share.py
@@ -2,8 +2,8 @@ from datadog import initialize, api
 
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-screenboard-share.rb
+++ b/ja/code_snippets/api-screenboard-share.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-screenboard-share.sh
+++ b/ja/code_snippets/api-screenboard-share.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 board_id=6334
 
 # Create a screenboard to share

--- a/ja/code_snippets/api-screenboard-update.py
+++ b/ja/code_snippets/api-screenboard-update.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-screenboard-update.rb
+++ b/ja/code_snippets/api-screenboard-update.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-screenboard-update.sh
+++ b/ja/code_snippets/api-screenboard-update.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -X PUT -H "Content-type: application/json" \
 -d '{

--- a/ja/code_snippets/api-search.py
+++ b/ja/code_snippets/api-search.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-search.rb
+++ b/ja/code_snippets/api-search.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-search.sh
+++ b/ja/code_snippets/api-search.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -G "https://api.datadoghq.com/api/v1/search" \
     -d "api_key=${api_key}" \

--- a/ja/code_snippets/api-tags-add.py
+++ b/ja/code_snippets/api-tags-add.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-tags-add.rb
+++ b/ja/code_snippets/api-tags-add.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-tags-add.sh
+++ b/ja/code_snippets/api-tags-add.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 host=YourHostName
 
 # Find a host to add a tag to

--- a/ja/code_snippets/api-tags-get-host.py
+++ b/ja/code_snippets/api-tags-get-host.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-tags-get-host.rb
+++ b/ja/code_snippets/api-tags-get-host.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-tags-get-host.sh
+++ b/ja/code_snippets/api-tags-get-host.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 # pass a single hostname as an argument to search for the specified host
 host=$1

--- a/ja/code_snippets/api-tags-get.py
+++ b/ja/code_snippets/api-tags-get.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-tags-get.rb
+++ b/ja/code_snippets/api-tags-get.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-tags-get.sh
+++ b/ja/code_snippets/api-tags-get.sh
@@ -1,4 +1,4 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl "https://api.datadoghq.com/api/v1/tags/hosts?api_key=${api_key}&application_key=${app_key}"

--- a/ja/code_snippets/api-tags-remove.py
+++ b/ja/code_snippets/api-tags-remove.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-tags-remove.rb
+++ b/ja/code_snippets/api-tags-remove.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-tags-remove.sh
+++ b/ja/code_snippets/api-tags-remove.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 # Find a host to remove a tag from
 host_name=$(curl -G "https://api.datadoghq.com/api/v1/search" \

--- a/ja/code_snippets/api-tags-update.py
+++ b/ja/code_snippets/api-tags-update.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-tags-update.rb
+++ b/ja/code_snippets/api-tags-update.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-tags-update.sh
+++ b/ja/code_snippets/api-tags-update.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 host_name=test.host
 
 curl -X PUT -H "Content-type: application/json" \

--- a/ja/code_snippets/api-user-create.py
+++ b/ja/code_snippets/api-user-create.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-user-create.rb
+++ b/ja/code_snippets/api-user-create.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-user-create.sh
+++ b/ja/code_snippets/api-user-create.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -X POST -H "Content-type: application/json" \
     -d '{"handle":"test@datadoghq.com","name":"test user"}' \

--- a/ja/code_snippets/api-user-disable.py
+++ b/ja/code_snippets/api-user-disable.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-user-disable.rb
+++ b/ja/code_snippets/api-user-disable.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-user-disable.sh
+++ b/ja/code_snippets/api-user-disable.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 user=test@datadoghq.com
 
 curl -X DELETE "https://api.datadoghq.com/api/v1/user/${user}?api_key=${api_key}&application_key=${app_key}"

--- a/ja/code_snippets/api-user-get-all.py
+++ b/ja/code_snippets/api-user-get-all.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-user-get-all.rb
+++ b/ja/code_snippets/api-user-get-all.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-user-get-all.sh
+++ b/ja/code_snippets/api-user-get-all.sh
@@ -1,4 +1,4 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -X GET "https://api.datadoghq.com/api/v1/user?api_key=${api_key}&application_key=${app_key}"

--- a/ja/code_snippets/api-user-get.py
+++ b/ja/code_snippets/api-user-get.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-user-get.rb
+++ b/ja/code_snippets/api-user-get.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-user-get.sh
+++ b/ja/code_snippets/api-user-get.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 user=test@datadoghq.com
 
 curl -X GET "https://api.datadoghq.com/api/v1/user/${user}?api_key=${api_key}&application_key=${app_key}"

--- a/ja/code_snippets/api-user-update.py
+++ b/ja/code_snippets/api-user-update.py
@@ -1,8 +1,8 @@
 from datadog import initialize, api
 
 options = {
-    'api_key': '9775a026f1ca7d1c6c5af9d94d9595a4',
-    'app_key': '87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
 }
 
 initialize(**options)

--- a/ja/code_snippets/api-user-update.rb
+++ b/ja/code_snippets/api-user-update.rb
@@ -2,8 +2,8 @@
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 

--- a/ja/code_snippets/api-user-update.sh
+++ b/ja/code_snippets/api-user-update.sh
@@ -1,5 +1,5 @@
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 user=test@datadoghq.com
 
 curl -X PUT -H "Content-type: application/json" \

--- a/ja/content/api/screenboards.md
+++ b/ja/content/api/screenboards.md
@@ -130,8 +130,8 @@ result = api.Screenboard.create(**board)
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 
@@ -156,8 +156,8 @@ result = dog.create_screenboard(board)
   </div>
   <div class="tab-pane fade in" id="screenboard_create-console">
 {{< highlight console >}}
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 
 curl -X POST -H "Content-type: application/json" \
 -d '{
@@ -230,8 +230,8 @@ result = api.Screenboard.update(board_id, **updated_board)
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 board_id = 1234
 
 dog = Dogapi::Client.new(api_key, app_key)
@@ -257,8 +257,8 @@ result = dog.update_screenboard(board_id, updated_board)
   </div>
   <div class="tab-pane fade in" id="screenboard_update-console">
 {{< highlight console >}}
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 board_id=1234
 
 curl -X PUT -H "Content-type: application/json" \
@@ -317,8 +317,8 @@ result = api.Screenboard.get(board_id)
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 board_id = 1234
 
 dog = Dogapi::Client.new(api_key, app_key)
@@ -328,8 +328,8 @@ result = dog.get_screenboard(board_id)
   </div>
   <div class="tab-pane fade in" id="screenboard_get-console">
 {{< highlight console >}}
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 board_id=1234
 
 curl -X GET \
@@ -372,8 +372,8 @@ result = api.Screenboard.delete(board_id)
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 board_id = 1234
 
 dog = Dogapi::Client.new(api_key, app_key)
@@ -383,8 +383,8 @@ result = dog.delete_screenboard(board_id)
   </div>
   <div class="tab-pane fade in" id="screenboard_delete-console">
 {{< highlight console >}}
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 board_id=1234
 
 curl -X DELETE \
@@ -427,8 +427,8 @@ result = api.Screenboard.share(board_id)
 require 'rubygems'
 require 'dogapi'
 
-api_key='9775a026f1ca7d1c6c5af9d94d9595a4'
-app_key='87ce4a24b5553d2e482ea8a8500e71b8ad4554ff'
+api_key='<YOUR_API_KEY>'
+app_key='<YOUR_APP_KEY>'
 board_id = 1234
 
 dog = Dogapi::Client.new(api_key, app_key)
@@ -439,8 +439,8 @@ result = dog.share_screenboard(board_id)
   </div>
   <div class="tab-pane fade in" id="screenboard_share-console">
 {{< highlight console >}}
-api_key=9775a026f1ca7d1c6c5af9d94d9595a4
-app_key=87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
 board_id=1234
 
 curl -X POST \


### PR DESCRIPTION
### What does this PR do?
Replace hardcoded API keys with placeholders:

* `<YOUR_API_KEY>`
* `<YOUR_APP_KEY>`

### Motivation
Some user complained that they can't cp/cv our example since the API keys displayed aren't valid..... 

### Preview link
