### PR TITLE
Adding missing content type

### DIFF
--- a/content/api/monitors/code_snippets/api-monitor-mute-all.sh
+++ b/content/api/monitors/code_snippets/api-monitor-mute-all.sh
@@ -2,5 +2,5 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -X POST "https://api.datadoghq.com/api/v1/monitor/mute_all?api_key=${api_key}&application_key=${app_key}"
+curl -X POST -H "Content-type: application/json" "https://api.datadoghq.com/api/v1/monitor/mute_all?api_key=${api_key}&application_key=${app_key}"
 

--- a/content/api/monitors/code_snippets/api-monitor-mute.sh
+++ b/content/api/monitors/code_snippets/api-monitor-mute.sh
@@ -12,4 +12,4 @@ monitor_id=$(curl -X POST -H "Content-type: application/json" \
   }' \
     "https://api.datadoghq.com/api/v1/monitor?api_key=${api_key}&application_key=${app_key}" | jq '.id')
 
-curl -X POST "https://api.datadoghq.com/api/v1/monitor/${monitor_id}/mute?api_key=${api_key}&application_key=${app_key}"
+curl -X POST -H "Content-type: application/json" "https://api.datadoghq.com/api/v1/monitor/${monitor_id}/mute?api_key=${api_key}&application_key=${app_key}"

--- a/content/api/monitors/code_snippets/api-monitor-unmute-all.sh
+++ b/content/api/monitors/code_snippets/api-monitor-unmute-all.sh
@@ -1,5 +1,5 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -X POST "https://api.datadoghq.com/api/v1/monitor/unmute_all?api_key=${api_key}&application_key=${app_key}"
+curl -X POST -H "Content-type: application/json" "https://api.datadoghq.com/api/v1/monitor/unmute_all?api_key=${api_key}&application_key=${app_key}"
 

--- a/ja/code_snippets/api-monitor-mute-all.sh
+++ b/ja/code_snippets/api-monitor-mute-all.sh
@@ -1,4 +1,4 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -X POST "https://api.datadoghq.com/api/v1/monitor/mute_all?api_key=${api_key}&application_key=${app_key}"
+curl -X POST -H "Content-type: application/json" "https://api.datadoghq.com/api/v1/monitor/mute_all?api_key=${api_key}&application_key=${app_key}"

--- a/ja/code_snippets/api-monitor-unmute-all.sh
+++ b/ja/code_snippets/api-monitor-unmute-all.sh
@@ -1,4 +1,4 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -X POST "https://api.datadoghq.com/api/v1/monitor/unmute_all?api_key=${api_key}&application_key=${app_key}"
+curl -X POST -H "Content-type: application/json" "https://api.datadoghq.com/api/v1/monitor/unmute_all?api_key=${api_key}&application_key=${app_key}"


### PR DESCRIPTION
 Some api calls (examples) using curl do not work.
https://docs.datadoghq.com/api/?lang=bash#mute-all-monitors
https://docs.datadoghq.com/api/?lang=bash#unmute-all-monitors
https://docs.datadoghq.com/api/?lang=bash#mute-a-monitor

For all these examples, this argument needs to be added: `-H "Content-type: application/json"`
Like: curl -X POST -H "Content-type: application/json" "https://api.datadoghq.com/api/v1/monitor/${monitor_id}/mute?api_key=${api_key}&application_key=${app_key}"
Instead of: curl -X POST "https://api.datadoghq.com/api/v1/monitor/<monitor-ID>/mute?api_key=<my-api-key>&application_key=<my-app-key>"

### Preview link

https://docs-staging.datadoghq.com/gus/api/api/?lang=bash#mute-all-monitors
https://docs-staging.datadoghq.com/gus/api/api/?lang=bash#unmute-all-monitors
https://docs-staging.datadoghq.com/gus/api/api/?lang=bash#mute-a-monitor