### PR TITLE
Update min macOS version for agent v6

### DIFF
--- a/content/agent/_index.fr.md
+++ b/content/agent/_index.fr.md
@@ -172,7 +172,7 @@ les bonne permissions: Si vous êtes capable d'ouvrir `datadog.yaml`, vous pouve
 | [RedHat/CentOS x86_64][9]          | RedHat/CentOS 6 et plus                                |
 | [SUSE Enterprise Linux x86_64][10] | SUSE 11 SP4 et plus (nous ne supportons pas SysVinit)       |
 | [Fedora x86_64][11]                | Fedora 26 et plus                                      |
-| [macOS][12]                        | macOS 10.10 et plus                                      |
+| [macOS][12]                        | macOS 10.12 et plus                                      |
 | [Windows server 64-bit][13]        | Windows server 2008r2 et plus                           |
 | [Windows 64-bit][13]               | Windows 7 et plus                                       |
 

--- a/content/agent/basic_agent_usage/osx.md
+++ b/content/agent/basic_agent_usage/osx.md
@@ -23,7 +23,7 @@ This page outlines the basic features of the Datadog Agent for macOS. If you hav
 
 By default, the Agent is installed in a sandbox located at `/opt/datadog-agent`. You're free to move this folder wherever you like; however, his documentation assumes a default installation location.
 
-**Note**: macOS 10.10 and above are supported.
+**Note**: macOS 10.12 and above are supported by the Agent v6, macOS 10.10 and above by the Agent v5.
 
 ## Commands
 


### PR DESCRIPTION
### What does this PR do?

Bump the minimum needed macOS version for agent v6 from 10.10 to 10.12

### Motivation

Agent v6 is not compatible with macOS < 10.12

### Preview link

https://docs-staging.datadoghq.com/remeh/macos-min-version/agent/basic_agent_usage/osx/?tab=agentv6
https://docs-staging.datadoghq.com/remeh/macos-min-version/agent/?tab=agentv6#supported-oss-versions