### PR TITLE
Typo

### DIFF
--- a/content/developers/metrics/histograms.md
+++ b/content/developers/metrics/histograms.md
@@ -31,7 +31,7 @@ Each one of these becomes a value in their respective metric time series that ar
 
 ## Submission
 
-### Agent sheck
+### Agent check
 
 
 | Method              | Overview                                                       |


### PR DESCRIPTION
Wikipedia : A typographical error (often shortened to typo), also called misprint, is a mistake made in the typing process (such as a spelling mistake) of printed material. Historically, this referred to mistakes in manual type-setting (typography). The term includes errors due to mechanical failure or slips of the hand or finger, but excludes errors of ignorance, such as spelling errors, or the flip-flopping of words such as "than" and "then". Before the arrival of printing, the "copyist's mistake" or "scribal error" was the equivalent for manuscripts. Most typos involve simple duplication, omission, transposition, or substitution of a small number of characters.