### PR TITLE
note on tags set by AD

### DIFF
--- a/content/agent/autodiscovery.md
+++ b/content/agent/autodiscovery.md
@@ -89,6 +89,8 @@ docker_labels_as_tags:
   com.docker.compose.service: service_name
 ```
 
+Note: Tags will only be set at the container start up.
+
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 
@@ -111,6 +113,8 @@ kubernetes_pod_labels_as_tags:
 kubernetes_pod_annotations_as_tags:
   app: kube_app
 ```
+
+Note: Tags will only be set at the pod start up.
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/agent/autodiscovery.md
+++ b/content/agent/autodiscovery.md
@@ -89,7 +89,7 @@ docker_labels_as_tags:
   com.docker.compose.service: service_name
 ```
 
-Note: Tags will only be set at the container start up.
+Note: Tags are only set at the container start up.
 
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
@@ -114,7 +114,7 @@ kubernetes_pod_annotations_as_tags:
   app: kube_app
 ```
 
-Note: Tags will only be set at the pod start up.
+Note: Tags are only set at the pod start up.
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/agent/autodiscovery.md
+++ b/content/agent/autodiscovery.md
@@ -89,7 +89,7 @@ docker_labels_as_tags:
   com.docker.compose.service: service_name
 ```
 
-Note: Tags are only set at the container start up.
+Note: Tags are only set when a container starts.
 
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
@@ -114,7 +114,7 @@ kubernetes_pod_annotations_as_tags:
   app: kube_app
 ```
 
-Note: Tags are only set at the pod start up.
+Note: Tags are only set when a pod starts.
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
### What does this PR do?
Add a note on when tags (labels, env vars, annotations) are set when using auto-discovery

### Motivation
Customer was thinking it was a bug when he updated its labels when it didn't show up in the UI.

