### PR TITLE
Add kube proxy alias

### DIFF
--- a/content/integrations/kubernetes.md
+++ b/content/integrations/kubernetes.md
@@ -10,6 +10,7 @@ is_public: true
 aliases:
     - /tracing/api/
     - /integrations/kubernetes_state/
+    - /integrations/kube_proxy/
 public_title: Datadog-Kubernetes Integration
 short_description: "Capture Pod scheduling events, track the status of your Kublets, and more"
 categories:


### PR DESCRIPTION
### What does this PR do?
- Add kube proxy alias

### Motivation
- 404 graph

### Preview link
https://docs-staging.datadoghq.com/ruth/kube-proxy-404//integrations/kube_proxy/
