### PR TITLE
Cecilia/network overhead

### DIFF
--- a/content/agent/_index.md
+++ b/content/agent/_index.md
@@ -85,6 +85,12 @@ With:
 * Network bandwidth: \~ 1900 B/s &#9660; | 800 B/s &#9650;
 * Disk: Linux 120MB | Windows 60MB
 
+Caveats:
+
+* Enabling integrations may increase the Agent's resource consumption.
+* Enabling JVM checks forces the Agent to use more memory, depending on the number of beans exposed by the monitored JVMs.
+* Enabling the trace/process/logging Agents may increase resource consumption.
+
 ## CLI
 
 The new command line interface for the Agent is sub-command based:

--- a/content/agent/_index.md
+++ b/content/agent/_index.md
@@ -72,6 +72,19 @@ With:
 
 **Note**: On Windows, `datadog.conf` is automatically upgraded to `datadog.yaml` on upgrade.
 
+## Resource overhead
+
+### Agent v6
+* CPU: \~ 0.12% of the CPU used on average
+* Memory: \~ 55Mo of RAM used
+* Network bandwidth: \~ 86 B/s &#9660; | 260 B/s &#9650;
+
+### Agent v5
+* CPU: \~ 0.35% of the CPU used on average
+* Memory: \~ 115Mo of RAM used
+* Network bandwidth: \~ 1900 B/s &#9660; | 800 B/s &#9650;
+* Disk: Linux 120MB | Windows 60MB
+
 ## CLI
 
 The new command line interface for the Agent is sub-command based:
@@ -122,6 +135,7 @@ Once the Agent is running, use the `datadog-agent launch-gui` command to launch 
 2. The GUI will only be launched if the user launching it has the correct user permissions. If you are able to open `datadog.yaml`, you are able to use the GUI.
 
 3. For security reasons, the GUI can **only** be accessed from the local network interface (```localhost```/```127.0.0.1```), so you must be on the same host that the Agent is running to use it. In other words, you can't run the Agent on a VM or a container and access it from the host machine.
+
 
 ## Supported OSs versions
 

--- a/content/agent/_index.md
+++ b/content/agent/_index.md
@@ -136,7 +136,6 @@ Once the Agent is running, use the `datadog-agent launch-gui` command to launch 
 
 3. For security reasons, the GUI can **only** be accessed from the local network interface (```localhost```/```127.0.0.1```), so you must be on the same host that the Agent is running to use it. In other words, you can't run the Agent on a VM or a container and access it from the host machine.
 
-
 ## Supported OSs versions
 
 ### Agent v6

--- a/content/getting_started/custom_metrics.md
+++ b/content/getting_started/custom_metrics.md
@@ -108,6 +108,17 @@ Ultimately, you’ll have 13 metrics using the following query: `count:service.r
 
 {{< img src="getting_started/custom_metrics/count_of_metrics.png" alt="count_of_metrics" responsive="true" style="width:70%;">}}
 
+## Overhead
+
+If you're submitting metrics directly to the Datadog API *without* using [DogStatsD][1], expect:
+
+* 64 bits for the timestamp
+* 64 bits for the value
+* 20 bytes for the metric names
+* 50 bytes for the timeseries
+
+The full payload is approximately \~ 100 bytes. However, with the DogStatsD API, compression is applied and the typical payload is very small.
+
 ## Custom metrics best practices
 
 * For querying purposes, we encourage you to limit the number of tags applied to 1,000 tags per metric. Going over this amount [slows down the graphs][8] in your dashboards due to the increase in cardinality.


### PR DESCRIPTION
Adding info on Agent resource overhead as well as network overhead on sending custom metrics. Card only requested network overhead for Agent, but as the CPU and memory usage is right there, I just put those in as well for completeness.

Sources:
https://help.datadoghq.com/hc/en-us/articles/203034929-What-is-the-Datadog-Agent-What-resources-does-it-consume-
https://help.datadoghq.com/hc/en-us/articles/203765485-How-do-I-submit-custom-metrics-What-s-their-overhead-
