### PR TITLE
add units to dt() function

### DIFF
--- a/content/graphing/functions/rate.md
+++ b/content/graphing/functions/rate.md
@@ -26,7 +26,7 @@ kind: documentation
 
 | Function | Description                                         | Example                |
 | :----    | :-------                                            | :---------             |
-| `dt()`   | Graph the time difference between submitted points. | `dt(<METRIC_NAME>{*})` |
+| `dt()`   | Graph the time difference in seconds between submitted points. | `dt(<METRIC_NAME>{*})` |
 
 ## Delta value
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Add unit to the description of the `dt()` function. 

### Motivation
<!-- What inspired you to submit this pull request?-->

Question in ticket from customer: https://datadog.zendesk.com/agent/tickets/191511

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

https://docs-staging.datadoghq.com/laura.hampton/time-delta-units/graphing/functions/rate/#delta-time

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
