### PR TITLE
remove beta banner for s3 archive docs and correct path

### DIFF
--- a/content/logs/s3.md
+++ b/content/logs/s3.md
@@ -4,10 +4,6 @@ kind: Documentation
 description: "Forward all your Datadog logs to S3 for long term storage."
 ---
 
-<div class="alert alert-warning">
-This feature is currently in beta. <br> 
-Ask your Sales representative or Customer Success Manager to have it enabled.
-</div>
 
 ## S3 Archives
 
@@ -59,7 +55,7 @@ However, after creating or updating your archive configurations, it can take sev
 
 The log archives that Datadog forwards to your S3 bucket are in zipped (gzip) JSON format. Under whatever prefix you indicate (or `/` if there is none), the archives are stored in a directory structure that indicates on what date and at what time the archive files were generated, like so:
 
-`/my/s3/prefix/date=20180515/hour=14/archive_143201.1234.7dq1a9mnSya3bFotoErfxl.json.gz`
+`/my/s3/prefix/dt=20180515/hour=14/archive_143201.1234.7dq1a9mnSya3bFotoErfxl.json.gz`
 
 This directory structure simplifies the process of querying your historical log archives based on their date. 
 


### PR DESCRIPTION
### What does this PR do?
Removes the beta banner for the s3 log archives feature. Also corrects the documented path for the archives (from `date=yyyymmdd` to `dt=yyyymmdd`)

### Motivation
Correct stuff.

### Preview link
https://docs-staging.datadoghq.com/estib/un-beta-s3-log-archives/logs/s3/
