### PR TITLE
document netcat UDS example

### DIFF
--- a/content/developers/dogstatsd/unix_socket.md
+++ b/content/developers/dogstatsd/unix_socket.md
@@ -44,7 +44,9 @@ Then [restart your Agent][1]. You can also set the socket path via the `DD_DOGST
 
 ### Client
 
-- The following DogStatsD client libraries support UDS traffic:
+#### Native support in client libraries
+
+The following DogStatsD client libraries natively support UDS traffic:
 
 | Language | Library                            |
 | :----    | :----                              |
@@ -57,7 +59,9 @@ Refer to the library's documentation on how to enable UDS traffic.
 
 **Note:** As with UDP, enabling client-side buffering is highly recommended to improve performance on heavy traffic. Refer to your client library's documentation for instructions.
 
-- Most implementations of `netcat` (`netcat-openbsd` on Debian, `nmap-ncat` on RHEL) support Unix Socket traffic via the `-U` flag. You can send DogStatsD metrics from a shell script with the following syntax:
+#### Using netcat
+
+To send metrics from shell scripts, or testing that DogStatsD is listening on the socket, you can use `netcat`. Most implementations of `netcat` (`netcat-openbsd` on Debian, `nmap-ncat` on RHEL) support Unix Socket traffic via the `-U` flag:
 
 ```bash
 echo -n "custom.metric.name:1|c" | nc -U -u -w1 /var/run/datadog/dsd.socket

--- a/content/developers/dogstatsd/unix_socket.md
+++ b/content/developers/dogstatsd/unix_socket.md
@@ -61,7 +61,7 @@ Refer to the library's documentation on how to enable UDS traffic.
 
 #### Using netcat
 
-To send metrics from shell scripts, or testing that DogStatsD is listening on the socket, you can use `netcat`. Most implementations of `netcat` (`netcat-openbsd` on Debian, `nmap-ncat` on RHEL) support Unix Socket traffic via the `-U` flag:
+To send metrics from shell scripts, or to test that DogStatsD is listening on the socket, you can use `netcat`. Most implementations of `netcat` (ex. `netcat-openbsd` on Debian or `nmap-ncat` on RHEL) support Unix Socket traffic via the `-U` flag:
 
 ```bash
 echo -n "custom.metric.name:1|c" | nc -U -u -w1 /var/run/datadog/dsd.socket

--- a/content/developers/dogstatsd/unix_socket.md
+++ b/content/developers/dogstatsd/unix_socket.md
@@ -44,7 +44,7 @@ Then [restart your Agent][1]. You can also set the socket path via the `DD_DOGST
 
 ### Client
 
-The following DogStatsD client libraries support UDS traffic:
+- The following DogStatsD client libraries support UDS traffic:
 
 | Language | Library                            |
 | :----    | :----                              |
@@ -56,6 +56,12 @@ The following DogStatsD client libraries support UDS traffic:
 Refer to the library's documentation on how to enable UDS traffic.
 
 **Note:** As with UDP, enabling client-side buffering is highly recommended to improve performance on heavy traffic. Refer to your client library's documentation for instructions.
+
+- Most implementations of `netcat` (`netcat-openbsd` on Debian, `nmap-ncat` on RHEL) support Unix Socket traffic via the `-U` flag. You can send DogStatsD metrics from a shell script with the following syntax:
+
+```bash
+echo -n "custom.metric.name:1|c" | nc -U -u -w1 /var/run/datadog/dsd.socket
+```
 
 ### Accessing the socket across containers
 


### PR DESCRIPTION
### What does this PR do?

Add netcat implementations that support Unix Socket traffic and an invocation example

### Motivation

Can be used for testing, or submitting metrics from shell scripts

### Preview link

https://docs-staging.datadoghq.com/xvello/netcat-uds/developers/dogstatsd/unix_socket/