### PR TITLE
fix supported pg versions and make other versions easier to read

### DIFF
--- a/content/tracing/setup/nodejs.md
+++ b/content/tracing/setup/nodejs.md
@@ -65,11 +65,11 @@ For details about how to how to toggle and configure plugins, check out the [API
 
 | Module        | Versions    | Support Type    |
 | :----------   | :---------- | :-------------- |
-| [express][8]  | 4.x         | Fully Supported |
-| [graphql][22] | 0.13.x      | Fully Supported |
+| [express][8]  | 4           | Fully Supported |
+| [graphql][22] | 0.13        | Fully Supported |
 | [hapi][9]     | ^17.1       | Fully Supported |
-| [koa][10]     | 2.x         | Fully Supported |
-| [restify][11] | 7.x         | Fully Supported |
+| [koa][10]     | 2           | Fully Supported |
+| [restify][11] | 7           | Fully Supported |
 
 [8]: https://expressjs.com/
 [22]: https://github.com/graphql/graphql-js
@@ -92,13 +92,13 @@ For details about how to how to toggle and configure plugins, check out the [API
 | Module                 | Versions    | Support Type    |
 | :----------            | :---------- | :-------------- |
 | [cassandra-driver][25] |             | Coming Soon     |
-| [elasticsearch][14]    | 15.x        | Fully Supported |
-| [ioredis][15]          | 4.x         | Fully Supported |
+| [elasticsearch][14]    | 15          | Fully Supported |
+| [ioredis][15]          | 4           | Fully Supported |
 | [memcached][24]        | ^2.2        | Fully Supported |
-| [mongodb-core][16]     | 3.x         | Fully Supported |
-| [mysql][17]            | 2.x         | Fully Supported |
+| [mongodb-core][16]     | 3           | Fully Supported |
+| [mysql][17]            | 2           | Fully Supported |
 | [mysql2][18]           | ^1.5        | Fully Supported |
-| [pg][19]               | 6.x         | Fully Supported |
+| [pg][19]               | 6 - 7       | Fully Supported |
 | [redis][20]            | ^2.6        | Fully Supported |
 
 [14]: https://github.com/elastic/elasticsearch-js

--- a/content/tracing/setup/nodejs.md
+++ b/content/tracing/setup/nodejs.md
@@ -115,8 +115,8 @@ For details about how to how to toggle and configure plugins, check out the [API
 
 | Module           | Versions    | Support Type    |
 | :----------      | :---------- | :-------------- |
-| [amqp10][27]*    | 3.x         | Fully Supported |
-| [amqplib][21]*   | 0.5.x       | Fully Supported |
+| [amqp10][27]*    | 3           | Fully Supported |
+| [amqplib][21]*   | 0.5         | Fully Supported |
 | [kafka-node][26] |             | Coming Soon     |
 | [rhea][28]*      |             | Coming Soon     |
 

--- a/content/tracing/setup/nodejs.md
+++ b/content/tracing/setup/nodejs.md
@@ -121,6 +121,7 @@ For details about how to how to toggle and configure plugins, check out the [API
 | [rhea][28]*      |             | Coming Soon     |
 
 **Note**: amqplib supports several message brokers including RabbitMQ and Apache Qpid.
+
 **Note**: amqp10 supports several message brokers including ActiveMQ and Apache Qpid.
 
 [21]: https://github.com/squaremo/amqp.node


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Fix supported `pg` versions since it was missing 7.x. It also improves readability of all versions by dropping the `.x` suffixes that is redundant, and fixes the compatibility notes not being stacked properly.

### Motivation

The supported `pg` versions were incorrect, and I took the opportunity to improve readability as well.

### Preview link

https://docs-staging.datadoghq.com/rochdev/dd-trace-js-0.6.0-fixes/tracing/setup/nodejs/#compatibility

### Additional Notes
