### PR TITLE
clean up per-platform Agent docs

### DIFF
--- a/content/agent/basic_agent_usage/amazonlinux.md
+++ b/content/agent/basic_agent_usage/amazonlinux.md
@@ -108,7 +108,6 @@ DD_API_KEY=YOUR_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/Dat
 #### Manual install
 
 1. Set up Datadog's Yum repo on your system by creating `/etc/yum.repos.d/datadog.repo` with the contents:
-
     ```ini
     [datadog]
     name=Datadog, Inc.
@@ -118,7 +117,7 @@ DD_API_KEY=YOUR_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/Dat
     gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
     ```
 
-2. Update your local yum repo and install the Agent:
+2. Update your local Yum repo and install the Agent:
     ```
     sudo yum makecache
     sudo yum install datadog-agent
@@ -129,43 +128,67 @@ DD_API_KEY=YOUR_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/Dat
     sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
     ```
 
-4. Re-start the Agent for Amazon Linux 2.0:
+4. (Re-)start the Agent:
+
+    * Amazon Linux 2.0:
     ```
     sudo systemctl restart datadog-agent.service
     ```
 
-5. Re-start the Agent for Amazon Linux 1.0:
+    * Amazon Linux 1.0:
     ```
     sudo initctl start datadog-agent
     ```
 
 ### Downgrade to Agent v5
 
-1. Add HTTPS compatibility to `apt`:
-    ```
-    sudo apt-get update
-    sudo apt-get install apt-transport-https
-    ```
-
-2. Remove the Agent v6 repository and ensure that the `stable` repository is present:
+1. Remove the Agent 6 Yum repo:
     ```shell
-    sudo rm /etc/yum.repos.d/datadog.repo [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
-    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE
+    rm /etc/yum.repos.d/datadog.repo [ ! -f /etc/yum.repos.d/datadog.repo ] && echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/rpm/x86_64/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public\n       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public' | sudo tee /etc/yum.repos.d/datadog.repo
     ```
 
-3. Update `apt` and downgrade the Agent:
+2. Update your local Yum cache and downgrade the Agent:
+    ```shell
+    sudo yum clean expire-cache metadata
+    sudo yum check-update
+    sudo yum remove datadog-agent
+    sudo yum install datadog-agent
     ```
-    sudo apt-get update
-    sudo apt-get remove datadog-agent
-    sudo apt-get install datadog-agent
+
+3. Back-sync configurations and AutoDiscovery templates (optional):
+
+    If you have made any changes to your configurations to support new Agent v6-only options, these will need to be reverted manually to something v5-compatible.
+
+4. Back-sync custom Agent checks (optional):
+
+    If you made any changes or added any new custom Agent checks while testing Agent 6 you might want to enable them back on Agent 5. You only need to back-sync checks which have been modified.
+
+    ```shell
+    sudo -u dd-agent -- cp /etc/datadog-agent/checks.d/<check>.py /etc/dd-agent/checks.d/
+    ```
+
+5. (Re-)start the Agent:
+
+    * Amazon Linux 2.0:
+    ```
+    sudo systemctl restart datadog-agent.service
+    ```
+
+    * Amazon Linux 1.0:
+    ```
+    sudo initctl start datadog-agent
+    ```
+
+6. Clean out /etc/datadog-agent (optional):
+    ```shell
+    sudo -u dd-agent -- rm -rf /etc/datadog-agent/
     ```
 
 ## Uninstall the Agent
 
 To uninstall the Agent, run: 
-
 ```
-sudo apt-get --purge remove datadog-agent -y
+sudo yum remove datadog-agent
 ```
 
 ## Further Reading

--- a/content/agent/basic_agent_usage/amazonlinux.md
+++ b/content/agent/basic_agent_usage/amazonlinux.md
@@ -142,32 +142,22 @@ DD_API_KEY=YOUR_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/Dat
 
 ### Downgrade to Agent v5
 
+Note that v6-specific changes to your configuration will *not* work after downgrading. You will need to manually address any incompatible configuraton or implementation issues.
+
 1. Remove the Agent 6 Yum repo:
     ```shell
     rm /etc/yum.repos.d/datadog.repo [ ! -f /etc/yum.repos.d/datadog.repo ] && echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/rpm/x86_64/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public\n       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public' | sudo tee /etc/yum.repos.d/datadog.repo
     ```
 
 2. Update your local Yum cache and downgrade the Agent:
-    ```shell
+    ```
     sudo yum clean expire-cache metadata
     sudo yum check-update
     sudo yum remove datadog-agent
     sudo yum install datadog-agent
     ```
 
-3. Back-sync configurations and AutoDiscovery templates (optional):
-
-    If you have made any changes to your configurations to support new Agent v6-only options, these will need to be reverted manually to something v5-compatible.
-
-4. Back-sync custom Agent checks (optional):
-
-    If you made any changes or added any new custom Agent checks while testing Agent 6 you might want to enable them back on Agent 5. You only need to back-sync checks which have been modified.
-
-    ```shell
-    sudo -u dd-agent -- cp /etc/datadog-agent/checks.d/<check>.py /etc/dd-agent/checks.d/
-    ```
-
-5. (Re-)start the Agent:
+3. (Re-)start the Agent:
 
     * Amazon Linux 2.0:
     ```
@@ -177,11 +167,6 @@ DD_API_KEY=YOUR_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/Dat
     * Amazon Linux 1.0:
     ```
     sudo initctl start datadog-agent
-    ```
-
-6. Clean out /etc/datadog-agent (optional):
-    ```shell
-    sudo -u dd-agent -- rm -rf /etc/datadog-agent/
     ```
 
 ## Uninstall the Agent

--- a/content/agent/basic_agent_usage/centos.md
+++ b/content/agent/basic_agent_usage/centos.md
@@ -18,16 +18,14 @@ further_reading:
 
 ## Overview
 
-This page outlines the basic features of the Datadog Agent. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration page][1].
-
-The process to upgrade from the previous version of the Agent is to re-run the installation.
+This page outlines the basic features of the Datadog Agent for Amazon Linux. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
 ## Commands
 
-Only the _lifecycle commands_ (i.e. `start`/`stop`/`restart`/`status` on the Agent service) run via `sudo service`/`sudo systemctl`. All other commands must be run via the `datadog-agent` command.
+In Agent v6, the service manager provided by the operating system is responsible for the Agent lifecycle, while other commands must be run via the Agent binary directly. In Agent v5, almost everything is done via the service manager.
 
 | Agent v5                                          | Agent v6                                               | Notes                              |
-| -----------------------------------------------   | ---------------------------------------                | -----------------------------      |
+| ------------------------------------------------- | ------------------------------------------------------ | ---------------------------------- |
 | `sudo service datadog-agent start`                | `sudo service datadog-agent start`                     | Start Agent as a service           |
 | `sudo service datadog-agent stop`                 | `sudo service datadog-agent stop`                      | Stop Agent running as a service    |
 | `sudo service datadog-agent restart`              | `sudo service datadog-agent restart`                   | Restart Agent running as a service |
@@ -37,91 +35,89 @@ Only the _lifecycle commands_ (i.e. `start`/`stop`/`restart`/`status` on the Age
 | `sudo service datadog-agent`                      | `sudo datadog-agent --help`                            | Display command usage              |
 | `sudo -u dd-agent -- dd-agent check <check_name>` | `sudo -u dd-agent -- datadog-agent check <check_name>` | Run a check                        |
 
-More information about the metrics, events, and service checks for an [Integrations][2] can be retrieved with the `check` command:
-```
-sudo service datadog-agent check [integration]
-```
-
-Add the `check_rate` argument to get the most recent values for rates:
-```
-sudo service datadog-agent check [integration] check_rate
-```
-
 **Note**: If `service` is not available on your system, use:
 
-* `upstart`-based systems: `sudo initctl start/stop/restart datadog-agent`
-* `systemd`-based systems: `sudo systemctl start/stop/restart datadog-agent`
+* `upstart`-based systems: `initctl`
+* `systemd`-based systems: `systemctl`
 
 [Learn more about Service lifecycle commands][4]
 
 ## Configuration
 
-The configuration files and folders for the Agent are located at:
+The configuration files and folders for for the Agent are located in:
 
-| Agent v5                                  |  Agent v6                          |
-|:-----|:----|
-|`/etc/dd-agent/datadog.conf`| `/etc/datadog-agent/datadog.yaml` |
+| Agent v5                     | Agent v6                          |
+| :-----                       | :----                             |
+| `/etc/dd-agent/datadog.conf` | `/etc/datadog-agent/datadog.yaml` |
 
 Configuration files for [Integrations][2]:
 
-| Agent v5                                  |  Agent v6                          |
-|:-----|:----|
-|`/etc/dd-agent/conf.d/`|`/etc/datadog-agent/conf.d/`|
+| Agent v5                | Agent v6                     |
+| :-----                  | :----                        |
+| `/etc/dd-agent/conf.d/` | `/etc/datadog-agent/conf.d/` |
+
 
 ## Troubleshooting
 
-Run the info or status command to see the state of the Agent. Agent logs are located in the `/var/log/datadog/` directory:
+Run the `status` (or `info` in v5) command to see the state of the Agent. The Agent logs are located in the `/var/log/datadog/` directory:
 
 * For Agent v6, all logs are consolidated in `agent.log`
 * For Agent v5, logs are split into:
-    * `datadog-supervisord.log`
-    * `collector.log`
-    * `dogstatsd.log`
-    * `forwarder.log`
+  * `datadog-supervisord.log`
+  * `collector.log`
+  * `dogstatsd.log`
+  * `forwarder.log`
 
 If you're still having trouble, [our support team][3] will be glad to provide further assistance.
+
+## Adding a custom Python package to the Agent
+
+The Agent contains an embedded Python environment at `/opt/datadog-agent/embedded/`. Common binaries such as `python` and `pip` are contained within `/opt/datadog-agent/embedded/bin/`.
+
+### Installing Python libraries
+
+Run the embedded `pip` via the Agent:
+```
+sudo -u dd-agent -- /opt/datadog-agent/embedded/bin/pip install <package_name>
+```
 
 ## Switch between Agent v5 and v6
 
 ### Upgrade to Agent 6
 
-A script is available to automatically install or upgrade the new Agent. It sets up the repos and installs the package for you; in case of upgrade, the import tool also searches for an existing `datadog.conf` from a prior version and converts Agent and checks configurations according to the new file format and filesystem layout.
+A script is available to automatically install or upgrade to the new Agent. It sets up the package repositories and installs the Agent package for you. When upgrading, the import tool also searches for an existing `datadog.conf` from a prior version, and converts Agent and Check configurations according to the new v6 format.
 
 #### One-step install
 
 ##### Upgrade
 
-The Agent v6 installer can automatically convert v5 configurations during upgrade:
-
-```bash
+The Agent v6 installer can automatically convert v5 configurations during the upgrade:
+```shell
 DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
 ```
 
-**Note**: The import process won't automatically move custom Agent checks. This is by design as we cannot guarantee full backwards compatibility out of the box.
+**Note:** The import process won't automatically move **custom** Agent checks. This is by design as we cannot guarantee full backwards compatibility out of the box.
 
 ##### Fresh install
 
-To install on a clean box (or have an existing Agent 5 install from which you do not wish to import the configuration) provide an API key:
-
-```bash
+This is very similar to the upgrade method above, except instead of specifying the upgrade flag, you must supply your API key. This method will also work on Agent v5 machines, however the existing configuration will *not* be converted.
+```shell
 DD_API_KEY=YOUR_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
 ```
 
 #### Manual install
 
 1. Set up Datadog's Yum repo on your system by creating `/etc/yum.repos.d/datadog.repo` with the contents:
-
     ```ini
     [datadog]
-    name = Datadog, Inc.
-    baseurl = https://yum.datadoghq.com/stable/6/x86_64/
+    name=Datadog, Inc.
+    baseurl=https://yum.datadoghq.com/stable/6/x86_64/
     enabled=1
     gpgcheck=1
     gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
     ```
 
 2. Update your local Yum repo and install the Agent:
-
     ```
     sudo yum makecache
     sudo yum remove datadog-agent-base
@@ -129,12 +125,11 @@ DD_API_KEY=YOUR_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/Dat
     ```
 
 3. Copy the example config into place and plug in your API key:
-
-    ```bash
+    ```shell
     sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
     ```
 
-4. Re-start the Agent.
+4. Restart the Agent.
 
     * Centos 7 and above:
     ```
@@ -149,21 +144,18 @@ DD_API_KEY=YOUR_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/Dat
 ### Downgrade to Agent v5
 
 1. Add HTTPS compatibility to `apt`:
-
     ```
     sudo apt-get update
     sudo apt-get install apt-transport-https
     ```
 
 2. Remove the Agent v6 repository and ensure that the `stable` repo is present:
-
-    ```bash
+    ```shell
     sudo rm /etc/yum.repos.d/datadog.repo [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
     sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE
     ```
 
 3. Update `apt` and downgrade the Agent:
-
     ```
     sudo apt-get update
     sudo apt-get remove datadog-agent
@@ -175,13 +167,11 @@ DD_API_KEY=YOUR_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/Dat
 To uninstall the Agent, run: 
 
 * For CentOS 5:
-
     ```
     $ sudo yum remove datadog-agent-base
     ```
 
 * For CentOS 6:
-
     ```
     $ sudo yum remove datadog-agent
     ```

--- a/content/agent/basic_agent_usage/centos.md
+++ b/content/agent/basic_agent_usage/centos.md
@@ -129,7 +129,7 @@ DD_API_KEY=YOUR_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/Dat
     sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
     ```
 
-4. Restart the Agent.
+4. Restart the Agent:
 
     * Centos 7 and above:
     ```
@@ -138,28 +138,34 @@ DD_API_KEY=YOUR_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/Dat
 
     * Centos 6:
     ```
-    sudo initctl start datadog-agent
+    sudo initctl restart datadog-agent
     ```
 
 ### Downgrade to Agent v5
 
-1. Add HTTPS compatibility to `apt`:
-    ```
-    sudo apt-get update
-    sudo apt-get install apt-transport-https
-    ```
-
-2. Remove the Agent v6 repository and ensure that the `stable` repo is present:
+1. Remove the Agent v6 repository and ensure that the `stable` repo is present:
     ```shell
     sudo rm /etc/yum.repos.d/datadog.repo [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
     sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE
     ```
 
-3. Update `apt` and downgrade the Agent:
+2. Update your local Yum cache and downgrade the Agent:
     ```
-    sudo apt-get update
-    sudo apt-get remove datadog-agent
-    sudo apt-get install datadog-agent
+    sudo yum clean expire-cache metadata
+    sudo yum check-update
+    sudo yum remove datadog-agent
+    sudo yum install datadog-agent
+    ```
+3. Restart the Agent:
+
+    * Centos 7 and above:
+    ```
+    sudo systemctl restart datadog-agent.service
+    ```
+
+    * Centos 6:
+    ```
+    sudo initctl restart datadog-agent
     ```
 
 ## Uninstall the Agent
@@ -168,12 +174,12 @@ To uninstall the Agent, run:
 
 * For CentOS 5:
     ```
-    $ sudo yum remove datadog-agent-base
+    sudo yum remove datadog-agent-base
     ```
 
 * For CentOS 6:
     ```
-    $ sudo yum remove datadog-agent
+    sudo yum remove datadog-agent
     ```
 
 ## Further Reading

--- a/content/agent/basic_agent_usage/deb.md
+++ b/content/agent/basic_agent_usage/deb.md
@@ -18,16 +18,14 @@ further_reading:
 
 ## Overview
 
-This page outlines the basic features of the Datadog Agent. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
-
-The process to upgrade from the previous version of the Agent is to re-run the installation.
+This page outlines the basic features of the Datadog Agent for Amazon Linux. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
 ## Commands
 
-Datadog Agent has some commands and only the _lifecycle commands_ (i.e. `start`/`stop`/`restart`/`status` on the Agent service) should be run with `sudo service`/`sudo systemctl`, all other commands need to be run with the `datadog-agent` command.
+In Agent v6, the service manager provided by the operating system is responsible for the Agent lifecycle, while other commands must be run via the Agent binary directly. In Agent v5, almost everything is done via the service manager.
 
 | Agent v5                                          | Agent v6                                               | Notes                              |
-| -----------------------------------------------   | ---------------------------------------                | -----------------------------      |
+| ------------------------------------------------- | ------------------------------------------------------ | ---------------------------------- |
 | `sudo service datadog-agent start`                | `sudo service datadog-agent start`                     | Start Agent as a service           |
 | `sudo service datadog-agent stop`                 | `sudo service datadog-agent stop`                      | Stop Agent running as a service    |
 | `sudo service datadog-agent restart`              | `sudo service datadog-agent restart`                   | Restart Agent running as a service |
@@ -37,25 +35,16 @@ Datadog Agent has some commands and only the _lifecycle commands_ (i.e. `start`/
 | `sudo service datadog-agent`                      | `sudo datadog-agent --help`                            | Display command usage              |
 | `sudo -u dd-agent -- dd-agent check <check_name>` | `sudo -u dd-agent -- datadog-agent check <check_name>` | Run a check                        |
 
-More information about the metrics, events, and service checks for an [Integrations][2] can be retrieved with the check command:
-```shell
-sudo service datadog-agent check [integration]
-```
+**Note**: If `service` is not available on your system, use:
 
-Add the check_rate argument to get the most recent values for rates:
-```shell
-sudo service datadog-agent check [integration] check_rate
-```
-
-**NB**: If `service` is not available on your system, use:
-
-* on `systemd`-based systems: `sudo systemctl start/stop/restart datadog-agent`
+* `upstart`-based systems: `initctl`
+* `systemd`-based systems: `systemctl`
 
 [Learn more about Service lifecycle commands][4]
 
 ## Configuration
 
-The configuration files and folders for the Agent are located at:
+The configuration files and folders for for the Agent are located in:
 
 | Agent v5                     | Agent v6                          |
 | :-----                       | :----                             |
@@ -67,111 +56,118 @@ Configuration files for [Integrations][2]:
 | :-----                  | :----                        |
 | `/etc/dd-agent/conf.d/` | `/etc/datadog-agent/conf.d/` |
 
+
 ## Troubleshooting
 
-Run the info or status command to see the state of the Agent.
-The Agent logs are located in the `/var/log/datadog/` directory:
+Run the `status` (or `info` in v5) command to see the state of the Agent. The Agent logs are located in the `/var/log/datadog/` directory:
 
-* For Agent v6 all logs are in the `agent.log` file
-* For Agent v5 logs are in:
-    
-    * `datadog-supervisord.log`
-    * `collector.log`
-    * `dogstatsd.log`
-    * `forwarder.log`
+* For Agent v6, all logs are consolidated in `agent.log`
+* For Agent v5, logs are split into:
+  * `datadog-supervisord.log`
+  * `collector.log`
+  * `dogstatsd.log`
+  * `forwarder.log`
 
 If you're still having trouble, [our support team][3] will be glad to provide further assistance.
 
-## Switch between Agent v5 and v6
-### Upgrade to Agent 6
+## Adding a custom Python package to the Agent
 
-A script is available to automatically install or upgrade the new Agent. It sets up the repos and installs the package for you; in case of upgrade, the import tool also searches for an existing `datadog.conf` from a prior version and converts Agent and checks configurations according to the new file format and filesystem layout.
-#### One-step install
-##### To Upgrade
+The Agent contains an embedded Python environment at `/opt/datadog-agent/embedded/`. Common binaries such as `python` and `pip` are contained within `/opt/datadog-agent/embedded/bin/`.
 
-The Agent 6.x installer can automatically convert your 5.x style Agent configuration at upgrade:  
+### Installing Python libraries
 
-```shell
- DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
+Run the embedded `pip` via the Agent:
+```
+sudo -u dd-agent -- /opt/datadog-agent/embedded/bin/pip install <package_name>
 ```
 
-**Note:** the import process won't automatically move custom Agent checks, this is by design since we cannot guarantee full backwards compatibility out of the box.
+## Switch between Agent v5 and v6
 
-##### To Install Fresh
+### Upgrade to Agent 6
 
-To install on a clean box (or have an existing Agent 5 install from which you do not wish to import the configuration) provide an API key:
+A script is available to automatically install or upgrade to the new Agent. It sets up the package repositories and installs the Agent package for you. When upgrading, the import tool also searches for an existing `datadog.conf` from a prior version, and converts Agent and Check configurations according to the new v6 format.
 
+#### One-step install
+
+##### Upgrade
+
+The Agent v6 installer can automatically convert v5 configurations during the upgrade:
 ```shell
- DD_API_KEY=YOUR_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
+DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
+```
+
+**Note:** The import process won't automatically move **custom** Agent checks. This is by design as we cannot guarantee full backwards compatibility out of the box.
+
+##### Fresh install
+
+This is very similar to the upgrade method above, except instead of specifying the upgrade flag, you must supply your API key. This method will also work on Agent v5 machines, however the existing configuration will *not* be converted.
+```shell
+DD_API_KEY=YOUR_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
 ```
 
 #### Manual install
 
-1. Set up apt so that it can download through https:
-
+1. Enable HTTPS support for APT:
     ```
     sudo apt-get update
     sudo apt-get install apt-transport-https
     ```
 
-2. Set up the Datadog deb repo on your system and import Datadog's apt key:
-
-    ```
+2. Set up the Datadog API repo on your system and import Datadog's APT key:
+    ```shell
     sudo sh -c "echo 'deb https://apt.datadoghq.com/ stable 6' > /etc/apt/sources.list.d/datadog.list"
     sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE
     ```
 
-    Note: You might need to install `dirmngr` to add Datadog's apt key.
+    Note: You might need to install `dirmngr` to import Datadog's APT key.
 
-3. Update your local apt repo and install the Agent:
-
+3. Update your local APT cache and install the Agent:
     ```
     sudo apt-get update
     sudo apt-get install datadog-agent
     ```
 
 4. Copy the example config into place and plug in your API key:
-
-    ```
+    ```shell
     sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml" 
     ```
 
 5. Start the Agent:
-
     ```
-    sudo systemctl restart datadog-agent.service
+    sudo service datadog-agent start
     ```
 
 ### Downgrade to Agent v5
 
-1. Set up apt so it can download through https
+1. Enable HTTPS support for APT:
     ```shell
     sudo apt-get update
     sudo apt-get install apt-transport-https
     ```
 
-2. Remove Agent 6 Repo and Ensure the stable repo is present
-
+2. Remove the Agent v6 repository and ensure that the `stable` repository is present:
     ```shell
     sudo rm /etc/apt/sources.list.d/datadog.list [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
     sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE
     ```
 
-3. Update apt and downgrade the Agent
-
-    ```shell
+3. Update APT and downgrade the Agent:
+    ```
     sudo apt-get update
     sudo apt-get remove datadog-agent
     sudo apt-get install datadog-agent
     ```
 
+4. Start the Agent:
+    ```
+    sudo service datadog-agent start
+    ```
+
 ## Uninstall the Agent
 
 To uninstall the Agent, run: 
-
 ```
 $ sudo apt-get --purge remove datadog-agent -y
-CentOS/RHEL/Amazon Linux
 ```
 
 ## Further Reading

--- a/content/agent/basic_agent_usage/deb.md
+++ b/content/agent/basic_agent_usage/deb.md
@@ -1,6 +1,7 @@
 ---
 title: Basic Agent Usage for Debian
 kind: documentation
+platform: Debian
 aliases:
     - /guides/basic_agent_usage/deb/
     - /agent/basic_agent_usage/install_debian_5/

--- a/content/agent/basic_agent_usage/fedora.md
+++ b/content/agent/basic_agent_usage/fedora.md
@@ -18,16 +18,14 @@ further_reading:
 
 ## Overview
 
-This page outlines the basic features of the Datadog Agent. If you haven't installed the Agent yet, instructions can be found [in the Datadog Agent Integration page][1].
-
-The process to upgrade from the previous version of the Agent is to re-run the installation.
+This page outlines the basic features of the Datadog Agent for Amazon Linux. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
 ## Commands
 
-Datadog Agent has some commands and only the _lifecycle commands_ (i.e. `start`/`stop`/`restart`/`status` on the Agent service) should be run with `sudo service`/`sudo initctl`/`sudo systemctl`, all other commands need to be run with the `datadog-agent` command.
+In Agent v6, the service manager provided by the operating system is responsible for the Agent lifecycle, while other commands must be run via the Agent binary directly. In Agent v5, almost everything is done via the service manager.
 
 | Agent v5                                          | Agent v6                                               | Notes                              |
-| -----------------------------------------------   | ---------------------------------------                | -----------------------------      |
+| ------------------------------------------------- | ------------------------------------------------------ | ---------------------------------- |
 | `sudo service datadog-agent start`                | `sudo service datadog-agent start`                     | Start Agent as a service           |
 | `sudo service datadog-agent stop`                 | `sudo service datadog-agent stop`                      | Stop Agent running as a service    |
 | `sudo service datadog-agent restart`              | `sudo service datadog-agent restart`                   | Restart Agent running as a service |
@@ -37,25 +35,16 @@ Datadog Agent has some commands and only the _lifecycle commands_ (i.e. `start`/
 | `sudo service datadog-agent`                      | `sudo datadog-agent --help`                            | Display command usage              |
 | `sudo -u dd-agent -- dd-agent check <check_name>` | `sudo -u dd-agent -- datadog-agent check <check_name>` | Run a check                        |
 
-More information about the metrics, events, and service checks for an [Integrations][2] can be retrieved with the check command:
-```shell
-sudo service datadog-agent check [integration]
-```
+**Note**: If `service` is not available on your system, use:
 
-Add the check_rate argument to get the most recent values for rates:
-```shell
-sudo service datadog-agent check [integration] check_rate
-```
+* `upstart`-based systems: `initctl`
+* `systemd`-based systems: `systemctl`
 
-**NB**: If `service` is not available on your system, use:
-
-* on `upstart`-based systems: `sudo start/stop/restart datadog-agent`
-* on `systemd`-based systems: `sudo systemctl start/stop/restart datadog-agent`
-* on `initctl`-based systems: `sudo initctl start/stop/restart datadog-agent`
+[Learn more about Service lifecycle commands][4]
 
 ## Configuration
 
-The configuration files and folders for the Agent are located at:
+The configuration files and folders for for the Agent are located in:
 
 | Agent v5                     | Agent v6                          |
 | :-----                       | :----                             |
@@ -67,119 +56,115 @@ Configuration files for [Integrations][2]:
 | :-----                  | :----                        |
 | `/etc/dd-agent/conf.d/` | `/etc/datadog-agent/conf.d/` |
 
+
 ## Troubleshooting
 
-Run the info or status command to see the state of the Agent.
-The Agent logs are located in the `/var/log/datadog/` directory:
+Run the `status` (or `info` in v5) command to see the state of the Agent. The Agent logs are located in the `/var/log/datadog/` directory:
 
-* For Agent v6 all logs are in the `agent.log` file
-* For Agent v5 logs are in:
-    
-    * `datadog-supervisord.log`
-    * `collector.log`
-    * `dogstatsd.log`
-    * `forwarder.log`
+* For Agent v6, all logs are consolidated in `agent.log`
+* For Agent v5, logs are split into:
+  * `datadog-supervisord.log`
+  * `collector.log`
+  * `dogstatsd.log`
+  * `forwarder.log`
 
 If you're still having trouble, [our support team][3] will be glad to provide further assistance.
 
-## Switch between Agent v5 and v6
-### Upgrade to Agent 6
-A script is available to automatically install or upgrade the new Agent. It sets up the repos and installs the package for you; in case of upgrade, the import tool also searches for an existing `datadog.conf` from a prior version and converts Agent and checks configurations according to the new file format and filesystem layout.
+## Adding a custom Python package to the Agent
 
-#### One-step install
-##### To Upgrade
+The Agent contains an embedded Python environment at `/opt/datadog-agent/embedded/`. Common binaries such as `python` and `pip` are contained within `/opt/datadog-agent/embedded/bin/`.
 
-The Agent 6.x installer can automatically convert your 5.x style Agent configuration at upgrade:  
+### Installing Python libraries
 
-```shell
- DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
+Run the embedded `pip` via the Agent:
+```
+sudo -u dd-agent -- /opt/datadog-agent/embedded/bin/pip install <package_name>
 ```
 
-**Note:** the import process won't automatically move custom Agent checks, this is by design since we cannot guarantee full backwards compatibility out of the box.
+## Switch between Agent v5 and v6
 
-##### To Install Fresh
+### Upgrade to Agent 6
 
-To install on a clean box (or have an existing Agent 5 install from which you do not wish to import the configuration) provide an API key:
+A script is available to automatically install or upgrade to the new Agent. It sets up the package repositories and installs the Agent package for you. When upgrading, the import tool also searches for an existing `datadog.conf` from a prior version, and converts Agent and Check configurations according to the new v6 format.
 
+#### One-step install
+
+##### Upgrade
+
+The Agent v6 installer can automatically convert v5 configurations during the upgrade:
 ```shell
- DD_API_KEY=YOUR_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
+DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
+```
+
+**Note:** The import process won't automatically move **custom** Agent checks. This is by design as we cannot guarantee full backwards compatibility out of the box.
+
+##### Fresh install
+
+This is very similar to the upgrade method above, except instead of specifying the upgrade flag, you must supply your API key. This method will also work on Agent v5 machines, however the existing configuration will *not* be converted.
+```shell
+DD_API_KEY=YOUR_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
 ```
 
 #### Manual install
-1. Set up Datadog's Yum repo on your system by creating /etc/yum.repos.d/datadog.repo with the contents:
 
-    ```
+1. Set up Datadog's Yum repo on your system by creating `/etc/yum.repos.d/datadog.repo` with the contents:
+    ```ini
     [datadog]
-    name = Datadog, Inc.
-    baseurl = https://yum.datadoghq.com/stable/6/x86_64/
+    name=Datadog, Inc.
+    baseurl=https://yum.datadoghq.com/stable/6/x86_64/
     enabled=1
     gpgcheck=1
     gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
     ```
 
-2. Update your local yum cache and install/update the Agent
-
+2. Update your local Yum repo and install the Agent:
     ```
     sudo yum makecache
+    sudo yum remove datadog-agent-base
     sudo yum install datadog-agent
     ```
 
-3. Import existing configuration (optional)
-
-    ```
+3. Copy the example config into place and plug in your API key:
+    ```shell
     sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
     ```
 
-5. Restart the Agent
-
+4. Restart the Agent
     ```
     sudo systemctl restart datadog-agent.service
     ```
 
 ### Downgrade to Agent v5
 
-1. Remove the Agent 6 Yum repo from your system:
+1. Remove the Agent v6 repository and ensure that the `stable` repo is present:
     ```shell 
     rm  /etc/yum.repos.d/datadog.repo [ ! -f /etc/yum.repos.d/datadog.repo ] && echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/rpm/x86_64/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public\n       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public' | sudo tee /etc/yum.repos.d/datadog.repo
     ```
 
-2. Update your local yum cache and downgrade the Agent
-    ```shell
+2. Update your local Yum cache and downgrade the Agent:
+    ```
     sudo yum clean expire-cache metadata
     sudo yum check-update
     sudo yum remove datadog-agent
     sudo yum install datadog-agent
     ```
 
-3. Back-sync configurations and AutoDiscovery templates (optional):
-    If you have made any changes to your configurations or templates, you might want to sync these back for Agent 5.
+3. Restart the Agent:
 
-    Note: please beware that if you have made any changes to your configurations to support new Agent v6-only options, these will not work anymore with Agent v5.
-
-4. Back-sync custom Agent checks (optional)
-    If you made any changes or added any new custom Agent checks while testing Agent 6 you might want to enable them back on Agent 5. Note: you only need to copy back checks you changed.
-    
-    ```shell
-    sudo -u dd-agent -- cp /etc/datadog-agent/checks.d/<check>.py /etc/dd-agent/checks.d/
+    * For systemd-based systems:
     ```
-
-5. Restart the Agent
-    ```shell
-    # Systemd
     sudo systemctl restart datadog-agent
-    # Upstart
-    sudo /etc/init.d/datadog-agent restart
     ```
 
-6. Clean out /etc/datadog-agent (optional)
-    ```shell
-    sudo -u dd-agent -- rm -rf /etc/datadog-agent/
+    * For upstart-based systems:
+    ```
+    sudo /etc/init.d/datadog-agent restart
     ```
 
 ## Uninstall the Agent
 
 ```
-$ sudo apt-get --purge remove datadog-agent -y
+sudo yum remove datadog-agent
 ```
 
 ## Further Reading

--- a/content/agent/basic_agent_usage/osx.md
+++ b/content/agent/basic_agent_usage/osx.md
@@ -19,16 +19,15 @@ further_reading:
 
 ## Overview
 
-This page outlines the basic features of the Datadog Agent.
-If you haven't installed the Agent yet, instructions can be found
-[in the Datadog Agent Integration page][1].  
+This page outlines the basic features of the Datadog Agent for Amazon Linux. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
-By default, your Agent is installed in its own sandbox located at `/opt/datadog-agent`. You're free to move this folder wherever you like.
-However, we assume that the Agent is installed in its default location, so be sure to modify the instructions accordingly if you decide to move it to another location.
+By default, the Agent is installed in a sandbox located at `/opt/datadog-agent`. You're free to move this folder wherever you like; however, his documentation assumes a default installation location.
 
 ## Commands
 
-_lifecycle commands_ (former `datadog-agent start`/`stop`/`restart`/`status` on the Agent 5) are replaced by `launchctl` commands on the `com.datadoghq.agent` service, and should be run under the logged-in user. For these commands, you can also use the Datadog Agent systray app, all the other commands can still be run with the `datadog-agent` command (located in the `PATH` (`/usr/local/bin/`) by default)
+In Agent v6, the `launchctl` service manager provided by the operating system is responsible for the Agent lifecycle, while other commands must be run via the Agent binary directly. Alternatively, lifecycle commands can also be managed via the systray app, and other commands can be executed via the web GUI.
+
+In Agent v5, everything is done via the binary directly. 
 
 | Agent v5                           | Agent v6                                             | Notes                              |
 | ---------------------------------- | ---------------------------------------------------- | ---------------------------------- |
@@ -57,20 +56,30 @@ Configuration files for [Integrations][2]:
 
 ## Troubleshooting
 
-Run the info or status command to see the state of the Agent.
-The Agent logs are located in the `/var/log/datadog/` directory:
+Run the `status` (or `info` in v5) command to see the state of the Agent. The Agent logs are located in the `/var/log/datadog/` directory:
 
-* For Agent v6 all logs are in the `agent.log` file
-* For Agent v5 logs are in:
-    
-    * `datadog-supervisord.log`
-    * `collector.log`
-    * `dogstatsd.log`
-    * `forwarder.log`
+* For Agent v6, all logs are consolidated in `agent.log`
+* For Agent v5, logs are split into:
+  * `datadog-supervisord.log`
+  * `collector.log`
+  * `dogstatsd.log`
+  * `forwarder.log`
 
 If you're still having trouble, [our support team][3] will be glad to provide further assistance.
 
+## Adding a custom Python package to the Agent
+
+The Agent contains an embedded Python environment at `/opt/datadog-agent/embedded/`. Common binaries such as `python` and `pip` are contained within `/opt/datadog-agent/embedded/bin/`.
+
+### Installing Python libraries
+
+Run the embedded `pip` via the Agent:
+```
+/opt/datadog-agent/embedded/bin/pip install <package_name>
+```
+
 ## Switch between Agent v5 and v6
+
 ### Upgrade to Agent 6
 
 You can either download the DMG package and install it manually, or use the one-line install script.
@@ -81,50 +90,53 @@ You can either download the DMG package and install it manually, or use the one-
 2. Install the DMG package
 3. Add your API key to `/opt/datadog-agent/etc/datadog.yaml`
 
-Then start the Datadog Agent app (once started, you should see it in the system tray), and manage the Agent from there. The Agent6 also ships a web-based GUI to edit the Agent configuration files and much more, refer to the [changes and deprecations document][changes] document for more information.
+Then start the Datadog Agent app (once started, you should see it in the system tray), and manage the Agent from there. Agent v6 includes a web-based GUI to edit the Agent configuration files and much more.
+
 ### Install script
+
 #### To Upgrade
 
-The Agent 6.x installer can automatically convert your 5.x style Agent configuration at upgrade:  
-
+The Agent v6 installer can automatically convert v5 configurations during the upgrade:
 ```shell
-  DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_mac_os.sh)"
+DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
 ```
+
+**Note:** The import process won't automatically move **custom** Agent checks. This is by design as we cannot guarantee full backwards compatibility out of the box.
 
 #### To Install Fresh
 
-In case you want to install on a clean box (or have an existing Agent 5 install
-from which you do not wish to import the configuration) you have to provide an
-api key:
-
+This is very similar to the upgrade method above, except instead of specifying the upgrade flag, you must supply your API key. This method will also work on Agent v5 machines, however the existing configuration will *not* be converted.
 ```shell
- DD_API_KEY=YOUR_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_mac_os.sh)"
+DD_API_KEY=YOUR_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
 ```
 
 ### Downgrade to Agent v5
 
 1. Stop the Agent with the systray app, if it's running
+
 2. Exit the systray app
+
 3. Uninstall the Datadog Agent application
+
 4. [Install the Agent 5 DMG package using your preferred installation method][1]
 
 ## Uninstall the Agent
 
-Stop and Close the Datadog Agent: via the bone icon in the Tray.
+1. Stop and close the Datadog Agent via the systray.
 
-Drag the Datadog Application from the application folder to the Trash Bin.
+2. Drag the Datadog Application from the application folder to the Trash Bin.
 
-```
-$ sudo rm -rf /opt/datadog-agent
-$ sudo rm -rf /usr/local/bin/datadog-agent
-$ sudo rm -rf ~/.datadog-agent/**​ #to remove broken symlinks
-```
-If you ran the optional install commands to have the Agent run at boot time, run the following to finish uninstalling:
-
-```
-$ sudo launchctl unload -w /Library/LaunchDaemons/com.datadoghq.agent.plist
-$ sudo rm /Library/LaunchDaemons/com.datadoghq.agent.plist
-```
+3. Remove the system elements:
+    ```
+    $ sudo rm -rf /opt/datadog-agent
+    $ sudo rm -rf /usr/local/bin/datadog-agent
+    $ sudo rm -rf ~/.datadog-agent/**​ #to remove broken symlinks
+    ```
+4. If you ran the optional install commands to have the Agent run at boot time, run the following to finish uninstalling:
+    ```
+    sudo launchctl unload -w /Library/LaunchDaemons/com.datadoghq.agent.plist
+    sudo rm /Library/LaunchDaemons/com.datadoghq.agent.plist
+    ```
 
 ## Further Reading
 

--- a/content/agent/basic_agent_usage/redhat.md
+++ b/content/agent/basic_agent_usage/redhat.md
@@ -3,7 +3,7 @@ title: Basic Agent Usage for Red Hat
 kind: documentation
 platform: Red Hat
 aliases:
-    - /guides/basic_agent_usage/centos/
+    - /guides/basic_agent_usage/redhat/
 further_reading:
 - link: "logs/"
   tag: "Documentation"

--- a/content/agent/basic_agent_usage/redhat.md
+++ b/content/agent/basic_agent_usage/redhat.md
@@ -3,7 +3,7 @@ title: Basic Agent Usage for Red Hat
 kind: documentation
 platform: Red Hat
 aliases:
-    - /guides/basic_agent_usage/redhat/
+    - /guides/basic_agent_usage/centos/
 further_reading:
 - link: "logs/"
   tag: "Documentation"
@@ -16,12 +16,16 @@ further_reading:
   text: Collect your traces
 ---
 
+## Overview
+
+This page outlines the basic features of the Datadog Agent for Amazon Linux. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
+
 ## Commands
 
-Datadog Agent has some commands and only the _lifecycle commands_ (i.e. `start`/`stop`/`restart`/`status` on the Agent service) should be run with `sudo service`/`sudo systemctl`, all other commands need to be run with the `datadog-agent` command.
+In Agent v6, the service manager provided by the operating system is responsible for the Agent lifecycle, while other commands must be run via the Agent binary directly. In Agent v5, almost everything is done via the service manager.
 
 | Agent v5                                          | Agent v6                                               | Notes                              |
-| -----------------------------------------------   | ---------------------------------------                | -----------------------------      |
+| ------------------------------------------------- | ------------------------------------------------------ | ---------------------------------- |
 | `sudo service datadog-agent start`                | `sudo service datadog-agent start`                     | Start Agent as a service           |
 | `sudo service datadog-agent stop`                 | `sudo service datadog-agent stop`                      | Stop Agent running as a service    |
 | `sudo service datadog-agent restart`              | `sudo service datadog-agent restart`                   | Restart Agent running as a service |
@@ -31,90 +35,89 @@ Datadog Agent has some commands and only the _lifecycle commands_ (i.e. `start`/
 | `sudo service datadog-agent`                      | `sudo datadog-agent --help`                            | Display command usage              |
 | `sudo -u dd-agent -- dd-agent check <check_name>` | `sudo -u dd-agent -- datadog-agent check <check_name>` | Run a check                        |
 
-More information about the metrics, events, and service checks for an [Integrations][1] can be retrieved with the check command:
-```shell
-sudo service datadog-agent check [integration]
-```
+**Note**: If `service` is not available on your system, use:
 
-Add the check_rate argument to get the most recent values for rates:
-```shell
-sudo service datadog-agent check [integration] check_rate
-```
+* `upstart`-based systems: `initctl`
+* `systemd`-based systems: `systemctl`
 
-**NB**: If `service` is not available on your system, use:
-
-* on `upstart`-based systems: `sudo start/stop/restart datadog-agent`
-* on `systemd`-based systems: `sudo systemctl start/stop/restart datadog-agent`
-
-[Learn more about Service lifecycle commands][3]
+[Learn more about Service lifecycle commands][4]
 
 ## Configuration
 
-The configuration files and folders for the Agent are located at:
+The configuration files and folders for for the Agent are located in:
 
 | Agent v5                     | Agent v6                          |
 | :-----                       | :----                             |
 | `/etc/dd-agent/datadog.conf` | `/etc/datadog-agent/datadog.yaml` |
 
-Configuration files for [Integrations][1]:
+Configuration files for [Integrations][2]:
 
 | Agent v5                | Agent v6                     |
 | :-----                  | :----                        |
 | `/etc/dd-agent/conf.d/` | `/etc/datadog-agent/conf.d/` |
 
+
 ## Troubleshooting
 
-Run the info or status command to see the state of the Agent.
-The Agent logs are located in the `/var/log/datadog/` directory:
+Run the `status` (or `info` in v5) command to see the state of the Agent. The Agent logs are located in the `/var/log/datadog/` directory:
 
-* For Agent v6 all logs are in the `agent.log` file
-* For Agent v5 logs are in:
-    
-    * `datadog-supervisord.log`
-    * `collector.log`
-    * `dogstatsd.log`
-    * `forwarder.log`
+* For Agent v6, all logs are consolidated in `agent.log`
+* For Agent v5, logs are split into:
+  * `datadog-supervisord.log`
+  * `collector.log`
+  * `dogstatsd.log`
+  * `forwarder.log`
 
-If you're still having trouble, [our support team][2] will be glad to provide further assistance.
+If you're still having trouble, [our support team][3] will be glad to provide further assistance.
 
-## Switch between Agent v5 and v6
-### Upgrade to Agent 6
-A script is available to automatically install or upgrade the new Agent. It sets up the repos and installs the package for you; in case of upgrade, the import tool also searches for an existing `datadog.conf` from a prior version and converts Agent and checks configurations according to the new file format and filesystem layout.
+## Adding a custom Python package to the Agent
 
-#### One-step install
-##### To Upgrade
+The Agent contains an embedded Python environment at `/opt/datadog-agent/embedded/`. Common binaries such as `python` and `pip` are contained within `/opt/datadog-agent/embedded/bin/`.
 
-The Agent 6.x installer can automatically convert your 5.x style Agent configuration at upgrade:  
+### Installing Python libraries
 
-```shell
- DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
+Run the embedded `pip` via the Agent:
+```
+sudo -u dd-agent -- /opt/datadog-agent/embedded/bin/pip install <package_name>
 ```
 
-**Note:** the import process won't automatically move custom Agent checks, this is by design since we cannot guarantee full backwards compatibility out of the box.
+## Switch between Agent v5 and v6
 
-##### To Install Fresh
+### Upgrade to Agent 6
 
-To install on a clean box (or have an existing Agent 5 install from which you do not wish to import the configuration) provide an API key:
+A script is available to automatically install or upgrade to the new Agent. It sets up the package repositories and installs the Agent package for you. When upgrading, the import tool also searches for an existing `datadog.conf` from a prior version, and converts Agent and Check configurations according to the new v6 format.
 
+#### One-step install
+
+##### Upgrade
+
+The Agent v6 installer can automatically convert v5 configurations during the upgrade:
 ```shell
- DD_API_KEY=YOUR_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
+DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
+```
+
+**Note:** The import process won't automatically move **custom** Agent checks. This is by design as we cannot guarantee full backwards compatibility out of the box.
+
+##### Fresh install
+
+This is very similar to the upgrade method above, except instead of specifying the upgrade flag, you must supply your API key. This method will also work on Agent v5 machines, however the existing configuration will *not* be converted.
+```shell
+DD_API_KEY=YOUR_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
 ```
 
 #### Manual install
 
-1. Set up Datadog's Yum repo on your system by creating /etc/yum.repos.d/datadog.repo with the contents:
-
-    ```
+1. Set up Datadog's Yum repo on your system by creating `/etc/yum.repos.d/datadog.repo` with the contents:
+    ```ini
     [datadog]
-    name = Datadog, Inc.
-    baseurl = https://yum.datadoghq.com/stable/6/x86_64/
+    name=Datadog, Inc.
+    baseurl=https://yum.datadoghq.com/stable/6/x86_64/
     enabled=1
     gpgcheck=1
     gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
     ```
 
-2. Update your local yum repo and install the Agent:
-
+2. Update your local Yum repo and install the Agent:
     ```
     sudo yum makecache
     sudo yum remove datadog-agent-base
@@ -122,75 +125,68 @@ To install on a clean box (or have an existing Agent 5 install from which you do
     ```
 
 3. Copy the example config into place and plug in your API key:
-
-    ```
+    ```shell
     sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
     ```
 
-4. Re-start the Agent on Centos 7 and above:
+4. Restart the Agent:
 
+    * Red Hat 7 and above:
     ```
     sudo systemctl restart datadog-agent.service
     ```
 
-5. Re-start the Agent on Centos 6:
-
+    * Red Hat 6:
     ```
-    sudo initctl start datadog-agent
+    sudo initctl restart datadog-agent
     ```
 
 ### Downgrade to Agent v5
 
-1. Remove the Agent 6 Yum repo from your system:
-    ```shell 
-    rm /etc/yum.repos.d/datadog.repo [ ! -f /etc/yum.repos.d/datadog.repo ] && echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/rpm/x86_64/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public\n       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public' | sudo tee /etc/yum.repos.d/datadog.repo
+1. Remove the Agent v6 repository and ensure that the `stable` repo is present:
+    ```shell
+    sudo rm /etc/yum.repos.d/datadog.repo [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
+    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE
     ```
 
-2. Update your local yum cache and downgrade the Agent
-    ```shell
+2. Update your local Yum cache and downgrade the Agent:
+    ```
     sudo yum clean expire-cache metadata
     sudo yum check-update
     sudo yum remove datadog-agent
     sudo yum install datadog-agent
     ```
+3. Restart the Agent:
 
-3. Back-sync configurations and AutoDiscovery templates (optional):
-    If you have made any changes to your configurations or templates, you might want to sync these back for Agent 5.
-
-    Note: please beware that if you have made any changes to your configurations to support new Agent v6-only options, these will not work anymore with Agent v5.
-
-4. Back-sync custom Agent checks (optional)
-    If you made any changes or added any new custom Agent checks while testing Agent 6 you might want to enable them back on Agent 5. Note: you only need to copy back checks you changed.
-    
-    ```shell
-    sudo -u dd-agent -- cp /etc/datadog-agent/checks.d/<check>.py /etc/dd-agent/checks.d/
+    * Red Hat 7 and above:
+    ```
+    sudo systemctl restart datadog-agent.service
     ```
 
-5. Restart the Agent
-    ```shell
-    # Systemd
-    sudo systemctl restart datadog-agent
-    # Upstart
-    sudo /etc/init.d/datadog-agent restart
+    * Red Hat 6:
     ```
-
-6. Clean out /etc/datadog-agent (optional)
-    ```shell
-    sudo -u dd-agent -- rm -rf /etc/datadog-agent/
+    sudo initctl restart datadog-agent
     ```
 
 ## Uninstall the Agent
 
 To uninstall the Agent, run: 
 
+* For Red Hat 5:
     ```
-    $ sudo yum remove datadog-agent
+    sudo yum remove datadog-agent-base
+    ```
+
+* For Red Hat 6:
+    ```
+    sudo yum remove datadog-agent
     ```
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /integrations
-[2]: /help
-[3]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md#service-lifecycle-commands
+[1]: https://app.datadoghq.com/account/settings#agent/redhat
+[2]: /integrations
+[3]: /help
+[4]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md#service-lifecycle-commands

--- a/content/agent/basic_agent_usage/suse.md
+++ b/content/agent/basic_agent_usage/suse.md
@@ -18,16 +18,14 @@ further_reading:
 
 ## Overview
 
-This page outlines the basic features of the Datadog Agent. If you haven't installed the Agent yet, instructions can be found [in the Datadog Agent Integration page][1].
-
-The process to upgrade from the previous version of the Agent is to re-run the installation.
+This page outlines the basic features of the Datadog Agent for Amazon Linux. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
 ## Commands
 
-Datadog Agent has some commands and only the _lifecycle commands_ (i.e. `start`/`stop`/`restart`/`status` on the Agent service) should be run with `sudo service`/`sudo systemctl`, all other commands need to be run with the `datadog-agent` command.
+In Agent v6, the service manager provided by the operating system is responsible for the Agent lifecycle, while other commands must be run via the Agent binary directly. In Agent v5, almost everything is done via the service manager.
 
 | Agent v5                                          | Agent v6                                               | Notes                              |
-| -----------------------------------------------   | ---------------------------------------                | -----------------------------      |
+| ------------------------------------------------- | ------------------------------------------------------ | ---------------------------------- |
 | `sudo service datadog-agent start`                | `sudo service datadog-agent start`                     | Start Agent as a service           |
 | `sudo service datadog-agent stop`                 | `sudo service datadog-agent stop`                      | Stop Agent running as a service    |
 | `sudo service datadog-agent restart`              | `sudo service datadog-agent restart`                   | Restart Agent running as a service |
@@ -37,25 +35,16 @@ Datadog Agent has some commands and only the _lifecycle commands_ (i.e. `start`/
 | `sudo service datadog-agent`                      | `sudo datadog-agent --help`                            | Display command usage              |
 | `sudo -u dd-agent -- dd-agent check <check_name>` | `sudo -u dd-agent -- datadog-agent check <check_name>` | Run a check                        |
 
-More information about the metrics, events, and service checks for an [Integrations][2] can be retrieved with the check command:
-```shell
-sudo service datadog-agent check [integration]
-```
+**Note**: If `service` is not available on your system, use:
 
-Add the check_rate argument to get the most recent values for rates:
-```shell
-sudo service datadog-agent check [integration] check_rate
-```
-
-**NB**: If `service` is not available on your system, use:
-
-* on `systemd`-based systems: `sudo systemctl start/stop/restart datadog-agent`
+* `upstart`-based systems: `initctl`
+* `systemd`-based systems: `systemctl`
 
 [Learn more about Service lifecycle commands][4]
 
 ## Configuration
 
-The configuration files and folders for the Agent are located at:
+The configuration files and folders for for the Agent are located in:
 
 | Agent v5                     | Agent v6                          |
 | :-----                       | :----                             |
@@ -67,11 +56,35 @@ Configuration files for [Integrations][2]:
 | :-----                  | :----                        |
 | `/etc/dd-agent/conf.d/` | `/etc/datadog-agent/conf.d/` |
 
+
+## Troubleshooting
+
+Run the `status` (or `info` in v5) command to see the state of the Agent. The Agent logs are located in the `/var/log/datadog/` directory:
+
+* For Agent v6, all logs are consolidated in `agent.log`
+* For Agent v5, logs are split into:
+  * `datadog-supervisord.log`
+  * `collector.log`
+  * `dogstatsd.log`
+  * `forwarder.log`
+
+If you're still having trouble, [our support team][3] will be glad to provide further assistance.
+
+## Adding a custom Python package to the Agent
+
+The Agent contains an embedded Python environment at `/opt/datadog-agent/embedded/`. Common binaries such as `python` and `pip` are contained within `/opt/datadog-agent/embedded/bin/`.
+
+### Installing Python libraries
+
+Run the embedded `pip` via the Agent:
+```
+sudo -u dd-agent -- /opt/datadog-agent/embedded/bin/pip install <package_name>
+```
+
 ## Upgrade to Agent 6
 
-1. Set up Datadog's Yum repo on your system by creating /etc/zypp/repos.d/datadog.repo with the contents:
-
-  ```
+1. Set up Datadog's Yum repo on your system by creating `/etc/zypp/repos.d/datadog.repo` with the contents:
+  ```ini
   [datadog]
   name=Datadog, Inc.
   enabled=1
@@ -82,8 +95,7 @@ Configuration files for [Integrations][2]:
   gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
   ```
 
-2. Update your local zypper repo and install the Agent:
-
+2. Update your local Zypper repo and install the Agent:
   ```
   sudo zypper refresh
   sudo rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY.public
@@ -91,31 +103,14 @@ Configuration files for [Integrations][2]:
   ```
 
 3. Copy the example config into place and plug in your API key:
-
-  ```
+  ```shell
   sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
   ```
 
 4. Re-start the Agent:
-
   ```
   sudo systemctl restart datadog-agent.service
   ```
-
-## Troubleshooting
-
-Run the info or status command to see the state of the Agent.
-The Agent logs are located in the `/var/log/datadog/` directory:
-
-* For Agent v6 all logs are in the `agent.log` file
-* For Agent v5 logs are in:
-    
-    * `datadog-supervisord.log`
-    * `collector.log`
-    * `dogstatsd.log`
-    * `forwarder.log`
-
-If you're still having trouble, [our support team][3] will be glad to provide further assistance.
 
 ## Further Reading
 

--- a/content/agent/basic_agent_usage/ubuntu.md
+++ b/content/agent/basic_agent_usage/ubuntu.md
@@ -18,16 +18,14 @@ further_reading:
 
 ## Overview
 
-This page outlines the basic features of the Datadog Agent. If you haven't installed the Agent yet, instructions can be found [in the Datadog Agent Integration page][1].
-
-The process to upgrade from the previous version of the Agent is to re-run the installation.
+This page outlines the basic features of the Datadog Agent for Amazon Linux. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
 ## Commands
 
-Datadog Agent has some commands and only the _lifecycle commands_ (i.e. `start`/`stop`/`restart`/`status` on the Agent service) should be run with `sudo service`/`sudo initctl`/`sudo systemctl`, all other commands need to be run with the `datadog-agent` command.
+In Agent v6, the service manager provided by the operating system is responsible for the Agent lifecycle, while other commands must be run via the Agent binary directly. In Agent v5, almost everything is done via the service manager.
 
 | Agent v5                                          | Agent v6                                               | Notes                              |
-| -----------------------------------------------   | ---------------------------------------                | -----------------------------      |
+| ------------------------------------------------- | ------------------------------------------------------ | ---------------------------------- |
 | `sudo service datadog-agent start`                | `sudo service datadog-agent start`                     | Start Agent as a service           |
 | `sudo service datadog-agent stop`                 | `sudo service datadog-agent stop`                      | Stop Agent running as a service    |
 | `sudo service datadog-agent restart`              | `sudo service datadog-agent restart`                   | Restart Agent running as a service |
@@ -37,27 +35,16 @@ Datadog Agent has some commands and only the _lifecycle commands_ (i.e. `start`/
 | `sudo service datadog-agent`                      | `sudo datadog-agent --help`                            | Display command usage              |
 | `sudo -u dd-agent -- dd-agent check <check_name>` | `sudo -u dd-agent -- datadog-agent check <check_name>` | Run a check                        |
 
-More information about the metrics, events, and service checks for an [Integrations][2] can be retrieved with the check command:
-```shell
-sudo service datadog-agent check [integration]
-```
+**Note**: If `service` is not available on your system, use:
 
-Add the check_rate argument to get the most recent values for rates:
-```shell
-sudo service datadog-agent check [integration] check_rate
-```
-
-**NB**: If `service` is not available on your system, use:
-
-* on `upstart`-based systems: `sudo start/stop/restart datadog-agent`
-* on `systemd`-based systems: `sudo systemctl start/stop/restart datadog-agent`
-* on `initctl`-based systems: `sudo initctl start/stop/restart datadog-agent`
+* `upstart`-based systems: `initctl`
+* `systemd`-based systems: `systemctl`
 
 [Learn more about Service lifecycle commands][4]
 
 ## Configuration
 
-The configuration files and folders for the Agent are located at:
+The configuration files and folders for for the Agent are located in:
 
 | Agent v5                     | Agent v6                          |
 | :-----                       | :----                             |
@@ -69,111 +56,123 @@ Configuration files for [Integrations][2]:
 | :-----                  | :----                        |
 | `/etc/dd-agent/conf.d/` | `/etc/datadog-agent/conf.d/` |
 
+
 ## Troubleshooting
 
-Run the info or status command to see the state of the Agent.
-The Agent logs are located in the `/var/log/datadog/` directory:
+Run the `status` (or `info` in v5) command to see the state of the Agent. The Agent logs are located in the `/var/log/datadog/` directory:
 
-* For Agent v6 all logs are in the `agent.log` file
-* For Agent v5 logs are in:
-    
-    * `datadog-supervisord.log`
-    * `collector.log`
-    * `dogstatsd.log`
-    * `forwarder.log`
+* For Agent v6, all logs are consolidated in `agent.log`
+* For Agent v5, logs are split into:
+  * `datadog-supervisord.log`
+  * `collector.log`
+  * `dogstatsd.log`
+  * `forwarder.log`
 
 If you're still having trouble, [our support team][3] will be glad to provide further assistance.
 
-## Switch between Agent v5 and v6
-### Upgrade to Agent 6
+## Adding a custom Python package to the Agent
 
-A script is available to automatically install or upgrade the new Agent. It sets up the repos and installs the package for you; in case of upgrade, the import tool also searches for an existing `datadog.conf` from a prior version and converts Agent and checks configurations according to the new file format and filesystem layout.
-#### One-step install
-##### To Upgrade
+The Agent contains an embedded Python environment at `/opt/datadog-agent/embedded/`. Common binaries such as `python` and `pip` are contained within `/opt/datadog-agent/embedded/bin/`.
 
-The Agent 6.x installer can automatically convert your 5.x style Agent configuration at upgrade:  
+### Installing Python libraries
 
-```shell
- DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
+Run the embedded `pip` via the Agent:
+```
+sudo -u dd-agent -- /opt/datadog-agent/embedded/bin/pip install <package_name>
 ```
 
-**Note:** the import process won't automatically move custom Agent checks, this is by design since we cannot guarantee full backwards compatibility out of the box.
+## Switch between Agent v5 and v6
 
-##### To Install Fresh
+### Upgrade to Agent 6
 
-To install on a clean box (or have an existing Agent 5 install from which you do not wish to import the configuration) provide an API key:
+A script is available to automatically install or upgrade to the new Agent. It sets up the package repositories and installs the Agent package for you. When upgrading, the import tool also searches for an existing `datadog.conf` from a prior version, and converts Agent and Check configurations according to the new v6 format.
 
+#### One-step install
+
+##### Upgrade
+
+The Agent v6 installer can automatically convert v5 configurations during the upgrade:
 ```shell
- DD_API_KEY=YOUR_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
+DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
+```
+
+**Note:** The import process won't automatically move **custom** Agent checks. This is by design as we cannot guarantee full backwards compatibility out of the box.
+
+##### Fresh install
+
+This is very similar to the upgrade method above, except instead of specifying the upgrade flag, you must supply your API key. This method will also work on Agent v5 machines, however the existing configuration will *not* be converted.
+```shell
+DD_API_KEY=YOUR_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
 ```
 
 #### Manual install
-1. Set up apt so it can download through https
 
+1. Enable HTTPS support for APT:
     ```
     sudo apt-get update
     sudo apt-get install apt-transport-https
     ```
 
-2. Set up the Datadog deb repo on your system and import Datadog's apt key:
-
-    ```
+2. Set up the Datadog API repo on your system and import Datadog's APT key:
+    ```shell
     sudo sh -c "echo 'deb https://apt.datadoghq.com/ stable 6' > /etc/apt/sources.list.d/datadog.list"
     sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE
     ```
 
-3. Update your local apt repo and install the Agent:
+    Note: You might need to install `dirmngr` to import Datadog's APT key.
 
+3. Update your local APT cache and install the Agent:
     ```
     sudo apt-get update
     sudo apt-get install datadog-agent
     ```
 
 4. Copy the example config into place and plug in your API key:
-
-    ```
-    sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
-    ```
-
-5. Start the Agent with Ubuntu 16.04 and higher:
-
-    ```
-    sudo systemctl restart datadog-agent.service
+    ```shell
+    sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml" 
     ```
 
-6. Start the Agent with Ubuntu 14.04:
+5. Start the Agent:
 
+    * Ubuntu 16.04 or higher:
+    ```
+    sudo systemctl start datadog-agent
+    ```
+
+    * Ubuntu 14.04 or lower:
     ```
     sudo initctl start datadog-agent
     ```
 
 ### Downgrade to Agent v5
 
-1. Set up apt so it can download through https
+1. Enable HTTPS support for APT:
     ```shell
     sudo apt-get update
     sudo apt-get install apt-transport-https
     ```
 
-2. Remove the Agent 6 repository and Ensure the stable repository is present
-
+2. Remove the Agent v6 repository and ensure that the `stable` repository is present:
     ```shell
     sudo rm /etc/apt/sources.list.d/datadog.list [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
     sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE
     ```
 
-3. Update apt and downgrade the Agent
-
-    ```shell
+3. Update APT and downgrade the Agent:
+    ```
     sudo apt-get update
     sudo apt-get remove datadog-agent
     sudo apt-get install datadog-agent
     ```
 
+4. Start the Agent:
+    ```
+    sudo service datadog-agent start
+    ```
+
 ## Uninstall the Agent
 
 To uninstall the Agent, run: 
-
 ```
 $ sudo apt-get --purge remove datadog-agent -y
 ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

This cleans up the per-platform Agent docs generally speaking.

### Motivation

Some of the content was out of date, some of it was confusing, and some of it was flat-out incorrect.

### Preview link

### Additional Notes

This is _not_ the final form of the per-platform Agent docs. This PR simply ensures that the existing docs aren't dangerous. There is still much more work to be done in terms of standardising and improving this documentation overall.
