### PR TITLE
Clarify sts:assumerole error

### DIFF
--- a/content/integrations/faq/error-datadog-not-authorized-sts-assume-role.md
+++ b/content/integrations/faq/error-datadog-not-authorized-sts-assume-role.md
@@ -20,7 +20,8 @@ Check the following points for the AWS account mentioned in the error:
   {{< img src="integrations/faq/aws-error-sts-assume-role-02.png" alt="Datadog AWS integration tile" responsive="true">}}
 5. Add the newly generated AWS External ID to your AWS trust policy:
   {{< img src="integrations/faq/aws-error-sts-assume-role-03.png" alt="AWS Trust Policy" responsive="true">}}
-6. If the error persists, repeat steps 2 through 7 of the [AWS Installation instructions][1].
+6. Note, after the configuration update the error may persist in the UI for a few hours while the changes propagate.
+7. If the error persists, repeat steps 2 through 7 of the [AWS Installation instructions][1].
 
 Still need help? Contact [Datadog support][3].
 


### PR DESCRIPTION
### What does this PR do?
Add detail about how sts:assumerole error may persist in the UI.

### Motivation
Additional information provided by Datadog's cloud integrations engineering team.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/setup/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/setup/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
