### PR TITLE
use dd-agent user to install python packages

### DIFF
--- a/content/agent/custom_python_package.md
+++ b/content/agent/custom_python_package.md
@@ -19,7 +19,7 @@ The python version embedded with the Agent is located here: `/opt/datadog-agent/
 The Agent also comes with pip; install python libraries using:
 
 ```bash
-sudo /opt/datadog-agent/embedded/bin/pip install <package_name>
+sudo -u dd-agent /opt/datadog-agent/embedded/bin/pip install <package_name>
 ```
 
 ### Windows


### PR DESCRIPTION
### What does this PR do?

From a customer testing:

> the issue was that running that pip command as root can install the packages owned by root with permissions that prevent the package folders in site-packages from being read by the agent

### Motivation
To prevent future users from envountering the issue where custom python checks are unable to use 3rd party libraries installed by root user

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
This makes sense, although I didn't have a chance to create an environment and test it myself, most other commands we use like this give access to dd-agent. 


