### PR TITLE
[apm/python] Add Python docs

### DIFF
--- a/content/tracing/advanced_usage/custom_tagging.md
+++ b/content/tracing/advanced_usage/custom_tagging.md
@@ -58,6 +58,21 @@ def handle_post(post_id):
     span.set_tag('post.id', post_id)
 ```
 
+**Adding tags to a current active span**
+
+The current span can be retrieved from the context in order to set tags. This way, if a span was started by our instrumentation, you can retrieve the span and add custom tags. Note that if a span does not exist, `None` will be returned:
+
+```python
+from ddtrace import tracer
+
+@app.route('/post/<int:post_id>')
+@tracer.wrap()
+def handle_post(post_id):
+  # get the active span in the context
+  current_span = tracer.get_span()
+  if current_span:
+    current_span.set_tag('post.id', post_id)
+```
 
 **Adding tags globally to all spans**
 

--- a/content/tracing/advanced_usage/custom_tagging.md
+++ b/content/tracing/advanced_usage/custom_tagging.md
@@ -44,6 +44,31 @@ class ServletImpl extends AbstractHttpServlet {
 
 {{% /tab %}}
 {{% tab "Python" %}}
+
+**Adding tags to a span**
+
+You can add tags directly to a span by calling `set_tag`. For example with the following Flask route handler:
+
+```python
+from ddtrace import tracer
+
+@app.route('/post/<int:post_id>')
+def handle_post(post_id):
+  with tracer.trace('web.request') as span:
+    span.set_tag('post.id', post_id)
+```
+
+
+**Adding tags globally to all spans**
+
+You can also add tags to all spans by configuring the tracer with the `tracer.set_tags` method:
+
+```python
+from ddtrace import tracer
+
+tracer.set_tags({ 'env': 'prod' })
+```
+
 {{% /tab %}}
 {{% tab "Ruby" %}}
 {{% /tab %}}

--- a/content/tracing/advanced_usage/custom_tagging.md
+++ b/content/tracing/advanced_usage/custom_tagging.md
@@ -47,7 +47,8 @@ class ServletImpl extends AbstractHttpServlet {
 
 **Adding tags to a span**
 
-You can add tags directly to a span by calling `set_tag`. For example with the following Flask route handler:
+You can add tags directly to a span by calling `set_tag`. For example with
+the following route handler:
 
 ```python
 from ddtrace import tracer
@@ -60,7 +61,10 @@ def handle_post(post_id):
 
 **Adding tags to a current active span**
 
-The current span can be retrieved from the context in order to set tags. This way, if a span was started by our instrumentation, you can retrieve the span and add custom tags. Note that if a span does not exist, `None` will be returned:
+The current span can be retrieved from the context in order to set tags. This
+way, if a span was started by our instrumentation, you can retrieve the span
+and add custom tags. Note that if a span does not exist, `None` will be
+returned:
 
 ```python
 from ddtrace import tracer
@@ -68,8 +72,8 @@ from ddtrace import tracer
 @app.route('/post/<int:post_id>')
 @tracer.wrap()
 def handle_post(post_id):
-  # get the active span in the context
-  current_span = tracer.get_span()
+  # get the active span in the context, put there by tracer.wrap()
+  current_span = tracer.current_span()
   if current_span:
     current_span.set_tag('post.id', post_id)
 ```

--- a/content/tracing/advanced_usage/debugging.md
+++ b/content/tracing/advanced_usage/debugging.md
@@ -10,6 +10,9 @@ Datadog debug settings are used to diagnose issues or audit trace data.
 To return debug level application logs, enable debug mode with the flag `-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug` when starting the JVM.
 {{% /tab %}}
 {{% tab "Python" %}}
+Debugging is disabled by default. To enable it set the environment variable
+`DATADOG_TRACE_DEBUG=true` when using `ddtrace-run`. Note that this will
+disable traces from being sent to Datadog.
 {{% /tab %}}
 {{% tab "Ruby" %}}
 {{% /tab %}}

--- a/content/tracing/advanced_usage/debugging.md
+++ b/content/tracing/advanced_usage/debugging.md
@@ -12,7 +12,7 @@ To return debug level application logs, enable debug mode with the flag `-Ddatad
 {{% tab "Python" %}}
 Debugging is disabled by default. To enable it set the environment variable
 `DATADOG_TRACE_DEBUG=true` when using `ddtrace-run`. Note that this will
-disable traces from being sent to Datadog.
+log a large amount of information. Use sparingly for debugging purposes only.
 {{% /tab %}}
 {{% tab "Ruby" %}}
 {{% /tab %}}

--- a/content/tracing/advanced_usage/distributed_tracing.md
+++ b/content/tracing/advanced_usage/distributed_tracing.md
@@ -75,7 +75,24 @@ public class MyHttpRequestExtractAdapter implements TextMap {
 
 {{% /tab %}}
 {{% tab "Python" %}}
-Distributed tracing is disabled by default. To enable it, refer to the instructions for the integrations that support distributed tracing.
+Distributed tracing is supported in the following frameworks. Please refer to
+the configuration documentation for each to enable it.
+
+| Framework/Library | Default  |                          API Documentation                          |
+| ----------------- | :------- | :------------------------------------------------------------------ |
+| aiohttp           | Disabled | http://pypi.datadoghq.com/trace/docs/web_integrations.html#aiohttp  |
+| bottle            | Enabled  | http://pypi.datadoghq.com/trace/docs/web_integrations.html#bottle   |
+| django            | Disabled | http://pypi.datadoghq.com/trace/docs/web_integrations.html#django   |
+| falcon            | Disabled | http://pypi.datadoghq.com/trace/docs/web_integrations.html#falcon   |
+| flask             | Disabled | http://pypi.datadoghq.com/trace/docs/web_integrations.html#flask    |
+| pylons            | Disabled | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pylons   |
+| pyramid           | Disabled | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pyramid  |
+| requests          | Enabled  | http://pypi.datadoghq.com/trace/docs/web_integrations.html#requests |
+| tornado           | Disabled | http://pypi.datadoghq.com/trace/docs/web_integrations.html#tornado  |
+
+To add your own distributed tracing refer to our [API documentation][py_dist_tracing].
+
+[py_dist_tracing]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#http-client
 {{% /tab %}}
 {{% tab "Ruby" %}}
 Distributed tracing allows you to propagate a single trace across multiple services, so you can see performance end-to-end.

--- a/content/tracing/advanced_usage/distributed_tracing.md
+++ b/content/tracing/advanced_usage/distributed_tracing.md
@@ -75,6 +75,7 @@ public class MyHttpRequestExtractAdapter implements TextMap {
 
 {{% /tab %}}
 {{% tab "Python" %}}
+Distributed tracing is disabled by default. To enable it, refer to the instructions for the integrations that support distributed tracing.
 {{% /tab %}}
 {{% tab "Ruby" %}}
 Distributed tracing allows you to propagate a single trace across multiple services, so you can see performance end-to-end.

--- a/content/tracing/advanced_usage/distributed_tracing.md
+++ b/content/tracing/advanced_usage/distributed_tracing.md
@@ -78,17 +78,17 @@ public class MyHttpRequestExtractAdapter implements TextMap {
 Distributed tracing is supported in the following frameworks. Please refer to
 the configuration documentation for each to enable it.
 
-| Framework/Library | Default  |                          API Documentation                          |
-| ----------------- | :------- | :------------------------------------------------------------------ |
-| aiohttp           | Disabled | http://pypi.datadoghq.com/trace/docs/web_integrations.html#aiohttp  |
-| bottle            | Enabled  | http://pypi.datadoghq.com/trace/docs/web_integrations.html#bottle   |
-| django            | Disabled | http://pypi.datadoghq.com/trace/docs/web_integrations.html#django   |
-| falcon            | Disabled | http://pypi.datadoghq.com/trace/docs/web_integrations.html#falcon   |
-| flask             | Disabled | http://pypi.datadoghq.com/trace/docs/web_integrations.html#flask    |
-| pylons            | Disabled | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pylons   |
-| pyramid           | Disabled | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pyramid  |
-| requests          | Enabled  | http://pypi.datadoghq.com/trace/docs/web_integrations.html#requests |
-| tornado           | Disabled | http://pypi.datadoghq.com/trace/docs/web_integrations.html#tornado  |
+| Framework/Library |                          API Documentation                          |
+| ----------------- | :------------------------------------------------------------------ |
+| aiohttp           | http://pypi.datadoghq.com/trace/docs/web_integrations.html#aiohttp  |
+| bottle            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#bottle   |
+| django            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#django   |
+| falcon            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#falcon   |
+| flask             | http://pypi.datadoghq.com/trace/docs/web_integrations.html#flask    |
+| pylons            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pylons   |
+| pyramid           | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pyramid  |
+| requests          | http://pypi.datadoghq.com/trace/docs/web_integrations.html#requests |
+| tornado           | http://pypi.datadoghq.com/trace/docs/web_integrations.html#tornado  |
 
 To add your own distributed tracing refer to our [API documentation][py_dist_tracing].
 

--- a/content/tracing/advanced_usage/logging.md
+++ b/content/tracing/advanced_usage/logging.md
@@ -57,9 +57,13 @@ Logback XML Pattern:
 
 {{% /tab %}}
 {{% tab "Python" %}}
+Getting the required information needed for logging is easy:
+
+```python
 from ddtrace import helpers
 
 trace_id, span_id = helpers.get_correlation_ids()
+```
 {{% /tab %}}
 {{% tab "Ruby" %}}
 {{% /tab %}}

--- a/content/tracing/advanced_usage/logging.md
+++ b/content/tracing/advanced_usage/logging.md
@@ -57,6 +57,9 @@ Logback XML Pattern:
 
 {{% /tab %}}
 {{% tab "Python" %}}
+from ddtrace import helpers
+
+trace_id, span_id = helpers.get_correlation_ids()
 {{% /tab %}}
 {{% tab "Ruby" %}}
 {{% /tab %}}

--- a/content/tracing/advanced_usage/manual_tracing.md
+++ b/content/tracing/advanced_usage/manual_tracing.md
@@ -33,6 +33,41 @@ public class MyClass {
 
 {{% /tab %}}
 {{% tab "Python" %}}
+
+We have a Flask Python application that when called on `/doc` returns **42**.
+We instrumented our python code in order to generate traces from it:
+
+```python
+import time
+import blinker as _
+
+from flask import Flask, Response
+
+from ddtrace import tracer
+from ddtrace.contrib.flask import TraceMiddleware
+
+# Tracer configuration
+tracer.configure(hostname='datadog')
+app = Flask('API')
+traced_app = TraceMiddleware(app, tracer, service='doc_service')
+
+@tracer.wrap(name='doc_work')
+def work():
+    time.sleep(0.5)
+    return 42
+
+@app.route('/doc/')
+def doc_resource():
+    time.sleep(0.3)
+    res = work()
+    time.sleep(0.3)
+    return Response(str(res), mimetype='application/json')
+```
+
+Each time its called, the following code produces this **trace**:
+
+{{< img src="tracing/simple_trace.png" alt="Simple Trace" responsive="true" >}}
+
 {{% /tab %}}
 {{% tab "Ruby" %}}
 If you aren't using supported library instrumentation (see [Library compatibility][ruby lib compatibility], you may want to to manually instrument your code. Adding tracing to your code is easy using the `Datadog.tracer.trace` method, which you can wrap around any Ruby code.

--- a/content/tracing/advanced_usage/manual_tracing.md
+++ b/content/tracing/advanced_usage/manual_tracing.md
@@ -52,7 +52,7 @@ in your application:
 ```python
   @tracer.wrap()
   def business_logic():
-    """A method that would be of interest to trace"""
+    """A method that would be of interest to trace."""
     # ...
     # ...
 ```
@@ -65,31 +65,30 @@ To trace an arbitrary block of code, you can use the [`ddtrace.Span`][py_span]
 context manager:
 
 ```python
-  import time
-
-  # trace some sleeping
-  with tracer.trace('time.sleep'):
-    # do interesting stuff besides sleeping for a second
-    time.sleep(1)
+  # trace some interesting operation
+  with tracer.trace('interesting.operations'):
+    # do some interesting operation(s)
+    # ...
+    # ...
 ```
 
 Further API details can be found at [`ddtrace.Tracer()`][py_tracer]
 
-**By Hand**
+**Using the API**
 
 If the above methods are still not enough to satisfy your tracing needs, a
 manual API is provided which will allow you to start and finish spans however
 you may require:
 
 ```python
-  span = tracer.trace('interesting.stuff')
+  span = tracer.trace('operations.of.interest')
 
-  # do interesting stuff in between
+  # do some operation(s) of interest in between
 
-  # make sure to call span.finish() or the span will not be sent to Datadog
+  # NOTE: make sure to call span.finish() or the entire trace will not be sent
+  # to Datadog
   span.finish()
 ```
-
 
 API details of the decorator can be found here:
 

--- a/content/tracing/advanced_usage/open_tracing.md
+++ b/content/tracing/advanced_usage/open_tracing.md
@@ -165,6 +165,7 @@ Notice the above examples only use the OpenTracing classes. Please reference the
 
 {{% /tab %}}
 {{% tab "Python" %}}
+Support for OpenTracing with Python is coming soon.
 {{% /tab %}}
 {{% tab "Ruby" %}}
 {{% /tab %}}

--- a/content/tracing/advanced_usage/priority_sampling.md
+++ b/content/tracing/advanced_usage/priority_sampling.md
@@ -40,7 +40,9 @@ public class MyClass {
 ```
 {{% /tab %}}
 {{% tab "Python" %}}
-To enable sampling priority in the tracer:
+Priority sampling is disabled by default. To enable it, configure the
+`priority_sampling` flag using the `tracer.configure` method:
+
 ```python
 tracer.configure(priority_sampling=True)
 ```
@@ -50,10 +52,10 @@ To set a custom priority to a trace:
 ```python
 from ddtrace.ext.priority import USER_REJECT, USER_KEEP
 
-context = tracer.context_provider.active()
+span = tracer.current_span()
 
 # indicate to not keep the trace
-context.sampling_priority = USER_REJECT
+span.context.sampling_priority = USER_REJECT
 ```
 
 The following priorities can be used.

--- a/content/tracing/advanced_usage/priority_sampling.md
+++ b/content/tracing/advanced_usage/priority_sampling.md
@@ -58,12 +58,12 @@ context.sampling_priority = USER_REJECT
 
 The following priorities can be used.
 
-|                   Sampling Value                   |                                                   Effect                                                   |
-| -------------------------------------------------- | :--------------------------------------------------------------------------------------------------------- |
-| ddtrace.span.context.sampling_priority.AUTO_REJECT | The sampler automatically decided to not keep the trace. The Agent will drop it.                           |
-| ddtrace.span.context.sampling_priority.AUTO_KEEP   | The sampler automatically decided to keep the trace. The Agent will keep it. Might be sampled server-side. |
-| ddtrace.span.context.sampling_priority.USER_REJECT | The user asked to not keep the trace. The Agent will drop it.                                              |
-| ddtrace.span.context.sampling_priority.USER_KEEP   | The user asked to keep the trace. The Agent will keep it. The server will keep it too.                     |
+| Sampling Value |                                                   Effect                                                   |
+| -------------- | :--------------------------------------------------------------------------------------------------------- |
+| AUTO_REJECT    | The sampler automatically decided to not keep the trace. The Agent will drop it.                           |
+| AUTO_KEEP      | The sampler automatically decided to keep the trace. The Agent will keep it. Might be sampled server-side. |
+| USER_REJECT    | The user asked to not keep the trace. The Agent will drop it.                                              |
+| USER_KEEP      | The user asked to keep the trace. The Agent will keep it. The server will keep it too.                     |
 
 {{% /tab %}}
 {{% tab "Ruby" %}}

--- a/content/tracing/advanced_usage/priority_sampling.md
+++ b/content/tracing/advanced_usage/priority_sampling.md
@@ -40,9 +40,31 @@ public class MyClass {
 ```
 {{% /tab %}}
 {{% tab "Python" %}}
+To enable sampling priority in the tracer:
 ```python
-This is some python code
+tracer.configure(priority_sampling=True)
 ```
+
+To set a custom priority to a trace:
+
+```python
+from ddtrace.ext.priority import USER_REJECT, USER_KEEP
+
+context = tracer.context_provider.active()
+
+# indicate to not keep the trace
+context.sampling_priority = USER_REJECT
+```
+
+The following priorities can be used.
+
+|                   Sampling Value                   |                                                   Effect                                                   |
+| -------------------------------------------------- | :--------------------------------------------------------------------------------------------------------- |
+| ddtrace.span.context.sampling_priority.AUTO_REJECT | The sampler automatically decided to not keep the trace. The Agent will drop it.                           |
+| ddtrace.span.context.sampling_priority.AUTO_KEEP   | The sampler automatically decided to keep the trace. The Agent will keep it. Might be sampled server-side. |
+| ddtrace.span.context.sampling_priority.USER_REJECT | The user asked to not keep the trace. The Agent will drop it.                                              |
+| ddtrace.span.context.sampling_priority.USER_KEEP   | The user asked to keep the trace. The Agent will keep it. The server will keep it too.                     |
+
 {{% /tab %}}
 {{% tab "Ruby" %}}
 ```ruby

--- a/content/tracing/setup/python.md
+++ b/content/tracing/setup/python.md
@@ -43,7 +43,8 @@ For example, if your application is started with `python app.py` then:
 $ ddtrace-run python app.py
 ```
 
-For more advanced usage check out our [API documentation](http://pypi.datadoghq.com/trace/docs/).
+For more advanced usage, configuration and fine-grained control check out our
+[API documentation](http://pypi.datadoghq.com/trace/docs/).
 
 
 ## Compatibility

--- a/content/tracing/setup/python.md
+++ b/content/tracing/setup/python.md
@@ -10,7 +10,7 @@ further_reading:
   text: Source code
 - link: "http://pypi.datadoghq.com/trace/docs/"
   tag: "Pypi"
-  text: APM (Tracing)
+  text: API Docs
 - link: "tracing/visualization/"
   tag: "Documentation"
   text: "Explore your services, resources and traces"
@@ -23,7 +23,7 @@ further_reading:
 For Python applications, note that tracing is disabled when your application is launched in <code>DEBUG</code> mode. Find more <a href="http://pypi.datadoghq.com/trace/docs/#module-ddtrace.contrib.django">here</a>.
 </div>
 
-## Installation
+## Installation and Getting Started
 
 To begin tracing applications written in Python, first [install and configure the Datadog Agent][1] (see additional documentation for [tracing Docker applications](/tracing/setup/docker/)).
 
@@ -33,93 +33,58 @@ Next, install the Datadog Tracing library using pip:
 pip install ddtrace
 ```
 
-Finally, import the tracer and instrument your code!
+Then to instrument your Python application use the included `ddtrace-run`
+command. To use it, prefix your Python entry-point command with
+`ddtrace-run`.
 
-## Example
+For example, if your application is started with `python app.py` then:
 
-```python
-
-from ddtrace import tracer
-
-with tracer.trace("web.request", service="my_service") as span:
-  span.set_tag("my_tag", "my_value")
+```sh
+$ ddtrace-run python app.py
 ```
 
-For more examples, see the [Getting Started section of library documentation][2].
+For more advanced usage check out our [API documentation](http://pypi.datadoghq.com/trace/docs/).
+
 
 ## Compatibility
 
+Python versions 2.7 and 3.4 and onwards are supported.
+
 {{< tabs >}}
-{{% tab "Framework Compatibility" %}}
+{{% tab "Web Framework" %}}
 
 The ddtrace library includes support for a number of web frameworks, including:
 
-| Framework | Framework Documentation        | PyPi Datadog Documentation                    |
-|-----------|--------------------------------|-----------------------------------------------|
-| Bottle    | https://bottlepy.org/          | http://pypi.datadoghq.com/trace/docs/#bottle  |
-| Django    | https://www.djangoproject.com/ | http://pypi.datadoghq.com/trace/docs/#django  |
-| Falcon    | https://falconframework.org/   | http://pypi.datadoghq.com/trace/docs/#falcon  |
-| Flask     | http://flask.pocoo.org/        | http://pypi.datadoghq.com/trace/docs/#flask   |
-| Pylons    | http://pylonsproject.org/      | http://pypi.datadoghq.com/trace/docs/#pylons  |
-| Pyramid   | https://trypyramid.com/        | http://pypi.datadoghq.com/trace/docs/#pyramid |
+|                Framework                 |  Support Type   |          PyPi Datadog Documentation           |
+| ---------------------------------------- | --------------- | --------------------------------------------- |
+| [Bottle](https://bottlepy.org/)          | Fully Supported | http://pypi.datadoghq.com/trace/docs/#bottle  |
+| [Django](https://www.djangoproject.com/) | Fully Supported | http://pypi.datadoghq.com/trace/docs/#django  |
+| [Falcon](https://falconframework.org/)   | Fully Supported | http://pypi.datadoghq.com/trace/docs/#falcon  |
+| [Flask](http://flask.pocoo.org/)         | Fully Supported | http://pypi.datadoghq.com/trace/docs/#flask   |
+| [Pylons](http://pylonsproject.org/)      | Fully Supported | http://pypi.datadoghq.com/trace/docs/#pylons  |
+| [Pyramid](https://trypyramid.com/)       | Fully Supported | http://pypi.datadoghq.com/trace/docs/#pyramid |
 
 {{% /tab %}}
 {{% tab "Library Compatibility" %}}
 
 The ddtrace library includes support for the following data stores and libraries:
 
-| Library       | Library Documentation                         | PyPi Datadog Documentation                          |
-|---------------|-----------------------------------------------|-----------------------------------------------------|
-| Cassandra     | http://cassandra.apache.org/                  | http://pypi.datadoghq.com/trace/docs/#cassandra     |
-| Elasticsearch | https://www.elastic.co/products/elasticsearch | http://pypi.datadoghq.com/trace/docs/#elasticsearch |
-| Flask Cache   | https://pythonhosted.org/Flask-Cache/         | http://pypi.datadoghq.com/trace/docs/#flask-cache   |
-| MongoDB       | https://www.mongodb.com/what-is-mongodb       | http://pypi.datadoghq.com/trace/docs/#mongodb       |
-| Memcached     | https://memcached.org/                        | http://pypi.datadoghq.com/trace/docs/#memcached     |
-| MySQL         | https://www.mysql.com/                        | http://pypi.datadoghq.com/trace/docs/#mysql         |
-| Postgres      | https://www.postgresql.org/                   | http://pypi.datadoghq.com/trace/docs/#postgres      |
-| Redis         | https://redis.io/                             | http://pypi.datadoghq.com/trace/docs/#redis         |
-| SQLAlchemy    | http://www.sqlalchemy.org/                    | http://pypi.datadoghq.com/trace/docs/#sqlalchemy    |
-| SQLite        | https://www.sqlite.org/                       | http://pypi.datadoghq.com/trace/docs/#sqlite        |
+|                            Library                             |  Support Type   |             PyPi Datadog Documentation              |
+| -------------------------------------------------------------- | --------------- | --------------------------------------------------- |
+| [Cassandra](https://cassandra.apache.org/)                     | Fully Supported | http://pypi.datadoghq.com/trace/docs/#cassandra     |
+| [Elasticsearch](https://www.elastic.co/products/elasticsearch) | Fully Supported | http://pypi.datadoghq.com/trace/docs/#elasticsearch |
+| [Flask Cache](https://pythonhosted.org/Flask-Cache/)           | Fully Supported | http://pypi.datadoghq.com/trace/docs/#flask-cache   |
+| [MongoDB](https://www.mongodb.com/what-is-mongodb)             | Fully Supported | http://pypi.datadoghq.com/trace/docs/#mongodb       |
+| [Memcached](https://memcached.org/)                            | Fully Supported | http://pypi.datadoghq.com/trace/docs/#memcached     |
+| [MySQL](https://www.mysql.com/)                                | Fully Supported | http://pypi.datadoghq.com/trace/docs/#mysql         |
+| [Postgres](https://www.postgresql.org/)                        | Fully Supported | http://pypi.datadoghq.com/trace/docs/#postgres      |
+| [Redis](https://redis.io/)                                     | Fully Supported | http://pypi.datadoghq.com/trace/docs/#redis         |
+| [SQLAlchemy](https://www.sqlalchemy.org/)                      | Fully Supported | http://pypi.datadoghq.com/trace/docs/#sqlalchemy    |
+| [SQLite](https://www.sqlite.org/)                              | Fully Supported | http://pypi.datadoghq.com/trace/docs/#sqlite        |
 
 
 {{% /tab %}}
 {{< /tabs >}}
-
-## Example: Simple tracing
-
-We have a Flask Python application that when called on `/doc` returns **42**.  
-We instrumented our python code in order to generate traces from it:
-
-```python
-import time
-import blinker as _
-
-from flask import Flask, Response
-
-from ddtrace import tracer
-from ddtrace.contrib.flask import TraceMiddleware
-
-# Tracer configuration
-tracer.configure(hostname='datadog')
-app = Flask('API')
-traced_app = TraceMiddleware(app, tracer, service='doc_service')
-
-@tracer.wrap(name='doc_work')
-def work():
-    time.sleep(0.5)
-    return 42
-
-@app.route('/doc/')
-def doc_resource():
-    time.sleep(0.3)
-    res = work()
-    time.sleep(0.3)
-    return Response(str(res), mimetype='application/json')
-```
-
-Each time its called, the following code produces this **trace**:
-
-{{< img src="tracing/simple_trace.png" alt="Simple Trace" responsive="true" >}}
 
 ## Further Reading
 


### PR DESCRIPTION
Note this PR is blocked on  https://github.com/DataDog/dd-trace-py/pull/539

**TODO**:
- [ ] for each section add cross references to API docs (once https://github.com/DataDog/dd-trace-py/pull/539 is merged)
- [ ] figure out and add what logging support exists in the python tracer

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
- refer to API docs for distributed tracing
- move tracing example from quickstart to manual section
- make quickstart docs concise
- add custom tagging docs
- add priority sampling docs
- add debugging docs

### Motivation
<!-- What inspired you to submit this pull request?-->
I'd like to dedicate this PR to @iFallUpHill.

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
