### PR TITLE
Adding DD_SITE documentation

### DIFF
--- a/content/agent/basic_agent_usage/_index.md
+++ b/content/agent/basic_agent_usage/_index.md
@@ -60,10 +60,15 @@ Manage the Datadog Agent and [Integrations][1] using configuration management to
 {{% /tab %}}
 {{< /tabs >}}
 
-
 ## Configuration files
 
 [Refer to the dedicated page for Agent configuration files][2].
+
+## Datadog Region
+
+To send your Agent data to [Datadog EU region][3], edit your [Agent main configuration file][4] `datadog.yaml` and set the `dd_site` parameter to:
+
+`dd_site:datadoghq.eu`
 
 ## Log location
 
@@ -93,3 +98,5 @@ The Datadog logs do a rollover every 10MB. When a rollover occurs, **one** backu
 
 [1]: /integrations
 [2]: /agent/faq/agent-configuration-files
+[3]: https://app.datadoghq.eu
+[4]: /agent/faq/agent-configuration-files/?tab=agentv6#agent-main-configuration-file

--- a/content/agent/basic_agent_usage/_index.md
+++ b/content/agent/basic_agent_usage/_index.md
@@ -66,7 +66,7 @@ Manage the Datadog Agent and [Integrations][1] using configuration management to
 
 ## Datadog Region
 
-To send your Agent data to [Datadog EU region][3], edit your [Agent main configuration file][4] `datadog.yaml` and set the `dd_site` parameter to:
+To send your Agent data to the [Datadog EU region][3], edit your [Agent main configuration file][4] `datadog.yaml` and set the `dd_site` parameter to:
 
 `dd_site:datadoghq.eu`
 

--- a/content/agent/docker/_index.md
+++ b/content/agent/docker/_index.md
@@ -50,7 +50,7 @@ The Agent is highly customizable. Here are the most used environment variables:
 | `DD_API_KEY`    | Your Datadog API key (**required**)                                                                                                                |
 | `DD_HOSTNAME`   | Hostname to use for metrics (if autodetection fails)                                                                                               |
 | `DD_TAGS`       | Host tags separated by spaces. For example: `simple-tag-0 tag-key-1:tag-value-1`                                                                   |
-| `DD_SITE`       | Region to send your metrics, traces, and logs. Available values are `datadoghq.com` for Datadog US region and `datadoghq.eu` for Datadog EU region |
+| `DD_SITE`       | Destination region for your metrics, traces, and logs. Valid options are `datadoghq.com` for the Datadog US region, and `datadoghq.eu` for the Datadog EU region |
 
 
 #### Optional collection Agents

--- a/content/agent/docker/_index.md
+++ b/content/agent/docker/_index.md
@@ -45,11 +45,13 @@ The Agent is highly customizable. Here are the most used environment variables:
 
 #### Global options
 
-| Env Variable  | Description                                                                      |
-|---------------|----------------------------------------------------------------------------------|
-| `DD_API_KEY`  | Your Datadog API key (**required**)                                              |
-| `DD_HOSTNAME` | Hostname to use for metrics (if autodetection fails)                             |
-| `DD_TAGS`     | Host tags separated by spaces. For example: `simple-tag-0 tag-key-1:tag-value-1` |
+| Env Variable    | Description                                                                                                                                        |
+| --------------- | ----------------------------------------------------------------------------------                                                                 |
+| `DD_API_KEY`    | Your Datadog API key (**required**)                                                                                                                |
+| `DD_HOSTNAME`   | Hostname to use for metrics (if autodetection fails)                                                                                               |
+| `DD_TAGS`       | Host tags separated by spaces. For example: `simple-tag-0 tag-key-1:tag-value-1`                                                                   |
+| `DD_SITE`       | Region to send your metrics, traces, and logs. Available values are `datadoghq.com` for Datadog US region and `datadoghq.eu` for Datadog EU region |
+
 
 #### Optional collection Agents
 

--- a/content/agent/kubernetes/daemonset_setup.md
+++ b/content/agent/kubernetes/daemonset_setup.md
@@ -149,6 +149,9 @@ spec:
               secretKeyRef:
                 name: datadog-secret
                 key: api-key
+          - name: DD_SITE
+            # Set DD_SITE to datadoghq.eu to send your Agent data to Datadog EU region 
+            value: "datadoghq.com"
           - name: DD_COLLECT_KUBERNETES_EVENTS
             value: "true"
           - name: DD_LEADER_ELECTION

--- a/content/agent/kubernetes/daemonset_setup.md
+++ b/content/agent/kubernetes/daemonset_setup.md
@@ -150,7 +150,7 @@ spec:
                 name: datadog-secret
                 key: api-key
           - name: DD_SITE
-            # Set DD_SITE to datadoghq.eu to send your Agent data to Datadog EU region 
+            # Set DD_SITE to datadoghq.eu to send your Agent data to the Datadog EU region 
             value: "datadoghq.com"
           - name: DD_COLLECT_KUBERNETES_EVENTS
             value: "true"


### PR DESCRIPTION
### What does this PR do?
Adds information in Agent setup instructions about DD_SITE in order to allow user to send Agent Data to Datadog EU region