### PR TITLE
Add warning to PagerDuty API curl example

### DIFF
--- a/content/api/integrations/code_snippets/api-integrations-pagerduty.sh
+++ b/content/api/integrations/code_snippets/api-integrations-pagerduty.sh
@@ -1,4 +1,5 @@
 # Create a new configuration.
+# WARNING: This will replace your current configuration.
 curl -v -X PUT -H "Content-type: application/json" \
 -d '{
       "services": [


### PR DESCRIPTION
### What does this PR do?
Adds a warning to PagerDuty API curl example about PUT method replacing current configuration due to common scenario of accidental deletions that results in support requests.

### Motivation
Support requests

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/setup/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/setup/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
