### PR TITLE
Convert errant hyphens to em-dashes on the autodiscovery page

### DIFF
--- a/content/agent/autodiscovery.md
+++ b/content/agent/autodiscovery.md
@@ -30,7 +30,7 @@ Here's a 5-minute video for a bird's eye view of Datadog Agent v6 Autodiscovery 
 
 ## How it Works
 
-In a traditional non-container environment, Datadog Agent configuration is-like the environment in which it runs-static. The Agent reads check configurations from disk when it starts, and as long as it's running, it continuously runs every configured check.
+In a traditional non-container environment, Datadog Agent configuration is&mdash;like the environment in which it runs&mdash;static. The Agent reads check configurations from disk when it starts, and as long as it's running, it continuously runs every configured check.
 The configuration files are static, and any network-related options configured within them serve to identify specific instances of a monitored service (e.g. a Redis instance at 10.0.0.61:6379).
 When an Agent check cannot connect to such a service, metrics will be missing until you troubleshoot the issue. The Agent check retries its failed connection attempts until an administrator revives the monitored service or fixes the check's configuration.
 
@@ -40,17 +40,17 @@ With Autodiscovery enabled, the Agent runs checks differently.
 
 Static configuration files aren't suitable for checks that collect data from ever-changing network endpoints, so Autodiscovery uses **templates** for check configuration. In each template, the Agent looks for two template variables-`%%host%%` and `%%port%%`-to appear in place of any normally-hardcoded network options. For example: a template for the Agent's [Go Expvar check][2] would contain the option `expvar_url: http://%%host%%:%%port%%`. For containers that have more than one IP address or exposed port, you can direct Autodiscovery to pick the right ones by using [template variable indexes](#supported-template-variables).
 
-Because templates don't identify specific instances of a monitored service-which `%%host%%`? which `%%port%%`?-Autodiscovery needs one or more **container identifiers** for each template so it can determine which IP(s) and Port(s) to substitute into the templates. For Docker, container identifiers are image names or container labels.
+Because templates don't identify specific instances of a monitored service&mdash;which `%%host%%`? which `%%port%%`?&mdash;Autodiscovery needs one or more **container identifiers** for each template so it can determine which IP(s) and Port(s) to substitute into the templates. For Docker, container identifiers are image names or container labels.
 
 Finally, Autodiscovery can load check templates from places other than disk. Other possible **template sources** include key-value stores like Consul, and, when running on Kubernetes, Pod annotations.
 
 ### Different Execution
 
-When the Agent starts with Autodiscovery enabled, it loads check templates from all available template sources-[not just one or another](#template-source-precedence)-along with the templates' container identifiers. Unlike in a traditional Agent setup, the Agent doesn't run all checks all the time; it decides which checks to enable by inspecting all containers currently running on the same host as the Agent.
+When the Agent starts with Autodiscovery enabled, it loads check templates from all available template sources&mdash;[not just one or another](#template-source-precedence)&mdash;along with the templates' container identifiers. Unlike in a traditional Agent setup, the Agent doesn't run all checks all the time; it decides which checks to enable by inspecting all containers currently running on the same host as the Agent.
 
 As the Agent inspects each running container, it checks if the container matches any of the container identifiers from any loaded templates. For each match, the Agent generates a static check configuration by substituting the matching container's IP address and port. Then it enables the check using the static configuration.
 
-The Agent watches for Docker events-container creation, destruction, starts, and stops-and enables, disables, and regenerates static check configurations on such events.
+The Agent watches for Docker events&mdash;container creation, destruction, starts, and stops&mdash;and enables, disables, and regenerates static check configurations on such events.
 
 ## How to set it up
 
@@ -141,7 +141,7 @@ The Agent looks for Autodiscovery templates in the `/etc/datadog-agent/conf.d` d
 
 Since 6.2.0 (and 5.24.0), the default templates use the default port for the monitored software, instead of auto-detecting it. If you need to use a different port, provide a custom Autodiscovery template either in [Docker container labels](#template-source-docker-label-annotations) or [Kubernetes pod annotations](#template-source-kubernetes-pod-annotations).
 
-These templates may suit you in basic cases, but if you need to use custom Agent check configurations-say you want to enable extra check options, use different container identifiers, or use template variable indexing- you'll have to write your own auto-conf files. You can then provide those in a few ways:
+These templates may suit you in basic cases, but if you need to use custom Agent check configurations&mdash;say you want to enable extra check options, use different container identifiers, or use template variable indexing&mdash;you'll have to write your own auto-conf files. You can then provide those in a few ways:
 
 1. Add them to each host that runs `docker-datadog-agent` and [mount the directory that contains them][15] into the datadog-agent container when starting it
 2. On Kubernetes, add them [using ConfigMaps][16]
@@ -170,7 +170,7 @@ It looks like a minimal [Apache check configuration][17], but notice the `ad_ide
 
 _Any_ `httpd` image. Suppose you have one container running `library/httpd:latest` and another running `yourusername/httpd:v2`. Autodiscovery applies the above template to both containers. When it's loading auto-conf files, Autodiscovery cannot distinguish between identically-named images from different sources or with different tags, and **you have to provide short names for container images**, e.g. `httpd`, NOT `library/httpd:latest`.
 
-If this is too limiting-if you need to apply different check configurations to different containers running the same image- [use labels to identify the containers][18]. Label each container differently, then add each label to any template file's `ad_identifiers` list (yes, `ad_identifiers` is where to put _any_ kind of container identifier, not just images).
+If this is too limiting&mdash;if you need to apply different check configurations to different containers running the same image&mdash;[use labels to identify the containers][18]. Label each container differently, then add each label to any template file's `ad_identifiers` list (yes, `ad_identifiers` is where to put _any_ kind of container identifier, not just images).
 
 ### Template Source: Key-value Store
 
@@ -255,7 +255,7 @@ etcdctl set /datadog/check_configs/library/httpd:latest/init_configs '[{}, {}]'
 etcdctl set /datadog/check_configs/library/httpd:latest/instances '[{"apache_status_url": "http://%%host%%/server-status?auto"},{"name": "My service", "url": "http://%%host%%", timeout: 1}]'
 ```
 
-Again, the order of each list matters. The Agent can only generate the HTTP check configuration correctly if all parts of its configuration have the same index across the three lists (they do-the index is 1).
+Again, the order of each list matters. The Agent can only generate the HTTP check configuration correctly if all parts of its configuration have the same index across the three lists (they do; the index is 1).
 
 ### Template Source: Kubernetes Pod Annotations
 
@@ -280,7 +280,7 @@ If you define your Kubernetes Pods directly (i.e. `kind: Pod`), add each Pod's a
 
 #### Pod Example: Apache check with website availability monitoring
 
-The following Pod annotation defines two templates-equivalent to those from the end of the previous section-for `apache` containers:
+The following Pod annotation defines two templates&mdash;equivalent to those from the end of the previous section&mdash;for `apache` containers:
 
 ```
 apiVersion: v1
@@ -401,7 +401,7 @@ The following template variables are currently handled by the Agent:
 
 You can identify containers by label rather than container name or image. Just label any container `com.datadoghq.ad.check.id: <SOME_LABEL>`, and then put `<SOME_LABEL>` anywhere you'd normally put a container name or image. For example, if you label a container `com.datadoghq.ad.check.id: special-container`, Autodiscovery applies to that container any auto-conf template that contains `special-container` in its `ad_identifiers` list.
 
-Autodiscovery can only identify each container by label OR image/name-not both-and labels take precedence. For a container that has a `com.datadoghq.ad.check.id: special-nginx` label and runs the `nginx` image, the Agent DOESN'T apply templates that include only `nginx` as a container identifier.
+Autodiscovery can only identify each container by label OR image/name&mdash;not both&mdash;and labels take precedence. For a container that has a `com.datadoghq.ad.check.id: special-nginx` label and runs the `nginx` image, the Agent DOESN'T apply templates that include only `nginx` as a container identifier.
 
 ### Template Source Precedence
 
@@ -432,7 +432,7 @@ DD_AC_EXCLUDE = "name:dd-agent"
 
 ## Troubleshooting
 
-When you're not sure if Autodiscovery is loading certain checks you've configured, use the Agent's `configcheck` init script command. For example, to confirm that your Redis template is being loaded from a Docker label annotation-not the default `redisdb.d/auto_conf.yaml` file:
+When you're not sure if Autodiscovery is loading certain checks you've configured, use the Agent's `configcheck` init script command. For example, to confirm that your Redis template is being loaded from a Docker label annotation&mdash;not the default `redisdb.d/auto_conf.yaml` file:
 
 ```
 # docker exec -it <agent_container_name> agent configcheck


### PR DESCRIPTION
### What does this PR do?
This replaces some errant hyphens that should be em-dashes on the Autodiscovery page.

### Motivation
The doc is hard to read in sections where the em-dash was converted to a hyphen. This should help.

### Preview link

### Additional Notes
<!-- Anything else we should know when reviewing?-->
