### PR TITLE
Correct title for the DogStatsD and Docker FAQ

### DIFF
--- a/content/integrations/faq/dogstatsd-and-docker.md
+++ b/content/integrations/faq/dogstatsd-and-docker.md
@@ -1,5 +1,5 @@
 ---
-title: Compose and the Datadog Agent
+title: DogStatsD and Docker
 kind: faq
 ---
 


### PR DESCRIPTION
### What does this PR do?

The title on this FAQ is currently "Compose and the Datadog Agent" - https://cl.ly/0S2H2x0f3r1y

We already have another FAQ with that title (https://docs.datadoghq.com/integrations/faq/compose-and-the-datadog-agent/), and this one should presumably be "DogStatsD and Docker" or something similar.

### Motivation

I was looking for this article and noticed the title is misleading

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
