### PR TITLE
Update rsyslog documentation for EU region

### DIFF
--- a/content/integrations/rsyslog.md
+++ b/content/integrations/rsyslog.md
@@ -234,7 +234,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
         $ActionSendStreamDriverMode 1
         $ActionSendStreamDriverAuthMode x509/name
         $ActionSendStreamDriverPermittedPeer *.logs.datadoghq.eu
-        *.* @@intake.logs.datadoghq.com:10516;DatadogFormat
+        *.* @@intake.logs.datadoghq.eu:443;DatadogFormat
         ```
 
 6. Restart Rsyslog and your new logs get forwarded directly to your Datadog account.


### PR DESCRIPTION

### What does this PR do?
Fix the configuration for Rsyslog with SSL encryption for the EU region.

### Motivation
EU region was linking to US endpoint.

### Preview link

https://docs-staging.datadoghq.com/nils/rsyslog-eu/integrations/rsyslog/?tab=datadogeuappdatadoghqeu

### Additional Notes
<!-- Anything else we should know when reviewing?-->
