### PR TITLE
dotnet tracing updates

### DIFF
--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -115,7 +115,7 @@ apk add libc6-compat
 
 **Note:** If your application runs on IIS and you used the MSI installer, you don't need to configure environment variables manually. You may skip this section.
 
-Automatic instrumention is enabled by setting 4 environment variables:
+Automatic instrumention is enabled by setting four environment variables:
 
 {{< tabs >}}
 
@@ -149,18 +149,18 @@ DD_INTEGRATIONS=(path to integrations.json)
 
 {{% tab ".NET Framework on Windows" %}}
 
-If you used the MSI installer on Windows, the required environment variables are already set for IIS. After restarting IIS, the .NET Tracer will be enabled.
+If you used the MSI installer on Windows, the required environment variables are already set for IIS. After restarting IIS, the .NET Tracer will be enabled. If your application runs on IIS and you used the MSI installer, you may skip the rest of this section.
 
-For applications not running in IIS, you need to set these 2 environment variables to enable automatic instrumentation:
+For applications not running in IIS, you need to set these two environment variables before starting your application to enable automatic instrumentation:
 
 ```
 COR_ENABLE_PROFILING=1
 COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 ```
 
-`CORECLR_PROFILER_PATH` is not required because the MSI installer registers the native COM library in the Windows Registry, and `DD_INTEGRATIONS` is set globally for all processes.
+`COR_PROFILER_PATH` is not required because the MSI installer registers the native COM library's path in the Windows Registry, and `DD_INTEGRATIONS` is set globally for all processes.
 
-If you did not use the MSI installer, you will need to set all 4 environment variables manually:
+If you did not use the MSI installer, you will need to set all four environment variables manually:
 
 ```
 COR_ENABLE_PROFILING=1
@@ -184,18 +184,18 @@ example.exe
 
 {{% tab ".NET Core on Windows" %}}
 
-If you used the MSI installer on Windows, the required environment variables are already set for IIS. After restarting IIS, the .NET Tracer will be enabled.
+If you used the MSI installer on Windows, the required environment variables are already set for IIS. After restarting IIS, the .NET Tracer will be enabled. If your application runs on IIS and you used the MSI installer, you may skip the rest of this section.
 
-For applications not running in IIS, you need to set these 2 environment variables to enable automatic instrumentation:
+For applications not running in IIS, you need to set these two environment variables before starting your application to enable automatic instrumentation:
 
 ```
-CORECLR_ENABLE_PROFILING=1
-CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+COR_ENABLE_PROFILING=1
+COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 ```
 
-`CORECLR_PROFILER_PATH` is not required because the MSI installer registers the native COM library in the Windows Registry, and `DD_INTEGRATIONS` is set globally for all processes.
+`CORECLR_PROFILER_PATH` is not required because the MSI installer registers the native COM library's path in the Windows Registry, and `DD_INTEGRATIONS` is set globally for all processes.
 
-If you did not use the MSI installer, you will need to set all 4 environment variables manually:
+If you did not use the MSI installer, you will need to set all four environment variables manually:
 
 ```
 CORECLR_ENABLE_PROFILING=1
@@ -219,7 +219,7 @@ dotnet.exe example.dll
 
 {{% tab ".NET Core on Linux" %}}
 
-On Linux, these 4 environment variables are required to enable automatic instrumentation:
+On Linux, these four environment variables are required to enable automatic instrumentation:
 
 ```
 CORECLR_ENABLE_PROFILING=1
@@ -228,18 +228,20 @@ CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
 DD_INTEGRATIONS=/opt/datadog/integrations.json
 ```
 
-For example, to set them from a bash file:
+For example, to set them from a bash file before starting you application:
 
 ```bash
+# set environment variables
 EXPORT CORECLR_ENABLE_PROFILING=1
 EXPORT CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 EXPORT CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
 EXPORT DD_INTEGRATIONS=/opt/datadog/integrations.json
 
+# start your application
 dotnet example.dll
 ```
 
-To set them for a systemd service, use `Environment=`:
+To set the environment variables for a `systemd` service, use `Environment=`:
 
 ```ini
 [Unit]
@@ -257,9 +259,9 @@ Environment=DD_INTEGRATIONS=/opt/datadog/integrations.json
 WantedBy=multi-user.target
 ```
 
-To set the environment variable on a Linux container in Docker, use `ENV`:
+To set the environment variables on a Linux container in Docker, use `ENV`:
 
-```text
+```docker
 ENV CORECLR_ENABLE_PROFILING=1
 ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -270,15 +270,15 @@ Don’t see your desired frameworks? We’re continually adding additional suppo
 
 The .NET tracer can instrument the following web frameworks automatically:
 
-| Web framework     | Versions  | Runtime             | OS      | Support Type |
-| :---------------- | :-------- | :------------------ | :------ | :----------- |
-| ASP.NET MVC 5     | 5.2+      | .NET Framework 4.5+ | Windows | Public Beta  |
-| ASP.NET MVC 4     | 4.0.40804 | .NET Framework 4.5+ | Windows | Public Beta  |
-| ASP.NET Web API 2 | 2.2+      | .NET Framework 4.5+ | Windows | Public Beta  |
-| ASP.NET Core MVC  | 2.0+      | .NET Framework 4.5+ | Windows | Public Beta  |
-| ASP.NET Core MVC  | 2.0+      | .NET Core 2.0+      | Windows | Public Beta  |
-| ASP.NET Core MVC  | 2.0+      | .NET Core 2.0+      | Linux   | Public Beta  |
-| ASP.NET WebForms  | 4.5+      | .NET Framework 4.5+ | Windows | Coming soon  |
+| Web framework     | Versions  | Runtime             | OS      | Support Type  |
+| :---------------- | :-------- | :------------------ | :------ | :------------ |
+| ASP.NET MVC 5     | 5.1.3+    | .NET Framework 4.5+ | Windows | Public Beta   |
+| ASP.NET MVC 4     | 4.0.40804 | .NET Framework 4.5+ | Windows | Public Beta   |
+| ASP.NET Web API 2 | 2.2+      | .NET Framework 4.5+ | Windows | Public Beta   |
+| ASP.NET WebForms  | 4.5+      | .NET Framework 4.5+ | Windows | _Coming soon_ |
+| ASP.NET Core MVC  | 2.0+      | .NET Framework 4.5+ | Windows | Public Beta   |
+| ASP.NET Core MVC  | 2.0+      | .NET Core 2.0+      | Windows | Public Beta   |
+| ASP.NET Core MVC  | 2.0+      | .NET Core 2.0+      | Linux   | Public Beta   |
 
 Don’t see your desired web frameworks? We’re continually adding additional support. [Check with the Datadog team][5] to see if we can help.
 
@@ -286,15 +286,15 @@ Don’t see your desired web frameworks? We’re continually adding additional s
 
 The .NET tracer's ability to automatically instrument data store access depends on the client libraries used:
 
-| Data store    | Library or NuGet package                 | Versions   | Support type |
-| :------------ | :--------------------------------------- | :--------- | :----------- |
-| MS SQL Server | `System.Data.SqlClient` (.NET Framework) | (built-in) | Public Beta  |
-| MS SQL Server | `System.Data.SqlClient` (NuGet)          | 4.1+       | Public Beta  |
-| Redis         | `StackExchange.Redis`                    | 1.0.187+   | Public Beta  |
-| Redis         | `ServiceStack.Redis`                     | 4.0.48+    | Public Beta  |
-| Elasticsearch | `NEST` / `Elasticsearch.Net`             | 6.0.0+     | Public Beta  |
-| MongoDB       | `MongoDB.Driver`                         |            | Coming soon  |
-| PostgreSQL    | `Npgsql`                                 |            | Coming soon  |
+| Data store    | Library or NuGet package                 | Versions   | Support type  |
+| :------------ | :--------------------------------------- | :--------- | :------------ |
+| MS SQL Server | `System.Data.SqlClient` (.NET Framework) | (built-in) | Public Beta   |
+| MS SQL Server | `System.Data.SqlClient` (NuGet)          | 4.1+       | Public Beta   |
+| Redis         | `StackExchange.Redis`                    | 1.0.187+   | Public Beta   |
+| Redis         | `ServiceStack.Redis`                     | 4.0.48+    | Public Beta   |
+| Elasticsearch | `NEST` / `Elasticsearch.Net`             | 6.0.0+     | Public Beta   |
+| MongoDB       | `MongoDB.Driver`                         |            | _Coming soon_ |
+| PostgreSQL    | `Npgsql`                                 |            | _Coming soon_ |
 
 Don’t see your desired data store libraries? We’re continually adding additional support. [Check with the Datadog team][5] to see if we can help.
 

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -53,7 +53,7 @@ Install the .NET Tracer on the host using the [MSI installer for Windows](https:
 
 - Native library: deployed into `Program Files` by default and registered as a COM library in the Windows Registry by the MSI installer.
 - Managed libraries: deployed into the Global Assembly Cache (GAC) by the MSI installer, where any .NET Framework application can access them.
-- Environment variables: added for IIS only by the MSI installer. Applications that do not run in IIS will need [additional configuration](https://docs-staging.datadoghq.com/lucas/dotnet-tracing-elasticsearch-versions/tracing/setup/dotnet#adding-environment-variables) to set these environment variables.
+- Environment variables: added for IIS only by the MSI installer. Applications that do not run in IIS will need [additional configuration](https://docs.datadoghq.com/tracing/setup/dotnet/?tab=netframeworkonwindows#adding-environment-variables) to set these environment variables.
 
 {{% /tab %}}
 
@@ -65,7 +65,7 @@ Add the `Datadog.Trace.ClrProfiler.Managed` [NuGet package](https://www.nuget.or
 
 - Native library: deployed into `Program Files` by default and registered as a COM library in the Windows Registry by the MSI installer.
 - Managed libraries: deployed together with your application when it is published (via NuGet package).
-- Environment variables: added for IIS only by the MSI installer. Applications that do not run in IIS will need [additional configuration](https://docs-staging.datadoghq.com/lucas/dotnet-tracing-elasticsearch-versions/tracing/setup/dotnet#adding-environment-variables) to set these environment variables.
+- Environment variables: added for IIS only by the MSI installer. Applications that do not run in IIS will need [additional configuration](https://docs.datadoghq.com/tracing/setup/dotnet/?tab=netcoreonwindows#adding-environment-variables) to set these environment variables.
 
 {{% /tab %}}
 
@@ -105,7 +105,7 @@ apk add libc6-compat
 
 - Native library: deployed into `/opt/datadog/` by default, or manually if using the `tar` package.
 - Managed libraries: deployed together with your application when it is published (via NuGet package).
-- Environment variables: [additional configuration](https://docs-staging.datadoghq.com/lucas/dotnet-tracing-elasticsearch-versions/tracing/setup/dotnet#adding-environment-variables) required.
+- Environment variables: [additional configuration](https://docs.datadoghq.com/tracing/setup/dotnet/?tab=netcoreonlinux#adding-environment-variables) required.
 
 {{% /tab %}}
 

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -26,12 +26,12 @@ To begin tracing applications written in any language, first [install and config
 
 ## Automatic Instrumentation
 
-Automatic instrumentation uses the Profiling API provided by .NET Framework and .NET Core to modify IL instructions at run time and inject instrumentation code into your application. With zero code changes and minimal configuration, the .NET Tracer automatically instruments all supported libraries out of the box.
+Automatic instrumentation uses the Profiling API provided by .NET Framework and .NET Core to modify IL instructions at runtime and inject instrumentation code into your application. With zero code changes and minimal configuration, the .NET Tracer automatically instruments all supported libraries out of the box.
 
 Automatic instrumentation captures:
 
 - Method execution time
-- Relevant trace data such as URL and status response codes for web requests or SQL query for database access
+- Relevant trace data, such as URL and status response codes for web requests or SQL queries for database access
 - Unhandled exceptions, including stacktraces if available
 - A total count of traces (e.g. web requests) flowing through the system
 
@@ -53,7 +53,7 @@ Install the .NET Tracer on the host using the [MSI installer for Windows](https:
 
 - Native library: deployed into `Program Files` by default and registered as a COM library in the Windows Registry by the MSI installer.
 - Managed libraries: deployed into the Global Assembly Cache (GAC) by the MSI installer, where any .NET Framework application can access them.
-- Environment variables: added for IIS only by the MSI installer. Applications that do not run in IIS will need [additional configuration](?tab=netframeworkonwindows#adding-environment-variables) to set these environment variables.
+- Environment variables: added for IIS only by the MSI installer. Applications that do not run in IIS need [additional configuration](?tab=netframeworkonwindows#adding-environment-variables) to set these environment variables.
 
 {{% /tab %}}
 
@@ -65,7 +65,7 @@ Add the `Datadog.Trace.ClrProfiler.Managed` [NuGet package](https://www.nuget.or
 
 - Native library: deployed into `Program Files` by default and registered as a COM library in the Windows Registry by the MSI installer.
 - Managed libraries: deployed together with your application when it is published (via NuGet package).
-- Environment variables: added for IIS only by the MSI installer. Applications that do not run in IIS will need [additional configuration](?tab=netcoreonwindows#adding-environment-variables) to set these environment variables.
+- Environment variables: added for IIS only by the MSI installer. Applications that do not run in IIS need [additional configuration](?tab=netcoreonwindows#adding-environment-variables) to set these environment variables.
 
 {{% /tab %}}
 
@@ -97,7 +97,7 @@ curl -L https://github.com/DataDog/dd-trace-csharp/releases/download/v0.5.2-beta
 | sudo tar xzf - -C /opt/datadog
 ```
 
-For Alpine Linux you will also need to install `libc6-compat`
+For Alpine Linux you also need to install `libc6-compat`
 
 ```bash
 apk add libc6-compat
@@ -115,15 +115,15 @@ apk add libc6-compat
 
 **Note:** If your application runs on IIS and you used the MSI installer, you don't need to configure environment variables manually and you may skip this section.
 
-**Note:** The profiler will try to attach to _any_ .NET process that is started while these environment variables are set. You should limit profiling only to the applications that need to be traced. **Do not set these environment variables globally as this will cause _all_ .NET processes on the host to be profiled.**
+**Note:** The profiler tries to attach to _any_ .NET process that is started while these environment variables are set. You should limit profiling only to the applications that need to be traced. **Do not set these environment variables globally as this causes _all_ .NET processes on the host to be profiled.**
 
 {{< tabs >}}
 
 {{% tab ".NET Framework on Windows" %}}
 
-If you used the MSI installer on Windows, the required environment variables are already set for IIS. After restarting IIS, the .NET Tracer will be enabled. If your application runs on IIS and you used the MSI installer, you may skip the rest of this section.
+If you used the MSI installer on Windows, the required environment variables are already set for IIS. After restarting IIS, the .NET Tracer becomes enabled. If your application runs on IIS and you used the MSI installer, you may skip the rest of this section.
 
-For applications not running in IIS, you need to set these two environment variables before starting your application to enable automatic instrumentation:
+For applications not running in IIS, set these two environment variables before starting your application to enable automatic instrumentation:
 
 ```
 COR_ENABLE_PROFILING=1
@@ -132,7 +132,7 @@ COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 
 `COR_PROFILER_PATH` is not required because the MSI installer registers the native COM library's path in the Windows Registry, and `DD_INTEGRATIONS` is set globally for all processes.
 
-If you did not use the MSI installer, you need to set all four environment variables:
+If you did not use the MSI installer, set all four environment variables:
 
 ```
 COR_ENABLE_PROFILING=1
@@ -162,7 +162,7 @@ For Windows Services, you can set environment variables in the multi-string key 
 
 If you used the MSI installer on Windows, the required environment variables are already set for IIS. After restarting IIS, the .NET Tracer will be enabled. If your application runs on IIS and you used the MSI installer, you may skip the rest of this section.
 
-For applications not running in IIS, you need to set these two environment variables before starting your application to enable automatic instrumentation:
+For applications not running in IIS, set these two environment variables before starting your application to enable automatic instrumentation:
 
 ```
 CORECLR_ENABLE_PROFILING=1
@@ -171,7 +171,7 @@ CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 
 `CORECLR_PROFILER_PATH` is not required because the MSI installer registers the native COM library's path in the Windows Registry, and `DD_INTEGRATIONS` is set globally for all processes.
 
-If you did not use the MSI installer, you need to set all four environment variables:
+If you did not use the MSI installer, set all four environment variables:
 
 ```
 CORECLR_ENABLE_PROFILING=1
@@ -264,7 +264,7 @@ The .NET tracer supports automatic instrumentation on the following runtimes:
 
 **Note**: Libraries that target .NET Standard 2.0 are supported when running on either .NET Framework 4.6.1+ or .NET Core 2.0+.
 
-Don’t see your desired frameworks? We’re continually adding additional support. [Check with the Datadog team][5] to see if we can help.
+Don’t see your desired frameworks? Datadog is continually adding additional support. [Check with the Datadog team][5] for help.
 
 ### Web Framework Integrations
 
@@ -280,7 +280,7 @@ The .NET tracer can instrument the following web frameworks automatically:
 | ASP.NET Core MVC  | 2.0+      | .NET Core 2.0+      | Windows | Public Beta   |
 | ASP.NET Core MVC  | 2.0+      | .NET Core 2.0+      | Linux   | Public Beta   |
 
-Don’t see your desired web frameworks? We’re continually adding additional support. [Check with the Datadog team][5] to see if we can help.
+Don’t see your desired frameworks? Datadog is continually adding additional support. [Check with the Datadog team][5] for help.
 
 ### Data Store Integrations
 
@@ -296,7 +296,7 @@ The .NET tracer's ability to automatically instrument data store access depends 
 | MongoDB       | `MongoDB.Driver`                         |            | _Coming soon_ |
 | PostgreSQL    | `Npgsql`                                 |            | _Coming soon_ |
 
-Don’t see your desired data store libraries? We’re continually adding additional support. [Check with the Datadog team][5] to see if we can help.
+Don’t see your desired frameworks? Datadog is continually adding additional support. [Check with the Datadog team][5] for help.
 
 ## Manual Instrumentation
 

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -26,7 +26,7 @@ To begin tracing applications written in any language, first [install and config
 
 ## Automatic Instrumentation
 
-Automatic instrumentation uses the Profiling API provided by .NET Framework and .NET Core to modify IL instructions at run time and inject instrumentation code. With zero code changes or configuration, the .NET tracer automatically instruments all supported libraries out of the box.
+Automatic instrumentation uses the Profiling API provided by .NET Framework and .NET Core to modify IL instructions at run time and inject instrumentation code into your application. With zero code changes and minimal configuration, the .NET Tracer automatically instruments all supported libraries out of the box.
 
 Automatic instrumentation captures:
 

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -39,7 +39,7 @@ Automatic instrumentation captures:
 
 There are three components needed to enable automatic instrumentation.
 
-- Native COM library that implements the Profiling API (a `.dll` file on Windows or `.so` on Linux) to intercept method calls and inject
+- Native COM library that implements the Profiling API (a `.dll` file on Windows or `.so` on Linux) to intercept method calls
 - Managed libraries that interact with your application to measure method execution time and extract data from method arguments
 - Several environment variables that enable the Profiling API and configure the .NET Tracer
 

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -53,7 +53,7 @@ Install the .NET Tracer on the host using the [MSI installer for Windows](https:
 
 - Native library: deployed into `Program Files` by default and registered as a COM library in the Windows Registry by the MSI installer.
 - Managed libraries: deployed into the Global Assembly Cache (GAC) by the MSI installer, where any .NET Framework application can access them.
-- Environment variables: added for IIS only by the MSI installer. Applications that do not run in IIS will need additional configuration (see below) to set these environment variables.
+- Environment variables: added for IIS only by the MSI installer. Applications that do not run in IIS will need [additional configuration](https://docs-staging.datadoghq.com/lucas/dotnet-tracing-elasticsearch-versions/tracing/setup/dotnet#adding-environment-variables) to set these environment variables.
 
 {{% /tab %}}
 
@@ -65,7 +65,7 @@ Add the `Datadog.Trace.ClrProfiler.Managed` [NuGet package](https://www.nuget.or
 
 - Native library: deployed into `Program Files` by default and registered as a COM library in the Windows Registry by the MSI installer.
 - Managed libraries: deployed together with your application when it is published (via NuGet package).
-- Environment variables: added for IIS only by the MSI installer. Applications that do not run in IIS will need additional configuration (see below) to set these environment variables.
+- Environment variables: added for IIS only by the MSI installer. Applications that do not run in IIS will need [additional configuration](https://docs-staging.datadoghq.com/lucas/dotnet-tracing-elasticsearch-versions/tracing/setup/dotnet#adding-environment-variables) to set these environment variables.
 
 {{% /tab %}}
 
@@ -105,7 +105,7 @@ apk add libc6-compat
 
 - Native library: deployed into `/opt/datadog/` by default, or manually if using the `tar` package.
 - Managed libraries: deployed together with your application when it is published (via NuGet package).
-- Environment variables: additional configuration required (see below).
+- Environment variables: [additional configuration](https://docs-staging.datadoghq.com/lucas/dotnet-tracing-elasticsearch-versions/tracing/setup/dotnet#adding-environment-variables) required.
 
 {{% /tab %}}
 

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -275,7 +275,7 @@ The .NET tracer can instrument the following web frameworks automatically:
 | ASP.NET MVC 5     | 5.1.3+    | .NET Framework 4.5+ | Windows | Public Beta   |
 | ASP.NET MVC 4     | 4.0.40804 | .NET Framework 4.5+ | Windows | Public Beta   |
 | ASP.NET Web API 2 | 2.2+      | .NET Framework 4.5+ | Windows | Public Beta   |
-| ASP.NET WebForms  | 4.5+      | .NET Framework 4.5+ | Windows | _Coming soon_ |
+| ASP.NET Web Forms | 4.5+      | .NET Framework 4.5+ | Windows | _Coming soon_ |
 | ASP.NET Core MVC  | 2.0+      | .NET Framework 4.5+ | Windows | Public Beta   |
 | ASP.NET Core MVC  | 2.0+      | .NET Core 2.0+      | Windows | Public Beta   |
 | ASP.NET Core MVC  | 2.0+      | .NET Core 2.0+      | Linux   | Public Beta   |

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -53,7 +53,7 @@ Install the .NET Tracer on the host using the [MSI installer for Windows](https:
 
 - Native library: deployed into `Program Files` by default and registered as a COM library in the Windows Registry by the MSI installer.
 - Managed libraries: deployed into the Global Assembly Cache (GAC) by the MSI installer, where any .NET Framework application can access them.
-- Environment variables: added for IIS only by the MSI installer. Applications that do not run in IIS will need [additional configuration](https://docs.datadoghq.com/tracing/setup/dotnet/?tab=netframeworkonwindows#adding-environment-variables) to set these environment variables.
+- Environment variables: added for IIS only by the MSI installer. Applications that do not run in IIS will need [additional configuration](?tab=netframeworkonwindows#adding-environment-variables) to set these environment variables.
 
 {{% /tab %}}
 
@@ -65,7 +65,7 @@ Add the `Datadog.Trace.ClrProfiler.Managed` [NuGet package](https://www.nuget.or
 
 - Native library: deployed into `Program Files` by default and registered as a COM library in the Windows Registry by the MSI installer.
 - Managed libraries: deployed together with your application when it is published (via NuGet package).
-- Environment variables: added for IIS only by the MSI installer. Applications that do not run in IIS will need [additional configuration](https://docs.datadoghq.com/tracing/setup/dotnet/?tab=netcoreonwindows#adding-environment-variables) to set these environment variables.
+- Environment variables: added for IIS only by the MSI installer. Applications that do not run in IIS will need [additional configuration](?tab=netcoreonwindows#adding-environment-variables) to set these environment variables.
 
 {{% /tab %}}
 
@@ -105,7 +105,7 @@ apk add libc6-compat
 
 - Native library: deployed into `/opt/datadog/` by default, or manually if using the `tar` package.
 - Managed libraries: deployed together with your application when it is published (via NuGet package).
-- Environment variables: [additional configuration](https://docs.datadoghq.com/tracing/setup/dotnet/?tab=netcoreonlinux#adding-environment-variables) required.
+- Environment variables: [additional configuration](?tab=netcoreonlinux#adding-environment-variables) required.
 
 {{% /tab %}}
 

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -49,7 +49,7 @@ How these components are installed on the host depends on the runtime environmen
 
 {{% tab ".NET Framework on Windows" %}}
 
-Install the .NET Tracer on the host using the [MSI installer for Windows][3]. Choose the platform that matches your application: x64 for 64-bits or x86 for 32-bits. You can install both side-by-side if needed.
+Install the .NET Tracer on the host using the [MSI installer for Windows](https://github.com/DataDog/dd-trace-csharp/releases). Choose the platform that matches your application: x64 for 64-bits or x86 for 32-bits. You can install both side-by-side if needed.
 
 - Native library: deployed into `Program Files` by default and registered as a COM library in the Windows Registry by the MSI installer.
 - Managed libraries: deployed into the Global Assembly Cache (GAC) by the MSI installer, so any .NET Framework application can find them without deploying them with the application.
@@ -59,9 +59,9 @@ Install the .NET Tracer on the host using the [MSI installer for Windows][3]. Ch
 
 {{% tab ".NET Core on Windows" %}}
 
-Install the .NET Tracer on the host using the [MSI installer for Windows][3]. Choose the platform that matches your application: x64 for 64-bits or x86 for 32-bits. You can install both side-by-side if needed.
+Install the .NET Tracer on the host using the [MSI installer for Windows](https://github.com/DataDog/dd-trace-csharp/releases). Choose the platform that matches your application: x64 for 64-bits or x86 for 32-bits. You can install both side-by-side if needed.
 
-Add the `Datadog.Trace.ClrProfiler.Managed` [NuGet package][10] to your application, matching the package version to the MSI installer above. Refer to the [NuGet documentation][11] for instructions on how to add a NuGet package to your application.
+Add the `Datadog.Trace.ClrProfiler.Managed` [NuGet package](https://www.nuget.org/packages/Datadog.Trace.ClrProfiler.Managed) to your application, matching the package version to the MSI installer above. Refer to the [NuGet documentation](https://docs.microsoft.com/en-us/nuget/consume-packages/ways-to-install-a-package) for instructions on how to add a NuGet package to your application.
 
 - Native library: deployed into `Program Files` by default and registered as a COM library in the Windows Registry by the MSI installer.
 - Managed libraries: deployed together with your application when it is published (via NuGet package).
@@ -71,9 +71,9 @@ Add the `Datadog.Trace.ClrProfiler.Managed` [NuGet package][10] to your applicat
 
 {{% tab ".NET Core on Linux" %}}
 
-Add the `Datadog.Trace.ClrProfiler.Managed` [NuGet package][10] to your application, matching the package version to the package below. Refer to the [NuGet documentation][11] for instructions on how to add a NuGet package to your application.
+Add the `Datadog.Trace.ClrProfiler.Managed` [NuGet package](https://www.nuget.org/packages/Datadog.Trace.ClrProfiler.Managed) to your application, matching the package version to the package below. Refer to the [NuGet documentation](https://docs.microsoft.com/en-us/nuget/consume-packages/ways-to-install-a-package) for instructions on how to add a NuGet package to your application.
 
-Install the .NET Tracer on the host using the using one of the packages available from the `dd-trace-csharp` [releases page][3].
+Install the .NET Tracer on the host using the using one of the packages available from the `dd-trace-csharp` [releases page](https://github.com/DataDog/dd-trace-csharp/releases).
 
 For Debian or Ubuntu, download and install the Debian package:
 
@@ -340,11 +340,8 @@ For more details on supported platforms, see the [.NET Standard documentation][6
 
 [1]: https://docs.datadoghq.com/tracing/setup
 [2]: /tracing/advanced_usage/?tab=net
-[3]: https://github.com/DataDog/dd-trace-csharp/releases
 [4]: https://www.nuget.org/packages/Datadog.Trace/
 [5]: /help
 [6]: https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support
 [8]: #manual-instrumentation
 [9]: https://support.microsoft.com/en-us/help/969864/using-iisreset-exe-to-restart-internet-information-services-iis-result
-[10]: https://www.nuget.org/packages/Datadog.Trace.ClrProfiler.Managed
-[11]: https://docs.microsoft.com/en-us/nuget/consume-packages/ways-to-install-a-package

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -61,7 +61,7 @@ Install the .NET Tracer on the host using the [MSI installer for Windows][3]. Ch
 
 Install the .NET Tracer on the host using the [MSI installer for Windows][3]. Choose the platform that matches your application: x64 for 64-bits or x86 for 32-bits. You can install both side-by-side if needed.
 
-Add the `Datadog.Trace.ClrProfiler.Managed` NuGet package to your application, matching the package version to the MSI installer above. Refer to the [NuGet documentation][11] for instructions on how to add a NuGet package to your application.
+Add the `Datadog.Trace.ClrProfiler.Managed` [NuGet package][10] to your application, matching the package version to the MSI installer above. Refer to the [NuGet documentation][11] for instructions on how to add a NuGet package to your application.
 
 - Native library: deployed into `Program Files` by default and registered as a COM library in the Windows Registry by the MSI installer.
 - Managed libraries: deployed together with your application when it is published (via NuGet package).
@@ -71,9 +71,9 @@ Add the `Datadog.Trace.ClrProfiler.Managed` NuGet package to your application, m
 
 {{% tab ".NET Core on Linux" %}}
 
-Add the `Datadog.Trace.ClrProfiler.Managed` NuGet package to your application, matching the package version to the package below. Refer to the [NuGet documentation][11] for instructions on how to add a NuGet package to your application.
+Add the `Datadog.Trace.ClrProfiler.Managed` [NuGet package][10] to your application, matching the package version to the package below. Refer to the [NuGet documentation][11] for instructions on how to add a NuGet package to your application.
 
-Install the .NET Tracer on the host using the using one of the package available from the `dd-trace-csharp` [releases page][10].
+Install the .NET Tracer on the host using the using one of the packages available from the `dd-trace-csharp` [releases page][3].
 
 For Debian or Ubuntu, download and install the Debian package:
 
@@ -318,7 +318,7 @@ Don’t see your desired data store libraries? We’re continually adding additi
 
 ## Manual Instrumentation
 
-To manually instrument your code, add the `Datadog.Trace` package from [NuGet][4] to your application. In your code, access the global tracer through `Datadog.Trace.Tracer.Instance` to create new spans.
+To manually instrument your code, add the `Datadog.Trace` [NuGet package][4] to your application. In your code, access the global tracer through the `Datadog.Trace.Tracer.Instance` property to create new spans.
 
 For more details on manual instrumentation and custom tagging, see [Advanced Usage][2].
 
@@ -346,5 +346,5 @@ For more details on supported platforms, see the [.NET Standard documentation][6
 [6]: https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support
 [8]: #manual-instrumentation
 [9]: https://support.microsoft.com/en-us/help/969864/using-iisreset-exe-to-restart-internet-information-services-iis-result
-[10]: https://github.com/DataDog/dd-trace-csharp/releases
+[10]: https://www.nuget.org/packages/Datadog.Trace.ClrProfiler.Managed
 [11]: https://docs.microsoft.com/en-us/nuget/consume-packages/ways-to-install-a-package

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -35,7 +35,7 @@ Automatic instrumentation captures:
 - Unhandled exceptions, including stacktraces if available
 - A total count of traces (e.g. web requests) flowing through the system
 
-### Installing .NET Tracer libraries
+### Installing libraries
 
 There are three components needed to enable automatic instrumentation.
 
@@ -111,7 +111,7 @@ apk add libc6-compat
 
 {{< /tabs >}}
 
-#### Adding Environment Variables
+### Adding Environment Variables
 
 **Note:** If your application runs on IIS and you used the MSI installer, you don't need to configure environment variables manually. You may skip this section.
 

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -241,7 +241,7 @@ WantedBy=multi-user.target
 
 To set the environment variables on a Linux container in Docker, use `ENV`:
 
-```docker
+```
 ENV CORECLR_ENABLE_PROFILING=1
 ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -40,7 +40,7 @@ Automatic instrumentation captures:
 There are three components needed to enable automatic instrumentation.
 
 - Native COM library that implements the Profiling API (a `.dll` file on Windows or `.so` on Linux) to intercept method calls
-- Managed libraries that interact with your application to measure method execution time and extract data from method arguments
+- Managed libraries (`Datadog.Trace.dll` and `Datadog.Trace.ClrProfiler.Managed.dll`) that interact with your application to measure method execution time and extract data from method arguments
 - Several environment variables that enable the Profiling API and configure the .NET Tracer
 
 How these components are installed on the host depends on the runtime environment:

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -52,7 +52,7 @@ How these components are installed on the host depends on the runtime environmen
 Install the .NET Tracer on the host using the [MSI installer for Windows](https://github.com/DataDog/dd-trace-csharp/releases). Choose the platform that matches your application: x64 for 64-bits or x86 for 32-bits. You can install both side-by-side if needed.
 
 - Native library: deployed into `Program Files` by default and registered as a COM library in the Windows Registry by the MSI installer.
-- Managed libraries: deployed into the Global Assembly Cache (GAC) by the MSI installer, so any .NET Framework application can find them without deploying them with the application.
+- Managed libraries: deployed into the Global Assembly Cache (GAC) by the MSI installer, where any .NET Framework application can access them.
 - Environment variables: added for IIS only by the MSI installer. Applications that do not run in IIS will need additional configuration (see below) to set these environment variables.
 
 {{% /tab %}}

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -17,7 +17,7 @@ further_reading:
 ---
 
 <div class="alert alert-warning">
-.NET Tracing is in an open Public Beta and will be Generally Available in November 2018.
+.NET Tracing is in an open Public Beta.
 </div>
 
 ## Getting Started

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -115,7 +115,11 @@ apk add libc6-compat
 
 **Note:** If your application runs on IIS and you used the MSI installer, you don't need to configure environment variables manually. You may skip this section.
 
-Automatic instrumention is enabled by setting 4 environment variables on .NET Framework:
+Automatic instrumention is enabled by setting 4 environment variables:
+
+{{< tabs >}}
+
+{{% tab ".NET Framework" %}}
 
 ```bash
 COR_ENABLE_PROFILING=1
@@ -124,9 +128,22 @@ COR_PROFILER_PATH=(path to Datadog.Trace.ClrProfiler.Native library)
 DD_INTEGRATIONS=(path to integrations.json)
 ```
 
-On .NET Core, the prefix changes from `COR` to `CORECLR`. For example, `COR_ENABLE_PROFILING` becomes `CORECLR_ENABLE_PROFILING`.
+{{% /tab %}}
 
-**Note:** The profiler will try to attach to _any_ .NET process that is started while these environment variables are set, so you will want to limit them only to the applications that need to be traced. _Do not set these environment variales globally for all processes._
+{{% tab ".NET Core" %}}
+
+```bash
+CORECLR_ENABLE_PROFILING=1
+CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+CORECLR_PROFILER_PATH=(path to Datadog.Trace.ClrProfiler.Native library)
+DD_INTEGRATIONS=(path to integrations.json)
+```
+
+{{% /tab %}}
+
+{{< /tabs >}}
+
+**Note:** The profiler will try to attach to _any_ .NET process that is started while these environment variables are set. You should limit profiling only to the applications that need to be traced. **Do not set these environment variables globally as this will cause all .NET processes to be profiled.**
 
 {{< tabs >}}
 

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -170,6 +170,7 @@ The .NET tracer can instrument the following web frameworks automatically:
 | ASP.NET Core MVC  | 2.0+      | .NET Framework 4.5+ | Windows | Public Beta  |
 | ASP.NET Core MVC  | 2.0+      | .NET Core 2.0+      | Windows | Public Beta  |
 | ASP.NET Core MVC  | 2.0+      | .NET Core 2.0+      | Linux   | Public Beta  |
+| ASP.NET WebForms  | 4.5+      | .NET Framework 4.5+ | Windows | Coming soon  |
 
 Don’t see your desired web frameworks? We’re continually adding additional support. [Check with the Datadog team][5] to see if we can help.
 
@@ -181,9 +182,9 @@ The .NET tracer's ability to automatically instrument data store access depends 
 | :------------ | :--------------------------------------- | :--------- | :----------- |
 | MS SQL Server | `System.Data.SqlClient` (.NET Framework) | (built-in) | Public Beta  |
 | MS SQL Server | `System.Data.SqlClient` (NuGet)          | 4.1+       | Public Beta  |
-| Redis         | `StackExchange.Redis`                    | 1.0-1.2.x  | Public Beta  |
-| Redis         | `ServiceStack.Redis`                     | 5.2.x      | Public Beta  |
-| Elasticsearch | `NEST` / `Elasticsearch.Net`             | 6.1.0      | Public Beta  |
+| Redis         | `StackExchange.Redis`                    | 1.0.187+   | Public Beta  |
+| Redis         | `ServiceStack.Redis`                     | 4.0.48+    | Public Beta  |
+| Elasticsearch | `NEST` / `Elasticsearch.Net`             | 6.0.0+     | Public Beta  |
 | MongoDB       | `MongoDB.Driver`                         |            | Coming soon  |
 | PostgreSQL    | `Npgsql`                                 |            | Coming soon  |
 

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -113,37 +113,9 @@ apk add libc6-compat
 
 ### Adding Environment Variables
 
-**Note:** If your application runs on IIS and you used the MSI installer, you don't need to configure environment variables manually. You may skip this section.
+**Note:** If your application runs on IIS and you used the MSI installer, you don't need to configure environment variables manually and you may skip this section.
 
-Automatic instrumention is enabled by setting four environment variables:
-
-{{< tabs >}}
-
-{{% tab ".NET Framework" %}}
-
-```bash
-COR_ENABLE_PROFILING=1
-COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
-COR_PROFILER_PATH=(path to Datadog.Trace.ClrProfiler.Native library)
-DD_INTEGRATIONS=(path to integrations.json)
-```
-
-{{% /tab %}}
-
-{{% tab ".NET Core" %}}
-
-```bash
-CORECLR_ENABLE_PROFILING=1
-CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
-CORECLR_PROFILER_PATH=(path to Datadog.Trace.ClrProfiler.Native library)
-DD_INTEGRATIONS=(path to integrations.json)
-```
-
-{{% /tab %}}
-
-{{< /tabs >}}
-
-**Note:** The profiler will try to attach to _any_ .NET process that is started while these environment variables are set. You should limit profiling only to the applications that need to be traced. **Do not set these environment variables globally as this will cause all .NET processes to be profiled.**
+**Note:** The profiler will try to attach to _any_ .NET process that is started while these environment variables are set. You should limit profiling only to the applications that need to be traced. **Do not set these environment variables globally as this will cause _all_ .NET processes on the host to be profiled.**
 
 {{< tabs >}}
 
@@ -160,7 +132,7 @@ COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 
 `COR_PROFILER_PATH` is not required because the MSI installer registers the native COM library's path in the Windows Registry, and `DD_INTEGRATIONS` is set globally for all processes.
 
-If you did not use the MSI installer, you will need to set all four environment variables manually:
+If you did not use the MSI installer, you need to set all four environment variables:
 
 ```
 COR_ENABLE_PROFILING=1
@@ -169,16 +141,20 @@ COR_PROFILER_PATH=C:\Program Files\Datadog\.NET Tracer\Datadog.Trace.ClrProfiler
 DD_INTEGRATIONS=C:\Program Files\Datadog\.NET Tracer\integrations.json
 ```
 
-One way of limiting the environment variables to your application only is by using a batch file to start your application:
+For example, to set them from a batch file before starting you application:
 
 ```bat
+rem Set environment variables
 SET COR_ENABLE_PROFILING=1
 SET COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 SET COR_PROFILER_PATH=C:\Program Files\Datadog\.NET Tracer\Datadog.Trace.ClrProfiler.Native.dll
 SET DD_INTEGRATIONS=C:\Program Files\Datadog\.NET Tracer\integrations.json
 
+rem Start application
 example.exe
 ```
+
+For Windows Services, you can set environment variables in the multi-string key `HKLM\System\CurrentControlSet\Services\{service name}\Environment`.
 
 {{% /tab %}}
 
@@ -189,13 +165,13 @@ If you used the MSI installer on Windows, the required environment variables are
 For applications not running in IIS, you need to set these two environment variables before starting your application to enable automatic instrumentation:
 
 ```
-COR_ENABLE_PROFILING=1
-COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+CORECLR_ENABLE_PROFILING=1
+CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 ```
 
 `CORECLR_PROFILER_PATH` is not required because the MSI installer registers the native COM library's path in the Windows Registry, and `DD_INTEGRATIONS` is set globally for all processes.
 
-If you did not use the MSI installer, you will need to set all four environment variables manually:
+If you did not use the MSI installer, you need to set all four environment variables:
 
 ```
 CORECLR_ENABLE_PROFILING=1
@@ -204,16 +180,20 @@ CORECLR_PROFILER_PATH=C:\Program Files\Datadog\.NET Tracer\Datadog.Trace.ClrProf
 DD_INTEGRATIONS=C:\Program Files\Datadog\.NET Tracer\integrations.json
 ```
 
-One way of limiting the environment variables to your application only is by using a batch file to start your application:
+For example, to set them from a batch file before starting you application:
 
 ```bat
+rem Set environment variables
 SET CORECLR_ENABLE_PROFILING=1
 SET CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 SET CORECLR_PROFILER_PATH=C:\Program Files\Datadog\.NET Tracer\Datadog.Trace.ClrProfiler.Native.dll
 SET DD_INTEGRATIONS=C:\Program Files\Datadog\.NET Tracer\integrations.json
 
+rem Start application
 dotnet.exe example.dll
 ```
+
+For Windows Services, you can set environment variables in the multi-string key `HKLM\System\CurrentControlSet\Services\{service name}\Environment`.
 
 {{% /tab %}}
 
@@ -231,13 +211,13 @@ DD_INTEGRATIONS=/opt/datadog/integrations.json
 For example, to set them from a bash file before starting you application:
 
 ```bash
-# set environment variables
+# Set environment variables
 EXPORT CORECLR_ENABLE_PROFILING=1
 EXPORT CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 EXPORT CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
 EXPORT DD_INTEGRATIONS=/opt/datadog/integrations.json
 
-# start your application
+# Start your application
 dotnet example.dll
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Reorganize installation instructions:
- use tabs to show/hide instructions for different runtime environments
  - .NET Framework on Windows
  - .NET Core on Windows
  - .NET Core on Linux
- expand heavily on configuring environment variables

Bonus: update supported library versions

### Motivation
Since the initial beta, which only supported .NET Framework applications on IIS, we added support for more environments (e.g. .NET Core, Linux, Docker). The documentation has been lagging behind a little and become too long and confusing as a single document without tabs.

Configuring environment variables has become a common support issue since it wasn't clear what was required and when.

### Preview link
https://docs-staging.datadoghq.com/lucas/dotnet-tracing-elasticsearch-versions/tracing/setup/dotnet/

### Additional Notes
N/A
