### PR TITLE
[doc] corrected typo in grep command on 202 faq

### DIFF
--- a/content/developers/faq/i-m-receiving-a-202-but-not-seeing-data.md
+++ b/content/developers/faq/i-m-receiving-a-202-but-not-seeing-data.md
@@ -13,7 +13,7 @@ Thus it is possible you could receive a 202 'success' response but not see your 
 
 To check your timestamp is correct run:
 ```
-date -u && curl -s --head https://app.datadoghq.com 2>&1 | grep Date
+date -u && curl -s --head https://app.datadoghq.com 2>&1 | grep date
 ```
 
 This outputs the current system’s date, and then make a request to our endpoint and grab the date on our end. If these are more than a few minutes apart, you may want to look at the time settings on your server.


### PR DESCRIPTION




<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

On developers/faq/i-m-receiving-a-202-but-not-seeing-data.md,  I changed `grep Date` to `grep date`

### Motivation

`grep Date` should be `grep date`, as the key of the relevant field returned by the API has "date: xxxxxxxx" on that line being grepped.

https://datadog.zendesk.com/agent/tickets/151545

### Preview link
https://cl.ly/0L2P0E0J0W2e

### Additional Notes
<!-- Anything else we should know when reviewing?-->
