### PR TITLE
Cloud Foundry Documentation update

### DIFF
--- a/content/integrations/cloud_foundry.md
+++ b/content/integrations/cloud_foundry.md
@@ -56,7 +56,7 @@ DogStatsD setup is now complete. See [the documentation][6] for more information
 
 ## Monitoring your Cloud Foundry cluster
 
-There are three points of integration with Datadog, each of which achieves a different goal:
+There are two points of integration with Datadog, each of which achieves a different goal:
 
 * **Datadog Agent BOSH release** — Install the Datadog Agent on every node in your deployment to track system, network, and disk metrics. Enable any other Agent checks you wish.
 * **Datadog Firehose Nozzle** — Deploy one or more Datadog Firehose Nozzle jobs. The jobs tap into your deployment's Loggregator Firehose and send all non-container metrics to Datadog.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- Changed "three" to "two"...Bosh Health integration was removed last week but # of integration points still remained at 3 when only 2 are referenced.-->

### Motivation
<!-- Noticed issue while preparing for call with Customer -->

### Preview link
<!-- https://docs.datadoghq.com/integrations/cloud_foundry/#monitoring-your-cloud-foundry-cluster -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
