### PR TITLE
Add information on stripping all process arguments.

### DIFF
--- a/content/graphing/infrastructure/process.md
+++ b/content/graphing/infrastructure/process.md
@@ -122,7 +122,7 @@ The next image shows one process on the Live Processes page whose arguments have
 
 Set `scrub_args` to `false` to completely disable the process arguments scrubbing.
 
-You can also scrub _all_ arguments from processes by enabling the `strip_proc_arguments` flag.
+You can also scrub **all** arguments from processes by enabling the `strip_proc_arguments` flag in your `datadog.yaml` configuration file:
 
 ```
 process_config:

--- a/content/graphing/infrastructure/process.md
+++ b/content/graphing/infrastructure/process.md
@@ -122,6 +122,13 @@ The next image shows one process on the Live Processes page whose arguments have
 
 Set `scrub_args` to `false` to completely disable the process arguments scrubbing.
 
+You can also scrub _all_ arguments from processes by enabling the `strip_proc_arguments` flag.
+
+```
+process_config:
+  strip_proc_arguments: true
+```
+
 ## Searching, Filtering, and Pivoting
 
 ### String Search


### PR DESCRIPTION
### What does this PR do?

This adds documentation on stripping all process arguments in the process-agent. This was added in https://github.com/DataDog/datadog-process-agent/pull/146 but never documented.

### Motivation

Missing documentation

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
