### PR TITLE
APM PHP - Distributed tracing and Priority sampling enabled by default

### DIFF
--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1010,6 +1010,10 @@ Distributed tracing is enabled by default for all supported integrations (see [C
 
 Coming Soon. Reach out to [the Datadog support team][1] to be part of the beta.
 
+{{% /tab %}}
+{{% tab "PHP" %}}
+
+Distributed tracing is enabled by default. 
 
 [1]: /help
 {{% /tab %}}
@@ -1201,6 +1205,10 @@ Once the sampling priority has been set, it cannot be changed. This is done auto
 
 Coming Soon. Reach out to [the Datadog support team][1] to be part of the beta.
 
+{{% /tab %}}
+{{% tab "PHP" %}}
+
+Priority sampling is enabled by default. 
 
 [1]: /help
 {{% /tab %}}


### PR DESCRIPTION


### What does this PR do?
Tell our customers that distributed tracing and priority sampling is now available and enabled by default in PHP dd tracer

### Motivation
Possibility to enable/disable distributed tracing and priority sampling #160, in 0.7.0 released 11 days ago
enabled by default:
https://github.com/DataDog/dd-trace-php/blob/0.7.0/src/DDTrace/Configuration.php

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/setup/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/setup/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
