### PR TITLE
Adding right tab when linking from setup

### DIFF
--- a/content/tracing/setup/go.md
+++ b/content/tracing/setup/go.md
@@ -14,11 +14,10 @@ further_reading:
 - link: "tracing/visualization/"
   tag: "Documentation"
   text: "Explore your services, resources and traces"
-- link: "tracing/advanced_usage/"
+- link: "tracing/advanced_usage/?tab=go"
   tag: "Advanced Usage"
   text: "Advanced Usage"
 ---
-
 ## Installation and Getting Started
 
 For configuration instructions and details about using the API, check out the Datadog [API documentation][api docs] for manual instrumentation, and the [integrations section][contrib docs] for Go libraries and frameworks supporting automatic instrumentation.

--- a/content/tracing/setup/java.md
+++ b/content/tracing/setup/java.md
@@ -11,7 +11,7 @@ further_reading:
 - link: "tracing/visualization/"
   tag: "Documentation"
   text: "Explore your services, resources and traces"
-- link: "tracing/advanced_usage/"
+- link: "tracing/advanced_usage/?tab=java"
   tag: "Advanced Usage"
   text: "Advanced Usage"
 ---

--- a/content/tracing/setup/nodejs.md
+++ b/content/tracing/setup/nodejs.md
@@ -15,7 +15,7 @@ further_reading:
 - link: "tracing/visualization/"
   tag: "Use the APM UI"
   text: "Explore your services, resources and traces"
-- link: "tracing/advanced_usage/"
+- link: "tracing/advanced_usage/?tab=nodejs"
   tag: "Advanced Usage"
   text: "Advanced Usage"
 ---

--- a/content/tracing/setup/python.md
+++ b/content/tracing/setup/python.md
@@ -14,7 +14,7 @@ further_reading:
 - link: "tracing/visualization/"
   tag: "Documentation"
   text: "Explore your services, resources and traces"
-- link: "tracing/advanced_usage/"
+- link: "tracing/advanced_usage/?tab=python"
   tag: "Advanced Usage"
   text: "Advanced Usage"
 ---

--- a/content/tracing/setup/ruby.md
+++ b/content/tracing/setup/ruby.md
@@ -17,7 +17,7 @@ further_reading:
 - link: "tracing/visualization/"
   tag: "Use the APM UI"
   text: "Explore your services, resources and traces"
-- link: "tracing/advanced_usage/"
+- link: "tracing/advanced_usage/?tab=ruby"
   tag: "Advanced Usage"
   text: "Advanced Usage"
 ---


### PR DESCRIPTION
### What does this PR do?
Adds the right tab selection when linking from a setup page to the advanced page one

### Motivation
https://github.com/DataDog/documentation/pull/3131/files#diff-a5530d4502bc749fab50e65d06176788R14