### PR TITLE
Remove outdated note about monitor time aggregators

### DIFF
--- a/content/monitors/monitor_types/metric.md
+++ b/content/monitors/monitor_types/metric.md
@@ -52,8 +52,8 @@ further_reading:
   * The **threshold** options vary slightly depending on what alert type you have chosen. For either case, you input a threshold and comparison type based on your metric. As you change your threshold, you can see the graph update with a marker showing the cutoff point.
   {{< img src="monitors/monitor_types/metric/metric_threshold.png" alt="metric threshold" responsive="true" >}}
   Note that you can use formatted values in this input based on the metric itself. For example, if you are monitoring `system.disk.used`, you can give a threshold of `20GB`.
-  For a **threshold alert** you are able to chose a *time aggregation* of the data. The alerting engine generates a single series and perform selected aggregation.
-  Let's look at the details of each option:
+  For a **threshold alert** you are able to chose a *time aggregation* of the data. The alerting engine generates a single series and performs selected aggregation.
+  The details of each option:
 
     * **on average**: The series is averaged to produce a single value that is checked against the threshold. It adds the `avg()` [functions][6] at the beginning of your monitor query.
 

--- a/content/monitors/monitor_types/metric.md
+++ b/content/monitors/monitor_types/metric.md
@@ -63,8 +63,6 @@ further_reading:
 
     * **in total**: If the summation of every point in the series is outside the threshold then an alert is triggered. It adds the `sum()` [functions][6] at the beginning of your monitor query.
 
-    Note the **on average** and **at all times** aggregations *require* a full window of data in the final series. This does *not* mean that each series must be full but that there shouldn't be a gap of more than 1 minute across all aggregated series. In other words, we recommend using **at least once** or **in total** for metrics with > 1 minute interval.
-
   - When you select the **change alert** option, you have additional parameters you can adjust:
 
     -  *change* is an absolute change of the value whereas *% change* is the percentage change of your value compared to its previous value (so if it was a value of 2 and now 4, the *% change* is 100%).

--- a/content/monitors/monitor_types/metric.md
+++ b/content/monitors/monitor_types/metric.md
@@ -51,22 +51,22 @@ further_reading:
 
   * The **threshold** options vary slightly depending on what alert type you have chosen. For either case, you input a threshold and comparison type based on your metric. As you change your threshold, you can see the graph update with a marker showing the cutoff point.
   {{< img src="monitors/monitor_types/metric/metric_threshold.png" alt="metric threshold" responsive="true" >}}
-  Note that you can use formatted values in this input based on the metric itself. For example, if you are monitoring `system.disk.used`, you can give a threshold of `20GB`.  
-  For a **threshold alert** you are able to chose a *time aggregation* of the data. The alerting engine generates a single series and perform selected aggregation.  
+  Note that you can use formatted values in this input based on the metric itself. For example, if you are monitoring `system.disk.used`, you can give a threshold of `20GB`.
+  For a **threshold alert** you are able to chose a *time aggregation* of the data. The alerting engine generates a single series and perform selected aggregation.
   Let's look at the details of each option:
-    
-    * **on average**: The series is averaged to produce a single value that is checked against the threshold. It adds the `avg()` [functions][6] at the beginning of your monitor query. 
-    
+
+    * **on average**: The series is averaged to produce a single value that is checked against the threshold. It adds the `avg()` [functions][6] at the beginning of your monitor query.
+
     * **at least once**: If any single value in the generated series crosses the threshold then an alert is triggered. It adds the `max()` [functions][6] at the beginning of your monitor query.
-    
+
     * **at all times**: If every point in the generated series is outside the threshold then an alert is triggered. It adds the `min()` [functions][6] at the beginning of your monitor query.
 
     * **in total**: If the summation of every point in the series is outside the threshold then an alert is triggered. It adds the `sum()` [functions][6] at the beginning of your monitor query.
-  
+
     Note the **on average** and **at all times** aggregations *require* a full window of data in the final series. This does *not* mean that each series must be full but that there shouldn't be a gap of more than 1 minute across all aggregated series. In other words, we recommend using **at least once** or **in total** for metrics with > 1 minute interval.
 
   - When you select the **change alert** option, you have additional parameters you can adjust:
-    
+
     -  *change* is an absolute change of the value whereas *% change* is the percentage change of your value compared to its previous value (so if it was a value of 2 and now 4, the *% change* is 100%).
     - You can compare the change of the value during a given timeframe by selecting the period you want to compare against. This can range from 5 minutes to up to 2 days.
     - Like the **threshold alert**, select the *time aggregation* and a *time window* on which the change is calculated.
@@ -79,18 +79,18 @@ further_reading:
 
 6. You can optionally **notify on no data** after a configurable timeframe. At the minimum, your chosen timeframe must be greater than 2x the alerting window. For example, if you are alerting over the last 5 minutes then you would need to wait at least 10 minutes before notifying on missing data.
 
-7. You can opt to **automatically resolve the monitor from a triggered state**.  
-    In general you'll want to leave this option off as you only want an alert to be resolved when it's fixed.  
-  
-    The most common use-case for this option is when you have very sparse counters, e.g. for errors. When errors stop occurring, the metric stops reporting. This prevents the monitor from resolving because there are no more values to trigger a resolution. You can also set **Recovery thresholds**: thresholds added to your monitor that define an additional condition to a monitor's recovery from alert or warning states.  
-  
-    When you set up a threshold metric monitor, you get alerted when a metric passes the alert threshold. The recovery threshold adds a condition to the monitor's recovery such that it only enters recovered state once it has passed the recovery threshold.  
-  
+7. You can opt to **automatically resolve the monitor from a triggered state**.
+    In general you'll want to leave this option off as you only want an alert to be resolved when it's fixed.
+
+    The most common use-case for this option is when you have very sparse counters, e.g. for errors. When errors stop occurring, the metric stops reporting. This prevents the monitor from resolving because there are no more values to trigger a resolution. You can also set **Recovery thresholds**: thresholds added to your monitor that define an additional condition to a monitor's recovery from alert or warning states.
+
+    When you set up a threshold metric monitor, you get alerted when a metric passes the alert threshold. The recovery threshold adds a condition to the monitor's recovery such that it only enters recovered state once it has passed the recovery threshold.
+
     **Note**: Your metric value needs to be strictly below/above the recovery threshold for the monitor to recover
 
 8. Configure your **notification options** Refer to the [Notifications][7] dedicated documentation page for a detailed options.
 
-## Further Reading 
+## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 


### PR DESCRIPTION
### What does this PR do?

It removes information that is out of date. I believe at one point we implicitly enabled "require a full window" for `on average` and `at all times`, but this is no longer the case. Users can now configure "require a full window" independently of the monitor's time aggregation method.