### PR TITLE
add note on using the javascript tracer with async/await

### DIFF
--- a/content/tracing/setup/javascript.md
+++ b/content/tracing/setup/javascript.md
@@ -32,6 +32,8 @@ For details about contributing, check out the [development guide][development do
 
 Node 4 is the minimum version supported by this library. However, it benefits significantly from the performance improvements introduced in Node 8.3+.
 
+**Note**: If you are using async/await natively, the `asyncHooks` experimental flag must be turned on in the [tracer settings][4] for context propagation to work properly.
+
 ### Installation
 
 To begin tracing Node.js applications, first [install and configure the Datadog Agent][1] (see additional documentation for [tracing Docker applications][3]).


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Add a note in the requirements of the JavaScript Tracer that turning on the experimental `asyncHooks` flag is a requirement for context propagation to work properly.

### Motivation

One of our customers had trouble setting up the tracer because they use async/await but didn't realize they need to do an additional step in that case to get the tracer to work.

### Preview link

https://docs.datadoghq.com/tracing/setup/javascript/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
