### PR TITLE
remove additional trailing period from notes column

### DIFF
--- a/data/libraries.yaml
+++ b/data/libraries.yaml
@@ -243,7 +243,7 @@ Tracing:
       link: https://github.com/DataDog/dd-trace-php/
       official: true
       authors: Datadog
-      notes: composer package is 'datadog/dd-trace'
+      notes: composer package is 'datadog/dd-trace'.
   - Python:
     - name: dd-trace-py
       link: https://github.com/DataDog/dd-trace-py

--- a/ja/layouts/shortcodes/tracing-libraries-table.html
+++ b/ja/layouts/shortcodes/tracing-libraries-table.html
@@ -15,7 +15,7 @@
             <td>{{ if eq $i 0}}<strong>{{ $libName }}</strong>{{ end }}</td>
             <td><a href="{{ $el.link }}">{{ $el.name }}</a></td>
             <td>{{ if $el.official}}<i class="glyphicon glyphicon-ok" aria-hidden="true"></i>{{ end }}</td>
-            <td>{{if $el.authors }}Written by {{ $el.authors }}{{ end }}{{ if $el.notes }}{{ $el.notes }}.{{ end }}</td>
+            <td>{{if $el.authors }}Written by {{ $el.authors }}{{ end }}{{ if $el.notes }}{{ $el.notes }}{{ end }}</td>
           </tr>
         {{ end }}
     {{ end }}

--- a/layouts/shortcodes/tracing-libraries-table.html
+++ b/layouts/shortcodes/tracing-libraries-table.html
@@ -33,7 +33,7 @@
                 <td><a href="{{ $el.link }}">{{ $el.name }}</a></td>
                 <td>{{ if $el.official}}<i class="icon-tick"></i>{{ end }}</td>
                 <td>{{if $el.authors }}{{ $el.authors }}{{ end }}</td>
-                <td>{{ if $el.notes }}{{ $el.notes }}.{{ end }}</td>
+                <td>{{ if $el.notes }}{{ $el.notes }}{{ end }}</td>
               </tr>
             {{ end }}
         {{ end }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes additional trailing period from notes column which causes double periods:
![image](https://user-images.githubusercontent.com/1851278/46429836-66ef4e80-c715-11e8-9719-80b8e0fb959b.png)

### Motivation
I noticed the double periods when adding a new library in #3276

### Preview link
https://docs-staging.datadoghq.com/lucas/remove-trailing-period/developers/libraries/#apm-tracing-client-libraries

### Additional Notes
<!-- Anything else we should know when reviewing?-->
