### PR TITLE
Update api-metrics-post.rb

### DIFF
--- a/content/api/metrics/code_snippets/api-metrics-post.rb
+++ b/content/api/metrics/code_snippets/api-metrics-post.rb
@@ -6,7 +6,7 @@ api_key = "<YOUR_API_KEY>"
 dog = Dogapi::Client.new(api_key)
 
 # Submit one metric value.
-dog.emit_point('some.metric.name', 50.0, : host => "my_host.example.com")
+dog.emit_point('some.metric.name', 50.0, :host => "my_host.example.com")
 
 # Submit multiple metric values
 points = [
@@ -14,7 +14,7 @@ points = [
     [Time.now + 10, 10.0],
     [Time.now + 20, 20.0]
 ]
-dog.emit_points('some.metric.name', points, : tags => ["version:1"])
+dog.emit_points('some.metric.name', points, :tags => ["version:1"])
 
 # Emit differents metrics in a single request to be more efficient
 dog.batch_metrics do


### PR DESCRIPTION

### What does this PR do?
The `post metrics to the API` Ruby example have incorrect spaces for the `host` and `tag` hashes. This PR removes those extra spaces.

### Motivation
Others in the DD community might run into an issue with some **copy/pasta** and run into an issue caused by the spaces

### Preview link
Not really applicable, given the scope of two `' '` being removed :)

### Additional Notes
NA
