### PR TITLE
Update _index.md

### DIFF
--- a/content/logs/explorer/_index.md
+++ b/content/logs/explorer/_index.md
@@ -203,7 +203,7 @@ Export your current Log Visualization with the *Export* functionality:
 | Button              | Description                                                                                                                                                                  |
 | ----                | -----                                                                                                                                                                        |
 | Export to Monitor   | Export the query applied to your Log Analytics in order to create the log monitor query for a new [log monitor][1] *This functionality is not available yet.*                |
-| Export to Timeboard | Export your Logstream as a widget to a [Timeboard][2]. |
+| Export to Timeboard | Export your Log Analytics as a widget to a [Timeboard][2]. |
 
 
 [1]: /monitors/monitor_types/log


### PR DESCRIPTION
### What does this PR do?
Wording under 'log analytics' tab referred to 'logstream'.  Updating 'logstream' to 'log analytics'.  

### Motivation
Customer inquiry about original documentation "export logstream to timeboard".  

### Preview link
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/logs/explorer/?tab=loganalytics
https://docs.datadoghq.com/cathleenwright/logstream_to_analytics_correction/logs/explorer/?tab=loganalytics

### Additional Notes
Previous PR removed notes about still in backlog in same doc: https://github.com/DataDog/documentation/pull/3790
