### PR TITLE
Removed Windows 2003 reference

### DIFF
--- a/content/agent/basic_agent_usage/windows.md
+++ b/content/agent/basic_agent_usage/windows.md
@@ -190,8 +190,6 @@ If you're still having trouble, [our support team][3] will be glad to provide fu
 
 Logs are available at:
 
-  * For Windows Server 2003, XP or older:
-`C:\Documents and Settings\All Users\Application Data\Datadog\logs\ddagent.log`
   * For Windows Server 2008, Vista and newer:
 `C:\ProgramData\datadog\logs\ddagent.log`
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes reference to Windows 2003

### Motivation
It's not supported

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
