### PR TITLE
update go examples

### DIFF
--- a/content/tracing/setup/docker.md
+++ b/content/tracing/setup/docker.md
@@ -66,7 +66,7 @@ docker run -d --name app \
               company/app:latest
 ```
 
-This exposes the hostname `datadog-agent` in your `app` container.  
+This exposes the hostname `datadog-agent` in your `app` container.
 If you're using `docker-compose`, `<NETWORK_NAME>` parameters are the ones defined under the `networks` section of your `docker-compose.yml`.
 
 Your application tracers must be configured to submit traces to this address. See the examples below for each supported language:
@@ -94,16 +94,13 @@ end
 #### Go
 
 ```go
-import ddtrace "github.com/DataDog/dd-trace-go/opentracing"
+package main
 
+import "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 func main() {
-    config := ddtrace.NewConfiguration()
-    config.AgentHostname = "datadog-agent"
-    config.AgentPort = "8126"
-
-    tracer, closer, err := ddtrace.NewTracer(config)
-    defer closer.Close()
+    tracer.Start(tracer.WithAgentAddr("datadog-agent:8126"))
+    defer tracer.Stop()
 }
 ```
 
@@ -137,7 +134,7 @@ const tracer = require('dd-trace').init({
 
 ### Docker host IP
 
-Agent container port `8126` should be linked to the host directly.  
+Agent container port `8126` should be linked to the host directly.
 Configure your application tracer to report to the default route of this container (determine this using the `ip route` command).
 
 The following is an example for the Python Tracer, assuming `172.17.0.1` is the default route:

--- a/content/tracing/setup/go.fr.md
+++ b/content/tracing/setup/go.fr.md
@@ -88,27 +88,20 @@ Client APM Datadog qui implémente un Tracer [OpenTracing][3].
 Afin d'utiliser le Datadog Tracer avec un API OpenTracing, vous devez initialiser le tracer avec un objet `Configuration` complet :
 
 ```go
+package main
+
 import (
-  // ddtrace namespace is suggested
-  ddtrace "github.com/DataDog/dd-trace-go/opentracing"
-  opentracing "github.com/opentracing/opentracing-go"
+    opentracing "github.com/opentracing/opentracing-go"
+    "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer"
+    "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 func main() {
-  // create a Tracer configuration
-  config := ddtrace.NewConfiguration()
-  config.ServiceName = "api-intake"
-  config.AgentHostname = "ddagent.consul.local"
+    // initialize a Tracer
+    tracer := opentracer.New(tracer.WithAgentAddr("ddagent.consul.local:8126"),
+        tracer.WithServiceName("api-intake"))
 
-  // initialize a Tracer and ensure a graceful shutdown
-  // using the `closer.Close()`
-  tracer, closer, err := ddtrace.NewTracer(config)
-  if err != nil {
-    // handle the configuration error
-  }
-  defer closer.Close()
-
-  // set the Datadog tracer as a GlobalTracer
+    // set the Datadog tracer as a GlobalTracer
   opentracing.SetGlobalTracer(tracer)
   startWebServer()
 }

--- a/content/tracing/setup/kubernetes.md
+++ b/content/tracing/setup/kubernetes.md
@@ -95,11 +95,11 @@ spec:
           name: cgroups
 ```
 
-To send custom metrics via dogstatsd from your application pods, uncomment the `# hostPort: 8125` line in your `datadog-agent.yaml` manifest. This exposes the DogStatsD port on each of your Kubernetes nodes. 
+To send custom metrics via dogstatsd from your application pods, uncomment the `# hostPort: 8125` line in your `datadog-agent.yaml` manifest. This exposes the DogStatsD port on each of your Kubernetes nodes.
 
-To send Traces from your application pods, uncomment the `# hostPort: 8126` line in your `datadog-agent.yaml` manifest. This exposes the Datadog Agent tracing port on each of your Kubernetes nodes. 
+To send Traces from your application pods, uncomment the `# hostPort: 8126` line in your `datadog-agent.yaml` manifest. This exposes the Datadog Agent tracing port on each of your Kubernetes nodes.
 
-**Warning**: This opens a port on your host. Make sure your firewall covers that correctly. 
+**Warning**: This opens a port on your host. Make sure your firewall covers that correctly.
 Another word of caution: some network plugging don't support `hostPorts` yet, so this won't work. The workaround in this case is to add `hostNetwork: true` in your agent pod specifications. This shares the network namespace of your host with the Datadog agent. Again, make sure this logic is okay with your security policies.
 
 Then, deploy the DemonSet with the command:
@@ -149,20 +149,24 @@ end
 #### Go
 
 ```go
+package main
+
 import (
+    "net"
     "os"
-    ddtrace "github.com/DataDog/dd-trace-go/opentracing"
+
+    "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
-
 func main() {
-    config := ddtrace.NewConfiguration()
-    config.AgentHostname = os.GetEnv("DD_AGENT_SERVICE_HOST")
-    config.AgentPort = os.GetEnv("DD_AGENT_SERVICE_PORT")
-
-    tracer, closer, err := ddtrace.NewTracer(config)
-    defer closer.Close()
+    addr := net.JoinHostPort(
+        os.Getenv("DD_AGENT_SERVICE_HOST"),
+        os.Getenv("DD_AGENT_SERVICE_PORT"),
+    )
+    tracer.Start(tracer.WithAgentAddr(addr))
+    defer tracer.Stop()
 }
+
 ```
 
 #### Java
@@ -187,10 +191,10 @@ java -javaagent:/path/to/the/dd-java-agent.jar \
 #### Node.js
 
 ```Node.js
-const tracer = require('dd-trace').init({ 
-  hostname: process.env.DD_AGENT_SERVICE_HOST, 
+const tracer = require('dd-trace').init({
+  hostname: process.env.DD_AGENT_SERVICE_HOST,
   port: process.env.DD_AGENT_SERVICE_PORT
-}) 
+})
 ```
 
 ## Further Reading


### PR DESCRIPTION
### What does this PR do?
Updates the Go examples so they work with the new API

### Motivation
The existing example were broken and confusing.

### Preview link
https://docs-staging.datadoghq.com/caleb/go-k8s/tracing/setup/kubernetes/#go
https://docs-staging.datadoghq.com/caleb/go-k8s/tracing/setup/docker/#go


