### PR TITLE
adding threshold_windows to api documentation

### DIFF
--- a/content/api/monitors/monitors_create.md
+++ b/content/api/monitors/monitors_create.md
@@ -9,13 +9,21 @@ external_redirect: /api/#create-a-monitor
 
 ##### ARGUMENTS
 *   **`type`** [*required*]:  
-    The type of the monitor, chosen from:  
-    *   `metric alert`
-    *   `service check`
-    *   `event alert`
-    *   `process alert`
+    The [type of the monitor][3], chosen from:  
+    *   `anomaly`
+    *   `apm`
     *   `composite`
-
+    *   `custom`
+    *   `event`
+    *   `forecast`
+    *   `host`
+    *   `integration`
+    *   `log`
+    *   `metric`
+    *   `network`
+    *   `outlier`
+    *   `process`
+    
 *   **`query`** [*required*]:  
     The query defines when the monitor triggers. Query syntax depends on what type of monitor you are creating:  
     ##### Metric Alert Query
@@ -140,3 +148,4 @@ external_redirect: /api/#create-a-monitor
 
 [1]: /monitors/monitor_types/#define-the-conditions
 [2]: /integrations/faq/list-of-api-source-attribute-value
+[3]: /monitors/monitor_types/

--- a/content/api/monitors/monitors_create.md
+++ b/content/api/monitors/monitors_create.md
@@ -7,7 +7,7 @@ external_redirect: /api/#create-a-monitor
 
 ## Create a monitor
 
-If you manage and deploy monitors programmatically, it’s easier to define the monitor in the Datadog UI and [export is valid JSON][4].
+If you manage and deploy monitors programmatically, it’s easier to define the monitor in the Datadog UI and [export its valid JSON][4].
 
 ##### ARGUMENTS
 *   **`type`** [*required*]:  

--- a/content/api/monitors/monitors_create.md
+++ b/content/api/monitors/monitors_create.md
@@ -112,6 +112,15 @@ external_redirect: /api/#create-a-monitor
         *   True: `[Triggered on {host:h1}] Monitor Title`
         *   False: `[Triggered] Monitor Title`
 
+    ##### Anomaly Options
+    _These options only apply to anomaly monitors and are ignored for other monitor types._
+
+    -   **`threshold_windows`** a dictionary containing `recovery_window` and `trigger_window`.
+        * `recovery_window` describes how long an anomalous metric must be normal before the alert recovers
+        * `trigger_window` describes how long a metric must be anomalous before an alert triggers
+
+            Example: `{'threshold_windows': {'recovery_window': 'last_15m', 'trigger_window': 'last_15m'}}`
+
     ##### Metric Alert Options
     _These options only apply to metric alerts._
 

--- a/content/api/monitors/monitors_create.md
+++ b/content/api/monitors/monitors_create.md
@@ -7,6 +7,8 @@ external_redirect: /api/#create-a-monitor
 
 ## Create a monitor
 
+If you manage and deploy monitors programmatically, it’s easier to define the monitor in the Datadog UI and [export is valid JSON][4].
+
 ##### ARGUMENTS
 *   **`type`** [*required*]:  
     The [type of the monitor][3], chosen from:  
@@ -149,3 +151,4 @@ external_redirect: /api/#create-a-monitor
 [1]: /monitors/monitor_types/#define-the-conditions
 [2]: /integrations/faq/list-of-api-source-attribute-value
 [3]: /monitors/monitor_types/
+[4]: /monitors/#export-your-monitor


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a section about the `threshold_windows` option to the API for creating monitors.


### Motivation
<!-- What inspired you to submit this pull request?-->
`threshold_windows` was added as an option and needs to be added to the API.

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
