### PR TITLE
Changes to proxy documentation

### DIFF
--- a/content/agent/proxy.fr.md
+++ b/content/agent/proxy.fr.md
@@ -196,7 +196,7 @@ Pour vérifier que tout fonctionne correctement, examinez les statistiques HAPro
 
 **Cette fonctionnalité est uniquement disponible sur l'Agent v5**
 
-Nous vous recommandons d'utiliser un proxy réel (un proxy Web ou HAProxy) pour transférer votre trafic vers Datadog. Cependant, si ces options ne sont pas disponibles, il est possible de configurer une instance de l'Agent v5 pour servir de proxy.
+Nous vous recommandons d'utiliser un proxy HTTP (un proxy Web ou HAProxy/Nginx) pour transférer votre trafic vers Datadog. Cependant, si cette option n'est pas disponible, il est possible de configurer une instance de l'Agent v5 pour servir de proxy.
 
 1. Désignez un noeud **exécutant l'agent datadog** comme proxy.
    Dans cet exemple, supposons que le nom du proxy est `proxy-node`. Ce noeud **doit** pouvoir atteindre `https://app.datadoghq.com`.

--- a/content/agent/proxy.fr.md
+++ b/content/agent/proxy.fr.md
@@ -20,37 +20,9 @@ Si votre configuration réseau restreint le trafic sortant, proxy tout le trafic
 
 Quelques options sont disponibles pour envoyer du trafic vers Datadog via SSL/TLS pour des hosts qui ne sont pas directement connectés à Internet.
 
-1. Utilisation de l'agent comme proxy (pour **jusqu'à 16 agents** par proxy)
-2. Utilisation d'un proxy Web (par exemple, Squid, Microsoft Web Proxy) déjà déployé sur votre réseau
-3. En utilisant HAProxy (si vous voulez proxy **plus de 16-20 Agents** via le
-le même proxy)
-
-## Utiliser l'Agent comme un proxy
-
-**Cette fonctionnalité n'est pas encore disponible pour l'Agent v6**
-
-1. Désignez un noeud **exécutant l'agent datadog** comme proxy.
-   Dans cet exemple, supposons que le nom du proxy est `proxy-node`. Ce noeud **doit** pouvoir atteindre `https://app.datadoghq.com`.
-
-2. Vérifier la connectivité SSL sur `proxy-node`
-    ```
-    curl -v https://app.datadoghq.com/account/login 2>&1 | grep "200 OK"
-    ```
-
-3. Autorise le trafic non local sur `proxy-node` en changeant la ligne suivante dans` datadog.conf`.
-     `# non_local_traffic: no` devrait être  `non_local_traffic: yes`.
-
-4. Assurez-vous que `proxy-node` peut être atteint à partir des autres noeuds sur le port 17123. Démarrez l'Agent sur le  `proxy-node` et exécutez sur les autres noeuds:
-
-    `curl -v http://proxy-node:17123/status 2>&1 | grep "200 OK"`
-
-5. Mettez à jour les nœuds non-proxy pour transmettre à `proxy-node`. Changez la ligne suivante dans `datadog.conf` depuis:
-
-    `dd_url: https://app.datadoghq.com`
-to
-    `dd_url: http://proxy-node:17123`
-
-6. Vérifiez sur la [page Infrastructure][1] que tous les nœuds rapportent des données à Datadog.
+1. Utilisation d'un proxy Web (par exemple, Squid, Microsoft Web Proxy) déjà déployé sur votre réseau
+2. En utilisant HAProxy (si vous voulez proxy **plus de 16-20 Agents** via le même proxy)
+3. Utilisation de l'agent comme proxy (pour **jusqu'à 16 agents** par proxy, **uniquement sur l'Agent v5**)
 
 ## Utilisation d'un proxy Web en tant que proxy
 
@@ -219,6 +191,35 @@ skip_ssl_validation: yes
 [Redémarez votre Agent][4]
 
 Pour vérifier que tout fonctionne correctement, examinez les statistiques HAProxy à `http://haproxy.example.com:3835` ainsi que la [Présentation de l'infrastructure][5].
+
+## Utiliser l'Agent comme un proxy
+
+**Cette fonctionnalité est uniquement disponible sur l'Agent v5**
+
+Nous vous recommandons d'utiliser un proxy réel (un proxy Web ou HAProxy) pour transférer votre trafic vers Datadog. Cependant, si ces options ne sont pas disponibles, il est possible de configurer une instance de l'Agent v5 pour servir de proxy.
+
+1. Désignez un noeud **exécutant l'agent datadog** comme proxy.
+   Dans cet exemple, supposons que le nom du proxy est `proxy-node`. Ce noeud **doit** pouvoir atteindre `https://app.datadoghq.com`.
+
+2. Vérifier la connectivité SSL sur `proxy-node`
+    ```
+    curl -v https://app.datadoghq.com/account/login 2>&1 | grep "200 OK"
+    ```
+
+3. Autorise le trafic non local sur `proxy-node` en changeant la ligne suivante dans` datadog.conf`.
+     `# non_local_traffic: no` devrait être  `non_local_traffic: yes`.
+
+4. Assurez-vous que `proxy-node` peut être atteint à partir des autres noeuds sur le port 17123. Démarrez l'Agent sur le  `proxy-node` et exécutez sur les autres noeuds:
+
+    `curl -v http://proxy-node:17123/status 2>&1 | grep "200 OK"`
+
+5. Mettez à jour les nœuds non-proxy pour transmettre à `proxy-node`. Changez la ligne suivante dans `datadog.conf` depuis:
+
+    `dd_url: https://app.datadoghq.com`
+to
+    `dd_url: http://proxy-node:17123`
+
+6. Vérifiez sur la [page Infrastructure][1] que tous les nœuds rapportent des données à Datadog.
 
 ## En apprendre plus
 

--- a/content/agent/proxy.md
+++ b/content/agent/proxy.md
@@ -21,37 +21,9 @@ If your network configuration restricted outbound traffic, proxy all Agent traff
 
 A few options are available to send traffic to Datadog over SSL/TLS for hosts that are not directly connected to the Internet.
 
-1. Using the Agent as a proxy (for **up to 16 Agents** per proxy)
-2. Using a web proxy (e.g. Squid, Microsoft Web Proxy) that is already deployed in your network
-3. Using HAProxy (if you want to proxy **more than 16-20 Agents** through the
-same proxy)
-
-## Using the Agent as a Proxy
-
-**This feature is not available for Agent v6 yet**
-
-1. Designate one node **running datadog-agent** as the proxy.  
-    In this example assume that the proxy name is `proxy-node`. This node **must** be able to reach `https://app.datadoghq.com`.
-
-2. Verify SSL connectivity on `proxy-node`  
-    ```
-    curl -v https://app.datadoghq.com/account/login 2>&1 | grep "200 OK"
-    ```
-
-3. Allow non-local traffic on `proxy-node` by changing the following line in `datadog.conf`.  
-     `# non_local_traffic: no` should read `non_local_traffic: yes`.
-
-4. Make sure `proxy-node` can be reached from the other nodes over port 17123. Start the Agent on the `proxy-node` and run on the other nodes:
-
-    `curl -v http://proxy-node:17123/status 2>&1 | grep "200 OK"`
-
-5. Update non-proxy nodes to forward to `proxy-node`. Change the following line in `datadog.conf` from:
-
-    `dd_url: https://app.datadoghq.com`
-to
-    `dd_url: http://proxy-node:17123`
-
-6. Verify on the [Infrastructure page][1] that all nodes report data to Datadog.
+1. Using a web proxy (e.g. Squid, Microsoft Web Proxy) that is already deployed in your network
+2. Using HAProxy (if you want to proxy **more than 16-20 Agents** through the same proxy)
+3. Using the Agent as a proxy (for **up to 16 Agents** per proxy, **only on Agent v5** )
 
 ## Using a Web Proxy as Proxy
 
@@ -59,7 +31,7 @@ Traditional web proxies are supported natively by the Agent. If you need to conn
 
 ### Agent v6
 
-Edit the `datadog.yaml` file with your proxy information. Use the `no_proxy` list to specify hosts that should bypass the proxy. 
+Edit the `datadog.yaml` file with your proxy information. Use the `no_proxy` list to specify hosts that should bypass the proxy.
 
 ```
 proxy:
@@ -220,6 +192,35 @@ skip_ssl_validation: yes
 Finally [restart the Agent][4].
 
 To verify that everything is working properly, review the HAProxy statistics at `http://haproxy.example.com:3835` as well as the [Infrastructure Overview][5]
+
+## Using the Agent as a Proxy
+
+**This feature is only available on Agent v5**
+
+We recommend using an actual proxy (a web proxy or HAProxy) to forward your traffic to Datadog, however if those options aren't available to you, it is possible to configure an instance of Agent v5 to serve as a proxy.
+
+1. Designate one node **running datadog-agent** as the proxy.  
+    In this example assume that the proxy name is `proxy-node`. This node **must** be able to reach `https://app.datadoghq.com`.
+
+2. Verify SSL connectivity on `proxy-node`  
+    ```
+    curl -v https://app.datadoghq.com/account/login 2>&1 | grep "200 OK"
+    ```
+
+3. Allow non-local traffic on `proxy-node` by changing the following line in `datadog.conf`.  
+     `# non_local_traffic: no` should read `non_local_traffic: yes`.
+
+4. Make sure `proxy-node` can be reached from the other nodes over port 17123. Start the Agent on the `proxy-node` and run on the other nodes:
+
+    `curl -v http://proxy-node:17123/status 2>&1 | grep "200 OK"`
+
+5. Update non-proxy nodes to forward to `proxy-node`. Change the following line in `datadog.conf` from:
+
+    `dd_url: https://app.datadoghq.com`
+to
+    `dd_url: http://proxy-node:17123`
+
+6. Verify on the [Infrastructure page][1] that all nodes report data to Datadog.
 
 ## Further Reading
 


### PR DESCRIPTION
### What does this PR do?
Re-phrasing and re-structuring our Proxy documentation to make it clearer to customers that agent-to-agent proxy is a feature only an Agent 5. Also makes it clearer that web or reverse-proxy tools are preferred over using the in-built agent proxy feature.