### PR TITLE
fixing typo

### DIFF
--- a/content/integrations/faq/using-rbac-permission-with-your-kubernetes-integration.md
+++ b/content/integrations/faq/using-rbac-permission-with-your-kubernetes-integration.md
@@ -87,7 +87,7 @@ subjects:
   ```
   ...
       spec:
-        serviceAccountName: datadog
+        serviceAccountName: datadog-agent
   ...
   ```
 


### PR DESCRIPTION
### What does this PR do?
Changes `serviceAccountName: datadog` to `serviceAccountName: datadog-agent` in order to match the RBAC in the faq. 

### Motivation
if you just copy/pasted everything in this faq and tried to configure RBAC for kubernetes it wouldn't work, you need the service account name to be `datadog-agent`