### PR TITLE
add linux documentation

### DIFF
--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -135,9 +135,9 @@ Environment=DD_INTEGRATIONS=/opt/datadog/integrations.json
 WantedBy=multi-user.target
 ```
 
-For Docker use `Env`:
+For Docker use `ENV`:
 
-```docker
+```text
 ENV CORECLR_ENABLE_PROFILING=1
 ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -66,9 +66,9 @@ Automatic instrumentation is available on Linux for .NET Core 2.0+. To set up au
 
 Traces are sent to a local Datadog Agent and then forwarded to Datadog. To install the agent, follow the [Linux instructions][1].
 
-#### Add the `Datadog.Trace.ClrProfiler.Managed` Nuget Package
+#### Add the `Datadog.Trace.ClrProfiler.Managed` NuGet Package
 
-To add the `Datadog.Trace.ClrProfiler.Managed` Nuget package to your project run the following:
+To add the `Datadog.Trace.ClrProfiler.Managed` NuGet package to your project run the following:
 
 ```bash
 dotnet add package Datadog.Trace.ClrProfiler.Managed --version 0.5.0-beta

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -2,18 +2,18 @@
 title: Tracing .NET Applications
 kind: Documentation
 aliases:
-- /tracing/dotnet
-- /tracing/languages/dotnet
+  - /tracing/dotnet
+  - /tracing/languages/dotnet
 further_reading:
-- link: "https://github.com/DataDog/dd-trace-csharp"
-  tag: "Github"
-  text: Source code
-- link: "tracing/visualization/"
-  tag: "Documentation"
-  text: "Explore your services, resources and traces"
-- link: "tracing/advanced_usage/?tab=net"
-  tag: "Advanced Usage"
-  text: "Advanced Usage"
+  - link: "https://github.com/DataDog/dd-trace-csharp"
+    tag: "Github"
+    text: Source code
+  - link: "tracing/visualization/"
+    tag: "Documentation"
+    text: "Explore your services, resources and traces"
+  - link: "tracing/advanced_usage/?tab=net"
+    tag: "Advanced Usage"
+    text: "Advanced Usage"
 ---
 
 <div class="alert alert-warning">
@@ -30,10 +30,10 @@ Automatic instrumentation uses the Profiling API provided by .NET Framework and 
 
 Automatic instrumentation captures:
 
-* Method execution time
-* Relevant trace data such as URL and status response codes for web requests or SQL query for database access
-* Unhandled exceptions, including stacktraces if available
-* A total count of traces (e.g. web requests) flowing through the system
+- Method execution time
+- Relevant trace data such as URL and status response codes for web requests or SQL query for database access
+- Unhandled exceptions, including stacktraces if available
+- A total count of traces (e.g. web requests) flowing through the system
 
 ### Windows
 
@@ -52,25 +52,92 @@ net start w3svc
 
 .NET Core doesn't support the Windows Global Assembly Cache (GAC) used by the .NET Framework. Instead, you can deploy Datadog's managed assemblies together with your application by adding the `Datadog.Trace.ClrProfiler.Managed` NuGet package. It is important that you match the versions of the NuGet package and the MSI installer.
 
-For example, if you are using the MSI installer for version `0.4.1-beta`, use:
+For example, if you are using the MSI installer for version `0.5.0-beta`, use:
 
 ```
-dotnet add package Datadog.Trace.ClrProfiler.Managed --version 0.4.1-beta
+dotnet add package Datadog.Trace.ClrProfiler.Managed --version 0.5.0-beta
 ```
 
 ### Linux
 
-Automatic instrumention for .NET Core on Linux is coming soon. To instrument your .NET Core applications on Linux today, use [manual instrumentation][8].
+Automatic instrumention is available on Linux for .NET Core 2.0+. To setup automatic instrumentation, 4 steps are necessary:
+
+1. [Install the Datadog Agent][1]
+1. Add the `Datadog.Trace.ClrProfiler.Managed` nuget package to your project:
+
+   ```bash
+   dotnet add package Datadog.Trace.ClrProfiler.Managed --version 0.5.0-beta
+   ```
+
+1. Install the `Datadog.Trace.ClrProfiler.Native` library, available from the `dd-trace-csharp` [releases page][10].
+
+   For Debian or Ubuntu, download and install the Debian package:
+
+   ```bash
+   curl -LO https://github.com/DataDog/dd-trace-csharp/releases/download/v0.5.0-beta/datadog-dotnet-apm_0.5.0_amd64.deb
+   sudo apt install ./datadog-dotnet-apm_0.5.0_amd64.deb
+   ```
+
+   For CentOS or Fedora, download and install the RPM package
+
+   ```bash
+   curl -LO https://github.com/DataDog/dd-trace-csharp/releases/download/v0.5.0-beta/datadog-dotnet-apm-0.5.0-1.x86_64.rpm
+   sudo rpm -Uvh datadog-dotnet-apm-0.5.0-1.x86_64.rpm
+   ```
+
+   A Tar archive is available for other distributions:
+
+   ```bash
+   sudo mkdir -p /opt/datadog
+   curl -L https://github.com/DataDog/dd-trace-csharp/releases/download/v0.5.0-beta/datadog-dotnet-apm-0.5.0.tar.gz \
+   | sudo tar xzf - -C /opt/datadog
+   ```
+
+   For Alpine Linux you will also need to install `libc6-compat`
+
+   ```bash
+   apk add libc6-compat
+   ```
+
+1. Add environment variables to your service to enable the .NET tracer.
+
+   For Systemd:
+
+   ```ini
+    [Unit]
+    Description=example
+
+    [Service]
+    ExecStart=/usr/bin/dotnet /app/example.dll
+    Restart=always
+    # Datadog .NET Tracer Environment Variables
+    Environment=CORECLR_ENABLE_PROFILING=1
+    Environment=CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+    Environment=CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
+    Environment=DD_INTEGRATIONS=/opt/datadog/integrations.json
+
+    [Install]
+    WantedBy=multi-user.target
+   ```
+
+   For Docker:
+
+   ```docker
+   ENV CORECLR_ENABLE_PROFILING=1
+   ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+   ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
+   ENV DD_INTEGRATIONS=/opt/datadog/integrations.json
+   ```
 
 ### Runtime Compatibility
 
 The .NET tracer supports automatic instrumentation on the following runtimes:
 
-| Runtime        | Versions | OS                | Support Type      |
-| :------------- | :------- | :---------------- | :---------------- |
-| .NET Framework | 4.5+     | Windows           | Public Beta       |
-| .NET Core      | 2.0+     | Windows           | Public Beta       |
-| .NET Core      | 2.0+     | Linux             | Coming soon       |
+| Runtime        | Versions | OS      | Support Type |
+| :------------- | :------- | :------ | :----------- |
+| .NET Framework | 4.5+     | Windows | Public Beta  |
+| .NET Core      | 2.0+     | Windows | Public Beta  |
+| .NET Core      | 2.0+     | Linux   | Public Beta  |
 
 **Note**: Libraries that target .NET Standard 2.0 are supported when running on either .NET Framework 4.6.1+ or .NET Core 2.0+.
 
@@ -80,14 +147,14 @@ Don’t see your desired frameworks? We’re continually adding additional suppo
 
 The .NET tracer can instrument the following web frameworks automatically:
 
-| Web framework     | Versions  | Runtime             | OS      | Support Type      |
-| :---------------- | :-------- | :------------------ | :------ | :---------------- |
-| ASP.NET MVC 5     | 5.2+      | .NET Framework 4.5+ | Windows | Public Beta       |
-| ASP.NET MVC 4     | 4.0.40804 | .NET Framework 4.5+ | Windows | Public Beta       |
-| ASP.NET Web API 2 | 2.2+      | .NET Framework 4.5+ | Windows | Public Beta       |
-| ASP.NET Core MVC  | 2.0+      | .NET Framework 4.5+ | Windows | Public Beta       |
-| ASP.NET Core MVC  | 2.0+      | .NET Core 2.0+      | Windows | Public Beta       |
-| ASP.NET Core MVC  | 2.0+      | .NET Core 2.0+      | Linux   | Coming soon       |
+| Web framework     | Versions  | Runtime             | OS      | Support Type |
+| :---------------- | :-------- | :------------------ | :------ | :----------- |
+| ASP.NET MVC 5     | 5.2+      | .NET Framework 4.5+ | Windows | Public Beta  |
+| ASP.NET MVC 4     | 4.0.40804 | .NET Framework 4.5+ | Windows | Public Beta  |
+| ASP.NET Web API 2 | 2.2+      | .NET Framework 4.5+ | Windows | Public Beta  |
+| ASP.NET Core MVC  | 2.0+      | .NET Framework 4.5+ | Windows | Public Beta  |
+| ASP.NET Core MVC  | 2.0+      | .NET Core 2.0+      | Windows | Public Beta  |
+| ASP.NET Core MVC  | 2.0+      | .NET Core 2.0+      | Linux   | Public Beta  |
 
 Don’t see your desired web frameworks? We’re continually adding additional support. [Check with the Datadog team][5] to see if we can help.
 
@@ -95,15 +162,15 @@ Don’t see your desired web frameworks? We’re continually adding additional s
 
 The .NET tracer's ability to automatically instrument data store access depends on the client libraries used:
 
-| Data store    | Library or NuGet package                          | Versions   | Support type    |
-| :---------    | :------------------------------------------------ | :-------   | :-------------- |
-| MS SQL Server | `System.Data.SqlClient` (.NET Framework)          | (built-in) | Public Beta     |
-| MS SQL Server | `System.Data.SqlClient` (NuGet)                   | 4.1+       | Public Beta     |
-| Redis         | `StackExchange.Redis`                             | 1.0-1.2.x  | Public Beta     |
-| Redis         | `ServiceStack.Redis`                              | 5.2.x      | Public Beta     |
-| Elasticsearch | `NEST` / `Elasticsearch.Net`                      | 6.1.0      | Public Beta     |
-| MongoDB       | `MongoDB.Driver`                                  |            | Coming soon     |
-| PostgreSQL    | `Npgsql`                                          |            | Coming soon     |
+| Data store    | Library or NuGet package                 | Versions   | Support type |
+| :------------ | :--------------------------------------- | :--------- | :----------- |
+| MS SQL Server | `System.Data.SqlClient` (.NET Framework) | (built-in) | Public Beta  |
+| MS SQL Server | `System.Data.SqlClient` (NuGet)          | 4.1+       | Public Beta  |
+| Redis         | `StackExchange.Redis`                    | 1.0-1.2.x  | Public Beta  |
+| Redis         | `ServiceStack.Redis`                     | 5.2.x      | Public Beta  |
+| Elasticsearch | `NEST` / `Elasticsearch.Net`             | 6.1.0      | Public Beta  |
+| MongoDB       | `MongoDB.Driver`                         |            | Coming soon  |
+| PostgreSQL    | `Npgsql`                                 |            | Coming soon  |
 
 Don’t see your desired data store libraries? We’re continually adding additional support. [Check with the Datadog team][5] to see if we can help.
 
@@ -137,3 +204,4 @@ For more details on supported platforms, see the [.NET Standard documentation][6
 [6]: https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support
 [8]: #manual-instrumentation
 [9]: https://support.microsoft.com/en-us/help/969864/using-iisreset-exe-to-restart-internet-information-services-iis-result
+[10]: https://github.com/DataDog/dd-trace-csharp/releases/tag/v0.5.0-beta

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -62,72 +62,87 @@ dotnet add package Datadog.Trace.ClrProfiler.Managed --version 0.5.0-beta
 
 Automatic instrumention is available on Linux for .NET Core 2.0+. To setup automatic instrumentation, 4 steps are necessary:
 
-1. [Install the Datadog Agent][1]
-1. Add the `Datadog.Trace.ClrProfiler.Managed` nuget package to your project:
+#### Install the Datadog Agent
 
-   ```bash
-   dotnet add package Datadog.Trace.ClrProfiler.Managed --version 0.5.0-beta
-   ```
+Traces are sent to a local Datadog Agent and then forwarded to Datadog. To install the agent, follow the [Linux instructions][1].
 
-1. Install the `Datadog.Trace.ClrProfiler.Native` library, available from the `dd-trace-csharp` [releases page][10].
+#### Add the `Datadog.Trace.ClrProfiler.Managed` Nuget Package
 
-   For Debian or Ubuntu, download and install the Debian package:
+To add the `Datadog.Trace.ClrProfiler.Managed` Nuget package to your project run the following:
 
-   ```bash
-   curl -LO https://github.com/DataDog/dd-trace-csharp/releases/download/v0.5.0-beta/datadog-dotnet-apm_0.5.0_amd64.deb
-   sudo apt install ./datadog-dotnet-apm_0.5.0_amd64.deb
-   ```
+```bash
+dotnet add package Datadog.Trace.ClrProfiler.Managed --version 0.5.0-beta
+```
 
-   For CentOS or Fedora, download and install the RPM package
+#### Install the `Datadog.Trace.ClrProfiler.Native` Library
 
-   ```bash
-   curl -LO https://github.com/DataDog/dd-trace-csharp/releases/download/v0.5.0-beta/datadog-dotnet-apm-0.5.0-1.x86_64.rpm
-   sudo rpm -Uvh datadog-dotnet-apm-0.5.0-1.x86_64.rpm
-   ```
+Automatic instrumention in Linux is implemented using a shared library available from the `dd-trace-csharp` [releases page][10].
 
-   A Tar archive is available for other distributions:
+For Debian or Ubuntu, download and install the Debian package:
 
-   ```bash
-   sudo mkdir -p /opt/datadog
-   curl -L https://github.com/DataDog/dd-trace-csharp/releases/download/v0.5.0-beta/datadog-dotnet-apm-0.5.0.tar.gz \
-   | sudo tar xzf - -C /opt/datadog
-   ```
+```bash
+curl -LO https://github.com/DataDog/dd-trace-csharp/releases/download/v0.5.0-beta/datadog-dotnet-apm_0.5.0_amd64.deb
+sudo apt install ./datadog-dotnet-apm_0.5.0_amd64.deb
+```
 
-   For Alpine Linux you will also need to install `libc6-compat`
+For CentOS or Fedora, download and install the RPM package
 
-   ```bash
-   apk add libc6-compat
-   ```
+```bash
+curl -LO https://github.com/DataDog/dd-trace-csharp/releases/download/v0.5.0-beta/datadog-dotnet-apm-0.5.0-1.x86_64.rpm
+sudo rpm -Uvh datadog-dotnet-apm-0.5.0-1.x86_64.rpm
+```
 
-1. Add environment variables to your service to enable the .NET tracer.
+A Tar archive is available for other distributions:
 
-   For Systemd:
+```bash
+sudo mkdir -p /opt/datadog
+curl -L https://github.com/DataDog/dd-trace-csharp/releases/download/v0.5.0-beta/datadog-dotnet-apm-0.5.0.tar.gz \
+| sudo tar xzf - -C /opt/datadog
+```
 
-   ```ini
-    [Unit]
-    Description=example
+For Alpine Linux you will also need to install `libc6-compat`
 
-    [Service]
-    ExecStart=/usr/bin/dotnet /app/example.dll
-    Restart=always
-    # Datadog .NET Tracer Environment Variables
-    Environment=CORECLR_ENABLE_PROFILING=1
-    Environment=CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
-    Environment=CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
-    Environment=DD_INTEGRATIONS=/opt/datadog/integrations.json
+```bash
+apk add libc6-compat
+```
 
-    [Install]
-    WantedBy=multi-user.target
-   ```
+#### Add Environment Variables
 
-   For Docker:
+Automatic instrumention for Linux is enabled by setting 4 environment variables:
 
-   ```docker
-   ENV CORECLR_ENABLE_PROFILING=1
-   ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
-   ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
-   ENV DD_INTEGRATIONS=/opt/datadog/integrations.json
-   ```
+```bash
+CORECLR_ENABLE_PROFILING=1
+CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
+DD_INTEGRATIONS=/opt/datadog/integrations.json
+```
+
+For a systemd service use `Environment=`:
+
+```ini
+[Unit]
+Description=example
+
+[Service]
+ExecStart=/usr/bin/dotnet /app/example.dll
+Restart=always
+Environment=CORECLR_ENABLE_PROFILING=1
+Environment=CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+Environment=CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
+Environment=DD_INTEGRATIONS=/opt/datadog/integrations.json
+
+[Install]
+WantedBy=multi-user.target
+```
+
+For Docker use `Env`:
+
+```docker
+ENV CORECLR_ENABLE_PROFILING=1
+ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
+ENV DD_INTEGRATIONS=/opt/datadog/integrations.json
+```
 
 ### Runtime Compatibility
 


### PR DESCRIPTION
### What does this PR do?
Adds documentation for automatic .net instrumentation for Linux.

### Motivation
We implemented Linux support.

### Preview link
https://docs-staging.datadoghq.com/caleb/dotnet-linux/tracing/setup/dotnet/

