### PR TITLE
Removed stray S in a url that should not be https

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To run the site without Docker and perform administrative tasks (compile metrics
 
 `make start`
 
-Documentation is available at `https://localhost:1313`
+Documentation is available at `http://localhost:1313`
 
 To run the site with Docker (easier setup, slower server), install [Docker](https://docs.docker.com/engine/installation/#supported-platforms) then execute: 
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Changed `https://localhost:1313` to `http://localhost:1313` in the main readme.

### Motivation
<!-- What inspired you to submit this pull request?-->
`https://localhost:1313` does not work.

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
