### PR TITLE
Fixing aliases

### DIFF
--- a/content/agent/faq/dogstream.md
+++ b/content/agent/faq/dogstream.md
@@ -1,9 +1,6 @@
 ---
 title: Dogstream
 kind: documentation
-aliases:
-    - /guides/logs/
-    - /agent/logs/
 ---
 
 <div class="alert alert-info">

--- a/content/logs/_index.md
+++ b/content/logs/_index.md
@@ -2,6 +2,9 @@
 title: Log Management
 kind: Documentation
 description: "Configure your Datadog Agent to gather logs from your host, containers & services."
+aliases:
+    - /guides/logs/
+    - /agent/logs/
 further_reading:
 - link: "logs/log_collection"
   tag: "Documentation"


### PR DESCRIPTION
### What does this PR do?

This URL:
http://docs.datadoghq.com/guides/logs/

Currently redirects to Dogstream:
https://docs.datadoghq.com/agent/faq/dogstream/

Change it to redirect to main logs page?
https://docs.datadoghq.com/logs/

### Motivation
Support feedback

### Preview link