### PR TITLE
adding placeholders for unimplemented Python/Ruby endpoint

### DIFF
--- a/content/api/monitors/code_snippets/api-monitor-validate.py
+++ b/content/api/monitors/code_snippets/api-monitor-validate.py
@@ -1,0 +1,2 @@
+# This is not yet supported by the Python Client for Datadog API
+# Consult the curl example

--- a/content/api/monitors/code_snippets/api-monitor-validate.rb
+++ b/content/api/monitors/code_snippets/api-monitor-validate.rb
@@ -1,0 +1,2 @@
+# This is not yet supported by the Ruby Client for Datadog API
+# Consult the curl example


### PR DESCRIPTION
### What does this PR do?
Final addition to [this previous PR](https://github.com/DataDog/documentation/pull/2722). Placeholder text for Python/Ruby code, the new validate monitor endpoint hasn't yet been added to the Python/Ruby APIs, only curl code is available. This PR just adds placeholder text (as seen in other sections with unimplemented endpoints) for Python and Ruby code.