### PR TITLE
style tab content links the same

### DIFF
--- a/src/scss/pages/_global.scss
+++ b/src/scss/pages/_global.scss
@@ -252,6 +252,7 @@ h5{
       border-bottom: 1px solid #000;
     }
   }
+  .tab-content a,
   & > a,
   & > p > a,
   & > ol li a,


### PR DESCRIPTION
### What does this PR do?
Makes sure that tab content has the same link styling as the rest of the page.

### Motivation
https://trello.com/c/vfUvwzZL/2571-links-lost-their-underline-in-tabs

### Preview link
Code tabs aren't used in prod yet i think so there isn't a direct page to view this on right now. 
https://docs-staging.datadoghq.com/david.jones/tab-content-links/

### Additional Notes

