### PR TITLE
de-duplicate embedded pip install instructions

### DIFF
--- a/content/agent/basic_agent_usage/amazonlinux.md
+++ b/content/agent/basic_agent_usage/amazonlinux.md
@@ -70,16 +70,11 @@ Run the `status` (or `info` in v5) command to see the state of the Agent. The Ag
 
 If you're still having trouble, [our support team][3] is glad to provide further assistance.
 
-## Adding a custom Python package to the Agent
+## Working with the embedded Agent
 
 The Agent contains an embedded Python environment at `/opt/datadog-agent/embedded/`. Common binaries such as `python` and `pip` are contained within `/opt/datadog-agent/embedded/bin/`.
 
-### Installing Python libraries
-
-Run the embedded `pip` via the Agent:
-```
-sudo -u dd-agent -- /opt/datadog-agent/embedded/bin/pip install <package_name>
-```
+See the instructions on how to [add packages to the embedded Agent][5] for more information.
 
 ## Switch between Agent v5 and v6
 
@@ -184,3 +179,4 @@ sudo yum remove datadog-agent
 [2]: /integrations
 [3]: /help
 [4]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md#service-lifecycle-commands
+[5]: /agent/custom_python_package

--- a/content/agent/basic_agent_usage/centos.md
+++ b/content/agent/basic_agent_usage/centos.md
@@ -70,16 +70,11 @@ Run the `status` (or `info` in v5) command to see the state of the Agent. The Ag
 
 If you're still having trouble, [our support team][3] is glad to provide further assistance.
 
-## Adding a custom Python package to the Agent
+## Working with the embedded Agent
 
 The Agent contains an embedded Python environment at `/opt/datadog-agent/embedded/`. Common binaries such as `python` and `pip` are contained within `/opt/datadog-agent/embedded/bin/`.
 
-### Installing Python libraries
-
-Run the embedded `pip` via the Agent:
-```
-sudo -u dd-agent -- /opt/datadog-agent/embedded/bin/pip install <package_name>
-```
+See the instructions on how to [add packages to the embedded Agent][5] for more information.
 
 ## Switch between Agent v5 and v6
 
@@ -190,3 +185,4 @@ To uninstall the Agent, run:
 [2]: /integrations
 [3]: /help
 [4]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md#service-lifecycle-commands
+[5]: /agent/custom_python_package

--- a/content/agent/basic_agent_usage/deb.md
+++ b/content/agent/basic_agent_usage/deb.md
@@ -5,6 +5,7 @@ platform: Debian
 aliases:
     - /guides/basic_agent_usage/deb/
     - /agent/basic_agent_usage/install_debian_5/
+    - /agent/basic_agent_usage/debian
 further_reading:
 - link: "logs/"
   tag: "Documentation"
@@ -71,16 +72,11 @@ Run the `status` (or `info` in v5) command to see the state of the Agent. The Ag
 
 If you're still having trouble, [our support team][3] is glad to provide further assistance.
 
-## Adding a custom Python package to the Agent
+## Working with the embedded Agent
 
 The Agent contains an embedded Python environment at `/opt/datadog-agent/embedded/`. Common binaries such as `python` and `pip` are contained within `/opt/datadog-agent/embedded/bin/`.
 
-### Installing Python libraries
-
-Run the embedded `pip` via the Agent:
-```
-sudo -u dd-agent -- /opt/datadog-agent/embedded/bin/pip install <package_name>
-```
+See the instructions on how to [add packages to the embedded Agent][5] for more information.
 
 ## Switch between Agent v5 and v6
 
@@ -179,3 +175,4 @@ $ sudo apt-get --purge remove datadog-agent -y
 [2]: /integrations
 [3]: /help
 [4]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md#service-lifecycle-commands
+[5]: /agent/custom_python_package

--- a/content/agent/basic_agent_usage/fedora.md
+++ b/content/agent/basic_agent_usage/fedora.md
@@ -70,16 +70,11 @@ Run the `status` (or `info` in v5) command to see the state of the Agent. The Ag
 
 If you're still having trouble, [our support team][3] is glad to provide further assistance.
 
-## Adding a custom Python package to the Agent
+## Working with the embedded Agent
 
 The Agent contains an embedded Python environment at `/opt/datadog-agent/embedded/`. Common binaries such as `python` and `pip` are contained within `/opt/datadog-agent/embedded/bin/`.
 
-### Installing Python libraries
-
-Run the embedded `pip` via the Agent:
-```
-sudo -u dd-agent -- /opt/datadog-agent/embedded/bin/pip install <package_name>
-```
+See the instructions on how to [add packages to the embedded Agent][5] for more information.
 
 ## Switch between Agent v5 and v6
 
@@ -174,3 +169,5 @@ sudo yum remove datadog-agent
 [1]: https://app.datadoghq.com/account/settings#agent/fedora
 [2]: /integrations
 [3]: /help
+[4]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md#service-lifecycle-commands
+[5]: /agent/custom_python_package

--- a/content/agent/basic_agent_usage/osx.md
+++ b/content/agent/basic_agent_usage/osx.md
@@ -67,16 +67,11 @@ Run the `status` (or `info` in v5) command to see the state of the Agent. The Ag
 
 If you're still having trouble, [our support team][3] is glad to provide further assistance.
 
-## Adding a custom Python package to the Agent
+## Working with the embedded Agent
 
 The Agent contains an embedded Python environment at `/opt/datadog-agent/embedded/`. Common binaries such as `python` and `pip` are contained within `/opt/datadog-agent/embedded/bin/`.
 
-### Installing Python libraries
-
-Run the embedded `pip` via the Agent:
-```
-/opt/datadog-agent/embedded/bin/pip install <package_name>
-```
+See the instructions on how to [add packages to the embedded Agent][5] for more information.
 
 ## Switch between Agent v5 and v6
 
@@ -146,3 +141,4 @@ DD_API_KEY=YOUR_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/Dat
 [2]: /integrations
 [3]: /help
 [4]: https://github.com/DataDog/datadog-agent/releases
+[5]: /agent/custom_python_package

--- a/content/agent/basic_agent_usage/redhat.md
+++ b/content/agent/basic_agent_usage/redhat.md
@@ -70,16 +70,11 @@ Run the `status` (or `info` in v5) command to see the state of the Agent. The Ag
 
 If you're still having trouble, [our support team][3] is glad to provide further assistance.
 
-## Adding a custom Python package to the Agent
+## Working with the embedded Agent
 
 The Agent contains an embedded Python environment at `/opt/datadog-agent/embedded/`. Common binaries such as `python` and `pip` are contained within `/opt/datadog-agent/embedded/bin/`.
 
-### Installing Python libraries
-
-Run the embedded `pip` via the Agent:
-```
-sudo -u dd-agent -- /opt/datadog-agent/embedded/bin/pip install <package_name>
-```
+See the instructions on how to [add packages to the embedded Agent][5] for more information.
 
 ## Switch between Agent v5 and v6
 
@@ -190,3 +185,4 @@ To uninstall the Agent, run:
 [2]: /integrations
 [3]: /help
 [4]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md#service-lifecycle-commands
+[5]: /agent/custom_python_package

--- a/content/agent/basic_agent_usage/suse.md
+++ b/content/agent/basic_agent_usage/suse.md
@@ -70,16 +70,11 @@ Run the `status` (or `info` in v5) command to see the state of the Agent. The Ag
 
 If you're still having trouble, [our support team][3] is glad to provide further assistance.
 
-## Adding a custom Python package to the Agent
+## Working with the embedded Agent
 
 The Agent contains an embedded Python environment at `/opt/datadog-agent/embedded/`. Common binaries such as `python` and `pip` are contained within `/opt/datadog-agent/embedded/bin/`.
 
-### Installing Python libraries
-
-Run the embedded `pip` via the Agent:
-```
-sudo -u dd-agent -- /opt/datadog-agent/embedded/bin/pip install <package_name>
-```
+See the instructions on how to [add packages to the embedded Agent][5] for more information.
 
 ## Upgrade to Agent 6
 
@@ -120,3 +115,4 @@ sudo -u dd-agent -- /opt/datadog-agent/embedded/bin/pip install <package_name>
 [2]: /integrations
 [3]: /help
 [4]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md#service-lifecycle-commands
+[5]: /agent/custom_python_package

--- a/content/agent/basic_agent_usage/ubuntu.md
+++ b/content/agent/basic_agent_usage/ubuntu.md
@@ -70,16 +70,11 @@ Run the `status` (or `info` in v5) command to see the state of the Agent. The Ag
 
 If you're still having trouble, [our support team][3] is glad to provide further assistance.
 
-## Adding a custom Python package to the Agent
+## Working with the embedded Agent
 
 The Agent contains an embedded Python environment at `/opt/datadog-agent/embedded/`. Common binaries such as `python` and `pip` are contained within `/opt/datadog-agent/embedded/bin/`.
 
-### Installing Python libraries
-
-Run the embedded `pip` via the Agent:
-```
-sudo -u dd-agent -- /opt/datadog-agent/embedded/bin/pip install <package_name>
-```
+See the instructions on how to [add packages to the embedded Agent][5] for more information.
 
 ## Switch between Agent v5 and v6
 
@@ -185,3 +180,4 @@ $ sudo apt-get --purge remove datadog-agent -y
 [2]: /integrations
 [3]: /help
 [4]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md#service-lifecycle-commands
+[5]: /agent/custom_python_package

--- a/content/agent/custom_python_package.md
+++ b/content/agent/custom_python_package.md
@@ -1,5 +1,5 @@
 ---
-title: Adding a custom python package to the Agent
+title: Adding a custom Python package to the Agent
 kind: documentation
 further_reading:
 - link: "logs/"
@@ -15,16 +15,17 @@ further_reading:
 
 ### Linux
 
-The python version embedded with the Agent is located here: `/opt/datadog-agent/embedded/bin/python`.
-The Agent also comes with pip; install python libraries using:
+The Agent contains an embedded Python environment at `/opt/datadog-agent/embedded/`. Common binaries such as `python` and `pip` are contained within `/opt/datadog-agent/embedded/bin/`.
 
-```bash
+Python packages can be installed via the embedded `pip`:
+
+```shell
 sudo -u dd-agent /opt/datadog-agent/embedded/bin/pip install <package_name>
 ```
 
 ### Windows
 
-Custom python packages can be installed using the Agent's embedded Python using the following command in Powershell:
+Custom Python packages can be installed using the Agent's embedded Python using the following command in Powershell:
 
 ```
 C:\"Program Files"\Datadog\"Datadog Agent"\embedded\python -m install <package_name>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes duplicated content regarding the embedded `pip` in the Agent.

### Motivation
Documentation hygiene.

### Preview link
> See the instructions on how to add packages to the embedded Agent for more information.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
