### PR TITLE
adding type support for metric post API

### DIFF
--- a/content/api/metrics/code_snippets/api-metrics-post.sh
+++ b/content/api/metrics/code_snippets/api-metrics-post.sh
@@ -8,6 +8,8 @@ curl  -X POST -H "Content-type: application/json" \
 -d "{ \"series\" :
          [{\"metric\":\"test.metric\",
           \"points\":[[$currenttime, 20]],
+          \"type\":\"rate\",
+          \"interval\": 20,
           \"host\":\"test.example.com\",
           \"tags\":[\"environment:test\"]}
         ]

--- a/content/api/metrics/metrics_timeseries.md
+++ b/content/api/metrics/metrics_timeseries.md
@@ -16,9 +16,9 @@ The metrics end-point allows you to post time-series data that can be graphed on
     * **`metric`** [*required*]:  
         The name of the time series
     * **`type`** [*optional*, *default*=**gauge**]:  
-        Type of your metric either: `gauge`, `rate`, or `count`
+        [Type](/developers/metrics/#metric-types) of your metric either: `gauge`, `rate`, or `count`
     * **`interval`** [*optional*, *default*=**None**]:  
-        If the type of the metric is `rate`, define the corresponding interval.
+        If the [type](/developers/metrics/#metric-types) of the metric is `rate` or `count`, define the corresponding interval.
     * **`points`** [*required*]:  
         A JSON array of points. Each point is of the form:  
         `[[POSIX_timestamp, numeric_value], ...]`  

--- a/content/api/metrics/metrics_timeseries.md
+++ b/content/api/metrics/metrics_timeseries.md
@@ -15,6 +15,10 @@ The metrics end-point allows you to post time-series data that can be graphed on
     
     * **`metric`** [*required*]:  
         The name of the time series
+    * **`type`** [*optional*, *default*=**gauge**]:  
+        Type of your metric either: `gauge`, `rate`, or `count`
+    * **`interval`** [*optional*, *default*=**None**]:  
+        If the type of the metric is `rate`, define the corresponding interval.
     * **`points`** [*required*]:  
         A JSON array of points. Each point is of the form:  
         `[[POSIX_timestamp, numeric_value], ...]`  


### PR DESCRIPTION
### What does this PR do?

We can now set the metric metadata when submitting points via the API!

Supported types are:

```
gauge
rate
count
```

which correspond to Datadog's in-app metric types: https://docs.datadoghq.com/developers/metrics/#metric-types

You can also set the sampling interval, which is used to de-normalize rate data, and to accurately display count/rate metrics as a per second rate.

Here is an example payload:

```
{ "series" :
         [{"metric":"test_0242ac110002",
          "points":[[1520894220,20]],
          "type":"rate",
          "interval": 20,
          "host":"test.example.com",
          "tags":["environment:test"]}
        ]
}
```

They are optional, The default metric type is gauge, and the default interval is none (which is ok).

One important point to mention is that metadata is stored per metric name, so a metric name can only have one metric type and interval.

## Preview

https://docs-staging.datadoghq.com/gus/post-api-update/api/?lang=python#post-time-series-points
