### PR TITLE
[monitors] fix stray default value text and spacing

### DIFF
--- a/content/api/monitors/monitors_edit.md
+++ b/content/api/monitors/monitors_edit.md
@@ -10,8 +10,8 @@ external_redirect: /api/#edit-a-monitor
 * **`query`** [*required*]:  
     The metric query to alert on.
 * **`name`** [*required*]:  
-    The name of the monitor." default="dynamic, based on query
-* **`message`** [*optional*, *default* = **dynamic, based on query**]:
+    The name of the monitor.
+* **`message`** [*optional*, *default*=**dynamic, based on query**]:
     A message to include with notifications for this monitor. Email notifications can be sent to specific users by using the same '@username' notation as events.
 * **`options`** [*optional*, *default*=**{}**]:  
     Refer to the create monitor documentation for details on the available options.


### PR DESCRIPTION
What does this PR do?
Cleans up some text that was accidentally left over from somewhere else.

### Motivation
I was using the docs and came across this non-sensical clause