### PR TITLE
fix what's next declaration in dogstatsd.md

### DIFF
--- a/content/developers/dogstatsd.md
+++ b/content/developers/dogstatsd.md
@@ -10,8 +10,11 @@ further_reading:
   tag: "Documentation"
   text: Learn more about Metrics
 - link: "developers/libraries"
-  tag: "Docuementation"
-  text: Datadog-official and community contributed API and DogStatsD client libraries
+  tag: "Documentation"
+  text: Official and Community-contributed API and DogStatsD client libraries
+- link: "https://github.com/DataDog/dd-agent/blob/master/dogstatsd.py"
+  tag: "Github"
+  text: DogStatsD source code
 ---
 
 The easiest way to get your custom application metrics into Datadog is to send them to DogStatsD, a metrics aggregation service bundled with the Datadog Agent. DogStatsD implements the [StatsD][5] protocol and adds a few Datadog-specific extensions:
@@ -405,10 +408,7 @@ PS C:\vagrant> .\send-statsd.ps1 "_e{$($title.length),$($text.Length)}:$title|$t
 
 ## Further Reading
 
-{{< whatsnext  >}}
-    {{< nextlink href="developers/libraries/" tag="Documentation" >}}Find a DogStatsD client library to suit your needs.{{< /nextlink >}}
-    {{< nextlink href="https://github.com/DataDog/dd-agent/blob/master/dogstatsd.py" tag="Github" >}}DogStatsD source code{{< /nextlink >}}
-{{< /whatsnext >}}
+{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/dd-agent/pull/2104
 [2]: /libraries/


### PR DESCRIPTION
### What does this PR do?
Replaces the manual "What's Next" section declaration with a partial as specified in the [Further Reading doc item](https://github.com/DataDog/documentation/wiki/Further-Reading-section). Also fixes a small typo.

### Motivation
@l0k0ms, basically.

### Preview ~~link~~ image
![image](https://user-images.githubusercontent.com/625232/39431982-a5931138-4c92-11e8-9893-d4a3bd5e6594.png)

### Additional Notes
Ideally we'd do this everywhere, I suppose, but I just happened to be looking at this file. 😉 