### PR TITLE
Moving confusing docker param from main setup page

### DIFF
--- a/content/tracing/setup/_index.md
+++ b/content/tracing/setup/_index.md
@@ -52,23 +52,23 @@ apm_config:
 
 [Reference the dedicated documentation to setup tracing with Docker][5].
 
-Find below the list of all available parameters for your `datadog.yaml` configuration file, and their Docker Environment variable equivalent.
+Find below the list of all available parameters for your `datadog.yaml` configuration file:
 
-| File setting              | Type        | Environment variable       | Description                                                                                                                                                        |
-| ------------------------- | ----------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `enabled`                 | boolean     | `DD_APM_ENABLED`           | When set to `true`, the Datadog Agent accepts trace metrics. Default value is `true`.                                                                              |
-| `apm_dd_url`              | string      | `DD_APM_DD_URL`            | Datadog API endpoint where traces are sent.                                                                                                                        |
-| `env`                     | string      | -                          | Default environment to which traces should be registered under (e.g. *staging*, *production*, etc..).                                                              |
-| `extra_sample_rate`       | float       | -                          | Use this setting to adjust the trace sample rate. The value should be a float between `0` (no sampling) and `1` (normal sampling). Default value is `1`.           |
-| `max_traces_per_second`   | float       | -                          | Maximum number of traces to sample per second. Set to `0` to disable the limit (*not recommended*). The default value is `10`.                                     |
-| `ignore_resources`        | list        | `DD_IGNORE_RESOURCE`       | A list of resources that the Agent should ignore. If using the environment variable, this should be a comma-separated list.                                        |
-| `log_file`                | string      | -                          | Location of the log file.                                                                                                                                          |
-| `replace_tags`            | list        |                            | A list of tag replacement rules. See the [Scrubbing sensitive information](#scrubbing-sensitive-information) section.                                              |
-| `receiver_port`           | number      | `DD_RECEIVER_PORT`         | Port that the Datadog Agent's trace receiver listen on. Default value is `8126`.                                                                                   |
-| `apm_non_local_traffic`   | boolean     | `DD_APM_NON_LOCAL_TRAFFIC` | Allows the Agent to receive outside connections. It then listen on all interfaces.                                                                                 |
-| `max_memory`              | float       | -                          | Maximum memory that the Agent is allowed to occupy. When this is exceeded the process is killed.                                                                   |
-| `max_cpu_percent`         | float       | -                          | Maximum CPU percentage that the Agent should use. The Agent automatically adjusts its pre-sampling rate to stay below this number.                                 |
-| `max_connections`         | number      | -                          | Maximum number of network connections that the Agent is allowed to use. When this is exceeded the process is killed.                                               |
+| File setting              | Type        | Description                                                                                                                                                        |
+| ------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `enabled`                 | boolean     | When set to `true`, the Datadog Agent accepts trace metrics. Default value is `true`.                                                                              |
+| `apm_dd_url`              | string      | Datadog API endpoint where traces are sent.                                                                                                                        |
+| `env`                     | string      | Default environment to which traces should be registered under (e.g. *staging*, *production*, etc..).                                                              |
+| `extra_sample_rate`       | float       | Use this setting to adjust the trace sample rate. The value should be a float between `0` (no sampling) and `1` (normal sampling). Default value is `1`.           |
+| `max_traces_per_second`   | float       | Maximum number of traces to sample per second. Set to `0` to disable the limit (*not recommended*). The default value is `10`.                                     |
+| `ignore_resources`        | list        | A list of resources that the Agent should ignore. If using the environment variable, this should be a comma-separated list.                                        |
+| `log_file`                | string      | Location of the log file.                                                                                                                                          |
+| `replace_tags`            | list        | A list of tag replacement rules. See the [Scrubbing sensitive information](#scrubbing-sensitive-information) section.                                              |
+| `receiver_port`           | number      | Port that the Datadog Agent's trace receiver listen on. Default value is `8126`.                                                                                   |
+| `apm_non_local_traffic`   | boolean     | Allows the Agent to receive outside connections. It then listen on all interfaces.                                                                                 |
+| `max_memory`              | float       | Maximum memory that the Agent is allowed to occupy. When this is exceeded the process is killed.                                                                   |
+| `max_cpu_percent`         | float       | Maximum CPU percentage that the Agent should use. The Agent automatically adjusts its pre-sampling rate to stay below this number.                                 |
+| `max_connections`         | number      | Maximum number of network connections that the Agent is allowed to use. When this is exceeded the process is killed.                                               |
   
 
 To get a an overview of all the possible settings for APM, take a look at the Agent's [`datadog.example.yaml`][21] configuration file.

--- a/content/tracing/setup/_index.md
+++ b/content/tracing/setup/_index.md
@@ -61,7 +61,7 @@ Find below the list of all available parameters for your `datadog.yaml` configur
 | `env`                     | string      | Default environment to which traces should be registered under (e.g. *staging*, *production*, etc..).                                                              |
 | `extra_sample_rate`       | float       | Use this setting to adjust the trace sample rate. The value should be a float between `0` (no sampling) and `1` (normal sampling). Default value is `1`.           |
 | `max_traces_per_second`   | float       | Maximum number of traces to sample per second. Set to `0` to disable the limit (*not recommended*). The default value is `10`.                                     |
-| `ignore_resources`        | list        | A list of resources that the Agent should ignore. If using the environment variable, this should be a comma-separated list.                                        |
+| `ignore_resources`        | list        | A list of resources that the Agent should ignore.                                                                                                                  |
 | `log_file`                | string      | Location of the log file.                                                                                                                                          |
 | `replace_tags`            | list        | A list of tag replacement rules. See the [Scrubbing sensitive information](#scrubbing-sensitive-information) section.                                              |
 | `receiver_port`           | number      | Port that the Datadog Agent's trace receiver listen on. Default value is `8126`.                                                                                   |

--- a/content/tracing/setup/docker.md
+++ b/content/tracing/setup/docker.md
@@ -16,7 +16,24 @@ Enable the [datadog-trace-agent][1] in the `datadog/agent` container by passing 
 
 **Note: APM is NOT available on Alpine Images**
 
-For additional information, see the [Agent 6 Docker documentation][2].
+List of all environment variable available:
+
+| Environment variable       | Description                                                                                  |
+| ------                     | ------                                                                                       |
+| `DD_API_KEY`               | [Datadog API Key][3]                                                                         |
+| `DD_APM_ENABLED`           | Set to `true` to enable APM for your Agent                                                   |
+| `DD_APM_DD_URL`            | Configure the APM URL to send your traces to                                                 |
+| `DD_PROXY_HTTPS`           | Set up the URL for the proxy to use                                                          |
+| `DD_HOSTNAME`              | Set manually the Agent hostname                                                              |
+| `DD_BIND_HOST`             | Set the StatsD & receiver hostname                                                           |
+| `DD_RECEIVER_PORT`         | Set the receiver port                                                                        |
+| `DD_DOGSTATSD_PORT`        | Set the DogStatsD port                                                                       |
+| `DD_APM_NON_LOCAL_TRAFFIC` | Allow non-local traffic when [tracing from other containers](#tracing-from-other-containers) |
+| `DD_IGNORE_RESOURCE`       | Configure the list of ignored resources                                                      |
+| `DD_LOG_LEVEL`             | Set the logging level                                                                        |
+| `DD_APM_ANALYZED_SPANS`    | Configure the spans to analyze for transactions                                              |
+| `DD_CONNECTION_LIMIT`      | Set the Limit of unique connections                                                          |
+
 
 ## Tracing from the host
 
@@ -150,3 +167,4 @@ tracer.configure(hostname='172.17.0.1', port=8126)
 
 [1]: https://github.com/DataDog/datadog-trace-agent
 [2]: /agent/basic_agent_usage/docker
+[3]: https://app.datadoghq.com/account/settings#api

--- a/content/tracing/setup/docker.md
+++ b/content/tracing/setup/docker.md
@@ -16,23 +16,24 @@ Enable the [datadog-trace-agent][1] in the `datadog/agent` container by passing 
 
 **Note: APM is NOT available on Alpine Images**
 
-List of all environment variable available:
+List of all environment variables available:
 
-| Environment variable       | Description                                                                                  |
-| ------                     | ------                                                                                       |
-| `DD_API_KEY`               | [Datadog API Key][3]                                                                         |
-| `DD_APM_ENABLED`           | When set to `true`, the Datadog Agent accepts trace metrics.                                 |
-| `DD_APM_DD_URL`            | Datadog API endpoint where traces are sent.                                                  |
-| `DD_PROXY_HTTPS`           | Set up the URL for the proxy to use                                                          |
-| `DD_HOSTNAME`              | Set manually the Agent hostname                                                              |
-| `DD_BIND_HOST`             | Set the StatsD & receiver hostname                                                           |
-| `DD_RECEIVER_PORT`         | Port that the Datadog Agent's trace receiver listen on. Default value is `8126`.             |
-| `DD_DOGSTATSD_PORT`        | Set the DogStatsD port                                                                       |
-| `DD_APM_NON_LOCAL_TRAFFIC` | Allow non-local traffic when [tracing from other containers](#tracing-from-other-containers) |
-| `DD_IGNORE_RESOURCE`       | A comma-separated list of resources that the Agent should ignore.                            |
-| `DD_LOG_LEVEL`             | Set the logging level                                                                        |
-| `DD_APM_ANALYZED_SPANS`    | Configure the spans to analyze for transactions                                              |
-| `DD_CONNECTION_LIMIT`      | Set the Limit of unique connections                                                          |
+| Environment variable       | Description                                                                                   |
+| ------                     | ------                                                                                        |
+| `DD_API_KEY`               | [Datadog API Key][3]                                                                          |
+| `DD_APM_ENABLED`           | When set to `true`, the Datadog Agent accepts trace metrics.                                  |
+| `DD_APM_DD_URL`            | Datadog API endpoint where traces are sent.                                                   |
+| `DD_PROXY_HTTPS`           | Set up the URL for the proxy to use.                                                          |
+| `DD_HOSTNAME`              | Set manually the Agent hostname.                                                              |
+| `DD_BIND_HOST`             | Set the StatsD & receiver hostname.                                                           |
+| `DD_RECEIVER_PORT`         | Port that the Datadog Agent's trace receiver listen on. Default value is `8126`.              |
+| `DD_DOGSTATSD_PORT`        | Set the DogStatsD port.                                                                       |
+| `DD_APM_NON_LOCAL_TRAFFIC` | Allow non-local traffic when [tracing from other containers](#tracing-from-other-containers). |
+| `DD_IGNORE_RESOURCE`       | A comma-separated list of resources that the Agent should ignore.                             |
+| `DD_LOG_LEVEL`             | Set the logging level.                                                                        |
+| `DD_APM_ANALYZED_SPANS`    | Configure the spans to analyze for transactions.                                              |
+| `DD_CONNECTION_LIMIT`      | Set the Limit of unique connections .                                                         |
+
 
 
 ## Tracing from the host

--- a/content/tracing/setup/docker.md
+++ b/content/tracing/setup/docker.md
@@ -21,15 +21,15 @@ List of all environment variable available:
 | Environment variable       | Description                                                                                  |
 | ------                     | ------                                                                                       |
 | `DD_API_KEY`               | [Datadog API Key][3]                                                                         |
-| `DD_APM_ENABLED`           | Set to `true` to enable APM for your Agent                                                   |
-| `DD_APM_DD_URL`            | Configure the APM URL to send your traces to                                                 |
+| `DD_APM_ENABLED`           | When set to `true`, the Datadog Agent accepts trace metrics.                                 |
+| `DD_APM_DD_URL`            | Datadog API endpoint where traces are sent.                                                  |
 | `DD_PROXY_HTTPS`           | Set up the URL for the proxy to use                                                          |
 | `DD_HOSTNAME`              | Set manually the Agent hostname                                                              |
 | `DD_BIND_HOST`             | Set the StatsD & receiver hostname                                                           |
-| `DD_RECEIVER_PORT`         | Set the receiver port                                                                        |
+| `DD_RECEIVER_PORT`         | Port that the Datadog Agent's trace receiver listen on. Default value is `8126`.             |
 | `DD_DOGSTATSD_PORT`        | Set the DogStatsD port                                                                       |
 | `DD_APM_NON_LOCAL_TRAFFIC` | Allow non-local traffic when [tracing from other containers](#tracing-from-other-containers) |
-| `DD_IGNORE_RESOURCE`       | Configure the list of ignored resources                                                      |
+| `DD_IGNORE_RESOURCE`       | A comma-separated list of resources that the Agent should ignore.                            |
 | `DD_LOG_LEVEL`             | Set the logging level                                                                        |
 | `DD_APM_ANALYZED_SPANS`    | Configure the spans to analyze for transactions                                              |
 | `DD_CONNECTION_LIMIT`      | Set the Limit of unique connections                                                          |


### PR DESCRIPTION
### What does this PR do?
Moves docker parameter to the dedicated tracing/setup/docker page

### Motivation
A customer was confused

### Preview link
