### PR TITLE
add deprecation notices to countER methods, etc.

### DIFF
--- a/content/developers/metrics/_index.md
+++ b/content/developers/metrics/_index.md
@@ -68,11 +68,11 @@ Datadog accepts metrics submitted from a variety of sources, and as a result the
 | [API][3]            | `api.Metric.send(type="count", ...)` | count             | count               |
 | [API][3]            | `api.Metric.send(type="rate", ...)`  | rate              | rate                |
 | [DogStatsD][1]      | `dog.gauge(...)`                     | gauge             | gauge               |
-| [DogStatsD][1]      | `dog.increment(...)`                 | counter           | rate                |
+| [DogStatsD][1]      | `dog.increment(...)`                 | counter <sup>deprecated</sup> | rate    |
 | [DogStatsD][1]      | `dog.histogram(...)`                 | histogram         | gauge, rate         |
 | [DogStatsD][1]      | `dog.set(...)`                       | set               | gauge               |
 | [Agent check][2]    | `self.gauge(...)`                    | gauge             | gauge               |
-| [Agent check][2]    | `self.increment(...)`                | counter           | rate                |
+| [Agent check][2]    | `self.increment(...)`                | counter <sup>deprecated</sup> | rate    |
 | [Agent check][2]    | `self.rate(...)`                     | rate              | gauge               |
 | [Agent check][2]    | `self.count(...)`                    | count             | count               |
 | [Agent check][2]    | `self.monotonic_count(...)`          | monotonic_count   | count               |

--- a/content/developers/metrics/counts.md
+++ b/content/developers/metrics/counts.md
@@ -19,21 +19,21 @@ Counters are used to count things.
 ### Agent check
 
 {{% table responsive="true" %}}
-|Method | Overview |
-|:---|:---|
-| self.increment(...) |  Used to modify a count of events identified by the metric key string: <ul><li>Can be called multiple times during a check's execution.</li><li>Stored as a RATE type in the Datadog web application. Each value in the stored timeseries is a delta of the counter's value between samples (time-normalized by the aggregation interval which defaults to 1 for Agent checks - so the value is generally the raw count value).</li><li>Handled by the aggregator Counter class</li></ul>|
-|self.decrement(...) |Used to modify a count of events identified by the metric key string:<ul><li>Can be called multiple times during a check's execution.</li><li>Stored as RATE type in the Datadog web application. Each value in the stored timeseries is a delta of the counter's value between samples (time-normalized by the aggregation interval which defaults to 1 for Agent checks - so the value is generally the raw count value).</li><li>Handled by the aggregator Counter class</li></ul>|
-|self.monotonic_count(...)|Submit the sampled raw value of your counter. Don't normalize the values to a rate, or calculate the deltas before submitting. If the value of your counter ever decreases between submissions the resulting stored value for that submission is 0:<ul><li>Should only be called once during a check. Throws away any value that is less than a previously submitted value. IE the counter should be monotonically increasing.</li><li>Stored as a COUNT type in the Datadog web application. Each value in the stored timeseries is a delta of the counter's value between samples (not time-normalized).</li></ul>|
-|self.count(...)|Submit the number of events that occurred during the check interval. If you're tracking a counter value that persists between checks, this means you must calculate the delta before submission:<ul><li>Should only be called once during a check.</li><li>Stored as a COUNT type in the Datadog web application. Each value in the stored timeseries is a delta of the counter's value between samples (not time-normalized).</li></ul>|
+| Method | Overview |
+| :----- | :------- |
+| self.increment()<br/><sup>deprecated</sup> | Used to modify a count of events identified by the metric key string: <ul><li>Can be called multiple times during a check's execution.</li><li>Stored as a RATE type in the Datadog web application. Each value in the stored timeseries is a delta of the counter's value between samples (time-normalized by the aggregation interval which defaults to 1 for Agent checks - so the value is generally the raw count value).</li><li>Handled by the aggregator Counter class</li></ul> |
+| self.decrement()<br /><sup>deprecated</sup> | Used to modify a count of events identified by the metric key string:<ul><li>Can be called multiple times during a check's execution.</li><li>Stored as RATE type in the Datadog web application. Each value in the stored timeseries is a delta of the counter's value between samples (time-normalized by the aggregation interval which defaults to 1 for Agent checks - so the value is generally the raw count value).</li><li>Handled by the aggregator Counter class</li></ul> |
+| self.monotonic_count(...) | Submit the sampled raw value of your counter. Don't normalize the values to a rate, or calculate the deltas before submitting. If the value of your counter ever decreases between submissions the resulting stored value for that submission is 0:<ul><li>Should only be called once during a check. Throws away any value that is less than a previously submitted value. IE the counter should be monotonically increasing.</li><li>Stored as a COUNT type in the Datadog web application. Each value in the stored timeseries is a delta of the counter's value between samples (not time-normalized).</li></ul> |
+| self.count(...) | Submit the number of events that occurred during the check interval. If you're tracking a counter value that persists between checks, this means you must calculate the delta before submission:<ul><li>Should only be called once during a check.</li><li>Stored as a COUNT type in the Datadog web application. Each value in the stored timeseries is a delta of the counter's value between samples (not time-normalized).</li></ul> |
 {{% /table %}}
 
 ### DogStatsD
 
 {{% table responsive="true" %}}
-|Method | Overview |
-|:---|:---|
-| dog.increment(...) | Used to increment a counter of events: <ul><li>Stored as a RATE type in the Datadog web application. Each value in the stored timeseries is a time-normalized delta of the counter's value over that statsd flush period.</li></ul>|
-|dog.decrement(...)| Used to decrement a counter of events: <ul><li>Stored as a RATE type in the Datadog web application. Each value in the stored timeseries is a time-normalized delta of the counter's value over that statsd flush period.</li></ul>|
+| Method | Overview |
+| :----- | :------- |
+| dog.increment(...)<br/><sup>deprecated</sup> | Used to increment a counter of events: <ul><li>Stored as a RATE type in the Datadog web application. Each value in the stored timeseries is a time-normalized delta of the counter's value over that statsd flush period.</li></ul> |
+| dog.decrement(...)<br/><sup>deprecated</sup> | Used to decrement a counter of events: <ul><li>Stored as a RATE type in the Datadog web application. Each value in the stored timeseries is a time-normalized delta of the counter's value over that statsd flush period.</li></ul> |
 {{% /table %}}
 
 #### Example


### PR DESCRIPTION
### What does this PR do?

Adds deprecation notices to the Counter-related methods et al.

### Motivation

These are all deprecated.

### Preview link

* https://docs-staging.datadoghq.com/phrawzty/deprecate_countER/developers/metrics/
![image](https://user-images.githubusercontent.com/625232/42387377-6662ff7a-8142-11e8-9c4d-1baf3838ccb3.png)

* https://docs-staging.datadoghq.com/phrawzty/deprecate_countER/developers/metrics/counts/
![image](https://user-images.githubusercontent.com/625232/42387435-8a211ed8-8142-11e8-8b64-c74747d034d2.png)


### Additional Notes

Assuming we like how this looks, the next logical PR will illustrate what our users need to do to replace this functionality. 😄 