### PR TITLE
Making default desc more universal

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2106,4 +2106,4 @@ params:
   home:
       meta_image: datadog_logo_share_tt.png
       meta_title: Getting Started with Datadog
-      meta_description: Datadog, leading service for cloud-scale monitoring.
+      meta_description: Datadog, the leading service for cloud-scale monitoring.

--- a/config.yaml
+++ b/config.yaml
@@ -2106,4 +2106,4 @@ params:
   home:
       meta_image: datadog_logo_share_tt.png
       meta_title: Getting Started with Datadog
-      meta_description: The leading service for cloud-scale monitoring.
+      meta_description: Datadog, leading service for cloud-scale monitoring.


### PR DESCRIPTION
### What does this PR do?
Rephrase slightly the default description for the doc

### Motivation

With the previous default description, we had sometimes weird combinations of text
![image](https://user-images.githubusercontent.com/3624790/44535527-7f258400-a6fa-11e8-9a7d-cfa3c87e106e.png)

now it's just better

![image](https://user-images.githubusercontent.com/3624790/44535547-93698100-a6fa-11e8-9ca4-df2001b905de.png)


### Preview link

https://docs-staging.datadoghq.com/gus/desc/account_management/saml/