### PR TITLE
Adding v0 for PHP & .NET tracing doc

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -413,11 +413,6 @@ languages:
           url: "tracing/setup/first_class_dimensions"
           weight: 110
           parent: customnav_tracingnav_setup
-        - identifier: customnav_tracingnav_dotnet
-          name: ".NET"
-          url: "tracing/setup/dotnet/"
-          weight: 115
-          parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_docker
           name: "Docker"
           url: "tracing/setup/docker/"
@@ -427,6 +422,11 @@ languages:
           name: "Kubernetes"
           url: "tracing/setup/kubernetes/"
           weight: 125
+          parent: customnav_tracingnav_setup
+         - identifier: customnav_tracingnav_dotnet
+          name: ".NET (Coming soon)"
+          url: "tracing/setup/dotnet/"
+          weight: 127
           parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_go
           name: "Go"
@@ -1261,11 +1261,6 @@ languages:
           url: "tracing/setup/first_class_dimensions"
           weight: 110
           parent: customnav_tracingnav_setup
-        - identifier: customnav_tracingnav_dotnet
-          name: ".NET"
-          url: "tracing/setup/dotnet/"
-          weight: 115
-          parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_docker
           name: "Docker"
           url: "tracing/setup/docker/"
@@ -1275,6 +1270,11 @@ languages:
           name: "Kubernetes"
           url: "tracing/setup/kubernetes/"
           weight: 125
+          parent: customnav_tracingnav_setup
+        - identifier: customnav_tracingnav_dotnet
+          name: ".NET (Coming soon)"
+          url: "tracing/setup/dotnet/"
+          weight: 127
           parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_go
           name: "Go"

--- a/config.yaml
+++ b/config.yaml
@@ -413,6 +413,11 @@ languages:
           url: "tracing/setup/first_class_dimensions"
           weight: 110
           parent: customnav_tracingnav_setup
+        - identifier: customnav_tracingnav_dotnet
+          name: ".NET"
+          url: "tracing/setup/dotnet/"
+          weight: 115
+          parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_docker
           name: "Docker"
           url: "tracing/setup/docker/"
@@ -438,10 +443,15 @@ languages:
           url: "tracing/setup/javascript/"
           weight: 145
           parent: customnav_tracingnav_setup
+        - identifier: customnav_tracingnav_php
+          name: "PHP"
+          url: "tracing/setup/php/"
+          weight: 150
+          parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_python
           name: "Python"
           url: "tracing/setup/python/"
-          weight: 150
+          weight: 155
           parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_ruby
           name: "Ruby"
@@ -1251,10 +1261,20 @@ languages:
           url: "tracing/setup/first_class_dimensions"
           weight: 110
           parent: customnav_tracingnav_setup
+        - identifier: customnav_tracingnav_dotnet
+          name: ".NET"
+          url: "tracing/setup/dotnet/"
+          weight: 115
+          parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_docker
           name: "Docker"
           url: "tracing/setup/docker/"
           weight: 120
+          parent: customnav_tracingnav_setup
+        - identifier: customnav_tracingnav_kubernetes
+          name: "Kubernetes"
+          url: "tracing/setup/kubernetes/"
+          weight: 125
           parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_go
           name: "Go"
@@ -1271,10 +1291,15 @@ languages:
           url: "tracing/setup/javascript/"
           weight: 145
           parent: customnav_tracingnav_setup
+        - identifier: customnav_tracingnav_php
+          name: "PHP"
+          url: "tracing/setup/php/"
+          weight: 150
+          parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_python
           name: "Python"
           url: "tracing/setup/python/"
-          weight: 150
+          weight: 155
           parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_ruby
           name: "Ruby"

--- a/config.yaml
+++ b/config.yaml
@@ -444,7 +444,7 @@ languages:
           weight: 145
           parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_php
-          name: "PHP (coming soon)"
+          name: "PHP (Coming soon)"
           url: "tracing/setup/php/"
           weight: 150
           parent: customnav_tracingnav_setup

--- a/config.yaml
+++ b/config.yaml
@@ -423,7 +423,7 @@ languages:
           url: "tracing/setup/kubernetes/"
           weight: 125
           parent: customnav_tracingnav_setup
-         - identifier: customnav_tracingnav_dotnet
+        - identifier: customnav_tracingnav_dotnet
           name: ".NET (Coming soon)"
           url: "tracing/setup/dotnet/"
           weight: 127

--- a/config.yaml
+++ b/config.yaml
@@ -444,7 +444,7 @@ languages:
           weight: 145
           parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_php
-          name: "PHP"
+          name: "PHP (coming soon)"
           url: "tracing/setup/php/"
           weight: 150
           parent: customnav_tracingnav_setup
@@ -1292,7 +1292,7 @@ languages:
           weight: 145
           parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_php
-          name: "PHP"
+          name: "PHP (Coming soon)"
           url: "tracing/setup/php/"
           weight: 150
           parent: customnav_tracingnav_setup

--- a/content/tracing/setup/_index.md
+++ b/content/tracing/setup/_index.md
@@ -4,9 +4,12 @@ kind: Documentation
 aliases:
   - /tracing/languages/
 further_reading:
-- link: "tracing/setup/environment"
+- link: "tracing/setup/first_class_dimensions"
   tag: "Documentation"
-  text: "Learn more about environment configuration"
+  text: "Learn more about first class dimensions"
+- link: "tracing/setup/dotnet"
+  tag: "Documentation"
+  text: .NET language instrumentation
 - link: "tracing/setup/docker"
   tag: "Documentation"
   text: Docker setup
@@ -22,6 +25,9 @@ further_reading:
 - link: "tracing/setup/javascript"
   tag: "Documentation"
   text: JavaScript language instrumentation
+- link: "tracing/setup/php"
+  tag: "Documentation"
+  text: PHP language instrumentation
 - link: "tracing/setup/python"
   tag: "Documentation"
   text: Python language instrumentation

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -21,8 +21,8 @@ APM .Net support is currently in alpha and provides limited automatic instrument
 
 ### Web Frameworks
 
-| Framework         | Versions    | Support Type    |
-| :---------------  | :---------- | :-------------- |
+| Framework                    | Versions    | Support Type    |
+| :---------------             | :---------- | :-------------- |
 | ASP.NET MVC<sup>1</sup>      | 5.x         | Alpha           |
 | ASP.NET Web API<sup>1</sup>  | 2.x         | Coming soon     |
 | ASP.NET Core MVC<sup>2</sup> | 2.0         | Alpha           |

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -23,12 +23,12 @@ APM .Net support is currently in alpha and provides limited automatic instrument
 
 | Framework         | Versions    | Support Type    |
 | :---------------  | :---------- | :-------------- |
-| ASP.NET MVC1      | 5.x         | Alpha           |
-| ASP.NET Web API1  | 2.x         | Coming soon     |
-| ASP.NET Core MVC2 | 2.0         | Alpha           |
+| ASP.NET MVC<sup>1</sup>      | 5.x         | Alpha           |
+| ASP.NET Web API<sup>1</sup>  | 2.x         | Coming soon     |
+| ASP.NET Core MVC<sup>2</sup> | 2.0         | Alpha           |
 
-1 Running on .NET Framework 4.5 or above
-2 Running on .NET Framework 4.6.1 or above, or on .NET Core 2.0 or above
+<sup>1</sup> Running on .NET Framework 4.5 or above  
+<sup>2</sup> Running on .NET Framework 4.6.1 or above, or on .NET Core 2.0 or above
 
 Don’t see what you're looking for? Please let us know more about your needs through [this survey][1].
 

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -1,5 +1,5 @@
 ---
-title: Tracing .NET Applications
+title: Tracing .NET Applications (Coming Soon)
 kind: Documentation
 further_reading:
 - link: "https://github.com/DataDog/dd-trace-csharp"
@@ -8,16 +8,23 @@ further_reading:
 - link: "tracing/visualization/"
   tag: "Documentation"
   text: "Explore your services, resources and traces"
+- link: "https://goo.gl/forms/SCKOOlHS7tNzyMt93"
+  tag: "Survey"
+  text: Request Beta Access
 ---
 
-The APM tracer for .NET applications is currently in **alpha** and not officially supported by Datadog. The officially supported Beta will launch as early as August 2018.  To be notified of the beta launch, [submit this form][1].
+<div class="alert alert-warning">
+The APM tracer for .NET applications is currently in <strong>alpha</strong> and not officially supported by Datadog.<br>
+The officially supported beta will launch as early as August 2018. To be notified of the beta launch, <a href="https://goo.gl/forms/SCKOOlHS7tNzyMt93">submit this form</a> <br>
+<strong>We do not recommend running the alpha tracer in production.</strong>
+</div>
 
 The unstable alpha tracer can be [accessed today on Github][2]. 
-**We do not recommend running the alpha tracer in production.**
 
-## Automatic Instrumentation
+## Planned Automatic Instrumentation for Beta (Coming Soon)
 
-APM .Net support is currently in alpha and provides limited automatic instrumentation.  Beta support is planned for August 2018 and will provide automatic instrumentation for popular frameworks and libraries.  See some of these listed below.  Don’t see your desired frameworks or libraries? Please let us know more about your needs through [this survey][1].
+APM .Net support is currently in alpha and provides limited automatic instrumentation. Planned beta support will provide automatic instrumentation for popular frameworks and libraries. See some of these listed below.
+Don’t see your desired frameworks or libraries? Please let us know more about your needs through [this survey][1].
 
 ### Web Frameworks
 

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -1,0 +1,52 @@
+---
+title: Tracing .NET Applications
+kind: Documentation
+further_reading:
+- link: "https://github.com/DataDog/dd-trace-csharp"
+  tag: "Github"
+  text: Source code
+- link: "tracing/visualization/"
+  tag: "Documentation"
+  text: "Explore your services, resources and traces"
+---
+
+The APM tracer for .NET applications is currently in **alpha** and not officially supported by Datadog. The officially supported Beta will launch as early as August 2018.  To be notified of the beta launch, [submit this form][1].
+
+The unstable alpha tracer can be [accessed today on Github][2]. 
+**We do not recommend running the alpha tracer in production.**
+
+## Automatic Instrumentation
+
+APM .Net support is currently in alpha and provides limited automatic instrumentation.  Beta support is planned for August 2018 and will provide automatic instrumentation for popular frameworks and libraries.  See some of these listed below.  Don’t see your desired frameworks or libraries? Please let us know more about your needs through [this survey][1].
+
+### Web Frameworks
+
+| Framework         | Versions    | Support Type    |
+| :---------------  | :---------- | :-------------- |
+| ASP.NET MVC1      | 5.x         | Alpha           |
+| ASP.NET Web API1  | 2.x         | Coming soon     |
+| ASP.NET Core MVC2 | 2.0         | Alpha           |
+
+1 Running on .NET Framework 4.5 or above
+2 Running on .NET Framework 4.6.1 or above, or on .NET Core 2.0 or above
+
+Don’t see what you're looking for? Please let us know more about your needs through [this survey][1].
+
+### Data Stores
+
+| Data Store                      | Versions    | Support Type    |
+| :------------------------------ | :---------- | :-------------- |
+| Ado.Net / System.Data.SqlClient |             | Alpha           |
+| Elasticsearch.net / NEST        |             | Coming Soon     |
+| MongoDB.Driver                  |             | Coming Soon     |
+| Postgres (Npgsql)               |             | Coming Soon     |
+| ServiceStack.Redis              |             | Coming Soon     |
+
+Don’t see what you're looking for? Please let us know more about your needs through [this survey][1].
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://goo.gl/forms/SCKOOlHS7tNzyMt93
+[2]: https://github.com/DataDog/dd-trace-csharp

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -14,8 +14,7 @@ further_reading:
 ---
 
 <div class="alert alert-warning">
-The APM tracer for .NET applications is currently in <strong>alpha</strong> and not officially supported by Datadog.<br>
-The officially supported beta will launch as early as August 2018. To be notified of the beta launch, <a href="https://goo.gl/forms/SCKOOlHS7tNzyMt93">submit this form</a> <br>
+The APM tracer for .NET applications is currently in <strong>alpha</strong> and not officially supported by Datadog. The officially supported beta will launch as early as August 2018. To be notified of the beta launch, <a href="https://goo.gl/forms/SCKOOlHS7tNzyMt93">submit this form</a> <br>
 <strong>We do not recommend running the alpha tracer in production.</strong>
 </div>
 

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -14,8 +14,7 @@ further_reading:
 ---
 
 <div class="alert alert-warning">
-The APM tracer for PHP applications is currently in <strong>alpha</strong> and not officially supported by Datadog.<br>
-The officially supported beta will launch as early as September 2018. To be notified of the beta launch, <a href="https://goo.gl/forms/rKjH2J6nJ585KXri2">submit this form</a> <br>
+The APM tracer for PHP applications is currently in <strong>alpha</strong> and not officially supported by Datadog. The officially supported beta will launch as early as September 2018. To be notified of the beta launch, <a href="https://goo.gl/forms/rKjH2J6nJ585KXri2">submit this form</a> <br>
 <strong>We do not recommend running the alpha tracer in production.</strong>
 </div>
 

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -1,5 +1,5 @@
 ---
-title: Tracing PHP Applications
+title: Tracing PHP Applications (Coming Soon)
 kind: Documentation
 further_reading:
 - link: "https://github.com/DataDog/dd-trace-php"
@@ -8,16 +8,22 @@ further_reading:
 - link: "tracing/visualization/"
   tag: "Documentation"
   text: "Explore your services, resources and traces"
+- link: "https://goo.gl/forms/rKjH2J6nJ585KXri2"
+  tag: "Survey"
+  text: Request Beta Access
 ---
 
-PHP APM is currently in **alpha**** and not officially supported by Datadog. The officially supported PHP Beta will launch as early as September 2018.  To be notified of the beta launch, [submit this form][1].
+<div class="alert alert-warning">
+The APM tracer for PHP applications is currently in <strong>alpha</strong> and not officially supported by Datadog.<br>
+The officially supported beta will launch as early as September 2018. To be notified of the beta launch, <a href="https://goo.gl/forms/rKjH2J6nJ585KXri2">submit this form</a> <br>
+<strong>We do not recommend running the alpha tracer in production.</strong>
+</div>
 
 The unstable alpha tracer can be [accessed today on Github][2].
-**We do not recommend running the alpha tracer in production.**
 
-## Automatic Instrumentation
+## Planned Automatic Instrumentation for Beta (Coming Soon)
 
-APM PHP support is currently in alpha and does not yet provide any automatic instrumentation.  Beta support is planned for September 2018 and will provide automatic instrumentation for popular frameworks and libraries.  See some of these listed below.  
+APM PHP support is currently in alpha and provides limited automatic instrumentation. Planned beta support will provide automatic instrumentation for popular frameworks and libraries. See some of these listed below.
 Don’t see your desired frameworks or libraries? Please let us know more about your needs through [this survey][1].
 
 ### Web Frameworks

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -32,12 +32,12 @@ Don’t see your desired web frameworks? Please let us know more about your need
 
 ### Data Stores
 
-| Module     | Versions    | Support Type |
-| :----------| :---------- | :----------- |
-| MYSQL      |             | Coming Soon  |
-| Redis      |             | Coming Soon  |
-| MongoDB    |             | Coming Soon  |
-| Postgres   |             | Coming Soon  |
+| Module      | Versions    | Support Type |
+| :---------- | :---------- | :----------- |
+| MYSQL       |             | Coming Soon  |
+| Redis       |             | Coming Soon  |
+| MongoDB     |             | Coming Soon  |
+| Postgres    |             | Coming Soon  |
 
 Don’t see your desired data stores? Please let us know more about your needs through [this survey][1].
 

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -1,0 +1,50 @@
+---
+title: Tracing PHP Applications
+kind: Documentation
+further_reading:
+- link: "https://github.com/DataDog/dd-trace-php"
+  tag: "Github"
+  text: Source code
+- link: "tracing/visualization/"
+  tag: "Documentation"
+  text: "Explore your services, resources and traces"
+---
+
+PHP APM is currently in **alpha**** and not officially supported by Datadog. The officially supported PHP Beta will launch as early as September 2018.  To be notified of the beta launch, [submit this form][1].
+
+The unstable alpha tracer can be [accessed today on Github][2].
+**We do not recommend running the alpha tracer in production.**
+
+## Automatic Instrumentation
+
+APM PHP support is currently in alpha and does not yet provide any automatic instrumentation.  Beta support is planned for September 2018 and will provide automatic instrumentation for popular frameworks and libraries.  See some of these listed below.  
+Don’t see your desired frameworks or libraries? Please let us know more about your needs through [this survey][1].
+
+### Web Frameworks
+
+| Module         | Versions    | Support Type    |
+| :-----------   | :---------- | :-------------- |
+| Laravel        |             | Coming soon     |
+| Symfony        |             | Coming soon     |
+| Zend Framework |             | Coming soon     |
+
+Don’t see your desired web frameworks? Please let us know more about your needs through [this survey][1].
+
+### Data Stores
+
+| Module     | Versions    | Support Type |
+| :----------| :---------- | :----------- |
+| MYSQL      |             | Coming Soon  |
+| Redis      |             | Coming Soon  |
+| MongoDB    |             | Coming Soon  |
+| Postgres   |             | Coming Soon  |
+
+Don’t see your desired data stores? Please let us know more about your needs through [this survey][1].
+
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://goo.gl/forms/rKjH2J6nJ585KXri2
+[2]: https://github.com/DataDog/dd-trace-php


### PR DESCRIPTION
### What does this PR do?

Add doc for alpha tracers for PHP and .NET 

### Motivation
PM request

### Preview link

* https://docs-staging.datadoghq.com/gus/apm-setup/tracing/setup/dotnet/
* https://docs-staging.datadoghq.com/gus/apm-setup/tracing/setup/php/