### PR TITLE
Enforcing custom Agent check wording

### DIFF
--- a/content/agent/agent_checks.md
+++ b/content/agent/agent_checks.md
@@ -20,7 +20,7 @@ further_reading:
 
 This page first looks at the `AgentCheck` interface, and then proposes a simple Agent Check that collects timing metrics and status events from HTTP services.  
 
-Custom checks are included in the main check run loop, meaning they run every check interval, which defaults to 15 seconds.
+Custom Agent checks are included in the main check run loop, meaning they run every check interval, which defaults to 15 seconds.
 
 ### Should you write an Agent Check or an Integration?
 
@@ -36,11 +36,11 @@ First off, ensure you've properly installed the [Agent][3] on your machine. If y
 
 ## Agent Check Interface
 
-All custom checks inherit from the `AgentCheck` class found in `checks/__init__.py` and require a `check()` method that takes one argument, `instance` which is a `dict` having the configuration of a particular instance. The `check` method is run once per instance defined in the check configuration (discussed later).  
+All custom Agent checks inherit from the `AgentCheck` class found in `checks/__init__.py` and require a `check()` method that takes one argument, `instance` which is a `dict` having the configuration of a particular instance. The `check` method is run once per instance defined in the check configuration (discussed later).  
 
 **Note**: 
 
-* Custom Checks aren't able to import modules by default, all your code should be in one single file.
+* Custom Agent Checks aren't able to import modules by default, all your code should be in one single file.
 
 * The datadog Agent installation has it's own embedded copy of python. Custom scripts importing pip-installed libraries fail unless datadog's own embedded copy of pip is used to install these third party libraries.
 
@@ -139,7 +139,7 @@ At the end of your check, all events are collected and flushed with the rest of 
 
 ### Sending service checks
 
-Your custom check can also report the status of a service by calling the `self.service_check(...)` method.
+Your custom Agent check can also report the status of a service by calling the `self.service_check(...)` method.
 
 The service_check method accepts the following arguments:
 
@@ -432,7 +432,7 @@ To test this, run:
 
 If your issue continues, reach out to Support with the [help page][11] that lists the paths it installs.
 
-### Testing custom checks on Windows
+### Testing custom Agent checks on Windows
 
 * **For Agent version < 5.12**:
     The Agent install includes a file called shell.exe in your Program Files directory for the Datadog Agent which you can use to run python within the Agent environment. Once your check (called `<CHECK_NAME>`) is written and you have the .py and .yaml files in their correct places, you can run the following in shell.exe:

--- a/content/agent/agent_checks.md
+++ b/content/agent/agent_checks.md
@@ -40,9 +40,8 @@ All custom Agent checks inherit from the `AgentCheck` class found in `checks/__i
 
 **Note**: 
 
-* Custom Agent Checks aren't able to import modules by default, all your code should be in one single file.
-
-* The datadog Agent installation has it's own embedded copy of python. Custom scripts importing pip-installed libraries fail unless datadog's own embedded copy of pip is used to install these third party libraries.
+* Custom Agent checks aren't able to import modules by default, all your code should be in one single file.
+* The Datadog Agent installation has its own embedded copy of Python. Custom scripts importing pip-installed libraries will fail unless Datadog's own embedded copy of pip is used to install these third-party libraries.
 
 ### `AgentCheck` interface for Agent v6
 

--- a/content/agent/autodiscovery.md
+++ b/content/agent/autodiscovery.md
@@ -73,7 +73,7 @@ The Agent looks for Autodiscovery templates in the `/etc/datadog-agent/conf.d` d
 
 Since 6.2.0 (and 5.24.0), the default templates use the default port for the monitored software, instead of auto-detecting it. If you need to use a different port, provide a custom Autodiscovery template either in [Docker container labels](#template-source-docker-label-annotations) or [Kubernetes pod annotations](#template-source-kubernetes-pod-annotations).
 
-These templates may suit you in basic cases, but if you need to use custom check configurations—say you want to enable extra check options, use different container identifiers, or use template variable indexing— you'll have to write your own auto-conf files. You can then provide those in a few ways:
+These templates may suit you in basic cases, but if you need to use custom Agent check configurations—say you want to enable extra check options, use different container identifiers, or use template variable indexing— you'll have to write your own auto-conf files. You can then provide those in a few ways:
 
 1. Add them to each host that runs docker-datadog-agent and [mount the directory that contains them][15] into the datadog-agent container when starting it
 2. On Kubernetes, add them [using ConfigMaps][16]

--- a/content/agent/basic_agent_usage/amazonlinux.md
+++ b/content/agent/basic_agent_usage/amazonlinux.md
@@ -98,8 +98,7 @@ The Agent 6.x installer can automatically convert your 5.x style Agent configura
  DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
 ```
 
-**Note:** the import process won't automatically move custom checks, this is by
-design since we cannot guarantee full backwards compatibility out of the box.
+**Note:** the import process won't automatically move custom Agent checks, this is by design since we cannot guarantee full backwards compatibility out of the box.
 
 ##### To Install Fresh
 

--- a/content/agent/basic_agent_usage/centos.md
+++ b/content/agent/basic_agent_usage/centos.md
@@ -98,8 +98,7 @@ The Agent 6.x installer can automatically convert your 5.x style Agent configura
  DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
 ```
 
-**Note:** the import process won't automatically move custom checks, this is by
-design since we cannot guarantee full backwards compatibility out of the box.
+**Note:** the import process won't automatically move custom Agent checks, this is by design since we cannot guarantee full backwards compatibility out of the box.
 
 ##### To Install Fresh
 

--- a/content/agent/basic_agent_usage/deb.md
+++ b/content/agent/basic_agent_usage/deb.md
@@ -96,8 +96,7 @@ The Agent 6.x installer can automatically convert your 5.x style Agent configura
  DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
 ```
 
-**Note:** the import process won't automatically move custom checks, this is by
-design since we cannot guarantee full backwards compatibility out of the box.
+**Note:** the import process won't automatically move custom Agent checks, this is by design since we cannot guarantee full backwards compatibility out of the box.
 
 ##### To Install Fresh
 

--- a/content/agent/basic_agent_usage/fedora.md
+++ b/content/agent/basic_agent_usage/fedora.md
@@ -97,8 +97,7 @@ The Agent 6.x installer can automatically convert your 5.x style Agent configura
  DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
 ```
 
-**Note:** the import process won't automatically move custom checks, this is by
-design since we cannot guarantee full backwards compatibility out of the box.
+**Note:** the import process won't automatically move custom Agent checks, this is by design since we cannot guarantee full backwards compatibility out of the box.
 
 ##### To Install Fresh
 
@@ -159,8 +158,8 @@ To install on a clean box (or have an existing Agent 5 install from which you do
 
     Note: please beware that if you have made any changes to your configurations to support new Agent v6-only options, these will not work anymore with Agent v5.
 
-4. Back-sync custom checks (optional)
-    If you made any changes or added any new custom checks while testing Agent 6 you might want to enable them back on Agent 5. Note: you only need to copy back checks you changed.
+4. Back-sync custom Agent checks (optional)
+    If you made any changes or added any new custom Agent checks while testing Agent 6 you might want to enable them back on Agent 5. Note: you only need to copy back checks you changed.
     
     ```shell
     sudo -u dd-agent -- cp /etc/datadog-agent/checks.d/<check>.py /etc/dd-agent/checks.d/

--- a/content/agent/basic_agent_usage/redhat.md
+++ b/content/agent/basic_agent_usage/redhat.md
@@ -90,8 +90,7 @@ The Agent 6.x installer can automatically convert your 5.x style Agent configura
  DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
 ```
 
-**Note:** the import process won't automatically move custom checks, this is by
-design since we cannot guarantee full backwards compatibility out of the box.
+**Note:** the import process won't automatically move custom Agent checks, this is by design since we cannot guarantee full backwards compatibility out of the box.
 
 ##### To Install Fresh
 
@@ -160,8 +159,8 @@ To install on a clean box (or have an existing Agent 5 install from which you do
 
     Note: please beware that if you have made any changes to your configurations to support new Agent v6-only options, these will not work anymore with Agent v5.
 
-4. Back-sync custom checks (optional)
-    If you made any changes or added any new custom checks while testing Agent 6 you might want to enable them back on Agent 5. Note: you only need to copy back checks you changed.
+4. Back-sync custom Agent checks (optional)
+    If you made any changes or added any new custom Agent checks while testing Agent 6 you might want to enable them back on Agent 5. Note: you only need to copy back checks you changed.
     
     ```shell
     sudo -u dd-agent -- cp /etc/datadog-agent/checks.d/<check>.py /etc/dd-agent/checks.d/

--- a/content/agent/basic_agent_usage/ubuntu.md
+++ b/content/agent/basic_agent_usage/ubuntu.md
@@ -98,8 +98,7 @@ The Agent 6.x installer can automatically convert your 5.x style Agent configura
  DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
 ```
 
-**Note:** the import process won't automatically move custom checks, this is by
-design since we cannot guarantee full backwards compatibility out of the box.
+**Note:** the import process won't automatically move custom Agent checks, this is by design since we cannot guarantee full backwards compatibility out of the box.
 
 ##### To Install Fresh
 

--- a/content/agent/faq/agent-5-autodiscovery.md
+++ b/content/agent/faq/agent-5-autodiscovery.md
@@ -85,7 +85,7 @@ The Agent looks for Autodiscovery templates in its `conf.d/auto_conf` directory,
 - [Redis][21]
 - [Riak][22]
 
-These templates may suit you in basic cases, but if you need to use custom check configurations—say you want to enable extra check options, use different container identifiers, or use [template variable indexing](#template-variable-indexes))— you'll have to write your own auto-conf files. You can then provide those in a few ways:
+These templates may suit you in basic cases, but if you need to use custom Agent check configurations—say you want to enable extra check options, use different container identifiers, or use [template variable indexing](#template-variable-indexes))— you'll have to write your own auto-conf files. You can then provide those in a few ways:
 
 1. Add them to each host that runs docker-dd-agent and [mount the directory that contains them][6] into the docker-dd-agent container when starting it
 2. Build your own docker image based on docker-dd-agent, adding your custom templates to `/etc/dd-agent/conf.d/auto_conf`

--- a/content/developers/_index.md
+++ b/content/developers/_index.md
@@ -13,7 +13,7 @@ Available endpoints can be found on [our dedicated API documentation page][1].
 In addition, [many libraries][2] are available to directly interact with the API.
 
 ## Submitting custom metrics
-While you can submit metrics directly through [our API][1], you can also submit metrics via the Datadog Agent using [DogStatsD][3] and custom checks.
+While you can submit metrics directly through [our API][1], you can also submit metrics via the Datadog Agent using [DogStatsD][3] and custom Agent checks.
 
 The Datadog Agent includes DogStatsD, a powerful statsd daemon with additional features, that provides better control over your metric metadata and aggregation.
 [Multiple libraries][4] are available to easily send metrics from your application to Datadog using [DogStatsD][3].

--- a/content/graphing/faq/how-do-i-add-hostname-to-event-titles-and-messages-submitted-by-my-custom-agent-checks.md
+++ b/content/graphing/faq/how-do-i-add-hostname-to-event-titles-and-messages-submitted-by-my-custom-agent-checks.md
@@ -3,7 +3,7 @@ title: How do I add hostname to event titles and messages submitted by my custom
 kind: faq
 ---
 
-When you submit events to your Datadog account from a [custom Agent check][1], they get a host tag associated with them by default. But it can sometimes be useful to include the hostname as part of the event title or content. This can be achieved if, in your custom check's code, you import `get_hostname` from `util`, and then feed `self.agentConfig` as an argument to `get_hostname`, as in this example:
+When you submit events to your Datadog account from a [custom Agent check][1], they get a host tag associated with them by default. But it can sometimes be useful to include the hostname as part of the event title or content. This can be achieved if, in your custom Agent check's code, you import `get_hostname` from `util`, and then feed `self.agentConfig` as an argument to `get_hostname`, as in this example:
 
 ```python
 

--- a/content/integrations/faq/how-can-i-gather-metrics-from-the-unix-shell.md
+++ b/content/integrations/faq/how-can-i-gather-metrics-from-the-unix-shell.md
@@ -5,14 +5,14 @@ kind: faq
 
 To gather metrics from the UNIX command line, we can use the unannounced shell integration.
 
-This integration has not yet been merged into the master branch, install this check as a custom check in the appropriate Datadog Agent [directories][1].
+This integration has not yet been merged into the master branch, install this check as a custom Agent check in the appropriate Datadog Agent [directories][1].
 
 You can find the integration files on GitHub:
 
 * [Shell YAML Example][2]
 * [Shell checks.d][3]
 
-This solution is a good alternative to creating a custom check for data you can easily gather directly from the UNIX shell. For example, sending a metric with a value of the number of files in a certain directory.
+This solution is a good alternative to creating a custom Agent check for data you can easily gather directly from the UNIX shell. For example, sending a metric with a value of the number of files in a certain directory.
 
 Caveat: 
 

--- a/ja/content/monitoring.md
+++ b/ja/content/monitoring.md
@@ -494,7 +494,7 @@ or service checks.
 メトリクスやイベント、あるいはサービスチェックを送信する独自のCheckの作成方法については、[「Agent Checkの書き方」](/ja/guides/agent_checks/)を参照してください。
 
 <!--
-1. Select your **custom check**.
+1. Select your **custom Agent check**.
 
 2. Select **host or tags** that you would like to monitor. The check will run
    for every unique set of tags from all monitored hosts. For example, the


### PR DESCRIPTION
### What does this PR do?

`Custom check` refers to a given type of monitor, and `custom Agent check` refers to checks custom that can be run by the DD agent. This PR update this consistency through the doc.