### PR TITLE
turn off algolia indexer for now

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -152,14 +152,13 @@ test_live_static:
     - master
 
 #index_algolia:
-index_algolia:
-  <<: *base_template
-  stage: post-deploy
-  environment: "live"
-  script:
-    - index_docsearch_algolia
-  only:
-    - master
+#  <<: *base_template
+#  stage: post-deploy
+#  environment: "live"
+#  script:
+#    - index_docsearch_algolia
+#  only:
+#    - master
 
 manage_translations:on-schedule:
   <<: *base_template


### PR DESCRIPTION
### What does this PR do?
Turn off re-indexing of docs site on master deploys until we can figure out when it does an incomplete index.

### Motivation
Search stopped working because an indexer run was incomplete

### Preview link


### Additional Notes

