### PR TITLE
add language to html tag for docsearch indexing help

### DIFF
--- a/layouts/_default/404-baseof.html
+++ b/layouts/_default/404-baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}" style="opacity:0">
+<html lang="{{ .Site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}" style="opacity:0">
 <head>
     <meta charset="utf-8">
     {{ partial "prefetch.html" . }}

--- a/layouts/_default/api-baseof.html
+++ b/layouts/_default/api-baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}" style="opacity:0">
+<html lang="{{ .Site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}" style="opacity:0">
 <head>
     <meta charset="utf-8">
     {{ partial "prefetch.html" . }}


### PR DESCRIPTION
### What does this PR do?
This PR makes sure we set the lang attribute  on`<html>` tags on all the base pages. 

### Motivation
The reason for this is to help with upcoming docsearch changes.

### Preview link
https://docs-staging.datadoghq.com/david.jones/html-lang/fr/api/?lang=python

### Additional Notes

