### PR TITLE
Update PHP tracer link to our own library

### DIFF
--- a/data/libraries.yaml
+++ b/data/libraries.yaml
@@ -240,8 +240,8 @@ Tracing:
       notes: OpenTracing API implementation in JavaScript for Node.js.
   - PHP:
     - name: dd-trace-php
-      link: https://github.com/jcchavezs/dd-trace-php/
-      authors: José Carlos Chávez
+      link: https://github.com/DataDog/dd-trace-php/
+      authors: Datadog
   - Python:
     - name: dd-trace-py
       link: https://github.com/DataDog/dd-trace-py


### PR DESCRIPTION
### What does this PR do?
Update the PHP tracing library data table entry to point to our own library

### Motivation
Noticed the outdated link

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
