### PR TITLE
Centralising all agent configuration files info

### DIFF
--- a/content/agent/_index.md
+++ b/content/agent/_index.md
@@ -76,39 +76,6 @@ With:
 
 **Note**: On Windows, `datadog.conf` is automatically upgraded to `datadog.yaml` on upgrade.
 
-## Configuration Files
-
-Prior releases of Datadog Agent stored configuration files in `/etc/dd-agent`.
-Starting with the 6.0 release configuration files will now be stored in
-`/etc/datadog-agent`.
-
-### Checks configuration files
-
-In order to provide a more flexible way to define the configuration for a check,
-from version 6.0.0 the Agent will load any valid YAML file contained in the folder:
-
-`/etc/datadog-agent/conf.d/<check_name>.d/`.
-
-This way, complex configurations can be broken down into multiple files: for example,
-a configuration for the `http_check` might look like this:
-
-```
-/etc/datadog-agent/conf.d/http_check.d/
-├── backend.yaml
-└── frontend.yaml
-```
-
-Autodiscovery template files will be stored in the configuration folder as well,
-for example this is how the `redisdb` check configuration folder looks like:
-
-```
-/etc/datadog-agent/conf.d/redisdb.d/
-├── auto_conf.yaml
-└── conf.yaml.example
-```
-
-To keep backwards compatibility, the Agent will still pick up configuration files in the form `/etc/datadog-agent/conf.d/<check_name>.yaml` but migrating to the new layout is strongly recommended.
-
 ## CLI
 
 The new command line interface for the Agent is sub-command based:

--- a/content/agent/basic_agent_usage/_index.md
+++ b/content/agent/basic_agent_usage/_index.md
@@ -12,6 +12,9 @@ further_reading:
 - link: "agent/faq/agent-commands"
   tag: "FAQ"
   text: "List of all Agent commands"
+- link: "agent/faq/agent-configuration-files"
+  tag: "FAQ"
+  text: "Location of all Agent configuration files"
 ---
 
 {{< partial name="platforms/platforms.html" >}}
@@ -36,17 +39,9 @@ Manage the Datadog Agent and [integrations][1] using configuration management to
 
 * [Installing Datadog Agent with Saltstack][8]
 
-## Configuration file
+## Configuration files
 
-The configuration files and folders for the Agent are located at:
-
-| OS                                         | Agent v5                                                                   | Agent v6                             |
-| :-------                                   | :--------                                                                  | :--------                            |
-| [Mac OS X][9]                              | `~/.datadog-agent/datadog.conf`                                            | `~/.datadog-agent/datadog.yaml`      |
-| [Linux][10]                                | `/etc/dd-agent/datadog.conf`                                               | `/etc/datadog-agent/datadog.yaml`    |
-| [Source][11]                               | `~/.datadog-agent/agent/datadog.conf`                                      | `/etc/datadog-agent/datadog.yaml`    |
-| [Windows Server 2008, Vista and newer][12] | `\\ProgramData\Datadog\datadog.conf`                                       | `\\ProgramData\Datadog\datadog.yaml` |
-| [Windows Server 2003, XP or older][12]     | `\\Documents and Settings\All Users\Application Data\Datadog\datadog.conf` | `n/a` _(unsupported OS)_             |
+[Refer to the dedicated page for Agent configuration files][13].
 
 ## Log location
 
@@ -71,3 +66,4 @@ The Datadog logs do a rollover every 10MB. When a rollover occurs, one backup is
 [10]: /agent/basic_agent_usage/ubuntu
 [11]: /agent/basic_agent_usage/source
 [12]: /agent/basic_agent_usage/windows
+[13]: /agent/faq/agent-configuration-files

--- a/content/agent/faq/_index.md
+++ b/content/agent/faq/_index.md
@@ -11,6 +11,7 @@ private: true
 * [Dogstream][3]
 * [Install core extras][4]
 * [Agent commands][5]
+* [Agent configuration files][19]
 * [How does Datadog determine the Agent hostname?][6]
 
 ## Installation
@@ -49,3 +50,4 @@ private: true
 [16]: /agent/faq/cannot-open-an-http-server-socket-error-reported-errno-eacces-13
 [17]: /agent/faq/why-don-t-i-see-the-system-processes-open-file-descriptors-metric
 [18]: /agent/faq/how-is-the-system-mem-used-metric-calculated
+[19]: /agent/faq/agent-configuration-files

--- a/content/agent/faq/agent-configuration-files.md
+++ b/content/agent/faq/agent-configuration-files.md
@@ -1,0 +1,67 @@
+---
+title: Agent configuration files
+kind: faq
+---
+
+## Agent main configuration file 
+
+The primary agent configuration file has been transitioned between Agent v5 and agent v6 respectively from **INI** format to **YAML** to better support complex configurations and for a more consistent experience across the Agent and Checks; as such `datadog.conf` is now retired in favor of `datadog.yaml`.
+
+| Platform                             | Agent v5                                                                   | Agent v6                             |
+| :--------                            | :-----                                                                     | :--------                            |
+| Linux                                | `/etc/dd-agent/datadog.conf`                                               | `/etc/datadog-agent/datadog.yaml`    |
+| CentOS                               | `/etc/dd-agent/datadog.conf`                                               | `/etc/datadog-agent/datadog.yaml`    |
+| Debian                               | `/etc/dd-agent/datadog.conf`                                               | `/etc/datadog-agent/datadog.yaml`    |
+| Fedora                               | `/etc/dd-agent/datadog.conf`                                               | `/etc/datadog-agent/datadog.yaml`    |
+| MacOS x                              | `~/.datadog-agent/datadog.conf`                                            | `~/.datadog-agent/datadog.yaml`      |
+| RedHat                               | `/etc/dd-agent/datadog.conf`                                               | `/etc/datadog-agent/datadog.yaml`    |
+| Source                               | `/etc/dd-agent/datadog.conf`                                               | `/etc/datadog-agent/datadog.yaml`    |
+| Suse                                 | `/etc/dd-agent/datadog.conf`                                               | `/etc/datadog-agent/datadog.yaml`    |
+| Ubuntu                               | `/etc/dd-agent/datadog.conf`                                               | `/etc/datadog-agent/datadog.yaml`    |
+| Windows Server 2008, Vista and newer | `\\ProgramData\Datadog\datadog.conf`                                       | `\\ProgramData\Datadog\datadog.yaml` |
+| Windows Server 2003, XP or older     | `\\Documents and Settings\All Users\Application Data\Datadog\datadog.conf` | `n/a` _(unsupported OS)_             |
+
+## Agent configuration directory
+
+Prior releases of Datadog Agent stored configuration files in `/dd-agent/conf.d/`. Starting with the 6.0 release configuration files are stored in
+`/datadog-agent/conf.d/<CHECK_NAME>`.
+
+| Platform                             | Agent v5                                                             | Agent v6                       |
+| :--------                            | :-----                                                               | :--------                      |
+| Linux                                | `/etc/dd-agent/conf.d/`                                              | `/etc/datadog-agent/conf.d/`   |
+| CentOS                               | `/etc/dd-agent/conf.d/`                                              | `/etc/datadog-agent/conf.d/`   |
+| Debian                               | `/etc/dd-agent/conf.d/`                                              | `/etc/datadog-agent/conf.d/`   |
+| Fedora                               | `/etc/dd-agent/conf.d/`                                              | `/etc/datadog-agent/conf.d/`   |
+| MacOS x                              | `~/.datadog-agent/conf.d/`                                           | `~/.datadog-agent/conf.d/`     |
+| RedHat                               | `/etc/dd-agent/conf.d/`                                              | `/etc/datadog-agent/conf.d/`   |
+| Source                               | `/etc/dd-agent/conf.d/`                                              | `/etc/datadog-agent/conf.d/`   |
+| Suse                                 | `/etc/dd-agent/conf.d/`                                              | `/etc/datadog-agent/conf.d/`   |
+| Ubuntu                               | `/etc/dd-agent/conf.d/`                                              | `/etc/datadog-agent/conf.d/`   |
+| Windows Server 2008, Vista and newer | `\\ProgramData\Datadog\conf.d`                                       | `\\ProgramData\Datadog\conf.d` |
+| Windows Server 2003, XP or older     | `\\Documents and Settings\All Users\Application Data\Datadog\conf.d` | `n/a` _(unsupported OS)_       |
+
+### Checks configuration files for Agent 6
+
+In order to provide a more flexible way to define the configuration for a check, from version 6.0.0 the Agent loads any valid YAML file contained in the folder:
+
+`/datadog-agent/conf.d/<check_name>.d/`.
+
+This way, complex configurations can be broken down into multiple files: for example, a configuration for the `http_check` might look like this:
+
+```
+/datadog-agent/conf.d/http_check.d/
+├── backend.yaml
+└── frontend.yaml
+```
+
+Autodiscovery template files will be stored in the configuration folder as well, for example this is how the `redisdb` check configuration folder looks like:
+
+```
+/datadog-agent/conf.d/redisdb.d/
+├── auto_conf.yaml
+└── conf.yaml.example
+```
+
+To keep backwards compatibility, the Agent still picks up configuration files in the form `/datadog-agent/conf.d/<check_name>.yaml` but migrating to the new layout is strongly recommended.
+
+[1]: /agent/basic_agent_usage/windows/#configuration

--- a/content/agent/faq/agent-configuration-files.md
+++ b/content/agent/faq/agent-configuration-files.md
@@ -44,7 +44,7 @@ Prior releases of Datadog Agent stored configuration files in `/dd-agent/conf.d/
 
 In order to provide a more flexible way to define the configuration for a check, from version 6.0.0 the Agent loads any valid YAML file contained in the folder:
 
-`/datadog-agent/conf.d/<check_name>.d/`.
+`/datadog-agent/conf.d/<CHECK_NAME>.d/`.
 
 This way, complex configurations can be broken down into multiple files: for example, a configuration for the `http_check` might look like this:
 
@@ -64,4 +64,9 @@ Autodiscovery template files will be stored in the configuration folder as well,
 
 To keep backwards compatibility, the Agent still picks up configuration files in the form `/datadog-agent/conf.d/<check_name>.yaml` but migrating to the new layout is strongly recommended.
 
+## JMX configuration file
+
+JMX Agent checks have an additional `metrics.yaml` file in their configuration folder. It is the list of all the beans that the Datadog Agent collects by default. It allows you not to list all the beans manually when you configure a check through [docker labels or k8s annotations][2].
+
 [1]: /agent/basic_agent_usage/windows/#configuration
+[2]: /agent/autodiscovery

--- a/content/agent/faq/agent-configuration-files.md
+++ b/content/agent/faq/agent-configuration-files.md
@@ -5,7 +5,7 @@ kind: faq
 
 ## Agent main configuration file 
 
-The primary agent configuration file has been transitioned between Agent v5 and agent v6 respectively from **INI** format to **YAML** to better support complex configurations and for a more consistent experience across the Agent and Checks; as such `datadog.conf` is now retired in favor of `datadog.yaml`.
+The Agent v6 configuration file uses **YAML** to better support complex configurations, and to provide a consistent configuration experience, as Checks also use YAML configuration files. Therefore, `datadog.conf` (v5) is now retired in favor of `datadog.yaml` (v6).
 
 | Platform                             | Agent v5                                                                   | Agent v6                             |
 | :--------                            | :-----                                                                     | :--------                            |
@@ -23,8 +23,7 @@ The primary agent configuration file has been transitioned between Agent v5 and 
 
 ## Agent configuration directory
 
-Prior releases of Datadog Agent stored configuration files in `/dd-agent/conf.d/`. Starting with the 6.0 release configuration files are stored in
-`/datadog-agent/conf.d/<CHECK_NAME>`.
+Prior releases of Datadog Agent stored configuration files in `/dd-agent/conf.d/`. Starting with the 6.0 release, configuration files are stored in `/datadog-agent/conf.d/<CHECK_NAME>`.
 
 | Platform                             | Agent v5                                                             | Agent v6                       |
 | :--------                            | :-----                                                               | :--------                      |
@@ -42,11 +41,11 @@ Prior releases of Datadog Agent stored configuration files in `/dd-agent/conf.d/
 
 ### Checks configuration files for Agent 6
 
-In order to provide a more flexible way to define the configuration for a check, from version 6.0.0 the Agent loads any valid YAML file contained in the folder:
+In order to provide a more flexible way to define the configuration for a check, from version 6.0.0, the Agent loads any valid YAML file contained in the folder:
 
 `/datadog-agent/conf.d/<CHECK_NAME>.d/`.
 
-This way, complex configurations can be broken down into multiple files: for example, a configuration for the `http_check` might look like this:
+This way, complex configurations can be broken down into multiple files. For example, a configuration for the `http_check` might look like this:
 
 ```
 /datadog-agent/conf.d/http_check.d/
@@ -54,7 +53,7 @@ This way, complex configurations can be broken down into multiple files: for exa
 └── frontend.yaml
 ```
 
-Autodiscovery template files will be stored in the configuration folder as well, for example this is how the `redisdb` check configuration folder looks like:
+Autodiscovery template files will be stored in the configuration folder as well. For example, consider `redisdb`:
 
 ```
 /datadog-agent/conf.d/redisdb.d/
@@ -62,11 +61,11 @@ Autodiscovery template files will be stored in the configuration folder as well,
 └── conf.yaml.example
 ```
 
-To keep backwards compatibility, the Agent still picks up configuration files in the form `/datadog-agent/conf.d/<check_name>.yaml` but migrating to the new layout is strongly recommended.
+To preserve backwards compatibility, the Agent still picks up configuration files in the form `/datadog-agent/conf.d/<check_name>.yaml`, but migrating to the new layout is strongly recommended.
 
 ## JMX configuration file
 
-JMX Agent checks have an additional `metrics.yaml` file in their configuration folder. It is the list of all the beans that the Datadog Agent collects by default. It allows you not to list all the beans manually when you configure a check through [docker labels or k8s annotations][2].
+JMX Agent checks have an additional `metrics.yaml` file in their configuration folder. It is a list of all the beans that the Datadog Agent collects by default. This way, you do not need to list all of the beans manually when you configure a check through [Docker labels or k8s annotations][2].
 
 [1]: /agent/basic_agent_usage/windows/#configuration
 [2]: /agent/autodiscovery


### PR DESCRIPTION
This PR: https://github.com/DataDog/integrations-core/pull/1805 changes slightly the wording on all agent-core integrations

We introduce the concept of `configuration directory` in order to make it easier to our customers, This PR creates a page with all links to all directory types for each platform and agent 5/6  so that we can link to it from all integrations-core readme.

### Preview link
<!-- Impacted pages preview links-->

* https://docs-staging.datadoghq.com/gus/agent-configuration-file/agent/faq/agent-configuration-files/