### PR TITLE
turn off algolia indexing for docs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -151,15 +151,15 @@ test_live_static:
   only:
     - master
 
-index_algolia:
-  <<: *base_template
-  stage: post-deploy
-  environment: "live"
-  script:
-    - pull_artifact_from_s3
-    - index_algolia
-  only:
-    - master
+#index_algolia:
+#  <<: *base_template
+#  stage: post-deploy
+#  environment: "live"
+#  script:
+#    - pull_artifact_from_s3
+#    - index_algolia
+#  only:
+#    - master
 
 manage_translations:on-schedule:
   <<: *base_template


### PR DESCRIPTION
### What does this PR do?
index_algolia is killing memory. disable until we release the new indexer
