### PR TITLE
putting kubeproxy metrics in with the other k8s metrics

### DIFF
--- a/content/agent/kubernetes/metrics.md
+++ b/content/agent/kubernetes/metrics.md
@@ -17,3 +17,6 @@ Note that `kubernetes_state.*` metrics are gathered from the `kube-state-metrics
 
 #### kube-dns
 {{< get-metrics-from-git "kube_dns" >}}
+
+#### Kubernetes Proxy
+{{< get-metrics-from-git "kube_proxy" >}}

--- a/content/agent/kubernetes/metrics.md
+++ b/content/agent/kubernetes/metrics.md
@@ -3,20 +3,20 @@ title: Kubernetes Metrics
 kind: documentation
 ---
 
-#### Kubernetes
+## Kubernetes
 {{< get-metrics-from-git "kubernetes" >}}
 
-#### Kubelet
+## Kubelet
 {{< get-metrics-from-git "kubelet" >}}
 
-#### kube-state-metrics
+## kube-state-metrics
 
 Note that `kubernetes_state.*` metrics are gathered from the `kube-state-metrics` API.
 
 {{< get-metrics-from-git "kubernetes_state" >}}
 
-#### kube-dns
+## kube-dns
 {{< get-metrics-from-git "kube_dns" >}}
 
-#### Kubernetes Proxy
+## Kubernetes Proxy
 {{< get-metrics-from-git "kube_proxy" >}}

--- a/content/integrations/kubernetes.md
+++ b/content/integrations/kubernetes.md
@@ -86,6 +86,9 @@ Note that `kubernetes_state.*` metrics are gathered from the `kube-state-metrics
 #### Kubernetes DNS
 {{< get-metrics-from-git "kube_dns" >}}
 
+#### Kubernetes Proxy
+{{< get-metrics-from-git "kube_proxy" >}}
+
 ### Events
 
 As the 5.17.0 release, Datadog Agent now supports built in [leader election option][6] for the Kubernetes event collector. Once enabled, you no longer need to deploy an additional event collection container to your cluster. Instead, Agents will coordinate to ensure only one Agent instance is gathering events at a given time, events below will be available:

--- a/local/bin/py/update_pre_build.py
+++ b/local/bin/py/update_pre_build.py
@@ -155,6 +155,7 @@ class PreBuild:
             'mesos_slave': {'action': 'merge', 'target': 'mesos', 'remove_header': False},
             'kafka_consumer': {'action': 'merge', 'target': 'kafka', 'remove_header': False},
             'kube_dns': {'action': 'discard', 'target': 'none', 'remove_header': False},
+            'kube_proxy': {'action': 'discard', 'target': 'none', 'remove_header': False},
             'kubernetes_state': {'action': 'discard', 'target': 'none', 'remove_header': False},
             'stride': {'action': 'discard', 'target': 'none', 'remove_header': False},
             'system_core': {'action': 'discard', 'target': 'system', 'remove_header': False},


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Removes the `kube_proxy` integrations page and puts its metrics in with the other K8s integrations metrics (e.g. `kube_dns`, `kubernetes_state`)

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
