### PR TITLE
Added a search bar to integrations page

### DIFF
--- a/layouts/partials/integrations/integrations.html
+++ b/layouts/partials/integrations/integrations.html
@@ -53,6 +53,11 @@
     {{ range $i, $e := (sort ($.Scratch.Get "filters")) }}<a data-ref="filter" data-filter=".cat-{{ replace $e "/" "" | urlize }}" href="#cat-{{ replace $e "/" "" | urlize }}" class="mb-1 mr-1 btn btn-sm-tag btn-outline-secondary sort-time sort-{{ replace $e "/" "" | urlize }}">{{ $e | upper }}</a>{{ end }}
 </div>
 
+<div class="input-group mt-4">
+    <span class="input-group-addon">{{ partial "img.html" (dict "root" . "src" "icons/nav_search.png" "alt" "search" "width" "25") }}</span>
+    <input class="form-control integration-search" data-ref="search" placeholder="Search for an integration..." />
+</div>
+
 <!-- using 5 col -->
 <div class="row no-gutters integration-tiles mt-4" data-ref="container">
     {{ range $i, $v := $integration_list }}

--- a/layouts/partials/integrations/integrations.html
+++ b/layouts/partials/integrations/integrations.html
@@ -54,7 +54,9 @@
 </div>
 
 <div class="input-group mt-4">
-    <span class="input-group-addon">{{ partial "img.html" (dict "root" . "src" "icons/nav_search.png" "alt" "search" "width" "25") }}</span>
+    <span class="input-group-prepend">
+        <span class="input-group-text">{{ partial "img.html" (dict "root" . "src" "icons/nav_search.png" "alt" "search" "width" "25") }}</span>
+    </span>
     <input class="form-control integration-search" data-ref="search" placeholder="Search for an integration..." />
 </div>
 

--- a/layouts/partials/integrations/integrations.js
+++ b/layouts/partials/integrations/integrations.js
@@ -45,6 +45,7 @@ document.addEventListener('DOMContentLoaded', function () {
     var mobilefilters = null;
     var sorts = document.querySelectorAll('[data-ref="sort"]');
     var container = document.querySelector('[data-ref="container"]');
+    var search = document.querySelector('[data-ref="search"]')
     var items = window.integrations;
 
     if(!container) return;
@@ -100,6 +101,19 @@ document.addEventListener('DOMContentLoaded', function () {
         pop.style.display = 'none';
         $(window).scrollTop(0);
     });
+    
+    var searchTimer;
+
+    search.addEventListener('input', function(e) {
+        var allBtn = controls.querySelector('[data-filter="all"]');
+
+        // search only executes after user is finished typing
+        clearTimeout(searchTimer);
+        searchTimer = setTimeout(function() {
+            activateButton(allBtn, filters);
+            updateData(e.target.value.toLowerCase(), true)
+        }, 400);
+    })
 
     // integrations dropdown select
     /*$('.integrations-select').on('change', function(e) {
@@ -132,22 +146,27 @@ document.addEventListener('DOMContentLoaded', function () {
 
         var filter = button.getAttribute('data-filter');
         activateButton(button, filters);
-        updateData(filter);
+        updateData(filter, false);
     }
 
-    function updateData(filter) {
+    function updateData(filter, isSearch) {
         var show = [];
         var hide = [];
         for(var i = 0; i < window.integrations.length; i++) {
             var item = window.integrations[i];
             var domitem = document.getElementById('mixid_'+item.id);
-            if(filter === 'all' || filter === '#all') {
+            if(filter === 'all' || filter === '#all' || (isSearch && !filter)) {
                 if(!is_safari) {
                     domitem.classList.remove('grayscale');
                 }
                 show.push(item);
             } else {
-                if(filter && item.tags.indexOf(filter.substr(1)) !== -1) {
+                var name = item.name ? item.name.toLowerCase() : '';
+                var public_title = item.public_title ? item.public_title.toLowerCase() : '';
+
+                if (filter
+                    && (isSearch && (name.includes(filter) || public_title.includes(filter)))
+                    || (!isSearch && item.tags.indexOf(filter.substr(1)) !== -1)) {
                     if(!is_safari) {
                         domitem.classList.remove('grayscale');
                     }
@@ -166,11 +185,16 @@ document.addEventListener('DOMContentLoaded', function () {
                 for(var i = 0; i < window.integrations.length; i++) {
                     var item = window.integrations[i];
                     var domitem = document.getElementById('mixid_'+item.id);
-                    if(filter === 'all' || filter === '#all') {
+                    if (filter === 'all' || filter === '#all' || (isSearch && !filter)) {
                         domitem.classList.remove('grayscale');
                         //show.push(item);
                     } else {
-                        if(filter && item.tags.indexOf(filter.substr(1)) !== -1) {
+                        var name = item.name ? item.name.toLowerCase() : '';
+                        var public_title = item.public_title ? item.public_title.toLowerCase() : '';
+
+                        if (filter
+                            && (isSearch && (name.includes(filter) || public_title.includes(filter)))
+                            || (!isSearch && item.tags.indexOf(filter.substr(1)) !== -1)) {
                             domitem.classList.remove('grayscale');
                             //show.push(item);
                         } else {
@@ -201,7 +225,7 @@ document.addEventListener('DOMContentLoaded', function () {
         if(current_cat === "") {
             activateButton(controls.querySelector('[data-filter="all"]'), filters);
             activateButton(mobilecontrols.querySelector('[data-filter="all"]'), mobilefilters);
-            updateData("all");
+            updateData("all", false);
         }
     });
 

--- a/layouts/partials/integrations/integrations.js
+++ b/layouts/partials/integrations/integrations.js
@@ -45,7 +45,7 @@ document.addEventListener('DOMContentLoaded', function () {
     var mobilefilters = null;
     var sorts = document.querySelectorAll('[data-ref="sort"]');
     var container = document.querySelector('[data-ref="container"]');
-    var search = document.querySelector('[data-ref="search"]')
+    var search = document.querySelector('[data-ref="search"]');
     var items = window.integrations;
 
     if(!container) return;
@@ -141,6 +141,8 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     function handleButtonClick(button, filters) {
+        // clear the search input
+        search.value = "";
         // If button is already active, or an operation is in progress, ignore the click
         if (button.classList.contains('active') || !button.getAttribute('data-filter')) return;
 

--- a/layouts/partials/integrations/integrations.scss
+++ b/layouts/partials/integrations/integrations.scss
@@ -13,7 +13,6 @@ $ddpurple:    #774DA2;
     width: 100%;
   }
 
-
   .grayscale {
     //-webkit-filter: grayscale(100%); /* Safari 6.0 - 9.0 */
     //filter: grayscale(100%);
@@ -81,6 +80,16 @@ $ddpurple:    #774DA2;
     }
 }
 
+.integration-search {
+  width: 100%;
+  margin-right: 19px;
+  border: 1px solid rgba(0,0,0,.125);
+  border-radius: .25rem;
+}
+
+.integration-search:focus {
+  border-color: $ddpurple;
+}
 
 .dropdown-menu {
   border:1px solid $ddpurple;


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This adds a search bar to the integrations page. The search currently filters based on the `name` and `public_name` fields for each integration:
![](https://dha4w82d62smt.cloudfront.net/items/3U3d1J3I0w1k2P1z0s10/Screen%20Recording%202018-05-03%20at%2004.37%20PM.gif?X-CloudApp-Visitor-Id=54032b591df9bcf04b7cfed437f1873b&v=081f6c36)
### Motivation
<!-- What inspired you to submit this pull request?-->
A search bar would help a user get to an integration page as quickly as possible if they already know which page they want to view. It's currently very time consuming to scroll through 200+ tiles to find a specific integration, and it's difficult to determine the current alphabetical order position you're looking at based on logos alone.

### Preview link
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/adisa/integrations-search/integrations/
### Additional Notes
<!-- Anything else we should know when reviewing?-->
