### PR TITLE
ignore python version from pyenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ Temporary Items
 
 # virtual env
 /hugpython/
+.python-version
 
 /DataDog-dogweb-*/
 Makefile.config


### PR DESCRIPTION
### What does this PR do?

Adds the .python-version file from pyenv to the ignore list.

### Motivation

Because PyYAML doesn't work with Python 3.7.0+ (see #3473), we'll need to increasingly rely on pyenv to ensure development work is done with older versions of python. Unless we want to specify a python version and include the .python-version file for it, then we should ignore it.

### Preview link
NA