### PR TITLE
fix navigation to be language relative and fix french files when link…

### DIFF
--- a/content/api/comments/comments_create.fr.md
+++ b/content/api/comments/comments_create.fr.md
@@ -18,4 +18,4 @@ Les commentaires sont fondamentalement des événements spéciaux qui apparaisse
 * **`related_event_id`** [*facultatif*, *défaut*=**None**] :
     L'ID d'un autre commentaire ou événement auquel répondre.
 
-[1]: /graphing/event_stream
+[1]: /fr/graphing/event_stream

--- a/content/api/downtimes/downtimes.fr.md
+++ b/content/api/downtimes/downtimes.fr.md
@@ -7,4 +7,4 @@ external_redirect: /api/#downtimes
 ## Downtimes
 Les [downtimes][1] vous permettent de mieux contrôler les notifications d'un monitor en vous permettant d'exclure des sous-groupes des contextes de l'alerte. Les paramètres de downtime, qui peuvent être planifiés avec une heure de début et de fin, désactivent toutes les notifications liées à des tags Datadog.
 
-[1]: /monitors/downtimes
+[1]: /fr/monitors/downtimes

--- a/content/api/events/events.fr.md
+++ b/content/api/events/events.fr.md
@@ -10,4 +10,4 @@ Le service d'événements vous permet de programmer l'envoi d'événements dans 
 
 Les événements sont limités à 4 000 caractères. Si un événement est envoyé avec un message contenant plus de 4 000 caractères, seuls les 4000 premiers caractères seront affichés.
 
-[1]: /graphing/event_stream
+[1]: /fr/graphing/event_stream

--- a/content/api/events/events_post.fr.md
+++ b/content/api/events/events_post.fr.md
@@ -35,5 +35,5 @@ Cet endpoint vous permet d'envoyer des événements dans le flux. Taguez-les, d�
     [Liste complète de valeurs d'attribut source][3]
 
 [1]: https://github.com/DataDog/dogapi-rb
-[2]: /graphing/event_stream/#markdown-events\
-[3]: /integrations/faq/list-of-api-source-attribute-value
+[2]: /fr/graphing/event_stream/#markdown-events\
+[3]: /fr/integrations/faq/list-of-api-source-attribute-value

--- a/content/api/graphs/graphs.fr.md
+++ b/content/api/graphs/graphs.fr.md
@@ -7,4 +7,4 @@ external_redirect: /api/#graphiques
 ## Graphiques
 Prenez des snapshots de [graphiques][1] à l'aide de l'API.
 
-[1]: /graphing
+[1]: /fr/graphing

--- a/content/api/graphs/graphs_snapshot.fr.md
+++ b/content/api/graphs/graphs_snapshot.fr.md
@@ -25,4 +25,4 @@ external_redirect: /api/#snapshot-de-graphique
     Le titre du graphique. Si aucun titre n'est spécifié, le graphique n'a pas de titre.
 
 [1]: http://andreafalzetti.github.io/blog/2017/04/17/datadog-png-snapshot-not-showing.html
-[2]: /graphing/graphing_json/#grammar
+[2]: /fr/graphing/graphing_json/#grammar

--- a/content/api/metrics/metrics_editmetadata.fr.md
+++ b/content/api/metrics/metrics_editmetadata.fr.md
@@ -24,4 +24,4 @@ L'endpoint des métadonnées des métriques vous permet de modifier les champs d
 * **`statsd_interval`** [*facultatif*, *défaut*=**None**] :
     Le cas échéant, statds transmet l'intervalle en secondes pour la métrique.
 
-[1]: /developers/metrics
+[1]: /fr/developers/metrics

--- a/content/api/monitors/monitors.fr.md
+++ b/content/api/monitors/monitors.fr.md
@@ -9,5 +9,5 @@ external_redirect: /api/#monitors
 Les [monitors][1] vous permettent de surveiller une métrique ou un check, en envoyant une notification à votre équipe lorsque certains seuils définis sont dépassés.
 Reportez-vous à la [page de création de monitors][2] pour en savoir plus sur la création de monitors.
 
-[1]: /monitors
-[2]: /monitors/monitor_types
+[1]: /fr/monitors
+[2]: /fr/monitors/monitor_types

--- a/content/api/monitors/monitors_muteall.fr.md
+++ b/content/api/monitors/monitors_muteall.fr.md
@@ -12,4 +12,4 @@ En désactivant tous les monitors, ceux-ci n'enverront plus de notifications par
 
 Cet endpoint ne prend aucun argument JSON.
 
-[1]: /graphing/event_stream
+[1]: /fr/graphing/event_stream

--- a/content/api/org/org.fr.md
+++ b/content/api/org/org.fr.md
@@ -7,4 +7,4 @@ external_redirect: /api/#organisations
 ## Organisations
 Créez, modifiez et gérez vos organisations. En savoir plus sur les [comptes multi-org][1].
 
-[1]: /account_management/multi_organization
+[1]: /fr/account_management/multi_organization

--- a/content/api/org/org_update.fr.md
+++ b/content/api/org/org_update.fr.md
@@ -17,4 +17,4 @@ external_redirect: /api/#mettre-a-jour-une-organisation
     *  **`saml_strict_mode`** : possède une propriété `enabled` (booléenne).
     * **`saml_autocreate_users_domains`** : possède deux propriétés, `enabled` (booléenne) et `domains`, qui correspond à la liste des domaines sans le symbole « @ ».
 
-[1]: /account_management/saml
+[1]: /fr/account_management/saml

--- a/content/api/overview/overview_code.fr.md
+++ b/content/api/overview/overview_code.fr.md
@@ -10,4 +10,4 @@ De nombreuses bibliothèques client exploitent l'API Datadog. [Découvrez-les][1
 ### SIGNATURE
 https://api.datadoghq.com/api/
 
-[1]: /developers/libraries
+[1]: /fr/developers/libraries

--- a/content/api/screenboards/screenboards.fr.md
+++ b/content/api/screenboards/screenboards.fr.md
@@ -8,4 +8,4 @@ external_redirect: /api/#screenboards
 
 Cet endpoint vous permet de programmer la création, la mise à jour, la suppression et la récupération de screenboards. [En apprendre plus sur les screenboards][1].
 
-[1]: /graphing/dashboards/screenboard
+[1]: /fr/graphing/dashboards/screenboard

--- a/content/api/screenboards/screenboards_update.fr.md
+++ b/content/api/screenboards/screenboards_update.fr.md
@@ -28,4 +28,4 @@ Remplacez une configuration de screenboard dans Datadog.
 * **`read_only`** [*facultatif*, *défaut*=**False**] :
     Indique si le screenboard est en lecture seule ou non.
 
-[1]: /graphing/dashboards/widgets
+[1]: /fr/graphing/dashboards/widgets

--- a/content/api/tags/tags.fr.md
+++ b/content/api/tags/tags.fr.md
@@ -13,5 +13,5 @@ Le composant de votre infrastructure responsable d'un tag est identifié par une
 
 [En savoir plus sur les tags sur la page de la documentation dédiée][2].
 
-[1]: /integrations/faq/list-of-api-source-attribute-value
-[2]: /tagging
+[1]: /fr/integrations/faq/list-of-api-source-attribute-value
+[2]: /fr/tagging

--- a/content/api/tags/tags_get.fr.md
+++ b/content/api/tags/tags_get.fr.md
@@ -13,4 +13,4 @@ Renvoie un mappage des tags et hôtes pour l'ensemble de votre infrastructure.
     Indique si les tags d'une source spécifique ou tous les tags doivent être affichés.
     [Liste complète de valeurs d'attribut source][1]
 
-[1]: /integrations/faq/list-of-api-source-attribute-value
+[1]: /fr/integrations/faq/list-of-api-source-attribute-value

--- a/content/api/tags/tags_get_host.fr.md
+++ b/content/api/tags/tags_get_host.fr.md
@@ -15,4 +15,4 @@ Renvoie la liste des tags qui s'appliquent à un hôte donné.
 * **`by_source`** [*facultatif*, *défaut*=**False**] :
    Renvoie les tags regroupés par source.
 
-[1]: /integrations/faq/list-of-api-source-attribute-value
+[1]: /fr/integrations/faq/list-of-api-source-attribute-value

--- a/content/api/timeboards/timeboards.fr.md
+++ b/content/api/timeboards/timeboards.fr.md
@@ -9,4 +9,4 @@ external_redirect: /api/#timeboards
 
 Cet endpoint vous permet de programmer la création, la mise à jour, la suppression et la récupération de timeboards. [En apprendre plus sur les timeboards][1].
 
-[1]: /graphing/dashboards/timeboard
+[1]: /fr/graphing/dashboards/timeboard

--- a/content/api/timeboards/timeboards_delete.fr.md
+++ b/content/api/timeboards/timeboards_delete.fr.md
@@ -9,4 +9,4 @@ external_redirect: /api/#supprimer-un-timeboard
 Supprime un [timeboard][1] existant.
 *Cet endpoint ne prend pas d'argument JSON*.
 
-[1]: /graphing/dashboards/timeboard
+[1]: /fr/graphing/dashboards/timeboard

--- a/content/api/timeboards/timeboards_getall.fr.md
+++ b/content/api/timeboards/timeboards_getall.fr.md
@@ -11,4 +11,4 @@ Récupérez toutes les spécifications de votre [timeboard][1].
 ##### Arguments
 *Cet endpoint ne prend aucun argument JSON.*
 
-[1]: /graphing/dashboards/timeboard
+[1]: /fr/graphing/dashboards/timeboard

--- a/content/api/timeboards/timeboards_update.fr.md
+++ b/content/api/timeboards/timeboards_update.fr.md
@@ -32,4 +32,4 @@ external_redirect: /api/#mettre-a-jour-un-timeboard
     * **`default`** [*facultatif*, *défaut*=**None**] :
     La valeur par défaut de la template variable lors du chargement du dashboard.
 
-[1]: /graphing
+[1]: /fr/graphing

--- a/content/api/tracing/tracing.fr.md
+++ b/content/api/tracing/tracing.fr.md
@@ -10,5 +10,5 @@ En savoir plus sur le [tracing avec Datadog][1] et [la terminologie APM][2].
 
 L'API de tracing est une API d'Agent plutôt qu'une API de service. Envoyez vos traces au endpoint local `http://localhost:8126/v0.3/traces` afin que votre Agent puisse ensuite les transférer à Datadog.
 
-[1]: /tracing
-[2]: /tracing/visualization/services_list
+[1]: /fr/tracing
+[2]: /fr/tracing/visualization/services_list

--- a/content/api/usage/usage_timeseries.fr.md
+++ b/content/api/usage/usage_timeseries.fr.md
@@ -15,4 +15,4 @@ Obtenez l'utilisation horaire pour [des métriques custom][1].
 * **`end_hr`** [*facultatif*, *défaut*=**1d+start_hr**] :
     datetime au format ISO-8601, UTC, à l'heure près : [AAAA-MM-JJThh]. Pour une utilisation se terminant AVANT cette heure.
 
-[1]: /developers/metrics/custom_metrics
+[1]: /fr/developers/metrics/custom_metrics

--- a/content/api/usage/usage_top_avg_metrics.fr.md
+++ b/content/api/usage/usage_top_avg_metrics.fr.md
@@ -15,4 +15,4 @@ Obtenez les principales [métriques custom][1] selon la moyenne horaire.
 * **`names`** [*facultatif*, *défaut*=**None**] :
     Liste des noms de métriques séparés par des virgules.
 
-[1]: /developers/metrics/custom_metrics
+[1]: /fr/developers/metrics/custom_metrics

--- a/content/api/users/users.fr.md
+++ b/content/api/users/users.fr.md
@@ -8,4 +8,4 @@ external_redirect: /api/#utilisateurs
 ## Utilisateurs
 Créez, modifiez et désactivez des utilisateurs. [En savoir plus sur la gestion de votre équipe][1].
 
-[1]: /account_management/team
+[1]: /fr/account_management/team

--- a/content/videos/anomaly_detection.fr.md
+++ b/content/videos/anomaly_detection.fr.md
@@ -12,4 +12,4 @@ private: true
 
 Les métriques évoluent sans cesse. Comment savoir si un changement est anormal ? Datadog propose désormais 4 [algorithmes de détection d'anomalies][1] pour différentes métriques et tendances de votre infrastructure.
 
-[1]: /monitors/monitor_types/anomaly
+[1]: /fr/monitors/monitor_types/anomaly

--- a/content/videos/share_screenboards.fr.md
+++ b/content/videos/share_screenboards.fr.md
@@ -16,4 +16,4 @@ private: true
 
 Datadog constitue non seulement la solution idéale pour les groupes DevOps, mais s'avère également très utile pour les dirigeants et les autres membres de votre entreprise. Regardez cette courte vidéo pour découvrir à quel point il est facile de partager votre [screenboard][1] avec vos cadres, vos clients ou toute autre personne qui cherche à consulter vos informations.
 
-[1]: /graphing/dashboards/screenboard
+[1]: /fr/graphing/dashboards/screenboard

--- a/layouts/partials/sidenav/recursive-nav.html
+++ b/layouts/partials/sidenav/recursive-nav.html
@@ -40,7 +40,7 @@
         {{ $active_page := (or (eq $ctx.RelPermalink $el_url) (and (eq $url_first_second $el_url) (not $element.Children)) (and (eq $url_first "/integrations/") (eq $el_url "/integrations/") ) ) }}
         {{ $open_parent := (or (and (eq $url_first $el_url) (ne $el_url "/")) (eq $url_first_second $el_url) (eq $url_first_second_third $el_url) $active_page) }}
         <li class="{{if $open_parent }}open{{ end }}">
-            <a href="{{ if eq $hash_check "#" }}{{$element.URL}}{{ else }}{{ $baseUrl }}/{{$element.URL}}{{ end }}" {{if $active_page }}class="active"{{ end }}>
+            <a href="{{ if eq $hash_check "#" }}{{$element.URL}}{{ else }}{{ $element.URL | absLangURL}}{{ end }}" {{if $active_page }}class="active"{{ end }}>
                 {{ if $element.Pre }}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" ($element.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" ($element.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}{{ end }} <span>{{ $element.Name }}</span>
             </a>
             {{ if eq $element.Name "Integrations" }}

--- a/layouts/shortcodes/absLangUrl.html
+++ b/layouts/shortcodes/absLangUrl.html
@@ -1,0 +1,1 @@
+{{- with index .Params 0 -}}{{ . | absLangURL }}{{- end -}}


### PR DESCRIPTION
### What does this PR do?
- Fix the side navigation so that it links to language relative pages
- Add a shortcode for absolute lang urls should we need it
- convert the current relative markdown links in fr pages to be prefixed with fr

### Motivation
Issue with the side nav

### Preview link
https://docs-staging.datadoghq.com/david.jones/lang-relative-links/

### Additional Notes

