### PR TITLE
Includes Tornado and Molten web frameworks

### DIFF
--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1046,6 +1046,7 @@ Distributed tracing is supported in the following frameworks:
 | django            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#django   |
 | falcon            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#falcon   |
 | flask             | http://pypi.datadoghq.com/trace/docs/web_integrations.html#flask    |
+| molten            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#molten   |
 | pylons            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pylons   |
 | pyramid           | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pyramid  |
 | requests          | http://pypi.datadoghq.com/trace/docs/other_integrations.html#requests |

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1048,7 +1048,7 @@ Distributed tracing is supported in the following frameworks:
 | flask             | http://pypi.datadoghq.com/trace/docs/web_integrations.html#flask    |
 | pylons            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pylons   |
 | pyramid           | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pyramid  |
-| requests          | http://pypi.datadoghq.com/trace/docs/web_integrations.html#requests |
+| requests          | http://pypi.datadoghq.com/trace/docs/other_integrations.html#requests |
 | tornado           | http://pypi.datadoghq.com/trace/docs/web_integrations.html#tornado  |
 
 To add your own distributed tracing check the [Datadog API documentation][1].

--- a/content/tracing/languages/python.md
+++ b/content/tracing/languages/python.md
@@ -61,6 +61,7 @@ The `ddtrace` library includes support for a number of web frameworks, including
 | [Django][6] | Fully Supported | http://pypi.datadoghq.com/trace/docs/web_integrations.html#django  |
 | [Falcon][7]   | Fully Supported | http://pypi.datadoghq.com/trace/docs/web_integrations.html#falcon  |
 | [Flask][8]         | Fully Supported | http://pypi.datadoghq.com/trace/docs/web_integrations.html#flask   |
+| [Molten][29]         | Fully Supported | http://pypi.datadoghq.com/trace/docs/web_integrations.html#molten   |
 | [Pylons][9]      | Fully Supported | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pylons  |
 | [Pyramid][10]       | Fully Supported | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pyramid |
 | [Tornado][28]       | Fully Supported | http://pypi.datadoghq.com/trace/docs/web_integrations.html#tornado |
@@ -131,3 +132,4 @@ The `ddtrace` library includes support for the following libraries:
 [26]: https://kombu.readthedocs.io/en/latest
 [27]: http://docs.python-requests.org/en/master
 [28]: http://www.tornadoweb.org/
+[29]: https://moltenframework.com/

--- a/content/tracing/languages/python.md
+++ b/content/tracing/languages/python.md
@@ -63,6 +63,7 @@ The `ddtrace` library includes support for a number of web frameworks, including
 | [Flask][8]         | Fully Supported | http://pypi.datadoghq.com/trace/docs/web_integrations.html#flask   |
 | [Pylons][9]      | Fully Supported | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pylons  |
 | [Pyramid][10]       | Fully Supported | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pyramid |
+| [Tornado][28]       | Fully Supported | http://pypi.datadoghq.com/trace/docs/web_integrations.html#tornado |
 
 #### Datastore Compatibility
 
@@ -129,3 +130,4 @@ The `ddtrace` library includes support for the following libraries:
 [25]: http://jinja.pocoo.org
 [26]: https://kombu.readthedocs.io/en/latest
 [27]: http://docs.python-requests.org/en/master
+[28]: http://www.tornadoweb.org/


### PR DESCRIPTION
#3828 ## What does this PR do?

- adds tornado to python.md  (already mentioned in _index.md)
- adds molten to both python.md and _index.md

### Motivation

Tornado thought to be unsupported as it was not listed, but it is and we have docs for it as well.

### Preview link

- https://docs-staging.datadoghq.com/ianb/apm_python_include_tornado/tracing/advanced_usage/?tab=python#distributed-tracing
- https://docs-staging.datadoghq.com/ianb/apm_python_include_tornado/tracing/languages/python/#web-framework-compatibility

### Additional Notes
<!-- Anything else we should know when reviewing?-->
