### PR TITLE
Add Networking and Proxying section to public security docs

### DIFF
--- a/content/security/agent.md
+++ b/content/security/agent.md
@@ -40,7 +40,7 @@ Datadog's Vulnerability Management program includes regular assessments of suppo
 
 Regarding its Container Agent specifically, Datadog performs regular vulnerability static analysis using [clair by CoreOS][6] and [snyk.io][7]. Additionally, Datadog leverages security scanning as part of its releases of the Container Agent to the [Docker Trusted Registry][8], as well as the [Red Hat Container Catalog][9]. In addition to Datadog's internal Vulnerability Management program, Datadog also partners with container security vendors.
 
-If you believe you've discovered a bug in Datadog's security, get in touch at [security@datadoghq.com][10] and we will get back to you within 24 hours. Our [PGP key][11] is available for download in case you need to encrypt communications with us. We request that you not publicly disclose the issue until we have had a chance to address it.
+If you believe you've discovered a bug in Datadog's security, get in touch at [security@datadoghq.com][10] and we will get back to you within 24 hours. Datadog's [PGP key][11] is available for download in case you need to encrypt communications with us. We request that you not publicly disclose the issue until we have had a chance to address it.
 
 ## [BETA] Secrets Management
 

--- a/content/security/agent.md
+++ b/content/security/agent.md
@@ -18,9 +18,13 @@ Customers can send data to the Datadog service by using a locally installed [Age
 
 The Datadog Agent submits data to Datadog over a TLS-encrypted TCP connection by default. As of version 6, the Agent can be configured to enforce TLS 1.2 when connecting to Datadog. Customers who require the use of "strong cryptography," for example, to meet PCI requirements, should use Agent v6 and set the `force_tls_12: true` setting in the Agent's configuration file.
 
+## Networking and Proxying
+
+Datadog is a SaaS product: customers need to establish an outbound connection from their network to the public internet in order to submit monitoring data. Traffic is always initiated by the Agent to Datadog via TLS-encrypted TCP connection by default. No sessions are ever initiated from Datadog back to the Agent. See the Agent's [Network][3] page for more information on configuring firewalls to whitelist the required Datadog domains and ports. Additionally, customers monitoring hosts with no direct connectivity to the public internet, or with restricted outbound traffic,  should consider submitting monitoring data via a [Proxy][4].
+
 ## Agent Logs Obfuscation
 
-The Datadog Agent generates local logs in order to support [Agent troubleshooting][3] as required. As a safety precaution, these local logs are filtered for some specific keywords and patterns that could indicate a potential credential (e.g. API key, password and token keywords, etc.), which are then obfuscated before being written to disk.
+The Datadog Agent generates local logs in order to support [Agent troubleshooting][5] as required. As a safety precaution, these local logs are filtered for some specific keywords and patterns that could indicate a potential credential (e.g. API key, password and token keywords, etc.), which are then obfuscated before being written to disk.
 
 ## Local HTTPS Server
 
@@ -34,13 +38,13 @@ Agent v6 comes bundled with a Graphical User Interface (GUI) by default, which l
 
 Datadog's Vulnerability Management program includes regular assessments of supporting infrastructure and application components, including active scans of core supporting services. Datadog Security teams perform monthly scans to identify configuration and software vulnerabilities, and track remediation of findings according to Datadog's Vulnerability Management policy.
 
-Regarding its Container Agent specifically, Datadog performs regular vulnerability static analysis using [clair by CoreOS][4] and [snyk.io][5]. Additionally, Datadog leverages security scanning as part of its releases of the Container Agent to the [Docker Trusted Registry][6], as well as the [Red Hat Container Catalog][7]. In addition to Datadog's internal Vulnerability Management program, Datadog also partners with container security vendors.
+Regarding its Container Agent specifically, Datadog performs regular vulnerability static analysis using [clair by CoreOS][6] and [snyk.io][7]. Additionally, Datadog leverages security scanning as part of its releases of the Container Agent to the [Docker Trusted Registry][8], as well as the [Red Hat Container Catalog][9]. In addition to Datadog's internal Vulnerability Management program, Datadog also partners with container security vendors.
 
-If you believe you've discovered a bug in Datadog's security, get in touch at [security@datadoghq.com][8] and we will get back to you within 24 hours. Our [PGP key][9] is available for download in case you need to encrypt communications with us. We request that you not publicly disclose the issue until we have had a chance to address it.
+If you believe you've discovered a bug in Datadog's security, get in touch at [security@datadoghq.com][10] and we will get back to you within 24 hours. Our [PGP key][11] is available for download in case you need to encrypt communications with us. We request that you not publicly disclose the issue until we have had a chance to address it.
 
 ## [BETA] Secrets Management
 
-Customers with a requirement to avoid storing secrets in plaintext in the Agent's configuration files can leverage the [secrets management][10] package. This package allows the Agent to call a user-provided executable to handle retrieval or decryption of secrets, which are then loaded in memory by the Agent. Users have the flexibility to design their executable according to their preferred key management service, authentication method, and continuous integration workflow.
+Customers with a requirement to avoid storing secrets in plaintext in the Agent's configuration files can leverage the [secrets management][12] package. This package allows the Agent to call a user-provided executable to handle retrieval or decryption of secrets, which are then loaded in memory by the Agent. Users have the flexibility to design their executable according to their preferred key management service, authentication method, and continuous integration workflow.
 
 ### Further Reading
 
@@ -49,11 +53,13 @@ Customers with a requirement to avoid storing secrets in plaintext in the Agent'
 [0]: /security/
 [1]: /agent/
 [2]: /api/
-[3]: /agent/troubleshooting/
-[4]: https://coreos.com/clair/
-[5]: https://snyk.io/
-[6]: https://docs.docker.com/v17.09/datacenter/dtr/2.4/guides/
-[7]: https://access.redhat.com/containers/
-[8]: mailto:security@datadoghq.com
-[9]: https://www.datadoghq.com/8869756E.asc.txt
-[10]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/secrets.md
+[3]: /agent/network/
+[4]: /agent/proxy/
+[5]: /agent/troubleshooting/
+[6]: https://coreos.com/clair/
+[7]: https://snyk.io/
+[8]: https://docs.docker.com/v17.09/datacenter/dtr/2.4/guides/
+[9]: https://access.redhat.com/containers/
+[10]: mailto:security@datadoghq.com
+[11]: https://www.datadoghq.com/8869756E.asc.txt
+[12]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/secrets.md

--- a/content/security/agent.md
+++ b/content/security/agent.md
@@ -20,7 +20,7 @@ The Datadog Agent submits data to Datadog over a TLS-encrypted TCP connection by
 
 ## Networking and Proxying
 
-Datadog is a SaaS product: customers need to establish an outbound connection from their network to the public internet in order to submit monitoring data. Traffic is always initiated by the Agent to Datadog via TLS-encrypted TCP connection by default. No sessions are ever initiated from Datadog back to the Agent. See the Agent's [Network][3] page for more information on configuring firewalls to whitelist the required Datadog domains and ports. Additionally, customers monitoring hosts with no direct connectivity to the public internet, or with restricted outbound traffic,  should consider submitting monitoring data via a [Proxy][4].
+Datadog is a SaaS product: customers need to establish an outbound connection from their network to the public internet in order to submit monitoring data. Traffic is always initiated by the Agent to Datadog via TLS-encrypted TCP connection by default. No sessions are ever initiated from Datadog back to the Agent. See the Agent's [Network][3] page for more information on configuring firewalls to whitelist the required Datadog domains and ports. Additionally, customers monitoring hosts with no direct connectivity to the public internet, or with restricted outbound traffic, should consider submitting monitoring data via a [Proxy][4].
 
 ## Agent Logs Obfuscation
 


### PR DESCRIPTION
Add Networking and Proxying section to the agent's public security doc.

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
Customer feedback on /security/agent, as reported by Gus.

### Preview link
TBD

### Additional Notes
Reviewed by #compliance -- now need documentation review
