### PR TITLE
Wrap placeholder <YOUR_API_KEY> with quotes

### DIFF
--- a/content/agent/basic_agent_usage/kubernetes.md
+++ b/content/agent/basic_agent_usage/kubernetes.md
@@ -65,7 +65,7 @@ spec:
             protocol: TCP
         env:
           - name: DD_API_KEY
-            value: <YOUR_API_KEY>
+            value: "<YOUR_API_KEY>"
           - name: DD_COLLECT_KUBERNETES_EVENTS
             value: "true"
           - name: DD_LEADER_ELECTION

--- a/content/tracing/setup/kubernetes.md
+++ b/content/tracing/setup/kubernetes.md
@@ -48,7 +48,7 @@ spec:
           - name: DD_APM_ENABLED
             value: "true"
           - name: DD_API_KEY
-            value: <YOUR_API_KEY>
+            value: "<YOUR_API_KEY>"
           - name: DD_COLLECT_KUBERNETES_EVENTS
             value: "true"
           - name: DD_LEADER_ELECTION


### PR DESCRIPTION
### What does this PR do?

This prevents the yaml syntax highlighting from going wild
after the `<` / `>` characters.

### Motivation

Was looking in https://docs.datadoghq.com/tracing/setup/kubernetes/ and noticed the syntax highlighting for the example was weird.

![dd-kubernetes-docs-before](https://user-images.githubusercontent.com/4542383/39843941-863100b8-53bb-11e8-9e01-77e8f1f5cf29.png)

### Preview link

![dd-kubernetes-docs-after](https://user-images.githubusercontent.com/4542383/39843949-8dbd15f6-53bb-11e8-93dd-cdc8cacb72ac.png)

### Additional Notes

Not sure why the syntax highlighting doesn't happen on this page which has a similar example: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/, but I went ahead and updated it regardless, for consistency.
