### PR TITLE
documenting support for log communication via socks5 proxy

### DIFF
--- a/content/logs/log_collection/_index.md
+++ b/content/logs/log_collection/_index.md
@@ -225,7 +225,7 @@ logs:
 
 ### Using a Proxy for Logs
 
-Logs make use of a different set of proxy settings than other data types forwarded by the Datadog Agent. This is due to the fact that logs are currently transported over TCP/SSL, while other features submit data via on HTTPS.
+Logs make use of a different set of proxy settings than other data types forwarded by the Datadog Agent. This is due to the fact that logs are currently transported over TCP/SSL, while other features submit data via HTTPS.
 
 To configure your Datadog Agent to forward logs through a proxy server, add these settings to the `datadog.yaml` configuration file:
 
@@ -238,7 +238,7 @@ logs_config:
 
 Then configure your proxy to forward logs to the endpoint `agent-intake.logs.datadoghq.com` on port `10516` with SSL activated. 
 
-With the most recent version of the datadog agent, you can alternatively send your logs to your Datadog account via a SOCKS5 proxy server. To do so, use the following settings in your `datadog.yaml` configuration file:
+With the most recent version of the datadog Agent, you can alternatively send your logs to your Datadog account via a SOCKS5 proxy server. To do so, use the following settings in your `datadog.yaml` configuration file:
 
 ```
 logs_config:

--- a/content/logs/log_collection/_index.md
+++ b/content/logs/log_collection/_index.md
@@ -225,9 +225,9 @@ logs:
 
 ### Using a Proxy for Logs
 
-Logs make use of a different set of proxy settings than other data types forwarded by the Datadog Agent. This is due to logs presently being transported over TCP/SSL, while other features submit data via on HTTPS.
+Logs make use of a different set of proxy settings than other data types forwarded by the Datadog Agent. This is due to the fact that logs are currently transported over TCP/SSL, while other features submit data via on HTTPS.
 
-To configure your Datadog Agent to forward logs through a proxy server, add these settings to the `datadog.yaml` configuration file:"
+To configure your Datadog Agent to forward logs through a proxy server, add these settings to the `datadog.yaml` configuration file:
 
 ```
 logs_config:
@@ -237,6 +237,13 @@ logs_config:
 ```
 
 Then configure your proxy to forward logs to the endpoint `agent-intake.logs.datadoghq.com` on port `10516` with SSL activated. 
+
+With the most recent version of the datadog agent, you can alternatively send your logs to your Datadog account via a SOCKS5 proxy server. To do so, use the following settings in your `datadog.yaml` configuration file:
+
+```
+logs_config:
+  socks5_proxy_address: <MY_SOCKS5_PROXY_URL>:<MY_SOCKS5_PROXY_PORT>
+```
 
 [Refer to our Agent proxy documentation page to learn how to forward your metrics with a proxy][8].
 


### PR DESCRIPTION
### What does this PR do?
Adds documentation for use of SOCKS5 proxy for communication of logs to datadog via the datadog agent

### Motivation
This proxy support was added in agent 6.4, which came out last week.

### Preview link
https://docs-staging.datadoghq.com/estib/logs-socks5-proxy/logs/log_collection/#using-a-proxy-for-logs

### Additional Notes
Thanks
