### PR TITLE
Update docker log collection instruction from the host

### DIFF
--- a/content/logs/log_collection/docker.md
+++ b/content/logs/log_collection/docker.md
@@ -75,7 +75,7 @@ Install the [latest version of the Agent 6](https://docs.datadoghq.com/logs/#get
 
 The Agent can collect logs from [files on the host](https://docs.datadoghq.com/logs/#custom-log-collection) or from [container stdout/stderr](#configuration-file-example).
 
-Collecting logs is *disabled* by default in the Datadog Agent. Add the following in `datadog.yaml`: 
+Collecting logs is *disabled* by default in the Datadog Agent. To enable it, add the following lines in your `datadog.yaml` configuration file: 
 
 ```
 logs_enabled: true

--- a/content/logs/log_collection/docker.md
+++ b/content/logs/log_collection/docker.md
@@ -75,10 +75,15 @@ Install the [latest version of the Agent 6](https://docs.datadoghq.com/logs/#get
 
 The Agent can collect logs from [files on the host](https://docs.datadoghq.com/logs/#custom-log-collection) or from [container stdout/stderr](#configuration-file-example).
 
-Collecting logs is *disabled* by default in the Datadog Agent. Add the following to it in `datadog.yaml`: 
+Collecting logs is *disabled* by default in the Datadog Agent. Add the following in `datadog.yaml`: 
 
 ```
 logs_enabled: true
+listeners:
+  - name: docker
+config_providers:
+  - name: docker
+    polling: true
 ```
 
 To collect logs from all your containers without any filtering, add the following at the end of `docker.d/conf.yaml` in your agent's `conf.d` directory:


### PR DESCRIPTION
### What does this PR do?
Fix the instruction for Docker log collection on the host

### Motivation
Since 6.5.2 it was required to do a little more setup when installing the agent from the host to collect docker logs.

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
