### PR TITLE
Adding precisions regarding format

### DIFF
--- a/content/agent/basic_agent_usage/docker.md
+++ b/content/agent/basic_agent_usage/docker.md
@@ -80,7 +80,7 @@ Either define them in your custom `datadog.yaml`, or set them as JSON maps in th
 
 Exclude containers from the metrics collection and Autodiscovery, if these are not useful for you. We already exclude Kubernetes and OpenShift `pause` containers by default. See the `datadog.yaml.example` file for more documentation, and examples:
 
-* `DD_AC_INCLUDE`: Space-separated strings of the whitelist of containers to always include e.g `"image:image_name_1 image:image_name_1"`
+* `DD_AC_INCLUDE`: Space-separated strings of the whitelist of containers to always include e.g `"image:image_name_1 image:image_name_2"`
 * `DD_AC_EXCLUDE`: Space-separated strings of the blacklist of containers to exclude e.g `"image:image_name_3 image:image_name_4"`
 
 **Note**: The `docker.containers.running`, `.stopped`, `.running.total` and `.stopped.total` metrics are not affected by these settings and always count all containers. This does not affect your per-container billing.

--- a/content/agent/basic_agent_usage/docker.md
+++ b/content/agent/basic_agent_usage/docker.md
@@ -78,9 +78,10 @@ Either define them in your custom `datadog.yaml`, or set them as JSON maps in th
 
 #### Ignore containers
 
-Exclude containers from the metrics collection and Autodiscovery, if these are not useful for you. We already exclude Kubernetes and OpenShift `pause` containers by default. See the `datadog.yaml.example` file for more documentation, and examples.
-- `DD_AC_INCLUDE`: whitelist of containers to always include
-- `DD_AC_EXCLUDE`: blacklist of containers to exclude
+Exclude containers from the metrics collection and Autodiscovery, if these are not useful for you. We already exclude Kubernetes and OpenShift `pause` containers by default. See the `datadog.yaml.example` file for more documentation, and examples:
+
+* `DD_AC_INCLUDE`: Separated string values of the whitelist of containers to always include e.g `"image:.*"`
+* `DD_AC_EXCLUDE`: Separated string values of the blacklist of containers to exclude e.g `"image:cp-kafka image:k8szk"`
 
 **Note**: The `docker.containers.running`, `.stopped`, `.running.total` and `.stopped.total` metrics are not affected by these settings and always count all containers. This does not affect your per-container billing.
 

--- a/content/agent/basic_agent_usage/docker.md
+++ b/content/agent/basic_agent_usage/docker.md
@@ -80,8 +80,8 @@ Either define them in your custom `datadog.yaml`, or set them as JSON maps in th
 
 Exclude containers from the metrics collection and Autodiscovery, if these are not useful for you. We already exclude Kubernetes and OpenShift `pause` containers by default. See the `datadog.yaml.example` file for more documentation, and examples:
 
-* `DD_AC_INCLUDE`: Separated string values of the whitelist of containers to always include e.g `"image:.*"`
-* `DD_AC_EXCLUDE`: Separated string values of the blacklist of containers to exclude e.g `"image:cp-kafka image:k8szk"`
+* `DD_AC_INCLUDE`: Space-separated strings of the whitelist of containers to always include e.g `"image:.*"`
+* `DD_AC_EXCLUDE`: Space-separated strings of the blacklist of containers to exclude e.g `"image:cp-kafka image:k8szk"`
 
 **Note**: The `docker.containers.running`, `.stopped`, `.running.total` and `.stopped.total` metrics are not affected by these settings and always count all containers. This does not affect your per-container billing.
 

--- a/content/agent/basic_agent_usage/docker.md
+++ b/content/agent/basic_agent_usage/docker.md
@@ -80,8 +80,8 @@ Either define them in your custom `datadog.yaml`, or set them as JSON maps in th
 
 Exclude containers from the metrics collection and Autodiscovery, if these are not useful for you. We already exclude Kubernetes and OpenShift `pause` containers by default. See the `datadog.yaml.example` file for more documentation, and examples:
 
-* `DD_AC_INCLUDE`: Space-separated strings of the whitelist of containers to always include e.g `"image:.*"`
-* `DD_AC_EXCLUDE`: Space-separated strings of the blacklist of containers to exclude e.g `"image:cp-kafka image:k8szk"`
+* `DD_AC_INCLUDE`: Space-separated strings of the whitelist of containers to always include e.g `"image:image_name_1 image:image_name_1"`
+* `DD_AC_EXCLUDE`: Space-separated strings of the blacklist of containers to exclude e.g `"image:image_name_3 image:image_name_4"`
 
 **Note**: The `docker.containers.running`, `.stopped`, `.running.total` and `.stopped.total` metrics are not affected by these settings and always count all containers. This does not affect your per-container billing.
 


### PR DESCRIPTION
### What does this PR do?

Update description for Docker DD_AC_EXCLUDE/_INCLUDE environment variables that can only take separated strings, but it's not explicitly stated

### Motivation
https://github.com/DataDog/datadog-agent/issues/1576

### Preview link

https://docs-staging.datadoghq.com/gus/docker/agent/basic_agent_usage/docker/#ignore-containers