### PR TITLE
[Usage Metering] Remove beta wording

### DIFF
--- a/content/api/usage/usage.md
+++ b/content/api/usage/usage.md
@@ -7,7 +7,7 @@ external_redirect: /api/#usage-metering
 
 ## Usage metering
 
-This API is currently in private beta. Python and Ruby clients are not yet supported.
+This API is available to all customers. Python and Ruby clients are not yet supported.
 
 The usage metering end-point allows you to:
 


### PR DESCRIPTION

### What does this PR do?
This PR removes beta wording from doc
### Motivation
<!-- What inspired you to submit this pull request?-->

https://trello.com/c/XNrijWUn/1391-remove-the-private-beta-wording-from-the-usage-api

### Preview link
<!-- Impacted pages preview links-->

https://docs.datadoghq.com/api/?lang=python#usage-metering
### Additional Notes
<!-- Anything else we should know when reviewing?-->
