### PR TITLE
Udpating upstart command for centOS

### DIFF
--- a/content/agent/basic_agent_usage/centos.md
+++ b/content/agent/basic_agent_usage/centos.md
@@ -51,7 +51,7 @@ sudo service datadog-agent check [integration] check_rate
 
 **NB**: If `service` is not available on your system, use:
 
-* on `upstart`-based systems: `sudo start/stop/restart datadog-agent`
+* on `upstart`-based systems: `sudo initctl start/stop/restart datadog-agent`
 * on `systemd`-based systems: `sudo systemctl start/stop/restart datadog-agent`
 
 [Learn more about Service lifecycle commands][4]


### PR DESCRIPTION
### What does this PR do?

For upstart, running the suggested commands sudo start datadog-agent runs it in the foreground, rather than in the background. Instead it should be sudo initctl start datadog-agent.

### Preview link

* https://docs-staging.datadoghq.com/gus/centos/agent/basic_agent_usage/centos/#commands