### PR TITLE
Adding POST/PUT disclaimer for integrations API

### DIFF
--- a/content/api/integrations/aws.md
+++ b/content/api/integrations/aws.md
@@ -12,7 +12,7 @@ Configure your Datadog-AWS integration directly through Datadog API.
 
 **Note**: 
 
-* Using the `POST` method updates your integration configuration by **adding** your new configuration to the current existing one in your Datadog organization. 
+* Using the `POST` method updates your integration configuration by **adding** your new configuration to the existing one in your Datadog organization. 
 * Using the `PUT` method updates your integration configuration by **replacing** your current configuration with the new one sent to your Datadog organization.
 
 ##### ARGUMENTS

--- a/content/api/integrations/aws.md
+++ b/content/api/integrations/aws.md
@@ -10,6 +10,9 @@ external_redirect: /api/#aws
 Configure your Datadog-AWS integration directly through Datadog API.  
 [Read more about Datadog-AWS integration][1]
 
+* Using the `POST` method updates your integration configuration by **adding** your new configuration to the current existing one in your Datadog organization. 
+* Using the `PUT` method updates your integration configuration by **replacing** your current configuration with the new one sent to your Datadog organization.
+
 ##### ARGUMENTS
 
 * **`account_id`** [*required*]:  

--- a/content/api/integrations/aws.md
+++ b/content/api/integrations/aws.md
@@ -10,6 +10,8 @@ external_redirect: /api/#aws
 Configure your Datadog-AWS integration directly through Datadog API.  
 [Read more about Datadog-AWS integration][1]
 
+**Note**: 
+
 * Using the `POST` method updates your integration configuration by **adding** your new configuration to the current existing one in your Datadog organization. 
 * Using the `PUT` method updates your integration configuration by **replacing** your current configuration with the new one sent to your Datadog organization.
 

--- a/content/api/integrations/gcp.md
+++ b/content/api/integrations/gcp.md
@@ -9,6 +9,8 @@ external_redirect: /api/#google-cloud-platform
 
 Configure your Datadog-Google Cloud Platform integration directly through the Datadog API. [Read more about Datadog-Google Cloud Platform integration][1]
 
+**Note**: 
+
 * Using the `POST` method updates your integration configuration by **adding** your new configuration to the current existing one in your Datadog organization. 
 * Using the `PUT` method updates your integration configuration by **replacing** your current configuration with the new one sent to your Datadog organization.
 

--- a/content/api/integrations/gcp.md
+++ b/content/api/integrations/gcp.md
@@ -11,7 +11,7 @@ Configure your Datadog-Google Cloud Platform integration directly through the Da
 
 **Note**: 
 
-* Using the `POST` method updates your integration configuration by **adding** your new configuration to the current existing one in your Datadog organization. 
+* Using the `POST` method updates your integration configuration by **adding** your new configuration to the existing one in your Datadog organization. 
 * Using the `PUT` method updates your integration configuration by **replacing** your current configuration with the new one sent to your Datadog organization.
 
 ##### ARGUMENTS

--- a/content/api/integrations/gcp.md
+++ b/content/api/integrations/gcp.md
@@ -9,6 +9,9 @@ external_redirect: /api/#google-cloud-platform
 
 Configure your Datadog-Google Cloud Platform integration directly through the Datadog API. [Read more about Datadog-Google Cloud Platform integration][1]
 
+* Using the `POST` method updates your integration configuration by **adding** your new configuration to the current existing one in your Datadog organization. 
+* Using the `PUT` method updates your integration configuration by **replacing** your current configuration with the new one sent to your Datadog organization.
+
 ##### ARGUMENTS
 
 All of the following fields' values are provided by the JSON service account key file created in the [GCP Console for service accounts][2]; Refer to the [Datadog-Google Cloud Platform integration installation instructions][4] to see how to generate one for your organization. 

--- a/content/api/integrations/pagerduty.md
+++ b/content/api/integrations/pagerduty.md
@@ -12,7 +12,7 @@ Configure your Datadog-PagerDuty integration directly through Datadog API.
 
 **Note**: 
 
-* Using the `POST` method updates your integration configuration by **adding** your new configuration to the current existing one in your Datadog organization. 
+* Using the `POST` method updates your integration configuration by **adding** your new configuration to the existing one in your Datadog organization. 
 * Using the `PUT` method updates your integration configuration by **replacing** your current configuration with the new one sent to your Datadog organization.
 
 ##### ARGUMENTS

--- a/content/api/integrations/pagerduty.md
+++ b/content/api/integrations/pagerduty.md
@@ -10,6 +10,11 @@ external_redirect: /api/#pagerduty
 Configure your Datadog-PagerDuty integration directly through Datadog API.  
 [Read more about Datadog-PagerDuty integration][1]
 
+**Note**: 
+
+* Using the `POST` method updates your integration configuration by **adding** your new configuration to the current existing one in your Datadog organization. 
+* Using the `PUT` method updates your integration configuration by **replacing** your current configuration with the new one sent to your Datadog organization.
+
 ##### ARGUMENTS
 
 * **`services`** [*required*]:    

--- a/content/api/integrations/slack.md
+++ b/content/api/integrations/slack.md
@@ -12,7 +12,7 @@ Configure your Datadog-Slack integration directly through Datadog API.
 
 **Note**: 
 
-* Using the `POST` method updates your integration configuration by **adding** your new configuration to the current existing one in your Datadog organization. 
+* Using the `POST` method updates your integration configuration by **adding** your new configuration to the existing one in your Datadog organization. 
 * Using the `PUT` method updates your integration configuration by **replacing** your current configuration with the new one sent to your Datadog organization.
 
 ##### ARGUMENTS

--- a/content/api/integrations/slack.md
+++ b/content/api/integrations/slack.md
@@ -10,6 +10,9 @@ external_redirect: /api/#slack
 Configure your Datadog-Slack integration directly through Datadog API.  
 [Read more about Datadog-Slack integration][1]
 
+* Using the `POST` method updates your integration configuration by **adding** your new configuration to the current existing one in your Datadog organization. 
+* Using the `PUT` method updates your integration configuration by **replacing** your current configuration with the new one sent to your Datadog organization.
+
 ##### ARGUMENTS
 
 * **`service_hooks`** [*required*]:  

--- a/content/api/integrations/slack.md
+++ b/content/api/integrations/slack.md
@@ -10,6 +10,8 @@ external_redirect: /api/#slack
 Configure your Datadog-Slack integration directly through Datadog API.  
 [Read more about Datadog-Slack integration][1]
 
+**Note**: 
+
 * Using the `POST` method updates your integration configuration by **adding** your new configuration to the current existing one in your Datadog organization. 
 * Using the `PUT` method updates your integration configuration by **replacing** your current configuration with the new one sent to your Datadog organization.
 

--- a/content/api/integrations/webhooks.md
+++ b/content/api/integrations/webhooks.md
@@ -10,6 +10,9 @@ external_redirect: /api/#webhooks
 Configure your Datadog-Webhooks integration directly through Datadog API.  
 [Read more about Datadog-Webhooks integration][1]
 
+* Using the `POST` method updates your integration configuration by **adding** your new configuration to the current existing one in your Datadog organization. 
+* Using the `PUT` method updates your integration configuration by **replacing** your current configuration with the new one sent to your Datadog organization.
+
 ##### ARGUMENTS
 
 * **`hooks`** [*required*]:  

--- a/content/api/integrations/webhooks.md
+++ b/content/api/integrations/webhooks.md
@@ -10,6 +10,8 @@ external_redirect: /api/#webhooks
 Configure your Datadog-Webhooks integration directly through Datadog API.  
 [Read more about Datadog-Webhooks integration][1]
 
+**Note**: 
+
 * Using the `POST` method updates your integration configuration by **adding** your new configuration to the current existing one in your Datadog organization. 
 * Using the `PUT` method updates your integration configuration by **replacing** your current configuration with the new one sent to your Datadog organization.
 

--- a/content/api/integrations/webhooks.md
+++ b/content/api/integrations/webhooks.md
@@ -12,7 +12,7 @@ Configure your Datadog-Webhooks integration directly through Datadog API.
 
 **Note**: 
 
-* Using the `POST` method updates your integration configuration by **adding** your new configuration to the current existing one in your Datadog organization. 
+* Using the `POST` method updates your integration configuration by **adding** your new configuration to the existing one in your Datadog organization. 
 * Using the `PUT` method updates your integration configuration by **replacing** your current configuration with the new one sent to your Datadog organization.
 
 ##### ARGUMENTS


### PR DESCRIPTION
### What does this PR do?
Adds a disclaimer for PUT/POST method logic in order to reduce confusion.

### Motivation
Better doc

### Preview link

* https://docs-staging.datadoghq.com/gus/integration-API/api/?lang=python#aws
* https://docs-staging.datadoghq.com/gus/integration-API/api/?lang=python#google-cloud-platform
* https://docs-staging.datadoghq.com/gus/integration-API/api/?lang=python#pagerduty
* https://docs-staging.datadoghq.com/gus/integration-API/api/?lang=python#webhooks
* https://docs-staging.datadoghq.com/gus/integration-API/api/?lang=python#slack