### PR TITLE
Fix reference on heroku log endpoint

### DIFF
--- a/content/agent/basic_agent_usage/heroku.md
+++ b/content/agent/basic_agent_usage/heroku.md
@@ -111,14 +111,14 @@ Add custom attributes to logs from your application by replacing the URL in the 
 {{% tab "US Region" %}}
 
 ```
-https://http-intake.logs.datad0g.com/v1/input/<DD_API_KEY>?ddsource=heroku&service=<SERVICE>&host=<HOST>&attribute_name=<VALUE>
+https://http-intake.logs.datadoghq.com/v1/input/<DD_API_KEY>?ddsource=heroku&service=<SERVICE>&host=<HOST>&attribute_name=<VALUE>
 ```
 
 {{% /tab %}}
 {{% tab "EU Region" %}}
 
 ```
-https://http-intake.logs.datad0g.eu/v1/input/<DD_API_KEY>?ddsource=heroku&service=<SERVICE>&host=<HOST>&attribute_name=<VALUE>
+https://http-intake.logs.datadoghq.eu/v1/input/<DD_API_KEY>?ddsource=heroku&service=<SERVICE>&host=<HOST>&attribute_name=<VALUE>
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
### What does this PR do?
Fix the endpoint for custom attributes on heroku. This was heading to staging.

### Motivation
Staging is for internal use only

### Preview link
https://docs-staging.datadoghq.com/nils/heroku-log-endpoint-fix/agent/basic_agent_usage/heroku/?tab=euregion#custom-attributes


### Additional Notes
<!-- Anything else we should know when reviewing?-->
