### PR TITLE
Fix typo in Log application code doc

### DIFF
--- a/content/logs/languages/_index.md
+++ b/content/logs/languages/_index.md
@@ -18,7 +18,7 @@ To enable those functionalities use the following attribute names:
 * `error.message`: Error message contained in the stack trace
 * `error.kind`: The type or "kind" of an error (i.e "Exception", "OSError", ...)
 
-**Note**: By default, [integration pipelines][1] attempt to remap default logging library parameters to those specific attributes and parse stack traces or traceback to automatically extract the `error.msg` and `error.kind`.
+**Note**: By default, [integration pipelines][1] attempt to remap default logging library parameters to those specific attributes and parse stack traces or traceback to automatically extract the `error.message` and `error.kind`.
 
 ## Send your application logs in JSON
 


### PR DESCRIPTION
### What does this PR do?
Fix a typo

### Motivation
The correct attribute is `error.message` and not `error.msg`

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
