### PR TITLE
[PROD] add "watch" verb for resources

### DIFF
--- a/content/integrations/faq/using-rbac-permission-with-your-kubernetes-integration.md
+++ b/content/integrations/faq/using-rbac-permission-with-your-kubernetes-integration.md
@@ -24,7 +24,7 @@ Use these Kubernetes RBAC entities to configure permissions for your Datadog Age
       - "pods"
       - "endpoints"   # kube_service tag
       - "componentstatuses"
-    verbs: ["get", "list"]
+    verbs: ["get", "watch", "list"]
   - apiGroups: [""]
     resources:
       - "configmaps"


### PR DESCRIPTION
according to the Kubernetes documentation itself (https://kubernetes.io/docs/admin/authorization/rbac/)
we need the "watch" verb to get info regarding events and pods

