### PR TITLE
add debug mode documentation for the javascript tracer

### DIFF
--- a/content/tracing/setup/javascript.md
+++ b/content/tracing/setup/javascript.md
@@ -79,7 +79,7 @@ For more information on manual instrumentation, check out the [API documentation
 
 ### Debug Mode
 
-Debug mode is disabled by default. To enable:
+Debug mode is disabled by default, to enable it:
 
 ```javascript
 const tracer = require('dd-trace').init({

--- a/content/tracing/setup/javascript.md
+++ b/content/tracing/setup/javascript.md
@@ -75,6 +75,20 @@ tracer
 
 For more information on manual instrumentation, check out the [API documentation][5].
 
+## Tracer Settings
+
+### Debug Mode
+
+Debug mode is disabled by default. To enable:
+
+```javascript
+const tracer = require('dd-trace').init({
+  debug: true
+})
+```
+
+For more tracer settings, check out the [API documentation][4].
+
 ## Distributed Tracing
 
 Distributed tracing allows you to propagate a single trace across multiple services, so you can see performance end-to-end.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Add documentation about the debug mode.

### Motivation

There have been cases where some customers didn't realize there was a debug mode before reporting issues.

### Preview link

https://docs.datadoghq.com/tracing/setup/javascript/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
