### PR TITLE
[PROD] Update dd-agent error.log and fix

### DIFF
--- a/content/agent/faq/why-don-t-i-see-the-system-processes-open-file-descriptors-metric.md
+++ b/content/agent/faq/why-don-t-i-see-the-system-processes-open-file-descriptors-metric.md
@@ -11,6 +11,7 @@ dd-agent ALL=NOPASSWD: /bin/ls /proc/*/fd/
 ```
 This allows the process check to use `sudo` to execute the `ls` command but only to the list of contents of the path `/proc/*/fd/`.
 
+If users see this line in the datadog error.log: `sudo: sorry, you must have a tty to run sudo`, users should visudo and comment out the line `Default requiretty`.
 
 See the following Github issues for more info on this matter as well as other potential methods of capturing this metric on Linux machines.
 


### PR DESCRIPTION
https://datadog.zendesk.com/agent/tickets/167609

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR adds an error that may occur in the error.log and the fix that comes with it. The error is caused from dd-agent not having a tty. 
