### PR TITLE
add javascript example in docker setup

### DIFF
--- a/content/tracing/setup/docker.md
+++ b/content/tracing/setup/docker.md
@@ -126,6 +126,15 @@ java -javaagent:/path/to/the/dd-java-agent.jar \
      -jar /your/app.jar
 ```
 
+#### JavaScript (beta)
+
+```javascript
+const tracer = require('dd-trace').init({
+  hostname: 'dd-agent',
+  port: 8126
+})
+```
+
 ### Docker host IP
 
 Agent container port `8126` should be linked to the host directly.  


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Add a JavaScript example in docker agent setup.

### Motivation

A customer using Docker reported that the tracer didn't work, but they just had to configure the tracer with the correct hostname.

### Preview link

https://docs.datadoghq.com/tracing/setup/docker/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
