### PR TITLE
[apm] add Docker and Kubernetes instructions

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -408,6 +408,11 @@ languages:
           url: "tracing/setup/docker/"
           weight: 120
           parent: customnav_tracingnav_setup
+        - identifier: customnav_tracingnav_kubernetes
+          name: "Kubernetes"
+          url: "tracing/setup/kubernetes/"
+          weight: 125
+          parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_go
           name: "Go"
           url: "tracing/setup/go/"

--- a/content/tracing/setup/_index.md
+++ b/content/tracing/setup/_index.md
@@ -10,6 +10,9 @@ further_reading:
 - link: "tracing/setup/docker"
   tag: "Documentation"
   text: Docker setup
+- link: "tracing/setup/kubernetes"
+  tag: "Documentation"
+  text: Kubernetes setup
 - link: "tracing/setup/go"
   tag: "Documentation"
   text: Go language instrumentation

--- a/content/tracing/setup/docker.md
+++ b/content/tracing/setup/docker.md
@@ -20,9 +20,9 @@ For additional information, see the [Agent 6 Docker documentation][2].
 
 ## Tracing from the host
 
-Tracing can be available on port `8126/tcp` from _any host_ by adding the option `-p 8126:8126/tcp` to the `docker run` command.
+Tracing is available on port `8126/tcp` from *any host* by adding the option `-p 8126:8126/tcp` to the `docker run` command.
 
-To make it available from _your host only_, use `-p 127.0.0.1:8126:8126/tcp` instead.
+To make it available from *your host only*, use `-p 127.0.0.1:8126:8126/tcp` instead.
 
 For example, the following command allows the Agent to receive traces from anywhere:
 
@@ -37,17 +37,17 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
 
 ## Tracing from other containers
 
-As with DogStatsD, traces can be submitted to the Agent from other containers either using Docker networks or with the Docker host IP.
+As with DogStatsD, traces can be submitted to the Agent from other containers either using [Docker networks](#docker-network) or with the [Docker host IP](#host-ip).
 
-### Using Docker Network
+### Docker Network
 
-As a first step, you need to create a user-defined bridge network:
+As a first step, create a user-defined bridge network:
 
 ```bash
 docker network create <NETWORK_NAME>
 ```
 
-Then you can start the Agent and the application container, connected to the network previously created:
+Then start the Agent and the application container, connected to the network previously created:
 
 ```bash
 # Datadog Agent
@@ -66,10 +66,10 @@ docker run -d --name app \
               company/app:latest
 ```
 
-This exposes the hostname `dd-agent` in your `app` container. If you're using `docker-compose`, `<NETWORK_NAME>` parameters are the ones
-defined under the `networks` section of your `docker-compose.yml`.
+This exposes the hostname `dd-agent` in your `app` container.  
+If you're using `docker-compose`, `<NETWORK_NAME>` parameters are the ones defined under the `networks` section of your `docker-compose.yml`.
 
-Your application tracers must be configured to submit traces to this address. See examples for each supported language below:
+Your application tracers must be configured to submit traces to this address. See the examples below for each supported language:
 
 #### Python
 
@@ -109,7 +109,7 @@ func main() {
 
 #### Java
 
-You can update the Java Agent configuration via environment variables:
+Either update the Java Agent configuration via environment variables:
 
 ```bash
 DD_AGENT_HOST=dd-agent \
@@ -126,9 +126,10 @@ java -javaagent:/path/to/the/dd-java-agent.jar \
      -jar /your/app.jar
 ```
 
-### Using Docker host IP
+### Docker host IP
 
-Agent container port `8126` should be linked to the host directly. Configure your application tracer to report to the default route of this container (you can determine this using the `ip route` command).
+Agent container port `8126` should be linked to the host directly.  
+Configure your application tracer to report to the default route of this container (determine this using the `ip route` command).
 
 The following is an example for the Python Tracer, assuming `172.17.0.1` is the default route:
 
@@ -143,4 +144,4 @@ tracer.configure(hostname='172.17.0.1', port=8126)
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/datadog-trace-agent
-[2]: {{< ref "agent/basic_agent_usage/docker.md" >}}
+[2]: /agent/basic_agent_usage/docker

--- a/content/tracing/setup/docker.md
+++ b/content/tracing/setup/docker.md
@@ -74,7 +74,6 @@ Your application tracers must be configured to submit traces to this address. Se
 #### Python
 
 ```python
-import os
 from ddtrace import tracer
 
 tracer.configure(

--- a/content/tracing/setup/docker.md
+++ b/content/tracing/setup/docker.md
@@ -4,7 +4,7 @@ kind: Documentation
 aliases:
 - /tracing/docker/
 further_reading:
-- link: "https://github.com/DataDog/docker-dd-agent"
+- link: "https://github.com/DataDog/datadog-trace-agent"
   tag: "Github"
   text: Source code
 - link: "tracing/visualization/"
@@ -12,47 +12,64 @@ further_reading:
   text: "Explore your services, resources and traces"
 ---
 
-Enable the [datadog-trace-agent][1] in the `docker-dd-agent` container by passing `DD_APM_ENABLED=true` as an environment variable.
+Enable the [datadog-trace-agent][1] in the `datadog/agent` container by passing `DD_APM_ENABLED=true` as an environment variable.
 
 **Note: APM is NOT available on Alpine Images**
 
-For additional information, see the [Datadog docker Github repository][2].
+For additional information, see the [Agent 6 Docker documentation][2].
 
 ## Tracing from the host
 
-Tracing can be available on port `8126/tcp from _any host_ by adding the option `-p 8126:8126/tcp` to the `docker run` command.
+Tracing can be available on port `8126/tcp` from _any host_ by adding the option `-p 8126:8126/tcp` to the `docker run` command.
 
 To make it available from _your host only_, use `-p 127.0.0.1:8126:8126/tcp` instead.
 
 For example, the following command allows the Agent to receive traces from anywhere:
 
 ```bash
-docker run -d --name dd-agent \
-  -v /var/run/docker.sock:/var/run/docker.sock:ro \
-  -v /proc/:/host/proc/:ro \
-  -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-  -e API_KEY={your_api_key_here} \
-  -e DD_APM_ENABLED=true \
-  -p 8126:8126/tcp \
-  datadog/docker-dd-agent
+docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
+              -v /proc/:/host/proc/:ro \
+              -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
+              -e DD_API_KEY=<YOUR_API_KEY> \
+              -e DD_APM_ENABLED=true \
+              datadog/agent:latest
 ```
 
 ## Tracing from other containers
 
-As with DogStatsD, traces can be submitted to the Agent from other containers either using Docker links or with the Docker host IP.
+As with DogStatsD, traces can be submitted to the Agent from other containers either using Docker networks or with the Docker host IP.
 
-### Using Docker links
+### Using Docker Network
+
+As a first step, you need to create a user-defined bridge network:
 
 ```bash
-docker run  --name my_container \
-            --all_your_flags \
-            --link dd-agent:dd-agent \
-            my_image
+docker network create <NETWORK_NAME>
 ```
 
-This exposes `DD_AGENT_PORT_8126_TCP_ADDR` and `DD_AGENT_PORT_8126_TCP_PORT` as environment variables. Your application tracer must be configured to submit traces to this address.
+Then you can start the Agent and the application container, connected to the network previously created:
 
-See examples for each supported language below:
+```bash
+# Datadog Agent
+docker run -d --name dd-agent \
+              --network <NETWORK_NAME> \
+              -v /var/run/docker.sock:/var/run/docker.sock:ro \
+              -v /proc/:/host/proc/:ro \
+              -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
+              -e DD_API_KEY=<YOUR_API_KEY> \
+              -e DD_APM_ENABLED=true \
+              datadog/agent:latest
+
+# Application
+docker run -d --name app \
+              --network <NETWORK_NAME> \
+              company/app:latest
+```
+
+This exposes the hostname `dd-agent` in your `app` container. If you're using `docker-compose`, `<NETWORK_NAME>` parameters are the ones
+defined under the `networks` section of your `docker-compose.yml`.
+
+Your application tracers must be configured to submit traces to this address. See examples for each supported language below:
 
 #### Python
 
@@ -61,8 +78,8 @@ import os
 from ddtrace import tracer
 
 tracer.configure(
-    hostname=os.environ['DD_AGENT_PORT_8126_TCP_ADDR'],
-    port=os.environ['DD_AGENT_PORT_8126_TCP_PORT'],
+    hostname='dd-agent',
+    port=8126,
 )
 ```
 
@@ -70,24 +87,21 @@ tracer.configure(
 
 ```ruby
 Datadog.configure do |c|
-  c.tracer hostname: ENV['DD_AGENT_PORT_8126_TCP_ADDR'],
-           port: ENV['DD_AGENT_PORT_8126_TCP_PORT']
+  c.tracer hostname: 'dd-agent',
+           port: 8126
 end
 ```
 
 #### Go
 
 ```go
-import (
-    "os"
+import ddtrace "github.com/DataDog/dd-trace-go/opentracing"
 
-    ddtrace "github.com/DataDog/dd-trace-go/opentracing"
-)
 
 func main() {
     config := ddtrace.NewConfiguration()
-    config.AgentHostname = os.GetEnv("DD_AGENT_PORT_8126_TCP_ADDR")
-    config.AgentPort = os.GetEnv("DD_AGENT_PORT_8126_TCP_PORT")
+    config.AgentHostname = "dd-agent"
+    config.AgentPort = 8126
 
     tracer, closer, err := ddtrace.NewTracer(config)
     defer closer.Close()
@@ -99,8 +113,8 @@ func main() {
 You can update the Java Agent configuration via environment variables:
 
 ```bash
-DD_AGENT_HOST=$DD_AGENT_PORT_8126_TCP_ADDR \
-DD_AGENT_PORT=$DD_AGENT_PORT_8126_TCP_PORT \
+DD_AGENT_HOST=dd-agent \
+DD_AGENT_PORT=8126 \
 java -javaagent:/path/to/the/dd-java-agent.jar -jar /your/app.jar
 ```
 
@@ -108,8 +122,8 @@ or via system properties:
 
 ```bash
 java -javaagent:/path/to/the/dd-java-agent.jar \
-     -Ddd.agent.host=$DD_AGENT_PORT_8126_TCP_ADDR \
-     -Ddd.agent.port=$DD_AGENT_PORT_8126_TCP_PORT \
+     -Ddd.agent.host=dd-agent \
+     -Ddd.agent.port=8126 \
      -jar /your/app.jar
 ```
 
@@ -130,4 +144,4 @@ tracer.configure(hostname='172.17.0.1', port=8126)
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/datadog-trace-agent
-[2]: https://github.com/DataDog/docker-dd-agent
+[2]: {{< ref "agent/basic_agent_usage/docker.md" >}}

--- a/content/tracing/setup/docker.md
+++ b/content/tracing/setup/docker.md
@@ -100,7 +100,7 @@ import ddtrace "github.com/DataDog/dd-trace-go/opentracing"
 func main() {
     config := ddtrace.NewConfiguration()
     config.AgentHostname = "dd-agent"
-    config.AgentPort = 8126
+    config.AgentPort = "8126"
 
     tracer, closer, err := ddtrace.NewTracer(config)
     defer closer.Close()

--- a/content/tracing/setup/kubernetes.md
+++ b/content/tracing/setup/kubernetes.md
@@ -1,0 +1,184 @@
+---
+title: Tracing Kubernetes Applications
+kind: Documentation
+aliases:
+- /tracing/kubernetes/
+further_reading:
+- link: "https://github.com/DataDog/datadog-trace-agent"
+  tag: "Github"
+  text: Source code
+- link: "tracing/visualization/"
+  tag: "Documentation"
+  text: "Explore your services, resources and traces"
+---
+
+Deploy the [datadog-trace-agent][1] pod in your Kubernetes Cluster using DaemonSets (recommended). The `datadog/agent`
+image must be configured to enable the Trace Agent, passing `DD_APM_ENABLED=true` as environment variable.
+
+For additional information or different installation processes, see the [Agent 6 Kubernetes documentation][2].
+
+## Deploy Agent DaemonSet
+
+Create the following `datadog-agent.yaml` manifest:
+
+```
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: datadog-agent
+spec:
+  template:
+    metadata:
+      labels:
+        app: datadog-agent
+      name: datadog-agent
+    spec:
+      serviceAccountName: datadog-agent
+      containers:
+      - image: datadog/agent:latest
+        imagePullPolicy: Always
+        name: datadog-agent
+        ports:
+          - containerPort: 8125
+            name: dogstatsdport
+            protocol: UDP
+          - containerPort: 8126
+            name: traceport
+            protocol: TCP
+        env:
+          - name: DD_APM_ENABLED
+            value: "true"
+          - name: DD_API_KEY
+            value: <YOUR_API_KEY>
+          - name: DD_COLLECT_KUBERNETES_EVENTS
+            value: "true"
+          - name: DD_LEADER_ELECTION
+            value: "true"
+          - name: KUBERNETES
+            value: "yes"
+          - name: DD_KUBERNETES_KUBELET_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "250m"
+        volumeMounts:
+          - name: dockersocket
+            mountPath: /var/run/docker.sock
+          - name: procdir
+            mountPath: /host/proc
+            readOnly: true
+          - name: cgroups
+            mountPath: /host/sys/fs/cgroup
+            readOnly: true
+        livenessProbe:
+          exec:
+            command:
+            - ./probe.sh
+          initialDelaySeconds: 15
+          periodSeconds: 5
+      volumes:
+        - hostPath:
+            path: /var/run/docker.sock
+          name: dockersocket
+        - hostPath:
+            path: /proc
+          name: procdir
+        - hostPath:
+            path: /sys/fs/cgroup
+          name: cgroups
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dd-agent
+spec:
+  selector:
+    app: datadog-agent
+  ports:
+  - name: traceport
+    port: 8126
+    targetPort: 8126
+```
+
+Then, you can deploy the DemonSet and the Service with the command:
+
+```bash
+kubectl create -f datadog-agent.yaml
+```
+
+This exposes the service `DD_AGENT_SERVICE_HOST` and `DD_AGENT_SERVICE_PORT` in your Kubernetes Cluster. If you prefer using the
+DNS discovery, check the [official documentation][3]. Your application tracers must be configured to submit traces to this address.
+See examples for each supported language below:
+
+#### Python
+
+```python
+import os
+from ddtrace import tracer
+
+tracer.configure(
+    hostname=os.environ['DD_AGENT_SERVICE_HOST'],
+    port=os.environ['DD_AGENT_SERVICE_PORT'],
+)
+```
+
+#### Ruby
+
+```ruby
+Datadog.configure do |c|
+  c.tracer hostname: ENV['DD_AGENT_SERVICE_HOST'],
+           port: ENV['DD_AGENT_SERVICE_PORT']
+end
+```
+
+#### Go
+
+```go
+import (
+    "os"
+    ddtrace "github.com/DataDog/dd-trace-go/opentracing"
+)
+
+
+func main() {
+    config := ddtrace.NewConfiguration()
+    config.AgentHostname = os.GetEnv("DD_AGENT_SERVICE_HOST")
+    config.AgentPort = os.GetEnv("DD_AGENT_SERVICE_PORT")
+
+    tracer, closer, err := ddtrace.NewTracer(config)
+    defer closer.Close()
+}
+```
+
+#### Java
+
+You can update the Java Agent configuration via environment variables:
+
+```bash
+DD_AGENT_HOST=$DD_AGENT_SERVICE_HOST \
+DD_AGENT_PORT=$DD_AGENT_SERVICE_PORT \
+java -javaagent:/path/to/the/dd-java-agent.jar -jar /your/app.jar
+```
+
+or via system properties:
+
+```bash
+java -javaagent:/path/to/the/dd-java-agent.jar \
+     -Ddd.agent.host=$DD_AGENT_SERVICE_HOST \
+     -Ddd.agent.port=$DD_AGENT_SERVICE_PORT \
+     -jar /your/app.jar
+```
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://github.com/DataDog/datadog-trace-agent
+[2]: {{< ref "agent/basic_agent_usage/kubernetes.md" >}}
+[3]: https://kubernetes.io/docs/concepts/services-networking/service/#discovering-services

--- a/content/tracing/setup/kubernetes.md
+++ b/content/tracing/setup/kubernetes.md
@@ -2,7 +2,7 @@
 title: Tracing Kubernetes Applications
 kind: Documentation
 aliases:
-- /tracing/kubernetes/
+  - /tracing/kubernetes/
 further_reading:
 - link: "https://github.com/DataDog/datadog-trace-agent"
   tag: "Github"
@@ -12,8 +12,7 @@ further_reading:
   text: "Explore your services, resources and traces"
 ---
 
-Deploy the [datadog-trace-agent][1] pod in your Kubernetes Cluster using DaemonSets (recommended). The `datadog/agent`
-image must be configured to enable the Trace Agent, passing `DD_APM_ENABLED=true` as environment variable.
+Deploy the [datadog-trace-agent][1] pod in your Kubernetes Cluster using DaemonSets (recommended). The `datadog/agent` image must be configured to enable the Trace Agent, passing `DD_APM_ENABLED=true` as environment variable.
 
 For additional information or different installation processes, see the [Agent 6 Kubernetes documentation][2].
 
@@ -21,7 +20,7 @@ For additional information or different installation processes, see the [Agent 6
 
 Create the following `datadog-agent.yaml` manifest:
 
-```
+```yaml
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -106,15 +105,16 @@ spec:
     targetPort: 8126
 ```
 
-Then, you can deploy the DemonSet and the Service with the command:
+Then, deploy the DemonSet and the Service with the command:
 
 ```bash
 kubectl create -f datadog-agent.yaml
 ```
 
-This exposes the service `DD_AGENT_SERVICE_HOST` and `DD_AGENT_SERVICE_PORT` in your Kubernetes Cluster. If you prefer using the
-DNS discovery, check the [official documentation][3]. Your application tracers must be configured to submit traces to this address.
-See examples for each supported language below:
+This exposes the service `DD_AGENT_SERVICE_HOST` and `DD_AGENT_SERVICE_PORT` in your Kubernetes Cluster. If you prefer using the DNS discovery, check the [official documentation][3].  
+
+Your application tracers must be configured to submit traces to this address.
+See the examples below for each supported language:
 
 #### Python
 
@@ -158,7 +158,7 @@ func main() {
 
 #### Java
 
-You can update the Java Agent configuration via environment variables:
+Update the Java Agent configuration via environment variables:
 
 ```bash
 DD_AGENT_HOST=$DD_AGENT_SERVICE_HOST \
@@ -180,5 +180,5 @@ java -javaagent:/path/to/the/dd-java-agent.jar \
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/datadog-trace-agent
-[2]: {{< ref "agent/basic_agent_usage/kubernetes.md" >}}
+[2]: /agent/basic_agent_usage/kubernetes
 [3]: https://kubernetes.io/docs/concepts/services-networking/service/#discovering-services


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
* Refactors Docker documentation
* Adds Kubernetes section for APM (Tracing)

### Motivation

Kubernetes documentation was missing and Docker was using a deprecated feature (container links) that we should not suggest.

### Preview link

* Docker: https://docs-staging.datadoghq.com/palazzem/apm-docker/tracing/setup/docker/
* Kubernetes (new section on left menu): https://docs-staging.datadoghq.com/palazzem/apm-docker/tracing/setup/kubernetes/

### Additional Notes

We have some duplication here, but I think it's fine since it's not going to change in the near future.
