### PR TITLE
fixes some formatting and grammar in the Docker log collection docs

### DIFF
--- a/content/logs/log_collection/docker.md
+++ b/content/logs/log_collection/docker.md
@@ -26,7 +26,7 @@ Two installations are possible:
 - on the host where the Agent is external to the Docker environment
 - or by deploying its containerized version in the Docker environment
 
-You can then choose to collect all the logs from all your environment's containers or to filter by container image name or container label to cherry pick what logs should be collected.
+You can then choose to collect all the logs from all your environment's containers, or to filter by container image name or container label to cherry pick what logs should be collected.
 
 ## Setup
 ### Option 1: Host installation
@@ -35,7 +35,7 @@ Install the [latest version of the Agent 6][1] on your host.
 
 The Agent can collect logs from [files on the host][2] or from [container stdout/stderr](#configuration-file-example).
 
-To collect logs from all your containers without filtering by image or label add the following at the end of `docker.d/conf.yaml` in your agent's `conf.d` directory:
+To collect logs from all your containers without filtering by image or label, add the following at the end of docker.d/conf.yaml in your agent's conf.d directory:
 
 ```
 logs:
@@ -49,7 +49,7 @@ logs:
 
 As explained above, the Agent also has a [containerized][3] installation.
 
-First, let’s create one directories on the host that we will later mount on the containerized Agent:
+First, let’s create one directory on the host that we will later mount on the containerized Agent:
 
 - `/opt/datadog-agent/run`: to make sure we do not lose any logs from containers during restarts or network issues we store on the host the last line that was collected for each container in this directory
 
@@ -112,7 +112,7 @@ logs:
 ```
 
 When filtering on the container image, both exact container image name or short names are supported.
-If you have one container running `library/httpd:latest`, the following filtering match this image name:
+If you have one container running `library/httpd:latest`, the following filtering matches this image name:
 
 * - `image: httpd`
 * - `image: library/httpd`
@@ -125,7 +125,7 @@ For more examples of configuration files or Agent capabilities (such as filterin
 
 Since version 6.2 of the Datadog Agent, you can configure log collection directly in the container labels.
 
-Autodiscovery expects labels to look like this format, depending on the file type:
+Autodiscovery expects labels to follow this format, depending on the file type:
 
 * Dockerfile: `LABEL "com.datadoghq.ad.logs"='[<LOGS_CONFIG>]'`
 * docker-compose.yaml:

--- a/content/logs/log_collection/docker.md
+++ b/content/logs/log_collection/docker.md
@@ -26,16 +26,16 @@ Two installations are possible:
 - on the host where the Agent is external to the Docker environment
 - or by deploying its containerized version in the Docker environment
 
-You can then choose to collect all the logs from all your environment container or to filter by container image name or container label to cherry pick what logs should be collected.
+You can then choose to collect all the logs from all your environment's containers or to filter by container image name or container label to cherry pick what logs should be collected.
 
 ## Setup
 ### Option 1: Host installation
 
 Install the [latest version of the Agent 6][1] on your host.
 
-The Agent can both collect logs from [files on the host][2] or from [container stdout/stderr](#configuration-file-example).
+The Agent can collect logs from [files on the host][2] or from [container stdout/stderr](#configuration-file-example).
 
-To collect logs from all your container without filtering by image or label add the following at the end of `docker.d/conf.yaml` in your agent's `conf.d` directory:
+To collect logs from all your containers without filtering by image or label add the following at the end of `docker.d/conf.yaml` in your agent's `conf.d` directory:
 
 ```
 logs:
@@ -43,13 +43,13 @@ logs:
       service: docker
 ```
 
-**Important note**: Integration pipelines and processors will not be installed automatically as the source tag is not set. The integrations setup is described below and it automatically installs integration pipelines that parse your logs and extract all the relevant information from them.
+**Important note**: Integration pipelines and processors will not be installed automatically as the source tag is not set. The integration setup is described below and it automatically installs integration pipelines that parse your logs and extract all the relevant information from them.
 
 ### Option 2: Container installation
 
 As explained above, the Agent also has a [containerized][3] installation.
 
-First let’s create one directories on the host that we will later mount on the containerized Agent:
+First, let’s create one directories on the host that we will later mount on the containerized Agent:
 
 - `/opt/datadog-agent/run`: to make sure we do not lose any logs from containers during restarts or network issues we store on the host the last line that was collected for each container in this directory
 
@@ -71,13 +71,13 @@ Important notes:
 
 - The Docker integration is enabled by default, as well as [autodiscovery][5] in auto configuration mode (remove the listeners: -docker section in `datadog.yaml` to disable it).
 
-- We recommend to always pick the latest version of Datadog Agent 6. [Consult the full list of available images for Agent 6][6].
+- We recommend always picking the latest version of Datadog Agent 6. [Consult the full list of available images for Agent 6][6].
 
-The command related to log collection are the following:
+The commands related to log collection are the following:
 
-* `-e DD_LOGS_ENABLED=true`: this parameter enables the log collection when set to true. The Agent now looks for log instructions in configuration files.
-* `-e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true`: this parameter add a log configuration that enabled log collection for all containers (see `Option 1` below) 
-* `-v /opt/datadog-agent/run:/opt/datadog-agent/run:rw`: mount the directory we created to store pointer on each container logs to make sure we do not lose any.
+* `-e DD_LOGS_ENABLED=true`: this parameter enables log collection when set to true. The Agent now looks for log instructions in configuration files.
+* `-e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true`: this parameter adds a log configuration that enables log collection for all containers (see `Option 1` below) 
+* `-v /opt/datadog-agent/run:/opt/datadog-agent/run:rw`: mount the directory we created to store pointers for each container's logs to make sure we do not lose any.
 
 ### Activate Log Collection
 
@@ -89,7 +89,7 @@ For containerized installation, begin by creating the configuration directory on
 
 - ` /opt/datadog-agent/conf.d`: this is the folder in which integration instructions are provided. Any configuration file added there is automatically picked up by the containerized Agent when restarted. To learn more about this topic refer to the dedicated documentation on [how to enable integrations with the docker agent][4].
 
-Then mount the directory by adding `-v /opt/datadog-agent/conf.d:/conf.d:ro` in the run command of the containerized agent.
+Then, mount the directory by adding `-v /opt/datadog-agent/conf.d:/conf.d:ro` in the run command of the containerized agent.
 
 To set the source for a given container filtered by image or label or name, update the log section in an integration or custom .yaml file in your agent's `conf.d` directory or the directory we just created for containerized installation.
 
@@ -112,7 +112,7 @@ logs:
 ```
 
 When filtering on the container image, both exact container image name or short names are supported.
-Suppose you have one container running `library/httpd:latest` the following filtering match this image name:
+If you have one container running `library/httpd:latest`, the following filtering match this image name:
 
 * - `image: httpd`
 * - `image: library/httpd`
@@ -125,7 +125,7 @@ For more examples of configuration files or Agent capabilities (such as filterin
 
 Since version 6.2 of the Datadog Agent, you can configure log collection directly in the container labels.
 
-Autodiscovery expects labels to look like these format, depending on the file type:
+Autodiscovery expects labels to look like this format, depending on the file type:
 
 * Dockerfile: `LABEL "com.datadoghq.ad.logs"='[<LOGS_CONFIG>]'`
 * docker-compose.yaml:
@@ -152,7 +152,7 @@ LABEL "com.datadoghq.ad.instances"='[{"nginx_status_url": "http://%%host%%:%%por
 LABEL "com.datadoghq.ad.logs"='[{"source": "nginx", "service": "webapp"}]'
 ```
 
-Check our [Autodiscovery Guide][8]for more information about Autodiscovery setup and examples.
+Check our [Autodiscovery Guide][8] for more information about Autodiscovery setup and examples.
 
 ## Further Reading
 


### PR DESCRIPTION
### What does this PR do?

Fixes some formatting and some grammar in the Docker log collection documentation

### Motivation

Saw some things to fix in the doc.  For instance, a missing space here - https://cl.ly/0J3L3T153U2r

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
