### PR TITLE
Don't utilize utilize when we can use use.

### DIFF
--- a/content/agent/autodiscovery.md
+++ b/content/agent/autodiscovery.md
@@ -56,7 +56,7 @@ The Agent watches for Docker events-container creation, destruction, starts, and
 
 The Datadog Docker Agent automatically auto-discovers other containers.
 
-To utilize Autodiscovery on the Datadog **Host** Agent, add these settings to your `datadog.yaml` configuration file:
+To use Autodiscovery on the Datadog **Host** Agent, add these settings to your `datadog.yaml` configuration file:
 
 ```
 # Autodiscovery settings for Datadog Host Agent

--- a/content/developers/faq/use-our-webhook-integration-to-create-a-trello-card.md
+++ b/content/developers/faq/use-our-webhook-integration-to-create-a-trello-card.md
@@ -5,7 +5,7 @@ kind: faq
 
 You can easily use our [Webhook Integration][1] to instantly create a trello card using our [@-notification feature][2].
 
-This flow utilizes the Trello REST POST card api endpoint to post the @notification to a relevant Trello list.
+This flow uses the Trello REST POST card api endpoint to post the @notification to a relevant Trello list.
 
 ## Steps to Success
 

--- a/content/graphing/faq/as_count_validation.md
+++ b/content/graphing/faq/as_count_validation.md
@@ -3,7 +3,7 @@ title: as_count in monitors
 kind: faq
 ---
 
-Datadog's graphs utilize [time aggregation][1] to reduce the point count on a timeframe. This is done for performance reasons, because granularity higher than 350 data-points in a graph doesn't provide additional insight.
+Datadog's graphs use [time aggregation][1] to reduce the point count on a timeframe. This is done for performance reasons, because granularity higher than 350 data-points in a graph doesn't provide additional insight.
 
 #### What changed?
 Previously, we allowed the creation of monitors that use `average`/`min`/`max` monitor aggregation with the `as_count` [function][2].

--- a/content/integrations/faq/docker-ecs-kubernetes-events.md
+++ b/content/integrations/faq/docker-ecs-kubernetes-events.md
@@ -75,7 +75,7 @@ The events below will be available per integration:
 
 [Learn more about Datadog-Kubernetes integration][6]
 
-To access and utilize these events in Datadog, use the following three methods:
+To access and use these events in Datadog, use the following three methods:
 
 * [Events stream][1]
 * [Monitors][2]

--- a/content/integrations/faq/how-to-make-trello-card-using-webhooks.md
+++ b/content/integrations/faq/how-to-make-trello-card-using-webhooks.md
@@ -5,7 +5,7 @@ kind: faq
 
 You can easily use our [Webhook Integration][1] to instantly create a trello card using our @-notification feature.
 
-This flow utilizes the Trello REST POST card api endpoint to post the @notification to a relevant Trello list.
+This flow uses the Trello REST POST card api endpoint to post the @notification to a relevant Trello list.
 
 ### Steps to Success
 

--- a/content/integrations/faq/troubleshooting-and-deep-dive-for-kafka.md
+++ b/content/integrations/faq/troubleshooting-and-deep-dive-for-kafka.md
@@ -24,9 +24,9 @@ There are four main components to Kafka:
 
 It is important to note that we currently have two distinct Kafka Integrations. The first is named [Kafka][4] while the second is [Kafka_Consumer][4].
 
-The [Kafka Integration][4] utilizes [Datadog's JMXFetch][5] application to pull metrics, just like our other Java based applications such as Cassandra, JMX, Tomcat, etc. This pulls metrics through the use of mBeans, where the engineering team has included a list of commonly used mBeans in the Kafka.yaml file. This can be extended with any other beans the user would like, or if your version of Kafka supports additional metrics.
+The [Kafka Integration][4] uses [Datadog's JMXFetch][5] application to pull metrics, just like our other Java based applications such as Cassandra, JMX, Tomcat, etc. This pulls metrics through the use of mBeans, where the engineering team has included a list of commonly used mBeans in the Kafka.yaml file. This can be extended with any other beans the user would like, or if your version of Kafka supports additional metrics.
 
-The [Kafka_Consumer Integration][6] collects metrics like our standard Python based checks. This utilizes an internal Zookeeper API. Zookeeper is an Apache application that is responsible for managing the configuration for the cluster of nodes known as the Kafka broker. (In version 0.9 of Kafka things are a bit different, Zookeeper is no longer required, see the Troubleshooting section for more information). This check picks up only three metrics, and these do not come from JMXFetch.
+The [Kafka_Consumer Integration][6] collects metrics like our standard Python based checks. This uses an internal Zookeeper API. Zookeeper is an Apache application that is responsible for managing the configuration for the cluster of nodes known as the Kafka broker. (In version 0.9 of Kafka things are a bit different, Zookeeper is no longer required, see the Troubleshooting section for more information). This check picks up only three metrics, and these do not come from JMXFetch.
 
 ## Troubleshooting:
 

--- a/content/monitors/faq/how-do-i-reduce-alert-flapping-noise.md
+++ b/content/monitors/faq/how-do-i-reduce-alert-flapping-noise.md
@@ -33,8 +33,8 @@ Your individual Datadog alerts with groups will [have notification][1] rollups o
     For example: if CPU is high AND disk is high on a host, trigger the alert.
 
 * Use some built-in analysis modules with Anomaly or Outlier
-    * Anomaly Detection utilizes some seasonality analysis to issue an alert when a data stream behaves in a historically inconsistent way.
-    * Outlier Detection utilizes other data streams of the same context to issue an alert when a stream behaves in a way different compared with its peers
+    * Anomaly Detection uses some seasonality analysis to issue an alert when a data stream behaves in a historically inconsistent way.
+    * Outlier Detection uses other data streams of the same context to issue an alert when a stream behaves in a way different compared with its peers
     * Both can also be used in conjunction with Composite alerts.
     * If you would like a visual introduction to anomaly and outlier detection, this gist is a [screenboard][2] post to the Datadog API with examples and documentation links for both.
 

--- a/content/monitors/faq/why-am-i-getting-so-many-no-data-alerts-for-my-metric-monitor.md
+++ b/content/monitors/faq/why-am-i-getting-so-many-no-data-alerts-for-my-metric-monitor.md
@@ -20,7 +20,7 @@ There are a couple Monitor configuration options that can be edited to properly 
 This is due to the limitations on how soon this metric is available from Cloudwatch.
 
 2. This option is the [Require a Full Window of Data][3] (or the ability to not require).  
-This option is typically recommended for metrics being reported by the Datadog Agent and ones that are coming in with the current timestamp. For slightly backfilled metrics, this option can cause No Data events or have the Monitor skip the current evaluation period due to the values not being present at the time the monitor evaluates. For this reason we recommend all sparse metrics or metrics that don't report at the same frequency, to utilize the option: Do Not [Require a Full Window of Data][3].
+This option is typically recommended for metrics being reported by the Datadog Agent and ones that are coming in with the current timestamp. For slightly backfilled metrics, this option can cause No Data events or have the Monitor skip the current evaluation period due to the values not being present at the time the monitor evaluates. For this reason we recommend all sparse metrics or metrics that don't report at the same frequency to use the option "Do Not [Require a Full Window of Data][3]".
 
 3. The last option here is the Delay Evaluation.  
 Since Monitors perform an evaluation every minute, it is looking back on the past X minutes of data. For backfilled metrics, like those coming from AWS, the monitor may be looking at a period of time when the data is not in Datadog. This causes false No Data alerts. Setting this field allows you to have the monitor wait, 900 seconds, so that the AWS metrics have 900 seconds to be available within Datadog before the monitor begins evaluation.

--- a/content/security/logs.md
+++ b/content/security/logs.md
@@ -15,7 +15,7 @@ The Log Management product supports multiple [environments and formats][1], allo
 
 ## Information Security
 
-The Datadog Agent submits Logs to Datadog over a TLS-encrypted TCP connection, requiring an outbound communication over port `10516`. Datadog utilizes symmetric encryption at rest (AES-256) for indexed Logs. Indexed Logs are deleted from the Datadog platform once their retention period, as defined by the customer, expires.
+The Datadog Agent submits Logs to Datadog over a TLS-encrypted TCP connection, requiring an outbound communication over port `10516`. Datadog uses symmetric encryption at rest (AES-256) for indexed Logs. Indexed Logs are deleted from the Datadog platform once their retention period, as defined by the customer, expires.
 
 ## Logs Filtering
 

--- a/content/tracing/getting_further/resource_monitor.md
+++ b/content/tracing/getting_further/resource_monitor.md
@@ -12,7 +12,7 @@ Utilize [the download button at the top of the graph][3] to save those Metrics t
 
 {{< img src="tracing/faq/apm_save_1.png" alt="APM save" responsive="true" >}}
 
-**Note**: To build Monitors over resources, utilize the resource tag that contains a hash of the resource Name. Find this by saving the metric to a Timeboard and utilizing the same query in a Metric Monitor:
+**Note**: To build Monitors over resources, use the resource tag that contains a hash of the resource Name. Find this by saving the metric to a Timeboard and utilizing the same query in a Metric Monitor:
 
 ## Creating a Monitor from this
 

--- a/content/tracing/setup/java.md
+++ b/content/tracing/setup/java.md
@@ -66,7 +66,7 @@ The tracer is configured using System Properties and Environment Variables as fo
 
 ## Automatic Instrumentation
 
-Automatic instrumentation for Java utilizes the `java-agent` instrumentation capabilities [provided by the JVM][8]. When a `java-agent` is registered, it has the ability to modify class files at load time.
+Automatic instrumentation for Java uses the `java-agent` instrumentation capabilities [provided by the JVM][8]. When a `java-agent` is registered, it has the ability to modify class files at load time.
 The `java-agent` uses the popular [Byte Buddy framework][9] to find the classes defined for instrumentation and modify those class bytes accordingly.
 
 Instrumentation may come from auto-instrumentation, the OpenTracing api, or a mixture of both. Instrumentation generally captures the following info:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Replaces almost every instance of `utilize` with `use`.

### Motivation

The word "utilize" is employed in one of two ways:
- Science and technology.
- Fluffing up common language.

I kept the former and dropped the latter.

### Preview link

### Additional Notes

Everybody has a hill they'll die on. This is mine.