### PR TITLE
Fix broken link

### DIFF
--- a/content/agent/troubleshooting.md
+++ b/content/agent/troubleshooting.md
@@ -148,6 +148,7 @@ In the commands below, replace `<CASE_ID>` with your Datadog support case ID, if
 | Windows      | Consult the dedicated [Windows documentation][10]       |
 | Heroku       | Consult the dedicated [Heroku documentation][13]        |
 
+[8]: /agent/#using-the-gui
 [10]: /agent/basic_agent_usage/windows/#agent-v6
 [13]: /agent/basic_agent_usage/heroku/#send-a-flare
 
@@ -306,7 +307,6 @@ sudo journalctl -u dd-agent.service
 [5]: /help
 [6]: /agent/faq/agent-commands/
 [7]: https://github.com/DataDog/dd-agent/blob/master/utils/flare.py
-[8]: /agent/#using-the-gui
 [9]: /agent/basic_agent_usage/windows/#agent-v5
 [10]: /agent/basic_agent_usage/windows/#agent-v6
 [11]: /agent/faq/agent-configuration-files/?tab=agentv6


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes broken link in troubleshooting page.

### Motivation
The link is broken due to a constraint with the Hugo markdown renderer. Each shortcode gets its own markdown context, so the link is invisible in that context.

### Preview link
http://docs-staging.datadoghq.com/svmhdvn/typo/agent/troubleshooting

### Additional Notes
<!-- Anything else we should know when reviewing?-->
