### PR TITLE
Fix validate monitor endpoint

### DIFF
--- a/content/api/monitors/monitors_validate_code.md
+++ b/content/api/monitors/monitors_validate_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#validate-a-monitor
 ---
 
 ##### Signature
-`POST https://api.datadoghq.com/api/v1/monitor`
+`POST https://api.datadoghq.com/api/v1/monitor/validate`
 ##### Example Request
 {{< code-snippets basename="api-monitor-validate" >}}
 ##### Example Response

--- a/content/developers/faq/datadog_collection.json
+++ b/content/developers/faq/datadog_collection.json
@@ -2293,7 +2293,7 @@
 							"raw": "{\n    \"type\": \"query alert\",\n    \"query\": \"min(last_5m):avg:fse_auto_process.request.duration{build:prod} + avg:cassandra.db.recent_read_latency_micros{host:fse-ldmx-f7-18} + avg:cassandra.db.recent_write_latency_micros{host:fse-ldmx-f7-18} + avg:redis.info.latency_ms{*} + avg:gunicorn.request.duration.avg{*} >= 550\"\n}"
 						},
 						"url": {
-							"raw": "https://api.datadoghq.com/api/v1/monitor?api_key={{dd_api_key}}&application_key={{dd_app_key}}",
+							"raw": "https://api.datadoghq.com/api/v1/monitor/validate?api_key={{dd_api_key}}&application_key={{dd_app_key}}",
 							"protocol": "https",
 							"host": [
 								"api",

--- a/static/json/datadog_collection.json
+++ b/static/json/datadog_collection.json
@@ -2370,7 +2370,7 @@
 							"raw": "{\n    \"type\": \"query alert\",\n    \"query\": \"min(last_5m):avg:fse_auto_process.request.duration{build:prod} + avg:cassandra.db.recent_read_latency_micros{host:fse-ldmx-f7-18} + avg:cassandra.db.recent_write_latency_micros{host:fse-ldmx-f7-18} + avg:redis.info.latency_ms{*} + avg:gunicorn.request.duration.avg{*} >= 550\"\n}"
 						},
 						"url": {
-							"raw": "https://api.datadoghq.com/api/v1/monitor?api_key={{dd_api_key}}&application_key={{dd_app_key}}",
+							"raw": "https://api.datadoghq.com/api/v1/monitor/validate?api_key={{dd_api_key}}&application_key={{dd_app_key}}",
 							"protocol": "https",
 							"host": [
 								"api",


### PR DESCRIPTION
### What does this PR do?
We have the create monitor endpoint in several places that should have the validate monitor endpoint: https://cl.ly/abdbcd0e06b5.

### Motivation

### Preview link

https://docs-staging.datadoghq.com/chrism/fix-monitor-validation-api/api/?lang=bash#validate-a-monitor

### Additional Notes
