### PR TITLE
[prod] update SOCKS5 proxy config

### DIFF
--- a/content/logs/log_collection/_index.md
+++ b/content/logs/log_collection/_index.md
@@ -255,7 +255,7 @@ logs_config:
 
 Then configure your proxy to forward logs to the endpoint `agent-intake.logs.datadoghq.com` on port `10516` with SSL activated. 
 
-With the most recent version of the datadog Agent, you can alternatively send your logs to your Datadog account via a SOCKS5 proxy server. To do so, use the following settings in your `datadog.yaml` configuration file:
+With Datadog Agent >= 6.4.1, you can alternatively send your logs to your Datadog account via a SOCKS5 proxy server. To do so, use the following settings in your `datadog.yaml` configuration file:
 
 ```
 logs_config:


### PR DESCRIPTION
### What does this PR do?
Thomson Reuters reached out regarding some confusion using SOCKS5 proxy when on v6.3.x. Requested v6.4.1 to be explicitly stated. For reference: https://datadog.zendesk.com/agent/tickets/161515

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->