### PR TITLE
Downtime wording update

### DIFF
--- a/content/monitors/downtimes.md
+++ b/content/monitors/downtimes.md
@@ -20,17 +20,21 @@ You may occasionally need to shut systems down or take them off-line to perform 
 
 You can schedule downtimes and/or mute your Datadog monitors so that they do not alert at specific times when you do not want them to.
 
-Monitors trigger events when they change state between ALERT, WARNING (if enabled), RESOLVED, and NO DATA (if enabled). But if a monitor has been silenced either by a downtime or muting, then any transition from RESOLVED to another state won't trigger an event (nor the notification channels that the event would have set off). Note that muting or unmuting a monitor via the UI deletes all scheduled downtimes associated with that monitor.
+Monitors trigger events when they change state between `ALERT`, `WARNING` (if enabled), `RESOLVED`, and `NO DATA` (if enabled). But if a monitor has been silenced either by a downtime or muting, then any transition from `RESOLVED` to another state **won't trigger an event** (nor the notification channels that the event would have set off). 
+
+**Note**: Muting or un-muting a monitor via the UI deletes all scheduled downtimes associated with that monitor.
 
 {{< img src="monitors/downtimes/downtime_on_alert.png" alt="downtime on alert" responsive="true" style="width:80%;">}}
 
-If a monitor transitions states during downtime (such as from OK to ALERT, WARNING, or NO DATA) and remains in that state once a scheduled downtime expires, it will NOT trigger a notification. However it WILL trigger a recovery event once data returns for that scope or the monitor returns to an OK state.
+If a monitor transitions states during downtime (such as from `OK` to `ALERT`, `WARNING`, or `NO DATA`) and remains in that state once a scheduled downtime expires, it will **NOT** trigger a notification. 
+However it WILL trigger a recovery event once data returns for that scope or the monitor returns to an `OK` state.
 
-This may seem unintuitive, but it is the expected behavior today, and it has been made this way to protect from potentially spammy no-data alerts when using the "Autoresolve" feature. If in these circumstances you would prefer that the monitor triggers a NO DATA event at the time that the silencing expires, there is a feature you can have enabled for your account to enable that behavior. To have that enabled, you can [reach out to the support team][5] to request it. This will only affect instances when a monitor exits a downtime period in a NO DATA state.
+This may seem unintuitive, but it is the expected behavior today, and it has been made this way to protect from potentially spammy `NO DATA` state alerts when using the *Autoresolve* feature. 
+If in these circumstances you would prefer that the monitor triggers a `NO DATA` state event at the time that the silencing expires, there is a feature you can have enabled for your account to enable that behavior. [Reach out to our support team][5] to request it. This will only affect instances when a monitor exits a downtime period in a NO DATA state.
 
 ## Manage Downtime
 
-Navigate to the [Manage Downtime][1] page by highlighting the "Monitors" tab in the main menu and selecting the "Manage Downtime" link. You may also navigate to the "Manage Downtime" page from other Monitor related pages by clicking the link at the top of the page.
+Navigate to the [Manage Downtime][1] page by highlighting the *Monitors* tab in the main menu and selecting the *Manage Downtime* link. You may also navigate to the *Manage Downtime* page from other Monitor related pages by clicking the link at the top of the page.
 
 {{< img src="monitors/downtimes/downtime-nav.png" alt="downtime-nav" responsive="true" >}}
 

--- a/content/monitors/downtimes.md
+++ b/content/monitors/downtimes.md
@@ -49,7 +49,7 @@ To schedule downtime, click the "Schedule Downtime" button in the upper right.
   {{< img src="monitors/downtimes/downtime-silence.png" alt="downtime-silence" responsive="true" style="width:80%;">}}
   You can select a specific monitor to silence, or leave this field empty to silence all monitors. You can also select a scope to constrain your downtime to a specific host, device or arbitrary tag.
   Refer to the [scope section][2] of the Graphing Primer using JSON for further information about scope.
-  If you choose to silence all monitors constrained by a scope, clicking the *Preview affected monitors* shows which monitors are currently affected. Any monitors within your scope that are created or edited after the downtime is schedule is also silenced.
+  If you choose to silence all monitors constrained by a scope, clicking the *Preview affected monitors* shows which monitors are currently affected. Any monitors within your scope that are created or edited after the downtime is scheduled are also silenced.
   Note that if a multi alert is included, it is only silenced for systems covered by the scope. 
   For example, if a downtime scope is set for `host:X` and a multi alert is triggered on both `host:X` and `host:Y`, Datadog generates a monitor notification for `host:Y`, but not `host:X`.
 

--- a/content/monitors/downtimes.md
+++ b/content/monitors/downtimes.md
@@ -29,7 +29,7 @@ Monitors trigger events when they change state between `ALERT`, `WARNING` (if en
 If a monitor transitions states during downtime (such as from `OK` to `ALERT`, `WARNING`, or `NO DATA`) and remains in that state once a scheduled downtime expires, it will **NOT** trigger a notification. 
 **However it WILL trigger a recovery event once data returns for that scope or the monitor returns to an `OK` state.**
 
-This behavour is designed to prevent spammy `NO DATA` state alerts when using the *Autoresolve* feature. If you would prefer that the monitor triggers a `NO DATA` state event at the time that the silencing expires, thisis  a feature that can be enabled for your account; [reach out to our support team][5] to request it. This will only affect instances when a monitor exits a downtime period in a `NO DATA` state.
+This behavior is designed to prevent spammy `NO DATA` state alerts when using the *Autoresolve* feature. If you would prefer that the monitor trigger a `NO DATA` state event at the time that the silencing expires, [reach out to our support team][5] to request that this feature is enabled for your account. This will only affect instances when a monitor exits a downtime period in a `NO DATA` state.
 
 ## Manage Downtime
 

--- a/content/monitors/downtimes.md
+++ b/content/monitors/downtimes.md
@@ -20,7 +20,7 @@ You may occasionally need to shut systems down or take them off-line to perform 
 
 You can schedule downtimes and/or mute your Datadog monitors so that they do not alert at specific times when you do not want them to.
 
-Monitors trigger events when they change state between `ALERT`, `WARNING` (if enabled), `RESOLVED`, and `NO DATA` (if enabled). But if a monitor has been silenced either by a downtime or muting, then any transition from `RESOLVED` to another state **won't trigger an event** (nor the notification channels that the event would have set off). 
+Monitors trigger events when they change state between `ALERT`, `WARNING` (if enabled), `RESOLVED`, and `NO DATA` (if enabled). If a monitor has been silenced either by a downtime or muting, then any transition from `RESOLVED` to another state will **neither trigger an event**, nor activate any associated notification channels. 
 
 **Note**: Muting or un-muting a monitor via the UI deletes all scheduled downtimes associated with that monitor.
 
@@ -29,8 +29,7 @@ Monitors trigger events when they change state between `ALERT`, `WARNING` (if en
 If a monitor transitions states during downtime (such as from `OK` to `ALERT`, `WARNING`, or `NO DATA`) and remains in that state once a scheduled downtime expires, it will **NOT** trigger a notification. 
 **However it WILL trigger a recovery event once data returns for that scope or the monitor returns to an `OK` state.**
 
-This may seem unintuitive, but it is the expected behavior today, and it has been made this way to protect from potentially spammy `NO DATA` state alerts when using the *Autoresolve* feature. 
-If in these circumstances you would prefer that the monitor triggers a `NO DATA` state event at the time that the silencing expires, there is a feature you can have enabled for your account to enable that behavior. [Reach out to our support team][5] to request it. This will only affect instances when a monitor exits a downtime period in a `NO DATA` state.
+This behavour is designed to prevent spammy `NO DATA` state alerts when using the *Autoresolve* feature. If you would prefer that the monitor triggers a `NO DATA` state event at the time that the silencing expires, thisis  a feature that can be enabled for your account; [reach out to our support team][5] to request it. This will only affect instances when a monitor exits a downtime period in a `NO DATA` state.
 
 ## Manage Downtime
 

--- a/content/monitors/downtimes.md
+++ b/content/monitors/downtimes.md
@@ -27,10 +27,10 @@ Monitors trigger events when they change state between `ALERT`, `WARNING` (if en
 {{< img src="monitors/downtimes/downtime_on_alert.png" alt="downtime on alert" responsive="true" style="width:80%;">}}
 
 If a monitor transitions states during downtime (such as from `OK` to `ALERT`, `WARNING`, or `NO DATA`) and remains in that state once a scheduled downtime expires, it will **NOT** trigger a notification. 
-However it WILL trigger a recovery event once data returns for that scope or the monitor returns to an `OK` state.
+**However it WILL trigger a recovery event once data returns for that scope or the monitor returns to an `OK` state.**
 
 This may seem unintuitive, but it is the expected behavior today, and it has been made this way to protect from potentially spammy `NO DATA` state alerts when using the *Autoresolve* feature. 
-If in these circumstances you would prefer that the monitor triggers a `NO DATA` state event at the time that the silencing expires, there is a feature you can have enabled for your account to enable that behavior. [Reach out to our support team][5] to request it. This will only affect instances when a monitor exits a downtime period in a NO DATA state.
+If in these circumstances you would prefer that the monitor triggers a `NO DATA` state event at the time that the silencing expires, there is a feature you can have enabled for your account to enable that behavior. [Reach out to our support team][5] to request it. This will only affect instances when a monitor exits a downtime period in a `NO DATA` state.
 
 ## Manage Downtime
 
@@ -50,8 +50,9 @@ To schedule downtime, click the "Schedule Downtime" button in the upper right.
   {{< img src="monitors/downtimes/downtime-silence.png" alt="downtime-silence" responsive="true" style="width:80%;">}}
   You can select a specific monitor to silence, or leave this field empty to silence all monitors. You can also select a scope to constrain your downtime to a specific host, device or arbitrary tag.
   Refer to the [scope section][2] of the Graphing Primer using JSON for further information about scope.
-  If you choose to silence all monitors constrained by a scope, clicking the "Preview affected monitors" shows which monitors are currently affected. Any monitors within your scope that are created or edited after the downtime is schedule is also silenced.
-  Note that if a multi alert is included, it is only silenced for systems covered by the scope. For example, if a downtime scope is set for `host:X` and a multi alert is triggered on both `host:X` and `host:Y`, Datadog generates a monitor notification for `host:Y`, but not `host:X`.
+  If you choose to silence all monitors constrained by a scope, clicking the *Preview affected monitors* shows which monitors are currently affected. Any monitors within your scope that are created or edited after the downtime is schedule is also silenced.
+  Note that if a multi alert is included, it is only silenced for systems covered by the scope. 
+  For example, if a downtime scope is set for `host:X` and a multi alert is triggered on both `host:X` and `host:Y`, Datadog generates a monitor notification for `host:Y`, but not `host:X`.
 
 2. Set a schedule.
   {{< img src="monitors/downtimes/downtime-schedule.png" alt="downtime-schedule" responsive="true" style="width:80%;">}}
@@ -59,7 +60,7 @@ To schedule downtime, click the "Schedule Downtime" button in the upper right.
 
 3. Add an optional message to notify your team
   {{< img src="monitors/downtimes/downtime-notify.png" alt="downtime-notify" responsive="true" style="width:80%;">}}
-  Enter a message to notify your team about this downtime. The message field allows standard [markdown formatting][3] as well as Datadog's @-notification syntax. The "Notify your team" field allows you to specify team members or send the message to a service [integration][4].
+  Enter a message to notify your team about this downtime. The message field allows standard [markdown formatting][3] as well as Datadog's @-notification syntax. The *Notify your team* field allows you to specify team members or send the message to a service [integration][4].
 
 ## Further Reading
 


### PR DESCRIPTION
### What does this PR do?
Updates wording for the downtime page to make it more readable.

Support team has created an image to summarize downtime behaviors with monitors. A request have been sent to DD design team in order to make it available for the doc.

### Motivation
Downtime behavior can be difficult to understand

### Preview link

* https://docs-staging.datadoghq.com/gus/downtime/monitors/downtimes/