### PR TITLE
updating the timestamp format for log archives documentation

### DIFF
--- a/content/logs/s3.md
+++ b/content/logs/s3.md
@@ -64,7 +64,7 @@ Within the zipped JSON file, each event's content is formatted as follows:
 ```
 {
     "_id": "123456789abcdefg",
-    "date": "2018-05-15T14:31:16.0002",
+    "date": "2018-05-15T14:31:16.003Z",
     "host": "i-12345abced6789efg",
     "source": "source_name",
     "service": "service_name",


### PR DESCRIPTION
### What does this PR do?
Changes the example timestamp in the documentation of our log archives from `2018-05-15T14:31:16.0002` to `2018-05-15T14:31:16.003Z`. 

### Motivation
We recently changed the timestamp format in our log archives, so this PR is to keep the documentation up to date. 

### Preview link
https://docs-staging.datadoghq.com/estib/update-log-archive-timestamp-format/logs/s3/

### Additional Notes
tanks bro
