### PR TITLE
Drop alpine images from docs

### DIFF
--- a/content/agent/faq/agent-commands.md
+++ b/content/agent/faq/agent-commands.md
@@ -112,9 +112,7 @@ aliases:
 | :--------           | :--------                                                                     |
 | Linux               | `sudo service datadog-agent status`                                           |
 | Docker (Debian)     | `sudo docker exec -it <container_name> s6-svstat /var/run/s6/services/agent/` |
-| Docker (Alpine)     | *unsupported Platform*                                                      |
 | Kubernetes          | `kubectl exec -it <pod-name> s6-svstat /var/run/s6/services/agent/`           |
-| Kubernetes (Alpine) | *unsupported Platform*                                                      |
 | macOS               | `launchctl list com.datadoghq.agent` *or* via the systray app                 |
 | Source              | `sudo service datadog-agent status`                                           |
 
@@ -128,9 +126,7 @@ aliases:
 | :--------           | :-----                                                                                                   |
 | Linux               | `sudo service datadog-agent status`                                                                      |
 | Docker (Debian)     | `sudo docker exec -it <container_name> /etc/init.d/datadog-agent status`                                 |
-| Docker (Alpine)     | `sudo docker exec -it <container_name> supervisorctl -c /opt/datadog-agent/agent/supervisor.conf status` |
 | Kubernetes          | `kubectl exec -it <pod-name> /etc/init.d/datadog-agent status`                                           |
-| Kubernetes (Alpine) | `kubectl exec -it <pod-name> supervisorctl -c /opt/datadog-agent/agent/supervisor.conf status`           |
 | macOS               | `datadog-agent status`                                                                                   |
 | Source              | `sudo ~/.datadog-agent/bin/agent status`                                                                 |
 | Windows             | [See the dedicated Windows documentation][2]                                                             |
@@ -153,9 +149,7 @@ Running an info command displays the status of your Datadog Agent and enabled in
 | :--------           | :--------                                            |
 | Linux               | `sudo datadog-agent status`                          |
 | Docker              | `sudo docker exec -it <container_name> agent status` |
-| Docker (Alpine)     | *unsupported Platform*                             |
 | Kubernetes          | `kubectl exec -it <pod-name> agent status`           |
-| Kubernetes (Alpine) | *unsupported Platform*                             |
 | macOS               | `datadog-agent status` or via the [web GUI][3]       |
 | Source              | `sudo datadog-agent status`                          |
 | Windows             | [See the dedicated Windows documentation][2]         |
@@ -188,9 +182,7 @@ A properly configured integration will be displayed under **Running Checks** wit
 | :--------           | :-----                                                                 |
 | Linux               | `sudo service datadog-agent info`                                      |
 | Docker              | `sudo docker exec -it <container_name> /etc/init.d/datadog-agent info` |
-| Docker (Alpine)     | `docker exec -it <container_name> /opt/datadog-agent/bin/agent info`   |
 | Kubernetes          | `kubectl exec -it <pod-name> /etc/init.d/datadog-agent info`           |
-| Kubernetes (Alpine) | `kubectl exec -it <pod-name> /opt/datadog-agent/bin/agent info`        |
 | macOS               | `datadog-agent info`                                                   |
 | Source              | `sudo ~/.datadog-agent/bin/info`                                       |
 | Windows             | [See the dedicated Windows documentation][2]                           |

--- a/content/agent/troubleshooting.md
+++ b/content/agent/troubleshooting.md
@@ -126,7 +126,6 @@ In the commands below, replace `<CASE_ID>` with your Datadog support case ID, if
 | :--------       | :-----                                                                  |
 | Linux           | `sudo /etc/init.d/datadog-agent flare <CASE_ID>`                        |
 | Docker          | `docker exec -it dd-agent /etc/init.d/datadog-agent flare <CASE_ID>`    |
-| Docker (Alpine) | `docker exec -it dd-agent /opt/datadog-agent/bin/agent flare <CASE_ID>` |
 | macOS           | `datadog-agent flare <CASE_ID>`                                         |
 | CentOS          | `sudo service datadog-agent flare <CASE_ID>`                            |
 | Debian          | `sudo service datadog-agent flare <CASE_ID>`                            |

--- a/content/graphing/infrastructure/livecontainers.md
+++ b/content/graphing/infrastructure/livecontainers.md
@@ -105,8 +105,6 @@ While actively working with the Containers page, metrics are collected at 2s res
 
 - Real-time (2s) data collection is turned off after 30 minutes. To resume real-time collection, refresh the page.
 
-- Live Containers is available for the default Debian docker-dd-agent image only.  It is not included in the Alpine image.
-
 - RBAC settings can restrict Kubernetes metadata collection. Refer to the [RBAC entites for the Datadog Agent][2].
 
 - In Kubernetes the `health` value is the containers' readiness probe, not it's liveness probe. 

--- a/content/graphing/infrastructure/process.md
+++ b/content/graphing/infrastructure/process.md
@@ -165,8 +165,6 @@ While actively working with the Live Processes, metrics are collected at 2s reso
 
 - Real-time (2s) data collection is turned off after 30 minutes. To resume real-time collection, refresh the page.
 
-- The Process Agent is available for the default Debian docker-dd-agent image only. It is not included in the Alpine image.
-
 - In container deployments, the `/etc/passwd` file mounted into the docker-dd-agent is necessary to collect usernames for each process. This is a public file and the Process Agent does not use any fields except the username. All features except the `user` metadata field will function without access to this file.
   - Note:  Live Processes only uses the host `passwd` file and will not perform username resolution for users created within containers.
 

--- a/content/tracing/setup/docker.md
+++ b/content/tracing/setup/docker.md
@@ -14,8 +14,6 @@ further_reading:
 
 Enable the [datadog-trace-agent][1] in the `datadog/agent` container by passing `DD_APM_ENABLED=true` as an environment variable.
 
-**Note: APM is NOT available on Alpine Images**
-
 List of all environment variables available:
 
 | Environment variable       | Description                                                                                   |


### PR DESCRIPTION
### What does this PR do?
Remove alpine images from docs.

### Motivation
Confusion as to which image to run.  We're pushing users to debian based images moving forward.

### Preview link
https://docs-staging.datadoghq.com/ilan/alpine/