### PR TITLE
Adding trailing note for slack channel

### DIFF
--- a/content/monitors/notifications.md
+++ b/content/monitors/notifications.md
@@ -302,6 +302,9 @@ For user groups, use `<!subteam^GROUP_ID|GROUP_NAME>`. To find the `GROUP_ID`, [
 <!subteam^12345|testers>
 ```
 
+Note: Trailing special characters in a channel name are unsupported for the Slack @-notifications. 
+e.g. `@----critical_alerts` works, but `@--critical_alerts--` won't receive any notifications.
+
 #### Using message template variables to dynamically create @-mentions
 
 Use message template variables within a monitor message to dynamically build **@-mentions**.


### PR DESCRIPTION
trailing special characters aren't supported for the notification 

e.g. `@--critical_alerts` is a valid notification, but `--critical_alerts--` is invalid. 