### PR TITLE
add code comment to make init order clearer

### DIFF
--- a/content/tracing/setup/javascript.md
+++ b/content/tracing/setup/javascript.md
@@ -47,6 +47,7 @@ npm install --save dd-trace
 Finally, import and initialize the tracer:
 
 ```js
+// This line must come before importing any instrumented module.
 const tracer = require('dd-trace').init()
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Add a code comment in the installation section to make it clearer that the tracer must be initialized before importing instrumented modules.

### Motivation

There have been cases where customers missed the note and didn't know why traces were not being reported.

### Preview link

https://docs.datadoghq.com/tracing/setup/javascript/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
