### PR TITLE
Add ddtrace requirement to ruby tracer

### DIFF
--- a/content/tracing/setup/ruby.md
+++ b/content/tracing/setup/ruby.md
@@ -54,6 +54,7 @@ The Ruby APM tracer sends trace data through the Datadog Agent.
 3. Create a `config/initializers/datadog.rb` file containing:
 
     ```ruby
+    require 'ddtrace'
     Datadog.configure do |c|
       # This will activate auto-instrumentation for Rails
       c.use :rails


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds a `require 'ddtrace'` to the Ruby instructions. A customer's install didn't work without it, so it's better to be explicit about it in our code example.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
