### PR TITLE
Cecilia/monitor muting

### DIFF
--- a/content/monitors/downtimes.md
+++ b/content/monitors/downtimes.md
@@ -20,7 +20,7 @@ You may occasionally need to shut systems down or take them off-line to perform 
 
 You can schedule downtimes and/or mute your Datadog monitors so that they do not alert at specific times when you do not want them to.
 
-Monitors trigger events when they change state between ALERT, WARNING (if enabled), RESOLVED, and NO DATA (if enabled). But if a monitor has been silenced either by a downtime or muting, then any transition from RESOLVED to another state won't trigger an event (nor the notification channels that the event would have set off).
+Monitors trigger events when they change state between ALERT, WARNING (if enabled), RESOLVED, and NO DATA (if enabled). But if a monitor has been silenced either by a downtime or muting, then any transition from RESOLVED to another state won't trigger an event (nor the notification channels that the event would have set off). Note that muting or unmuting a monitor via the UI deletes all scheduled downtimes associated with that monitor.
 
 {{< img src="monitors/downtimes/downtime_on_alert.png" alt="downtime on alert" responsive="true" popup="true" style="width:80%;">}}
 

--- a/content/monitors/monitor_status.md
+++ b/content/monitors/monitor_status.md
@@ -34,6 +34,8 @@ Some options are available in the upper right corner of the page:
     Choose to mute a monitor directly on its status page. Use the *Scope* field to narrow your downtime.
     Refer to the [dedicated downtime documentation][2] to learn how to mute multiple scopes or multiple monitors at the same time.
 
+    NOTE: muting a monitor deletes all scheduled downtimes associated with that monitor.
+
     {{< img src="monitors/monitor_status/status_mute_monitor.png" alt="status mute monitor" responsive="true" popup="true" style="width:30%;">}}
 
 * **Resolve a monitor**:

--- a/content/monitors/monitor_status.md
+++ b/content/monitors/monitor_status.md
@@ -34,7 +34,7 @@ Some options are available in the upper right corner of the page:
     Choose to mute a monitor directly on its status page. Use the *Scope* field to narrow your downtime.
     Refer to the [dedicated downtime documentation][2] to learn how to mute multiple scopes or multiple monitors at the same time.
 
-    NOTE: muting a monitor deletes all scheduled downtimes associated with that monitor.
+    NOTE: muting or unmuting a monitor via the UI deletes all scheduled downtimes associated with that monitor.
 
     {{< img src="monitors/monitor_status/status_mute_monitor.png" alt="status mute monitor" responsive="true" popup="true" style="width:30%;">}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Updates monitor/monitor_status and monitor/downtimes to reflect the effect of muting/unmuting monitors on scheduled downtimes.

### Motivation
<!-- What inspired you to submit this pull request?-->
Muting/unmuting a monitor deletes all scheduled downtimes associated with that monitor. This is now reflected in documentation.


### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
The monitor_status page isn't actually linked to from the left nav bar (or from anything else, it appears)
