### PR TITLE
Adds a section to the proxy page about forwarding logs with HAProxy

### DIFF
--- a/content/agent/proxy.md
+++ b/content/agent/proxy.md
@@ -60,13 +60,14 @@ Do not forget to [restart the Agent][2] for the new settings to take effect.
 
 ## Using HAProxy as a Proxy
 
-### HAProxy configuration
-
 [HAProxy][3] is a free, fast, and reliable solution offering proxying for TCP and HTTP applications. While HAProxy is usually used as a load balancer to distribute incoming requests to pools servers, you can also use it to proxy Agent traffic to Datadog from hosts that have no outside connectivity.
 
 This is the best option if you do not have a web proxy readily available in your network, and you wish to proxy a large number of Agents. In some cases, a single HAProxy instance is sufficient to handle local Agent traffic in your network—each proxy can accommodate upwards of 1000 Agents. (Be aware that this figure is a conservative estimate based on the performance of m3.xl instances specifically. Numerous network-related variables can influence load on proxies. As always, deploy under a watchful eye. Visit [HAProxy documentation][6] for additional information.)
 
 `agent ---> haproxy ---> Datadog`
+
+### Proxy metric forwarding with HAProxy
+#### HAProxy configuration
 
 We assume that HAProxy is installed on a host that has connectivity to Datadog.  
 Use the following configuration file if you do not already have it configured.
@@ -146,10 +147,83 @@ Once the HAProxy configuration is in place, you can reload it or restart HAProxy
 
 **We recommend having a `cron` job that reloads HAProxy every 10 minutes** (usually doing something like `service haproxy reload`) to force a refresh of HAProxy's DNS cache, in case `app.datadoghq.com` fails over to another IP.
 
+#### Datadog Agent configuration
+##### Agent v>6
+
+Edit each Agent to point to HAProxy by setting its `dd_url` to the address of HAProxy (e.g. `haproxy.example.com`). 
+This `dd_url` setting can be found in the `datadog.yaml` file. 
+
+`dd_url: https://haproxy.example.com:3834`
+
+To send traces or processes through the proxy, setup the following in the `datadog.yaml` file:
+
+```
+apm_config:
+    endpoint: https://haproxy.example.com:3835
+
+process_config:
+    url: https://haproxy.example.com:3836
+```
+
+Then edit the `datadog.yaml` Agent configuration file and set `skip_ssl_validation` to `true`. This is needed to prevent Python from complaining about the discrepancy between the hostname on the SSL certificate (`app.datadoghq.com`) and your HAProxy hostname.:
+
+```
+skip_ssl_validation: true
+```
+
+Finally [restart the Agent][4].
+
+To verify that everything is working properly, review the HAProxy statistics at `http://haproxy.example.com:3835` as well as the [Infrastructure Overview][5].
+
+##### Agent v<6
+
+Edit each Agent to point to HAProxy by setting its `dd_url` to the address of HAProxy (e.g. `haproxy.example.com`). 
+This `dd_url` setting can be found in the `datadog.conf` file. 
+
+`dd_url: https://haproxy.example.com:3834`
+
+To send traces or processes through the proxy, setup the following in the `datadog.conf` file:
+
+```
+[trace.api]
+endpoint = https://haproxy.example.com:3835
+
+[process.api]
+url = https://haproxy.example.com:3836
+```
+
+Edit your supervisor configuration to disable SSL certificate verification. This is needed to prevent Python from complaining about the discrepancy between the hostname on the SSL certificate (`app.datadoghq.com`) and your HAProxy hostname. The supervisor configuration found at:
+
+* `/etc/dd-agent/supervisor_ddagent.conf` on Debian-based systems
+* `/etc/dd-agent/supervisor.conf` on Red Hat-based systems
+* `/opt/local/datadog/supervisord/supervisord.conf` on SmartOS
+* `/usr/local/etc/datadog/supervisord/supervisord.conf` on FreeBSD
+* `~/.datadog-agent/supervisord/supervisord.conf` on Mac OS X
+
+Assuming that the supervisor file is found at `<SUP_FILE>`
+
+```bash
+sed -i 's/ddagent.py/ddagent.py --sslcheck=0/' <SUP_FILE>
+```
+
+For the Windows Agent (Starting from Agent version 3.9.2), edit your configuration file `datadog.conf` and add this option:
+
+```
+skip_ssl_validation: yes
+```
+
+Finally [restart the Agent][4].
+
+To verify that everything is working properly, review the HAProxy statistics at `http://haproxy.example.com:3835` as well as the [Infrastructure Overview][5].
+
 ### Proxy log forwarding with HAProxy
+**This feature is only available for Agent v6**
+
 If your network configuration restricts outbound traffic, you can use a proxy to send logs from the Datadog Agent or 3rd party log collectors to the Datadog logs intake.
 
-Unlike the metrics intake API, which listens on HTTPS 443, the logs intake uses TCP (Layer 4) on port 10516 (for TLS and 10514 for plaintext). Here is a basic HAProxy configuration file used to proxy logs to the Datadog intake. In this example, HAProxy also uses TLS wrapping to ensure that internal plaintext logs are encrypted between your proxy and Datadog's log intake API endpoint:
+#### HAProxy configuration
+
+Unlike the metrics intake API, which listens on HTTPS `443`, the logs intake uses TCP (Layer 4) on port `10516` (for TLS and `10514` for plaintext). Here is a basic HAProxy configuration file used to proxy logs to the Datadog intake. In this example, HAProxy also uses TLS wrapping to ensure that internal plaintext logs are encrypted between your proxy and Datadog's log intake API endpoint:
 
 ```
 global
@@ -193,6 +267,8 @@ backend logs_backend
     server datadog agent-intake.logs.datadoghq.com:10516 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt
 ```
 
+#### Datadog Agent configuration
+
 When using the Datadog Agent as the logs collector, the Agent itself also needs to be instructed to use the newly created proxy instead of establishing a connection directly with the logs intake. This is done with the following options in `datadog.yaml`:
 
 ```
@@ -203,75 +279,6 @@ logs_config:
 ```
 
 Note: here, the `dev_mode_no_ssl: true` line is correct, because HAProxy establishes the SSL/TLS connection. Do not run with this option if you do not intend to use a proxy, which can encrypt the connection to the logs intake.
-
-### Datadog Agent configuration
-#### Agent v>6
-
-Edit each Agent to point to HAProxy by setting its `dd_url` to the address of HAProxy (e.g. `haproxy.example.com`). 
-This `dd_url` setting can be found in the `datadog.yaml` file. 
-
-`dd_url: https://haproxy.example.com:3834`
-
-To send traces or processes through the proxy, setup the following in the `datadog.yaml` file:
-
-```
-apm_config:
-    endpoint: https://haproxy.example.com:3835
-
-process_config:
-    url: https://haproxy.example.com:3836
-```
-
-Then edit the `datadog.yaml` Agent configuration file and set `skip_ssl_validation` to `true`. This is needed to prevent Python from complaining about the discrepancy between the hostname on the SSL certificate (`app.datadoghq.com`) and your HAProxy hostname.:
-
-```
-skip_ssl_validation: true
-```
-
-Finally [restart the Agent][4].
-
-To verify that everything is working properly, review the HAProxy statistics at `http://haproxy.example.com:3835` as well as the [Infrastructure Overview][5].
-
-#### Agent v<6
-
-Edit each Agent to point to HAProxy by setting its `dd_url` to the address of HAProxy (e.g. `haproxy.example.com`). 
-This `dd_url` setting can be found in the `datadog.conf` file. 
-
-`dd_url: https://haproxy.example.com:3834`
-
-To send traces or processes through the proxy, setup the following in the `datadog.conf` file:
-
-```
-[trace.api]
-endpoint = https://haproxy.example.com:3835
-
-[process.api]
-url = https://haproxy.example.com:3836
-```
-
-Edit your supervisor configuration to disable SSL certificate verification. This is needed to prevent Python from complaining about the discrepancy between the hostname on the SSL certificate (`app.datadoghq.com`) and your HAProxy hostname. The supervisor configuration found at:
-
-* `/etc/dd-agent/supervisor_ddagent.conf` on Debian-based systems
-* `/etc/dd-agent/supervisor.conf` on Red Hat-based systems
-* `/opt/local/datadog/supervisord/supervisord.conf` on SmartOS
-* `/usr/local/etc/datadog/supervisord/supervisord.conf` on FreeBSD
-* `~/.datadog-agent/supervisord/supervisord.conf` on Mac OS X
-
-Assuming that the supervisor file is found at `<SUP_FILE>`
-
-```bash
-sed -i 's/ddagent.py/ddagent.py --sslcheck=0/' <SUP_FILE>
-```
-
-For the Windows Agent (Starting from Agent version 3.9.2), edit your configuration file `datadog.conf` and add this option:
-
-```
-skip_ssl_validation: yes
-```
-
-Finally [restart the Agent][4].
-
-To verify that everything is working properly, review the HAProxy statistics at `http://haproxy.example.com:3835` as well as the [Infrastructure Overview][5].
 
 ## Using the Agent as a Proxy
 

--- a/content/agent/proxy.md
+++ b/content/agent/proxy.md
@@ -148,7 +148,7 @@ Once the HAProxy configuration is in place, you can reload it or restart HAProxy
 **We recommend having a `cron` job that reloads HAProxy every 10 minutes** (usually doing something like `service haproxy reload`) to force a refresh of HAProxy's DNS cache, in case `app.datadoghq.com` fails over to another IP.
 
 #### Datadog Agent configuration
-##### Agent v>6
+##### Agent v6
 
 Edit each Agent to point to HAProxy by setting its `dd_url` to the address of HAProxy (e.g. `haproxy.example.com`). 
 This `dd_url` setting can be found in the `datadog.yaml` file. 
@@ -165,7 +165,7 @@ process_config:
     url: https://haproxy.example.com:3836
 ```
 
-Then edit the `datadog.yaml` Agent configuration file and set `skip_ssl_validation` to `true`. This is needed to prevent Python from complaining about the discrepancy between the hostname on the SSL certificate (`app.datadoghq.com`) and your HAProxy hostname.:
+Then edit the `datadog.yaml` Agent configuration file and set `skip_ssl_validation` to `true`. This is needed to make the Agent ignore the  discrepancy between the hostname on the SSL certificate (`app.datadoghq.com`) and your HAProxy hostname:
 
 ```
 skip_ssl_validation: true
@@ -175,7 +175,7 @@ Finally [restart the Agent][4].
 
 To verify that everything is working properly, review the HAProxy statistics at `http://haproxy.example.com:3835` as well as the [Infrastructure Overview][5].
 
-##### Agent v<6
+##### Agent v5
 
 Edit each Agent to point to HAProxy by setting its `dd_url` to the address of HAProxy (e.g. `haproxy.example.com`). 
 This `dd_url` setting can be found in the `datadog.conf` file. 

--- a/content/agent/proxy.md
+++ b/content/agent/proxy.md
@@ -62,9 +62,9 @@ Do not forget to [restart the Agent][2] for the new settings to take effect.
 
 ### HAProxy configuration
 
-[HAProxy][3] is a free, very fast and reliable solution offering proxying for TCP and HTTP applications. While HAProxy is usually used as a load balancer to distribute incoming requests to pools servers, you can also use it to proxy Agent traffic to Datadog from hosts that have no outside connectivity.
+[HAProxy][3] is a free, fast, and reliable solution offering proxying for TCP and HTTP applications. While HAProxy is usually used as a load balancer to distribute incoming requests to pools servers, you can also use it to proxy Agent traffic to Datadog from hosts that have no outside connectivity.
 
-This is the best option if you do not have a web proxy readily available in your network and you wish to proxy a large number of Agents. In some cases a single HAProxy instance is sufficient to handle local Agent traffic in your network - each proxy can accommodate upwards of 1000 Agents (be aware that this figure is a conservative estimate based on the performance of m3.xl instances specifically. Numerous network-related variables can influence load on proxies. As always, deploy under a watchful eye. Visit [HAProxy documentation][6] for additional information).
+This is the best option if you do not have a web proxy readily available in your network, and you wish to proxy a large number of Agents. In some cases, a single HAProxy instance is sufficient to handle local Agent traffic in your network—each proxy can accommodate upwards of 1000 Agents. (Be aware that this figure is a conservative estimate based on the performance of m3.xl instances specifically. Numerous network-related variables can influence load on proxies. As always, deploy under a watchful eye. Visit [HAProxy documentation][6] for additional information.)
 
 `agent ---> haproxy ---> Datadog`
 
@@ -145,6 +145,64 @@ backend datadog-processes
 Once the HAProxy configuration is in place, you can reload it or restart HAProxy.
 
 **We recommend having a `cron` job that reloads HAProxy every 10 minutes** (usually doing something like `service haproxy reload`) to force a refresh of HAProxy's DNS cache, in case `app.datadoghq.com` fails over to another IP.
+
+### Proxy log forwarding with HAProxy
+If your network configuration restricts outbound traffic, you can use a proxy to send logs from the Datadog Agent or 3rd party log collectors to the Datadog logs intake.
+
+Unlike the metrics intake API, which listens on HTTPS 443, the logs intake uses TCP (Layer 4) on port 10516 (for TLS and 10514 for plaintext). Here is a basic HAProxy configuration file used to proxy logs to the Datadog intake. In this example, HAProxy also uses TLS wrapping to ensure that internal plaintext logs are encrypted between your proxy and Datadog's log intake API endpoint:
+
+```
+global
+    log 127.0.0.1 local0
+    maxconn 4096
+    stats socket /tmp/haproxy 
+
+# Some sane defaults
+defaults
+    log global
+    option dontlognull
+    retries 3
+    option redispatch
+    timeout client 5s
+    timeout server 5s
+    timeout connect 5s
+
+# This declares a view into HAProxy statistics, on port 3835
+# You do not need credentials to view this page and you can
+# turn it off once you are done with setup.
+listen stats
+    bind *:3833
+    mode http
+    stats enable
+    stats uri /
+
+# Logs frontend
+frontend logs_frontend
+    bind *:10514
+    mode tcp
+    default_backend logs_backend
+
+# Logs backend
+# agent-intake.logs.datadoghq.com used specifically for agent logs
+# intake.logs.datadoghq.com is also available for logs submitted without an agent
+# ca-certificates.crt located in /etc/ssl/certs/ for Ubuntu 16.04
+backend logs_backend
+    balance roundrobin
+    mode tcp
+    option tcplog
+    server datadog agent-intake.logs.datadoghq.com:10516 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt
+```
+
+When using the Datadog Agent as the logs collector, the Agent itself also needs to be instructed to use the newly created proxy instead of establishing a connection directly with the logs intake. This is done with the following options in `datadog.yaml`:
+
+```
+logs_config:
+  dd_url: myProxyServer.myDomain
+  dd_port: 10514
+  dev_mode_no_ssl: true
+```
+
+Note: here, the `dev_mode_no_ssl: true` line is correct, because HAProxy establishes the SSL/TLS connection. Do not run with this option if you do not intend to use a proxy, which can encrypt the connection to the logs intake.
 
 ### Datadog Agent configuration
 #### Agent v>6


### PR DESCRIPTION
### What does this PR do?
Documents how to configure HAProxy to forward logs with the Agent
### Motivation
[trello card](https://trello.com/c/33mLHfvu/2828-document-how-to-configure-haproxy-to-forward-logs-with-the-agent)

### Preview link

* https://docs-staging.datadoghq.com/cecilia/haproxy_config/agent/proxy/