### PR TITLE
Add .NET tracing beta documentation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -542,7 +542,7 @@ languages:
           weight: 180
           parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_dotnet
-          name: ".NET (Beta)"
+          name: ".NET"
           url: "tracing/setup/dotnet/"
           weight: 190
           parent: customnav_tracingnav_setup
@@ -1584,7 +1584,7 @@ languages:
           weight: 180
           parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_dotnet
-          name: ".NET (Beta)"
+          name: ".NET"
           url: "tracing/setup/dotnet/"
           weight: 190
           parent: customnav_tracingnav_setup

--- a/config.yaml
+++ b/config.yaml
@@ -542,7 +542,7 @@ languages:
           weight: 180
           parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_dotnet
-          name: ".NET (Coming soon)"
+          name: ".NET (Beta)"
           url: "tracing/setup/dotnet/"
           weight: 190
           parent: customnav_tracingnav_setup
@@ -1584,7 +1584,7 @@ languages:
           weight: 180
           parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_dotnet
-          name: ".NET (Coming soon)"
+          name: ".NET (Beta)"
           url: "tracing/setup/dotnet/"
           weight: 190
           parent: customnav_tracingnav_setup

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -113,7 +113,7 @@ Access the current active span from any method within your code. Note, however, 
 # e.g. adding tag to active span
 
 current_span = Datadog.tracer.active_span
-current_span.set_tag('my_tag', 'my_value') unless current_span.nil?
+current_span.set_tag('<TAG_KEY>', '<TAG_VALUE>') unless current_span.nil?
 ```
 
 **Adding tags globally to all spans**
@@ -157,7 +157,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-    tracer.Start(tracer.WithServiceName("my-blog"))
+    tracer.Start(tracer.WithServiceName("<SERVICE_NAME>"))
     defer tracer.Stop()
     http.HandleFunc("/posts", handler)
     log.Fatal(http.ListenAndServe(":8080", nil))
@@ -234,7 +234,7 @@ Access the current active span from any method within your code. Note, however, 
 const scope = tracer.scopeManager().active()
 const span = scope.span()
 
-span.setTag('my_tag', 'my_value')
+span.setTag('<TAG_KEY>', '<TAG_VALUE>')
 ```
 
 {{% /tab %}}
@@ -271,14 +271,13 @@ Access the current active span from any method within your code.
 ```csharp
 // add tag to active span
 var span = Tracer.Instance.ActiveScope.Span;
-span.SetTag("my_tag", "my_value");
+span.SetTag("<TAG_KEY>", "<TAG_VALUE>");
 ```
 
 **Note**: If the method is called and there is no span currently active, `Tracer.Instance.ActiveScope` returns `null`.
 
 {{% /tab %}}
 {{< /tabs >}}
-
 
 ## Manual Instrumentation
 
@@ -393,7 +392,7 @@ If you aren't using supported library instrumentation (see [library compatibilit
 # with Datadog tracing around the request,
 # database query, and rendering steps.
 get '/posts' do
-  Datadog.tracer.trace('web.request', service: 'my-blog', resource: 'GET /posts') do |span|
+  Datadog.tracer.trace('web.request', service: '<SERVICE_NAME>', resource: 'GET /posts') do |span|
     # Trace the activerecord call
     Datadog.tracer.trace('posts.fetch') do
       @posts = Posts.order(created_at: :desc).limit(10)
@@ -432,7 +431,7 @@ import "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 func main() {
     // Start the tracer with zero or more options.
-    tracer.Start(tracer.WithServiceName("my-service"))
+    tracer.Start(tracer.WithServiceName("<SERVICE_NAME>"))
     defer tracer.Stop()
 
     // Create a span for a web request at the /posts URL.
@@ -440,7 +439,7 @@ func main() {
     defer span.Finish()
 
     // Set metadata
-    span.SetTag("my_tag", "my_value")
+    span.SetTag("<TAG_KEY>", "<TAG_VALUE>")
 }
 ```
 
@@ -470,7 +469,7 @@ For more information on manual instrumentation, see the [API documentation][node
 {{% /tab %}}
 {{% tab ".NET" %}}
 
-If you aren’t using libraries supported by automatic instrumentation (see [Library compatibility][dotnet compatibility]), you may want to manually instrument your code.
+If you aren’t using libraries supported by automatic instrumentation (see [Library compatibility][dotnet compatibility]), you should manually instrument your code.
 
 The following example initializes a Datadog Tracer and creates a span called `web.request`:
 
@@ -562,9 +561,9 @@ class InstrumentedClass {
          */
         Tracer tracer = GlobalTracer.get();
 
-        Scope scope = tracer.buildSpan("operation-name").startActive(true);
+        Scope scope = tracer.buildSpan("<OPERATION_NAME>").startActive(true);
         try {
-            scope.span().setTag(DDTags.SERVICE_NAME, "my-new-service");
+            scope.span().setTag(DDTags.SERVICE_NAME, "<SERVICE_NAME>");
 
             // The code you're tracing
             Thread.sleep(1000);
@@ -591,8 +590,8 @@ class InstrumentedClass {
     void method0() {
         Tracer tracer = GlobalTracer.get();
 
-        try (Scope scope = tracer.buildSpan("operation-name").startActive(true)) {
-            scope.span().setTag(DDTags.SERVICE_NAME, "my-new-service");
+        try (Scope scope = tracer.buildSpan("<OPERATION_NAME>").startActive(true)) {
+            scope.span().setTag(DDTags.SERVICE_NAME, "<SERVICE_NAME>");
             Thread.sleep(1000);
         }
     }
@@ -690,12 +689,12 @@ def init_tracer(service_name):
     return tracer
 
 def my_operation():
-  span = opentracing.tracer.start_span('my_operation_name')
-  span.set_tag('my_tag', 'myvalue')
+  span = opentracing.tracer.start_span('<OPERATION_NAME>')
+  span.set_tag('<TAG_KEY>', '<TAG_VALUE>')
   time.sleep(0.05)
   span.finish()
 
-init_tracer('my_service_name')
+init_tracer('<SERVICE_NAME>')
 my_operation()
 ```
 
@@ -733,7 +732,7 @@ import (
 func main() {
     // Start the regular tracer and return it as an opentracing.Tracer interface. You
     // may use the same set of options as you normally would with the Datadog tracer.
-    t := opentracer.New(tracer.WithServiceName("my-service"))
+    t := opentracer.New(tracer.WithServiceName("<SERVICE_NAME>"))
 
     // Stop it using the regular Stop call for the tracer package.
     defer tracer.Stop()
@@ -1314,7 +1313,7 @@ Datadog client log messages are marked with ``[ddtrace]``, so you can isolate th
 Additionally, it is possible to override the default logger and replace it with a custom one. This is done using the ``log`` attribute of the tracer.
 
 ```ruby
-f = File.new("my-custom.log", "w+")           # Log messages should go there
+f = File.new("<FILENAME>.log", "w+")           # Log messages should go there
 Datadog.configure do |c|
   c.tracer log: Logger.new(f)                 # Overriding the default tracer
 end

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -788,7 +788,8 @@ For OpenTracing support, add the [`Datadog.Trace.OpenTracing`][dotnet opentracin
 public void ConfigureServices(IServiceCollection services)
 {
     // create an OpenTracing ITracer with default setting
-    OpenTracing.ITracer tracer = Datadog.Trace.OpenTracing.OpenTracingTracerFactory.CreateTracer();
+    OpenTracing.ITracer tracer =
+        Datadog.Trace.OpenTracing.OpenTracingTracerFactory.CreateTracer();
     
     // to use tracer with ASP.NET Core dependency injection
     services.AddSingleton<ITracer>(tracer);

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -467,7 +467,7 @@ For more information on manual instrumentation, see the [API documentation][node
 {{% /tab %}}
 {{% tab ".NET" %}}
 
-If you aren’t using supported library instrumentation (see [Library compatibility][dotnet compatibility]), you may want to manually instrument your code.
+If you aren’t using libraries supported by automatic instrumentation (see [Library compatibility][dotnet compatibility]), you may want to manually instrument your code.
 
 The following example initializes a Datadog Tracer and creates a span called `web.request`:
 
@@ -981,6 +981,13 @@ Distributed tracing is enabled by default for all supported integrations (see [C
 [nodejs compatibility]: /tracing/setup/nodejs/#compatibility
 
 {{% /tab %}}
+{{% tab ".NET" %}}
+
+Coming Soon. Reach out to [the Datadog support team][contact support] to be part of the beta.
+
+[contact support]: https://docs.datadoghq.com/help
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ## Priority Sampling
@@ -1145,6 +1152,13 @@ Coming Soon. Reach out to [the Datadog support team][contact support] to be part
 [contact support]: https://docs.datadoghq.com/help
 
 {{% /tab %}}
+{{% tab ".NET" %}}
+
+Coming Soon. Reach out to [the Datadog support team][contact support] to be part of the beta.
+
+[contact support]: https://docs.datadoghq.com/help
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ## Logging
@@ -1251,6 +1265,13 @@ func handler(w http.ResponseWriter, r *http.Request) {
 Coming Soon. Reach out to [the Datadog support team][contact support] to be part of the beta.
 
 [contact support]: https://docs.datadoghq.com/help
+{{% /tab %}}
+{{% tab ".NET" %}}
+
+Coming Soon. Reach out to [the Datadog support team][contact support] to be part of the beta.
+
+[contact support]: https://docs.datadoghq.com/help
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1360,6 +1381,15 @@ const tracer = require('dd-trace').init({
 For more tracer settings, check out the [API documentation][nodejs api doc].
 
 [nodejs api doc]: https://datadog.github.io/dd-trace-js/#tracer-settings
+
+{{% /tab %}}
+{{% tab ".NET" %}}
+
+Debug mode is disabled by default. To enable, set the `isDebugEnabled` argument to `true` when creating a new tracer instance:
+
+```csharp
+var tracer = Datadog.Trace.Tracer.Create(isDebugEnabled: true);
+```
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -242,7 +242,7 @@ span.setTag('my_tag', 'my_value')
 
 **Adding tags to a span**
 
-Add tags directly to a span by calling `SetTag()`. For example, with the following ASP.NET MVC action method:
+Add tags directly to a span by calling `SetTag()`. For example:
 
 ```csharp
 // An example of an ASP.NET MVC action,
@@ -256,7 +256,8 @@ public class HomeController
             scope.Span.SetTag("http.url", HttpContext.Request.RawUrl);
             scope.Span.SetTag("http.method", HttpContext.Request.HttpMethod);
 
-            // do work...
+            // do some work...
+
             return View();
         }
     }
@@ -268,7 +269,7 @@ public class HomeController
 Access the current active span from any method within your code. Note, however, that if the method is called and there is no span currently active, `Tracer.Instance.Active` returns `null`.
 
 ```csharp
-// e.g. adding tag to active span
+// add tag to active span
 var span = Tracer.Instance.ActiveScope.Span;
 span.SetTag("my_tag", "my_value");
 ```
@@ -474,16 +475,13 @@ The following example initializes a Datadog Tracer and creates a span called `we
 ```csharp
 using Datadog.Trace;
 
-var scope = Tracer.Instance.StartActive('web.request');
+var scope = Tracer.Instance.StartActive("web.request");
 var span = scope.Span;
 
-span.SetTag('http.url', '/login');
+span.SetTag("http.url", "/login");
 span.Finish();
 ```
 
-For more information on manual instrumentation, see the [API documentation][dotnet api doc].
-
-[dotnet api doc]: https://datadog.github.io/dd-trace-csharp/#manual-instrumentation
 [dotnet compatibility]: /tracing/setup/dotnet/#compatibility
 
 {{% /tab %}}
@@ -782,17 +780,17 @@ The following tags are available to override Datadog specific options:
 {{% /tab %}}
 {{% tab ".NET" %}}
 
-For OpenTracing support, add the [`Datadog.Trace.OpenTracing`][dotnet opentracing] NuGet package to your application. During application start up, initialize the OpenTracing library:
+For OpenTracing support, add the [`Datadog.Trace.OpenTracing`][dotnet opentracing] NuGet package to your application. During application start-up, initialize the OpenTracing library:
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
     // create an OpenTracing ITracer with default setting
-    ITracer tracer = OpenTracingTracerFactory.CreateTracer();
+    OpenTracing.ITracer tracer = Datadog.Trace.OpenTracing.OpenTracingTracerFactory.CreateTracer();
     
     // to use tracer with ASP.NET Core dependency injection
     services.AddSingleton<ITracer>(tracer);
 
-    // use use tracer with GlobalTracer.Instance
+    // to use tracer with OpenTracing.GlobalTracer.Instance
     GlobalTracer.Register(tracer);
 }
 ```

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -266,13 +266,15 @@ public class HomeController
 
 **Adding tags to a current active span**
 
-Access the current active span from any method within your code. Note, however, that if the method is called and there is no span currently active, `Tracer.Instance.Active` returns `null`.
+Access the current active span from any method within your code. 
 
 ```csharp
 // add tag to active span
 var span = Tracer.Instance.ActiveScope.Span;
 span.SetTag("my_tag", "my_value");
 ```
+
+**Note**: If the method is called and there is no span currently active, `Tracer.Instance.Active` returns `null`.
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -781,6 +783,7 @@ The following tags are available to override Datadog specific options:
 {{% tab ".NET" %}}
 
 For OpenTracing support, add the [`Datadog.Trace.OpenTracing`][dotnet opentracing] NuGet package to your application. During application start-up, initialize the OpenTracing library:
+
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
@@ -1383,7 +1386,7 @@ For more tracer settings, check out the [API documentation][nodejs api doc].
 {{% /tab %}}
 {{% tab ".NET" %}}
 
-Debug mode is disabled by default. To enable, set the `isDebugEnabled` argument to `true` when creating a new tracer instance:
+Debug mode is disabled by default. To enable it, set the `isDebugEnabled` argument to `true` when creating a new tracer instance:
 
 ```csharp
 var tracer = Datadog.Trace.Tracer.Create(isDebugEnabled: true);

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -274,7 +274,7 @@ var span = Tracer.Instance.ActiveScope.Span;
 span.SetTag("my_tag", "my_value");
 ```
 
-**Note**: If the method is called and there is no span currently active, `Tracer.Instance.Active` returns `null`.
+**Note**: If the method is called and there is no span currently active, `Tracer.Instance.ActiveScope` returns `null`.
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/tracing/setup/_index.md
+++ b/content/tracing/setup/_index.md
@@ -32,7 +32,7 @@ To start tracing your application:
       {{< nextlink href="tracing/setup/ruby" tag="Ruby" >}}Ruby language instrumentation{{< /nextlink >}}
       {{< nextlink href="tracing/setup/go" tag="Go" >}}Go language instrumentation.{{< /nextlink >}}
       {{< nextlink href="tracing/setup/nodejs" tag="Nodejs" >}}Node.js language instrumentation.{{< /nextlink >}}
-      {{< nextlink href="tracing/setup/dotnet" tag=".NET" >}}.NET language instrumentation. (Beta){{< /nextlink >}}
+      {{< nextlink href="tracing/setup/dotnet" tag=".NET" >}}.NET language instrumentation.{{< /nextlink >}}
       {{< nextlink href="tracing/setup/php" tag="PHP" >}}PHP language instrumentation. (Coming Soon){{< /nextlink >}}
   {{< /whatsnext >}}
 

--- a/content/tracing/setup/_index.md
+++ b/content/tracing/setup/_index.md
@@ -32,7 +32,7 @@ To start tracing your application:
       {{< nextlink href="tracing/setup/ruby" tag="Ruby" >}}Ruby language instrumentation{{< /nextlink >}}
       {{< nextlink href="tracing/setup/go" tag="Go" >}}Go language instrumentation.{{< /nextlink >}}
       {{< nextlink href="tracing/setup/nodejs" tag="Nodejs" >}}Node.js language instrumentation.{{< /nextlink >}}
-      {{< nextlink href="tracing/setup/dotnet" tag=".NET" >}}.NET language instrumentation. (Coming Soon){{< /nextlink >}}
+      {{< nextlink href="tracing/setup/dotnet" tag=".NET" >}}.NET language instrumentation. (Beta){{< /nextlink >}}
       {{< nextlink href="tracing/setup/php" tag="PHP" >}}PHP language instrumentation. (Coming Soon){{< /nextlink >}}
   {{< /whatsnext >}}
 

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -17,7 +17,7 @@ further_reading:
 ---
 
 <div class="alert alert-warning">
-.NET Tracing is currently in an open Public Beta and will be Generally Available in October 2018.
+.NET Tracing is in an open Public Beta and will be Generally Available in October 2018.
 </div>
 
 ## Installation and Getting Started

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -20,9 +20,9 @@ further_reading:
 
 To begin tracing applications written in any language, first [install and configure the Datadog Agent][1].
 
-To use automatic instrumentation on Windows, download the latest Windows installer from the public [GitHub repository][3]. To instrument Windows services (including web applications running on IIS), reboot the host after running the installer so these services can pick up the required environment variables added by the installer.
+To use automatic instrumentation on Windows, download the latest MSI installer for Windows from the public [GitHub repository][3]. To instrument Windows services (including web applications running on IIS), reboot the host after running the installer so these services can pick up the required environment variables added by the installer.
 
-[Download Windows installer][3]
+[Download MSI installer for Windows][3]
 
 ## Automatic Instrumentation
 

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -54,7 +54,8 @@ The .NET tracer can instrument the following web frameworks automatically:
 
 | Web framework    | Versions | Runtime             | OS      | Support Type      |
 | :--------------- | :------- | :------------------ | :------ | :---------------- |
-| ASP.NET MVC      | 5.2+     | .NET Framework 4.5+ | Windows | Fully supported   |
+| ASP.NET MVC      | 5.2.x    | .NET Framework 4.5+ | Windows | Fully supported   |
+| ASP.NET Web API  | 2.2.x    | .NET Framework 4.5+ | Windows | Fully supported   |
 | ASP.NET Core MVC | 2.0+     | .NET Framework 4.5+ | Windows | Fully supported   |
 | ASP.NET Core MVC | 2.0+     | .NET Core 2.0.x     | Windows | Fully supported   |
 | ASP.NET Core MVC | 2.0+     | .NET Core 2.0.x     | Linux   | Coming soon       |

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -20,11 +20,13 @@ further_reading:
 
 To begin tracing applications written in any language, first [install and configure the Datadog Agent][1].
 
+To use automatic instrumentation on Windows, download the latest Windows installer from the public [GitHub repository][3]. To instrument Windows services (including web applications running on IIS), reboot the host after running the installer so these services can pick up the required environment variables added by the installer.
+
+[Download Windows installer][3]
+
 ## Automatic Instrumentation
 
-Automatic instrumentation uses the [Profiling API][2] provided by .NET Framework and .NET Core to modify IL instructions at run time and inject instrumentation code. With zero code changes or configuration, the .NET tracer automatically instruments all supported libraries out of the box.
-
-To use automatic instrumentation on Windows, download the latest Windows installer from the public [GitHub repository][3]. For Windows services (including web applications running on IIS), rebooting is necessary for these services to pick up the environment variables required by the Profiling API.
+Automatic instrumentation uses the Profiling API provided by .NET Framework and .NET Core to modify IL instructions at run time and inject instrumentation code. With zero code changes or configuration, the .NET tracer automatically instruments all supported libraries out of the box.
 
 Automatic instrumentation captures:
 

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -1,61 +1,87 @@
 ---
-title: Tracing .NET Applications (Coming Soon)
+title: Tracing .NET Applications (Beta)
 kind: Documentation
+aliases:
+- /tracing/dotnet
+- /tracing/languages/dotnet
 further_reading:
+- link: "https://github.com/DataDog/dd-trace-csharp"
+  tag: "Github"
+  text: Source code
 - link: "tracing/visualization/"
   tag: "Documentation"
   text: "Explore your services, resources and traces"
-- link: "https://goo.gl/forms/SCKOOlHS7tNzyMt93"
-  tag: "Survey"
-  text: Request Beta Access
+- link: "tracing/advanced_usage/"
+  tag: "Advanced Usage"
+  text: "Advanced Usage"
 ---
 
-<div class="alert alert-warning">
-Tracing for .NET is coming soon. The officially supported Beta will launch as early as September 2018. To be notified of the beta launch, fill out the survey below.
-</div>
+## Installation and Getting Started
 
-{{< whatsnext desc="To be notified of the Beta launch, submit this form:">}}
-    {{< nextlink href="https://goo.gl/forms/SCKOOlHS7tNzyMt93" tag="Survey" >}}.NET Beta Access Survey{{< /nextlink >}}
-{{< /whatsnext >}}
+To begin tracing applications written in any language, first [install and configure the Datadog Agent][1].
 
-<br>
+## Automatic Instrumentation
 
-## Planned Automatic Instrumentation for Beta (Coming Soon)
+Automatic instrumentation uses the [Profiling API][2] provided by .NET Framework and .NET Core to modify IL instructions at run time and inject instrumentation code. With zero code changes or configuration, the .NET tracer will automatically instrument all supported libraries out of the box.
 
-Planned support will provide automatic instrumentation for popular frameworks and libraries. See some of these listed below. Don't see your desired frameworks or libraries?
-Let Datadog know more about your needs through [this survey][1].
+To use automatic instrumentation on Windows, download the latest Windows installer from the public [GitHub repository][3]. For Windows services (including web applications running on IIS), rebooting is necessary for these services to pick up the environment variables required by the Profiling API.
+
+Automatic instrumentation will capture:
+* Method execution time
+* Relevant trace data such as URL and status response codes for web requests or SQL query for database access
+* Unhandled exceptions, including stacktrace if available
+* A total count of traces (requests) flowing through the system
+
+## Compatibility
+
+The .NET tracer supports automatic instrumentation on the following .NET runtimes:
+
+| .NET Runtime   | Versions | OS      | Support Type      |
+| :------------- | :------- | :------ | :---------------- |
+| .NET Framework | 4.5+     | Windows |  Fully supported  |
+| .NET Core      | 2.0.x    | Windows |  Fully supported  |
+| .NET Core      | 2.0.x    | Linux   |  Coming soon      |
+| .NET Core      | 2.1.3+   |         |  Coming soon      |
+
+### Integrations
+
+*Note:* Libraries that target .NET Standard 2.0 are fully supported when running on either .NET Framework 4.6.1+ or .NET Core 2.0.x.
 
 #### Web Framework Compatibility
 
-| Framework                    | Versions    | Support Type                           |
-| :---------------             | :---------- | :------------------------------------- |
-| ASP.NET Core MVC<sup>2</sup> | 2.0         | Coming soon (est. September 2018 Beta) |
-| ASP.NET MVC<sup>1</sup>      | 5.x         | Coming soon (est. September 2018 Beta) |
-| ASP.NET Web API<sup>1</sup>  | 2.x         | Coming soon (est. September 2018 Beta) |
+The .NET tracer can instrument the following web frameworks automatically:
 
-<sup>1</sup> Running on .NET Framework 4.5 or above
-<sup>2</sup> Running on .NET Framework 4.6.1 or above, or on .NET Core 2.0 or above
+| Web framework    | Versions | Runtime        | OS      | Support Type      |
+| :--------------- | :------- | :------------- | :------ | :---------------- |
+| ASP.NET MVC      | 5.2.3+   | .NET Framework | Windows | Fully supported   |
+| ASP.NET Core MVC | 2.0.x    | .NET Framework | Windows | Fully supported   |
+| ASP.NET Core MVC | 2.0.x    | .NET Core      | Windows | Fully supported   |
+| ASP.NET Core MVC | 2.0.x    | .NET Core      | Linux   | Coming soon       |
+| ASP.NET Core MVC | 2.1.3+   |                |         | Coming soon       |
 
-Don't see what you're looking for? Let Datadog know more about your needs through [this survey][1].
-
-[1]: https://goo.gl/forms/SCKOOlHS7tNzyMt93
+Don't see your desired web frameworks? We're continually adding additional support, [check with the Datadog team][5] to see if we can help.
 
 #### Data Store Compatibility
 
-| Data Store                      | Versions    | Support Type                           |
-| :------------------------------ | :---------- | :------------------------------------- |
-| Ado.Net / System.Data.SqlClient | Coming soon | Coming soon (est. September 2018 Beta) |
-| Elasticsearch.net / NEST        | Coming soon | Coming soon (est. September 2018 Beta) |
-| MongoDB.Driver                  | Coming soon | Coming soon (est. September 2018 Beta) |
-| Postgres (Npgsql)               | Coming soon | Coming soon (est. September 2018 Beta) |
-| StackExchange.Redis             | Coming soon | Coming soon (est. September 2018 Beta) |
+The .NET tracer's ability to automatically instrument data store access depends on the client libraries used:
 
-Don't see what you're looking for? Let Datadog know more about your needs through [this survey][1].
+| Data store    | Client library or NuGet package     | Versions | Support type    |
+| :---------    | :---------------------------------- | :------- | :-------------- |
+| MS SQL Server | Built-in .NET Framework `SqlClient` |          | Fully supported |
+| MS SQL Server | `System.Data.SqlClient`             | 4.1+     | Fully supported |
+| Redis         | `StackExchange.Redis`               |          | Coming soon     |
+| Elasticsearch | `NEST` / `Elasticsearch.Net`        |          | Coming soon     |
+| MongoDB       | `MongoDB.Driver`                    |          | Coming soon     |
+| PostgreSQL    | `Npgsql`                            |          | Coming soon     |
 
-[1]: https://goo.gl/forms/SCKOOlHS7tNzyMt93
+Don't see your desired datastores? We're continually adding additional support, [check with the Datadog team][5] to see if we can help.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://goo.gl/forms/SCKOOlHS7tNzyMt93
+[1]: https://docs.datadoghq.com/tracing/setup
+[2]: https://docs.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/
+[3]: https://github.com/DataDog/dd-trace-csharp/releases
+[4]: https://www.nuget.org/packages/Datadog.Trace/
+[5]: /help

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -51,7 +51,7 @@ The .NET tracer supports automatic instrumentation on the following .NET runtime
 | .NET Core      | 2.1.3+   |         | Coming soon       |
 
 **Note**: Libraries that target .NET Standard 2.0 are supported when running on either .NET Framework 4.6.1+ or .NET Core 2.0.x.
-
+Don’t see your desired frameworks? We’re continually adding additional support. [Check with the Datadog team][5] to see if we can help.
 
 ### Web Framework Integrations
 
@@ -65,7 +65,7 @@ The .NET tracer can instrument the following web frameworks automatically:
 | ASP.NET Core MVC | 2.0+     | .NET Core 2.0.x     | Windows | Public Beta       |
 | ASP.NET Core MVC | 2.0+     | .NET Core 2.0.x     | Linux   | Coming soon       |
 
-Don't see your desired web frameworks? [Check with the Datadog Support team][5] to see if we can help.
+Don’t see your desired web frameworks? We’re continually adding additional support. [Check with the Datadog team][5] to see if we can help.
 
 ### Data Store Integrations
 
@@ -80,7 +80,7 @@ The .NET tracer's ability to automatically instrument data store access depends 
 | MongoDB       | `MongoDB.Driver`                    |          | Coming soon     |
 | PostgreSQL    | `Npgsql`                            |          | Coming soon     |
 
-Don't see your desired data store? [Check with the Datadog Support team][5] to see if we can help.
+Don’t see your desired data store libraries? We’re continually adding additional support. [Check with the Datadog team][5] to see if we can help.
 
 ## Manual Instrumentation
 

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -35,7 +35,7 @@ Automatic instrumentation captures:
 * Unhandled exceptions, including stacktrace if available
 * A total count of traces (requests) flowing through the system
 
-## Compatibility
+### Runtime Compatibility
 
 The .NET tracer supports automatic instrumentation on the following .NET runtimes:
 
@@ -48,9 +48,8 @@ The .NET tracer supports automatic instrumentation on the following .NET runtime
 
 **Note**: Libraries that target .NET Standard 2.0 are fully supported when running on either .NET Framework 4.6.1+ or .NET Core 2.0.x.
 
-### Integrations
 
-#### Web Framework Compatibility
+### Web Framework Integrations
 
 The .NET tracer can instrument the following web frameworks automatically:
 
@@ -64,7 +63,7 @@ The .NET tracer can instrument the following web frameworks automatically:
 
 Don't see your desired web frameworks? [Check with the Datadog Support team][5] to see if we can help.
 
-#### Data Store Compatibility
+### Data Store Integrations
 
 The .NET tracer's ability to automatically instrument data store access depends on the client libraries used:
 
@@ -79,12 +78,16 @@ The .NET tracer's ability to automatically instrument data store access depends 
 
 Don't see your desired data store? [Check with the Datadog Support team][5] to see if we can help.
 
+## Manual Instrumentation
+
+To manually instrument your code, see [Advanced Usage][2].
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://docs.datadoghq.com/tracing/setup
-[2]: https://docs.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/
+[2]: /tracing/advanced_usage/?tab=net
 [3]: https://github.com/DataDog/dd-trace-csharp/releases
 [4]: https://www.nuget.org/packages/Datadog.Trace/
 [5]: /help

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -27,6 +27,7 @@ Automatic instrumentation uses the [Profiling API][2] provided by .NET Framework
 To use automatic instrumentation on Windows, download the latest Windows installer from the public [GitHub repository][3]. For Windows services (including web applications running on IIS), rebooting is necessary for these services to pick up the environment variables required by the Profiling API.
 
 Automatic instrumentation will capture:
+
 * Method execution time
 * Relevant trace data such as URL and status response codes for web requests or SQL query for database access
 * Unhandled exceptions, including stacktrace if available
@@ -43,9 +44,9 @@ The .NET tracer supports automatic instrumentation on the following .NET runtime
 | .NET Core      | 2.0.x    | Linux   |  Coming soon      |
 | .NET Core      | 2.1.3+   |         |  Coming soon      |
 
-### Integrations
-
 *Note:* Libraries that target .NET Standard 2.0 are fully supported when running on either .NET Framework 4.6.1+ or .NET Core 2.0.x.
+
+### Integrations
 
 #### Web Framework Compatibility
 
@@ -65,7 +66,7 @@ Don't see your desired web frameworks? We're continually adding additional suppo
 
 The .NET tracer's ability to automatically instrument data store access depends on the client libraries used:
 
-| Data store    | Client library or NuGet package     | Versions | Support type    |
+| Data store    | Library or NuGet package     | Versions | Support type    |
 | :---------    | :---------------------------------- | :------- | :-------------- |
 | MS SQL Server | Built-in .NET Framework `SqlClient` |          | Fully supported |
 | MS SQL Server | `System.Data.SqlClient`             | 4.1+     | Fully supported |

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -11,7 +11,7 @@ further_reading:
 - link: "tracing/visualization/"
   tag: "Documentation"
   text: "Explore your services, resources and traces"
-- link: "tracing/advanced_usage/"
+- link: "tracing/advanced_usage/?tab=net"
   tag: "Advanced Usage"
   text: "Advanced Usage"
 ---

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -45,12 +45,12 @@ The .NET tracer supports automatic instrumentation on the following .NET runtime
 
 | .NET Runtime   | Versions | OS      | Support Type      |
 | :------------- | :------- | :------ | :---------------- |
-| .NET Framework | 4.5+     | Windows | Fully supported   |
-| .NET Core      | 2.0.x    | Windows | Fully supported   |
+| .NET Framework | 4.5+     | Windows | Public Beta       |
+| .NET Core      | 2.0.x    | Windows | Public Beta       |
 | .NET Core      | 2.0.x    | Linux   | Coming soon       |
 | .NET Core      | 2.1.3+   |         | Coming soon       |
 
-**Note**: Libraries that target .NET Standard 2.0 are fully supported when running on either .NET Framework 4.6.1+ or .NET Core 2.0.x.
+**Note**: Libraries that target .NET Standard 2.0 are supported when running on either .NET Framework 4.6.1+ or .NET Core 2.0.x.
 
 
 ### Web Framework Integrations
@@ -59,10 +59,10 @@ The .NET tracer can instrument the following web frameworks automatically:
 
 | Web framework    | Versions | Runtime             | OS      | Support Type      |
 | :--------------- | :------- | :------------------ | :------ | :---------------- |
-| ASP.NET MVC      | 5.2.x    | .NET Framework 4.5+ | Windows | Fully supported   |
-| ASP.NET Web API  | 2.2.x    | .NET Framework 4.5+ | Windows | Fully supported   |
-| ASP.NET Core MVC | 2.0+     | .NET Framework 4.5+ | Windows | Fully supported   |
-| ASP.NET Core MVC | 2.0+     | .NET Core 2.0.x     | Windows | Fully supported   |
+| ASP.NET MVC      | 5.2.x    | .NET Framework 4.5+ | Windows | Public Beta       |
+| ASP.NET Web API  | 2.2.x    | .NET Framework 4.5+ | Windows | Public Beta       |
+| ASP.NET Core MVC | 2.0+     | .NET Framework 4.5+ | Windows | Public Beta       |
+| ASP.NET Core MVC | 2.0+     | .NET Core 2.0.x     | Windows | Public Beta       |
 | ASP.NET Core MVC | 2.0+     | .NET Core 2.0.x     | Linux   | Coming soon       |
 
 Don't see your desired web frameworks? [Check with the Datadog Support team][5] to see if we can help.
@@ -73,8 +73,8 @@ The .NET tracer's ability to automatically instrument data store access depends 
 
 | Data store    | Library or NuGet package            | Versions | Support type    |
 | :---------    | :---------------------------------- | :------- | :-------------- |
-| MS SQL Server | Built-in .NET Framework `SqlClient` |          | Fully supported |
-| MS SQL Server | `System.Data.SqlClient`             | 4.1+     | Fully supported |
+| MS SQL Server | Built-in .NET Framework `SqlClient` |          | Public Beta     |
+| MS SQL Server | `System.Data.SqlClient`             | 4.1+     | Public Beta     |
 | Redis         | `StackExchange.Redis`               |          | Coming soon     |
 | Elasticsearch | `NEST` / `Elasticsearch.Net`        |          | Coming soon     |
 | MongoDB       | `MongoDB.Driver`                    |          | Coming soon     |

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -1,5 +1,5 @@
 ---
-title: Tracing .NET Applications (Beta)
+title: Tracing .NET Applications
 kind: Documentation
 aliases:
 - /tracing/dotnet
@@ -15,6 +15,10 @@ further_reading:
   tag: "Advanced Usage"
   text: "Advanced Usage"
 ---
+
+<div class="alert alert-warning">
+.NET Tracing is currently in an open Public Beta and will be Generally Available in October 2018.
+</div>
 
 ## Installation and Getting Started
 

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -51,6 +51,7 @@ The .NET tracer supports automatic instrumentation on the following .NET runtime
 | .NET Core      | 2.1.3+   |         | Coming soon       |
 
 **Note**: Libraries that target .NET Standard 2.0 are supported when running on either .NET Framework 4.6.1+ or .NET Core 2.0.x.
+
 Don’t see your desired frameworks? We’re continually adding additional support. [Check with the Datadog team][5] to see if we can help.
 
 ### Web Framework Integrations

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -52,13 +52,12 @@ The .NET tracer supports automatic instrumentation on the following .NET runtime
 
 The .NET tracer can instrument the following web frameworks automatically:
 
-| Web framework    | Versions | Runtime        | OS      | Support Type      |
-| :--------------- | :------- | :------------- | :------ | :---------------- |
-| ASP.NET MVC      | 5.2.3+   | .NET Framework | Windows | Fully supported   |
-| ASP.NET Core MVC | 2.0.x    | .NET Framework | Windows | Fully supported   |
-| ASP.NET Core MVC | 2.0.x    | .NET Core      | Windows | Fully supported   |
-| ASP.NET Core MVC | 2.0.x    | .NET Core      | Linux   | Coming soon       |
-| ASP.NET Core MVC | 2.1.3+   |                |         | Coming soon       |
+| Web framework    | Versions | Runtime             | OS      | Support Type      |
+| :--------------- | :------- | :------------------ | :------ | :---------------- |
+| ASP.NET MVC      | 5.2+     | .NET Framework 4.5+ | Windows | Fully supported   |
+| ASP.NET Core MVC | 2.0+     | .NET Framework 4.5+ | Windows | Fully supported   |
+| ASP.NET Core MVC | 2.0+     | .NET Core 2.0.x     | Windows | Fully supported   |
+| ASP.NET Core MVC | 2.0+     | .NET Core 2.0.x     | Linux   | Coming soon       |
 
 Don't see your desired web frameworks? [Check with the Datadog Support team][5] to see if we can help.
 

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -22,11 +22,11 @@ To begin tracing applications written in any language, first [install and config
 
 ## Automatic Instrumentation
 
-Automatic instrumentation uses the [Profiling API][2] provided by .NET Framework and .NET Core to modify IL instructions at run time and inject instrumentation code. With zero code changes or configuration, the .NET tracer will automatically instrument all supported libraries out of the box.
+Automatic instrumentation uses the [Profiling API][2] provided by .NET Framework and .NET Core to modify IL instructions at run time and inject instrumentation code. With zero code changes or configuration, the .NET tracer automatically instruments all supported libraries out of the box.
 
 To use automatic instrumentation on Windows, download the latest Windows installer from the public [GitHub repository][3]. For Windows services (including web applications running on IIS), rebooting is necessary for these services to pick up the environment variables required by the Profiling API.
 
-Automatic instrumentation will capture:
+Automatic instrumentation captures:
 
 * Method execution time
 * Relevant trace data such as URL and status response codes for web requests or SQL query for database access
@@ -39,12 +39,12 @@ The .NET tracer supports automatic instrumentation on the following .NET runtime
 
 | .NET Runtime   | Versions | OS      | Support Type      |
 | :------------- | :------- | :------ | :---------------- |
-| .NET Framework | 4.5+     | Windows |  Fully supported  |
-| .NET Core      | 2.0.x    | Windows |  Fully supported  |
-| .NET Core      | 2.0.x    | Linux   |  Coming soon      |
-| .NET Core      | 2.1.3+   |         |  Coming soon      |
+| .NET Framework | 4.5+     | Windows | Fully supported   |
+| .NET Core      | 2.0.x    | Windows | Fully supported   |
+| .NET Core      | 2.0.x    | Linux   | Coming soon       |
+| .NET Core      | 2.1.3+   |         | Coming soon       |
 
-*Note:* Libraries that target .NET Standard 2.0 are fully supported when running on either .NET Framework 4.6.1+ or .NET Core 2.0.x.
+**Note**: Libraries that target .NET Standard 2.0 are fully supported when running on either .NET Framework 4.6.1+ or .NET Core 2.0.x.
 
 ### Integrations
 
@@ -60,13 +60,13 @@ The .NET tracer can instrument the following web frameworks automatically:
 | ASP.NET Core MVC | 2.0.x    | .NET Core      | Linux   | Coming soon       |
 | ASP.NET Core MVC | 2.1.3+   |                |         | Coming soon       |
 
-Don't see your desired web frameworks? We're continually adding additional support, [check with the Datadog team][5] to see if we can help.
+Don't see your desired web frameworks? [Check with the Datadog Support team][5] to see if we can help.
 
 #### Data Store Compatibility
 
 The .NET tracer's ability to automatically instrument data store access depends on the client libraries used:
 
-| Data store    | Library or NuGet package     | Versions | Support type    |
+| Data store    | Library or NuGet package            | Versions | Support type    |
 | :---------    | :---------------------------------- | :------- | :-------------- |
 | MS SQL Server | Built-in .NET Framework `SqlClient` |          | Fully supported |
 | MS SQL Server | `System.Data.SqlClient`             | 4.1+     | Fully supported |
@@ -75,7 +75,7 @@ The .NET tracer's ability to automatically instrument data store access depends 
 | MongoDB       | `MongoDB.Driver`                    |          | Coming soon     |
 | PostgreSQL    | `Npgsql`                            |          | Coming soon     |
 
-Don't see your desired datastores? We're continually adding additional support, [check with the Datadog team][5] to see if we can help.
+Don't see your desired data store? [Check with the Datadog Support team][5] to see if we can help.
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR adds documentation for .NET tracing support in APM in preparation for public beta on Sept 14.

### Motivation
There was minimal documentation (and nothing at all in `Advanced Usage`) and public beta will be released Sept 14.

### Preview link
- [/tracing/setup/dotnet](https://docs-staging.datadoghq.com/lucas/tracing-dotnet/tracing/setup/dotnet/)
- [/tracing/advanced_usage/?tab=net](https://docs-staging.datadoghq.com/lucas/tracing-dotnet/tracing/advanced_usage/?tab=net)

### Additional Notes
N/A
