### PR TITLE
Update use case issue for monitor1.value

### DIFF
--- a/content/monitors/monitor_types/composite.md
+++ b/content/monitors/monitor_types/composite.md
@@ -89,7 +89,7 @@ Write a notification message as you would with any other monitor, using the `@-s
 
 {{< img src="monitors/monitor_types/composite/writing-notification.png" alt="writing notification" responsive="true" style="width:80%;">}}
 
-You can use template variables like `{{monitor1.value}}`, `{{monitor2.value}}`, etc.
+You can use template variables like `{{a.value}}`, `{{b.value}}` (for monitor use cases), etc.
 
 In addition to your own message, notifications (e.g. emails) for the composite monitor shows the status of the individual monitors:
 


### PR DESCRIPTION
{{monitor1.value}}  && {{monitor2.value}} is not ever used. 
The better case is {{a.value}} && {{b.value}} and specify that these are pertaining to monitors.

https://datadog.zendesk.com/agent/tickets/171883