### PR TITLE
reference StackExchange.Redis

### DIFF
--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -46,7 +46,7 @@ Don't see what you're looking for? Please let us know more about your needs thro
 | Elasticsearch.net / NEST        | Coming soon | Coming soon (est. September 2018 Beta) |
 | MongoDB.Driver                  | Coming soon | Coming soon (est. September 2018 Beta) |
 | Postgres (Npgsql)               | Coming soon | Coming soon (est. September 2018 Beta) |
-| ServiceStack.Redis              | Coming soon | Coming soon (est. September 2018 Beta) |
+| StackExchange.Redis             | Coming soon | Coming soon (est. September 2018 Beta) |
 
 Don't see what you're looking for? Please let us know more about your needs through [this survey][1].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR updates the .NET tracing (APM) documentation to refer the the correct `redis` library.

### Motivation
We are adding support for `StackExchange.Redis` before `ServiceStack.Redis` (those are two different libraries to access redis). We should set the correct customer expectations.

### Preview link
https://github.com/DataDog/documentation/compare/lpimentel/fix-redis-reference?short_path=a5530d4#diff-a5530d4502bc749fab50e65d06176788
