### PR TITLE
Add debugging info back in

### DIFF
--- a/content/tracing/setup/java.md
+++ b/content/tracing/setup/java.md
@@ -217,6 +217,9 @@ Now add `@Trace` to methods to have them be traced when running with `dd-java-ag
 
 Datadog's [JMX Integration][7] monitors additional metrics around: JVM heap memory, thread count, and garbage collection. Use it in conjunction with APM for an even broader view into your Java app's performance.
 
+## Debugging
+To return debug level application logs, enable debug mode with the flag `-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug` when starting the JVM.
+
 ## Performance
 
 Java APM has minimal impact on the overhead of an application:


### PR DESCRIPTION
To distinguish it from the regular agent flare


It was [removed](https://github.com/DataDog/documentation/commit/9e7be12f289488729c4a61d96e76f3d270caa3de#diff-850656b27e778ff91d8e3774f8a16285L578) last month, perhaps accidentally, but I think it's useful to have there.
