### PR TITLE
PHP beta documentation (to go live on Wed 31st Oct)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -577,7 +577,7 @@ languages:
           weight: 190
           parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_php
-          name: "PHP (Coming soon)"
+          name: "PHP"
           url: "tracing/setup/php/"
           weight: 195
           parent: customnav_tracingnav_setup
@@ -1629,7 +1629,7 @@ languages:
           weight: 190
           parent: customnav_tracingnav_setup
         - identifier: customnav_tracingnav_php
-          name: "PHP (Coming soon)"
+          name: "PHP"
           url: "tracing/setup/php/"
           weight: 195
           parent: customnav_tracingnav_setup

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1445,8 +1445,6 @@ var tracer = Datadog.Trace.Tracer.Create(isDebugEnabled: true);
 {{% /tab %}}
 {{% tab "PHP" %}}
 
-Debug mode is currently not easily inaccessible.
-
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -492,7 +492,7 @@ using(var scope = Tracer.Instance.StartActive("web.request"))
 
 {{% /tab %}}
 {{% tab "PHP" %}}
-If you aren’t using libraries supported by automatic instrumentation (see [Library compatibility][php compatibility]), you should manually instrument your code.
+If you aren’t using libraries supported by automatic instrumentation (see [library compatibility][php compatibility]), manually instrument your code.
 
 The following example uses the global Datadog Tracer and creates a span to trace a web request:
 

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -260,6 +260,24 @@ span?.SetTag("<TAG_KEY>", "<TAG_VALUE>");
 **Note**: `Datadog.Trace.Tracer.Instance.ActiveScope` returns `null` if there is no active span.
 
 {{% /tab %}}
+{{% tab "PHP" %}}
+
+Add tags directly to a `OpenTracing\Span` object by calling `Span.setTag()`. For example:
+
+```php
+use OpenTracing\GlobalTracer;
+
+// get the currently active span (can be null)
+if (($span = GlobalTracer::get()->getActiveSpan()) !== null){
+
+  // add a tag to the span
+  $span->setTag("<TAG_KEY>", "<TAG_VALUE>");
+}
+```
+
+**Note**: `GlobalTracer::get()->getActiveSpan()` returns `null` if there is no active span.
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ## Manual Instrumentation
@@ -471,6 +489,30 @@ using(var scope = Tracer.Instance.StartActive("web.request"))
 ```
 
 [dotnet compatibility]: /tracing/setup/dotnet/#compatibility
+
+{{% /tab %}}
+{{% tab "PHP" %}}
+If you aren’t using libraries supported by automatic instrumentation (see [Library compatibility][php compatibility]), you should manually instrument your code.
+
+The following example uses the global Datadog Tracer and creates a span to trace a web request:
+
+```php
+use OpenTracing\GlobalTracer;
+use DDTrace\Tags;
+
+$scope = GlobalTracer::get()->startActiveSpan("web.request");
+$span = $scope->getSpan();
+
+$span->setResource($request->url);
+$span->setTag(Tags\SPAN_TYPE, Types\WEB_SERVLET);
+$span->setTag('http.method', $request->method);
+
+// do some work...
+
+$span->finish();
+```
+
+[php compatibility]: /tracing/setup/php/#compatibility
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -1399,6 +1441,11 @@ Debug mode is disabled by default. To enable it, set the `isDebugEnabled` argume
 ```csharp
 var tracer = Datadog.Trace.Tracer.Create(isDebugEnabled: true);
 ```
+
+{{% /tab %}}
+{{% tab "PHP" %}}
+
+Debug mode is currently not easily inaccessible.
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -499,6 +499,7 @@ The following example uses the global Datadog Tracer and creates a span to trace
 ```php
 use OpenTracing\GlobalTracer;
 use DDTrace\Tags;
+use DDTrace\Types;
 
 $scope = GlobalTracer::get()->startActiveSpan("web.request");
 $span = $scope->getSpan();

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -61,7 +61,7 @@ PHP APM includes support for the following PHP versions:
 
 ## Automatic Instrumentation
 
-Automatic instrumentation uses `ddtrace` extension to modify runtime and inject custom PHP code around specific methods. When [tracing is enabled][5] the PHP tracer is able to automatically instrument all supported libraries out of the box.
+Automatic instrumentation uses the `ddtrace` extension to modify PHP's runtime and inject custom PHP code around specific methods. When [tracing is enabled][5] the PHP tracer is able to automatically instrument all supported libraries out of the box.
 
 Automatic instrumentation captures:
 

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -21,7 +21,7 @@ The APM tracer for PHP applications is in Open Public Beta.
 
 To begin tracing applications written in PHP, first [install and configure the Datadog Agent][1] (see additional documentation for [tracing Docker applications][7]).
 
-Next, install the Datadog PHP extension [from source][3] or by using one of the precompiled packages for supported distributions. The latest packages can be found on GitHub's [dd-trace-php releases page][4]:
+Next, install the Datadog PHP extension using one of the precompiled packages for supported distributions. The latest packages can be found on GitHub's [releases page][4]. If you don't find your distribution, you can install the PHP extension [from source][3]
 
 ```bash
 # using RPM package (RHEL/Centos 6+, Fedora 20+)
@@ -86,6 +86,8 @@ Automatic instrumentation captures:
 | Yii            | 2.0.x       | Coming Soon        |
 | Slim           | 3.x         | Coming Soon        |
 
+Don't see your desired web frameworks? Let Datadog know more about your needs through [this survey][8]
+
 #### Library Compatibility
 
 | Module        | Versions              | Support Type       |
@@ -98,6 +100,8 @@ Automatic instrumentation captures:
 | MongoDB       | 1.x                   | Coming Soon        |
 | Doctrine      | 2.6                   | Coming Soon        |
 
+Don't see your desired libraries? Let Datadog know more about your needs through [this survey][8].
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -109,3 +113,4 @@ Automatic instrumentation captures:
 [5]: https://github.com/DataDog/dd-trace-php/blob/master/docs/getting_started.md#enabling-tracing
 [6]: https://github.com/DataDog/dd-trace-php/blob/master/docs/getting_started.md#alternative-install-datadogdd-trace-package-without-changing-minimum-stability
 [7]: /tracing/setup/docker/
+[8]: https://goo.gl/forms/rKjH2J6nJ585KXri2

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -66,7 +66,7 @@ Automatic instrumentation uses the `ddtrace` extension to modify PHP's runtime a
 Automatic instrumentation captures:
 
 * Method execution time.
-* Relevant trace data such as URL and status response codes for web requests or SQL query for database access
+* Relevant trace data, such as URL and status response codes for web requests or SQL queries for database access.
 * Unhandled exceptions, including stacktraces if available.
 * A total count of traces (e.g. web requests) flowing through the system.
 

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -1,5 +1,5 @@
 ---
-title: Tracing PHP Applications (Coming Soon)
+title: Tracing PHP Applications
 kind: Documentation
 further_reading:
 - link: "https://github.com/DataDog/dd-trace-php"
@@ -8,9 +8,9 @@ further_reading:
 - link: "tracing/visualization/"
   tag: "Documentation"
   text: "Explore your services, resources and traces"
-- link: "https://goo.gl/forms/rKjH2J6nJ585KXri2"
-  tag: "Survey"
-  text: Request Beta Access
+- link: "tracing/advanced_usage/?tab=php"
+  tag: "Advanced Usage"
+  text: "Advanced Usage"
 ---
 
 <div class="alert alert-warning">
@@ -19,42 +19,32 @@ The APM tracer for PHP applications is in Open Public Beta.
 
 ## Installation and Getting Started
 
-
-
-Next, install the Datadog Tracing library, `ddtrace`, using pip:
-
-```python
-pip install ddtrace
-```
-
-Then to instrument your Python application use the included `ddtrace-run` command. To use it, prefix your Python entry-point command with `ddtrace-run`.
-
-For example, if your application is started with `python app.py` then:
----
-
 To begin tracing applications written in PHP, first [install and configure the Datadog Agent][1] (see additional documentation for [tracing Docker applications](/tracing/setup/docker/)).
 
-Next, install the Datadog PHP extension using one of precompiled packages for supported distributions - or from source[3]
-Packages for latest release can be found on GitHub release page[4] https://github.com/DataDog/dd-trace-rb/releases/latest
-
-Installing the precompiled extension using RPM package (RHEL/Centos 6+, Fedora 20+)
-
+Next, install the Datadog PHP extension using one of precompiled packages for supported distributions - or [from source][3]
+Latest release packages can be found on GitHub's [release page][4]
+#### Installing the precompiled extension
 ```bash
+# using RPM package (RHEL/Centos 6+, Fedora 20+)
 rpm -ivh ddtrace.rpm
-```
 
-Installing the precompiled extension using DEB package (Debian Jessie + , Ubuntu 14.04+)
-
-```bash
+# using DEB package (Debian Jessie + , Ubuntu 14.04+)
 deb -i ddtrace.deb
-```
 
-Installing the precompiled package from tar.gz archive (Other distributions using glibc)
-
-```bash
+# using tar.gz archive (Other distributions using glibc)
 tar -xf ddtrace.tar.gz -C /
 /opt/datadog-php/bin/post_install.sh
 ```
+
+Next, install DataDog tracing library using composer:
+
+```bash
+composer config minimum-stability beta # required to install opentracing 1.0.0-beta5
+composer require opentracing/opentracing
+composer require datadog/dd-trace
+```
+
+Note: you can also install the DataDog library without changing minimum-stability by following this [guide][6]
 
 ## Compatibility
 
@@ -62,14 +52,14 @@ PHP APM includes support for the following PHP versions:
 
 | Version | Support type |
 | -----   | ------------ |
-| 5.6.x   | Coming Soon  |
 | 7.0.x   | Public Beta  |
 | 7.1.x   | Public Beta  |
 | 7.2.x   | Public Beta  |
+| 5.6.x   | Coming Soon  |
 
 ## Automatic Instrumentation
 
-Automatic instrumentation uses `ddtrace` extension to modify runtime and inject custom PHP code around specific methods. With tiny bit of configuration the PHP tracer is able to automatically instrument all supported libraries out of the box.
+Automatic instrumentation uses `ddtrace` extension to modify runtime and inject custom PHP code around specific methods. When [configured][5] the PHP tracer is able to automatically instrument all supported libraries out of the box.
 
 Automatic instrumentation captures:
 
@@ -111,3 +101,7 @@ Automatic instrumentation captures:
 
 [1]: https://docs.datadoghq.com/tracing/setup
 [2]: https://github.com/DataDog/dd-trace-php
+[3]: https://github.com/DataDog/dd-trace-php/blob/master/docs/getting_started.md#compiling-and-installing-the-extension-manually
+[4]: https://github.com/DataDog/dd-trace-rb/releases/latest
+[5]: https://github.com/DataDog/dd-trace-php/blob/master/docs/getting_started.md#enabling-tracing
+[6]: https://github.com/DataDog/dd-trace-php/blob/master/docs/getting_started.md#alternative-install-datadogdd-trace-package-without-changing-minimum-stability

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -46,7 +46,7 @@ composer require opentracing/opentracing
 composer require datadog/dd-trace
 ```
 
-**Note:** You can [install the DataDog library without changing minimum-stability][6]
+**Note:** You can [install the Datadog library without changing minimum-stability][6]
 
 ## Compatibility
 

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -57,7 +57,7 @@ PHP APM includes support for the following PHP versions:
 | 7.0.x   | Public Beta  |
 | 7.1.x   | Public Beta  |
 | 7.2.x   | Public Beta  |
-| 5.6.x   | Coming Soon  |
+| 5.6.x   | Alpha        |
 
 ## Automatic Instrumentation
 

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -38,7 +38,7 @@ tar -xf datadog-php-tracer.tar.gz -C /
 /opt/datadog-php/bin/post-install.sh
 ```
 
-Finally, install DataDog tracing library using composer:
+Finally, install the DataDog tracing library using composer:
 
 ```bash
 composer config minimum-stability beta # required to install opentracing 1.0.0-beta5

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -14,16 +14,47 @@ further_reading:
 ---
 
 <div class="alert alert-warning">
-The APM tracer for PHP applications is in alpha and not officially supported by Datadog. The officially supported beta will launch as early as October 2018. We do not recommend running the alpha tracer in production.
+The APM tracer for PHP applications is in Open Public Beta.
 </div>
 
-{{< whatsnext desc="To be notified of the beta launch, submit this form:">}}
-    {{< nextlink href="https://goo.gl/forms/rKjH2J6nJ585KXri2" tag="Survey" >}}PHP Beta Access Survey{{< /nextlink >}}
-{{< /whatsnext >}}
+## Installation and Getting Started
 
-<br>
 
-The unstable alpha tracer can be [accessed today on Github][2].
+
+Next, install the Datadog Tracing library, `ddtrace`, using pip:
+
+```python
+pip install ddtrace
+```
+
+Then to instrument your Python application use the included `ddtrace-run` command. To use it, prefix your Python entry-point command with `ddtrace-run`.
+
+For example, if your application is started with `python app.py` then:
+---
+
+To begin tracing applications written in PHP, first [install and configure the Datadog Agent][1] (see additional documentation for [tracing Docker applications](/tracing/setup/docker/)).
+
+Next, install the Datadog PHP extension using one of precompiled packages for supported distributions - or from source[3]
+Packages for latest release can be found on GitHub release page[4] https://github.com/DataDog/dd-trace-rb/releases/latest
+
+Installing the precompiled extension using RPM package (RHEL/Centos 6+, Fedora 20+)
+
+```bash
+rpm -ivh ddtrace.rpm
+```
+
+Installing the precompiled extension using DEB package (Debian Jessie + , Ubuntu 14.04+)
+
+```bash
+deb -i ddtrace.deb
+```
+
+Installing the precompiled package from tar.gz archive (Other distributions using glibc)
+
+```bash
+tar -xf ddtrace.tar.gz -C /
+/opt/datadog-php/bin/post_install.sh
+```
 
 ## Compatibility
 
@@ -31,52 +62,52 @@ PHP APM includes support for the following PHP versions:
 
 | Version | Support type |
 | -----   | ------------ |
-| 5.6.x   | Alpha        |
-| 7.0.x   | Alpha        |
-| 7.1.x   | Alpha        |
-| 7.2.x   | Alpha        |
+| 5.6.x   | Coming Soon  |
+| 7.0.x   | Public Beta  |
+| 7.1.x   | Public Beta  |
+| 7.2.x   | Public Beta  |
+
+## Automatic Instrumentation
+
+Automatic instrumentation uses `ddtrace` extension to modify runtime and inject custom PHP code around specific methods. With tiny bit of configuration the PHP tracer is able to automatically instrument all supported libraries out of the box.
+
+Automatic instrumentation captures:
+
+* Method execution time
+* Relevant trace data such as URL and status response codes for web requests or SQL query for database access
+* Unhandled exceptions, including stacktraces if available
+* A total count of traces (e.g. web requests) flowing through the system
 
 ### Integrations
-
-APM PHP support is in alpha and provides limited automatic instrumentation. Planned beta support will provide automatic instrumentation for popular frameworks and libraries. See some of these listed below.
-Don't see your desired frameworks or libraries? Let Datadog know more about your needs through [this survey][1].
 
 #### Framework Compatibility
 
 | Module         | Versions    | Support Type       |
 | :-----------   | :---------- | :----------------- |
-| Laravel        | 5.x         | Alpha              |
-| Symfony        | 3.x         | Alpha              |
-| Magento        | 2.x         | Coming Soon [beta] |
-| Zend Framework | 3.x         | Coming Soon [beta] |
-| CakePHP        | 3.x         | Coming Soon [beta] |
-| Drupal         | 7.x         | Coming Soon [beta] |
-| Wordpress      | 4.x         | Coming Soon [beta] |
-| Slim           | 3.x         | Coming Soon [beta] |
-
-Don't see your desired web frameworks? Let Datadog know more about your needs through [this survey][1].
-
-[1]: https://goo.gl/forms/rKjH2J6nJ585KXri2
+| Laravel        | 5.x         | Public Beta        |
+| Symfony        | 3.x         | Public Beta        |
+| Magento        | 2.x         | Coming Soon        |
+| Zend Framework | 3.x         | Coming Soon        |
+| CakePHP        | 3.x         | Coming Soon        |
+| Drupal         | 7.x         | Coming Soon        |
+| Wordpress      | 4.x         | Coming Soon        |
+| Slim           | 3.x         | Coming Soon        |
 
 #### Library Compatibility
 
 | Module        | Versions              | Support Type       |
 | :------------ | :-------------------- | :----------------- |
-| Memcached     | *(Any Supported PHP)* | Alpha              |
-| Mysqli        | *(Any Supported PHP)* | Alpha              |
-| PDO           | *(Any Supported PHP)* | Alpha              |
-| Predis        | 1.1                   | Alpha              |
-| pgsql         | *(Any Supported PHP)* | Coming Soon [beta] |
-| MongoDB       | 1.x                   | Coming Soon [beta] |
-| Doctrine      | 2.6                   | Coming Soon [beta] |
-
-Don't see your desired libraries? Let Datadog know more about your needs through [this survey][1].
-
-[1]: https://goo.gl/forms/rKjH2J6nJ585KXri2
+| Memcached     | *(Any Supported PHP)* | Public Beta        |
+| Mysqli        | *(Any Supported PHP)* | Public Beta        |
+| PDO           | *(Any Supported PHP)* | Public Beta        |
+| Predis        | 1.1                   | Public Beta        |
+| pgsql         | *(Any Supported PHP)* | Coming Soon        |
+| MongoDB       | 1.x                   | Coming Soon        |
+| Doctrine      | 2.6                   | Coming Soon        |
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://goo.gl/forms/rKjH2J6nJ585KXri2
+[1]: https://docs.datadoghq.com/tracing/setup
 [2]: https://github.com/DataDog/dd-trace-php

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -19,10 +19,9 @@ The APM tracer for PHP applications is in Open Public Beta.
 
 ## Installation and Getting Started
 
-To begin tracing applications written in PHP, first [install and configure the Datadog Agent][1] (see additional documentation for [tracing Docker applications](/tracing/setup/docker/)).
+To begin tracing applications written in PHP, first [install and configure the Datadog Agent][1] (see additional documentation for [tracing Docker applications][7]).
 
-Next, install the Datadog PHP extension using one of precompiled packages for supported distributions - or [from source][3]
-Latest release packages can be found on GitHub's [release page][4]
+Next, install [from source][3] the Datadog PHP extension or by using one of the precompiled packages for supported distributions. Latest release packages can be found on GitHub's [dd-trace-php releases page][4]:
 
 ```bash
 # using RPM package (RHEL/Centos 6+, Fedora 20+)
@@ -44,7 +43,7 @@ composer require opentracing/opentracing
 composer require datadog/dd-trace
 ```
 
-**Note:** you can also install the DataDog library without changing minimum-stability by following this [guide][6]
+**Note:** You can [install the DataDog library without changing minimum-stability][6]
 
 ## Compatibility
 
@@ -59,14 +58,14 @@ PHP APM includes support for the following PHP versions:
 
 ## Automatic Instrumentation
 
-Automatic instrumentation uses `ddtrace` extension to modify runtime and inject custom PHP code around specific methods. When [configured][5] the PHP tracer is able to automatically instrument all supported libraries out of the box.
+Automatic instrumentation uses `ddtrace` extension to modify runtime and inject custom PHP code around specific methods. When [tracing is enabled][5] the PHP tracer is able to automatically instrument all supported libraries out of the box.
 
 Automatic instrumentation captures:
 
-* Method execution time
+* Method execution time.
 * Relevant trace data such as URL and status response codes for web requests or SQL query for database access
-* Unhandled exceptions, including stacktraces if available
-* A total count of traces (e.g. web requests) flowing through the system
+* Unhandled exceptions, including stacktraces if available.
+* A total count of traces (e.g. web requests) flowing through the system.
 
 ### Integrations
 
@@ -99,9 +98,10 @@ Automatic instrumentation captures:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://docs.datadoghq.com/tracing/setup
+[1]: /tracing/setup
 [2]: https://github.com/DataDog/dd-trace-php
 [3]: https://github.com/DataDog/dd-trace-php/blob/master/docs/getting_started.md#compiling-and-installing-the-extension-manually
-[4]: https://github.com/DataDog/dd-trace-rb/releases/latest
+[4]: https://github.com/DataDog/dd-trace-php/releases/latest
 [5]: https://github.com/DataDog/dd-trace-php/blob/master/docs/getting_started.md#enabling-tracing
 [6]: https://github.com/DataDog/dd-trace-php/blob/master/docs/getting_started.md#alternative-install-datadogdd-trace-package-without-changing-minimum-stability
+[7]: /tracing/setup/docker/

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -83,6 +83,7 @@ Automatic instrumentation captures:
 | CakePHP        | 3.x         | Coming Soon        |
 | Drupal         | 7.x         | Coming Soon        |
 | Wordpress      | 4.x         | Coming Soon        |
+| Yii            | 2.0.x       | Coming Soon        |
 | Slim           | 3.x         | Coming Soon        |
 
 #### Library Compatibility

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -23,7 +23,7 @@ To begin tracing applications written in PHP, first [install and configure the D
 
 Next, install the Datadog PHP extension using one of precompiled packages for supported distributions - or [from source][3]
 Latest release packages can be found on GitHub's [release page][4]
-#### Installing the precompiled extension
+
 ```bash
 # using RPM package (RHEL/Centos 6+, Fedora 20+)
 rpm -ivh ddtrace.rpm
@@ -36,7 +36,7 @@ tar -xf ddtrace.tar.gz -C /
 /opt/datadog-php/bin/post_install.sh
 ```
 
-Next, install DataDog tracing library using composer:
+Finally, install DataDog tracing library using composer:
 
 ```bash
 composer config minimum-stability beta # required to install opentracing 1.0.0-beta5
@@ -44,7 +44,7 @@ composer require opentracing/opentracing
 composer require datadog/dd-trace
 ```
 
-Note: you can also install the DataDog library without changing minimum-stability by following this [guide][6]
+**Note:** you can also install the DataDog library without changing minimum-stability by following this [guide][6]
 
 ## Compatibility
 

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -28,10 +28,10 @@ Latest release packages can be found on GitHub's [release page][4]
 # using RPM package (RHEL/Centos 6+, Fedora 20+)
 rpm -ivh ddtrace.rpm
 
-# using DEB package (Debian Jessie + , Ubuntu 14.04+)
+# using DEB package (Debian Jessie+ , Ubuntu 14.04+)
 deb -i ddtrace.deb
 
-# using tar.gz archive (Other distributions using glibc)
+# using tar.gz archive (Other distributions using libc6)
 tar -xf ddtrace.tar.gz -C /
 /opt/datadog-php/bin/post_install.sh
 ```

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -30,7 +30,7 @@ rpm -ivh datadog-php-tracer.rpm
 # using DEB package (Debian Jessie+ , Ubuntu 14.04+)
 deb -i datadog-php-tracer.deb
 
-# using APK package (Alpine Linux)
+# using APK package (Alpine)
 apk add datadog-php-tracer.apk --allow-untrusted
 
 # using tar.gz archive (Other distributions using libc6)

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -21,7 +21,7 @@ The APM tracer for PHP applications is in Open Public Beta.
 
 To begin tracing applications written in PHP, first [install and configure the Datadog Agent][1] (see additional documentation for [tracing Docker applications][7]).
 
-Next, install [from source][3] the Datadog PHP extension or by using one of the precompiled packages for supported distributions. Latest release packages can be found on GitHub's [dd-trace-php releases page][4]:
+Next, install the Datadog PHP extension [from source][3] or by using one of the precompiled packages for supported distributions. The latest packages can be found on GitHub's [dd-trace-php releases page][4]:
 
 ```bash
 # using RPM package (RHEL/Centos 6+, Fedora 20+)

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -38,7 +38,7 @@ tar -xf datadog-php-tracer.tar.gz -C /
 /opt/datadog-php/bin/post-install.sh
 ```
 
-Finally, install the DataDog tracing library using composer:
+Finally, install the Datadog tracing library using composer:
 
 ```bash
 composer config minimum-stability beta # required to install opentracing 1.0.0-beta5

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -25,14 +25,17 @@ Next, install [from source][3] the Datadog PHP extension or by using one of the 
 
 ```bash
 # using RPM package (RHEL/Centos 6+, Fedora 20+)
-rpm -ivh ddtrace.rpm
+rpm -ivh datadog-php-tracer.rpm
 
 # using DEB package (Debian Jessie+ , Ubuntu 14.04+)
-deb -i ddtrace.deb
+deb -i datadog-php-tracer.deb
+
+# using APK package (Alpine Linux)
+apk add datadog-php-tracer.apk --allow-untrusted
 
 # using tar.gz archive (Other distributions using libc6)
-tar -xf ddtrace.tar.gz -C /
-/opt/datadog-php/bin/post_install.sh
+tar -xf datadog-php-tracer.tar.gz -C /
+/opt/datadog-php/bin/post-install.sh
 ```
 
 Finally, install DataDog tracing library using composer:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Improves PHP APM documentation by adding information how to install PHP Extension required by the tracing library

### Motivation

### Preview link
http://localhost:1313/tracing/setup/php/

### Additional Notes
- This should only go live on Wed 31st of October
- ~~The URLs to artifacts required for installation are currently worked on - so verifying correctness of this guide is blocked at this moment (will update this description once they're up)~~ Artifacts are up - https://github.com/DataDog/dd-trace-php/releases/latest