### PR TITLE
Add Rails logging configuration for Ruby APM correlation

### DIFF
--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -107,7 +107,7 @@ end
 
 **Adding tags to a current active span**
 
-Access the current active span from any method within your code. Note, however, that if the method is called and there is no span currently active, `active_span` will be nil.
+Access the current active span from any method within your code. Note, however, that if the method is called and there is no span currently active, `active_span` is nil.
 
 ```ruby
 # e.g. adding tag to active span
@@ -458,14 +458,14 @@ Further API details can be found at [`ddtrace.Tracer()`][4]
 
 **Using the API**
 
-If the above methods are still not enough to satisfy your tracing needs, a manual API is provided which will allow you to start and finish spans however you may require:
+If the above methods are still not enough to satisfy your tracing needs, a manual API is provided which allows you to start and finish spans however you may require:
 
 ```python
   span = tracer.trace('operations.of.interest')
 
   # do some operation(s) of interest in between
 
-  # NOTE: make sure to call span.finish() or the entire trace will not be sent
+  # NOTE: make sure to call span.finish() or the entire trace is not sent
   # to Datadog
   span.finish()
 ```
@@ -920,9 +920,9 @@ const tracer = opentracing.globalTracer()
 
 The following tags are available to override Datadog specific options:
 
-* `service.name`: The service name to be used for this span. The service name from the tracer will be used if this is not provided.
-* `resource.name`: The resource name to be used for this span. The operation name will be used if this is not provided.
-* `span.type`: The span type to be used for this span. Will fallback to `custom` if not provided.
+* `service.name`: The service name to be used for this span. The service name from the tracer is used if this is not provided.
+* `resource.name`: The resource name to be used for this span. The operation name is used if this is not provided.
+* `span.type`: The span type to be used for this span. The span type falls back to `custom` if not provided.
 
 [1]: https://doc.esdoc.org/github.com/opentracing/opentracing-javascript
 [2]: https://datadog.github.io/dd-trace-js
@@ -1009,7 +1009,7 @@ final SpanContext extractedContext =
                              new MyHttpRequestExtractAdapter(request));
 
 try (Scope scope = tracer.buildSpan("httpServerSpan").asChildOf(extractedContext).startActive(true)) {
-    final Span span = scope.span(); // will be a child of http client span in step 1
+    final Span span = scope.span(); // is a child of http client span in step 1
     // http server impl...
 }
 
@@ -1535,7 +1535,7 @@ To properly correlate with Datadog logging, be sure the following is present:
  - `dd.trace_id=<TRACE_ID>`: Where `<TRACE_ID>` is equal to `Datadog.tracer.active_correlation.trace_id` or `0` if no trace is active.
  - `dd.span_id=<SPAN_ID>`: Where `<SPAN_ID>` is equal to `Datadog.tracer.active_correlation.span_id` or `0` if no trace is active.
 
-By default, `Datadog::Correlation::Identifier#to_s` will return `dd.trace_id=<TRACE_ID> dd.span_id=<SPAN_ID>`.
+By default, `Datadog::Correlation::Identifier#to_s` returns `dd.trace_id=<TRACE_ID> dd.span_id=<SPAN_ID>`.
 
 An example of this in practice:
 

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1508,26 +1508,25 @@ hello()
 {{% /tab %}}
 {{% tab "Ruby" %}}
 
-To retrieve trace and span IDs for the active trace, use `Datadog.tracer.active_correlation`:
+**Enable Log Injection for Rails Applications**
+
+Rails applications which are configured with a `ActiveSupport::TaggedLogging` logger can append correlation IDs as tags to log output. The default Rails logger implements this tagged logging, making it easier to add correlation tags.
+
+In your Rails environment configuration file, add the following:
 
 ```ruby
-# When a trace is active...
-Datadog.tracer.trace('correlation.example') do
-  # Returns #<Datadog::Correlation::Identifier>
-  correlation = Datadog.tracer.active_correlation
-  correlation.trace_id # => 5963550561812073440
-  correlation.span_id # => 2232727802607726424
+Rails.application.configure do
+  config.log_tags = [proc { Datadog.tracer.active_correlation.to_s }]
 end
 
-# When a trace isn't active...
-correlation = Datadog.tracer.active_correlation
-# Returns #<Datadog::Correlation::Identifier>
-correlation = Datadog.tracer.active_correlation
-correlation.trace_id # => 0
-correlation.span_id # => 0
+# Web requests will produce:
+# [dd.trace_id=7110975754844687674 dd.span_id=7518426836986654206] Started GET "/articles" for 172.22.0.1 at 2019-01-16 18:50:57 +0000
+# [dd.trace_id=7110975754844687674 dd.span_id=7518426836986654206] Processing by ArticlesController#index as */*
+# [dd.trace_id=7110975754844687674 dd.span_id=7518426836986654206]   Article Load (0.5ms)  SELECT "articles".* FROM "articles"
+# [dd.trace_id=7110975754844687674 dd.span_id=7518426836986654206] Completed 200 OK in 7ms (Views: 5.5ms | ActiveRecord: 0.5ms)
 ```
 
-**For Ruby applications**
+**Manual Injection**
 
 To add correlation IDs to your logger, add a log formatter which retrieves the correlation IDs with `Datadog.tracer.active_correlation`, then add them to the message.
 
@@ -1557,24 +1556,6 @@ logger.warn('This is an untraced operation.')
 # When a trace is active
 Datadog.tracer.trace('my.operation') { logger.warn('This is a traced operation.') }
 # [2019-01-16 18:38:41 +0000][my_app][WARN][dd.trace_id=8545847825299552251 dd.span_id=3711755234730770098] This is a traced operation.
-```
-
-**For Rails applications**
-
-Rails applications which are configured with a `ActiveSupport::TaggedLogging` logger can append correlation IDs as tags to log output. The default Rails logger implements this tagged logging, making it easier to add correlation tags.
-
-In your Rails environment configuration file, add the following:
-
-```ruby
-Rails.application.configure do
-  config.log_tags = [proc { Datadog.tracer.active_correlation.to_s }]
-end
-
-# Web requests will produce:
-# [dd.trace_id=7110975754844687674 dd.span_id=7518426836986654206] Started GET "/articles" for 172.22.0.1 at 2019-01-16 18:50:57 +0000
-# [dd.trace_id=7110975754844687674 dd.span_id=7518426836986654206] Processing by ArticlesController#index as */*
-# [dd.trace_id=7110975754844687674 dd.span_id=7518426836986654206]   Article Load (0.5ms)  SELECT "articles".* FROM "articles"
-# [dd.trace_id=7110975754844687674 dd.span_id=7518426836986654206] Completed 200 OK in 7ms (Views: 5.5ms | ActiveRecord: 0.5ms)
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
### What does this PR do?

Adds another example of configuring Ruby APM with correlation IDs for Rails logging.

### Motivation

Make it clearer for our Rails users how to activate this in the simplest possible manner.

### Preview link

https://docs-staging.datadoghq.com/delner/apm_ruby_add_rails_log_example/tracing/languages/ruby/

### Additional Notes

Describes https://github.com/DataDog/dd-trace-rb/pull/673
