### PR TITLE
Removing deprecated run_check argument

### DIFF
--- a/content/api/integrations/code_snippets/api-integrations-pagerduty.sh
+++ b/content/api/integrations/code_snippets/api-integrations-pagerduty.sh
@@ -14,7 +14,7 @@ curl -v -X PUT -H "Content-type: application/json" \
       "schedules": ["https://my-pd.pagerduty.com/schedules#PCPYT4M", "https://my-pd.pagerduty.com/schedules#PKTPB7P"],
       "api_token": "<PAGERDUTY_TOKEN>"
   }' \
-"https://api.datadoghq.com/api/v1/integration/pagerduty?api_key=${api_key}&application_key=${app_key}&run_check=true"
+"https://api.datadoghq.com/api/v1/integration/pagerduty?api_key=${api_key}&application_key=${app_key}"
 
 curl -v "https://api.datadoghq.com/api/v1/integration/pagerduty?api_key=${api_key}&application_key=${app_key}"
 

--- a/content/api/integrations/code_snippets/api-integrations-slack.sh
+++ b/content/api/integrations/code_snippets/api-integrations-slack.sh
@@ -23,7 +23,7 @@ curl -v -X POST -H "Content-type: application/json" \
       }
     ]
   }' \
-"https://api.datadoghq.com/api/v1/integration/slack?api_key=${api_key}&application_key=${app_key}&run_check=true"
+"https://api.datadoghq.com/api/v1/integration/slack?api_key=${api_key}&application_key=${app_key}"
 
 curl -v -X PUT -H "Content-type: application/json" \
 -d '{
@@ -50,7 +50,7 @@ curl -v -X PUT -H "Content-type: application/json" \
       }
     ]
 }' \
-"https://api.datadoghq.com/api/v1/integration/slack?api_key=${api_key}&application_key=${app_key}&run_check=true"
+"https://api.datadoghq.com/api/v1/integration/slack?api_key=${api_key}&application_key=${app_key}"
 
 curl -v "https://api.datadoghq.com/api/v1/integration/slack?api_key=${api_key}&application_key=${app_key}"
 

--- a/content/api/integrations/code_snippets/api-integrations-webhooks.sh
+++ b/content/api/integrations/code_snippets/api-integrations-webhooks.sh
@@ -11,7 +11,7 @@ curl -v -X POST -H "Content-type: application/json" \
       }
     ]
 }' \
-"https://api.datadoghq.com/api/v1/integration/webhooks?api_key=${api_key}&application_key=${app_key}&run_check=true"
+"https://api.datadoghq.com/api/v1/integration/webhooks?api_key=${api_key}&application_key=${app_key}"
 
 curl -v -X PUT -H "Content-type: application/json" \
 -d '{
@@ -22,7 +22,7 @@ curl -v -X PUT -H "Content-type: application/json" \
       }
     ]
 }' \
-"https://api.datadoghq.com/api/v1/integration/webhooks?api_key=${api_key}&application_key=${app_key}&run_check=true"
+"https://api.datadoghq.com/api/v1/integration/webhooks?api_key=${api_key}&application_key=${app_key}"
 
 curl -v "https://api.datadoghq.com/api/v1/integration/webhooks?api_key=${api_key}&application_key=${app_key}"
 

--- a/content/api/integrations/pagerduty.md
+++ b/content/api/integrations/pagerduty.md
@@ -31,19 +31,5 @@ Configure your Datadog-PagerDuty integration directly through Datadog API.
 * **`api_token`** [*required*]:  
     Your PagerDuty API token.
 
-* **`run_check`** [*optional*, *default*=**false**]:  
-    Determines if the integration install check is run before returning a response.
-
-    * If **true**:
-
-        - The install check is run
-        - If there’s an error in the configuration the error is returned
-        - If there’s no error, *204 No Content* response code is returned
-
-    * If **false**:
-
-        - We return a *202 accepted*
-        - Install check is run after returning a response
-
 [1]: /integrations/pagerduty
 [2]: https://www.pagerduty.com/docs/guides/datadog-integration-guide/

--- a/content/api/integrations/slack.md
+++ b/content/api/integrations/slack.md
@@ -35,19 +35,5 @@ Configure your Datadog-Slack integration directly through Datadog API.
     * **`account`** [*required*]:  
         Account to which the channel belongs to.
 
-* **`run_check`** [*optional*, *default*=**false**]:  
-    Determines if the integration install check is run before returning a response.
-
-    * If **true**:
-
-        - The install check is run
-        - If there’s an error in the configuration the error is returned
-        - If there’s no error, *204 No Content* response code is returned
-
-    * If **false**:
-
-        - We return a *202 accepted*
-        - Install check is run after returning a response
-
 [1]: /integrations/slack
 [2]: /monitors/notifications/#slack-integration

--- a/content/api/integrations/webhooks.md
+++ b/content/api/integrations/webhooks.md
@@ -31,19 +31,5 @@ Configure your Datadog-Webhooks integration directly through Datadog API.
     * **`headers`** [*optional*, *default*=**None**]:  
         Headers attached to your Webhook.
 
-* **`run_check`** [*optional*, *default*=**false**]:  
-    Determines if the integration install check is run before returning a response.
-
-    * If **true**:
-
-        - The install check is run
-        - If there’s an error in the configuration the error is returned
-        - If there’s no error, *204 No Content* response code is returned
-
-    * If **false**:
-
-        - We return a *202 accepted*
-        - Install check is run after returning a response
-
 [1]: /integrations/webhooks
 [2]: /monitors/notifications


### PR DESCRIPTION
### What does this PR do?

Removes deprecated `run_check` argument for integrations API
 
### Motivation
https://github.com/DataDog/documentation/issues/2469

### Preview 

https://docs-staging.datadoghq.com/gus/integrations-api-update/api/?lang=python#pagerduty