### PR TITLE
David.jones/search remove filters

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -70,9 +70,6 @@
          apiKey: 'c7ec32b3838892b10610af30d06a4e42',
          indexName: 'docsearch_docs_prod',
          inputSelector: '.docssearch-input',
-         algoliaOptions: {
-            'facetFilters': ['language:en']
-         },
          autocompleteOptions: {
             autoselect: false
          },
@@ -97,9 +94,6 @@
          apiKey: 'c7ec32b3838892b10610af30d06a4e42',
          indexName: 'docsearch_docs_prod',
          inputSelector: '.docssearch-input-m',
-         algoliaOptions: {
-            'facetFilters': ['language:en']
-         },
          autocompleteOptions: {
             autoselect: false
          },

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -71,8 +71,7 @@
          indexName: 'docsearch_docs_prod',
          inputSelector: '.docssearch-input',
          algoliaOptions: {
-            'facetFilters': ['language:en'],
-            'filters': '(tags:docs OR tags:api)'
+            'facetFilters': ['language:en']
          },
          autocompleteOptions: {
             autoselect: false
@@ -99,8 +98,7 @@
          indexName: 'docsearch_docs_prod',
          inputSelector: '.docssearch-input-m',
          algoliaOptions: {
-            'facetFilters': ['language:en'],
-            'filters': '(tags:docs OR tags:api)'
+            'facetFilters': ['language:en']
          },
          autocompleteOptions: {
             autoselect: false

--- a/src/js/datadog-docs.js
+++ b/src/js/datadog-docs.js
@@ -70,8 +70,6 @@ $(document).ready(function () {
             params: {
                 hitsPerPage: 200,
                 attributesToRetrieve: "*",
-                facetFilters: ['language:'+lang],
-                filters: '(tags:docs OR tags:api)'
             }
         }], function (err, results) {
             if (!err) {

--- a/src/js/datadog-docs.js
+++ b/src/js/datadog-docs.js
@@ -69,7 +69,7 @@ $(document).ready(function () {
             query: decodeURIComponent(query),
             params: {
                 hitsPerPage: 200,
-                attributesToRetrieve: "*",
+                attributesToRetrieve: "*"
             }
         }], function (err, results) {
             if (!err) {
@@ -87,7 +87,7 @@ $(document).ready(function () {
                             '<a href="' + hit["url"] + '">' + getTitle(hit) + '</a></div>';
                         formatted_results += '<div class="tipue_search_content_url">' +
                             '<a href="' + hit["url"] + '">' + hit["url"].replace('https://docs.datadoghq.com', '') + '</a></div>';
-                        var text = hit._snippetResult.content.value;
+                        var text = hit._highlightResult.content.value;
                         formatted_results += '<div class="tipue_search_content_text">' +
                             text + '</div>';
                         formatted_results += '</div>';
@@ -294,7 +294,7 @@ $(document).ready(function () {
 
                             formatted_results += '<div class="tipue_search_content_title">' +
                                 '<a href="' + hits[i]["url"] + '">' + getTitle(hits[i]) + '</a></div>';
-                            var text = hits[i]._snippetResult.content.value;
+                            var text = hits[i]._highlightResult.content.value;
                             formatted_results += '<div class="tipue_search_content_text">' +
                                 text + '</div>';
 


### PR DESCRIPTION
### What does this PR do?
This attempts to fix changes with algolia's docsearch API. 
- Filters stopped working 
- `_snippetResult` is no longer an attribute in the response data for `/search/`

### Motivation
websites channel notification

### Preview link
https://docs-staging.datadoghq.com/david.jones/search-remove-filters/
https://docs-staging.datadoghq.com/david.jones/search-remove-filters/search/?s=docker

### Additional Notes
French results may come through in the search as we removed filters to get any data to show
