### PR TITLE
journald Update with containerised instruction

### DIFF
--- a/content/integrations/journald.md
+++ b/content/integrations/journald.md
@@ -87,9 +87,9 @@ logs:
 
 ##### Collect Container tags
 
-Tags are critical for finding information in highly dynamic containerized environments. Which is why the agent is able to collect container tags in journald logs.
+Tags are critical for finding information in highly dynamic containerized environments, which is why the Agent can collect container tags in journald logs.
 
-This should work automatically when the Agent is running from the host. If you are using the containerized version of the Datadog Agent, mount your journald path and the following directory:
+This works automatically when the Agent is running from the host. If you are using the containerized version of the Datadog Agent, mount your journald path and the following directory:
 
 - `/etc/machine-id`: this ensure that the Agent can query the journald that is stored on the host.
 

--- a/content/integrations/journald.md
+++ b/content/integrations/journald.md
@@ -87,11 +87,11 @@ logs:
 
 ##### Collect Container tags
 
-Tags are critical for finding information in highly dynamic containerized environments. Which is why the agent is able to collect container tags on journald logs.
+Tags are critical for finding information in highly dynamic containerized environments. Which is why the agent is able to collect container tags in journald logs.
 
-This should work directly when the agent is running from the host. If you are using the containerized version of the Datadog Agent, simply mount the path of the journal and the following directory:
+This should work automatically when the Agent is running from the host. If you are using the containerized version of the Datadog Agent, mount your journald path and the following directory:
 
-- `/etc/machine-id`: this ensure that the agent can query the journal that is stored on the host.
+- `/etc/machine-id`: this ensure that the Agent can query the journald that is stored on the host.
 
 Finally, [restart the agent][2].
 

--- a/content/integrations/journald.md
+++ b/content/integrations/journald.md
@@ -85,6 +85,16 @@ logs:
       - sshd.service
 ```
 
+##### Collect Container tags
+
+Tags are critical for finding information in highly dynamic containerized environments. Which is why the agent is able to collect container tags on journald logs.
+
+This should work directly when the agent is running from the host. If you are using the containerized version of the Datadog Agent, simply mount the path of the journal and the following directory:
+
+- `/etc/machine-id`: this ensure that the agent can query the journal that is stored on the host.
+
+Finally, [restart the agent][2].
+
 ## Troubleshooting
 
 Need help? Contact [Datadog Support][3].


### PR DESCRIPTION
### What does this PR do?
Add instruction to get container metadata as tags on the journald logs

### Motivation
In the agent 6.4, it is now possible to get container metadata as tags on journald logs.

### Preview link
https://docs-staging.datadoghq.com/nils/journald-container/integrations/journald/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
