### PR TITLE
Remove outdated reference to log collection instruction

### DIFF
--- a/content/agent/kubernetes/integrations.md
+++ b/content/agent/kubernetes/integrations.md
@@ -53,21 +53,6 @@ And in the manifest of your Agent (DaemonSet/deployment) add the following:
 [...]
 ```
 
-To enable [Log collection][2] add the following lines in your `http-config`:
-
-```yaml
-[...]
-data:
-  http-config: |-
-  [...]
-    logs:
-      - type: docker
-        service: docker
-        source: kubernetes
-```
-
-Learn more about this in [the Docker log collection documentation][3].
-
 ### Mounting a custom configuration file in a container with a ConfigMap
 
 To mount a custom `datadog.yaml` in a container with a ConfigMap, employ the following in your DaemonSet manifest:


### PR DESCRIPTION
### What does this PR do?
Remove outdated reference to log collection instruction

### Motivation
The way to configure log collection now is with pod annotations or container labels.
Config map should be used to configure custom log collection from files

### Preview link
https://docs-staging.datadoghq.com/nils/log-k8/agent/kubernetes/integrations/#configmap

### Additional Notes
<!-- Anything else we should know when reviewing?-->
