### PR TITLE
Adding note about span metadata

### DIFF
--- a/content/tagging/assigning_tags.md
+++ b/content/tagging/assigning_tags.md
@@ -130,6 +130,17 @@ Tracer.Instance.ActiveScope.Span.SetTag("env", "<ENVIRONMENT>");
 {{% /tab %}}
 {{< /tabs >}}
 
+**Note**: Span metadata must respect a typed tree structure. Each node of the tree is split by a `.` and a node can be of a single type: it can't be both an object (with sub-nodes) and a string for instance.
+
+So this example of span metadata is invalid:
+
+```json
+{
+  "key": "value",
+  "key.subkey": "value_2"
+}
+```
+
 ## UI
 
 {{< tabs >}}

--- a/content/tracing/visualization/trace.md
+++ b/content/tracing/visualization/trace.md
@@ -44,7 +44,9 @@ Click on a span in the flame graph to show its metadata below the graph. If ther
 
 {{< img src="tracing/visualization/trace/trace_error.png" alt="Trace Error" responsive="true" style="width:90%;">}}
 
-If you are analyzing a trace reporting an error, the error has a specific display if you follow the special meaning tags rules. When submitting your traces you can add attributes to the `meta` parameter. Some attributes have special meanings that lead to a dedicated display or specific behavior in Datadog:
+If you are analyzing a trace reporting an error, the error has a specific display if you follow the special meaning tags rules. When submitting your traces you can add attributes to the `meta` parameter. 
+
+Some attributes have special meanings that lead to a dedicated display or specific behavior in Datadog:
 
 | Attribute     | Description                                                                                                                                                                        |
 | ----          | ------                                                                                                                                                                             |


### PR DESCRIPTION
### What does this PR do?
Adds note about span metadata that must follow the same restrictions as logs attributes.