### PR TITLE
Add section about configuration files

### DIFF
--- a/content/agent/basic_agent_usage/docker.md
+++ b/content/agent/basic_agent_usage/docker.md
@@ -94,9 +94,9 @@ Exclude containers from the metrics collection and Autodiscovery, if these are n
 
 ### Configuration files
 
-You can also mount YAML configuration files in the `/conf.d` folder, they will automatically be copied to `/etc/datadog-agent/conf.d/` when the container starts.  The same can be done for the `/checks.d` folder. Any Python files in the `/checks.d` folder will automatically be copied to `/etc/datadog-agent/checks.d/` when the container starts.
+You can also mount YAML configuration files in the `/conf.d` folder. They will automatically be copied to `/etc/datadog-agent/conf.d/` when the container starts. The same can be done for the `/checks.d` folder: any Python files in the `/checks.d` folder will automatically be copied to `/etc/datadog-agent/checks.d/` when the container starts.
 
-1. Create a configuration folder on the host and write your YAML files in it.  The examples below can be used for the `/checks.d` folder as well.
+1. Create a configuration folder on the host and write your YAML files in it. The examples below can be used for the `/checks.d` folder as well.
 
     ```
     mkdir /opt/datadog-agent-conf.d
@@ -116,7 +116,7 @@ You can also mount YAML configuration files in the `/conf.d` folder, they will a
 
     _The important part here is `-v /opt/datadog-agent-conf.d:/conf.d:ro`_
 
-Now when the container starts, all files in `/opt/datadog-agent-conf.d` with a `.yaml` extension will be copied to `/etc/datadog-agent/conf.d/`. Please note that to add new files you will need to restart the container.
+Now when the container starts, all files in `/opt/datadog-agent-conf.d` with a `.yaml` extension will be copied to `/etc/datadog-agent/conf.d/`. Note that to add new files you will need to restart the container.
 
 ## Further Reading
 

--- a/content/agent/basic_agent_usage/docker.md
+++ b/content/agent/basic_agent_usage/docker.md
@@ -92,6 +92,32 @@ Exclude containers from the metrics collection and Autodiscovery, if these are n
 
 **Note**: The `docker.containers.running`, `.stopped`, `.running.total` and `.stopped.total` metrics are not affected by these settings and always count all containers. This does not affect your per-container billing.
 
+### Configuration files
+
+You can also mount YAML configuration files in the `/conf.d` folder, they will automatically be copied to `/etc/dd-agent/conf.d/` when the container starts.  The same can be done for the `/checks.d` folder. Any Python files in the `/checks.d` folder will automatically be copied to `/etc/dd-agent/checks.d/` when the container starts.
+
+1. Create a configuration folder on the host and write your YAML files in it.  The examples below can be used for the `/checks.d` folder as well.
+
+    ```
+    mkdir /opt/dd-agent-conf.d
+    touch /opt/dd-agent-conf.d/nginx.yaml
+    ```
+
+2. When creating the container, mount this new folder to `/conf.d`.
+    ```
+    docker run -d --name dd-agent \
+      -v /var/run/docker.sock:/var/run/docker.sock:ro \
+      -v /proc/:/host/proc/:ro \
+      -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
+      -v /opt/dd-agent-conf.d:/conf.d:ro \
+      -e API_KEY={your_api_key_here} \
+      datadog/docker-dd-agent
+    ```
+
+    _The important part here is `-v /opt/dd-agent-conf.d:/conf.d:ro`_
+
+Now when the container starts, all files in `/opt/dd-agent-conf.d` with a `.yaml` extension will be copied to `/etc/dd-agent/conf.d/`. Please note that to add new files you will need to restart the container.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/agent/basic_agent_usage/docker.md
+++ b/content/agent/basic_agent_usage/docker.md
@@ -94,13 +94,13 @@ Exclude containers from the metrics collection and Autodiscovery, if these are n
 
 ### Configuration files
 
-You can also mount YAML configuration files in the `/conf.d` folder, they will automatically be copied to `/etc/dd-agent/conf.d/` when the container starts.  The same can be done for the `/checks.d` folder. Any Python files in the `/checks.d` folder will automatically be copied to `/etc/dd-agent/checks.d/` when the container starts.
+You can also mount YAML configuration files in the `/conf.d` folder, they will automatically be copied to `/etc/datadog-agent/conf.d/` when the container starts.  The same can be done for the `/checks.d` folder. Any Python files in the `/checks.d` folder will automatically be copied to `/etc/datadog-agent/checks.d/` when the container starts.
 
 1. Create a configuration folder on the host and write your YAML files in it.  The examples below can be used for the `/checks.d` folder as well.
 
     ```
-    mkdir /opt/dd-agent-conf.d
-    touch /opt/dd-agent-conf.d/nginx.yaml
+    mkdir /opt/datadog-agent-conf.d
+    touch /opt/datadog-agent-conf.d/nginx.yaml
     ```
 
 2. When creating the container, mount this new folder to `/conf.d`.
@@ -109,14 +109,14 @@ You can also mount YAML configuration files in the `/conf.d` folder, they will a
       -v /var/run/docker.sock:/var/run/docker.sock:ro \
       -v /proc/:/host/proc/:ro \
       -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-      -v /opt/dd-agent-conf.d:/conf.d:ro \
+      -v /opt/datadog-agent-conf.d:/conf.d:ro \
       -e API_KEY={your_api_key_here} \
-      datadog/docker-dd-agent
+       datadog/agent:latest
     ```
 
-    _The important part here is `-v /opt/dd-agent-conf.d:/conf.d:ro`_
+    _The important part here is `-v /opt/datadog-agent-conf.d:/conf.d:ro`_
 
-Now when the container starts, all files in `/opt/dd-agent-conf.d` with a `.yaml` extension will be copied to `/etc/dd-agent/conf.d/`. Please note that to add new files you will need to restart the container.
+Now when the container starts, all files in `/opt/datadog-agent-conf.d` with a `.yaml` extension will be copied to `/etc/datadog-agent/conf.d/`. Please note that to add new files you will need to restart the container.
 
 ## Further Reading
 


### PR DESCRIPTION
### What does this PR do?
Add a section about mounting configuration files. This is also described here: https://github.com/DataDog/docker-dd-agent#configuration-files

### Motivation
Add instructions in the documentation for better clarity.

### Preview link
https://github.com/DataDog/documentation/blob/davidb/docker-mount-conf/content/agent/basic_agent_usage/docker.md#configuration-files