### PR TITLE
fixing public id api

### DIFF
--- a/content/api/org/code_snippets/api-org-get.sh
+++ b/content/api/org/code_snippets/api-org-get.sh
@@ -1,4 +1,4 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -X GET "https://app.datadoghq.com/api/v1/org?api_key=<api_key_here>&application_key=<app_key_here>"
+curl -X GET "https://api.datadoghq.com/api/v1/org?api_key=<api_key_here>&application_key=<app_key_here>"

--- a/content/api/org/code_snippets/api-org-get.sh
+++ b/content/api/org/code_snippets/api-org-get.sh
@@ -1,4 +1,4 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -X GET "https://api.datadoghq.com/api/v1/org?api_key=<api_key_here>&application_key=<app_key_here>"
+curl -X GET "https://api.datadoghq.com/api/v1/org?api_key=${api_key}&application_key=${app_key}"

--- a/content/api/org/code_snippets/api-org-get.sh
+++ b/content/api/org/code_snippets/api-org-get.sh
@@ -1,5 +1,4 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
-public_id=axd2s
 
-curl -X GET "https://api.datadoghq.com/api/v1/org/${public_id}?api_key=${api_key}&application_key=${app_key}"
+curl -X GET "https://app.datadoghq.com/api/v1/org?api_key=<api_key_here>&application_key=<app_key_here>"

--- a/content/api/org/org_get_code.md
+++ b/content/api/org/org_get_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#get-organization
 ---
 
 ##### Signature
-`GET https://api.datadoghq.com/api/v1/org/:public_id`
+`GET https://api.datadoghq.com/api/v1/org`
 ##### Example Request
 {{< code-snippets basename="api-org-get" >}}
 ##### Example Response


### PR DESCRIPTION
### What does this PR do?
API docs had it so that you needed to supply the public_id in order to get your org's public_id. This PR changes that. Have independently verified that this works.

### Motivation
Request from support.
