### PR TITLE
Yaxis, fixing parameter values

### DIFF
--- a/content/graphing/miscellaneous/graphingjson.md
+++ b/content/graphing/miscellaneous/graphingjson.md
@@ -284,12 +284,12 @@ Filter configuration allows you to automatically change y-axis bounds based on a
 
 For y-axis filtering, there are two ways to set up the configuration.
 
-To begin, there is a simple configuration where you specify an absolute value or a percentage and all values above the value or all values that sit within the top ##% are cutoff.
+To begin, there is a simple configuration where you specify an absolute value or a percentage and all top values or all values that sit within the top `X%` are cutoff.
 
 Examples:
 
     "yaxis": {
-        "filter": 30 // all values above 30 do not appear
+        "filter": 30 // all top 30 values do not appear
     }
 
     "yaxis": {
@@ -309,7 +309,7 @@ The following shows all data except those with values higher than 15:
 
     "yaxis": {
         "filter": {
-            "above": 15
+            "top": 15
         }
     }
 
@@ -317,7 +317,7 @@ The following hides data points below 2:
 
     "yaxis": {
         "filter": {
-            "below": 2
+            "bottom": 2
         }
     }
 
@@ -337,7 +337,7 @@ Here is a full JSON example:
     "scale": "log"
     "filter": {
          "top": "5%",
-         "below": 15
+         "bottom": 15
      }
   },
 }

--- a/content/graphing/miscellaneous/graphingjson.md
+++ b/content/graphing/miscellaneous/graphingjson.md
@@ -284,7 +284,7 @@ Filter configuration allows you to automatically change y-axis bounds based on a
 
 For y-axis filtering, there are two ways to set up the configuration.
 
-To begin, there is a simple configuration where you specify an absolute value or a percentage and all top values or all values that sit within the top `X%` are cutoff.
+To begin, there is a simple configuration where you specify an absolute value or a percentage. All top values or all values that sit within the top `X%` are cut off.
 
 Examples:
 


### PR DESCRIPTION
## What does this PR do?

Filtering top and bottom can be done via string (percentage) or number, using:

```
- filter: "5%" // shorthand notation
- filter: {
 top: "5%"
}
```
- or -

```
- filter: 19000   // shorthand notation
- filter: {
 top: 19000
}
```

Notations `above` or `below` are just alias of `top` and `bottom`.
