### PR TITLE
Remove mention of https connections to proxies in Agent6 config

### DIFF
--- a/content/agent/proxy.md
+++ b/content/agent/proxy.md
@@ -35,8 +35,8 @@ Edit the `datadog.yaml` file with your proxy information. Use the `no_proxy` lis
 
 ```
 proxy:
-    http: http(s)://user:password@proxy_for_http:port
-    https: http(s)://user:password@proxy_for_https:port
+    http: http://user:password@proxy_for_http:port
+    https: http://user:password@proxy_for_https:port
 #   no_proxy:
 #     - host1
 #     - host2


### PR DESCRIPTION
### What does this PR do?

Removes mention of https connections to proxies in Agent6 config

### Motivation

Although the Agent 6 (since 6.3.0) technically supports connecting to
proxies using HTTPS, all known Datadog customers that use proxies
connect to their proxies using HTTP.

Specifying `https://` also leads to a silent breaking behavior when
upgrading from v6 versions earlier than 6.3.0 and 6.3+ versions.

To avoid confusion, let's simply remove the mention of the `https://`
scheme for the proxy URL.
