### PR TITLE
includes version when LogConfig K8s annotation was introduced

### DIFF
--- a/content/agent/autodiscovery.md
+++ b/content/agent/autodiscovery.md
@@ -265,6 +265,8 @@ Again, the order of each list matters. The Agent can only generate the HTTP chec
 
 Store check templates in Kubernetes Pod annotations. With Autodiscovery enabled, the Agent detects if it's running on Kubernetes and automatically searches all Pod annotations for check templates.
 
+Since version 6.5 of the Datadog Agent, it is also possible to configure log collection in Kubernetes Pod annotations.
+
 Autodiscovery expects annotations to look like this:
 
 ```

--- a/content/logs/log_collection/docker.md
+++ b/content/logs/log_collection/docker.md
@@ -107,8 +107,8 @@ The source and service values can be overriden thanks to Autodiscovery as descri
 
 The second step is to use Autodiscovery to customize the `source` and `service` value. This allows Datadog to identify the log source for each container.
 
-Since version 6.2 of the Datadog Agent, you can configure log collection directly in the container labels. 
-Pod annotations are also supported for Kubernetes environment, see the [Kubernetes Autodiscovery documentation][12].
+Since version 6.2 of the Datadog Agent, you can configure log collection directly in the Docker container labels. 
+Since version 6.5 of the Datadog Agent, Pod annotations are also supported for Kubernetes environment, see the [Kubernetes Autodiscovery documentation][12].
 
 Autodiscovery expects labels to follow this format, depending on the file type:
 


### PR DESCRIPTION
### What does this PR do?
Mentions the version when LogConfig in PodAnnotations got supported.

### Motivation
Got a case complaining that it isn't working; found out later that they're using the version just before it got supported.

### Preview link

- https://docs.datadoghq.com/agent/autodiscovery/?tab=docker#template-source-kubernetes-pod-annotations
- https://docs.datadoghq.com/logs/log_collection/docker/?tab=nginxdockerfile#activate-log-integrations

### Additional Notes
- for autodiscovery.md, language borrowed from https://docs.datadoghq.com/agent/autodiscovery/?tab=docker#template-source-docker-label-annotations
