### PR TITLE
Fix confusion on tag allowed characters

### DIFF
--- a/content/tagging/_index.md
+++ b/content/tagging/_index.md
@@ -38,7 +38,7 @@ Containers and cloud environments regularly churn through hosts, so it is critic
 
 Below are Datadog's tagging restrictions, requirements, and suggestions:
 
-1. Tags must **start with a letter** and after that may contain the characters listed below. Other special characters are converted to underscores:
+1. Tags must **start with a letter** and after that may contain the characters listed below:
 
     * Alphanumerics
     * Underscores
@@ -46,6 +46,8 @@ Below are Datadog's tagging restrictions, requirements, and suggestions:
     * Colons
     * Periods
     * Slashes
+    
+    Other special characters are converted to underscores.
 
     **Note**: A tag cannot end with a colon, for example `tag:`
 


### PR DESCRIPTION
### Motivation

I got confused various times reading that line. I first thought that the listed characters were the ones to be converted.
@vinvol got tricked too.

### What does this PR do?

Make it clear that the list aren't the special characters.

There might be better rephrasing possible, edit as you please! But you get the idea / this one does the job.

### Preview link

https://docs.datadoghq.com/tagging/#defining-tags

### Additional Notes

_do_ + _re_ + _mi_ + _fa_. That's a note addition.
