### PR TITLE
Regex pattern multiline logs Docker compose

### DIFF
--- a/content/logs/log_collection/docker.md
+++ b/content/logs/log_collection/docker.md
@@ -181,7 +181,7 @@ Use the `com.datadoghq.ad.logs` label as below on your containers to make sure t
 
   ```
   labels:
-    com.datadoghq.ad.logs: '[{"source": "java", "service": "myapp", "log_processing_rules": [{"type": "multi_line", "name": "log_start_with_date", "pattern" : "\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01])"}]}]'
+    com.datadoghq.ad.logs: '[{"source": "java", "service": "myapp", "log_processing_rules": [{"type": "multi_line", "name": "log_start_with_date", "pattern" : "\\d{4}-(0?[1-9]|1[012])-(0?[1-9]|[12][0-9]|3[01])"}]}]'
   ```
 See the [multi-line processing rule documentation][13] to get more pattern examples.
 

--- a/content/logs/log_collection/docker.md
+++ b/content/logs/log_collection/docker.md
@@ -181,7 +181,7 @@ Use the `com.datadoghq.ad.logs` label as below on your containers to make sure t
 
   ```
   labels:
-    com.datadoghq.ad.logs: '[{"source": "java", "service": "myapp", "log_processing_rules": [{"type": "multi_line", "name": "log_start_with_date", "pattern" : "\\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])"}]}]'
+    com.datadoghq.ad.logs: '[{"source": "java", "service": "myapp", "log_processing_rules": [{"type": "multi_line", "name": "log_start_with_date", "pattern" : "\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01])"}]}]'
   ```
 See the [multi-line processing rule documentation][13] to get more pattern examples.
 


### PR DESCRIPTION
### What does this PR do?
Previous PR: https://github.com/DataDog/documentation/pull/3423

This was retested after further discussions with the customer, and it appears that the correct regex is `\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01])` and not `\\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])`.

Procedure we followed to have this tested:
- Spin up a VM with Agent on host
- Create a container thanks to a Docker compose with different regex patterns (see below)
- Ssh into the container
- Create a file containing Java logs from the [doc](https://docs.datadoghq.com/logs/log_collection/docker/?tab=javamultilinelogs#activate-log-integrations) 

```
2018-01-03T09:24:24.983Z UTC Exception in thread "main" java.lang.NullPointerException
        at com.example.myproject.Book.getTitle(Book.java:16)
        at com.example.myproject.Author.getBookTitles(Author.java:25)
        at com.example.myproject.Bootstrap.main(Bootstrap.java:14)
```

- Have these Java logs collected by the Agent `cat JavaFiles >> /proc/1/fd/1`
- Check on the Log Explorer if logs are appearing

Details on tested patterns:

```
web:
    image: nginx:latest
    ports:
      - "80:80"
    labels:
      com.datadoghq.ad.check_names: '["nginx"]'
      com.datadoghq.ad.init_configs: '[{}]'
      com.datadoghq.ad.instances: '[{"nginx_status_url": "http://localhost/nginx_status/"}]'
      com.datadoghq.ad.logs: '[{"source": "nginx",  "service": "nginx", "log_processing_rules": [{"type": "multi_line", "name": "new_log_start_with_date", "pattern": "foo"}]}]'
```

Logs coming in & multiline pattern not detected, several Java logs are aggregated into one single log: https://cl.ly/9f0e8e59270c 

```
web:
    image: nginx:latest
    ports:
      - "80:80"
    labels:
      com.datadoghq.ad.check_names: '["nginx"]'
      com.datadoghq.ad.init_configs: '[{}]'
      com.datadoghq.ad.instances: '[{"nginx_status_url": "http://localhost/nginx_status/"}]'
      com.datadoghq.ad.logs: '[{"source": "nginx",  "service": "nginx", "log_processing_rules": [{"type": "multi_line", "name": "new_log_start_with_date", "pattern": "\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])"}]}]'
```

No logs coming in at all

```
web:
    image: nginx:latest
    ports:
      - "80:80"
    labels:
      com.datadoghq.ad.check_names: '["nginx"]'
      com.datadoghq.ad.init_configs: '[{}]'
      com.datadoghq.ad.instances: '[{"nginx_status_url": "http://localhost/nginx_status/"}]'
      com.datadoghq.ad.logs: '[{"source": "nginx",  "service": "nginx", "log_processing_rules": [{"type": "multi_line", "name": "new_log_start_with_date", "pattern": "\\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])"}]}]'
```

No logs coming in at all

```
web:
    image: nginx:latest
    ports:
      - "80:80"
    labels:
      com.datadoghq.ad.check_names: '["nginx"]'
      com.datadoghq.ad.init_configs: '[{}]'
      com.datadoghq.ad.instances: '[{"nginx_status_url": "http://localhost/nginx_status/"}]'
      com.datadoghq.ad.logs: '[{"source": "nginx",  "service": "nginx", "log_processing_rules": [{"type": "multi_line", "name": "new_log_start_with_date", "pattern": "\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01])"}]}]'
```

Logs are coming in and being parsed correctly: https://cl.ly/7ee992482582 

### Motivation
This PR is related to the same ticket as the previous one: https://datadog.zendesk.com/agent/tickets/178123
