### PR TITLE
fix typos (*_eva_path -> *_eval_path)

### DIFF
--- a/content/monitors/faq/as-count-monitor-evaluation.md
+++ b/content/monitors/faq/as-count-monitor-evaluation.md
@@ -7,7 +7,7 @@ kind: faq
 
 Currently monitors that have the `as_count` modifier use a separate evaluation path than other monitors. In certain use-cases this this can result in unexpected behavior. We intend to migrate all monitors with `as_count` to the same evaluation path as other monitors, but this doc explains the underlying issue and will guide you through the migration process.
 
-Let's call the current evaluation path for `as_count` monitors `current_eval_path` and the new one `new_eval_path`.  
+Let's call the current evaluation path for `as_count` monitors `current_eval_path` and the new one `new_eval_path`.
 
 The difference between those two evaluation paths is that complex monitor queries, especially those that have division, may produce **unintended results** depending on the time aggregation function. Let's say that you have 2 metrics, *A* and *B*:
 
@@ -30,7 +30,7 @@ Suppose we wish to monitor an error rate, which we calculate as:
 
 Let’s take this query for the time frame between *11:00:00* and *11:05:00*:
 
-`sum(last_5m): sum:requests.error{*}.as_count() / sum:requests.total{*}.as_count()`   
+`sum(last_5m): sum:requests.error{*}.as_count() / sum:requests.total{*}.as_count()`
 
 For the 5 min timeframe there are 5 time series points (zeros excluded):
 
@@ -69,8 +69,8 @@ Notice that the results are completely different. Remember that each query consi
 
 | Path | Behavior | Expanded expression |
 |:--------|:--------|:--------|
-|**`current_eva_path`** | Aggregation function applied *before* evaluation | **(a0 + a1 + ... + a4)/(b0 + b1 + ... + b4)** |
-|**`new_eva_path`** | Aggregation function applied *after* evaluation |**(a0/b0 + a1/b2 + ... + a4/b4)**|
+|**`current_eval_path`** | Aggregation function applied *before* evaluation | **(a0 + a1 + ... + a4)/(b0 + b1 + ... + b4)** |
+|**`new_eval_path`** | Aggregation function applied *after* evaluation |**(a0/b0 + a1/b2 + ... + a4/b4)**|
 
 
 ### Sparse metric problem
@@ -89,7 +89,7 @@ Here is the behavior difference:
 | `current_eval_path` | (10 + 10 + 10) / (0 + 1 + NaN) | 30 |
 | `new_eval_path` | 10/0 + 10/1 + 10/NaN | 10 |
 
-Note that both evaluations are correct -- it depends on your intention. 
+Note that both evaluations are correct -- it depends on your intention.
 
 ## Workaround
 
@@ -98,7 +98,7 @@ Since this special behavior is tied to the `as_count` modifier, we encourage rep
 *Example:* Suppose you wish to monitor the error rate of a service:
 
 Suppose you want to be alerted when the error rate is above 50% in total during the past 5 min. You might have a query like:
-`sum(last_5m):sum:requests.error{*}.as_count() / sum:requests.total{*}.as_count() > 0.5 ` 
+`sum(last_5m):sum:requests.error{*}.as_count() / sum:requests.total{*}.as_count() > 0.5 `
 
 To correctly rewrite it in the explicit format, the query can be rewritten like:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes two small typos. Looks like my editor also removed some spaces.

### Motivation
Dislike of typos!

### Preview link
https://docs-staging.datadoghq.com/celene/ascount_typo/monitors/faq/as-count-monitor-evaluation/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
