### PR TITLE
Bolding note on Event Stream docs

### DIFF
--- a/content/graphing/event_stream/_index.md
+++ b/content/graphing/event_stream/_index.md
@@ -54,7 +54,7 @@ Combine prefixes to construct more complex searches. For example, if you wanted 
 
 `sources:nagios,chef status:error cassandra`
 
-Note: no spaces after the colon or commas in these lists and anything not attached to a prefix goes to full text search.
+**Note**: no spaces after the colon or commas in these lists and anything not attached to a prefix goes to full text search.
 
 ## Show events unaggregated
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
"Note" wasn't in bold, now it is.

### Motivation
The note was not super visible before. Usage of `Note:` generally should occur in bold.
