### PR TITLE
Improved handling for python environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ hugpython: hugpython/bin/activate  ## build virtualenv used for tests.
 
 hugpython/bin/activate: local/etc/requirements3.txt  ## start python virtual environment.
 	@if [ ${PY3} != "false" ]; then \
-		test -d ${VIRENV} || ${PY3} -m venv ${VIRENV}; \
+		test -x ${VIRENV}/bin/pip || ${PY3} -m venv --clear ${VIRENV}; \
 		$(VIRENV)/bin/pip install -r local/etc/requirements3.txt; \
 	else printf "\e[93mPython 3 is required to fetch integrations and run tests.\033[0m Try https://github.com/pyenv/pyenv.\n"; fi
 


### PR DESCRIPTION
### What does this PR do?
This provides a better test to determine if the virtual environment exists and a better fix if it does not.

### Motivation
I had a messed up `hugpython` dir: it was missing `hugpython/bin`. Under the existing code, the Makefile would evaluate this as ok, try to run pip, and fail hard. This update specifically checks for pip. 

Also, when creating the virtual env, if it already existed, the current code would only partially re-create it. This update passes the --clear flag, so that it will destroy and recreate the hugpython venv if necessary.

### Preview link
N/A

### Additional Notes
