### PR TITLE
Name is actually an optional param, update docs to reflect

### DIFF
--- a/content/api/monitors/monitors_showall.md
+++ b/content/api/monitors/monitors_showall.md
@@ -9,7 +9,7 @@ external_redirect: /api/#get-all-monitor-details
 ##### ARGUMENTS
 * **`group_states`** [*optional*, *default*=**None**]:
     If this argument is set, the returned data includes additional information (if available) regarding the specified group states, including the last notification timestamp, last resolution timestamp and details about the last time the monitor was triggered. The argument should include a string list indicating what, if any, group states to include. Choose one or more from 'all', 'alert', 'warn', or 'no data'. Example: 'alert,warn'
-* **`name`** [*required*]:  
+* **`name`** [*optional*, default=**None**]:
     A string to filter monitors by name
 * **`tags`** [*optional*, *default*=**None**]:  
     A comma separated list indicating what tags, if any, should be used to filter the list of monitorsby scope, e.g. `host:host0`. For more information, see the `tags` parameter for the appropriate `query` argument in the [Create a monitor](#monitor-create) section above.


### PR DESCRIPTION
### What does this PR do?

Updated documentation around the monitoring endpoint that erroneously indicates that `name` is a required param for listing monitors
See https://docs.datadoghq.com/api/?lang=bash#get-all-monitor-details it

### Motivation
I've been contributing to https://github.com/zorkian/go-datadog-api and noticed this when adding full support for this endpoint.