### PR TITLE
Docs for proxies that have support for datadog APM

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -739,11 +739,23 @@ languages:
         #  weight: 100
         #  parent: menu_references_tracing
 
-        - identifier: customnav_tracingnav_security
-          name: "Security"
-          url: "tracing/security"
+        # Proxy Configuration
+        - identifier: customnav_tracingnav_proxy_config
+          name: "Proxy Configuration"
+          url: "tracing/proxies/"
           weight: 70
           parent: menu_references_tracing
+        - identifier: customnav_tracingnav_proxy_config_nginx
+          name: "NGINX"
+          url: "tracing/proxies/nginx"
+          weight: 710
+          parent: customnav_tracingnav_proxy_config
+        - identifier: customnav_tracingnav_proxy_config_envoy
+          name: "Envoy"
+          url: "tracing/proxies/envoy"
+          weight: 720
+          parent: customnav_tracingnav_proxy_config
+
 
         # TRACING/APM - Subnav end
 
@@ -1780,6 +1792,23 @@ languages:
           url: "developers/libraries/#apm-tracing-client-libraries"
           weight: 60
           parent: menu_references_tracing
+
+        # Proxy Configuration
+        - identifier: customnav_tracingnav_proxy_config
+          name: "Proxy Configuration"
+          url: "tracing/proxies/"
+          weight: 70
+          parent: menu_references_tracing
+        - identifier: customnav_tracingnav_proxy_config_nginx
+          name: "NGINX"
+          url: "tracing/proxies/nginx"
+          weight: 710
+          parent: customnav_tracingnav_proxy_config
+        - identifier: customnav_tracingnav_proxy_config_envoy
+          name: "Envoy"
+          url: "tracing/proxies/envoy"
+          weight: 720
+          parent: customnav_tracingnav_proxy_config
 
         #- identifier: customnav_tracingnav_faq
         #  name: "FAQ"

--- a/content/tracing/proxies/_index.md
+++ b/content/tracing/proxies/_index.md
@@ -1,0 +1,10 @@
+---
+title: Proxy Configuration
+kind: documentation
+---
+
+{{< whatsnext desc="Support for Datadog APM is available in these proxy applications:">}}
+    {{< nextlink href="tracing/proxies/nginx" >}}NGINX Open Source{{< /nextlink >}}
+    {{< nextlink href="tracing/proxies/envoy" >}}Envoy{{< /nextlink >}}
+{{< /whatsnext >}}
+

--- a/content/tracing/proxies/envoy.md
+++ b/content/tracing/proxies/envoy.md
@@ -21,9 +21,14 @@ It is available in the `envoyproxy/envoy:latest` docker container, and is includ
 
 ## Enabling Datadog APM
 
-Three settings are required to enable Datadog APM in Envoy.
+Three settings are required to enable Datadog APM in Envoy:
+
+- a cluster for submitting traces to the Datadog Agent
+- `tracing` configuration to enable the Datadog APM extension
+- `http_connection_manager` configuration to activate tracing
 
 A cluster for submitting traces to the Datadog Agent needs to be added.
+
 ```yaml
   clusters:
   ... existing cluster configs ...
@@ -36,9 +41,11 @@ A cluster for submitting traces to the Datadog Agent needs to be added.
         address: localhost
         port_value: 8126
 ```
-The address value may need to be changed if Envoy is running in a container or orchestrated environment.
+
+The `address` value may need to be changed if Envoy is running in a container or orchestrated environment.
 
 Envoy's tracing configuration needs to use the Datadog APM extension.
+
 ```yaml
 tracing:
   http:
@@ -47,10 +54,12 @@ tracing:
       collector_cluster: datadog_agent
       service_name: envoy
 ```
+
 The `collector_cluster` value must match the name provided for the Datadog Agent cluster.
 The `service_name` can be changed to a meaningful value for your usage of Envoy.
 
 Finally, the `http_connection_manager` sections need to include additional configuration to enable tracing.
+
 ```yaml
       - name: envoy.http_connection_manager
         config:

--- a/content/tracing/proxies/envoy.md
+++ b/content/tracing/proxies/envoy.md
@@ -36,7 +36,7 @@ A cluster for submitting traces to the Datadog Agent needs to be added.
         address: localhost
         port_value: 8126
 ```
-The address value may need to be changed if envoy is running in a container or orchestrated environment.
+The address value may need to be changed if Envoy is running in a container or orchestrated environment.
 
 Envoy's tracing configuration needs to use the Datadog APM extension.
 ```yaml
@@ -94,7 +94,7 @@ static_resources:
     - socket_address:
         address: service2
         port_value: 80
-  # The cluster to communicate with the datadog agent
+  # The cluster to communicate with the Datadog Agent
   - name: datadog_agent
     connect_timeout: 1s
     type: strict_dns

--- a/content/tracing/proxies/envoy.md
+++ b/content/tracing/proxies/envoy.md
@@ -63,7 +63,6 @@ Finally, the `http_connection_manager` sections need to include additional confi
 ```yaml
       - name: envoy.http_connection_manager
         config:
-          generate_request_id: true
           tracing:
             operation_name: egress
 ```
@@ -122,7 +121,6 @@ static_resources:
       - name: envoy.http_connection_manager
         config:
           # Enable tracing for this listener
-          generate_request_id: true
           tracing:
             operation_name: egress
           codec_type: auto

--- a/content/tracing/proxies/envoy.md
+++ b/content/tracing/proxies/envoy.md
@@ -1,0 +1,66 @@
+---
+title: Envoy
+kind: Documentation
+further_reading:
+- link: "tracing/visualization/"
+  tag: "Use the APM UI"
+  text: "Explore your services, resources and traces"
+- link: "https://www.envoyproxy.io/"
+  tag: "Documentation"
+  text: "Envoy website"
+- link: "https://www.envoyproxy.io/docs/envoy/latest/"
+  tag: "Documentation"
+  text: "Envoy documentation"
+- link: "https://github.com/DataDog/dd-opentracing-cpp"
+  tag: "Source Code"
+  text: Datadog OpenTracing C++ Client
+---
+
+Support for Datadog APM has been included in Envoy.
+It is available in the `envoyproxy/envoy:latest` docker container, and is included in the upcoming 1.9.0 release.
+
+## Enabling Datadog APM
+
+Three settings are required to enable Datadog APM in Envoy.
+
+A cluster for submitting traces to the Datadog Agent needs to be added.
+```yaml
+  clusters:
+  ... existing cluster configs ...
+  - name: datadog_agent
+    connect_timeout: 1s
+    type: strict_dns
+    lb_policy: round_robin
+    hosts:
+    - socket_address:
+        address: localhost
+        port_value: 8126
+```
+The address value may need to be changed if envoy is running in a container or orchestrated environment.
+
+Envoy's tracing configuration needs to use the Datadog APM extension.
+```yaml
+tracing:
+  http:
+    name: envoy.tracers.datadog
+    config:
+      collector_cluster: datadog_agent
+      service_name: envoy
+```
+The `collector_cluster` value must match the name provided for the Datadog Agent cluster.
+The `service_name` can be changed to a meaningful value for your usage of Envoy.
+
+Finally, the `http_connection_manager` sections need to include additional configuration to enable tracing.
+```yaml
+      - name: envoy.http_connection_manager
+        config:
+	  generate_request_id: true
+          tracing:
+            operation_name: egress
+```
+
+After completing this configuration, HTTP requests to Envoy will initiate and propagate Datadog traces, and will appear in the APM UI.
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}

--- a/content/tracing/proxies/envoy.md
+++ b/content/tracing/proxies/envoy.md
@@ -54,7 +54,7 @@ Finally, the `http_connection_manager` sections need to include additional confi
 ```yaml
       - name: envoy.http_connection_manager
         config:
-	  generate_request_id: true
+          generate_request_id: true
           tracing:
             operation_name: egress
 ```

--- a/content/tracing/proxies/nginx.md
+++ b/content/tracing/proxies/nginx.md
@@ -1,0 +1,92 @@
+---
+title: NGINX
+kind: Documentation
+further_reading:
+- link: "tracing/visualization/"
+  tag: "Use the APM UI"
+  text: "Explore your services, resources and traces"
+- link: "https://www.nginx.com/"
+  tag: "Documentation"
+  text: "NGINX website"
+- link: "https://github.com/opentracing-contrib/nginx-opentracing"
+  tag: "Source Code"
+  text: "NGINX plugin for OpenTracing"
+- link: "https://github.com/DataDog/dd-opentracing-cpp"
+  tag: "Source Code"
+  text: Datadog OpenTracing C++ Client
+---
+
+Support for Datadog APM is available for NGINX using a combination of plugins and configuration.
+The instructions below use NGINX from the official [linux repositories][nginx-repos], and pre-built binaries for the plugins
+
+## Plugin Installation
+
+The following plugins must be installed
+
+- NGINX plugin for OpenTracing - [v0.7.0][ot-plugin] - installed in `/usr/lib/nginx/modules`
+- Datadog Opentracing C++ Plugin - [v0.3.5][dd-plugin] - installed in `/usr/local/lib`
+
+Commands to download and install these modules:
+```bash
+# Install NGINX plugin for OpenTracing
+wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/v0.7.0/linux-amd64-nginx-1.14.0-ngx_http_module.so.tgz
+tar zxf linux-amd64-nginx-1.14.0-ngx_http_module.so.tgz -C /usr/lib/nginx/modules
+# Install Datadog Opentracing C++ Plugin
+wget https://github.com/DataDog/dd-opentracing-cpp/releases/download/v0.3.5/linux-amd64-libdd_opentracing_plugin.so.gz
+gunzip linux-amd64-libdd_opentracing_plugin.so.gz -c > /usr/local/lib/libdd_opentracing_plugin.so
+```
+
+## NGINX Configuration
+
+The nginx configuration must load the OpenTracing module
+```nginx
+load_module modules/ngx_http_opentracing_module.so; # Load OpenTracing module
+```
+
+The `http` section enables the opentracing module and loads the Datadog tracer.
+```nginx
+    opentracing on; # Enable OpenTracing
+    opentracing_tag http_user_agent $http_user_agent; # Add a tag to each trace!
+    opentracing_trace_locations off; # Emit only one span per request.
+
+    # Load the Datadog tracing implementation, and the given config file.
+    opentracing_load_tracer /usr/local/lib/libdd_opentracing_plugin.so /etc/dd-config.json;
+```
+
+Locations within the server where tracing is desired should add the following:
+```nginx
+            opentracing_operation_name "$request_method $uri";
+            opentracing_tag "resource.name" "/";
+```
+
+A config file for the Datadog tracing implementation is also required.
+```json
+{
+  "service": "nginx",
+  "operation_name_override": "nginx.handle",
+  "agent_host": "localhost",
+  "agent_port": 8126
+}
+```
+
+The `service` value can be modified to a meaningful value for your usage of NGINX.
+The `agent_host` value mayb need to be changed if NGINX is running in a container or orchestrated environment.
+
+Complete examples:
+
+- [nginx.conf][example-nginx]
+- [dd-config.json][example-dd-config]
+
+
+After completing this configuration, HTTP requests to NGINX will initiate and propagate Datadog traces, and will appear in the APM UI.
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[nginx-repos]: http://nginx.org/en/linux_packages.html#stable
+[ot-plugin]: https://github.com/opentracing-contrib/nginx-opentracing/releases/download/v0.7.0/linux-amd64-nginx-1.14.0-ngx_http_module.so.tgz
+[dd-plugin]: https://github.com/DataDog/dd-opentracing-cpp/releases/download/v0.3.5/linux-amd64-libdd_opentracing_plugin.so.gz
+[example-nginx]: https://github.com/DataDog/dd-opentracing-cpp/blob/master/examples/nginx-tracing/nginx.conf
+[example-dd-config]: https://github.com/DataDog/dd-opentracing-cpp/blob/master/examples/nginx-tracing/dd-config.json
+

--- a/content/tracing/proxies/nginx.md
+++ b/content/tracing/proxies/nginx.md
@@ -27,6 +27,7 @@ The following plugins must be installed:
 - Datadog OpenTracing C++ Plugin - [v0.3.5][dd-plugin] - installed in `/usr/local/lib`
 
 Commands to download and install these modules:
+
 ```bash
 # Install NGINX plugin for OpenTracing
 wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/v0.7.0/linux-amd64-nginx-1.14.0-ngx_http_module.so.tgz
@@ -38,12 +39,14 @@ gunzip linux-amd64-libdd_opentracing_plugin.so.gz -c > /usr/local/lib/libdd_open
 
 ## NGINX Configuration
 
-The NGINX configuration must load the OpenTracing module
+The NGINX configuration must load the OpenTracing module.
+
 ```nginx
 load_module modules/ngx_http_opentracing_module.so; # Load OpenTracing module
 ```
 
 The `http` section enables the OpenTracing module and loads the Datadog tracer:
+
 ```nginx
     opentracing on; # Enable OpenTracing
     opentracing_tag http_user_agent $http_user_agent; # Add a tag to each trace!
@@ -54,12 +57,14 @@ The `http` section enables the OpenTracing module and loads the Datadog tracer:
 ```
 
 Locations within the server where tracing is desired should add the following:
+
 ```nginx
             opentracing_operation_name "$request_method $uri";
             opentracing_tag "resource.name" "/";
 ```
 
 A config file for the Datadog tracing implementation is also required:
+
 ```json
 {
   "service": "nginx",

--- a/content/tracing/proxies/nginx.md
+++ b/content/tracing/proxies/nginx.md
@@ -70,7 +70,7 @@ A config file for the Datadog tracing implementation is also required.
 ```
 
 The `service` value can be modified to a meaningful value for your usage of NGINX.
-The `agent_host` value mayb need to be changed if NGINX is running in a container or orchestrated environment.
+The `agent_host` value may need to be changed if NGINX is running in a container or orchestrated environment.
 
 Complete examples:
 

--- a/content/tracing/proxies/nginx.md
+++ b/content/tracing/proxies/nginx.md
@@ -16,15 +16,15 @@ further_reading:
   text: Datadog OpenTracing C++ Client
 ---
 
-Support for Datadog APM is available for NGINX using a combination of plugins and configuration.
-The instructions below use NGINX from the official [linux repositories][nginx-repos], and pre-built binaries for the plugins
+Support for Datadog APM is available for NGINX using a combination of plugins and configurations.
+The instructions below use NGINX from the official [Linux repositories][nginx-repos] and pre-built binaries for the plugins.
 
 ## Plugin Installation
 
-The following plugins must be installed
+The following plugins must be installed:
 
 - NGINX plugin for OpenTracing - [v0.7.0][ot-plugin] - installed in `/usr/lib/nginx/modules`
-- Datadog Opentracing C++ Plugin - [v0.3.5][dd-plugin] - installed in `/usr/local/lib`
+- Datadog OpenTracing C++ Plugin - [v0.3.5][dd-plugin] - installed in `/usr/local/lib`
 
 Commands to download and install these modules:
 ```bash
@@ -38,12 +38,12 @@ gunzip linux-amd64-libdd_opentracing_plugin.so.gz -c > /usr/local/lib/libdd_open
 
 ## NGINX Configuration
 
-The nginx configuration must load the OpenTracing module
+The NGINX configuration must load the OpenTracing module
 ```nginx
 load_module modules/ngx_http_opentracing_module.so; # Load OpenTracing module
 ```
 
-The `http` section enables the opentracing module and loads the Datadog tracer.
+The `http` section enables the OpenTracing module and loads the Datadog tracer:
 ```nginx
     opentracing on; # Enable OpenTracing
     opentracing_tag http_user_agent $http_user_agent; # Add a tag to each trace!
@@ -59,7 +59,7 @@ Locations within the server where tracing is desired should add the following:
             opentracing_tag "resource.name" "/";
 ```
 
-A config file for the Datadog tracing implementation is also required.
+A config file for the Datadog tracing implementation is also required:
 ```json
 {
   "service": "nginx",


### PR DESCRIPTION
### What does this PR do?
Adds documentation for proxy servers that are able to generate and propagate tracing data for APM.

### Motivation
This relates to recent development for nginx and envoy to add these features.

### Additional Notes
First time submitting docs changes, so review should have a strong focus on the style and tone requirements, in addition to the content.