### PR TITLE
Update config curl wrong link

### DIFF
--- a/content/agent/faq/forwarder-logs-contain-599-response-code.md
+++ b/content/agent/faq/forwarder-logs-contain-599-response-code.md
@@ -90,5 +90,5 @@ If you've done everything above and continue to have issues, send support@datado
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/DataDog/dd-agent/blob/master/datadog.conf.example#L93
+[1]: https://github.com/DataDog/dd-agent/blob/master/datadog.conf.example#L106
 [2]: /agent/#send-a-flare


### PR DESCRIPTION
Fix the wrongly assigned link, it used to point to an empty line and fixed to point to the right config 

Screenshot: https://cl.ly/381G0h3W3c2j

Trello card: https://trello.com/c/SuDH0IpY/1492-update-config-link-on-faq-page-regarding-forwarder-logs