### PR TITLE
Correct "from the query to the graph" example

### DIFF
--- a/content/graphing/functions/_index.md
+++ b/content/graphing/functions/_index.md
@@ -110,11 +110,11 @@ Note that the Datadog backend tries to keep the number of intervals to a number 
 Now you can mix data from different source into a single line.
 
 You have ~300 points for each source. Each of them represents a minute.
-In this example, for each minute, Datadog computes the sum across all sources, resulting in the following graph:
+In this example, for each minute, Datadog computes the average across all sources, resulting in the following graph:
 
 {{< img src="graphing/miscellaneous/from_query_to_graph/metrics_graph_4.png" alt="metrics_graph_4" responsive="true" style="width:75%;">}}
 
-The value obtained (25.74GB) is the sum of the values reported by all sources (see previous image).
+The value obtained (25.74GB) is the average of the values reported by all sources (see previous image).
 
 Note: Of course, if there is only one source (for instance, if we had chosen the scope `{host:moby, device:/dev/disk}` for the query), using `sum`/`avg`/`max`/`min` has no effect as no space aggregation needs to be performed. [See here for more information][10].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
It changes the aggregator type from sum to average in the spatial aggregation example, as illustrated by the embedded graph.

### Preview link
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/xavier.lucas/graphing-functions-aggregator-example/graphing/functions/#proceed-to-space-aggregation

<!-- This is the base preview link. Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->