### PR TITLE
Adding link if service is not available

### DIFF
--- a/content/agent/faq/agent-commands.md
+++ b/content/agent/faq/agent-commands.md
@@ -6,6 +6,7 @@ aliases:
     - /agent/faq/start-stop-restart-the-datadog-agent
 ---
 
+
 ## Start/Stop/Restart the Agent 
 ### Start the Agent
 
@@ -16,6 +17,8 @@ aliases:
 |Source|`sudo ~/.datadog-agent/bin/agent start`|`sudo service datadog-agent start`|
 |Windows|[Consult our dedicated windows doc][1]|[Consult our dedicated windows doc][1]|
 
+**Note**: If you are using a Linux based system and the `service` wrapper command is not available, [consult the list of alternatives][4]
+
 ### Stop the Agent
 
 |Platform|Agent v5 |Agent v6|
@@ -24,6 +27,9 @@ aliases:
 |MacOS x|`/usr/local/bin/datadog-agent stop` |`launchctl stop com.datadoghq.agent` or systray app  |
 |Source|`sudo ~/.datadog-agent/bin/agent stop`|`sudo service datadog-agent stop`|
 |Windows|[Consult our dedicated windows doc][1]|[Consult our dedicated windows doc][1]|
+
+**Note**: If you are using a Linux based system and the `service` wrapper command is not available, [consult the list of alternatives][4]
+
 ### Restart the Agent 
 
 |Platform|Agent v5 |Agent v6|
@@ -32,6 +38,8 @@ aliases:
 |MacOS x|`/usr/local/bin/datadog-agent restart `|_run `stop` then `start`_ or systray app|
 |Source|`sudo ~/.datadog-agent/bin/agent restart`|`n/a`|
 |Windows|[Consult our dedicated windows doc][1]|[Consult our dedicated windows doc][1]|
+
+**Note**: If you are using a Linux based system and the `service` wrapper command is not available, [consult the list of alternatives][4]
 
 ## Agent Status and Information
 
@@ -45,6 +53,8 @@ aliases:
 |MacOS x|`datadog-agent status`             | `launchctl list com.datadoghq.agent` or systray app|
 |Source|`sudo ~/.datadog-agent/bin/agent status`|`sudo service datadog-agent status`|
 |Windows|[Consult our dedicated windows doc][2]|[Consult our dedicated windows doc][2]|
+
+**Note**: If you are using a Linux based system and the `service` wrapper command is not available, [consult the list of alternatives][4]
 
 ### Agent Information
 
@@ -73,7 +83,9 @@ The `[OK]` in the Agent output implies that the check was configured/run correct
 |Source|`sudo ~/.datadog-agent/bin/info`|`sudo datadog-agent status`|
 |Windows|[Consult our dedicated windows doc][2]|[Consult our dedicated windows doc][2]|
 
+**Note**: If you are using a Linux based system and the `service` wrapper command is not available, [consult the list of alternatives][4]
+
 [1]: /agent/basic_agent_usage/windows
 [2]: /agent/basic_agent_usage/windows/#status-and-information
 [3]: /agent/#using-the-gui
-
+[4]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md#service-lifecycle-commands


### PR DESCRIPTION
### What does this PR do?

In our official docs page we have the default agent commands listed like sudo service datadog-agent restart to restart the datadog-agent service. However, this is only if the service wrapper command is available. If it's not, these commands will fail. If this happens, please check this page:
