### PR TITLE
Fix agent name in the exclusion example

### DIFF
--- a/content/logs/log_collection/docker.md
+++ b/content/logs/log_collection/docker.md
@@ -249,7 +249,7 @@ DD_AC_INCLUDE = "image:cp-kafka image:k8szk"
 Or to exclude a specific container name:
 
 ```
-DD_AC_EXCLUDE = "name:dd-agent"
+DD_AC_EXCLUDE = "name:datadog-agent"
 ```
 
 {{% /tab %}}
@@ -271,7 +271,7 @@ ac_include: ["image:cp-kafka", "image:k8szk"]
 Or to exclude the Datadog Agent:
 
 ```
-ac_exclude = ["name:dd-agent"]
+ac_exclude = ["name:datadog-agent"]
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
### What does this PR do?
Fix the name in the exclusion example

### Motivation
In the top command, we set the name as `datadog-agent` then in the exclusion example we used the old agent 5 name `dd-agent`. 
This needed to be updated.

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
