### PR TITLE
.NET Tracing documentation tweaks

### DIFF
--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -242,39 +242,22 @@ span.setTag('<TAG_KEY>', '<TAG_VALUE>')
 
 **Adding tags to a span**
 
-Add tags directly to a span by calling `SetTag()`. For example:
+Add tags directly to a `Datadog.Trace.Span` object by calling `Span.SetTag()`. For example:
 
 ```csharp
-// An example of an ASP.NET MVC action,
-// with Datadog tracing around the request.
-public class HomeController
-{
-    public ActionResult Index()
-    {
-        using (var scope = Tracer.Instance.StartActive("web.request"))
-        {
-            scope.Span.SetTag("http.url", HttpContext.Request.RawUrl);
-            scope.Span.SetTag("http.method", HttpContext.Request.HttpMethod);
+using Datadog.Trace;
 
-            // do some work...
+// get the global tracer
+var tracer = Tracer.Instance;
 
-            return View();
-        }
-    }
-}
+// get the currently active span (can be null)
+var span = tracer.ActiveScope?.Span;
+
+// add a tag to the span
+span?.SetTag("<TAG_KEY>", "<TAG_VALUE>");
 ```
 
-**Adding tags to a current active span**
-
-Access the current active span from any method within your code. 
-
-```csharp
-// add tag to active span
-var span = Tracer.Instance.ActiveScope.Span;
-span.SetTag("<TAG_KEY>", "<TAG_VALUE>");
-```
-
-**Note**: If the method is called and there is no span currently active, `Tracer.Instance.ActiveScope` returns `null`.
+**Note**: `Datadog.Trace.Tracer.Instance.ActiveScope` returns `null` if there is no active span.
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -471,16 +454,20 @@ For more information on manual instrumentation, see the [API documentation][node
 
 If you aren’t using libraries supported by automatic instrumentation (see [Library compatibility][dotnet compatibility]), you should manually instrument your code.
 
-The following example initializes a Datadog Tracer and creates a span called `web.request`:
+The following example uses the global Datadog Tracer and creates a span to trace a web request:
 
 ```csharp
 using Datadog.Trace;
 
-var scope = Tracer.Instance.StartActive("web.request");
-var span = scope.Span;
+using(var scope = Tracer.Instance.StartActive("web.request"))
+{
+    var span = scope.Span;
+    span.Type = SpanTypes.Web;
+    span.ResourceName = request.Url;
+    span.SetTag(Tags.HttpMethod, request.Method);
 
-span.SetTag("http.url", "/login");
-span.Finish();
+    // do some work...
+}
 ```
 
 [dotnet compatibility]: /tracing/setup/dotnet/#compatibility

--- a/content/tracing/getting_further/first_class_dimensions.md
+++ b/content/tracing/getting_further/first_class_dimensions.md
@@ -103,6 +103,14 @@ from ddtrace import tracer
 tracer.set_tags({'env': 'prod'})
 ```
 {{% /tab %}}
+{{% tab ".NET" %}}
+
+```csharp
+using Datadog.Tracing;
+Tracer.Instance.ActiveScope.Span.SetTag("env", "prod");
+```
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### Viewing Data by Environment

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -78,14 +78,14 @@ Don’t see your desired web frameworks? We’re continually adding additional s
 
 The .NET tracer's ability to automatically instrument data store access depends on the client libraries used:
 
-| Data store    | Library or NuGet package                          | Versions | Support type    |
-| :---------    | :------------------------------------------------ | :------- | :-------------- |
-| MS SQL Server | `System.Data.SqlClient` (.NET Framework built-in) |          | Public Beta     |
-| MS SQL Server | `System.Data.SqlClient` (NuGet)                   | 4.1+     | Public Beta     |
-| Redis         | `StackExchange.Redis`                             |          | Coming soon     |
-| Elasticsearch | `NEST` / `Elasticsearch.Net`                      |          | Coming soon     |
-| MongoDB       | `MongoDB.Driver`                                  |          | Coming soon     |
-| PostgreSQL    | `Npgsql`                                          |          | Coming soon     |
+| Data store    | Library or NuGet package                          | Versions   | Support type    |
+| :---------    | :------------------------------------------------ | :-------   | :-------------- |
+| MS SQL Server | `System.Data.SqlClient` (.NET Framework)          | (built-in) | Public Beta     |
+| MS SQL Server | `System.Data.SqlClient` (NuGet)                   | 4.1+       | Public Beta     |
+| Redis         | `StackExchange.Redis`                             |            | Coming soon     |
+| Elasticsearch | `NEST` / `Elasticsearch.Net`                      |            | Coming soon     |
+| MongoDB       | `MongoDB.Driver`                                  |            | Coming soon     |
+| PostgreSQL    | `Npgsql`                                          |            | Coming soon     |
 
 Don’t see your desired data store libraries? We’re continually adding additional support. [Check with the Datadog team][5] to see if we can help.
 

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -20,19 +20,9 @@ further_reading:
 .NET Tracing is in an open Public Beta and will be Generally Available in October 2018.
 </div>
 
-## Installation and Getting Started
+## Getting Started
 
 To begin tracing applications written in any language, first [install and configure the Datadog Agent][1].
-
-### Windows
-
-To use automatic instrumentation on Windows, download the latest MSI installer for Windows from the public [GitHub repository][3]. To instrument Windows services (including web applications running on IIS), reboot the host after running the installer so these services can pick up the required environment variables added by the installer.
-
-[Download MSI installer for Windows][3]
-
-### Linux
-
-Automatic instrumention for .NET Core on Linux is coming soon.
 
 ## Automatic Instrumentation
 
@@ -43,7 +33,17 @@ Automatic instrumentation captures:
 * Method execution time
 * Relevant trace data such as URL and status response codes for web requests or SQL query for database access
 * Unhandled exceptions, including stacktrace if available
-* A total count of traces (requests) flowing through the system
+* A total count of traces (e.g. web requests) flowing through the system
+
+### Windows
+
+To use automatic instrumentation on Windows, download the latest MSI installer for Windows from the public [GitHub repository][3]. To instrument Windows services (including web applications running on IIS), reboot the host after running the installer so these services can pick up the required environment variables added by the installer.
+
+[Download MSI installer for Windows][3]
+
+### Linux
+
+Automatic instrumention for .NET Core on Linux is coming soon.
 
 ### Runtime Compatibility
 

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -93,7 +93,7 @@ Don’t see your desired data store libraries? We’re continually adding additi
 
 Manual instrumentation is supported on .NET Framework 4.5+ on Windows and on any platform that implements .NET Standard 2.0, including .NET Core 2.0+ on Windows, Linux, and macOS, Xamarin on iOS and Android, and Mono. See the [.NET Standard documentation][6] for more details on supported platforms.
 
-To manually instrument your code, add the [`Datadog.Trace`][4] NuGet package to your application. In your code, access the global tracer through `Datadog.Trace.Tracer.Instance` to create new spans.
+To manually instrument your code, add the `Datadog.Trace` package from [NuGet][4] to your application. In your code, access the global tracer through `Datadog.Trace.Tracer.Instance` to create new spans.
 
 For more details on manual instrumentation and custom tagging, see [Advanced Usage][2].
 

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -91,7 +91,9 @@ Don’t see your desired data store libraries? We’re continually adding additi
 
 ## Manual Instrumentation
 
-To manually instrument your code, see [Advanced Usage][2].
+To manually instrument your code, add the [`Datadog.Tracing`][6] NuGet package to your application. Access the global tracer in `Datadog.Trace.Tracer.Instance` to create new spans.
+
+For more details, see [Advanced Usage][2].
 
 ## Further Reading
 
@@ -102,3 +104,4 @@ To manually instrument your code, see [Advanced Usage][2].
 [3]: https://github.com/DataDog/dd-trace-csharp/releases
 [4]: https://www.nuget.org/packages/Datadog.Trace/
 [5]: /help
+[6]: https://www.nuget.org/packages/Datadog.Trace/

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -91,9 +91,11 @@ Don’t see your desired data store libraries? We’re continually adding additi
 
 ## Manual Instrumentation
 
-To manually instrument your code, add the [`Datadog.Tracing`][6] NuGet package to your application. Access the global tracer in `Datadog.Trace.Tracer.Instance` to create new spans.
+Manual instrumentation is supported on .NET Framework 4.5+ on Windows and on any platform that implements .NET Standard 2.0, including .NET Core 2.0+ on Windows, Linux, and macOS, Xamarin on iOS and Android, and Mono. See the [.NET Standard documentation][6] for more details on supported platforms.
 
-For more details, see [Advanced Usage][2].
+To manually instrument your code, add the [`Datadog.Trace`][4] NuGet package to your application. In your code, access the global tracer through `Datadog.Trace.Tracer.Instance` to create new spans.
+
+For more details on manual instrumentation and custom tagging, see [Advanced Usage][2].
 
 ## Further Reading
 
@@ -104,4 +106,4 @@ For more details, see [Advanced Usage][2].
 [3]: https://github.com/DataDog/dd-trace-csharp/releases
 [4]: https://www.nuget.org/packages/Datadog.Trace/
 [5]: /help
-[6]: https://www.nuget.org/packages/Datadog.Trace/
+[6]: https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -49,12 +49,12 @@ Automatic instrumentation captures:
 
 The .NET tracer supports automatic instrumentation on the following .NET runtimes:
 
-| .NET Runtime   | Versions | OS      | Support Type      |
-| :------------- | :------- | :------ | :---------------- |
-| .NET Framework | 4.5+     | Windows | Public Beta       |
-| .NET Core      | 2.0.x    | Windows | Public Beta       |
-| .NET Core      | 2.0.x    | Linux   | Coming soon       |
-| .NET Core      | 2.1.3+   |         | Coming soon       |
+| .NET Runtime   | Versions | OS                | Support Type      |
+| :------------- | :------- | :---------------- | :---------------- |
+| .NET Framework | 4.5+     | Windows           | Public Beta       |
+| .NET Core      | 2.0.x    | Windows           | Public Beta       |
+| .NET Core      | 2.0.x    | Linux             | Coming soon       |
+| .NET Core      | 2.1.3+   | Windows and Linux | Coming soon       |
 
 **Note**: Libraries that target .NET Standard 2.0 are supported when running on either .NET Framework 4.6.1+ or .NET Core 2.0.x.
 
@@ -78,14 +78,14 @@ Don’t see your desired web frameworks? We’re continually adding additional s
 
 The .NET tracer's ability to automatically instrument data store access depends on the client libraries used:
 
-| Data store    | Library or NuGet package            | Versions | Support type    |
-| :---------    | :---------------------------------- | :------- | :-------------- |
-| MS SQL Server | Built-in .NET Framework `SqlClient` |          | Public Beta     |
-| MS SQL Server | `System.Data.SqlClient`             | 4.1+     | Public Beta     |
-| Redis         | `StackExchange.Redis`               |          | Coming soon     |
-| Elasticsearch | `NEST` / `Elasticsearch.Net`        |          | Coming soon     |
-| MongoDB       | `MongoDB.Driver`                    |          | Coming soon     |
-| PostgreSQL    | `Npgsql`                            |          | Coming soon     |
+| Data store    | Library or NuGet package                          | Versions | Support type    |
+| :---------    | :------------------------------------------------ | :------- | :-------------- |
+| MS SQL Server | `System.Data.SqlClient` (.NET Framework built-in) |          | Public Beta     |
+| MS SQL Server | `System.Data.SqlClient` (NuGet)                   | 4.1+     | Public Beta     |
+| Redis         | `StackExchange.Redis`                             |          | Coming soon     |
+| Elasticsearch | `NEST` / `Elasticsearch.Net`                      |          | Coming soon     |
+| MongoDB       | `MongoDB.Driver`                                  |          | Coming soon     |
+| PostgreSQL    | `Npgsql`                                          |          | Coming soon     |
 
 Don’t see your desired data store libraries? We’re continually adding additional support. [Check with the Datadog team][5] to see if we can help.
 


### PR DESCRIPTION
### What does this PR do?

`/tracing/setup/dotnet`
- move Windows and Linux installation sections under "Automatic Instrumentation"
- adds missing OS value in table
- clarify the 2 different `SqlClient` versions
- add code sample under "Manual Instrumentation"

`/tracing/advanced_usage`
- improve focus of code sample under each section (tagging sample vs custom instrumentation sample)

### Motivation
Feedback from team members (and self!) after reviewing the newly published documentation. 

### Preview link
- [/tracing/setup/dotnet](https://docs-staging.datadoghq.com/lucas/tracing-setup-dotnet/tracing/setup/dotnet/)
- [/tracing/advanced_usage/?tab=net](https://docs-staging.datadoghq.com/lucas/tracing-setup-dotnet/tracing/advanced_usage/?tab=net)

### Additional Notes
<!-- Anything else we should know when reviewing?-->
