### PR TITLE
add reboot to Mac uninstall instructions

### DIFF
--- a/content/agent/faq/how-do-i-uninstall-the-agent.md
+++ b/content/agent/faq/how-do-i-uninstall-the-agent.md
@@ -34,6 +34,7 @@ sudo rm -rf /opt/datadog-agent
 sudo rm -rf /usr/local/bin/datadog-agent
 sudo rm -rf ~/.datadog-agent/**​ #to remove broken symlinks
 ```
+Then, reboot your machine for changes to take effect.
 
 ### Windows
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds instructions for the user to reboot their Mac after uninstalling the agent. 

### Motivation
<!-- What inspired you to submit this pull request?-->

Chat with customer whose Mac was still sending metrics and appearing in the host map after he had completed the steps in the documentation. 

### Preview link
<!-- Impacted pages preview links-->

https://docs-staging.datadoghq.com/laura.hampton/add-restart-for-mac-uninstall/agent/faq/how-do-i-uninstall-the-agent/?tab=agentv6#mac-os

<!-- This is the base preview link. Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
