### PR TITLE
Adding survey button for tracing alpha integrations doc pages

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -421,16 +421,6 @@ languages:
         - identifier: customnav_tracingnav_kubernetes
           name: "Kubernetes"
           url: "tracing/setup/kubernetes/"
-          weight: 125
-          parent: customnav_tracingnav_setup
-        - identifier: customnav_tracingnav_dotnet
-          name: ".NET (Coming soon)"
-          url: "tracing/setup/dotnet/"
-          weight: 127
-          parent: customnav_tracingnav_setup
-        - identifier: customnav_tracingnav_go
-          name: "Go"
-          url: "tracing/setup/go/"
           weight: 130
           parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_java
@@ -438,30 +428,40 @@ languages:
           url: "tracing/setup/java/"
           weight: 140
           parent: customnav_tracingnav_setup
-        - identifier: customnav_tracingnav_javascript
-          name: "JavaScript"
-          url: "tracing/setup/javascript/"
-          weight: 145
-          parent: customnav_tracingnav_setup
-        - identifier: customnav_tracingnav_php
-          name: "PHP (Coming soon)"
-          url: "tracing/setup/php/"
-          weight: 150
-          parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_python
           name: "Python"
           url: "tracing/setup/python/"
-          weight: 155
+          weight: 150
           parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_ruby
           name: "Ruby"
           url: "tracing/setup/ruby/"
           weight: 160
           parent: customnav_tracingnav_setup
+        - identifier: customnav_tracingnav_go
+          name: "Go"
+          url: "tracing/setup/go/"
+          weight: 170
+          parent: customnav_tracingnav_setup
+        - identifier: customnav_tracingnav_javascript
+          name: "JavaScript"
+          url: "tracing/setup/javascript/"
+          weight: 180
+          parent: customnav_tracingnav_setup
+        - identifier: customnav_tracingnav_dotnet
+          name: ".NET (Coming soon)"
+          url: "tracing/setup/dotnet/"
+          weight: 190
+          parent: customnav_tracingnav_setup
+        - identifier: customnav_tracingnav_php
+          name: "PHP (Coming soon)"
+          url: "tracing/setup/php/"
+          weight: 195
+          parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_libraries
           name: "Community Libraries"
-          url: "libraries/#apm-tracing-client-libraries"
-          weight: 170
+          url: "developers/libraries/#apm-tracing-client-libraries"
+          weight: 199
           parent: customnav_tracingnav_setup
 
         # Using the APM UI
@@ -1264,16 +1264,6 @@ languages:
         - identifier: customnav_tracingnav_kubernetes
           name: "Kubernetes"
           url: "tracing/setup/kubernetes/"
-          weight: 125
-          parent: customnav_tracingnav_setup
-        - identifier: customnav_tracingnav_dotnet
-          name: ".NET (Coming soon)"
-          url: "tracing/setup/dotnet/"
-          weight: 127
-          parent: customnav_tracingnav_setup
-        - identifier: customnav_tracingnav_go
-          name: "Go"
-          url: "tracing/setup/go/"
           weight: 130
           parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_java
@@ -1281,30 +1271,40 @@ languages:
           url: "tracing/setup/java/"
           weight: 140
           parent: customnav_tracingnav_setup
-        - identifier: customnav_tracingnav_javascript
-          name: "JavaScript"
-          url: "tracing/setup/javascript/"
-          weight: 145
-          parent: customnav_tracingnav_setup
-        - identifier: customnav_tracingnav_php
-          name: "PHP (Coming soon)"
-          url: "tracing/setup/php/"
-          weight: 150
-          parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_python
           name: "Python"
           url: "tracing/setup/python/"
-          weight: 155
+          weight: 150
           parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_ruby
           name: "Ruby"
           url: "tracing/setup/ruby/"
           weight: 160
           parent: customnav_tracingnav_setup
+        - identifier: customnav_tracingnav_go
+          name: "Go"
+          url: "tracing/setup/go/"
+          weight: 170
+          parent: customnav_tracingnav_setup
+        - identifier: customnav_tracingnav_javascript
+          name: "JavaScript"
+          url: "tracing/setup/javascript/"
+          weight: 180
+          parent: customnav_tracingnav_setup
+        - identifier: customnav_tracingnav_dotnet
+          name: ".NET (Coming soon)"
+          url: "tracing/setup/dotnet/"
+          weight: 190
+          parent: customnav_tracingnav_setup
+        - identifier: customnav_tracingnav_php
+          name: "PHP (Coming soon)"
+          url: "tracing/setup/php/"
+          weight: 195
+          parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_librairies
           name: "Bibliothèques de la communauté"
-          url: "libraries/#apm-tracing-client-libraries"
-          weight: 170
+          url: "developers/libraries/#apm-tracing-client-libraries"
+          weight: 199
           parent: customnav_tracingnav_setup
 
         # Using the APM UI

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -11,11 +11,11 @@ further_reading:
 ---
 
 <div class="alert alert-warning">
-The APM tracer for .NET applications is currently in alpha and not officially supported by Datadog. The officially supported beta will launch as early as August 2018. We do not recommend running the alpha tracer in production.
+Tracing for .NET applications is coming soon from Datadog. The officially supported beta will launch as early as August 2018. To be notified of the beta launch, fill out the survey below.
 </div>
 
 {{< whatsnext desc="To be notified of the beta launch, submit this form:">}}
-    {{< nextlink href="https://goo.gl/forms/SCKOOlHS7tNzyMt93" tag="Survey" >}}.NET beta survey{{< /nextlink >}}
+    {{< nextlink href="https://goo.gl/forms/SCKOOlHS7tNzyMt93" tag="Survey" >}}.NET Beta Access Survey{{< /nextlink >}}
 {{< /whatsnext >}}
 
 <br>
@@ -41,11 +41,11 @@ Don’t see what you're looking for? Please let us know more about your needs th
 
 | Data Store                      | Versions    | Support Type    |
 | :------------------------------ | :---------- | :-------------- |
-| Ado.Net / System.Data.SqlClient |             | Coming soon     |
-| Elasticsearch.net / NEST        |             | Coming Soon     |
-| MongoDB.Driver                  |             | Coming Soon     |
-| Postgres (Npgsql)               |             | Coming Soon     |
-| ServiceStack.Redis              |             | Coming Soon     |
+| Ado.Net / System.Data.SqlClient | Coming soon | Coming soon     |
+| Elasticsearch.net / NEST        | Coming soon | Coming Soon     |
+| MongoDB.Driver                  | Coming soon | Coming Soon     |
+| Postgres (Npgsql)               | Coming soon | Coming Soon     |
+| ServiceStack.Redis              | Coming soon | Coming Soon     |
 
 Don’t see what you're looking for? Please let us know more about your needs through [this survey][1].
 

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -2,9 +2,6 @@
 title: Tracing .NET Applications (Coming Soon)
 kind: Documentation
 further_reading:
-- link: "https://github.com/DataDog/dd-trace-csharp"
-  tag: "Github"
-  text: Source code
 - link: "tracing/visualization/"
   tag: "Documentation"
   text: "Explore your services, resources and traces"
@@ -14,8 +11,14 @@ further_reading:
 ---
 
 <div class="alert alert-warning">
-Tracing for .NET applications is coming soon from Datadog. The officially supported beta will launch as early as August 2018. To be notified of the beta launch, <a href="https://goo.gl/forms/SCKOOlHS7tNzyMt93">submit this form</a> <br>.
+The APM tracer for .NET applications is currently in alpha and not officially supported by Datadog. The officially supported beta will launch as early as August 2018. We do not recommend running the alpha tracer in production.
 </div>
+
+{{< whatsnext desc="To be notified of the beta launch, submit this form:">}}
+    {{< nextlink href="https://goo.gl/forms/SCKOOlHS7tNzyMt93" tag="Survey" >}}.NET beta survey{{< /nextlink >}}
+{{< /whatsnext >}}
+
+<br>
 
 ## Planned Automatic Instrumentation for Beta (Coming Soon)
 

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -2,6 +2,9 @@
 title: Tracing PHP Applications (Coming Soon)
 kind: Documentation
 further_reading:
+- link: "https://github.com/DataDog/dd-trace-php"
+  tag: "Github"    
+  text: Source code
 - link: "tracing/visualization/"
   tag: "Documentation"
   text: "Explore your services, resources and traces"
@@ -15,10 +18,12 @@ The APM tracer for PHP applications is currently in alpha and not officially sup
 </div>
 
 {{< whatsnext desc="To be notified of the beta launch, submit this form:">}}
-    {{< nextlink href="https://goo.gl/forms/rKjH2J6nJ585KXri2" tag="Survey" >}}PHP beta survey{{< /nextlink >}}
+    {{< nextlink href="https://goo.gl/forms/rKjH2J6nJ585KXri2" tag="Survey" >}}PHP Beta Access Survey{{< /nextlink >}}
 {{< /whatsnext >}}
 
 <br>
+
+The unstable alpha tracer can be [accessed today on Github][2].
 
 ## Planned Automatic Instrumentation for Beta (Coming Soon)
 
@@ -29,9 +34,9 @@ Don’t see your desired frameworks or libraries? Please let us know more about 
 
 | Module         | Versions    | Support Type    |
 | :-----------   | :---------- | :-------------- |
-| Laravel        |             | Coming soon     |
-| Symfony        |             | Coming soon     |
-| Zend Framework |             | Coming soon     |
+| Laravel        | Coming soon | Coming soon     |
+| Symfony        | Coming soon | Coming soon     |
+| Zend Framework | Coming soon | Coming soon     |
 
 Don’t see your desired web frameworks? Please let us know more about your needs through [this survey][1].
 
@@ -39,10 +44,10 @@ Don’t see your desired web frameworks? Please let us know more about your need
 
 | Module      | Versions    | Support Type |
 | :---------- | :---------- | :----------- |
-| MYSQL       |             | Coming Soon  |
-| Redis       |             | Coming Soon  |
-| MongoDB     |             | Coming Soon  |
-| Postgres    |             | Coming Soon  |
+| MYSQL       | Coming soon | Coming Soon  |
+| Redis       | Coming soon | Coming Soon  |
+| MongoDB     | Coming soon | Coming Soon  |
+| Postgres    | Coming soon | Coming Soon  |
 
 Don’t see your desired data stores? Please let us know more about your needs through [this survey][1].
 

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -2,9 +2,6 @@
 title: Tracing PHP Applications (Coming Soon)
 kind: Documentation
 further_reading:
-- link: "https://github.com/DataDog/dd-trace-php"
-  tag: "Github"
-  text: Source code
 - link: "tracing/visualization/"
   tag: "Documentation"
   text: "Explore your services, resources and traces"
@@ -14,11 +11,14 @@ further_reading:
 ---
 
 <div class="alert alert-warning">
-The APM tracer for PHP applications is currently in alpha and not officially supported by Datadog. The officially supported beta will launch as early as September 2018. To be notified of the beta launch, <a href="https://goo.gl/forms/rKjH2J6nJ585KXri2">submit this form</a> <br>
-We do not recommend running the alpha tracer in production.
+The APM tracer for PHP applications is currently in alpha and not officially supported by Datadog. The officially supported beta will launch as early as September 2018. We do not recommend running the alpha tracer in production.
 </div>
 
-The unstable alpha tracer can be [accessed today on Github][2].
+{{< whatsnext desc="To be notified of the beta launch, submit this form:">}}
+    {{< nextlink href="https://goo.gl/forms/rKjH2J6nJ585KXri2" tag="Survey" >}}PHP beta survey{{< /nextlink >}}
+{{< /whatsnext >}}
+
+<br>
 
 ## Planned Automatic Instrumentation for Beta (Coming Soon)
 


### PR DESCRIPTION
### What does this PR do?

* Changes the layout for the call to action for the survey
* Removes link to github repo at the bottom of the page

### Motivation
PM request

### Preview link
* https://docs-staging.datadoghq.com/gus/tracing-button/tracing/setup/php/
* https://docs-staging.datadoghq.com/gus/tracing-button/tracing/setup/dotnet/