### PR TITLE
external links add target-blank

### DIFF
--- a/src/js/datadog-docs.js
+++ b/src/js/datadog-docs.js
@@ -492,4 +492,12 @@ $(document).ready(function () {
     var elements = document.querySelectorAll('.sticky');
     Stickyfill.add(elements);
 
+    // add targer-blank to external links
+    var newLinks = document.getElementsByTagName("a");
+    for(i = 0; i < newLinks.length; i++) {
+        if(!newLinks[i].href.includes("datadoghq.com") && !newLinks[i].href.includes("localhost:1313")){
+            $("a[href='" + newLinks[i].href + "']").attr("target", "_blank");
+        }
+    }
+
 });


### PR DESCRIPTION
### What does this PR do?
Adding `target="blank"` to external hyperlinks within Docs pages

### Motivation
Making sure that visitors still stay within Datadog domain when they are forwarded to external destinations.

### Preview link
https://docs-staging.datadoghq.com/won/links-target-add/
