### PR TITLE
Prod: fix curl payload for not interpreted variables

### DIFF
--- a/content/api/monitors/code_snippets/api-monitor-bulk-resolve.sh
+++ b/content/api/monitors/code_snippets/api-monitor-bulk-resolve.sh
@@ -5,15 +5,12 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-monitor_id= <YOUR_MONITOR_ID>
-group_1=<YOUR_FIRST_GROUP>
-group_2=<YOUR_FIRST_GROUP>
 
 curl -X POST -H "Content-type: application/json" \
 -d '{
 "resolve": [
-          {"${monitor_id}": "${group_1}"},
-          {"${monitor_id}": "${group_2}"}
+          {"<YOUR_MONITOR_ID>": "<YOUR_FIRST_GROUP>"},
+          {"<YOUR_MONITOR_ID>": "<YOUR_SECOND_GROUP>"}
       ]
 }' \
     "https://app.datadoghq.com/monitor/bulk_resolve?api_key=${api_key}&application_key=${app_key}"


### PR DESCRIPTION
### What does this PR do?
Update the payload of the CURL request to resolve monitors, monitor_id and host group were used as variables and in bash, inside single quotes, the variables are not interpreted

### Motivation
Request came directly from a client
ZD ticket: https://datadog.zendesk.com/agent/tickets/159233

### Preview link
https://docs.datadoghq.com/api/?lang=bash#resolve-monitor
