### PR TITLE
remove API ToC item from Developer Tools section

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -615,11 +615,6 @@ languages:
           pre: "nav_developers"
           weight: 100
         # DEVELOPERS - Subnav start
-        - identifier: customnav_developersnav_api
-          name: "API"
-          url: "api/"
-          weight: 20
-          parent: menu_references_developers
         - identifier: customnav_developersnav_dogstatsd
           name: "DogStatsD"
           url: "developers/dogstatsd/"


### PR DESCRIPTION
### What does this PR do?
Removes the API sub-section ToC item from the Developer Tools section.

### Motivation
API is its own top-level item.

### Preview link
<!-- Impacted pages preview links-->
![image](https://user-images.githubusercontent.com/625232/39570197-e24aa8ca-4ec7-11e8-8437-0e25c1e9587e.png)