### PR TITLE
The datadog-agent command does not exist within the kubernetes container

### DIFF
--- a/content/agent/faq/agent-commands.md
+++ b/content/agent/faq/agent-commands.md
@@ -50,7 +50,7 @@ aliases:
 |Linux|`sudo service datadog-agent status`|`sudo datadog-agent status`|
 |Docker (Debian)|`sudo docker exec -it <container_name> /etc/init.d/datadog-agent status`|`sudo docker exec -it <container_name> s6-svstat /var/run/s6/services/agent/`|
 |Docker (Alpine)|`sudo docker exec -it <container_name> supervisorctl -c /opt/datadog-agent/agent/supervisor.conf status`|`n/a`|
-|Kubernetes|`kubectl exec -it <pod-name> /etc/init.d/datadog-agent status`|`kubectl exec -it <pod-name> s6-svstat /var/run/s6/services/agent/`|
+|Kubernetes|`kubectl exec -it <pod-name> /opt/datadog-agent/bin/agent/agent status`|`kubectl exec -it <pod-name> s6-svstat /var/run/s6/services/agent/`|
 |MacOS x|`datadog-agent status`             | `launchctl list com.datadoghq.agent` or systray app|
 |Source|`sudo ~/.datadog-agent/bin/agent status`|`sudo service datadog-agent status`|
 |Windows|[Consult our dedicated windows doc][2]|[Consult our dedicated windows doc][2]|
@@ -80,7 +80,7 @@ The `[OK]` in the Agent output implies that the check was configured/run correct
 |Linux|`sudo service datadog-agent info`|`sudo datadog-agent status`|
 |Docker|`sudo docker exec -it <container_name> /etc/init.d/datadog-agent info`|`sudo docker exec -it <container_name> agent status`|
 |Docker (Alpine)|`docker exec -it <container_name> /opt/datadog-agent/bin/agent info`|`n/a`|
-|Kubernetes|`kubectl exec -it <pod-name> /etc/init.d/datadog-agent info`|`kubectl exec -it <pod-name> agent status`|
+|Kubernetes|`kubectl exec -it <pod-name> /opt/datadog-agent/bin/agent/agent info`|`kubectl exec -it <pod-name> agent status`|
 |MacOS x|`datadog-agent info`               | `datadog-agent status` or [web GUI][3]                    |
 |Source|`sudo ~/.datadog-agent/bin/info`|`sudo datadog-agent status`|
 |Windows|[Consult our dedicated windows doc][2]|[Consult our dedicated windows doc][2]|


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

The example command does not work in the latest datadog container. This was tested on Azure AKS kubernetes.

```bash
$ kubectl exec -it datadog-agent-c2tnp /etc/init.d/datadog-agent info
rpc error: code = 2 desc = oci runtime error: exec failed: container_linux.go:247: starting container process caused "exec: \"/etc/init.d/datadog-agent\": stat /etc/init.d/datadog-agent: no such file or directory"

command terminated with exit code 126
```

### Motivation
<!-- What inspired you to submit this pull request?-->

Friendly community commit :-)
