### PR TITLE
Fixing attribtue -> attribute typo.

### DIFF
--- a/content/logs/log_collection/csharp.md
+++ b/content/logs/log_collection/csharp.md
@@ -266,7 +266,7 @@ logs:
     ##   port / path : (mandatory) Set port if type is tcp or udp. Set path if type is file
     ##   service : (mandatory) name of the service owning the log
     ##   source : (mandatory) attribute that defines which integration is sending the logs
-    ##   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribtue
+    ##   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribute
     ##   tags: (optional) add tags to each logs collected
 
   - type: file

--- a/content/logs/log_collection/go.md
+++ b/content/logs/log_collection/go.md
@@ -88,7 +88,7 @@ logs:
     #   port / path : (mandatory) Set port if type is tcp or udp. Set path if type is file
     #   service : (mandatory) name of the service owning the log
     #   source : (mandatory) attribute that defines which integration is sending the logs
-    #   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribtue
+    #   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribute
     #   tags: (optional) add tags to each logs collected
 
   - type: file

--- a/content/logs/log_collection/java.md
+++ b/content/logs/log_collection/java.md
@@ -197,7 +197,7 @@ logs:
     ##   port / path : (mandatory) Set port if type is tcp or udp. Set path if type is file
     ##   service : (mandatory) name of the service owning the log
     ##   source : (mandatory) attribute that defines which integration is sending the logs
-    ##   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribtue
+    ##   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribute
     ##   tags: (optional) add tags to each logs collected
 
   - type: file

--- a/content/logs/log_collection/nodejs.md
+++ b/content/logs/log_collection/nodejs.md
@@ -93,7 +93,7 @@ logs:
     ##   port / path : (mandatory) Set port if type is tcp or udp. Set path if type is file
     ##   service : (mandatory) name of the service owning the log
     ##   source : (mandatory) attribute that defines which integration is sending the logs
-    ##   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribtue
+    ##   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribute
     ##   tags: (optional) add tags to each logs collected
 
   - type: file

--- a/content/logs/log_collection/php.md
+++ b/content/logs/log_collection/php.md
@@ -97,7 +97,7 @@ logs:
     ##   port/path: (mandatory) Set port if type is tcp or udp. Set path if type is file
     ##   service: (mandatory) name of the service owning the log
     ##   source: (mandatory) attribute that defines which integration is sending the logs
-    ##   sourcecategory: (optional) Multiple value attribute. Can be used to refine the source attribtue
+    ##   sourcecategory: (optional) Multiple value attribute. Can be used to refine the source attribute
     ##   tags: (optional) add tags to each logs collected
 
   - type: file
@@ -197,7 +197,7 @@ logs:
     ##   port/path: (mandatory) Set port if type is tcp or udp. Set path if type is file
     ##   service: (mandatory) name of the service owning the log
     ##   source: (mandatory) attribute that defines which integration is sending the logs
-    ##   sourcecategory: (optional) Multiple value attribute. Can be used to refine the source attribtue
+    ##   sourcecategory: (optional) Multiple value attribute. Can be used to refine the source attribute
     ##   tags: (optional) add tags to each logs collected
 
   - type: file
@@ -386,7 +386,7 @@ logs:
     ##   port / path: (mandatory) Set port if type is tcp or udp. Set path if type is file
     ##   service: (mandatory) name of the service owning the log
     ##   source: (mandatory) attribute that defines which integration is sending the logs
-    ##   sourcecategory: (optional) Multiple value attribute. Can be used to refine the source attribtue
+    ##   sourcecategory: (optional) Multiple value attribute. Can be used to refine the source attribute
     ##   tags: (optional) add tags to each logs collected
 
   - type: file

--- a/content/logs/log_collection/python.md
+++ b/content/logs/log_collection/python.md
@@ -123,7 +123,7 @@ logs:
     ##   port / path : (mandatory) Set port if type is tcp or udp. Set path if type is file
     ##   service : (mandatory) name of the service owning the log
     ##   source : (mandatory) attribute that defines which integration is sending the logs
-    ##   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribtue
+    ##   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribute
     ##   tags: (optional) add tags to each logs collected
 
   - type: file

--- a/content/logs/log_collection/ruby.md
+++ b/content/logs/log_collection/ruby.md
@@ -144,7 +144,7 @@ logs:
     ##   port / path : (mandatory) Set port if type is tcp or udp. Set path if type is file
     ##   service : (mandatory) name of the service owning the log
     ##   source : (mandatory) attribute that defines which integration is sending the logs
-    ##   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribtue
+    ##   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribute
     ##   tags: (optional) add tags to each logs collected
 
   - type: file


### PR DESCRIPTION
Done via:

```
git grep -l attribtue | xargs sed -i s/attribtue/attribute/g
```

I originally discovered this while reading [1].

[1]: https://docs.datadoghq.com/logs/log_collection/python/