### PR TITLE
Switching to 256MB mem limit

### DIFF
--- a/content/agent/basic_agent_usage/kubernetes.md
+++ b/content/agent/basic_agent_usage/kubernetes.md
@@ -81,7 +81,7 @@ spec:
             memory: "128Mi"
             cpu: "100m"
           limits:
-            memory: "512Mi"
+            memory: "256Mi"
             cpu: "250m"
         volumeMounts:
           - name: dockersocket

--- a/content/tracing/setup/kubernetes.md
+++ b/content/tracing/setup/kubernetes.md
@@ -64,7 +64,7 @@ spec:
             memory: "128Mi"
             cpu: "100m"
           limits:
-            memory: "512Mi"
+            memory: "256Mi"
             cpu: "250m"
         volumeMounts:
           - name: dockersocket


### PR DESCRIPTION
Agent 6 only needs 256MB of mem max in k8