### PR TITLE
add note re: unique custom check names

### DIFF
--- a/content/developers/agent_checks.md
+++ b/content/developers/agent_checks.md
@@ -180,6 +180,12 @@ module).
 
 Each check has a [YAML][8] configuration file that is placed in the `conf.d` directory. The file name should match the name of the check module (e.g.: `haproxy.py` and `haproxy.yaml`).  
 
+Due to the way Agent checks are packaged and distributed, custom checks cannot have the same name as a existing check or library within the Agent's embedded environment. Use `pip` to display a list of effectively unusable names:
+
+```
+$ sudo /opt/datadog-agent/embedded/bin/pip freeze
+```
+
 **Note**: YAML files must use spaces instead of tabs.
 
 The configuration file has the following structure:


### PR DESCRIPTION
### What does this PR do?

Clarifies that custom checks cannot use the name of an existing Python package and adds simple instructions to list unusable names (i.e. `pip freeze`).

### Motivation

https://trello.com/c/CCAUVECH/2902-updated-language-for-custom-agent-check

### Preview link

https://docs-staging.datadoghq.com/phrawzty/clarify_custom_check_names/developers/agent_checks/#configuration

### Additional Notes
