### PR TITLE
David.jones/api show subnav

### DIFF
--- a/layouts/partials/sidenav/sidenav.scss
+++ b/layouts/partials/sidenav/sidenav.scss
@@ -118,7 +118,7 @@ aside.sidenav {
       margin-top:5px;
     }
     ul li > ul {
-      display: none;
+      /*display: none;*/
     }
     ul li.open > ul {
       display:block;

--- a/layouts/partials/sidenav/sidenav.scss
+++ b/layouts/partials/sidenav/sidenav.scss
@@ -118,7 +118,7 @@ aside.sidenav {
       margin-top:5px;
     }
     ul li > ul {
-      /*display: none;*/
+      display: none;
     }
     ul li.open > ul {
       display:block;
@@ -195,7 +195,7 @@ aside.sidenav-api {
     overflow-y: auto;
     margin:0;
     ul li > ul {
-      //display: block;
+      display: block;
       list-style-type:none;
       padding-left:20px;
       li a {


### PR DESCRIPTION
### What does this PR do?
This PR shows the side nav open all the time on the api page.

### Motivation
The motivation was actually to counter a bad user interface experience when scrolling to the bottom of the page and the sub items auto expanding which was causing jumps in the page.

https://trello.com/c/7tPnaH1h/2146-double-scroll-on-api-page

### Preview link
https://docs-staging.datadoghq.com/david.jones/api-show-subnav/api/?lang=python

### Additional Notes

