### PR TITLE
update nodejs documentation to match new layout

### DIFF
--- a/content/tracing/advanced_usage/custom_tagging.md
+++ b/content/tracing/advanced_usage/custom_tagging.md
@@ -50,5 +50,50 @@ class ServletImpl extends AbstractHttpServlet {
 {{% tab "Go" %}}
 {{% /tab %}}
 {{% tab "Node.js" %}}
+**Adding tags to a span**
+
+You can add tags directly to the span objects directly by calling `setTag` or `addTags`:
+
+```javascript
+// An example of an Express endpoint,
+// with Datadog tracing around the request.
+app.get('/posts', (req, res) => {
+  const span = tracer.startSpan('web.request')
+
+  span.setTag('http.url', req.url)
+  span.addTags({
+    'http.method': req.method
+  })
+})
+```
+
+**Adding tags to a current active span**
+
+You can also access the current active span from any method within your code. Note however that if the method is called and there is no span currently active `tracer.scopeManager().active()` will return `null`.
+
+```javascript
+// e.g. adding tag to active span
+
+const scope = tracer.scopeManager().active()
+const span = scope.span()
+
+span.setTag('my_tag', 'my_value')
+```
+
+**Adding tags globally to all spans**
+
+You can also add tags to all spans by configuring the tracer with the `tags` option:
+
+```javascript
+tracer.init({
+  tags: {
+    env: 'prod'
+  }
+})
+```
+
+See the [API documentation][nodejs api doc] for more details.
+
+[nodejs api doc]: https://datadog.github.io/dd-trace-js/
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/tracing/advanced_usage/logging.md
+++ b/content/tracing/advanced_usage/logging.md
@@ -63,5 +63,26 @@ Logback XML Pattern:
 {{% tab "Go" %}}
 {{% /tab %}}
 {{% tab "Node.js" %}}
+By default, logging from this library is disabled. In order to get debbuging information and errors sent to logs, the `debug` options should be set to `true` in the [init()](https://datadog.github.io/dd-trace-js/Tracer.html#init) method.
+
+The tracer will then log debug information to `console.log()` and errors to `console.error()`. This behavior can be changed by passing a custom logger to the tracer. The logger should contain a `debug()` and `error()` methods that can handle messages and errors, respectively.
+
+For example:
+
+```javascript
+const bunyan = require('bunyan')
+const logger = bunyan.createLogger({
+  name: 'dd-trace',
+  level: 'trace'
+})
+
+const tracer = require('dd-trace').init({
+  logger: {
+    debug: message => logger.trace(message),
+    error: err => logger.error(err)
+  },
+  debug: true
+})
+```
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/tracing/advanced_usage/open_tracing.md
+++ b/content/tracing/advanced_usage/open_tracing.md
@@ -241,5 +241,30 @@ make use of the same tracer. Make sure to check out the [API documentation][open
 [opentracing go]: https://github.com/opentracing/opentracing-go
 {{% /tab %}}
 {{% tab "Node.js" %}}
+This library is OpenTracing compliant. Use the OpenTracing API and the Datadog Tracer (dd-trace) library to measure execution times for specific pieces of code. In the following example, a Datadog Tracer is initialized and used as a global tracer:
+
+aboutraw—
+This library is OpenTracing compliant. Use the [OpenTracing API](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/) and the Datadog Tracer (dd-trace) library to measure execution times for specific pieces of code. In the following example, a Datadog Tracer is initialized and used as a global tracer:
+
+```javascript
+// server.js
+
+const tracer = require('dd-trace').init()
+const opentracing = require('opentracing')
+
+opentracing.initGlobalTracer(tracer)
+
+const app = require('./app.js')
+
+// app.js
+
+const tracer = opentracing.globalTracer()
+```
+
+The following tags are available to override Datadog specific options:
+
+* `service.name`: The service name to be used for this span. The service name from the tracer will be used if this is not provided.
+* `resource.name`: The resource name to be used for this span. The operation name will be used if this is not provided.
+* `span.type`: The span type to be used for this span. Will fallback to `custom` if not provided.
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/tracing/advanced_usage/priority_sampling.md
+++ b/content/tracing/advanced_usage/priority_sampling.md
@@ -69,10 +69,6 @@ Possible values for the sampling priority tag are:
 
 {{% /tab %}}
 {{% tab "Node.js" %}}
-
-```javascript
-This is some node code
-```
-
+Coming Soon.
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Update the Node.js documentation to match the new layout.

### Motivation

So the current Node.js documentation doesn't end up in `/dev/null`

### Preview link

https://docs-staging.datadoghq.com/rochdev/apm-nodejs-layout/tracing/advanced_usage/

### Additional Notes

This PR increased my copy paste skills by 2 points