### PR TITLE
use dpkg instead of apt in .net linux instructions

### DIFF
--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -82,7 +82,7 @@ For Debian or Ubuntu, download and install the Debian package:
 
 ```bash
 curl -LO https://github.com/DataDog/dd-trace-csharp/releases/download/v0.5.0-beta/datadog-dotnet-apm_0.5.0_amd64.deb
-sudo apt install ./datadog-dotnet-apm_0.5.0_amd64.deb
+sudo dpkg -i ./datadog-dotnet-apm_0.5.0_amd64.deb
 ```
 
 For CentOS or Fedora, download and install the RPM package


### PR DESCRIPTION
### What does this PR do?
Changes the debian installation instructions to use `dpkg` instead of `apt`, since `apt install` is a more recent feature of `apt` not available in debian 8. `dpkg -i` should work everywhere.

### Motivation
To fix the instructions for debian 8.

### Preview link
https://docs-staging.datadoghq.com/caleb/dotnet-debian/tracing/setup/dotnet/
