### PR TITLE
all: update datadog-trace-agent links

### DIFF
--- a/content/agent/apm/_index.md
+++ b/content/agent/apm/_index.md
@@ -196,9 +196,8 @@ Primary tags appear at the top of APM pages. Use these selectors to slice the da
 
 [1]: /tracing/faq/agent-5-tracing-setup
 [2]: https://github.com/DataDog/dd-trace-py/blob/69693dc7cdaed3a2b6a855325109fa100e42e254/ddtrace/writer.py#L159
-[3]: https://github.com/DataDog/datadog-trace-agent/blob/master/config/agent.go#L95
 [4]: https://app.datadoghq.com/account/settings#agent
-[5]: https://github.com/DataDog/datadog-trace-agent#run-on-osx
+[5]: https://github.com/DataDog/datadog-agent/tree/master/docs/trace-agent#run-on-macos
 [6]: /developers/libraries/#community-tracing-apm-libraries
 [7]: https://app.datadoghq.com/apm/home?env=
 [8]: /tracing/visualization

--- a/content/agent/docker/apm.md
+++ b/content/agent/docker/apm.md
@@ -6,7 +6,7 @@ aliases:
   - /tracing/setup/docker/
   - /agent/apm/docker
 further_reading:
-- link: "https://github.com/DataDog/datadog-trace-agent"
+- link: "https://github.com/DataDog/datadog-agent/tree/master/pkg/trace"
   tag: "Github"
   text: Source code
 - link: "https://docs.datadoghq.com/integrations/amazon_ecs/#trace-collection"
@@ -17,7 +17,7 @@ further_reading:
   text: "Explore your services, resources and traces"
 ---
 
-Enable the [datadog-trace-agent][1] in the `datadog/agent` container by passing `DD_APM_ENABLED=true` as an environment variable.
+Enable the Trace Agent in the `datadog/agent` container by passing `DD_APM_ENABLED=true` as an environment variable.
 
 ## Tracing from the host
 
@@ -172,6 +172,5 @@ tracer.configure(hostname='172.17.0.1', port=8126)
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/DataDog/datadog-trace-agent
 [2]: https://app.datadoghq.com/account/settings#api
 [3]: /agent/apm/#environment

--- a/content/tracing/faq/agent-5-tracing-setup.md
+++ b/content/tracing/faq/agent-5-tracing-setup.md
@@ -74,8 +74,8 @@ Trace search is available for Agent 5.25.0+. For more information, see the set u
 Need help? Contact [Datadog support][11].
 
 
-[1]: https://github.com/DataDog/datadog-trace-agent#run-on-osx
-[2]: https://github.com/DataDog/datadog-trace-agent#run-on-windows
+[1]: https://github.com/DataDog/datadog-agent/tree/master/docs/trace-agent#run-on-macos
+[1]: https://github.com/DataDog/datadog-agent/tree/master/docs/trace-agent#run-on-windows
 [3]: /agent/faq/where-is-the-configuration-file-for-the-agent
 [4]: https://app.datadoghq.com/account/settings#agent
 [5]: https://hub.docker.com/r/datadog/docker-dd-agent

--- a/ja/content/tracing/docker.md
+++ b/ja/content/tracing/docker.md
@@ -9,7 +9,7 @@ title: Tracing Docker Applications
 
 <div class='alert alert-info'><strong>NOTICE:</strong>アクセスいただきありがとうございます。こちらのページは現在英語のみのご用意となっております。引き続き日本語化の範囲を広げてまいりますので、皆様のご理解のほどよろしくお願いいたします。</div>
 
-Enable the [datadog-trace-agent](https://github.com/DataDog/datadog-trace-agent) in the `docker-dd-agent` container by passing `DD_APM_ENABLED=true` as an environment variable
+Enable the trace-agent in the `docker-dd-agent` container by passing `DD_APM_ENABLED=true` as an environment variable
 
 **Note: APM is NOT available on Alpine Images**
 

--- a/ja/content/tracing/faq.md
+++ b/ja/content/tracing/faq.md
@@ -23,18 +23,18 @@ Tracing data is stored for about 36 hours.
 
 ### How often does the trace agent send stats?
 
-The application code instrumentation flushes to the Agent every 1 s ([see here for the Python client](https://github.com/DataDog/dd-trace-py/blob/69693dc7cdaed3a2b6a855325109fa100e42e254/ddtrace/writer.py#L159) for instance) and the Agent flushes to the [Datadog API every 10s](https://github.com/DataDog/datadog-trace-agent/blob/master/config/agent.go#L95).
+The application code instrumentation flushes to the Agent every second ([see here for the Python client](https://github.com/DataDog/dd-trace-py/blob/69693dc7cdaed3a2b6a855325109fa100e42e254/ddtrace/writer.py#L159) for instance) and the Agent flushes traces every 5 seconds and stats every 10 seconds to the Datadog API.
 
 ### Is the Trace Agent open source?
 
-Yes, [check it out on GitHub](https://github.com/DataDog/datadog-trace-agent).
+Yes, [check it out on GitHub](https://github.com/DataDog/datadog-agent). The code for the trace agent is contained in the `cmd/trace-agent` and `pkg/trace` subdirectories.
 
 ### On what platforms can I run the Trace Agent?
 
 Trace Agent packages are available for:
 
 * Linux - packaged with the Datadog Agent since v5.11.0
-* Mac OS - packaged separately, see the [Trace Agent releases](https://github.com/DataDog/datadog-trace-agent/releases/)
+* Mac OS - packaged separately, see the [Trace Agent releases (pre-6.9.0)](https://github.com/DataDog/datadog-trace-agent/releases/). As of 6.9.0, the Trace Agent must be compiled from source from within the [Datadog Agent repository](https://github.com/DataDog/datadog-agent/tree/master/cmd/trace-agent).
 * Docker - included in the [docker-dd-agent](https://github.com/DataDog/docker-dd-agent) container
 
 For other platforms, you must install from source.

--- a/ja/content/tracing/index.md
+++ b/ja/content/tracing/index.md
@@ -17,7 +17,7 @@ Datadog's integrated APM tool eliminates the traditional separation between infr
 
 The Datadog APM is included in our Enterprise plan or as an upgrade to our Pro plan. A free 14-day trial is available.  Registered users can visit the [APM page of the Datadog app](https://app.datadoghq.com/trace/home) to get started.
 
-APM is available as part of the Datadog Agent with versions 5.11+ as part of the one line install for the Linux and Docker Agents. Currently, [Mac](https://github.com/DataDog/datadog-trace-agent#run-on-osx) and [Windows](https://github.com/DataDog/datadog-trace-agent#run-on-windows) users must perform a manual install of the APM Agent (aka Trace Agent) via a separate install process. The Agent can be enabled by including the following in your Datadog agent configuration file: `apm_enabled: true`
+APM is available as part of the Datadog Agent with versions 5.11+ as part of the one line install for the Linux and Docker Agents. Currently, [Mac](https://github.com/DataDog/datadog-agent/tree/master/docs/trace-agent#run-on-macos) and [Windows](https://github.com/DataDog/datadog-agent/tree/master/docs/trace-agent#run-on-windows) users must perform a manual install of the APM Agent (aka Trace Agent) via a separate install process. The Agent can be enabled by including the following in your Datadog agent configuration file: `apm_enabled: true`
 
 <div class="alert alert-info">
 APM is enabled by default after Datadog agent 5.13 (on Linux and Docker), and can be disabled by adding the parameter: <code>apm_enabled: no</code> in your Datadog agent configuration file.


### PR DESCRIPTION
The datadog-trace-agent was merged into the datadog-agent (https://github.com/DataDog/datadog-agent/pull/2909). This change updates any broken links pointing to the old repository.

Depends on https://github.com/DataDog/datadog-agent/pull/2940