### PR TITLE
Escaping backslash for logs collection with Docker compose

### DIFF
--- a/content/logs/log_collection/docker.md
+++ b/content/logs/log_collection/docker.md
@@ -181,7 +181,7 @@ Use the `com.datadoghq.ad.logs` label as below on your containers to make sure t
 
   ```
   labels:
-    com.datadoghq.ad.logs: '[{"source": "java", "service": "myapp", "log_processing_rules": [{"type": "multi_line", "name": "log_start_with_date", "pattern" : "\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])"}]}]'
+    com.datadoghq.ad.logs: '[{"source": "java", "service": "myapp", "log_processing_rules": [{"type": "multi_line", "name": "log_start_with_date", "pattern" : "\\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])"}]}]'
   ```
 See the [multi-line processing rule documentation][13] to get more pattern examples.
 


### PR DESCRIPTION
### What does this PR do?

After several tests, it appears that when building containers using docker-compose with the documentation pattern (`"\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])"`), no logs whatsoever are coming in. 
According to Nils: 
> the pattern is not recognised as valid then. And when we fail to parse the configuration we do not tail the container at all (hopefully this will get changed in 6.7 - not 6.6)

This was tested with Postgresql logs, that do not start with a timestamp:
- When using this `"\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])"` as regex pattern, no logs at all are coming in
- When using this `"\\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])"` as regex pattern, logs are coming in
- When using `"foo"` as regex pattern, logs are coming in

It was also tested with Nginx logs, that do start with a timestamp
- When using this `"\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])"` as regex pattern, no logs at all are coming in
- When using this `"\\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])"` as regex pattern, logs are coming in

I performed several other tests that seem to converge toward this same conclusion but I could definitely use a double check by someone else.
Customer ended up with this conclusion as well: 
- First ticket: https://datadog.zendesk.com/agent/tickets/174263
- Second ticket: https://datadog.zendesk.com/agent/tickets/178123

More details about this on this Slack convo: 
https://dd.slack.com/archives/C6QR6DXJ4/p1540287215000100 
https://cl.ly/c48752cc034f

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
