### PR TITLE
Update cloudfoundry log collection documentation

### DIFF
--- a/content/integrations/cloud_foundry.md
+++ b/content/integrations/cloud_foundry.md
@@ -139,7 +139,7 @@ The following parameters can be used to configure log collection:
 
 **Example**:
 
-An `app01` java application is running in cloudfoundry. The following configuration redirect the container `stdout`/`stderr` to the local port 10514 and then configure the agent to collect logs from that port while setting the proper value for `service` and `source`:
+An `app01` Java application is running in Cloud Foundry. The following configuration redirects the container `stdout`/`stderr` to the local port 10514. It then configures the Agent to collect logs from that port while setting the proper value for `service` and `source`:
 
 ```
 # Redirect Stdout/Stderr to port 10514

--- a/content/integrations/cloud_foundry.md
+++ b/content/integrations/cloud_foundry.md
@@ -125,7 +125,7 @@ cf set-env $YOUR_APP_NAME DD_ENABLE_CHECKS false
 # Redirect Container Stdout/Stderr to a local port so the agent can collect the logs
 cf set-env $YOUR_APP_NAME STD_LOG_COLLECTION_PORT <PORT>
 # Configure the agent to collect logs from the wanted port and set the value for source and service
-cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG '[{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]'
+cf set-env $YOUR_APP_NAME LOGS_CONFIG '[{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]'
 # restage the application to get it to pick up the new environment variable and use the buildpack
 cf restage $YOUR_APP_NAME
 ```
@@ -135,7 +135,7 @@ cf restage $YOUR_APP_NAME
 The following parameters can be used to configure log collection:
 
 - `STD_LOG_COLLECTION_PORT`: Must be used when collecting logs from `stdout`/`stderr`. It redirects the `stdout`/`stderr` stream to the corresponding local port value.
-- `DD_LOGS_CONFIG_CUSTOM_CONFIG`: Use this option to configure the agent to listen to a local TCP port and set the value for the `service` and `source` parameters.
+- `LOGS_CONFIG`: Use this option to configure the agent to listen to a local TCP port and set the value for the `service` and `source` parameters.
 
 **Example**:
 
@@ -145,7 +145,7 @@ An `app01` Java application is running in Cloud Foundry. The following configura
 # Redirect Stdout/Stderr to port 10514
 cf set-env $YOUR_APP_NAME STD_LOG_COLLECTION_PORT 10514
 # Configure the agent to listen to that port
-cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG '[{"type":"tcp","port":"10514","source":"java","service":"app01"}]'
+cf set-env $YOUR_APP_NAME LOGS_CONFIG '[{"type":"tcp","port":"10514","source":"java","service":"app01"}]'
 ```
 
 ### Build

--- a/content/integrations/cloud_foundry.md
+++ b/content/integrations/cloud_foundry.md
@@ -111,7 +111,7 @@ cf set-env <YOUR_APP> DD_API_KEY <DD_API_KEY>
 cf restage <YOUR_APP>
 ```
 
-#### Log Collection (beta)
+#### Log Collection
 
 **Enable log collection**:
 

--- a/content/integrations/cloud_foundry.md
+++ b/content/integrations/cloud_foundry.md
@@ -111,7 +111,9 @@ cf set-env <YOUR_APP> DD_API_KEY <DD_API_KEY>
 cf restage <YOUR_APP>
 ```
 
-#### Log Collection (closed beta)
+#### Log Collection (beta)
+
+**Enable log collection**:
 
 To start collecting logs from your application in CloudFoundry, the Agent contained in the buildpack needs to be activated and log collection enabled.
 
@@ -120,19 +122,30 @@ cf set-env $YOUR_APP_NAME RUN_AGENT true
 cf set-env $YOUR_APP_NAME DD_LOGS_ENABLED true
 # Disable the Agent core checks to disable system metrics collection
 cf set-env $YOUR_APP_NAME DD_ENABLE_CHECKS false
+# Redirect Container Stdout/Stderr to a local port so the agent can collect the logs
+cf set-env $YOUR_APP_NAME STD_LOG_COLLECTION_PORT <PORT>
+# Configure the agent to collect logs from the wanted port and set the value for source and service
+cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG '[{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]'
 # restage the application to get it to pick up the new environment variable and use the buildpack
 cf restage $YOUR_APP_NAME
 ```
 
-By default, the Agent collects logs from `stdout`/`stderr` and listens to TCP port 10514.
-It is possible to ask the Agent to listen on a different TCP port if you are streaming logs from your application in TCP.
-To disable log collection from `stdout`/`stderr`, use the following configuration:
+**Configure log collection**:
+
+The following parameters can be used to configure log collection:
+
+- `STD_LOG_COLLECTION_PORT`: Must be used when collecting logs from `stdout`/`stderr`. It redirects the `stdout`/`stderr` stream to the corresponding local port value.
+- `DD_LOGS_CONFIG_CUSTOM_CONFIG`: Use this option to configure the agent to listen to a local TCP port and set the value for the `service` and `source` parameters.
+
+**Example**:
+
+An `app01` java application is running in cloudfoundry. The following configuration redirect the container `stdout`/`stderr` to the local port 10514 and then configure the agent to collect logs from that port while setting the proper value for `service` and `source`:
 
 ```
-# override the TCP port
-cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_TCP_FORWARD_PORT 10514
-# disable log collection on stdout/stderr
-cf set-env $YOUR_APP_NAME DISABLE_STD_LOG_COLLECTION true
+# Redirect Stdout/Stderr to port 10514
+cf set-env $YOUR_APP_NAME STD_LOG_COLLECTION_PORT 10514
+# Configure the agent to listen to that port
+cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG '[{"type":"tcp","port":"10514","source":"java","service":"app01"}]'
 ```
 
 ### Build


### PR DESCRIPTION
### What does this PR do?

Update the configuration instructions to collect logs from Cloudfoundry container

PENDING release of the new version.

### Motivation

It was not possible to configure the service or source value in Cloudfoundry. The latest version of the buildpack adds a `CUSTOM_CONFIG` environment variable that let users set the values for `service` and `source`.
This needed to be documented.

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
