### PR TITLE
Akka instrumentation is not enabled by default yet.

### DIFF
--- a/content/tracing/setup/java.md
+++ b/content/tracing/setup/java.md
@@ -56,7 +56,7 @@ We officially support the Java JRE 1.7 and higher of both Oracle JDK and OpenJDK
 
 | Server                       | Versions   | Support Type    | JVM Arg to enable                                                             |
 | :--------------------------- | :--------- | :-------------- | :----------------                                                             |
-| Akka-Http Server             | 10.0+      | Fully Supported | N/A                                                                           |
+| Akka-Http Server             | 10.0+      | Fully Supported | `-Ddd.integration.akka-http.enabled=true`                                     |
 | Java Servlet Compatible      | 2.3+, 3.0+ | Fully Supported | N/A                                                                           |
 | Jax-RS Annotations           | JSR311-API | Fully Supported | N/A                                                                           |
 | Jetty (non-Servlet)          | 8+         | Beta            | `-Ddd.integration.jetty.enabled=true`                                         |


### PR DESCRIPTION
A follow up PR will be made to update this in the future when it is enabled.

https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/instrumentation/akka-http-10.0/src/main/scala/datadog/trace/instrumentation/akkahttp/AkkaHttpServerInstrumentation.java#L45
