### PR TITLE
Grammar/Capitalization cleanup, content/monitors/notifications.md

### DIFF
--- a/content/monitors/notifications.md
+++ b/content/monitors/notifications.md
@@ -116,7 +116,7 @@ The conditional variables available are:
 | `{{#is_exact_match}}`      | Show when the context matches a string exactly        |
 | `{{^is_alert_recovery}}`   | Show unless monitor recovers from an alert            |
 | `{{#is_alert_to_warning}}` | Show when monitor transitions from alert to warning   |
-| `{{#Is_no_data_recovery}}` | Show when monitor recovers from a no data             |
+| `{{#is_no_data_recovery}}` | Show when monitor recovers from a no data             |
 | `{{#is_warning_recovery}}` | Show when monitor recovers from a warning             |
 | `{{^is_alert_to_warning}}` | Show unless monitor transitions from alert to warning |
 | `{{^is_no_data_recovery}}` | Show unless monitor recovers from a no data           |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

On page: https://docs.datadoghq.com/monitors/notifications/?tab=is_alertis_warning#conditional-variables

Grammar cleanup, _{{#Is_no_data_recovery}}_ to _{{#is_no_data_recovery}}_

### Motivation
<!-- What inspired you to submit this pull request?-->

Initial requester of escalation.

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
