### PR TITLE
adds note about multiple grok parsing rules to parsing docs

### DIFF
--- a/content/logs/processing/parsing.md
+++ b/content/logs/processing/parsing.md
@@ -49,6 +49,9 @@ You would have at the end this structured log:
 
 {{< img src="logs/processing/parsing/parsing_example_1.png" alt="Parsing example 1" responsive="true" style="width:80%;">}}
 
+
+**Note**: If you have multiple parsing rules in a single grok parser only one can match any given log.  The first one that matches from top to bottom is the one that does the parsing. 
+
 ## Matcher
 
 Here is the list of all the matchers natively implemented by Datadog:

--- a/content/logs/processing/parsing.md
+++ b/content/logs/processing/parsing.md
@@ -49,7 +49,6 @@ You would have at the end this structured log:
 
 {{< img src="logs/processing/parsing/parsing_example_1.png" alt="Parsing example 1" responsive="true" style="width:80%;">}}
 
-
 **Note**: If you have multiple parsing rules in a single Grok parser, only one can match any given log. The first one that matches from top to bottom is the one that does the parsing. 
 
 ## Matcher

--- a/content/logs/processing/parsing.md
+++ b/content/logs/processing/parsing.md
@@ -50,7 +50,7 @@ You would have at the end this structured log:
 {{< img src="logs/processing/parsing/parsing_example_1.png" alt="Parsing example 1" responsive="true" style="width:80%;">}}
 
 
-**Note**: If you have multiple parsing rules in a single grok parser only one can match any given log.  The first one that matches from top to bottom is the one that does the parsing. 
+**Note**: If you have multiple parsing rules in a single Grok parser, only one can match any given log. The first one that matches from top to bottom is the one that does the parsing. 
 
 ## Matcher
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds a note about about having multiple parsing rules in a single grok parser.  

### Motivation
<!-- What inspired you to submit this pull request?-->

A support ticket that generated an escalation

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
