### PR TITLE
Fixing placeholder value for AD with consul

### DIFF
--- a/content/agent/autodiscovery.md
+++ b/content/agent/autodiscovery.md
@@ -126,7 +126,7 @@ In the `datadog.yaml` file, set the `sd_config_backend`, `sd_backend_host`, and 
 
 #   - name: consul
 #     polling: true
-#     template_dir: /datadog/check_configs
+#     template_dir: datadog/check_configs
 #     template_url: http://127.0.0.1
 #     ca_file:
 #     ca_path:


### PR DESCRIPTION
##What does this PR do?

Fixing displayed placeholder value for consul

##Motivation

There is a / in the sample config that causes issues with the Consul integration.


Config file PR: https://github.com/DataDog/datadog-agent/pull/1696