### PR TITLE
Fix kubernetes cluster agent commands

### DIFF
--- a/content/agent/kubernetes/cluster.md
+++ b/content/agent/kubernetes/cluster.md
@@ -119,10 +119,10 @@ datadog-cluster-agent   1         1         1            1           1d
 NAME                   TYPE                                  DATA      AGE
 datadog-auth-token     Opaque                                1         1d
 
--> kubectl get pods -l app:datadog-cluster-agent
+-> kubectl get pods -l app=datadog-cluster-agent
 datadog-cluster-agent-8568545574-x9tc9   1/1       Running   0          2h
 
--> kubectl get service -l app:datadog-cluster-agent
+-> kubectl get service -l app=datadog-cluster-agent
 NAME                    TYPE           CLUSTER-IP       EXTERNAL-IP        PORT(S)          AGE
 datadog-cluster-agent   ClusterIP      10.100.202.234   none               5005/TCP         1d
 ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This fixes a syntax issue with commands of the kubernetes cluster agent documentation.

### Motivation
<!-- What inspired you to submit this pull request?-->
Commands failing while going through the documentation.

### Preview link
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/xavier.lucas/k8s-cluster-agent-labels/

<!-- This is the base preview link. Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->