### PR TITLE
Java tracer MDC autoinjection docs.

### DIFF
--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1408,15 +1408,16 @@ The purpose of this section is to explain how the correlation between traces and
 {{< tabs >}}
 {{% tab "Java" %}}
 
-The simplest way to inject trace identifiers is to leverage the MDC Frameworks ([Map Diagnostic Context][1]) to automatically add the trace and span ids into the logs. Datadog MDC keys may be injected automatically with a tracer integration, or manually injected with Datadog APIs.
+Leverage the MDC Frameworks ([Map Diagnostic Context][1]) to automatically add the trace and span ids into your logs. Datadog MDC keys may be injected automatically with a tracer integration, or manually injected with Datadog APIs.
 
 **How to enable Log Injection***
+
 1. Enable injection in the [Java Tracer's configuration][3]. Note: Currently only slf4j is supported for MDC autoinjection.
-1. Alternatively, Use Datadog `CorrelationIdentifier#getTraceId()`, and `CorrelationIdentifier#getSpanId()` APIs to inject identifiers at the beginning and end of each span to log (see examples below).
-2. Configure MDC to use the injected Keys
+2. Alternatively, Use Datadog `CorrelationIdentifier#getTraceId()`, and `CorrelationIdentifier#getSpanId()` APIs to inject identifiers at the beginning and end of each span to log (see examples below).
+3. Configure MDC to use the injected Keys:
   * `dd.trace_id` Active trace id during the log statement (or `0` if no trace)
   * `dd.span_id` Active trace id during the log statement (or `0` if no trace)
-3. If logs are already JSON formatted, there should be nothing left to do. [See our Java logging documentation][2] to add those two identifiers in raw logs or to learn how to log in JSON.
+4. If logs are already JSON formatted, there should be nothing left to do. [See our Java logging documentation][2] to add those two identifiers in raw logs or to learn how to log in JSON.
 
 **Manual Injection log4j2 example**:
 

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1408,12 +1408,17 @@ The purpose of this section is to explain how the correlation between traces and
 {{< tabs >}}
 {{% tab "Java" %}}
 
-The idea is to leverage the MDC ([Map Diagnostic Context][1]) to automatically add the trace and span identifier into the logs.
-The Datadog Java tracer exposes two API calls to allow printing trace and span identifiers along with log statements, `CorrelationIdentifier#getTraceId()`, and `CorrelationIdentifier#getSpanId()`.
+The simplest way to inject trace identifiers is to leverage the MDC Frameworks ([Map Diagnostic Context][1]) to automatically add the trace and span ids into the logs. Datadog MDC keys may be injected automatically with a tracer integration, or manually injected with Datadog APIs.
 
-- To inject those identifier into application logs using MDC frameworks, use the following method:
+**How to enable Log Injection***
+1. Enable injection in the [Java Tracer's configuration][3]. Note: Currently only slf4j is supported for MDC autoinjection.
+1. Alternatively, Use Datadog `CorrelationIdentifier#getTraceId()`, and `CorrelationIdentifier#getSpanId()` APIs to inject identifiers at the beginning and end of each span to log (see examples below).
+2. Configure MDC to use the injected Keys
+  * `dd.trace_id` Active trace id during the log statement (or `0` if no trace)
+  * `dd.span_id` Active trace id during the log statement (or `0` if no trace)
+3. If logs are already JSON formatted, there should be nothing left to do. [See our Java logging documentation][2] to add those two identifiers in raw logs or to learn how to log in JSON.
 
-**log4j2**:
+**Manual Injection log4j2 example**:
 
 ```java
 import org.apache.logging.log4j.ThreadContext;
@@ -1429,7 +1434,7 @@ try {
 }
 ```
 
-**slf4j/logback**:
+**Manual Injection slf4j/logback example**:
 
 ```java
 import org.slf4j.MDC;
@@ -1445,13 +1450,9 @@ try {
 }
 ```
 
-- Add those identifiers in the logs:
-
-If logs are already JSON formatted, there should be nothing left to do.
-[See our Java logging documentation][2] to add those two identifiers in raw logs or to learn how to log in JSON.
-
 [1]: https://logback.qos.ch/manual/mdc.html
 [2]: https://docs.datadoghq.com/logs/log_collection/java/?tab=log4j#configure-your-logger
+[3]: https://docs.datadoghq.com/tracing/languages/java/#configuration
 {{% /tab %}}
 {{% tab "Python" %}}
 Getting the required information needed for logging is easy:

--- a/content/tracing/languages/java.md
+++ b/content/tracing/languages/java.md
@@ -172,6 +172,7 @@ The tracer is configured using System Properties and Environment Variables as fo
 | `dd.jmxfetch.refresh-beans-period` | `DD_JMXFETCH_REFRESH_BEANS_PERIOD` | `600`                | How often to refresh list of avalable JMX beans (in seconds).                                                                                                                                                           |
 | `dd.jmxfetch.statsd.host`          | `DD_JMXFETCH_STATSD_HOST`          | same as `agent.host` | Statsd host to send JMX metrics to.                                                                                                                                                                                     |
 | `dd.jmxfetch.statsd.port`          | `DD_JMXFETCH_STATSD_PORT`          | 8125                 | Statsd port to send JMX metrics to.                                                                                                                                                                                     |
+| `dd.logs.injection`                | `DD_LOGS_INJECTION`                | false                | Enabled automatic MDC key injection for Datadog trace and span ids to.                                                                                                                                                                                     |
 
 [1]: /tracing/setup/docker
 [2]: /tracing/advanced_usage/?tab=java#distributed-tracing
@@ -223,6 +224,33 @@ Now add `@Trace` to methods to have them be traced when running with `dd-java-ag
 
 Datadog's Java Tracer provides support for 'in-process' JMX metrics collection. This is enabled with `jmxfetch.enabled` configuration parameter. Additional JMX metrics are configured using configuration files that are passed to `jmxfetch.metrics-configs`. Contents of those configuration files are equivalent to contents of the `conf` section for external jmxfetch. See [JMX Integration][8] for further details on configuration.
 By default, when JMX metrics collection is enabled it monitors JVM heap memory, thread count, and garbage collection. Use it in conjunction with APM for a broader view into your Java application's performance.
+
+## Logs Slf4j+MDC Autoinjection
+
+The Java tracer also provides an option to enable automatic key injection for slf4j users.
+
+To enable automatic log injection:
+1. Enable injection in the tracer's configuration. [See ## Configuration](#Configuration)
+2. Configure slf4j to use the injected Keys
+  * `dd.trace_id` Active trace id during the log statement (or `0` if no trace)
+  * `dd.span_id` Active trace id during the log statement (or `0` if no trace)
+  * Log format must contain a snippet of both keys. Example: `dd.trace_id=%X{dd.trace_id} dd.span_id=%X{dd.span_id}`
+
+Example `logback.xml` configuration:
+```
+<configuration debug="true">
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] dd.trace_id=%X{dd.trace_id} dd.span_id=%X{dd.span_id} %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>
+```
 
 ## Performance
 

--- a/content/tracing/languages/java.md
+++ b/content/tracing/languages/java.md
@@ -172,11 +172,12 @@ The tracer is configured using System Properties and Environment Variables as fo
 | `dd.jmxfetch.refresh-beans-period` | `DD_JMXFETCH_REFRESH_BEANS_PERIOD` | `600`                | How often to refresh list of avalable JMX beans (in seconds).                                                                                                                                                           |
 | `dd.jmxfetch.statsd.host`          | `DD_JMXFETCH_STATSD_HOST`          | same as `agent.host` | Statsd host to send JMX metrics to.                                                                                                                                                                                     |
 | `dd.jmxfetch.statsd.port`          | `DD_JMXFETCH_STATSD_PORT`          | 8125                 | Statsd port to send JMX metrics to.                                                                                                                                                                                     |
-| `dd.logs.injection`                | `DD_LOGS_INJECTION`                | false                | Enabled automatic MDC key injection for Datadog trace and span ids to.                                                                                                                                                                                     |
+| `dd.logs.injection`                | `DD_LOGS_INJECTION`                | false                | Enabled automatic MDC key injection for Datadog trace and span ids. See [Advanced Usage][4] for details                                                                                                                 |
 
 [1]: /tracing/setup/docker
 [2]: /tracing/advanced_usage/?tab=java#distributed-tracing
 [3]: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java#L37
+[4]: https://docs.datadoghq.com/tracing/advanced_usage/?tab=java#logging
 {{% /table %}}
 
 **Note**:
@@ -224,33 +225,6 @@ Now add `@Trace` to methods to have them be traced when running with `dd-java-ag
 
 Datadog's Java Tracer provides support for 'in-process' JMX metrics collection. This is enabled with `jmxfetch.enabled` configuration parameter. Additional JMX metrics are configured using configuration files that are passed to `jmxfetch.metrics-configs`. Contents of those configuration files are equivalent to contents of the `conf` section for external jmxfetch. See [JMX Integration][8] for further details on configuration.
 By default, when JMX metrics collection is enabled it monitors JVM heap memory, thread count, and garbage collection. Use it in conjunction with APM for a broader view into your Java application's performance.
-
-## Logs Slf4j+MDC Autoinjection
-
-The Java tracer also provides an option to enable automatic key injection for slf4j users.
-
-To enable automatic log injection:
-1. Enable injection in the tracer's configuration. [See ## Configuration](#Configuration)
-2. Configure slf4j to use the injected Keys
-  * `dd.trace_id` Active trace id during the log statement (or `0` if no trace)
-  * `dd.span_id` Active trace id during the log statement (or `0` if no trace)
-  * Log format must contain a snippet of both keys. Example: `dd.trace_id=%X{dd.trace_id} dd.span_id=%X{dd.span_id}`
-
-Example `logback.xml` configuration:
-```
-<configuration debug="true">
-
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] dd.trace_id=%X{dd.trace_id} dd.span_id=%X{dd.span_id} %-5level %logger{36} - %msg%n</pattern>
-    </encoder>
-  </appender>
-
-  <root level="info">
-    <appender-ref ref="STDOUT" />
-  </root>
-</configuration>
-```
 
 ## Performance
 


### PR DESCRIPTION
Docs for Java Tracer's upcoming MDC autoinjection feature.

This can be merged once java tracer 0.21.0 is released.