### PR TITLE
Add API docs for process alert creation

### DIFF
--- a/content/api/monitors/monitors_create.md
+++ b/content/api/monitors/monitors_create.md
@@ -59,6 +59,16 @@ external_redirect: /api/#create-a-monitor
     *   **`rollup`** the stats rollup method. `count` is the only supported method now.
     *   **`last`** the timeframe to roll up the counts. Examples: 60s, 4h. Supported timeframes: s, m, h and d.
 
+    ##### Process Alert Query
+
+    `processes(search).over(tags).rollup('count').last(timeframe) operator #`
+
+    *   **`search`** free text search string for querying processes. Matching processes will match results on the [Live Processes](/graphing/infrastructure/process/) page
+    *   **`tags`** one or more tags (comma-separated)
+    *   **`timeframe`** the timeframe to roll up the counts. Examples: 60s, 4h. Supported timeframes: s, m, h and d
+    *   **`operator`** <, <=, >, >=, ==, or !=
+    *   **`#`** an integer or decimal number used to set the threshold
+
     ##### Composite Query
 
     `12345 && 67890`, where `12345` and `67890` are the IDs of non-composite monitors

--- a/content/api/monitors/monitors_create.md
+++ b/content/api/monitors/monitors_create.md
@@ -63,7 +63,7 @@ external_redirect: /api/#create-a-monitor
 
     `processes(search).over(tags).rollup('count').last(timeframe) operator #`
 
-    *   **`search`** free text search string for querying processes. Matching processes will match results on the [Live Processes](/graphing/infrastructure/process/) page
+    *   **`search`** free text search string for querying processes. Matching processes match results on the [Live Processes](/graphing/infrastructure/process/) page
     *   **`tags`** one or more tags (comma-separated)
     *   **`timeframe`** the timeframe to roll up the counts. Examples: 60s, 4h. Supported timeframes: s, m, h and d
     *   **`operator`** <, <=, >, >=, ==, or !=


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

This adds API docs for creating process alert monitors. This feature is not yet released for all customers so we should hold for the [feature flag](https://github.com/DataDog/consul-config/blob/master/datadog/prod/features/live_process_alerting) to be enabled for all (hopefully next week).

cc @mikezvi 

### Motivation

New feature for live processes

### Preview link

https://docs-staging.datadoghq.com/conor/process-query-api/api/?lang=python#monitors

### Additional Notes

The preview feature by branch is super nice :)
