### PR TITLE
Adding disclaimer for nodejs instrumentation builds

### DIFF
--- a/content/tracing/setup/nodejs.md
+++ b/content/tracing/setup/nodejs.md
@@ -47,13 +47,13 @@ const tracer = require('dd-trace').init()
 
 See the [tracer settings][4] for the list of initialization options.
 
-**Note**: The tracer must be initialized before importing any instrumented module.
-
+<div class="alert alert-info">
+You must import and initialize the tracer library in an external file and then import that file as a whole when building your application with a transpilers. This prevents hoisting and ensures that the trace library gets imported and initialized before importing any other instrumented module.
+</div>
 
 ## Compatibility
 
 Node `^4.7`, `^6.9` and `>=8` are supported by this library. However, it benefits significantly from the performance improvements introduced in Node `>=8.3`.
-
 
 ### Integrations
 

--- a/content/tracing/setup/nodejs.md
+++ b/content/tracing/setup/nodejs.md
@@ -48,7 +48,7 @@ const tracer = require('dd-trace').init()
 See the [tracer settings][4] for the list of initialization options.
 
 <div class="alert alert-info">
-You must import and initialize the tracer library in an external file and then import that file as a whole when building your application with a transpilers. This prevents hoisting and ensures that the trace library gets imported and initialized before importing any other instrumented module.
+You must import and initialize the tracer library in an external file and then import that file as a whole when building your application with a transpiler. This prevents hoisting and ensures that the tracer library gets imported and initialized before importing any other instrumented module.
 </div>
 
 ## Compatibility


### PR DESCRIPTION
### What does this PR do?
Adds a note with best practices regarding importing and initializing the trace library for users who use transpilers such as Webpack. Customers were noticing that the init.() call was being made very late and as a result, traces were not getting collected. 

### Motivation
The problem with Webpack (and transpilers in general) is that they do hoisting, meaning they move your code around according to best practices. The best way to avoid this, is to move both importing and initializing the library to an external file, and then import that file as a whole. 

Otherwise the tracer lib might be initialise after being instrumented in a module resulting in missing traces.

### Preview link
