### PR TITLE
Update the PHP getting-started docs

### DIFF
--- a/content/tracing/languages/php.md
+++ b/content/tracing/languages/php.md
@@ -9,7 +9,7 @@ further_reading:
   tag: "GitHub"
   text: "Source code"
 - link: "tracing/visualization/"
-  tag: "Documentation"
+  tag: "Use the APM UI"
   text: "Explore your services, resources and traces"
 - link: "tracing/advanced_usage/?tab=php"
   tag: "Advanced Usage"
@@ -22,104 +22,254 @@ The APM tracer for PHP applications is in Open Public Beta.
 
 ## Installation and Getting Started
 
-To begin tracing applications written in PHP, first [install and configure the Datadog Agent][1], see additional documentation for [tracing Docker applications][2] or [Kubernetes applications][3].
+For descriptions of terminology used in APM, take a look at the [official documentation][1].
 
-Next, install the Datadog PHP extension using one of the precompiled packages for supported distributions. The latest packages can be found on GitHub's [releases page][4]. If you don't find your distribution, you can install the PHP extension [from source][5]
+For details about contributing the PHP tracer, check out the [contributing guide][2].
+
+### Setup the Datadog Agent
+
+The PHP APM tracer sends trace data through the Datadog Agent.
+
+[Install and configure the Datadog Agent][3], see the additional documentation for [tracing Docker applications][4] or [Kubernetes applications][5].
+
+Make sure the Agent has **[APM enabled][6]**.
+
+### Install the extension
+
+Install the PHP extension using one of the [precompiled packages for supported distributions][7]. If you don't find your distribution, you can install the PHP extension [from PECL][8] or [from source][9].
+
+Once downloaded, install the package with one of the commands below.
 
 ```bash
 # using RPM package (RHEL/Centos 6+, Fedora 20+)
-rpm -ivh datadog-php-tracer.rpm
+$ rpm -ivh datadog-php-tracer.rpm
 
 # using DEB package (Debian Jessie+ , Ubuntu 14.04+)
-deb -i datadog-php-tracer.deb
+$ deb -i datadog-php-tracer.deb
 
 # using APK package (Alpine)
-apk add datadog-php-tracer.apk --allow-untrusted
+$ apk add datadog-php-tracer.apk --allow-untrusted
 
 # using tar.gz archive (Other distributions using libc6)
-tar -xf datadog-php-tracer.tar.gz -C /
-/opt/datadog-php/bin/post-install.sh
+$ tar -xf datadog-php-tracer.tar.gz -C /
+  /opt/datadog-php/bin/post-install.sh
 ```
 
-Finally, install the Datadog tracing library using composer:
+### Install from PECL
+
+<div class="alert alert-warning">
+Installing the PHP tracer via PECL is an experimental feature.
+</div>
+
+Alternatively install the extension from the [PECL package **datadog_trace**][10].
 
 ```bash
-composer config minimum-stability beta # required to install opentracing 1.0.0-beta5
-composer require opentracing/opentracing
-composer require datadog/dd-trace
+$ sudo pecl install datadog_trace-beta
 ```
 
-**Note:** You can [install the Datadog library without changing minimum-stability][6]
+Next, [enable the extension][11].
+
+### Install from source
+
+[Download the source code **tar.gz** or **zip** file][7] from the releases page and unzip the file. Then compile and install the extension with the commands below.
+
+```bash
+$ cd /path/to/dd-trace-php
+$ phpize
+$ ./configure --enable-ddtrace
+$ make
+$ sudo make install
+```
+
+#### Enable the extension
+
+Modify the **php.ini** to enable the **ddtrace** extension. To find out where the INI file is, run the following command:
+
+```bash
+$ php --ini
+
+Configuration File (php.ini) Path: /usr/local/etc/php/7.2
+Loaded Configuration File:         /usr/local/etc/php/7.2/php.ini
+...
+```
+
+Add the following line to the **php.ini** file.
+
+```ini
+extension=ddtrace.so
+```
+
+After restarting the web server/PHP SAPI (e.g., `$ sudo apachectl restart`, `$ sudo service php-fpm restart`, etc) the extension is enabled. To confirm that the extension is loaded, run:
+
+```bash
+$ php --ri=ddtrace
+
+ddtrace
+
+
+Datadog PHP tracer extension
+...
+```
 
 ## Compatibility
 
-PHP APM includes support for the following PHP versions:
+PHP APM supports the following PHP versions:
 
 | Version | Support type |
-| -----   | ------------ |
-| 7.0.x   | Public Beta  |
-| 7.1.x   | Public Beta  |
-| 7.2.x   | Public Beta  |
-| 5.6.x   | Public Beta  |
+| :------ | :----------- |
+| 7.2.x   | Beta         |
+| 7.1.x   | Beta         |
+| 7.0.x   | Beta         |
+| 5.6.x   | Beta         |
+| 5.4.x   | Experimental |
 
 ## Automatic Instrumentation
 
-Automatic instrumentation uses the `ddtrace` extension to modify PHP's runtime and inject custom PHP code around specific methods. When [tracing is enabled][7] the PHP tracer is able to automatically instrument all supported libraries out of the box.
+Tracing is automatically instrumented by default so once the extension is installed, **ddtrace** will trace your application and send traces to the Agent.
+
+Automatic instrumentation works by modifying PHP's runtime to wrap certain functions and methods in order to trace them. The PHP tracer supports automatic instrumentation for [several libraries][12].
 
 Automatic instrumentation captures:
 
-* Method execution time.
-* Relevant trace data, such as URL and status response codes for web requests or SQL queries for database access.
-* Unhandled exceptions, including stacktraces if available.
-* A total count of traces (e.g. web requests) flowing through the system.
+* Method execution time
+* Relevant trace data, such as URL and status response codes for web requests or SQL queries for database access
+* Unhandled exceptions, including stacktraces if available
+* A total count of traces (e.g., web requests) flowing through the system
+
+## Manual instrumentation
+
+Although automatic instrumentation will work in most cases, there are some special bootstrapping contextes where automatic instrumentation will not work as expected. In these cases, disable automatic instrumentation and manually enable it.
+
+First install the PHP tracer dependency with Composer:
+
+```bash
+$ composer require datadog/dd-trace
+```
+
+Then include the PHP tracer boostrap file right after the composer autoloader.
+
+```php
+// The existing Composer autoloader
+require '<APP_ROOT>/vendor/autoload.php';
+
+// Add the PHP tracer bootstrap
+require '<APP_ROOT>/vendor/datadog/dd-trace/bridge/dd_init.php';
+```
+
+### Zend Framework 1 integration
+
+Zend Framework 1 is automatically instrumented by default so you are not required to modify your ZF1 project. However, if automatic instrumentation is disabled, enable the tracer manually.
+
+First, [download the latest source code from the releases page][7]. Extract the zip file and copy the **src/DDTrace** folder to your application's **library** folder. Then add the following to your **application/configs/application.ini** file.
+
+```ini
+autoloaderNamespaces[] = "DDTrace_"
+pluginPaths.DDTrace = APPLICATION_PATH "/../library/DDTrace/Integrations/ZendFramework/V1"
+resources.ddtrace = true
+```
+
+## View the trace
+
+Assuming the Agent is running with APM enabled and it is configured with your API key, and assuming the **ddtrace** extension is installed and instrumented properly into your app, visit a tracing-enabled enpoint of your app and check out the [APM UI][13] to see the traces.
+
+**It might take a few minutes before traces appear in the UI.** Just refresh the page a few times until you see the screen change.
+
+## Trace a custom function or method
+
+The `dd_trace()` function hooks into existing functions and methods to:
+
+* Open a span before the code executes
+* Set additional tags or errors on the span
+* Close the span when it is done
+* Modify the arguments or the return value
+
+For example, trace the `CustomDriver::doWork()` method, add custom tags, report any exceptions as errors on the span and then re-throw the exeptions.
+
+```php
+dd_trace("CustomDriver", "doWork", function (...$args) {
+    // Start a new span
+    $scope = GlobalTracer::get()->startActiveSpan('CustomDriver.doWork');
+    $span = $scope->getSpan();
+
+    // Access object members via $this
+    $span->setTag(Tags\RESOURCE_NAME, $this->workToDo);
+    
+    try {
+        // Execute the original method
+        $result = $this->doWork(...$args);
+        // Set a tag based on the return value
+        $span->setTag('doWork.size', count($result));
+        return $result;
+    } catch (Exception $e) {
+        // Inform the tracer that there was an exception thrown
+        $span->setError($e);
+        // Bubble up the exception
+        throw $e
+    } finally {
+        // Close the span
+        $span->finish();
+    }
+});
+```
+
+## Configuration
+
+Configure the agent connection parameters via environment variables.
+
+| Env variable               | Default     | Note                                                                       |
+| :------------------------- | :---------- | :------------------------------------------------------------------------- |
+| `DD_TRACE_ENABLED`         | `true`      | Enable the tracer globally                                                 |
+| `DD_INTEGRATIONS_DISABLED` | `null`      | CSV list of disabled extensions; e.g., `curl,mysqli`                       |
+| `DD_AGENT_HOST`            | `localhost` | The Agent host name                                                        |
+| `DD_TRACE_AGENT_PORT`      | `8126`      | The Agent port number                                                      |
+| `DD_AUTOFINISH_SPANS`      | `false`     | Whether or not spans are automatically finished when the tracer is flushed |
 
 ### Integrations
 
 #### Framework Compatibility
 
-| Module         | Versions    | Support Type       |
-| :-----------   | :---------- | :----------------- |
-| Laravel        | 5.x         | Public Beta        |
-| Laravel        | 4.2         | Coming Soon        |
-| Symfony        | 4.x         | Public Beta        |
-| Symfony        | 3.x         | Public Beta        |
-| Magento        | 2.x         | Coming Soon        |
-| Zend Framework | 3.x         | Coming Soon        |
-| CakePHP        | 3.x         | Coming Soon        |
-| Drupal         | 7.x         | Coming Soon        |
-| Wordpress      | 4.x         | Coming Soon        |
-| Yii            | 2.0.x       | Coming Soon        |
-| Slim           | 3.x         | Coming Soon        |
+| Module         | Versions | Support Type |
+| :------------- | :------- | :----------- |
+| Laravel        | 5.x      | Beta         |
+| Laravel        | 4.2      | Beta         |
+| Symfony        | 4.x      | Beta         |
+| Symfony        | >= 3.3   | Beta         |
+| Zend Framework | 1.12     | Beta         |
 
-Don't see your desired web frameworks? Let Datadog know more about your needs through [this survey][8]
+Don't see your desired web frameworks? Let Datadog know more about your needs through [this survey][14].
 
 #### Library Compatibility
 
 | Module        | Versions                   | Support Type |
 | :------------ | :------------------------- | :----------- |
-| Curl          | *(Any Supported PHP)*      | Public Beta  |
-| Doctrine      | 2.6                        | Coming Soon  |
-| Elasticsearch | 1.x                        | Public Beta  |
-| Eloquent      | Laravel supported versions | Public Beta  |
-| Guzzle        | 5.x                        | Public Beta  |
-| Memcached     | *(Any Supported PHP)*      | Public Beta  |
-| MongoDB       | 1.4.x                      | Public Beta  |
-| Mysqli        | *(Any Supported PHP)*      | Public Beta  |
-| PDO           | *(Any Supported PHP)*      | Public Beta  |
-| pgsql         | *(Any Supported PHP)*      | Coming Soon  |
-| Predis        | 1.1                        | Public Beta  |
+| Curl          | *(Any Supported PHP)*      | Beta         |
+| Elasticsearch | 1.x                        | Beta         |
+| Eloquent      | Laravel supported versions | Beta         |
+| Guzzle        | 6.x                        | Beta         |
+| Guzzle        | 5.x                        | Beta         |
+| Memcached     | *(Any Supported PHP)*      | Beta         |
+| MongoDB       | 1.4.x                      | Beta         |
+| Mysqli        | *(Any Supported PHP)*      | Beta         |
+| PDO           | *(Any Supported PHP)*      | Beta         |
+| Predis        | 1.1                        | Beta         |
 
-Don't see your desired libraries? Let Datadog know more about your needs through [this survey][8].
+Don't see your desired libraries? Let Datadog know more about your needs through [this survey][14].
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/setup
-[2]: /tracing/setup/docker
-[3]: /agent/kubernetes/daemonset_setup/#trace-collection
-[4]: https://github.com/DataDog/dd-trace-php/releases/latest
-[5]: https://github.com/DataDog/dd-trace-php/blob/master/docs/getting_started.md#compiling-and-installing-the-extension-manually
-[6]: https://github.com/DataDog/dd-trace-php/blob/master/docs/getting_started.md#alternative-install-datadogdd-trace-package-without-changing-minimum-stability
-[7]: https://github.com/DataDog/dd-trace-php/blob/master/docs/getting_started.md#enabling-tracing
-[8]: https://goo.gl/forms/rKjH2J6nJ585KXri2
+[1]: /tracing/visualization
+[2]: https://github.com/DataDog/dd-trace-php/blob/master/CONTRIBUTING.md
+[3]: /agent/?tab=agentv6
+[4]: /tracing/setup/docker
+[5]: /agent/kubernetes/daemonset_setup/#trace-collection
+[6]: /agent/apm/?tab=agent630#agent-configuration
+[7]: https://github.com/DataDog/dd-trace-php/releases/latest
+[8]: #install-from-pecl
+[9]: #install-from-source
+[10]: https://pecl.php.net/package/datadog_trace
+[11]: #enable-the-extension
+[12]: #library-compatibility
+[13]: https://app.datadoghq.com/apm/services
+[14]: https://goo.gl/forms/rKjH2J6nJ585KXri2


### PR DESCRIPTION
### What does this PR do?
This moves & updates the getting-started documentation from the [PHP tracer repo](https://github.com/DataDog/dd-trace-php) into the documentation site.

### Motivation
To prep the PHP tracer for GA.

### Preview link
My [preview link](https://docs-staging.datadoghq.com/sammyk/update-php-docs/tracing/languages/php/) is broken. I updated my `github_personal_token` env var with my personal token. I'm curious what I did wrong?

### Additional Notes
The link to the Google Docs form to request integrations/frameworks is broken in this PR and in production. I'm on the search for the updated link. :)
