### PR TITLE
Update docs about sysvinit support

### DIFF
--- a/content/agent/_index.fr.md
+++ b/content/agent/_index.fr.md
@@ -167,7 +167,7 @@ les bonne permissions: Si vous êtes capable d'ouvrir `datadog.yaml`, vous pouve
 ### Agent v6
 | OS                                 | Versions supportées                                       |
 | :----                              | :----                                                    |
-| [Debian x86_64][7]                 | Debian 7 (wheezy) et plus (nous ne supportons pas SysVinit) |
+| [Debian x86_64][7]                 | Debian 7 (wheezy) et plus (nous supportons SysVinit dans l'agent 6.6.0 et plus) |
 | [Ubuntu x86_64][8]                 | Ubuntu 14.04 et plus                                   |
 | [RedHat/CentOS x86_64][9]          | RedHat/CentOS 6 et plus                                |
 | [SUSE Enterprise Linux x86_64][10] | SUSE 11 SP4 et plus (nous ne supportons pas SysVinit)       |

--- a/content/agent/_index.md
+++ b/content/agent/_index.md
@@ -154,18 +154,18 @@ Once the Agent is running, use the `datadog-agent launch-gui` command to launch 
 {{< tabs >}}
 {{% tab "Agent v6" %}}
 
-| OS                                 | Supported versions                                       |
-| :----                              | :----                                                    |
-| [Debian x86_64][7]                 | Debian 7 (wheezy) and above (we do not support SysVinit) |
-| [Ubuntu x86_64][8]                 | Ubuntu 14.04 and above                                   |
-| [RedHat/CentOS x86_64][9]          | RedHat/CentOS 6 and above                                |
-| [Docker][14]                       | Version 1.12 and higher                                  |
-| [Kubernetes][15]                   | Version 1.3 and higher                                   |
-| [SUSE Enterprise Linux x86_64][10] | SUSE 11 SP4 and above (we do not support SysVinit)       |
-| [Fedora x86_64][11]                | Fedora 26 and above                                      |
-| [MacOS][12]                        | macOS 10.10 and above                                    |
-| [Windows server 64-bit][13]        | Windows server 2008r2 or above                           |
-| [Windows 64-bit][13]               | Windows 7 or above                                       |
+| OS                                 | Supported versions                                                  |
+| :----                              | :----                                                               |
+| [Debian x86_64][7]                 | Debian 7 (wheezy) and above (we support SysVinit in agent 6.6.0 and above) |
+| [Ubuntu x86_64][8]                 | Ubuntu 14.04 and above                                              |
+| [RedHat/CentOS x86_64][9]          | RedHat/CentOS 6 and above                                           |
+| [Docker][14]                       | Version 1.12 and higher                                             |
+| [Kubernetes][15]                   | Version 1.3 and higher                                              |
+| [SUSE Enterprise Linux x86_64][10] | SUSE 11 SP4 and above (we do not support SysVinit)                  |
+| [Fedora x86_64][11]                | Fedora 26 and above                                                 |
+| [MacOS][12]                        | macOS 10.10 and above                                               |
+| [Windows server 64-bit][13]        | Windows server 2008r2 or above                                      |
+| [Windows 64-bit][13]               | Windows 7 or above                                                  |
 
 **Note**: [Source][16] install may work on operating systems not listed here and is supported on a best effort basis.
 

--- a/content/agent/basic_agent_usage/deb.md
+++ b/content/agent/basic_agent_usage/deb.md
@@ -22,7 +22,7 @@ further_reading:
 
 This page outlines the basic features of the Datadog Agent for Debian. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
-**Note**: Debian 7 (wheezy) and above (we do not support SysVinit) are supported.
+**Note**: Debian 7 (wheezy) and above (we support SysVinit in agent 6.6.0 above) are supported.
 
 ## Commands
 

--- a/content/agent/basic_agent_usage/deb.md
+++ b/content/agent/basic_agent_usage/deb.md
@@ -22,7 +22,7 @@ further_reading:
 
 This page outlines the basic features of the Datadog Agent for Debian. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
-**Note**: Debian 7 (wheezy) and above (we support SysVinit in agent 6.6.0 above) are supported.
+**Note**: Debian 7 (wheezy) and above (we support SysVinit in Agent 6.6.0 above) are supported.
 
 ## Commands
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update docs about sysvinit support
### Motivation
<!-- What inspired you to submit this pull request?-->
Sysvinit support will be added for debian in agent 6.6.0
### Preview link
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/agent/?tab=linux
https://docs.datadoghq.com/agent/basic_agent_usage/deb/?tab=agentv6
https://docs.datadoghq.com/fr/agent/?tab=linux
### Additional Notes
<!-- Anything else we should know when reviewing?-->
The public docs should only be updated after the agent release