### PR TITLE
[metrics] Remove deprecation notice on Dogstatsd Counter type

### DIFF
--- a/content/developers/metrics/_index.md
+++ b/content/developers/metrics/_index.md
@@ -71,7 +71,7 @@ Datadog accepts metrics submitted from a variety of sources, and as a result the
 | [DogStatsD][1]      | `dog.gauge(...)`                     | gauge             | gauge               |
 | [DogStatsD][1]      | `dog.distribution(...)`              | distribution      | distribution        |
 | [DogStatsD][1]      | `dog.histogram(...)`                 | histogram         | gauge, rate         |
-| [DogStatsD][1]      | `dog.increment(...)`                 | counter <sup>deprecated</sup> | rate    |
+| [DogStatsD][1]      | `dog.increment(...)`                 | counter           | rate                |
 | [DogStatsD][1]      | `dog.set(...)`                       | set               | gauge               |
 | [Agent check][2]    | `self.count(...)`                    | count             | count               |
 | [Agent check][2]    | `self.gauge(...)`                    | gauge             | gauge               |

--- a/content/developers/metrics/counts.md
+++ b/content/developers/metrics/counts.md
@@ -32,8 +32,8 @@ Counters are used to count things.
 {{% table responsive="true" %}}
 | Method | Overview |
 | :----- | :------- |
-| dog.increment(...)<br/><sup>deprecated</sup> | Used to increment a counter of events: <ul><li>Stored as a RATE type in the Datadog web application. Each value in the stored timeseries is a time-normalized delta of the counter's value over that statsd flush period.</li></ul> |
-| dog.decrement(...)<br/><sup>deprecated</sup> | Used to decrement a counter of events: <ul><li>Stored as a RATE type in the Datadog web application. Each value in the stored timeseries is a time-normalized delta of the counter's value over that statsd flush period.</li></ul> |
+| dog.increment(...) | Used to increment a counter of events: <ul><li>Stored as a RATE type in the Datadog web application. Each value in the stored timeseries is a time-normalized delta of the counter's value over that statsd flush period.</li></ul> |
+| dog.decrement(...) | Used to decrement a counter of events: <ul><li>Stored as a RATE type in the Datadog web application. Each value in the stored timeseries is a time-normalized delta of the counter's value over that statsd flush period.</li></ul> |
 {{% /table %}}
 
 #### Example


### PR DESCRIPTION
### What does this PR do?

Remove deprecation notice on Dogstatsd Counter type

### Motivation

`Counter`s are deprecated for Agent Checks, but not for Dogstatsd

### Preview link