### PR TITLE
made the description of the link listing template var a touch more ob…

### DIFF
--- a/content/monitors/notifications.md
+++ b/content/monitors/notifications.md
@@ -63,7 +63,7 @@ and the corresponding event notification:
 * Template variable content is escaped by default. If your variable
 contains JSON or code that you would NOT like to be escaped, use triple braces instead of double braces (e.g. `{{{event.text}}}`).
 
-* See a complete list of contextual template variables available to your monitor by clicking the "Use message template variables" link or in the list of suggestions that appears when you type `{{` to begin a template variable name.
+* See a complete list of contextual template variables available to your monitor by clicking the **Use message template variables** link or in the list of suggestions that appears when you type `{{` to begin a template variable name. The variables available are different depending on the combination of metric, tags, and other features of the monitor you are working on.
 
 * The tag template variables can also be used in the monitor titles (names), but the variables are only populated in the text of Datadog child events (not the parent, which displays an aggregation summary). 
 


### PR DESCRIPTION
…vious

### What does this PR do?
clarifies the list of template variables available for a monitor. the original ticket suggested making a list of common variables, but there are no common variables beyond what is documented. I made the link a bit more obvious when reading so someone remembers to click it. The on screen docs in that 'use message template variables' is really a great link to use and should be open by default, and we already document it, so i think this is the best that can be done.


### Motivation
card on the trello

### Preview link

https://docs-staging.datadoghq.com/mattw/tempvars/monitors/notifications
