### PR TITLE
Update PHP in advanced instrumentation docs

### DIFF
--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -266,13 +266,13 @@ span?.SetTag("<TAG_KEY>", "<TAG_VALUE>");
 Add tags directly to a `DDTrace\Span` object by calling `Span::setTag()`.
 
 ```php
-dd_trace('my_function', function () {
+dd_trace('<FUNCTION_NAME>', function () {
     $scope = \DDTrace\GlobalTracer::get()
-      ->startActiveSpan('my_function');
+      ->startActiveSpan('<FUNCTION_NAME>');
     $span = $scope->getSpan();
     $span->setTag('<TAG_KEY>', '<TAG_VALUE>');
 
-    $result = my_function();
+    $result = <FUNCTION_NAME>();
 
     $scope->close();
     return $result;


### PR DESCRIPTION
### What does this PR do?
This is a complement to #3826 and adds the missing docs/updates the docs for PHP in the advanced instrumentation section.

### Motivation
To get the PHP tracer ready for GA.

### Preview link
[Preview link](https://docs-staging.datadoghq.com/sammyk/update-php-advanced-docs/tracing/advanced_usage/?tab=php)

### Additional Notes
It'd be nice if we could get syntax highlighting rocking for the PHP code examples. I'll dig into this a bit later, but if anyone knows a quick way to do this, feel free! :)