### PR TITLE
prepare glossary for publish

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -868,11 +868,11 @@ languages:
           url: "videos/"
           pre: "nav_videos"
           weight: 130
-#        - identifier: menu_references_glossary
-#          name: "Glossary"
-#          url: "glossary/"
-#          pre: "nav_glossary"
-#          weight: 120
+        - identifier: menu_references_glossary
+          name: "Glossary"
+          url: "glossary/"
+          pre: "nav_glossary"
+          weight: 120
 
         - identifier: menu_references_help
           name: "Help"
@@ -1694,11 +1694,11 @@ languages:
           url: "videos/"
           pre: "nav_videos"
           weight: 130
-#        - identifier: menu_references_glossary
-#          name: "Glossary"
-#          url: "glossary/"
-#          pre: "nav_glossary"
-#          weight: 120
+        - identifier: menu_references_glossary
+          name: "Glossaire"
+          url: "glossary/"
+          pre: "nav_glossary"
+          weight: 120
 
         - identifier: menu_references_help
           name: "Help"

--- a/content/glossary.md
+++ b/content/glossary.md
@@ -1,72 +1,51 @@
 ---
 title: Glossary
 kind: Documentation
-draft: true
 ---
 
-**Agent**
+#### Agent
 
-**API**
+The Agent is a small application that runs on hosts. It executes checks and manages the flow of information from the host to the Datadog platform. The Agent is open source and compiled binaries are made available for Windows, OS X, and many flavors of Linux.
+
+See the [Agent documentation][8] for more information.
+
+#### API
 
 Datadog provides an HTTP API in order to interact programmatically with the platform. Every feature, resource, and mechanism is accessible via the API. Interacting with the API manually is a great way to learn how Datadog works under the hood. In production however, you will use a purpose-built tool, library, or interface — such as the Datadog product itself — as an abstraction layer between you and the API.
 
 See the [API documentation][1] for more information.
 
-**Check**
+#### Check
 
 Checks are small Python programs run periodically by the Agent. A Check performs an action and then gathers the result, which the Agent then stores and reports to the Datadog platform. These programs are freeform and are generally used to collect metrics from custom environments or applications.
 
 Note that the word “check” — when not capitalized — refers to the generic act of taking a measurement.
 
-**Client Library**
+#### Client Library
 
 There are a number of libraries in a variety of languages that help you instrument your applications with Datadog directly. Datadog provides official libraries for C#, Golang, Java, PHP, Python, and Ruby. Libraries in other languages have been contributed by the community, and are supported on a best-effort basis.
 
 Libraries are designed to interact with either the API or DogStatsD, though a handful provide support for both.
 
-See the [Libraries documentation][2]
+See the [Libraries documentation][2] for more information.
 
-**Dashboard**
-
-**DogStatsD**
+#### DogStatsD
 
 DogStatsD refers to two related things: a protocol based on [StatsD][3], and an application for reporting metrics which implements that protocol. The DogStatsD protocol is an extension of the StatsD protocol, with some modifications that are specific to the Datadog platform. The DogStatsD application is a service that is bundled with the Agent, and is used as a lightweight mechanism for reporting metrics.
 
 See the [DogStatsD documentation][4] for more information.
 
-**Downtime**
-
-**Embed**
-
-**Integration**
+#### Integration
 
 An Integration is a way to get data from your systems into Datadog. Integrations gather data from a given source, ensure that those data are classified correctly, and provide some other assets to assist with configuration and usage. Data sources can be pretty much anything from daemons on a server, to cloud services, to third-party APIs, and more.
 
 See the [Integrations documentation][5] for more information.
 
-**Monitor**
+#### Multiple-organization ("multi-org") accounts
 
-**Multiple-organization accounts (multi-org accounts)**
+Multi-org accounts allow a parent-organization to create multiple child-organizations. This is most often used with Managed Service Providers (MSPs) that have many customers. Each customer requires their own organization that is not accessible by other customers. All billing for multi-org accounts is performed on the parent-organization and usage reports for the parent-organization include usage information for all child-organizations.
 
-Multi-org accounts allow a parent-organization to create multiple child-organizations. This is most often used with Managed Service Providers (MSPs) that have many customers. Each customer requires their own organization that is not accessible by other customers. All billing for multi-org accounts will be performed on the parent-organization and usage reports for the parent-organization will include usage information for all child-organizations.
-
-**Notebooks**
-
-**Scope**
-
-**Screenboard**
-
-**Service** (for APM)
-
-**Snapshot**
-
-**Span**
-
-**Tag**
-
-**Timeboard**
-
-**Tracer**
+#### Tracer
 
 Datadog supports distributed tracing via the APM Integration. This allows you to instrument your existing code and see requests as they pass through all your systems. It works across different languages, databases, and RPC frameworks. Many languages are [supported natively][6]; however, developers can add their own language support by creating a custom shipper.
 
@@ -79,3 +58,4 @@ See the [Tracing documentation][7] for more information.
 [5]: https://docs.datadoghq.com/developers/integrations/
 [6]: https://docs.datadoghq.com/developers/libraries/#apm-tracing-client-libraries
 [7]: https://docs.datadoghq.com/tracing/
+[8]: https://docs.datadoghq.com/agent/

--- a/content/glossary.md
+++ b/content/glossary.md
@@ -1,6 +1,7 @@
 ---
 title: Glossary
 kind: Documentation
+disable_toc: true
 ---
 
 #### Agent


### PR DESCRIPTION
### What does this PR do?

This (re-)adds the Glossary section. It is not complete, but it is a good start and we can iterate from here.

### Motivation

Improve the developer experience by making things easier to find and learn about.

### Preview link

https://docs-staging.datadoghq.com/phrawzty/prep_glossary_for_publish/glossary

### Additional Notes

This does *not* add the Glossary to the navigation menu. We must decide where we'd like this nav item to be positioned. I'm open to discussion on this. 😄 
*Edit*: It already had a nav bar config, so I uncommented it.