### PR TITLE
Fix camelcase on GitHub

### DIFF
--- a/content/account_management/_index.fr.md
+++ b/content/account_management/_index.fr.md
@@ -39,7 +39,7 @@ Si vous êtes un administrateur d'organisation, consultez les ressources suivant
 * [Gérer les comptes multi-organisations][8]
 * [Modifier votre plan Datadog et afficher l'historique d'utilisation et de facturation][9]
 
-## Connexion à Github
+## Connexion à GitHub
 
 Si vous avez installé [l'intégration GitHub][10] pour créer des événements dans Datadog, associez votre compte GitHub personnel à votre compte utilisateur Datadog. Une fois vos comptes reliés, tous les commentaires que vous publierez sur les événements GitHub dans Datadog seront automatiquement réintégrés dans l'issue correspondante ou dans la pull request dans GitHub.
 

--- a/content/account_management/_index.md
+++ b/content/account_management/_index.md
@@ -41,7 +41,7 @@ If you are an organization administrator, reference the additional documentation
 * [Manage multi-organization accounts][9]
 * [Change your Datadog plan and view usage and billing history][10]
 
-## Connecting to Github
+## Connecting to GitHub
 
 If you have installed the [GitHub integration][11] to create events in Datadog, link your personal GitHub account to your Datadog user account. By linking your accounts, any comments you post to GitHub events in Datadog will be automatically posted back into the corresponding issue or pull request in GitHub.
 

--- a/content/agent/basic_agent_usage/_index.fr.md
+++ b/content/agent/basic_agent_usage/_index.fr.md
@@ -20,15 +20,15 @@ further_reading:
 Gérez l'Agent Datadog et ses [intégrations][1] en utilisant des outils de gestion de configurations:
 
 ### Cookbook Chef
-* [Github du projet Chef][2]
+* [GitHub du projet Chef][2]
 * [Installer l'Agent Datadog avec Chef][3]
 
 ### Puppet
-* [Github du projet Puppet][4]
+* [GitHub du projet Puppet][4]
 * [Installer l'Agent Datadog avec Puppet][5]
 
 ### Ansible
-* [Github du projet Ansible][6]
+* [GitHub du projet Ansible][6]
 * [Installer l'Agent Datadog avec Ansible][7]
 
 ### SaltStack

--- a/content/agent/basic_agent_usage/_index.md
+++ b/content/agent/basic_agent_usage/_index.md
@@ -26,7 +26,7 @@ Manage the Datadog Agent and [Integrations][1] using configuration management to
 {{< tabs >}}
 {{% tab "Chef Cookbook" %}}
 
-* [Chef Github project][1]
+* [Chef GitHub project][1]
 * [Installing Datadog Agent with Chef][2]
 
 
@@ -35,7 +35,7 @@ Manage the Datadog Agent and [Integrations][1] using configuration management to
 {{% /tab %}}
 {{% tab "Puppet" %}}
 
-* [Puppet Github project][1]
+* [Puppet GitHub project][1]
 * [Installing Datadog Agent with Puppet][2]
 
 
@@ -44,7 +44,7 @@ Manage the Datadog Agent and [Integrations][1] using configuration management to
 {{% /tab %}}
 {{% tab "Ansible" %}}
 
-* [Ansible Github project][1]
+* [Ansible GitHub project][1]
 * [Installing Datadog Agent with Ansible][2]
 
 

--- a/content/agent/basic_agent_usage/heroku.fr.md
+++ b/content/agent/basic_agent_usage/heroku.fr.md
@@ -50,7 +50,7 @@ En plus des variables d'environnement présentées ci-dessus, vous pouvez en dé
 | `DD_SERVICE_ENV` | *Optionnel* L'agent Datadog essaie automatiquement d'identifier votre environnement en recherchant un tag de la forme `env:<environment name>`. Pour plus d'informations, consultez la page [Environnements de traçage Datadog][5]. |
 
 ## Plus d'informations
-Visitez la [page du projet Github][6] pour plus d'informations et pour consultez le code source.
+Visitez la [page du projet GitHub][6] pour plus d'informations et pour consultez le code source.
 
 [1]: http://docs.datadoghq.com/libraries/
 [2]: https://app.datadoghq.com/account/settings#api

--- a/content/agent/basic_agent_usage/heroku.md
+++ b/content/agent/basic_agent_usage/heroku.md
@@ -116,7 +116,7 @@ agent -c /app/.apt/etc/datadog-agent/datadog.yaml flare
 
 ## More information
 
-Visit the [Github project page][6] for more information and to view the source code.
+Visit the [GitHub project page][6] for more information and to view the source code.
 
 [1]: /libraries
 [2]: https://app.datadoghq.com/account/settings#api

--- a/content/agent/faq/why-don-t-i-see-the-system-processes-open-file-descriptors-metric.md
+++ b/content/agent/faq/why-don-t-i-see-the-system-processes-open-file-descriptors-metric.md
@@ -23,7 +23,7 @@ If users see this line in the Datadog error.log: `sudo: sorry, you must have a t
 
 If you are running Agent v6 less than 6.3, try updating the Agent and using the `try_sudo` option. If you are unable to update, a workaround for this issue is running the Agent as `root`.
 
-**NOTE**: It is not recommended to run the Agent as `root`. This isn't specific to the Datadog Agent or due to any concern that something untrustworthy is happening in any way, but it isn't recommended to run the daemon as `root` as this is best practice for most processes on Linux. If you have any personal cause for concern, the Agent is open source and may be audited by you or your team via the [Github repository][1].
+**NOTE**: It is not recommended to run the Agent as `root`. This isn't specific to the Datadog Agent or due to any concern that something untrustworthy is happening in any way, but it isn't recommended to run the daemon as `root` as this is best practice for most processes on Linux. If you have any personal cause for concern, the Agent is open source and may be audited by you or your team via the [GitHub repository][1].
 
 1. [Stop the Agent][2]
 
@@ -40,7 +40,7 @@ If you are running Agent v6 less than 6.3, try updating the Agent and using the 
 
 If you are running Agent v5, try updating to the latest version of Agent 6 and using the `try_sudo` option. If you are unable to update, a workaround for this issue is running the Agent as `root`.
 
-**NOTE**: It is not recommended to run the Agent as `root`. This isn't specific to the Datadog Agent or due to any concern that something untrustworthy is happening in any way, but it isn't recommended to run the daemon as `root` as this is best practice for most processes on Linux. If you have any personal cause for concern, the Agent is open source and may be audited by you or your team via the [Github repository][1].
+**NOTE**: It is not recommended to run the Agent as `root`. This isn't specific to the Datadog Agent or due to any concern that something untrustworthy is happening in any way, but it isn't recommended to run the daemon as `root` as this is best practice for most processes on Linux. If you have any personal cause for concern, the Agent is open source and may be audited by you or your team via the [GitHub repository][1].
 
 1. [Stop the Agent][2]
 
@@ -57,7 +57,7 @@ If you are running Agent v5, try updating to the latest version of Agent 6 and u
 {{% /tab %}}
 {{< /tabs >}}
 
-See the following Github issues for more information and other potential methods of capturing this metric on Linux machines.
+See the following GitHub issues for more information and other potential methods of capturing this metric on Linux machines.
 
 * https://github.com/DataDog/dd-agent/issues/853
 * https://github.com/DataDog/dd-agent/issues/2033

--- a/content/agent/kubernetes/cluster.md
+++ b/content/agent/kubernetes/cluster.md
@@ -15,7 +15,7 @@ further_reading:
   tag: "Documentation"
   text: "Custom Integrations"
 - link: "https://github.com/DataDog/datadog-agent/blob/master/docs/cluster-agent/GETTING_STARTED.md#troubleshooting"
-  tag: "Github"
+  tag: "GitHub"
   text: "Troubleshooting the Datadog Cluster Agent"
 ---
 

--- a/content/developers/dogstatsd/_index.fr.md
+++ b/content/developers/dogstatsd/_index.fr.md
@@ -13,7 +13,7 @@ further_reading:
     tag: Documentation
     text: Bibliothèques pour l'API et DogStatsD officielles et maintenue par la communauté
   - link: "https://github.com/DataDog/datadog-agent/tree/master/pkg/dogstatsd"
-    tag: "Github"
+    tag: "GitHub"
     text: Code source de DogStatsD
 ---
 

--- a/content/developers/dogstatsd/_index.md
+++ b/content/developers/dogstatsd/_index.md
@@ -13,7 +13,7 @@ further_reading:
   tag: "Documentation"
   text: "Official and Community-contributed API and DogStatsD client libraries"
 - link: "https://github.com/DataDog/datadog-agent/tree/master/pkg/dogstatsd"
-  tag: "Github"
+  tag: "GitHub"
   text: "DogStatsD source code"
 ---
 

--- a/content/developers/dogstatsd/data_types.md
+++ b/content/developers/dogstatsd/data_types.md
@@ -10,7 +10,7 @@ further_reading:
   tag: "Documentation"
   text: "Official and Community-contributed API and DogStatsD client libraries"
 - link: "https://github.com/DataDog/datadog-agent/tree/master/pkg/dogstatsd"
-  tag: "Github"
+  tag: "GitHub"
   text: "DogStatsD source code"
 ---
 

--- a/content/developers/dogstatsd/datagram_shell.fr.md
+++ b/content/developers/dogstatsd/datagram_shell.fr.md
@@ -10,7 +10,7 @@ further_reading:
     tag: "Documentation"
     text: "Bibliothèques pour l'API et DogStatsD officielles et maintenue par la communauté"
   - link: "https://github.com/DataDog/datadog-agent/tree/master/pkg/dogstatsd"
-    tag: "Github"
+    tag: "GitHub"
     text: "Code source de DogStatsD"
 ---
 

--- a/content/developers/dogstatsd/datagram_shell.md
+++ b/content/developers/dogstatsd/datagram_shell.md
@@ -10,7 +10,7 @@ further_reading:
   tag: "Documentation"
   text: "Official and Community-contributed API and DogStatsD client libraries"
 - link: "https://github.com/DataDog/datadog-agent/tree/master/pkg/dogstatsd"
-  tag: "Github"
+  tag: "GitHub"
   text: "DogStatsD source code"
 ---
 

--- a/content/developers/dogstatsd/unix_socket.md
+++ b/content/developers/dogstatsd/unix_socket.md
@@ -10,7 +10,7 @@ further_reading:
   tag: "Documentation"
   text: "Official and Community-contributed API and DogStatsD client libraries"
 - link: "https://github.com/DataDog/datadog-agent/tree/master/pkg/dogstatsd"
-  tag: "Github"
+  tag: "GitHub"
   text: "DogStatsD source code"
 ---
 

--- a/content/developers/office_hours.md
+++ b/content/developers/office_hours.md
@@ -26,7 +26,7 @@ Office hours will be held in #integrations in the [Datadog Community Slack][1] (
 
 ### List of open source projects
 
-Discover the full list of [Datadog open-source projects at Github][5].
+Discover the full list of [Datadog open-source projects at GitHub][5].
 
 
 [1]: https://datadoghq.slack.com

--- a/content/graphing/_index.fr.md
+++ b/content/graphing/_index.fr.md
@@ -158,8 +158,8 @@ Note: comme la fonction log logarithmique n'accepte pas les valeurs négatives, 
 
 ### Superposer des événements pour un contexte supplémentaire
 
-Ajoutez des événements du système associé pour ajouter encore plus de contexte à votre graphique. Un exemple consisterait à ajouter des validations Github, des déploiements Jenkins ou des événements de création Docker. Cliquez simplement sur le bouton Overlay Events et entrez une requête pour trouver et afficher vos événements.
-Pour montrer quelque chose d'une source telle que Github, utilisez `sources: github`. Pour tous les événements avec le tag `role:web`, utilisez `tag:role:web`.
+Ajoutez des événements du système associé pour ajouter encore plus de contexte à votre graphique. Un exemple consisterait à ajouter des validations GitHub, des déploiements Jenkins ou des événements de création Docker. Cliquez simplement sur le bouton Overlay Events et entrez une requête pour trouver et afficher vos événements.
+Pour montrer quelque chose d'une source telle que GitHub, utilisez `sources: github`. Pour tous les événements avec le tag `role:web`, utilisez `tag:role:web`.
 
 {{< img src="graphing/index/overlay_events.png" alt="Overlay Events" responsive="true" style="width:75%;" >}}
 

--- a/content/graphing/_index.md
+++ b/content/graphing/_index.md
@@ -157,7 +157,7 @@ Note: as the mathematical log function doesn't accept negative values, the Datad
 
 ### Overlay events for additional context
 
-Add events from related systems to add even more context to your graph. For example, you can add Github commits, Jenkins deploys, or Docker creation events. Click the Overlay Events button and enter a query to find and display your events. Use the same query format as for [the event stream][16], for example:
+Add events from related systems to add even more context to your graph. For example, you can add GitHub commits, Jenkins deploys, or Docker creation events. Click the Overlay Events button and enter a query to find and display your events. Use the same query format as for [the event stream][16], for example:
 
 | Query                  | Description                                               |
 | -----                  | ----                                                      |

--- a/content/graphing/event_stream/_index.fr.md
+++ b/content/graphing/event_stream/_index.fr.md
@@ -14,7 +14,7 @@ Notez cependant que les filtres effectuent une recherche de correspondance exact
 | Filter                                          | Description                                                                      |
 | --------                                        | -------------                                                                    |
 | user:pup@datadoghq.com                          | Trouver tous les évènements avec des commentaires écrits par pup@datadoghq.com.                              |
-| sources:github,chef                             | Montrer les évènements Github OU Chef.                                                 |
+| sources:github,chef                             | Montrer les évènements GitHub OU Chef.                                                 |
 | tags:env-prod OR db                             | Montre les évènements taggués #env-prod OU #db.                                        |
 | tags:security-group:sg-123 AND role:common-node | Montre les évènements taggués #security-group:sg-123 ET #role:common-node.            |
 | hosts:i-0ade23e6,db.myapp.com                   | Montre les évènements en provenance de i-0ade23e6 OU db.myapp.com.                                     |

--- a/content/graphing/event_stream/_index.md
+++ b/content/graphing/event_stream/_index.md
@@ -15,7 +15,7 @@ Note that filters perform an exact match search and don't work with partial stri
 | Filter                                            | Description                                                                              |
 | --------                                          | -------------                                                                            |
 | `user:pup@datadoghq.com`                          | Find all events with comments by pup@datadoghq.com.                                      |
-| `sources:github,chef`                             | Show events from Github OR Chef.                                                         |
+| `sources:github,chef`                             | Show events from GitHub OR Chef.                                                         |
 | `tags:env-prod OR db`                             | Show events tagged with #env-prod OR #db.                                                |
 | `tags:security-group:sg-123 AND role:common-node` | Show events tagged with `#security-group:sg-123` AND `#role:common-node`.                |
 | `hosts:i-0ade23e6,db.myapp.com`                   | Show events from i-0ade23e6 OR db.myapp.com.                                             |

--- a/content/graphing/metrics/summary.md
+++ b/content/graphing/metrics/summary.md
@@ -42,7 +42,7 @@ Every piece of metric metadata can be manually edited:
 
 * Edit the metric description to help understand what a metric does.
 
-    If a metric is coming from an integration and you notice a wrong description, [open an issue in the Datadog documentation Github repository][11] for a fix.
+    If a metric is coming from an integration and you notice a wrong description, [open an issue in the Datadog documentation GitHub repository][11] for a fix.
 
 * Edit the metric unit or add a custom unit for a custom metrics.
 

--- a/content/integrations/faq/_index.md
+++ b/content/integrations/faq/_index.md
@@ -61,7 +61,7 @@ aliases:
 * [Why isn't Elasticsearch sending all my metrics?][35]
 * [Agent can't connect][36]
 
-## Git & Github
+## Git & GitHub
 
 * [Why events don't appear to be showing up in the event stream with my github integration ?][37]
 

--- a/content/integrations/faq/compose-and-the-datadog-agent.md
+++ b/content/integrations/faq/compose-and-the-datadog-agent.md
@@ -54,7 +54,7 @@ Finally our `redisdb.yaml` is patterned after the [redisdb.yaml.example file][4]
       - host: redis
         port: 6379
 
-For a more complete example, see our [Docker Compose example project on Github][5].
+For a more complete example, see our [Docker Compose example project on GitHub][5].
 
 [1]: https://docs.docker.com/compose/overview
 [2]: /integrations/docker_daemon

--- a/content/integrations/faq/dogstatsd-and-docker.md
+++ b/content/integrations/faq/dogstatsd-and-docker.md
@@ -45,7 +45,7 @@ docker run -d --name my-web-app \
     my-web-app
 ```
 
-For another example using DogStatsD, see our [Docker Compose example project on Github][6].
+For another example using DogStatsD, see our [Docker Compose example project on GitHub][6].
 
 [1]: /integrations
 [2]: /developers/libraries

--- a/content/integrations/faq/list-of-api-source-attribute-value.md
+++ b/content/integrations/faq/list-of-api-source-attribute-value.md
@@ -105,7 +105,7 @@ kind: faq
 |Ganglia|GANGLIA|
 |Gearman|GEARMAN|
 |Git|GIT|
-|Github|GITHUB|
+|GitHub|GITHUB|
 |Go Expvar|GOEXPVAR|
 |Google App Engine|GAE|
 |Google Cloud Big Query|GCPBIGQUERY|

--- a/content/integrations/faq/why-events-don-t-appear-to-be-showing-up-in-the-event-stream-with-my-github-integration.md
+++ b/content/integrations/faq/why-events-don-t-appear-to-be-showing-up-in-the-event-stream-with-my-github-integration.md
@@ -3,9 +3,9 @@ title: Why events don't appear to be showing up in the event stream with my gith
 kind: faq
 ---
 
-First you need to configure your Github integration, see [this dedicated documentation article][1].
+First you need to configure your GitHub integration, see [this dedicated documentation article][1].
 
-Then, If you have setup your Webhook on the relevant Github repositories and you can see it sending data but events don't appear to be showing up in the event stream this might come from your Webhook settings:
+Then, If you have setup your Webhook on the relevant GitHub repositories and you can see it sending data but events don't appear to be showing up in the event stream this might come from your Webhook settings:
 
 Instead of having your Webhook configured with content-type:application/x-www-form-urlencoded
 

--- a/content/tracing/setup/docker.md
+++ b/content/tracing/setup/docker.md
@@ -5,7 +5,7 @@ aliases:
 - /tracing/docker/
 further_reading:
 - link: "https://github.com/DataDog/datadog-trace-agent"
-  tag: "Github"
+  tag: "GitHub"
   text: "Source code"
 - link: "tracing/visualization/"
   tag: "Documentation"

--- a/content/tracing/setup/dotnet.md
+++ b/content/tracing/setup/dotnet.md
@@ -6,7 +6,7 @@ aliases:
   - /tracing/languages/dotnet
 further_reading:
   - link: "https://github.com/DataDog/dd-trace-csharp"
-    tag: "Github"
+    tag: "GitHub"
     text: "Source code"
   - link: "tracing/visualization/"
     tag: "Documentation"

--- a/content/tracing/setup/go.md
+++ b/content/tracing/setup/go.md
@@ -6,7 +6,7 @@ aliases:
 - /tracing/languages/go
 further_reading:
 - link: "https://github.com/DataDog/dd-trace-go/tree/v1"
-  tag: "Github"
+  tag: "GitHub"
   text: "Source code"
 - link: "https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
   tag: "GoDoc"

--- a/content/tracing/setup/java.md
+++ b/content/tracing/setup/java.md
@@ -6,7 +6,7 @@ aliases:
 - /tracing/languages/java
 further_reading:
 - link: "https://github.com/DataDog/dd-trace-java"
-  tag: "Github"
+  tag: "GitHub"
   text: "Datadog Java APM source code"
 - link: "tracing/visualization/"
   tag: "Documentation"

--- a/content/tracing/setup/kubernetes.md
+++ b/content/tracing/setup/kubernetes.md
@@ -5,7 +5,7 @@ aliases:
   - /tracing/kubernetes/
 further_reading:
 - link: "https://github.com/DataDog/datadog-trace-agent"
-  tag: "Github"
+  tag: "GitHub"
   text: "Source code"
 - link: "tracing/visualization/"
   tag: "Documentation"

--- a/content/tracing/setup/nodejs.md
+++ b/content/tracing/setup/nodejs.md
@@ -7,7 +7,7 @@ aliases:
 - /tracing/setup/javascript/
 further_reading:
 - link: "https://github.com/DataDog/dd-trace-js"
-  tag: "Github"
+  tag: "GitHub"
   text: "Source code"
 - link: "https://datadog.github.io/dd-trace-js"
   tag: "Documentation"

--- a/content/tracing/setup/php.md
+++ b/content/tracing/setup/php.md
@@ -3,7 +3,7 @@ title: Tracing PHP Applications
 kind: Documentation
 further_reading:
 - link: "https://github.com/DataDog/dd-trace-php"
-  tag: "Github"
+  tag: "GitHub"
   text: "Source code"
 - link: "tracing/visualization/"
   tag: "Documentation"

--- a/content/tracing/setup/python.md
+++ b/content/tracing/setup/python.md
@@ -6,7 +6,7 @@ aliases:
 - /tracing/languages/python/
 further_reading:
 - link: "https://github.com/DataDog/dd-trace-py"
-  tag: "Github"
+  tag: "GitHub"
   text: "Source code"
 - link: "http://pypi.datadoghq.com/trace/docs/"
   tag: "Pypi"

--- a/content/tracing/setup/ruby.md
+++ b/content/tracing/setup/ruby.md
@@ -6,7 +6,7 @@ aliases:
 - /tracing/languages/ruby/
 further_reading:
 - link: "https://github.com/DataDog/dd-trace-rb"
-  tag: "Github"
+  tag: "GitHub"
   text: "Source code"
 - link: "https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md"
   tag: "Documentation"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Corrects occurances of "Github" to "GitHub".

### Motivation
A user commented and made a PR on the Heroku repo.

### Preview link
https://docs-staging.datadoghq.com/jyee/github_caps/
