### PR TITLE
Updated environment variable link in Kubernetes documentation for agent usage.

### DIFF
--- a/content/agent/basic_agent_usage/kubernetes.md
+++ b/content/agent/basic_agent_usage/kubernetes.md
@@ -329,7 +329,7 @@ It can be configured with the environment variable `DD_LEADER_LEASE_DURATION`.
 [4]: /integrations/faq/using-rbac-permission-with-your-kubernetes-integration
 [5]: https://app.datadoghq.com/account/settings#api
 [6]: https://kubernetes.io/docs/concepts/configuration/secret/
-[7]: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables
+[7]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
 [8]: /agent/basic_agent_usage/docker/#environment-variables
 [9]: https://docs.datadoghq.com/agent/autodiscovery
 [10]: /logs


### PR DESCRIPTION
### What does this PR do?
Changes the link for `[7]`.

> Replace `YOUR_API_KEY` with [your api key][5] or use [Kubernetes secrets][6] to set your API key [as an environment variable][7].

### Motivation
[Documentation request](https://trello.com/c/wAOcuYoD/1194-kubernetes-documentation-updates-regarding-environment-variables):

> A client thought the latter hyperlink would be best served to link to https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/, as it explains how to expose the host IP using environment variables.

### Preview link
[/agent/basic_agent_usage/kubernetes/](https://docs-staging.datadoghq.com/andrew.mcburney/kube_env_updates/agent/basic_agent_usage/kubernetes/)

### Additional Notes
N/A
