### PR TITLE
as_count monitor query doc

### DIFF
--- a/content/monitors/faq/_index.md
+++ b/content/monitors/faq/_index.md
@@ -20,6 +20,7 @@ private: true
     {{< nextlink href="monitors/faq/sending-datadog-events-to-your-moogsoft-aiops-instance" >}}Sending Datadog Events to your Moogsoft AIOps instance.{{< /nextlink >}}
     {{< nextlink href="monitors/faq/how-can-i-setup-an-alert-for-when-a-specific-tag-stops-reporting" >}}How can I setup an alert for when a specific tag stops reporting?{{< /nextlink >}}
     {{< nextlink href="monitors/faq/can-i-create-monitor-dependencies" >}}Can I create monitor dependencies?{{< /nextlink >}}
+    {{< nextlink href="monitors/faq/as-count-monitor-evaluation" >}}as_count() monitor evaluation{{< /nextlink >}}
 
 {{< /whatsnext >}}
 

--- a/content/monitors/faq/as-count-monitor-evaluation.md
+++ b/content/monitors/faq/as-count-monitor-evaluation.md
@@ -5,7 +5,7 @@ kind: faq
 
 ## Overview
 
-Currently all monitors that have the `as_count` modifier use a separate evaluation path than other monitors. In certain use-cases this this can result in unexpected behavior. We intend to migrate all monitors with `as_count` to the same evaluation path as other monitors, but this doc explains the underlying issue and will guide you through the migration process.
+Currently monitors that have the `as_count` modifier use a separate evaluation path than other monitors. In certain use-cases this this can result in unexpected behavior. We intend to migrate all monitors with `as_count` to the same evaluation path as other monitors, but this doc explains the underlying issue and will guide you through the migration process.
 
 Let's call the current evaluation path for `as_count` monitors `current_eva_path` and the new one `new_eva_path`.  
 

--- a/content/monitors/faq/as-count-monitor-evaluation.md
+++ b/content/monitors/faq/as-count-monitor-evaluation.md
@@ -5,7 +5,7 @@ kind: faq
 
 ## Overview
 
-Currently all monitors that have the `as_count` modifier are using a separate evaluation path than the other monitors. In certain use-cases this this can result in unexpected behavior. We intend to migrate all monitors with `as_count` to the same evaluation path as other monitors, but this doc explains the underlying issue and will guide you with the migration process.
+Currently all monitors that have the `as_count` modifier use a separate evaluation path than other monitors. In certain use-cases this this can result in unexpected behavior. We intend to migrate all monitors with `as_count` to the same evaluation path as other monitors, but this doc explains the underlying issue and will guide you through the migration process.
 
 Let's call the current evaluation path for `as_count` monitors `current_eva_path` and the new one `new_eva_path`.  
 

--- a/content/monitors/faq/as-count-monitor-evaluation.md
+++ b/content/monitors/faq/as-count-monitor-evaluation.md
@@ -83,12 +83,15 @@ Here is the behavior difference:
 | `current_eva_path` | (10 + 10 + 10) / (0 + 1 + NaN) | 30 |
 | `new_eva_path` | 10/0 + 10/1 + 10/NaN | 10 |
 
-## Which result is correct?
+Note that both evaluations are correct -- it depends on your intention. Because the current query language is ambiguous, we recommend rewriting your query to make your intended query explicit. Please [reach out to us][1] if you have any question regarding those changes.  
 
-**Both**, It depends on your intention. The understanding of the internals of each way is crucial to properly treat the results, feel free [to reach out to us][1] if you have any question regarding those changes.  
 
-Since this special behavior is tied to the `as_count`​ modifier, we encourage replacing `as_count` with `as_rate()` or `rollup(sum)` in these scenarios in order to benefit from the `new_eva_path` logic right now, a.k.a: Aggregation function applied **after** evaluation.  
+## Workaround
 
-*Example*: `min(last_5m):sum:requests.error{*}.as_rate() / sum:requests.total{*}.as_rate() > 0.5 ` alerts you when the error rate is above 50% at all times during the past 5 min.
+Since this special behavior is tied to the `as_count`​ modifier, we encourage replacing `as_count` with `as_rate()` or `rollup(sum)` in these scenarios.  
+
+*Example*: Suppose you wish to monitor the error rate of a service:
+
+`min(last_5m):sum:requests.error{*}.as_rate() / sum:requests.total{*}.as_rate() > 0.5 ` alerts you when the error rate is above 50% at all times during the past 5 min.
 
 [1]: /help

--- a/content/monitors/faq/as-count-monitor-evaluation.md
+++ b/content/monitors/faq/as-count-monitor-evaluation.md
@@ -13,8 +13,8 @@ The difference between those two evaluation paths is that complex monitor querie
 
 | Path | Behavior | Expanded expression |
 |:--------|:--------|:--------|
-|**`current_eva_path`** | Aggregation function applied **before** evaluation | **(a0+...+a4)/(b0+...+b4)** |
-|**`new_eva_path`** | Aggregation function applied **after** evaluation |**(a0/b0+...+a4/b4)**|
+|**`current_eva_path`** | Aggregation function applied *before* evaluation | **(a0 + a1 + ... + a4)/(b0 + b1 + ... + b4)** |
+|**`new_eva_path`** | Aggregation function applied *after* evaluation |**(a0/b0 + a1/b2 + ... + a4/b4)**|
 
 #### Why ?
 
@@ -28,7 +28,7 @@ compute the point by point ratio so it wasn't possible to accommodate such an im
 
 ## Example
 
-Let’s take this query for the  *2018-03-13T11:00:00* *2018-03-13T11:05:00* time frame.:
+Let’s take this query for the  *2018-03-13T11:00:00* to *2018-03-13T11:05:00* time frame:
 
 `sum:requests.error{*}.as_count()/sum:requests.total{*}.as_count()`   
 
@@ -62,8 +62,8 @@ Here is the result of the evaluation depending of the path:
 
 | Path | Behavior | Expanded expression | Result|
 |:--------|:--------|:-----|:-----|
-|**`current_eva_path`** | Aggregation function applied **before** evaluation | **(a0+...+a4)/(b0+...+b4)** | **0.6**|
-|**`new_eva_path`** | Aggregation function applied **after** evaluation|**(a0/b0+...+a4/b4)**|**3**|
+|**`current_eva_path`** | Aggregation function applied *before* evaluation | **(1+2+...+5)/(5+5+...+5)** | **0.6**|
+|**`new_eva_path`** | Aggregation function applied *after* evaluation|**(1/5 + 2/5 + ... + 5/5)**|**3**|
 
 As one may notice the results are completely different.
 
@@ -83,16 +83,16 @@ Here is the behavior difference:
 | `current_eva_path` | (10 + 10 + 10) / (0 + 1 + NaN) | 30 |
 | `new_eva_path` | 10/0 + 10/1 + 10/NaN | 10 |
 
-Note that both evaluations are correct -- it depends on your intention. Because the current query language is ambiguous, we recommend rewriting your query to make your intended query explicit. Please [reach out to us][1] if you have any question regarding those changes.  
+Note that both evaluations are correct -- it depends on your intention. Because the current query language is ambiguous, we recommend rewriting your query to make your intended query explicit. Please [reach out to us][1] if you have any questions regarding these changes.  
 
 
 ## Workaround
 
-Since this special behavior is tied to the `as_count`​ modifier, we encourage replacing `as_count` with `as_rate()` or `rollup(sum)` in these scenarios.  
+Since this special behavior is tied to the `as_count` modifier, we encourage replacing `as_count` with `as_rate()` or `rollup(sum)` in these scenarios.  
 
-*Example*: Suppose you wish to monitor the error rate of a service:
+*Example:* Suppose you wish to monitor the error rate of a service:
 
-***Incorrect!***
+
 
 Suppose you want to be alerted when the error rate is above 50% at all times during the past 5 min. You might have a query like:
 `min(last_5m):sum:requests.error{*}.as_count() / sum:requests.total{*}.as_count() > 0.5 ` 

--- a/content/monitors/faq/as-count-monitor-evaluation.md
+++ b/content/monitors/faq/as-count-monitor-evaluation.md
@@ -24,11 +24,11 @@ Normal timeseries graphs like:
 
 `sum:requests.error{*}.as_count()/ sum:requests.total{*}.as_count()` 
 
-compute the point by point ratio so it wasn't possible to accommodate such an important use case as what's my ratio of request error. Thus an exception has been made for monitors involving arithmetics and at least 1 `as_count` modifier.
+compute the point by point ratio so it wasn't possible to accommodate such an important use case as what's my ratio of request error. Thus an exception has been made for monitors involving arithmetic and at least 1 `as_count` modifier.
 
 ## Example
 
-Let’s take this query for the  *2018-03-13T11:00:00* to *2018-03-13T11:05:00* time frame:
+Let’s take this query for the time frame between *11:00:00* and *11:05:00*:
 
 `sum:requests.error{*}.as_count()/sum:requests.total{*}.as_count()`   
 
@@ -83,22 +83,22 @@ Here is the behavior difference:
 | `current_eva_path` | (10 + 10 + 10) / (0 + 1 + NaN) | 30 |
 | `new_eva_path` | 10/0 + 10/1 + 10/NaN | 10 |
 
-Note that both evaluations are correct -- it depends on your intention. Because the current query language is ambiguous, we recommend rewriting your query to make your intended query explicit. Please [reach out to us][1] if you have any questions regarding these changes.  
+Note that both evaluations are correct -- it depends on your intention. 
 
 
 ## Workaround
 
-Since this special behavior is tied to the `as_count` modifier, we encourage replacing `as_count` with `as_rate()` or `rollup(sum)` in these scenarios.  
+Since this special behavior is tied to the `as_count` modifier, we encourage replacing `as_count` with the `as_rate()` and  `rollup(sum)` operators to make your intended query explicit.  
 
 *Example:* Suppose you wish to monitor the error rate of a service:
-
-
 
 Suppose you want to be alerted when the error rate is above 50% at all times during the past 5 min. You might have a query like:
 `min(last_5m):sum:requests.error{*}.as_count() / sum:requests.total{*}.as_count() > 0.5 ` 
 
 To correctly rewrite it in the explicit format, the query can be rewritten like:
 
-`min(last_5m):sum:requests.error{*}.as_rate() / sum:requests.total{*}.as_rate() > 0.5 ` 
+`min(last_30m): ( default(sum:requests.error{*}.as_rate().rollup(60, sum),0) / sum:requests.total{*}.as_rate().rollup(60, sum) )`
+
+Please [reach out to us][1] if you have any questions regarding these changes.  
 
 [1]: /help

--- a/content/monitors/faq/as-count-monitor-evaluation.md
+++ b/content/monitors/faq/as-count-monitor-evaluation.md
@@ -7,20 +7,24 @@ kind: faq
 
 Currently all monitors that have the `as_count` modifier are using a separate evaluation path than the other monitors. In certain use-cases this this can result in unexpected behavior. **We intend to migrate all monitors with `as_count` to the same evaluation path as other monitors.**
 
-Let's call the current evaluation path for `as_count` monitors `current_eva_path` and the new one `new_eva_path`. The biggest difference between the two paths is that:
+Let's call the current evaluation path for `as_count` monitors **`current_eva_path`** and the new one **`new_eva_path`**.  
 
-* `current_eva_path`: applies the time aggregation function for each metric series **before** evaluating the expression.
-* `new_eva_path`: applies the time aggregation function for each metric series **after** evaluating the expression.
+The difference between those two evaluation paths is that complex monitor queries, **especially those that have division or multiplication**, produce different results depending on the time aggregation function:
 
-The consequence of this is that complex monitor queries, **especially those that have division or multiplication**, produce different results depending on the time aggregation function.
+| Path | Behavior | Expanded expression |
+|:--------|:--------|:--------|
+|**`current_eva_path`** | Aggregation function applied **before** evaluation | **(a0+...+a4)/(b0+...+b4)** |
+|**`new_eva_path`** | Aggregation function applied **after** evaluation |**(a0/b0+...+a4/b4)**|
 
-## Why ?
+#### Why ?
 
 Many of our customers need to be alerted when the total global error rate over a certain time-period is too high.
 
-Normal timeserie graphs `sum:requests.error{*}.as_count()/ sum:requests.total{*}.as_count()` compute the point by point ratio so it wasn't possible to accommodate this important use case.
+Normal timeserie graphs like:  
 
-Thus an exception has been made for monitors involving arithmetics and at least 1 `as_count` modifier.
+`sum:requests.error{*}.as_count()/ sum:requests.total{*}.as_count()` 
+
+compute the point by point ratio so it wasn't possible to accommodate such an important use case as what's my ratio of request error. Thus an exception has been made for monitors involving arithmetics and at least 1 `as_count` modifier.
 
 ## Example
 
@@ -56,14 +60,14 @@ For the 5 min timeframe there are 5 time series points (zeros excluded):
 
 Here is the result of the evaluation depending of the path:
 
-| Path | Expanded expression | Result|
-|:--------|:--------|:-----|
-|`current_eva_path`: Aggregation function applied **before** evaluation | **(a0+...+a4)/(b0+...+b4)** | **0.6**|
-|`new_eva_path`: Aggregation function applied **after** evaluation|**(a0/b0+...+a4/b4)**|**1**|
+| Path | Behavior | Expanded expression | Result|
+|:--------|:--------|:-----|:-----|
+|**`current_eva_path`** | Aggregation function applied **before** evaluation | **(a0+...+a4)/(b0+...+b4)** | **0.6**|
+|**`new_eva_path`** | Aggregation function applied **after** evaluation|**(a0/b0+...+a4/b4)**|**3**|
 
 As one may notice the results are completely different.
 
-## Sparse metric problem
+### Sparse metric problem
 
 In case of sparse or *0* metrics in the denominator some results are rejected in case of `new_eva_path`.
 
@@ -79,13 +83,11 @@ Here is the behavior difference:
 | `current_eva_path` | (10 + 10 + 10) / (0 + 1 + NaN) | 30 |
 | `new_eva_path` | 10/0 + 10/1 + 10/NaN | 10 |
 
-## Quiz: which result is correct?
+## Which result is correct?
 
-**Both**, It depends on your intention. The understanding of the internals of each way is crucial to properly treat the results, feel free [to reach out to us][1] if you have any question regarding those changes
+**Both**, It depends on your intention. The understanding of the internals of each way is crucial to properly treat the results, feel free [to reach out to us][1] if you have any question regarding those changes.  
 
-### Covering other use cases
-
-Since this special behavior is tied to the `as_count`​ modifier, we encourage replacing `as_count` with `as_rate()` or `rollup(sum)` in these scenarios in order to benefit from the `new_eva_path` logic right now.  
+Since this special behavior is tied to the `as_count`​ modifier, we encourage replacing `as_count` with `as_rate()` or `rollup(sum)` in these scenarios in order to benefit from the `new_eva_path` logic right now, a.k.a: Aggregation function applied **after** evaluation.  
 
 *Example*: `min(last_5m):sum:requests.error{*}.as_rate() / sum:requests.total{*}.as_rate() > 0.5 ` alerts you when the error rate is above 50% at all times during the past 5 min.
 

--- a/content/monitors/faq/as-count-monitor-evaluation.md
+++ b/content/monitors/faq/as-count-monitor-evaluation.md
@@ -5,14 +5,14 @@ kind: faq
 
 ## Overview
 
-Currently all monitors that have `as_count` modifier are using a separate evaluation path that the other monitors, which can lead in certain use-cases to a different monitor behavior one could expect. **We intend to migrate monitor with `as_count` to the same endpoint as all monitor. Here is the impact of such decisions.**  
+Currently all monitors that have `as_count` modifier are using a separate evaluation path that the other monitors, which can lead in certain use-cases to a different monitor behavior one could expect. **We intend to migrate monitor with `as_count` to the same evaluation path as all monitor. Here is the impact of such decisions.**  
 
 Let's call the current evaluation path for `as_count` monitors `current_eva_path` and the new one `new_eva_path`. The biggest difference between the two paths is that:
 
 * `current_eva_path`: applies the time aggregation function for each metric series **before** evaluating the expression.
 * `new_eva_path`: applies the time aggregation function for each metric series **after** evaluating the expression.
 
-The consequence of this is that complex monitor query, **especially those that have division**, produce different result depending on the time aggregation function.
+The consequence of this is that complex monitor query, **especially those that have division or multiplication**, produce different result depending on the time aggregation function.
 
 ## Example
 
@@ -20,29 +20,27 @@ Let’s take this query for the  *2018-03-13T11:00:00* *2018-03-13T11:05:00* tim
 
 `sum(last_5m):sum:dd.alerting.sla.missing.1m0s{*}.as_count() / sum:dd.alerting.sla.expected.1m0s{*}.as_count()`   
 
-For the 5mn timeframe there are 5 time series for each metric (zeros excluded):
+For the 5 min timeframe there are 5 time series points (zeros excluded):
 
-Numerator, `sum:dd.alerting.sla.missing.1m0s{*}.as_count()`:
+**Numerator**, `sum:dd.alerting.sla.missing.1m0s{*}.as_count()`:
 
-```
+| Timestamp | Value|
+|:----------|:-----|
 | 2018-03-13 11:00:30 | 82        |
 | 2018-03-13 11:01:30 | 78        |
 | 2018-03-13 11:02:40 | 608       |
 | 2018-03-13 11:03:30 | 161.00001 |
 | 2018-03-13 11:04:40 | 166       |
-```
 
-Denominator, `sum:dd.alerting.sla.expected.1m0s{*}.as_count()`:
+**Denominator**, `sum:dd.alerting.sla.expected.1m0s{*}.as_count()`:
 
-```
+| Timestamp | Value|
+|:----------|:-----|
 | 2018-03-13 11:00:30 | 464972 |
 | 2018-03-13 11:01:30 | 464974 |
 | 2018-03-13 11:02:40 | 464973 |
 | 2018-03-13 11:03:30 | 464974 |
 | 2018-03-13 11:04:40 | 464973 |
-```
-
-The complete results for numerator and denominator of can be found [here][1]
 
 Here is the result of the evaluation depending of the path:
 
@@ -71,6 +69,6 @@ Here is the behavior difference:
 
 ## Quiz: which result is correct?
 
-**Both**, it depends on your intention. The understanding of the internals of each way is crucial to properly treat the results, feel free [to reach out to us](/help) if you have any question regarding those changes
+**Both**, it depends on your intention. The understanding of the internals of each way is crucial to properly treat the results, feel free [to reach out to us][1] if you have any question regarding those changes
 
-[1]: https://gist.github.com/niamster/45e94337063000b4dfec9f03afcf1411
+[1]: /help

--- a/content/monitors/faq/as-count-monitor-evaluation.md
+++ b/content/monitors/faq/as-count-monitor-evaluation.md
@@ -24,23 +24,27 @@ For the 5 min timeframe there are 5 time series points (zeros excluded):
 
 **Numerator**, `sum:dd.alerting.sla.missing.1m0s{*}.as_count()`:
 
-| Timestamp | Value|
-|:----------|:-----|
+```
+| Timestamp           | Value     |
+|:--------------------|:----------|
 | 2018-03-13 11:00:30 | 82        |
 | 2018-03-13 11:01:30 | 78        |
 | 2018-03-13 11:02:40 | 608       |
 | 2018-03-13 11:03:30 | 161.00001 |
 | 2018-03-13 11:04:40 | 166       |
+```
 
 **Denominator**, `sum:dd.alerting.sla.expected.1m0s{*}.as_count()`:
 
-| Timestamp | Value|
-|:----------|:-----|
+```
+| Timestamp           | Value  |
+|:--------------------|:-------|
 | 2018-03-13 11:00:30 | 464972 |
 | 2018-03-13 11:01:30 | 464974 |
 | 2018-03-13 11:02:40 | 464973 |
 | 2018-03-13 11:03:30 | 464974 |
 | 2018-03-13 11:04:40 | 464973 |
+```
 
 Here is the result of the evaluation depending of the path:
 

--- a/content/monitors/faq/as-count-monitor-evaluation.md
+++ b/content/monitors/faq/as-count-monitor-evaluation.md
@@ -97,7 +97,7 @@ Suppose you want to be alerted when the error rate is above 50% at all times dur
 
 To correctly rewrite it in the explicit format, the query can be rewritten like:
 
-`min(last_30m): ( default(sum:requests.error{*}.as_rate().rollup(60, sum),0) / sum:requests.total{*}.as_rate().rollup(60, sum) )`
+`min(last_5m): ( default(sum:requests.error{*}.as_rate().rollup(60, sum),0) / sum:requests.total{*}.as_rate().rollup(60, sum) )`
 
 Please [reach out to us][1] if you have any questions regarding these changes.  
 

--- a/content/monitors/faq/as-count-monitor-evaluation.md
+++ b/content/monitors/faq/as-count-monitor-evaluation.md
@@ -1,0 +1,76 @@
+---
+title: as_count() monitor evaluation changes
+kind: faq
+---
+
+## Overview
+
+Currently all monitors that have `as_count` modifier are using a separate evaluation path that the other monitors, which can lead in certain use-cases to a different monitor behavior one could expect. **We intend to migrate monitor with `as_count` to the same endpoint as all monitor. Here is the impact of such decisions.**  
+
+Let's call the current evaluation path for `as_count` monitors `current_eva_path` and the new one `new_eva_path`. The biggest difference between the two paths is that:
+
+* `current_eva_path`: applies the time aggregation function for each metric series **before** evaluating the expression.
+* `new_eva_path`: applies the time aggregation function for each metric series **after** evaluating the expression.
+
+The consequence of this is that complex monitor query, **especially those that have division**, produce different result depending on the time aggregation function.
+
+## Example
+
+Let’s take this query for the  *2018-03-13T11:00:00* *2018-03-13T11:05:00* time frame.:
+
+`sum(last_5m):sum:dd.alerting.sla.missing.1m0s{*}.as_count() / sum:dd.alerting.sla.expected.1m0s{*}.as_count()`   
+
+For the 5mn timeframe there are 5 time series for each metric (zeros excluded):
+
+Numerator, `sum:dd.alerting.sla.missing.1m0s{*}.as_count()`:
+
+```
+| 2018-03-13 11:00:30 | 82        |
+| 2018-03-13 11:01:30 | 78        |
+| 2018-03-13 11:02:40 | 608       |
+| 2018-03-13 11:03:30 | 161.00001 |
+| 2018-03-13 11:04:40 | 166       |
+```
+
+Denominator, `sum:dd.alerting.sla.expected.1m0s{*}.as_count()`:
+
+```
+| 2018-03-13 11:00:30 | 464972 |
+| 2018-03-13 11:01:30 | 464974 |
+| 2018-03-13 11:02:40 | 464973 |
+| 2018-03-13 11:03:30 | 464974 |
+| 2018-03-13 11:04:40 | 464973 |
+```
+
+The complete results for numerator and denominator of can be found [here][1]
+
+Here is the result of the evaluation depending of the path:
+
+| Path | Expanded expression | Result|
+|:--------|:--------|:-----|
+|`current_eva_path`: Aggregation function applied **before** evaluation | **(a0+...+a4)/(b0+...+b4)** | **0.00047099 ~ 0.0005**|
+|`new_eva_path`: Aggregation function applied **after** evaluation|**(a0/b0+...+a4/b4)**|**0.0023549 ~ 0.0024**|
+
+As one may notice the results are completely different.
+
+## Sparse metric problem
+
+In case of sparse or *0* metrics in the denominator some results are rejected in case of `new_eva_path`.
+
+Let’s have following metrics:
+
+* `A = (10, 10, 10)` 
+* `B = (0, 1, -)`
+
+Here is the behavior difference: 
+
+| Path | Evaluation | Result |
+|:------|:------|:-------|
+| `current_eva_path` | (10 + 10 + 10) / (0 + 1 + NaN) | 30 |
+| `new_eva_path` | 10/0 + 10/1 + 10/NaN | 10 |
+
+## Quiz: which result is correct?
+
+**Both**, it depends on your intention. The understanding of the internals of each way is crucial to properly treat the results, feel free [to reach out to us](/help) if you have any question regarding those changes
+
+[1]: https://gist.github.com/niamster/45e94337063000b4dfec9f03afcf1411

--- a/content/monitors/faq/as-count-monitor-evaluation.md
+++ b/content/monitors/faq/as-count-monitor-evaluation.md
@@ -20,7 +20,7 @@ The difference between those two evaluation paths is that complex monitor querie
 
 Many of our customers need to be alerted when the total global error rate over a certain time-period is too high.
 
-Normal timeserie graphs like:  
+Normal timeseries graphs like:  
 
 `sum:requests.error{*}.as_count()/ sum:requests.total{*}.as_count()` 
 

--- a/content/monitors/faq/as-count-monitor-evaluation.md
+++ b/content/monitors/faq/as-count-monitor-evaluation.md
@@ -5,11 +5,11 @@ kind: faq
 
 ## Overview
 
-Currently all monitors that have the `as_count` modifier are using a separate evaluation path than the other monitors. In certain use-cases this this can result in unexpected behavior. **We intend to migrate all monitors with `as_count` to the same evaluation path as other monitors.**
+Currently all monitors that have the `as_count` modifier are using a separate evaluation path than the other monitors. In certain use-cases this this can result in unexpected behavior. We intend to migrate all monitors with `as_count` to the same evaluation path as other monitors, but this doc explains the underlying issue and will guide you with the migration process.
 
-Let's call the current evaluation path for `as_count` monitors **`current_eva_path`** and the new one **`new_eva_path`**.  
+Let's call the current evaluation path for `as_count` monitors `current_eva_path` and the new one `new_eva_path`.  
 
-The difference between those two evaluation paths is that complex monitor queries, **especially those that have division or multiplication**, produce different results depending on the time aggregation function:
+The difference between those two evaluation paths is that complex monitor queries, especially those that have division or multiplication, may produce **unintended results** depending on the time aggregation function:
 
 | Path | Behavior | Expanded expression |
 |:--------|:--------|:--------|
@@ -92,6 +92,13 @@ Since this special behavior is tied to the `as_count`​ modifier, we encourage 
 
 *Example*: Suppose you wish to monitor the error rate of a service:
 
-`min(last_5m):sum:requests.error{*}.as_rate() / sum:requests.total{*}.as_rate() > 0.5 ` alerts you when the error rate is above 50% at all times during the past 5 min.
+***Incorrect!***
+
+Suppose you want to be alerted when the error rate is above 50% at all times during the past 5 min. You might have a query like:
+`min(last_5m):sum:requests.error{*}.as_count() / sum:requests.total{*}.as_count() > 0.5 ` 
+
+To correctly rewrite it in the explicit format, the query can be rewritten like:
+
+`min(last_5m):sum:requests.error{*}.as_rate() / sum:requests.total{*}.as_rate() > 0.5 ` 
 
 [1]: /help


### PR DESCRIPTION
### What does this PR do?

Currently, if a user creates a monitor with a query of the format SUM(A).as_count() / SUM(B).as_count(), it won't actually work the way the customer expects.

The long-term plan is to display a warning in the monitor-creation UI, and to ideally guide them through a better creation flow.

In the meantime though, it's super confusing to everyone (particularly users), and we encounter this issue all the time. 

### Preview link

https://docs-staging.datadoghq.com/gus/monitor-kb/monitors/faq/as-count-monitor-evaluation/
