### PR TITLE
Add logs correlation and integrations to Ruby APM

### DIFF
--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1488,7 +1488,7 @@ To add correlation IDs to your logger, add a log formatter which retrieves the c
 
 To properly correlate with Datadog logging, be sure the following is present:
 
- - `dd.trace_id=<trace_id>`: Where `<trace_id>` is `Datadog.tracer.active_correlation.trace_id`. `0` if no trace active.
+ - `dd.trace_id=<TRACE_ID>`: Where `<TRACE_ID>` is equal to `Datadog.tracer.active_correlation.trace_id` or `0` if no trace is active.
  - `dd.span_id=<SPAN_ID>`: Where `<SPAN_ID>` is equal to `Datadog.tracer.active_correlation.span_id` or `0` if no trace is active.
 
 An example of this in practice:

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1465,7 +1465,7 @@ trace_id, span_id = helpers.get_correlation_ids()
 {{% /tab %}}
 {{% tab "Ruby" %}}
 
-To retrieve trace and span IDs for the active trace, one can use `Datadog.tracer.active_correlation`:
+To retrieve trace and span IDs for the active trace, use `Datadog.tracer.active_correlation`:
 
 ```ruby
 # When a trace is active...

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1484,7 +1484,7 @@ correlation.trace_id # => 0
 correlation.span_id # => 0
 ```
 
-To add correlation IDs to your logger, simply add a log formatter which retrieve the correlation IDs via `Datadog.tracer.active_correlation`, then add them to the message.
+To add correlation IDs to your logger, add a log formatter which retrieves the correlation IDs with `Datadog.tracer.active_correlation`, then add them to the message.
 
 To properly correlate with Datadog logging, be sure the following is present:
 

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1465,10 +1465,47 @@ trace_id, span_id = helpers.get_correlation_ids()
 {{% /tab %}}
 {{% tab "Ruby" %}}
 
-Coming Soon. Reach out to [the Datadog support team][1] to be part of the beta.
+To retrieve trace and span IDs for the active trace, one can use `Datadog.tracer.active_correlation`:
 
+```ruby
+# When a trace is active...
+Datadog.tracer.trace('correlation.example') do
+  # Returns #<Datadog::Correlation::Identifier>
+  correlation = Datadog.tracer.active_correlation
+  correlation.trace_id # => 5963550561812073440
+  correlation.span_id # => 2232727802607726424
+end
 
-[1]: /help
+# When a trace isn't active...
+correlation = Datadog.tracer.active_correlation
+# Returns #<Datadog::Correlation::Identifier>
+correlation = Datadog.tracer.active_correlation
+correlation.trace_id # => 0
+correlation.span_id # => 0
+```
+
+To add correlation IDs to your logger, simply add a log formatter which retrieve the correlation IDs via `Datadog.tracer.active_correlation`, then add them to the message.
+
+To properly correlate with Datadog logging, be sure the following is present:
+
+ - `dd.trace_id=<trace_id>`: Where `<trace_id>` is `Datadog.tracer.active_correlation.trace_id`. `0` if no trace active.
+ - `dd.span_id=<span_id>`: Where `<span_id>` is `Datadog.tracer.active_correlation.span_id`. `0` if no trace active.
+
+An example of this in practice:
+
+```ruby
+require 'ddtrace'
+require 'logger'
+
+logger = Logger.new(STDOUT)
+logger.progname = 'my_app'
+logger.formatter  = proc do |severity, datetime, progname, msg|
+  # Returns Datadog::Correlation::Identifier
+  ids = Datadog.tracer.active_correlation
+  "[#{datetime}][#{progname}][#{severity}][dd.trace_id=#{ids.trace_id} dd.span_id=#{ids.span_id}] #{msg}\n"
+end
+```
+
 {{% /tab %}}
 {{% tab "Go" %}}
 The Go tracer exposes two API calls to allow printing trace and span identifiers along with log statements using exported methods from `SpanContext` type:

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1489,7 +1489,7 @@ To add correlation IDs to your logger, add a log formatter which retrieves the c
 To properly correlate with Datadog logging, be sure the following is present:
 
  - `dd.trace_id=<trace_id>`: Where `<trace_id>` is `Datadog.tracer.active_correlation.trace_id`. `0` if no trace active.
- - `dd.span_id=<span_id>`: Where `<span_id>` is `Datadog.tracer.active_correlation.span_id`. `0` if no trace active.
+ - `dd.span_id=<SPAN_ID>`: Where `<SPAN_ID>` is equal to `Datadog.tracer.active_correlation.span_id` or `0` if no trace is active.
 
 An example of this in practice:
 

--- a/content/tracing/languages/ruby.md
+++ b/content/tracing/languages/ruby.md
@@ -141,6 +141,7 @@ Ruby APM includes support for the following libraries and frameworks:
 | [Resque][55]                   | `>= 1.0, < 2.0`        | Fully Supported | *[Link][56]*     |
 | [RestClient][57]               | `>= 1.8`               | Fully Supported | *[Link][58]*     |
 | [Sequel][59]                   | `>= 3.41`              | Fully Supported | *[Link][60]*     |
+| [Shoryuken][67]                | `>= 4.0.2`             | Fully Supported | *[Link][68]*     |
 | [Sidekiq][61]                  | `>= 4.0`               | Fully Supported | *[Link][62]*     |
 | [Sinatra][63]                  | `>= 1.4.5`             | Fully Supported | *[Link][64]*     |
 | [Sucker Punch][65]             | `>= 2.0`               | Fully Supported | *[Link][66]*     |


### PR DESCRIPTION
### What does this PR do?

 Updates the Ruby APM documentation with:

 - New Shoryuken integration
 - Logs correlation instructions

### Motivation

New features in latest Ruby APM releases.

### Preview links

https://docs-staging.datadoghq.com/delner/apm_ruby_logs_correlation_and_integrations/tracing/advanced_usage/?tab=ruby#logging

https://docs-staging.datadoghq.com/delner/apm_ruby_logs_correlation_and_integrations/tracing/languages/ruby/#library-compatibility

### Additional Notes

None.
