### PR TITLE
Update download link for dd-java-agent

### DIFF
--- a/content/tracing/setup/java.md
+++ b/content/tracing/setup/java.md
@@ -30,7 +30,7 @@ To begin tracing applications written in any language, first [install and config
 Next, download `dd-java-agent.jar` that contains the Agent class files:
 
 ```shell
-wget -O dd-java-agent.jar 'https://search.maven.org/remote_content?g=com.datadoghq&a=dd-java-agent&v=LATEST'
+wget -O dd-java-agent.jar 'https://search.maven.org/classic/remote_content?g=com.datadoghq&a=dd-java-agent&v=LATEST'
 ```
 
 Finally, add the following JVM argument when starting your application in your IDE, your Maven or Gradle application script, or your `java -jar` command:


### PR DESCRIPTION
The Original link: https://search.maven.org/remote_content?g=com.datadoghq&a=dd-java-agent&v=LATEST is now giving 404 error. Issue is that sonatype has updated their site and broke our “link”

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
