### PR TITLE
[doc] Removed duplicate 'avg'

### DIFF
--- a/content/graphing/dashboards/widgets.md
+++ b/content/graphing/dashboards/widgets.md
@@ -162,7 +162,7 @@ Example of Query Value widget for the [API][1]
 
 The Query Value Widget only displays one Value, unlike a timeseries for example, that displays several points.
 
-Let's say you are on a Timeseries and you are currently displaying the past hour, this button allows you to either display the `avg` / `max` / `min` / `avg` / `sum` / `last value` of ALL points that are rendered during that 1 hour range timeframe - depending on the aggregation chosen above.
+Let's say you are on a Timeseries and you are currently displaying the past hour, this button allows you to either display the `avg` / `max` / `min` / `sum` / `last value` of ALL points that are rendered during that 1 hour range timeframe - depending on the aggregation chosen above.
 
 ## Scatter Plot
 

--- a/content/graphing/dashboards/widgets.md
+++ b/content/graphing/dashboards/widgets.md
@@ -160,9 +160,9 @@ Example of Query Value widget for the [API][1]
 
 {{< img src="graphing/dashboards/widgets/query_value_widget.png" alt="query_value_widget" responsive="true" style="width:50%;">}}
 
-The Query Value Widget only displays one Value, unlike a timeseries for example, that displays several points.
+The Query Value Widget only displays one value, unlike a timeseries for example, that displays several points.
 
-Let's say you are on a Timeseries and you are currently displaying the past hour, this button allows you to either display the `avg` / `max` / `min` / `sum` / `last value` of ALL points that are rendered during that 1 hour range timeframe - depending on the aggregation chosen above.
+If you are on a Timeseries and you are currently displaying the past hour, this button allows you to either display the `avg` / `max` / `min` / `sum` / `last value` of ALL points that are rendered during that 1 hour range timeframe—depending on the aggregation chosen above.
 
 ## Scatter Plot
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes the a duplicate 'avg' from the section (What does “Take the X value from the displayed timeframe” mean?)

### Motivation
Found the duplicate

### Preview link
https://docs-staging.datadoghq.com/ayylam/dashboards-widgetmd-remove-dup-avg-text/graphing/dashboards/widgets/


### Additional Notes
<!-- Anything else we should know when reviewing?-->
