### PR TITLE
remove upercase from the uwsgi source value

### DIFF
--- a/content/integrations/uwsgi.md
+++ b/content/integrations/uwsgi.md
@@ -57,7 +57,7 @@ logs:
   - type: file
     path: /var/log/uwsgi/uwsgi.log
     service: <MY_APPLICATION>
-    source: uWSGI
+    source: uwsgi
 ```
 
 Finally, [restart the agent][3].


### PR DESCRIPTION
### What does this PR do?

There was no legitimate reason to have upercase and in case we ever collect metrics for this integration that could break the link.

Must be merged after: https://github.com/DataDog/logs-backend/pull/1453

### Motivation
Lowercase is the logical way to go if we have a choice.

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
Customer impact already handled.