### PR TITLE
Manage Downtimes Link Correction

### DIFF
--- a/content/monitors/downtimes.md
+++ b/content/monitors/downtimes.md
@@ -65,7 +65,7 @@ To schedule downtime, click the "Schedule Downtime" button in the upper right.
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadog.com/monitors#/downtime
+[1]: https://app.datadoghq.com/monitors#/downtime
 [2]: /graphing/graphing_json/#scope
 [3]: http://daringfireball.net/projects/markdown/syntax
 [4]: https://app.datadoghq.com/account/settings#integrations


### PR DESCRIPTION
### What does this PR do?
Corrects `app.datadog.com` -> `app.datadoghq.com` in 'Manage Downtime'
https://docs.datadoghq.com/monitors/downtimes/#manage-downtime

