### PR TITLE
Java Tracer 0.14.0 Release Doc update

### DIFF
--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -576,7 +576,7 @@ public class Application {
         // Initialize the tracer from environment variables or system properties
         Tracer tracer = new DDTracer();
         GlobalTracer.register(tracer);
-        // register the same tracer with the Datadog api
+        // register the same tracer with the Datadog API
         datadog.trace.api.GlobalTracer.registerIfAbsent(tracer);
 
         // OR from the API
@@ -584,7 +584,7 @@ public class Application {
         Sampler sampler = new AllSampler();
         Tracer tracer = new DDTracer(writer, sampler);
         GlobalTracer.register(tracer);
-        // register the same tracer with the Datadog api
+        // register the same tracer with the Datadog API
         datadog.trace.api.GlobalTracer.registerIfAbsent(tracer);
 
         // ...

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -576,12 +576,16 @@ public class Application {
         // Initialize the tracer from environment variables or system properties
         Tracer tracer = new DDTracer();
         GlobalTracer.register(tracer);
+        // register the same tracer with the Datadog api
+        datadog.trace.api.GlobalTracer.registerIfAbsent(tracer);
 
         // OR from the API
         Writer writer = new DDAgentWriter();
         Sampler sampler = new AllSampler();
         Tracer tracer = new DDTracer(writer, sampler);
         GlobalTracer.register(tracer);
+        // register the same tracer with the Datadog api
+        datadog.trace.api.GlobalTracer.registerIfAbsent(tracer);
 
         // ...
     }


### PR DESCRIPTION
Small doc change for java manual tracer install for the 0.14.0 release.

Preview Link https://docs-staging.datadoghq.com/ark/java-tracer-0.14.0-release/tracing/setup/java/#custom-instrumentation-examples