### PR TITLE
Clarify the behavior of the monitor validation endpoint

### DIFF
--- a/content/api/monitors/code_snippets/api-monitor-validate.sh
+++ b/content/api/monitors/code_snippets/api-monitor-validate.sh
@@ -8,6 +8,13 @@ app_key=<YOUR_APP_KEY>
 curl -X POST -H "Content-type: application/json" \
 -d '{
       "type": "metric alert",
-      "query": "avg(last_5m):sum:system.net.bytes_rcvd{host:host0} > 100"
+      "query": "THIS QUERY IS INVALID",
+      "name": "Bytes received on host0",
+      "message": "We may need to add web hosts if this is consistently high.",
+      "tags": ["app:webserver", "frontend"],
+      "options": {
+      	"notify_no_data": true,
+      	"no_data_timeframe": 20
+      }
 }' \
     "https://api.datadoghq.com/api/v1/monitor/validate?api_key=${api_key}&application_key=${app_key}"

--- a/content/api/monitors/code_snippets/result.api-monitor-validate.sh
+++ b/content/api/monitors/code_snippets/result.api-monitor-validate.sh
@@ -1,3 +1,5 @@
 {
-	
+    "errors": [
+        "The value provided for parameter 'query' is invalid"
+    ]
 }

--- a/content/api/monitors/monitors_validate.md
+++ b/content/api/monitors/monitors_validate.md
@@ -5,29 +5,6 @@ order: 17.11
 external_redirect: /api/#validate-a-monitor
 ---
 ## Validate a monitor
-##### ARGUMENTS
-*   **`type`** [*required*]:  
-    The [type of the monitor][1], chosen from:  
+Validates a monitor definition (see [Create a monitor][1] for details on constructing a monitor definition).
 
-| Monitor Type | type attribute value |
-| :--------    | :-------             |
-| anomaly      | `query alert`        |
-| apm          | `query alert`        |
-| composite    | `composite`          |
-| custom       | `service check`      |
-| event        | `event alert`        |
-| forecast     | `query alert`        |
-| host         | `service check`      |
-| integration  | `query alert`        |
-| live process | `process alert`      |
-| logs         | `log alert`          |
-| metric       | `query alert`        |
-| network      | `service check`      |
-| outlier      | `query alert`        |
-| process      | `service check`      |
-    
-*   **`query`** [*required*]:  
-    The query defines when the monitor triggers. Query syntax depends on monitor type. See [Create a monitor][2] for details.
-
-[1]: /monitors/monitor_types
-[2]: /api/#create-a-monitor
+[1]: /api/#create-a-monitor


### PR DESCRIPTION
### What does this PR do?

It updates the API docs to clarify that the monitor validation endpoint accepts a complete monitor definition.

### Motivation

A user was unable to successfully validate an anomaly detection monitor because they only supplied the type and query, as suggested by the example.

### Preview link

https://docs-staging.datadoghq.com/chrism/monitor-validation/api/?lang=bash#validate-a-monitor