### PR TITLE
Add information for why DB services aren't visible in trace search list

### DIFF
--- a/content/integrations/faq/list-of-api-source-attribute-value.md
+++ b/content/integrations/faq/list-of-api-source-attribute-value.md
@@ -75,6 +75,7 @@ kind: faq
 |Ceph|CEPH|
 |Chatwork|CHATWORK|
 |Chef|CHEF|
+|Circleci|CIRCLECI|
 |Cisco Aci|CISCOACI|
 |Cloud Foundry|CLOUDFOUNDRY|
 |Cloudhealth|CLOUDHEALTH|

--- a/content/tracing/search.md
+++ b/content/tracing/search.md
@@ -33,9 +33,11 @@ further_reading:
 
 Use Trace Search & Analytics to filter application performance metrics and [APM events][8] by user-defined tags. It allows deep exploration of the web requests flowing through your service.
 
-Trace Search & Analytics can be enabled per APM service and per host. A service on which it is enabled exposes all its APM Events to Datadog.
+Trace Search & Analytics can be enabled per APM service and per host. A service on which it is enabled exposes all its APM Events to Datadog. 
 
-In this view you can:
+Downstream services like databases and cache layers won't be in the list of available services (as they don't generate traces on their own), but their information will be picked up by the top level services that call them.
+
+In the Trace Search view you can:
 
 * [Interact with the Time range](#time-range)
 * [Display lists of Traces](#trace-stream)

--- a/content/tracing/search.md
+++ b/content/tracing/search.md
@@ -35,7 +35,7 @@ Use Trace Search & Analytics to filter application performance metrics and [APM 
 
 Trace Search & Analytics can be enabled per APM service and per host. A service on which it is enabled exposes all its APM Events to Datadog. 
 
-Downstream services like databases and cache layers won't be in the list of available services (as they don't generate traces on their own), but their information will be picked up by the top level services that call them.
+Downstream services like databases and cache layers aren't in the list of available services (as they don't generate traces on their own), but their information is picked up by the top level services that call them.
 
 In the Trace Search view you can:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add clarification for why DB / Cache services aren't visible in the list of Trace Search services.

DB and Cache services don't create their own traces, they only generate traces from the upstream service applications that call them. Thus, adding them to the list of services doesn't really make sense, as they're not really services themselves (from an instrumentation viewpoint).

### Motivation
<!-- What inspired you to submit this pull request?-->
Customer confusion about "missing" services available in Trace Search.

### Preview link
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/kirk.kaiser/clarify-trace-search-other-services/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
