### PR TITLE
Removing api Titles + Placeholders update

### DIFF
--- a/content/api/authentication/authentication_code.fr.md
+++ b/content/api/authentication/authentication_code.fr.md
@@ -4,6 +4,7 @@ type: apicode
 order: 2
 external_redirect: /api/#authentication
 ---
-### EXEMPLE
+**EXEMPLE**:
+
 {{< code-snippets basename="api-auth" >}}
 

--- a/content/api/authentication/authentication_code.md
+++ b/content/api/authentication/authentication_code.md
@@ -4,6 +4,7 @@ type: apicode
 order: 2
 external_redirect: /api/#authentication
 ---
-### EXAMPLE
+**EXAMPLE**:
+
 {{< code-snippets basename="api-auth" >}}
 

--- a/content/api/checks/checks_post.fr.md
+++ b/content/api/checks/checks_post.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#post-a-check-run
 
 ## Envoyer le résultat d'un check
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 * **`check`** *[obligatoire]*:  
     Le texte du message
@@ -21,7 +21,6 @@ external_redirect: /api/#post-a-check-run
     * 1 : Warning
     * 2 : CRITICAL
     * 3 : UNKNOWN
-
 
 * **`timestamp`** *[optionnel]*:  
     Timestamp POSIX de l'événement.

--- a/content/api/checks/checks_post.md
+++ b/content/api/checks/checks_post.md
@@ -7,7 +7,7 @@ external_redirect: /api/#post-a-check-run
 
 ## Post A check run
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 * **`check`** *[required]*:  
     The text for the message

--- a/content/api/checks/checks_post_code.fr.md
+++ b/content/api/checks/checks_post_code.fr.md
@@ -5,11 +5,15 @@ order: 6.1
 external_redirect: /api/#post-a-check-run
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/check_run`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-checks-post" >}}
 
-##### Exemple de réponse
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-checks-post" >}}
 

--- a/content/api/checks/checks_post_code.md
+++ b/content/api/checks/checks_post_code.md
@@ -5,11 +5,15 @@ order: 6.1
 external_redirect: /api/#post-a-check-run
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/check_run`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-checks-post" >}}
 
-##### Example Response
+**Example Response**:
+
 {{< code-snippets basename="result.api-checks-post" >}}
 

--- a/content/api/comments/comments_create.fr.md
+++ b/content/api/comments/comments_create.fr.md
@@ -8,7 +8,8 @@ external_redirect: /api/#create-a-comment
 ## Créer un commentaire
 Les commentaires sont essentiellement des cas spéciaux d'évènements qui s'apparaissent dans le [flux d'évènements][1]. Ils peuvent entamer un nouveau fil de discussion ou, facultativement, répondre dans un autre fil.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`message`** [*obligatoire*]:  
   Le texte du commentaire
 

--- a/content/api/comments/comments_create.md
+++ b/content/api/comments/comments_create.md
@@ -8,7 +8,8 @@ external_redirect: /api/#create-a-comment
 ## Create A Comment
 Comments are essentially special forms of events that appear in the [event stream][1]. They can start a new discussion thread or optionally, reply in another thread.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`message`** [*required*]:  
     The comment text.
 

--- a/content/api/comments/comments_create_code.fr.md
+++ b/content/api/comments/comments_create_code.fr.md
@@ -5,10 +5,15 @@ order: 7.1
 external_redirect: /api/#create-a-comment
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/comments`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-comment-create" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-comment-create" >}}
 

--- a/content/api/comments/comments_create_code.md
+++ b/content/api/comments/comments_create_code.md
@@ -5,10 +5,15 @@ order: 7.1
 external_redirect: /api/#create-a-comment
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/comments`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-comment-create" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-comment-create" >}}
 

--- a/content/api/comments/comments_delete_code.fr.md
+++ b/content/api/comments/comments_delete_code.fr.md
@@ -5,10 +5,15 @@ order: 7.3
 external_redirect: /api/#delete-a-comment
 ---
 
-##### Signature
+**Signature**:
+
 `DELETE https://api.datadoghq.com/api/v1/comments/:comment_id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-comment-delete" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 *Cet endpoint ne renvoie aucun objet JSON en cas de requête réussie.*
 

--- a/content/api/comments/comments_delete_code.fr.md
+++ b/content/api/comments/comments_delete_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#delete-a-comment
 
 **Signature**:
 
-`DELETE https://api.datadoghq.com/api/v1/comments/:comment_id`
+`DELETE https://api.datadoghq.com/api/v1/comments/<COMMENT_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/comments/comments_delete_code.md
+++ b/content/api/comments/comments_delete_code.md
@@ -5,10 +5,15 @@ order: 7.3
 external_redirect: /api/#delete-a-comment
 ---
 
-##### Signature
+**Signature**:
+
 `DELETE https://api.datadoghq.com/api/v1/comments/:comment_id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-comment-delete" >}}
-##### Example Response
+
+**Example Response**:
+
 *This end point does not return JSON on successful requests.*
 

--- a/content/api/comments/comments_delete_code.md
+++ b/content/api/comments/comments_delete_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#delete-a-comment
 
 **Signature**:
 
-`DELETE https://api.datadoghq.com/api/v1/comments/:comment_id`
+`DELETE https://api.datadoghq.com/api/v1/comments/<COMMENT_ID>`
 
 **Example Request**:
 

--- a/content/api/comments/comments_edit.fr.md
+++ b/content/api/comments/comments_edit.fr.md
@@ -7,7 +7,8 @@ external_redirect: /api/#edit-a-comment
 
 ## Modifier un commentaire
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`message`** [*optionnel*, *défaut* = **original message**]:  
     Le texte du commentaire.
 

--- a/content/api/comments/comments_edit.md
+++ b/content/api/comments/comments_edit.md
@@ -7,7 +7,8 @@ external_redirect: /api/#edit-a-comment
 
 ## Edit A Comment
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`message`** [*optional*, *default* = **original message**]:  
     The comment text.
 

--- a/content/api/comments/comments_edit_code.fr.md
+++ b/content/api/comments/comments_edit_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#edit-a-comment
 
 **Signature**:
 
-`PUT https://api.datadoghq.com/api/v1/comments/:comment_id`
+`PUT https://api.datadoghq.com/api/v1/comments/<COMMENT_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/comments/comments_edit_code.fr.md
+++ b/content/api/comments/comments_edit_code.fr.md
@@ -5,10 +5,15 @@ order: 7.2
 external_redirect: /api/#edit-a-comment
 ---
 
-##### Signature
+**Signature**:
+
 `PUT https://api.datadoghq.com/api/v1/comments/:comment_id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-comment-edit" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-comment-edit" >}}
 

--- a/content/api/comments/comments_edit_code.md
+++ b/content/api/comments/comments_edit_code.md
@@ -5,10 +5,15 @@ order: 7.2
 external_redirect: /api/#edit-a-comment
 ---
 
-##### Signature
+**Signature**:
+
 `PUT https://api.datadoghq.com/api/v1/comments/:comment_id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-comment-edit" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-comment-edit" >}}
 

--- a/content/api/comments/comments_edit_code.md
+++ b/content/api/comments/comments_edit_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#edit-a-comment
 
 **Signature**:
 
-`PUT https://api.datadoghq.com/api/v1/comments/:comment_id`
+`PUT https://api.datadoghq.com/api/v1/comments/<COMMENT_ID>`
 
 **Example Request**:
 

--- a/content/api/dashboard_lists/dashboard_lists_add_items.fr.md
+++ b/content/api/dashboard_lists/dashboard_lists_add_items.fr.md
@@ -9,7 +9,7 @@ external_redirect: /api/#add-items-to-a-dashboard-list
 
 Rajoute un ou plusieurs dashboards à une dashboard list.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 *   **`dashboards`** [*obligatoire*]:
     Une liste de dashboards à ajouter à la dashboard list.

--- a/content/api/dashboard_lists/dashboard_lists_add_items.md
+++ b/content/api/dashboard_lists/dashboard_lists_add_items.md
@@ -9,7 +9,7 @@ external_redirect: /api/#add-items-to-a-dashboard-list
 
 Add dashboards to an existing dashboard list.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 *   **`dashboards`** [*required*]:
     A list of dashboards to add to the list.

--- a/content/api/dashboard_lists/dashboard_lists_add_items_code.md
+++ b/content/api/dashboard_lists/dashboard_lists_add_items_code.md
@@ -5,14 +5,14 @@ order: 8.7
 external_redirect: /api/#add-items-to-a-dashboard-list
 ---
 
-##### Signature
+**Signature**:
 
 `POST https://api.datadoghq.com/api/v1/dashboard/lists/manual/:list_id/dashboards`
 
-##### Example Request
+**Example Request**:
 
 {{< code-snippets basename="api-dashboard-list-add-items" >}}
 
-##### Example Response
+**Example Response**:
 
 {{< code-snippets basename="result.api-dashboard-list-add-items" >}}

--- a/content/api/dashboard_lists/dashboard_lists_add_items_code.md
+++ b/content/api/dashboard_lists/dashboard_lists_add_items_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#add-items-to-a-dashboard-list
 
 **Signature**:
 
-`POST https://api.datadoghq.com/api/v1/dashboard/lists/manual/:list_id/dashboards`
+`POST https://api.datadoghq.com/api/v1/dashboard/lists/manual/<LIST_ID>/dashboards`
 
 **Example Request**:
 

--- a/content/api/dashboard_lists/dashboard_lists_create.md
+++ b/content/api/dashboard_lists/dashboard_lists_create.md
@@ -9,7 +9,7 @@ external_redirect: /api/#create-a-dashboard-list
 
 Create an empty dashboard list.
 
-##### Arguments
+**ARGUMENTS**:
 
 *   **`name`** [*required*]:
     The name of the dashboard list.

--- a/content/api/dashboard_lists/dashboard_lists_create_code.fr.md
+++ b/content/api/dashboard_lists/dashboard_lists_create_code.fr.md
@@ -5,14 +5,14 @@ order: 8.3
 external_redirect: /api/#create-a-dashboard-list
 ---
 
-##### Signature
+**Signature**:
 
 `POST https://api.datadoghq.com/api/v1/dashboard/lists/manual`
 
-##### Exemple de requête
+**Exemple de requête**:
 
 {{< code-snippets basename="api-dashboard-list-create" >}}
 
-##### Exemple de réponse
+**Exemple de réponse**:
 
 {{< code-snippets basename="result.api-dashboard-list-create" >}}

--- a/content/api/dashboard_lists/dashboard_lists_create_code.md
+++ b/content/api/dashboard_lists/dashboard_lists_create_code.md
@@ -5,14 +5,14 @@ order: 8.3
 external_redirect: /api/#create-a-dashboard-list
 ---
 
-##### Signature
+**Signature**:
 
 `POST https://api.datadoghq.com/api/v1/dashboard/lists/manual`
 
-##### Example Request
+**Example Request**:
 
 {{< code-snippets basename="api-dashboard-list-create" >}}
 
-##### Example Response
+**Example Response**:
 
 {{< code-snippets basename="result.api-dashboard-list-create" >}}

--- a/content/api/dashboard_lists/dashboard_lists_delete.md
+++ b/content/api/dashboard_lists/dashboard_lists_delete.md
@@ -9,6 +9,6 @@ external_redirect: /api/#delete-a-dashboard-list
 
 Delete an existing dashboard list.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 This end point takes no JSON arguments.

--- a/content/api/dashboard_lists/dashboard_lists_delete_code.md
+++ b/content/api/dashboard_lists/dashboard_lists_delete_code.md
@@ -5,14 +5,14 @@ order: 8.5
 external_redirect: /api/#delete-a-dashboard-list
 ---
 
-##### Signature
+**Signature**:
 
 `DELETE https://api.datadoghq.com/api/v1/dashboard/lists/manual/:list_id`
 
-##### Example Request
+**Example Request**:
 
 {{< code-snippets basename="api-dashboard-list-delete" >}}
 
-##### Example Response
+**Example Response**:
 
 {{< code-snippets basename="result.api-dashboard-list-delete" >}}

--- a/content/api/dashboard_lists/dashboard_lists_delete_code.md
+++ b/content/api/dashboard_lists/dashboard_lists_delete_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#delete-a-dashboard-list
 
 **Signature**:
 
-`DELETE https://api.datadoghq.com/api/v1/dashboard/lists/manual/:list_id`
+`DELETE https://api.datadoghq.com/api/v1/dashboard/lists/manual/<LIST_ID>`
 
 **Example Request**:
 

--- a/content/api/dashboard_lists/dashboard_lists_delete_items.md
+++ b/content/api/dashboard_lists/dashboard_lists_delete_items.md
@@ -9,7 +9,7 @@ external_redirect: /api/#delete-items-from-a-dashboard-list
 
 Delete dashboards from an existing dashboard list.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 *   **`dashboards`** [*required*]:
     A list of dashboards to remove from the list.

--- a/content/api/dashboard_lists/dashboard_lists_delete_items_code.fr.md
+++ b/content/api/dashboard_lists/dashboard_lists_delete_items_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#delete-items-from-a-dashboard-list
 
 **Signature**:
 
-`DELETE https://api.datadoghq.com/api/v1/dashboard/lists/manual/:list_id/dashboards`
+`DELETE https://api.datadoghq.com/api/v1/dashboard/lists/manual/<LIST_ID>/dashboards`
 
 **Exemple de requête**:
 

--- a/content/api/dashboard_lists/dashboard_lists_delete_items_code.fr.md
+++ b/content/api/dashboard_lists/dashboard_lists_delete_items_code.fr.md
@@ -5,14 +5,14 @@ order: 8.9
 external_redirect: /api/#delete-items-from-a-dashboard-list
 ---
 
-##### Signature
+**Signature**:
 
 `DELETE https://api.datadoghq.com/api/v1/dashboard/lists/manual/:list_id/dashboards`
 
-##### Exemple de requête
+**Exemple de requête**:
 
 {{< code-snippets basename="api-dashboard-list-delete-items" >}}
 
-##### Exemple de réponse
+**Exemple de réponse**:
 
 {{< code-snippets basename="result.api-dashboard-list-delete-items" >}}

--- a/content/api/dashboard_lists/dashboard_lists_delete_items_code.md
+++ b/content/api/dashboard_lists/dashboard_lists_delete_items_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#delete-items-from-a-dashboard-list
 
 **Signature**:
 
-`DELETE https://api.datadoghq.com/api/v1/dashboard/lists/manual/:list_id/dashboards`
+`DELETE https://api.datadoghq.com/api/v1/dashboard/lists/manual/<LIST_ID>/dashboards`
 
 **Example Request**:
 

--- a/content/api/dashboard_lists/dashboard_lists_delete_items_code.md
+++ b/content/api/dashboard_lists/dashboard_lists_delete_items_code.md
@@ -5,14 +5,14 @@ order: 8.9
 external_redirect: /api/#delete-items-from-a-dashboard-list
 ---
 
-##### Signature
+**Signature**:
 
 `DELETE https://api.datadoghq.com/api/v1/dashboard/lists/manual/:list_id/dashboards`
 
-##### Example Request
+**Example Request**:
 
 {{< code-snippets basename="api-dashboard-list-delete-items" >}}
 
-##### Example Response
+**Example Response**:
 
 {{< code-snippets basename="result.api-dashboard-list-delete-items" >}}

--- a/content/api/dashboard_lists/dashboard_lists_get.fr.md
+++ b/content/api/dashboard_lists/dashboard_lists_get.fr.md
@@ -9,6 +9,6 @@ external_redirect: /api/#get-a-dashboard-list
 
 Récupère toutes les spécifications d'une Dashboard List.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 Cet endpoint ne prend aucun argument JSON.

--- a/content/api/dashboard_lists/dashboard_lists_get.md
+++ b/content/api/dashboard_lists/dashboard_lists_get.md
@@ -9,6 +9,6 @@ external_redirect: /api/#get-a-dashboard-list
 
 Fetch an existing dashboard list's definition.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 This end point takes no JSON arguments.

--- a/content/api/dashboard_lists/dashboard_lists_get_all.md
+++ b/content/api/dashboard_lists/dashboard_lists_get_all.md
@@ -9,6 +9,6 @@ external_redirect: /api/#get-all-dashboard-lists
 
 Fetch all of your existing dashboard list definitions.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 This end point takes no JSON arguments.

--- a/content/api/dashboard_lists/dashboard_lists_get_all_code.fr.md
+++ b/content/api/dashboard_lists/dashboard_lists_get_all_code.fr.md
@@ -5,14 +5,14 @@ order: 8.2
 external_redirect: /api/#get-all-dashboard-lists
 ---
 
-##### Signature
+**Signature**:
 
 `GET https://api.datadoghq.com/api/v1/dashboard/lists/manual`
 
-##### Exemple de requête
+**Exemple de requête**:
 
 {{< code-snippets basename="api-dashboard-list-get-all" >}}
 
-##### Exemple de réponse
+**Exemple de réponse**:
 
 {{< code-snippets basename="result.api-dashboard-list-get-all" >}}

--- a/content/api/dashboard_lists/dashboard_lists_get_all_code.md
+++ b/content/api/dashboard_lists/dashboard_lists_get_all_code.md
@@ -5,14 +5,14 @@ order: 8.2
 external_redirect: /api/#get-all-dashboard-lists
 ---
 
-##### Signature
+**Signature**:
 
 `GET https://api.datadoghq.com/api/v1/dashboard/lists/manual`
 
-##### Example Request
+**Example Request**:
 
 {{< code-snippets basename="api-dashboard-list-get-all" >}}
 
-##### Example Response
+**Example Response**:
 
 {{< code-snippets basename="result.api-dashboard-list-get-all" >}}

--- a/content/api/dashboard_lists/dashboard_lists_get_code.fr.md
+++ b/content/api/dashboard_lists/dashboard_lists_get_code.fr.md
@@ -5,14 +5,14 @@ order: 8.1
 external_redirect: /api/#get-a-dashboard-list
 ---
 
-##### Signature
+**Signature**:
 
 `GET https://api.datadoghq.com/api/v1/dashboard/lists/manual/:list_id`
 
-##### Exemple de requête
+**Exemple de requête**:
 
 {{< code-snippets basename="api-dashboard-list-get" >}}
 
-##### Exemple de réponse
+**Exemple de réponse**:
 
 {{< code-snippets basename="result.api-dashboard-list-get" >}}

--- a/content/api/dashboard_lists/dashboard_lists_get_code.fr.md
+++ b/content/api/dashboard_lists/dashboard_lists_get_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#get-a-dashboard-list
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/dashboard/lists/manual/:list_id`
+`GET https://api.datadoghq.com/api/v1/dashboard/lists/manual/<LIST_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/dashboard_lists/dashboard_lists_get_code.md
+++ b/content/api/dashboard_lists/dashboard_lists_get_code.md
@@ -5,14 +5,14 @@ order: 8.1
 external_redirect: /api/#get-a-dashboard-list
 ---
 
-##### Signature
+**Signature**:
 
 `GET https://api.datadoghq.com/api/v1/dashboard/lists/manual/:list_id`
 
-##### Example Request
+**Example Request**:
 
 {{< code-snippets basename="api-dashboard-list-get" >}}
 
-##### Example Response
+**Example Response**:
 
 {{< code-snippets basename="result.api-dashboard-list-get" >}}

--- a/content/api/dashboard_lists/dashboard_lists_get_code.md
+++ b/content/api/dashboard_lists/dashboard_lists_get_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#get-a-dashboard-list
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/dashboard/lists/manual/:list_id`
+`GET https://api.datadoghq.com/api/v1/dashboard/lists/manual/<LIST_ID>`
 
 **Example Request**:
 

--- a/content/api/dashboard_lists/dashboard_lists_get_items.md
+++ b/content/api/dashboard_lists/dashboard_lists_get_items.md
@@ -9,6 +9,6 @@ external_redirect: /api/#get-items-of-a-dashboard-list
 
 Fetch the dashboard list's dashboard definitions.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 This end point takes no JSON arguments.

--- a/content/api/dashboard_lists/dashboard_lists_get_items_code.fr.md
+++ b/content/api/dashboard_lists/dashboard_lists_get_items_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#get-items-of-a-dashboard-list
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/dashboard/lists/manual/:list_id/dashboards`
+`GET https://api.datadoghq.com/api/v1/dashboard/lists/manual/<LIST_ID>/dashboards`
 
 **Exemple de requête**:
 

--- a/content/api/dashboard_lists/dashboard_lists_get_items_code.fr.md
+++ b/content/api/dashboard_lists/dashboard_lists_get_items_code.fr.md
@@ -5,14 +5,14 @@ order: 8.6
 external_redirect: /api/#get-items-of-a-dashboard-list
 ---
 
-##### Signature
+**Signature**:
 
 `GET https://api.datadoghq.com/api/v1/dashboard/lists/manual/:list_id/dashboards`
 
-##### Exemple de requête
+**Exemple de requête**:
 
 {{< code-snippets basename="api-dashboard-list-get-items" >}}
 
-##### Exemple de réponse
+**Exemple de réponse**:
 
 {{< code-snippets basename="result.api-dashboard-list-get-items" >}}

--- a/content/api/dashboard_lists/dashboard_lists_get_items_code.md
+++ b/content/api/dashboard_lists/dashboard_lists_get_items_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#get-items-of-a-dashboard-list
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/dashboard/lists/manual/:list_id/dashboards`
+`GET https://api.datadoghq.com/api/v1/dashboard/lists/manual/<LIST_ID>/dashboards`
 
 **Example Request**:
 

--- a/content/api/dashboard_lists/dashboard_lists_get_items_code.md
+++ b/content/api/dashboard_lists/dashboard_lists_get_items_code.md
@@ -5,14 +5,14 @@ order: 8.6
 external_redirect: /api/#get-items-of-a-dashboard-list
 ---
 
-##### Signature
+**Signature**:
 
 `GET https://api.datadoghq.com/api/v1/dashboard/lists/manual/:list_id/dashboards`
 
-##### Example Request
+**Example Request**:
 
 {{< code-snippets basename="api-dashboard-list-get-items" >}}
 
-##### Example Response
+**Example Response**:
 
 {{< code-snippets basename="result.api-dashboard-list-get-items" >}}

--- a/content/api/dashboard_lists/dashboard_lists_update.md
+++ b/content/api/dashboard_lists/dashboard_lists_update.md
@@ -9,7 +9,7 @@ external_redirect: /api/#update-a-dashboard-list
 
 Update the name of a dashboard list
 
-##### Arguments
+**ARGUMENTS**:
 
 *   **`name`** [*required*]:
     The name of the dashboard list.

--- a/content/api/dashboard_lists/dashboard_lists_update_code.fr.md
+++ b/content/api/dashboard_lists/dashboard_lists_update_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#update-a-dashboard-list
 
 **Signature**:
 
-`PUT https://api.datadoghq.com/api/v1/dashboard/lists/manual/:list_id`
+`PUT https://api.datadoghq.com/api/v1/dashboard/lists/manual/<LIST_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/dashboard_lists/dashboard_lists_update_code.fr.md
+++ b/content/api/dashboard_lists/dashboard_lists_update_code.fr.md
@@ -5,14 +5,14 @@ order: 8.4
 external_redirect: /api/#update-a-dashboard-list
 ---
 
-##### Signature
+**Signature**:
 
 `PUT https://api.datadoghq.com/api/v1/dashboard/lists/manual/:list_id`
 
-##### Exemple de requête
+**Exemple de requête**:
 
 {{< code-snippets basename="api-dashboard-list-update" >}}
 
-##### Exemple de réponse
+**Exemple de réponse**:
 
 {{< code-snippets basename="result.api-dashboard-list-update" >}}

--- a/content/api/dashboard_lists/dashboard_lists_update_code.md
+++ b/content/api/dashboard_lists/dashboard_lists_update_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#update-a-dashboard-list
 
 **Signature**:
 
-`PUT https://api.datadoghq.com/api/v1/dashboard/lists/manual/:list_id`
+`PUT https://api.datadoghq.com/api/v1/dashboard/lists/manual/<LIST_ID>`
 
 **Example Request**:
 

--- a/content/api/dashboard_lists/dashboard_lists_update_code.md
+++ b/content/api/dashboard_lists/dashboard_lists_update_code.md
@@ -5,14 +5,14 @@ order: 8.4
 external_redirect: /api/#update-a-dashboard-list
 ---
 
-##### Signature
+**Signature**:
 
 `PUT https://api.datadoghq.com/api/v1/dashboard/lists/manual/:list_id`
 
-##### Example Request
+**Example Request**:
 
 {{< code-snippets basename="api-dashboard-list-update" >}}
 
-##### Example Response
+**Example Response**:
 
 {{< code-snippets basename="result.api-dashboard-list-update" >}}

--- a/content/api/dashboard_lists/dashboard_lists_update_items.md
+++ b/content/api/dashboard_lists/dashboard_lists_update_items.md
@@ -9,7 +9,7 @@ external_redirect: /api/#update-items-of-a-dashboard-list
 
 Update dashboards of an existing dashboard list.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 *   **`dashboards`** [*required*]:
     The new list of dashboards for the dashboard list.

--- a/content/api/dashboard_lists/dashboard_lists_update_items_code.md
+++ b/content/api/dashboard_lists/dashboard_lists_update_items_code.md
@@ -5,14 +5,14 @@ order: 8.8
 external_redirect: /api/#update-items-of-a-dashboard-list
 ---
 
-##### Signature
+**Signature**:
 
 `PUT https://api.datadoghq.com/api/v1/dashboard/lists/manual/:list_id/dashboards`
 
-##### Example Request
+**Example Request**:
 
 {{< code-snippets basename="api-dashboard-list-update-items" >}}
 
-##### Example Response
+**Example Response**:
 
 {{< code-snippets basename="result.api-dashboard-list-update-items" >}}

--- a/content/api/dashboard_lists/dashboard_lists_update_items_code.md
+++ b/content/api/dashboard_lists/dashboard_lists_update_items_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#update-items-of-a-dashboard-list
 
 **Signature**:
 
-`PUT https://api.datadoghq.com/api/v1/dashboard/lists/manual/:list_id/dashboards`
+`PUT https://api.datadoghq.com/api/v1/dashboard/lists/manual/<LIST_ID>/dashboards`
 
 **Example Request**:
 

--- a/content/api/downtimes/downtimes_cancel.fr.md
+++ b/content/api/downtimes/downtimes_cancel.fr.md
@@ -6,7 +6,9 @@ external_redirect: /api/#cancel-monitor-downtime
 ---
 
 ## Annuler le downtime d'un monitor
-##### ARGUMENTS
+
+**ARGUMENTS**:
+
 * **`id`** [*obligatoire*]:  
     L'id entier du downtime à annuler
 

--- a/content/api/downtimes/downtimes_cancel.md
+++ b/content/api/downtimes/downtimes_cancel.md
@@ -6,7 +6,9 @@ external_redirect: /api/#cancel-monitor-downtime
 ---
 
 ## Cancel Monitor Downtime
-##### ARGUMENTS
+
+**ARGUMENTS**:
+
 * **`id`** [*required*]:  
     The integer id of the downtime to be canceled
 

--- a/content/api/downtimes/downtimes_cancel_code.fr.md
+++ b/content/api/downtimes/downtimes_cancel_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#cancel-monitor-downtime
 
 **Signature**:
 
-`DELETE https://api.datadoghq.com/api/v1/downtime/:downtime_id`
+`DELETE https://api.datadoghq.com/api/v1/downtime/<DOWNTIME_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/downtimes/downtimes_cancel_code.fr.md
+++ b/content/api/downtimes/downtimes_cancel_code.fr.md
@@ -5,10 +5,15 @@ order: 9.3
 external_redirect: /api/#cancel-monitor-downtime
 ---
 
-##### Signature
+**Signature**:
+
 `DELETE https://api.datadoghq.com/api/v1/downtime/:downtime_id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-monitor-cancel-downtime" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 *Cet endpoint ne renvoie aucun objet JSON en cas de requête réussie.*
 

--- a/content/api/downtimes/downtimes_cancel_code.md
+++ b/content/api/downtimes/downtimes_cancel_code.md
@@ -5,10 +5,15 @@ order: 9.3
 external_redirect: /api/#cancel-monitor-downtime
 ---
 
-##### Signature
+**Signature**:
+
 `DELETE https://api.datadoghq.com/api/v1/downtime/:downtime_id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-monitor-cancel-downtime" >}}
-##### Example Response
+
+**Example Response**:
+
 *This end point does not return JSON on successful requests.*
 

--- a/content/api/downtimes/downtimes_cancel_code.md
+++ b/content/api/downtimes/downtimes_cancel_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#cancel-monitor-downtime
 
 **Signature**:
 
-`DELETE https://api.datadoghq.com/api/v1/downtime/:downtime_id`
+`DELETE https://api.datadoghq.com/api/v1/downtime/<DOWNTIME_ID>`
 
 **Example Request**:
 

--- a/content/api/downtimes/downtimes_cancel_scope.fr.md
+++ b/content/api/downtimes/downtimes_cancel_scope.fr.md
@@ -6,7 +6,9 @@ external_redirect: /api/#cancel-monitor-downtime-by-scope
 ---
 
 ## Annuler les downtimes de monitor par scope
-##### ARGUMENTS
+
+**ARGUMENTS**:
+
 * **`scope`** [*obligatoire*]:  
     Annule tous les downtimes avec le scope donné, par exemple:
 

--- a/content/api/downtimes/downtimes_cancel_scope.md
+++ b/content/api/downtimes/downtimes_cancel_scope.md
@@ -6,7 +6,9 @@ external_redirect: /api/#cancel-monitor-downtime-by-scope
 ---
 
 ## Cancel Monitor Downtimes By Scope
-##### ARGUMENTS
+
+**ARGUMENTS**:
+
 * **`scope`** [*required*]:  
     Cancel all downtimes with the given scope(s), e.g.:
 

--- a/content/api/downtimes/downtimes_cancel_scope_code.fr.md
+++ b/content/api/downtimes/downtimes_cancel_scope_code.fr.md
@@ -5,10 +5,15 @@ order: 9.4
 external_redirect: /api/#cancel-monitor-downtime-by-scope
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/downtime/cancel/by_scope`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-monitor-cancel-downtime-by-scope" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-monitor-cancel-downtime-by-scope" >}}
 

--- a/content/api/downtimes/downtimes_cancel_scope_code.md
+++ b/content/api/downtimes/downtimes_cancel_scope_code.md
@@ -5,10 +5,15 @@ order: 9.4
 external_redirect: /api/#cancel-monitor-downtime-by-scope
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/downtime/cancel/by_scope`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-monitor-cancel-downtime-by-scope" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-monitor-cancel-downtime-by-scope" >}}
 

--- a/content/api/downtimes/downtimes_get.fr.md
+++ b/content/api/downtimes/downtimes_get.fr.md
@@ -6,7 +6,8 @@ external_redirect: /api/#get-a-monitor-downtime
 ---
 
 ## Récupérer le downtime d'un monitor
-##### ARGUMENTS
+
+**ARGUMENTS**:
 
 Cet endpoint ne prend aucun argument JSON.
 

--- a/content/api/downtimes/downtimes_get.md
+++ b/content/api/downtimes/downtimes_get.md
@@ -6,7 +6,8 @@ external_redirect: /api/#get-a-monitor-downtime
 ---
 
 ## Get a monitor downtime
-##### ARGUMENTS
+
+**ARGUMENTS**:
 
 This end point takes no JSON arguments.
 

--- a/content/api/downtimes/downtimes_get_code.fr.md
+++ b/content/api/downtimes/downtimes_get_code.fr.md
@@ -6,7 +6,7 @@ external_redirect: /api/#get-a-monitor-downtime
 ---
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/downtime/:downtime_id`
+`GET https://api.datadoghq.com/api/v1/downtime/<DOWNTIME_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/downtimes/downtimes_get_code.fr.md
+++ b/content/api/downtimes/downtimes_get_code.fr.md
@@ -4,10 +4,15 @@ type: apicode
 order: 9.5
 external_redirect: /api/#get-a-monitor-downtime
 ---
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/downtime/:downtime_id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-monitor-get-downtime" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-monitor-get-downtime" >}}
 

--- a/content/api/downtimes/downtimes_get_code.md
+++ b/content/api/downtimes/downtimes_get_code.md
@@ -4,10 +4,15 @@ type: apicode
 order: 9.5
 external_redirect: /api/#get-a-monitor-downtime
 ---
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/downtime/:downtime_id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-monitor-get-downtime" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-monitor-get-downtime" >}}
 

--- a/content/api/downtimes/downtimes_get_code.md
+++ b/content/api/downtimes/downtimes_get_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#get-a-monitor-downtime
 ---
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/downtime/:downtime_id`
+`GET https://api.datadoghq.com/api/v1/downtime/<DOWNTIME_ID>`
 
 **Example Request**:
 

--- a/content/api/downtimes/downtimes_getall.fr.md
+++ b/content/api/downtimes/downtimes_getall.fr.md
@@ -6,7 +6,9 @@ external_redirect: /api/#get-all-monitor-downtimes
 ---
 
 ## Récupérer tous les downtimes de monitor
-##### ARGUMENTS
+
+**ARGUMENTS**:
+
 * **`current_only`** [*optionnel*, *défaut* = **False**]:  
     Ne renvoye que les downtimes actifs lorsque la requêtes est faite.
 

--- a/content/api/downtimes/downtimes_getall.md
+++ b/content/api/downtimes/downtimes_getall.md
@@ -6,7 +6,9 @@ external_redirect: /api/#get-all-monitor-downtimes
 ---
 
 ## Get all monitor downtimes
-##### ARGUMENTS
+
+**ARGUMENTS**:
+
 * **`current_only`** [*optional*, *default* = **False**]:  
     Only return downtimes that are activewhen the request is made.
 

--- a/content/api/downtimes/downtimes_getall_code.fr.md
+++ b/content/api/downtimes/downtimes_getall_code.fr.md
@@ -5,10 +5,15 @@ order: 9.6
 external_redirect: /api/#get-all-monitor-downtimes
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/downtime`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-monitor-get-downtimes" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-monitor-get-downtimes" >}}
 

--- a/content/api/downtimes/downtimes_getall_code.md
+++ b/content/api/downtimes/downtimes_getall_code.md
@@ -5,10 +5,15 @@ order: 9.6
 external_redirect: /api/#get-all-monitor-downtimes
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/downtime`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-monitor-get-downtimes" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-monitor-get-downtimes" >}}
 

--- a/content/api/downtimes/downtimes_schedule.fr.md
+++ b/content/api/downtimes/downtimes_schedule.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#schedule-monitor-downtime
 
 ## Planifier le downtime d'un monitor
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 * **`scope`** [*obligatoire*]:  
     Le(s) contexte(s) auquel (auxquels) s'applique le downtime, ex. `host:app2`. Fournissez plusieurs contextes sous la forme d'une liste séparée par des virgules, par ex. `env:dev, env:prod`. Le downtime qui en résulte s'applique aux sources qui correspondent à TOUS les contextes fournies (c'est-à-dire `env: dev` **ET**` env: prod`), PAS à certaines d'entre elles.

--- a/content/api/downtimes/downtimes_schedule.md
+++ b/content/api/downtimes/downtimes_schedule.md
@@ -7,7 +7,7 @@ external_redirect: /api/#schedule-monitor-downtime
 
 ## Schedule monitor downtime
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 * **`scope`** [*required*]:
     The scope(s) to which the downtime applies, e.g. `host:app2`. Provide multiple scopes as a comma-separated list, e.g. `env:dev,env:prod`. The resulting downtime applies to sources that matches ALL provided scopes (i.e. `env:dev` **AND** `env:prod`), NOT any of them.

--- a/content/api/downtimes/downtimes_schedule_code.fr.md
+++ b/content/api/downtimes/downtimes_schedule_code.fr.md
@@ -5,10 +5,15 @@ order: 9.1
 external_redirect: /api/#schedule-monitor-downtime
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/downtime`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-monitor-schedule-downtime" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-monitor-schedule-downtime" >}}
 

--- a/content/api/downtimes/downtimes_schedule_code.md
+++ b/content/api/downtimes/downtimes_schedule_code.md
@@ -5,10 +5,15 @@ order: 9.1
 external_redirect: /api/#schedule-monitor-downtime
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/downtime`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-monitor-schedule-downtime" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-monitor-schedule-downtime" >}}
 

--- a/content/api/downtimes/downtimes_update.fr.md
+++ b/content/api/downtimes/downtimes_update.fr.md
@@ -6,7 +6,8 @@ external_redirect: /api/#update-monitor-downtime
 ---
 
 ## Mettre à jour le temps d'arrêt d'un monitor
-##### ARGUMENTS
+
+**ARGUMENTS**:
 
 * **`id`** [*obligatoire*]:  
     L'id entier du downtime à mettre à jour

--- a/content/api/downtimes/downtimes_update.md
+++ b/content/api/downtimes/downtimes_update.md
@@ -6,7 +6,8 @@ external_redirect: /api/#update-monitor-downtime
 ---
 
 ## Update monitor downtime
-##### ARGUMENTS
+
+**ARGUMENTS**:
 
 * **`id`** [*required*]:
     The integer id of the downtime to be updated

--- a/content/api/downtimes/downtimes_update_code.fr.md
+++ b/content/api/downtimes/downtimes_update_code.fr.md
@@ -5,10 +5,15 @@ order: 9.2
 external_redirect: /api/#update-monitor-downtime
 ---
 
-##### Signature
+**Signature**:
+
 `PUT https://api.datadoghq.com/api/v1/downtime/:downtime_id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-monitor-update-downtime" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-monitor-update-downtime" >}}
 

--- a/content/api/downtimes/downtimes_update_code.fr.md
+++ b/content/api/downtimes/downtimes_update_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#update-monitor-downtime
 
 **Signature**:
 
-`PUT https://api.datadoghq.com/api/v1/downtime/:downtime_id`
+`PUT https://api.datadoghq.com/api/v1/downtime/<DOWNTIME_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/downtimes/downtimes_update_code.md
+++ b/content/api/downtimes/downtimes_update_code.md
@@ -5,10 +5,15 @@ order: 9.2
 external_redirect: /api/#update-monitor-downtime
 ---
 
-##### Signature
+**Signature**:
+
 `PUT https://api.datadoghq.com/api/v1/downtime/:downtime_id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-monitor-update-downtime" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-monitor-update-downtime" >}}
 

--- a/content/api/downtimes/downtimes_update_code.md
+++ b/content/api/downtimes/downtimes_update_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#update-monitor-downtime
 
 **Signature**:
 
-`PUT https://api.datadoghq.com/api/v1/downtime/:downtime_id`
+`PUT https://api.datadoghq.com/api/v1/downtime/<DOWNTIME_ID>`
 
 **Example Request**:
 

--- a/content/api/embeds/embeds_create.fr.md
+++ b/content/api/embeds/embeds_create.fr.md
@@ -9,7 +9,7 @@ external_redirect: /api/#create-embed
 
 Crée un nouveau graphe intégrable.
 
-Retourne: Un JSON composé des mêmes éléments retournés par GET api/v1/graph/embed/:embed_id. En cas d'échec, la valeur de retour est un JSON contenant un message d'erreur {errors: [messages]}.
+Retourne: Un JSON composé des mêmes éléments retournés par GET api/v1/graph/embed/<EMBED_ID>. En cas d'échec, la valeur de retour est un JSON contenant un message d'erreur {errors: [messages]}.
 
 Note: Si un embed existe déjà pour la même requête dans une organisation donnée, l'embed le plus ancien est renvoyé au lieu de créer un nouvel embed.
 

--- a/content/api/embeds/embeds_create.fr.md
+++ b/content/api/embeds/embeds_create.fr.md
@@ -13,7 +13,8 @@ Retourne: Un JSON composé des mêmes éléments retournés par GET api/v1/graph
 
 Note: Si un embed existe déjà pour la même requête dans une organisation donnée, l'embed le plus ancien est renvoyé au lieu de créer un nouvel embed.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`graph_json`** [*obligatoire*]:  
     La définition du graphique en JSON. Même format que celui disponible dans l'onglet JSON de l'éditeur de graphique dans Datadog.
 * **`timeframe`** [*optionnel*, *défaut*=**1_hour**]:  

--- a/content/api/embeds/embeds_create.md
+++ b/content/api/embeds/embeds_create.md
@@ -9,7 +9,7 @@ external_redirect: /api/#create-embed
 
 Creates a new embeddable graph.
 
-Returns: A JSON consisting of the same elements returned by GET api/v1/graph/embed/:embed_id. On failure, the return value is a JSON containing an error message {errors: [messages]}.
+Returns: A JSON consisting of the same elements returned by GET api/v1/graph/embed/<EMBED_ID>. On failure, the return value is a JSON containing an error message {errors: [messages]}.
 
 Note: If an embed already exists for the exact same query in a given organization, the older embed is returned instead of creating a new embed.
 

--- a/content/api/embeds/embeds_create.md
+++ b/content/api/embeds/embeds_create.md
@@ -13,7 +13,8 @@ Returns: A JSON consisting of the same elements returned by GET api/v1/graph/emb
 
 Note: If an embed already exists for the exact same query in a given organization, the older embed is returned instead of creating a new embed.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`graph_json`** [*required*]:  
     The graph definition in JSON. Same format that is available on the JSON tab of the graph editor
 * **`timeframe`** [*optional*, *default*=**1_hour**]:  

--- a/content/api/embeds/embeds_create_code.fr.md
+++ b/content/api/embeds/embeds_create_code.fr.md
@@ -5,9 +5,14 @@ order: 10.2
 external_redirect: /api/#create-embed
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/graph/embed`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-embeds-create" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-embeds-create" >}}

--- a/content/api/embeds/embeds_create_code.md
+++ b/content/api/embeds/embeds_create_code.md
@@ -5,9 +5,14 @@ order: 10.2
 external_redirect: /api/#create-embed
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/graph/embed`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-embeds-create" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-embeds-create" >}}

--- a/content/api/embeds/embeds_enable.fr.md
+++ b/content/api/embeds/embeds_enable.fr.md
@@ -10,6 +10,6 @@ Activer un embed spécifié.
 
 Renvoie: Un JSON contenant le message de réussite {success: [message]}. En cas d'échec, la valeur de retour est un JSON contenant un message d'erreur {errors: [messages]}.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 Cet endpoint ne prend aucun argument JSON.

--- a/content/api/embeds/embeds_enable.md
+++ b/content/api/embeds/embeds_enable.md
@@ -10,6 +10,6 @@ Enable a specified embed.
 
 Returns: A JSON containing the success message {success: [message]}. On failure, the return value is a JSON containing an error message {errors: [messages]}.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 This end point takes no JSON arguments.

--- a/content/api/embeds/embeds_enable_code.fr.md
+++ b/content/api/embeds/embeds_enable_code.fr.md
@@ -5,9 +5,14 @@ order: 10.4
 external_redirect: /api/#enable-embed
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/graph/embed/:embed_id/enable`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-embeds-enable" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-embeds-enable" >}}

--- a/content/api/embeds/embeds_enable_code.fr.md
+++ b/content/api/embeds/embeds_enable_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#enable-embed
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/graph/embed/:embed_id/enable`
+`GET https://api.datadoghq.com/api/v1/graph/embed/<EMBED_ID>/enable`
 
 **Exemple de requête**:
 

--- a/content/api/embeds/embeds_enable_code.md
+++ b/content/api/embeds/embeds_enable_code.md
@@ -5,9 +5,14 @@ order: 10.4
 external_redirect: /api/#enable-embed
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/graph/embed/:embed_id/enable`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-embeds-enable" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-embeds-enable" >}}

--- a/content/api/embeds/embeds_enable_code.md
+++ b/content/api/embeds/embeds_enable_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#enable-embed
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/graph/embed/:embed_id/enable`
+`GET https://api.datadoghq.com/api/v1/graph/embed/<EMBED_ID>/enable`
 
 **Example Request**:
 

--- a/content/api/embeds/embeds_get.fr.md
+++ b/content/api/embeds/embeds_get.fr.md
@@ -20,7 +20,8 @@ Réponse: Un objet JSON avec 8 éléments:
 
 En cas d'échec, la valeur de retour est un JSON contenant un message d'erreur {errors: [messages]}.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`size`** [*optionnel*, *défaut*=**medium**]:  
   La taille du graphique, doit être parmis:
     * **small**, 

--- a/content/api/embeds/embeds_get.md
+++ b/content/api/embeds/embeds_get.md
@@ -20,7 +20,8 @@ Returns: A JSON object with 8 elements:
 
 On failure, the return value is a JSON containing an error message {errors: [messages]}.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`size`** [*optional*, *default*=**medium**]:  
     The size of the graph. Must be one:
     * **small**, 

--- a/content/api/embeds/embeds_get_code.fr.md
+++ b/content/api/embeds/embeds_get_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#get-specific-embed
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/graph/embed/:embed_id`
+`GET https://api.datadoghq.com/api/v1/graph/embed/<EMBED_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/embeds/embeds_get_code.fr.md
+++ b/content/api/embeds/embeds_get_code.fr.md
@@ -5,9 +5,14 @@ order: 10.3
 external_redirect: /api/#get-specific-embed
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/graph/embed/:embed_id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-embeds-get" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-embeds-get" >}}

--- a/content/api/embeds/embeds_get_code.md
+++ b/content/api/embeds/embeds_get_code.md
@@ -5,9 +5,14 @@ order: 10.3
 external_redirect: /api/#get-specific-embed
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/graph/embed/:embed_id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-embeds-get" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-embeds-get" >}}

--- a/content/api/embeds/embeds_get_code.md
+++ b/content/api/embeds/embeds_get_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#get-specific-embed
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/graph/embed/:embed_id`
+`GET https://api.datadoghq.com/api/v1/graph/embed/<EMBED_ID>`
 
 **Example Request**:
 

--- a/content/api/embeds/embeds_getall.fr.md
+++ b/content/api/embeds/embeds_getall.fr.md
@@ -8,7 +8,7 @@ external_redirect: /api/#get-all-embeds
 ## Récupérer tous les embeds
 Obtient une liste de graphiques embeddable précédemment créés.
 
-Renvoie: Une liste JSON contenant des informations sur les embeds créés précédemment à la fois à partir de l'interface utilisateur et de l'API. Chaque réponse de graphique JSON est dans le même format que celui renvoyé par GET api/v1/graph/embed/:embed_id.
+Renvoie: Une liste JSON contenant des informations sur les embeds créés précédemment à la fois à partir de l'interface utilisateur et de l'API. Chaque réponse de graphique JSON est dans le même format que celui renvoyé par GET api/v1/graph/embed/<EMBED_ID>.
 
 **ARGUMENTS**:
 

--- a/content/api/embeds/embeds_getall.fr.md
+++ b/content/api/embeds/embeds_getall.fr.md
@@ -10,6 +10,6 @@ Obtient une liste de graphiques embeddable précédemment créés.
 
 Renvoie: Une liste JSON contenant des informations sur les embeds créés précédemment à la fois à partir de l'interface utilisateur et de l'API. Chaque réponse de graphique JSON est dans le même format que celui renvoyé par GET api/v1/graph/embed/:embed_id.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 Cet endpoint ne prend aucun argument JSON.

--- a/content/api/embeds/embeds_getall.md
+++ b/content/api/embeds/embeds_getall.md
@@ -10,6 +10,6 @@ Gets a list of previously created embeddable graphs.
 
 Returns: A JSON list containing information on previously created embeds from both the UI and the API. Each JSON graph response is in the same format as returned by GET api/v1/graph/embed/:embed_id.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 This end point takes no JSON arguments.

--- a/content/api/embeds/embeds_getall.md
+++ b/content/api/embeds/embeds_getall.md
@@ -8,7 +8,7 @@ external_redirect: /api/#get-all-embeds
 ## Get all embeds
 Gets a list of previously created embeddable graphs.
 
-Returns: A JSON list containing information on previously created embeds from both the UI and the API. Each JSON graph response is in the same format as returned by GET api/v1/graph/embed/:embed_id.
+Returns: A JSON list containing information on previously created embeds from both the UI and the API. Each JSON graph response is in the same format as returned by GET api/v1/graph/embed/<EMBED_ID>.
 
 **ARGUMENTS**:
 

--- a/content/api/embeds/embeds_getall_code.fr.md
+++ b/content/api/embeds/embeds_getall_code.fr.md
@@ -5,9 +5,14 @@ order: 10.1
 external_redirect: /api/#get-all-embeds
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/graph/embed`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-embeds-get-all" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-embeds-get-all" >}}

--- a/content/api/embeds/embeds_getall_code.md
+++ b/content/api/embeds/embeds_getall_code.md
@@ -5,9 +5,14 @@ order: 10.1
 external_redirect: /api/#get-all-embeds
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/graph/embed`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-embeds-get-all" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-embeds-get-all" >}}

--- a/content/api/embeds/embeds_revoke.fr.md
+++ b/content/api/embeds/embeds_revoke.fr.md
@@ -10,6 +10,6 @@ Révoquer un embed spécifié.
 
 Renvoie: Un JSON contenant le message de réussite {success: [message]}. En cas d'échec, la valeur de retour est un JSON contenant un message d'erreur {errors: [messages]}.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 Cet endpoint ne prend aucun argument JSON.

--- a/content/api/embeds/embeds_revoke.md
+++ b/content/api/embeds/embeds_revoke.md
@@ -10,6 +10,6 @@ Revoke a specified embed.
 
 Returns: A JSON containing the success message {success: [message]}. On failure, the return value is a JSON containing an error message {errors: [messages]}.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 This end point takes no JSON arguments.

--- a/content/api/embeds/embeds_revoke_code.fr.md
+++ b/content/api/embeds/embeds_revoke_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#revoke-embed
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/graph/embed/:embed_id/revoke`
+`GET https://api.datadoghq.com/api/v1/graph/embed/<EMBED_ID>/revoke`
 
 **Exemple de requête**:
 

--- a/content/api/embeds/embeds_revoke_code.fr.md
+++ b/content/api/embeds/embeds_revoke_code.fr.md
@@ -5,9 +5,14 @@ order: 10.5
 external_redirect: /api/#revoke-embed
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/graph/embed/:embed_id/revoke`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-embeds-revoke" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-embeds-revoke" >}}

--- a/content/api/embeds/embeds_revoke_code.md
+++ b/content/api/embeds/embeds_revoke_code.md
@@ -5,9 +5,14 @@ order: 10.5
 external_redirect: /api/#revoke-embed
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/graph/embed/:embed_id/revoke`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-embeds-revoke" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-embeds-revoke" >}}

--- a/content/api/embeds/embeds_revoke_code.md
+++ b/content/api/embeds/embeds_revoke_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#revoke-embed
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/graph/embed/:embed_id/revoke`
+`GET https://api.datadoghq.com/api/v1/graph/embed/<EMBED_ID>/revoke`
 
 **Example Request**:
 

--- a/content/api/errors/code_snippets/api-error.json
+++ b/content/api/errors/code_snippets/api-error.json
@@ -1,5 +1,5 @@
-{ 'errors': [
-    'Something bad happened to the server.',
-    'Your query made the server very sad.'
+{ "errors": [
+    "Something bad happened to the server.",
+    "Your query made the server very sad."
   ]
 }

--- a/content/api/errors/code_snippets/api-warning.json
+++ b/content/api/errors/code_snippets/api-warning.json
@@ -1,6 +1,6 @@
-{ 'some_thing': ...,
-  'some_other_thing': ...,
-  'warnings': [
-      'This is a deprecated API.'
+{ "some_thing": "...",
+  "some_other_thing": "...",
+  "warnings": [
+      "This is a deprecated API."
   ]
 }

--- a/content/api/errors/errors_code.fr.md
+++ b/content/api/errors/errors_code.fr.md
@@ -4,7 +4,7 @@ type: apicode
 order: 3
 external_redirect: /api/#success-and-errors
 ---
-##### Code d'état
+**Code d'état**:
 
 * `200 200`
 * `201 Created`
@@ -26,7 +26,10 @@ external_redirect: /api/#success-and-errors
 * `OK 201`
 * `Unauthorized 403`
 
-##### Exemple de réponse de type Error
+**Exemple de réponse de type Error**:
+
 {{< code-snippets basename="api-error" static="true" >}}
-##### Exemple de réponse de type Warning</h5>
+
+**Exemple de réponse de type Warning**:
+
 {{< code-snippets basename="api-warning" static="true" >}}

--- a/content/api/errors/errors_code.md
+++ b/content/api/errors/errors_code.md
@@ -4,7 +4,7 @@ type: apicode
 order: 3
 external_redirect: /api/#success-and-errors
 ---
-##### Status Codes
+**Status Codes**:
 
 * `200 200`
 * `201 Created`
@@ -26,7 +26,10 @@ external_redirect: /api/#success-and-errors
 * `OK 201`
 * `Unauthorized 403`
 
-##### Example Error Response
+**Example Error Response**
+
 {{< code-snippets basename="api-error" static="true" >}}
-##### Example Warning Response</h5>
+
+**Example Warning Response**:
+
 {{< code-snippets basename="api-warning" static="true" >}}

--- a/content/api/events/events_delete.fr.md
+++ b/content/api/events/events_delete.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#delete-an-event
 ## Supprimer un événement
 Cet endpoint vous permet de supprimer un événement.
 
-#### ARGUMENTS
+**ARGUMENTS**:
 
 Cet endpoint ne prend aucun argument JSON.
 

--- a/content/api/events/events_delete.md
+++ b/content/api/events/events_delete.md
@@ -7,7 +7,7 @@ external_redirect: /api/#delete-an-event
 ## Delete an event
 This end point allows you to delete an event.
 
-#### ARGUMENTS
+**ARGUMENTS**:
 
 This end point takes no JSON arguments.
 

--- a/content/api/events/events_delete_code.fr.md
+++ b/content/api/events/events_delete_code.fr.md
@@ -6,7 +6,7 @@ external_redirect: /api/#delete-an-event
 ---
 **Signature**:
 
-`DELETE https://api.datadoghq.com/api/v1/events/:event_id`
+`DELETE https://api.datadoghq.com/api/v1/events/<EVENT_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/events/events_delete_code.fr.md
+++ b/content/api/events/events_delete_code.fr.md
@@ -4,10 +4,15 @@ type: apicode
 order: 11.3
 external_redirect: /api/#delete-an-event
 ---
-##### Signature
+**Signature**:
+
 `DELETE https://api.datadoghq.com/api/v1/events/:event_id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-events-delete" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-events-delete" >}}
 

--- a/content/api/events/events_delete_code.md
+++ b/content/api/events/events_delete_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#delete-an-event
 ---
 **Signature**:
 
-`DELETE https://api.datadoghq.com/api/v1/events/:event_id`
+`DELETE https://api.datadoghq.com/api/v1/events/<EVENT_ID>`
 
 **Example Request**:
 

--- a/content/api/events/events_delete_code.md
+++ b/content/api/events/events_delete_code.md
@@ -4,10 +4,15 @@ type: apicode
 order: 11.3
 external_redirect: /api/#delete-an-event
 ---
-##### Signature
+**Signature**:
+
 `DELETE https://api.datadoghq.com/api/v1/events/:event_id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-events-delete" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-events-delete" >}}
 

--- a/content/api/events/events_get.fr.md
+++ b/content/api/events/events_get.fr.md
@@ -9,7 +9,7 @@ external_redirect: /api/#get-an-event
 Cet endpoint vous permet d'interroger les détails d'un événement.
 Note: si l'événement que vous interrogez contient des mises en forme de n'importe quel type, vous pouvez voir des caractères tels que%, \, n dans votre réponse.
 
-#### ARGUMENTS
+**ARGUMENTS**:
 
 Cet endpoint ne prend aucun argument JSON.
 

--- a/content/api/events/events_get.md
+++ b/content/api/events/events_get.md
@@ -9,7 +9,7 @@ external_redirect: /api/#get-an-event
 This end point allows you to query for event details.
 Note: if the event you're querying contains markdown formatting of any kind, you may see characters such as %,\,n in your output
 
-#### ARGUMENTS
+**ARGUMENTS**:
 
 This end point takes no JSON arguments.
 

--- a/content/api/events/events_get_code.fr.md
+++ b/content/api/events/events_get_code.fr.md
@@ -5,10 +5,15 @@ order: 11.2
 external_redirect: /api/#get-an-event
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/events/:event_id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-events-get" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-events-get" >}}
 

--- a/content/api/events/events_get_code.fr.md
+++ b/content/api/events/events_get_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#get-an-event
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/events/:event_id`
+`GET https://api.datadoghq.com/api/v1/events/<EVENT_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/events/events_get_code.md
+++ b/content/api/events/events_get_code.md
@@ -5,10 +5,15 @@ order: 11.2
 external_redirect: /api/#get-an-event
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/events/:event_id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-events-get" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-events-get" >}}
 

--- a/content/api/events/events_get_code.md
+++ b/content/api/events/events_get_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#get-an-event
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/events/:event_id`
+`GET https://api.datadoghq.com/api/v1/events/<EVENT_ID>`
 
 **Example Request**:
 

--- a/content/api/events/events_post.fr.md
+++ b/content/api/events/events_post.fr.md
@@ -8,7 +8,8 @@ external_redirect: /api/#post-an-event
 ## Envoyer un événement
 Ce endpoint vous permet de publier des événements dans le flux d'événement dans Datadog. Taggez-les, définissez la priorité et comment les regrouper avec d'autres événements.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`title`** [*obligatoire*]:  
     Le titre de l'événement *Limité à 100 caractères.*
     Utilisez `msg_title` avec [La bibliothèque Datadog Ruby][1].

--- a/content/api/events/events_post.md
+++ b/content/api/events/events_post.md
@@ -8,7 +8,8 @@ external_redirect: /api/#post-an-event
 ## Post an event
 This end point allows you to post events to the stream. Tag them, set priority and event aggregate them with other events.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`title`** [*required*]:  
     The event title. *Limited to 100 characters.*  
     Use `msg_title` with [the Datadog Ruby library][1].

--- a/content/api/events/events_post_code.fr.md
+++ b/content/api/events/events_post_code.fr.md
@@ -5,10 +5,15 @@ order: 11.1
 external_redirect: /api/#post-an-event
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/events`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-events-post" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-events-post" >}}
 

--- a/content/api/events/events_post_code.md
+++ b/content/api/events/events_post_code.md
@@ -5,10 +5,15 @@ order: 11.1
 external_redirect: /api/#post-an-event
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/events`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-events-post" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-events-post" >}}
 

--- a/content/api/events/events_query.fr.md
+++ b/content/api/events/events_query.fr.md
@@ -9,7 +9,8 @@ external_redirect: /api/#query-the-event-stream
 Le [flux d'événements][1] peut être interrogé et filtré par heure, priorité, sources et tags.
 Remarque: si l'événement que vous interrogez contient des mises en forme de n'importe quel type, vous pouvez voir des caractères tels que%, \,n dans votre résultat.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`start`** [*obligatoire*]:  
     POSIX timestamp.
 * **`end`** [*obligatoire*]:  

--- a/content/api/events/events_query.md
+++ b/content/api/events/events_query.md
@@ -9,7 +9,8 @@ external_redirect: /api/#query-the-event-stream
 The [event stream][1] can be queried and filtered by time, priority, sources and tags.
 Note: if the event you're querying contains markdown formatting of any kind, you may see characters such as %,\,n in your output
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`start`** [*required*]:  
     POSIX timestamp.
 * **`end`** [*required*]:  

--- a/content/api/events/events_query_code.fr.md
+++ b/content/api/events/events_query_code.fr.md
@@ -5,10 +5,15 @@ order: 11.4
 external_redirect: /api/#query-the-event-stream
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/events`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-events-stream" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-events-stream" >}}
 

--- a/content/api/events/events_query_code.md
+++ b/content/api/events/events_query_code.md
@@ -5,10 +5,15 @@ order: 11.4
 external_redirect: /api/#query-the-event-stream
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/events`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-events-stream" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-events-stream" >}}
 

--- a/content/api/graphs/graphs_snapshot.fr.md
+++ b/content/api/graphs/graphs_snapshot.fr.md
@@ -9,7 +9,7 @@ external_redirect: /api/#graph-snapshot
 
 **Note**: Quand un snapshot est créé, [il y a du retard][1] avant sa disponibilité.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 * **`metric_query`** [*obligatoire*]:  
     La requête de la métrique.

--- a/content/api/graphs/graphs_snapshot.md
+++ b/content/api/graphs/graphs_snapshot.md
@@ -9,7 +9,7 @@ external_redirect: /api/#graph-snapshot
 
 **Note**: When a snapshot is created, [there is some delay][1] before it is available.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 * **`metric_query`** [*required*]:  
     The metric query.

--- a/content/api/graphs/graphs_snapshot_code.fr.md
+++ b/content/api/graphs/graphs_snapshot_code.fr.md
@@ -5,10 +5,15 @@ order: 12.1
 external_redirect: /api/#graph-snapshot
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/graph/snapshot`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-graph-snapshot" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-graph-snapshot" >}}
 

--- a/content/api/graphs/graphs_snapshot_code.md
+++ b/content/api/graphs/graphs_snapshot_code.md
@@ -5,10 +5,15 @@ order: 12.1
 external_redirect: /api/#graph-snapshot
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/graph/snapshot`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-graph-snapshot" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-graph-snapshot" >}}
 

--- a/content/api/hosts/hosts_mute.fr.md
+++ b/content/api/hosts/hosts_mute.fr.md
@@ -6,7 +6,8 @@ external_redirect: /api/#mute-a-host
 ---
 
 ## Mettre en sourdine un serveur
-##### ARGUMENTS
+
+**ARGUMENTS**:
 
 * **`end`** [*optionnel*, *défaut*=**None**]:  
     Timestamp POSIX lorsque l'hôte est désactivé. S'il est omis, l'hôte reste muet jusqu'à ce qu'il soit explicitement désactivé.

--- a/content/api/hosts/hosts_mute.md
+++ b/content/api/hosts/hosts_mute.md
@@ -6,7 +6,8 @@ external_redirect: /api/#mute-a-host
 ---
 
 ## Mute a host
-##### ARGUMENTS
+
+**ARGUMENTS**:
 
 * **`end`** [*optional*, *default*=**None**]:
     POSIX timestamp when the host is unmuted. If omitted, the host remains muted until explicitly unmuted.

--- a/content/api/hosts/hosts_mute_code.fr.md
+++ b/content/api/hosts/hosts_mute_code.fr.md
@@ -5,9 +5,14 @@ order: 13.3
 external_redirect: /api/#mute-a-host
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/host/:hostname/mute`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-host-mute" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-host-mute" >}}

--- a/content/api/hosts/hosts_mute_code.fr.md
+++ b/content/api/hosts/hosts_mute_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#mute-a-host
 
 **Signature**:
 
-`POST https://api.datadoghq.com/api/v1/host/:hostname/mute`
+`POST https://api.datadoghq.com/api/v1/host/<HOSTNAME>/mute`
 
 **Exemple de requête**:
 

--- a/content/api/hosts/hosts_mute_code.md
+++ b/content/api/hosts/hosts_mute_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#mute-a-host
 
 **Signature**:
 
-`POST https://api.datadoghq.com/api/v1/host/:hostname/mute`
+`POST https://api.datadoghq.com/api/v1/host/<HOSTNAME>/mute`
 
 **Example Request**:
 

--- a/content/api/hosts/hosts_mute_code.md
+++ b/content/api/hosts/hosts_mute_code.md
@@ -5,9 +5,14 @@ order: 13.3
 external_redirect: /api/#mute-a-host
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/host/:hostname/mute`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-host-mute" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-host-mute" >}}

--- a/content/api/hosts/hosts_search.fr.md
+++ b/content/api/hosts/hosts_search.fr.md
@@ -8,7 +8,7 @@ external_redirect: /api/#search-hosts
 ## Search hosts
 Cet endpoit permet de rechercher les hôtes par nom, alias ou tag. Les hôtes actifs au cours des 3 dernières heures sont inclus. Les résultats sont paginés avec un maximum de 100 résultats à chaque fois.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 * **`filter`** [*optionnel*, *défaut*=**None**]:  
     Texte de requête pour filtrer les résultats de la recherche.

--- a/content/api/hosts/hosts_search.md
+++ b/content/api/hosts/hosts_search.md
@@ -8,7 +8,7 @@ external_redirect: /api/#search-hosts
 ## Search hosts
 This endpoint allows searching for hosts by name, alias, or tag. Hosts live within the past 3 hours are included. Results are paginated with a max of 100 results at a time.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 * **`filter`** [*optional*, *default*=**None**]:
     Query string to filter search results.

--- a/content/api/hosts/hosts_search_code.fr.md
+++ b/content/api/hosts/hosts_search_code.fr.md
@@ -5,9 +5,14 @@ order: 13.1
 external_redirect: /api/#search-hosts
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/hosts`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-hosts-search" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-hosts-search" >}}

--- a/content/api/hosts/hosts_search_code.md
+++ b/content/api/hosts/hosts_search_code.md
@@ -5,9 +5,14 @@ order: 13.1
 external_redirect: /api/#search-hosts
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/hosts`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-hosts-search" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-hosts-search" >}}

--- a/content/api/hosts/hosts_totals.md
+++ b/content/api/hosts/hosts_totals.md
@@ -8,6 +8,6 @@ external_redirect: /api/#host-totals
 ## Host totals
 This endpoint returns the total number of active and up hosts in your Datadog account. Active means the host has reported in the past hour, and up means it has reported in the past two hours.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 This end point takes no JSON arguments.

--- a/content/api/hosts/hosts_totals_code.fr.md
+++ b/content/api/hosts/hosts_totals_code.fr.md
@@ -5,9 +5,14 @@ order: 13.2
 external_redirect: /api/#host-totals
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/hosts/totals`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-hosts-totals" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-hosts-totals" >}}

--- a/content/api/hosts/hosts_totals_code.md
+++ b/content/api/hosts/hosts_totals_code.md
@@ -5,9 +5,14 @@ order: 13.2
 external_redirect: /api/#host-totals
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/hosts/totals`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-hosts-totals" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-hosts-totals" >}}

--- a/content/api/hosts/hosts_unmute.fr.md
+++ b/content/api/hosts/hosts_unmute.fr.md
@@ -6,6 +6,7 @@ external_redirect: /api/#unmute-a-host
 ---
 
 ## Activer un hôte
-##### ARGUMENTS
+
+**ARGUMENTS**:
 
 Cet endpoint ne prend aucun argument JSON.

--- a/content/api/hosts/hosts_unmute.md
+++ b/content/api/hosts/hosts_unmute.md
@@ -6,6 +6,7 @@ external_redirect: /api/#unmute-a-host
 ---
 
 ## Unmute a host
-##### ARGUMENTS
+
+**ARGUMENTS**:
 
 This end point takes no JSON arguments.

--- a/content/api/hosts/hosts_unmute_code.fr.md
+++ b/content/api/hosts/hosts_unmute_code.fr.md
@@ -5,9 +5,14 @@ order: 13.4
 external_redirect: /api/#unmute-a-host
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/host/:hostname/unmute`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-host-unmute" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-host-unmute" >}}

--- a/content/api/hosts/hosts_unmute_code.fr.md
+++ b/content/api/hosts/hosts_unmute_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#unmute-a-host
 
 **Signature**:
 
-`POST https://api.datadoghq.com/api/v1/host/:hostname/unmute`
+`POST https://api.datadoghq.com/api/v1/host/<HOSTNAME>/unmute`
 
 **Exemple de requête**:
 

--- a/content/api/hosts/hosts_unmute_code.md
+++ b/content/api/hosts/hosts_unmute_code.md
@@ -5,9 +5,14 @@ order: 13.4
 external_redirect: /api/#unmute-a-host
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/host/:hostname/unmute`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-host-unmute" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-host-unmute" >}}

--- a/content/api/hosts/hosts_unmute_code.md
+++ b/content/api/hosts/hosts_unmute_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#unmute-a-host
 
 **Signature**:
 
-`POST https://api.datadoghq.com/api/v1/host/:hostname/unmute`
+`POST https://api.datadoghq.com/api/v1/host/<HOSTNAME>/unmute`
 
 **Example Request**:
 

--- a/content/api/integrations/aws.fr.md
+++ b/content/api/integrations/aws.fr.md
@@ -10,7 +10,7 @@ external_redirect: /api/#aws
 Configurer votre intégration Datadog-AWS directement via l'API Datadog.  
 [En apprendre plus sur l'intégration Datadog-AWS][1]
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 * **`account_id`** [*obligatoire*]:  
     Votre identifiant de compte AWS sans tirets.

--- a/content/api/integrations/aws.md
+++ b/content/api/integrations/aws.md
@@ -10,7 +10,7 @@ external_redirect: /api/#aws
 Configure your Datadog-AWS integration directly through Datadog API.  
 [Read more about Datadog-AWS integration][1]
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 * **`account_id`** [*required*]:  
     Your AWS Account ID without dashes.  

--- a/content/api/integrations/aws_code.fr.md
+++ b/content/api/integrations/aws_code.fr.md
@@ -5,12 +5,15 @@ order: 14.1
 external_redirect: /api/#aws
 ---
 
-##### Signature
+**Signature**:
+
 `https://api.datadoghq.com/api/v1/integration/aws`
 
-##### Exemple de requête
+**Exemple de requête**:
+
 {{< code-snippets basename="api-integrations-aws" >}}
 
-##### Exemple de réponse
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-integrations-aws" >}}
 

--- a/content/api/integrations/aws_code.md
+++ b/content/api/integrations/aws_code.md
@@ -5,12 +5,15 @@ order: 14.1
 external_redirect: /api/#aws
 ---
 
-##### Signature
+**Signature**:
+
 `https://api.datadoghq.com/api/v1/integration/aws`
 
-##### Example Request
+**Example Request**:
+
 {{< code-snippets basename="api-integrations-aws" >}}
 
-##### Example Response
+**Example Response**:
+
 {{< code-snippets basename="result.api-integrations-aws" >}}
 

--- a/content/api/integrations/pagerduty.md
+++ b/content/api/integrations/pagerduty.md
@@ -10,7 +10,7 @@ external_redirect: /api/#pagerduty
 Configure your Datadog-PagerDuty integration directly through Datadog API.  
 [Read more about Datadog-PagerDuty integration][1]
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 * **`services`** [*required*]:    
     Array of PagerDuty service objects. [Learn how to configure you Datadog service with PagerDuty documentation][2]. A PagerDuty service object is composed by:  

--- a/content/api/integrations/pagerduty_code.fr.md
+++ b/content/api/integrations/pagerduty_code.fr.md
@@ -5,11 +5,15 @@ order: 14.2
 external_redirect: /api/#pagerduty
 ---
 
-##### Signature
+**Signature**:
+
 `https://api.datadoghq.com/api/v1/integration/pagerduty`
 
-##### Exemple de requête
+**Exemple de requête**:
+
 {{< code-snippets basename="api-integrations-pagerduty" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-integrations-pagerduty" >}}
 

--- a/content/api/integrations/pagerduty_code.md
+++ b/content/api/integrations/pagerduty_code.md
@@ -5,11 +5,15 @@ order: 14.2
 external_redirect: /api/#pagerduty
 ---
 
-##### Signature
+**Signature**:
+
 `https://api.datadoghq.com/api/v1/integration/pagerduty`
 
-##### Example Request
+**Example Request**:
+
 {{< code-snippets basename="api-integrations-pagerduty" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-integrations-pagerduty" >}}
 

--- a/content/api/integrations/slack.fr.md
+++ b/content/api/integrations/slack.fr.md
@@ -10,7 +10,7 @@ external_redirect: /api/#slack
 Configurer votre intégration Datadog-Slack directement via l'API Datadog.  
 [En apprendre plus sur l'intégration Datadog-Slack][1]
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 * **`service_hooks`** [*obligatoire*]:  
     Tableau d'objets de hook de service (le hook de service est généré pour votre compte dans votre page d'administration Slack). Un objet de hook de service est composé de :
@@ -20,8 +20,6 @@ Configurer votre intégration Datadog-Slack directement via l'API Datadog.
 
     * **`url`** [*obligatoire*]:  
         Votre URL Slack Service Hook.
-
-
 
 * **`channels`** [*obligatoire*]:  
     Tableau d'objets des canaux Slack à publier dedans. Un objet de canal Slack est composé de :

--- a/content/api/integrations/slack.md
+++ b/content/api/integrations/slack.md
@@ -10,7 +10,7 @@ external_redirect: /api/#slack
 Configure your Datadog-Slack integration directly through Datadog API.  
 [Read more about Datadog-Slack integration][1]
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 * **`service_hooks`** [*required*]:  
     Array of service hook objects (the service hook is generated for your slack account in your Slack account administration page). A service hook object is composed by:

--- a/content/api/integrations/slack_code.fr.md
+++ b/content/api/integrations/slack_code.fr.md
@@ -5,11 +5,15 @@ order: 14.3
 external_redirect: /api/#slack
 ---
 
-##### Signature
+**Signature**:
+
 `https://api.datadoghq.com/api/v1/integration/slack`
 
-##### Exemple de requête
+**Exemple de requête**:
+
 {{< code-snippets basename="api-integrations-slack" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-integrations-slack" >}}
 

--- a/content/api/integrations/slack_code.md
+++ b/content/api/integrations/slack_code.md
@@ -5,11 +5,15 @@ order: 14.3
 external_redirect: /api/#slack
 ---
 
-##### Signature
+**Signature**:
+
 `https://api.datadoghq.com/api/v1/integration/slack`
 
-##### Example Request
+**Example Request**:
+
 {{< code-snippets basename="api-integrations-slack" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-integrations-slack" >}}
 

--- a/content/api/integrations/webhooks.md
+++ b/content/api/integrations/webhooks.md
@@ -10,7 +10,7 @@ external_redirect: /api/#webhooks
 Configure your Datadog-Webhooks integration directly through Datadog API.  
 [Read more about Datadog-Webhooks integration][1]
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 * **`hooks`** [*required*]:  
     Array of Webhook objects. A Webhook object is composed by:

--- a/content/api/integrations/webhooks_code.fr.md
+++ b/content/api/integrations/webhooks_code.fr.md
@@ -5,12 +5,15 @@ order: 14.4
 external_redirect: /api/#webhooks
 ---
 
-##### Signature
+**Signature**:
+
 `https://api.datadoghq.com/api/v1/integration/webhooks`
 
-##### Exemple de requête
+**Exemple de requête**:
+
 {{< code-snippets basename="api-integrations-webhooks" >}}
 
-##### Exemple de réponse
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-integrations-webhooks" >}}
 

--- a/content/api/integrations/webhooks_code.md
+++ b/content/api/integrations/webhooks_code.md
@@ -5,12 +5,15 @@ order: 14.4
 external_redirect: /api/#webhooks
 ---
 
-##### Signature
+**Signature**:
+
 `https://api.datadoghq.com/api/v1/integration/webhooks`
 
-##### Example Request
+**Example Request**:
+
 {{< code-snippets basename="api-integrations-webhooks" >}}
 
-##### Example Response
+**Example Response**:
+
 {{< code-snippets basename="result.api-integrations-webhooks" >}}
 

--- a/content/api/metrics/metrics_editmetadata.fr.md
+++ b/content/api/metrics/metrics_editmetadata.fr.md
@@ -9,7 +9,7 @@ external_redirect: /api/#edit-metric-metadata
 L'endpoint des métadonnées des métriques vous permet de modifier les métadonnées sur une métrique spécifique.
 [En apprendre plus sur les différents types supportés][1]
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 * **`type`** [*obligatoire*]:  
     [Type de la métrique][1] tel **gauge** ou **rate**

--- a/content/api/metrics/metrics_editmetadata.md
+++ b/content/api/metrics/metrics_editmetadata.md
@@ -9,7 +9,7 @@ external_redirect: /api/#edit-metric-metadata
 The metrics metadata endpoint allows you to edit fields of a metric's metadata.
 [Find more about supported types][1]
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 * **`type`** [*required*]:  
     [Metric type][1] such as **gauge** or **rate**

--- a/content/api/metrics/metrics_editmetadata_code.fr.md
+++ b/content/api/metrics/metrics_editmetadata_code.fr.md
@@ -6,7 +6,7 @@ external_redirect: /api/#edit-metric-metadata
 ---
 **Signature**:
 
-`PUT https://api.datadoghq.com/api/v1/metrics/:metric_name`
+`PUT https://api.datadoghq.com/api/v1/metrics/<METRIC_NAME>`
 
 **Exemple de requête**:
 

--- a/content/api/metrics/metrics_editmetadata_code.fr.md
+++ b/content/api/metrics/metrics_editmetadata_code.fr.md
@@ -4,10 +4,15 @@ type: apicode
 order: 15.5
 external_redirect: /api/#edit-metric-metadata
 ---
-##### Signature
+**Signature**:
+
 `PUT https://api.datadoghq.com/api/v1/metrics/:metric_name`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-metric-metadata-update" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-metric-metadata-update" >}}
 

--- a/content/api/metrics/metrics_editmetadata_code.md
+++ b/content/api/metrics/metrics_editmetadata_code.md
@@ -4,10 +4,15 @@ type: apicode
 order: 15.5
 external_redirect: /api/#edit-metric-metadata
 ---
-##### Signature
+**Signature**:
+
 `PUT https://api.datadoghq.com/api/v1/metrics/:metric_name`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-metric-metadata-update" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-metric-metadata-update" >}}
 

--- a/content/api/metrics/metrics_editmetadata_code.md
+++ b/content/api/metrics/metrics_editmetadata_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#edit-metric-metadata
 ---
 **Signature**:
 
-`PUT https://api.datadoghq.com/api/v1/metrics/:metric_name`
+`PUT https://api.datadoghq.com/api/v1/metrics/<METRIC_NAME>`
 
 **Example Request**:
 

--- a/content/api/metrics/metrics_list.fr.md
+++ b/content/api/metrics/metrics_list.fr.md
@@ -8,7 +8,8 @@ external_redirect: /api/#get-list-of-active-metrics
 ## Récupérer la liste des métriques actives
 Obtenez la liste des métriques de reporting actives d'un instant donné jusqu'à maintenant. Cet endpoint n'est pas disponible dans les bibliothèques Python et Ruby.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`from`** [*obligatoire*]:  
     Secondes depuis EPOCH unix
 

--- a/content/api/metrics/metrics_list.md
+++ b/content/api/metrics/metrics_list.md
@@ -8,7 +8,8 @@ external_redirect: /api/#get-list-of-active-metrics
 ## Get list of active metrics
 Get the list of actively reporting metrics from a given time until now. This endpoint is not available in the Python and Ruby libraries.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`from`** [*required*]:  
     Seconds since the unix epoch
 

--- a/content/api/metrics/metrics_list_code.fr.md
+++ b/content/api/metrics/metrics_list_code.fr.md
@@ -5,10 +5,15 @@ order: 15.1
 external_redirect: /api/#get-list-of-active-metrics
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/metrics`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-metrics-list" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-metrics-list" >}}
 

--- a/content/api/metrics/metrics_list_code.md
+++ b/content/api/metrics/metrics_list_code.md
@@ -5,10 +5,15 @@ order: 15.1
 external_redirect: /api/#get-list-of-active-metrics
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/metrics`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-metrics-list" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-metrics-list" >}}
 

--- a/content/api/metrics/metrics_querytime.fr.md
+++ b/content/api/metrics/metrics_querytime.fr.md
@@ -8,7 +8,8 @@ external_redirect: /api/#query-time-series-points
 ## Requêter les points de séries temporelles
 Cet endpoint vous permet de requêter des métriques de n'importe quelle période.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`from`** [*obligatoire*]:  
     Secondes depuis EPOCH unix
 * **`to`** [*obligatoire*]:  

--- a/content/api/metrics/metrics_querytime.md
+++ b/content/api/metrics/metrics_querytime.md
@@ -10,7 +10,8 @@ This end point allows you to query for metrics from any time period.
 
 *Note:* In Python, `from` is a reserved word. So instead, the Python API uses the `start` and `end` parameters in the function call.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`from`** [*required except in Python*]:  
     Seconds from the unix epoch 
 * **`to`** [*required except in Python*]:  

--- a/content/api/metrics/metrics_querytime_code.fr.md
+++ b/content/api/metrics/metrics_querytime_code.fr.md
@@ -5,10 +5,15 @@ order: 15.3
 external_redirect: /api/#query-time-series-points
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/query`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-metrics-query" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-metrics-query" >}}
 

--- a/content/api/metrics/metrics_querytime_code.md
+++ b/content/api/metrics/metrics_querytime_code.md
@@ -5,10 +5,15 @@ order: 15.3
 external_redirect: /api/#query-time-series-points
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/query`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-metrics-query" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-metrics-query" >}}
 

--- a/content/api/metrics/metrics_search.md
+++ b/content/api/metrics/metrics_search.md
@@ -8,7 +8,7 @@ external_redirect: /api/#search-metrics
 ## Search metrics
 This end point allows you to search for metrics from the last 24 hours in Datadog.
 
+**ARGUMENTS**:
 
-##### ARGUMENTS
 * `q` [*required*]:
     The query string. Must be prefixed with `metrics:`.

--- a/content/api/metrics/metrics_search_code.fr.md
+++ b/content/api/metrics/metrics_search_code.fr.md
@@ -5,9 +5,14 @@ order: 15.6
 external_redirect: /api/#search-metrics
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/search`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-metrics-search" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-metrics-search" >}}

--- a/content/api/metrics/metrics_search_code.md
+++ b/content/api/metrics/metrics_search_code.md
@@ -5,9 +5,14 @@ order: 15.6
 external_redirect: /api/#search-metrics
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/search`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-metrics-search" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-metrics-search" >}}

--- a/content/api/metrics/metrics_timeseries.md
+++ b/content/api/metrics/metrics_timeseries.md
@@ -8,7 +8,7 @@ external_redirect: /api/#post-time-series-points
 ## Post timeseries points
 The metrics end-point allows you to post time-series data that can be graphed on Datadog's dashboards.
 
-#### ARGUMENTS
+**ARGUMENTS**:
 
 * **`series`** [*required*]:  
     Pass a JSON array where each item in the array contains the following arguments:

--- a/content/api/metrics/metrics_timeseries_code.fr.md
+++ b/content/api/metrics/metrics_timeseries_code.fr.md
@@ -5,8 +5,11 @@ order: 15.2
 external_redirect: /api/#post-time-series-points
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/series`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-metrics-post" >}}
 

--- a/content/api/metrics/metrics_timeseries_code.md
+++ b/content/api/metrics/metrics_timeseries_code.md
@@ -5,8 +5,11 @@ order: 15.2
 external_redirect: /api/#post-time-series-points
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/series`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-metrics-post" >}}
 

--- a/content/api/metrics/metrics_viewmetadata.fr.md
+++ b/content/api/metrics/metrics_viewmetadata.fr.md
@@ -8,7 +8,7 @@ external_redirect: /api/#view-metric-metadata
 
 L'endpoint des métadonnées des métriques vous permet d'obtenir des métadonnées sur une métrique spécifique.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 Cet endpoint ne prend aucun argument JSON.
 

--- a/content/api/metrics/metrics_viewmetadata.md
+++ b/content/api/metrics/metrics_viewmetadata.md
@@ -8,7 +8,7 @@ external_redirect: /api/#view-metric-metadata
 
 The metrics metadata endpoint allows you to get metadata about a specific metric.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 This end point takes no JSON arguments.
 

--- a/content/api/metrics/metrics_viewmetadata_code.fr.md
+++ b/content/api/metrics/metrics_viewmetadata_code.fr.md
@@ -5,10 +5,15 @@ order: 15.4
 external_redirect: /api/#view-metric-metadata
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/metrics/:metric_name`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-metric-metadata-get" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-metric-metadata-get" >}}
 

--- a/content/api/metrics/metrics_viewmetadata_code.fr.md
+++ b/content/api/metrics/metrics_viewmetadata_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#view-metric-metadata
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/metrics/:metric_name`
+`GET https://api.datadoghq.com/api/v1/metrics/<METRIC_NAME>`
 
 **Exemple de requête**:
 

--- a/content/api/metrics/metrics_viewmetadata_code.md
+++ b/content/api/metrics/metrics_viewmetadata_code.md
@@ -5,10 +5,15 @@ order: 15.4
 external_redirect: /api/#view-metric-metadata
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/metrics/:metric_name`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-metric-metadata-get" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-metric-metadata-get" >}}
 

--- a/content/api/metrics/metrics_viewmetadata_code.md
+++ b/content/api/metrics/metrics_viewmetadata_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#view-metric-metadata
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/metrics/:metric_name`
+`GET https://api.datadoghq.com/api/v1/metrics/<METRIC_NAME>`
 
 **Example Request**:
 

--- a/content/api/monitors/code_snippets/api-monitor-bulk-resolve.sh
+++ b/content/api/monitors/code_snippets/api-monitor-bulk-resolve.sh
@@ -5,7 +5,6 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-
 curl -X POST -H "Content-type: application/json" \
 -d '{
 "resolve": [

--- a/content/api/monitors/monitors_create.md
+++ b/content/api/monitors/monitors_create.md
@@ -9,7 +9,8 @@ external_redirect: /api/#create-a-monitor
 
 If you manage and deploy monitors programmatically, it's easier to define the monitor in the Datadog UI and [export its valid JSON][4].
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 *   **`type`** [*required*]:  
     The [type of the monitor][3], chosen from:  
 
@@ -32,7 +33,9 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
     
 *   **`query`** [*required*]:  
     The query defines when the monitor triggers. Query syntax depends on what type of monitor you are creating:  
-    ##### Metric Alert Query
+    
+    **Metric Alert Query**:
+
     `time_aggr(time_window):space_aggr:metric{tags} [by {key}] operator #`
 
     -   `time_aggr`: avg, sum, max, min, change, or pct_change
@@ -52,14 +55,15 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
 
     Use this to create an outlier monitor using the following query: `avg(last_30m):outliers(avg:system.cpu.user{role:es-events-data} by {host}, 'dbscan', 7) > 0`
 
-    ##### Service Check Query
+    **Service Check Query**:
+
     `"check".over(tags).last(count).count_by_status()`
 
     *   **`check`** name of the check, e.g. datadog.agent.up
     *   **`tags`** one or more quoted tags (comma-separated), or "*". e.g.: `.over("env:prod", "role:db")`
     *   **`count`** must be at >= your max threshold (defined in the `options`). e.g. if you want to notify on 1 critical, 3 ok and 2 warn statuses count should be 3.
 
-    ##### Event Alert Query
+    **Event Alert Query**:
 
     `events('sources:nagios status:error,warning priority:normal tags: "string query"').rollup("count").last("1h")"`
 
@@ -74,7 +78,7 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
     *   **`rollup`** the stats rollup method. `count` is the only supported method now.
     *   **`last`** the timeframe to roll up the counts. Examples: 60s, 4h. Supported timeframes: s, m, h and d.
 
-    ##### Process Alert Query
+    **Process Alert Query**:
 
     `processes(search).over(tags).rollup('count').last(timeframe) operator #`
 
@@ -84,7 +88,7 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
     *   **`operator`** <, <=, >, >=, ==, or !=
     *   **`#`** an integer or decimal number used to set the threshold
 
-    ##### Composite Query
+    **Composite Query**:
 
     `12345 && 67890`, where `12345` and `67890` are the IDs of non-composite monitors
 
@@ -97,7 +101,7 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
 
 * **`options`** [*optional*, *default*=**{}**]:  
     A dictionary of options for the monitor. There are options that are common to all types as well as options that are specific to certain monitor types.  
-    ##### Common Options
+    **Common Options**:
 
     *   **`silenced`** dictionary of scopes to timestamps or `None`. Each scope is muted until the given POSIX timestamp or forever if the value is `None`. Default: **None**  
         Examples:
@@ -126,7 +130,8 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
         *   True: `[Triggered on {host:h1}] Monitor Title`
         *   False: `[Triggered] Monitor Title`
 
-    ##### Anomaly Options
+    **Anomaly Options**:
+
     _These options only apply to anomaly monitors and are ignored for other monitor types._
 
     -   **`threshold_windows`** a dictionary containing `recovery_window` and `trigger_window`.
@@ -135,7 +140,7 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
 
             Example: `{'threshold_windows': {'recovery_window': 'last_15m', 'trigger_window': 'last_15m'}}`
 
-    ##### Metric Alert Options
+    **Metric Alert Options**:
     _These options only apply to metric alerts._
 
     -   **`thresholds`** a dictionary of thresholds by threshold type. There are two threshold types for metric alerts: *critical* and *warning*. *Critical* is defined in the query, but can also be specified in this option. *Warning* threshold can only be specified using the thresholds option.
@@ -145,7 +150,8 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
 
     -   **`evaluation_delay`** Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min), the timeframe is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55. This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
 
-    ##### Service Check Options
+    **Service Check Options**:
+
     _These options only apply to service checks and are ignored for other monitor types._
 
     -   **`thresholds`** a dictionary of thresholds by status. Because service checks can have multiple thresholds, we don't define them directly in the query.

--- a/content/api/monitors/monitors_create_code.fr.md
+++ b/content/api/monitors/monitors_create_code.fr.md
@@ -5,10 +5,15 @@ order: 16.1
 external_redirect: /api/#create-a-monitor
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/monitor`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-monitor-create" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-monitor-create" >}}
 

--- a/content/api/monitors/monitors_create_code.md
+++ b/content/api/monitors/monitors_create_code.md
@@ -5,10 +5,15 @@ order: 16.1
 external_redirect: /api/#create-a-monitor
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/monitor`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-monitor-create" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-monitor-create" >}}
 

--- a/content/api/monitors/monitors_delete.fr.md
+++ b/content/api/monitors/monitors_delete.fr.md
@@ -6,7 +6,8 @@ external_redirect: /api/#delete-a-monitor
 ---
 
 ## Supprimer un monitor
-##### ARGUMENTS
+
+**ARGUMENTS**:
 
 Cet endpoint ne prend aucun argument JSON.
 

--- a/content/api/monitors/monitors_delete.md
+++ b/content/api/monitors/monitors_delete.md
@@ -6,7 +6,8 @@ external_redirect: /api/#delete-a-monitor
 ---
 
 ## Delete a monitor
-##### ARGUMENTS
+
+**ARGUMENTS**:
 
 This end point takes no JSON arguments.
 

--- a/content/api/monitors/monitors_delete_code.fr.md
+++ b/content/api/monitors/monitors_delete_code.fr.md
@@ -5,10 +5,15 @@ order: 16.4
 external_redirect: /api/#delete-a-monitor
 ---
 
-##### Signature
+**Signature**:
+
 `DELETE https://api.datadoghq.com/api/v1/monitor/:monitor_id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-monitor-delete" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-monitor-delete" >}}
 

--- a/content/api/monitors/monitors_delete_code.fr.md
+++ b/content/api/monitors/monitors_delete_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#delete-a-monitor
 
 **Signature**:
 
-`DELETE https://api.datadoghq.com/api/v1/monitor/:monitor_id`
+`DELETE https://api.datadoghq.com/api/v1/monitor/<MONITOR_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/monitors/monitors_delete_code.md
+++ b/content/api/monitors/monitors_delete_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#delete-a-monitor
 
 **Signature**:
 
-`DELETE https://api.datadoghq.com/api/v1/monitor/:monitor_id`
+`DELETE https://api.datadoghq.com/api/v1/monitor/<MONITOR_ID>`
 
 **Example Request**:
 

--- a/content/api/monitors/monitors_delete_code.md
+++ b/content/api/monitors/monitors_delete_code.md
@@ -5,10 +5,15 @@ order: 16.4
 external_redirect: /api/#delete-a-monitor
 ---
 
-##### Signature
+**Signature**:
+
 `DELETE https://api.datadoghq.com/api/v1/monitor/:monitor_id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-monitor-delete" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-monitor-delete" >}}
 

--- a/content/api/monitors/monitors_edit.fr.md
+++ b/content/api/monitors/monitors_edit.fr.md
@@ -6,7 +6,9 @@ external_redirect: /api/#edit-a-monitor
 ---
 
 ## Modifier un monitor
-##### ARGUMENTS
+
+**ARGUMENTS**:
+
 * **`query`** [*obligatoire*]:  
   La requête de la métrique que l'on veut monitorer.
 * **`name`** [*obligatoire*]:

--- a/content/api/monitors/monitors_edit.md
+++ b/content/api/monitors/monitors_edit.md
@@ -6,7 +6,9 @@ external_redirect: /api/#edit-a-monitor
 ---
 
 ## Edit A Monitor
-##### ARGUMENTS
+
+**ARGUMENTS**:
+
 * **`query`** [*required*]:  
     The metric query to alert on.
 * **`name`** [*required*]:  

--- a/content/api/monitors/monitors_edit_code.fr.md
+++ b/content/api/monitors/monitors_edit_code.fr.md
@@ -5,10 +5,15 @@ order: 16.3
 external_redirect: /api/#edit-a-monitor
 ---
 
-##### Signature
+**Signature**:
+
 `PUT https://api.datadoghq.com/api/v1/monitor/:monitor_id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-monitor-edit" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-monitor-edit" >}}
 

--- a/content/api/monitors/monitors_edit_code.fr.md
+++ b/content/api/monitors/monitors_edit_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#edit-a-monitor
 
 **Signature**:
 
-`PUT https://api.datadoghq.com/api/v1/monitor/:monitor_id`
+`PUT https://api.datadoghq.com/api/v1/monitor/<MONITOR_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/monitors/monitors_edit_code.md
+++ b/content/api/monitors/monitors_edit_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#edit-a-monitor
 
 **Signature**:
 
-`PUT https://api.datadoghq.com/api/v1/monitor/:monitor_id`
+`PUT https://api.datadoghq.com/api/v1/monitor/<MONITOR_ID>`
 
 **Example Request**:
 

--- a/content/api/monitors/monitors_edit_code.md
+++ b/content/api/monitors/monitors_edit_code.md
@@ -5,10 +5,15 @@ order: 16.3
 external_redirect: /api/#edit-a-monitor
 ---
 
-##### Signature
+**Signature**:
+
 `PUT https://api.datadoghq.com/api/v1/monitor/:monitor_id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-monitor-edit" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-monitor-edit" >}}
 

--- a/content/api/monitors/monitors_get.fr.md
+++ b/content/api/monitors/monitors_get.fr.md
@@ -4,7 +4,9 @@ type: apicontent
 order: 16.2
 ---
 ## Récupère les détails d'un monitor
-##### ARGUMENTS
+
+**ARGUMENTS**:
+
 * **`group_states`** [*optionnel*, *défaut*=**None**]:  
     Si cet argument est défini, les données renvoyées incluent des informations supplémentaires concernant les états des groupes spécifiés, notamment le timestamp de la dernière notification, le timestamp de dernière résolution et les détails sur la dernière fois que le monitor a été déclenché. L'argument doit inclure une liste de string indiquant, le cas échéant, les états de groupe à inclure. Choisissez un ou plusieurs parmis **all**, **alert**, **warn**, or **no data**. Exemple: alert,warn'" 
 

--- a/content/api/monitors/monitors_get.md
+++ b/content/api/monitors/monitors_get.md
@@ -4,7 +4,9 @@ type: apicontent
 order: 16.2
 ---
 ## Get a monitor's details
-##### ARGUMENTS
+
+**ARGUMENTS**:
+
 * **`group_states`** [*optional*, *default*=**None**]:  
     If this argument is set, the returned data includes additional information (if available) regarding the specified group states, including the last notification timestamp, last resolution timestamp and details about the last time the monitor was triggered. The argument should include a string list indicating what, if any, group states to include. Choose one or more from **all**, **alert**, **warn**, or **no data**. Example: 'alert,warn'" 
 

--- a/content/api/monitors/monitors_get_code.fr.md
+++ b/content/api/monitors/monitors_get_code.fr.md
@@ -5,10 +5,15 @@ order: 16.2
 external_redirect: /api/#get-a-monitor-s-details
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/monitor/:monitor_id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-monitor-show" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-monitor-show" >}}
 

--- a/content/api/monitors/monitors_get_code.fr.md
+++ b/content/api/monitors/monitors_get_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#get-a-monitor-s-details
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/monitor/:monitor_id`
+`GET https://api.datadoghq.com/api/v1/monitor/<MONITOR_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/monitors/monitors_get_code.md
+++ b/content/api/monitors/monitors_get_code.md
@@ -5,10 +5,15 @@ order: 16.2
 external_redirect: /api/#get-a-monitor-s-details
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/monitor/:monitor_id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-monitor-show" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-monitor-show" >}}
 

--- a/content/api/monitors/monitors_get_code.md
+++ b/content/api/monitors/monitors_get_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#get-a-monitor-s-details
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/monitor/:monitor_id`
+`GET https://api.datadoghq.com/api/v1/monitor/<MONITOR_ID>`
 
 **Example Request**:
 

--- a/content/api/monitors/monitors_mute.fr.md
+++ b/content/api/monitors/monitors_mute.fr.md
@@ -7,7 +7,8 @@ external_redirect: /api/#mute-a-monitor
 
 ## Désactiver un monitor
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`scope`** [*optionnel*, *défaut*=**None**]:  
     Le context auquel appliquer le silence, ex. **role:db**.
 * **`end`** [*optionnel*, *défaut*=**None**]:  

--- a/content/api/monitors/monitors_mute.md
+++ b/content/api/monitors/monitors_mute.md
@@ -7,7 +7,8 @@ external_redirect: /api/#mute-a-monitor
 
 ## Mute a monitor
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`scope`** [*optional*, *default*=**None**]:  
     The scope to apply the mute to, e.g. **role:db**.
     For example, if your alert is grouped by `{host}`, you might mute `host:app1`.

--- a/content/api/monitors/monitors_mute_code.fr.md
+++ b/content/api/monitors/monitors_mute_code.fr.md
@@ -5,10 +5,15 @@ order: 16.9
 external_redirect: /api/#mute-a-monitor
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/monitor/:monitor_id/mute`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-monitor-mute" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-monitor-mute" >}}
 

--- a/content/api/monitors/monitors_mute_code.fr.md
+++ b/content/api/monitors/monitors_mute_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#mute-a-monitor
 
 **Signature**:
 
-`POST https://api.datadoghq.com/api/v1/monitor/:monitor_id/mute`
+`POST https://api.datadoghq.com/api/v1/monitor/<MONITOR_ID>/mute`
 
 **Exemple de requête**:
 

--- a/content/api/monitors/monitors_mute_code.md
+++ b/content/api/monitors/monitors_mute_code.md
@@ -5,10 +5,15 @@ order: 16.9
 external_redirect: /api/#mute-a-monitor
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/monitor/:monitor_id/mute`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-monitor-mute" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-monitor-mute" >}}
 

--- a/content/api/monitors/monitors_mute_code.md
+++ b/content/api/monitors/monitors_mute_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#mute-a-monitor
 
 **Signature**:
 
-`POST https://api.datadoghq.com/api/v1/monitor/:monitor_id/mute`
+`POST https://api.datadoghq.com/api/v1/monitor/<MONITOR_ID>/mute`
 
 **Example Request**:
 

--- a/content/api/monitors/monitors_muteall.fr.md
+++ b/content/api/monitors/monitors_muteall.fr.md
@@ -8,7 +8,7 @@ external_redirect: /api/#mute-all-monitors
 ## Désactiver tous les monitors
 Désactiver tous les monitors les empêche de notifier par e-mail et de poster des événements dans le [flux d'événements][1]. Les changements d'état ne sont visibles que par une vérification visuelle sur la page d'alerte.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 Cet endpoint ne prend aucun argument JSON.
 

--- a/content/api/monitors/monitors_muteall.md
+++ b/content/api/monitors/monitors_muteall.md
@@ -8,7 +8,7 @@ external_redirect: /api/#mute-all-monitors
 ## Mute all monitors
 Muting prevents all monitors from notifying through email and posts to the [event stream][1]. State changes are only visible by checking the alert page.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 This end point takes no JSON arguments.
 

--- a/content/api/monitors/monitors_muteall_code.fr.md
+++ b/content/api/monitors/monitors_muteall_code.fr.md
@@ -5,10 +5,15 @@ order: 16.7
 external_redirect: /api/#mute-all-monitors
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/monitor/mute_all`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-monitor-mute-all" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-monitor-mute-all" >}}
 

--- a/content/api/monitors/monitors_muteall_code.md
+++ b/content/api/monitors/monitors_muteall_code.md
@@ -5,10 +5,15 @@ order: 16.7
 external_redirect: /api/#mute-all-monitors
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/monitor/mute_all`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-monitor-mute-all" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-monitor-mute-all" >}}
 

--- a/content/api/monitors/monitors_resolve.fr.md
+++ b/content/api/monitors/monitors_resolve.fr.md
@@ -7,7 +7,8 @@ external_redirect: /api/#resolve-monitor
 
 ## Résoudre un monitor
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`resolve`** [*obligatoire*]:  
     Tableau de groupe(s) à résoudre pour un monitor_id donné, par ex.
     `{"monitor_id": "group_to_resolve"}`  

--- a/content/api/monitors/monitors_resolve.md
+++ b/content/api/monitors/monitors_resolve.md
@@ -7,7 +7,8 @@ external_redirect: /api/#resolve-monitor
 
 ## Resolve monitor
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`resolve`** [*required*]:
     Array of group(s) to resolve for a given monitor_id, e.g.:
     `{"monitor_id": "group_to_resolve"}`

--- a/content/api/monitors/monitors_resolve_code.fr.md
+++ b/content/api/monitors/monitors_resolve_code.fr.md
@@ -5,10 +5,15 @@ order: 16.6
 external_redirect: /api/#resolve-monitor
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://app.datadoghq.com/monitor/bulk_resolve`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-monitor-bulk-resolve" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-monitor-bulk-resolve" >}}
 

--- a/content/api/monitors/monitors_resolve_code.md
+++ b/content/api/monitors/monitors_resolve_code.md
@@ -5,10 +5,15 @@ order: 16.6
 external_redirect: /api/#resolve-monitor
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://app.datadoghq.com/monitor/bulk_resolve`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-monitor-bulk-resolve" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-monitor-bulk-resolve" >}}
 

--- a/content/api/monitors/monitors_showall.md
+++ b/content/api/monitors/monitors_showall.md
@@ -6,7 +6,9 @@ external_redirect: /api/#get-all-monitor-details
 ---
 
 ## Get all monitor details
-##### ARGUMENTS
+
+**ARGUMENTS**:
+
 * **`group_states`** [*optional*, *default*=**None**]:
     If this argument is set, the returned data includes additional information (if available) regarding the specified group states, including the last notification timestamp, last resolution timestamp and details about the last time the monitor was triggered. The argument should include a string list indicating what, if any, group states to include. Choose one or more from 'all', 'alert', 'warn', or 'no data'. Example: 'alert,warn'
 * **`name`** [*required*]:  

--- a/content/api/monitors/monitors_showall_code.fr.md
+++ b/content/api/monitors/monitors_showall_code.fr.md
@@ -5,10 +5,15 @@ order: 16.5
 external_redirect: /api/#get-all-monitor-details
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/monitor`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-monitor-show-all" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-monitor-show-all" >}}
 

--- a/content/api/monitors/monitors_showall_code.md
+++ b/content/api/monitors/monitors_showall_code.md
@@ -5,10 +5,15 @@ order: 16.5
 external_redirect: /api/#get-all-monitor-details
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/monitor`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-monitor-show-all" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-monitor-show-all" >}}
 

--- a/content/api/monitors/monitors_unmute.fr.md
+++ b/content/api/monitors/monitors_unmute.fr.md
@@ -7,7 +7,8 @@ external_redirect: /api/#unmute-a-monitor
 
 ## Activer un monitor
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`scope`** [*optionnel*, *défaut*=**None**]:  
     Le context auquel appliquer le silence:
     Par exemple, si votre alerte est groupée par {host}, vous pouvez ignorer 'host:app1'

--- a/content/api/monitors/monitors_unmute.md
+++ b/content/api/monitors/monitors_unmute.md
@@ -7,7 +7,8 @@ external_redirect: /api/#unmute-a-monitor
 
 ## Unmute a monitor
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`scope`** [*optional*, *default*=**None**]:  
     The scope to apply the mute to.  
     For example, if your alert is grouped by {host}, you might mute 'host:app1'

--- a/content/api/monitors/monitors_unmute_code.fr.md
+++ b/content/api/monitors/monitors_unmute_code.fr.md
@@ -5,10 +5,15 @@ order: 16.91
 external_redirect: /api/#unmute-a-monitor
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/monitor/:monitor_id/unmute`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-monitor-unmute" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-monitor-unmute" >}}
 

--- a/content/api/monitors/monitors_unmute_code.fr.md
+++ b/content/api/monitors/monitors_unmute_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#unmute-a-monitor
 
 **Signature**:
 
-`POST https://api.datadoghq.com/api/v1/monitor/:monitor_id/unmute`
+`POST https://api.datadoghq.com/api/v1/monitor/<MONITOR_ID>/unmute`
 
 **Exemple de requête**:
 

--- a/content/api/monitors/monitors_unmute_code.md
+++ b/content/api/monitors/monitors_unmute_code.md
@@ -5,10 +5,15 @@ order: 16.91
 external_redirect: /api/#unmute-a-monitor
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/monitor/:monitor_id/unmute`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-monitor-unmute" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-monitor-unmute" >}}
 

--- a/content/api/monitors/monitors_unmute_code.md
+++ b/content/api/monitors/monitors_unmute_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#unmute-a-monitor
 
 **Signature**:
 
-`POST https://api.datadoghq.com/api/v1/monitor/:monitor_id/unmute`
+`POST https://api.datadoghq.com/api/v1/monitor/<MONITOR_ID>/unmute`
 
 **Example Request**:
 

--- a/content/api/monitors/monitors_unmuteall.fr.md
+++ b/content/api/monitors/monitors_unmuteall.fr.md
@@ -8,7 +8,7 @@ external_redirect: /api/#unmute-all-monitors
 ## Activer tous les monitors
 Désactive l'inhibition de tous les monitors. Lève une erreur si la fonction "mute all" n'a pas été activée auparavant.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 Cet endpoint ne prend aucun argument JSON.
 

--- a/content/api/monitors/monitors_unmuteall.md
+++ b/content/api/monitors/monitors_unmuteall.md
@@ -8,7 +8,7 @@ external_redirect: /api/#unmute-all-monitors
 ## Unmute all monitors
 Disables muting all monitors. Throws an error if mute all was not enabled previously.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 This end point takes no JSON arguments.
 

--- a/content/api/monitors/monitors_unmuteall_code.fr.md
+++ b/content/api/monitors/monitors_unmuteall_code.fr.md
@@ -5,10 +5,15 @@ order: 16.8
 external_redirect: /api/#unmute-all-monitors
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/monitor/unmute_all`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-monitor-unmute-all" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 *Cet endpoint ne renvoie aucun objet JSON en cas de requête réussie.*
 

--- a/content/api/monitors/monitors_unmuteall_code.md
+++ b/content/api/monitors/monitors_unmuteall_code.md
@@ -5,10 +5,15 @@ order: 16.8
 external_redirect: /api/#unmute-all-monitors
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/monitor/unmute_all`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-monitor-unmute-all" >}}
-##### Example Response
+
+**Example Response**:
+
 *This end point does not return JSON on successful requests.*
 

--- a/content/api/monitors/monitors_validate.md
+++ b/content/api/monitors/monitors_validate.md
@@ -4,7 +4,9 @@ type: apicontent
 order: 16.11
 ---
 ## Validate a monitor
-##### ARGUMENTS
+
+**ARGUMENTS**:
+
 *   **`type`** [*required*]:  
     The [type of the monitor][1], chosen from:  
 

--- a/content/api/monitors/monitors_validate_code.md
+++ b/content/api/monitors/monitors_validate_code.md
@@ -4,10 +4,15 @@ type: apicode
 order: 16.11
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/monitor`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-monitor-validate" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-monitor-validate" >}}
 

--- a/content/api/org/idp_update.fr.md
+++ b/content/api/org/idp_update.fr.md
@@ -7,7 +7,8 @@ external_redirect: /api/#upload-idp-metadata
 
 ## Uploader les métadonnées IdP
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`idp_file`** [*obligatoire*]:  
      Le chemin vers le fichier de métadonnées XML que vous voulez utiliser
 

--- a/content/api/org/idp_update.md
+++ b/content/api/org/idp_update.md
@@ -7,7 +7,8 @@ external_redirect: /api/#upload-idp-metadata
 
 ## Upload IdP metadata
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`idp_file`** [*required*]:  
      The path to the XML metadata file you wish to upload.
 

--- a/content/api/org/idp_update_code.fr.md
+++ b/content/api/org/idp_update_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#upload-idp-metadata
 
 **Signature**:
 
-`POST https://api.datadoghq.com/api/v1/org/:public_id/idp_metadata`
+`POST https://api.datadoghq.com/api/v1/org/<PUBLIC_ID>/idp_metadata`
 
 **Exemple de requête**:
 

--- a/content/api/org/idp_update_code.fr.md
+++ b/content/api/org/idp_update_code.fr.md
@@ -5,10 +5,15 @@ order: 17.4
 external_redirect: /api/#upload-idp-metadata
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/org/:public_id/idp_metadata`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-org-update" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-org-update" >}}
 

--- a/content/api/org/idp_update_code.md
+++ b/content/api/org/idp_update_code.md
@@ -5,10 +5,15 @@ order: 17.4
 external_redirect: /api/#upload-idp-metadata
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/org/:public_id/idp_metadata`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-org-update" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-org-update" >}}
 

--- a/content/api/org/idp_update_code.md
+++ b/content/api/org/idp_update_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#upload-idp-metadata
 
 **Signature**:
 
-`POST https://api.datadoghq.com/api/v1/org/:public_id/idp_metadata`
+`POST https://api.datadoghq.com/api/v1/org/<PUBLIC_ID>/idp_metadata`
 
 **Example Request**:
 

--- a/content/api/org/org_create.md
+++ b/content/api/org/org_create.md
@@ -9,7 +9,7 @@ external_redirect: /api/#create-child-organization
 
 This endpoint requires the [multi-org account][1] feature and must be enabled by [contacting support][2].
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 * **`name`** [*required*]:
     The name of the new child-organization, limited to 32 characters.

--- a/content/api/org/org_create_code.fr.md
+++ b/content/api/org/org_create_code.fr.md
@@ -5,10 +5,15 @@ order: 17.1
 external_redirect: /api/#create-child-organization
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/org`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-org-create" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-org-create" >}}
 

--- a/content/api/org/org_create_code.md
+++ b/content/api/org/org_create_code.md
@@ -5,10 +5,15 @@ order: 17.1
 external_redirect: /api/#create-child-organization
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/org`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-org-create" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-org-create" >}}
 

--- a/content/api/org/org_get.fr.md
+++ b/content/api/org/org_get.fr.md
@@ -6,7 +6,9 @@ external_redirect: /api/#get-organization
 ---
 
 ## Obtenir une organisation
-##### ARGUMENTS
+
+**ARGUMENTS**:
+
 * **`public_id`** [*obligatoire*]:  
     L'ID public de l'organisation
 

--- a/content/api/org/org_get.md
+++ b/content/api/org/org_get.md
@@ -6,7 +6,9 @@ external_redirect: /api/#get-organization
 ---
 
 ## Get organization
-##### ARGUMENTS
+
+**ARGUMENTS**:
+
 * **`public_id`** [*required*]:  
     The public id of the organization.
 

--- a/content/api/org/org_get_code.fr.md
+++ b/content/api/org/org_get_code.fr.md
@@ -5,10 +5,15 @@ order: 17.2
 external_redirect: /api/#get-organization
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/org/:public_id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-org-get" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-org-get" >}}
 

--- a/content/api/org/org_get_code.fr.md
+++ b/content/api/org/org_get_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#get-organization
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/org/:public_id`
+`GET https://api.datadoghq.com/api/v1/org/<PUBLIC_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/org/org_get_code.md
+++ b/content/api/org/org_get_code.md
@@ -5,10 +5,15 @@ order: 17.2
 external_redirect: /api/#get-organization
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/org`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-org-get" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-org-get" >}}
 

--- a/content/api/org/org_update.fr.md
+++ b/content/api/org/org_update.fr.md
@@ -7,7 +7,8 @@ external_redirect: /api/#update-organization
 
 ## Mise à jour d'une organisation
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`name`** [*optionnel*]:  
     Le nom de l'organisation
 * **`settings`** [*optionnel*]:  

--- a/content/api/org/org_update.md
+++ b/content/api/org/org_update.md
@@ -7,7 +7,8 @@ external_redirect: /api/#update-organization
 
 ## Update organization
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`name`** [*optional*]:  
     The organization name.
 * **`settings`** [*optional*]:  

--- a/content/api/org/org_update_code.fr.md
+++ b/content/api/org/org_update_code.fr.md
@@ -5,10 +5,15 @@ order: 17.3
 external_redirect: /api/#update-organization
 ---
 
-##### Signature
+**Signature**:
+
 `PUT https://api.datadoghq.com/api/v1/org/:public_id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-org-update" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-org-update" >}}
 

--- a/content/api/org/org_update_code.fr.md
+++ b/content/api/org/org_update_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#update-organization
 
 **Signature**:
 
-`PUT https://api.datadoghq.com/api/v1/org/:public_id`
+`PUT https://api.datadoghq.com/api/v1/org/<PUBLIC_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/org/org_update_code.md
+++ b/content/api/org/org_update_code.md
@@ -5,10 +5,15 @@ order: 17.3
 external_redirect: /api/#update-organization
 ---
 
-##### Signature
+**Signature**:
+
 `PUT https://api.datadoghq.com/api/v1/org/:public_id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-org-update" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-org-update" >}}
 

--- a/content/api/org/org_update_code.md
+++ b/content/api/org/org_update_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#update-organization
 
 **Signature**:
 
-`PUT https://api.datadoghq.com/api/v1/org/:public_id`
+`PUT https://api.datadoghq.com/api/v1/org/<PUBLIC_ID>`
 
 **Example Request**:
 

--- a/content/api/overview/overview_code.fr.md
+++ b/content/api/overview/overview_code.fr.md
@@ -4,10 +4,11 @@ type: apicode
 order: 1
 external_redirect: /api/#overview
 ---
-### SIGNATURE
+
 De nombreuses bibliothèques exploitent l'API Datadog. [Découvrez-les][1].
 
-### SIGNATURE
-https://api.datadoghq.com/api/
+**SIGNATURE**:
+
+`https://api.datadoghq.com/api/`
 
 [1]: https://docs.datadoghq.com/developers/libraries/

--- a/content/api/overview/overview_code.md
+++ b/content/api/overview/overview_code.md
@@ -4,10 +4,11 @@ type: apicode
 order: 1
 external_redirect: /api/#overview
 ---
-### SIGNATURE
+
 There are many client libraries that wrap the Datadog API. [Check them out][1].
 
-### SIGNATURE
-https://api.datadoghq.com/api/
+**SIGNATURE**:
+
+`https://api.datadoghq.com/api/`
 
 [1]: https://docs.datadoghq.com/developers/libraries/

--- a/content/api/rate_limiting/rate_limiting_code.fr.md
+++ b/content/api/rate_limiting/rate_limiting_code.fr.md
@@ -4,7 +4,7 @@ type: apicode
 order: 4
 external_redirect: /api/#rate-limiting
 ---
-##### Headers de Rate Limit 
+**Headers de Rate Limit**:
 
 * `X-RateLimit-Limit` Nombre de requêtes autorisées sur une période donnée
 * `X-RateLimit-Period` durée en secondes pour les réinitialisations (alignées sur le calendrier)

--- a/content/api/rate_limiting/rate_limiting_code.md
+++ b/content/api/rate_limiting/rate_limiting_code.md
@@ -4,7 +4,7 @@ type: apicode
 order: 4
 external_redirect: /api/#rate-limiting
 ---
-##### Rate Limit Headers
+**Rate Limit Headers**:
 
 * `X-RateLimit-Limit` number of requests allowed in a time period
 * `X-RateLimit-Period` length of time in seconds for resets (calendar aligned)

--- a/content/api/screenboards/screenboards_create.fr.md
+++ b/content/api/screenboards/screenboards_create.fr.md
@@ -6,7 +6,9 @@ external_redirect: /api/#create-a-screenboard
 ---
 
 ## Créer un Screenboard
-##### Arguments
+
+**ARGUMENTS**:
+
 * **`board_title`** [*obligatoire*]:  
     Le nom du dashboard.
 * **`description`** [*optionnel*, *défaut*=**None**]:  

--- a/content/api/screenboards/screenboards_create.md
+++ b/content/api/screenboards/screenboards_create.md
@@ -6,7 +6,9 @@ external_redirect: /api/#create-a-screenboard
 ---
 
 ## Create a Screenboard
-##### Arguments
+
+**ARGUMENTS**:
+
 * **`board_title`** [*required*]:  
     The name of the dashboard.    
 * **`description`** [*optional*, *default*=**None**]:  

--- a/content/api/screenboards/screenboards_create_code.fr.md
+++ b/content/api/screenboards/screenboards_create_code.fr.md
@@ -5,10 +5,15 @@ order: 18.1
 external_redirect: /api/#create-a-screenboard
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/screen`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-screenboard-create" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-screenboard-create" >}}
 

--- a/content/api/screenboards/screenboards_create_code.md
+++ b/content/api/screenboards/screenboards_create_code.md
@@ -5,10 +5,15 @@ order: 18.1
 external_redirect: /api/#create-a-screenboard
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/screen`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-screenboard-create" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-screenboard-create" >}}
 

--- a/content/api/screenboards/screenboards_delete.fr.md
+++ b/content/api/screenboards/screenboards_delete.fr.md
@@ -7,6 +7,8 @@ external_redirect: /api/#delete-a-screenboard
 
 ## Supprimer un Screenboard
 Supprime un Screenboard existant.
-##### ARGUMENTS
+
+**ARGUMENTS**:
+
 Cet endpoint ne prend aucun argument JSON.
 

--- a/content/api/screenboards/screenboards_delete.md
+++ b/content/api/screenboards/screenboards_delete.md
@@ -7,6 +7,8 @@ external_redirect: /api/#delete-a-screenboard
 
 ## Delete a Screenboard
 Delete an existing Screenboard.
-##### ARGUMENTS
+
+**ARGUMENTS**:
+
 This end point takes no JSON arguments.
 

--- a/content/api/screenboards/screenboards_delete_code.fr.md
+++ b/content/api/screenboards/screenboards_delete_code.fr.md
@@ -5,10 +5,15 @@ order: 18.3
 external_redirect: /api/#delete-a-screenboard
 ---
 
-##### Signature
+**Signature**:
+
 `DELETE https://api.datadoghq.com/api/v1/screen/:board_id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-screenboard-delete" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 *Cet endpoint ne renvoie aucun objet JSON en cas de requête réussie.*
 

--- a/content/api/screenboards/screenboards_delete_code.fr.md
+++ b/content/api/screenboards/screenboards_delete_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#delete-a-screenboard
 
 **Signature**:
 
-`DELETE https://api.datadoghq.com/api/v1/screen/:board_id`
+`DELETE https://api.datadoghq.com/api/v1/screen/<SCREEENBOARD_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/screenboards/screenboards_delete_code.md
+++ b/content/api/screenboards/screenboards_delete_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#delete-a-screenboard
 
 **Signature**:
 
-`DELETE https://api.datadoghq.com/api/v1/screen/:board_id`
+`DELETE https://api.datadoghq.com/api/v1/screen/<SCREEENBOARD_ID>`
 
 **Example Request**:
 

--- a/content/api/screenboards/screenboards_delete_code.md
+++ b/content/api/screenboards/screenboards_delete_code.md
@@ -5,10 +5,15 @@ order: 18.3
 external_redirect: /api/#delete-a-screenboard
 ---
 
-##### Signature
+**Signature**:
+
 `DELETE https://api.datadoghq.com/api/v1/screen/:board_id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-screenboard-delete" >}}
-##### Example Response
+
+**Example Response**:
+
 *This end point does not return JSON on successful requests.*
 

--- a/content/api/screenboards/screenboards_get.fr.md
+++ b/content/api/screenboards/screenboards_get.fr.md
@@ -8,7 +8,7 @@ external_redirect: /api/#get-a-screenboard
 ## Récupérer un Screenboard
 Récupère toutes les spécifications d'un Screenboard.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 Cet endpoint ne prend aucun argument JSON.
 

--- a/content/api/screenboards/screenboards_get.md
+++ b/content/api/screenboards/screenboards_get.md
@@ -8,7 +8,7 @@ external_redirect: /api/#get-a-screenboard
 ## Get a Screenboard
 Fetch an existing Screenboard's definition.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 This end point takes no JSON arguments.
 

--- a/content/api/screenboards/screenboards_get_code.fr.md
+++ b/content/api/screenboards/screenboards_get_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#get-a-screenboard
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/screen/:board_id`
+`GET https://api.datadoghq.com/api/v1/screen/<SCREEENBOARD_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/screenboards/screenboards_get_code.fr.md
+++ b/content/api/screenboards/screenboards_get_code.fr.md
@@ -5,10 +5,15 @@ order: 18.4
 external_redirect: /api/#get-a-screenboard
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/screen/:board_id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-screenboard-get" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-screenboard-get" >}}
 

--- a/content/api/screenboards/screenboards_get_code.md
+++ b/content/api/screenboards/screenboards_get_code.md
@@ -5,10 +5,15 @@ order: 18.4
 external_redirect: /api/#get-a-screenboard
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/screen/:board_id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-screenboard-get" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-screenboard-get" >}}
 

--- a/content/api/screenboards/screenboards_get_code.md
+++ b/content/api/screenboards/screenboards_get_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#get-a-screenboard
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/screen/:board_id`
+`GET https://api.datadoghq.com/api/v1/screen/<SCREEENBOARD_ID>`
 
 **Example Request**:
 

--- a/content/api/screenboards/screenboards_getall.fr.md
+++ b/content/api/screenboards/screenboards_getall.fr.md
@@ -9,7 +9,7 @@ external_redirect: /api/#get-all-screenboards
 
 Récupère toutes les spécifications de vos Screenboards.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 Cet endpoint ne prend aucun argument JSON.
 

--- a/content/api/screenboards/screenboards_getall.md
+++ b/content/api/screenboards/screenboards_getall.md
@@ -9,7 +9,7 @@ external_redirect: /api/#get-all-screenboards
 
 Fetch all of your Screenboards' definitions.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 This end point takes no JSON arguments.
 

--- a/content/api/screenboards/screenboards_getall_code.fr.md
+++ b/content/api/screenboards/screenboards_getall_code.fr.md
@@ -5,10 +5,15 @@ order: 18.5
 external_redirect: /api/#get-all-screenboards
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/screen`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-screenboard-get-all" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-screenboard-get-all" >}}
 

--- a/content/api/screenboards/screenboards_getall_code.md
+++ b/content/api/screenboards/screenboards_getall_code.md
@@ -5,10 +5,15 @@ order: 18.5
 external_redirect: /api/#get-all-screenboards
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/screen`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-screenboard-get-all" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-screenboard-get-all" >}}
 

--- a/content/api/screenboards/screenboards_revoke.fr.md
+++ b/content/api/screenboards/screenboards_revoke.fr.md
@@ -9,7 +9,7 @@ external_redirect: /api/#revoke-a-shared-a-screenboard
 
 Révoque un Screenboard qui est actuellement partagé.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 Cet endpoint ne prend aucun argument JSON.
 

--- a/content/api/screenboards/screenboards_revoke.md
+++ b/content/api/screenboards/screenboards_revoke.md
@@ -9,6 +9,6 @@ external_redirect: /api/#revoke-a-shared-a-screenboard
 
 Revoke a shared Screenboard.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 This end point takes no JSON arguments.

--- a/content/api/screenboards/screenboards_revoke_code.fr.md
+++ b/content/api/screenboards/screenboards_revoke_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#revoke-a-shared-a-screenboard
 
 **Signature**:
 
-`DELETE https://api.datadoghq.com/api/v1/screen/share/:board_id`
+`DELETE https://api.datadoghq.com/api/v1/screen/share/<SCREEENBOARD_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/screenboards/screenboards_revoke_code.fr.md
+++ b/content/api/screenboards/screenboards_revoke_code.fr.md
@@ -5,10 +5,15 @@ order: 18.7
 external_redirect: /api/#revoke-a-shared-a-screenboard
 ---
 
-##### Signature
+**Signature**:
+
 `DELETE https://api.datadoghq.com/api/v1/screen/share/:board_id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-screenboard-revoke" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 *Cet endpoint ne renvoie aucun objet JSON en cas de requête réussie.*
 

--- a/content/api/screenboards/screenboards_revoke_code.md
+++ b/content/api/screenboards/screenboards_revoke_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#revoke-a-shared-a-screenboard
 
 **Signature**:
 
-`DELETE https://api.datadoghq.com/api/v1/screen/share/:board_id`
+`DELETE https://api.datadoghq.com/api/v1/screen/share/<SCREEENBOARD_ID>`
 
 **Example Request**:
 

--- a/content/api/screenboards/screenboards_revoke_code.md
+++ b/content/api/screenboards/screenboards_revoke_code.md
@@ -5,10 +5,15 @@ order: 18.7
 external_redirect: /api/#revoke-a-shared-a-screenboard
 ---
 
-##### Signature
+**Signature**:
+
 `DELETE https://api.datadoghq.com/api/v1/screen/share/:board_id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-screenboard-revoke" >}}
-##### Example Response
+
+**Example Response**:
+
 *This end point does not return JSON on successful requests.*
 

--- a/content/api/screenboards/screenboards_share.fr.md
+++ b/content/api/screenboards/screenboards_share.fr.md
@@ -9,7 +9,7 @@ external_redirect: /api/#share-a-screenboard
 
 Partage un Screenboard existant avec un URL public.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 Cet endpoint ne prend aucun argument JSON.
 

--- a/content/api/screenboards/screenboards_share.md
+++ b/content/api/screenboards/screenboards_share.md
@@ -9,7 +9,7 @@ external_redirect: /api/#share-a-screenboard
 
 Share an existing Screenboard's with a public URL.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 This end point takes no JSON arguments.
 

--- a/content/api/screenboards/screenboards_share_code.fr.md
+++ b/content/api/screenboards/screenboards_share_code.fr.md
@@ -5,10 +5,15 @@ order: 18.6
 external_redirect: /api/#share-a-screenboard
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/screen/share/:board_id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-screenboard-share" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-screenboard-share" >}}
 

--- a/content/api/screenboards/screenboards_share_code.fr.md
+++ b/content/api/screenboards/screenboards_share_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#share-a-screenboard
 
 **Signature**:
 
-`POST https://api.datadoghq.com/api/v1/screen/share/:board_id`
+`POST https://api.datadoghq.com/api/v1/screen/share/<SCREEENBOARD_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/screenboards/screenboards_share_code.md
+++ b/content/api/screenboards/screenboards_share_code.md
@@ -5,10 +5,15 @@ order: 18.6
 external_redirect: /api/#share-a-screenboard
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/screen/share/:board_id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-screenboard-share" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-screenboard-share" >}}
 

--- a/content/api/screenboards/screenboards_share_code.md
+++ b/content/api/screenboards/screenboards_share_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#share-a-screenboard
 
 **Signature**:
 
-`POST https://api.datadoghq.com/api/v1/screen/share/:board_id`
+`POST https://api.datadoghq.com/api/v1/screen/share/<SCREEENBOARD_ID>`
 
 **Example Request**:
 

--- a/content/api/screenboards/screenboards_update.fr.md
+++ b/content/api/screenboards/screenboards_update.fr.md
@@ -11,7 +11,7 @@ Remplacer une configuration de Screenboard dans Datadog.
 
 **Note**: Vous devez envoyer la configuration originale de Screenboard avec vos mises à jour sinon les widgets originaux sont effacés.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 * **`board_title`** [*obligatoire*]:  
     Le nom du dashboard.

--- a/content/api/screenboards/screenboards_update.md
+++ b/content/api/screenboards/screenboards_update.md
@@ -11,7 +11,7 @@ Override a Screenboard configuration in Datadog.
 
 **Note**: You must send the entire original Screenboard configuration along with your updates otherwise the original widgets are erased.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 * **`board_title`** [*required*]:
     The name of the dashboard.

--- a/content/api/screenboards/screenboards_update_code.fr.md
+++ b/content/api/screenboards/screenboards_update_code.fr.md
@@ -5,10 +5,15 @@ order: 18.2
 external_redirect: /api/#update-a-screenboard
 ---
 
-##### Signature
+**Signature**:
+
 `PUT https://api.datadoghq.com/api/v1/screen/:board_id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-screenboard-update" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-screenboard-update" >}}
 

--- a/content/api/screenboards/screenboards_update_code.fr.md
+++ b/content/api/screenboards/screenboards_update_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#update-a-screenboard
 
 **Signature**:
 
-`PUT https://api.datadoghq.com/api/v1/screen/:board_id`
+`PUT https://api.datadoghq.com/api/v1/screen/<SCREEENBOARD_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/screenboards/screenboards_update_code.md
+++ b/content/api/screenboards/screenboards_update_code.md
@@ -5,10 +5,15 @@ order: 18.2
 external_redirect: /api/#update-a-screenboard
 ---
 
-##### Signature
+**Signature**:
+
 `PUT https://api.datadoghq.com/api/v1/screen/:board_id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-screenboard-update" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-screenboard-update" >}}
 

--- a/content/api/screenboards/screenboards_update_code.md
+++ b/content/api/screenboards/screenboards_update_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#update-a-screenboard
 
 **Signature**:
 
-`PUT https://api.datadoghq.com/api/v1/screen/:board_id`
+`PUT https://api.datadoghq.com/api/v1/screen/<SCREEENBOARD_ID>`
 
 **Example Request**:
 

--- a/content/api/tags/tags_add.fr.md
+++ b/content/api/tags/tags_add.fr.md
@@ -8,7 +8,7 @@ external_redirect: /api/#add-tags-to-a-host
 ## Ajouter des tags à un hôte
 Cet endpoint vous permet d'ajouter des tags à un hôte.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 * **`tags`** [*obligatoire*]:  
     Une liste de tags à appliquer à l'hôte.

--- a/content/api/tags/tags_add.md
+++ b/content/api/tags/tags_add.md
@@ -8,7 +8,7 @@ external_redirect: /api/#add-tags-to-a-host
 ## Add tags to a host
 This end point allows you to add tags to a host.
 
-##### ARGUMENTS
+**ARGUMENTS**:
 
 * **`tags`** [*required*]:  
     A list of tags to apply to the host

--- a/content/api/tags/tags_add_code.fr.md
+++ b/content/api/tags/tags_add_code.fr.md
@@ -5,10 +5,15 @@ order: 20.3
 external_redirect: /api/#add-tags-to-a-host
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/tags/hosts/:host_name`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-tags-add" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-tags-add" >}}
 

--- a/content/api/tags/tags_add_code.fr.md
+++ b/content/api/tags/tags_add_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#add-tags-to-a-host
 
 **Signature**:
 
-`POST https://api.datadoghq.com/api/v1/tags/hosts/:host_name`
+`POST https://api.datadoghq.com/api/v1/tags/hosts/<HOSTNAME>`
 
 **Exemple de requête**:
 

--- a/content/api/tags/tags_add_code.md
+++ b/content/api/tags/tags_add_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#add-tags-to-a-host
 
 **Signature**:
 
-`POST https://api.datadoghq.com/api/v1/tags/hosts/:host_name`
+`POST https://api.datadoghq.com/api/v1/tags/hosts/<HOSTNAME>`
 
 **Example Request**:
 

--- a/content/api/tags/tags_add_code.md
+++ b/content/api/tags/tags_add_code.md
@@ -5,10 +5,15 @@ order: 20.3
 external_redirect: /api/#add-tags-to-a-host
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/tags/hosts/:host_name`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-tags-add" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-tags-add" >}}
 

--- a/content/api/tags/tags_delete.fr.md
+++ b/content/api/tags/tags_delete.fr.md
@@ -8,7 +8,8 @@ external_redirect: /api/#remove-host-tags
 ## Retirer les tags d'un hôte
 Cet endpoint vous permet de retirer tous les tags d'un hôte donné.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`source`** [*facultatif*, *défaut*=**users**]:  
     La source des tags (par exemple, chef, puppet).
     [Liste des valeurs de l'attribut source de l'API][1].

--- a/content/api/tags/tags_delete.md
+++ b/content/api/tags/tags_delete.md
@@ -8,7 +8,8 @@ external_redirect: /api/#remove-host-tags
 ## Remove host tags
 This end point allows you to remove all tags for a given host.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`source`** [*optional*, *default*=**users**]:  
     The source of the tags (e.g. chef, puppet).  
     [Complete list of source attribute values][1]

--- a/content/api/tags/tags_delete_code.fr.md
+++ b/content/api/tags/tags_delete_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#remove-host-tags
 
 **Signature**:
 
-`DELETE https://api.datadoghq.com/api/v1/tags/hosts/:host_name`
+`DELETE https://api.datadoghq.com/api/v1/tags/hosts/<HOSTNAME>`
 
 **Exemple de requête**:
 

--- a/content/api/tags/tags_delete_code.fr.md
+++ b/content/api/tags/tags_delete_code.fr.md
@@ -5,10 +5,15 @@ order: 20.5
 external_redirect: /api/#remove-host-tags
 ---
 
-##### Signature
+**Signature**:
+
 `DELETE https://api.datadoghq.com/api/v1/tags/hosts/:host_name`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-tags-remove" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 *Cet endpoint ne renvoie aucun objet JSON en cas de requête réussie.*
 

--- a/content/api/tags/tags_delete_code.md
+++ b/content/api/tags/tags_delete_code.md
@@ -5,10 +5,15 @@ order: 20.5
 external_redirect: /api/#remove-host-tags
 ---
 
-##### Signature
+**Signature**:
+
 `DELETE https://api.datadoghq.com/api/v1/tags/hosts/:host_name`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-tags-remove" >}}
-##### Example Response
+
+**Example Response**:
+
 *This end point does not return JSON on successful requests.*
 

--- a/content/api/tags/tags_delete_code.md
+++ b/content/api/tags/tags_delete_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#remove-host-tags
 
 **Signature**:
 
-`DELETE https://api.datadoghq.com/api/v1/tags/hosts/:host_name`
+`DELETE https://api.datadoghq.com/api/v1/tags/hosts/<HOSTNAME>`
 
 **Example Request**:
 

--- a/content/api/tags/tags_get.fr.md
+++ b/content/api/tags/tags_get.fr.md
@@ -8,7 +8,8 @@ external_redirect: /api/#get-tags
 ## Récupérer des tags
 Renvoie un mappage des tags et hôtes pour l'ensemble de votre infrastructure.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`source`** [*optionnel*, *défaut*=**None**]:  
     Affiche uniquement les tags d'une source particulière Sinon, montre tous les tags.
     [Liste des valeurs de l'attribut source de l'API][1].

--- a/content/api/tags/tags_get.md
+++ b/content/api/tags/tags_get.md
@@ -8,7 +8,8 @@ external_redirect: /api/#get-tags
 ## Get tags
 Return a mapping of tags to hosts for your whole infrastructure.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`source`** [*optional*, *default*=**None**]:  
     Only show tags from a particular source. Otherwise shows all tags.  
     [Complete list of source attribute values][1]

--- a/content/api/tags/tags_get_code.fr.md
+++ b/content/api/tags/tags_get_code.fr.md
@@ -5,10 +5,15 @@ order: 20.1
 external_redirect: /api/#get-tags
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/tags/hosts`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-tags-get" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-tags-get" >}}
 

--- a/content/api/tags/tags_get_code.md
+++ b/content/api/tags/tags_get_code.md
@@ -5,10 +5,15 @@ order: 20.1
 external_redirect: /api/#get-tags
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/tags/hosts`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-tags-get" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-tags-get" >}}
 

--- a/content/api/tags/tags_get_host.fr.md
+++ b/content/api/tags/tags_get_host.fr.md
@@ -8,7 +8,8 @@ external_redirect: /api/#get-host-tags
 ## Récupérer les tags d'un hôte
 Renvoie la liste des tags qui s'appliquent à un hôte donné.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`source`** [*optionnel*, *défaut*=**None**]:  
     Affiche uniquement les tags d'une source particulière Sinon, montre tous les tags.
     [Liste des valeurs de l'attribut source de l'API][1].

--- a/content/api/tags/tags_get_host.md
+++ b/content/api/tags/tags_get_host.md
@@ -8,7 +8,8 @@ external_redirect: /api/#get-host-tags
 ## Get host tags
 Return the list of tags that apply to a given host.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`source`** [*optional*, *default*=**None**]:  
     Only show tags from a particular source. Otherwise shows all tags.  
     [Complete list of source attribute values][1]

--- a/content/api/tags/tags_get_host_code.fr.md
+++ b/content/api/tags/tags_get_host_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#get-host-tags
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/tags/hosts/:host_name`
+`GET https://api.datadoghq.com/api/v1/tags/hosts/<HOSTNAME>`
 
 **Exemple de requête**:
 

--- a/content/api/tags/tags_get_host_code.fr.md
+++ b/content/api/tags/tags_get_host_code.fr.md
@@ -5,10 +5,15 @@ order: 20.2
 external_redirect: /api/#get-host-tags
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/tags/hosts/:host_name`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-tags-get-host" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-tags-get-host" >}}
 

--- a/content/api/tags/tags_get_host_code.md
+++ b/content/api/tags/tags_get_host_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#get-host-tags
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/tags/hosts/:host_name`
+`GET https://api.datadoghq.com/api/v1/tags/hosts/<HOSTNAME>`
 
 **Example Request**:
 

--- a/content/api/tags/tags_get_host_code.md
+++ b/content/api/tags/tags_get_host_code.md
@@ -5,10 +5,15 @@ order: 20.2
 external_redirect: /api/#get-host-tags
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/tags/hosts/:host_name`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-tags-get-host" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-tags-get-host" >}}
 

--- a/content/api/tags/tags_update.fr.md
+++ b/content/api/tags/tags_update.fr.md
@@ -8,7 +8,8 @@ external_redirect: /api/#update-host-tags
 ## Mettre à jour les tags d'un hôte
 Cet endpoint vous permet de mettre à jour les tags d'un hôte donné.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`tags`** [*obligatoire*]:  
     Une liste de tags
 * **`source`** [*optionnel*, *défaut*=**users**]:  

--- a/content/api/tags/tags_update.md
+++ b/content/api/tags/tags_update.md
@@ -8,7 +8,8 @@ external_redirect: /api/#update-host-tags
 ## Update host tags
 This end point allows you to update all tags for a given host.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`tags`** [*required*]:  
     A list of tags
 * **`source`** [*optional*, *default*=**users**]:  

--- a/content/api/tags/tags_update_code.fr.md
+++ b/content/api/tags/tags_update_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#update-host-tags
 
 **Signature**:
 
-`PUT https://api.datadoghq.com/api/v1/tags/hosts/:host_name`
+`PUT https://api.datadoghq.com/api/v1/tags/hosts/<HOSTNAME>`
 
 **Exemple de requête**:
 

--- a/content/api/tags/tags_update_code.fr.md
+++ b/content/api/tags/tags_update_code.fr.md
@@ -5,10 +5,15 @@ order: 20.4
 external_redirect: /api/#update-host-tags
 ---
 
-##### Signature
+**Signature**:
+
 `PUT https://api.datadoghq.com/api/v1/tags/hosts/:host_name`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-tags-update" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-tags-update" >}}
 

--- a/content/api/tags/tags_update_code.md
+++ b/content/api/tags/tags_update_code.md
@@ -5,10 +5,15 @@ order: 20.4
 external_redirect: /api/#update-host-tags
 ---
 
-##### Signature
+**Signature**:
+
 `PUT https://api.datadoghq.com/api/v1/tags/hosts/:host_name`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-tags-update" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-tags-update" >}}
 

--- a/content/api/tags/tags_update_code.md
+++ b/content/api/tags/tags_update_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#update-host-tags
 
 **Signature**:
 
-`PUT https://api.datadoghq.com/api/v1/tags/hosts/:host_name`
+`PUT https://api.datadoghq.com/api/v1/tags/hosts/<HOSTNAME>`
 
 **Example Request**:
 

--- a/content/api/timeboards/timeboards_create.fr.md
+++ b/content/api/timeboards/timeboards_create.fr.md
@@ -6,7 +6,8 @@ external_redirect: /api/#create-a-timeboard
 ---
 
 ## Créer un Timeboard
-##### Arguments
+
+**ARGUMENTS**:
 
 * **`title`** [*obligatoire*]:  
     Le nom du dashboard.

--- a/content/api/timeboards/timeboards_create.md
+++ b/content/api/timeboards/timeboards_create.md
@@ -6,7 +6,8 @@ external_redirect: /api/#create-a-timeboard
 ---
 
 ## Create a Timeboard
-##### Arguments
+
+**ARGUMENTS**:
 
 * **`title`** [*required*]:  
     The name of the dashboard.

--- a/content/api/timeboards/timeboards_create_code.fr.md
+++ b/content/api/timeboards/timeboards_create_code.fr.md
@@ -5,10 +5,15 @@ order: 21.1
 external_redirect: /api/#create-a-timeboard
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/dash`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-dashboard-create" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-dashboard-create" >}}
 

--- a/content/api/timeboards/timeboards_create_code.md
+++ b/content/api/timeboards/timeboards_create_code.md
@@ -5,10 +5,15 @@ order: 21.1
 external_redirect: /api/#create-a-timeboard
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/dash`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-dashboard-create" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-dashboard-create" >}}
 

--- a/content/api/timeboards/timeboards_delete_code.fr.md
+++ b/content/api/timeboards/timeboards_delete_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#delete-a-timeboard
 
 **Signature**:
 
-`DELETE https://api.datadoghq.com/api/v1/dash/:dash_id`
+`DELETE https://api.datadoghq.com/api/v1/dash/<TIMEBOARD_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/timeboards/timeboards_delete_code.fr.md
+++ b/content/api/timeboards/timeboards_delete_code.fr.md
@@ -5,10 +5,15 @@ order: 21.3
 external_redirect: /api/#delete-a-timeboard
 ---
 
-##### Signature
+**Signature**:
+
 `DELETE https://api.datadoghq.com/api/v1/dash/:dash_id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-dashboard-delete" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 *Cet endpoint ne renvoie aucun objet JSON en cas de requête réussie.*
 

--- a/content/api/timeboards/timeboards_delete_code.md
+++ b/content/api/timeboards/timeboards_delete_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#delete-a-timeboard
 
 **Signature**:
 
-`DELETE https://api.datadoghq.com/api/v1/dash/:dash_id`
+`DELETE https://api.datadoghq.com/api/v1/dash/<TIMEBOARD_ID>`
 
 **Example Request**:
 

--- a/content/api/timeboards/timeboards_delete_code.md
+++ b/content/api/timeboards/timeboards_delete_code.md
@@ -5,10 +5,15 @@ order: 21.3
 external_redirect: /api/#delete-a-timeboard
 ---
 
-##### Signature
+**Signature**:
+
 `DELETE https://api.datadoghq.com/api/v1/dash/:dash_id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-dashboard-delete" >}}
-##### Example Response
+
+**Example Response**:
+
 *This end point does not return JSON on successful requests.*
 

--- a/content/api/timeboards/timeboards_get.fr.md
+++ b/content/api/timeboards/timeboards_get.fr.md
@@ -8,6 +8,7 @@ external_redirect: /api/#get-a-timeboard
 ## Récupérer un Timeboard
 Récupère toutes les spécifications d'un Dashboard.
 
-##### Arguments
+**ARGUMENTS**:
+
 *Cet endpoint ne prend aucun argument JSON.*
 

--- a/content/api/timeboards/timeboards_get.md
+++ b/content/api/timeboards/timeboards_get.md
@@ -8,6 +8,7 @@ external_redirect: /api/#get-a-timeboard
 ## Get a Timeboard
 Fetch an existing dashboard's definition.
 
-##### Arguments
+**ARGUMENTS**:
+
 *This end point takes no JSON arguments.*
 

--- a/content/api/timeboards/timeboards_get_code.fr.md
+++ b/content/api/timeboards/timeboards_get_code.fr.md
@@ -5,10 +5,15 @@ order: 21.5
 external_redirect: /api/#get-a-timeboard
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/dash/:dash_id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-dashboard-get" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-dashboard-get" >}}
 

--- a/content/api/timeboards/timeboards_get_code.fr.md
+++ b/content/api/timeboards/timeboards_get_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#get-a-timeboard
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/dash/:dash_id`
+`GET https://api.datadoghq.com/api/v1/dash/<TIMEBOARD_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/timeboards/timeboards_get_code.md
+++ b/content/api/timeboards/timeboards_get_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#get-a-timeboard
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/dash/:dash_id`
+`GET https://api.datadoghq.com/api/v1/dash/<TIMEBOARD_ID>`
 
 **Example Request**:
 

--- a/content/api/timeboards/timeboards_get_code.md
+++ b/content/api/timeboards/timeboards_get_code.md
@@ -5,10 +5,15 @@ order: 21.5
 external_redirect: /api/#get-a-timeboard
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/dash/:dash_id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-dashboard-get" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-dashboard-get" >}}
 

--- a/content/api/timeboards/timeboards_getall.fr.md
+++ b/content/api/timeboards/timeboards_getall.fr.md
@@ -8,7 +8,8 @@ external_redirect: /api/#get-all-timeboards
 ## Récupérer tous les Timeboards
 Récupère toutes les spécifications de votre [Timeboard][1].
 
-##### Arguments
+**ARGUMENTS**:
+
 *Cet endpoint ne prend aucun argument JSON.*
 
 [1]: /graphing/dashboards/timeboard

--- a/content/api/timeboards/timeboards_getall.md
+++ b/content/api/timeboards/timeboards_getall.md
@@ -8,7 +8,8 @@ external_redirect: /api/#get-all-timeboards
 ## Get all Timeboards
 Fetch all of your [timeboard][1]' definitions.
 
-##### Arguments
+**ARGUMENTS**:
+
 *This end point takes no JSON arguments.*
 
 [1]: /graphing/dashboards/timeboard

--- a/content/api/timeboards/timeboards_getall_code.fr.md
+++ b/content/api/timeboards/timeboards_getall_code.fr.md
@@ -5,10 +5,15 @@ order: 21.4
 external_redirect: /api/#get-all-timeboards
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/dash`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-dashboard-get-all" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-dashboard-get-all" >}}
 

--- a/content/api/timeboards/timeboards_getall_code.md
+++ b/content/api/timeboards/timeboards_getall_code.md
@@ -5,10 +5,15 @@ order: 21.4
 external_redirect: /api/#get-all-timeboards
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/dash`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-dashboard-get-all" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-dashboard-get-all" >}}
 

--- a/content/api/timeboards/timeboards_update.fr.md
+++ b/content/api/timeboards/timeboards_update.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#update-a-timeboard
 
 ## Mettre à jour un Timeboard
 
-##### Arguments
+**ARGUMENTS**:
 
 * **`title`** [*obligatoire*]:  
     Le nom du dashboard.

--- a/content/api/timeboards/timeboards_update.md
+++ b/content/api/timeboards/timeboards_update.md
@@ -7,7 +7,7 @@ external_redirect: /api/#update-a-timeboard
 
 ## Update a Timeboard
 
-##### Arguments
+**ARGUMENTS**:
 
 * **`title`** [*required*]:  
     The name of the dashboard.

--- a/content/api/timeboards/timeboards_update_code.fr.md
+++ b/content/api/timeboards/timeboards_update_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#update-a-timeboard
 
 **Signature**:
 
-`PUT https://api.datadoghq.com/api/v1/dash/:dash_id`
+`PUT https://api.datadoghq.com/api/v1/dash/<TIMEBOARD_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/timeboards/timeboards_update_code.fr.md
+++ b/content/api/timeboards/timeboards_update_code.fr.md
@@ -5,10 +5,15 @@ order: 21.2
 external_redirect: /api/#update-a-timeboard
 ---
 
-##### Signature
+**Signature**:
+
 `PUT https://api.datadoghq.com/api/v1/dash/:dash_id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-dashboard-update" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-dashboard-update" >}}
 

--- a/content/api/timeboards/timeboards_update_code.md
+++ b/content/api/timeboards/timeboards_update_code.md
@@ -5,10 +5,15 @@ order: 21.2
 external_redirect: /api/#update-a-timeboard
 ---
 
-##### Signature
+**Signature**:
+
 `PUT https://api.datadoghq.com/api/v1/dash/:dash_id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-dashboard-update" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-dashboard-update" >}}
 

--- a/content/api/timeboards/timeboards_update_code.md
+++ b/content/api/timeboards/timeboards_update_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#update-a-timeboard
 
 **Signature**:
 
-`PUT https://api.datadoghq.com/api/v1/dash/:dash_id`
+`PUT https://api.datadoghq.com/api/v1/dash/<TIMEBOARD_ID>`
 
 **Example Request**:
 

--- a/content/api/tracing/send_service.fr.md
+++ b/content/api/tracing/send_service.fr.md
@@ -6,7 +6,8 @@ external_redirect: /api/#send-services
 ---
 
 ## Envoyer vos services
-##### Arguments
+
+**ARGUMENTS**:
 
 *   **`service`** - _obligatoire._ Le nom du service en tant que clé de dictionnaire, [En apprendre plus][1].
 *   **`app`** - _obligatoire._ Le nom de l'application.

--- a/content/api/tracing/send_service.md
+++ b/content/api/tracing/send_service.md
@@ -6,7 +6,8 @@ external_redirect: /api/#send-services
 ---
 
 ## Send services
-##### Arguments
+
+**ARGUMENTS**:
 
 *   **`service`** - _Required._ The service name as a dictionary key, [Learn more][1].
 *   **`app`** - _Required._ The name of the application.

--- a/content/api/tracing/send_service_code.fr.md
+++ b/content/api/tracing/send_service_code.fr.md
@@ -5,13 +5,15 @@ order: 22.2
 external_redirect: /api/#send-services
 ---
 
-##### Signature
+**Signature**:
+
 `PUT  http://localhost:8126/v0.3/traces`
 
-##### Exemple de requête
+**Exemple de requête**:
+
 {{< code-snippets basename="send_service" >}}
 
-##### Exemple de réponse
+**Exemple de réponse**:
 
 {{< code-snippets basename="result.send_service" >}}
 

--- a/content/api/tracing/send_service_code.md
+++ b/content/api/tracing/send_service_code.md
@@ -5,13 +5,15 @@ order: 22.2
 external_redirect: /api/#send-services
 ---
 
-##### Signature
+**Signature**:
+
 `PUT  http://localhost:8126/v0.3/services`
 
-##### Example Request
+**Example Request**:
+
 {{< code-snippets basename="send_service" >}}
 
-##### Example Response
+**Example Response**:
 
 {{< code-snippets basename="result.send_service" >}}
 

--- a/content/api/tracing/send_trace.fr.md
+++ b/content/api/tracing/send_trace.fr.md
@@ -26,7 +26,7 @@ et chaque span est une dictionnaire avec un `trace_id`, `span_id`, `resource`…
 
 **n.b.** : Chaque span dans une trace devrait utiliser les mêmes trace_id.
 
-##### Arguments
+**ARGUMENTS**:
 
 *   **`trace_id`** - _Obligatoire_  Un identifiant unique en nombre entier (64-bits non signé) de la trace contenant cette span.
 *   **`span_id`** - _obligatoire._ L'ID entier de la span (64 bits non signé).

--- a/content/api/tracing/send_trace.md
+++ b/content/api/tracing/send_trace.md
@@ -26,7 +26,7 @@ and each span is a dictionary with a `trace_id`, `span_id`, `resource`..
 
 **Note**: Each span within a trace should use the same trace_id.
 
-##### Arguments
+**ARGUMENTS**:
 
 *   **`trace_id`** - _Required._ The unique integer (64-bit unsigned) ID of the trace containing this span.
 *   **`span_id`** - _Required._ The span integer (64-bit unsigned) ID.

--- a/content/api/tracing/send_trace_code.fr.md
+++ b/content/api/tracing/send_trace_code.fr.md
@@ -5,14 +5,15 @@ order: 22.1
 external_redirect: /api/#send-traces
 ---
 
-##### Signature
+**Signature**:
+
 `PUT  http://localhost:8126/v0.3/traces`
 
-##### Exemple de requête
+**Exemple de requête**:
 
 {{< code-snippets basename="send_trace" >}}
 
-##### Exemple de réponse
+**Exemple de réponse**:
 
 {{< code-snippets basename="result.send_trace" >}}
 

--- a/content/api/tracing/send_trace_code.md
+++ b/content/api/tracing/send_trace_code.md
@@ -5,14 +5,15 @@ order: 22.1
 external_redirect: /api/#send-traces
 ---
 
-##### Signature
+**Signature**:
+
 `PUT  http://localhost:8126/v0.3/traces`
 
-##### Example Request
+**Example Request**:
 
 {{< code-snippets basename="send_trace" >}}
 
-##### Example Response
+**Example Response**:
 
 {{< code-snippets basename="result.send_trace" >}}
 

--- a/content/api/usage/usage_hosts.md
+++ b/content/api/usage/usage_hosts.md
@@ -9,13 +9,14 @@ external_redirect: /api/#get-hourly-usage-for-hosts-and-containers
 
 Get Hourly Usage For Hosts and Containers.
 
-##### Arguments
+**ARGUMENTS**:
+
 * **`start_hr`** [*required*]:  
     datetime in ISO-8601 format, UTC, precise to hour: [YYYY-MM-DDThh] for usage beginning at this hour
 * **`end_hr`** [*optional*, *default*=**1d+start_hr**]:  
     datetime in ISO-8601 format, UTC, precise to hour: [YYYY-MM-DDThh] for usage ending BEFORE this hour
 
-##### Response
+**Response**:
 
 * **`container_count`**:  
     Shows the total number of containers reporting via the Docker integration during the hour.

--- a/content/api/usage/usage_hosts_code.fr.md
+++ b/content/api/usage/usage_hosts_code.fr.md
@@ -5,10 +5,15 @@ order: 23.1
 external_redirect: /api/#get-hourly-usage-for-hosts-and-containers
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/usage/hosts`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-billing-usage-hosts" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-billing-usage-hosts" >}}
 

--- a/content/api/usage/usage_hosts_code.md
+++ b/content/api/usage/usage_hosts_code.md
@@ -5,10 +5,15 @@ order: 23.1
 external_redirect: /api/#get-hourly-usage-for-hosts-and-containers
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/usage/hosts`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-billing-usage-hosts" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-billing-usage-hosts" >}}
 

--- a/content/api/usage/usage_multi_org.fr.md
+++ b/content/api/usage/usage_multi_org.fr.md
@@ -9,7 +9,8 @@ external_redirect: /api/#get-usage-across-your-multi-org-account
 
 Récupérer l'utilisation de votre compte multi-org
 
-##### Arguments
+**ARGUMENTS**:
+
 * **`start_month`** [*obligatoire*]:  
     Datetime dans le format ISO-8601 , UTC, précis au mois: [YYYY-MM] Pour l'usage depuis le début de ce mois. Maximum de 15 mois dans le passé.
 * **`end_month`** [*optionnel*, *défaut*=**current_month-3d**]:

--- a/content/api/usage/usage_multi_org.md
+++ b/content/api/usage/usage_multi_org.md
@@ -9,7 +9,8 @@ external_redirect: /api/#get-usage-across-your-multi-org-account
 
 Get usage across your multi-org account
 
-##### Arguments
+**ARGUMENTS**:
+
 * **`start_month`** [*required*]:  
     Datetime in ISO-8601 format, UTC, precise to month: [YYYY-MM] for usage beginning in this month. Maximum of 15 months ago.
 * **`end_month`** [*optional*, *default*=**current_month-3d**]:

--- a/content/api/usage/usage_multi_org_code.fr.md
+++ b/content/api/usage/usage_multi_org_code.fr.md
@@ -5,10 +5,15 @@ order: 23.4
 external_redirect: /api/#get-usage-across-your-multi-org-account
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/usage/summary`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-billing-usage-summary" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-billing-usage-summary" >}}
 

--- a/content/api/usage/usage_multi_org_code.md
+++ b/content/api/usage/usage_multi_org_code.md
@@ -5,10 +5,15 @@ order: 23.4
 external_redirect: /api/#get-usage-across-your-multi-org-account
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/usage/summary`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-billing-usage-summary" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-billing-usage-summary" >}}
 

--- a/content/api/usage/usage_timeseries.fr.md
+++ b/content/api/usage/usage_timeseries.fr.md
@@ -9,7 +9,8 @@ external_redirect: /api/#get-hourly-usage-for-custom-metrics
 
 Récupérer l'utilisation horaire pour [les métriques custom][1].
 
-##### Arguments
+**ARGUMENTS**:
+
 * **`start_hr`** [*obligatoire*]:  
     datetime dans le format ISO-8601 , UTC, précis à l'heure: [YYYY-MM-DDThh] Pour l'usage depuis le début de cette heure
 * **`end_hr`** [*optionnel*, *défaut*=**1d+start_hr**]:  

--- a/content/api/usage/usage_timeseries.md
+++ b/content/api/usage/usage_timeseries.md
@@ -9,7 +9,8 @@ external_redirect: /api/#get-hourly-usage-for-custom-metrics
 
 Get Hourly Usage For [Custom Metrics][1].
 
-##### Arguments
+**ARGUMENTS**:
+
 * **`start_hr`** [*required*]:  
     datetime in ISO-8601 format, UTC, precise to hour: [YYYY-MM-DDThh] for usage beginning at this hour
 * **`end_hr`** [*optional*, *default*=**1d+start_hr**]:  

--- a/content/api/usage/usage_timeseries_code.fr.md
+++ b/content/api/usage/usage_timeseries_code.fr.md
@@ -5,10 +5,15 @@ order: 23.2
 external_redirect: /api/#get-hourly-usage-for-custom-metrics
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/usage/timeseries`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-billing-usage-timeseries" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-billing-usage-timeseries" >}}
 

--- a/content/api/usage/usage_timeseries_code.md
+++ b/content/api/usage/usage_timeseries_code.md
@@ -5,10 +5,15 @@ order: 23.2
 external_redirect: /api/#get-hourly-usage-for-custom-metrics
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/usage/timeseries`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-billing-usage-timeseries" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-billing-usage-timeseries" >}}
 

--- a/content/api/usage/usage_top_avg_metrics.fr.md
+++ b/content/api/usage/usage_top_avg_metrics.fr.md
@@ -9,7 +9,8 @@ external_redirect: /api/#get-top-500-custom-metrics-by-hourly-average
 
 Obtenez le top des [métriques customisés][1] par moyenne horaire
 
-##### Arguments
+**ARGUMENTS**:
+
 * **`month`** [*obligatoire*]:  
     datetime dans le format ISO-8601 , UTC, précis au mois: [YYYY-MM] Pour l'usage depuis le début de cette heure
 * **`names`** [*optionnel*, *défaut*=**None**]:  

--- a/content/api/usage/usage_top_avg_metrics.md
+++ b/content/api/usage/usage_top_avg_metrics.md
@@ -9,7 +9,8 @@ external_redirect: /api/#get-top-500-custom-metrics-by-hourly-average
 
 Get Top [Custom Metrics][1] By Hourly Average.
 
-##### Arguments
+**ARGUMENTS**:
+
 * **`month`** [*required*]:  
     datetime in ISO-8601 format, UTC, precise to month: [YYYY-MM] for usage beginning at this hour.
 * **`names`** [*optional*, *default*=**None**]:  

--- a/content/api/usage/usage_top_avg_metrics_code.fr.md
+++ b/content/api/usage/usage_top_avg_metrics_code.fr.md
@@ -5,10 +5,15 @@ order: 23.3
 external_redirect: /api/#get-top-500-custom-metrics-by-hourly-average
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/usage/top_avg_metrics`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-billing-usage-top-avg-metrics" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-billing-usage-top-avg-metrics" >}}
 

--- a/content/api/usage/usage_top_avg_metrics_code.md
+++ b/content/api/usage/usage_top_avg_metrics_code.md
@@ -5,10 +5,15 @@ order: 23.3
 external_redirect: /api/#get-top-500-custom-metrics-by-hourly-average
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/usage/top_avg_metrics`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-billing-usage-top-avg-metrics" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-billing-usage-top-avg-metrics" >}}
 

--- a/content/api/users/users_create.fr.md
+++ b/content/api/users/users_create.fr.md
@@ -6,7 +6,8 @@ external_redirect: /api/#create-user
 ---
 
 ## Créer un utilisateur
-##### ARGUMENTS
+
+**ARGUMENTS**:
 
 * **`handle`** [*obligatoire*]:  
     Le handle utilisateur, doit être un email valide.

--- a/content/api/users/users_create.md
+++ b/content/api/users/users_create.md
@@ -6,7 +6,8 @@ external_redirect: /api/#create-user
 ---
 
 ## Create user
-##### ARGUMENTS
+
+**ARGUMENTS**:
 
 * **`handle`** [*required*]:  
     The user handle, must be a valid email.

--- a/content/api/users/users_create_code.fr.md
+++ b/content/api/users/users_create_code.fr.md
@@ -5,10 +5,15 @@ order: 24.1
 external_redirect: /api/#create-user
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/user`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-user-create" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-user-create" >}}
 

--- a/content/api/users/users_create_code.md
+++ b/content/api/users/users_create_code.md
@@ -5,10 +5,15 @@ order: 24.1
 external_redirect: /api/#create-user
 ---
 
-##### Signature
+**Signature**:
+
 `POST https://api.datadoghq.com/api/v1/user`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-user-create" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-user-create" >}}
 

--- a/content/api/users/users_delete.fr.md
+++ b/content/api/users/users_delete.fr.md
@@ -8,7 +8,8 @@ external_redirect: /api/#disable-user
 ## Désactiver un utilisateur
 Ne peut être utilisé qu'avec des clés d'application disponibles pour les administrateurs.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`id`** [*obligatoire*]:  
     Le handle de l'utilisateur.
 

--- a/content/api/users/users_delete.md
+++ b/content/api/users/users_delete.md
@@ -8,7 +8,8 @@ external_redirect: /api/#disable-user
 ## Disable user
 Can only be used with application keys belonging to administrators.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`id`** [*required*]:  
     The handle of the user.
 

--- a/content/api/users/users_delete_code.fr.md
+++ b/content/api/users/users_delete_code.fr.md
@@ -5,10 +5,15 @@ order: 24.5
 external_redirect: /api/#disable-user
 ---
 
-##### Signature
+**Signature**:
+
 `DELETE https://api.datadoghq.com/api/v1/user/:id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-user-disable" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-user-disable" >}}
 

--- a/content/api/users/users_delete_code.fr.md
+++ b/content/api/users/users_delete_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#disable-user
 
 **Signature**:
 
-`DELETE https://api.datadoghq.com/api/v1/user/:id`
+`DELETE https://api.datadoghq.com/api/v1/user/<USER_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/users/users_delete_code.md
+++ b/content/api/users/users_delete_code.md
@@ -5,10 +5,15 @@ order: 24.5
 external_redirect: /api/#disable-user
 ---
 
-##### Signature
+**Signature**:
+
 `DELETE https://api.datadoghq.com/api/v1/user/:id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-user-disable" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-user-disable" >}}
 

--- a/content/api/users/users_delete_code.md
+++ b/content/api/users/users_delete_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#disable-user
 
 **Signature**:
 
-`DELETE https://api.datadoghq.com/api/v1/user/:id`
+`DELETE https://api.datadoghq.com/api/v1/user/<USER_ID>`
 
 **Example Request**:
 

--- a/content/api/users/users_get.fr.md
+++ b/content/api/users/users_get.fr.md
@@ -6,7 +6,9 @@ external_redirect: /api/#get-user
 ---
 
 ## Récupérer un utilisateur
-##### ARGUMENTS
+
+**ARGUMENTS**:
+
 * **`id`** [*obligatoire*]:  
     Le handle de l'utilisateur.
 

--- a/content/api/users/users_get.md
+++ b/content/api/users/users_get.md
@@ -6,7 +6,9 @@ external_redirect: /api/#get-user
 ---
 
 ## Get user
-##### ARGUMENTS
+
+**ARGUMENTS**:
+
 * **`id`** [*required*]:  
     The handle of the user.
 

--- a/content/api/users/users_get_code.fr.md
+++ b/content/api/users/users_get_code.fr.md
@@ -5,10 +5,15 @@ order: 24.2
 external_redirect: /api/#get-user
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/user/:id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-user-get" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-user-get" >}}
 

--- a/content/api/users/users_get_code.fr.md
+++ b/content/api/users/users_get_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#get-user
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/user/:id`
+`GET https://api.datadoghq.com/api/v1/user/<USER_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/users/users_get_code.md
+++ b/content/api/users/users_get_code.md
@@ -5,10 +5,15 @@ order: 24.2
 external_redirect: /api/#get-user
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/user/:id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-user-get" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-user-get" >}}
 

--- a/content/api/users/users_get_code.md
+++ b/content/api/users/users_get_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#get-user
 
 **Signature**:
 
-`GET https://api.datadoghq.com/api/v1/user/:id`
+`GET https://api.datadoghq.com/api/v1/user/<USER_ID>`
 
 **Example Request**:
 

--- a/content/api/users/users_getall.fr.md
+++ b/content/api/users/users_getall.fr.md
@@ -6,7 +6,8 @@ external_redirect: /api/#get-all-users
 ---
 
 ## Récupérer tous les utilisateurs
-##### ARGUMENTS
+
+**ARGUMENTS**:
 
 Cet endpoint ne prend aucun argument JSON.
 

--- a/content/api/users/users_getall.md
+++ b/content/api/users/users_getall.md
@@ -6,7 +6,8 @@ external_redirect: /api/#get-all-users
 ---
 
 ## Get all users
-##### ARGUMENTS
+
+**ARGUMENTS**:
 
 This end point takes no JSON arguments.
 

--- a/content/api/users/users_getall_code.fr.md
+++ b/content/api/users/users_getall_code.fr.md
@@ -5,10 +5,15 @@ order: 24.3
 external_redirect: /api/#get-all-users
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/user`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-user-get-all" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-user-get-all" >}}
 

--- a/content/api/users/users_getall_code.md
+++ b/content/api/users/users_getall_code.md
@@ -5,10 +5,15 @@ order: 24.3
 external_redirect: /api/#get-all-users
 ---
 
-##### Signature
+**Signature**:
+
 `GET https://api.datadoghq.com/api/v1/user`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-user-get-all" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-user-get-all" >}}
 

--- a/content/api/users/users_update.fr.md
+++ b/content/api/users/users_update.fr.md
@@ -8,7 +8,8 @@ external_redirect: /api/#update-user
 ## Mettre à jour un utilisateur
 Ne peut être utilisé qu'avec des clés d'application disponibles pour les administrateurs.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`id`** [*obligatoire*]:  
     Le handle de l'utilisateur.
 * **`name`** [*optionnel*, *défaut*=**None**]:  

--- a/content/api/users/users_update.md
+++ b/content/api/users/users_update.md
@@ -8,7 +8,8 @@ external_redirect: /api/#update-user
 ## Update user
 Can only be used with application keys belonging to administrators.
 
-##### ARGUMENTS
+**ARGUMENTS**:
+
 * **`id`** [*required*]:  
     The handle of the user.
 * **`name`** [*optional*, *default*=**None**]:  

--- a/content/api/users/users_update_code.fr.md
+++ b/content/api/users/users_update_code.fr.md
@@ -7,7 +7,7 @@ external_redirect: /api/#update-user
 
 **Signature**:
 
-`PUT https://api.datadoghq.com/api/v1/user/:id`
+`PUT https://api.datadoghq.com/api/v1/user/<USER_ID>`
 
 **Exemple de requête**:
 

--- a/content/api/users/users_update_code.fr.md
+++ b/content/api/users/users_update_code.fr.md
@@ -5,10 +5,15 @@ order: 24.4
 external_redirect: /api/#update-user
 ---
 
-##### Signature
+**Signature**:
+
 `PUT https://api.datadoghq.com/api/v1/user/:id`
-##### Exemple de requête
+
+**Exemple de requête**:
+
 {{< code-snippets basename="api-user-update" >}}
-##### Exemple de réponse
+
+**Exemple de réponse**:
+
 {{< code-snippets basename="result.api-user-update" >}}
 

--- a/content/api/users/users_update_code.md
+++ b/content/api/users/users_update_code.md
@@ -5,10 +5,15 @@ order: 24.4
 external_redirect: /api/#update-user
 ---
 
-##### Signature
+**Signature**:
+
 `PUT https://api.datadoghq.com/api/v1/user/:id`
-##### Example Request
+
+**Example Request**:
+
 {{< code-snippets basename="api-user-update" >}}
-##### Example Response
+
+**Example Response**:
+
 {{< code-snippets basename="result.api-user-update" >}}
 

--- a/content/api/users/users_update_code.md
+++ b/content/api/users/users_update_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#update-user
 
 **Signature**:
 
-`PUT https://api.datadoghq.com/api/v1/user/:id`
+`PUT https://api.datadoghq.com/api/v1/user/<USER_ID>`
 
 **Example Request**:
 

--- a/content/integrations/faq/list-of-api-source-attribute-value.md
+++ b/content/integrations/faq/list-of-api-source-attribute-value.md
@@ -78,6 +78,7 @@ kind: faq
 |Chef|CHEF|
 |Circleci|CIRCLECI|
 |Cisco Aci|CISCOACI|
+|Cloudflare|CLOUDFLARE|
 |Cloud Foundry|CLOUDFOUNDRY|
 |Cloudhealth|CLOUDHEALTH|
 |Cloudnetworkhealth|CLOUDNETWORKHEALTH|


### PR DESCRIPTION
### What does this PR do?

* Remove useless titles from the API section and transform them into bold text.
* Update placeholders in signatures to match contributing guidelines

### Motivation
The new search is sensitive to titles, in order to avoid weird results when it comes to the API pages, this PR removes useless titles and put instead bold text.

### Preview link
