### PR TITLE
content/tracing/setup: update Go setup documentation for v1

### DIFF
--- a/content/tracing/setup/go.md
+++ b/content/tracing/setup/go.md
@@ -108,7 +108,7 @@ Make sure to take a look at our integrations package [godoc page][contrib godoc]
 
 ## OpenTracing Support
 
-Import the [`opentracer` package][opentracing] to expose the Datadog tracer as an [OpenTracing][3] compatible tracer.
+Import the [`opentracer` package][opentracing godoc] to expose the Datadog tracer as an [OpenTracing][3] compatible tracer.
 
 ### Example
 

--- a/content/tracing/setup/go.md
+++ b/content/tracing/setup/go.md
@@ -18,26 +18,18 @@ further_reading:
 
 ## Getting started
 
-For configuration instructions and details about using the API, check out our [API documentation][api docs] for manual
-instrumentation, and our [integrations section][contrib docs] for libraries and frameworks supporting automatic instrumentation.
+For configuration instructions and details about using the API, check out our [API documentation][api docs] for manual instrumentation, and our [integrations section][contrib docs] for Go libraries and frameworks supporting automatic instrumentation.
 
-For descriptions of terminology used in APM, take a look at the [Getting started with APM][getting started] section.
+For a description of the terminology used in APM, take a look at the [Getting started with APM section][getting started]. For details about contributing, check the official repository [README.md file][repo readme]. 
 
-For details about contributing, check the official repository [README.md file][repo readme]. If you are migrating from an older
-version of the tracer (e.g. 0.6.x) you can find some more guidance in our [migration document][migrating].
-
-[api docs]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace
-[contrib docs]: #automatic-instrumentation
-[getting started]: https://docs.datadoghq.com/tracing/visualization/
-[repo readme]: https://github.com/DataDog/dd-trace-go/tree/v1#contributing
-[migrating]: https://github.com/DataDog/dd-trace-go/tree/v1/MIGRATING.md
+Consult our [migration document][migrating] if you need to migrate from an older version of the tracer (e.g. v<0.6.x) to newest version.
 
 ### Requirements
 
-To begin tracing applications written in Go, your environment must first meet the following requirements:
+To begin tracing your Go applications, your environment must first meet the following requirements:
 
-* Run the Datadog Agent >= 5.21.1. See ["Install and configure the Datadog Agent"][1] (additional documentation for [tracing Docker applications](/tracing/setup/docker/)).
-* Go 1.9+
+* Runing the Datadog Agent >= 5.21.1. See ["Install and configure the Datadog Agent"][1] (additional documentation for [tracing Docker applications](/tracing/setup/docker/)).
+* Using Go 1.9+
 
 ### Installation
 
@@ -47,14 +39,13 @@ Next, install the Go tracer from its canonical import path:
 go get gopkg.in/DataDog/dd-trace-go.v1/...
 ```
 
-If you see errors related to the integrations folder (`contrib`), simply ignore them, they are there only due to our
-support for older versions of modern libraries (such as our gRPC integration).
+If you see errors related to the integrations folder (`contrib`), simply ignore them, they are there only due to our support for older versions of modern libraries (such as our gRPC integration).
 
 You are now ready to import the tracer and start instrumenting your code!
 
 ## Manual instrumentation
 
-To make use of manual instrumentation, use the `tracer` package whch is thoroughly documented on our [godoc page][tracer godoc]. One simplistic example would be:
+To make use of manual instrumentation, use the `tracer` package which is documented on our [godoc page][tracer godoc]. One simplistic example would be:
 
 ```go
 package main
@@ -75,17 +66,17 @@ func main() {
 }
 ```
 
-Full documentation regarding the options for starting the tracer or creating and finishing spans can be found in the official [API documentation][tracer godoc].
+Consult the official [API documentation][tracer godoc] to discover all options for starting the tracer or creating and finishing spans.
 
 ## Automatic instrumentation
 
-We have built a series of pluggable packages which provide out-of-the-box support for instrumenting a series of libraries
-and frameworks. A table listing the currently supported integrations can be seen below. The [official documentation][contrib godoc]
-also provides a good overview of the supported packages, their APIs, along with usage examples.
+We have built a series of pluggable packages which provide out-of-the-box support for instrumenting a series of libraries and frameworks. Find below the list of currently supported integrations. 
+
+**Note**: The [official documentation][contrib godoc] also provides a good overview of the supported packages, their APIs, along with usage examples.
 
 ### Frameworks
 
-The following list of web frameworks can be integrated with using one of our helper packages.
+Integrate the Go tracer with the following list of web frameworks using one of our helper packages.
 
 
 | Framework     | Framework Documentation                 | GoDoc Datadog Documentation                                                          |
@@ -97,7 +88,7 @@ The following list of web frameworks can be integrated with using one of our hel
 
 ### Library Compatibility
 
-It also includes support for the following data stores and libraries:
+The Go tracer includes support for the following data stores and libraries:
 
 
 | Library             | Library Documentation                                                 | GoDoc Datadog Documentation                                                                |
@@ -117,12 +108,11 @@ Make sure to take a look at our integrations package [godoc page][contrib godoc]
 
 ## OpenTracing Support
 
-The repository contains a package which can be used to expose the Datadog tracer as an [OpenTracing][3] compatible tracer. The usage is simple, straight-forward and
-can be accomplished by importing the [`opentracer` package][opentracing godoc].
+Import the [`opentracer` package][opentracing] to expose the Datadog tracer as an [OpenTracing][3] compatible tracer.
 
 ### Example
 
-A basic usage example can be seen below.
+A basic usage would be:
 
 ```go
 package main
@@ -149,12 +139,12 @@ func main() {
 }
 ```
 
-Note that using the [OpenTracing API][4] in parallel with the regular API or our integrations is fully supported. Under the hood, all of them
+**Note**: Using the [OpenTracing API][4] in parallel with the regular API or our integrations is fully supported. Under the hood, all of them
 make use of the same tracer. Make sure to check out the [API documentation][opentracing godoc] for more examples and details.
 
 ## Further Reading
 
-More information on topics such as distributed tracing and sampling priority can be found in the [package documentation][tracer godoc].
+Find more information in the [package documentation][tracer godoc] about distributed tracing and sampling priority.
 
 {{< partial name="whats-next/whats-next.html" >}}
 
@@ -164,3 +154,8 @@ More information on topics such as distributed tracing and sampling priority can
 [tracer godoc]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer
 [contrib godoc]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib
 [opentracing godoc]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer
+[api docs]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace
+[contrib docs]: #automatic-instrumentation
+[getting started]: https://docs.datadoghq.com/tracing/visualization/
+[repo readme]: https://github.com/DataDog/dd-trace-go/tree/v1#contributing
+[migrating]: https://github.com/DataDog/dd-trace-go/tree/v1/MIGRATING.md

--- a/content/tracing/setup/go.md
+++ b/content/tracing/setup/go.md
@@ -41,33 +41,6 @@ go get gopkg.in/DataDog/dd-trace-go.v1/ddtrace
 
 You are now ready to import the tracer and start instrumenting your code!
 
-## Manual Instrumentation
-
-To make use of manual instrumentation, use the `tracer` package which is documented on our [godoc page][tracer godoc]. One simple example would be:
-
-```go
-package main
-
-import "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
-
-func main() {
-    // Start the tracer with zero or more options.
-    tracer.Start(tracer.WithServiceName("my-service"))
-    defer tracer.Stop()
-
-    // Create a span for a web request at the /posts URL.
-    span := tracer.StartSpan("web.request", tracer.ResourceName("/posts"))
-    defer span.Finish()
-
-    // Set metadata
-    span.SetTag("my_tag", "my_value")
-}
-```
-
-## OpenTracing Support
-
-Import the [`opentracer` package][opentracing godoc] to expose the Datadog tracer as an [OpenTracing][3] compatible tracer.
-
 ## Automatic Instrumentation
 
 We have built a series of pluggable packages which provide out-of-the-box support for instrumenting a series of libraries and frameworks. Find below the list of currently supported integrations. 
@@ -101,7 +74,32 @@ The Go tracer includes support for the following data stores and libraries. Make
 | SQL                 | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/database/sql | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/database/sql                      |
 | SQLx                | https://github.com/jmoiron/sqlx                                       | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/jmoiron/sqlx                      |
 
-___
+## Manual Instrumentation
+
+To make use of manual instrumentation, use the `tracer` package which is documented on our [godoc page][tracer godoc]. One simple example would be:
+
+```go
+package main
+
+import "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+
+func main() {
+    // Start the tracer with zero or more options.
+    tracer.Start(tracer.WithServiceName("my-service"))
+    defer tracer.Stop()
+
+    // Create a span for a web request at the /posts URL.
+    span := tracer.StartSpan("web.request", tracer.ResourceName("/posts"))
+    defer span.Finish()
+
+    // Set metadata
+    span.SetTag("my_tag", "my_value")
+}
+```
+
+## OpenTracing Support
+
+Import the [`opentracer` package][opentracing godoc] to expose the Datadog tracer as an [OpenTracing][3] compatible tracer.
 
 ### Example
 

--- a/content/tracing/setup/go.md
+++ b/content/tracing/setup/go.md
@@ -137,9 +137,9 @@ make use of the same tracer. Make sure to check out the [API documentation][open
 
 ## Sampling / Distributed Tracing
 
-Distributed tracing allows you to propagate a single trace across multiple services, so you can see performance end-to-end. For more details about how to use and configure distributed tracing, check out the [package documentation][tracer godoc].
+See your end-to-end performances by propagating a single trace across multiple services with distributed tracing. For more details about how to use and configure distributed tracing, check out the [package documentation][tracer godoc].
 
-Make use of priority sampling to ensure that distributed traces are complete. You may set the sampling priority of a trace by adding the `sampling.priority` tag to its root span. This will be propagated throughout the entire stack. For example:
+Make use of priority sampling to ensure that distributed traces are complete. Set the sampling priority of a trace by adding the `sampling.priority` tag to its root span. This is then propagated throughout the entire stack. For example:
 
 ```go
 span.SetTag(ext.SamplingPriority, ext.PriorityUserKeep)

--- a/content/tracing/setup/go.md
+++ b/content/tracing/setup/go.md
@@ -135,7 +135,7 @@ make use of the same tracer. Make sure to check out the [API documentation][open
 
 ## Sampling / Distributed Tracing
 
-See your end-to-end performances by propagating a single trace across multiple services with distributed tracing. For more details about how to use and configure distributed tracing, check out the [package documentation][tracer godoc].
+Propagate a single trace across multiple services with distributed tracing. For more details about how to use and configure distributed tracing, check out the [godoc page][tracer godoc].
 
 Make use of priority sampling to ensure that distributed traces are complete. Set the sampling priority of a trace by adding the `sampling.priority` tag to its root span. This is then propagated throughout the entire stack. For example:
 

--- a/content/tracing/setup/go.md
+++ b/content/tracing/setup/go.md
@@ -16,7 +16,7 @@ further_reading:
   text: "Explore your services, resources and traces"
 ---
 
-## Getting started
+## Getting Started
 
 For configuration instructions and details about using the API, check out our [API documentation][api docs] for manual instrumentation, and our [integrations section][contrib docs] for Go libraries and frameworks supporting automatic instrumentation.
 
@@ -41,9 +41,9 @@ go get gopkg.in/DataDog/dd-trace-go.v1/ddtrace
 
 You are now ready to import the tracer and start instrumenting your code!
 
-## Manual instrumentation
+## Manual Instrumentation
 
-To make use of manual instrumentation, use the `tracer` package which is documented on our [godoc page][tracer godoc]. One simplistic example would be:
+To make use of manual instrumentation, use the `tracer` package which is documented on our [godoc page][tracer godoc]. One simple example would be:
 
 ```go
 package main
@@ -64,13 +64,15 @@ func main() {
 }
 ```
 
-Consult the official [API documentation][tracer godoc] to discover all options for starting the tracer or creating and finishing spans.
+## OpenTracing Support
 
-## Automatic instrumentation
+Import the [`opentracer` package][opentracing godoc] to expose the Datadog tracer as an [OpenTracing][3] compatible tracer.
+
+## Automatic Instrumentation
 
 We have built a series of pluggable packages which provide out-of-the-box support for instrumenting a series of libraries and frameworks. Find below the list of currently supported integrations. 
 
-**Note**: The [official documentation][contrib godoc] also provides a good overview of the supported packages, their APIs, along with usage examples.
+**Note**: The [official documentation][contrib godoc] also provides a detailed overview of the supported packages and their APIs, along with usage examples.
 
 ### Frameworks
 
@@ -86,8 +88,7 @@ Integrate the Go tracer with the following list of web frameworks using one of o
 
 ### Library Compatibility
 
-The Go tracer includes support for the following data stores and libraries:
-
+The Go tracer includes support for the following data stores and libraries. Make sure to visit our integrations package [godoc page][contrib godoc] for an in-depth look.
 
 | Library             | Library Documentation                                                 | GoDoc Datadog Documentation                                                                |
 | ------------------- | --------------------------------------------------                    | ------------------------------------------------------------------------------------------ |
@@ -101,12 +102,6 @@ The Go tracer includes support for the following data stores and libraries:
 | SQLx                | https://github.com/jmoiron/sqlx                                       | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/jmoiron/sqlx                      |
 
 ___
-
-Make sure to take a look at our integrations package [godoc page][contrib godoc] for an in-depth look.
-
-## OpenTracing Support
-
-Import the [`opentracer` package][opentracing godoc] to expose the Datadog tracer as an [OpenTracing][3] compatible tracer.
 
 ### Example
 
@@ -123,8 +118,8 @@ import (
 )
 
 func main() {
-    // Start the regular tracer and return it as an opentracing.Tracer. You may use
-    // the same set of options as you normally would with the Datadog tracer.
+    // Start the regular tracer and return it as an opentracing.Tracer interface. You
+    // may use the same set of options as you normally would with the Datadog tracer.
     t := opentracer.Start(tracer.WithServiceName("my-service"))
 
     // Stop it using the regular Stop call.
@@ -140,9 +135,24 @@ func main() {
 **Note**: Using the [OpenTracing API][4] in parallel with the regular API or our integrations is fully supported. Under the hood, all of them
 make use of the same tracer. Make sure to check out the [API documentation][opentracing godoc] for more examples and details.
 
-## Further Reading
+## Sampling / Distributed Tracing
 
-Find more information in the [package documentation][tracer godoc] about distributed tracing and sampling priority.
+Distributed tracing allows you to propagate a single trace across multiple services, so you can see performance end-to-end. For more details about how to use and configure distributed tracing, check out the [package documentation][tracer godoc].
+
+Make use of priority sampling to ensure that distributed traces are complete. You may set the sampling priority of a trace by adding the `sampling.priority` tag to its root span. This will be propagated throughout the entire stack. For example:
+
+```go
+span.SetTag(ext.SamplingPriority, ext.PriorityUserKeep)
+```
+
+Possible values for the sampling priority tag are:
+
+| Sampling Value             | Effect                                                                                                      |
+| -------------------------- | :---------------------------------------------------------------------------------------------------------- |
+| ext.PriorityAutoReject     | The sampler automatically decided to not keep the trace. The Agent will drop it.                            |
+| ext.PriorityAutoKeep       | The sampler automatically decided to keep the trace. The Agent will keep it. Might be sampled server-side.  |
+| ext.PriorityUserReject     | The user asked to not keep the trace. The Agent will drop it.                                               |
+| ext.PriorityUserKeep       | The user asked to keep the trace. The Agent will keep it. The server will keep it too.                      |
 
 {{< partial name="whats-next/whats-next.html" >}}
 

--- a/content/tracing/setup/go.md
+++ b/content/tracing/setup/go.md
@@ -151,6 +151,7 @@ Possible values for the sampling priority tag are:
 | ext.PriorityAutoKeep       | The sampler automatically decided to keep the trace. The Agent will keep it. Might be sampled server-side.  |
 | ext.PriorityUserReject     | The user asked to not keep the trace. The Agent will drop it.                                               |
 | ext.PriorityUserKeep       | The user asked to keep the trace. The Agent will keep it. The server will keep it too.                      |
+## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 

--- a/content/tracing/setup/go.md
+++ b/content/tracing/setup/go.md
@@ -5,10 +5,10 @@ aliases:
 - /tracing/go/
 - /tracing/languages/go
 further_reading:
-- link: "https://github.com/DataDog/dd-trace-go"
+- link: "https://github.com/DataDog/dd-trace-go/tree/v1"
   tag: "Github"
   text: Source code
-- link: "https://godoc.org/github.com/DataDog/dd-trace-go/tracer"
+- link: "https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
   tag: "GoDoc"
   text: Package page
 - link: "tracing/visualization/"
@@ -16,45 +16,75 @@ further_reading:
   text: "Explore your services, resources and traces"
 ---
 
-## Installation
+## Getting started
 
-To begin tracing applications written in Go, first [install and configure the Datadog Agent][1] (see additional documentation for [tracing Docker applications](/tracing/setup/docker/)).
+For configuration instructions and details about using the API, check out our [API documentation][api docs] for manual
+instrumentation, and our [integrations section][contrib docs] for libraries and frameworks supporting automatic instrumentation.
 
-Next, install the Go Tracer from the Github repository:
+For descriptions of terminology used in APM, take a look at the [Getting started with APM][getting started] section.
+
+For details about contributing, check the official repository [README.md file][repo readme].
+
+[api docs]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace
+[contrib docs]: #automatic-instrumentation
+[getting started]: https://docs.datadoghq.com/tracing/visualization/
+[repo readme]: https://github.com/DataDog/dd-trace-go/tree/v1#contributing
+
+### Requirements
+
+To begin tracing applications written in Go, your environment must first meet the following requirements:
+
+* Run the Datadog Agent >= 5.21.1. See ["Install and configure the Datadog Agent"][1] (additional documentation for [tracing Docker applications](/tracing/setup/docker/)).
+* Go 1.9+
+
+### Installation
+
+Next, install the Go tracer from its canonical import path:
 
 ```go
-go get "github.com/DataDog/dd-trace-go/tracer"
+go get gopkg.in/DataDog/dd-trace-go.v1/...
 ```
 
-Finally, import the tracer and instrument your code!
+If you see errors related to the integrations folder (`contrib`), simply ignore them, they are there only due to our
+support for older versions of modern libraries (such as our gRPC integration).
 
-## Example
+You are now ready to import the tracer and start instrumenting your code!
+
+## Manual instrumentation
+
+To make use of manual instrumentation, use the `tracer` package whch is thoroughly documented on our [godoc page][tracer godoc]. One simplistic example would be:
 
 ```go
 package main
 
-import (
-  "github.com/DataDog/dd-trace-go/tracer"
-)
+import "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
-func main {
-  span := tracer.NewRootSpan("web.request", "my_service", "resource_name")
-  defer span.Finish()
-  span.SetMeta("my_tag", "my_value")
+func main() {
+	// Start the tracer with zero or more options.
+	tracer.Start(tracer.WithServiceName("my-service"))
+	defer tracer.Stop()
+
+	// Create a span for a web request at the /posts URL.
+	span := tracer.StartSpan("web.request", tracer.ResourceName("/posts"))
+	defer span.Finish()
+
+	// Set metadata
+	span.SetTag("my_tag", "my_value")
 }
 ```
 
-For another example, see the [`example_test.go`][2] file in the Go Tracer package
+Full documentation regarding the options for starting the tracer or creating and finishing spans can be found in the official [API documentation][tracer godoc].
 
-## Compatibility
+## Automatic instrumentation
 
-Currently, only Go 1.7+ is supported.
+We have built a series of pluggable packages which provide out-of-the-box support for instrumenting a series of libraries
+and frameworks. A table listing the currently supported integrations can be seen below. The [official documentation][contrib godoc]
+also provides a good overview of the supported packages, their APIs, along with usage examples.
 
-### Framework Compatibility
+### Frameworks
 
-The ddtrace library includes support for a number of web frameworks, including:
+The following list of web frameworks can be integrated with using one of our helper packages.
 
-___
 
 | Framework     | Framework Documentation                 | GoDoc Datadog Documentation                                                          |
 | ------------- | --------------------------------------- | ------------------------------------------------------------------------------------ |
@@ -67,7 +97,6 @@ ___
 
 It also includes support for the following data stores and libraries:
 
-___
 
 | Library             | Library Documentation                                                 | GoDoc Datadog Documentation                                                                |
 | ------------------- | --------------------------------------------------                    | ------------------------------------------------------------------------------------------ |
@@ -80,53 +109,56 @@ ___
 | SQL                 | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/database/sql | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/database/sql                      |
 | SQLx                | https://github.com/jmoiron/sqlx                                       | https://godoc.org/github.com/DataDog/dd-trace-go/contrib/jmoiron/sqlx                      |
 
-### OpenTracing API
+___
 
-Datadog APM client that implements an [OpenTracing][3] Tracer.
+Make sure to take a look at our integrations package [godoc page][contrib godoc] for an in-depth look.
 
-**Initialization**
+## OpenTracing Support
 
-To start using the Datadog Tracer with the OpenTracing API, you should first initialize the tracer with a proper `Configuration` object:
+The repository contains a package which can be used to expose the Datadog tracer as an [OpenTracing][3] compatible tracer. The usage is simple, straight-forward and
+can be accomplished by importing the [`opentracer` package][opentracing godoc].
+
+### Example
+
+A basic usage example can be seen below.
 
 ```go
+package main
+
 import (
-  // ddtrace namespace is suggested
-  ddtrace "github.com/DataDog/dd-trace-go/opentracing"
-  opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 func main() {
-  // create a Tracer configuration
-  config := ddtrace.NewConfiguration()
-  config.ServiceName = "api-intake"
-  config.AgentHostname = "ddagent.consul.local"
+	// Start the regular tracer and return it as an opentracing.Tracer. You may use
+	// the same set of options as you normally would with the Datadog tracer.
+	t := opentracer.Start(tracer.WithServiceName("my-service"))
 
-  // initialize a Tracer and ensure a graceful shutdown
-  // using the `closer.Close()`
-  tracer, closer, err := ddtrace.NewTracer(config)
-  if err != nil {
-    // handle the configuration error
-  }
-  defer closer.Close()
+	// Stop it using the regular Stop call.
+	defer tracer.Stop()
+	
+	// Set the global OpenTracing tracer.
+	opentracing.SetGlobalTracer(t)
 
-  // set the Datadog tracer as a GlobalTracer
-  opentracing.SetGlobalTracer(tracer)
-  startWebServer()
+	// Use the OpenTracing API as usual.
 }
 ```
 
-Function `NewTracer(config)` returns an `io.Closer` instance that can be used to gracefully shutdown the `tracer`. It's recommended to always call the `closer.Close(), otherwise internal buffers are not flushed and you may lose some traces.
-
-**Usage**
-
-See [Opentracing documentation][4] for some usage patterns. Legacy documentation is available in [GoDoc format][5].
+Note that using the [OpenTracing API][4] in parallel with the regular API or our integrations is fully supported. Under the hood, all of them
+make use of the same tracer. Make sure to check out the [API documentation][opentracing godoc] for more examples and details.
 
 ## Further Reading
+
+More information on topics such as distributed tracing and sampling priority can be found in the [package documentation][tracer godoc].
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /tracing/setup
-[2]: https://github.com/DataDog/dd-trace-go/blob/master/tracer/example_test.go
 [3]: http://opentracing.io
 [4]: https://github.com/opentracing/opentracing-go
-[5]: https://godoc.org/github.com/DataDog/dd-trace-go/tracer
+[tracer godoc]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer
+[contrib godoc]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib
+[opentracing godoc]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer

--- a/content/tracing/setup/go.md
+++ b/content/tracing/setup/go.md
@@ -36,10 +36,8 @@ To begin tracing your Go applications, your environment must first meet the foll
 Next, install the Go tracer from its canonical import path:
 
 ```go
-go get gopkg.in/DataDog/dd-trace-go.v1/...
+go get gopkg.in/DataDog/dd-trace-go.v1/ddtrace
 ```
-
-If you see errors related to the integrations folder (`contrib`), simply ignore them, they are there only due to our support for older versions of modern libraries (such as our gRPC integration).
 
 You are now ready to import the tracer and start instrumenting your code!
 


### PR DESCRIPTION
Updates the documentation for setting up the Go tracer v1.

🔗 [Staging preview](https://docs-staging.datadoghq.com/gbbr/go-doc/tracing/setup/go/)

---

⚠️ Do not merge. This tracer is not yet launched and we need to first do a thorough review on staging, testing as well as time the moment that this PR goes in.
