### PR TITLE
Add link to our own .NET tracer library

### DIFF
--- a/data/libraries.yaml
+++ b/data/libraries.yaml
@@ -10,7 +10,7 @@ Classic:
       dogstatsd: true
       authors: Garrett Sickles
       notes: C++ header library to send metrics to your Datadog account.
-  - C#:
+  - C# / .NET:
     - name: dogstatsd-csharp-client
       link: https://github.com/DataDog/dogstatsd-csharp-client
       official: true
@@ -199,7 +199,12 @@ Classic:
       api: true
       authors: Jacob Aronoff
 Tracing:
-  - C#:
+  - C# / .NET:
+    - name: dd-trace-csharp
+      link: https://github.com/DataDog/dd-trace-csharp
+      official: true
+      notes: NuGet package is `Datadog.Trace`.
+      authors: Datadog
     - name: DatadogSharp
       link: https://github.com/neuecc/DatadogSharp
       dogstatsd: true

--- a/data/libraries.yaml
+++ b/data/libraries.yaml
@@ -207,7 +207,6 @@ Tracing:
       authors: Datadog
     - name: DatadogSharp
       link: https://github.com/neuecc/DatadogSharp
-      dogstatsd: true
       notes: Also supports DogStatsD.
       authors: Yoshifumi Kawai
   - Elixir:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds Datadog's official .NET tracing library to the list of libraries.

### Motivation
Datadog's official library went Public Beta recently.

### Preview link
https://docs-staging.datadoghq.com/lucas/dotnet-tracing-library/developers/libraries/#apm-tracing-client-libraries

### Additional Notes
<!-- Anything else we should know when reviewing?-->
