### PR TITLE
Udate APM k8s doc

### DIFF
--- a/content/tracing/setup/kubernetes.md
+++ b/content/tracing/setup/kubernetes.md
@@ -116,16 +116,16 @@ apiVersion: apps/v1
 kind: Deployment
 ...
     spec:
-    containers:
-    - name: container-name
+        containers:
+        - name: container-name
         image: container-image/tag
         env:
-        - name: DD_AGENT_SERVICE_HOST
-            valueFrom:
-            fieldRef:
-                fieldPath: status.hostIP
-        - name: DD_AGENT_SERVICE_PORT
-          value: "8126"
+            - name: DD_AGENT_SERVICE_HOST
+                valueFrom:
+                fieldRef:
+                    fieldPath: status.hostIP
+            - name: DD_AGENT_SERVICE_PORT
+            value: "8126"
 ```
 
 Your application level tracers must then be configured to submit traces to this address.

--- a/content/tracing/setup/kubernetes.md
+++ b/content/tracing/setup/kubernetes.md
@@ -32,7 +32,6 @@ spec:
         app: datadog-agent
       name: datadog-agent
     spec:
-      serviceAccountName: datadog-agent
       containers:
       - image: datadog/agent:latest
         imagePullPolicy: Always
@@ -113,13 +112,20 @@ Because of the `hostPort` directive, you can then send traces to the `hostIP` of
 Your application containers will need the Node IP and port set as environment variables:
 
 ```yaml
-env:
-  - name: DD_AGENT_SERVICE_HOST
-    valueFrom:
-      fieldRef:
-        fieldPath: status.hostIP
-  - name: DD_AGENT_SERVICE_PORT
-    value: 8126
+apiVersion: apps/v1
+kind: Deployment
+...
+    spec:
+    containers:
+    - name: container-name
+        image: container-image/tag
+        env:
+        - name: DD_AGENT_SERVICE_HOST
+            valueFrom:
+            fieldRef:
+                fieldPath: status.hostIP
+        - name: DD_AGENT_SERVICE_PORT
+          value: "8126"
 ```
 
 Your application level tracers must then be configured to submit traces to this address.


### PR DESCRIPTION
### What does this PR do?
Minor updates to the APM k8s doc:

- remove reference to the `serviceAccountName`. Make it more consistent with what we have in app and in other parts of the documentation (applying the DaemonSet will fail if this SA does not exist).
- "8126" as env var needs to be a string. Otherwise applying the Deployment/Pod... manifest will throw an error along the lines of `cannot convert int64 to string`. 
- expand the application manifest to better explain where those env vars should be. 

### Motivation

Testing with minikube. 

### Preview link

https://docs.datadoghq.com/tracing/setup/kubernetes/