### PR TITLE
mount docker socket readOnly

### DIFF
--- a/static/json/datadog-agent-ecs.json
+++ b/static/json/datadog-agent-ecs.json
@@ -9,7 +9,8 @@
       "mountPoints": [
         {
           "containerPath": "/var/run/docker.sock",
-          "sourceVolume": "docker_sock"
+          "sourceVolume": "docker_sock",
+          "readOnly": true
         },
         {
           "containerPath": "/host/sys/fs/cgroup",


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Mounts docker socket readOnly.

### Motivation
<!-- What inspired you to submit this pull request?-->
Customer request. Verified with Kenefah that readOnly is correct. Also submitted a PR to update the integration README.
### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
