### PR TITLE
add Validate Monitor to API docs

### DIFF
--- a/content/api/monitors/monitors_unmute.md
+++ b/content/api/monitors/monitors_unmute.md
@@ -1,7 +1,7 @@
 ---
 title: Unmute a monitor
 type: apicontent
-order: 16.10
+order: 16.91
 external_redirect: /api/#unmute-a-monitor
 ---
 

--- a/content/api/monitors/monitors_unmute_code.md
+++ b/content/api/monitors/monitors_unmute_code.md
@@ -1,7 +1,7 @@
 ---
 title: Unmute a monitor
 type: apicode
-order: 16.10
+order: 16.91
 external_redirect: /api/#unmute-a-monitor
 ---
 

--- a/content/api/monitors/monitors_validate.md
+++ b/content/api/monitors/monitors_validate.md
@@ -25,4 +25,4 @@ order: 16.11
     The query defines when the monitor triggers. Query syntax depends on monitor type. See [Create a monitor][2] for details.
 
 [1]: /monitors/monitor_types/
-[2]: /monitors/#create-a-monitor
+[2]: /api/#create-a-monitor

--- a/content/api/monitors/monitors_validate.md
+++ b/content/api/monitors/monitors_validate.md
@@ -1,0 +1,25 @@
+---
+title: Validate a monitor
+type: apicontent
+order: 16.11
+---
+## Validate a monitor
+##### ARGUMENTS
+*   **`type`** [*required*]:  
+    The [type of the monitor][3], chosen from:  
+    *   `anomaly`
+    *   `apm`
+    *   `composite`
+    *   `custom`
+    *   `event`
+    *   `forecast`
+    *   `host`
+    *   `integration`
+    *   `log`
+    *   `metric`
+    *   `network`
+    *   `outlier`
+    *   `process`
+    
+*   **`query`** [*required*]:  
+    The query defines when the monitor triggers.

--- a/content/api/monitors/monitors_validate.md
+++ b/content/api/monitors/monitors_validate.md
@@ -6,7 +6,7 @@ order: 16.11
 ## Validate a monitor
 ##### ARGUMENTS
 *   **`type`** [*required*]:  
-    The [type of the monitor][3], chosen from:  
+    The [type of the monitor][1], chosen from:  
     *   `anomaly`
     *   `apm`
     *   `composite`
@@ -22,4 +22,7 @@ order: 16.11
     *   `process`
     
 *   **`query`** [*required*]:  
-    The query defines when the monitor triggers.
+    The query defines when the monitor triggers. Query syntax depends on monitor type. See [Create a monitor][2] for details.
+
+[1]: /monitors/monitor_types/
+[2]: /monitors/#create-a-monitor

--- a/content/api/monitors/monitors_validate_code.md
+++ b/content/api/monitors/monitors_validate_code.md
@@ -1,0 +1,5 @@
+---
+title: Validate a monitor
+type: apicode
+order: 16.11
+---


### PR DESCRIPTION
### What does this PR do?
Adds a Validate Monitor section to the API docs. Also changes the ordering of the "Unmute a monitor" section so that it makes more sense — previously it was right after "Create a monitor," I changed it to be right after "Mute a monitor"

### Preview link
https://docs-staging.datadoghq.com/cecilia/api_validate_monitor/api/?lang=python#validate-a-monitor