### PR TITLE
Python log injection

### DIFF
--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1465,10 +1465,28 @@ This integration for logs works if the log entry includes:
 - `dd.trace_id=%(dd.trace_id)s`
 - `dd.span_id=%(dd.span_id)s`
 
-See our [Python logging documentation][1] for usage examples.
+An example of this in practice with manual instrumentation:
+
+``` python
+from ddtrace import patch_all; patch_all(logging=True)
+import logging
+from ddtrace import tracer
+
+FORMAT = ('%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] '
+          '[dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s] '
+          '- %(message)s')
+logging.basicConfig(format=FORMAT)
+log = logging.getLogger()
+log.level = logging.INFO
 
 
-[1]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#logs-injection
+@tracer.wrap()
+def hello():
+    log.info('Hello, World!')
+
+hello()
+```
+
 {{% /tab %}}
 {{% tab "Ruby" %}}
 

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1460,7 +1460,7 @@ To inject trace information from Python into logs:
 1. Set the environment variable `DD_LOGS_INJECTION=true` when using `ddtrace-run` or manually patch the `logging` module.
 2. Update your log formatter to include ``dd.trace_id`` and ``dd.span_id`` attributes from the log record.
 
-The integration with logs occurs as long as the log entry includes:
+This integration for logs works if the log entry includes:
 
 - `dd.trace_id=%(dd.trace_id)s`
 - `dd.span_id=%(dd.span_id)s`

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1455,7 +1455,7 @@ If logs are already JSON formatted, there should be nothing left to do.
 {{% /tab %}}
 {{% tab "Python" %}}
 
-You have two ways to inject trace informations into your logs in Python:
+You have two ways to inject trace information into your logs in Python:
 
 1. Automatically: Set the environment variable `DD_LOGS_INJECTION=true` when using `ddtrace-run`.
 2. Manually: Patch your `logging` module by updating your log formatter to include the ``dd.trace_id`` and ``dd.span_id`` attributes from the log record.

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1460,7 +1460,7 @@ To inject trace information from Python into logs:
 1. Set the environment variable `DD_LOGS_INJECTION=true` when using `ddtrace-run` or manually patch the `logging` module.
 2. Update your log formatter to include ``dd.trace_id`` and ``dd.span_id`` attributes from the log record.
 
-This integration for logs works if the log entry includes:
+This integration for logs works if the log format includes:
 
 - `dd.trace_id=%(dd.trace_id)s`
 - `dd.span_id=%(dd.span_id)s`

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1457,7 +1457,7 @@ If logs are already JSON formatted, there should be nothing left to do.
 
 You have two ways to inject trace informations into your logs in Python:
 
-1. Automatically: set the environment variable `DD_LOGS_INJECTION=true` when using `ddtrace-run`.
+1. Automatically: Set the environment variable `DD_LOGS_INJECTION=true` when using `ddtrace-run`.
 2. Manually: Patch your `logging` module by updating your log formatter to include the ``dd.trace_id`` and ``dd.span_id`` attributes from the log record.
 
 This integration with logs works if the log format includes:
@@ -1476,7 +1476,7 @@ FORMAT = ('%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] '
           '[dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s] '
           '- %(message)s')
 logging.basicConfig(format=FORMAT)
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 log.level = logging.INFO
 
 @tracer.wrap()

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1455,34 +1455,17 @@ If logs are already JSON formatted, there should be nothing left to do.
 {{% /tab %}}
 {{% tab "Python" %}}
 
-To inject trace information from Python into logs:
+You have two ways to inject trace informations into your logs in Python:
 
-1. Set the environment variable `DD_LOGS_INJECTION=true` when using `ddtrace-run` or manually patch the `logging` module.
-2. Update your log formatter to include ``dd.trace_id`` and ``dd.span_id`` attributes from the log record.
+1. Automatically: set the environment variable `DD_LOGS_INJECTION=true` when using `ddtrace-run`.
+2. Manually: Patch your `logging` module by updating your log formatter to include the ``dd.trace_id`` and ``dd.span_id`` attributes from the log record.
 
-This integration for logs works if the log format includes:
+This integration with logs works if the log format includes:
 
 - `dd.trace_id=%(dd.trace_id)s`
 - `dd.span_id=%(dd.span_id)s`
 
-An example of this in practice when using ``ddtrace-run`` with environment variable ``DD_LOGS_INJECTION=true``:
-
-``` python
-import logging
-from ddtrace import tracer
-
-log = logging.getLogger()
-log.level = logging.INFO
-
-
-@tracer.wrap()
-def hello():
-    log.info('Hello, World!')
-
-hello()
-```
-
-An example of this in practice with manual instrumentation:
+For instance: 
 
 ``` python
 from ddtrace import patch_all; patch_all(logging=True)
@@ -1495,7 +1478,6 @@ FORMAT = ('%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] '
 logging.basicConfig(format=FORMAT)
 log = logging.getLogger()
 log.level = logging.INFO
-
 
 @tracer.wrap()
 def hello():

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1455,7 +1455,7 @@ If logs are already JSON formatted, there should be nothing left to do.
 {{% /tab %}}
 {{% tab "Python" %}}
 
-To inject trace information in Python into logs, you must:
+To inject trace information from Python into logs:
 
 1. Set the environment variable `DD_LOGS_INJECTION=true` when using `ddtrace-run` or manually patch the `logging` module.
 2. Update your log formatter to include ``dd.trace_id`` and ``dd.span_id`` attributes from the log record.

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1454,14 +1454,21 @@ If logs are already JSON formatted, there should be nothing left to do.
 [2]: https://docs.datadoghq.com/logs/log_collection/java/?tab=log4j#configure-your-logger
 {{% /tab %}}
 {{% tab "Python" %}}
-Getting the required information needed for logging is easy:
 
-```python
-from ddtrace import helpers
+To inject trace information in Python into logs, you must:
 
-trace_id, span_id = helpers.get_correlation_ids()
-```
+1. Set the environment variable `DD_LOGS_INJECTION=true` when using `ddtrace-run` or manually patch the `logging` module.
+2. Update your log formatter to include ``dd.trace_id`` and ``dd.span_id`` attributes from the log record.
 
+The integration with logs occurs as long as the log entry includes:
+
+- `dd.trace_id=%(dd.trace_id)s`
+- `dd.span_id=%(dd.span_id)s`
+
+See our [Python logging documentation][1] for usage examples.
+
+
+[1]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#logs-injection
 {{% /tab %}}
 {{% tab "Ruby" %}}
 

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1465,6 +1465,23 @@ This integration for logs works if the log format includes:
 - `dd.trace_id=%(dd.trace_id)s`
 - `dd.span_id=%(dd.span_id)s`
 
+An example of this in practice when using ``ddtrace-run`` with environment variable ``DD_LOGS_INJECTION=true``:
+
+``` python
+import logging
+from ddtrace import tracer
+
+log = logging.getLogger()
+log.level = logging.INFO
+
+
+@tracer.wrap()
+def hello():
+    log.info('Hello, World!')
+
+hello()
+```
+
 An example of this in practice with manual instrumentation:
 
 ``` python


### PR DESCRIPTION
Documentation for logs injection added to `dd-trace-py` with `v0.20`. This can be merged once this release is completed.