### PR TITLE
Clarify using template vars in event stream

### DIFF
--- a/content/graphing/dashboards/_index.md
+++ b/content/graphing/dashboards/_index.md
@@ -37,13 +37,16 @@ This open the template variable editing panel.
 
 A template variable is defined by a name and optional parameters for 'Tag Group' and 'Default Tag.' A tag group is a prefix shared among several tags, like `redis_port` for the tags `redis_port:6379` and `redis_port:6380`. Setting a tag group eliminates irrelevant tags from the variable's scope selector, and removes the prefix from the listed values for clarity - so you'll see `6379` and `6380` in the 'Default Tag' dropdown instead. The 'Default Tag' option determines the initial value for the variable on dashboard load.
 
-## Using template variables in graph editors
+## Using template variables in graph editors/widgets
 
 {{< img src="graphing/dashboards/redis-tpl-graph-editor.png" alt="Redis-tpl graph editor" responsive="true" style="width:70%;" >}}
 
 Once defined, template variables appear alongside normal tag and host options in graph editors. If you set `6379` as the value of `$redis`, all graphs defined with `$redis` is scoped to `redis_port:6379`.
 
 {{< img src="graphing/dashboards/redis-tpl-selected.png" alt="Redis tpl selected" responsive="true" popup="true" style="width:70%;">}}
+
+You can also use them explicitly in widgets like Event Stream, with a query like `tags:$redis`.
+
 
 ## Event Correlation at Design Time
 Event Correlation refers to overlaying events on top of a dashboard graph and is an important feature of the Datadog platform. You can setup correlation at two different times: either when you setup the dashboard or adhoc at the time you view the dashboard.

--- a/content/graphing/dashboards/_index.md
+++ b/content/graphing/dashboards/_index.md
@@ -45,7 +45,7 @@ Once defined, template variables appear alongside normal tag and host options in
 
 {{< img src="graphing/dashboards/redis-tpl-selected.png" alt="Redis tpl selected" responsive="true" popup="true" style="width:70%;">}}
 
-You can also use them explicitly in widgets like Event Stream, with a query like `tags:$redis`.
+You can also use them explicitly in widgets such as Event Stream, with a query of the form `tags:$redis`.
 
 
 ## Event Correlation at Design Time


### PR DESCRIPTION
### What does this PR do?
Clarifies template variable usage in event stream widget and any other potential widget with query field.

### Motivation
A user inquired why some of their template variables weren't working in the event stream widget, in https://datadog.zendesk.com/agent/tickets/140322. Following an investigation and slack discussion, I realized the 'tags:' prefix needed to be explicitly set. The behavior is not immediately intuitive as template variables work for some tags due to the String search behavior and finding the tags in the event text itself.