### PR TITLE
add troubleshooting information about Heroku

### DIFF
--- a/content/agent/basic_agent_usage/heroku.md
+++ b/content/agent/basic_agent_usage/heroku.md
@@ -57,6 +57,63 @@ Heroku dynos are ephemeral-they can move to different host machines whenever new
 
 Depending on your use case, you may want to set your hostname so that hosts are aggregated and report a lower number.  To do this, Set `DD_DYNO_HOST` to `true`. This causes the Agent to report the hostname as the dyno name (e.g. `web.1` or `run.1234`), so your host count will match your dyno usage. One drawback is that you may see some metrics continuity errors whenever a dyno is cycled.
 
+## Files Locations
+
+- The Datadog Agent is installed at `/app/.apt/opt/datadog-agent`
+- The Datadog Agent configuration files are at `/app/.apt/etc/datadog-agent`
+- The Datadog Agent logs are at `/app/.apt/var/log/datadog`
+
+
+## Troubleshooting
+
+You can verify that the Datadog Agent is listening by sending a custom metric: 
+
+```shell
+# From your project directory:
+heroku run bash
+
+# Once your Dyno has started and you are at the command line
+echo -n "custom_metric:60|g|#shell" >/dev/udp/localhost/8125
+```
+
+After a few moments, use the log explorer to verify that the metric was received.
+
+It can also be helpful to obtain logs from your running dyno:
+
+Download Datadog Agent logs:
+
+```shell
+heroku ps:copy /app/.apt/var/log/datadog/datadog.log --dyno=<YOUR DYNO NAME>
+```
+
+Download Datadog Trace Agent logs:
+
+```shell
+heroku ps:copy /app/.apt/var/log/datadog/datadog-apm.log --dyno=<YOUR DYNO NAME>
+```
+
+## Send a flare
+
+You can easily generate a flare by running:
+
+```shell
+# From your project directory:
+heroku run bash
+
+# Once your Dyno has started and you are at the command line, send a flare:
+agent -c /app/.apt/etc/datadog-agent/datadog.yaml flare
+```
+
+The flare will contain the environment information and Datadog Agent configuration. However, since this is a new, stand-alone Dyno, the logs will be sparse and may not contain full log information.
+
+You can generate a more complete flare by setting your API key as an environment variable by running:
+
+```shell
+heroku ps:exec
+DD_API_KEY=<API KEY>
+agent -c /app/.apt/etc/datadog-agent/datadog.yaml flare
+```
+
 ## More information
 
 Visit the [Github project page][6] for more information and to view the source code.

--- a/content/agent/basic_agent_usage/heroku.md
+++ b/content/agent/basic_agent_usage/heroku.md
@@ -78,7 +78,7 @@ echo -n "custom_metric:60|g|#shell" >/dev/udp/localhost/8125
 
 After a few moments, use the log explorer to verify that the metric was received.
 
-It can also be helpful to obtain logs from your running dyno:
+It can also be helpful to obtain Agent and Trace Agent logs from your running dyno.
 
 Download Datadog Agent logs:
 

--- a/content/agent/basic_agent_usage/heroku.md
+++ b/content/agent/basic_agent_usage/heroku.md
@@ -55,7 +55,7 @@ In addition to the environment variables shown above, there are a number of othe
 
 Heroku dynos are ephemeral-they can move to different host machines whenever new code is deployed, configuration changes are made, or resouce needs/availability changes. This makes Heroku flexible and responsive, but can potentially lead to a high number of reported hosts in Datadog. Datadog bills on a per-host basis, and the buildpack default is to report actual hosts, which can lead to higher than expected costs.
 
-Depending on your use case, you may want to set your hostname so that hosts are aggregated and report a lower number.  To do this, Set `DD_DYNO_HOST` to `true`. This causes the Agent to report the hostname as the dyno name (e.g. `web.1` or `run.1234`), so your host count will match your dyno usage. One drawback is that you may see some metrics continuity errors whenever a dyno is cycled.
+Depending on your use case, you may want to set your hostname so that hosts are aggregated and report a lower number. To do this, Set `DD_DYNO_HOST` to `true`. This causes the Agent to report the hostname as the dyno name (e.g. `web.1` or `run.1234`), so your host count will match your dyno usage. One drawback is that you may see some metrics continuity errors whenever a dyno is cycled.
 
 ## Files Locations
 
@@ -94,7 +94,7 @@ heroku ps:copy /app/.apt/var/log/datadog/datadog-apm.log --dyno=<YOUR DYNO NAME>
 
 ## Send a flare
 
-You can easily generate a flare by running:
+Generate a flare by running:
 
 ```shell
 # From your project directory:
@@ -104,7 +104,7 @@ heroku run bash
 agent -c /app/.apt/etc/datadog-agent/datadog.yaml flare
 ```
 
-The flare will contain the environment information and Datadog Agent configuration. However, since this is a new, stand-alone Dyno, the logs will be sparse and may not contain full log information.
+The flare contains the environment information and Datadog Agent configuration. However, since this is a new, stand-alone dyno, the logs will be sparse and may not contain full log information.
 
 You can generate a more complete flare by setting your API key as an environment variable by running:
 

--- a/content/agent/troubleshooting.md
+++ b/content/agent/troubleshooting.md
@@ -146,8 +146,8 @@ In the commands below, replace `<CASE_ID>` with your Datadog support case ID, if
 | Suse       | `sudo datadog-agent flare <CASE_ID>`                  |
 | Source     | `sudo datadog-agent flare <CASE_ID>`                  |
 | Windows    | Consult the dedicated [Windows documentation][10]     |
+| Heroku     | Consult the dedicated [Heroku documentation][13]      |
 
-[10]: /agent/basic_agent_usage/windows/#agent-v6
 
 {{% /tab %}}
 {{% tab "Agent v5" %}}
@@ -309,3 +309,4 @@ sudo journalctl -u dd-agent.service
 [10]: /agent/basic_agent_usage/windows/#agent-v6
 [11]: /agent/faq/agent-configuration-files/?tab=agentv6
 [12]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md#service-lifecycle-commands
+[13]: /agent/basic_agent_usage/heroku/#send-a-flare


### PR DESCRIPTION
### What does this PR do?

Include troubleshooting information about heroku

### Motivation

When I get tickets from customer with Heroku, linking to the docs is not helpful since the instructions aren't there

Here is the slack discussion that instigated me doing this: https://gist.github.com/nicholas-devlin/603f99f19c37cd35797763a7d0dc6c42
### Preview link

https://docs.datadoghq.com/agent/troubleshooting/?tab=agentv6#send-a-flare

https://docs.datadoghq.com/agent/basic_agent_usage/heroku/

### Additional Notes

Basing my formatting off of https://docs.datadoghq.com/agent/basic_agent_usage/windows/?tab=agentv6#agent-v6

Pulling information from https://github.com/DataDog/heroku-buildpack-datadog#submitting-issues and https://help.datadoghq.com/hc/en-us/articles/115003873966-Troubleshooting-Datadog-on-Heroku-Tips
