### PR TITLE
Correct nginx_status_url in Dockerfile LABEL example

### DIFF
--- a/content/agent/autodiscovery.md
+++ b/content/agent/autodiscovery.md
@@ -372,7 +372,7 @@ EXPOSE 8080
 COPY nginx.conf /etc/nginx/nginx.conf
 LABEL "com.datadoghq.ad.check_names"='["nginx"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'
-LABEL "com.datadoghq.ad.instances"='[{"nginx_status_url": "http://%%host%%/nginx_status:%%port%%"}]'
+LABEL "com.datadoghq.ad.instances"='[{"nginx_status_url": "http://%%host%%:%%port%%/nginx_status"}]'
 LABEL "com.datadoghq.ad.logs"='[{"source": "nginx", "service": "webapp"}]'
 ```
 


### PR DESCRIPTION
### What does this PR do?

Correct `nginx_status_url` in Dockerfile LABEL example; The `:port` must come before the `/path`.

### Motivation

This typo was introduced in commit 7e15957fe414b001a7ca648adef3d1fe4c9a0792 (nearly a year ago). Matt Weber noticed today: https://datadoghq.slack.com/archives/C3BM8SGKZ/p1538064969000100

### Preview link

### Additional Notes
