### PR TITLE
Remove distributions metric

### DIFF
--- a/content/developers/metrics/_index.md
+++ b/content/developers/metrics/_index.md
@@ -49,11 +49,10 @@ Metrics reported by the Agent are in a pseudo-hierarchical dotted format (e.g. `
 
 The "Datadog in-app type" affects how a given metric is interpreted in query results and graph visualizations across the application. The metric type visible on the [metric summary page][20] is the Datadog in-app type. You should only change the type if you have started submitting this metric with a new type, and should be aware that changing the type may render historical data nonsensical.
 
-In the Datadog web application there are five metric types (though one is deprecated):
+In the Datadog web application there are four metric types (though one is deprecated):
 
 * COUNT
 * COUNTER (deprecated)
-* DISTRIBUTION
 * GAUGE
 * RATE
 
@@ -69,7 +68,6 @@ Datadog accepts metrics submitted from a variety of sources, and as a result the
 | [API][3]            | `api.Metric.send(type="gauge", ...)` | gauge             | gauge               |
 | [API][3]            | `api.Metric.send(type="rate", ...)`  | rate              | rate                |
 | [DogStatsD][1]      | `dog.gauge(...)`                     | gauge             | gauge               |
-| [DogStatsD][1]      | `dog.distribution(...)`              | distribution      | distribution        |
 | [DogStatsD][1]      | `dog.histogram(...)`                 | histogram         | gauge, rate         |
 | [DogStatsD][1]      | `dog.increment(...)`                 | counter           | rate                |
 | [DogStatsD][1]      | `dog.set(...)`                       | set               | gauge               |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes distributions metric because it's not actually an in-app metric type.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
