### PR TITLE
remove "count" in SQL stored procedure faq

### DIFF
--- a/content/integrations/faq/how-to-collect-metrics-with-sql-stored-procedure.md
+++ b/content/integrations/faq/how-to-collect-metrics-with-sql-stored-procedure.md
@@ -12,14 +12,14 @@ further_reading:
 
 ## Setup a Stored Procedure
 
-A temporary table must be setup to collect the custom metrics for reporting to Datadog. The table needs following columns:
+A temporary table must be setup to collect the custom metrics for reporting to Datadog. The table needs the following columns:
 
 | Column | Description                                                                                                                 |
 | -----  | ----                                                                                                                        |
 | metric | The name of the metric as it appears in Datadog.                                                                            |
-| type   | The [metric type][1] (gauge, rate, count, or [histogram][2]. |
+| type   | The [metric type][1] (gauge, rate, or [histogram][2]). |
 | value  | The value of the metric (must be convertible to a float).                                                                   |
-| tags   | The tags that will appear in Datadog separated by a comma.                                                                  |
+| tags   | The tags that appear in Datadog separated by a comma.                                                                  |
 
 The following stored procedure is created within the master database:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes "count" metric type, which is not supported for SQL server custom metrics. Also some minor syntax/grammar updates.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
