### PR TITLE
Fixing variable name

### DIFF
--- a/content/agent/autodiscovery.md
+++ b/content/agent/autodiscovery.md
@@ -320,11 +320,13 @@ The following template variables are currently handled by the Agent:
 
 - Container IP: `host`
   - `%%host%%`: autodetect the network (use `bridge` or, if only one network is attached, this one)
-  - `%%host_network%%`: specify the network name to use, when attached to several networks
+  - `%%host_<NETWORK NAME>%%`: specify the network name to use, when attached to several networks (e.g `%%host_bridge%%`, `%%host_myredisnetwork%%`, ...)
+
 - Container port: `port`
   - `%%port%%`: use the highest exposed port **sorted numerically and in ascending order** (eg. 8443 for a container that exposes ports 80, 443, and 8443)
   - `%%port_0%%`: use the first port **sorted numerically and in ascending order** (for the same container, `%%port_0%%` refers to port 80, `%%port_1%%` refers to 443
   - If your target port is constant, we recommend you directly specify it, without using the `port` variable
+
 - Environment variable: `env` (added in Agent 6.1)
   - `%%env_MYENVVAR%%`: use the contents of the `$MYENVVAR` environment variable **as seen by the Agent process**
 

--- a/content/agent/autodiscovery.md
+++ b/content/agent/autodiscovery.md
@@ -320,7 +320,7 @@ The following template variables are currently handled by the Agent:
 
 - Container IP: `host`
   - `%%host%%`: autodetect the network (use `bridge` or, if only one network is attached, this one)
-  - `%%host_<NETWORK NAME>%%`: specify the network name to use, when attached to several networks (e.g `%%host_bridge%%`, `%%host_myredisnetwork%%`, ...)
+  - `%%host_<NETWORK NAME>%%`: specify the network name to use, when attached to several networks (e.g. `%%host_bridge%%`, `%%host_myredisnetwork%%`, ...)
 
 - Container port: `port`
   - `%%port%%`: use the highest exposed port **sorted numerically and in ascending order** (eg. 8443 for a container that exposes ports 80, 443, and 8443)


### PR DESCRIPTION
The network specification as described in that linked section is not clear enough. This is the line in question:

```
%%host_network%%: specify the network name to use, when attached to several networks
```

The confusing part of that statement is that `host_network` seems like a reserved word and the reader may get the question of "how do you specify a network with a dynamic variable such as `%%host_network%%`. 

In truth, `host_network` is not a reserved word. It was meant to indicate that they can append the network name to `host_` to specify the network, for example:

`%%host_NETWORKNAME%%`
`%%host_bridge%%`
`%%host_mynewnetwork%%`
`%%host_myredisnetwork%%`