### PR TITLE
fix log4net raw string convertion pattern by removing %d because it i…

### DIFF
--- a/content/logs/languages/csharp.md
+++ b/content/logs/languages/csharp.md
@@ -235,7 +235,7 @@ If you have followed the instructions you should see in your file (for example `
 If despite the benefits of logging in JSON you wish to remain in a raw string format, we recommend to update the `log4net convertion pattern` to automatically parse your logs with the c# integration pipeline as follows:
 
 ```
-<param name="ConversionPattern" value="%date%d{yyyy-MM-dd HH:mm:ss.SSS} %level [%thread] %logger %method:%line - %message%n" />
+<param name="ConversionPattern" value="%date{yyyy-MM-dd HH:mm:ss.SSS} %level [%thread] %logger %method:%line - %message%n" />
 ```
 
 ## Configure your Datadog Agent


### PR DESCRIPTION
…s the same as %date ref:https://logging.apache.org/log4net/log4net-1.2.13/release/sdk/log4net.Layout.PatternLayout.html

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fix log4net raw string convertion pattern by removing %d because it is the same as %date ref: https://logging.apache.org/log4net/log4net-1.2.13/release/sdk/log4net.Layout.PatternLayout.html

### Motivation
A client noticed it: https://datadog.zendesk.com/agent/tickets/150864

### Preview link
https://docs.datadoghq.com/logs/languages/csharp/#log4net
