### PR TITLE
use hashed img path for og image default

### DIFF
--- a/layouts/partials/imgurl.html
+++ b/layouts/partials/imgurl.html
@@ -1,0 +1,1 @@
+{{ $.Site.Params.img_url }}images/{{ (index .root.Site.Data.manifests.images .src ) }}

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,3 +1,4 @@
+{{ $dot := . }}
 {{ $.Scratch.Add "meta_image" "" }}
 {{ $meta_image := $.Scratch.Get "meta_image" }}
 
@@ -37,7 +38,7 @@
 <meta property="og:title" content="{{ $meta_title }}"/>
 <meta property="og:type" content="article"/>
 <meta property="og:url" content="{{ $.Permalink }}"/>
-{{ if $meta_image}}<meta property="og:image" content="{{.Site.Params.img_url}}images{{ $meta_image }}"/>{{ else }}<meta property="og:image" content="https://s3.amazonaws.com/origin-static-assets/img/dd-docs-meta-image.png"/>{{ end }}
+{{ if $meta_image}}<meta property="og:image" content="{{.Site.Params.img_url}}images{{ $meta_image }}"/>{{ else }}<meta property="og:image" content="{{.Site.Params.img_url}}{{- partial "imgurl.html" (dict "root" $dot "src" "dd-docs-meta-image.png" ) -}}"/>{{ end }}
 <meta property="og:description" content="{{ $meta_desc }}"/>
 <meta property="og:site_name" content="Datadog Infrastructure and Application Monitoring"/>
 <meta property="article:author" content="Datadog"/>


### PR DESCRIPTION
### What does this PR do?
This pr makes sure we use the hashed image url for meta tag og:image default value.

### Motivation
There was an issue with uploading replacement images and them not being seen.

### Preview link
view page source
https://docs-staging.datadoghq.com/david.jones/imgurl-partial/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
