### PR TITLE
Fixing ad link

### DIFF
--- a/content/logs/log_collection/docker.md
+++ b/content/logs/log_collection/docker.md
@@ -148,7 +148,7 @@ EXPOSE 8080
 COPY nginx.conf /etc/nginx/nginx.conf
 LABEL "com.datadoghq.ad.check_names"='["nginx"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'
-LABEL "com.datadoghq.ad.instances"='[{"nginx_status_url": "http://%%host%%/nginx_status:%%port%%"}]'
+LABEL "com.datadoghq.ad.instances"='[{"nginx_status_url": "http://%%host%%:%%port%%/nginx_status"}]'
 LABEL "com.datadoghq.ad.logs"='[{"source": "nginx", "service": "webapp"}]'
 ```
 


### PR DESCRIPTION
### What does this PR do?

Fix ad link for NGINX setup

The old format is wrong: `http://%%host%%/nginx_status:%%port%%` but according to the conf.example file: https://github.com/DataDog/integrations-core/blob/master/nginx/conf.yaml.example#L21
it should be `%%host%%:%%port%%/nginx_status`

### Motivation

Support request

### Preview link
