### PR TITLE
Update api/integrations.md to remove PUT call that does not exist

### DIFF
--- a/content/api/integrations/integrations.md
+++ b/content/api/integrations/integrations.md
@@ -20,11 +20,6 @@ Available endpoints are:
 
 * To **create** an integration or **append** its configuration in Datadog:  
     **`POST /api/v1/integration/<SOURCE_TYPE_NAME>`**
-    
-* To **replace** an integration configuration:  
-    **`PUT /api/v1/integration/<SOURCE_TYPE_NAME>`**
-    
-     CAUTION: Using `PUT` will remove/replace existing configurations.
 
 * To read an integration configuration:  
     **`GET /api/v1/integration/<SOURCE_TYPE_NAME>`**


### PR DESCRIPTION

### What does this PR do?
The docs currently describe a PUT option for this API https://docs.datadoghq.com/api/?lang=python#integrations but it does not exist. Customers are getting confused so we should remove it https://dd.slack.com/archives/C40H90DG9/p1548289685239300

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
