### PR TITLE
Won/new sitemap param

### DIFF
--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -2,7 +2,7 @@
   {{ range where (where .Data.Pages "Params.beta" "!=" true) ".Params.is_public" "!=" false }}
   	  {{ if and (not (eq .Section "videos")) (not .Params.private) }}
 	  <url>
-	    <loc>{{ .Permalink }} {{ .Section }}</loc>
+	    <loc>{{ .Permalink }}</loc>
 	    <lastmod>{{ safeHTML ( .Date.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ with .Sitemap.ChangeFreq }}
 	    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
 	    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,10 +1,12 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {{ range where (where .Data.Pages "Params.beta" "!=" true) ".Params.is_public" "!=" false }}
-  <url>
-    <loc>{{ .Permalink }}</loc>
-    <lastmod>{{ safeHTML ( .Date.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ with .Sitemap.ChangeFreq }}
-    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
-    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}
-  </url>
+  	  {{ if and (not (eq .Section "videos")) (not .Params.private) }}
+	  <url>
+	    <loc>{{ .Permalink }} {{ .Section }}</loc>
+	    <lastmod>{{ safeHTML ( .Date.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ with .Sitemap.ChangeFreq }}
+	    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+	    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}
+	  </url>
+	  {{ end }}
   {{ end }}
 </urlset>


### PR DESCRIPTION
### What does this PR do?
Removing the pages with `private: true` front-matter and video posts from sitemap.

### Motivation
Requested. Part of ongoing Docsearch project.

### Preview link
https://docs-staging.datadoghq.com/won/new-sitemap-param

### Additional Notes
N/A
