### PR TITLE
Adding log http limits

### DIFF
--- a/content/api/logs/logs.md
+++ b/content/api/logs/logs.md
@@ -13,4 +13,4 @@ Send your logs to your Datadog platform over HTTP, limits per http request are:
 * Maximum size for a single log: 256kB
 * Maximum array size if sending multiple logs in a array: 50 entries
 
-**Note**: If you are in Datadog EU `app.datadoghq.eu`, the HTTP log endpoint is: `http-intake.logs.datadoghq.eu`
+**Note**: If you are in Datadog EU region (`app.datadoghq.eu`), the HTTP log endpoint is: `http-intake.logs.datadoghq.eu`

--- a/content/api/logs/logs.md
+++ b/content/api/logs/logs.md
@@ -7,10 +7,10 @@ external_redirect: /api/#logs
 
 ## Logs
 
-<div class="alert alert-warning">
-This API endpoint is in beta.
-</div>
+Send your logs to your Datadog platform over HTTP, limits per http request are:
 
-Send your logs to your Datadog platform over HTTP.
+* Maximum content size per payload: 2MB
+* Maximum size for a single log: 256kB
+* Maximum array size if sending multiple logs in a array: 50 entries
 
 **Note**: If you are in Datadog EU `app.datadoghq.eu`, the HTTP log endpoint is: `http-intake.logs.datadoghq.eu`

--- a/content/api/logs/logs.md
+++ b/content/api/logs/logs.md
@@ -7,10 +7,10 @@ external_redirect: /api/#logs
 
 ## Logs
 
-Send your logs to your Datadog platform over HTTP, limits per http request are:
+Send your logs to your Datadog platform over HTTP. Limits per HTTP request are:
 
 * Maximum content size per payload: 2MB
 * Maximum size for a single log: 256kB
-* Maximum array size if sending multiple logs in a array: 50 entries
+* Maximum array size if sending multiple logs in an array: 50 entries
 
-**Note**: If you are in Datadog EU region (`app.datadoghq.eu`), the HTTP log endpoint is: `http-intake.logs.datadoghq.eu`
+**Note**: If you are in the Datadog EU region (`app.datadoghq.eu`), the HTTP log endpoint is: `http-intake.logs.datadoghq.eu`.


### PR DESCRIPTION
Limit per http request are:

maxContentSize: 2MB
maxMessageSize: 256kB
maxArraySize: 50

Removing beta flag since now the endpoint is fully supported and GA 