### PR TITLE
Clarify start and end are only options in Python

### DIFF
--- a/content/api/metrics/metrics_querytime.md
+++ b/content/api/metrics/metrics_querytime.md
@@ -8,15 +8,17 @@ external_redirect: /api/#query-time-series-points
 ## Query time series points
 This end point allows you to query for metrics from any time period.
 
+*Note:* In Python, `from` is a reserved word. So instead, the Python API uses the `start` and `end` parameters in the function call.
+
 ##### ARGUMENTS
-* **`from`** [*required*]:  
-    Seconds from the unix epoch
-* **`to`** [*required*]:  
-    Seconds to the unix epoch
-* **`start`** [*optional*, *default*=**None**]:  
-    Seconds since the unix epoch
-* **`end`** [*optional*, *default*=**None**]:  
-    Seconds since the unix epoch
+* **`from`** [*required except Python*]:  
+    Seconds from the unix epoch 
+* **`to`** [*required except Python*]:  
+    Seconds to the unix epoch 
+* **`start`** [*required in Python*, *default*=**None**]:  
+    Seconds since the unix epoch 
+* **`end`** [*required in Python*, *default*=**None**]:  
+    Seconds since the unix epoch 
 * **`query`** [*required*]:  
     The query string
 

--- a/content/api/metrics/metrics_querytime.md
+++ b/content/api/metrics/metrics_querytime.md
@@ -11,9 +11,9 @@ This end point allows you to query for metrics from any time period.
 *Note:* In Python, `from` is a reserved word. So instead, the Python API uses the `start` and `end` parameters in the function call.
 
 ##### ARGUMENTS
-* **`from`** [*required except Python*]:  
+* **`from`** [*required except in Python*]:  
     Seconds from the unix epoch 
-* **`to`** [*required except Python*]:  
+* **`to`** [*required except in Python*]:  
     Seconds to the unix epoch 
 * **`start`** [*required in Python*, *default*=**None**]:  
     Seconds since the unix epoch 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

In the metrics query, `from` is a reserved keyword in Python. This clarifies that the `start` and `end` keywords are only required in Python.

### Motivation
<!-- What inspired you to submit this pull request?-->

A customer was confused by the current implementation. This clarifies why the Python API doesn't use the otherwise required `from`.

### Preview link
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/kirk.kaiser/python-api-metric-note/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
