### PR TITLE
Update Docker and Container Docs

### DIFF
--- a/content/agent/basic_agent_usage/docker.md
+++ b/content/agent/basic_agent_usage/docker.md
@@ -93,8 +93,7 @@ Exclude containers from the metrics collection and Autodiscovery, if these are n
 
 #### Misc
 
-- `DD_PROCESS_AGENT_CONTAINER_SOURCE`: Overrides container source auto-detection to force a single source. e.g `"docker", "ecs_fargate", "kubelet"`
-
+- `DD_PROCESS_AGENT_CONTAINER_SOURCE`: Overrides container source auto-detection to force a single source. e.g `"docker"`, `"ecs_fargate"`, `"kubelet"`
 ### Configuration files
 
 You can also mount YAML configuration files in the `/conf.d` folder. They will automatically be copied to `/etc/datadog-agent/conf.d/` when the container starts. The same can be done for the `/checks.d` folder: any Python files in the `/checks.d` folder will automatically be copied to `/etc/datadog-agent/checks.d/` when the container starts.

--- a/content/agent/basic_agent_usage/docker.md
+++ b/content/agent/basic_agent_usage/docker.md
@@ -91,6 +91,10 @@ Exclude containers from the metrics collection and Autodiscovery, if these are n
 
 **Note**: The `docker.containers.running`, `.stopped`, `.running.total` and `.stopped.total` metrics are not affected by these settings and always count all containers. This does not affect your per-container billing.
 
+#### Misc
+
+- `DD_PROCESS_AGENT_CONTAINER_SOURCE`: Overrides container source auto-detection to force a single source. e.g `"docker", "ecs_fargate", "kubelet"`
+
 ### Configuration files
 
 You can also mount YAML configuration files in the `/conf.d` folder. They will automatically be copied to `/etc/datadog-agent/conf.d/` when the container starts. The same can be done for the `/checks.d` folder: any Python files in the `/checks.d` folder will automatically be copied to `/etc/datadog-agent/checks.d/` when the container starts.

--- a/content/agent/basic_agent_usage/docker.md
+++ b/content/agent/basic_agent_usage/docker.md
@@ -94,6 +94,7 @@ Exclude containers from the metrics collection and Autodiscovery, if these are n
 #### Misc
 
 - `DD_PROCESS_AGENT_CONTAINER_SOURCE`: Overrides container source auto-detection to force a single source. e.g `"docker"`, `"ecs_fargate"`, `"kubelet"`
+
 ### Configuration files
 
 You can also mount YAML configuration files in the `/conf.d` folder. They will automatically be copied to `/etc/datadog-agent/conf.d/` when the container starts. The same can be done for the `/checks.d` folder: any Python files in the `/checks.d` folder will automatically be copied to `/etc/datadog-agent/checks.d/` when the container starts.

--- a/content/graphing/infrastructure/livecontainers.md
+++ b/content/graphing/infrastructure/livecontainers.md
@@ -109,7 +109,7 @@ While actively working with the Containers page, metrics are collected at 2s res
 
 - RBAC settings can restrict Kubernetes metadata collection. Refer to the [RBAC entites for the Datadog Agent][2].
 
-- The `health` value is the containers' readiness probe, not it's liveness probe. 
+- In Kubernetes the `health` value is the containers' readiness probe, not it's liveness probe. 
 
 [1]: https://github.com/DataDog/docker-dd-agent
 [2]: https://gist.github.com/hkaj/404385619e5908f16ea3134218648237

--- a/content/graphing/infrastructure/livecontainers.md
+++ b/content/graphing/infrastructure/livecontainers.md
@@ -109,6 +109,8 @@ While actively working with the Containers page, metrics are collected at 2s res
 
 - RBAC settings can restrict Kubernetes metadata collection. Refer to the [RBAC entites for the Datadog Agent][2].
 
+- The `health` value is the containers' readiness probe, not it's liveness probe. 
+
 [1]: https://github.com/DataDog/docker-dd-agent
 [2]: https://gist.github.com/hkaj/404385619e5908f16ea3134218648237
 


### PR DESCRIPTION
### What does this PR do?
This pr adds the DD_PROCESS_AGENT_CONTAINER_SOURCE option in the docker.md page and a `health` explanation in the livecontainers.md page

### Motivation
Request by @xvello for next agent release

### Preview link
https://docs-staging.datadoghq.com/victor.atteh/update_docker_container_docs/
`DD_PROCESS_AGENT_CONTAINER_SOURCE` edit - https://docs-staging.datadoghq.com/victor.atteh/update_docker_container_docs/agent/basic_agent_usage/docker/#misc
`health` edit - https://docs-staging.datadoghq.com/victor.atteh/update_docker_container_docs/graphing/infrastructure/livecontainers/#notes-known-issues
