### PR TITLE
clarify pip invocation under macOS

### DIFF
--- a/content/agent/custom_python_package.fr.md
+++ b/content/agent/custom_python_package.fr.md
@@ -22,6 +22,8 @@ L'Agent vient également avec pip, installer les bibliothèques python en utilis
 sudo -u dd-agent /opt/datadog-agent/embedded/bin/pip install <package_name>
 ```
 
+**Note:** Dans macOS, supprimez `-u dd-agent` de cette commande.
+
 ### Windows
 
 Les packages python custom peuvent être installés à l'aide de l'Agent avec la commande suivante dans Powershell:

--- a/content/agent/custom_python_package.md
+++ b/content/agent/custom_python_package.md
@@ -23,6 +23,8 @@ Python packages can be installed via the embedded `pip`:
 sudo -u dd-agent /opt/datadog-agent/embedded/bin/pip install <package_name>
 ```
 
+**Note:** On macOS, remove `-u dd-agent` from this command.
+
 ### Windows
 
 Custom Python packages can be installed using the Agent's embedded Python using the following command in Powershell:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Clarifies how to invoke the embedded `pip` in macOS.

### Motivation
Public Slack: https://datadoghq.slack.com/archives/C3BM8SGKZ/p1534497545000100
> As per this page, minus `-u dd-agent` part which doesn't apply to macOS

### Preview link

**Note:** On macOS, remove `-u dd-agent` from this command.
**Note:** Dans macOS, supprimez `-u dd-agent` de cette commande.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
