### PR TITLE
Add shortcode for wistia

### DIFF
--- a/content/account_management/multi_organization.md
+++ b/content/account_management/multi_organization.md
@@ -16,6 +16,10 @@ This is typically used by Managed Service Providers that have customers which sh
 
 The Multi-organization Account feature must be enabled by support. If this is a feature you need, [contact us][2]!
 
+Here's a two-minute video walkthrough:
+
+{{<wistia tg9ufqbin9>}} 
+
 ## Create a new child-organization
 
 1. After the feature has been enabled, visit the [New Account Page][3].

--- a/content/account_management/saml/_index.md
+++ b/content/account_management/saml/_index.md
@@ -9,6 +9,8 @@ further_reading:
   text: Configuring Teams & Organizations with Multiple Accounts
 ---
 
+{{<wistia 2qe33x8h3v>}}
+
 **This documentation assumes that you already have a SAML Identity Provider up and running.**
 
 Configuring [SAML (Security Assertion Markup Language)][1] for your Datadog account lets you and all your teammates log in to Datadog using the credentials stored in your organization's Active Directory, LDAP, or other identity store that has been configured with a SAML Identity Provider.

--- a/content/account_management/saml/_index.md
+++ b/content/account_management/saml/_index.md
@@ -9,13 +9,15 @@ further_reading:
   text: Configuring Teams & Organizations with Multiple Accounts
 ---
 
-{{<wistia 2qe33x8h3v>}}
-
 **This documentation assumes that you already have a SAML Identity Provider up and running.**
 
 Configuring [SAML (Security Assertion Markup Language)][1] for your Datadog account lets you and all your teammates log in to Datadog using the credentials stored in your organization's Active Directory, LDAP, or other identity store that has been configured with a SAML Identity Provider.
 
 **Note**: Created users must accept email verification in order for SAML to work.
+
+Here's a two-minute video walkthrough:
+
+{{< wistia 2qe33x8h3v >}}
 
 ## Configure SAML
 

--- a/content/account_management/team.md
+++ b/content/account_management/team.md
@@ -11,6 +11,8 @@ further_reading:
   text: Configuring Teams & Organizations with Multiple Accounts
 ---
 
+{{< wistia 3rrd63kxzu >}}
+
 ## Add new members
 
 1. To add members to a team, start by visiting the [Team Page][1].

--- a/content/agent/autodiscovery.md
+++ b/content/agent/autodiscovery.md
@@ -24,7 +24,9 @@ further_reading:
 
 This page covers Autodiscovery with Agent 6 only, [refer to the dedicated documentation to setup Autodiscovery with Agent 5][1]
 
-Watch our [Datadog Autodiscovery on Docker with Labels using Agent v6 video][24] for a bird's eye view of this functionality.
+Here's a 5-minute video for a bird's eye view of Datadog Agent v6 Autodiscovery functionality.
+
+{{< wistia mlxx0j6txw >}}
 
 ## How it Works
 

--- a/content/tracing/setup/_index.md
+++ b/content/tracing/setup/_index.md
@@ -38,6 +38,8 @@ further_reading:
 
 This documentation covers Agent v6 only, to know how to set up APM tracing with Agent v5, [refer to the dedicated APM with Agent v5 doc][1].
 
+{{< wistia ps2vn2rask >}}
+
 ## Setup process
 
 With our infrastructure monitoring, metrics are sent to the Agent, which then forwards them to Datadog. Similarly, tracing metrics are also sent to the Agent: the application code instrumentation flushes to the Agent every 1 s ([see here for the Python client](https://github.com/DataDog/dd-trace-py/blob/69693dc7cdaed3a2b6a855325109fa100e42e254/ddtrace/writer.py#L159) for instance) and the Agent flushes to the [Datadog API every 10s][2].

--- a/layouts/shortcodes/wistia.html
+++ b/layouts/shortcodes/wistia.html
@@ -1,0 +1,9 @@
+<div class="wistia wistia-{{ index .Params 0 }}">
+  <script src="https://fast.wistia.com/embed/medias/{{ index .Params 0 }}.jsonp" async></script>
+  <script src="https://fast.wistia.com/assets/external/E-v1.js" async></script>
+  <div class="wistia_responsive_padding" style="padding:56.25% 0 0 0;position:relative;">
+    <div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;">
+      <span class="wistia_embed wistia_async_{{ index .Params 0 }} popover=true popoverAnimateThumbnail=true videoFoam=true" style="display:inline-block;height:100%;width:100%"></span>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
### What does this PR do?
For some reason the docs site couldn't add videos from wistia except on the videos section. weird. This fixes that omission and lets me see how stupid easy making shortcodes is.

### Motivation
wistia is simply better than vimeo or youtube

### Preview link
https://docs-staging.datadoghq.com/mattw/addwistiasc/account_management/saml/

### Additional Notes
its awesome
