### PR TITLE
Change location of account management faq link

### DIFF
--- a/content/account_management/faq/_index.md
+++ b/content/account_management/faq/_index.md
@@ -10,6 +10,7 @@ private: true
 * [Help! My Password email never came through!][2]
 * [Is it possible to have my login belong to multiple Datadog organizations?][3]
 * [What are Datadog's password requirements?][4]
+* [How do I access my support ticket?][18]
 
 ## Service Providers
 
@@ -45,3 +46,4 @@ private: true
 [15]: /account_management/faq/how-do-i-setup-microsoft-active-directory-federation-services-as-a-saml-idp
 [16]: /account_management/faq/can-i-use-a-proxy-to-connect-my-servers-to-datadog
 [17]: /account_management/faq/how-is-datadog-retrieving-my-data-are-my-data-and-credentials-safe
+[18]: /account_management/faq/access-your-support-ticket

--- a/content/account_management/faq/access-your-support-ticket.md
+++ b/content/account_management/faq/access-your-support-ticket.md
@@ -1,6 +1,8 @@
 ---
 title: Access your support ticket
 kind: faq
+aliases:
+  - /developers/faq/access-your-support-ticket
 ---
 
 If you already have opened at least one ticket to support@datadoghq.com follow this process to access all your Datadog support tickets:


### PR DESCRIPTION
### What does this PR do?
Moves `developers/faq/access-your-support-ticket/ ` to `account_management/faq/access-your-support-ticket/`. Adds an alias just in case anyone was linking to the old incorrect link, adds new link to the account management faq index.

### Motivation
Request in #documentation
