### PR TITLE
add priority sampling and new integrations docs for Node APM v0.6.0

### DIFF
--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1135,9 +1135,30 @@ Possible values for the sampling priority tag are:
 {{% /tab %}}
 {{% tab "Node.js" %}}
 
-Coming Soon. Reach out to [the Datadog support team][contact support] to be part of the beta.
+Priority sampling is enabled by default. The sampler automatically assigns a value of `AUTO_REJECT` or `AUTO_KEEP` to traces, depending on their service and volume.
 
-[contact support]: https://docs.datadoghq.com/help
+You can also set this priority manually to either drop a non-interesting trace or to keep an important one. For that, set the `sampling.priority` tag to:
+
+```javascript
+const priority = require('dd-trace/ext/priority')
+
+// To reject the trace
+span.setTag('sampling.priority', priority.USER_REJECT)
+
+// To keep the trace
+span.setTag('sampling.priority', priority.USER_KEEP)
+```
+
+Possible values for the sampling priority tag are:
+
+| Sampling Value | Effect                                                                                                     |
+| --------       | :--------------------------------------------------                                                        |
+| `AUTO_REJECT`  | The sampler automatically decided to not keep the trace. The Agent will drop it.                           |
+| `AUTO_KEEP`    | The sampler automatically decided to keep the trace. The Agent will keep it. Might be sampled server-side. |
+| `USER_REJECT`  | The user asked to not keep the trace. The Agent will drop it.                                              |
+| `USER_KEEP`    | The user asked to keep the trace. The Agent will keep it. The server will keep it too.                     |
+
+Once the sampling priority has been set, it cannot be changed. This is done automatically whenever a span is finished or the trace is propagated. Setting it manually should thus be done before either occur.
 
 {{% /tab %}}
 {{% tab ".NET" %}}

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1137,7 +1137,7 @@ Possible values for the sampling priority tag are:
 
 Priority sampling is enabled by default. The sampler automatically assigns a value of `AUTO_REJECT` or `AUTO_KEEP` to traces, depending on their service and volume.
 
-You can also set this priority manually to either drop a non-interesting trace or to keep an important one. For that, set the `sampling.priority` tag to:
+Set this priority manually to either drop a non-interesting trace or to keep an important one with the `sampling.priority` tag:
 
 ```javascript
 const priority = require('dd-trace/ext/priority')

--- a/content/tracing/setup/nodejs.md
+++ b/content/tracing/setup/nodejs.md
@@ -67,9 +67,9 @@ For details about how to how to toggle and configure plugins, check out the [API
 | :----------   | :---------- | :-------------- |
 | [express][8]  | 4.x         | Fully Supported |
 | [graphql][22] | 0.13.x      | Fully Supported |
-| [hapi][9]     |             | Coming Soon     |
-| [koa][10]     |             | Coming Soon     |
-| [restify][11] |             | Coming Soon     |
+| [hapi][9]     | ^17.1       | Fully Supported |
+| [koa][10]     | 2.x         | Fully Supported |
+| [restify][11] | 7.x         | Fully Supported |
 
 [8]: https://expressjs.com/
 [22]: https://github.com/graphql/graphql-js
@@ -91,15 +91,15 @@ For details about how to how to toggle and configure plugins, check out the [API
 
 | Module                 | Versions    | Support Type    |
 | :----------            | :---------- | :-------------- |
+| [cassandra-driver][25] |             | Coming Soon     |
 | [elasticsearch][14]    | 15.x        | Fully Supported |
+| [ioredis][15]          | 4.x         | Fully Supported |
+| [memcached][24]        | ^2.2        | Fully Supported |
 | [mongodb-core][16]     | 3.x         | Fully Supported |
 | [mysql][17]            | 2.x         | Fully Supported |
 | [mysql2][18]           | ^1.5        | Fully Supported |
 | [pg][19]               | 6.x         | Fully Supported |
 | [redis][20]            | ^2.6        | Fully Supported |
-| [cassandra-driver][25] |             | Coming Soon     |
-| [ioredis][15]          |             | Coming Soon     |
-| [memcached][24]        |             | Coming Soon     |
 
 [14]: https://github.com/elastic/elasticsearch-js
 [15]: https://github.com/luin/ioredis
@@ -115,13 +115,18 @@ For details about how to how to toggle and configure plugins, check out the [API
 
 | Module           | Versions    | Support Type    |
 | :----------      | :---------- | :-------------- |
+| [amqp10][27]*    | 3.x         | Fully Supported |
 | [amqplib][21]*   | 0.5.x       | Fully Supported |
 | [kafka-node][26] |             | Coming Soon     |
+| [rhea][28]*      |             | Coming Soon     |
 
-**Note**: amqplib supports several message brokers including RabbitMQ and ActiveMQ.
+**Note**: amqplib supports several message brokers including RabbitMQ and Apache Qpid.
+**Note**: amqp10 supports several message brokers including ActiveMQ and Apache Qpid.
 
 [21]: https://github.com/squaremo/amqp.node
 [26]: https://github.com/SOHU-Co/kafka-node
+[27]: https://github.com/noodlefrenzy/node-amqp10
+[28]: https://github.com/amqp/rhea
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Adds documentation for the new features of Node APM v0.6.0

### Motivation

Documenting the available features.

### Preview link

https://docs-staging.datadoghq.com/rochdev/dd-trace-js-0.6.0/tracing/advanced_usage/?tab=nodejs#priority-sampling
https://docs-staging.datadoghq.com/rochdev/dd-trace-js-0.6.0/tracing/setup/nodejs/#compatibility

### Additional Notes

