### PR TITLE
[apm/php] Update symfony 3.x beta support

### DIFF
--- a/content/tracing/languages/php.md
+++ b/content/tracing/languages/php.md
@@ -82,7 +82,7 @@ Automatic instrumentation captures:
 | Laravel        | 5.x         | Public Beta        |
 | Laravel        | 4.2         | Coming Soon        |
 | Symfony        | 4.x         | Public Beta        |
-| Symfony        | 3.x         | Coming Soon        |
+| Symfony        | 3.x         | Public Beta        |
 | Magento        | 2.x         | Coming Soon        |
 | Zend Framework | 3.x         | Coming Soon        |
 | CakePHP        | 3.x         | Coming Soon        |


### PR DESCRIPTION
### What does this PR do?
Update APM php integration docs to show that we now support Symfony 3.x integration.

### Motivation
We recently have added support for older versions of Symfony, specifically the 3.4 branch. We should now report this new support in our APM php docs.

### Preview link
[Preview](https://docs-staging.datadoghq.com/php/symfony-3-beta/tracing/languages/php/)
