### PR TITLE
Update link to latest version available

### DIFF
--- a/content/agent/basic_agent_usage/windows.md
+++ b/content/agent/basic_agent_usage/windows.md
@@ -314,7 +314,7 @@ Again, due to the sensitivity of yaml, if you've tried the above and cannot get 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/account/settings#agent/windows
-[2]: https://github.com/DataDog/datadog-agent/releases
+[2]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-6-latest.amd64.msi
 [3]: /help
 [4]: /agent/faq/agent-commands
 [5]: /agent/#using-the-gui


### PR DESCRIPTION
See https://dd.slack.com/archives/C3RERH7PF/p1532011621000501

olivier.vielpeau [5 hours ago]
we stopped putting the download links in the github releases because we want the source of truth to remain what’s in the agent install pages (https://app.datadoghq.com/account/settings#agent)
In particular, for Windows, the windows page links to a JSON file that lists all the available versions and their download URLs, and can be used programmatically by customers

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
