### PR TITLE
add clarification on exporting monitors alerts

### DIFF
--- a/content/monitors/faq/how-can-i-export-alert-history.md
+++ b/content/monitors/faq/how-can-i-export-alert-history.md
@@ -4,7 +4,7 @@ kind: faq
 disable_toc: true
 ---
 
-To gather an audit trail of all Monitor Alerts that have triggered during a specific period of time, reach out on the [Datadog monitor report page][1]. This generates a CSV for the past half year (182 days). 
+To gather an audit trail of all Monitor Alerts that have triggered during a specific period of time, reach out on the [Datadog monitor report page][1]. This generates a CSV for the past half year (182 days). This report is *not* live; it is updated once a week.
 
 **Note**: You need to be an Administrator of your organization to access this page.
 


### PR DESCRIPTION
### What does this PR do?
Adds a clarification that the monitor alerts report is not live, but updated once a week.

### Motivation
Request from trello

