### PR TITLE
Laura.hampton/exclude tags in event stream

### DIFF
--- a/content/graphing/event_stream/_index.md
+++ b/content/graphing/event_stream/_index.md
@@ -22,6 +22,7 @@ Note that filters perform an exact match search and don't work with partial stri
 | status:error                                    | Show events with error status. (supports: 'error', 'warning', 'success')         |
 | priority:low                                    | Show only low-priority events. (supports: 'low' or 'normal'. defaults to 'all')  |
 | incident:claimed                                | Show only claimed incidents. (supports: 'open', 'claimed', 'resolved', or 'all') |
+|cloud_provider:* NOT "azure" | Show only cloud providers not tagged with "azure"|
 
 Full text search works on all keywords provided in the search query after applying any filters. Full text search looks inside the event text, title, tags, users who commented on the event and host names and devices tied to the event for any related information.
 

--- a/content/graphing/event_stream/_index.md
+++ b/content/graphing/event_stream/_index.md
@@ -22,7 +22,7 @@ Note that filters perform an exact match search and don't work with partial stri
 | status:error                                    | Show events with error status. (supports: 'error', 'warning', 'success')         |
 | priority:low                                    | Show only low-priority events. (supports: 'low' or 'normal'. defaults to 'all')  |
 | incident:claimed                                | Show only claimed incidents. (supports: 'open', 'claimed', 'resolved', or 'all') |
-|cloud_provider:* NOT "azure" | Show all cloud providers except the ones tagged with "azure"|
+| cloud_provider:* NOT "azure"                    | Show all cloud providers except the ones tagged with "azure"                     |
 
 Full text search works on all keywords provided in the search query after applying any filters. Full text search looks inside the event text, title, tags, users who commented on the event and host names and devices tied to the event for any related information.
 

--- a/content/graphing/event_stream/_index.md
+++ b/content/graphing/event_stream/_index.md
@@ -22,7 +22,7 @@ Note that filters perform an exact match search and don't work with partial stri
 | status:error                                    | Show events with error status. (supports: 'error', 'warning', 'success')         |
 | priority:low                                    | Show only low-priority events. (supports: 'low' or 'normal'. defaults to 'all')  |
 | incident:claimed                                | Show only claimed incidents. (supports: 'open', 'claimed', 'resolved', or 'all') |
-|cloud_provider:* NOT "azure" | Show only cloud providers not tagged with "azure"|
+|cloud_provider:* NOT "azure" | Show all cloud providers except the ones tagged with "azure"|
 
 Full text search works on all keywords provided in the search query after applying any filters. Full text search looks inside the event text, title, tags, users who commented on the event and host names and devices tied to the event for any related information.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR adds information on how to exclude tags from an Event Stream. 

### Motivation
Many of our users have requested information on how to exclude specific tags in the Event Stream, but this information is not explicitly documented. This PR highlights the instructions on how to exclude tags in the query, and make the information easier to find. 

### Preview link
https://docs-staging.datadoghq.com/laura.hampton/exclude-tags-in-event-stream/graphing/event_stream/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
