### PR TITLE
Inaccurate description

### DIFF
--- a/content/logs/processing/attributes_naming_convention.md
+++ b/content/logs/processing/attributes_naming_convention.md
@@ -74,7 +74,7 @@ Typical integrations relying on these attributes include [Apache][7], Rails, [AW
 | **Fullname**       | **Type** | **Description**                                                                                          |
 | :---               | :---     | :----                                                                                                    |
 | `http.url`         | `string` | The URL of the HTTP request.                                                                             |
-| `http.status_code` | `number` | The IP address the client connected to.                                                                  |
+| `http.status_code` | `number` | The HTTP response status code.                                                                  |
 | `http.method`      | `string` | The HTTP verb of the request.                                                                            |
 | `http.referer`     | `string` | The HTTP referer.                                                                                        |
 | `http.request_id`  | `string` | The HTTP request ID.                                                                                     |


### PR DESCRIPTION
http.status_code description doesn't makes sense. It's not displaying IP addresses

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
A fix

### Motivation
Inaccuracy in the docs 

