### PR TITLE
Remove height and width values

### DIFF
--- a/content/api/screenboards/screenboards_create.md
+++ b/content/api/screenboards/screenboards_create.md
@@ -15,10 +15,6 @@ external_redirect: /api/#create-a-screenboard
     [A list of widget definitions][1].
 * **`template_variables`** [*optional*, *default*=**None**]:  
     A list of template variables for using Dashboard templating.
-* **`width`** [*optional*, *default*=**None**]:  
-    Screenboard width in pixels
-* **`height`** [*optional*, *default*=**None**]:  
-    Height in pixels.
 * **`read_only`** [*optional*, *default*=**False**]:  
     The read-only status of the screenboard.
 


### PR DESCRIPTION

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Removed the height and width properties in the screenboard API calls as they are computed dynamically now.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
