### PR TITLE
Add note about non local traffic for APM in basic configuration

### DIFF
--- a/content/agent/basic_agent_usage/docker.md
+++ b/content/agent/basic_agent_usage/docker.md
@@ -56,6 +56,7 @@ Optional collection Agents are disabled by default for security or performance r
 | Env Variable               | Description                                                                                                                                        |
 |----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
 | `DD_APM_ENABLED`           | Run the trace-agent along with the infrastructure Agent, allowing the container to accept traces on `8126/tcp`.                                    |
+| `DD_APM_NON_LOCAL_TRAFFIC` | Required to allow the Agent container to accept traces at `8126/tcp` from other containers.                                                        |
 | `DD_LOGS_ENABLED`          | Run the [log-agent][3] along with the infrastructure Agent.                                                                                        |
 | `DD_PROCESS_AGENT_ENABLED` | Enable live process collection in the [process-agent][4]. The Live Container View is already enabled by default if the Docker socket is available. |
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds a mention of enabling the non local traffic for APM in the Agent container. Otherwise, you might miss it, and the Agent w/ traces won't work out of the box. (Defaulting to listening on `localhost`)

### Motivation
<!-- What inspired you to submit this pull request?-->
Customer was confused, and it wasn't immediately obvious why the Agent's behavior changed after 6.2.1

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/setup/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/setup/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
