### PR TITLE
Docker with a capital D

### DIFF
--- a/content/agent/autodiscovery.md
+++ b/content/agent/autodiscovery.md
@@ -82,7 +82,7 @@ Since 6.2.0 (and 5.24.0), the default templates use the default port for the mon
 
 These templates may suit you in basic cases, but if you need to use custom Agent check configurations—say you want to enable extra check options, use different container identifiers, or use template variable indexing— you'll have to write your own auto-conf files. You can then provide those in a few ways:
 
-1. Add them to each host that runs docker-datadog-agent and [mount the directory that contains them][15] into the datadog-agent container when starting it
+1. Add them to each host that runs `docker-datadog-agent` and [mount the directory that contains them][15] into the datadog-agent container when starting it
 2. On Kubernetes, add them [using ConfigMaps][16]
 
 The check name is extracted from the template file name. To run the `checkname` integration, the template file must either:
@@ -270,7 +270,7 @@ spec:
 
 The Agent detects if it's running on Docker and automatically searches all labels for check templates.
 
-Since version 6.2 of the Datadog Agent, it is also possible to configure docker log collection in container labels.
+Since version 6.2 of the Datadog Agent, it is also possible to configure Docker log collection in container labels.
 Check our [Docker Log collection guide][23] for more information about the setup.
 
 Autodiscovery expects labels to look like these examples, depending on the file type:
@@ -345,7 +345,7 @@ If you provide a template for the same check type via multiple template sources,
 
 ## Troubleshooting
 
-When you're not sure if Autodiscovery is loading certain checks you've configured, use the Agent's `configcheck` init script command. For example, to confirm that your Redis template is being loaded from a docker label annotation—not the default `redisdb.d/auto_conf.yaml` file:
+When you're not sure if Autodiscovery is loading certain checks you've configured, use the Agent's `configcheck` init script command. For example, to confirm that your Redis template is being loaded from a Docker label annotation—not the default `redisdb.d/auto_conf.yaml` file:
 
 ```
 # docker exec -it <agent_container_name> agent configcheck


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Capitalises Docker when used as a proper name.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes

Also puts backticks around a thing.
