### PR TITLE
change all yes/no to true/false in agent config files

### DIFF
--- a/content/agent/kubernetes/daemonset_setup.md
+++ b/content/agent/kubernetes/daemonset_setup.md
@@ -135,7 +135,7 @@ spec:
           - name: DD_LEADER_ELECTION
             value: "true"
           - name: KUBERNETES
-            value: "yes"
+            value: "true"
           - name: DD_KUBERNETES_KUBELET_HOST
             valueFrom:
               fieldRef:
@@ -251,8 +251,8 @@ To enable [Trace collection][20] with your DaemonSet:
     (...)
     ```
 
-2. Uncomment the `# hostPort: 8126` line. 
-  This exposes the Datadog Agent tracing port on each of your Kubernetes nodes. 
+2. Uncomment the `# hostPort: 8126` line.
+  This exposes the Datadog Agent tracing port on each of your Kubernetes nodes.
 
   **Warning**: This opens a port on your host. Make sure your firewall only allows access from your applications or trusted sources.
   Another word of caution: some network plugins don't support `hostPorts` yet, so this won't work. The workaround in this case is to add `hostNetwork: true` in your agent pod specifications. This shares the network namespace of your host with the Datadog agent. This also means that all ports opened on the container are also opened on the host. If a port is used both on the host and in your container, they conflict (since they share the same network namespace) and the pod will not start. Not all Kubernetes installations allow this.
@@ -276,7 +276,7 @@ To send custom metrics via DogStatsD, set the `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` v
 
 Learn more about this in the [Docker DogStatsD documentation][19]
 
-To send custom metrics via DogStatsD from your application pods, uncomment the `# hostPort: 8125` line in your `datadog-agent.yaml` manifest. This exposes the DogStatsD port on each of your Kubernetes nodes. 
+To send custom metrics via DogStatsD from your application pods, uncomment the `# hostPort: 8125` line in your `datadog-agent.yaml` manifest. This exposes the DogStatsD port on each of your Kubernetes nodes.
 
 **Warning**: This opens a port on your host. Make sure your firewall only allows access from your applications or trusted sources.
 Another word of caution: some network plugins don't support `hostPorts` yet, so this won't work. The workaround in this case is to add `hostNetwork: true` in your agent pod specifications. This shares the network namespace of your host with the Datadog agent. This also means that all ports opened on the container are also opened on the host. If a port is used both on the host and in your container, they conflict (since they share the same network namespace) and the pod will not start. Not all Kubernetes installations allow this.

--- a/content/agent/proxy.md
+++ b/content/agent/proxy.md
@@ -31,7 +31,7 @@ Traditional web proxies are supported natively by the Agent. If you need to conn
 
 ### Agent v6
 
-Set different proxy servers for `https` and `http` requests in your Agent `datadog.yaml` configuration file. 
+Set different proxy servers for `https` and `http` requests in your Agent `datadog.yaml` configuration file.
 The Agent uses `https` to send data to Datadog, but integrations might use `http` to gather metrics. No matter the proxied requests, you can activate SSL on your proxy server. Below are some configuration examples for your `datadog.yaml` file:
 
 Setting an HTTP proxy for all `https` requests:
@@ -115,7 +115,7 @@ This is the best option if you do not have a web proxy readily available in your
 ### Proxy metric forwarding with HAProxy
 #### HAProxy configuration
 
-We assume that HAProxy is installed on a host that has connectivity to Datadog.  
+We assume that HAProxy is installed on a host that has connectivity to Datadog.
 Use the following configuration file if you do not already have it configured.
 
 ```
@@ -196,8 +196,8 @@ Once the HAProxy configuration is in place, you can reload it or restart HAProxy
 #### Datadog Agent configuration
 ##### Agent v6
 
-Edit each Agent to point to HAProxy by setting its `dd_url` to the address of HAProxy (e.g. `haproxy.example.com`). 
-This `dd_url` setting can be found in the `datadog.yaml` file. 
+Edit each Agent to point to HAProxy by setting its `dd_url` to the address of HAProxy (e.g. `haproxy.example.com`).
+This `dd_url` setting can be found in the `datadog.yaml` file.
 
 `dd_url: https://haproxy.example.com:3834`
 
@@ -223,8 +223,8 @@ To verify that everything is working properly, review the HAProxy statistics at 
 
 ##### Agent v5
 
-Edit each Agent to point to HAProxy by setting its `dd_url` to the address of HAProxy (e.g. `haproxy.example.com`). 
-This `dd_url` setting can be found in the `datadog.conf` file. 
+Edit each Agent to point to HAProxy by setting its `dd_url` to the address of HAProxy (e.g. `haproxy.example.com`).
+This `dd_url` setting can be found in the `datadog.conf` file.
 
 `dd_url: https://haproxy.example.com:3834`
 
@@ -268,15 +268,15 @@ To verify that everything is working properly, review the HAProxy statistics at 
 
 We recommend using an actual proxy (a web proxy or HAProxy) to forward your traffic to Datadog, however if those options aren't available to you, it is possible to configure an instance of Agent v5 to serve as a proxy.
 
-1. Designate one node **running datadog-agent** as the proxy.  
+1. Designate one node **running datadog-agent** as the proxy.
     In this example assume that the proxy name is `proxy-node`. This node **must** be able to reach `https://app.datadoghq.com`.
 
-2. Verify SSL connectivity on `proxy-node`  
+2. Verify SSL connectivity on `proxy-node`
     ```
     curl -v https://app.datadoghq.com/account/login 2>&1 | grep "200 OK"
     ```
 
-3. Allow non-local traffic on `proxy-node` by changing the following line in `datadog.conf`.  
+3. Allow non-local traffic on `proxy-node` by changing the following line in `datadog.conf`.
      `# non_local_traffic: no` should read `non_local_traffic: yes`.
 
 4. Make sure `proxy-node` can be reached from the other nodes over port 17123. Start the Agent on the `proxy-node` and run on the other nodes:

--- a/content/developers/dogstatsd/_index.fr.md
+++ b/content/developers/dogstatsd/_index.fr.md
@@ -56,7 +56,7 @@ Si cette fonction s'exécute cent fois pendant le flush interval (dix secondes, 
 
 Commencez par éditer votre fichier `datadog.yaml` en décommentant les lignes suivantes:
 ```
-use_dogstatsd: yes
+use_dogstatsd: true
 
 ...
 

--- a/content/developers/dogstatsd/_index.md
+++ b/content/developers/dogstatsd/_index.md
@@ -54,7 +54,7 @@ If this function executes one hundred times during a flush interval (ten seconds
 
 First, edit your `datadog.yaml` file to uncomment the following lines:
 ```
-use_dogstatsd: yes
+use_dogstatsd: true
 
 ...
 

--- a/content/integrations/cloud_foundry.md
+++ b/content/integrations/cloud_foundry.md
@@ -189,7 +189,7 @@ addons:
     release: datadog-agent
   properties:
     dd:
-      use_dogstatsd: yes
+      use_dogstatsd: true
       dogstatsd_port: 18125               # Many CF deployments have a StatsD already on port 8125
       api_key: <DD_API_KEY>
       tags: ["cloudfoundry_deployment_1"] # any tags you wish

--- a/content/security/agent.md
+++ b/content/security/agent.md
@@ -15,7 +15,7 @@ Customers can send data to the Datadog service by using a locally installed [Age
 
 ## Information Security
 
-The Datadog Agent submits data to Datadog over a TLS-encrypted TCP connection by default. As of version 6, the Agent can be configured to enforce TLS 1.2 when connecting to Datadog. Customers who require the use of "strong cryptography," for example, to meet PCI requirements, should use Agent v6 and set the `force_tls_12: yes` setting in the Agent's configuration file.
+The Datadog Agent submits data to Datadog over a TLS-encrypted TCP connection by default. As of version 6, the Agent can be configured to enforce TLS 1.2 when connecting to Datadog. Customers who require the use of "strong cryptography," for example, to meet PCI requirements, should use Agent v6 and set the `force_tls_12: true` setting in the Agent's configuration file.
 
 ## Agent Logs Obfuscation
 

--- a/content/tracing/faq/agent-5-tracing-setup.md
+++ b/content/tracing/faq/agent-5-tracing-setup.md
@@ -10,7 +10,7 @@ APM is available as part of the Datadog Agent with versions 5.11+ as part of the
 
 The Agent can be enabled by including the following in your [Datadog Agent configuration file][3]:
 ```
-apm_enabled: yes
+apm_enabled: true
 ```
 
 <div class="alert alert-info">

--- a/content/tracing/setup/kubernetes.md
+++ b/content/tracing/setup/kubernetes.md
@@ -56,7 +56,7 @@ spec:
           - name: DD_LEADER_ELECTION
             value: "true"
           - name: KUBERNETES
-            value: "yes"
+            value: "true"
           - name: DD_KUBERNETES_KUBELET_HOST
             valueFrom:
               fieldRef:

--- a/ja/content/integrations/cloud_foundry.md
+++ b/ja/content/integrations/cloud_foundry.md
@@ -62,7 +62,7 @@ addons:
     release: datadog-agent
   properties:
     dd:
-      use_dogstatsd: yes
+      use_dogstatsd: true
       dogstatsd_port: 18125               # Many CF deployments have a StatsD already on port 8125
       api_key: <YOUR_DATADOG_API_KEY>
       tags: ["cloudfoundry_deployment_1"] # any tags you wish

--- a/ja/content/tracing/index.md
+++ b/ja/content/tracing/index.md
@@ -17,7 +17,7 @@ Datadog's integrated APM tool eliminates the traditional separation between infr
 
 The Datadog APM is included in our Enterprise plan or as an upgrade to our Pro plan. A free 14-day trial is available.  Registered users can visit the [APM page of the Datadog app](https://app.datadoghq.com/trace/home) to get started.
 
-APM is available as part of the Datadog Agent with versions 5.11+ as part of the one line install for the Linux and Docker Agents. Currently, [Mac](https://github.com/DataDog/datadog-trace-agent#run-on-osx) and [Windows](https://github.com/DataDog/datadog-trace-agent#run-on-windows) users must perform a manual install of the APM Agent (aka Trace Agent) via a separate install process. The Agent can be enabled by including the following in your Datadog agent configuration file: `apm_enabled: yes`
+APM is available as part of the Datadog Agent with versions 5.11+ as part of the one line install for the Linux and Docker Agents. Currently, [Mac](https://github.com/DataDog/datadog-trace-agent#run-on-osx) and [Windows](https://github.com/DataDog/datadog-trace-agent#run-on-windows) users must perform a manual install of the APM Agent (aka Trace Agent) via a separate install process. The Agent can be enabled by including the following in your Datadog agent configuration file: `apm_enabled: true`
 
 <div class="alert alert-info">
 APM is enabled by default after Datadog agent 5.13 (on Linux and Docker), and can be disabled by adding the parameter: <code>apm_enabled: no</code> in your Datadog agent configuration file.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Changes all boolean values in agent 6 config files from `yes`/`no` to `true`/`false`.

### Motivation
Sister of https://github.com/DataDog/datadog-agent/pull/2171
Main goal was to avoid confusion when using environment variable instead of config files as `yes`/`no` is not supported in that case.

### Preview link

