### PR TITLE
don't send faq files to transifex anymore

### DIFF
--- a/translate.yaml
+++ b/translate.yaml
@@ -16,6 +16,7 @@ sources:
 - src: "i18n/en.json"
   dst: "{lang}.json"
 ignores:
+  - "content/**/faq/*.md"
   - "**/*.fr.md"
   - "**/*.fr.yaml"
   - "**/*.fr.json"


### PR DESCRIPTION
### What does this PR do?
This PR is a config update to stop sending the faq pages for translation during the nightly task.

### Motivation
https://trello.com/c/mrmc2g1P/2222-remove-all-faq-from-transifex

### Preview link
Preview link shouldn't show any differences as this is a config change.
https://docs-staging.datadoghq.com/david.jones/remove-faq-translations/

### Additional Notes

