### PR TITLE
Adding non integrations folders

### DIFF
--- a/local/bin/py/update_pre_build.py
+++ b/local/bin/py/update_pre_build.py
@@ -146,6 +146,8 @@ class PreBuild:
             'cassandra_nodetool': {'action': 'merge', 'target': 'cassandra', 'remove_header': False},
             'datadog_checks_base': {'action': 'discard', 'target': 'none', 'remove_header': False},
             'datadog_checks_tests_helper': {'action': 'discard', 'target': 'none', 'remove_header': False},
+            'dev': {'action': 'discard', 'target': 'none', 'remove_header': False},
+            'docs': {'action': 'discard', 'target': 'none', 'remove_header': False},
             'gitlab_runner': {'action': 'merge', 'target': 'gitlab', 'remove_header': False},
             'hdfs_datanode': {'action': 'merge', 'target': 'hdfs', 'remove_header': False},
             'hdfs_namenode': {'action': 'merge', 'target': 'hdfs', 'remove_header': False},


### PR DESCRIPTION
### What does this PR do?

Dev and doc folders on integrations core are not integrations. Hence we need to discard their content.

Their content will be pulled automatically in an upcoming PR