### PR TITLE
Add monitor tags to downtime API docs

### DIFF
--- a/content/api/downtimes/code_snippets/result.api-monitor-get-downtime.py
+++ b/content/api/downtimes/code_snippets/result.api-monitor-get-downtime.py
@@ -3,6 +3,7 @@
  'end': 1420447087,
  'id': 2910,
  'message': 'Doing some testing on staging.',
+ 'monitor_tags': ['*'],
  'scope': ['env:staging'],
  'start': 1420387032
  }

--- a/content/api/downtimes/code_snippets/result.api-monitor-get-downtime.sh
+++ b/content/api/downtimes/code_snippets/result.api-monitor-get-downtime.sh
@@ -1,8 +1,10 @@
-{'active': True,
-  'disabled': False,
-  'end': 1420447087,
-  'id': 2910,
-  'message': 'Doing some testing on staging.',
-  'scope': ['env:staging'],
-  'start': 1420387032
+{
+  "active": True,
+  "disabled": False,
+  "end": 1420447087,
+  "id": 2910,
+  "message": "Doing some testing on staging.",
+  "monitor_tags": ["*"],
+  "scope": ["env:staging"],
+  "start": 1420387032
 }

--- a/content/api/downtimes/code_snippets/result.api-monitor-get-downtimes.py
+++ b/content/api/downtimes/code_snippets/result.api-monitor-get-downtimes.py
@@ -6,6 +6,7 @@
         'disabled': True,
         'end': 1412793983,
         'id': 1625,
+        'monitor_tags': ['*'],
         'scope': ['env:staging'],
         'start': 1412792983
     },
@@ -14,6 +15,7 @@
         'disabled': True,
         'end': None,
         'id': 1626,
+        'monitor_tags': ['*'],
         'scope': ['*'],
         'start': 1412792985
     }

--- a/content/api/downtimes/code_snippets/result.api-monitor-get-downtimes.rb
+++ b/content/api/downtimes/code_snippets/result.api-monitor-get-downtimes.rb
@@ -4,6 +4,7 @@
         "disabled" => true,
         "start" => 1412792983,
         "active" => false,
+        "monitor_tags" => ["*"],
         "scope" => ["env:staging"],
         "id" => 1625
     }, {
@@ -11,6 +12,7 @@
         "disabled" => true,
         "start" => 1412792985,
         "active" => false,
+        "monitor_tags" => ["*"],
         "scope" => ["*"],
         "id" => 1626
     }]

--- a/content/api/downtimes/code_snippets/result.api-monitor-get-downtimes.sh
+++ b/content/api/downtimes/code_snippets/result.api-monitor-get-downtimes.sh
@@ -4,6 +4,7 @@
     "disabled": true,
     "end": 1412793983,
     "id": 1625,
+    "monitor_tags": ["*"],
     "scope": [
       "env:staging"
     ],
@@ -14,6 +15,7 @@
     "disabled": true,
     "end": null,
     "id": 1626,
+    "monitor_tags": ["*"],
     "scope": [
       "*"
     ],

--- a/content/api/downtimes/code_snippets/result.api-monitor-schedule-downtime.py
+++ b/content/api/downtimes/code_snippets/result.api-monitor-schedule-downtime.py
@@ -8,6 +8,7 @@
     'id': 169267576,
     'message': None,
     'monitor_id': None,
+    'monitor_tags': ['*'],
     'parent_id': None,
     'recurrence': {
         'period': 1,

--- a/content/api/downtimes/code_snippets/result.api-monitor-schedule-downtime.rb
+++ b/content/api/downtimes/code_snippets/result.api-monitor-schedule-downtime.rb
@@ -8,6 +8,7 @@
         "end" => 1445978819,
         "parent_id" => nil,
         "monitor_id" => nil,
+        "monitor_tags": ["*"],
         "recurrence" => {
             "until_date" => 1448387219,
             "until_occurrences" => nil,

--- a/content/api/downtimes/code_snippets/result.api-monitor-schedule-downtime.sh
+++ b/content/api/downtimes/code_snippets/result.api-monitor-schedule-downtime.sh
@@ -7,6 +7,7 @@
   "id": 169267786,
   "message": null,
   "monitor_id": null,
+  "monitor_tags": ["*"],
   "parent_id": null,
   "recurrence": {
     "period": 1,

--- a/content/api/downtimes/code_snippets/result.api-monitor-update-downtime.py
+++ b/content/api/downtimes/code_snippets/result.api-monitor-update-downtime.py
@@ -5,6 +5,7 @@
     'end': 1420447087,
     'id': 2910,
     'message': 'Doing some testing on staging.',
+    'monitor_tags': ['*'],
     'scope': ['env:staging'],
     'start': 1420387032
 }

--- a/content/api/downtimes/code_snippets/result.api-monitor-update-downtime.rb
+++ b/content/api/downtimes/code_snippets/result.api-monitor-update-downtime.rb
@@ -4,6 +4,7 @@
         "disabled" => false,
         "start" => 1418224729,
         "active" => true,
+        "monitor_tags": ["*"],
         "scope" => ["env:testing"],
         "message" => "Doing some testing on staging.",
         "id" => 4336

--- a/content/api/downtimes/code_snippets/result.api-monitor-update-downtime.sh
+++ b/content/api/downtimes/code_snippets/result.api-monitor-update-downtime.sh
@@ -4,6 +4,7 @@
   "end": 1418303372,
   "id": 4336,
   "message": "Doing some testing on staging",
+  "monitor_tags": ["*"],
   "scope": [
     "env:staging"
   ],

--- a/content/api/downtimes/downtimes_schedule.md
+++ b/content/api/downtimes/downtimes_schedule.md
@@ -9,19 +9,21 @@ external_redirect: /api/#schedule-monitor-downtime
 
 ##### ARGUMENTS
 
-* **`scope`** [*required*]:  
+* **`scope`** [*required*]:
     The scope(s) to which the downtime applies, e.g. `host:app2`. Provide multiple scopes as a comma-separated list, e.g. `env:dev,env:prod`. The resulting downtime applies to sources that matches ALL provided scopes (i.e. `env:dev` **AND** `env:prod`), NOT any of them.
-* **`monitor_id`** [*optional*, *default*=**None**]:  
+* **`monitor_tags`** [*optional*, *default*=**no monitor tag filter**]:
+    A comma-separated list of monitor tags, i.e. tags that are applied directly to monitors, *not* tags that are used in monitor queries (which are filtered by the `scope` parameter), to which the downtime applies. The resulting downtime applies to monitors that match ALL provided monitor tags (i.e. service:postgres AND team:frontend), NOT any of them.
+* **`monitor_id`** [*optional*, *default*=**None**]:
     A single monitor to which the downtime applies. If not provided, the downtime applies to all monitors.
-* **`start`** [*optional*, *default*=**None**]:  
+* **`start`** [*optional*, *default*=**None**]:
     POSIX timestamp to start the downtime. If not provided, the downtime starts the moment it is created.
-* **`end`** [*optional*, *default*=**None**]:  
+* **`end`** [*optional*, *default*=**None**]:
     POSIX timestamp to end the downtime. If not provided, the downtime is in effect indefinitely (i.e. until you cancel it).
-* **`message`** [*optional*, *default*=**None**]:  
+* **`message`** [*optional*, *default*=**None**]:
     A message to include with notifications for this downtime. Email notifications can be sent to specific users by using the same '@username' notation as events
-* **`timezone`** [*optional*, *default* = **UTC**]:  
+* **`timezone`** [*optional*, *default* = **UTC**]:
     The timezone for the downtime.
-* **`recurrence`** [*optional*, *default*=**None**]:  
+* **`recurrence`** [*optional*, *default*=**None**]:
     An object defining the recurrence of the downtime with a variety of parameters:
     *   **`type`** the type of recurrence. Choose from: `days`, `weeks`, `months`, `years`.
     *   **`period`** how often to repeat as an integer. For example to repeat every 3 days, select a type of `days` and a period of `3`.

--- a/content/api/downtimes/downtimes_schedule.md
+++ b/content/api/downtimes/downtimes_schedule.md
@@ -12,7 +12,7 @@ external_redirect: /api/#schedule-monitor-downtime
 * **`scope`** [*required*]:
     The scope(s) to which the downtime applies, e.g. `host:app2`. Provide multiple scopes as a comma-separated list, e.g. `env:dev,env:prod`. The resulting downtime applies to sources that matches ALL provided scopes (i.e. `env:dev` **AND** `env:prod`), NOT any of them.
 * **`monitor_tags`** [*optional*, *default*=**no monitor tag filter**]:
-    A comma-separated list of monitor tags, i.e. tags that are applied directly to monitors, *not* tags that are used in monitor queries (which are filtered by the `scope` parameter), to which the downtime applies. The resulting downtime applies to monitors that match ALL provided monitor tags (i.e. service:postgres AND team:frontend), NOT any of them.
+    A comma-separated list of monitor tags, i.e. tags that are applied directly to monitors, *not* tags that are used in monitor queries (which are filtered by the `scope` parameter), to which the downtime applies. The resulting downtime applies to monitors that match ALL provided monitor tags (i.e. `service:postgres` **AND** `team:frontend`), NOT any of them.
 * **`monitor_id`** [*optional*, *default*=**None**]:
     A single monitor to which the downtime applies. If not provided, the downtime applies to all monitors.
 * **`start`** [*optional*, *default*=**None**]:

--- a/content/api/downtimes/downtimes_update.md
+++ b/content/api/downtimes/downtimes_update.md
@@ -8,21 +8,23 @@ external_redirect: /api/#update-monitor-downtime
 ## Update monitor downtime
 ##### ARGUMENTS
 
-* **`id`** [*required*]:  
+* **`id`** [*required*]:
     The integer id of the downtime to be updated
-* **`scope`** [*required*]:  
+* **`scope`** [*required*]:
     The scope to which the downtime applies, e.g. 'host:app2'. Provide multiple scopes as a comma-separated list, e.g. 'env:dev,env:prod'. The resulting downtime applies to sources that matches ALL provided scopes (i.e. env:dev AND env:prod), NOT any of them.
-* **`monitor_id`** [*optional*, *default*=**None**]:  
+* **`monitor_tags`** [*optional*, *default*=**no monitor tag filter**]:
+    A comma-separated list of monitor tags, i.e. tags that are applied directly to monitors, *not* tags that are used in monitor queries (which are filtered by the `scope` parameter), to which the downtime applies. The resulting downtime applies to monitors that match ALL provided monitor tags (i.e. service:postgres AND team:frontend), NOT any of them.
+* **`monitor_id`** [*optional*, *default*=**None**]:
     A single monitor to which the downtime applies. If not provided, the downtime applies to all monitors.
-* **`start`** [*optional*, *default* = **original start**]:  
+* **`start`** [*optional*, *default* = **original start**]:
     POSIX timestamp to start the downtime.
 * **`end`** [*optional*, *default* = **original end**]:
     POSIX timestamp to end the downtime. If not provided, the downtime is in effect indefinitely (i.e. until you cancel it).
-* **`message`** [*required*, *default* = **original message**]:  
+* **`message`** [*required*, *default* = **original message**]:
     A message to include with notifications for this downtime. Email notifications can be sent to specific users by using the same '@username' notation as events
-* **`timezone`** [*optional*, default = **original timezone** ]:  
+* **`timezone`** [*optional*, default = **original timezone** ]:
     The timezone for the downtime.
-* **`recurrence`** [*optional*, *default* = **original recurrence**]:  
+* **`recurrence`** [*optional*, *default* = **original recurrence**]:
     An object defining the recurrence of the downtime with a variety of parameters:
     *   **`type`** the type of recurrence. Choose from: `days`, `weeks`, `months`, `years`.
     *   **`period`** how often to repeat as an integer. For example to repeat every 3 days, select a type of `days` and a period of `3`.

--- a/content/api/downtimes/downtimes_update.md
+++ b/content/api/downtimes/downtimes_update.md
@@ -13,7 +13,7 @@ external_redirect: /api/#update-monitor-downtime
 * **`scope`** [*required*]:
     The scope to which the downtime applies, e.g. 'host:app2'. Provide multiple scopes as a comma-separated list, e.g. 'env:dev,env:prod'. The resulting downtime applies to sources that matches ALL provided scopes (i.e. env:dev AND env:prod), NOT any of them.
 * **`monitor_tags`** [*optional*, *default*=**no monitor tag filter**]:
-    A comma-separated list of monitor tags, i.e. tags that are applied directly to monitors, *not* tags that are used in monitor queries (which are filtered by the `scope` parameter), to which the downtime applies. The resulting downtime applies to monitors that match ALL provided monitor tags (i.e. service:postgres AND team:frontend), NOT any of them.
+    A comma-separated list of monitor tags, i.e. tags that are applied directly to monitors, *not* tags that are used in monitor queries (which are filtered by the `scope` parameter), to which the downtime applies. The resulting downtime applies to monitors that match ALL provided monitor tags (i.e. `service:postgres` **AND** `team:frontend`), NOT any of them.
 * **`monitor_id`** [*optional*, *default*=**None**]:
     A single monitor to which the downtime applies. If not provided, the downtime applies to all monitors.
 * **`start`** [*optional*, *default* = **original start**]:


### PR DESCRIPTION
### What does this PR do?
It adds monitor tags to downtime API docs (the arguments and example responses).

### Motivation
It is now possible to schedule downtimes over monitor tags.

### Preview link
https://docs-staging.datadoghq.com/chrism/monitor-tag-downtimes/api/?lang=bash#schedule-monitor-downtime