### PR TITLE
Adding k8 legacy instructions

### DIFF
--- a/content/agent/basic_agent_usage/kubernetes.md
+++ b/content/agent/basic_agent_usage/kubernetes.md
@@ -324,11 +324,11 @@ It can be configured with the environment variable `DD_LEADER_LEASE_DURATION`.
 Our default configuration targets Kubernetes 1.7.6 and later, as the Datadog Agent relies on features and endpoints introduced in this version. More installation steps are required for older versions:
 
 - [RBAC objects][16] (`ClusterRoles` and `ClusterRoleBindings`) are available since Kubernetes 1.6 and OpenShift 1.3, but are available under different `apiVersion` prefixes:
-  
+
   * `rbac.authorization.k8s.io/v1` in Kubernetes 1.8+ (and OpenShift 3.9+), the default apiVersion we target
   * `rbac.authorization.k8s.io/v1beta1` in Kubernetes 1.5 to 1.7 (and OpenShift 3.7)
   * `v1` in Openshift 1.3 to 3.6
-  
+
     Apply our yaml manifests with the following `sed` invocations:
 
     ```
@@ -347,8 +347,8 @@ Our default configuration targets Kubernetes 1.7.6 and later, as the Datadog Age
 
 - Our default daemonset makes use of the [downward API][7] to pass the kubelet's IP to the agent. This only works on versions 1.7 and up. For older versions, here are other ways to enable kubelet connectivity:
 
-  * On versions 1.6, use `fieldPath: spec.nodeName` and check if your node name is resolvable and reachable from the pod
-  * If `DD_KUBERNETES_KUBELET_HOST` is unset, the agent retrieves the node hostname from docker and tries to connect there. See `docker info | grep "Name:"` and check if the name is resolvable and reachable
+  * On version 1.6, use `fieldPath: spec.nodeName` and verify your node name is resolvable and reachable from the pod.
+  * If `DD_KUBERNETES_KUBELET_HOST` is unset, the agent retrieves the node hostname from docker and tries to connect there. See `docker info | grep "Name:"` and verify the name is resolvable and reachable.
   * If the IP of the docker default gateway is constant across your cluster, pass that IP in the `DD_KUBERNETES_KUBELET_HOST` envvar. You can retrieve the IP with the `ip addr show | grep docker0` command.
 
 - Our default configuration relies on [bearer token authentication][18] to the APIserver and kubelet. On 1.3, the kubelet does not support bearer token auth, setup client certificates for the `datadog-agent` serviceaccount and pass them to the agent.

--- a/content/agent/basic_agent_usage/kubernetes.md
+++ b/content/agent/basic_agent_usage/kubernetes.md
@@ -12,7 +12,7 @@ aliases:
     - /integrations/faq/gathering-kubernetes-events
 ---
 
-**Note**: Agent version 6.0 and above only support versions of Kubernetes higher than 1.7.6. For prior versions of Kubernetes, use [Agent 5.x][16].
+**Note**: Agent version 6.0 and above only support versions of Kubernetes higher than 1.7.6. For prior versions of Kubernetes, consult the [Legacy Kubernetes versions section](#legacy-kubernetes-versions).
 
 There are two installation processes available to gather metrics, traces and logs from your Kubernetes Clusters:
 
@@ -319,6 +319,40 @@ This functionality is disabled by default, enabling the event collection will ac
 The leaderLeaseDuration is the duration for which a leader stays elected. It should be > 30 seconds and is 60 seconds by default. The longer it is, the less frequently your Agents hit the apiserver with requests, but it also means that if the leader dies (and under certain conditions), events can be missed until the lease expires and a new leader takes over.
 It can be configured with the environment variable `DD_LEADER_LEASE_DURATION`.
 
+### Legacy Kubernetes versions
+
+Our default configuration targets Kubernetes 1.7.6 and later, as the Datadog Agent relies on features and endpoints introduced in this version. More installation steps are required for older versions:
+
+- [RBAC objects][16] (`ClusterRoles` and `ClusterRoleBindings`) are available since Kubernetes 1.6 and OpenShift 1.3, but are available under different `apiVersion` prefixes:
+  
+  * `rbac.authorization.k8s.io/v1` in Kubernetes 1.8+ (and OpenShift 3.9+), the default apiVersion we target
+  * `rbac.authorization.k8s.io/v1beta1` in Kubernetes 1.5 to 1.7 (and OpenShift 3.7)
+  * `v1` in Openshift 1.3 to 3.6
+  
+    Apply our yaml manifests with the following `sed` invocations:
+
+    ```
+    sed "s%authorization.k8s.io/v1%authorization.k8s.io/v1beta1%" clusterrole.yaml | kubectl apply -f -
+    sed "s%authorization.k8s.io/v1%authorization.k8s.io/v1beta1%" clusterrolebinding.yaml | kubectl apply -f -
+    ```
+
+    or for Openshift 1.3 to 3.6:
+
+    ```
+    sed "s%rbac.authorization.k8s.io/v1%v1%" clusterrole.yaml | oc apply -f -
+    sed "s%rbac.authorization.k8s.io/v1%v1%" clusterrolebinding.yaml | oc apply -f -
+    ```
+
+- The `kubelet` check retrieves metrics from the Kubernetes 1.7.6+ (OpenShift 3.7.0+) prometheus endpoint. [Enable cAdvisor port mode][17] for older versions.
+
+- Our default daemonset makes use of the [downward API][7] to pass the kubelet's IP to the agent. This only works on versions 1.7 and up. For older versions, here are other ways to enable kubelet connectivity:
+
+  * On versions 1.6, use `fieldPath: spec.nodeName` and check if your node name is resolvable and reachable from the pod
+  * If `DD_KUBERNETES_KUBELET_HOST` is unset, the agent retrieves the node hostname from docker and tries to connect there. See `docker info | grep "Name:"` and check if the name is resolvable and reachable
+  * If the IP of the docker default gateway is constant across your cluster, pass that IP in the `DD_KUBERNETES_KUBELET_HOST` envvar. You can retrieve the IP with the `ip addr show | grep docker0` command.
+
+- Our default configuration relies on [bearer token authentication][18] to the APIserver and kubelet. On 1.3, the kubelet does not support bearer token auth, setup client certificates for the `datadog-agent` serviceaccount and pass them to the agent.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -338,4 +372,6 @@ It can be configured with the environment variable `DD_LEADER_LEASE_DURATION`.
 [13]: /agent/autodiscovery
 [14]: https://app.datadoghq.com/account/settings#agent
 [15]: /agent/faq/agent-commands/#agent-status-and-information
-[16]: https://github.com/DataDog/dd-agent
+[16]: https://kubernetes.io/docs/admin/authorization/rbac/
+[17]: https://github.com/DataDog/integrations-core/tree/master/kubelet#compatibility
+[18]: https://kubernetes.io/docs/admin/authentication/#service-account-tokens

--- a/content/agent/faq/docker-jmx.md
+++ b/content/agent/faq/docker-jmx.md
@@ -3,9 +3,9 @@ title: Docker JMX
 kind: faq
 ---
 
-The standard datadog/docker-dd-agent:latest image for running [the docker container][1] `dd-agent` does not have JMX installed in it, since that's some additional weight that isn't always useful.
+The standard datadog/docker-dd-agent:latest image for running [the docker container][1] `datadog-agent` does not have JMX installed in it, since that's some additional weight that isn't always useful.
 
-If you are interested in adding JMX-related integrations to your docker containerized `dd-agent`, use the docker images that end in "-jmx" to install a version that does include JMX, e.g, `datadog/agent:latest-jmx`.
+If you are interested in adding JMX-related integrations to your docker containerized `datadog-agent`, use the docker images that end in "-jmx" to install a version that does include JMX, e.g, `datadog/agent:latest-jmx`.
 Execute a docker-run with those images and the `SD_JMX_ENABLE=true` environment variable, and then use [service discovery][2] to collect metrics over JMX using your dd-agent.
 
 ## Autodiscovery

--- a/content/integrations/faq/list-of-api-source-attribute-value.md
+++ b/content/integrations/faq/list-of-api-source-attribute-value.md
@@ -32,6 +32,7 @@ kind: faq
 |Amazon Kms|KMS|
 |Amazon Lambda|LAMBDA|
 |Amazon Machine Learning|MACHINELEARNING|
+|Amazon Mq|MQ|
 |Amazon Ops Works|OPSWORKS|
 |Amazon Polly|POLLY|
 |Amazon Rds|RDS|

--- a/content/integrations/faq/troubleshooting-jmx-integrations.md
+++ b/content/integrations/faq/troubleshooting-jmx-integrations.md
@@ -11,18 +11,23 @@ If you're able to connect using JConsole, run the following:
 java -jar /opt/datadog-agent/agent/checks/libs/jmxterm-1.0-DATADOG-uber.jar -l localhost:PORT -u USER -p PASSWORD
 ```
 
-If you're able to connect using the command above run: beans
+If you're able to connect using the command above run: `beans`. Then send us a copy of the results from above along with for Agent v6:
 
-Send us a copy of the results from above along with:
+* Content of `/var/log/datadog/agent.log`
+* Output of the [info command][3]
+* Output of: `ps aux | grep jmxfetch`
+* A copy of the YAML integration (send the file)
+
+For Agent v5, please follow those instructions: 
 
 * [Agent logs][2]
-* Output of the [info command][3])
-* Output of: ps aux | grep jmxfetch
-* /var/log/datadog/jmxfetch.log
+* Output of the [info command][3]
+* Output of: `ps aux | grep jmxfetch`
+* Content of `/var/log/datadog/jmxfetch.log`
 * Output of: `sudo /etc/init.d/datadog-agent jmx list_everything`
 * A copy of the YAML integration (send the file)
 
-Note, if you're able to see some metrics (`jvm.heap_memory`, `jvm.non_heap_memory`, etc.) it is a sign that JMXFetch is properly running, in this scenario the likely issue is connected to a misconfiguration in your YAML if you're targeting another application.
+**Note**: if you're able to see some metrics (`jvm.heap_memory`, `jvm.non_heap_memory`, etc.) it is a sign that JMXFetch is properly running, in this scenario the likely issue is connected to a misconfiguration in your YAML if you're targeting another application.
 
 [1]: https://docs.oracle.com/javase/8/docs/technotes/guides/management/faq.html
 [2]: /agent/faq/send-logs-and-configs-to-datadog-via-flare-command

--- a/content/integrations/faq/troubleshooting-jmx-integrations.md
+++ b/content/integrations/faq/troubleshooting-jmx-integrations.md
@@ -11,14 +11,16 @@ If you're able to connect using JConsole, run the following:
 java -jar /opt/datadog-agent/agent/checks/libs/jmxterm-1.0-DATADOG-uber.jar -l localhost:PORT -u USER -p PASSWORD
 ```
 
-If you're able to connect using the command above run: `beans`. Then send us a copy of the results from above along with for Agent v6:
+If you're able to connect using the command above, run: `beans` and send us a copy of the results from above along with the following information.
+
+For Agent v6:
 
 * Content of `/var/log/datadog/agent.log`
 * Output of the [info command][3]
 * Output of: `ps aux | grep jmxfetch`
 * A copy of the YAML integration (send the file)
 
-For Agent v5, please follow those instructions: 
+For Agent v5:
 
 * [Agent logs][2]
 * Output of the [info command][3]
@@ -27,7 +29,7 @@ For Agent v5, please follow those instructions:
 * Output of: `sudo /etc/init.d/datadog-agent jmx list_everything`
 * A copy of the YAML integration (send the file)
 
-**Note**: if you're able to see some metrics (`jvm.heap_memory`, `jvm.non_heap_memory`, etc.) it is a sign that JMXFetch is properly running, in this scenario the likely issue is connected to a misconfiguration in your YAML if you're targeting another application.
+**Note**: if you're able to see some metrics (`jvm.heap_memory`, `jvm.non_heap_memory`, etc.) it is a sign that JMXFetch is properly running. If you're targeting another application and not seeing related metrics, the likely issue is a misconfiguration in your YAML.
 
 [1]: https://docs.oracle.com/javase/8/docs/technotes/guides/management/faq.html
 [2]: /agent/faq/send-logs-and-configs-to-datadog-via-flare-command


### PR DESCRIPTION
### What does this PR do?

Push content from https://github.com/DataDog/datadog-agent/pull/1616/ to the doc + fix on instructions for agent v5 and v6

### Preview link

* https://docs-staging.datadoghq.com/gus/docker-doc-update/agent/basic_agent_usage/kubernetes/#legacy-kubernetes-versions