### PR TITLE
added samples of query params to api

### DIFF
--- a/content/api/monitors/code_snippets/api-monitor-search.py
+++ b/content/api/monitors/code_snippets/api-monitor-search.py
@@ -9,3 +9,7 @@ initialize(**options)
 
 # Search monitors
 api.Monitor.search()
+
+# Examples of possible query parameters:
+# api.Monitor.search(query="id:7100311")
+# api.Monitor.search(query="title:foo metric:system.core.idle status:Alert")

--- a/content/api/monitors/code_snippets/api-monitor-search.rb
+++ b/content/api/monitors/code_snippets/api-monitor-search.rb
@@ -8,3 +8,8 @@ dog = Dogapi::Client.new(api_key, app_key)
 
 # Search monitors
 dog.search_monitors()
+
+# Examples of possible query parameters:
+# dog.search_monitors(query="id:7100311")
+# dog.search_monitors(query="title:foo metric:system.core.idle status:Alert")
+

--- a/content/api/monitors/monitors_search.md
+++ b/content/api/monitors/monitors_search.md
@@ -15,6 +15,8 @@ Search and filter your monitors details.
     
     After entering a search query in your [Manage Monitor page][1] use the query parameter value in the URL of the page as value for this parameter. Consult the dedicated [manage monitor documentation][2] page to learn more.
 
+    The query can contain any number of space-separated monitor attributes, for instance `query="type:metric status:alert"`.
+
 * **`page`** [*optional*, *default* = **0**]: 
     
     Page to start paginating from.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds samples of how to construct query params in the search monitors documentation

### Motivation
Support request h/t Danni Liu

### Preview link
https://docs-staging.datadoghq.com/cswatt/api-monitors-search-query-examples/api/?lang=python#monitors-search
