### PR TITLE
Remove deprecated API

### DIFF
--- a/content/api/hosts/code_snippets/api-host-unmute.py
+++ b/content/api/hosts/code_snippets/api-host-unmute.py
@@ -8,7 +8,7 @@ options = {
 initialize(**options)
 
 # Find a host to unmute
-hosts = api.Infrastructure.search(q='hosts:')
+hosts = api.Hosts.search(q='hosts:')
 
 # Unmute host
 api.Host.unmute(hosts['results']['hosts'][0])

--- a/content/api/metrics/code_snippets/api-metrics-search.py
+++ b/content/api/metrics/code_snippets/api-metrics-search.py
@@ -7,4 +7,4 @@ options = {
 
 initialize(**options)
 
-api.Infrastructure.search(q="metrics:system")
+api.Hosts.search(q="metrics:system")

--- a/content/api/tags/code_snippets/api-tags-add.py
+++ b/content/api/tags/code_snippets/api-tags-add.py
@@ -6,5 +6,5 @@ options = {
 }
 
 initialize(**options)
-hosts = api.Infrastructure.search(q='hosts:')
+hosts = api.Hosts.search(q='hosts:')
 api.Tag.create(hosts['results']['hosts'][0], tags=["role:codesample"])

--- a/content/api/tags/code_snippets/api-tags-get-host.py
+++ b/content/api/tags/code_snippets/api-tags-get-host.py
@@ -8,5 +8,5 @@ options = {
 initialize(**options)
 
 # Get tags by host id.
-hosts = api.Infrastructure.search(q='hosts:')
+hosts = api.Hosts.search(q='hosts:')
 print api.Tag.get(hosts['results']['hosts'][0])


### PR DESCRIPTION
### What does this PR do?
- Replace deprecated API `Infrastructure.search` with `Hosts.search`

### Motivation
- Trello request
- https://github.com/DataDog/datadogpy/pull/261

### Preview link
https://docs-staging.datadoghq.com/ruth/api-deprecation/api/
