### PR TITLE
[agent][windows] adding note for install command-line options

### DIFF
--- a/content/agent/basic_agent_usage/windows.md
+++ b/content/agent/basic_agent_usage/windows.md
@@ -46,6 +46,8 @@ The following configuration command line options are available when installing t
 | `PROXY_USER`      | String | If using a proxy, sets your proxy user. [Learn more on using a proxy with the Datadog Agent][8].                                                                                                              |
 | `PROXY_PASSWORD`  | String | If using a proxy, sets your proxy password. [Learn more on using a proxy with the Datadog Agent][8].                                                                                                          |
 
+Note: if a valid `datadog.yaml` is found, that file will take precedence over specified command-line options. In practice this means, most of these options will only typically apply to fresh installs. Of course you can always modify the relevant options in the `datadog.yaml`.
+
 ## Agent Commands
 
 The execution of the Agent is controlled by the Windows Service Control Manager.

--- a/content/agent/basic_agent_usage/windows.md
+++ b/content/agent/basic_agent_usage/windows.md
@@ -46,7 +46,7 @@ The following configuration command line options are available when installing t
 | `PROXY_USER`      | String | If using a proxy, sets your proxy user. [Learn more on using a proxy with the Datadog Agent][8].                                                                                                              |
 | `PROXY_PASSWORD`  | String | If using a proxy, sets your proxy password. [Learn more on using a proxy with the Datadog Agent][8].                                                                                                          |
 
-Note: if a valid `datadog.yaml` is found, that file will take precedence over specified command-line options. In practice this means, most of these options will only typically apply to fresh installs. Of course you can always modify the relevant options in the `datadog.yaml`.
+Note: if a valid `datadog.yaml` is found, that file takes precedence over specified command-line options. In practice this means, most of these options only typically applies to fresh installs. Of course you can always modify the relevant options in the `datadog.yaml`.
 
 ## Agent Commands
 

--- a/content/agent/basic_agent_usage/windows.md
+++ b/content/agent/basic_agent_usage/windows.md
@@ -46,7 +46,7 @@ The following configuration command line options are available when installing t
 | `PROXY_USER`      | String | If using a proxy, sets your proxy user. [Learn more on using a proxy with the Datadog Agent][8].                                                                                                              |
 | `PROXY_PASSWORD`  | String | If using a proxy, sets your proxy password. [Learn more on using a proxy with the Datadog Agent][8].                                                                                                          |
 
-Note: if a valid `datadog.yaml` is found, that file takes precedence over specified command-line options. In practice this means, most of these options only typically applies to fresh installs. Of course you can always modify the relevant options in the `datadog.yaml`.
+Note: If a valid `datadog.yaml` is found, that file takes precedence over all specified command-line options.
 
 ## Agent Commands
 

--- a/content/agent/basic_agent_usage/windows.md
+++ b/content/agent/basic_agent_usage/windows.md
@@ -46,7 +46,7 @@ The following configuration command line options are available when installing t
 | `PROXY_USER`      | String | If using a proxy, sets your proxy user. [Learn more on using a proxy with the Datadog Agent][8].                                                                                                              |
 | `PROXY_PASSWORD`  | String | If using a proxy, sets your proxy password. [Learn more on using a proxy with the Datadog Agent][8].                                                                                                          |
 
-Note: If a valid `datadog.yaml` is found, that file takes precedence over all specified command-line options.
+Note: If a valid `datadog.yaml` is found and has an `API_KEY` configured, that file takes precedence over all specified command-line options.
 
 ## Agent Commands
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a note regarding command-line options for the windows install.

### Motivation
Some misunderstanding during testing of new proxy settings.

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
