### PR TITLE
Wrong quotes used in Curl example of get monitor

### DIFF
--- a/content/api/monitors/code_snippets/result.api-monitor-show.sh
+++ b/content/api/monitors/code_snippets/result.api-monitor-show.sh
@@ -4,7 +4,7 @@
   "message": "We may need to add web hosts if this is consistently high.",
   "name": "Bytes received on host0",
   "options": {
-    'no_data_timeframe': 20,
+    "no_data_timeframe": 20,
     "notify_audit": false,
     "notify_no_data": false,
     "silenced": {}


### PR DESCRIPTION
### What does this PR do?
Changed single quotes to double quotes in the Curl result for getting a monitor.

### Motivation
Creating library and using examples from the documentation showed an error in my tests.
