### PR TITLE
Fix broken internal lik

### DIFF
--- a/content/monitors/monitor_types/anomaly.md
+++ b/content/monitors/monitor_types/anomaly.md
@@ -183,7 +183,7 @@ Create **A**: an anomaly monitor to alert on values above the bounds; and **B**:
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/monitors#/create
-[2]: /#anomaly-detetion-algorithms
+[2]: #anomaly-detection-algorithms
 [3]: /graphing/#aggregate-and-rollup
 [4]: https://en.wikipedia.org/wiki/Autoregressive_integrated_moving_average
 [5]: https://en.wikipedia.org/wiki/Decomposition_of_time_series


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes an internal link in the anomaly detection docs.

### Motivation
The internal link wasn't working correctly (was sending people back to the main docs page).

### Preview link
https://docs-staging.datadoghq.com/john/fix-internal-link/monitors/monitor_types/anomaly/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
