### PR TITLE
Fix priority sampling default setting for Java

### DIFF
--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1202,7 +1202,7 @@ For a more detailed explanations of sampling and priority sampling, check the [s
 {{< tabs >}}
 {{% tab "Java" %}}
 
-Priority sampling is disabled by default. To enable it, configure the `priority.sampling` flag to `true` ([see how to configure the java client][1].
+Priority sampling is enabled by default. To disable it, configure the `priority.sampling` flag to `false` ([see how to configure the java client][1].
 
 
 Current Priority Values (more may be added in the future):


### PR DESCRIPTION
### What does this PR do?

According to this code: 

https://github.com/DataDog/dd-trace-java/blob/82dcc3ce6c89e6a0a3c3bb7fdd58336160434b16/dd-trace-api/src/main/java/datadog/trace/api/Config.java#L69 

```
private static final boolean DEFAULT_PRIORITY_SAMPLING_ENABLED = true;
```

And documentation about Java tracer System Properties and Environment Variables, `DD_PRIORITY_SAMPLING` default value is `true`:

https://docs.datadoghq.com/tracing/languages/java/#configuration 

This PR is to update this documentation to match.


### Motivation
Updated documentation to correct default value.  

### Additional Notes
Please confirm with the Java APM team what the default `DD_PRIORITY_SAMPLING` value is or should be.  