### PR TITLE
[doc] Fix run command example in Docker APM doc

### DIFF
--- a/content/agent/docker/apm.md
+++ b/content/agent/docker/apm.md
@@ -21,17 +21,17 @@ Enable the [datadog-trace-agent][1] in the `datadog/agent` container by passing 
 
 ## Tracing from the host
 
-Tracing is available on port `8126/tcp` from *any host* by adding the option `-p 8126:8126/tcp` to the `docker run` command.
+Tracing is available on port `8126/tcp` from *your host only* by adding the option `-p 127.0.0.1:8126:8126/tcp` to the `docker run` command.
 
-To make it available from *your host only*, use `-p 127.0.0.1:8126:8126/tcp` instead.
+To make it available from *any host*, use `-p 8126:8126/tcp` instead.
 
-For example, the following command allows the Agent to receive traces from anywhere:
+For example, the following command allows the Agent to receive traces from your host only:
 
 ```bash
 docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /proc/:/host/proc/:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-              -p 8126:8126/tcp \
+              -p 127.0.0.1:8126:8126/tcp \
               -e DD_API_KEY=<YOUR_API_KEY> \
               -e DD_APM_ENABLED=true \
               datadog/agent:latest

--- a/content/agent/docker/apm.md
+++ b/content/agent/docker/apm.md
@@ -31,6 +31,7 @@ For example, the following command allows the Agent to receive traces from anywh
 docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /proc/:/host/proc/:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
+              -p 8126:8126/tcp \
               -e DD_API_KEY=<YOUR_API_KEY> \
               -e DD_APM_ENABLED=true \
               datadog/agent:latest


### PR DESCRIPTION
### What does this PR do?
This section of documentation explains how to collect traces from a host (or any hosts) via a Docker Agent, stating to use option `-p 8126:8126/tcp`.  But the example `run` command doesn't include this option.  Fixing example to include this.

### Motivation
`run` command example doesn't match what's being explained in this documentation

### Preview link

### Additional Notes
Confirmed with @Simwar and @DylanLovesCoffee during Support Containers office hours that this example code block should be updated.  