### PR TITLE
remove doc_link usage

### DIFF
--- a/layouts/partials/integrations/integrations.html
+++ b/layouts/partials/integrations/integrations.html
@@ -25,7 +25,8 @@
     {{ $src := (print "integrations_logos/" ($urlname | lower) ".png")}}
     {{ $indx := (index .Site.Data.manifests.images $src )}}
     {{ if $indx }}
-        {{ $.Scratch.Add "ints" (dict "id" $k "name" $v.Params.name "tags" ($.Scratch.Get "curr_categories") "item_class" "" "redirect" $v.Params.doc_link "blurb" $v.Params.short_description "public_title" $v.Params.public_title) }}
+        {{ $doc_link := (print "/integrations/" $v.Params.name "/") }}
+        {{ $.Scratch.Add "ints" (dict "id" $k "name" $v.Params.name "tags" ($.Scratch.Get "curr_categories") "item_class" "" "redirect" $doc_link "blurb" $v.Params.short_description "public_title" $v.Params.public_title) }}
     {{ end }}
 {{ end }}
 


### PR DESCRIPTION
### What does this PR do?
This PR removes the usage of doc_link from integrations so that the new declarative integrations format can be used.

### Motivation
https://trello.com/c/WH86Ingd/2511-remove-doclink-logic-from-the-doc-website

### Preview link
https://docs-staging.datadoghq.com/david.jones/remove-doclink/integrations/

### Additional Notes

