### PR TITLE
Michaelw/use git last mod

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 title: "Docs"
 baseURL: "http://localhost:1313/"
 metadataformat: "yaml"
-
+enableGitInfo: true
 canonifyURLs: true
 pygmentsuseclasses: true
 pygmentsCodeFences: true
@@ -57,7 +57,7 @@ languages:
           url: "agent/"
           pre: "nav_agent"
           weight: 40
-        ## Basic Agent usage  
+        ## Basic Agent usage
         - identifier: customnav_agentnav_basic_usage
           name: "Basic Agent Usage"
           url: "agent/basic_agent_usage/"

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -3,9 +3,11 @@
   	  {{ if not .Params.private }}
 	  <url>
 	    <loc>{{ .Permalink }}</loc>
-	    <lastmod>{{ safeHTML ( .Date.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ with .Sitemap.ChangeFreq }}
-	    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
-	    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}
+      {{ if not .Lastmod.IsZero }}
+      <lastmod>{{ safeHTML (.Lastmod.Format "2006-01-02T15:04:05-07:00") }}</lastmod>
+      {{ end }}
+      {{ with .Sitemap.ChangeFreq }}<changefreq>{{ . }}</changefreq>{{ end }}
+      {{ if ge .Sitemap.Priority 0.0 }}<priority>{{ .Sitemap.Priority }}</priority>{{ end }}
 	  </url>
 	  {{ end }}
   {{ end }}

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -2,7 +2,6 @@
   {{ range where (where .Data.Pages "Params.beta" "!=" true) ".Params.is_public" "!=" false }}
   	  {{ if not .Params.private }}
 	  <url>
-      <gitinfo>{{ .GitInfo }}</gitinfo>
 	    <loc>{{ .Permalink }}</loc>
       {{ if not .Lastmod.IsZero }}
       <lastmod>{{ safeHTML (.Lastmod.Format "2006-01-02T15:04:05-07:00") }}</lastmod>

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -2,6 +2,7 @@
   {{ range where (where .Data.Pages "Params.beta" "!=" true) ".Params.is_public" "!=" false }}
   	  {{ if not .Params.private }}
 	  <url>
+      <gitinfo>{{ .GitInfo }}</gitinfo>
 	    <loc>{{ .Permalink }}</loc>
       {{ if not .Lastmod.IsZero }}
       <lastmod>{{ safeHTML (.Lastmod.Format "2006-01-02T15:04:05-07:00") }}</lastmod>


### PR DESCRIPTION
### What does this PR do?
timestamps are off on most posts in the sitemap because date/lastModified is not being explicitly set. This PR will attempt to use the git info for dateModified and remove the node if the date can't be determined. This _may_ not work as our gitsync to gitlab may not carry over date modified. 

### Motivation
https://trello.com/c/goFDL30c/2830-last-modified-times-on-translations-sitemap-is-incorrect

### Preview link
https://docs-staging.datadoghq.com/michaelw/use-git-last-mod/en/sitemap.xml
