### PR TITLE
Add message about unavailability of kube_dns metrics on AKS

### DIFF
--- a/content/integrations/kubernetes.md
+++ b/content/integrations/kubernetes.md
@@ -56,6 +56,8 @@ To gather your kube-state metrics:
 
 Since [Agent v6][4], Kubernetes DNS integration works automatically with the [Autodiscovery][5].
 
+- Please note that these metrics are unavailable for Azure Kubernetes Service (AKS) at this point in time.  
+
 ## Collect container logs
 
 **Available for Agent >6.0**


### PR DESCRIPTION
### What does this PR do?
This PR adds a note about Azure Kubernetes Service not have kube_dns metrics available. You can see there is a request here:

- https://github.com/Azure/AKS/issues/345

### Motivation
To add a note for people running Datadog monitoring on AKS. 

### Preview Link:
https://docs-staging.datadoghq.com/spencer.brown/add-message-for-kube-dns-azure/integrations/kubernetes/#setup-kubernetes-dns