### PR TITLE
Update how-datadog-agent-determines-the-hostname.md

### DIFF
--- a/content/agent/faq/how-datadog-agent-determines-the-hostname.md
+++ b/content/agent/faq/how-datadog-agent-determines-the-hostname.md
@@ -21,9 +21,9 @@ For Agent 6, some differences in hostname resolution apply. See our document on 
 {{% /tab %}}
 {{< /tabs >}}
 
-The Datadog Agent collects potential hostnames from a number of different sources. To see all the names the Agent is detecting, [run the Agent info command][1], for example:
+The Datadog Agent collects potential hostnames from a number of different sources. To see all the names the Agent is detecting, [run the Agent status command][1], for example:
 ```
-$ sudo /etc/init.d/datadog-agent info
+$ sudo /etc/init.d/datadog-agent status
 
 ...
 


### PR DESCRIPTION
### What does this PR do?
Update `info` to `status` on https://docs.datadoghq.com/agent/faq/how-datadog-agent-determines-the-hostname/?tab=agentv6#pagetitle

Current:
```
To see all the names the Agent is detecting, run the Agent info command, for example:

$ sudo /etc/init.d/datadog-agent info
```
Proposed:

```
To see all the names the Agent is detecting, run the Agent status command, for example:

$ sudo /etc/init.d/datadog-agent status
```
### Motivation

```
sudo /etc/init.d/datadog-agent info 
Usage: /etc/init.d/datadog-agent {start|stop|restart|status} 
```

### Preview link
https://docs-staging.datadoghq.com/cathleenwright/info_to_status/agent/faq/how-datadog-agent-determines-the-hostname/?tab=agentv6#pagetitle

### Additional Notes
- Confirmed with #documentation _info command deprecated in agent 6_
- No change to link path