### PR TITLE
dsd6 unix sockets documentation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -680,19 +680,19 @@ languages:
           url: "developers/dogstatsd/"
           weight: 30
           parent: menu_references_developers
-        - identifier: customnav_developersnav_dogstatsd_unix_socket
-          name: "Unix Domain Socket usage"
-          url: "developers/dogstatsd/unix_socket"
-          weight: 301
-          parent: customnav_developersnav_dogstatsd
         - identifier: customnav_developersnav_dogstatsd_data_types
           name: "Data Types and Tags"
           url: "developers/dogstatsd/data_types"
-          weight: 302
+          weight: 301
           parent: customnav_developersnav_dogstatsd
         - identifier: customnav_developersnav_dogstatsd_datagram_shell
           name: "Datagram and Shell Usage"
           url: "developers/dogstatsd/datagram_shell"
+          weight: 302
+          parent: customnav_developersnav_dogstatsd
+        - identifier: customnav_developersnav_dogstatsd_unix_socket
+          name: "Unix Domain Socket usage"
+          url: "developers/dogstatsd/unix_socket"
           weight: 303
           parent: customnav_developersnav_dogstatsd
         - identifier: customnav_developersnav_metrics

--- a/config.yaml
+++ b/config.yaml
@@ -680,15 +680,20 @@ languages:
           url: "developers/dogstatsd/"
           weight: 30
           parent: menu_references_developers
+        - identifier: customnav_developersnav_dogstatsd_unix_socket
+          name: "Unix Domain Socket usage"
+          url: "developers/dogstatsd/unix_socket"
+          weight: 301
+          parent: customnav_developersnav_dogstatsd
         - identifier: customnav_developersnav_dogstatsd_data_types
           name: "Data Types and Tags"
           url: "developers/dogstatsd/data_types"
-          weight: 301
+          weight: 302
           parent: customnav_developersnav_dogstatsd
         - identifier: customnav_developersnav_dogstatsd_datagram_shell
           name: "Datagram and Shell Usage"
           url: "developers/dogstatsd/datagram_shell"
-          weight: 302
+          weight: 303
           parent: customnav_developersnav_dogstatsd
         - identifier: customnav_developersnav_metrics
           name: "Metrics"

--- a/content/agent/basic_agent_usage/docker.md
+++ b/content/agent/basic_agent_usage/docker.md
@@ -66,6 +66,8 @@ Send custom metrics via [the statsd protocol][5]:
 - `DD_DOGSTATSD_SOCKET`: path to the unix socket to listen to. Must be in a `rw` mounted volume.
 - `DD_DOGSTATSD_ORIGIN_DETECTION`: enable container detection and tagging for unix socket metrics.
 
+[Learn more about DogStatsD over Unix Domain Sockets with Docker][9].
+
 #### Tagging
 
 We automatically collect common tags from [Docker][6], [Kubernetes][7], [ECS][8], [Swarm, Mesos, Nomad and Rancher][6], and allow you to extract even more tags with the following options:
@@ -102,3 +104,4 @@ Exclude containers from the metrics collection and Autodiscovery, if these are n
 [6]: https://github.com/DataDog/datadog-agent/blob/master/pkg/tagger/collectors/docker_extract.go
 [7]: https://github.com/DataDog/datadog-agent/blob/master/pkg/tagger/collectors/kubelet_extract.go
 [8]: https://github.com/DataDog/datadog-agent/blob/master/pkg/tagger/collectors/ecs_extract.go
+[9]: /developers/dogstatsd/unix_socket

--- a/content/developers/dogstatsd/_index.md
+++ b/content/developers/dogstatsd/_index.md
@@ -63,7 +63,7 @@ dogstatsd_port: 8125
 
 Then [restart your Agent][5].
 
-By default, DogStatsD listens on UDP port **8125**. If you need to change this, configure the `dogstatsd_port` option in the main [Agent configuration file][2], and restart the client. You can also configure DogStatsD to use a [Unix Domain Socket][10]
+By default, DogStatsD listens on UDP port **8125**. If you need to change this, configure the `dogstatsd_port` option in the main [Agent configuration file][2], and restart the client. You can also configure DogStatsD to use a [Unix Domain Socket][10].
 
 ### Code
 

--- a/content/developers/dogstatsd/_index.md
+++ b/content/developers/dogstatsd/_index.md
@@ -63,7 +63,7 @@ dogstatsd_port: 8125
 
 Then [restart your Agent][5].
 
-By default, DogStatsD listens on UDP port **8125**. If you need to change this, configure the `dogstatsd_port` option in the main [Agent configuration file][2], and restart the client.
+By default, DogStatsD listens on UDP port **8125**. If you need to change this, configure the `dogstatsd_port` option in the main [Agent configuration file][2], and restart the client. You can also configure DogStatsD to use a [Unix Domain Socket][10]
 
 ### Code
 
@@ -114,3 +114,4 @@ If you're interested in learning more about the datagram format used by DogStats
 [7]: /developers/dogstatsd/data_types
 [8]: /developers/dogstatsd/datagram_shell
 [9]: https://github.com/DataDog/dd-agent/pull/2104
+[10]: /developers/dogstatsd/unix_socket

--- a/content/developers/dogstatsd/unix_socket.md
+++ b/content/developers/dogstatsd/unix_socket.md
@@ -20,7 +20,7 @@ While UDP works great on `localhost`, it can be a challenge to setup in containe
 
 * Bypassing the networking stack brings a significant performance improvement for high traffic
 * While UDP has no error handling, UDS allows the Agent to detect dropped packets and connection errors, while still allowing a non-blocking use
-* DogStatsD is able to detect the origin container of metrics and tag them accordingly
+* DogStatsD is able to detect the container from which metrics originated, and tag those metrics accordingly
 
 ## How it works
 
@@ -28,7 +28,7 @@ Instead of using an `IP:port` pair to establish connections, Unix Domain Sockets
 
 When the Agent restarts, the existing socket is deleted and replaced by a new one. Client libraries detect this change and connect seamlessly to the new socket.
 
-**Note:** By design, UDS traffic is local to the host, which means the Datadog Agent must run on every host you will be sending metrics from. 
+**Note:** By design, UDS traffic is local to the host, which means the Datadog Agent must run on every host you will be sending metrics from.
 
 ## Setup
 
@@ -93,7 +93,7 @@ volumeMounts:
 ...
 volumes:
 - hostPath:
-    path: /var/run/datadog/    
+    path: /var/run/datadog/
   name: dsdsocket
 ```
 
@@ -107,7 +107,7 @@ When running inside a container, DogStatsd needs to run in the host PID namespac
 
 ## Client library implementation guidelines
 
-Adding UDS support to existing libraries can be achieved as the protocol is very close to UDP. Implementation guidelines and a testing checklist are available in the [datadog-agent wiki][7].
+Adding UDS support to existing libraries can be easily achieved as the protocol is very close to UDP. Implementation guidelines and a testing checklist are available in the [datadog-agent wiki][7].
 
 ## Further reading
 

--- a/content/developers/dogstatsd/unix_socket.md
+++ b/content/developers/dogstatsd/unix_socket.md
@@ -16,19 +16,19 @@ further_reading:
 
 Starting with version 6.0, the Datadog Agent is able to ingest metrics via a Unix Domain Socket (UDS), as an alternative to UDP, when running on Linux systems.
 
-While UDP works great on `localhost`, it can be a challenge to setup in containerized environments. Unix Domain Sockets allow to easily establish the connection via a socket file, regardless of the IP of the Datadog Agent container. It also enables the following benefits:
+While UDP works great on `localhost`, it can be a challenge to setup in containerized environments. Unix Domain Sockets allow you to easily establish the connection via a socket file, regardless of the IP of the Datadog Agent container. It also enables the following benefits:
 
 - bypassing the networking stack brings a significant performance improvement for high traffic
-- while UDP has no error handling, UDS allows to detect dropped packets and connection errors, while still allowing a non-blocking use
-- DogStatsD is be able to detect the origin container of metrics and tag them accordingly
+- while UDP has no error handling, UDS allows the Agent to detect dropped packets and connection errors, while still allowing a non-blocking use
+- DogStatsD is able to detect the origin container of metrics and tag them accordingly
 
 ## How it works
 
 Instead of using an `IP:port` pair to establish connections, Unix Domain Sockets use a placeholder socket file. Once the connection is open, data is transmitted in the same [datagram format][2] as UDP.
 
-When the agent restarts, the existing socket is deleted and replaced by a new one. Client libraries detect this change and connect seamlessly to the new one.
+When the Agent restarts, the existing socket is deleted and replaced by a new one. Client libraries detect this change and connect seamlessly to the new one.
 
-**Note:** by design, UDS traffic is local to the host, which means the Datadog Agent must run on every host you will be sending metrics from. 
+**Note:** By design, UDS traffic is local to the host, which means the Datadog Agent must run on every host you will be sending metrics from. 
 
 ## Setup
 
@@ -53,7 +53,7 @@ The following DogStatsD client libraries support UDS traffic:
 
 Refer to the library's documentation on how to enable UDS traffic.
 
-**Note:** as with UDP, enabling client-side buffering is highly recommended to improve performance on heavy traffic. Refer to your client library's documentation for instructions.
+**Note:** As with UDP, enabling client-side buffering is highly recommended to improve performance on heavy traffic. Refer to your client library's documentation for instructions.
 
 ### Accessing the socket across containers
 
@@ -97,7 +97,7 @@ volumes:
 
 ## Using Origin Detection for container tagging
 
-Origin Detection allows DogStatsD to detect the container metrics come from, and tag metrics automatically. When this mode is enabled, all metrics received via UDS will be tagged by the same container tags as Autodiscovery metrics. **Note:** `container_id`, `container_name` and `pod_name` tags will not be added, to avoid creating too many custom metric contexts.
+Origin Detection allows DogStatsD to detect where the container metrics come from, and tag metrics automatically. When this mode is enabled, all metrics received via UDS will be tagged by the same container tags as Autodiscovery metrics. **Note:** `container_id`, `container_name` and `pod_name` tags will not be added, to avoid creating too many custom metric contexts.
 
 To enable this, enable the `dogstatsd_origin_detection` option in your `datadog.yaml`, or set the environment variable `DD_DOGSTATSD_ORIGIN_DETECTION=true`, and [restart your Agent][1].
 
@@ -105,7 +105,7 @@ When running inside a container, DogStatsd needs to run in the host PID namespac
 
 ## Client library implementation guidelines
 
-Adding UDS support to existing libraries is usually pretty simple as the protocol is very close to UDP. Implementation guidelines and a testing checklist are available in the [datadog-agent wiki](https://github.com/DataDog/datadog-agent/wiki/Unix-Domain-Sockets-support)
+Adding UDS support to existing libraries is usually simple as the protocol is very close to UDP. Implementation guidelines and a testing checklist are available in the [datadog-agent wiki][7].
 
 ## Further reading
 
@@ -117,4 +117,5 @@ Adding UDS support to existing libraries is usually pretty simple as the protoco
 [4]: https://github.com/DataDog/java-dogstatsd-client
 [5]: https://github.com/DataDog/datadogpy
 [6]: https://github.com/DataDog/dogstatsd-ruby
+[7]: https://github.com/DataDog/datadog-agent/wiki/Unix-Domain-Sockets-support
 

--- a/content/developers/dogstatsd/unix_socket.md
+++ b/content/developers/dogstatsd/unix_socket.md
@@ -1,7 +1,7 @@
 ---
 title: DogStatsD over Unix Domain Socket
 kind: documentation
-description: Usage documentation for DogStatsD over Unix Domain Sockets.
+description: "Usage documentation for DogStatsD over Unix Domain Sockets".
 further_reading:
 - link: "developers/dogstatsd"
   tag: "Documentation"
@@ -18,9 +18,9 @@ Starting with version 6.0, the Datadog Agent is able to ingest metrics via a Uni
 
 While UDP works great on `localhost`, it can be a challenge to setup in containerized environments. Unix Domain Sockets allow you to easily establish the connection via a socket file, regardless of the IP of the Datadog Agent container. It also enables the following benefits:
 
-- bypassing the networking stack brings a significant performance improvement for high traffic
-- while UDP has no error handling, UDS allows the Agent to detect dropped packets and connection errors, while still allowing a non-blocking use
-- DogStatsD is able to detect the origin container of metrics and tag them accordingly
+* Bypassing the networking stack brings a significant performance improvement for high traffic
+* While UDP has no error handling, UDS allows the Agent to detect dropped packets and connection errors, while still allowing a non-blocking use
+* DogStatsD is able to detect the origin container of metrics and tag them accordingly
 
 ## How it works
 
@@ -46,10 +46,12 @@ Then [restart your Agent][1]. You can also set the socket path via the `DD_DOGST
 
 The following DogStatsD client libraries support UDS traffic:
 
-- Golang: [DataDog/datadog-go][3]
-- Java: [DataDog/java-dogstatsd-client][4]
-- Python: [DataDog/datadogpy][5]
-- Ruby: [DataDog/dogstatsd-ruby][6]
+| Language | Library                            |
+| :----    | :----                              |
+| Golang   | [DataDog/datadog-go][3]            |
+| Java     | [DataDog/java-dogstatsd-client][4] |
+| Python   | [DataDog/datadogpy][5]             |
+| Ruby     | [DataDog/dogstatsd-ruby][6]        |
 
 Refer to the library's documentation on how to enable UDS traffic.
 
@@ -63,8 +65,8 @@ Mounting the parent folder instead of the individual socket enables socket commu
 
 #### Docker: bind mount
 
-- Start the Agent container with `-v /var/run/datadog:/var/run/datadog`
-- Start your containers with `-v /var/run/datadog:/var/run/datadog:ro`
+* Start the Agent container with `-v /var/run/datadog:/var/run/datadog`
+* Start your containers with `-v /var/run/datadog:/var/run/datadog:ro`
 
 #### Kubernetes: `hostPath` volume
 

--- a/content/developers/dogstatsd/unix_socket.md
+++ b/content/developers/dogstatsd/unix_socket.md
@@ -107,7 +107,7 @@ When running inside a container, DogStatsd needs to run in the host PID namespac
 
 ## Client library implementation guidelines
 
-Adding UDS support to existing libraries is usually simple as the protocol is very close to UDP. Implementation guidelines and a testing checklist are available in the [datadog-agent wiki][7].
+Adding UDS support to existing libraries can be achieved as the protocol is very close to UDP. Implementation guidelines and a testing checklist are available in the [datadog-agent wiki][7].
 
 ## Further reading
 
@@ -120,4 +120,3 @@ Adding UDS support to existing libraries is usually simple as the protocol is ve
 [5]: https://github.com/DataDog/datadogpy
 [6]: https://github.com/DataDog/dogstatsd-ruby
 [7]: https://github.com/DataDog/datadog-agent/wiki/Unix-Domain-Sockets-support
-

--- a/content/developers/dogstatsd/unix_socket.md
+++ b/content/developers/dogstatsd/unix_socket.md
@@ -1,7 +1,7 @@
 ---
 title: DogStatsD over Unix Domain Socket
 kind: documentation
-description: "Usage documentation for DogStatsD over Unix Domain Sockets".
+description: "Usage documentation for DogStatsD over Unix Domain Sockets"
 further_reading:
 - link: "developers/dogstatsd"
   tag: "Documentation"
@@ -26,7 +26,7 @@ While UDP works great on `localhost`, it can be a challenge to setup in containe
 
 Instead of using an `IP:port` pair to establish connections, Unix Domain Sockets use a placeholder socket file. Once the connection is open, data is transmitted in the same [datagram format][2] as UDP.
 
-When the Agent restarts, the existing socket is deleted and replaced by a new one. Client libraries detect this change and connect seamlessly to the new one.
+When the Agent restarts, the existing socket is deleted and replaced by a new one. Client libraries detect this change and connect seamlessly to the new socket.
 
 **Note:** By design, UDS traffic is local to the host, which means the Datadog Agent must run on every host you will be sending metrics from. 
 
@@ -97,11 +97,11 @@ volumes:
   name: dsdsocket
 ```
 
-## Using Origin Detection for container tagging
+## Using origin detection for container tagging
 
-Origin Detection allows DogStatsD to detect where the container metrics come from, and tag metrics automatically. When this mode is enabled, all metrics received via UDS will be tagged by the same container tags as Autodiscovery metrics. **Note:** `container_id`, `container_name` and `pod_name` tags will not be added, to avoid creating too many custom metric contexts.
+Origin detection allows DogStatsD to detect where the container metrics come from, and tag metrics automatically. When this mode is enabled, all metrics received via UDS will be tagged by the same container tags as Autodiscovery metrics. **Note:** `container_id`, `container_name` and `pod_name` tags will not be added, to avoid creating too many custom metric contexts.
 
-To enable this, enable the `dogstatsd_origin_detection` option in your `datadog.yaml`, or set the environment variable `DD_DOGSTATSD_ORIGIN_DETECTION=true`, and [restart your Agent][1].
+To use origin detection, enable the `dogstatsd_origin_detection` option in your `datadog.yaml`, or set the environment variable `DD_DOGSTATSD_ORIGIN_DETECTION=true`, and [restart your Agent][1].
 
 When running inside a container, DogStatsd needs to run in the host PID namespace for origin detection to work reliably. You can enable this via the docker `--pid=host` flag.
 

--- a/content/developers/dogstatsd/unix_socket.md
+++ b/content/developers/dogstatsd/unix_socket.md
@@ -1,0 +1,120 @@
+---
+title: DogStatsD over Unix Domain Socket
+kind: documentation
+description: Usage documentation for DogStatsD over Unix Domain Sockets.
+further_reading:
+- link: "developers/dogstatsd"
+  tag: "Documentation"
+  text: "Introduction to DogStatsD"
+- link: "developers/libraries"
+  tag: "Documentation"
+  text: "Official and Community-contributed API and DogStatsD client libraries"
+- link: "https://github.com/DataDog/datadog-agent/tree/master/pkg/dogstatsd"
+  tag: "Github"
+  text: "DogStatsD source code"
+---
+
+Starting with version 6.0, the Datadog Agent is able to ingest metrics via a Unix Domain Socket (UDS), as an alternative to UDP, when running on Linux systems.
+
+While UDP works great on `localhost`, it can be a challenge to setup in containerized environments. Unix Domain Sockets allow to easily establish the connection via a socket file, regardless of the IP of the Datadog Agent container. It also enables the following benefits:
+
+- bypassing the networking stack brings a significant performance improvement for high traffic
+- while UDP has no error handling, UDS allows to detect dropped packets and connection errors, while still allowing a non-blocking use
+- DogStatsD is be able to detect the origin container of metrics and tag them accordingly
+
+## How it works
+
+Instead of using an `IP:port` pair to establish connections, Unix Domain Sockets use a placeholder socket file. Once the connection is open, data is transmitted in the same [datagram format][2] as UDP.
+
+When the agent restarts, the existing socket is deleted and replaced by a new one. Client libraries detect this change and connect seamlessly to the new one.
+
+**Note:** by design, UDS traffic is local to the host, which means the Datadog Agent must run on every host you will be sending metrics from. 
+
+## Setup
+
+### Agent
+
+Edit your `datadog.yaml` file to set the `dogstatsd_socket` option to the path where DogStatsD should create its listening socket:
+
+```
+dogstatsd_socket: /var/run/datadog/dsd.socket
+```
+
+Then [restart your Agent][1]. You can also set the socket path via the `DD_DOGSTATSD_SOCKET` environment variable.
+
+### Client
+
+The following DogStatsD client libraries support UDS traffic:
+
+- Golang: [DataDog/datadog-go][3]
+- Java: [DataDog/java-dogstatsd-client][4]
+- Python: [DataDog/datadogpy][5]
+- Ruby: [DataDog/dogstatsd-ruby][6]
+
+Refer to the library's documentation on how to enable UDS traffic.
+
+**Note:** as with UDP, enabling client-side buffering is highly recommended to improve performance on heavy traffic. Refer to your client library's documentation for instructions.
+
+### Accessing the socket across containers
+
+When running in a containerized environment, the socket file needs to be accessible to the client containers. To achieve this, we recommend mounting a host directory on both sides (read-only in your client containers, read-write in the Agent container).
+
+Mounting the parent folder instead of the individual socket enables socket communication to persist across DogStatsD restarts.
+
+#### Docker: bind mount
+
+- Start the Agent container with `-v /var/run/datadog:/var/run/datadog`
+- Start your containers with `-v /var/run/datadog:/var/run/datadog:ro`
+
+#### Kubernetes: `hostPath` volume
+
+Mount the folder in your `datadog-agent` container:
+
+```
+volumeMounts:
+  - name: dsdsocket
+    mountPath: /var/run/datadog
+...
+volumes:
+- hostPath:
+    path: /var/run/datadog/
+  name: dsdsocket
+```
+
+Expose the same folder in your client containers:
+
+```
+volumeMounts:
+  - name: dsdsocket
+    mountPath: /var/run/datadog
+    readOnly: true
+...
+volumes:
+- hostPath:
+    path: /var/run/datadog/    
+  name: dsdsocket
+```
+
+## Using Origin Detection for container tagging
+
+Origin Detection allows DogStatsD to detect the container metrics come from, and tag metrics automatically. When this mode is enabled, all metrics received via UDS will be tagged by the same container tags as Autodiscovery metrics. **Note:** `container_id`, `container_name` and `pod_name` tags will not be added, to avoid creating too many custom metric contexts.
+
+To enable this, enable the `dogstatsd_origin_detection` option in your `datadog.yaml`, or set the environment variable `DD_DOGSTATSD_ORIGIN_DETECTION=true`, and [restart your Agent][1].
+
+When running inside a container, DogStatsd needs to run in the host PID namespace for origin detection to work reliably. You can enable this via the docker `--pid=host` flag.
+
+## Client library implementation guidelines
+
+Adding UDS support to existing libraries is usually pretty simple as the protocol is very close to UDP. Implementation guidelines and a testing checklist are available in the [datadog-agent wiki](https://github.com/DataDog/datadog-agent/wiki/Unix-Domain-Sockets-support)
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /agent/faq/agent-commands
+[2]: /developers/dogstatsd/data_types
+[3]: https://github.com/DataDog/datadog-go
+[4]: https://github.com/DataDog/java-dogstatsd-client
+[5]: https://github.com/DataDog/datadogpy
+[6]: https://github.com/DataDog/dogstatsd-ruby
+


### PR DESCRIPTION
### What does this PR do?

Document the Dogstatsd Unix Socket support in Agent 6.0+
Put on a separate page, need to create links to it.

### Preview link

https://docs-staging.datadoghq.com/xvello/dsd_uds/developers/dogstatsd/unix_socket/
