### PR TITLE
Ruby APM new layout

### DIFF
--- a/content/tracing/advanced_usage/custom_tagging.md
+++ b/content/tracing/advanced_usage/custom_tagging.md
@@ -46,6 +46,34 @@ class ServletImpl extends AbstractHttpServlet {
 {{% tab "Python" %}}
 {{% /tab %}}
 {{% tab "Ruby" %}}
+**Adding tags to a span**
+
+You can add tags directly `Datadog::Span` objects directly by calling `#set_tag`:
+
+```ruby
+# An example of a Sinatra endpoint,
+# with Datadog tracing around the request.
+get '/posts' do
+  Datadog.tracer.trace('web.request') do |span|
+    span.set_tag('http.url', request.path)
+  end
+end
+```
+
+**Adding tags globally to all spans**
+
+You can also add tags to all spans by configuring the tracer with the `tags` option:
+
+```ruby
+Datadog.configure do |c|
+  c.tracer tags: { 'env' => 'prod' }
+end
+```
+
+See the [API documentation][ruby api doc] for more details.
+
+[ruby api doc]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md#environment-and-tags
+
 {{% /tab %}}
 {{% tab "Go" %}}
 {{% /tab %}}

--- a/content/tracing/advanced_usage/custom_tagging.md
+++ b/content/tracing/advanced_usage/custom_tagging.md
@@ -62,7 +62,7 @@ end
 
 **Adding tags to a current active span**
 
-You can also access the current active span from any method within your code. Note however that if the method is called and there is no span currently active `active_span` will be nil.
+You can also access the current active span from any method within your code. Note, however, that if the method is called and there is no span currently active, `active_span` will be nil.
 
 ```ruby
 # e.g. adding tag to active span

--- a/content/tracing/advanced_usage/custom_tagging.md
+++ b/content/tracing/advanced_usage/custom_tagging.md
@@ -48,7 +48,7 @@ class ServletImpl extends AbstractHttpServlet {
 {{% tab "Ruby" %}}
 **Adding tags to a span**
 
-You can add tags directly `Datadog::Span` objects directly by calling `#set_tag`:
+You can add tags directly to `Datadog::Span` objects directly by calling `#set_tag`:
 
 ```ruby
 # An example of a Sinatra endpoint,
@@ -58,6 +58,17 @@ get '/posts' do
     span.set_tag('http.url', request.path)
   end
 end
+```
+
+**Adding tags to a current active span**
+
+You can also access the current active span from any method within your code. Note however that if the method is called and there is no span currently active `active_span` will be nil.
+
+```ruby
+# e.g. adding tag to active span
+
+current_span = Datadog.tracer.active_span
+current_span.set_tag('my_tag', 'my_value') unless current_span.nil?
 ```
 
 **Adding tags globally to all spans**

--- a/content/tracing/advanced_usage/debugging.md
+++ b/content/tracing/advanced_usage/debugging.md
@@ -12,6 +12,14 @@ To return debug level application logs, enable debug mode with the flag `-Ddatad
 {{% tab "Python" %}}
 {{% /tab %}}
 {{% tab "Ruby" %}}
+Debug mode is disabled by default. To enable:
+
+```ruby
+Datadog.configure do |c|
+  c.tracer debug: true
+end
+```
+
 {{% /tab %}}
 {{% tab "Go" %}}
 {{% /tab %}}

--- a/content/tracing/advanced_usage/distributed_tracing.md
+++ b/content/tracing/advanced_usage/distributed_tracing.md
@@ -77,8 +77,6 @@ public class MyHttpRequestExtractAdapter implements TextMap {
 {{% tab "Python" %}}
 {{% /tab %}}
 {{% tab "Ruby" %}}
-Distributed tracing allows you to propagate a single trace across multiple services, so you can see performance end-to-end.
-
 Distributed tracing is disabled by default. For more details about how to activate and configure distributed tracing, check out the [API documentation][distributed tracing ruby].
 
 [distributed tracing ruby]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md#distributed-tracing

--- a/content/tracing/advanced_usage/logging.md
+++ b/content/tracing/advanced_usage/logging.md
@@ -61,9 +61,9 @@ Logback XML Pattern:
 {{% tab "Ruby" %}}
 By default, all logs are processed by the default Ruby logger. When using Rails, you should see the messages in your application log file.
 
-Datadog client log messages are marked with ``[ddtrace]`` so you should be able to isolate them from other messages.
+Datadog client log messages are marked with ``[ddtrace]``, so you can isolate them from other messages.
 
-Additionally, it is possible to override the default logger and replace it by a custom one. This is done using the ``log`` attribute of the tracer.
+Additionally, it is possible to override the default logger and replace it with a custom one. This is done using the ``log`` attribute of the tracer.
 
 ```ruby
 f = File.new("my-custom.log", "w+")           # Log messages should go there

--- a/content/tracing/advanced_usage/logging.md
+++ b/content/tracing/advanced_usage/logging.md
@@ -59,6 +59,25 @@ Logback XML Pattern:
 {{% tab "Python" %}}
 {{% /tab %}}
 {{% tab "Ruby" %}}
+By default, all logs are processed by the default Ruby logger. When using Rails, you should see the messages in your application log file.
+
+Datadog client log messages are marked with ``[ddtrace]`` so you should be able to isolate them from other messages.
+
+Additionally, it is possible to override the default logger and replace it by a custom one. This is done using the ``log`` attribute of the tracer.
+
+```ruby
+f = File.new("my-custom.log", "w+")           # Log messages should go there
+Datadog.configure do |c|
+  c.tracer log: Logger.new(f)                 # Overriding the default tracer
+end
+
+Datadog::Tracer.log.info { "this is typically called by tracing code" }
+```
+
+See [the API documentation][ruby logging docs] for more details.
+
+[ruby logging docs]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md#custom-logging
+
 {{% /tab %}}
 {{% tab "Go" %}}
 {{% /tab %}}

--- a/content/tracing/advanced_usage/manual_tracing.md
+++ b/content/tracing/advanced_usage/manual_tracing.md
@@ -38,6 +38,9 @@ public class MyClass {
 If you aren't using supported library instrumentation (see [Library compatibility][ruby lib compatibility], you may want to to manually instrument your code. Adding tracing to your code is easy using the `Datadog.tracer.trace` method, which you can wrap around any Ruby code.
 
 ```ruby
+# An example of a Sinatra endpoint,
+# with Datadog tracing around the request,
+# database query, and rendering steps.
 get '/posts' do
   Datadog.tracer.trace('web.request', service: 'my-blog', resource: 'GET /posts') do |span|
     # Trace the activerecord call

--- a/content/tracing/advanced_usage/open_tracing.md
+++ b/content/tracing/advanced_usage/open_tracing.md
@@ -167,6 +167,7 @@ Notice the above examples only use the OpenTracing classes. Please reference the
 {{% tab "Python" %}}
 {{% /tab %}}
 {{% tab "Ruby" %}}
+Support for OpenTracing with Ruby is coming soon.
 {{% /tab %}}
 {{% tab "Go" %}}
 Import the [`opentracer` package][opentracing godoc] to expose the Datadog tracer as an [OpenTracing][open tracing] compatible tracer.

--- a/content/tracing/setup/ruby.md
+++ b/content/tracing/setup/ruby.md
@@ -22,7 +22,7 @@ further_reading:
   text: "Advanced Usage"
 ---
 
-## Getting started
+## Installation and Getting Started
 
 For configuration instructions, and details about using the API, check out our [API documentation][api docs] and [gem documentation][gem docs].
 
@@ -34,10 +34,6 @@ For details about contributing, check out the [development guide][development do
 [gem docs]: http://gems.datadoghq.com/trace/docs/
 [visualization docs]: https://docs.datadoghq.com/tracing/visualization/
 [development docs]: https://github.com/DataDog/dd-trace-rb/blob/master/README.md#development
-
-## Installation
-
-The following steps will help you quickly start tracing your Ruby application.
 
 ### Setup the Datadog Agent
 
@@ -88,73 +84,6 @@ The Ruby APM tracer sends trace data through the Datadog Agent.
 
 After setting up, your services will appear on the [APM services page][3] within a few minutes. Learn more about [using the APM UI][4].
 
-## Configuration
-
-To activate more advanced features, change tracer behavior, or trace additional code, you must add additional configuration.
-
-### Integration instrumentation
-
-APM provides out-of-the-box support for many popular integrations. Although none are active by default, you can easily activate them in `Datadog.configure`.
-
-**Example**
-
-```ruby
-require 'ddtrace'
-require 'sinatra'
-require 'active_record'
-
-Datadog.configure do |c|
-  c.use :sinatra
-  c.use :active_record
-end
-
-# Now write your code naturally, it's traced automatically.
-get '/home' do
-  @posts = Posts.order(created_at: :desc).limit(10)
-  erb :index
-end
-```
-
-For list of available integrations, see [Library compatibility](#library-compatibility).
-
-### Tracer settings
-
-**Enabling/disabling**
-
-Tracing is enabled by default. To disable it (i.e. in a test environment):
-
-```ruby
-Datadog.configure do |c|
-  c.tracer enabled: false
-end
-```
-
-**Debug mode**
-
-Debug mode is disabled by default. To enable:
-
-```ruby
-Datadog.configure do |c|
-  c.tracer debug: true
-end
-```
-
-For more tracer settings, check out the [API documentation][6].
-
-### Priority sampling
-
-Priority sampling allows you to configure which traces are most important and should be kept after sampling.
-
-Priority sampling is disabled by default. For more details about how to activate and configure priority sampling, check out the [API documentation][7].
-
-### Processing pipeline
-
-The processing Pipeline allows you to modify traces before they are sent to the agent. This can be useful for customizing trace content or removing unwanted traces.
-
-It provides **filtering** for removing spans that match certain criteria, and **processing** for modifying spans.
-
-For more details about how to activate and configure the processing pipeline, check out the [API documentation][9].
-
 ## Compatibility
 
 {{< tabs >}}
@@ -163,18 +92,18 @@ For more details about how to activate and configure the processing pipeline, ch
 Ruby APM includes support for the following Ruby interpreters:
 
 
-| Type  | Documentation              | Version | Support type |
-| ----- | -------------------------- | -----   | ------------ |
-| MRI   | https://www.ruby-lang.org/ | 1.9.1   | Experimental |
-|       |                            | 1.9.3   | Full         |
-|       |                            | 2.0     | Full         |
-|       |                            | 2.1     | Full         |
-|       |                            | 2.2     | Full         |
-|       |                            | 2.3     | Full         |
-|       |                            | 2.4     | Full         |
-| JRuby | http://jruby.org/          | 9.1.5   | Experimental |
+| Type                               | Version | Support type    |
+| ---------------------------------- | -----   | --------------- |
+| [MRI](https://www.ruby-lang.org/)  | 1.9.1   | Experimental    |
+|                                    | 1.9.3   | Fully supported |
+|                                    | 2.0     | Fully supported |
+|                                    | 2.1     | Fully supported |
+|                                    | 2.2     | Fully supported |
+|                                    | 2.3     | Fully supported |
+|                                    | 2.4     | Fully supported |
+| [JRuby](http://jruby.org/)         | 9.1.5   | Experimental    |
 
-*Full* support indicates all tracer features are available.
+*Fully supported* support indicates all tracer features are available.
 
 *Experimental* indicates most features should be available, but unverified.
 
@@ -184,40 +113,51 @@ Ruby APM includes support for the following Ruby interpreters:
 Ruby APM includes support for the following web servers:
 
 
-| Type      | Documentation                     | Version      | Support type |
-| --------- | --------------------------------- | ------------ | ------------ |
-| Puma      | http://puma.io/                   | 2.16+ / 3.6+ | Full         |
-| Unicorn   | https://bogomips.org/unicorn/     | 4.8+ / 5.1+  | Full         |
-| Passenger | https://www.phusionpassenger.com/ | 5.0+         | Full         |
+| Type                                           | Version      | Support type    |
+| ---------------------------------------------- | ------------ | --------------- |
+| [Puma](http://puma.io/)                        | 2.16+ / 3.6+ | Fully supported |
+| [Unicorn](https://bogomips.org/unicorn/)       | 4.8+ / 5.1+  | Fully supported |
+| [Passenger](https://www.phusionpassenger.com/) | 5.0+         | Fully supported |
+
+*Fully supported* support indicates all tracer features are available.
+
+*Experimental* indicates most features should be available, but unverified.
 
 {{% /tab %}}
 {{% tab "Library compatibility" %}}
 
 Ruby APM includes support for the following libraries and frameworks:
 
-| Name           | Key             | Versions Supported     | How to configure | Gem source   |
-| ------         | ----            | -----                  | -------          | ---------    |
-| Active Record  | `active_record` | `>= 3.2, < 5.2`        | *[Link][10]*     | *[Link][11]* |
-| AWS            | `aws`           | `>= 2.0`               | *[Link][12]*     | *[Link][13]* |
-| Dalli          | `dalli`         | `>= 2.7`               | *[Link][14]*     | *[Link][15]* |
-| Elastic Search | `elasticsearch` | `>= 6.0`               | *[Link][16]*     | *[Link][17]* |
-| Excon          | `excon`         | `>= 0.62`              | *[Link][18]*     | *[Link][19]* |
-| Faraday        | `faraday`       | `>= 0.14`              | *[Link][20]*     | *[Link][21]* |
-| gRPC           | `grpc`          | `>= 1.10`              | *[Link][22]*     | *[Link][23]* |
-| Grape          | `grape`         | `>= 1.0`               | *[Link][24]*     | *[Link][25]* |
-| GraphQL        | `graphql`       | `>= 1.7.9`             | *[Link][26]*     | *[Link][27]* |
-| MongoDB        | `mongo`         | `>= 2.0, < 2.5`        | *[Link][28]*     | *[Link][29]* |
-| Net/HTTP       | `http`          | *(Any supported Ruby)* | *[Link][30]*     | *[Link][31]* |
-| Racecar        | `racecar`       | `>= 0.3.5`             | *[Link][32]*     | *[Link][33]* |
-| Rack           | `rack`          | `>= 1.4.7`             | *[Link][34]*     | *[Link][35]* |
-| Rails          | `rails`         | `>= 3.2, < 5.2`        | *[Link][36]*     | *[Link][37]* |
-| Rake           | `rake`          | `>= 12.0`              | *[Link][38]*     | *[Link][39]* |
-| Redis          | `redis`         | `>= 3.2, < 4.0`        | *[Link][40]*     | *[Link][41]* |
-| Resque         | `resque`        | `>= 1.0, < 2.0`        | *[Link][42]*     | *[Link][43]* |
-| Sequel         | `sequel`        | `>= 3.41`              | *[Link][44]*     | *[Link][45]* |
-| Sidekiq        | `sidekiq`       | `>= 4.0`               | *[Link][46]*     | *[Link][47]* |
-| Sinatra        | `sinatra`       | `>= 1.4.5`             | *[Link][48]*     | *[Link][49]* |
-| Sucker Punch   | `sucker_punch`  | `>= 2.0`               | *[Link][50]*     | *[Link][51]* |
+| Name                 | Versions Supported     | Support type    | How to configure |
+| -------------------- | ---------------------- | --------------- | ---------------- |
+| [Active Record][11]  | `>= 3.2, < 5.2`        | Fully supported | *[Link][10]*     |
+| [AWS][13]            | `>= 2.0`               | Fully supported | *[Link][12]*     |
+| [Dalli][15]          | `>= 2.7`               | Fully supported | *[Link][14]*     |
+| [DelayedJob][53]     | `>= 4.1`               | Fully supported | *[Link][52]*     |
+| [Elastic Search][17] | `>= 6.0`               | Fully supported | *[Link][16]*     |
+| [Excon][19]          | `>= 0.62`              | Fully supported | *[Link][18]*     |
+| [Faraday][21]        | `>= 0.14`              | Fully supported | *[Link][20]*     |
+| [gRPC][23]           | `>= 1.10`              | Fully supported | *[Link][22]*     |
+| [Grape][25]          | `>= 1.0`               | Fully supported | *[Link][24]*     |
+| [GraphQL][27]        | `>= 1.7.9`             | Fully supported | *[Link][26]*     |
+| [MongoDB][29]        | `>= 2.0, < 2.5`        | Fully supported | *[Link][28]*     |
+| [MySQL2][55]         | `>= 0.5`               | Fully supported | *[Link][54]*     |
+| [Net/HTTP][31]       | *(Any supported Ruby)* | Fully supported | *[Link][30]*     |
+| [Racecar][33]        | `>= 0.3.5`             | Fully supported | *[Link][32]*     |
+| [Rack][35]           | `>= 1.4.7`             | Fully supported | *[Link][34]*     |
+| [Rails][37]          | `>= 3.2, < 5.2`        | Fully supported | *[Link][36]*     |
+| [Rake][39]           | `>= 12.0`              | Fully supported | *[Link][38]*     |
+| [Redis][41]          | `>= 3.2, < 4.0`        | Fully supported | *[Link][40]*     |
+| [Resque][43]         | `>= 1.0, < 2.0`        | Fully supported | *[Link][42]*     |
+| [RestClient][57]     | `>= 1.8`               | Fully supported | *[Link][56]*     |
+| [Sequel][45]         | `>= 3.41`              | Fully supported | *[Link][44]*     |
+| [Sidekiq][47]        | `>= 4.0`               | Fully supported | *[Link][46]*     |
+| [Sinatra][49]        | `>= 1.4.5`             | Fully supported | *[Link][48]*     |
+| [Sucker Punch][51]   | `>= 2.0`               | Fully supported | *[Link][50]*     |
+
+*Fully supported* support indicates all tracer features are available.
+
+*Experimental* indicates most features should be available, but unverified.
 
 [10]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md#active-record
 [11]: https://github.com/rails/rails/tree/master/activerecord
@@ -261,9 +201,66 @@ Ruby APM includes support for the following libraries and frameworks:
 [49]: https://github.com/sinatra/sinatra
 [50]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md#sucker-punch
 [51]: https://github.com/brandonhilkert/sucker_punch
+[52]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md#delayedjob
+[53]: https://github.com/collectiveidea/delayed_job
+[54]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md#mysql2
+[55]: https://github.com/brianmario/mysql2
+[56]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md#restclient
+[57]: https://github.com/rest-client/rest-client
 
 {{% /tab %}}
 {{< /tabs >}}
+
+## Configuration
+
+To activate more advanced features, change tracer behavior, or trace additional code, you must add additional configuration.
+
+### Integration instrumentation
+
+APM provides out-of-the-box support for many popular integrations. Although none are active by default, you can easily activate them in `Datadog.configure`.
+
+**Example**
+
+```ruby
+require 'ddtrace'
+require 'sinatra'
+require 'active_record'
+
+Datadog.configure do |c|
+  c.use :sinatra
+  c.use :active_record
+end
+
+# Now write your code naturally, it's traced automatically.
+get '/home' do
+  @posts = Posts.order(created_at: :desc).limit(10)
+  erb :index
+end
+```
+
+For list of available integrations, see [Library compatibility](#library-compatibility).
+
+### Tracer settings
+
+**Enabling/disabling**
+
+Tracing is enabled by default. To disable it (i.e. in a test environment):
+
+```ruby
+Datadog.configure do |c|
+  c.tracer enabled: false
+end
+```
+
+For more tracer settings, check out the [API documentation][6].
+
+### Processing pipeline
+
+The processing Pipeline allows you to modify traces before they are sent to the agent. This can be useful for customizing trace content or removing unwanted traces.
+
+It provides **filtering** for removing spans that match certain criteria, and **processing** for modifying spans.
+
+For more details about how to activate and configure the processing pipeline, check out the [API documentation][9].
 
 ## Further reading
 

--- a/content/tracing/setup/ruby.md
+++ b/content/tracing/setup/ruby.md
@@ -256,7 +256,7 @@ For more tracer settings, check out the [API documentation][6].
 
 ### Processing pipeline
 
-The processing Pipeline allows you to modify traces before they are sent to the agent. This can be useful for customizing trace content or removing unwanted traces.
+The processing pipeline allows you to modify traces before they are sent to the agent. This can be useful for customizing trace content or removing unwanted traces.
 
 It provides **filtering** for removing spans that match certain criteria, and **processing** for modifying spans.
 


### PR DESCRIPTION
### What does this PR do?
Adds more Ruby APM documentation to match the new layout described in #2909.

### Motivation
@palazzem and @iFallUpHill are my inspiration.

### Preview link

* https://docs-staging.datadoghq.com/delner/apm-ruby-layout/tracing/setup/ruby/
* https://docs-staging.datadoghq.com/delner/apm-ruby-layout/tracing/advanced_usage/custom_tagging/
* https://docs-staging.datadoghq.com/delner/apm-ruby-layout/tracing/advanced_usage/logging/
* https://docs-staging.datadoghq.com/delner/apm-ruby-layout/tracing/setup/ruby/
* https://docs-staging.datadoghq.com/delner/apm-ruby-layout/tracing/advanced_usage/priority_sampling/

### Additional Notes
This is intended to be merged into #2909.
