### PR TITLE
remove mention of puppy agent

### DIFF
--- a/content/agent/faq/upgrade-to-agent-v6.md
+++ b/content/agent/faq/upgrade-to-agent-v6.md
@@ -19,7 +19,7 @@ Agent 6 is the latest major version of the Datadog Agent. The big difference bet
 
 * Agent 6 uses ports `5000` and `5001` by default. You can specify different ports for `expvar_port` and `cmd_port` in the `datadog.yaml` file.
 
-* Custom build your Agent v6 and [DogStatsD][1] much easier and with many more configuration options, to include or exclude almost anything. There is also a "puppy" Agent, a minimal installation.
+* Custom build your Agent v6 and [DogStatsD][1] much easier and with many more configuration options, to include or exclude almost anything.
 
 ### Agent v6 new functionalities
 


### PR DESCRIPTION
### What does this PR do?
Removes the only mention of the puppy agent

### Motivation
From support -- we don't have documentation of the puppy agent yet, so the mention here basically gives no information and only leads to confusion.

### Preview link


### Additional Notes

