### PR TITLE
Correct priority type so it reads 'normal' (default) instead of 'None'

### DIFF
--- a/content/api/events/code_snippets/result.api-events-post.py
+++ b/content/api/events/code_snippets/result.api-events-post.py
@@ -4,7 +4,7 @@
         'date_happened': 1419436860,
         'handle': None,
         'id': 2603387619536318140,
-        'priority': None,
+        'priority': 'normal',
         'related_event_id': None,
         'tags': ['version:1', 'application:web'],
         'text': 'And let me tell you all about it here!',


### PR DESCRIPTION
Corrects the priority type in the python example. It was previously set to "None" (this option doesn't exist).