### PR TITLE
Enable APM by default on Elastic Beanstalk example

### DIFF
--- a/ja/content/integrations/awsbeanstalk.md
+++ b/ja/content/integrations/awsbeanstalk.md
@@ -76,6 +76,14 @@ The following snippet illustrates a `Dockerrun.aws.json` declaring the Datadog a
             {
               "name": "TAGS",
               "value": "simple-tag-0, tag-key-1:tag-value-1"
+            },
+            {
+              "name": "DD_APM_ENABLED",
+              "value": "True"
+            },
+            {
+              "name": "DD_APM_NON_LOCAL_TRAFFIC",
+              "value": "True"
             }
       ],
       "memory": 256,


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Enables APM by default for the Elastic Beanstalk example.

### Motivation
<!-- What inspired you to submit this pull request?-->
The APM team has been working to improve the eases of installation for the APM tracer. This has meant enabling it by default, in as many places as possible.

### Preview link
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/kirk.kaiser/elastic-beanstalk-apm-by-default/integrations/amazon_elasticbeanstalk/#task-definition

^^^ does not match my changes

### Additional Notes
<!-- Anything else we should know when reviewing?-->
