### PR TITLE
Add aliases for top 404 URLs

### DIFF
--- a/content/agent/docker/_index.md
+++ b/content/agent/docker/_index.md
@@ -4,6 +4,7 @@ kind: documentation
 aliases:
   - /guides/basic_agent_usage/docker/
   - /agent/docker
+  - /agent/basic_agent_usage/docker/
 further_reading:
 - link: "agent/faq/getting-further-with-docker"
   tag: "FAQ"

--- a/content/logs/archives/s3.md
+++ b/content/logs/archives/s3.md
@@ -3,7 +3,8 @@ title: Archives on AWS S3
 kind: Documentation
 description: "Forward all your Datadog logs to S3 for long term storage."
 aliases:
-  - /logs/s3
+  - /logs/s3/
+  - /logs/archives/
 ---
 
 

--- a/content/tracing/languages/cpp.md
+++ b/content/tracing/languages/cpp.md
@@ -4,6 +4,7 @@ kind: Documentation
 aliases:
 - /tracing/cpp/
 - /tracing/setup/cpp/
+- /agent/apm/cpp/
 further_reading:
 - link: "https://github.com/DataDog/dd-opentracing-cpp"
   tag: "Github"

--- a/content/tracing/languages/dotnet.md
+++ b/content/tracing/languages/dotnet.md
@@ -4,6 +4,7 @@ kind: Documentation
 aliases:
   - /tracing/dotnet
   - /tracing/setup/dotnet
+  - /agent/apm/dotnet/
 further_reading:
   - link: "https://github.com/DataDog/dd-trace-csharp"
     tag: "GitHub"

--- a/content/tracing/languages/go.md
+++ b/content/tracing/languages/go.md
@@ -4,6 +4,7 @@ kind: Documentation
 aliases:
 - /tracing/go/
 - /tracing/setup/go
+- /agent/apm/go/
 further_reading:
 - link: "https://github.com/DataDog/dd-trace-go/tree/v1"
   tag: "GitHub"

--- a/content/tracing/languages/java.md
+++ b/content/tracing/languages/java.md
@@ -4,6 +4,7 @@ kind: Documentation
 aliases:
 - /tracing/java
 - /tracing/setup/java
+- /agent/apm/java/
 further_reading:
 - link: "https://github.com/DataDog/dd-trace-java"
   tag: "GitHub"

--- a/content/tracing/languages/nodejs.md
+++ b/content/tracing/languages/nodejs.md
@@ -6,6 +6,7 @@ aliases:
 - /tracing/setup/nodejs/
 - /tracing/languages/javascript/
 - /tracing/setup/javascript/
+-- /agent/apm/nodejs/
 further_reading:
 - link: "https://github.com/DataDog/dd-trace-js"
   tag: "GitHub"

--- a/content/tracing/languages/nodejs.md
+++ b/content/tracing/languages/nodejs.md
@@ -6,7 +6,7 @@ aliases:
 - /tracing/setup/nodejs/
 - /tracing/languages/javascript/
 - /tracing/setup/javascript/
--- /agent/apm/nodejs/
+- /agent/apm/nodejs/
 further_reading:
 - link: "https://github.com/DataDog/dd-trace-js"
   tag: "GitHub"

--- a/content/tracing/languages/php.md
+++ b/content/tracing/languages/php.md
@@ -3,6 +3,7 @@ title: Tracing PHP Applications
 kind: Documentation
 aliases:
 - /tracing/setup/php
+- /agent/apm/php/
 further_reading:
 - link: "https://github.com/DataDog/dd-trace-php"
   tag: "GitHub"

--- a/content/tracing/languages/python.md
+++ b/content/tracing/languages/python.md
@@ -4,6 +4,7 @@ kind: Documentation
 aliases:
 - /tracing/python/
 - /tracing/setup/python/
+- /agent/apm/python/
 further_reading:
 - link: "https://github.com/DataDog/dd-trace-py"
   tag: "GitHub"

--- a/content/tracing/languages/ruby.md
+++ b/content/tracing/languages/ruby.md
@@ -4,6 +4,7 @@ kind: Documentation
 aliases:
 - /tracing/ruby/
 - /tracing/setup/ruby/
+- /agent/apm/ruby/
 further_reading:
 - link: "https://github.com/DataDog/dd-trace-rb"
   tag: "GitHub"

--- a/local/bin/py/update_pre_build.py
+++ b/local/bin/py/update_pre_build.py
@@ -141,7 +141,7 @@ class PreBuild:
         self.pool_size = 5
         self.integration_mutations = OrderedDict({
             'hdfs': {'action': 'create', 'target': 'hdfs', 'remove_header': False, 'fm': {'is_public': True, 'kind': 'integration', 'integration_title': 'Hdfs', 'short_description': 'Track cluster disk usage, volume failures, dead DataNodes, and more.'}},
-            'mesos': {'action': 'create', 'target': 'mesos', 'remove_header': False, 'fm': {'is_public': True, 'kind': 'integration', 'integration_title': 'Mesos', 'short_description': 'Track cluster resource usage, master and slave counts, tasks statuses, and more.'}},
+            'mesos': {'action': 'create', 'target': 'mesos', 'remove_header': False, 'fm': {'aliases': ['/integrations/mesos_master/','/integrations/mesos_slave/'], 'is_public': True, 'kind': 'integration', 'integration_title': 'Mesos', 'short_description': 'Track cluster resource usage, master and slave counts, tasks statuses, and more.'}},
             'activemq_xml': {'action': 'merge', 'target': 'activemq', 'remove_header': False},
             'cassandra_nodetool': {'action': 'merge', 'target': 'cassandra', 'remove_header': False},
             'datadog_checks_base': {'action': 'discard', 'target': 'none', 'remove_header': False},


### PR DESCRIPTION
### What does this PR do?
- Add aliases for top 404 URLs

### Motivation
404 logs

### Preview link
https://docs-staging.datadoghq.com/ruth/docs-404s/agent/basic_agent_usage/docker/
https://docs-staging.datadoghq.com/ruth/docs-404s/integrations/mesos_master/
https://docs-staging.datadoghq.com/ruth/docs-404s/integrations/mesos_slave/
https://docs-staging.datadoghq.com/ruth/docs-404s/logs/archives/
https://docs-staging.datadoghq.com/ruth/docs-404s/agent/apm/cpp/
https://docs-staging.datadoghq.com/ruth/docs-404s/agent/apm/dotnet/
https://docs-staging.datadoghq.com/ruth/docs-404s/agent/apm/go/
https://docs-staging.datadoghq.com/ruth/docs-404s/agent/apm/java/
https://docs-staging.datadoghq.com/ruth/docs-404s/agent/apm/nodejs/
https://docs-staging.datadoghq.com/ruth/docs-404s/agent/apm/php/
https://docs-staging.datadoghq.com/ruth/docs-404s/agent/apm/python/
https://docs-staging.datadoghq.com/ruth/docs-404s/agent/apm/ruby/

### Additional Notes
Additional PR - https://github.com/DataDog/dogweb/pull/33433
