### PR TITLE
add the integration ref name to id attribute in docs

### DIFF
--- a/layouts/partials/integrations/integrations.html
+++ b/layouts/partials/integrations/integrations.html
@@ -83,7 +83,7 @@
         {{ if $indx }}
             {{ if $formatname }}
             <div id="mixid_{{$i}}" class="col-6 col-sm-4 col-md-3 col-lg-3 col-xl-2-4 mix text-center {{ range $i, $e := $v.Params.categories }} cat-{{ replace $e "/" "" | urlize }} {{ end }}" data-id="{{ $i }}" data-ref="item">
-                <div class="card">
+                <div id="{{ $v.Params.name }}" class="card">
                     <a class="card-img" href="{{ (print "integrations/" ($urlname | lower)) | absLangURL }}">
                         {{ $.Scratch.Set "url" ""}}
                         {{ if $indx }}


### PR DESCRIPTION
### What does this PR do?
add unique integration id to html

### Motivation
make the page easier to consume

### Preview link
https://docs-staging.datadoghq.com/michaelw/add-id-integrations/integrations/
