### PR TITLE
Fixed environment variable name to start the agent

### DIFF
--- a/content/integrations/cloud_foundry.md
+++ b/content/integrations/cloud_foundry.md
@@ -116,7 +116,7 @@ cf restage <YOUR_APP>
 To start collecting logs from your application in CloudFoundry, the Agent contained in the buildpack needs to be activated and log collection enabled.
 
 ```
-cf set-env $YOUR_APP_NAME RUN_PUPPY true
+cf set-env $YOUR_APP_NAME RUN_AGENT true
 cf set-env $YOUR_APP_NAME DD_LOGS_ENABLED true
 # Disable the Agent core checks to disable system metrics collection
 cf set-env $YOUR_APP_NAME DD_ENABLE_CHECKS false


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Renamed `RUN_PUPPY` in `RUN_AGENT`.

### Motivation
Properly start the agent.
