### PR TITLE
content/tracing: s/sampling_priority/sampling.priority/g

### DIFF
--- a/content/tracing/getting_further/trace_sampling_and_storage.md
+++ b/content/tracing/getting_further/trace_sampling_and_storage.md
@@ -75,7 +75,7 @@ Because Signature Sampling decisions are made at the [Agent][4] level, it is not
 
 #### How it works
 
-Each trace has a `sampling_priority` attribute, which is assigned at its inception and propagated along the entire trace:
+Each trace has a `sampling.priority` attribute, which is assigned at its inception and propagated along the entire trace:
 
 | Value                  | Type                        | Action                                                                                               |
 | :--------------------- | :----------------           | :----------                                                                                          |
@@ -131,11 +131,11 @@ Once a trace has been viewed, it continues to be available by using its trace ID
 
 This section documents how the priority sampling is implemented in the clients directly.
 
-The `sampling_priority` is an attribute of the Context that has to be propagated over the wire next to the `trace_id` and `span_id` attributes. When propagated over HTTP, its header is `x-datadog-sampling-priority`. When creating remote spans from this propagated attribute, **the same sampling priority value has to be used for the remote trace**.
+The `sampling.priority` is an attribute of the Context that has to be propagated over the wire next to the `trace_id` and `span_id` attributes. When propagated over HTTP, its header is `x-datadog-sampling-priority`. When creating remote spans from this propagated attribute, **the same sampling priority value has to be used for the remote trace**.
 
-The `sampling_priority` value must be the same across all the pieces of a trace (when spread across hosts or asynchronous tasks). So it should not be modified after any context propagation (remote call, fork, ...).
+The `sampling.priority` value must be the same across all the pieces of a trace (when spread across hosts or asynchronous tasks). So it should not be modified after any context propagation (remote call, fork, ...).
 
-The initial `sampling_priority` value is computed at the root span creation. The initial value can either be **0** or **1**. This initial decision is made by the client but the Agent provides a "rate" to decide if it should be a **0** or a **1**.
+The initial `sampling.priority` value is computed at the root span creation. The initial value can either be **0** or **1**. This initial decision is made by the client but the Agent provides a "rate" to decide if it should be a **0** or a **1**.
 The response of the Agent to any flush is a JSON containing a `rate_by_service` key which contains a mapping of services to a rate (between 0 and 1). This rate decides the probability of priority **1** being assigned to new traces:
 
 ```json
@@ -147,12 +147,12 @@ The response of the Agent to any flush is a JSON containing a `rate_by_service` 
 }
 ```
 
-With that example, if you create a new trace with a root span of service **webapp**, the Agent will pick between a sampling_priority of 1 (with a 94% chance) or a priority of 0 (with a 6% chance).
+With that example, if you create a new trace with a root span of service **webapp**, the Agent will pick between a `sampling.priority` of 1 (with a 94% chance) or a priority of 0 (with a 6% chance).
 This mechanism is meant to ensure that good proportion of low QPS services are sampled(high QPS services have a lower rate) and that the total resulting volume sampled aligns with the `max_traces_per_second` parameter configured in the Agent.
 
 The client allows a sampling priority of **-1** (drop the trace fully) or **2** (force its sampling). This should be done only after any context propagation. If this happens after the propagation of a context, the system can't ensure that the entire trace is sampled properly.
 
-When serialized/flushed to the Agent, the `sampling_priority` is stored in the `_sampling_priority_v1` key of the `metrics` attribute. Example with JSON (similar with msgpack).
+When serialized/flushed to the Agent, the `sampling.priority` is stored in the `_sampling_priority_v1` key of the `metrics` attribute. Example with JSON (similar with msgpack).
 
 ```json
 [


### PR DESCRIPTION
The common name for the sampling priority tag is "sampling.priority",
not "sampling_priority". This change updates the documentation to
reflect this.