### PR TITLE
Add dummy link to ignore

### DIFF
--- a/local/etc/links.ignore
+++ b/local/etc/links.ignore
@@ -34,3 +34,4 @@ https://sidekiq.org/
 https://uptime.com/push-notifications/manage/
 https://manage.windowsazure.com
 http://ec2-54-85-23-10.compute-1.amazonaws.com
+https://docs.datadoghq.com/**LINK_TO_INTEGERATION_SITE**


### PR DESCRIPTION
this link

https://docs.datadoghq.com/**LINK_TO_INTEGERATION_SITE**

is present in the doc but is not a real link.