### PR TITLE
Add info about viewing all org tickets

### DIFF
--- a/content/developers/faq/access-your-support-ticket.md
+++ b/content/developers/faq/access-your-support-ticket.md
@@ -15,3 +15,4 @@ From here, you should be able to see your requests:
 
 However, if you don't see this after logging in, click on your name in the upper right hand corner, and then select "My Activities" from there.
 
+If you would like to view your entire organization's tickets, please reach out to our support team at support@datadoghq.com directly.


### PR DESCRIPTION
To match our public KB and inform customers about how to view all of their organization's tickets.
https://help.datadoghq.com/hc/en-us/articles/115003349826-How-can-I-access-my-Datadog-support-tickets-

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
