### PR TITLE
Fixing integrations core pattern

### DIFF
--- a/content/integrations/faq/list-of-api-source-attribute-value.md
+++ b/content/integrations/faq/list-of-api-source-attribute-value.md
@@ -8,12 +8,14 @@ kind: faq
 |Activemq|ACTIVEMQ|
 |Airbrake|AIRBRAKE|
 |Akamai|AKAMAI|
+|Alibaba Cloud|ALIBABACLOUD|
 |Amazon Api Gateway|APIGATEWAY|
 |Amazon Auto Scaling|AUTOSCALING|
 |Amazon Billing|BILLING|
 |Amazon Cloudfront|CLOUDFRONT|
 |Amazon Cloudsearch|CLOUDSEARCH|
 |Amazon Cloudtrail|CLOUDTRAIL|
+|Amazon Codebuild|CODEBUILD|
 |Amazon Codedeploy|CODEDEPLOY|
 |Amazon Directconnect|DIRECTCONNECT|
 |Amazon Dynamodb|DYNAMODB|
@@ -74,6 +76,8 @@ kind: faq
 |Ceph|CEPH|
 |Chatwork|CHATWORK|
 |Chef|CHEF|
+|Circleci|CIRCLECI|
+|Cisco Aci|CISCOACI|
 |Cloud Foundry|CLOUDFOUNDRY|
 |Cloudhealth|CLOUDHEALTH|
 |Cloudnetworkhealth|CLOUDNETWORKHEALTH|
@@ -115,6 +119,7 @@ kind: faq
 |Google Cloudsql|GCPCLOUDSQL|
 |Google Compute Engine|GCPCOMPUTE|
 |Google Container Engine|GCPCONTAINER|
+|Google Hangouts Chat|HANGOUTS|
 |Gunicorn|GUNICORN|
 |Haproxy|HAPROXY|
 |Hdfs|HDFS|
@@ -151,6 +156,7 @@ kind: faq
 |New Relic|NEWRELIC|
 |Nginx|NGINX|
 |Node|NODE|
+|Office 365 Groups|OFFICE365GROUPS|
 |Openstack|OPENSTACK|
 |Opsgenie|OPSGENIE|
 |Opsmatic|OPSMATIC|
@@ -193,6 +199,7 @@ kind: faq
 |Teamcity|TEAMCITY|
 |Tokumx|TOKUMX|
 |Tomcat|TOMCAT|
+|Travis Ci|TRAVISCI|
 |Upstart|UPSTART|
 |User|DOGWEBPUBLISHER|
 |Users|DOGWEBPUBLISHER|
@@ -210,3 +217,4 @@ kind: faq
 |Yarn|YARN|
 |Zendesk|ZENDESK|
 |Zookeeper|ZOOKEEPER|
+

--- a/local/bin/py/update_pre_build.py
+++ b/local/bin/py/update_pre_build.py
@@ -210,7 +210,7 @@ class PreBuild:
         dogweb_globs = ['integration/**/*_metadata.csv', 'integration/**/manifest.json',
                         'integration/**/service_checks.json', 'integration/**/README.md',
                         'dd/utils/context/source.py']
-        integrations_globs = ['**/metadata.csv', '**/manifest.json', '**/service_checks.json', '**/README.md','docs/**']
+        integrations_globs = ['*[!}]/metadata.csv', '*[!}]/manifest.json', '*[!}]/service_checks.json', '*[!}]/README.md', 'docs/**']
         extras_globs = ['**/metadata.csv', '**/manifest.json', '**/service_checks.json', '**/README.md']
 
         # sync from dogweb, download if we don't have it (token required)


### PR DESCRIPTION
### What does this PR do?

Fix doc build by making pulling patterns more restrictive. 

Otherwise we pull template files for integrations.