### PR TITLE
API Timeboard curl/shell "viz" fix

### DIFF
--- a/content/api/timeboards/code_snippets/api-dashboard-create.sh
+++ b/content/api/timeboards/code_snippets/api-dashboard-create.sh
@@ -9,9 +9,9 @@ curl  -X POST -H "Content-type: application/json" \
               "events": [],
               "requests": [
                   {"q": "avg:system.mem.free{*}"}
-              ]
-          },
-          "viz": "timeseries"
+              ],
+              "viz": "timeseries"
+          }
       }],
       "title" : "Average Memory Free Shell",
       "description" : "A dashboard with memory info.",

--- a/content/api/timeboards/code_snippets/api-dashboard-delete.sh
+++ b/content/api/timeboards/code_snippets/api-dashboard-delete.sh
@@ -11,9 +11,9 @@ dash_id=$(curl  -X POST -H "Content-type: application/json" \
               "events": [],
               "requests": [
                   {"q": "avg:system.mem.free{*}"}
-              ]
-          },
-          "viz": "timeseries"
+              ],
+              "viz": "timeseries"
+          }
       }],
       "title" : "Average Memory Free Shell",
       "description" : "A dashboard with memory info.",

--- a/content/api/timeboards/code_snippets/api-dashboard-get.sh
+++ b/content/api/timeboards/code_snippets/api-dashboard-get.sh
@@ -11,9 +11,9 @@ dash_id=$(curl  -X POST -H "Content-type: application/json" \
               "events": [],
               "requests": [
                   {"q": "avg:system.mem.free{*}"}
-              ]
-          },
-          "viz": "timeseries"
+              ],
+              "viz": "timeseries"
+          }
       }],
       "title" : "Average Memory Free Shell",
       "description" : "A dashboard with memory info.",

--- a/content/api/timeboards/code_snippets/api-dashboard-update.sh
+++ b/content/api/timeboards/code_snippets/api-dashboard-update.sh
@@ -28,11 +28,11 @@ dash_id=$(curl  -X POST -H "Content-type: application/json" \
 curl  -X PUT -H "Content-type: application/json" \
 -d '{
       "graphs" : [{
-          "title": "Average Memory Free",
+          "title": "Sum of Memory Free",
           "definition": {
               "events": [],
               "requests": [
-                  {"q": "avg:system.mem.free{*}"}
+                  {"q": "sum:system.mem.free{*}"}
               ],
               "viz": "timeseries"
           }

--- a/content/api/timeboards/code_snippets/api-dashboard-update.sh
+++ b/content/api/timeboards/code_snippets/api-dashboard-update.sh
@@ -11,9 +11,9 @@ dash_id=$(curl  -X POST -H "Content-type: application/json" \
               "events": [],
               "requests": [
                   {"q": "avg:system.mem.free{*}"}
-              ]
-          },
-          "viz": "timeseries"
+              ],
+              "viz": "timeseries"
+          }
       }],
       "title" : "Average Memory Free Shell",
       "description" : "A dashboard with memory info.",

--- a/content/api/timeboards/code_snippets/api-dashboard-update.sh
+++ b/content/api/timeboards/code_snippets/api-dashboard-update.sh
@@ -28,14 +28,14 @@ dash_id=$(curl  -X POST -H "Content-type: application/json" \
 curl  -X PUT -H "Content-type: application/json" \
 -d '{
       "graphs" : [{
-          "title": "Sum of Memory Free",
+          "title": "Average Memory Free",
           "definition": {
               "events": [],
               "requests": [
-                  {"q": "sum:system.mem.free{*}"}
-              ]
-          },
-          "viz": "timeseries"
+                  {"q": "avg:system.mem.free{*}"}
+              ],
+              "viz": "timeseries"
+          }
       }],
       "title" : "Sum Memory Free Shell",
       "description" : "An updated dashboard with memory info.",


### PR DESCRIPTION
### What does this PR do?
Updates incorrect curl/shell commands for creating/updating timeboards on API

- [Create a Timeboard](https://docs.datadoghq.com/api/?lang=bash#create-a-timeboard)
- [Update a Timeboard](https://docs.datadoghq.com/api/?lang=bash#update-a-timeboard)
- [Delete a Timeboard](https://docs.datadoghq.com/api/?lang=bash#delete-a-timeboard)
- [Get a Timeboard](https://docs.datadoghq.com/api/?lang=bash#get-a-timeboard)

### Motivation
Error found with customer troubleshooting, confirmed with engineering discrepancy between curl and python examples.  `"viz"` should be within `"definition"` bracket to reflect change.  

Current example does not apply the "viz" property to graph when submitting.  Proposed change allows for "viz" properties:
- "viz": "timeseries"
- "viz": "query_value"
- "viz": "heatmap"
- "viz": "distribution"
- "viz": "toplist"
- "viz": "change"
- "viz": "hostmap"
