### PR TITLE
Document all the log available API for EU and US

### DIFF
--- a/content/logs/_index.md
+++ b/content/logs/_index.md
@@ -75,28 +75,40 @@ This will produce the following result in your [live tail page][39]:
 
 ### Datadog Logs Endpoints
 
+There are two cateogries of endpoint to send logs to Datadog, those that support a SSL encrypted connection and others with an unencrypted one.
+We always recommend to use the SSL encryption when possible and the Datadog Agent use an SSL encrypted connection to send logs to Datadog ([more information available here][40]).
+
 The endpoints that can be used to send logs to Datadog:
 
 {{< tabs >}}
 {{% tab "US Region" %}}
 
-| Endpoint                           | Port    | Description                                                                                                           |
+
+| Endpoints for SSL encrypted connections     | Port    | Description                                                                                                           |
 | :--------------------------------- | :------ | :-------                                                                                                              |
 | `agent-intake.logs.datadoghq.com`  | `10516` | Used by the Agent to send logs in protobuf format over an SSL-encrypted TCP connection.                       |
 | `intake.logs.datadoghq.com`        | `10516` | Used by custom forwarders to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection.   |
-| `intake.logs.datadoghq.com`        | `10514` | Used by custom forwarders to send logs in raw, Syslog, or JSON format over an unecrypted TCP connection.          |
 | `lambda-intake.logs.datadoghq.com` | `10516` | Used by Lambda functions to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection. |
+
+
+| Endpoint for unencrypted connections        | Port    | Description                                                                                                           |
+| :--------------------------------- | :------ | :-------   
+| `intake.logs.datadoghq.com`        | `10514` | Used by custom forwarders to send logs in raw, Syslog, or JSON format over an unecrypted TCP connection.          |
 
 
 {{% /tab %}}
 {{% tab "EU Region" %}}
 
-| Endpoint                           | Port    | Description                                                                                                           |
+| Endpoints for SSL encrypted connections                       | Port    | Description                                                                                                           |
 | :--------------------------------- | :------ | :-------                                                                                                              |
 | `agent-intake.logs.datadoghq.eu`   | `443`   | Used by the Agent to send logs in protobuf format over an SSL-encrypted TCP connection.                         |
 | `tcp-intake.logs.datadoghq.eu`     | `443`   | Used by custom forwarders to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection.   |
-| `tcp-intake.logs.datadoghq.eu`     | `1883`  | Used by custom forwarders to send logs in raw, Syslog, or JSON format format over an unecrypted TCP connection.          |
 | `lambda-intake.logs.datadoghq.eu`  | `443`   | Used by Lambda functions to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection. |
+
+
+| Endpoint for unencrypted connections                           | Port    | Description                                                                                                           |
+| :--------------------------------- | :------ | :-------   
+| `tcp-intake.logs.datadoghq.eu`     | `1883`  | Used by custom forwarders to send logs in raw, Syslog, or JSON format format over an unecrypted TCP connection.          |
 
 
 {{% /tab %}}
@@ -161,3 +173,4 @@ Your logs are collected and centralized into the [Log Explorer][17] view. You ca
 [37]: /integrations/#cat-log-collection
 [38]: https://app.datadoghq.com/account/settings#api
 [39]: https://app.datadoghq.com/logs/livetail
+[40]: https://docs.datadoghq.com/security/logs/#information-security

--- a/content/logs/_index.md
+++ b/content/logs/_index.md
@@ -81,7 +81,7 @@ Find below all the endpoints that can be used to send logs to Datadog:
 {{% tab "US Region" %}}
 
 | Endpoint                           | Port    | Description                                                                                                           |
-| :-------                           | :------ | :-------                                                                                                              |
+| :--------------------------------- | :------ | :-------                                                                                                              |
 | `agent-intake.logs.datadoghq.com`  | `10516` | Endpoint used by the agent to send logs in protobuf format over a SSL encrypted TCP connection.                       |
 | `intake.logs.datadoghq.com`        | `10516` | Endpoint used by custom forwarders to send logs in raw, Syslog, or JSON format over a SSL encrypted TCP connection.   |
 | `intake.logs.datadoghq.com`        | `10514` | Endpoint used by custom forwarders to send logs in raw, Syslog, or JSON format format over a TCP connection.          |
@@ -91,12 +91,12 @@ Find below all the endpoints that can be used to send logs to Datadog:
 {{% /tab %}}
 {{% tab "EU Region" %}}
 
-| Endpoint                          | Port    | Description                                                                                                           |
-| :-------                          | :------ | :-------                                                                                                              |
-| `agent-intake.logs.datadoghq.eu`  | `443`   | Endpoint used by the agent to send logs in protobuf format over SSL encrypted TCP connection.                         |
-| `tcp-intake.logs.datadoghq.eu`    | `443`   | Endpoint used by custom forwarders to send logs in raw, Syslog, or JSON format over a SSL encrypted TCP connection.   |
-| `tcp-intake.logs.datadoghq.eu`    | `1883`  | Endpoint used by custom forwarders to send logs in raw, Syslog, or JSON format format over a TCP connection.          |
-| `lambda-intake.logs.datadoghq.eu` | `443`   | Endpoint used by the Lambda function to send logs in raw, Syslog, or JSON format over a SSL encrypted TCP connection. |
+| Endpoint                           | Port    | Description                                                                                                           |
+| :--------------------------------- | :------ | :-------                                                                                                              |
+| `agent-intake.logs.datadoghq.eu`   | `443`   | Endpoint used by the agent to send logs in protobuf format over SSL encrypted TCP connection.                         |
+| `tcp-intake.logs.datadoghq.eu`     | `443`   | Endpoint used by custom forwarders to send logs in raw, Syslog, or JSON format over a SSL encrypted TCP connection.   |
+| `tcp-intake.logs.datadoghq.eu`     | `1883`  | Endpoint used by custom forwarders to send logs in raw, Syslog, or JSON format format over a TCP connection.          |
+| `lambda-intake.logs.datadoghq.eu`  | `443`   | Endpoint used by the Lambda function to send logs in raw, Syslog, or JSON format over a SSL encrypted TCP connection. |
 
 
 {{% /tab %}}

--- a/content/logs/_index.md
+++ b/content/logs/_index.md
@@ -73,6 +73,35 @@ This will produce the following result in your [live tail page][39]:
 
 {{< img src="logs/custom_log_telnet.png" alt="Custom telnet" responsive="true" style="width:70%;">}}
 
+### Endpoints for logs
+
+Here are all the endpoints that can be used to send logs to Datadog:
+
+
+{{< tabs >}}
+{{% tab "US Region" %}}
+
+| Endpoint   | Port    | Description                                                                                                                                                                                         |
+| :-------   | :------ | :-------                                                                                                                                                                                           |
+| `agent-intake.logs.datadoghq.com`    | `10516` | Endpoint used by the agent to send logs in protobuf format over SSL encrypted TCP connection                              |
+| `intake.logs.datadoghq.com`    | `10516` | Endpoint used by custom forwarder to send logs in raw, Syslog or JSON format over a SSL encrypted connection.                          |
+| `intake.logs.datadoghq.com`    | `10514` | Endpoint used by custom forwarder to send logs in raw, Syslog or JSON format format over a TCP connection                          |
+| `lambda-intake.logs.datadoghq.com`    | `10516` | Endpoint used by the Lambda function to send logs in raw, Syslog or JSON format over a SSL encrypted TCP connection            |
+
+{{% /tab %}}
+{{% tab "EU Region" %}}
+
+| Endpoint   | Port    | Description                                                                                                                                                                                         |
+| :-------   | :------ | :-------                                                                                                                                                                                           |
+| `agent-intake.logs.datadoghq.eu`    | `443` | Endpoint used by the agent to send logs in protobuf format over SSL encrypted TCP connection                                        |
+| `tcp-intake.logs.datadoghq.eu`    | `443` | Endpoint used by custom forwarder to send logs in raw, Syslog or JSON format over a SSL encrypted connection.                      |
+| `tcp-intake.logs.datadoghq.eu`    | `1883` | Endpoint used by custom forwarder to send logs in raw, Syslog or JSON format format over a TCP connection                          |
+| `lambda-intake.logs.datadoghq.eu`    | `443` | Endpoint used by the Lambda function to send logs in raw, Syslog or JSON format over a SSL encrypted TCP connection            |
+
+{{% /tab %}}
+{{< /tabs >}}
+
+
 ### Reserved attributes
 
 Here are some key attributes you should pay attention to when setting up your project:

--- a/content/logs/_index.md
+++ b/content/logs/_index.md
@@ -73,30 +73,31 @@ This will produce the following result in your [live tail page][39]:
 
 {{< img src="logs/custom_log_telnet.png" alt="Custom telnet" responsive="true" style="width:70%;">}}
 
-### Endpoints for logs
+### Datadog Logs Endpoints
 
-Here are all the endpoints that can be used to send logs to Datadog:
-
+Find below all the endpoints that can be used to send logs to Datadog:
 
 {{< tabs >}}
 {{% tab "US Region" %}}
 
-| Endpoint   | Port    | Description                                                                                                                                                                                         |
-| :-------   | :------ | :-------                                                                                                                                                                                           |
-| `agent-intake.logs.datadoghq.com`    | `10516` | Endpoint used by the agent to send logs in protobuf format over SSL encrypted TCP connection                              |
-| `intake.logs.datadoghq.com`    | `10516` | Endpoint used by custom forwarder to send logs in raw, Syslog or JSON format over a SSL encrypted connection.                          |
-| `intake.logs.datadoghq.com`    | `10514` | Endpoint used by custom forwarder to send logs in raw, Syslog or JSON format format over a TCP connection                          |
-| `lambda-intake.logs.datadoghq.com`    | `10516` | Endpoint used by the Lambda function to send logs in raw, Syslog or JSON format over a SSL encrypted TCP connection            |
+| Endpoint                           | Port    | Description                                                                                                           |
+| :-------                           | :------ | :-------                                                                                                              |
+| `agent-intake.logs.datadoghq.com`  | `10516` | Endpoint used by the agent to send logs in protobuf format over a SSL encrypted TCP connection.                       |
+| `intake.logs.datadoghq.com`        | `10516` | Endpoint used by custom forwarders to send logs in raw, Syslog, or JSON format over a SSL encrypted TCP connection.   |
+| `intake.logs.datadoghq.com`        | `10514` | Endpoint used by custom forwarders to send logs in raw, Syslog, or JSON format format over a TCP connection.          |
+| `lambda-intake.logs.datadoghq.com` | `10516` | Endpoint used by the Lambda function to send logs in raw, Syslog, or JSON format over a SSL encrypted TCP connection. |
+
 
 {{% /tab %}}
 {{% tab "EU Region" %}}
 
-| Endpoint   | Port    | Description                                                                                                                                                                                         |
-| :-------   | :------ | :-------                                                                                                                                                                                           |
-| `agent-intake.logs.datadoghq.eu`    | `443` | Endpoint used by the agent to send logs in protobuf format over SSL encrypted TCP connection                                        |
-| `tcp-intake.logs.datadoghq.eu`    | `443` | Endpoint used by custom forwarder to send logs in raw, Syslog or JSON format over a SSL encrypted connection.                      |
-| `tcp-intake.logs.datadoghq.eu`    | `1883` | Endpoint used by custom forwarder to send logs in raw, Syslog or JSON format format over a TCP connection                          |
-| `lambda-intake.logs.datadoghq.eu`    | `443` | Endpoint used by the Lambda function to send logs in raw, Syslog or JSON format over a SSL encrypted TCP connection            |
+| Endpoint                          | Port    | Description                                                                                                           |
+| :-------                          | :------ | :-------                                                                                                              |
+| `agent-intake.logs.datadoghq.eu`  | `443`   | Endpoint used by the agent to send logs in protobuf format over SSL encrypted TCP connection.                         |
+| `tcp-intake.logs.datadoghq.eu`    | `443`   | Endpoint used by custom forwarders to send logs in raw, Syslog, or JSON format over a SSL encrypted TCP connection.   |
+| `tcp-intake.logs.datadoghq.eu`    | `1883`  | Endpoint used by custom forwarders to send logs in raw, Syslog, or JSON format format over a TCP connection.          |
+| `lambda-intake.logs.datadoghq.eu` | `443`   | Endpoint used by the Lambda function to send logs in raw, Syslog, or JSON format over a SSL encrypted TCP connection. |
+
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/logs/_index.md
+++ b/content/logs/_index.md
@@ -23,15 +23,15 @@ The Log Management solution is an all-in-one comprehensive solution that compris
 
 ## Log Collection
 
-Log collection is the beginning of your journey in the wonderful world of log-management. Use the [Datadog Agent][6] to collect logs directly from your hosts or your containerized environments. You can collect AWS service logs with Datadog's [AWS Lambda function](#from-aws-services).If you are already using a log-shipper daemon, refer to the dedicated documentation for [Rsyslog][1], [Syslog-ng][2], [NXlog][3], [FluentD][4], and [Logstash][5].
+Log collection is the beginning of your journey in the wonderful world of log management. Use the [Datadog Agent][6] to collect logs directly from your hosts or your containerized environments. You can collect AWS service logs with Datadog's [AWS Lambda function](#from-aws-services).If you are already using a log-shipper daemon, refer to the dedicated documentation for [Rsyslog][1], [Syslog-ng][2], [NXlog][3], [FluentD][4], and [Logstash][5].
 
-Integrations and Log Collection are intimately tied together, by collecting Logs the right way you make sure to auto-configure all the the subsequent components such as [processing][33], [parsing][29], and [facets][18] in the Explorer. **[Discover the log integrations supported by Datadog][37]**. You can also define custom log sources if there isn't an integration for your source yet.
+Integrations and Log Collection are intimately tied together. By collecting Logs the right way, you enable all the the subsequent components such as [processing][33], [parsing][29], and [facets][18] in the Explorer. **[Discover the log integrations supported by Datadog][37]**. You can also define custom log sources if there isn't an integration for your source yet.
 
 <div class="alert alert-warning">
 <a href="https://docs.datadoghq.com/integrations/#cat-log-collection">Consult the current list of available supported integrations</a>.
 </div>
 
-Find below the different ways and places to collect logs.
+The different ways and places from which to collect logs.
 
 ### From your hosts
 
@@ -75,17 +75,17 @@ This will produce the following result in your [live tail page][39]:
 
 ### Datadog Logs Endpoints
 
-Find below all the endpoints that can be used to send logs to Datadog:
+The endpoints that can be used to send logs to Datadog:
 
 {{< tabs >}}
 {{% tab "US Region" %}}
 
 | Endpoint                           | Port    | Description                                                                                                           |
 | :--------------------------------- | :------ | :-------                                                                                                              |
-| `agent-intake.logs.datadoghq.com`  | `10516` | Endpoint used by the agent to send logs in protobuf format over a SSL encrypted TCP connection.                       |
-| `intake.logs.datadoghq.com`        | `10516` | Endpoint used by custom forwarders to send logs in raw, Syslog, or JSON format over a SSL encrypted TCP connection.   |
-| `intake.logs.datadoghq.com`        | `10514` | Endpoint used by custom forwarders to send logs in raw, Syslog, or JSON format format over a TCP connection.          |
-| `lambda-intake.logs.datadoghq.com` | `10516` | Endpoint used by the Lambda function to send logs in raw, Syslog, or JSON format over a SSL encrypted TCP connection. |
+| `agent-intake.logs.datadoghq.com`  | `10516` | Used by the Agent to send logs in protobuf format over an SSL-encrypted TCP connection.                       |
+| `intake.logs.datadoghq.com`        | `10516` | Used by custom forwarders to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection.   |
+| `intake.logs.datadoghq.com`        | `10514` | Used by custom forwarders to send logs in raw, Syslog, or JSON format over an unecrypted TCP connection.          |
+| `lambda-intake.logs.datadoghq.com` | `10516` | Used by Lambda functions to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection. |
 
 
 {{% /tab %}}
@@ -93,10 +93,10 @@ Find below all the endpoints that can be used to send logs to Datadog:
 
 | Endpoint                           | Port    | Description                                                                                                           |
 | :--------------------------------- | :------ | :-------                                                                                                              |
-| `agent-intake.logs.datadoghq.eu`   | `443`   | Endpoint used by the agent to send logs in protobuf format over SSL encrypted TCP connection.                         |
-| `tcp-intake.logs.datadoghq.eu`     | `443`   | Endpoint used by custom forwarders to send logs in raw, Syslog, or JSON format over a SSL encrypted TCP connection.   |
-| `tcp-intake.logs.datadoghq.eu`     | `1883`  | Endpoint used by custom forwarders to send logs in raw, Syslog, or JSON format format over a TCP connection.          |
-| `lambda-intake.logs.datadoghq.eu`  | `443`   | Endpoint used by the Lambda function to send logs in raw, Syslog, or JSON format over a SSL encrypted TCP connection. |
+| `agent-intake.logs.datadoghq.eu`   | `443`   | Used by the Agent to send logs in protobuf format over an SSL-encrypted TCP connection.                         |
+| `tcp-intake.logs.datadoghq.eu`     | `443`   | Used by custom forwarders to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection.   |
+| `tcp-intake.logs.datadoghq.eu`     | `1883`  | Used by custom forwarders to send logs in raw, Syslog, or JSON format format over an unecrypted TCP connection.          |
+| `lambda-intake.logs.datadoghq.eu`  | `443`   | Used by Lambda functions to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection. |
 
 
 {{% /tab %}}


### PR DESCRIPTION
### What does this PR do?
It describes the list of available API to send logs in EU and US region.

### Motivation
It was not clear anywhere in the documentation what were the available endpoint to submit logs for US and EU region.

### Preview link
<!-- Impacted pages preview links-->

* https://docs-staging.datadoghq.com/nils/EU-US-log-endpoint/logs/?tab=usregion#datadog-logs-endpoints
