### PR TITLE
Path update

### DIFF
--- a/content/agent/autodiscovery.md
+++ b/content/agent/autodiscovery.md
@@ -123,7 +123,7 @@ Each **Template Source** section below shows a different way to configure check 
 
 Storing templates as local files is easy to understand and doesn't require an external service or a specific orchestration platform. The downside is that you have to restart your Agent containers each time you change, add, or remove templates.
 
-The Agent looks for Autodiscovery templates in the `/etc/datadog-agent/conf.d` directory, which contains default templates for the following checks:
+The Agent looks for Autodiscovery templates in the `/conf.d` directory, which contains default templates for the following checks:
 
 - [Apache][3]
 - [Consul][4]


### PR DESCRIPTION
What is the correct/prefered datadog configuration folder when configuring 
Autodiscory checks, is it /conf.d or /etc/datadog-agent/conf.d/? 

* https://docs.datadoghq.com/agent/kubernetes/integrations/#configmap here says it's ` /conf.d. `
* https://docs.datadoghq.com/agent/autodiscovery/?tab=kubernetes#template-source-files-auto-conf says it's `/etc/datadog-agent/conf.d.`

Actually, this is not made clear there, but the files in /conf.d are copied in /etc/datadog-agent/conf.d at startup of the container, where they are read by the agent.
So user should mount in /conf.d . the issue with mounting in /etc/datadog-agent/conf.d is that the configmap erases the files that are already present there
