### PR TITLE
performace/automatic intru./trace reporting documentation

### DIFF
--- a/content/tracing/setup/java.md
+++ b/content/tracing/setup/java.md
@@ -89,7 +89,7 @@ To report a trace to Datadog the following happens:
   * Queue is size-bound and doesn't grow past a set limit of 7000 traces
   * Once the size limit is reached, traces are discarded
   * A count of the total traces is captured to ensure accurate throughput
-* In a separate reporting thread, the trace queue is flushed and traces are sent to the Datadog-agent via http
+* In a separate reporting thread, the trace queue is flushed and traces are are encoded via msgpack then sent to the Datadog Agent via http
 * Queue flushing happens on a schedule of once per second
 
 To see the actual code, documentation and usage examples for any of the 

--- a/content/tracing/setup/java.md
+++ b/content/tracing/setup/java.md
@@ -61,11 +61,40 @@ The tracer is configured using System Properties and Environment Variables as fo
 * If the same key type is set for both, the system property configuration takes priority.
 * System properties can be used as JVM parameters.
 
+## Automatic Instrumentation
+
+Automatic instrumentation for Java utilizes the `java-agent` instrumentation capabilities [provided by the JVM][8]. When a `java-agent` is registered, it has the ability to modify class files at load time. 
+The Agent uses the popular [Byte Buddy framework][9] to find the classes defined for instrumentation and modify those class bytes accordingly.
+
+Instrumentation may come from auto-instrumentation, the OpenTracing api, or a mixture of both. Instrumentation generally captures the following info:
+
+* Method execution time
+* Timing duration is captured using the JVM's nanotime clock unless a timestamp is provided from the OpenTracing api
+* Key/value tag pairs
+* Errors and stacktraces which are unhanded by the application
+* A total count of traces (requests) flowing through the system
+
 ## Manual Instrumentation
 
 Before instrumenting your application, review Datadog’s [APM Terminology][5] and familiarize yourself with the core concepts of Datadog APM. If you aren't using a [supported framework instrumentation](#integrations), or you would like additional depth in your application’s traces, you may want to to manually instrument your code.
 
 Do this either using the [Trace annotation](#trace-annotation) for simple method call tracing or with the [OpenTracing API](#opentracing-api) for complex tracing.
+
+### Trace Reporting
+
+To report a trace to Datadog the following happens:
+
+* Trace completes
+* Trace is pushed to an asynchronous queue of traces
+  * Queue is size-bound and doesn't grow past a set limit of 7000 traces
+  * Once the size limit is reached, traces are discarded
+  * A count of the total traces is captured to ensure accurate throughput
+* In a separate reporting thread, the trace queue is flushed and traces are sent to the Datadog-agent via http
+* Queue flushing happens on a schedule of once per second
+
+To see the actual code, documentation and usage examples for any of the 
+libraries and frameworks that Datadog supports, check the full list of auto-
+instrumented components for Java applications [in the integration section](#integrations).
 
 ### Trace Annotation
 
@@ -401,7 +430,12 @@ Don't see your desired framework? We're continually adding additional support, [
 
 ## Performance
 
-Typical CPU overhead with the Java tracer is up to 3%.
+Java APM has minimal impact on the overhead of an application:
+
+* No collections maintained by Java APM grow unbounded in memory
+* Reporting traces does not block the application thread
+* Java APM typically adds no more than a 3% increase in CPU usage
+* Java APM typically adds no more than a 3% increase in JVM heap usage
 
 ## Further Reading
 
@@ -414,3 +448,5 @@ Typical CPU overhead with the Java tracer is up to 3%.
 [5]: /tracing/visualization/services_list/
 [6]: https://github.com/opentracing/opentracing-java
 [7]: https://docs.datadoghq.com/integrations/java/
+[8]: https://docs.oracle.com/javase/8/docs/api/java/lang/instrument/package-summary.html
+[9]: http://bytebuddy.net/


### PR DESCRIPTION
### What does this PR do?

Adds performace/automatic intru./trace reporting documentation

### Motivation
PM request

### Preview link
Those 3 sections were added:

* https://docs-staging.datadoghq.com/gus/tracing-java/tracing/setup/java/#automatic-instrumentation
* https://docs-staging.datadoghq.com/gus/tracing-java/tracing/setup/java/#trace-reporting
* https://docs-staging.datadoghq.com/gus/tracing-java/tracing/setup/java/#performance