### PR TITLE
Fixed minor grammar

### DIFF
--- a/content/tagging/using_tags.md
+++ b/content/tagging/using_tags.md
@@ -61,7 +61,7 @@ When creating a [monitor][8]:
 * Use tags in the `excluding:` textbox to remove the corresponding metrics of the monitor scope.
 {{< img src="tagging/monitortags_1.png" alt="excluding textbox tags in Monitors" responsive="true" style="width:70%;">}}
 
-* Use tags in the `avg by` textbox transform your monitor into a multi-alert monitor on each value of this tags.
+* Use tags in the `avg by` textbox to transform your monitor into a multi-alert monitor on each value of this tags.
 {{< img src="tagging/monitortags_2.png" alt="excluding textbox tags in Monitors" responsive="true" style="width:70%;">}}
 Tags on these events are related to the `avg by:` value. In order to have host-related tags (such as AWS integration tags), use `avg by: host`
 


### PR DESCRIPTION
"Use tags in the `avg by` textbox transform your monitor" should be
"Use tags in the `avg by` textbox to transform your monitor"

Line 64

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
