### PR TITLE
Add simultaneous alert alert recovery to faq

### DIFF
--- a/content/monitors/monitor_types/anomaly.md
+++ b/content/monitors/monitor_types/anomaly.md
@@ -36,8 +36,6 @@ To create an anomaly detection monitor, navigate to the [New Monitor][1] page an
 
 You should now see the form above, with a handful of parameters that help determine when to alert on anomalous behavior. If you only care about unusually high or unusually low values, you can choose to only alert on values above or below the bounds. The next selection determines the length of the alert window, which specifies how long a metric needs to be anomalous before an alert triggers. Beware that if the alert window is too short, you might get false alarms due to spurious noise. Finally, the recovery period specifies for how long the metric must be normal before the alert recovers.
 
-Setting different windows for the alert and alert recovery periods might lead to an ambiguous state. The alert and alert recovery window sizes should be set such that both cannot be satisfied at the same time. For example, setting an alert threshold at 50% for a 2-hour window (i.e., 1 hour has to be anomalous to trigger the alert) and the recovery threshold at 50% for a 10-minute window (i.e., 5 minutes have to be non-anomalous to recover) might result in triggering the alert and the alert recovery states simultaneously. If the last 5 minutes are not anomalous but the 1 hour before that _was_ anomalous, both the alert and the alert recovery will be triggered.
-
 Complete the rest of the steps in the New Monitor form (**Say what's happening**, etc) and click **Save** to create the Anomaly monitor.
 
 ### Advanced Options
@@ -180,6 +178,10 @@ If the rollup is set explicitly on the query, the rollup interval option for the
 ### I don't care if my metric is anomalous if its value is less than X, can I somehow ignore those anomalies?
 
 Create **A**: an anomaly monitor to alert on values above the bounds; and **B**: a separate [metric monitor][9] with a threshold alert to alert on values greater than X; and then finally a [composite monitor][10] on **A && B**.
+
+### Why am I prevented from saving a monitor with a message like ''alert and alert recovery criteria are such that the monitor can be simultaneously in alert and alert recovery states?"
+
+Setting different windows for the alert and alert recovery periods might lead to an ambiguous state. The alert and alert recovery window sizes should be set such that both cannot be satisfied at the same time. For example, setting an alert threshold at 50% for a 2-hour window (i.e., 1 hour has to be anomalous to trigger the alert) and the recovery threshold at 50% for a 10-minute window (i.e., 5 minutes have to be non-anomalous to recover) might result in triggering the alert and the alert recovery states simultaneously. If the last 5 minutes are not anomalous but the 1 hour before that _was_ anomalous, both the alert and the alert recovery will be triggered.
 
 ## Further Reading
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Follows the previous [PR](https://github.com/DataDog/documentation/pull/2733), by making the added text a FAQ.

### Motivation
<!-- What inspired you to submit this pull request?-->
[Trello Card](https://trello.com/c/RDGAAYnH/50-anomaly-monitor-error-on-edit-page-cant-reproduce-on-my-side)

### Preview link
[Monitor Types - Anomaly](https://docs.datadoghq.com/monitors/monitor_types/anomaly/)
### Additional Notes
<!-- Anything else we should know when reviewing?-->
