### PR TITLE
explain that only admins can create or edit archive configs

### DIFF
--- a/content/logs/s3.md
+++ b/content/logs/s3.md
@@ -11,6 +11,8 @@ This feature is currently in Limited Beta. Ask your Sales representative or Cust
 ## S3 Archives
 
 Configure your Datadog account to forward all the logs ingested to your own S3 bucket. This allows you to keep in long-term storage all the logs that you used Datadog to aggregate. This guide shows you how to set this up.
+
+Note: only Datadog users with admin status can create, modify, or delete log archive configurations.
  
 ## Create and Configure an S3 Bucket
 
@@ -42,7 +44,7 @@ Configure your Datadog account to forward all the logs ingested to your own S3 b
 
     {{< img src="logs/archives/log_archives_s3_iam_policy.png" alt="IAM Policy for S3 Archives" responsive="true" popup="true" style="width:75%;">}}
 
-3. Go to your [Pipelines page in your Datadog application][3], and select the **Add archive** option at the bottom.
+3. Go to your [Pipelines page in your Datadog application][3], and select the **Add archive** option at the bottom. Only Datadog users with admin status can complete this and the following step.
 
 4. Input your bucket name. Optionally input a prefix directory for all the content of your log archives. Save your archive, and you are finished. 
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a note in the s3 log archive setup documentation to make it clear that only users with admin status can configure log archives. 

### Motivation
To avoid many annoying tickets. 

### Preview link
https://docs-staging.datadoghq.com/estib/only-admins-edit-log-archive-configs/logs/s3/
