### PR TITLE
Fix reference to the service port

### DIFF
--- a/content/tracing/setup/kubernetes.md
+++ b/content/tracing/setup/kubernetes.md
@@ -118,7 +118,7 @@ env:
     valueFrom:
       fieldRef:
         fieldPath: status.hostIP
-  - name: DD_AGENT_PORT
+  - name: DD_AGENT_SERVICE_PORT
     value: 8126
 ```
 


### PR DESCRIPTION
### What does this PR do?
`DD_AGENT_SERVICE_PORT` instead of `DD_AGENT_PORT`

### Motivation
Minor typo.

### Preview link
https://github.com/DataDog/documentation/blob/davidb/tracing-k8s/content/tracing/setup/kubernetes.md