### PR TITLE
Add hostname requirements

### DIFF
--- a/content/tagging/assigning_tags.md
+++ b/content/tagging/assigning_tags.md
@@ -24,7 +24,9 @@ There are several places tags can be assigned: [configuration files](#configurat
 The hostname (tag key `host`) is [assigned automatically][6] by the Datadog Agent. To customize the hostname, use the Agent configuration file, `datadog.yaml`:
 
 ```yaml
-# Force the hostname to whatever you want. (default: auto-detected)
+# Set the hostname (default: auto-detected)
+# Must comply with RFC-1123, which permits only:
+# "A" to "Z", "a" to "z", "0" to "9", and the hyphen (-)
 hostname: mymachine.mydomain
 ```
 


### PR DESCRIPTION
### What does this PR do?
- Add hostname requirements from: https://help.datadoghq.com/hc/en-us/articles/203139789-What-characters-are-allowed-in-my-hostname-

### Motivation
KB site migration

### Preview link
https://docs-staging.datadoghq.com/ruth/hostname/tagging/assigning_tags/?tab=go#configuration-files

### Additional Notes
Code references:
- Agent 5 - https://github.com/DataDog/dd-agent/blob/master/utils/hostname.py#L17
- Agent 6 - https://github.com/DataDog/datadog-agent/blob/master/pkg/util/hostname.go#L29
