### PR TITLE
K8s correction

### DIFF
--- a/content/agent/basic_agent_usage/kubernetes.md
+++ b/content/agent/basic_agent_usage/kubernetes.md
@@ -58,9 +58,11 @@ spec:
         name: datadog-agent
         ports:
           - containerPort: 8125
+            hostPort: 8125
             name: dogstatsdport
             protocol: UDP
           - containerPort: 8126
+            hostPort: 8126
             name: traceport
             protocol: TCP
         env:


### PR DESCRIPTION
hostPort should be added here. Customers will copy this, try to enable APM, and fail because the host port isn't called out clearly. By giving this default, we'll avoid those challenges.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes the K8s template to correctly open ports.

### Motivation
Frustrated customers.

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
