### PR TITLE
change the header on the api nav to say docs as it links back to the …

### DIFF
--- a/layouts/partials/sidenav/sidenav-api.html
+++ b/layouts/partials/sidenav/sidenav-api.html
@@ -1,7 +1,7 @@
 <aside class="sidenav sidenav-api">
     <div class="row sticky">
         <div class="col">
-            <a href="{{ "" | absLangURL }}"><h4>{{ i18n "datadog_api" }}</h4></a>
+            <a href="{{ "" | absLangURL }}"><h4>{{ i18n "datadog_docs" }}</h4></a>
             <div class="sidenav-nav">
                 <ul class="list-unstyled">
                     {{ range $index, $element := sort (where .Site.Pages "Type" "=" "apicontent") "Params.order" }}


### PR DESCRIPTION
### What does this PR do?
This PR makes the header/link above the left nav on the api pages match the rest of the site. 

### Motivation
https://trello.com/c/F3yAq0US/2165-when-viewing-api-pages-the-main-link-back-to-docs-should-be-clear

### Preview link
https://docs-staging.datadoghq.com/david.jones/api-link-back/api/

Note the link above the nav on the left used to say "Datadog API" now it says "Datadog Docs" like the rest of the site.

### Additional Notes

