### PR TITLE
Fix links to sample config files

### DIFF
--- a/content/integrations/system.md
+++ b/content/integrations/system.md
@@ -109,6 +109,6 @@ The system swap check is included in the [Datadog Agent][4] package, so you don'
 [3]: /integrations/process/
 [4]: https://app.datadoghq.com/account/settings#agent
 [4]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
-[5]: https://github.com/DataDog/integrations-core/blob/master/system_core/conf.yaml.example
-[6]: https://github.com/DataDog/integrations-core/blob/master/system_swap/conf.yaml.example
+[5]: https://github.com/DataDog/integrations-core/blob/master/system_core/datadog_checks/system_core/data/conf.yaml.example
+[6]: https://github.com/DataDog/integrations-core/blob/master/system_swap/datadog_checks/system_swap/data/conf.yaml.example
 [7]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent


### PR DESCRIPTION
### What does this PR do?
Fix broken links for the sample configuration files for `system_core` and system_swap`

### Motivation
Links were redirecting to previous locations.

### Preview link
https://docs.datadoghq.com/integrations/system/#configuration