### PR TITLE
Refactoring troubleshooting agent check

### DIFF
--- a/content/agent/troubleshooting.md
+++ b/content/agent/troubleshooting.md
@@ -85,7 +85,7 @@ In the commands below, replace `<CASE_ID>` with your Datadog support case ID, if
 
 ## Status of an Agent check
 
-Agent checks shouldn't be directly called from Python and instead must be called by the Agent.
+Agent checks can’t be directly called from python and instead need to be called by the Agent.
 
 To test an Agent check, run:
 

--- a/content/agent/troubleshooting.md
+++ b/content/agent/troubleshooting.md
@@ -85,27 +85,27 @@ In the commands below, replace `<CASE_ID>` with your Datadog support case ID, if
 
 ## Status of an Agent check
 
-Agent checks can't be directly called from python and instead need to be called by the Agent.
+Agent checks shouldn't be directly called from Python and instead must be called by the Agent.
 
-To test an agent check, run:
+To test an Agent check, run:
 
 | Agent version | Command                                             |
 | :------       | :----                                               |
 | v5.x          | `sudo -u dd-agent dd-agent check <CHECK_NAME>`      |
 | v6.x          | `sudo -u dd-agent datadog-agent check <CHECK_NAME>` |
 
-If you want to include rate metrics, add `--check-rate` to your command, for instance for agent v6.x run:
+If you want to include rate metrics, add `--check-rate` to your command, for instance for Agent v6.x run:
 
 ```
 sudo -u dd-agent datadog-agent check <CHECK_NAME> --check-rate
 ```
 
-If your issue continues, reach out to Support with the [help page][5] that lists the paths it installs.
+If your issue continues, [reach out to our Support team][5] with a [flare](#flare).
 
 ### Windows
 
 * **For Agent version < 5.12**:
-    The Agent install includes a file called shell.exe in your Program Files directory for the Datadog Agent which you can use to run python within the Agent environment. Once your check (called `<CHECK_NAME>`) is written and you have the .py and .yaml files in their correct places, you can run the following in shell.exe:
+    The Agent install includes a file called `shell.exe` in your `\Program Files\` directory for the Datadog Agent which you can use to run python within the Agent environment. Once your check (called `<CHECK_NAME>`) is written and you have the `.py` and `.yaml` files in their correct places, you can run the following in shell.exe:
     ```
     from checks import run_check
     run_check('<CHECK_NAME>')
@@ -123,7 +123,7 @@ If your issue continues, reach out to Support with the [help page][5] that lists
 * **For Agent version > 6.0**:
     Run the following script, with the proper `<CHECK_NAME>`:
     ```
-    C:\program files\datadog\datadog agent\embedded\agent.exe check <CHECK_NAME>
+    C:\Program Files\Datadog\Datadog agent\embedded\agent.exe check <CHECK_NAME>
     ```
 
 ## FAQ

--- a/content/agent/troubleshooting.md
+++ b/content/agent/troubleshooting.md
@@ -83,6 +83,49 @@ In the commands below, replace `<CASE_ID>` with your Datadog support case ID, if
 | Source          | `sudo ~/.datadog-agent/bin/agent flare <CASE_ID>`                       | `sudo datadog-agent flare <CASE_ID>`                  |
 | Windows         | [Consult our dedicated windows doc][9]                                  | [Consult our dedicated windows doc][10]               |
 
+## Status of an Agent check
+
+Agent checks can't be directly called from python and instead need to be called by the Agent.
+
+To test an agent check, run:
+
+| Agent version | Command                                             |
+| :------       | :----                                               |
+| v5.x          | `sudo -u dd-agent dd-agent check <CHECK_NAME>`      |
+| v6.x          | `sudo -u dd-agent datadog-agent check <CHECK_NAME>` |
+
+If you want to include rate metrics, add `--check-rate` to your command, for instance for agent v6.x run:
+
+```
+sudo -u dd-agent datadog-agent check <CHECK_NAME> --check-rate
+```
+
+If your issue continues, reach out to Support with the [help page][5] that lists the paths it installs.
+
+### Windows
+
+* **For Agent version < 5.12**:
+    The Agent install includes a file called shell.exe in your Program Files directory for the Datadog Agent which you can use to run python within the Agent environment. Once your check (called `<CHECK_NAME>`) is written and you have the .py and .yaml files in their correct places, you can run the following in shell.exe:
+    ```
+    from checks import run_check
+    run_check('<CHECK_NAME>')
+    ```
+    This outputs any metrics or events that the check returns.
+
+* **For Agent version >= 5.12**:
+    Run the following script, with the proper `<CHECK_NAME>`:
+    `<INSTALL_DIR>/embedded/python.exe <INSTALL_DIR>agent/agent.py check <CHECK_NAME>`
+    For example, to run the disk check:
+    ```
+    C:\Program' 'Files\Datadog\Datadog' 'Agent\embedded\python.exe C:\Program' 'Files\Datadog\Datadog' 'Agent\agent\agent.py check disk
+    ```
+
+* **For Agent version > 6.0**:
+    Run the following script, with the proper `<CHECK_NAME>`:
+    ```
+    C:\program files\datadog\datadog agent\embedded\agent.exe check <CHECK_NAME>
+    ```
+
 ## FAQ
 
 * [Common Windows Agent Installation Error 1721][11]

--- a/content/agent/troubleshooting.md
+++ b/content/agent/troubleshooting.md
@@ -105,7 +105,7 @@ If your issue continues, [reach out to our Support team][5] with a [flare](#flar
 ### Windows
 
 * **For Agent version < 5.12**:
-    The Agent install includes a file called `shell.exe` in your `\Program Files\` directory for the Datadog Agent which you can use to run python within the Agent environment. Once your check (called `<CHECK_NAME>`) is written and you have the `.py` and `.yaml` files in their correct places, you can run the following in shell.exe:
+    The Agent install includes a file called `shell.exe` in your `\Program Files\` directory for the Datadog Agent which you can use to run Python within the Agent environment. Once your check (called `<CHECK_NAME>`) is written and you have the `.py` and `.yaml` files in their correct places, you can run the following in shell.exe:
     ```
     from checks import run_check
     run_check('<CHECK_NAME>')

--- a/content/agent/troubleshooting.md
+++ b/content/agent/troubleshooting.md
@@ -85,7 +85,7 @@ In the commands below, replace `<CASE_ID>` with your Datadog support case ID, if
 
 ## Status of an Agent check
 
-Agent checks must be called by the Agent, to test an Agent check run:
+Agent checks must be called by the Agent. To test an Agent check, run:
 
 | Agent version | Command                                             |
 | :------       | :----                                               |

--- a/content/agent/troubleshooting.md
+++ b/content/agent/troubleshooting.md
@@ -85,9 +85,7 @@ In the commands below, replace `<CASE_ID>` with your Datadog support case ID, if
 
 ## Status of an Agent check
 
-Agent checks can’t be directly called from python and instead need to be called by the Agent.
-
-To test an Agent check, run:
+Agent checks must be called by the Agent, to test an Agent check run:
 
 | Agent version | Command                                             |
 | :------       | :----                                               |

--- a/content/developers/agent_checks.md
+++ b/content/developers/agent_checks.md
@@ -423,40 +423,7 @@ class HTTPCheck(AgentCheck):
 
 ## Troubleshooting
 
-Custom Agent checks can't be directly called from python and instead need to be called by the Agent.
-
-To test this, run:
-
-| Agent version | Command                                             |
-| :------       | :----                                               |
-| v5.x          | `sudo -u dd-agent dd-agent check <CHECK_NAME>`      |
-| v6.x          | `sudo -u dd-agent datadog-agent check <CHECK_NAME>` |
-
-If you want to include rate metrics, add `--check-rate` to your command, for instance for agent v6.x run:
-
-```
-sudo -u dd-agent datadog-agent check <CHECK_NAME> --check-rate
-```
-
-If your issue continues, reach out to Support with the [help page][11] that lists the paths it installs.
-
-### Testing custom Agent checks on Windows
-
-* **For Agent version < 5.12**:
-    The Agent install includes a file called shell.exe in your Program Files directory for the Datadog Agent which you can use to run python within the Agent environment. Once your check (called `<CHECK_NAME>`) is written and you have the .py and .yaml files in their correct places, you can run the following in shell.exe:
-    ```
-    from checks import run_check
-    run_check('<CHECK_NAME>')
-    ```
-    This outputs any metrics or events that the check returns.
-
-* **For Agent version >= 5.12**:
-    Run the following script, with the proper `<CHECK_NAME>`:
-    `<INSTALL_DIR>/embedded/python.exe <INSTALL_DIR>agent/agent.py check <CHECK_NAME>`
-    For example, to run the disk check:
-    ```
-    C:\Program' 'Files\Datadog\Datadog' 'Agent\embedded\python.exe C:\Program' 'Files\Datadog\Datadog' 'Agent\agent\agent.py check disk
-    ```
+[Refer to the Agent dedicated troubleshooting documentation page][]
 
 ## Further Reading
 
@@ -474,3 +441,4 @@ If your issue continues, reach out to Support with the [help page][11] that list
 [10]: /agent/faq/agent-commands
 [11]: /help
 [12]: /agent/custom_python_package/
+[13]: /agent/troubleshooting/#status-of-an-agent-check

--- a/content/developers/agent_checks.md
+++ b/content/developers/agent_checks.md
@@ -423,7 +423,7 @@ class HTTPCheck(AgentCheck):
 
 ## Troubleshooting
 
-[Refer to the Agent dedicated troubleshooting documentation page][]
+[Refer to the Agent dedicated troubleshooting documentation page][13]
 
 ## Further Reading
 


### PR DESCRIPTION
### What does this PR do?
Moves troubleshooting section for agent check from the agent check page to the main agent troubleshooting page to make it more consistent.

### Motivation
Support feedback

### Preview link

* https://docs-staging.datadoghq.com/gus/windows-check/agent/troubleshooting/#status-of-an-agent-check
* https://docs-staging.datadoghq.com/gus/windows-check/developers/agent_checks/#troubleshooting