### PR TITLE
Add rollup video and caveats on rollup use in monitors

### DIFF
--- a/content/graphing/miscellaneous/functions.md
+++ b/content/graphing/miscellaneous/functions.md
@@ -341,9 +341,13 @@ The span value is the number of data points. So `median_9()` uses the last 9 dat
 
 ### .rollup()
 
+{{< vimeo 264998150 >}}
+
 Recommended for expert users only. Appending this function to the end of a query allows you to control the number of raw points rolled up into a single point plotted on the graph. The function takes two parameters, method and time: `.rollup(method,time)`
 
 The method can be sum/min/max/count/avg and time is in seconds. You can use either one individually, or both together like `.rollup(sum,120)`. We impose a limit of 350 points per time range. For example, if you're requesting `.rollup(20)` for a month-long window, we return data at a rollup far greater than 20 seconds in order to prevent returning a gigantic number of points.
+
+Note that rollups should usually be avoided in [monitor][7] queries, because of the possibility of misalignment between the rollup interval and the evaluation window of the monitor. The start and end of rollup intervals are aligned to UNIX time, not to the start and end of monitor queries, which means that a monitor may evaluate (and trigger on) an incomplete rollup interval containing only a small sample of data. To avoid this issue, users should delay the evaluation of the monitor by (at least) the length of the rollup interval.
 
 ### .as_count() or as_rate()
 
@@ -429,3 +433,4 @@ Highlight outliers series; see our [Outlier Monitor][3] page for more info.
 [4]: /graphing/faq/as_count_validation
 [5]: /getting_started/from_the_query_to_the_graph/#proceed-to-space-aggregation
 [6]: /help
+[7]: /monitors/monitor_types/metric/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a video about how the rollup function works, as well as some caveats about the function's use, as suggested by @chrismdd 

### Motivation
We created a cool new video to help users understand rollups, and we want them to see it!

### Preview link
https://docs-staging.datadoghq.com/john/add_rollups_video/graphing/miscellaneous/functions/#rollup

### Additional Notes
<!-- Anything else we should know when reviewing?-->
