### PR TITLE
Add autodiscovery instructions for dd host agent

### DIFF
--- a/content/agent/autodiscovery.md
+++ b/content/agent/autodiscovery.md
@@ -56,7 +56,7 @@ The Agent watches for Docker events-container creation, destruction, starts, and
 
 The Datadog Docker Agent automatically auto-discovers other containers.
 
-To utilize autodiscovery on the Datadog **Host** Agent, you will need to add these settings to `datadog.yaml`:
+To utilize Autodiscovery on the Datadog **Host** Agent, you will need to add these settings to `datadog.yaml`:
 
 ```
 # Autodiscovery settings for Datadog Host Agent

--- a/content/agent/autodiscovery.md
+++ b/content/agent/autodiscovery.md
@@ -417,18 +417,13 @@ instances:
 [4]: https://github.com/DataDog/integrations-core/blob/master/consul/datadog_checks/consul/data/auto_conf.yaml
 [5]: https://github.com/DataDog/integrations-core/blob/master/couch/datadog_checks/couch/data/auto_conf.yaml
 [6]: https://github.com/DataDog/integrations-core/blob/master/couchbase/datadog_checks/couchbase/data/auto_conf.yaml
-[7]:
-https://github.com/DataDog/integrations-core/blob/master/elastic/datadog_checks/elastic/data/auto_conf.yaml
+[7]: https://github.com/DataDog/integrations-core/blob/master/elastic/datadog_checks/elastic/data/auto_conf.yaml
 [8]: https://github.com/DataDog/integrations-core/blob/master/etcd/datadog_checks/etcd/data/auto_conf.yaml
-[9]:
-https://github.com/DataDog/integrations-core/blob/master/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
-[10]:
-https://github.com/DataDog/integrations-core/blob/master/kube_dns/datadog_checks/kube_dns/data/auto_conf.yaml
-[11]:
-https://github.com/DataDog/integrations-core/blob/master/kyototycoon/datadog_checks/kyototycoon/data/auto_conf.yaml
+[9]: https://github.com/DataDog/integrations-core/blob/master/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
+[10]: https://github.com/DataDog/integrations-core/blob/master/kube_dns/datadog_checks/kube_dns/data/auto_conf.yaml
+[11]: https://github.com/DataDog/integrations-core/blob/master/kyototycoon/datadog_checks/kyototycoon/data/auto_conf.yaml
 [12]: https://github.com/DataDog/integrations-core/blob/master/mcache/datadog_checks/mcache/data/auto_conf.yaml
-[13]:
-https://github.com/DataDog/integrations-core/blob/master/redisdb/datadog_checks/redisdb/data/auto_conf.yaml
+[13]: https://github.com/DataDog/integrations-core/blob/master/redisdb/datadog_checks/redisdb/data/auto_conf.yaml
 [14]: https://github.com/DataDog/integrations-core/blob/master/riak/datadog_checks/riak/data/auto_conf.yaml
 [15]: https://github.com/DataDog/datadog-agent
 [16]: /agent/basic_agent_usage/kubernetes/#configmap

--- a/content/agent/autodiscovery.md
+++ b/content/agent/autodiscovery.md
@@ -56,6 +56,17 @@ The Agent watches for Docker events-container creation, destruction, starts, and
 
 The Datadog Docker Agent automatically auto-discovers other containers.
 
+To utilize autodiscovery on the Datadog **Host** Agent, you will need to add these settings to `datadog.yaml`:
+
+```
+# Autodiscovery settings for Datadog Host Agent
+listeners:
+  - name: docker
+config_providers:
+  - name: docker
+    polling: true
+```
+
 ## Setting up Check Templates
 
 Each **Template Source** section below shows a different way to configure check templates and their container identifiers.
@@ -406,17 +417,17 @@ instances:
 [4]: https://github.com/DataDog/integrations-core/blob/master/consul/datadog_checks/consul/data/auto_conf.yaml
 [5]: https://github.com/DataDog/integrations-core/blob/master/couch/datadog_checks/couch/data/auto_conf.yaml
 [6]: https://github.com/DataDog/integrations-core/blob/master/couchbase/datadog_checks/couchbase/data/auto_conf.yaml
-[7]: 
+[7]:
 https://github.com/DataDog/integrations-core/blob/master/elastic/datadog_checks/elastic/data/auto_conf.yaml
 [8]: https://github.com/DataDog/integrations-core/blob/master/etcd/datadog_checks/etcd/data/auto_conf.yaml
-[9]: 
+[9]:
 https://github.com/DataDog/integrations-core/blob/master/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
-[10]: 
+[10]:
 https://github.com/DataDog/integrations-core/blob/master/kube_dns/datadog_checks/kube_dns/data/auto_conf.yaml
-[11]: 
+[11]:
 https://github.com/DataDog/integrations-core/blob/master/kyototycoon/datadog_checks/kyototycoon/data/auto_conf.yaml
 [12]: https://github.com/DataDog/integrations-core/blob/master/mcache/datadog_checks/mcache/data/auto_conf.yaml
-[13]: 
+[13]:
 https://github.com/DataDog/integrations-core/blob/master/redisdb/datadog_checks/redisdb/data/auto_conf.yaml
 [14]: https://github.com/DataDog/integrations-core/blob/master/riak/datadog_checks/riak/data/auto_conf.yaml
 [15]: https://github.com/DataDog/datadog-agent


### PR DESCRIPTION
### What does this PR do?
Add autodiscovery instructions for dd host agent to:
https://docs.datadoghq.com/agent/autodiscovery/#how-to-set-it-up

### Motivation
Trello card request
