### PR TITLE
updating deprecated method name

### DIFF
--- a/content/integrations/faq/why-isn-t-elasticsearch-sending-all-my-metrics.md
+++ b/content/integrations/faq/why-isn-t-elasticsearch-sending-all-my-metrics.md
@@ -4,7 +4,7 @@ kind: faq
 ---
 
 If you've configured the Elasticsearch integration but feel you are not being sent all the available metrics, it may be because your cluster is hosted externally.
-If this is the case, change your `elastic.yaml` configuration file to include `is_external: true`. This parameter defaults to false for customers pointing to localhost.
+If this is the case, change your `elastic.yaml` configuration file to include `cluster_stats: true`. This parameter defaults to false for customers pointing to localhost.
 
 Make sure to [restart your Agent][1] after updating this configuration, and you should be seeing more metrics coming in from this configuration.
 


### PR DESCRIPTION
### What does this PR do?
`is_external` is deprecated, should be updated to `cluster_stats`

### Motivation
trello request
