### PR TITLE
Add last_triggered_at variable for monitor notifications

### DIFF
--- a/content/monitors/notifications.md
+++ b/content/monitors/notifications.md
@@ -48,6 +48,7 @@ Use variables to customize your monitor notifications, the available variables a
 | `{{warn_threshold}}` | Display the warning threshold selected in the monitor's *Set alert conditions* section if any. |
 | `{{ok_threshold}}`   | Display the value that recovered the monitor.                                                  |
 | `{{comparator}}`     | Display the relational value selected in the monitor's *Set alert conditions* section.         |
+| `{{last_triggered_at}}`     | Display the UTC date/time when the monitor last triggered.         |
 
 ### Tag variables
 


### PR DESCRIPTION
### What does this PR do?
Adds a `last_triggered_at` variable to the Variables table in monitor notifications.

### Motivation
Request from @MargotLepizzera 

### Preview link
<!-- Impacted pages preview links-->
