### PR TITLE
David.jones/docsearch improve

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:david.jones_config-facets
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
   tags:
     - "runner:main"
     - "size:large"
@@ -89,15 +89,6 @@ test_preview_links:
   only:
     - /.+?\/[a-zA-Z0-9_-]+/
 
-index_algolia:
-  <<: *base_template
-  stage: post-deploy
-  environment: "preview"
-  script:
-    - index_docsearch_algolia
-  only:
-    - /.+?\/[a-zA-Z0-9_-]+/
-
 # ================== live ================== #
 build_live:
   <<: *base_template
@@ -160,14 +151,14 @@ test_live_static:
   only:
     - master
 
-#index_algolia:
-#  <<: *base_template
-#  stage: post-deploy
-#  environment: "live"
-#  script:
-#    - index_docsearch_algolia
-#  only:
-#    - master
+index_algolia:
+  <<: *base_template
+  stage: post-deploy
+  environment: "live"
+  script:
+    - index_docsearch_algolia
+  only:
+    - master
 
 manage_translations:on-schedule:
   <<: *base_template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:david.jones_config-facets
   tags:
     - "runner:main"
     - "size:large"
@@ -86,6 +86,15 @@ test_preview_links:
   script:
     - pull_artifact_from_s3
     - test_site_links "links" "${URL}" "True" "False" "True"
+  only:
+    - /.+?\/[a-zA-Z0-9_-]+/
+
+index_algolia:
+  <<: *base_template
+  stage: post-deploy
+  environment: "preview"
+  script:
+    - index_docsearch_algolia
   only:
     - /.+?\/[a-zA-Z0-9_-]+/
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -71,8 +71,7 @@
          indexName: 'docsearch_docs_prod',
          inputSelector: '.docssearch-input',
          algoliaOptions: {
-            'facetFilters': ['language:en'],
-            'filters': '(tags:docs OR tags:api)'
+            'facetFilters': ['language:{{ .Site.Language.Lang }}']
          },
          autocompleteOptions: {
             autoselect: false
@@ -99,8 +98,7 @@
          indexName: 'docsearch_docs_prod',
          inputSelector: '.docssearch-input-m',
          algoliaOptions: {
-            'facetFilters': ['language:en'],
-            'filters': '(tags:docs OR tags:api)'
+            'facetFilters': ['language:{{ .Site.Language.Lang }}']
          },
          autocompleteOptions: {
             autoselect: false

--- a/src/js/datadog-docs.js
+++ b/src/js/datadog-docs.js
@@ -70,8 +70,7 @@ $(document).ready(function () {
             params: {
                 hitsPerPage: 200,
                 attributesToRetrieve: "*",
-                facetFilters: ['language:'+lang],
-                filters: '(tags:docs OR tags:api)'
+                facetFilters: ['language:'+lang]
             }
         }], function (err, results) {
             if (!err) {


### PR DESCRIPTION
### What does this PR do?

This PR 
- changes the docsearch js settings to use facet filters only. 
- enables the docsearch indexer gitlab task again which has a check for failure

### Motivation
Recommendations from algolia and issues indexing last week

### Preview link
https://docs-staging.datadoghq.com/david.jones/docsearch-improve/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
