### PR TITLE
at all times --> in total

### DIFF
--- a/content/monitors/faq/as-count-monitor-evaluation.md
+++ b/content/monitors/faq/as-count-monitor-evaluation.md
@@ -97,7 +97,7 @@ Since this special behavior is tied to the `as_count` modifier, we encourage rep
 
 *Example:* Suppose you wish to monitor the error rate of a service:
 
-Suppose you want to be alerted when the error rate is above 50% at all times during the past 5 min. You might have a query like:
+Suppose you want to be alerted when the error rate is above 50% in total during the past 5 min. You might have a query like:
 `sum(last_5m):sum:requests.error{*}.as_count() / sum:requests.total{*}.as_count() > 0.5 ` 
 
 To correctly rewrite it in the explicit format, the query can be rewritten like:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Example talks about an error rate being above 50% "at all times"; query uses `sum` so for accuracy, the example should be talking about an error rate being above 50% "in total."