### PR TITLE
add compatibility notes for Node APM

### DIFF
--- a/content/tracing/setup/nodejs.md
+++ b/content/tracing/setup/nodejs.md
@@ -66,10 +66,10 @@ For details about how to how to toggle and configure plugins, check out the [API
 | Module        | Versions    | Support Type    | Notes                        |
 | :----------   | :---------- | :-------------- | :--------------------------- |
 | [express][8]  | 4           | Fully Supported | Supports Sails, Loopback, and [more][29] |
-| [graphql][22] | 0.13        | Fully Supported |
-| [hapi][9]     | ^17.1       | Fully Supported |
-| [koa][10]     | 2           | Fully Supported |
-| [restify][11] | 7           | Fully Supported |
+| [graphql][22] | 0.13        | Fully Supported |                              |
+| [hapi][9]     | ^17.1       | Fully Supported |                              |
+| [koa][10]     | 2           | Fully Supported |                              |
+| [restify][11] | 7           | Fully Supported |                              |
 
 [8]: https://expressjs.com/
 [22]: https://github.com/graphql/graphql-js
@@ -90,17 +90,17 @@ For details about how to how to toggle and configure plugins, check out the [API
 
 #### Data Store Compatibility
 
-| Module                 | Versions    | Support Type    |
-| :----------            | :---------- | :-------------- |
-| [cassandra-driver][25] |             | Coming Soon     |
-| [elasticsearch][14]    | 15          | Fully Supported |
-| [ioredis][15]          | 4           | Fully Supported |
-| [memcached][24]        | ^2.2        | Fully Supported |
-| [mongodb-core][16]     | 3           | Fully Supported |
-| [mysql][17]            | 2           | Fully Supported |
-| [mysql2][18]           | ^1.5        | Fully Supported |
-| [pg][19]               | 6 - 7       | Fully Supported |
-| [redis][20]            | ^2.6        | Fully Supported |
+| Module                 | Versions    | Support Type    |  Notes              |
+| :----------            | :---------- | :-------------- | :------------------ |
+| [cassandra-driver][25] |             | Coming Soon     |                     |
+| [elasticsearch][14]    | 15          | Fully Supported |                     |
+| [ioredis][15]          | 4           | Fully Supported |                     |
+| [memcached][24]        | ^2.2        | Fully Supported |                     |
+| [mongodb-core][16]     | 3           | Fully Supported | Supports Mongoose   |
+| [mysql][17]            | 2           | Fully Supported |                     |
+| [mysql2][18]           | ^1.5        | Fully Supported |                     |
+| [pg][19]               | 6 - 7       | Fully Supported |                     |
+| [redis][20]            | ^2.6        | Fully Supported |                     |
 
 [14]: https://github.com/elastic/elasticsearch-js
 [15]: https://github.com/luin/ioredis
@@ -118,8 +118,8 @@ For details about how to how to toggle and configure plugins, check out the [API
 | :----------      | :---------- | :-------------- | :------------------------ |
 | [amqp10][27]     | 3           | Fully Supported | Supports AMQP 1.0 brokers (i.e. ActiveMQ, Apache Qpid) | 
 | [amqplib][21]    | 0.5         | Fully Supported | Supports AMQP 0.9 brokers (i.e. RabbitMQ, Apache Qpid) |
-| [kafka-node][26] |             | Coming Soon     |
-| [rhea][28]       |             | Coming Soon     |
+| [kafka-node][26] |             | Coming Soon     |                           |
+| [rhea][28]       |             | Coming Soon     |                           |
 
 [21]: https://github.com/squaremo/amqp.node
 [26]: https://github.com/SOHU-Co/kafka-node

--- a/content/tracing/setup/nodejs.md
+++ b/content/tracing/setup/nodejs.md
@@ -63,9 +63,9 @@ For details about how to how to toggle and configure plugins, check out the [API
 
 #### Web Framework Compatibility
 
-| Module        | Versions    | Support Type    |
-| :----------   | :---------- | :-------------- |
-| [express][8]  | 4           | Fully Supported |
+| Module        | Versions    | Support Type    | Notes                        |
+| :----------   | :---------- | :-------------- | :--------------------------- |
+| [express][8]  | 4           | Fully Supported | Supports Sails, Loopback, and [more][29] |
 | [graphql][22] | 0.13        | Fully Supported |
 | [hapi][9]     | ^17.1       | Fully Supported |
 | [koa][10]     | 2           | Fully Supported |
@@ -76,6 +76,7 @@ For details about how to how to toggle and configure plugins, check out the [API
 [9]: https://hapijs.com/
 [10]: https://koajs.com/
 [11]: http://restify.com/
+[29]: https://expressjs.com/en/resources/frameworks.html
 
 #### Native Module Compatibility
 
@@ -113,16 +114,12 @@ For details about how to how to toggle and configure plugins, check out the [API
 
 #### Worker Compatibility
 
-| Module           | Versions    | Support Type    |
-| :----------      | :---------- | :-------------- |
-| [amqp10][27]*    | 3           | Fully Supported |
-| [amqplib][21]*   | 0.5         | Fully Supported |
+| Module           | Versions    | Support Type    | Notes                     |
+| :----------      | :---------- | :-------------- | :------------------------ |
+| [amqp10][27]     | 3           | Fully Supported | Supports AMQP 1.0 brokers (i.e. ActiveMQ, Apache Qpid) | 
+| [amqplib][21]    | 0.5         | Fully Supported | Supports AMQP 0.9 brokers (i.e. RabbitMQ, Apache Qpid) |
 | [kafka-node][26] |             | Coming Soon     |
-| [rhea][28]*      |             | Coming Soon     |
-
-**Note**: amqplib supports several message brokers including RabbitMQ and Apache Qpid.
-
-**Note**: amqp10 supports several message brokers including ActiveMQ and Apache Qpid.
+| [rhea][28]       |             | Coming Soon     |
 
 [21]: https://github.com/squaremo/amqp.node
 [26]: https://github.com/SOHU-Co/kafka-node


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Adds compatibility notes for Node APM

### Motivation

Frequent questions on whether we support frameworks that are based on modules we support.

### Preview link

https://docs-staging.datadoghq.com/rochdev/node-apm-compat-notes/tracing/setup/nodejs/#compatibility

### Additional Notes

Note sure this is the best format to list these. Also should we add links to the supported frameworks and/or versions?
