### PR TITLE
Fixed formatting issues with code blocks

### DIFF
--- a/content/agent/faq/agent-5-autodiscovery.md
+++ b/content/agent/faq/agent-5-autodiscovery.md
@@ -382,17 +382,12 @@ checks:
 [12]: https://github.com/DataDog/integrations-core/blob/master/consul/datadog_checks/consul/data/auto_conf.yaml
 [13]: https://github.com/DataDog/integrations-core/blob/master/couch/datadog_checks/couch/data/auto_conf.yaml
 [14]: https://github.com/DataDog/integrations-core/blob/master/couchbase/datadog_checks/couchbase/data/auto_conf.yaml
-[15]: 
-https://github.com/DataDog/integrations-core/blob/master/elastic/datadog_checks/elastic/data/auto_conf.yaml
+[15]: https://github.com/DataDog/integrations-core/blob/master/elastic/datadog_checks/elastic/data/auto_conf.yaml
 [16]: https://github.com/DataDog/integrations-core/blob/master/etcd/datadog_checks/etcd/data/auto_conf.yaml
-[17]: 
-https://github.com/DataDog/integrations-core/blob/master/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
-[18]: 
-https://github.com/DataDog/integrations-core/blob/master/kube_dns/datadog_checks/kube_dns/data/auto_conf.yaml
-[19]: 
-https://github.com/DataDog/integrations-core/blob/master/kyototycoon/datadog_checks/kyototycoon/data/auto_conf.yaml
+[17]: https://github.com/DataDog/integrations-core/blob/master/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
+[18]: https://github.com/DataDog/integrations-core/blob/master/kube_dns/datadog_checks/kube_dns/data/auto_conf.yaml
+[19]: https://github.com/DataDog/integrations-core/blob/master/kyototycoon/datadog_checks/kyototycoon/data/auto_conf.yaml
 [20]: https://github.com/DataDog/integrations-core/blob/master/mcache/datadog_checks/mcache/data/auto_conf.yaml
-[21]: 
-https://github.com/DataDog/integrations-core/blob/master/redisdb/datadog_checks/redisdb/data/auto_conf.yaml
+[21]: https://github.com/DataDog/integrations-core/blob/master/redisdb/datadog_checks/redisdb/data/auto_conf.yaml
 [22]: https://github.com/DataDog/integrations-core/blob/master/riak/datadog_checks/riak/data/auto_conf.yaml
 [23]: /agent/faq/agent-commands/#start-stop-restart-the-agent

--- a/content/agent/faq/getting-further-with-docker.md
+++ b/content/agent/faq/getting-further-with-docker.md
@@ -32,7 +32,7 @@ dd-agent reports disk metrics and rates for every partition that is accessible (
 
 * Expose their whole host filesystem to the container: `-v /:/host/rootfs:ro` : this can be useful if mount points are unpredictable or rapidly changing. The Agent reports every partition mounted on the system, but might probably throw "permission denied" warning on some virtual mount points (shm, netns...)
 
-If your Agent container runs with `--privileged`, it has full access to the `/dev` folder and its block devices. You can mount the desired block devices into the container so that they are reported by the Agent. To monitor `loop0, one could add to `entrypoint.sh`:
+If your Agent container runs with `--privileged`, it has full access to the `/dev` folder and its block devices. You can mount the desired block devices into the container so that they are reported by the Agent. To monitor `loop0`, one could add to `entrypoint.sh`:
 
 ```
 mkdir -p /tmp/mnt/loop0 && mount /dev/loop0 /tmp/mnt/loop0

--- a/content/api/troubleshooting/troubleshooting.fr.md
+++ b/content/api/troubleshooting/troubleshooting.fr.md
@@ -23,6 +23,6 @@ Cela affiche la date du système actuel, puis fait une requête à notre endpoin
 
 Certains champs ne sont pas obligatoires pour la requête, mais nécessitent une entrée valide. Par exemple, en soumettant un événement, le champ `priority` doit être l'une des quatre options données.
 
-Tout autre texte entraîne un succès 202, mais aucun événement n'apparaît. Avoir un 'source_type_name` invalide n'empêche pas l'événement d'apparaître, mais ce champ est supprimé lors de la soumission.
+Tout autre texte entraîne un succès 202, mais aucun événement n'apparaît. Avoir un `source_type_name` invalide n'empêche pas l'événement d'apparaître, mais ce champ est supprimé lors de la soumission.
 
 **Note**: Nos clés API sont sensibles aux majuscules. Tous vos attributs JSON pour les endpoint POST doivent être en minuscules.

--- a/content/integrations/amazon_web_services.fr.md
+++ b/content/integrations/amazon_web_services.fr.md
@@ -85,7 +85,7 @@ Si vous déployez dans ces régions, veuillez passer la séction  <a href="#conf
 
 1.  Créez un nouveau rôle dans la [console IAM d'AWS][45].
 2.  Sélectionnez `Un autre compte AWS` pour le Role Type.
-3.  Pour Account ID, entrez 464622532012` (identifiant de compte Datadog). Cela signifie que vous accordez à Datadog un accès en lecture seule à vos données AWS.
+3.  Pour Account ID, entrez `464622532012` (identifiant de compte Datadog). Cela signifie que vous accordez à Datadog un accès en lecture seule à vos données AWS.
 4.  Cochez la case `Require external ID` et entrez celle générée [dans l'application Datadog][46]. Assurez-vous de laisser **Require MFA** désactivé. *Pour plus d'informations sur External ID, reportez-vous à [ce document dans le Guide de l'utilisateur IAM][47]*.
 5.  Cliquez sur `Next: Permissions`.
 6.  Cliquez sur `Create Policy`. Notez que si vous avez déjà créé la politique, recherchez-la sur cette page et utilisez-la avec "select it". Sinon, complétez ce qui suit pour en créer une nouvelle.

--- a/content/logs/log_collection/_index.md
+++ b/content/logs/log_collection/_index.md
@@ -81,7 +81,7 @@ logs:
 
 {{% tab "Stream logs from TCP/UDP" %}}
 
-To gather logs from your `<APP_NAME>` application that does not log to a file, but instead forwards its logs via TCP over port **10518**, create a ``<APP_NAME>.d/conf.yaml` file at the root of your [Agent's configuration directory][9] with the following content:
+To gather logs from your `<APP_NAME>` application that does not log to a file, but instead forwards its logs via TCP over port **10518**, create a `<APP_NAME>.d/conf.yaml` file at the root of your [Agent's configuration directory][9] with the following content:
 
 ```
 logs:

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -300,7 +300,7 @@ public class MyClass {
 
 If you aren't using supported library instrumentation (see [library compatibility][python lib compatibility]), you may want to manually instrument your code.
 
-You may also want to extend the functionality of the ``ddtrace`` library or gain finer control over instrumenting your application. Several techniques are provided by the library to accomplish this.
+You may also want to extend the functionality of the `ddtrace` library or gain finer control over instrumenting your application. Several techniques are provided by the library to accomplish this.
 
 The following examples use the global tracer object which can be imported via:
 
@@ -310,7 +310,7 @@ The following examples use the global tracer object which can be imported via:
 
 **Decorator**
 
-``ddtrace`` provides a decorator that can be used to trace a particular method in your application:
+`ddtrace` provides a decorator that can be used to trace a particular method in your application:
 
 ```python
   @tracer.wrap()
@@ -1295,7 +1295,7 @@ end
 
 By default, all logs are processed by the default Ruby logger. When using Rails, you should see the messages in your application log file.
 
-Datadog client log messages are marked with ``[ddtrace]``, so you can isolate them from other messages.
+Datadog client log messages are marked with `[ddtrace]`, so you can isolate them from other messages.
 
 Additionally, it is possible to override the default logger and replace it with a custom one. This is done using the ``log`` attribute of the tracer.
 

--- a/content/tracing/faq/my-trace-agent-log-renders-empty-service-error.md
+++ b/content/tracing/faq/my-trace-agent-log-renders-empty-service-error.md
@@ -3,7 +3,7 @@ title: My trace-agent.log renders "empty `service`" error
 kind: faq
 ---
 
-If your Agent is not rendering your traces on the UI, the first place to look for errors is the `trace-agent.log.
+If your Agent is not rendering your traces on the UI, the first place to look for errors is the `trace-agent.log`.
 
 You may see the following errors :
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes missing and extra backticks on code blocks (formatting fixes)

### Motivation
These were caught by a script I've written to fix markdown link formatting.

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
