### PR TITLE
nest s3 under archives and update path of archives in s3

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -672,10 +672,15 @@ languages:
           weight: 90
           parent: menu_references_logs
         - identifier: customnav_lognav_archives
-          name: "Archives on AWS S3"
+          name: "Archives"
           url: "logs/s3"
           weight: 100
           parent: menu_references_logs
+        - identifier: customnav_lognav_archives_s3
+          name: "AWS S3"
+          url: "logs/s3"
+          weight: 1010
+          parent: customnav_lognav_archives
 
         #- identifier: customnav_lognav_faq
         #  name: "FAQ"

--- a/content/logs/s3.md
+++ b/content/logs/s3.md
@@ -5,7 +5,7 @@ description: "Forward all your Datadog logs to S3 for long term storage."
 ---
 
 <div class="alert alert-warning">
-This feature is currently in limited beta. <br> 
+This feature is currently in beta. <br> 
 Ask your Sales representative or Customer Success Manager to have it enabled.
 </div>
 
@@ -59,7 +59,7 @@ However, after creating or updating your archive configurations, it can take sev
 
 The log archives that Datadog forwards to your S3 bucket are in zipped (gzip) JSON format. Under whatever prefix you indicate (or / if there is none), the archives are stored in a directory structure that indicates on what date and at what time the archive files were generated, like so:
 
-`/my/s3/prefix/year=2018/month=05/day=15/archive_143201.1234.7dq1a9mnSya3bFotoErfxl.json.gz`
+`/my/s3/prefix/date=20180515/hour=14/archive_143201.1234.7dq1a9mnSya3bFotoErfxl.json.gz`
 
 This directory structure simplifies the process of querying your historical log archives based on their date. 
 


### PR DESCRIPTION
### What does this PR do?
2 changes:
1. nest the `AWS S3 Archives` page under a more general `Archives` category.
2. Update the directory path of the archive contents

### Motivation
For...
1. We do not want to suggest that the only kind of archiving that we are planning for is the s3 archiving. We want to suggest that more kinds of archives are to come. 
2. A heartfelt love of humankind and the distribution of correct information. 

### Preview link
https://docs-staging.datadoghq.com/estib/update-s3-archive-path/logs/s3/

