### PR TITLE
Change tracer.set_tags function to correct argument.

### DIFF
--- a/content/tracing/getting_further/first_class_dimensions.md
+++ b/content/tracing/getting_further/first_class_dimensions.md
@@ -100,7 +100,7 @@ Datadog.tracer.set_tags('env' => 'prod')
 
 ```python
 from ddtrace import tracer
-tracer.set_tags({'env', 'prod'})
+tracer.set_tags({'env': 'prod'})
 ```
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/tracing/getting_further/first_class_dimensions.md
+++ b/content/tracing/getting_further/first_class_dimensions.md
@@ -100,7 +100,7 @@ Datadog.tracer.set_tags('env' => 'prod')
 
 ```python
 from ddtrace import tracer
-tracer.set_tags('env', 'prod')
+tracer.set_tags({'env', 'prod'})
 ```
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

In the First Class Dimensions setup, I changed the Python tracer.set_tags function to the correct argument. The tracer.set_tags function takes in a dictionary.
tracer.set_tags({'env': 'prod'})

https://trello.com/c/LNAGv3iz/549-python-ddtrace-set-tags-wrong-arguments


