### PR TITLE
Fix indentation on the Deployment manifest

### DIFF
--- a/content/tracing/setup/kubernetes.md
+++ b/content/tracing/setup/kubernetes.md
@@ -116,15 +116,15 @@ apiVersion: apps/v1
 kind: Deployment
 ...
     spec:
-        containers:
-        - name: container-name
+      containers:
+      - name: container-name
         image: container-image/tag
         env:
-            - name: DD_AGENT_SERVICE_HOST
-                valueFrom:
-                fieldRef:
-                    fieldPath: status.hostIP
-            - name: DD_AGENT_SERVICE_PORT
+          - name: DD_AGENT_SERVICE_HOST
+            valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+          - name: DD_AGENT_SERVICE_PORT
             value: "8126"
 ```
 


### PR DESCRIPTION
### What does this PR do?
Fix indentation as it was slighly off on https://github.com/DataDog/documentation/pull/3306

### Preview link
https://docs.datadoghq.com/tracing/setup/kubernetes/