### PR TITLE
add link to staging docs to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,5 +9,9 @@
 ### Preview link
 <!-- Impacted pages preview links-->
 
+<!-- link to preview on staging:
+https://docs-staging.datadoghq.com/<BRANCH_NAME>
+-->
+
 ### Additional Notes
 <!-- Anything else we should know when reviewing?-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,8 +9,11 @@
 ### Preview link
 <!-- Impacted pages preview links-->
 
-<!-- link to preview on staging:
-https://docs-staging.datadoghq.com/<BRANCH_NAME>
+<!-- This is the base preview link. Replace the branch name and add the complete path:
+https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>
+
+For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/setup/dotnet/", this is the preview link:
+https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/setup/dotnet/
 -->
 
 ### Additional Notes


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Edit this repository's PR template to add a preview link to the staging docs so contributors can easily find the link (since we don't get them via Slack anymore).

### Motivation
I always have to look up the URL to staging docs to include it here, so I thought it would be helpful to include it right in the PR template. It was also discussed [on Slack](https://dd.slack.com/archives/C0DESMBQU/p1544103803029200).

### Preview link
N/A

### Additional Notes
N/A
