### PR TITLE
Spelling correction on Log Status Remapper Section

### DIFF
--- a/content/logs/processing/processors.md
+++ b/content/logs/processing/processors.md
@@ -74,7 +74,7 @@ However, be aware that each incoming status value is mapped as follows:
 * Strings beginning with **n** (case-insensitive) map to **notice (5)**
 * Strings beginning with **i** (case-insensitive) map to **info (6)**
 * Strings beginning with **d**, **trace** or **verbose** (case-insensitive) map to **debug (7)**
-* Strings matching **OK** or **Sucess** (case-insensitive) map to **OK**
+* Strings matching **OK** or **Success** (case-insensitive) map to **OK**
 * All others map to **info (6)**
 
 ## Service Remapper


### PR DESCRIPTION
![sectiontoupdate](https://cl.ly/27c89cd8fd57/Image%2525202019-01-02%252520at%2525205.52.26%252520PM.png)

### What does this PR do?
Corrects spelling error -> **Sucess** to **Success** on https://docs.datadoghq.com/logs/processing/processors/#log-status-remapper

### Motivation
Discovery

### Preview link
https://docs-staging.datadoghq.com/cathleenwright/logstatusremapper_spellingfix/logs/processing/processors/#log-status-remapper


