### PR TITLE
Updated API collection to most recent Postman Collection version

### DIFF
--- a/static/json/datadog.postman_collection_scrubbed.json
+++ b/static/json/datadog.postman_collection_scrubbed.json
@@ -21,7 +21,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/validate?api_key=INSERT_API_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/validate?api_key=<INSERT_API_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -36,7 +36,7 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								}
 							]
 						},
@@ -67,7 +67,7 @@
 							"raw": "{\n      \"check\": \"app.is_ok\",\n      \"host_name\": \"my_hostname\",\n      \"status\": 0\n  }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/check_run?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/check_run?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -82,11 +82,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -117,7 +117,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/comments/3843084207937032193?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/comments/3843084207937032193?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -133,11 +133,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -161,7 +161,7 @@
 							"raw": "{\n      \"message\" : \"There is a problem with the database2.\",\n      \"handle\":\"email@domain.com\"\n  }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/comments?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/comments?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -176,11 +176,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -204,7 +204,7 @@
 							"raw": "{\n      \"message\" : \"Try embedded comment to previous post\",\n      \"handle\":\"email@domain.com\",\n      \"related_event_id\":\"4315245270133755906\"\n  }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/comments?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/comments?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -219,11 +219,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -247,7 +247,7 @@
 							"raw": "{\n      \"message\" : \"Try Changing the Wording\"\n  }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/comments/3843084207937032193?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/comments/3843084207937032193?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -263,11 +263,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -298,7 +298,7 @@
 							"raw": "{\"scope\":\"region:midwest\"}"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/downtime/cancel/by_scope?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/downtime/cancel/by_scope?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -315,11 +315,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -338,7 +338,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/downtime?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/downtime?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -353,11 +353,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -376,7 +376,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/downtime?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&start=1493343426&end=1556415426&type=weeks&period=1&week_days=Mon,Tue,Wed,Thu,Fri&until_date=1491026399&scope=region:midwest",
+							"raw": "https://app.datadoghq.com/api/v1/downtime?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>&start=1493343426&end=1556415426&type=weeks&period=1&week_days=Mon,Tue,Wed,Thu,Fri&until_date=1491026399&scope=region:midwest",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -391,11 +391,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								},
 								{
 									"key": "start",
@@ -442,7 +442,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/downtime/223886958?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&start=1493343426&end=1556415426&type=weeks&period=1&week_days=Mon,Tue,Wed,Thu,Fri,Sat&until_date=1491026399&scope=region:midwest",
+							"raw": "https://app.datadoghq.com/api/v1/downtime/223886958?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>&start=1493343426&end=1556415426&type=weeks&period=1&week_days=Mon,Tue,Wed,Thu,Fri,Sat&until_date=1491026399&scope=region:midwest",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -458,11 +458,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								},
 								{
 									"key": "start",
@@ -509,7 +509,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/downtime/223886958?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/downtime/223886958?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -525,11 +525,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -548,7 +548,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/downtime/223886958?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/downtime/223886958?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -564,11 +564,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -594,7 +594,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/graph/embed/45d8cf2d01e0673beadeb88f4368db271376eefd11d76e4eaf3cfae18f47e0f5?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/graph/embed/45d8cf2d01e0673beadeb88f4368db271376eefd11d76e4eaf3cfae18f47e0f5?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -611,11 +611,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -634,7 +634,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/graph/embed/9405f66beea59813e322e236da9dd31006267c4fc970442c5547f9fd7a676678/enable?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/graph/embed/9405f66beea59813e322e236da9dd31006267c4fc970442c5547f9fd7a676678/enable?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -652,11 +652,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -675,7 +675,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/graph/embed/9405f66beea59813e322e236da9dd31006267c4fc970442c5547f9fd7a676678/revoke?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/graph/embed/9405f66beea59813e322e236da9dd31006267c4fc970442c5547f9fd7a676678/revoke?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -693,11 +693,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -742,7 +742,7 @@
 							]
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/graph/embed?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/graph/embed?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -758,11 +758,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -781,7 +781,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/graph/embed?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/graph/embed?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -797,11 +797,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -832,7 +832,7 @@
 							"raw": "{\n\t\"title\":\"Something big happened!\",\n\"text\":\"And let me tell you all about it here!\",\n\"tags\":\"environment:prod\"\n}"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/events/1044739812528776191?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/events/1044739812528776191?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -848,11 +848,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -876,7 +876,7 @@
 							"raw": "{\n\t\"title\":\"Something big happened!\",\n\"text\":\"And let me tell you all about it here!\",\n\"tags\":\"environment:prod\"\n}"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/events/1044739812528776191?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/events/1044739812528776191?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -892,11 +892,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -920,7 +920,7 @@
 							"raw": "{\n\t\"title\":\"Something big happened!\",\n\"text\":\"And let me tell you all about it here!\",\n\"tags\":\"environment:prod\"\n}"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/events?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&start=1493127756&end=1493386969",
+							"raw": "https://app.datadoghq.com/api/v1/events?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>&start=1493127756&end=1493386969",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -935,11 +935,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								},
 								{
 									"key": "start",
@@ -971,7 +971,7 @@
 							"raw": "{\n        \"alert_type\": \"success\",\n        \"title\": \"prod auth build #3991 succeeded on PROD\",\n       \n        \"text\": \"Jenkins Build #3991 completed (16.48 secs) \\n without error.\",\n        \"tags\": [\n           \n            \"result:success\"\n        ],\n        \"device_name\": null,\n        \"priority\": \"low\",\n        \"source_type_name\":\"jenkins\"\n    \n}"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/events?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/events?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -986,11 +986,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -1016,7 +1016,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/graph/snapshot?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&metric_query=system.load.1{*}&start=1493127756&end=1493387140",
+							"raw": "https://app.datadoghq.com/api/v1/graph/snapshot?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>&metric_query=system.load.1{*}&start=1493127756&end=1493387140",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -1032,11 +1032,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								},
 								{
 									"key": "metric_query",
@@ -1079,7 +1079,7 @@
 							"raw": "{\n      \"message\": \"Un-Muting this host for a test!\"\n  }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/host/my_hostname/unmute?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/host/my_hostname/unmute?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -1096,11 +1096,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -1124,7 +1124,7 @@
 							"raw": "{\n      \"message\": \"Muting this host for a test!\"\n  }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/host/my_hostname/mute?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/host/my_hostname/mute?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -1141,11 +1141,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -1169,7 +1169,7 @@
 							"raw": "{ \"series\" :\n         [{\"metric\":\"test.metric\",\n          \"points\":[1493127756,20],\n          \"type\":\"gauge\",\n          \"host\":\"test.example.com\",\n          \"tags\":[\"environment:test\"]}\n        ]\n    }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/reports/v2/overview?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&tags=os:windows",
+							"raw": "https://app.datadoghq.com/reports/v2/overview?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>&tags=os:windows",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -1184,11 +1184,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								},
 								{
 									"key": "tags",
@@ -1216,7 +1216,7 @@
 							"raw": "{ \"series\" :\n         [{\"metric\":\"test.metric\",\n          \"points\":[1493127756,20],\n          \"type\":\"gauge\",\n          \"host\":\"test.example.com\",\n          \"tags\":[\"environment:test\"]}\n        ]\n    }"
 						},
 						"url": {
-							"raw": "https://api.datadoghq.com/api/v1/hosts?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://api.datadoghq.com/api/v1/hosts?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"api",
@@ -1231,11 +1231,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								},
 								{
 									"key": "tags",
@@ -1274,7 +1274,7 @@
 									"raw": "{\n       \"services\": [\n        {\n          \"service_name\": \"test_00\",\n          \"service_key\": \"<PAGERDUTY_SERVICE_KEY>\"\n        },\n        {\n          \"service_name\": \"test_01\",\n          \"service_key\": \"<PAGERDUTY_SERVICE_KEY>\"\n        }\n      ],\n      \"subdomain\": \"my-pd\",\n      \"schedules\": [\"https://my-pd.pagerduty.com/schedules#PCPYT4M\", \"https://my-pd.pagerduty.com/schedules#PKTPB7P\"],\n      \"api_token\": \"<PAGERDUTY_TOKEN>\"\n    }\n"
 								},
 								"url": {
-									"raw": "https://app.datadoghq.com/api/v1/integration/pagerduty?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+									"raw": "https://app.datadoghq.com/api/v1/integration/pagerduty?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 									"protocol": "https",
 									"host": [
 										"app",
@@ -1290,11 +1290,11 @@
 									"query": [
 										{
 											"key": "api_key",
-											"value": "INSERT_API_KEY_HERE"
+											"value": "<INSERT_API_KEY_HERE>"
 										},
 										{
 											"key": "application_key",
-											"value": "INSERT_APP_KEY_HERE"
+											"value": "<INSERT_APP_KEY_HERE>"
 										}
 									]
 								},
@@ -1326,7 +1326,7 @@
 									"raw": "{\n        \"account_id\": \"YOUR_AWS_ACCOUNT_ID\",\n        \"role_name\": \"DatadogAWSIntegrationRole\"\n    }\n"
 								},
 								"url": {
-									"raw": "https://app.datadoghq.com/api/v1/integration/aws?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+									"raw": "https://app.datadoghq.com/api/v1/integration/aws?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 									"protocol": "https",
 									"host": [
 										"app",
@@ -1342,11 +1342,11 @@
 									"query": [
 										{
 											"key": "api_key",
-											"value": "INSERT_API_KEY_HERE"
+											"value": "<INSERT_API_KEY_HERE>"
 										},
 										{
 											"key": "application_key",
-											"value": "INSERT_APP_KEY_HERE"
+											"value": "<INSERT_APP_KEY_HERE>"
 										}
 									]
 								},
@@ -1370,7 +1370,7 @@
 									"raw": "{\n        \"account_id\": \"YOUR_AWS_ACCOUNT_ID\",\n        \"filter_tags\": [\"env:staging\"],\n        \"host_tags\": [\"account:staging\",\"account:customer1\"],\n        \"role_name\": \"DatadogAWSIntegrationRole\"\n    }\n"
 								},
 								"url": {
-									"raw": "https://app.datadoghq.com/api/v1/integration/aws?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+									"raw": "https://app.datadoghq.com/api/v1/integration/aws?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 									"protocol": "https",
 									"host": [
 										"app",
@@ -1386,11 +1386,11 @@
 									"query": [
 										{
 											"key": "api_key",
-											"value": "INSERT_API_KEY_HERE"
+											"value": "<INSERT_API_KEY_HERE>"
 										},
 										{
 											"key": "application_key",
-											"value": "INSERT_APP_KEY_HERE"
+											"value": "<INSERT_APP_KEY_HERE>"
 										}
 									]
 								},
@@ -1409,7 +1409,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "https://app.datadoghq.com/api/v1/integration/aws?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+									"raw": "https://app.datadoghq.com/api/v1/integration/aws?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 									"protocol": "https",
 									"host": [
 										"app",
@@ -1425,11 +1425,11 @@
 									"query": [
 										{
 											"key": "api_key",
-											"value": "INSERT_API_KEY_HERE"
+											"value": "<INSERT_API_KEY_HERE>"
 										},
 										{
 											"key": "application_key",
-											"value": "INSERT_APP_KEY_HERE"
+											"value": "<INSERT_APP_KEY_HERE>"
 										}
 									]
 								},
@@ -1461,7 +1461,7 @@
 									"raw": "{\n    \"hooks\": [\n      {\n        \"name\": \"somehook\",\n        \"url\": \"http://requestb.in/v1srg7v1\",\n        \"use_custom_payload\": \"false\",\n        \"custom_payload\": \"\",\n        \"encode_as_form\": \"false\",\n        \"headers\": \"\"\n    \t}\n]}"
 								},
 								"url": {
-									"raw": "https://app.datadoghq.com/api/v1/integration/webhooks?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+									"raw": "https://app.datadoghq.com/api/v1/integration/webhooks?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 									"protocol": "https",
 									"host": [
 										"app",
@@ -1477,11 +1477,11 @@
 									"query": [
 										{
 											"key": "api_key",
-											"value": "INSERT_API_KEY_HERE"
+											"value": "<INSERT_API_KEY_HERE>"
 										},
 										{
 											"key": "application_key",
-											"value": "INSERT_APP_KEY_HERE"
+											"value": "<INSERT_APP_KEY_HERE>"
 										}
 									]
 								},
@@ -1505,7 +1505,7 @@
 									"raw": "{\n    \"hooks\": [\n      {\n        \"name\": \"anotherone\",\n        \"url\": \"http://requestb.in/v1srg7v1\"\n      }\n    ]\n}"
 								},
 								"url": {
-									"raw": "https://app.datadoghq.com/api/v1/integration/webhooks?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+									"raw": "https://app.datadoghq.com/api/v1/integration/webhooks?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 									"protocol": "https",
 									"host": [
 										"app",
@@ -1521,11 +1521,11 @@
 									"query": [
 										{
 											"key": "api_key",
-											"value": "INSERT_API_KEY_HERE"
+											"value": "<INSERT_API_KEY_HERE>"
 										},
 										{
 											"key": "application_key",
-											"value": "INSERT_APP_KEY_HERE"
+											"value": "<INSERT_APP_KEY_HERE>"
 										}
 									]
 								},
@@ -1557,7 +1557,7 @@
 									"raw": "{\"service_hooks\": [\n      {\n        \"account\": \"Main_Account\",\n        \"url\": \"https://hooks.slack.com/services/1/1\"\n      },\n      {\n        \"account\": \"doghouse\",\n        \"url\": \"https://hooks.slack.com/services/2/2\"\n      }\n    ],\n    \"channels\": [\n      {\n        \"channel_name\": \"#private\",\n        \"transfer_all_user_comments\": \"false\",\n        \"account\": \"Main_Account\"\n      },\n      {\n        \"channel_name\": \"#heresachannel\",\n        \"transfer_all_user_comments\": \"false\",\n        \"account\": \"doghouse\"\n      }\n    ]\n}"
 								},
 								"url": {
-									"raw": "https://app.datadoghq.com/api/v1/integration/slack?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+									"raw": "https://app.datadoghq.com/api/v1/integration/slack?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 									"protocol": "https",
 									"host": [
 										"app",
@@ -1573,11 +1573,11 @@
 									"query": [
 										{
 											"key": "api_key",
-											"value": "INSERT_API_KEY_HERE"
+											"value": "<INSERT_API_KEY_HERE>"
 										},
 										{
 											"key": "application_key",
-											"value": "INSERT_APP_KEY_HERE"
+											"value": "<INSERT_APP_KEY_HERE>"
 										}
 									]
 								},
@@ -1601,7 +1601,7 @@
 									"raw": "{\"service_hooks\": [\n      {\n        \"account\": \"Main_Account\",\n        \"url\": \"https://hooks.slack.com/services/1/1\"\n      },\n      {\n        \"account\": \"doghouse\",\n        \"url\": \"https://hooks.slack.com/services/2/2\"\n      }\n    ],\n    \"channels\": [\n      {\n        \"channel_name\": \"#private\",\n        \"transfer_all_user_comments\": \"false\",\n        \"account\": \"Main_Account\"\n      },\n      {\n        \"channel_name\": \"#heresachannel\",\n        \"transfer_all_user_comments\": \"false\",\n        \"account\": \"doghouse\"\n      }\n    ]\n}"
 								},
 								"url": {
-									"raw": "https://app.datadoghq.com/api/v1/integration/slack?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+									"raw": "https://app.datadoghq.com/api/v1/integration/slack?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 									"protocol": "https",
 									"host": [
 										"app",
@@ -1617,11 +1617,11 @@
 									"query": [
 										{
 											"key": "api_key",
-											"value": "INSERT_API_KEY_HERE"
+											"value": "<INSERT_API_KEY_HERE>"
 										},
 										{
 											"key": "application_key",
-											"value": "INSERT_APP_KEY_HERE"
+											"value": "<INSERT_APP_KEY_HERE>"
 										}
 									]
 								},
@@ -1690,7 +1690,7 @@
 							"raw": "{ \"series\" :\n         [{\"metric\":\"test.metric2\",\n          \"points\":[[\"{{$timestamp}}\", \"{{$randomInt}}\"]],\n          \"type\":\"gauge\",\n          \"tags\":\"source:Postman,test\",\n          \"host\":\"macbookPro\"\n         }\n        ]\n    }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/series?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/series?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -1705,11 +1705,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -1733,7 +1733,7 @@
 							"raw": "{ \"series\" :\n         [{\"metric\":\"test.metric\",\n          \"points\":[1493127756,20],\n          \"type\":\"gauge\",\n          \"host\":\"test.example.com\",\n          \"tags\":[\"environment:test\"]}\n        ]\n    }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/query?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&from=1493127756&to=1493388187&query=system.cpu.idle{*}by{host}",
+							"raw": "https://app.datadoghq.com/api/v1/query?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>&from=1493127756&to=1493388187&query=system.cpu.idle{*}by{host}",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -1748,11 +1748,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								},
 								{
 									"key": "from",
@@ -1783,7 +1783,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/metrics/system.cpu.system?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/metrics/system.cpu.system?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -1799,11 +1799,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -1827,7 +1827,7 @@
 							"raw": "{\n    \"description\": \"The percent of time the CPU spent running the kernel 2.\",\n    \"short_name\": \"cpu system\",\n    \"integration\": \"system\",\n    \"statsd_interval\": null,\n    \"per_unit\": null,\n    \"type\": \"gauge\",\n    \"unit\": \"percent\"\n}"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/metrics/system.cpu.system?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/metrics/system.cpu.system?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -1843,11 +1843,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -1866,7 +1866,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/metrics?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&from=1488386651",
+							"raw": "https://app.datadoghq.com/api/v1/metrics?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>&from=1488386651",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -1881,11 +1881,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								},
 								{
 									"key": "from",
@@ -1920,7 +1920,7 @@
 							"raw": "{\n      \"type\": \"metric alert\",\n      \"query\": \"avg(last_5m):sum:system.net.bytes_rcvd{host:host0} > 100\",\n      \"name\": \"Bytes received on host0\",\n      \"message\": \"We may need to add web hosts if this is consistently high.\",\n      \"tags\": [\"app:webserver\", \"frontend\"],\n      \"options\": {\n      \t\"notify_no_data\": true,\n      \t\"no_data_timeframe\": 20\n      }\n    }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/monitor?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/monitor?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -1935,11 +1935,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -1963,7 +1963,7 @@
 							"raw": "{\n      \"type\": \"metric alert\",\n      \"query\": \"avg(last_5m):sum:system.net.bytes_rcvd{host:host0} > 100\",\n      \"name\": \"Bytes received on host0\",\n      \"message\": \"We may need to add web hosts if this is consistently high.\",\n      \"tags\": [\"app:webserver\", \"frontend\"],\n      \"options\": {\n      \t\"notify_no_data\": true,\n      \t\"no_data_timeframe\": 20\n      }\n    }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/monitor/1959920/mute?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/monitor/1959920/mute?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -1980,11 +1980,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -2008,7 +2008,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/monitor?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/monitor?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -2023,11 +2023,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -2051,7 +2051,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/monitor/unmute_all?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/monitor/unmute_all?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -2067,11 +2067,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -2095,7 +2095,7 @@
 							"raw": "{\n      \"type\": \"metric alert\",\n      \"query\": \"avg(last_5m):sum:system.net.bytes_rcvd{host:host0} > 100\",\n      \"name\": \"Bytes received on host0\",\n      \"message\": \"We may need to add web hosts if this is consistently high.\",\n      \"tags\": [\"app:webserver\", \"frontend\"],\n      \"options\": {\n      \t\"notify_no_data\": true,\n      \t\"no_data_timeframe\": 20\n      }\n    }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/monitor/1959920/unmute?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/monitor/1959920/unmute?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -2112,11 +2112,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -2140,7 +2140,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/monitor/mute_all?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/monitor/mute_all?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -2156,11 +2156,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -2184,7 +2184,7 @@
 							"raw": "{\n        \"tags\": [],\n        \"deleted\": null,\n        \"query\": \"\\\"windows_service.state\\\".over(\\\"host:GamingPC\\\",\\\"service:termservice\\\").by(\\\"host\\\",\\\"service\\\").last(4).count_by_status()\",\n        \"message\": \"Example Windows Service Check for {{service.name}} on {{host.name}}\",\n        \"matching_downtimes\": [],\n        \"id\": 4769031,\n        \"multi\": true,\n        \"name\": \"Windows Service Check\",\n        \"created\": \"2018-04-25T16:06:10.564735+00:00\",\n        \"created_at\": 1524672370000,\n        \"creator\": {\n            \"id\": 580920,\n            \"handle\": \"brendan.roche@datadoghq.com\",\n            \"name\": \"Brendan Roche\",\n            \"email\": \"brendan.roche@datadoghq.com\"\n        },\n        \"org_id\": 104001,\n        \"modified\": \"2018-04-25T16:06:10.564735+00:00\",\n        \"overall_state_modified\": null,\n        \"overall_state\": \"No Data\",\n        \"type\": \"service check\",\n        \"options\": {\n            \"notify_audit\": false,\n            \"locked\": false,\n            \"timeout_h\": 0,\n            \"silenced\": {},\n            \"thresholds\": {\n                \"warning\": 3,\n                \"ok\": 3,\n                \"critical\": 3\n            },\n            \"new_host_delay\": 300,\n            \"notify_no_data\": false,\n            \"renotify_interval\": 0,\n            \"no_data_timeframe\": 2\n        }\n    }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/monitor/4769031?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/monitor/4769031?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -2200,11 +2200,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -2228,7 +2228,7 @@
 							"raw": "{\n      \"type\": \"metric alert\",\n      \"query\": \"avg(last_5m):sum:system.net.bytes_rcvd{host:host0} > 100\",\n      \"name\": \"Bytes received on host0\",\n      \"message\": \"We may need to add web hosts if this is consistently high.\",\n      \"tags\": [\"app:webserver\", \"frontend\"],\n      \"options\": {\n      \t\"notify_no_data\": true,\n      \t\"no_data_timeframe\": 20\n      }\n    }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/monitor/1959920?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/monitor/1959920?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -2244,11 +2244,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -2272,7 +2272,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/monitor/1959920?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/monitor/1959920?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -2288,11 +2288,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -2323,7 +2323,7 @@
 							"raw": "{ \"series\" :\n         [{\"metric\":\"symantec.job.duration\",\n          \"points\":[[1500326997,20]],\n          \"type\":\"gauge\",\n          \"host\":\"test.example.com\",\n          \"tags\":[\"jobId:12345,datacenter:dc1,app:app1\"]}\n        ]\n    }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/org?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/org?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -2338,11 +2338,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						}
@@ -2433,7 +2433,7 @@
 							"raw": "{\n    \"name\" : \"Setup Child Org Via API\",\n    \"subscription\" : {\n        \"type\" : \"trial\"\n    },\n    \"billing\" : {\n        \"type\" : \"parent_billing\"\n    }\n}"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/org?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/org?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -2448,11 +2448,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -2505,7 +2505,7 @@
 							"raw": "{\n    \"board_title\": \"Number of Agents or EC2 reporting\",\n    \"read_only\": false,\n    \"created\": \"2017-04-25T22:12:54.909853+00:00\",\n    \"modified\": \"2017-04-25T22:15:01.403148+00:00\",\n    \"height\": 768,\n    \"width\": 1024,\n    \"widgets\": [\n        {\n            \"x\": 24,\n            \"title\": \"New Agents reporting, past week\",\n            \"height\": 57,\n            \"width\": 59,\n            \"timeframe\": \"1w\",\n            \"y\": 30,\n            \"query\": \"Datadog agent started\",\n            \"type\": \"event_stream\"\n        },\n        {\n            \"title_size\": 16,\n            \"title\": true,\n            \"title_align\": \"left\",\n            \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n            \"height\": 26,\n            \"tile_def\": {\n                \"viz\": \"timeseries\",\n                \"requests\": [\n                    {\n                        \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                        \"aggregator\": \"avg\",\n                        \"conditional_formats\": [],\n                        \"type\": \"line\"\n                    }\n                ]\n            },\n            \"width\": 47,\n            \"timeframe\": \"1w\",\n            \"y\": 1,\n            \"x\": 1,\n            \"type\": \"timeseries\"\n        },\n        {\n            \"title_size\": 16,\n            \"title\": true,\n            \"title_align\": \"left\",\n            \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n            \"height\": 26,\n            \"tile_def\": {\n                \"viz\": \"timeseries\",\n                \"requests\": [\n                    {\n                        \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                        \"aggregator\": \"avg\",\n                        \"conditional_formats\": [],\n                        \"type\": \"line\"\n                    }\n                ]\n            },\n            \"width\": 47,\n            \"timeframe\": \"1w\",\n            \"y\": 1,\n            \"x\": 50,\n            \"type\": \"timeseries\"\n        }\n    ],\n    \"id\": 177964\n}"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/screen/177964?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/screen/177964?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -2521,11 +2521,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -2549,7 +2549,7 @@
 							"raw": "{\n        \"width\": 1024,\n        \"height\": 768,\n        \"board_title\": \"Number of Agents or EC2 reporting\",\n        \"widgets\": [\n            {\n                \"type\": \"event_stream\",\n                \"title\": \"New Agents reporting, past week\",\n                \"height\": 57,\n                \"width\": 59,\n\n                \"y\": 30,\n                \"x\": 24,\n\n                \"query\": \"Datadog agent started\",\n                \"timeframe\": \"1w\"\n            },\n            {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 1,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                 }\n            },\n    {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 50,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                     }\n\n                 }\n        ]\n    }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/screen/share/178837?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/screen/share/178837?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -2566,11 +2566,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -2594,7 +2594,7 @@
 							"raw": "{\n        \"width\": 1024,\n        \"height\": 768,\n        \"board_title\": \"Number of Agents or EC2 reporting\",\n        \"widgets\": [\n            {\n                \"type\": \"event_stream\",\n                \"title\": \"New Agents reporting, past week\",\n                \"height\": 57,\n                \"width\": 59,\n\n                \"y\": 30,\n                \"x\": 24,\n\n                \"query\": \"Datadog agent started\",\n                \"timeframe\": \"1w\"\n            },\n            {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 1,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                 }\n            },\n    {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 50,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                     }\n\n                 }\n        ]\n    }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/screen?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/screen?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -2609,11 +2609,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -2637,7 +2637,7 @@
 							"raw": "{\n    \"board_title\": \"Number of Agents or EC2 reporting\",\n    \"read_only\": false,\n    \"created\": \"2017-04-25T22:12:54.909853+00:00\",\n    \"modified\": \"2017-04-25T22:15:01.403148+00:00\",\n    \"height\": 768,\n    \"width\": 1024,\n    \"widgets\": [\n        {\n            \"x\": 24,\n            \"title\": \"New Agents reporting, past week\",\n            \"height\": 57,\n            \"width\": 59,\n            \"timeframe\": \"1w\",\n            \"y\": 30,\n            \"query\": \"Datadog agent started\",\n            \"type\": \"event_stream\"\n        },\n        {\n            \"title_size\": 16,\n            \"title\": true,\n            \"title_align\": \"left\",\n            \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n            \"height\": 26,\n            \"tile_def\": {\n                \"viz\": \"timeseries\",\n                \"requests\": [\n                    {\n                        \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                        \"aggregator\": \"avg\",\n                        \"conditional_formats\": [],\n                        \"type\": \"line\"\n                    }\n                ]\n            },\n            \"width\": 47,\n            \"timeframe\": \"1w\",\n            \"y\": 1,\n            \"x\": 1,\n            \"type\": \"timeseries\"\n        },\n        {\n            \"title_size\": 16,\n            \"title\": true,\n            \"title_align\": \"left\",\n            \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n            \"height\": 26,\n            \"tile_def\": {\n                \"viz\": \"timeseries\",\n                \"requests\": [\n                    {\n                        \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                        \"aggregator\": \"avg\",\n                        \"conditional_formats\": [],\n                        \"type\": \"line\"\n                    }\n                ]\n            },\n            \"width\": 47,\n            \"timeframe\": \"1w\",\n            \"y\": 1,\n            \"x\": 50,\n            \"type\": \"timeseries\"\n        }\n    ],\n    \"id\": 177964\n}"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/screen/177964?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/screen/177964?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -2653,11 +2653,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -2681,7 +2681,7 @@
 							"raw": "{\n        \"width\": 1024,\n        \"height\": 768,\n        \"board_title\": \"Number of Agents or EC2 reporting\",\n        \"widgets\": [\n            {\n                \"type\": \"event_stream\",\n                \"title\": \"New Agents reporting, past week\",\n                \"height\": 57,\n                \"width\": 59,\n\n                \"y\": 30,\n                \"x\": 24,\n\n                \"query\": \"Datadog agent started\",\n                \"timeframe\": \"1w\"\n            },\n            {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 1,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                 }\n            },\n    {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 50,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                     }\n\n                 }\n        ]\n    }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/screen?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/screen?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -2696,11 +2696,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -2724,7 +2724,7 @@
 							"raw": "{\n        \"width\": 1024,\n        \"height\": 768,\n        \"board_title\": \"Number of Agents or EC2 reporting\",\n        \"widgets\": [\n            {\n                \"type\": \"event_stream\",\n                \"title\": \"New Agents reporting, past week\",\n                \"height\": 57,\n                \"width\": 59,\n\n                \"y\": 30,\n                \"x\": 24,\n\n                \"query\": \"Datadog agent started\",\n                \"timeframe\": \"1w\"\n            },\n            {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 1,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                 }\n            },\n    {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 50,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                     }\n\n                 }\n        ]\n    }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/screen/share/178837?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/screen/share/178837?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -2741,11 +2741,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -2769,7 +2769,7 @@
 							"raw": "{\n        \"width\": 1024,\n        \"height\": 768,\n        \"board_title\": \"Number of Agents or EC2 reporting\",\n        \"widgets\": [\n            {\n                \"type\": \"event_stream\",\n                \"title\": \"New Agents reporting, past week\",\n                \"height\": 57,\n                \"width\": 59,\n\n                \"y\": 30,\n                \"x\": 24,\n\n                \"query\": \"Datadog agent started\",\n                \"timeframe\": \"1w\"\n            },\n            {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 1,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                 }\n            },\n    {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 50,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                     }\n\n                 }\n        ]\n    }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/screen/177964?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/screen/177964?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -2785,11 +2785,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -2820,7 +2820,7 @@
 							"raw": "{\n        \"width\": 1024,\n        \"height\": 768,\n        \"board_title\": \"Number of Agents or EC2 reporting\",\n        \"widgets\": [\n            {\n                \"type\": \"event_stream\",\n                \"title\": \"New Agents reporting, past week\",\n                \"height\": 57,\n                \"width\": 59,\n\n                \"y\": 30,\n                \"x\": 24,\n\n                \"query\": \"Datadog agent started\",\n                \"timeframe\": \"1w\"\n            },\n            {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 1,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                 }\n            },\n    {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 50,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                     }\n\n                 }\n        ]\n    }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/search?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&q=cpu",
+							"raw": "https://app.datadoghq.com/api/v1/search?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>&q=cpu",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -2835,11 +2835,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								},
 								{
 									"key": "q",
@@ -2874,7 +2874,7 @@
 							"raw": "{\n  \"tags\": [\n    \"aws:cloudformation:stack-name:myfirstinstance\",\n    \"name:myfirstinstance\",\n    \"demo\",\n    \"image:ami-80861296\",\n    \"region:us-east-1\",\n    \"instance-type:t2.micro\",\n    \"aws:cloudformation:logical-id:webserverinstance\",\n    \"security-group:sg-658ba51a\",\n    \"availability-zone:us-east-1c\",\n    \"kernel:none\",\n    \"aws:cloudformation:stack-id:arn:aws:cloudformation:us-east-1:989648780687:stack/myfirstinstance/7f4b9880-250e-11e7-94ec-500c20fefad2\"\n  ]\n}"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/tags/hosts/i-0f125915827da9af1?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&hostname=i-0f125915827da9af1",
+							"raw": "https://app.datadoghq.com/api/v1/tags/hosts/i-0f125915827da9af1?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>&hostname=i-0f125915827da9af1",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -2891,11 +2891,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								},
 								{
 									"key": "hostname",
@@ -2923,7 +2923,7 @@
 							"raw": "{\n  \"tags\": [\n    \"blank:test2\"\n  ]\n}"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/tags/hosts/i-0f125915827da9af1?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&hostname=i-0f125915827da9af1",
+							"raw": "https://app.datadoghq.com/api/v1/tags/hosts/i-0f125915827da9af1?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>&hostname=i-0f125915827da9af1",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -2940,11 +2940,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								},
 								{
 									"key": "hostname",
@@ -2971,7 +2971,7 @@
 							"raw": "{\n  \"tags\": [\n    \"aws:cloudformation:stack-name:myfirstinstance\",\n    \"name:myfirstinstance\",\n    \"demo\",\n    \"image:ami-80861296\",\n    \"region:us-east-1\",\n    \"instance-type:t2.micro\",\n    \"aws:cloudformation:logical-id:webserverinstance\",\n    \"security-group:sg-658ba51a\",\n    \"availability-zone:us-east-1c\",\n    \"kernel:none\",\n    \"aws:cloudformation:stack-id:arn:aws:cloudformation:us-east-1:989648780687:stack/myfirstinstance/7f4b9880-250e-11e7-94ec-500c20fefad2\",\n  ]\n}"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/tags/hosts/i-0f125915827da9af1?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&hostname=i-0f125915827da9af1",
+							"raw": "https://app.datadoghq.com/api/v1/tags/hosts/i-0f125915827da9af1?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>&hostname=i-0f125915827da9af1",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -2988,11 +2988,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								},
 								{
 									"key": "hostname",
@@ -3027,7 +3027,7 @@
 							"raw": "{\n      \"graphs\" : [{\n          \"title\": \"Average Memory Free\",\n          \"definition\": {\n              \"events\": [],\n              \"requests\": [\n                  {\"q\": \"avg:system.mem.free{*}\"}\n              ]\n          },\n          \"viz\": \"timeseries\"\n      }],\n      \"title\" : \"Average Memory Free Shell\",\n      \"description\" : \"A dashboard with memory info.\",\n      \"template_variables\": [{\n          \"name\": \"host1\",\n          \"prefix\": \"host\",\n          \"default\": \"host:my-host\"\n      }],\n      \"read_only\": \"True\"\n    }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/dash?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/dash?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -3042,11 +3042,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -3070,7 +3070,7 @@
 							"raw": "{\n      \"graphs\" : [{\n          \"title\": \"Average Memory Free\",\n          \"definition\": {\n              \"events\": [],\n              \"requests\": [\n                  {\"q\": \"avg:system.mem.free{*}\"}\n              ]\n          },\n          \"viz\": \"timeseries\"\n      }],\n      \"title\" : \"Average Memory Free Shell 2\",\n      \"description\" : \"A dashboard with memory info.\",\n      \"template_variables\": [{\n          \"name\": \"host1\",\n          \"prefix\": \"host\",\n          \"default\": \"host:my-host\"\n      }],\n      \"read_only\": \"True\"\n    }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/dash/306185?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/dash/306185?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -3086,11 +3086,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -3114,7 +3114,7 @@
 							"raw": "{\n      \"graphs\" : [{\n          \"title\": \"Average Memory Free\",\n          \"definition\": {\n              \"events\": [],\n              \"requests\": [\n                  {\"q\": \"avg:system.mem.free{*}\"}\n              ]\n          },\n          \"viz\": \"timeseries\"\n      }],\n      \"title\" : \"Average Memory Free Shell 2\",\n      \"description\" : \"A dashboard with memory info.\",\n      \"template_variables\": [{\n          \"name\": \"host1\",\n          \"prefix\": \"host\",\n          \"default\": \"host:my-host\"\n      }],\n      \"read_only\": \"True\"\n    }"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/dash?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/dash?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -3129,11 +3129,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -3157,7 +3157,7 @@
 							"raw": "{\n    \"description\": \"created by brendan.roche@datadoghq.com\",\n    \"graphs\": [\n        {\n            \"definition\": {\n                \"autoscale\": false,\n                \"custom_unit\": \"\\u00b0F\",\n                \"precision\": \"0\",\n                \"requests\": [\n                    {\n                        \"aggregator\": \"last\",\n                        \"conditional_formats\": [],\n                        \"q\": \"avg:weather.temp_f_broomfield{*}\"\n                    }\n                ],\n                \"status\": \"done\",\n                \"viz\": \"query_value\"\n            },\n            \"title\": \"Broomfield Current Temp\"\n        },\n        {\n            \"definition\": {\n                \"autoscale\": false,\n                \"custom_unit\": \"MPH\",\n                \"precision\": \"0\",\n                \"requests\": [\n                    {\n                        \"aggregator\": \"last\",\n                        \"conditional_formats\": [],\n                        \"q\": \"avg:weather.wind_mph_broomfield{*}\",\n                        \"type\": \"line\"\n                    }\n                ],\n                \"status\": \"done\",\n                \"viz\": \"query_value\"\n            },\n            \"title\": \"Broomfield Wind Strength\"\n        },\n        {\n            \"definition\": {\n                \"autoscale\": false,\n                \"custom_unit\": \"%\",\n                \"precision\": \"0\",\n                \"requests\": [\n                    {\n                        \"aggregator\": \"last\",\n                        \"conditional_formats\": [],\n                        \"q\": \"avg:weather.humidity_broomfield{*}\"\n                    }\n                ],\n                \"status\": \"done\",\n                \"viz\": \"query_value\"\n            },\n            \"title\": \"Broomfield Humidity\"\n        },\n        {\n            \"definition\": {\n                \"autoscale\": true,\n                \"requests\": [\n                    {\n                        \"aggregator\": \"avg\",\n                        \"conditional_formats\": [],\n                        \"q\": \"avg:weather.temp_f_broomfield{*}\",\n                        \"style\": {\n                            \"palette\": \"orange\"\n                        },\n                        \"type\": \"line\"\n                    }\n                ],\n                \"status\": \"done\",\n                \"viz\": \"timeseries\"\n            },\n            \"title\": \"Broomfield Temp\"\n        },\n        {\n            \"definition\": {\n                \"autoscale\": true,\n                \"requests\": [\n                    {\n                        \"aggregator\": \"avg\",\n                        \"conditional_formats\": [],\n                        \"q\": \"avg:weather.wind_mph_broomfield{*}\",\n                        \"style\": {\n                            \"palette\": \"orange\"\n                        },\n                        \"type\": \"area\"\n                    }\n                ],\n                \"status\": \"done\",\n                \"viz\": \"timeseries\"\n            },\n            \"title\": \"Broomfield Wind\"\n        }\n    ],\n    \"read_only\": false,\n    \"template_variables\": [\n        {\n            \"default\": \"*\",\n            \"name\": \"source\",\n            \"prefix\": \"source\"\n        }\n    ],\n    \"title\": \"Broomfield CO Weather\"\n}"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/dash/346679?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/dash/346679?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -3173,11 +3173,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -3203,7 +3203,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/usage/top_avg_metrics?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&month=2018-02&names=aws.ec2.spot_history,system.processes.number",
+							"raw": "https://app.datadoghq.com/api/v1/usage/top_avg_metrics?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>&month=2018-02&names=aws.ec2.spot_history,system.processes.number",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -3219,11 +3219,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								},
 								{
 									"key": "month",
@@ -3252,7 +3252,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/usage/hosts?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&start_hr=2018-03-16T00&end_hr=2018-03-17T00",
+							"raw": "https://app.datadoghq.com/api/v1/usage/hosts?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>&start_hr=2018-03-16T00&end_hr=2018-03-17T00",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -3268,11 +3268,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								},
 								{
 									"key": "start_hr",
@@ -3301,7 +3301,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/usage/timeseries?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&start_hr=2018-03-01T14&end_hr=2018-03-02T14",
+							"raw": "https://app.datadoghq.com/api/v1/usage/timeseries?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>&start_hr=2018-03-01T14&end_hr=2018-03-02T14",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -3317,11 +3317,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								},
 								{
 									"key": "start_hr",
@@ -3350,7 +3350,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/usage/summary?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&start_month=2018-03",
+							"raw": "https://app.datadoghq.com/api/v1/usage/summary?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>&start_month=2018-03",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -3366,11 +3366,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								},
 								{
 									"key": "start_month",
@@ -3413,7 +3413,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/user?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/user?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -3428,11 +3428,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -3451,7 +3451,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/user/test@gmail.com?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/user/test@gmail.com?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -3467,11 +3467,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -3495,7 +3495,7 @@
 							"raw": "{\n  \"user\": {\n    \"disabled\": false,\n    \"handle\": \"email@domain.com\",\n    \"name\": \"Brendan Michael Roche 2\",\n    \"is_admin\": true,\n    \"role\": null,\n    \"access_role\": \"adm\",\n    \"verified\": true,\n    \"email\": \"email@domain.com\",\n    \"icon\": \"https://secure.gravatar.com/avatar/df46ee85ff1cbb518b20c8cab742b9ea?s=48&d=retro\"\n  }\n}"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/user/email@domain.com?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/user/email@domain.com?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -3511,11 +3511,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -3534,7 +3534,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/user/email@domain.com?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/user/email@domain.com?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -3550,11 +3550,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},
@@ -3578,7 +3578,7 @@
 							"raw": "{\n    \"disabled\": false,\n    \"handle\": \"test@gmail.com\",\n    \"name\": \"Testy McTestingson\",\n    \"is_admin\": true,\n    \"role\": null,\n    \"access_role\": \"adm\",\n    \"verified\": true,\n    \"email\": \"test@gmail.com\",\n    \"icon\": \"https://secure.gravatar.com/avatar/df46ee85ff1cbb518b20c8cab742b9ea?s=48&d=retro\"\n  }\n"
 						},
 						"url": {
-							"raw": "https://app.datadoghq.com/api/v1/user?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/user?api_key=<INSERT_API_KEY_HERE>&application_key=<INSERT_APP_KEY_HERE>",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -3593,11 +3593,11 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE"
+									"value": "<INSERT_API_KEY_HERE>"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE"
+									"value": "<INSERT_APP_KEY_HERE>"
 								}
 							]
 						},

--- a/static/json/datadog.postman_collection_scrubbed.json
+++ b/static/json/datadog.postman_collection_scrubbed.json
@@ -1,282 +1,719 @@
 {
-	"variables": [],
 	"info": {
-		"name": "DataDog",
-		"_postman_id": "37963f90-488f-e6c9-ef12-09b16a489ea9",
-		"description": "Top Level Folder For DataDog API calls",
-		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+		"_postman_id": "a952bc30-8300-4e5a-886f-10d1394117bd",
+		"name": "Datadog API Collection",
+		"description": "Top Level Folder For Datadog API calls",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
+			"_postman_id": "e2926d67-1afd-4860-9fc8-ca3d0e4d7f1b",
 			"name": "Authentication",
-			"description": "All requests to Datadog's API must be authenticated. Requests that write data require reporting access and require an API key. Requests that read data require full access and also require an application key.",
 			"item": [
 				{
+					"_postman_id": "421021b8-0738-4cad-8407-583f8ce11044",
 					"name": "Authentication Check",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/validate?api_key=INSERT_API_KEY_HERE",
 						"method": "GET",
 						"header": [],
 						"body": {
 							"mode": "raw",
 							"raw": ""
 						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/validate?api_key=INSERT_API_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"validate"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								}
+							]
+						},
 						"description": "This GET call just checks to see if an API call key is valid."
 					},
 					"response": []
 				}
-			]
+			],
+			"description": "All requests to Datadog's API must be authenticated. Requests that write data require reporting access and require an API key. Requests that read data require full access and also require an application key."
 		},
 		{
+			"_postman_id": "0d45b92e-591b-41df-a81b-56837db9ee8f",
 			"name": "Checks",
-			"description": "The service check endpoint allows you to post check statuses for use with monitors.",
 			"item": [
 				{
+					"_postman_id": "b3016d93-67a6-4f10-bc97-4f15161d5d6c",
 					"name": "Enter Check Status",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/check_run?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n      \"check\": \"app.is_ok\",\n      \"host_name\": \"my_hostname\",\n      \"status\": 0\n  }"
 						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/check_run?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"check_run"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
 						"description": "This POST call allows for you to POST check statuses for use with monitors"
 					},
 					"response": []
 				}
-			]
+			],
+			"description": "The service check endpoint allows you to post check statuses for use with monitors."
 		},
 		{
+			"_postman_id": "e9b7136a-ad6e-4f4f-9fe6-abd1cc22fe70",
 			"name": "Comments",
-			"description": "Comments are essentially special forms of events that appear in the stream. They can start a new discussion thread or optionally, reply in another thread.\n\nARGUMENTS\n\n* message [required]\n     **The comment text.\n* handle [optional, default=application key owner]\n     **The handle of the user making the comment.\n* related_event_id [optional, default=None]\n     **The id of another comment or event to reply to",
 			"item": [
 				{
-					"name": "POST A Comment",
+					"_postman_id": "2cd0f3ad-19cb-451e-b9a7-0e2c3857d5cc",
+					"name": "Delete Comment",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/comments?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "POST",
+						"method": "DELETE",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n      \"message\" : \"There is a problem with the database2.\",\n      \"handle\":\"bmroche@gmail.com\"\n  }"
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/comments/3843084207937032193?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"comments",
+								"3843084207937032193"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "This POST call allows for you to DELETE a previously posted comment by commentId"
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "886b11a1-d2c0-4d4b-8094-bfa09bd86d37",
+					"name": "POST A Comment",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n      \"message\" : \"There is a problem with the database2.\",\n      \"handle\":\"email@domain.com\"\n  }"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/comments?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"comments"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
 						},
 						"description": "This POST call allows for you to POST status messages, or reply to another thread (if related_event_id is passed)"
 					},
 					"response": []
 				},
 				{
+					"_postman_id": "e3240834-3ce8-4eb0-9ca6-f8808affda47",
 					"name": "Reply To Comment",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/comments?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n      \"message\" : \"Try embedded comment to previous post\",\n      \"handle\":\"bmroche@gmail.com\",\n      \"related_event_id\":\"3843081237765820421\"\n  }"
+							"raw": "{\n      \"message\" : \"Try embedded comment to previous post\",\n      \"handle\":\"email@domain.com\",\n      \"related_event_id\":\"4315245270133755906\"\n  }"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/comments?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"comments"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
 						},
 						"description": "This POST call allows for you to POST status messages to a previous post via ID."
 					},
 					"response": []
 				},
 				{
+					"_postman_id": "32c39e0a-6fac-4cae-b680-489bc606e67c",
 					"name": "Change Previous Comment",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/comments/3843084207937032193?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n      \"message\" : \"Try Changing the Wording\"\n  }"
 						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/comments/3843084207937032193?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"comments",
+								"3843084207937032193"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
 						"description": "This POST call allows for you to change a previously posted comment by commentId"
 					},
 					"response": []
-				},
-				{
-					"name": "Delete Comment",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/comments/3843084207937032193?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"description": "This POST call allows for you to DELETE a previously posted comment by commentId"
-					},
-					"response": []
 				}
-			]
+			],
+			"description": "Comments are essentially special forms of events that appear in the stream. They can start a new discussion thread or optionally, reply in another thread.\n\nARGUMENTS\n\n* message [required]\n     **The comment text.\n* handle [optional, default=application key owner]\n     **The handle of the user making the comment.\n* related_event_id [optional, default=None]\n     **The id of another comment or event to reply to"
 		},
 		{
+			"_postman_id": "20793786-62f3-48a4-b5b3-6c87fb20c67a",
 			"name": "Downtimes",
-			"description": "Downtiming gives you greater control over monitor notifications by allowing you to globally exclude scopes from alerting. Downtime settings, which can be scheduled with start and end times, prevent all alerting related to specified Datadog tags.",
 			"item": [
 				{
-					"name": "Schedule Downtime",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/downtime?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&start=1493343426&end=1556415426&type=weeks&period=1&week_days=Mon,Tue,Wed,Thu,Fri&until_date=1491026399&scope=region:midwest",
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"description": "Schedule a single Downtime.\n\nARGUMENTS\n\n* scope [required]\nThe scope(s) to which the downtime will apply, e.g. 'host:app2'. Provide multiple scopes as a comma-separated list, e.g. 'env:dev,env:prod'. The resulting downtime applies to sources that matches ALL provided scopes (i.e. env:dev AND env:prod), NOT any of them.\n\n*monitor_id [optional, default=None]\nA single monitor to which the downtime will apply. If not provided, the downtime will apply to all monitors.\n\n*start [optional, default=None]\nPOSIX timestamp to start the downtime. If not provided, the downtime starts the moment it is created.\n\n*end [optional, default=None]\nPOSIX timestamp to end the downtime. If not provided, the downtime will be in effect indefinitely (i.e. until you cancel it).\n\n*message [optional, default=None]\nA message to include with notifications for this downtime. Email notifications can be sent to specific users by using the same '@username' notation as events\n\n*monitor_id [optional, default=None]\nThe id of a specific monitor to apply the downtime to.\n\n*recurrence [optional, default=None]\nAn object defining the recurrence of the downtime with a variety of parameters:\n\n*type the type of recurrence. Choose from: days, weeks, months, years.\n\n*period how often to repeat as an integer. For example to repeat every 3 days, select a type of days and a period of 3.\n\n*week_days (optional) a list of week days to repeat on. Choose from: Mon, Tue, Wed, Thu, Fri, Sat or Sun. Only applicable when type is weeks. First letter must be capitalized.\n\n*until_occurrences (optional) how many times the downtime will be rescheduled. until_occurences and \n\n*until_date are mutually exclusive\nuntil_date (optional) the date at which the recurrence should end as a POSIX timestmap. until_occurences and until_date are mutually exclusive\n\n*timezone [optional, default=UTC]\nThe timezone for the downtime."
-					},
-					"response": []
-				},
-				{
-					"name": "Update A Downtime",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/downtime/223886958?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&start=1493343426&end=1556415426&type=weeks&period=1&week_days=Mon,Tue,Wed,Thu,Fri,Sat&until_date=1491026399&scope=region:midwest",
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"description": "Update a single Downtime by downtime_id.\n\nARGUMENTS\n\n* scope [required]\nThe scope(s) to which the downtime will apply, e.g. 'host:app2'. Provide multiple scopes as a comma-separated list, e.g. 'env:dev,env:prod'. The resulting downtime applies to sources that matches ALL provided scopes (i.e. env:dev AND env:prod), NOT any of them.\n\n*monitor_id [optional, default=None]\nA single monitor to which the downtime will apply. If not provided, the downtime will apply to all monitors.\n\n*start [optional, default=None]\nPOSIX timestamp to start the downtime. If not provided, the downtime starts the moment it is created.\n\n*end [optional, default=None]\nPOSIX timestamp to end the downtime. If not provided, the downtime will be in effect indefinitely (i.e. until you cancel it).\n\n*message [optional, default=None]\nA message to include with notifications for this downtime. Email notifications can be sent to specific users by using the same '@username' notation as events\n\n*monitor_id [optional, default=None]\nThe id of a specific monitor to apply the downtime to.\n\n*recurrence [optional, default=None]\nAn object defining the recurrence of the downtime with a variety of parameters:\n\n*type the type of recurrence. Choose from: days, weeks, months, years.\n\n*period how often to repeat as an integer. For example to repeat every 3 days, select a type of days and a period of 3.\n\n*week_days (optional) a list of week days to repeat on. Choose from: Mon, Tue, Wed, Thu, Fri, Sat or Sun. Only applicable when type is weeks. First letter must be capitalized.\n\n*until_occurrences (optional) how many times the downtime will be rescheduled. until_occurences and \n\n*until_date are mutually exclusive\nuntil_date (optional) the date at which the recurrence should end as a POSIX timestmap. until_occurences and until_date are mutually exclusive\n\n*timezone [optional, default=UTC]\nThe timezone for the downtime."
-					},
-					"response": []
-				},
-				{
-					"name": "GET A Downtime",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/downtime/223886958?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "GET",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"description": "Get Downtime Detail by downtime_id"
-					},
-					"response": []
-				},
-				{
-					"name": "GET ALL Downtimes",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/downtime?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "GET",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"description": "Get All Scheduled Downtimes"
-					},
-					"response": []
-				},
-				{
+					"_postman_id": "2425ac0f-5ec4-479e-8303-df7e5e921cbc",
 					"name": "DELETE All Downtimes By Scope",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/downtime/cancel/by_scope?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\"scope\":\"region:midwest\"}"
 						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/downtime/cancel/by_scope?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"downtime",
+								"cancel",
+								"by_scope"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
 						"description": "DELETE all Downtimes that match the scope of X"
 					},
 					"response": []
 				},
 				{
+					"_postman_id": "30b7650f-81b0-4362-9567-9f2bebad3a27",
+					"name": "GET ALL Downtimes",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/downtime?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"downtime"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "Get All Scheduled Downtimes"
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "a23b4e73-a43a-4744-910b-fffa6f8f3328",
+					"name": "Schedule Downtime",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/downtime?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&start=1493343426&end=1556415426&type=weeks&period=1&week_days=Mon,Tue,Wed,Thu,Fri&until_date=1491026399&scope=region:midwest",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"downtime"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								},
+								{
+									"key": "start",
+									"value": "1493343426"
+								},
+								{
+									"key": "end",
+									"value": "1556415426"
+								},
+								{
+									"key": "type",
+									"value": "weeks"
+								},
+								{
+									"key": "period",
+									"value": "1"
+								},
+								{
+									"key": "week_days",
+									"value": "Mon,Tue,Wed,Thu,Fri"
+								},
+								{
+									"key": "until_date",
+									"value": "1491026399"
+								},
+								{
+									"key": "scope",
+									"value": "region:midwest"
+								}
+							]
+						},
+						"description": "Schedule a single Downtime.\n\nARGUMENTS\n\n* scope [required]\nThe scope(s) to which the downtime will apply, e.g. 'host:app2'. Provide multiple scopes as a comma-separated list, e.g. 'env:dev,env:prod'. The resulting downtime applies to sources that matches ALL provided scopes (i.e. env:dev AND env:prod), NOT any of them.\n\n*monitor_id [optional, default=None]\nA single monitor to which the downtime will apply. If not provided, the downtime will apply to all monitors.\n\n*start [optional, default=None]\nPOSIX timestamp to start the downtime. If not provided, the downtime starts the moment it is created.\n\n*end [optional, default=None]\nPOSIX timestamp to end the downtime. If not provided, the downtime will be in effect indefinitely (i.e. until you cancel it).\n\n*message [optional, default=None]\nA message to include with notifications for this downtime. Email notifications can be sent to specific users by using the same '@username' notation as events\n\n*monitor_id [optional, default=None]\nThe id of a specific monitor to apply the downtime to.\n\n*recurrence [optional, default=None]\nAn object defining the recurrence of the downtime with a variety of parameters:\n\n*type the type of recurrence. Choose from: days, weeks, months, years.\n\n*period how often to repeat as an integer. For example to repeat every 3 days, select a type of days and a period of 3.\n\n*week_days (optional) a list of week days to repeat on. Choose from: Mon, Tue, Wed, Thu, Fri, Sat or Sun. Only applicable when type is weeks. First letter must be capitalized.\n\n*until_occurrences (optional) how many times the downtime will be rescheduled. until_occurences and \n\n*until_date are mutually exclusive\nuntil_date (optional) the date at which the recurrence should end as a POSIX timestmap. until_occurences and until_date are mutually exclusive\n\n*timezone [optional, default=UTC]\nThe timezone for the downtime."
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "4a75c610-1361-4d60-8e8a-f5a9e8325b55",
+					"name": "Update A Downtime",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/downtime/223886958?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&start=1493343426&end=1556415426&type=weeks&period=1&week_days=Mon,Tue,Wed,Thu,Fri,Sat&until_date=1491026399&scope=region:midwest",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"downtime",
+								"223886958"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								},
+								{
+									"key": "start",
+									"value": "1493343426"
+								},
+								{
+									"key": "end",
+									"value": "1556415426"
+								},
+								{
+									"key": "type",
+									"value": "weeks"
+								},
+								{
+									"key": "period",
+									"value": "1"
+								},
+								{
+									"key": "week_days",
+									"value": "Mon,Tue,Wed,Thu,Fri,Sat"
+								},
+								{
+									"key": "until_date",
+									"value": "1491026399"
+								},
+								{
+									"key": "scope",
+									"value": "region:midwest"
+								}
+							]
+						},
+						"description": "Update a single Downtime by downtime_id.\n\nARGUMENTS\n\n* scope [required]\nThe scope(s) to which the downtime will apply, e.g. 'host:app2'. Provide multiple scopes as a comma-separated list, e.g. 'env:dev,env:prod'. The resulting downtime applies to sources that matches ALL provided scopes (i.e. env:dev AND env:prod), NOT any of them.\n\n*monitor_id [optional, default=None]\nA single monitor to which the downtime will apply. If not provided, the downtime will apply to all monitors.\n\n*start [optional, default=None]\nPOSIX timestamp to start the downtime. If not provided, the downtime starts the moment it is created.\n\n*end [optional, default=None]\nPOSIX timestamp to end the downtime. If not provided, the downtime will be in effect indefinitely (i.e. until you cancel it).\n\n*message [optional, default=None]\nA message to include with notifications for this downtime. Email notifications can be sent to specific users by using the same '@username' notation as events\n\n*monitor_id [optional, default=None]\nThe id of a specific monitor to apply the downtime to.\n\n*recurrence [optional, default=None]\nAn object defining the recurrence of the downtime with a variety of parameters:\n\n*type the type of recurrence. Choose from: days, weeks, months, years.\n\n*period how often to repeat as an integer. For example to repeat every 3 days, select a type of days and a period of 3.\n\n*week_days (optional) a list of week days to repeat on. Choose from: Mon, Tue, Wed, Thu, Fri, Sat or Sun. Only applicable when type is weeks. First letter must be capitalized.\n\n*until_occurrences (optional) how many times the downtime will be rescheduled. until_occurences and \n\n*until_date are mutually exclusive\nuntil_date (optional) the date at which the recurrence should end as a POSIX timestmap. until_occurences and until_date are mutually exclusive\n\n*timezone [optional, default=UTC]\nThe timezone for the downtime."
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "9f57edf8-418a-4314-a238-26ca7438cf31",
+					"name": "GET A Downtime",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/downtime/223886958?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"downtime",
+								"223886958"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "Get Downtime Detail by downtime_id"
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "03c72126-2816-421f-ad68-bac904ff3a25",
 					"name": "DELTE A Downtime",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/downtime/223886958?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 						"method": "DELETE",
 						"header": [],
 						"body": {
 							"mode": "raw",
 							"raw": ""
 						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/downtime/223886958?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"downtime",
+								"223886958"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
 						"description": "DELETE a Downtime Detail by downtime_id"
 					},
 					"response": []
 				}
-			]
+			],
+			"description": "Downtiming gives you greater control over monitor notifications by allowing you to globally exclude scopes from alerting. Downtime settings, which can be scheduled with start and end times, prevent all alerting related to specified Datadog tags."
 		},
 		{
+			"_postman_id": "f92ca4b0-ac50-4c5f-8986-47edf2cafad1",
 			"name": "Embeddable Graphs",
-			"description": "You can interact with embeddable graphs through the API.",
 			"item": [
 				{
-					"name": "GET ALL Embeddable Graphs",
+					"_postman_id": "99097c79-d14c-4273-819e-bf39c6f48e29",
+					"name": "GET A Specific Embeddable Graphs",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/graph/embed?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 						"method": "GET",
 						"header": [],
 						"body": {
 							"mode": "raw",
 							"raw": ""
 						},
-						"description": "GET ALL Embeddable Graphs"
-					},
-					"response": []
-				},
-				{
-					"name": "GET A Specific Embeddable Graphs",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/graph/embed/45d8cf2d01e0673beadeb88f4368db271376eefd11d76e4eaf3cfae18f47e0f5?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "GET",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/graph/embed/45d8cf2d01e0673beadeb88f4368db271376eefd11d76e4eaf3cfae18f47e0f5?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"graph",
+								"embed",
+								"45d8cf2d01e0673beadeb88f4368db271376eefd11d76e4eaf3cfae18f47e0f5"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
 						},
 						"description": "GET A Specific Embeddable Graphs"
 					},
 					"response": []
 				},
 				{
+					"_postman_id": "e3f92e64-7873-4769-8d88-7709db68b0a0",
+					"name": "Enable A Specific Embed",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/graph/embed/9405f66beea59813e322e236da9dd31006267c4fc970442c5547f9fd7a676678/enable?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"graph",
+								"embed",
+								"9405f66beea59813e322e236da9dd31006267c4fc970442c5547f9fd7a676678",
+								"enable"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "Enable A Specific Embed by embed_id"
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "61ff58a6-00f9-44cc-b3ba-04f9b5ba5ffc",
+					"name": "Revoke A Specific Embed",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/graph/embed/9405f66beea59813e322e236da9dd31006267c4fc970442c5547f9fd7a676678/revoke?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"graph",
+								"embed",
+								"9405f66beea59813e322e236da9dd31006267c4fc970442c5547f9fd7a676678",
+								"revoke"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "Revoke A Specific Embed by embed_id"
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "fd0bbd65-4a18-4e0d-97bb-26efb13deba5",
 					"name": "Create An Embeddable Graph",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/graph/embed?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded",
-								"description": ""
+								"value": "application/x-www-form-urlencoded"
 							}
 						],
 						"body": {
@@ -304,481 +741,1361 @@
 								}
 							]
 						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/graph/embed?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"graph",
+								"embed"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
 						"description": "Creates a new embeddable graph.\n\nReturns: A JSON consisting of the same elements returned by GET api/v1/graph/embed/:embed_id. On failure, the return value will be a JSON containing an error message {errors: [messages]}.\n\nNote: If an embed already exists for the exact same query in a given organization, the older embed will be returned instead of creating a new embed.\n\nARGUMENTS\n\n*graph_json [required]\nThe graph definition in JSON. Same format that is available on the JSON tab of the graph editor\n\n*timeframe [optional, default=1_hour]\nThe timegrame for the graph. Must be one of 1_hour, 4_hours, 1_day, 2_days, and 1_week.\n\n*size [optional, default=medium]\nThe size of the graph. Must be one of small, medium, large, and xlarge.\n\n*legend [optional, default=no]\nThe flag determining if the graph includes a legend. Must be one of yes or no.\n\n*title [optional, default=Embed created through API]\nDetermines graph title. Must be at least 1 character."
 					},
 					"response": []
 				},
 				{
-					"name": "Enable A Specific Embed",
+					"_postman_id": "5b119c79-d1ac-47bb-a6dd-a16364116c9c",
+					"name": "GET ALL Embeddable Graphs",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/graph/embed/9405f66beea59813e322e236da9dd31006267c4fc970442c5547f9fd7a676678/enable?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 						"method": "GET",
 						"header": [],
 						"body": {
 							"mode": "raw",
 							"raw": ""
 						},
-						"description": "Enable A Specific Embed by embed_id"
-					},
-					"response": []
-				},
-				{
-					"name": "Revoke A Specific Embed",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/graph/embed/9405f66beea59813e322e236da9dd31006267c4fc970442c5547f9fd7a676678/revoke?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "GET",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/graph/embed?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"graph",
+								"embed"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
 						},
-						"description": "Revoke A Specific Embed by embed_id"
+						"description": "GET ALL Embeddable Graphs"
 					},
 					"response": []
 				}
-			]
+			],
+			"description": "You can interact with embeddable graphs through the API."
 		},
 		{
+			"_postman_id": "fd7f3c06-bc9f-468a-ae08-d153e7627a15",
 			"name": "Events",
-			"description": "The events service allows you to programatically post events to the stream and fetch events from the stream.",
 			"item": [
 				{
-					"name": "Post an Event",
+					"_postman_id": "62a231b2-e9b3-4e3f-8f20-bbe4430a2a0f",
+					"name": "Get Event Details",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/events?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "POST",
+						"method": "GET",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n\t\"title\":\"Something big happened!\",\n\"text\":\"And let me tell you all about it here!\",\n\"tags\":\"environment:prod\"\n}"
 						},
-						"description": "This end point allows you to post events to the stream. You can tag them, set priority and event aggregate them with other events.\n\nARGUMENTS\n\n*title [required]\nThe event title. Limited to 100 characters.\n\n*text [required]\nThe body of the event. Limited to 4000 characters. The text supports markdown.\n\n*date_happened [optional, default=now]\nPOSIX timestamp of the event.\n\n*priority [optional, default='normal']\nThe priority of the event ('normal' or 'low').\n\n*host [optional, default=None]\nHost name to associate with the event.\n\n*tags [optional, default=None]\nA list of tags to apply to the event.\n\n*alert_type [optional, default='info']\n\"error\", \"warning\", \"info\" or \"success\".\n\n*aggregation_key [optional, default=None]\nAn arbitrary string to use for aggregation, max length of 100 characters. If you specify a key, all events using that key will be grouped together in the Event Stream.\n\n*source_type_name [optional, default=None]\nThe type of event being posted.\n\n*Options: nagios, hudson, jenkins, user, my apps, feed, chef, puppet, git, bitbucket, fabric, capistrano"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Event Details",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/events/1044739812528776191?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n\t\"title\":\"Something big happened!\",\n\"text\":\"And let me tell you all about it here!\",\n\"tags\":\"environment:prod\"\n}"
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/events/1044739812528776191?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"events",
+								"1044739812528776191"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
 						},
 						"description": "Get event details by event_id"
 					},
 					"response": []
 				},
 				{
+					"_postman_id": "7d648b9f-0851-4201-88ff-33d8784697e2",
 					"name": "DELETE An Event",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/events/1044739812528776191?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n\t\"title\":\"Something big happened!\",\n\"text\":\"And let me tell you all about it here!\",\n\"tags\":\"environment:prod\"\n}"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/events/1044739812528776191?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"events",
+								"1044739812528776191"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
 						},
 						"description": "DELETE event details by event_id"
 					},
 					"response": []
 				},
 				{
+					"_postman_id": "450f8b15-9f14-4954-b4fe-32dc4fe9d328",
 					"name": "Query Event Stream",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/events?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&start=1493127756&end=1493386969",
 						"method": "GET",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n\t\"title\":\"Something big happened!\",\n\"text\":\"And let me tell you all about it here!\",\n\"tags\":\"environment:prod\"\n}"
 						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/events?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&start=1493127756&end=1493386969",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"events"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								},
+								{
+									"key": "start",
+									"value": "1493127756"
+								},
+								{
+									"key": "end",
+									"value": "1493386969"
+								}
+							]
+						},
 						"description": "The event stream can be queried and filtered by time, priority, sources and tags.\n\nARGUMENTS\n\n*start [required]\nPOSIX timestamp\n\n*end [required]\nPOSIX timestamp\n\n*priority [optional, default=None]\n'low' or 'normal'\n\n*sources [optional, default=None]\nA comma separated string of sources\n\n*tags [optional, default=None]\nA comma separated string of tags"
 					},
 					"response": []
+				},
+				{
+					"_postman_id": "fbb0cf6d-cd30-44d1-9591-b342a286a5c6",
+					"name": "Post an Event",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n        \"alert_type\": \"success\",\n        \"title\": \"prod auth build #3991 succeeded on PROD\",\n       \n        \"text\": \"Jenkins Build #3991 completed (16.48 secs) \\n without error.\",\n        \"tags\": [\n           \n            \"result:success\"\n        ],\n        \"device_name\": null,\n        \"priority\": \"low\",\n        \"source_type_name\":\"jenkins\"\n    \n}"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/events?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"events"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "This end point allows you to post events to the stream. You can tag them, set priority and event aggregate them with other events.\n\nARGUMENTS\n\n*title [required]\nThe event title. Limited to 100 characters.\n\n*text [required]\nThe body of the event. Limited to 4000 characters. The text supports markdown.\n\n*date_happened [optional, default=now]\nPOSIX timestamp of the event.\n\n*priority [optional, default='normal']\nThe priority of the event ('normal' or 'low').\n\n*host [optional, default=None]\nHost name to associate with the event.\n\n*tags [optional, default=None]\nA list of tags to apply to the event.\n\n*alert_type [optional, default='info']\n\"error\", \"warning\", \"info\" or \"success\".\n\n*aggregation_key [optional, default=None]\nAn arbitrary string to use for aggregation, max length of 100 characters. If you specify a key, all events using that key will be grouped together in the Event Stream.\n\n*source_type_name [optional, default=None]\nThe type of event being posted.\n\n*Options: nagios, hudson, jenkins, user, my apps, feed, chef, puppet, git, bitbucket, fabric, capistrano"
+					},
+					"response": []
 				}
-			]
+			],
+			"description": "The events service allows you to programatically post events to the stream and fetch events from the stream."
 		},
 		{
+			"_postman_id": "016df3c8-622d-4f4c-a77c-ad0f4c760ad5",
 			"name": "Graphs",
-			"description": "You can take graph snapshots using the API.",
 			"item": [
 				{
+					"_postman_id": "29c92c58-5973-492e-91bb-e738210c7ba0",
 					"name": "Graph a Snapshot",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/graph/snapshot?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&metric_query=system.load.1{*}&start=1493127756&end=1493387140",
 						"method": "GET",
 						"header": [],
 						"body": {
 							"mode": "raw",
 							"raw": ""
 						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/graph/snapshot?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&metric_query=system.load.1{*}&start=1493127756&end=1493387140",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"graph",
+								"snapshot"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								},
+								{
+									"key": "metric_query",
+									"value": "system.load.1{*}"
+								},
+								{
+									"key": "start",
+									"value": "1493127756"
+								},
+								{
+									"key": "end",
+									"value": "1493387140"
+								}
+							]
+						},
 						"description": "ARGUMENTS\n\n*metric_query [required]\nThe metric query.\n\n*start [required]\nThe POSIX timestamp of the start of the query.\n\n*end [required]\nThe POSIX timestamp of the end of the query.\n\n*event_query [optional, default=None]\nA query that will add event bands to the graph.\n\n*graph_def [optional, default=None]\nA JSON document defining the graph. graph_def can be used instead of metric_query. The JSON document uses the grammar defined here and should be formatted to a single line then URLEncoded. The graph_def argument is only available in the REST API and not using the Ruby or Python wrappers.\n\n*title [optional, default=None]\nA title for the graph. If no title is specified, the graph will not have a title."
 					},
 					"response": []
 				}
-			]
+			],
+			"description": "You can take graph snapshots using the API."
 		},
 		{
+			"_postman_id": "d9ee0b51-7b67-40c4-804e-3aed0dbec291",
 			"name": "Hosts",
-			"description": "",
 			"item": [
 				{
-					"name": "Mute a Host",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/host/my_hostname/mute?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n      \"message\": \"Muting this host for a test!\"\n  }"
-						},
-						"description": "ARGUMENTS\n\n*end [optional, default=None]\nPOSIX timestamp when the host will be unmuted. If omitted, the host will remain muted until explicitly unmuted.\n\n*message [optional, default=None]\nMessage to associate with the muting of this host\n\n*override [optional, default=False]\nIf true and the host is already muted, will replace existing host mute settings."
-					},
-					"response": []
-				},
-				{
+					"_postman_id": "489311ec-cb3e-4e4b-866f-207b264568d3",
 					"name": "Unmute a Host",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/host/my_hostname/unmute?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n      \"message\": \"Un-Muting this host for a test!\"\n  }"
 						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/host/my_hostname/unmute?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"host",
+								"my_hostname",
+								"unmute"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
 						"description": "ARGUMENTS\n\nThis end point takes no JSON arguments."
 					},
 					"response": []
-				}
-			]
-		},
-		{
-			"name": "Metrics",
-			"description": "The metrics end-point allows you to:\n\n*Post metrics data so it can be graphed on Datadog's dashboards\n\n*Query metrics from any time period\n\nAs occurs within the Datadog UI, a graph can only contain a set number of points and as the timeframe over which a metric is viewed increases, aggregation between points will occur to stay below that set number.\n\nThus, if you are querying for larger timeframes of data, the points returned will be more aggregated. The max granularity within Datadog is one point per second, so if you had submitted points at that interval and requested a very small interval from the query API (in this case, probably less than 100 seconds), you could end up getting all of those points back. Otherwise, our algorithm tries to return about 150 points per any given time window, so you'll see coarser and coarser granularity as the amount of time requested increases. We do this time aggregation via averages.",
-			"item": [
-				{
-					"name": "Get All Active Metrics",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/metrics?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&from=1488386651",
-						"method": "GET",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"description": "ARGUMENTS\n\n* from [required]\nseconds since the unix epoch"
-					},
-					"response": []
 				},
 				{
-					"name": "View Metric Data",
+					"_postman_id": "6341f471-7898-4116-82a0-36193760e81c",
+					"name": "Mute a Host",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/metrics/system.cpu.system?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "GET",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"description": "ARGUMENTS\n\nThis endpoint takes no JSON arguments"
-					},
-					"response": []
-				},
-				{
-					"name": "Edit Metric Data",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/metrics/system.cpu.system?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "PUT",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"description\": \"The percent of time the CPU spent running the kernel 2.\",\n    \"short_name\": \"cpu system\",\n    \"integration\": \"system\",\n    \"statsd_interval\": null,\n    \"per_unit\": null,\n    \"type\": \"gauge\",\n    \"unit\": \"percent\"\n}"
-						},
-						"description": "ARGUMENTS\n\nThe metrics metadata endpoint allows you to edit fields of a metric's metadata.\n\nARGUMENTS\n\n*type [optional, default=None]\nmetric type such as 'gauge' or 'rate'\n\n*description [optional, default=None]\nstring description of the metric\n\n*short_name [optional, default=None]\nshort name string of the metric\n\n*unit [optional, default=None]\nprimary unit of the metric such as 'byte' or 'operation'\n\n*per_unit [optional, default=None]\n'per' unit of the metric such as 'second' in 'bytes per second'\n\n*statsd_interval [optional, default=None]\nif applicable, statds flush interval in seconds for the metric"
-					},
-					"response": []
-				},
-				{
-					"name": "POST Time Series Point",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/series?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{ \"series\" :\n         [{\"metric\":\"test.metric\",\n          \"points\":[[1493127756,20]],\n          \"type\":\"gauge\",\n          \"host\":\"test.example.com\",\n          \"tags\":[\"environment:test\"]}\n        ]\n    }"
+							"raw": "{\n      \"message\": \"Muting this host for a test!\"\n  }"
 						},
-						"description": "The metrics end-point allows you to post time-series data that can be graphed on Datadog's dashboards.\n\nARGUMENTS\n\n*series [required]\nA JSON array of metrics where each item in the array contains the following arguments:\n\n*metric [required]\nThe name of the time series\n\n*points [required]\nA JSON array of points. Each point is of the form:\n[[POSIX_timestamp, numeric_value], ...]\nNote that the timestamp should be in seconds, must be current, and the numeric value is a 32bit float gauge-type value. Current is defined as not more than 10 minutes in the future or more than 1 hour in the past.\n\n*host [optional, default=None]\nThe name of the host that produced the metric.\n\n*tags [optional, default=None]\nA list of tags associated with the metric."
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/host/my_hostname/mute?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"host",
+								"my_hostname",
+								"mute"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "ARGUMENTS\n\n*end [optional, default=None]\nPOSIX timestamp when the host will be unmuted. If omitted, the host will remain muted until explicitly unmuted.\n\n*message [optional, default=None]\nMessage to associate with the muting of this host\n\n*override [optional, default=False]\nIf true and the host is already muted, will replace existing host mute settings."
 					},
 					"response": []
 				},
 				{
-					"name": "Query Time Series Points",
+					"_postman_id": "6fe451b0-f2bc-4ee8-88ba-40d0050f9a68",
+					"name": "Infastructure List Query",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/query?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&from=1493127756&to=1493388187&query=system.cpu.idle{*}by{host}",
 						"method": "GET",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{ \"series\" :\n         [{\"metric\":\"test.metric\",\n          \"points\":[1493127756,20],\n          \"type\":\"gauge\",\n          \"host\":\"test.example.com\",\n          \"tags\":[\"environment:test\"]}\n        ]\n    }"
 						},
-						"description": "This end point allows you to query for metrics from any time period.\n\nARGUMENTS\n\n*from [required]\nseconds since the unix epoch\n\n*to [required]\nseconds since the unix epoch\n\n*query [required]\nThe query string\n\n\nQUERY LANGUAGE\n\nAny query used for a graph can be used here. See here for more details. The time between from and to should be less than 24 hours. If it is longer, you will receive points with less granularity."
+						"url": {
+							"raw": "https://app.datadoghq.com/reports/v2/overview?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&tags=os:windows",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"reports",
+								"v2",
+								"overview"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								},
+								{
+									"key": "tags",
+									"value": "os:windows"
+								}
+							]
+						},
+						"description": "https://help.datadoghq.com/hc/en-us/articles/115003306746-Query-the-Infrastructure-List-via-the-API\n\n\ntags: string. A comma-delimited list of what host tags you want to filter down by (uses AND logic; returns data only for those hosts that have all these tags associated with them)\nhostnames[]: list of strings. A list of those specific hostnames you want to query data from\nwith_apps: boolean. If true, will display the applications(integrations) that are associated with a given host.\nwith_mute_status: boolean. If true, will display whether the host is muted by a downtime or not\nwith_source: boolean. If true, returns a list of sources from which metrics are reported for this host. For example, you might see 'aws', or 'agent', or 'azure' in this list.\nwith_aliases: boolean. If true, will display aliases for this host. Here is information about aliases and what they are.\nwith_meta: boolean. If true, will include metadata about the host with things like disk information/ IP addresses/ etc"
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "63921e50-1379-4b99-9209-b8f0293beb4a",
+					"name": "Query Hosts",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{ \"series\" :\n         [{\"metric\":\"test.metric\",\n          \"points\":[1493127756,20],\n          \"type\":\"gauge\",\n          \"host\":\"test.example.com\",\n          \"tags\":[\"environment:test\"]}\n        ]\n    }"
+						},
+						"url": {
+							"raw": "https://api.datadoghq.com/api/v1/hosts?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"api",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"hosts"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								},
+								{
+									"key": "tags",
+									"value": "10.31.10.6",
+									"disabled": true
+								}
+							]
+						},
+						"description": "This endpoint allows searching for hosts by name, alias, or tag. Hosts live within the past 3 hours are included. Results are paginated with a max of 100 results at a time.\n\nARGUMENTS\nfilter [optional, default=None]: Query string to filter search results.\nsort_field [optional, default=cpu]: Sort hosts by the given field. Options: status, apps, cpu, iowait, load\nsort_dir [optional, default=desc]: Direction of sort. Options: asc, desc\nstart [optional, default=0]: Host result to start search from.\ncount [optional, default=100]: Number of host results to return. Max 100."
 					},
 					"response": []
 				}
 			]
 		},
 		{
-			"name": "Monitors",
-			"description": "Monitors allow you to watch a metric or check that you care about, notifying your team when some defined threshold is exceeded. Please refer to the Guide to Monitors for more information on creating monitors.",
+			"_postman_id": "fb4763bb-351d-4df0-b121-9f7b4ae8218e",
+			"name": "Integrations",
 			"item": [
 				{
-					"name": "Create a Monitor ",
+					"_postman_id": "0defc4a1-6904-42a6-a60d-c5cec61023d6",
+					"name": "PagerDuty",
+					"item": [
+						{
+							"_postman_id": "20868576-9743-426e-b055-0c5bd795712a",
+							"name": "POST Pager Duty Account Details via API",
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n       \"services\": [\n        {\n          \"service_name\": \"test_00\",\n          \"service_key\": \"<PAGERDUTY_SERVICE_KEY>\"\n        },\n        {\n          \"service_name\": \"test_01\",\n          \"service_key\": \"<PAGERDUTY_SERVICE_KEY>\"\n        }\n      ],\n      \"subdomain\": \"my-pd\",\n      \"schedules\": [\"https://my-pd.pagerduty.com/schedules#PCPYT4M\", \"https://my-pd.pagerduty.com/schedules#PKTPB7P\"],\n      \"api_token\": \"<PAGERDUTY_TOKEN>\"\n    }\n"
+								},
+								"url": {
+									"raw": "https://app.datadoghq.com/api/v1/integration/pagerduty?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+									"protocol": "https",
+									"host": [
+										"app",
+										"datadoghq",
+										"com"
+									],
+									"path": [
+										"api",
+										"v1",
+										"integration",
+										"pagerduty"
+									],
+									"query": [
+										{
+											"key": "api_key",
+											"value": "INSERT_API_KEY_HERE"
+										},
+										{
+											"key": "application_key",
+											"value": "INSERT_APP_KEY_HERE"
+										}
+									]
+								},
+								"description": "Configure your Datadog-PagerDuty integration directly through Datadog API."
+							},
+							"response": []
+						}
+					],
+					"description": "Configure your Datadog-PagerDuty integration directly through Datadog API.\nRead more about Datadog-PagerDuty integration\n\nARGUMENTS\nservices [required]:\nArray of PagerDuty service objects. Learn how to configure you Datadog service with PagerDuty documentation. A PagerDuty service object is composed by:\n\nservice_name [required]:\nYour Service name in PagerDuty.\n\nservice_key [required]:\nYour Service name associated service key in Pagerduty.\n\nsubdomain [required]:\nYour PagerDuty accounts personalized sub-domain name.\n\nschedules [required]: Array of your schedule URLs e.g:\n[\"https://my-pd.pagerduty.com/schedules#PCPYT4M\", \"https://my-pd.pagerduty.com/schedules#PKTPB7P\"]\n\napi_token [required]:\nYour PagerDuty API token.\n\nrun_check [optional, default=false]:\nDetermines if the integration install check is run before returning a response.\n\nIf true:\n\nThe install check is run\nIf there’s an error in the configuration the error is returned\nIf there’s no error, 204 No Content response code is returned\nIf false:\n\nWe return a 202 accepted\nInstall check is run after returning a response",
+					"_postman_isSubFolder": true
+				},
+				{
+					"_postman_id": "a60a2f5a-7698-4ba9-b083-1a1140e56bc2",
+					"name": "AWS",
+					"item": [
+						{
+							"_postman_id": "507533d3-393a-49ea-8e38-7c7b05627b40",
+							"name": "DELETE AWS Integration Details",
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n        \"account_id\": \"YOUR_AWS_ACCOUNT_ID\",\n        \"role_name\": \"DatadogAWSIntegrationRole\"\n    }\n"
+								},
+								"url": {
+									"raw": "https://app.datadoghq.com/api/v1/integration/aws?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+									"protocol": "https",
+									"host": [
+										"app",
+										"datadoghq",
+										"com"
+									],
+									"path": [
+										"api",
+										"v1",
+										"integration",
+										"aws"
+									],
+									"query": [
+										{
+											"key": "api_key",
+											"value": "INSERT_API_KEY_HERE"
+										},
+										{
+											"key": "application_key",
+											"value": "INSERT_APP_KEY_HERE"
+										}
+									]
+								},
+								"description": "ARGUMENTS\n\n"
+							},
+							"response": []
+						},
+						{
+							"_postman_id": "bbfd8ee7-ce6a-4b02-8023-85682a670663",
+							"name": "POST AWS Integration Details",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n        \"account_id\": \"YOUR_AWS_ACCOUNT_ID\",\n        \"filter_tags\": [\"env:staging\"],\n        \"host_tags\": [\"account:staging\",\"account:customer1\"],\n        \"role_name\": \"DatadogAWSIntegrationRole\"\n    }\n"
+								},
+								"url": {
+									"raw": "https://app.datadoghq.com/api/v1/integration/aws?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+									"protocol": "https",
+									"host": [
+										"app",
+										"datadoghq",
+										"com"
+									],
+									"path": [
+										"api",
+										"v1",
+										"integration",
+										"aws"
+									],
+									"query": [
+										{
+											"key": "api_key",
+											"value": "INSERT_API_KEY_HERE"
+										},
+										{
+											"key": "application_key",
+											"value": "INSERT_APP_KEY_HERE"
+										}
+									]
+								},
+								"description": "ARGUMENTS\n\n"
+							},
+							"response": []
+						},
+						{
+							"_postman_id": "e58241fe-5405-44f7-af8f-baf9ec4d36ef",
+							"name": "Get AWS Integration Details",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "https://app.datadoghq.com/api/v1/integration/aws?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+									"protocol": "https",
+									"host": [
+										"app",
+										"datadoghq",
+										"com"
+									],
+									"path": [
+										"api",
+										"v1",
+										"integration",
+										"aws"
+									],
+									"query": [
+										{
+											"key": "api_key",
+											"value": "INSERT_API_KEY_HERE"
+										},
+										{
+											"key": "application_key",
+											"value": "INSERT_APP_KEY_HERE"
+										}
+									]
+								},
+								"description": "ARGUMENTS\n\n"
+							},
+							"response": []
+						}
+					],
+					"description": "Configure your Datadog-AWS integration directly through Datadog API.\n\nMore Details Here: https://docs.datadoghq.com/integrations/amazon_web_services/",
+					"_postman_isSubFolder": true
+				},
+				{
+					"_postman_id": "fcd7c7c7-aec3-4a03-ab1c-b3a6236cb408",
+					"name": "Webhooks",
+					"item": [
+						{
+							"_postman_id": "35b23a36-8c37-47a5-a005-f3b13f0c2a0e",
+							"name": "POST Webhooks Integration Details via API",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"hooks\": [\n      {\n        \"name\": \"somehook\",\n        \"url\": \"http://requestb.in/v1srg7v1\",\n        \"use_custom_payload\": \"false\",\n        \"custom_payload\": \"\",\n        \"encode_as_form\": \"false\",\n        \"headers\": \"\"\n    \t}\n]}"
+								},
+								"url": {
+									"raw": "https://app.datadoghq.com/api/v1/integration/webhooks?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+									"protocol": "https",
+									"host": [
+										"app",
+										"datadoghq",
+										"com"
+									],
+									"path": [
+										"api",
+										"v1",
+										"integration",
+										"webhooks"
+									],
+									"query": [
+										{
+											"key": "api_key",
+											"value": "INSERT_API_KEY_HERE"
+										},
+										{
+											"key": "application_key",
+											"value": "INSERT_APP_KEY_HERE"
+										}
+									]
+								},
+								"description": "ARGUMENTS\n\n"
+							},
+							"response": []
+						},
+						{
+							"_postman_id": "f0d28ae1-b19f-4464-a887-f8d0cd396110",
+							"name": "PUT Additional Webhooks Integration Details via API",
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"hooks\": [\n      {\n        \"name\": \"anotherone\",\n        \"url\": \"http://requestb.in/v1srg7v1\"\n      }\n    ]\n}"
+								},
+								"url": {
+									"raw": "https://app.datadoghq.com/api/v1/integration/webhooks?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+									"protocol": "https",
+									"host": [
+										"app",
+										"datadoghq",
+										"com"
+									],
+									"path": [
+										"api",
+										"v1",
+										"integration",
+										"webhooks"
+									],
+									"query": [
+										{
+											"key": "api_key",
+											"value": "INSERT_API_KEY_HERE"
+										},
+										{
+											"key": "application_key",
+											"value": "INSERT_APP_KEY_HERE"
+										}
+									]
+								},
+								"description": "ARGUMENTS\n\n"
+							},
+							"response": []
+						}
+					],
+					"description": "Webhooks\nConfigure your Datadog-Webhooks integration directly through Datadog API.\nRead more about Datadog-Webhooks integration\n\nARGUMENTS\nhooks [required]:\nArray of Webhook objects. A Webhook object is composed by:\n\nname [required]:\nYour Webhook name.\nLearn more on how to use it in monitor notifications.\nurl [required]:\nYour Webhook URL.\nuse_custom_payload [optional, default=False]:\nIf true, allow you to specify a custom payload for your Webhook.\n\ncustom_payload [optional, default=None]:\nIf use_custom_payloag is true, specify your own payload to add your own custom fields to the request using those variables.\n\nencode_as_form [optional, default=False]:\nIf use_custom_payload is true, set this to true to have your payload to be URL-encoded.\n\nheaders [optional, default=None]:\nHeaders attached to your Webhook.\n\nrun_check [optional, default=false]:\nDetermines if the integration install check is run before returning a response.\n\nIf true:\n\nThe install check is run\nIf there’s an error in the configuration the error is returned\nIf there’s no error, 204 No Content response code is returned\nIf false:\n\nWe return a 202 accepted\nInstall check is run after returning a response",
+					"_postman_isSubFolder": true
+				},
+				{
+					"_postman_id": "b49fb88b-d369-47ab-b709-da953c5f8546",
+					"name": "Slack",
+					"item": [
+						{
+							"_postman_id": "7e2c6dfc-3c01-447f-8c10-3262fcbc1d20",
+							"name": "PUT Slack Service_Hooks and Channels Via API",
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\"service_hooks\": [\n      {\n        \"account\": \"Main_Account\",\n        \"url\": \"https://hooks.slack.com/services/1/1\"\n      },\n      {\n        \"account\": \"doghouse\",\n        \"url\": \"https://hooks.slack.com/services/2/2\"\n      }\n    ],\n    \"channels\": [\n      {\n        \"channel_name\": \"#private\",\n        \"transfer_all_user_comments\": \"false\",\n        \"account\": \"Main_Account\"\n      },\n      {\n        \"channel_name\": \"#heresachannel\",\n        \"transfer_all_user_comments\": \"false\",\n        \"account\": \"doghouse\"\n      }\n    ]\n}"
+								},
+								"url": {
+									"raw": "https://app.datadoghq.com/api/v1/integration/slack?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+									"protocol": "https",
+									"host": [
+										"app",
+										"datadoghq",
+										"com"
+									],
+									"path": [
+										"api",
+										"v1",
+										"integration",
+										"slack"
+									],
+									"query": [
+										{
+											"key": "api_key",
+											"value": "INSERT_API_KEY_HERE"
+										},
+										{
+											"key": "application_key",
+											"value": "INSERT_APP_KEY_HERE"
+										}
+									]
+								},
+								"description": "Configure your Datadog-Slack integration directly through Datadog API."
+							},
+							"response": []
+						},
+						{
+							"_postman_id": "2953e2ef-2f73-4c87-821b-6d0f10480f6b",
+							"name": "POST Slack Account Details Via API",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\"service_hooks\": [\n      {\n        \"account\": \"Main_Account\",\n        \"url\": \"https://hooks.slack.com/services/1/1\"\n      },\n      {\n        \"account\": \"doghouse\",\n        \"url\": \"https://hooks.slack.com/services/2/2\"\n      }\n    ],\n    \"channels\": [\n      {\n        \"channel_name\": \"#private\",\n        \"transfer_all_user_comments\": \"false\",\n        \"account\": \"Main_Account\"\n      },\n      {\n        \"channel_name\": \"#heresachannel\",\n        \"transfer_all_user_comments\": \"false\",\n        \"account\": \"doghouse\"\n      }\n    ]\n}"
+								},
+								"url": {
+									"raw": "https://app.datadoghq.com/api/v1/integration/slack?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+									"protocol": "https",
+									"host": [
+										"app",
+										"datadoghq",
+										"com"
+									],
+									"path": [
+										"api",
+										"v1",
+										"integration",
+										"slack"
+									],
+									"query": [
+										{
+											"key": "api_key",
+											"value": "INSERT_API_KEY_HERE"
+										},
+										{
+											"key": "application_key",
+											"value": "INSERT_APP_KEY_HERE"
+										}
+									]
+								},
+								"description": "Configure your Datadog-Slack integration directly through Datadog API."
+							},
+							"response": []
+						}
+					],
+					"description": "Configure your Datadog-Slack integration directly through Datadog API.\nRead more about Datadog-Slack integration\n\nARGUMENTS\nservice_hooks [required]:\nArray of service hook objects (the service hook is generated for your slack account in your Slack account administration page). A service hook object is composed by:\n\naccount [required]:\nYour Slack account name.\n\nurl [required]:\nYour Slack Service Hook URL.\n\nchannels [required]:\nArray of slack channel objects to post to. A slack channel object is composed by:\n\nchannel_name [required]:\nYour channel name e.g: #general, #private\n\ntransfer_all_user_comments [optional, default=False]:\nTo be notified for every comment on a graph, set it to true. If set to False use the @slack-channel_name syntax for comments to be posted to slack.\n\naccount [required]:\nAccount to which the channel belongs to.\n\nrun_check [optional, default=false]:\nDetermines if the integration install check is run before returning a response.\n\nIf true:\n\nThe install check is run\nIf there’s an error in the configuration the error is returned\nIf there’s no error, 204 No Content response code is returned\nIf false:\n\nWe return a 202 accepted\nInstall check is run after returning a response",
+					"_postman_isSubFolder": true
+				}
+			],
+			"description": "Configure your Datadog integrations via Datadog API, current configurable integrations are:\n\nAWS\nPagerDuty\nSlack\nWebhooks\nAvailable Endpoints are:\n\nTo Create an integration in Datadog:\nPOST /api/v1/integration/<source_type_name>\n\nTo edit an integration configuration:\nPUT /api/v1/integration/<source_type_name>\n\nTo get an integration status:\nGET /api/v1/integration/<source_type_name>\n\nTo delete an integration from Datadog:\nDELETE /api/v1/integration/<source_type_name>",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "cee8587f-57a4-4835-8a94-9db6cc75c767",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "81e73228-13c1-444f-8424-202bff06c2ec",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"_postman_id": "0ba6493a-ce64-4665-ac43-d39f9e0ede39",
+			"name": "Metrics",
+			"item": [
+				{
+					"_postman_id": "4e1527f0-35c3-49ac-9533-b2c60cdf87e6",
+					"name": "POST Time Series Point",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "5edede57-369e-4c98-b74c-267e1aa0f014",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/monitor?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{ \"series\" :\n         [{\"metric\":\"test.metric2\",\n          \"points\":[[\"{{$timestamp}}\", \"{{$randomInt}}\"]],\n          \"type\":\"gauge\",\n          \"tags\":\"source:Postman,test\",\n          \"host\":\"macbookPro\"\n         }\n        ]\n    }"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/series?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"series"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "The metrics end-point allows you to post time-series data that can be graphed on Datadog's dashboards.\n\nARGUMENTS\n\n*series [required]\nA JSON array of metrics where each item in the array contains the following arguments:\n\n*metric [required]\nThe name of the time series\n\n*points [required]\nA JSON array of points. Each point is of the form:\n[[POSIX_timestamp, numeric_value], ...]\nNote that the timestamp should be in seconds, must be current, and the numeric value is a 32bit float gauge-type value. Current is defined as not more than 10 minutes in the future or more than 1 hour in the past.\n\n*host [optional, default=None]\nThe name of the host that produced the metric.\n\n*tags [optional, default=None]\nA list of tags associated with the metric."
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "e80a5fe1-d7e1-4f81-8358-9196cc2990f1",
+					"name": "Query Time Series Points",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{ \"series\" :\n         [{\"metric\":\"test.metric\",\n          \"points\":[1493127756,20],\n          \"type\":\"gauge\",\n          \"host\":\"test.example.com\",\n          \"tags\":[\"environment:test\"]}\n        ]\n    }"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/query?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&from=1493127756&to=1493388187&query=system.cpu.idle{*}by{host}",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"query"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								},
+								{
+									"key": "from",
+									"value": "1493127756"
+								},
+								{
+									"key": "to",
+									"value": "1493388187"
+								},
+								{
+									"key": "query",
+									"value": "system.cpu.idle{*}by{host}"
+								}
+							]
+						},
+						"description": "This end point allows you to query for metrics from any time period.\n\nARGUMENTS\n\n*from [required]\nseconds since the unix epoch\n\n*to [required]\nseconds since the unix epoch\n\n*query [required]\nThe query string\n\n\nQUERY LANGUAGE\n\nAny query used for a graph can be used here. See here for more details. The time between from and to should be less than 24 hours. If it is longer, you will receive points with less granularity."
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "4d36836d-e7c1-4008-8200-b4b29b0abd66",
+					"name": "View Metric Data",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/metrics/system.cpu.system?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"metrics",
+								"system.cpu.system"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "ARGUMENTS\n\nThis endpoint takes no JSON arguments"
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "92549aa8-3e2c-40b8-a6dd-71efb16b9af0",
+					"name": "Edit Metric Data",
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"description\": \"The percent of time the CPU spent running the kernel 2.\",\n    \"short_name\": \"cpu system\",\n    \"integration\": \"system\",\n    \"statsd_interval\": null,\n    \"per_unit\": null,\n    \"type\": \"gauge\",\n    \"unit\": \"percent\"\n}"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/metrics/system.cpu.system?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"metrics",
+								"system.cpu.system"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "ARGUMENTS\n\nThe metrics metadata endpoint allows you to edit fields of a metric's metadata.\n\nARGUMENTS\n\n*type [optional, default=None]\nmetric type such as 'gauge' or 'rate'\n\n*description [optional, default=None]\nstring description of the metric\n\n*short_name [optional, default=None]\nshort name string of the metric\n\n*unit [optional, default=None]\nprimary unit of the metric such as 'byte' or 'operation'\n\n*per_unit [optional, default=None]\n'per' unit of the metric such as 'second' in 'bytes per second'\n\n*statsd_interval [optional, default=None]\nif applicable, statds flush interval in seconds for the metric"
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "4bd1a49a-1882-4d9d-b389-4bc5139c4199",
+					"name": "Get All Active Metrics",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/metrics?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&from=1488386651",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"metrics"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								},
+								{
+									"key": "from",
+									"value": "1488386651"
+								}
+							]
+						},
+						"description": "ARGUMENTS\n\n* from [required]\nseconds since the unix epoch"
+					},
+					"response": []
+				}
+			],
+			"description": "The metrics end-point allows you to:\n\n*Post metrics data so it can be graphed on Datadog's dashboards\n\n*Query metrics from any time period\n\nAs occurs within the Datadog UI, a graph can only contain a set number of points and as the timeframe over which a metric is viewed increases, aggregation between points will occur to stay below that set number.\n\nThus, if you are querying for larger timeframes of data, the points returned will be more aggregated. The max granularity within Datadog is one point per second, so if you had submitted points at that interval and requested a very small interval from the query API (in this case, probably less than 100 seconds), you could end up getting all of those points back. Otherwise, our algorithm tries to return about 150 points per any given time window, so you'll see coarser and coarser granularity as the amount of time requested increases. We do this time aggregation via averages."
+		},
+		{
+			"_postman_id": "f1a74d36-cdf5-415f-9765-57d25c8dc8c0",
+			"name": "Monitors",
+			"item": [
+				{
+					"_postman_id": "89d0de24-6605-4727-8894-c051bba914eb",
+					"name": "Create a Monitor ",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n      \"type\": \"metric alert\",\n      \"query\": \"avg(last_5m):sum:system.net.bytes_rcvd{host:host0} > 100\",\n      \"name\": \"Bytes received on host0\",\n      \"message\": \"We may need to add web hosts if this is consistently high.\",\n      \"tags\": [\"app:webserver\", \"frontend\"],\n      \"options\": {\n      \t\"notify_no_data\": true,\n      \t\"no_data_timeframe\": 20\n      }\n    }"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/monitor?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"monitor"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
 						},
 						"description": "http://docs.datadoghq.com/api/?lang=console#monitors"
 					},
 					"response": []
 				},
 				{
-					"name": "Get a Monitor's Details",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/monitor/1959920?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n      \"type\": \"metric alert\",\n      \"query\": \"avg(last_5m):sum:system.net.bytes_rcvd{host:host0} > 100\",\n      \"name\": \"Bytes received on host0\",\n      \"message\": \"We may need to add web hosts if this is consistently high.\",\n      \"tags\": [\"app:webserver\", \"frontend\"],\n      \"options\": {\n      \t\"notify_no_data\": true,\n      \t\"no_data_timeframe\": 20\n      }\n    }"
-						},
-						"description": "ARGUMENTS\n\n*group_states [optional, default=None]\n\nIf this argument is set, the returned data will include additional information (if available) regarding the specified group states, including the last notification timestamp, last resolution timestamp and details about the last time the monitor was triggered. The argument should include a string list indicating what, if any, group states to include. Choose one or more from 'all', 'alert', 'warn', or 'no data'. Example: 'alert,warn'"
-					},
-					"response": []
-				},
-				{
-					"name": "Edit a Monitor's Details",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/monitor/1959920?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "PUT",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"tags\": [\n        \"app:webserver\",\n        \"frontend\"\n    ],\n    \"deleted\": null,\n    \"query\": \"avg(last_5m):sum:system.net.bytes_rcvd{host:host0} > 100\",\n    \"message\": \"We may need to add web hosts NOW if this is consistently high.\",\n    \"id\": 1959920,\n    \"multi\": false,\n    \"name\": \"Bytes received on host0\",\n    \"created\": \"2017-04-28T14:09:23.046108+00:00\",\n    \"created_at\": 1493388563000,\n    \"creator\": {\n        \"id\": 508262,\n        \"handle\": \"bmroche@gmail.com\",\n        \"name\": \"Brendan Roche\",\n        \"email\": \"bmroche@gmail.com\"\n    },\n    \"org_id\": 104001,\n    \"modified\": \"2017-04-28T14:09:23.046108+00:00\",\n    \"overall_state_modified\": null,\n    \"overall_state\": \"No Data\",\n    \"type\": \"metric alert\",\n    \"options\": {\n        \"notify_audit\": false,\n        \"locked\": false,\n        \"silenced\": {},\n        \"no_data_timeframe\": 20,\n        \"new_host_delay\": 300,\n        \"require_full_window\": true,\n        \"notify_no_data\": true\n    }\n}"
-						},
-						"description": "ARGUMENTS\n\n*query [required]\nThe metric query to alert on.\n\n*name [optional, default=dynamic, based on query]\nThe name of the monitor.\n\n*message [optional, default=dynamic, based on query]\nA message to include with notifications for this monitor. Email notifications can be sent to specific users by using the same '@username' notation as events.\n\n*options [optional, default=None]\nRefer to the create monitor documentation for details on the available options.\n\n*tags [optional, default=empty list]\nA list of tags to associate with your monitor. This can help you categorize and filter monitors."
-					},
-					"response": []
-				},
-				{
-					"name": "DELETE a Monitor",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/monitor/1959920?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"description": "ARGUMENTS\n\nThis end point takes no JSON arguments."
-					},
-					"response": []
-				},
-				{
-					"name": "GET All Monitor Details",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/monitor?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"description": "ARGUMENTS\n\n*group_states [optional, default=None]\nIf this argument is set, the returned data will include additional information (if available) regarding the specified group states, including the last notification timestamp, last resolution timestamp and details about the last time the monitor was triggered. The argument should include a string list indicating what, if any, group states to include. Choose one or more from 'all', 'alert', 'warn', or 'no data'. Example: 'alert,warn'\n\n*name [optional, default=None]\nA string to filter monitors by name\n\n*tags [optional, default=None]\nA comma separated list indicating what tags, if any, should be used to filter the list of monitors by scope, e.g. host:host0. For more information, see the tags parameter for the appropriate query argument in the Create a monitor section above.\n\n*monitor_tags [optional, default=None]\nA comma separated list indicating what service and/or custom tags, if any, should be used to filter the list of monitors. Tags created in the Datadog UI will automatically have the \"service\" key prepended (e.g. service:my-app)"
-					},
-					"response": []
-				},
-				{
-					"name": "Mute All Monitors",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/monitor/mute_all?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"description": "Muting will prevent all monitors from notifying through email and posts to the event stream. State changes will only be visible by checking the alert page.\n\nARGUMENTS\n\nThis end point takes no JSON arguments."
-					},
-					"response": []
-				},
-				{
-					"name": "Unmute All Monitors",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/monitor/unmute_all?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"description": "Disables muting all monitors. Throws an error if mute all was not enabled previously.\n\nARGUMENTS\n\nThis end point takes no JSON arguments."
-					},
-					"response": []
-				},
-				{
+					"_postman_id": "2e6bc5b1-4e94-42ad-b021-f17d82e368ea",
 					"name": "Mute A Specific Monitor",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/monitor/1959920/mute?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n      \"type\": \"metric alert\",\n      \"query\": \"avg(last_5m):sum:system.net.bytes_rcvd{host:host0} > 100\",\n      \"name\": \"Bytes received on host0\",\n      \"message\": \"We may need to add web hosts if this is consistently high.\",\n      \"tags\": [\"app:webserver\", \"frontend\"],\n      \"options\": {\n      \t\"notify_no_data\": true,\n      \t\"no_data_timeframe\": 20\n      }\n    }"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/monitor/1959920/mute?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"monitor",
+								"1959920",
+								"mute"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
 						},
 						"description": "ARGUMENTS\n\n*scope [optional, default=None]\nThe scope to apply the mute to, e.g. role:db\n\n*end [optional, default=None]\nA POSIX timestamp for when the mute should end"
 					},
 					"response": []
 				},
 				{
-					"name": "Unmute A Specific Monitor",
+					"_postman_id": "a774c3ae-c17a-4e49-9e00-709fe0f9254a",
+					"name": "GET All Monitor Details",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/monitor/1959920/unmute?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/monitor?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"monitor"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "ARGUMENTS\n\n*group_states [optional, default=None]\nIf this argument is set, the returned data will include additional information (if available) regarding the specified group states, including the last notification timestamp, last resolution timestamp and details about the last time the monitor was triggered. The argument should include a string list indicating what, if any, group states to include. Choose one or more from 'all', 'alert', 'warn', or 'no data'. Example: 'alert,warn'\n\n*name [optional, default=None]\nA string to filter monitors by name\n\n*tags [optional, default=None]\nA comma separated list indicating what tags, if any, should be used to filter the list of monitors by scope, e.g. host:host0. For more information, see the tags parameter for the appropriate query argument in the Create a monitor section above.\n\n*monitor_tags [optional, default=None]\nA comma separated list indicating what service and/or custom tags, if any, should be used to filter the list of monitors. Tags created in the Datadog UI will automatically have the \"service\" key prepended (e.g. service:my-app)"
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "5b9d8fcd-86bc-42e8-bfd8-443921c3f426",
+					"name": "Unmute All Monitors",
+					"request": {
 						"method": "POST",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/monitor/unmute_all?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"monitor",
+								"unmute_all"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "Disables muting all monitors. Throws an error if mute all was not enabled previously.\n\nARGUMENTS\n\nThis end point takes no JSON arguments."
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "a2b4cbf2-3883-4e33-8bff-b10fa3fd75ad",
+					"name": "Unmute A Specific Monitor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n      \"type\": \"metric alert\",\n      \"query\": \"avg(last_5m):sum:system.net.bytes_rcvd{host:host0} > 100\",\n      \"name\": \"Bytes received on host0\",\n      \"message\": \"We may need to add web hosts if this is consistently high.\",\n      \"tags\": [\"app:webserver\", \"frontend\"],\n      \"options\": {\n      \t\"notify_no_data\": true,\n      \t\"no_data_timeframe\": 20\n      }\n    }"
 						},
-						"description": "ARGUMENTS\n\n*scope [optional, default=None]\nThe scope to apply the mute to. For example, if your alert is grouped by {host}, you might mute 'host:app1'\n\n*all_scopes [optional, default=False]\nClear muting across all scopes"
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Org",
-			"description": "Manage parent / child orgs here",
-			"item": [
-				{
-					"name": "Get all Orgs",
-					"request": {
 						"url": {
-							"raw": "https://api.datadoghq.com/api/v1/org?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/monitor/1959920/unmute?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -788,45 +2105,225 @@
 							"path": [
 								"api",
 								"v1",
-								"org"
+								"monitor",
+								"1959920",
+								"unmute"
 							],
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE",
-									"equals": true,
-									"description": ""
+									"value": "INSERT_API_KEY_HERE"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE",
-									"equals": true,
-									"description": ""
+									"value": "INSERT_APP_KEY_HERE"
 								}
-							],
-							"variable": []
+							]
 						},
+						"description": "ARGUMENTS\n\n*scope [optional, default=None]\nThe scope to apply the mute to. For example, if your alert is grouped by {host}, you might mute 'host:app1'\n\n*all_scopes [optional, default=False]\nClear muting across all scopes"
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "02085ca9-8c7c-41a9-a75b-e9c89cad1826",
+					"name": "Mute All Monitors",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/monitor/mute_all?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"monitor",
+								"mute_all"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "Muting will prevent all monitors from notifying through email and posts to the event stream. State changes will only be visible by checking the alert page.\n\nARGUMENTS\n\nThis end point takes no JSON arguments."
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "9e9cd7be-5e72-4b80-9a8f-ef1582cec908",
+					"name": "Edit a Monitor's Details",
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n        \"tags\": [],\n        \"deleted\": null,\n        \"query\": \"\\\"windows_service.state\\\".over(\\\"host:GamingPC\\\",\\\"service:termservice\\\").by(\\\"host\\\",\\\"service\\\").last(4).count_by_status()\",\n        \"message\": \"Example Windows Service Check for {{service.name}} on {{host.name}}\",\n        \"matching_downtimes\": [],\n        \"id\": 4769031,\n        \"multi\": true,\n        \"name\": \"Windows Service Check\",\n        \"created\": \"2018-04-25T16:06:10.564735+00:00\",\n        \"created_at\": 1524672370000,\n        \"creator\": {\n            \"id\": 580920,\n            \"handle\": \"brendan.roche@datadoghq.com\",\n            \"name\": \"Brendan Roche\",\n            \"email\": \"brendan.roche@datadoghq.com\"\n        },\n        \"org_id\": 104001,\n        \"modified\": \"2018-04-25T16:06:10.564735+00:00\",\n        \"overall_state_modified\": null,\n        \"overall_state\": \"No Data\",\n        \"type\": \"service check\",\n        \"options\": {\n            \"notify_audit\": false,\n            \"locked\": false,\n            \"timeout_h\": 0,\n            \"silenced\": {},\n            \"thresholds\": {\n                \"warning\": 3,\n                \"ok\": 3,\n                \"critical\": 3\n            },\n            \"new_host_delay\": 300,\n            \"notify_no_data\": false,\n            \"renotify_interval\": 0,\n            \"no_data_timeframe\": 2\n        }\n    }"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/monitor/4769031?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"monitor",
+								"4769031"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "ARGUMENTS\n\n*query [required]\nThe metric query to alert on.\n\n*name [optional, default=dynamic, based on query]\nThe name of the monitor.\n\n*message [optional, default=dynamic, based on query]\nA message to include with notifications for this monitor. Email notifications can be sent to specific users by using the same '@username' notation as events.\n\n*options [optional, default=None]\nRefer to the create monitor documentation for details on the available options.\n\n*tags [optional, default=empty list]\nA list of tags to associate with your monitor. This can help you categorize and filter monitors."
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "b1a73400-7e6b-4d73-acc9-5a78348ed305",
+					"name": "Get a Monitor's Details",
+					"request": {
 						"method": "GET",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n      \"type\": \"metric alert\",\n      \"query\": \"avg(last_5m):sum:system.net.bytes_rcvd{host:host0} > 100\",\n      \"name\": \"Bytes received on host0\",\n      \"message\": \"We may need to add web hosts if this is consistently high.\",\n      \"tags\": [\"app:webserver\", \"frontend\"],\n      \"options\": {\n      \t\"notify_no_data\": true,\n      \t\"no_data_timeframe\": 20\n      }\n    }"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/monitor/1959920?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"monitor",
+								"1959920"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "ARGUMENTS\n\n*group_states [optional, default=None]\n\nIf this argument is set, the returned data will include additional information (if available) regarding the specified group states, including the last notification timestamp, last resolution timestamp and details about the last time the monitor was triggered. The argument should include a string list indicating what, if any, group states to include. Choose one or more from 'all', 'alert', 'warn', or 'no data'. Example: 'alert,warn'"
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "e1fb8c14-30fc-4ad3-a8e4-52b6a7309424",
+					"name": "DELETE a Monitor",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/monitor/1959920?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"monitor",
+								"1959920"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "ARGUMENTS\n\nThis end point takes no JSON arguments."
+					},
+					"response": []
+				}
+			],
+			"description": "Monitors allow you to watch a metric or check that you care about, notifying your team when some defined threshold is exceeded. Please refer to the Guide to Monitors for more information on creating monitors."
+		},
+		{
+			"_postman_id": "96264ab8-6045-4c1a-939a-72ee78b72967",
+			"name": "Organizations",
+			"item": [
+				{
+					"_postman_id": "38c1051e-d979-4b49-a342-25d12e2c7382",
+					"name": "Get all Orgs",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{ \"series\" :\n         [{\"metric\":\"symantec.job.duration\",\n          \"points\":[[1500326997,20]],\n          \"type\":\"gauge\",\n          \"host\":\"test.example.com\",\n          \"tags\":[\"jobId:12345,datacenter:dc1,app:app1\"]}\n        ]\n    }"
 						},
-						"description": ""
-					},
-					"response": []
-				},
-				{
-					"name": "Create Child Org",
-					"request": {
 						"url": {
-							"raw": "https://api.datadoghq.com/api/v1/org?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"raw": "https://app.datadoghq.com/api/v1/org?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 							"protocol": "https",
 							"host": [
 								"app",
@@ -841,448 +2338,1297 @@
 							"query": [
 								{
 									"key": "api_key",
-									"value": "INSERT_API_KEY_HERE",
-									"equals": true,
-									"description": ""
+									"value": "INSERT_API_KEY_HERE"
 								},
 								{
 									"key": "application_key",
-									"value": "INSERT_APP_KEY_HERE",
-									"equals": true,
-									"description": ""
+									"value": "INSERT_APP_KEY_HERE"
 								}
-							],
-							"variable": []
-						},
-						"method": "POST",
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "318183e4-130d-49fb-bfb8-93323f19beae",
+					"name": "PUT Organization Update",
+					"request": {
+						"method": "PUT",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"name\" : \"Brendan Test via API\",\n    \"subscription\" : {\n        \"type\" : \"trial\"\n    },\n    \"billing\" : {\n        \"type\" : \"parent_billing\"\n    }\n}"
+							"raw": "{\n        \"settings\": {\n            \"saml\": {\n                \"enabled\": false\n            },\n            \"saml_strict_mode\": {\n                \"enabled\": false\n            },\n            \"saml_idp_initiated_login\": {\n                \"enabled\": false\n            },\n            \"saml_autocreate_users_domains\": {\n                \"enabled\": false,\n                \"domains\": [\n                    \"my-org.com\",\n                    \"example.com\"\n                ]\n            }\n        }\n}"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/org/e5637d13b",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"org",
+								"e5637d13b"
+							]
+						},
+						"description": "ARGUMENTS\nname [optional]:\nThe organization name.\nsettings [optional]:\nA JSON array of settings. Settings include:\nsaml - Set the boolean property enabled to enable or disable single sign on with SAML. See the SAML documentation for more information about all SAML settings.\nsaml_idp_initiated_login - has one property enabled (boolean).v\nsaml_strict_mode - has one property enabled (boolean).\nsaml_autocreate_users_domains - has two properties: enabled (boolean) and domains which is a list of domains without the @ symbol."
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "1f70afe9-8b8c-417b-8c70-9d92329f92c0",
+					"name": "POST Organization IdP Provider",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n        \"settings\": {\n            \"saml\": {\n                \"enabled\": true\n            },\n            \"saml_strict_mode\": {\n                \"enabled\": true\n            },\n            \"saml_idp_initiated_login\": {\n                \"enabled\": true\n            },\n            \"saml_autocreate_users_domains\": {\n                \"enabled\": true,\n                \"domains\": [\n                    \"my-org.com\",\n                    \"example.com\"\n                ]\n            }\n        }"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/org/idp_metadata",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"org",
+								"idp_metadata"
+							]
+						},
+						"description": "ARGUMENTS\nidp_file [required]:\nThe path to the XML metadata file you wish to upload."
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "5b1e04df-c7f6-4eec-8737-dce2bdd90f54",
+					"name": "Create Child Org",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\" : \"Setup Child Org Via API\",\n    \"subscription\" : {\n        \"type\" : \"trial\"\n    },\n    \"billing\" : {\n        \"type\" : \"parent_billing\"\n    }\n}"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/org?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"org"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
 						},
 						"description": "create child org, based off api_key and app_key"
 					},
 					"response": []
 				}
+			],
+			"description": "This endpoint requires the multi-org account feature and must be enabled by contacting support.\n\nMulti-org feature:https://docs.datadoghq.com/account_management/multi_organization\n",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "4bfcbf69-1cf1-43f5-bcb1-7eb0e3d3b95f",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "8192426f-c281-4ad7-88a5-012c97209c9c",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
 			]
 		},
 		{
+			"_postman_id": "c2936f08-27eb-4956-b17b-757e31349c09",
 			"name": "Screenboards",
-			"description": "You can view more detailed documentation on the Screenboard API at http://docs.datadoghq.com/api/screenboards/.",
 			"item": [
 				{
-					"name": "Setup New Screenboard",
+					"_postman_id": "e07eb102-506c-4705-b37c-9624e435bfae",
+					"name": "Update ScreenBoard",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/screen?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n        \"width\": 1024,\n        \"height\": 768,\n        \"board_title\": \"Number of Agents or EC2 reporting\",\n        \"widgets\": [\n            {\n                \"type\": \"event_stream\",\n                \"title\": \"New Agents reporting, past week\",\n                \"height\": 57,\n                \"width\": 59,\n\n                \"y\": 30,\n                \"x\": 24,\n\n                \"query\": \"Datadog agent started\",\n                \"time\": {\"live_span\": \"1w\"}\n            },\n            {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 1,\n\n               \"time\": {\"live_span\": \"1w\"}\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                 }\n            },\n    {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 50,\n\n               \"time\": {\"live_span\": \"1w\"}\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                     }\n\n                 }\n        ]\n    }"
-						},
-						"description": "ARGUMENTS\n\n*board_title [required]\nThe name of the dashboard.\n\n*description [optional, default=None]\nA description of the dashboard's content.\n\n*widgets [required]\nA list of widget definitions. See here for more examples.\n\n*template_variables [optional, default=None]\nA list of template variables for using Dashboard templating.\n\n*width [optional, default=None]\nScreenboard width in pixels\n\n*height [optional, default=None]\nHeight in pixels.\n\n*read_only [optional, default=False]\nThe read-only status of the screenboard."
-					},
-					"response": []
-				},
-				{
-					"name": "Update Screenboard",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/screen/177964?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"board_title\": \"Number of Agents or EC2 reporting\",\n    \"read_only\": false,\n    \"created\": \"2017-04-25T22:12:54.909853+00:00\",\n    \"modified\": \"2017-04-25T22:15:01.403148+00:00\",\n    \"height\": 768,\n    \"width\": 1024,\n    \"widgets\": [\n        {\n            \"x\": 24,\n            \"title\": \"New Agents reporting, past week\",\n            \"height\": 57,\n            \"width\": 59,\n            \"time\": {\"live_span\": \"1w\"}\n            \"y\": 30,\n            \"query\": \"Datadog agent started\",\n            \"type\": \"event_stream\"\n        },\n        {\n            \"title_size\": 16,\n            \"title\": true,\n            \"title_align\": \"left\",\n            \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n            \"height\": 26,\n            \"tile_def\": {\n                \"viz\": \"timeseries\",\n                \"requests\": [\n                    {\n                        \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                        \"aggregator\": \"avg\",\n                        \"conditional_formats\": [],\n                        \"type\": \"line\"\n                    }\n                ]\n            },\n            \"width\": 47,\n            \"time\": {\"live_span\": \"1w\"}\n            \"y\": 1,\n            \"x\": 1,\n            \"type\": \"timeseries\"\n        },\n        {\n            \"title_size\": 16,\n            \"title\": true,\n            \"title_align\": \"left\",\n            \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n            \"height\": 26,\n            \"tile_def\": {\n                \"viz\": \"timeseries\",\n                \"requests\": [\n                    {\n                        \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                        \"aggregator\": \"avg\",\n                        \"conditional_formats\": [],\n                        \"type\": \"line\"\n                    }\n                ]\n            },\n            \"width\": 47,\n            \"time\": {\"live_span\": \"1w\"}\n            \"y\": 1,\n            \"x\": 50,\n            \"type\": \"timeseries\"\n        }\n    ],\n    \"id\": 177964\n}"
+							"raw": "{\n    \"board_title\": \"Number of Agents or EC2 reporting\",\n    \"read_only\": false,\n    \"created\": \"2017-04-25T22:12:54.909853+00:00\",\n    \"modified\": \"2017-04-25T22:15:01.403148+00:00\",\n    \"height\": 768,\n    \"width\": 1024,\n    \"widgets\": [\n        {\n            \"x\": 24,\n            \"title\": \"New Agents reporting, past week\",\n            \"height\": 57,\n            \"width\": 59,\n            \"timeframe\": \"1w\",\n            \"y\": 30,\n            \"query\": \"Datadog agent started\",\n            \"type\": \"event_stream\"\n        },\n        {\n            \"title_size\": 16,\n            \"title\": true,\n            \"title_align\": \"left\",\n            \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n            \"height\": 26,\n            \"tile_def\": {\n                \"viz\": \"timeseries\",\n                \"requests\": [\n                    {\n                        \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                        \"aggregator\": \"avg\",\n                        \"conditional_formats\": [],\n                        \"type\": \"line\"\n                    }\n                ]\n            },\n            \"width\": 47,\n            \"timeframe\": \"1w\",\n            \"y\": 1,\n            \"x\": 1,\n            \"type\": \"timeseries\"\n        },\n        {\n            \"title_size\": 16,\n            \"title\": true,\n            \"title_align\": \"left\",\n            \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n            \"height\": 26,\n            \"tile_def\": {\n                \"viz\": \"timeseries\",\n                \"requests\": [\n                    {\n                        \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                        \"aggregator\": \"avg\",\n                        \"conditional_formats\": [],\n                        \"type\": \"line\"\n                    }\n                ]\n            },\n            \"width\": 47,\n            \"timeframe\": \"1w\",\n            \"y\": 1,\n            \"x\": 50,\n            \"type\": \"timeseries\"\n        }\n    ],\n    \"id\": 177964\n}"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/screen/177964?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"screen",
+								"177964"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
 						},
 						"description": "Will update Screenboard definition"
 					},
 					"response": []
 				},
 				{
-					"name": "GET Screenboard Definition",
+					"_postman_id": "fee8918e-f65e-4dee-a983-940127d817ce",
+					"name": "Revoke Share of Screenboard",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/screen/177964?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n        \"width\": 1024,\n        \"height\": 768,\n        \"board_title\": \"Number of Agents or EC2 reporting\",\n        \"widgets\": [\n            {\n                \"type\": \"event_stream\",\n                \"title\": \"New Agents reporting, past week\",\n                \"height\": 57,\n                \"width\": 59,\n\n                \"y\": 30,\n                \"x\": 24,\n\n                \"query\": \"Datadog agent started\",\n                \"time\": {\"live_span\": \"1w\"}\n            },\n            {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 1,\n\n               \"time\": {\"live_span\": \"1w\"}\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                 }\n            },\n    {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 50,\n\n               \"time\": {\"live_span\": \"1w\"}\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                     }\n\n                 }\n        ]\n    }"
-						},
-						"description": "Will get screenboard definition by screenboard id"
-					},
-					"response": []
-				},
-				{
-					"name": "DELETE Screenboard",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/screen/177964?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"board_title\": \"Number of Agents or EC2 reporting\",\n    \"read_only\": false,\n    \"created\": \"2017-04-25T22:12:54.909853+00:00\",\n    \"modified\": \"2017-04-25T22:15:01.403148+00:00\",\n    \"height\": 768,\n    \"width\": 1024,\n    \"widgets\": [\n        {\n            \"x\": 24,\n            \"title\": \"New Agents reporting, past week\",\n            \"height\": 57,\n            \"width\": 59,\n            \"time\": {\"live_span\": \"1w\"}\n            \"y\": 30,\n            \"query\": \"Datadog agent started\",\n            \"type\": \"event_stream\"\n        },\n        {\n            \"title_size\": 16,\n            \"title\": true,\n            \"title_align\": \"left\",\n            \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n            \"height\": 26,\n            \"tile_def\": {\n                \"viz\": \"timeseries\",\n                \"requests\": [\n                    {\n                        \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                        \"aggregator\": \"avg\",\n                        \"conditional_formats\": [],\n                        \"type\": \"line\"\n                    }\n                ]\n            },\n            \"width\": 47,\n            \"time\": {\"live_span\": \"1w\"}\n            \"y\": 1,\n            \"x\": 1,\n            \"type\": \"timeseries\"\n        },\n        {\n            \"title_size\": 16,\n            \"title\": true,\n            \"title_align\": \"left\",\n            \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n            \"height\": 26,\n            \"tile_def\": {\n                \"viz\": \"timeseries\",\n                \"requests\": [\n                    {\n                        \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                        \"aggregator\": \"avg\",\n                        \"conditional_formats\": [],\n                        \"type\": \"line\"\n                    }\n                ]\n            },\n            \"width\": 47,\n            \"time\": {\"live_span\": \"1w\"}\n            \"y\": 1,\n            \"x\": 50,\n            \"type\": \"timeseries\"\n        }\n    ],\n    \"id\": 177964\n}"
+							"raw": "{\n        \"width\": 1024,\n        \"height\": 768,\n        \"board_title\": \"Number of Agents or EC2 reporting\",\n        \"widgets\": [\n            {\n                \"type\": \"event_stream\",\n                \"title\": \"New Agents reporting, past week\",\n                \"height\": 57,\n                \"width\": 59,\n\n                \"y\": 30,\n                \"x\": 24,\n\n                \"query\": \"Datadog agent started\",\n                \"timeframe\": \"1w\"\n            },\n            {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 1,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                 }\n            },\n    {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 50,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                     }\n\n                 }\n        ]\n    }"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/screen/share/178837?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"screen",
+								"share",
+								"178837"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "Revoke a currently shared screenboard's.\n\nARGUMENTS\n\nThis end point takes no JSON arguments."
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "8f51838d-1b2a-4aaa-99d5-b7620e3dbcd6",
+					"name": "Setup New ScreenBoard",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n        \"width\": 1024,\n        \"height\": 768,\n        \"board_title\": \"Number of Agents or EC2 reporting\",\n        \"widgets\": [\n            {\n                \"type\": \"event_stream\",\n                \"title\": \"New Agents reporting, past week\",\n                \"height\": 57,\n                \"width\": 59,\n\n                \"y\": 30,\n                \"x\": 24,\n\n                \"query\": \"Datadog agent started\",\n                \"timeframe\": \"1w\"\n            },\n            {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 1,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                 }\n            },\n    {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 50,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                     }\n\n                 }\n        ]\n    }"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/screen?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"screen"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "ARGUMENTS\n\n*board_title [required]\nThe name of the dashboard.\n\n*description [optional, default=None]\nA description of the dashboard's content.\n\n*widgets [required]\nA list of widget definitions. See here for more examples.\n\n*template_variables [optional, default=None]\nA list of template variables for using Dashboard templating.\n\n*width [optional, default=None]\nScreenboard width in pixels\n\n*height [optional, default=None]\nHeight in pixels.\n\n*read_only [optional, default=False]\nThe read-only status of the screenboard."
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "bc969fcb-cdb8-4c53-b46c-817ec7bedd43",
+					"name": "DELETE ScreenBoard",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"board_title\": \"Number of Agents or EC2 reporting\",\n    \"read_only\": false,\n    \"created\": \"2017-04-25T22:12:54.909853+00:00\",\n    \"modified\": \"2017-04-25T22:15:01.403148+00:00\",\n    \"height\": 768,\n    \"width\": 1024,\n    \"widgets\": [\n        {\n            \"x\": 24,\n            \"title\": \"New Agents reporting, past week\",\n            \"height\": 57,\n            \"width\": 59,\n            \"timeframe\": \"1w\",\n            \"y\": 30,\n            \"query\": \"Datadog agent started\",\n            \"type\": \"event_stream\"\n        },\n        {\n            \"title_size\": 16,\n            \"title\": true,\n            \"title_align\": \"left\",\n            \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n            \"height\": 26,\n            \"tile_def\": {\n                \"viz\": \"timeseries\",\n                \"requests\": [\n                    {\n                        \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                        \"aggregator\": \"avg\",\n                        \"conditional_formats\": [],\n                        \"type\": \"line\"\n                    }\n                ]\n            },\n            \"width\": 47,\n            \"timeframe\": \"1w\",\n            \"y\": 1,\n            \"x\": 1,\n            \"type\": \"timeseries\"\n        },\n        {\n            \"title_size\": 16,\n            \"title\": true,\n            \"title_align\": \"left\",\n            \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n            \"height\": 26,\n            \"tile_def\": {\n                \"viz\": \"timeseries\",\n                \"requests\": [\n                    {\n                        \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                        \"aggregator\": \"avg\",\n                        \"conditional_formats\": [],\n                        \"type\": \"line\"\n                    }\n                ]\n            },\n            \"width\": 47,\n            \"timeframe\": \"1w\",\n            \"y\": 1,\n            \"x\": 50,\n            \"type\": \"timeseries\"\n        }\n    ],\n    \"id\": 177964\n}"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/screen/177964?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"screen",
+								"177964"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
 						},
 						"description": "Will DELETE Screenboard definition"
 					},
 					"response": []
 				},
 				{
+					"_postman_id": "bfde70fa-b1b5-4a58-a4d4-5fcd5866cc0d",
 					"name": "Get All Screenboards",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/screen?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 						"method": "GET",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n        \"width\": 1024,\n        \"height\": 768,\n        \"board_title\": \"Number of Agents or EC2 reporting\",\n        \"widgets\": [\n            {\n                \"type\": \"event_stream\",\n                \"title\": \"New Agents reporting, past week\",\n                \"height\": 57,\n                \"width\": 59,\n\n                \"y\": 30,\n                \"x\": 24,\n\n                \"query\": \"Datadog agent started\",\n                \"time\": {\"live_span\": \"1w\"}\n            },\n            {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 1,\n\n               \"time\": {\"live_span\": \"1w\"}\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                 }\n            },\n    {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 50,\n\n               \"time\": {\"live_span\": \"1w\"}\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                     }\n\n                 }\n        ]\n    }"
+							"raw": "{\n        \"width\": 1024,\n        \"height\": 768,\n        \"board_title\": \"Number of Agents or EC2 reporting\",\n        \"widgets\": [\n            {\n                \"type\": \"event_stream\",\n                \"title\": \"New Agents reporting, past week\",\n                \"height\": 57,\n                \"width\": 59,\n\n                \"y\": 30,\n                \"x\": 24,\n\n                \"query\": \"Datadog agent started\",\n                \"timeframe\": \"1w\"\n            },\n            {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 1,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                 }\n            },\n    {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 50,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                     }\n\n                 }\n        ]\n    }"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/screen?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"screen"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
 						},
 						"description": "Fetch all of your screenboards' definitions.\n\nARGUMENTS\n\nThis end point takes no JSON arguments."
 					},
 					"response": []
 				},
 				{
+					"_postman_id": "ac5f6963-d7dc-4e28-92c3-ee77c0e60a30",
 					"name": "Share A Screenboard",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/screen/share/178837?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 						"method": "GET",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n        \"width\": 1024,\n        \"height\": 768,\n        \"board_title\": \"Number of Agents or EC2 reporting\",\n        \"widgets\": [\n            {\n                \"type\": \"event_stream\",\n                \"title\": \"New Agents reporting, past week\",\n                \"height\": 57,\n                \"width\": 59,\n\n                \"y\": 30,\n                \"x\": 24,\n\n                \"query\": \"Datadog agent started\",\n                \"time\": {\"live_span\": \"1w\"}\n            },\n            {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 1,\n\n               \"time\": {\"live_span\": \"1w\"}\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                 }\n            },\n    {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 50,\n\n               \"time\": {\"live_span\": \"1w\"}\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                     }\n\n                 }\n        ]\n    }"
+							"raw": "{\n        \"width\": 1024,\n        \"height\": 768,\n        \"board_title\": \"Number of Agents or EC2 reporting\",\n        \"widgets\": [\n            {\n                \"type\": \"event_stream\",\n                \"title\": \"New Agents reporting, past week\",\n                \"height\": 57,\n                \"width\": 59,\n\n                \"y\": 30,\n                \"x\": 24,\n\n                \"query\": \"Datadog agent started\",\n                \"timeframe\": \"1w\"\n            },\n            {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 1,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                 }\n            },\n    {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 50,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                     }\n\n                 }\n        ]\n    }"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/screen/share/178837?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"screen",
+								"share",
+								"178837"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
 						},
 						"description": "Share an existing screenboard's with a public URL.\n\nARGUMENTS\n\nThis end point takes no JSON arguments."
 					},
 					"response": []
 				},
 				{
-					"name": "Revoke Share of Screenboard",
+					"_postman_id": "9f8da152-2153-41e3-bc05-2ca88536be88",
+					"name": "GET ScreenBoard Definition",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/screen/share/178837?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n        \"width\": 1024,\n        \"height\": 768,\n        \"board_title\": \"Number of Agents or EC2 reporting\",\n        \"widgets\": [\n            {\n                \"type\": \"event_stream\",\n                \"title\": \"New Agents reporting, past week\",\n                \"height\": 57,\n                \"width\": 59,\n\n                \"y\": 30,\n                \"x\": 24,\n\n                \"query\": \"Datadog agent started\",\n                \"time\": {\"live_span\": \"1w\"}\n            },\n            {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 1,\n\n               \"time\": {\"live_span\": \"1w\"}\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                 }\n            },\n    {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 50,\n\n               \"time\": {\"live_span\": \"1w\"}\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                     }\n\n                 }\n        ]\n    }"
-						},
-						"description": "Revoke a currently shared screenboard's.\n\nARGUMENTS\n\nThis end point takes no JSON arguments."
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Search",
-			"description": "This end point allows you to search for entities from the last 24 hours in Datadog. The currently searchable entities are:\n\n* hosts\n* metrics\n\nARGUMENTS\n\n* q [required]\nThe query string\n\n\nQUERY LANGUAGE\n\nSearch queries allow for limited faceting. Available facets are:\n\n* hosts\n* metrics\n\n\nFaceting your search limits your results to only matches of the specified type. Un-faceted queries return results for all possible types.\n\nUn-faceted queries are of the form:\n* query_string\nFaceted queries are of the form:\n* facet:query_string",
-			"item": [
-				{
-					"name": "Search",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/search?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&q=cpu",
 						"method": "GET",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n        \"width\": 1024,\n        \"height\": 768,\n        \"board_title\": \"Number of Agents or EC2 reporting\",\n        \"widgets\": [\n            {\n                \"type\": \"event_stream\",\n                \"title\": \"New Agents reporting, past week\",\n                \"height\": 57,\n                \"width\": 59,\n\n                \"y\": 30,\n                \"x\": 24,\n\n                \"query\": \"Datadog agent started\",\n                \"time\": {\"live_span\": \"1w\"}\n            },\n            {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 1,\n\n               \"time\": {\"live_span\": \"1w\"}\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                 }\n            },\n    {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 50,\n\n               \"time\": {\"live_span\": \"1w\"}\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                     }\n\n                 }\n        ]\n    }"
+							"raw": "{\n        \"width\": 1024,\n        \"height\": 768,\n        \"board_title\": \"Number of Agents or EC2 reporting\",\n        \"widgets\": [\n            {\n                \"type\": \"event_stream\",\n                \"title\": \"New Agents reporting, past week\",\n                \"height\": 57,\n                \"width\": 59,\n\n                \"y\": 30,\n                \"x\": 24,\n\n                \"query\": \"Datadog agent started\",\n                \"timeframe\": \"1w\"\n            },\n            {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 1,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                 }\n            },\n    {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 50,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                     }\n\n                 }\n        ]\n    }"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/screen/177964?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"screen",
+								"177964"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "Will get screenboard definition by screenboard id"
+					},
+					"response": []
+				}
+			],
+			"description": "You can view more detailed documentation on the Screenboard API at http://docs.datadoghq.com/api/screenboards/."
+		},
+		{
+			"_postman_id": "0b3bf667-d9b6-4233-b284-4b82e517fc74",
+			"name": "Search",
+			"item": [
+				{
+					"_postman_id": "a1b8215f-fd16-49ae-9d88-52254cad5152",
+					"name": "Search",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n        \"width\": 1024,\n        \"height\": 768,\n        \"board_title\": \"Number of Agents or EC2 reporting\",\n        \"widgets\": [\n            {\n                \"type\": \"event_stream\",\n                \"title\": \"New Agents reporting, past week\",\n                \"height\": 57,\n                \"width\": 59,\n\n                \"y\": 30,\n                \"x\": 24,\n\n                \"query\": \"Datadog agent started\",\n                \"timeframe\": \"1w\"\n            },\n            {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"Agent host count reporting (system.cpu.user)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 1,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:system.cpu.user{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                 }\n            },\n    {\"type\": \"timeseries\",\n\n               \"title\": true,\n               \"title_size\": 16,\n               \"title_align\": \"left\",\n               \"title_text\": \"AWS host count reporting (ec2.host_ok)\",\n\n               \"height\": 26,\n               \"width\": 47,\n\n               \"y\": 1,\n               \"x\": 50,\n\n               \"timeframe\": \"1w\",\n                 \"tile_def\": {\n                   \"viz\": \"timeseries\",\n                   \"requests\": [\n                      {\n                           \"q\": \"count:aws.ec2.host_ok{*}.rollup(max,3600)\",\n                           \"aggregator\": \"avg\",\n                           \"conditional_formats\": [],\n                           \"type\": \"line\"\n\n                      }\n                      ]\n                     }\n\n                 }\n        ]\n    }"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/search?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&q=cpu",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"search"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								},
+								{
+									"key": "q",
+									"value": "cpu"
+								}
+							]
 						},
 						"description": "This end point allows you to search for entities from the last 24 hours in Datadog. The currently searchable entities are:\n\nhosts\n*metrics\n*ARGUMENTS\n\n*q [required]\nThe query string\nQUERY LANGUAGE\n\nSearch queries allow for limited faceting. Available facets are:\n\n*hosts\n*metrics\nFaceting your search limits your results to only matches of the specified type. Un-faceted queries return results for all possible types.\n\nUn-faceted queries are of the form:\n\n*query_string\nFaceted queries are of the form:\n\n*facet:query_string"
 					},
 					"response": []
 				}
-			]
+			],
+			"description": "This end point allows you to search for entities from the last 24 hours in Datadog. The currently searchable entities are:\n\n* hosts\n* metrics\n\nARGUMENTS\n\n* q [required]\nThe query string\n\n\nQUERY LANGUAGE\n\nSearch queries allow for limited faceting. Available facets are:\n\n* hosts\n* metrics\n\n\nFaceting your search limits your results to only matches of the specified type. Un-faceted queries return results for all possible types.\n\nUn-faceted queries are of the form:\n* query_string\nFaceted queries are of the form:\n* facet:query_string"
 		},
 		{
+			"_postman_id": "aefeeb08-bb2e-4e06-bcc8-8a96873a8abe",
 			"name": "Tags",
-			"description": "The tag end point allows you to tag hosts with keywords meaningful to you - like role:database. All metrics sent from a host will have its tags applied. When fetching and applying tags to a particular host, you can refer to hosts by name (yourhost.example.com).\n\nThe component of your infrastructure responsible for a tag is identified by a source. Valid sources are: nagios, hudson, jenkins, users, feed, chef, puppet, git, bitbucket, fabric, capistrano.",
 			"item": [
 				{
-					"name": "Get All Host Tags",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/tags/hosts/i-0f125915827da9af1?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&hostname=i-0f125915827da9af1",
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"tags\": [\n    \"aws:cloudformation:stack-name:myfirstinstance\",\n    \"name:myfirstinstance\",\n    \"demo\",\n    \"image:ami-80861296\",\n    \"region:us-east-1\",\n    \"instance-type:t2.micro\",\n    \"aws:cloudformation:logical-id:webserverinstance\",\n    \"security-group:sg-658ba51a\",\n    \"availability-zone:us-east-1c\",\n    \"kernel:none\",\n    \"aws:cloudformation:stack-id:arn:aws:cloudformation:us-east-1:989648780687:stack/myfirstinstance/7f4b9880-250e-11e7-94ec-500c20fefad2\",\n  ]\n}"
-						},
-						"description": "Get all host tags by hostname"
-					},
-					"response": []
-				},
-				{
-					"name": "Add Tags By Hostname",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/tags/hosts/i-0f125915827da9af1?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&hostname=i-0f125915827da9af1",
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"tags\": [\n    \"blank:test2\"\n  ]\n}"
-						},
-						"description": ""
-					},
-					"response": []
-				},
-				{
+					"_postman_id": "93cccec2-05a8-4609-95d7-731a032a0caf",
 					"name": "Update All Tags By Hostname",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/tags/hosts/i-0f125915827da9af1?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&hostname=i-0f125915827da9af1",
 						"method": "PUT",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n  \"tags\": [\n    \"aws:cloudformation:stack-name:myfirstinstance\",\n    \"name:myfirstinstance\",\n    \"demo\",\n    \"image:ami-80861296\",\n    \"region:us-east-1\",\n    \"instance-type:t2.micro\",\n    \"aws:cloudformation:logical-id:webserverinstance\",\n    \"security-group:sg-658ba51a\",\n    \"availability-zone:us-east-1c\",\n    \"kernel:none\",\n    \"aws:cloudformation:stack-id:arn:aws:cloudformation:us-east-1:989648780687:stack/myfirstinstance/7f4b9880-250e-11e7-94ec-500c20fefad2\"\n  ]\n}"
 						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/tags/hosts/i-0f125915827da9af1?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&hostname=i-0f125915827da9af1",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"tags",
+								"hosts",
+								"i-0f125915827da9af1"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								},
+								{
+									"key": "hostname",
+									"value": "i-0f125915827da9af1"
+								}
+							]
+						},
 						"description": "The POST will update all tags, not just the one new tag."
 					},
 					"response": []
-				}
-			]
-		},
-		{
-			"name": "Timeboards",
-			"description": "This endpoint allows you to programmatically create, update delete and query timeboards.",
-			"item": [
+				},
 				{
-					"name": "Create a Timeboard",
+					"_postman_id": "4b3fe529-4dc7-40b8-b12d-096417babdf8",
+					"name": "Add Tags By Hostname",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/dash?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"tags\": [\n    \"blank:test2\"\n  ]\n}"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/tags/hosts/i-0f125915827da9af1?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&hostname=i-0f125915827da9af1",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"tags",
+								"hosts",
+								"i-0f125915827da9af1"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								},
+								{
+									"key": "hostname",
+									"value": "i-0f125915827da9af1"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "c780f403-d832-4b5d-921e-c81095a057f1",
+					"name": "Get All Host Tags",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"tags\": [\n    \"aws:cloudformation:stack-name:myfirstinstance\",\n    \"name:myfirstinstance\",\n    \"demo\",\n    \"image:ami-80861296\",\n    \"region:us-east-1\",\n    \"instance-type:t2.micro\",\n    \"aws:cloudformation:logical-id:webserverinstance\",\n    \"security-group:sg-658ba51a\",\n    \"availability-zone:us-east-1c\",\n    \"kernel:none\",\n    \"aws:cloudformation:stack-id:arn:aws:cloudformation:us-east-1:989648780687:stack/myfirstinstance/7f4b9880-250e-11e7-94ec-500c20fefad2\",\n  ]\n}"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/tags/hosts/i-0f125915827da9af1?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&hostname=i-0f125915827da9af1",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"tags",
+								"hosts",
+								"i-0f125915827da9af1"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								},
+								{
+									"key": "hostname",
+									"value": "i-0f125915827da9af1"
+								}
+							]
+						},
+						"description": "Get all host tags by hostname"
+					},
+					"response": []
+				}
+			],
+			"description": "The tag end point allows you to tag hosts with keywords meaningful to you - like role:database. All metrics sent from a host will have its tags applied. When fetching and applying tags to a particular host, you can refer to hosts by name (yourhost.example.com).\n\nThe component of your infrastructure responsible for a tag is identified by a source. Valid sources are: nagios, hudson, jenkins, users, feed, chef, puppet, git, bitbucket, fabric, capistrano."
+		},
+		{
+			"_postman_id": "e0272a2b-4ba7-47d3-9398-04259e01c471",
+			"name": "Timeboards",
+			"item": [
+				{
+					"_postman_id": "1b688e6a-dcad-41b4-b38e-0431af822e38",
+					"name": "Create a Timeboard",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n      \"graphs\" : [{\n          \"title\": \"Average Memory Free\",\n          \"definition\": {\n              \"events\": [],\n              \"requests\": [\n                  {\"q\": \"avg:system.mem.free{*}\"}\n              ]\n          },\n          \"viz\": \"timeseries\"\n      }],\n      \"title\" : \"Average Memory Free Shell\",\n      \"description\" : \"A dashboard with memory info.\",\n      \"template_variables\": [{\n          \"name\": \"host1\",\n          \"prefix\": \"host\",\n          \"default\": \"host:my-host\"\n      }],\n      \"read_only\": \"True\"\n    }"
 						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/dash?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"dash"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
 						"description": "ARGUMENTS\n\n*title [required]\nThe name of the dashboard.\n\n*description [required]\nA description of the dashboard's content.\n\n*graphs [required]\nA list of graph definitions. Graph definitions follow this form:\n\n**title [required]\nThe name of the graph.\n\n**definition [required]\nThe graph definition. \n\n***Example:\n{\"requests\": [{\"q\": \"system.cpu.idle{*} by {host}\"}\n\n\n**template_variables [optional, default=None]\nA list of template variables for using Dashboard templating. Template variable definitions follow this \n\n**form:\n\n***name [required]\nThe name of the variable.\n\n***prefix [optional, default=None]\nThe tag prefix associated with the variable. Only tags with this prefix will appear in the variable dropdown.\n\n***default [optional, default=None]\nThe default value for the template variable on dashboard load"
 					},
 					"response": []
 				},
 				{
-					"name": "Update a Timeboard",
+					"_postman_id": "a9fbf4ef-0633-40b3-bd85-2d3197ec1ce1",
+					"name": "Get A TimeBoard",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/dash/281866?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "PUT",
+						"method": "GET",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n      \"graphs\" : [{\n          \"title\": \"Average Memory Free\",\n          \"definition\": {\n              \"events\": [],\n              \"requests\": [\n                  {\"q\": \"avg:system.mem.free{*}\"}\n              ]\n          },\n          \"viz\": \"timeseries\"\n      }],\n      \"title\" : \"Average Memory Free Shell 2\",\n      \"description\" : \"A dashboard with memory info.\",\n      \"template_variables\": [{\n          \"name\": \"host1\",\n          \"prefix\": \"host\",\n          \"default\": \"host:my-host\"\n      }],\n      \"read_only\": \"True\"\n    }"
 						},
-						"description": "ARGUMENTS\n\n*title [required]\nThe name of the dashboard.\n\n*description [required]\nA description of the dashboard's contents.\n\n*graphs [required]\nA list of graph definitions. Graph definitions follow this form:\n\n*title [required]\nThe name of the graph.\n\n*definition [required]\nThe graph definition. Read the Graph Guide for more on graphs. Example:\n{\"requests\": [{\"q\": \"system.cpu.idle{*} by {host}\"}\n\n*template_variables [optional, default=None]\nA list of template variables for using Dashboard templating. Template variable definitions follow this form:\n\n*name [required]\nThe name of the variable.\n\n*prefix [optional, default=None]\nThe tag prefix associated with the variable. Only tags with this prefix will appear in the variable dropdown.\n\n*default [optional, default=None]\nThe default value for the template variable on dashboard load"
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/dash/306185?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"dash",
+								"306185"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "Fetch an existing dashboard's definition.\n\nARGUMENTS\n\nThis end point takes no JSON arguments."
 					},
 					"response": []
 				},
 				{
-					"name": "Get All Timeboards",
+					"_postman_id": "0d2936dd-ad1e-486e-bf13-28ebef28dd43",
+					"name": "Get All TimeBoards",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/dash?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 						"method": "GET",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n      \"graphs\" : [{\n          \"title\": \"Average Memory Free\",\n          \"definition\": {\n              \"events\": [],\n              \"requests\": [\n                  {\"q\": \"avg:system.mem.free{*}\"}\n              ]\n          },\n          \"viz\": \"timeseries\"\n      }],\n      \"title\" : \"Average Memory Free Shell 2\",\n      \"description\" : \"A dashboard with memory info.\",\n      \"template_variables\": [{\n          \"name\": \"host1\",\n          \"prefix\": \"host\",\n          \"default\": \"host:my-host\"\n      }],\n      \"read_only\": \"True\"\n    }"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/dash?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"dash"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
 						},
 						"description": "Fetch all of your timeboards' definitions.\n\nARGUMENTS\n\nThis end point takes no JSON arguments."
 					},
 					"response": []
 				},
 				{
-					"name": "Get A Timeboard",
+					"_postman_id": "9934a38e-f1da-470a-95ad-1db410ab693d",
+					"name": "Update a Timeboard",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/dash/281799?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "GET",
+						"method": "PUT",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n      \"graphs\" : [{\n          \"title\": \"Average Memory Free\",\n          \"definition\": {\n              \"events\": [],\n              \"requests\": [\n                  {\"q\": \"avg:system.mem.free{*}\"}\n              ]\n          },\n          \"viz\": \"timeseries\"\n      }],\n      \"title\" : \"Average Memory Free Shell 2\",\n      \"description\" : \"A dashboard with memory info.\",\n      \"template_variables\": [{\n          \"name\": \"host1\",\n          \"prefix\": \"host\",\n          \"default\": \"host:my-host\"\n      }],\n      \"read_only\": \"True\"\n    }"
+							"raw": "{\n    \"description\": \"created by brendan.roche@datadoghq.com\",\n    \"graphs\": [\n        {\n            \"definition\": {\n                \"autoscale\": false,\n                \"custom_unit\": \"\\u00b0F\",\n                \"precision\": \"0\",\n                \"requests\": [\n                    {\n                        \"aggregator\": \"last\",\n                        \"conditional_formats\": [],\n                        \"q\": \"avg:weather.temp_f_broomfield{*}\"\n                    }\n                ],\n                \"status\": \"done\",\n                \"viz\": \"query_value\"\n            },\n            \"title\": \"Broomfield Current Temp\"\n        },\n        {\n            \"definition\": {\n                \"autoscale\": false,\n                \"custom_unit\": \"MPH\",\n                \"precision\": \"0\",\n                \"requests\": [\n                    {\n                        \"aggregator\": \"last\",\n                        \"conditional_formats\": [],\n                        \"q\": \"avg:weather.wind_mph_broomfield{*}\",\n                        \"type\": \"line\"\n                    }\n                ],\n                \"status\": \"done\",\n                \"viz\": \"query_value\"\n            },\n            \"title\": \"Broomfield Wind Strength\"\n        },\n        {\n            \"definition\": {\n                \"autoscale\": false,\n                \"custom_unit\": \"%\",\n                \"precision\": \"0\",\n                \"requests\": [\n                    {\n                        \"aggregator\": \"last\",\n                        \"conditional_formats\": [],\n                        \"q\": \"avg:weather.humidity_broomfield{*}\"\n                    }\n                ],\n                \"status\": \"done\",\n                \"viz\": \"query_value\"\n            },\n            \"title\": \"Broomfield Humidity\"\n        },\n        {\n            \"definition\": {\n                \"autoscale\": true,\n                \"requests\": [\n                    {\n                        \"aggregator\": \"avg\",\n                        \"conditional_formats\": [],\n                        \"q\": \"avg:weather.temp_f_broomfield{*}\",\n                        \"style\": {\n                            \"palette\": \"orange\"\n                        },\n                        \"type\": \"line\"\n                    }\n                ],\n                \"status\": \"done\",\n                \"viz\": \"timeseries\"\n            },\n            \"title\": \"Broomfield Temp\"\n        },\n        {\n            \"definition\": {\n                \"autoscale\": true,\n                \"requests\": [\n                    {\n                        \"aggregator\": \"avg\",\n                        \"conditional_formats\": [],\n                        \"q\": \"avg:weather.wind_mph_broomfield{*}\",\n                        \"style\": {\n                            \"palette\": \"orange\"\n                        },\n                        \"type\": \"area\"\n                    }\n                ],\n                \"status\": \"done\",\n                \"viz\": \"timeseries\"\n            },\n            \"title\": \"Broomfield Wind\"\n        }\n    ],\n    \"read_only\": false,\n    \"template_variables\": [\n        {\n            \"default\": \"*\",\n            \"name\": \"source\",\n            \"prefix\": \"source\"\n        }\n    ],\n    \"title\": \"Broomfield CO Weather\"\n}"
 						},
-						"description": "Fetch an existing dashboard's definition.\n\nARGUMENTS\n\nThis end point takes no JSON arguments."
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/dash/346679?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"dash",
+								"346679"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "ARGUMENTS\n\n*title [required]\nThe name of the dashboard.\n\n*description [required]\nA description of the dashboard's contents.\n\n*graphs [required]\nA list of graph definitions. Graph definitions follow this form:\n\n*title [required]\nThe name of the graph.\n\n*definition [required]\nThe graph definition. Read the Graph Guide for more on graphs. Example:\n{\"requests\": [{\"q\": \"system.cpu.idle{*} by {host}\"}\n\n*template_variables [optional, default=None]\nA list of template variables for using Dashboard templating. Template variable definitions follow this form:\n\n*name [required]\nThe name of the variable.\n\n*prefix [optional, default=None]\nThe tag prefix associated with the variable. Only tags with this prefix will appear in the variable dropdown.\n\n*default [optional, default=None]\nThe default value for the template variable on dashboard load"
 					},
 					"response": []
 				}
-			]
+			],
+			"description": "This endpoint allows you to programmatically create, update delete and query timeboards."
 		},
 		{
-			"name": "Users",
-			"description": "You can create, edit, and disable users.",
+			"_postman_id": "af5e4f1f-4074-444d-8852-d27310e1ec4b",
+			"name": "Usage Metering",
 			"item": [
 				{
-					"name": "Get All Users of An Org",
+					"_postman_id": "629538cf-3458-4b4b-923f-04a331f5059f",
+					"name": "GET Top 500 Custom Metrics by Hourly Usage",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/user?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 						"method": "GET",
 						"header": [],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/usage/top_avg_metrics?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&month=2018-02&names=aws.ec2.spot_history,system.processes.number",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"usage",
+								"top_avg_metrics"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								},
+								{
+									"key": "month",
+									"value": "2018-02",
+									"description": "Required: datetime in ISO-8601 format, UTC, precise to month: [YYYY-MM] for usage beginning at this hour."
+								},
+								{
+									"key": "names",
+									"value": "aws.ec2.spot_history,system.processes.number",
+									"description": "optional: comma-separated list of metric names "
+								}
+							]
+						},
+						"description": "Get Top Custom Metrics By Hourly Average.\n\nArguments\nmonth [required]:\ndatetime in ISO-8601 format, UTC, precise to month: [YYYY-MM] for usage beginning at this hour.\nnames [optional, default=None]:\nComma-separated list of metric names."
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "b6bc303e-68e9-40ad-8396-0eaf232b0928",
+					"name": "GET Hourly Usage For Hosts and Containers",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/usage/hosts?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&start_hr=2018-03-16T00&end_hr=2018-03-17T00",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"usage",
+								"hosts"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								},
+								{
+									"key": "start_hr",
+									"value": "2018-03-16T00",
+									"description": "datetime in ISO-8601 format, UTC, precise to hour: [YYYY-MM-DDThh] for usage beginning at this hour"
+								},
+								{
+									"key": "end_hr",
+									"value": "2018-03-17T00",
+									"description": "datetime in ISO-8601 format, UTC, precise to hour: [YYYY-MM-DDThh] for usage ending BEFORE this hour"
+								}
+							]
+						},
+						"description": "Get Hourly Usage For Hosts and Containers.\n\nArguments\nstart_hr [required]:\ndatetime in ISO-8601 format, UTC, precise to hour: [YYYY-MM-DDThh] for usage beginning at this hour\nend_hr [optional, default=1d+start_hr]:\ndatetime in ISO-8601 format, UTC, precise to hour: [YYYY-MM-DDThh] for usage ending BEFORE this hour\n\n\nResponse\ncontainer_count:\nShows the total number of containers reporting via the Docker integration during the hour.\nhost_count:\nContains the total number of billable infrastructure hosts reporting during a given hour. This is the sum of agent_host_count, aws_host_count, and gcp_host_count.\nhour:\nThe hour for the usage.\napm_host_count:\nShows the total number of hosts using APM during the hour. For Pro plans, these are counted as billable (except during trial periods). For Enterprise plans, APM hosts are included in the price of infrastructure hosts (see host_count) and not billed separately.\nagent_host_count:\nContains the total number of infrastructure hosts reporting during a given hour that were running the Datadog Agent.\ngcp_host_count:\nContains the total number of hosts that reported via the Google Cloud integration (and were NOT running the Datadog Agent).\naws_host_count:\nContains the total number of hosts that reported via the AWS integration (and were NOT running the Datadog Agent). When AWS or GCP hosts are also running the Datadog Agent, they are counted as Agent hosts, NOT as AWS or GCP"
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "7821c493-fb71-4800-85a0-77688b5b9277",
+					"name": "GET Hourly Usage for Custom Metrics",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/usage/timeseries?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&start_hr=2018-03-01T14&end_hr=2018-03-02T14",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"usage",
+								"timeseries"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								},
+								{
+									"key": "start_hr",
+									"value": "2018-03-01T14",
+									"description": "Required: datetime in ISO-8601 format, UTC, precise to hour: [YYYY-MM-DDThh] for usage beginning at this hour"
+								},
+								{
+									"key": "end_hr",
+									"value": "2018-03-02T14",
+									"description": "Optional: datetime in ISO-8601 format, UTC, precise to hour: [YYYY-MM-DDThh] for usage ending BEFORE this hour"
+								}
+							]
+						},
+						"description": "Get Top Custom Metrics By Hourly Average.\n\nArguments\nmonth [required]:\ndatetime in ISO-8601 format, UTC, precise to month: [YYYY-MM] for usage beginning at this hour.\nnames [optional, default=None]:\nComma-separated list of metric names."
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "3cfcddcc-88aa-4c1a-ae60-cede9dbd3c67",
+					"name": "GET Multi-Org Usage Details",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/usage/summary?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE&start_month=2018-03",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"usage",
+								"summary"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								},
+								{
+									"key": "start_month",
+									"value": "2018-03",
+									"description": "[required]:\nDatetime in ISO-8601 format, UTC, precise to month: [YYYY-MM] for usage beginning in this month. Maximum of 15 months ago."
+								},
+								{
+									"key": "end_month",
+									"value": "2018-04",
+									"description": "[optional, default=current_month-3d]: Datetime in ISO-8601 format, UTC, precise to month: [YYYY-MM] for usage ending this month.",
+									"disabled": true
+								},
+								{
+									"key": "include_org_ids",
+									"value": "76293afda",
+									"description": "[optional, default=true]: Include usage summaries for each sub-org.",
+									"disabled": true
+								}
+							]
+						},
+						"description": "Get usage across your multi-org account\n\nArguments\nstart_month [required]:\nDatetime in ISO-8601 format, UTC, precise to month: [YYYY-MM] for usage beginning in this month. Maximum of 15 months ago.\nend_month [optional, default=current_month-3d]: Datetime in ISO-8601 format, UTC, precise to month: [YYYY-MM] for usage ending this month.\ninclude_org_details [optional, default=true]: Include usage summaries for each sub-org."
+					},
+					"response": []
+				}
+			],
+			"description": "This API is currently in private beta. Python and Ruby clients are not yet supported.\n\nThe usage metering end-point allows you to:\n\nGet Hourly Usage For Hosts and Containers\nGet Hourly Usage For Custom Metrics\nGet Top Custom Metrics By Hourly Average\nUsage data is delayed by up to 72 hours from when it was incurred. It is retained for the past 15 months."
+		},
+		{
+			"_postman_id": "7be842fb-9ae8-465a-a818-c60443a8a776",
+			"name": "Users",
+			"item": [
+				{
+					"_postman_id": "424eccd9-6f32-425c-ac6b-63210ecb0380",
+					"name": "Get All Users of An Org",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/user?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"user"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
 						},
 						"description": "Get's all user details for an org"
 					},
 					"response": []
 				},
 				{
-					"name": "Get Single User of An Org by handle",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/user/bmroche@gmail.com?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "GET",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"description": "Get user info from handle"
-					},
-					"response": []
-				},
-				{
-					"name": "Update User Info by Handle",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/user/bmroche@gmail.com?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "PUT",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"user\": {\n    \"disabled\": false,\n    \"handle\": \"bmroche@gmail.com\",\n    \"name\": \"Brendan Michael Roche 2\",\n    \"is_admin\": true,\n    \"role\": null,\n    \"access_role\": \"adm\",\n    \"verified\": true,\n    \"email\": \"bmroche@gmail.com\",\n    \"icon\": \"https://secure.gravatar.com/avatar/df46ee85ff1cbb518b20c8cab742b9ea?s=48&d=retro\"\n  }\n}"
-						},
-						"description": "Update User Profile by handle"
-					},
-					"response": []
-				},
-				{
-					"name": "Create User for an Org",
-					"request": {
-						"url": "https://api.datadoghq.com/api/v1/user?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"disabled\": false,\n    \"handle\": \"test@gmail.com\",\n    \"name\": \"Testy McTestingson\",\n    \"is_admin\": true,\n    \"role\": null,\n    \"access_role\": \"adm\",\n    \"verified\": true,\n    \"email\": \"test@gmail.com\",\n    \"icon\": \"https://secure.gravatar.com/avatar/df46ee85ff1cbb518b20c8cab742b9ea?s=48&d=retro\"\n  }\n"
-						},
-						"description": "Create new user"
-					},
-					"response": []
-				},
-				{
+					"_postman_id": "cb8042a3-8c9c-4912-82f0-13701bafed0a",
 					"name": "Disable A Users by Handle",
 					"request": {
-						"url": "https://api.datadoghq.com/api/v1/user/test@gmail.com?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
 						"method": "DELETE",
 						"header": [],
 						"body": {
 							"mode": "raw",
 							"raw": ""
 						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/user/test@gmail.com?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"user",
+								"test@gmail.com"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
 						"description": "DELETE a user by handle"
 					},
 					"response": []
+				},
+				{
+					"_postman_id": "6e78bc2d-bcf1-4101-827c-81821b30474e",
+					"name": "Update User Info by Handle",
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"user\": {\n    \"disabled\": false,\n    \"handle\": \"email@domain.com\",\n    \"name\": \"Brendan Michael Roche 2\",\n    \"is_admin\": true,\n    \"role\": null,\n    \"access_role\": \"adm\",\n    \"verified\": true,\n    \"email\": \"email@domain.com\",\n    \"icon\": \"https://secure.gravatar.com/avatar/df46ee85ff1cbb518b20c8cab742b9ea?s=48&d=retro\"\n  }\n}"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/user/email@domain.com?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"user",
+								"email@domain.com"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "Update User Profile by handle"
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "1dcb053b-d913-4485-b48d-b6cc51db0416",
+					"name": "Get Single User of An Org by handle",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/user/email@domain.com?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"user",
+								"email@domain.com"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "Get user info from handle"
+					},
+					"response": []
+				},
+				{
+					"_postman_id": "7383c6c1-f0e8-4538-a80e-e584a3f11953",
+					"name": "Create User for an Org",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"disabled\": false,\n    \"handle\": \"test@gmail.com\",\n    \"name\": \"Testy McTestingson\",\n    \"is_admin\": true,\n    \"role\": null,\n    \"access_role\": \"adm\",\n    \"verified\": true,\n    \"email\": \"test@gmail.com\",\n    \"icon\": \"https://secure.gravatar.com/avatar/df46ee85ff1cbb518b20c8cab742b9ea?s=48&d=retro\"\n  }\n"
+						},
+						"url": {
+							"raw": "https://app.datadoghq.com/api/v1/user?api_key=INSERT_API_KEY_HERE&application_key=INSERT_APP_KEY_HERE",
+							"protocol": "https",
+							"host": [
+								"app",
+								"datadoghq",
+								"com"
+							],
+							"path": [
+								"api",
+								"v1",
+								"user"
+							],
+							"query": [
+								{
+									"key": "api_key",
+									"value": "INSERT_API_KEY_HERE"
+								},
+								{
+									"key": "application_key",
+									"value": "INSERT_APP_KEY_HERE"
+								}
+							]
+						},
+						"description": "Create new user"
+					},
+					"response": []
 				}
-			]
+			],
+			"description": "You can create, edit, and disable users."
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "c41623be-f6de-4e50-b2d7-a774bd352140",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "72537730-7e9d-49b3-96a1-49995ee97eba",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
 		}
 	]
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR updates the `datadog_collection_scrubbed.json` from the docs page to the most recent version found in this KB: https://help.datadoghq.com/hc/en-us/articles/115002182863-Using-Postman-With-Datadog-APIs

** I also replaced all `{{dd_api_key}}` and `{{dd_app_key}}` type template variables with just `INSERT YOUR API KEY` and `INSERT YOUR APP KEY` to match the older doc's format and to make sure the variables didn't have any weird behavior. 
 
### Motivation
<!-- What inspired you to submit this pull request?-->
I had a ticket where the customer was using the api paths from the docs to try to get and post to the dashboards and it was no longer working. 

### Preview link
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/api/?lang=bash#get-all-dashboard-lists

### Additional Notes
<!-- Anything else we should know when reviewing?-->

https://trello.com/c/aK7wNWxw/1852-update-api-documentation

