### PR TITLE
escape apostrophe in sidenav links

### DIFF
--- a/layouts/partials/sidenav/sidenav-api.html
+++ b/layouts/partials/sidenav/sidenav-api.html
@@ -9,7 +9,7 @@
                     {{ if (or (in (string $element.Params.order) ".") (eq $index 0)) }}
                         <!-- display nested items in nav, ones with . in order -->
                         <li>
-                            <a href="#{{ lower (replace $element.Title " " "-") }}">
+                            <a href="#{{ lower (replace (replace $element.Title "'" " ") " " "-") }}">
                                 <span>{{ $element.Title }}</span>
                             </a>
                         </li>
@@ -20,7 +20,7 @@
                             </li>
                         {{ end }}
                         <li>
-                            <a href="#{{ lower (replace $element.Title " " "-") }}">
+                            <a href="#{{ lower (replace (replace $element.Title "'" " ") " " "-") }}">
                                 <span>{{ $element.Title }}</span>
                             </a>
                             <ul>


### PR DESCRIPTION
### What does this PR do?
This change fixes an issue with API navigation links that have an apostrophe in them causing links to not work

### Motivation
https://trello.com/c/SnfuCioK/2200-broken-link-on-doc-api

### Preview link
https://docs-staging.datadoghq.com/david.jones/api-link-fix/api/
Go to the api page click on monitors and try and click on "get a monitor's details" it should now work

### Additional Notes

