### PR TITLE
Fixing description parameter

### DIFF
--- a/content/api/timeboards/timeboards_update.md
+++ b/content/api/timeboards/timeboards_update.md
@@ -11,7 +11,7 @@ external_redirect: /api/#update-a-timeboard
 
 * **`title`** [*required*]:  
     The name of the dashboard.
-* **`description`** [*optional*]:  
+* **`description`** [*required*]:  
     A description of the dashboard's contents.
 * **`graphs`** [*required*]:  
     A list of graph definitions. Graph definitions follow this form:


### PR DESCRIPTION
Under "Update a Timeboard" description is listed as an "optional" argument but should be listed as a "required" argument.