### PR TITLE
Document tracer support for Ruby 2.5 

### DIFF
--- a/content/tracing/setup/ruby.md
+++ b/content/tracing/setup/ruby.md
@@ -102,6 +102,7 @@ Ruby APM includes support for the following Ruby interpreters:
 |                                    | 2.2     | Fully Supported |
 |                                    | 2.3     | Fully Supported |
 |                                    | 2.4     | Fully Supported |
+|                                    | 2.5     | Fully Supported |
 | [JRuby](http://jruby.org/)         | 9.1.5   | Experimental    |
 
 #### Web Server Compatibility


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Document tracer support for Ruby 2.5 
<!-- A brief description of the change being made with this pull request.-->

### Motivation
A query from a client "do we support ruby 2.5?"
<!-- What inspired you to submit this pull request?-->

### Preview link
https://docs.datadoghq.com/tracing/setup/ruby/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
