### PR TITLE
[doc]Added example for muting several monitors

### DIFF
--- a/content/api/monitors/monitors_mute.md
+++ b/content/api/monitors/monitors_mute.md
@@ -10,7 +10,7 @@ external_redirect: /api/#mute-a-monitor
 ##### ARGUMENTS
 * **`scope`** [*optional*, *default*=**None**]:  
     The scope to apply the mute to, e.g. **role:db**.
-    For example, if your alert is grouped by {host}, you might mute 'host:app1'
+    For example, if your alert is grouped by `{host}`, you might mute `host:app1`.
 * **`end`** [*optional*, *default*=**None**]:  
     A POSIX timestamp for when the mute should end.
 

--- a/content/api/monitors/monitors_mute.md
+++ b/content/api/monitors/monitors_mute.md
@@ -10,6 +10,7 @@ external_redirect: /api/#mute-a-monitor
 ##### ARGUMENTS
 * **`scope`** [*optional*, *default*=**None**]:  
     The scope to apply the mute to, e.g. **role:db**.
+    For example, if your alert is grouped by {host}, you might mute 'host:app1'
 * **`end`** [*optional*, *default*=**None**]:  
     A POSIX timestamp for when the mute should end.
 


### PR DESCRIPTION
Customer mentioned that it would be logical to have this example here as well as in the unmute monitor section
### What does this PR do?
This PR adds an example under the api examples for mute monitor 


### Motivation
A customer said it would make sense to add this example under mute a monitor since it was already under unmute a monitor. They said it would have saved them time. 


### Preview link
https://docs.datadoghq.com/api/?lang=bash#mute-a-monitor

### Additional Notes
See:

https://datadog.zendesk.com/agent/tickets/164716
