### PR TITLE
update .NET Tracer release date

### DIFF
--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -17,7 +17,7 @@ further_reading:
 ---
 
 <div class="alert alert-warning">
-.NET Tracing is in an open Public Beta and will be Generally Available in October 2018.
+.NET Tracing is in an open Public Beta and will be Generally Available in November 2018.
 </div>
 
 ## Getting Started

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -64,7 +64,7 @@ Automatic instrumentation is available on Linux for .NET Core 2.0+. To set up au
 
 #### Install the Datadog Agent
 
-Traces are sent to a local Datadog Agent and then forwarded to Datadog. To install the agent, follow the [Linux instructions][1].
+Traces are sent to a local Datadog Agent and then forwarded to Datadog. To install the Agent, follow the [Linux instructions][1].
 
 #### Add the `Datadog.Trace.ClrProfiler.Managed` NuGet Package
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update release date of .NET Tracer

### Motivation
Release date was pushed back to November. Docs say October and today is the last day.

### Preview link
https://docs-staging.datadoghq.com/lucas/dotnet-tracer-release-date/tracing/setup/dotnet/

### Additional Notes
Also capitalized one instance of "Agent", as suggested [here](https://github.com/DataDog/documentation/pull/3401#pullrequestreview-170296668).
