### PR TITLE
fit rawgithub images for now

### DIFF
--- a/layouts/integrations/single.html
+++ b/layouts/integrations/single.html
@@ -1,5 +1,7 @@
 {{ define "main" }}
-    <h1 id="pagetitle">{{ if .Params.integration_title }}{{ .Params.integration_title }}{{ else }}{{.Title}}{{ end }}</h1>
-    {{ partial "integration-labels/integration-labels.html" . }}
-    {{ .Content }}
+    <div class="integrations-single">
+        <h1 id="pagetitle">{{ if .Params.integration_title }}{{ .Params.integration_title }}{{ else }}{{.Title}}{{ end }}</h1>
+        {{ partial "integration-labels/integration-labels.html" . }}
+        {{ .Content }}
+    </div>
 {{ end }}

--- a/layouts/partials/integrations/integrations.scss
+++ b/layouts/partials/integrations/integrations.scss
@@ -1,5 +1,13 @@
 $ddpurple:    #774DA2;
 
+
+.integrations-single {
+  img {
+    max-width: 100%;
+    height: auto;
+  }
+}
+
 .filters {
   margin-top:40px;
   a {


### PR DESCRIPTION
### What does this PR do?
This PR makes integrations detail page images be responsive.

### Motivation
This is to counter the large raw github images we are now pulling in that are breaking out of the design.

### Preview link
https://docs-staging.datadoghq.com/david.jones/fix-integration-detail-imgs/integrations/haproxy/

Compared to prod:
https://docs.datadoghq.com/integrations/haproxy/

### Additional Notes
The first step is to show them in a nicer way we will do further pipeline work to improve how these images are used
