### PR TITLE
Clarify syntax for user group notifications to Slack

### DIFF
--- a/content/monitors/notifications.md
+++ b/content/monitors/notifications.md
@@ -296,7 +296,8 @@ Would produce this slack message:
 
 You can also mention **@here** or **@channel** using `<!here>` or `<!channel>`, respectively. 
 
-For user groups, use `<!subteam^GROUP_ID|GROUP_NAME>`. To find the `GROUP_ID`, [query the API for Slack with the method in Slack's documentation][10]. For example, for a user group named "testers" you would use the following syntax:
+For user groups, use `<!subteam^GROUP_ID|GROUP_NAME>`. To find the `GROUP_ID`, [query the `usergroups.list` API endpoint of Slack][10]. For example, for a user group named `testers` you would use the following syntax:
+
 ```
 <!subteam^12345|testers>
 ```

--- a/content/monitors/notifications.md
+++ b/content/monitors/notifications.md
@@ -294,7 +294,12 @@ Would produce this slack message:
 
 {{< img src="monitors/notifications/notification_slack_preview.png" alt="notification_slack_preview" responsive="true" style="width:50%;" >}}
 
-You can also mention **@here** or **@channel** using `<!here>` or `<!channel>`, respectively. For user groups, use `<subteam^ID|handle>`.
+You can also mention **@here** or **@channel** using `<!here>` or `<!channel>`, respectively. 
+
+For user groups, use `<!subteam^GROUP_ID|GROUP_NAME>`. To find the `GROUP_ID`, [query the API for Slack with the method in Slack's documentation][10]. For example, for a user group named "testers" you would use the following syntax:
+```
+<!subteam^12345|testers>
+```
 
 #### Using message template variables to dynamically create @-mentions
 
@@ -306,7 +311,7 @@ For example, if the rendered variable is setup as a channel in the Slack integra
 
 * `@slack-{{host.name}}` post a slack message to the #host.name channel in Slack.
 
-[Learn more about how to setup conditional contacts and messages in a single monitor][10]
+[Learn more about how to setup conditional contacts and messages in a single monitor][11]
 
 ### Hipchat integration
 
@@ -327,4 +332,5 @@ Use `@here` in the monitor message to notify everybody in a given Hipchat channe
 [7]: /monitors/monitor_types/network
 [8]: /monitors/monitor_types/custom_check
 [9]: /monitors/monitor_types/event
-[10]: /monitors/faq/how-do-i-setup-conditional-contacts-and-messages-in-a-single-monitor
+[10]: https://api.slack.com/methods/usergroups.list
+[11]: /monitors/faq/how-do-i-setup-conditional-contacts-and-messages-in-a-single-monitor


### PR DESCRIPTION
Adds some clarification to the user group notification syntax since it wasn't very clear what "handle" and "ID" were referring too. 

Also adds a '!' inside the beginning of the brackets. The notification won't work without this.