### PR TITLE
Add alias for 404 link

### DIFF
--- a/content/logs/faq/_index.md
+++ b/content/logs/faq/_index.md
@@ -1,7 +1,9 @@
 ---
-title: Log FAQ
+title: Logs FAQ
 kind: faq
 private: true
+aliases:
+    - /logs/faq/instance-initialization-error-while-sending-logs-from-datadog-agent/
 ---
 
 {{< whatsnext desc="List of Frequently Asked Questions:" >}}


### PR DESCRIPTION
### What does this PR do?
- Add alias for previously deleted FAQ
- Change `Log FAQ` to `Logs FAQ`

### Motivation
- Twelve 404 requests in the last week

### Preview link
https://docs-staging.datadoghq.com/ruth/logs-faq-404/logs/faq/instance-initialization-error-while-sending-logs-from-datadog-agent/
