### PR TITLE
agent/network: add note to recommend not using a subset of IPs

### DIFF
--- a/content/agent/network.fr.md
+++ b/content/agent/network.fr.md
@@ -68,7 +68,7 @@ Si une seule de ces sections vous intéresse, pour chacune des sections il exist
 
 ### Note
 
-Nous recommandons à nos clients d'autoriser *toutes* ces IPs pour identifier le trafic provenant de Datadog. Toutes ces IPs ne sont pas toujours actives, à tout moment leur état peut changer entre actif/inactif sans avertissement (pour une opération de maintenance de Datadog ou de nos fournisseurs d'hébergement).
+Vous devriez autoriser *toutes* ces IPs pour identifier le trafic provenant de Datadog. Ces IPs ne sont pas toujours toutes actives, à tout moment leur état peut changer entre actif/inactif sans avertissement (pour une opération de maintenance de Datadog ou de nos fournisseurs d'hébergement).
 
 ## Ports ouverts
 

--- a/content/agent/network.fr.md
+++ b/content/agent/network.fr.md
@@ -66,6 +66,10 @@ Si une seule de ces sections vous intéresse, pour chacune des sections il exist
 * [https://ip-ranges.datadoghq.com/logs.json][10] pour les IPs utilisées pour le traffic des logs
 * [https://ip-ranges.datadoghq.com/apm.json][11] pour les IPs utilisées pour le traffic APM
 
+### Note
+
+Nous recommandons à nos clients d'autoriser *toutes* ces IPs pour identifier le trafic provenant de Datadog. Toutes ces IPs ne sont pas toujours actives, à tout moment leur état peut changer entre actif/inactif sans avertissement (pour une opération de maintenance de Datadog ou de nos fournisseurs d'hébergement).
+
 ## Ports ouverts
 
 **Tout le traffic sortant est envoyé en TCP SSL sur le port 443.**

--- a/content/agent/network.fr.md
+++ b/content/agent/network.fr.md
@@ -68,7 +68,7 @@ Si une seule de ces sections vous intéresse, pour chacune des sections il exist
 
 ### Note
 
-Vous devriez autoriser *toutes* ces IPs pour identifier le trafic provenant de Datadog. Ces IPs ne sont pas toujours toutes actives, à tout moment leur état peut changer entre actif/inactif sans avertissement (pour une opération de maintenance de Datadog ou de nos fournisseurs d'hébergement).
+Vous devriez autoriser *toutes* ces IPs pour identifier le trafic provenant/à destination de Datadog. Ces IPs ne sont pas toujours toutes actives, à tout moment leur état peut changer entre actif/inactif sans avertissement (pour une opération de maintenance de Datadog ou de nos fournisseurs d'hébergement).
 
 ## Ports ouverts
 

--- a/content/agent/network.md
+++ b/content/agent/network.md
@@ -65,6 +65,9 @@ If you are interested by only one of the sections of this document, for each sec
 * [https://ip-ranges.datadoghq.com/logs.json][10] for the IPs used to receive logs data
 * [https://ip-ranges.datadoghq.com/apm.json][11] for the IPs used to receive APM data
 
+### Note
+
+We highly recommend customers to whitelist *all* of these IPs for identifying Datadog traffic and never use a subset of them. All these IPs are not all active at some point in time and their state might change without notice (maintenance from Datadog or our different cloud providers).
 
 ## Open Ports
 

--- a/content/agent/network.md
+++ b/content/agent/network.md
@@ -67,7 +67,7 @@ If you are interested by only one of the sections of this document, for each sec
 
 ### Note
 
-We highly recommend customers to whitelist *all* of these IPs for identifying Datadog traffic and never use a subset of them. All these IPs are not all active at some point in time and their state might change without notice (maintenance from Datadog or our different cloud providers).
+You should whitelist *all* of these IPs for identifying Datadog servers and never use a subset of them. All these IPs are not all active at some point in time and their state might change without notice (maintenance from Datadog or our different cloud providers).
 
 ## Open Ports
 

--- a/content/agent/network.md
+++ b/content/agent/network.md
@@ -27,13 +27,9 @@ further_reading:
   * **Agents < 5.2.0** `app.datadoghq.com`
   *  **Agents >= 5.2.0** `<version>-app.agent.datadoghq.com`
 
-This decision was taken after the POODLE problem, now versioned endpoints start with Agent 5.2.0, i.e. each version of the Agent hits a different endpoint based on the version of the *Forwarder*.  
+This decision was taken after the POODLE problem. Versioned endpoints start with Agent v5.2.0, where each version of the Agent calls a different endpoint based on the version of the *Forwarder*. For example, Agent v5.2.0 calls `5-2-0-app.agent.datadoghq.com`. Therefore you must whitelist `*.agent.datadoghq.com` in your firewall(s).
 
-* i.e. Agent 5.2.0 hits `5-2-0-app.agent.datadoghq.com`  
-
-As a consequence whitelist `*.agent.datadoghq.com` in your firewalls.
-
-These domains are **CNAME** records pointing to a set of static IP addresses, these addresses can be found at:  
+These domains are **CNAME** records pointing to a set of static IP addresses. These addresses can be found at:  
 
 * **[https://ip-ranges.datadoghq.com][4]**
 
@@ -41,33 +37,33 @@ The information is structured as JSON following this schema:
 
 ```
 {
-    "version": 1,                       // <-- we increment this every time the information is changed
-    "modified": "YYYY-MM-DD-HH-MM-SS",  // <-- the timestamp of the last modification
-    "agents": {                         // <-- in this section the IPs used by the agent to submit metrics to Datadog
-        "prefixes_ipv4": [              // <-- a list of IPv4 CIDR blocks
+    "version": 1,                       // <-- incremented every time this information is changed
+    "modified": "YYYY-MM-DD-HH-MM-SS",  // <-- timestamp of the last modification
+    "agents": {                         // <-- the IPs used by the agent to submit metrics to Datadog
+        "prefixes_ipv4": [              // <-- list of IPv4 CIDR blocks
             "a.b.c.d/x",
             ...
         ],
-        "prefixes_ipv6": [              // <-- a list of IPv6 CIDR blocks
+        "prefixes_ipv6": [              // <-- list of IPv6 CIDR blocks
             ...
         ]
     },
-    "apm": {...},                       // <-- same structure as "agents" but IPs used for the APM agent data
-    "logs": {...},                      // <-- same for the logs agent data
-    "process": {...},                   // <-- same for the process agent data
-    "api": {...},                       // <-- not relevant for agent traffic (submitting data via API)
-    "webhooks": {...}                   // <-- not relevant for agent traffic (Datadog source IPs delivering webhooks)
+    "apm": {...},                       // <-- same structure as "agents" but IPs used for the APM Agent data
+    "logs": {...},                      // <-- same for the logs Agent data
+    "process": {...},                   // <-- same for the process Agent data
+    "api": {...},                       // <-- not used for Agent traffic (submitting data via API)
+    "webhooks": {...}                   // <-- not used for Agent traffic (Datadog source IPs delivering webhooks)
 }
 ```
 
-If you are interested by only one of the sections of this document, for each section there is also a dedicated endpoint at `https://ip-ranges.datadoghq.com/<section>.json`, for instance:
+Each section ash a dedicated endpoint at `https://ip-ranges.datadoghq.com/<section>.json`, for example:
 
 * [https://ip-ranges.datadoghq.com/logs.json][10] for the IPs used to receive logs data
 * [https://ip-ranges.datadoghq.com/apm.json][11] for the IPs used to receive APM data
 
 ### Note
 
-You should whitelist *all* of these IPs for identifying Datadog servers and never use a subset of them. All these IPs are not all active at some point in time and their state might change without notice (maintenance from Datadog or our different cloud providers).
+You should whitelist all of these IPs; while only a subset are active at any given moment, there are variations over time within the entire set due to regular network operation and maintenance.
 
 ## Open Ports
 

--- a/content/agent/network.md
+++ b/content/agent/network.md
@@ -56,7 +56,7 @@ The information is structured as JSON following this schema:
 }
 ```
 
-Each section ash a dedicated endpoint at `https://ip-ranges.datadoghq.com/<section>.json`, for example:
+Each section has a dedicated endpoint at `https://ip-ranges.datadoghq.com/<section>.json`, for example:
 
 * [https://ip-ranges.datadoghq.com/logs.json][10] for the IPs used to receive logs data
 * [https://ip-ranges.datadoghq.com/apm.json][11] for the IPs used to receive APM data


### PR DESCRIPTION
Reference:
https://trello.com/c/8Jc2M1gj/2614-make-clear-in-documentation-to-not-select-a-subset-of-ips
https://trello.com/c/xwQjTfyA/872-track-customers-prospects-who-use-egress-rules-on-aws

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add a note for customers to discourage a behavior that we heard about through the support team and that would end up breaking their data stream in unexpected ways.
<!-- A brief description of the change being made with this pull request.-->

### Preview link
https://docs-staging.datadoghq.com/leo/add-ips/agent/network/?tab=agentv6#note
https://docs-staging.datadoghq.com/leo/add-ips/fr/agent/network/?tab=agentv6#note
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
