### PR TITLE
Being consistent with monitor definition

### DIFF
--- a/content/api/monitors/code_snippets/api-monitor-create.py
+++ b/content/api/monitors/code_snippets/api-monitor-create.py
@@ -15,7 +15,7 @@ options = {
 tags = ["app:webserver", "frontend"]
 api.Monitor.create(
     type="metric alert",
-    query="avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 100",
+    query="avg(last_5m):sum:system.net.bytes_rcvd{host:host0} > 100",
     name="Bytes received on host0",
     message="We may need to add web hosts if this is consistently high.",
     tags=tags,

--- a/content/api/monitors/code_snippets/api-monitor-create.rb
+++ b/content/api/monitors/code_snippets/api-monitor-create.rb
@@ -12,4 +12,4 @@ options = {
     'no_data_timeframe' => 20
 }
 tags = ['app:webserver', 'frontend']
-dog.monitor("metric alert", "avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 100", :name => "Bytes received on host0", :message => "We may need to add web hosts if this is consistently high.", :tags => tags, :options => options)
+dog.monitor("metric alert", "avg(last_5m):sum:system.net.bytes_rcvd{host:host0} > 100", :name => "Bytes received on host0", :message => "We may need to add web hosts if this is consistently high.", :tags => tags, :options => options)

--- a/content/api/monitors/code_snippets/api-monitor-edit.py
+++ b/content/api/monitors/code_snippets/api-monitor-edit.py
@@ -10,7 +10,7 @@ initialize(**options)
 # Edit an existing monitor
 api.Monitor.update(
     2081,
-    query="avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 100",
+    query="avg(last_5m):sum:system.net.bytes_rcvd{host:host0} > 100",
     name="Bytes received on host0",
     message="We may need to add web hosts if this is consistently high."
 )

--- a/content/api/monitors/code_snippets/api-monitor-edit.rb
+++ b/content/api/monitors/code_snippets/api-monitor-edit.rb
@@ -7,4 +7,4 @@ app_key = '<YOUR_APP_KEY>'
 dog = Dogapi::Client.new(api_key, app_key)
 
 # Edit an existing monitor
-dog.update_monitor(91879, "avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 100", :message => "Bytes received on host0", :name => "We may need to add web hosts if this is consistently high.")
+dog.update_monitor(91879, "avg(last_5m):sum:system.net.bytes_rcvd{host:host0} > 100", :message => "Bytes received on host0", :name => "We may need to add web hosts if this is consistently high.")


### PR DESCRIPTION
In the create a monitor via API doc: 

The `no_data_timeframe` has the following description 

> no_data_timeframe: the number of minutes before a monitor notifies when data stops reporting. Must be at least 2x the monitor timeframe for metric alerts or 2 minutes for service checks. Default: 2x timeframe for metric alerts, 2 minutes for service checks


However in the example, we have set no_data_timeframe to 20 mins and time window to 1h (60mins) which is incorrect/confusing. 

in `python`

```
...
 "no_data_timeframe": 20
... 
query="avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 100" 
...
```

In `ruby`:

```
...
'no_data_timeframe' => 20
...
"avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 100", 
...
```


This PR fixes this issue.