### PR TITLE
Fix broken link

### DIFF
--- a/content/agent/docker/apm.md
+++ b/content/agent/docker/apm.md
@@ -9,7 +9,7 @@ further_reading:
 - link: "https://github.com/DataDog/datadog-trace-agent"
   tag: "Github"
   text: Source code
-- link: "agent/apm/ecs"
+- link: "https://docs.datadoghq.com/integrations/amazon_ecs/#trace-collection"
   tag: "Documentation"
   text: "Trace your ECS applications"
 - link: "tracing/visualization/"


### PR DESCRIPTION
### What does this PR do?
- Fix broken link

### Motivation
- 404 URL graph in Docs Dashboard

### Preview link
https://docs-staging.datadoghq.com/ruth/docs-404s-3/agent/docker/apm/#further-reading

### Additional Notes
Current Hugo template will not allow `integrations/amazon_ecs/#trace-collection`. This will be looked at in a different card.
