### PR TITLE
[Agent 6.4] Udpate the article for Agent log only collection

### DIFF
--- a/content/logs/faq/can-the-datadog-agent-be-used-to-send-only-logs.md
+++ b/content/logs/faq/can-the-datadog-agent-be-used-to-send-only-logs.md
@@ -19,14 +19,18 @@ It is not recommended to use the Agent for log collection only. Using metric col
 
 However, it is still possible to configure the Agent to only collect logs.
 
-The Agent sends metrics to a specific url that is specified in the `datadog.yaml` file.
+The Agent sends metrics and other payloads to Datadog. To make sure that the agent only sends logs, it is possible to disable the payloads sent by the agent since the version 6.4 thanks to the following steps:
 
 1. Open `datadog.yaml` ([locate this configuration file on your instance][3])
-2. Edit the `dd_url` attribute to any custom value, for example:
+2. Add the `enable_payloads` attribute as below:
 
-    ```
-    dd_url: xyz
-    ```
+```
+enable_payloads:
+  series: false
+  events: false
+  service_checks: false
+  sketches: false
+```
 
 3. Configure the Agent to collect logs as explained in our [log documentation page][2].
 4. [Restart the Agent][4]

--- a/content/logs/faq/can-the-datadog-agent-be-used-to-send-only-logs.md
+++ b/content/logs/faq/can-the-datadog-agent-be-used-to-send-only-logs.md
@@ -19,20 +19,20 @@ It is not recommended to use the Agent for log collection only. Using metric col
 
 However, it is still possible to configure the Agent to only collect logs.
 
-The Agent sends metrics and other payloads to Datadog. To make sure that the agent only sends logs, it is possible to disable the payloads sent by the agent since the version 6.4 thanks to the following steps:
+The Agent sends metrics and other payloads to Datadog. To make sure that the Agent only sends logs, it is possible to disable payloads sent by the Agent since the Agent version 6.4 with the following steps:
 
-1. Open `datadog.yaml` ([locate this configuration file on your instance][3])
+1. Open the `datadog.yaml` file ([locate this configuration file for your platform][3]).
 2. Add the `enable_payloads` attribute as below:
 
-```
-enable_payloads:
-  series: false
-  events: false
-  service_checks: false
-  sketches: false
-```
+  ```
+  enable_payloads:
+    series: false
+    events: false
+    service_checks: false
+    sketches: false
+  ```
 
-3. Configure the Agent to collect logs as explained in our [log documentation page][2].
+3. Configure the Agent to collect logs as explained in the [log documentation page][2].
 4. [Restart the Agent][4]
 
 ## Further Reading


### PR DESCRIPTION
### What does this PR do?
Update the article to send only logs with a Datadog Agent.

### Motivation
In the version 6.4, there is a new clean way to remove all the metrics, traces and other payloads and this needed to be documented as the old way was not very clean.

### Preview link
<!-- Impacted pages preview links-->

* https://docs-staging.datadoghq.com/nils/agent-collect-logs-only/logs/faq/can-the-datadog-agent-be-used-to-send-only-logs/