### PR TITLE
Remove beta from pattern documentation

### DIFF
--- a/content/logs/explorer/patterns.md
+++ b/content/logs/explorer/patterns.md
@@ -1,5 +1,5 @@
 ---
-title: Log Patterns (Beta)
+title: Log Patterns
 kind: documentation
 description: "Spot Log Patterns"
 aliases:


### PR DESCRIPTION
### What does this PR do?
Remove the beta flag

### Motivation
It is not beta anymore.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/setup/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/setup/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
