### PR TITLE
adding tag extraction documentation

### DIFF
--- a/content/agent/autodiscovery.md
+++ b/content/agent/autodiscovery.md
@@ -67,7 +67,7 @@ config_providers:
     polling: true
 ```
 
-## Tag extraction
+### Tag extraction
 
 {{< tabs >}}
 {{% tab "Docker" %}}

--- a/content/agent/autodiscovery.md
+++ b/content/agent/autodiscovery.md
@@ -67,6 +67,32 @@ config_providers:
     polling: true
 ```
 
+## Tag extraction
+
+You can extract container and pod labels, as well as environment variables and annotations, as metric tags. If you prefix your tag name with `+`, the tag will only be added to high cardinality metrics.
+
+### Docker tag extraction
+
+```
+docker_labels_as_tags:
+  label_name:                  tag_name
+  high_cardinality_label_name: +tag_name
+docker_env_as_tags:
+  ENVVAR_NAME: tag_name
+```
+
+### Kubernetes tag extraction
+
+```
+kubernetes_pod_labels_as_tags:
+  app:               kube_app
+  pod-template-hash: +kube_pod-template-hash
+
+kubernetes_pod_annotations_as_tags:
+  app:               kube_app
+  pod-template-hash: +kube_pod-template-hash
+```
+
 ## Setting up Check Templates
 
 Each **Template Source** section below shows a different way to configure check templates and their container identifiers.

--- a/content/agent/autodiscovery.md
+++ b/content/agent/autodiscovery.md
@@ -69,29 +69,68 @@ config_providers:
 
 ## Tag extraction
 
-You can extract container and pod labels, as well as environment variables and annotations, as metric tags. If you prefix your tag name with `+`, the tag will only be added to high cardinality metrics.
+{{< tabs >}}
+{{% tab "Docker" %}}
 
-### Docker tag extraction
+The Datadog Agent can extract container labels and environment variables as metric tags with the following configuration in your `datadog.yaml` file:
 
 ```
 docker_labels_as_tags:
-  label_name:                  tag_name
-  high_cardinality_label_name: +tag_name
+  <LABEL_NAME>: <TAG_NAME>
+
 docker_env_as_tags:
-  ENVVAR_NAME: tag_name
+  <ENVVAR_NAME>: <TAG_NAME>
 ```
 
-### Kubernetes tag extraction
+If you prefix your tag name with `+`, the tag is only added to high cardinality metrics.
+
+```
+docker_labels_as_tags:
+  <HIGH_CARDINALITY_LABEL_NAME>: +<TAG_NAME>
+```
+
+For example you could set up:
+
+```
+docker_labels_as_tags:
+  com.docker.compose.service: service_name
+  com.docker.compose.project: +project_name
+```
+
+{{% /tab %}}
+{{% tab "Kubernetes" %}}
+
+The Datadog Agent can extract pod labels and annotations as metric tags with the following configuration in your `datadog.yaml` file:
 
 ```
 kubernetes_pod_labels_as_tags:
-  app:               kube_app
+  <POD_LABEL>: <TAG_NAME>
+
+kubernetes_pod_annotations_as_tags:
+  <POD_ANNOTATIONS>: <TAG_NAME>
+```
+
+If you prefix your tag name with `+`, the tag is only added to high cardinality metrics.
+
+```
+kubernetes_pod_labels_as_tags:
+  <HIGH_CARDINALITY_POD_LABEL>: +<TAG_NAME>
+```
+
+For example you could set up:
+
+```
+kubernetes_pod_labels_as_tags:
+  app: kube_app
   pod-template-hash: +kube_pod-template-hash
 
 kubernetes_pod_annotations_as_tags:
-  app:               kube_app
+  app: kube_app
   pod-template-hash: +kube_pod-template-hash
 ```
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Setting up Check Templates
 

--- a/content/agent/autodiscovery.md
+++ b/content/agent/autodiscovery.md
@@ -82,19 +82,11 @@ docker_env_as_tags:
   <ENVVAR_NAME>: <TAG_NAME>
 ```
 
-If you prefix your tag name with `+`, the tag is only added to high cardinality metrics.
-
-```
-docker_labels_as_tags:
-  <HIGH_CARDINALITY_LABEL_NAME>: +<TAG_NAME>
-```
-
 For example you could set up:
 
 ```
 docker_labels_as_tags:
   com.docker.compose.service: service_name
-  com.docker.compose.project: +project_name
 ```
 
 {{% /tab %}}
@@ -110,23 +102,14 @@ kubernetes_pod_annotations_as_tags:
   <POD_ANNOTATIONS>: <TAG_NAME>
 ```
 
-If you prefix your tag name with `+`, the tag is only added to high cardinality metrics.
-
-```
-kubernetes_pod_labels_as_tags:
-  <HIGH_CARDINALITY_POD_LABEL>: +<TAG_NAME>
-```
-
 For example you could set up:
 
 ```
 kubernetes_pod_labels_as_tags:
   app: kube_app
-  pod-template-hash: +kube_pod-template-hash
 
 kubernetes_pod_annotations_as_tags:
   app: kube_app
-  pod-template-hash: +kube_pod-template-hash
 ```
 
 {{% /tab %}}

--- a/content/integrations/faq/list-of-api-source-attribute-value.md
+++ b/content/integrations/faq/list-of-api-source-attribute-value.md
@@ -78,6 +78,7 @@ kind: faq
 |Chef|CHEF|
 |Circleci|CIRCLECI|
 |Cisco Aci|CISCOACI|
+|Cloudflare|CLOUDFLARE|
 |Cloud Foundry|CLOUDFOUNDRY|
 |Cloudhealth|CLOUDHEALTH|
 |Cloudnetworkhealth|CLOUDNETWORKHEALTH|


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a section to the Autodiscovery page about tag extraction capabilities in Docker and Kubernetes

### Motivation
These options [existed](https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml#L443-L473) but were not documented.

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

https://docs-staging.datadoghq.com/cswatt/autodiscovery-docker-tags-options/agent/autodiscovery/?tab=docker#tag-extraction