### PR TITLE
Activating log and processes collection by default + EU support

### DIFF
--- a/static/json/datadog-agent-ecs-eu.json
+++ b/static/json/datadog-agent-ecs-eu.json
@@ -39,6 +39,14 @@
           "value": "<YOUR_API_KEY>"
         },
         {
+          "name": "DD_SITE",
+          "value": "datadoghq.eu"
+        },
+        {
+          "name": "DD_LOGS_CONFIG_LOGS_DD_URL",
+          "value": "agent-intake.logs.datadoghq.eu:443"
+        },
+        {
           "name": "DD_LOGS_ENABLED",
           "value": "true"
         },
@@ -84,7 +92,7 @@
     },
     {
       "host": {
-        "sourcePath": "/cgroup/"
+        "sourcePath": "/sys/fs/cgroup/"
       },
       "name": "cgroup"
     }

--- a/static/json/datadog-agent-ecs-eu.json
+++ b/static/json/datadog-agent-ecs-eu.json
@@ -57,10 +57,6 @@
         {
           "name": "DD_PROCESS_AGENT_ENABLED",
           "value": "true"
-        },
-        {
-          "name": "SD_BACKEND",
-          "value": "docker"
         }
       ]
     }

--- a/static/json/datadog-agent-ecs-eu.json
+++ b/static/json/datadog-agent-ecs-eu.json
@@ -48,7 +48,7 @@
         },
         {
           "name": "DD_LOGS_ENABLED",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL",
@@ -56,7 +56,7 @@
         },
         {
           "name": "DD_PROCESS_AGENT_ENABLED",
-          "value": "true"
+          "value": "false"
         }
       ]
     }

--- a/static/json/datadog-agent-ecs.json
+++ b/static/json/datadog-agent-ecs.json
@@ -40,7 +40,7 @@
         },
         {
           "name": "DD_LOGS_ENABLED",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL",
@@ -48,7 +48,7 @@
         },
         {
           "name": "DD_PROCESS_AGENT_ENABLED",
-          "value": "true"
+          "value": "false"
         }
       ]
     }

--- a/static/json/datadog-agent-ecs.json
+++ b/static/json/datadog-agent-ecs.json
@@ -49,10 +49,6 @@
         {
           "name": "DD_PROCESS_AGENT_ENABLED",
           "value": "true"
-        },
-        {
-          "name": "SD_BACKEND",
-          "value": "docker"
         }
       ]
     }

--- a/static/json/datadog-agent-ecs.json
+++ b/static/json/datadog-agent-ecs.json
@@ -18,6 +18,16 @@
           "readOnly": true
         },
         {
+          "containerPath": "/etc/passwd",
+          "sourceVolume": "passwd",
+          "readOnly": true
+        },
+        {
+          "containerPath": "/opt/datadog-agent/run",
+          "sourceVolume": "pointdir",
+          "readOnly": false
+        },
+        {
           "containerPath": "/host/proc",
           "sourceVolume": "proc",
           "readOnly": true
@@ -26,11 +36,23 @@
       "environment": [
         {
           "name": "DD_API_KEY",
-          "value": "INSERT_API_KEY"
+          "value": "<YOUR_API_KEY>"
         },
         {
-      	  "name": "SD_BACKEND",
-	  "value": "docker"
+          "name": "DD_LOGS_ENABLED",
+          "value": "true"
+        },
+        {
+          "name": "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL",
+          "value": "true"
+        },
+        {
+          "name": "DD_PROCESS_AGENT_ENABLED",
+          "value": "true"
+        },
+        {
+          "name": "SD_BACKEND",
+          "value": "docker"
         }
       ]
     }
@@ -47,6 +69,18 @@
         "sourcePath": "/proc/"
       },
       "name": "proc"
+    },
+    {
+      "host": {
+        "sourcePath": "/opt/datadog-agent/run"
+      },
+      "name": "pointdir"
+    },
+    {
+      "host": {
+        "sourcePath": "/etc/passwd"
+      },
+      "name": "passwd"
     },
     {
       "host": {

--- a/static/json/datadog-agent-ecs1-eu.json
+++ b/static/json/datadog-agent-ecs1-eu.json
@@ -57,10 +57,6 @@
         {
           "name": "DD_PROCESS_AGENT_ENABLED",
           "value": "true"
-        },
-        {
-          "name": "SD_BACKEND",
-          "value": "docker"
         }
       ]
     }

--- a/static/json/datadog-agent-ecs1-eu.json
+++ b/static/json/datadog-agent-ecs1-eu.json
@@ -18,6 +18,11 @@
           "readOnly": true
         },
         {
+          "containerPath": "/etc/passwd",
+          "sourceVolume": "passwd",
+          "readOnly": true
+        },
+        {
           "containerPath": "/opt/datadog-agent/run",
           "sourceVolume": "pointdir",
           "readOnly": false
@@ -34,6 +39,14 @@
           "value": "<YOUR_API_KEY>"
         },
         {
+          "name": "DD_SITE",
+          "value": "datadoghq.eu"
+        },
+        {
+          "name": "DD_LOGS_CONFIG_LOGS_DD_URL",
+          "value": "agent-intake.logs.datadoghq.eu:443"
+        },
+        {
           "name": "DD_LOGS_ENABLED",
           "value": "true"
         },
@@ -42,8 +55,12 @@
           "value": "true"
         },
         {
-      	  "name": "SD_BACKEND",
-	  "value": "docker"
+          "name": "DD_PROCESS_AGENT_ENABLED",
+          "value": "true"
+        },
+        {
+          "name": "SD_BACKEND",
+          "value": "docker"
         }
       ]
     }
@@ -66,6 +83,12 @@
         "sourcePath": "/opt/datadog-agent/run"
       },
       "name": "pointdir"
+    },
+    {
+      "host": {
+        "sourcePath": "/etc/passwd"
+      },
+      "name": "passwd"
     },
     {
       "host": {

--- a/static/json/datadog-agent-ecs1-eu.json
+++ b/static/json/datadog-agent-ecs1-eu.json
@@ -48,7 +48,7 @@
         },
         {
           "name": "DD_LOGS_ENABLED",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL",
@@ -56,7 +56,7 @@
         },
         {
           "name": "DD_PROCESS_AGENT_ENABLED",
-          "value": "true"
+          "value": "false"
         }
       ]
     }

--- a/static/json/datadog-agent-ecs1.json
+++ b/static/json/datadog-agent-ecs1.json
@@ -40,7 +40,7 @@
         },
         {
           "name": "DD_LOGS_ENABLED",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL",
@@ -48,7 +48,7 @@
         },
         {
           "name": "DD_PROCESS_AGENT_ENABLED",
-          "value": "true"
+          "value": "false"
         }
       ]
     }

--- a/static/json/datadog-agent-ecs1.json
+++ b/static/json/datadog-agent-ecs1.json
@@ -49,10 +49,6 @@
         {
           "name": "DD_PROCESS_AGENT_ENABLED",
           "value": "true"
-        },
-        {
-          "name": "SD_BACKEND",
-          "value": "docker"
         }
       ]
     }

--- a/static/json/dd-agent-ecs.json
+++ b/static/json/dd-agent-ecs.json
@@ -25,11 +25,11 @@
       "environment": [
         {
           "name": "API_KEY",
-          "value": "INSERT_API_KEY"
+          "value": "<DATADOG_API_KEY>"
         },
         {
       	  "name": "SD_BACKEND",
-	  "value": "docker"
+	        "value": "docker"
         }
       ]
     }


### PR DESCRIPTION
### What does this PR do?
Activates Log and processes collection by default for AWS ECS task description + EU support

### Motivation
Better product, easier config.
