### PR TITLE
[agent/faq] Update uninstall instructions for Agent 6 and CentOS

### DIFF
--- a/content/agent/faq/how-do-i-uninstall-the-agent.md
+++ b/content/agent/faq/how-do-i-uninstall-the-agent.md
@@ -24,6 +24,7 @@ sudo yum remove datadog-agent
 1. Stop and close the Datadog Agent: via the bone icon in the Tray.
 2. Drag the Datadog Application from the application folder to the Trash Bin.
 3. Run:
+
 ```
 sudo rm -rf /opt/datadog-agent
 sudo rm -rf /usr/local/bin/datadog-agent
@@ -52,6 +53,7 @@ Uninstall the Agent using Add/Remove Programs, alternatively, it's possible to t
 1. Stop and Close the Datadog Agent: via the bone icon in the Tray.
 2. Drag the Datadog Application from the application folder to the Trash Bin.
 3. Run:
+
 ```
 sudo rm -rf /opt/datadog-agent
 sudo rm -rf /usr/local/bin/datadog-agent

--- a/content/agent/faq/how-do-i-uninstall-the-agent.md
+++ b/content/agent/faq/how-do-i-uninstall-the-agent.md
@@ -15,34 +15,19 @@ sudo apt-get --purge remove datadog-agent -y
 
 ### CentOS
 
-* For CentOS 5:
-
-    ```
-    sudo yum remove datadog-agent-base
-    ```
-
-* For CentOS 6:
-
-    ```
-    sudo yum remove datadog-agent
-    ```
+```
+sudo yum remove datadog-agent
+```
 
 ### Mac OS
 
-Stop and close the Datadog Agent: via the bone icon in the Tray.
-
-Drag the Datadog Application from the application folder to the Trash Bin.
-
+1. Stop and close the Datadog Agent: via the bone icon in the Tray.
+2. Drag the Datadog Application from the application folder to the Trash Bin.
+3. Run:
 ```
 sudo rm -rf /opt/datadog-agent
 sudo rm -rf /usr/local/bin/datadog-agent
 sudo rm -rf ~/.datadog-agent/**​ #to remove broken symlinks
-```
-If you ran the optional install commands to have the Agent run at boot time, run the following to finish uninstalling:
-
-```
-sudo launchctl unload -w /Library/LaunchDaemons/com.datadoghq.agent.plist
-sudo  rm /Library/LaunchDaemons/com.datadoghq.agent.plist
 ```
 
 ### Redhat
@@ -64,17 +49,16 @@ Uninstall the Agent using Add/Remove Programs, alternatively, it's possible to t
 ## Agent v5
 ### Mac OS
 
-Stop and Close the Datadog Agent: via the bone icon in the Tray.
-
-Drag the Datadog Application from the application folder to the Trash Bin.
-
+1. Stop and Close the Datadog Agent: via the bone icon in the Tray.
+2. Drag the Datadog Application from the application folder to the Trash Bin.
+3. Run:
 ```
 sudo rm -rf /opt/datadog-agent
 sudo rm -rf /usr/local/bin/datadog-agent
 sudo rm -rf ~/.datadog-agent/ #to remove broken symlinks
 ```
 
-If you ran the optional install commands to have the Agent run at boot time, run the following to finish uninstalling:
+If you ran the optional install commands to have the agentent run at boot time, run the following to finish uninstalling:
 
 ```
 sudo launchctl unload -w /Library/LaunchDaemons/com.datadoghq.agent.plist
@@ -89,17 +73,9 @@ sudo apt-get --purge remove datadog-agent -y
 
 ### CentOS/RHEL/Amazon Linux
 
-* CentOS 5
-
-    ```
-    sudo yum remove datadog-agent-base
-    ```
-
-* CentOS 6
-    
-    ```
-    sudo yum remove datadog-agent
-    ```
+```
+sudo yum remove datadog-agent
+```
 
 ### Windows
 

--- a/content/agent/faq/how-do-i-uninstall-the-agent.md
+++ b/content/agent/faq/how-do-i-uninstall-the-agent.md
@@ -60,7 +60,7 @@ sudo rm -rf /usr/local/bin/datadog-agent
 sudo rm -rf ~/.datadog-agent/ #to remove broken symlinks
 ```
 
-If you ran the optional install commands to have the agentent run at boot time, run the following to finish uninstalling:
+If you ran the optional install commands to have the Agent run at boot time, run the following to finish uninstalling:
 
 ```
 sudo launchctl unload -w /Library/LaunchDaemons/com.datadoghq.agent.plist

--- a/content/agent/faq/how-do-i-uninstall-the-agent.md
+++ b/content/agent/faq/how-do-i-uninstall-the-agent.md
@@ -8,12 +8,12 @@ further_reading:
 ---
 
 ## Agent v6
-### Amazon Linux/Debian/Fedora/Ubuntu
+### Debian/Ubuntu
 ```
 sudo apt-get --purge remove datadog-agent -y
 ```
 
-### CentOS
+### CentOS/RHEL/Fedora/Amazon Linux
 
 ```
 sudo yum remove datadog-agent
@@ -71,7 +71,7 @@ sudo rm /Library/LaunchDaemons/com.datadoghq.agent.plist
 sudo apt-get --purge remove datadog-agent -y
 ```
 
-### CentOS/RHEL/Amazon Linux
+### CentOS/RHEL/Fedora/Amazon Linux
 
 ```
 sudo yum remove datadog-agent


### PR DESCRIPTION
### What does this PR do?

Updates uninstall instructions for Agent 6 and CentOS

### Motivation

* fix CentOS commands
* remove outdated part of mac instructions for Agent6


Preview: https://docs-staging.datadoghq.com/olivier.vielpeau/fix-uninstall-instructions/agent/faq/how-do-i-uninstall-the-agent/