### PR TITLE
K8 and Logs: Update the link to the Daemonset log instruction

### DIFF
--- a/content/integrations/kubernetes.md
+++ b/content/integrations/kubernetes.md
@@ -153,4 +153,4 @@ To get a better idea of how (or why) to integrate your Kubernetes service, check
 [12]: /integrations/faq/using-rbac-permission-with-your-kubernetes-integration
 [13]: https://www.datadoghq.com/blog/monitoring-kubernetes-era/
 [14]: https://app.datadoghq.com/account/settings#agent/kubernetes
-[15]: https://docs.datadoghq.com/logs/log_collection/docker/#setup
+[15]: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup


### PR DESCRIPTION
### What does this PR do?
Update Link in the log collection instruction for Kubernetes Integration 

### Motivation
The link was pointing to instruction that do not contain Log collection setup.

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
