### PR TITLE
Changing region into site

### DIFF
--- a/content/agent/basic_agent_usage/_index.md
+++ b/content/agent/basic_agent_usage/_index.md
@@ -66,7 +66,7 @@ Manage the Datadog Agent and [Integrations][1] using configuration management to
 
 ## Datadog Region
 
-To send your Agent data to the [Datadog EU region][3], edit your [Agent main configuration file][4] `datadog.yaml` and set the `dd_site` parameter to:
+To send your Agent data to the [Datadog EU site][3], edit your [Agent main configuration file][4] `datadog.yaml` and set the `dd_site` parameter to:
 
 `dd_site:datadoghq.eu`
 

--- a/content/agent/basic_agent_usage/heroku.md
+++ b/content/agent/basic_agent_usage/heroku.md
@@ -83,14 +83,14 @@ To send all these logs to Datadog:
 * Set up the HTTPS drain with the following command:
 
 {{< tabs >}}
-{{% tab "US Region" %}}
+{{% tab "US Site" %}}
 
 ```
 heroku drains:add https://http-intake.logs.datadoghq.com/v1/input/<DD_API_KEY>?ddsource=heroku&service=<SERVICE>&host=<HOST> -a <APPLICATION_NAME>
 ```
 
 {{% /tab %}}
-{{% tab "EU Region" %}}
+{{% tab "EU Site" %}}
 
 ```
 heroku drains:add https://http-intake.logs.datadoghq.eu/v1/input/<DD_API_KEY>?ddsource=heroku&service=<SERVICE>&host=<HOST> -a <APPLICATION_NAME>
@@ -108,14 +108,14 @@ heroku drains:add https://http-intake.logs.datadoghq.eu/v1/input/<DD_API_KEY>?dd
 Add custom attributes to logs from your application by replacing the URL in the drain as follows:
 
 {{< tabs >}}
-{{% tab "US Region" %}}
+{{% tab "US Site" %}}
 
 ```
 https://http-intake.logs.datadoghq.com/v1/input/<DD_API_KEY>?ddsource=heroku&service=<SERVICE>&host=<HOST>&attribute_name=<VALUE>
 ```
 
 {{% /tab %}}
-{{% tab "EU Region" %}}
+{{% tab "EU Site" %}}
 
 ```
 https://http-intake.logs.datadoghq.eu/v1/input/<DD_API_KEY>?ddsource=heroku&service=<SERVICE>&host=<HOST>&attribute_name=<VALUE>

--- a/content/agent/docker/_index.md
+++ b/content/agent/docker/_index.md
@@ -45,12 +45,13 @@ The Agent is highly customizable. Here are the most used environment variables:
 
 #### Global options
 
-| Env Variable    | Description                                                                                                                                        |
-| --------------- | ----------------------------------------------------------------------------------                                                                 |
-| `DD_API_KEY`    | Your Datadog API key (**required**)                                                                                                                |
-| `DD_HOSTNAME`   | Hostname to use for metrics (if autodetection fails)                                                                                               |
-| `DD_TAGS`       | Host tags separated by spaces. For example: `simple-tag-0 tag-key-1:tag-value-1`                                                                   |
-| `DD_SITE`       | Destination region for your metrics, traces, and logs. Valid options are `datadoghq.com` for the Datadog US region, and `datadoghq.eu` for the Datadog EU region |
+| Env Variable    | Description                                                                                                                                                 |
+| --------------- | ----------------------------------------------------------------------------------                                                                          |
+| `DD_API_KEY`    | Your Datadog API key (**required**)                                                                                                                         |
+| `DD_HOSTNAME`   | Hostname to use for metrics (if autodetection fails)                                                                                                        |
+| `DD_TAGS`       | Host tags separated by spaces. For example: `simple-tag-0 tag-key-1:tag-value-1`                                                                            |
+| `DD_SITE`       | Destination site for your metrics, traces, and logs. Valid options are `datadoghq.com` for the Datadog US site, and `datadoghq.eu` for the Datadog EU site. |
+
 
 
 #### Optional collection Agents

--- a/content/agent/docker/apm.md
+++ b/content/agent/docker/apm.md
@@ -40,24 +40,24 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
 
 List of all environment variables available for tracing with the Docker Agent:
 
-| Environment variable       | Description                                                                                                                 |
-| ------                     | ------                                                                                                                      |
-| `DD_API_KEY`               | [Datadog API Key][2]                                                                                                        |
-| `DD_PROXY_HTTPS`           | Set up the URL for the proxy to use.                                                                                        |
-| `DD_HOSTNAME`              | Set the Agent hostname manually.                                                                                            |
-| `DD_DOGSTATSD_PORT`        | Set the DogStatsD port.                                                                                                     |
-| `DD_BIND_HOST`             | Set the StatsD & receiver hostname.                                                                                         |
-| `DD_LOG_LEVEL`             | Set the logging level. (`trace`/`debug`/`info`/`warn`/`error`/`critical`/`off`)                                             |
-| `DD_APM_ENABLED`           | When set to `true`, the Datadog Agent accepts trace metrics.                                                                |
-| `DD_APM_CONNECTION_LIMIT`  | Sets the maximum connection limit for a 30 second time window.                                                              |
-| `DD_APM_DD_URL`            | Datadog API endpoint where traces are sent. For Datadog EU region set `DD_APM_DD_URL` to `https://trace.agent.datadoghq.eu` |
-| `DD_APM_RECEIVER_PORT`     | Port that the Datadog Agent's trace receiver listen on. Default value is `8126`.                                            |
-| `DD_APM_NON_LOCAL_TRAFFIC` | Allow non-local traffic when [tracing from other containers](#tracing-from-other-containers).                               |
-| `DD_APM_IGNORE_RESOURCE`   | A comma-separated list of endpoints and resources that the Agent should ignore (i.e. health checks endpoints).              |
-| `DD_APM_ANALYZED_SPANS`    | Configure the spans to analyze for transactions.                                                                            |
-| `DD_APM_ENV`               | Sets the default [environment][3] for your traces.                                                                          |
-| `DD_APM_MAX_EPS`           | Sets the maximum APM events per second.                                                                                     |
-| `DD_APM_MAX_TPS`           | Sets the maximum traces per second.                                                                                         |
+| Environment variable       | Description                                                                                                               |
+| ------                     | ------                                                                                                                    |
+| `DD_API_KEY`               | [Datadog API Key][1]                                                                                                      |
+| `DD_PROXY_HTTPS`           | Set up the URL for the proxy to use.                                                                                      |
+| `DD_HOSTNAME`              | Set the Agent hostname manually.                                                                                          |
+| `DD_DOGSTATSD_PORT`        | Set the DogStatsD port.                                                                                                   |
+| `DD_BIND_HOST`             | Set the StatsD & receiver hostname.                                                                                       |
+| `DD_LOG_LEVEL`             | Set the logging level. (`trace`/`debug`/`info`/`warn`/`error`/`critical`/`off`)                                           |
+| `DD_APM_ENABLED`           | When set to `true`, the Datadog Agent accepts trace metrics.                                                              |
+| `DD_APM_CONNECTION_LIMIT`  | Sets the maximum connection limit for a 30 second time window.                                                            |
+| `DD_APM_DD_URL`            | Datadog API endpoint where traces are sent. For Datadog EU site set `DD_APM_DD_URL` to `https://trace.agent.datadoghq.eu` |
+| `DD_APM_RECEIVER_PORT`     | Port that the Datadog Agent's trace receiver listen on. Default value is `8126`.                                          |
+| `DD_APM_NON_LOCAL_TRAFFIC` | Allow non-local traffic when [tracing from other containers](#tracing-from-other-containers).                             |
+| `DD_APM_IGNORE_RESOURCE`   | A comma-separated list of endpoints and resources that the Agent should ignore (i.e. health checks endpoints).            |
+| `DD_APM_ANALYZED_SPANS`    | Configure the spans to analyze for transactions.                                                                          |
+| `DD_APM_ENV`               | Sets the default [environment][2] for your traces.                                                                        |
+| `DD_APM_MAX_EPS`           | Sets the maximum APM events per second.                                                                                   |
+| `DD_APM_MAX_TPS`           | Sets the maximum traces per second.                                                                                       |
 
 ## Tracing from other containers
 
@@ -172,5 +172,5 @@ tracer.configure(hostname='172.17.0.1', port=8126)
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[2]: https://app.datadoghq.com/account/settings#api
-[3]: /agent/apm/#environment
+[1]: https://app.datadoghq.com/account/settings#api
+[2]: /agent/apm/#environment

--- a/content/agent/kubernetes/daemonset_setup.md
+++ b/content/agent/kubernetes/daemonset_setup.md
@@ -150,7 +150,7 @@ spec:
                 name: datadog-secret
                 key: api-key
           - name: DD_SITE
-            # Set DD_SITE to datadoghq.eu to send your Agent data to the Datadog EU region 
+            # Set DD_SITE to datadoghq.eu to send your Agent data to the Datadog EU site 
             value: "datadoghq.com"
           - name: DD_COLLECT_KUBERNETES_EVENTS
             value: "true"

--- a/content/agent/proxy.md
+++ b/content/agent/proxy.md
@@ -180,7 +180,7 @@ This is the best option if you do not have a web proxy readily available in your
 HAProxy should be installed on a host that has connectivity to Datadog. Use the following configuration file if you do not already have it configured.
 
 {{< tabs >}}
-{{% tab "Datadog US app.datadoghq.com" %}}
+{{% tab "Datadog US site" %}}
 
 ```
 # Basic configuration
@@ -271,7 +271,7 @@ Once the HAProxy configuration is in place, you can reload it or restart HAProxy
 **It is recommended to have a `cron` job that reloads HAProxy every 10 minutes** (usually doing something like `service haproxy reload`) to force a refresh of HAProxy's DNS cache, in case `app.datadoghq.com` fails over to another IP.
 
 {{% /tab %}}
-{{% tab "Datadog EU app.datadoghq.eu" %}}
+{{% tab "Datadog EU site" %}}
 
 ```
 # Basic configuration

--- a/content/api/logs/logs.md
+++ b/content/api/logs/logs.md
@@ -13,4 +13,4 @@ Send your logs to your Datadog platform over HTTP. Limits per HTTP request are:
 * Maximum size for a single log: 256kB
 * Maximum array size if sending multiple logs in an array: 50 entries
 
-**Note**: If you are in the Datadog EU region (`app.datadoghq.eu`), the HTTP log endpoint is: `http-intake.logs.datadoghq.eu`.
+**Note**: If you are in the Datadog EU site (`app.datadoghq.eu`), the HTTP log endpoint is: `http-intake.logs.datadoghq.eu`.

--- a/content/integrations/nxlog.md
+++ b/content/integrations/nxlog.md
@@ -25,7 +25,7 @@ Configure NXLog to gather logs from your host, containers, & services.
 ### Log collection
 
 {{< tabs >}}
-{{% tab "Datadog US app.datadoghq.com" %}}
+{{% tab "Datadog US site" %}}
 
 1. Configure NXLog to send your logs to your Datadog platform
     Replace the whole file in `C:\Program Files\nxlog\conf` by the following:
@@ -127,7 +127,7 @@ Configure NXLog to gather logs from your host, containers, & services.
 
 [1]: /crt/intake.logs.datadoghq.com.crt
 {{% /tab %}}
-{{% tab "Datadog EU app.datadoghq.eu" %}}
+{{% tab "Datadog EU site" %}}
 
 1. Configure NXLog to send your logs to your Datadog platform
     Replace the whole file in `C:\Program Files\nxlog\conf` by the following:

--- a/content/integrations/rsyslog.md
+++ b/content/integrations/rsyslog.md
@@ -25,7 +25,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
 ### Log collection
 
 {{< tabs >}}
-{{% tab "Datadog US app.datadoghq.com" %}}
+{{% tab "Datadog US site" %}}
 
 1. (Optional) Activate Rsyslog file monitoring module.  
     If you want to watch/monitor specific log files, then you have to activate the imfile module by adding this to  your `rsyslog.conf`:
@@ -150,7 +150,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
 [1]: /crt/intake.logs.datadoghq.com.crt
 [2]: /crt/FULL_intake.logs.datadoghq.com.crt
 {{% /tab %}}
-{{% tab "Datadog EU app.datadoghq.eu" %}}
+{{% tab "Datadog EU site" %}}
 
 1. (Optional) Activate Rsyslog file monitoring module.  
     If you want to watch/monitor specific log files, then you have to activate the imfile module by adding this to  your `rsyslog.conf`:

--- a/content/integrations/syslog_ng.md
+++ b/content/integrations/syslog_ng.md
@@ -26,7 +26,7 @@ Configure Syslog-ng to gather logs from your host, containers, & services.
 ### Log collection
 
 {{< tabs >}}
-{{% tab "Datadog US app.datadoghq.com" %}}
+{{% tab "Datadog US site" %}}
 
 1. Collect system logs and log files in `/etc/syslog-ng/syslog-ng.conf` make sure the source is correctly defined:
     ```
@@ -94,7 +94,7 @@ Configure Syslog-ng to gather logs from your host, containers, & services.
 [1]: /crt/intake.logs.datadoghq.com.crt
 [2]: https://syslog-ng.com/documents/html/syslog-ng-ose-latest-guides/en/syslog-ng-ose-guide-admin/html/tlsoptions.html
 {{% /tab %}}
-{{% tab "Datadog EU app.datadoghq.eu" %}}
+{{% tab "Datadog EU site" %}}
 
 1. Collect system logs and log files in `/etc/syslog-ng/syslog-ng.conf` make sure the source is correctly defined:
     ```

--- a/content/logs/_index.md
+++ b/content/logs/_index.md
@@ -81,7 +81,7 @@ You should use the encrypted endpoint when possible. The Datadog Agent uses the 
 Endpoints that can be used to send logs to Datadog:
 
 {{< tabs >}}
-{{% tab "US Region" %}}
+{{% tab "US Site" %}}
 
 
 | Endpoints for SSL encrypted connections | Port    | Description                                                                                                                                                                 |
@@ -97,7 +97,7 @@ Endpoints that can be used to send logs to Datadog:
 | `intake.logs.datadoghq.com`          | `10514` | Used by custom forwarders to send logs in raw, Syslog, or JSON format over an unecrypted TCP connection. |
 
 {{% /tab %}}
-{{% tab "EU Region" %}}
+{{% tab "EU Site" %}}
 
 | Endpoints for SSL encrypted connections | Port  | Description                                                                                                                                                                 |
 |-----------------------------------------|-------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/content/logs/log_collection/java.md
+++ b/content/logs/log_collection/java.md
@@ -403,7 +403,7 @@ Configure the Logback logger to stream logs directly to Datadog by adding the fo
 
 - Replace `<API_KEY>` with your Datadog API key value
 - `%mdc{keyThatDoesNotExist}` is added because the XML configuration trims whitespace, as explained [here][4]
-- See the list of [available endpoints for the EU region][5]
+- See the list of [available endpoints for the EU site][5]
 
 More information available on the prefix parameter in the [Logback documentation][4].
 

--- a/content/synthetics/_index.md
+++ b/content/synthetics/_index.md
@@ -14,7 +14,7 @@ further_reading:
   text: "Configure an Uptime Check"
 ---
 
-<div class="alert alert-warning">Synthetics is currently in beta for the Datadog US Region. To request access complete the <a href="https://app.datadoghq.com/synthetics/beta">Datadog Synthetics Request form</a>.</div>
+<div class="alert alert-warning">Synthetics is currently in beta for the Datadog US Site. To request access complete the <a href="https://app.datadoghq.com/synthetics/beta">Datadog Synthetics Request form</a>.</div>
 
 ## Overview
 

--- a/content/synthetics/faq/uptime-check-internal-website.md
+++ b/content/synthetics/faq/uptime-check-internal-website.md
@@ -11,7 +11,7 @@ further_reading:
   text: "Manage your checks"
 ---
 
-<div class="alert alert-warning">Synthetics is in beta for the Datadog US Region. To request access, complete the <a href="https://app.datadoghq.com/synthetics/beta">Datadog Synthetics request form</a>.</div>
+<div class="alert alert-warning">Synthetics is in beta for the Datadog US Site. To request access, complete the <a href="https://app.datadoghq.com/synthetics/beta">Datadog Synthetics request form</a>.</div>
 
 Monitor your internal staging/intranet environment by appending authentication credentials in the **Advanced options** of your Uptime Check to satisfy security concerns.
 

--- a/content/synthetics/uptime_check.md
+++ b/content/synthetics/uptime_check.md
@@ -12,7 +12,7 @@ further_reading:
   text: "Manage your checks"
 ---
 
-<div class="alert alert-warning">Synthetics is in beta for the Datadog US Region. To request access, complete the <a href="https://app.datadoghq.com/synthetics/beta">Datadog Synthetics request form</a>.</div>
+<div class="alert alert-warning">Synthetics is in beta for the Datadog US Site. To request access, complete the <a href="https://app.datadoghq.com/synthetics/beta">Datadog Synthetics request form</a>.</div>
 
 ## Overview
 


### PR DESCRIPTION
### What does this PR do?
Moving forward we should use the terminology "Datadog site" when referring to Datadog EU.