### PR TITLE
Updating go doc link

### DIFF
--- a/content/tracing/getting_further/trace_sampling_and_storage.md
+++ b/content/tracing/getting_further/trace_sampling_and_storage.md
@@ -186,6 +186,6 @@ When serialized/flushed to the Agent, the `sampling_priority` is stored in the `
 [3]: /tracing/visualization/resource
 [4]: /agent
 [5]: http://pypi.datadoghq.com/trace/docs/#priority-sampling
-[6]: https://godoc.org/github.com/DataDog/dd-trace-go/tracer#Span.SetSamplingPriority
+[6]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/#Span.SetSamplingPriority
 [7]: /tracing/setup/java/#sampling-distributed-tracing
 [8]: http://www.rubydoc.info/gems/ddtrace/#Priority_sampling

--- a/content/tracing/setup/go.fr.md
+++ b/content/tracing/setup/go.fr.md
@@ -8,7 +8,7 @@ further_reading:
   - link: 'https://github.com/DataDog/dd-trace-go'
     tag: « Github »
     text: Code source
-  - link: 'https://godoc.org/github.com/DataDog/dd-trace-go/tracer'
+  - link: 'https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer'
     tag: GoDoc
     text: Page des packages
   - link: tracing/visualization/
@@ -128,4 +128,4 @@ Consultez la [documentation Opentracing][4] pour des modèles d'utilisation. Doc
 [2]: https://github.com/DataDog/dd-trace-go/blob/master/tracer/example_test.go
 [3]: http://opentracing.io
 [4]: https://github.com/opentracing/opentracing-go
-[5]: https://godoc.org/github.com/DataDog/dd-trace-go/tracer
+[5]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer

--- a/content/tracing/visualization/_index.fr.md
+++ b/content/tracing/visualization/_index.fr.md
@@ -96,7 +96,7 @@ Les Spans sont associées à un [service][8] et éventuellement une [ressource][
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://godoc.org/github.com/DataDog/dd-trace-go/tracer#service
+[1]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/#service
 [2]: /tracing/setup/java/#configuration
 [3]: http://pypi.datadoghq.com/trace/docs/#get-started
 [4]: http://www.rubydoc.info/gems/ddtrace/

--- a/content/tracing/visualization/_index.md
+++ b/content/tracing/visualization/_index.md
@@ -96,7 +96,7 @@ Spans are associated with a [service][8] and optionally a [resource][13]. Each s
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://godoc.org/github.com/DataDog/dd-trace-go/tracer#service
+[1]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/#service
 [2]: /tracing/setup/java/#configuration
 [3]: http://pypi.datadoghq.com/trace/docs/#get-started
 [4]: http://www.rubydoc.info/gems/ddtrace/

--- a/ja/content/tracing/go.md
+++ b/ja/content/tracing/go.md
@@ -51,4 +51,4 @@ Currently, only Go 1.7 is supported. The following Go libraries are supported:
 
 The Go integration [source code can be found on Github](https://github.com/DataDog/dd-trace-go).
 
-You can find additional documentation on [the GoDoc Package page](https://godoc.org/github.com/DataDog/dd-trace-go/tracer).
+You can find additional documentation on [the GoDoc Package page](https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer).


### PR DESCRIPTION
### What does this PR do?

Go Tracer doc is now versioned.

We moved from: `https://godoc.org/github.com/DataDog/dd-trace-go/tracer`

to `https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/`
