### PR TITLE
Adding DD_APM_NON_LOCAL_TRAFFIC=true when tracing from other containers

### DIFF
--- a/content/tracing/setup/docker.md
+++ b/content/tracing/setup/docker.md
@@ -58,6 +58,7 @@ docker run -d --name datadog-agent \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
               -e DD_API_KEY=<YOUR_API_KEY> \
               -e DD_APM_ENABLED=true \
+              -e DD_APM_NON_LOCAL_TRAFFIC=true \
               datadog/agent:latest
 
 # Application


### PR DESCRIPTION
### What does this PR do?

Correct docker launch command when tracing from other containers by adding the DD_APM_NON_LOCAL_TRAFFIC=true variable.

### Motivation

Customer feedback

### Preview link

* https://docs-staging.datadoghq.com/gus/tracing-docker-fix/tracing/setup/docker/?tab=java#docker-network