### PR TITLE
Add NGINX proxy for logs

### DIFF
--- a/content/agent/proxy.md
+++ b/content/agent/proxy.md
@@ -444,6 +444,97 @@ To verify that everything is working properly, review the HAProxy statistics at 
 {{% /tab %}}
 {{< /tabs >}}
 
+## Using NGINX as a Proxy
+
+[NGINX][3] is a web server which can also be used as a reverse proxy, load balancer, mail proxy, and HTTP cache. You can use NGINX as a Proxy to send logs to Datadog:
+
+`agent ---> nginx ---> Datadog` or  
+`external log shipper ---> nginx ---> Datadog`
+
+### Proxy forwarding with NGINX
+#### NGINX configuration
+
+This example `nginx.conf` can be used to proxy logs to the Datadog intake. It does TLS wrapping to ensure internal plaintext logs are encrypted between your proxy and Datadog's log intake API endpoint:
+
+```
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+pid /run/nginx.pid; 
+
+include /usr/share/nginx/modules/*.conf;
+events {
+    worker_connections 1024;
+}
+# TCP Proxy for Datadog logs
+stream {
+    server {
+        listen 10514; #proxy listen port
+        proxy_ssl on;
+        proxy_pass agent-intake.logs.datadoghq.com:10516;
+    }
+}
+```
+
+#### Shipper configuration
+
+{{< tabs >}}
+{{% tab "Agent v6" %}}
+
+To use the Datadog Agent as the logs collector, instruct the Agent to use the newly created proxy instead of establishing a connection directly with the logs intake by updating `datadog.yaml`:
+
+```yaml
+logs_config:
+  dd_url: myProxyServer.myDomain
+  dd_port: 10514
+  dev_mode_use_proto: false
+  dev_mode_no_ssl: true
+```
+
+The `dev_mode_no_ssl` parameter is set to `true` because establishing the SSL/TLS connection is handled by NGINX's `proxy_ssl on` option. **Note**: Set this option to `false` if you don't intend to use a proxy which can encrypt the connection to the logs intake.
+
+{{% /tab %}}
+{{% tab "NXLogs" %}}
+
+In Windows, NXLogs is frequently used as a logs collector. In the configuration, change the host and port in the `<Output>` block to those of your proxy instead of the Datadog intake.
+
+**Example**:
+
+```
+<Output out>
+  Module om_tcp
+  Host myProxyServer.myDomain
+  Port 10514
+  Exec to_syslog_ietf();
+  Exec $raw_event="<YOUR_DATADOG_API_KEY> "+$raw_event;
+</Output>
+```
+
+{{% /tab %}}
+{{% tab "Fluentd" %}}
+
+In container environments, Fluentd is frequently used as a logs collector. Add the following to your configuration file:
+
+```
+<match datadog.**>
+  @type datadog
+  @id awesome_agent
+  api_key <YOUR_DATADOG_API_KEY>
+  host myProxyServer.myDomain
+  use_ssl false
+  #port 10514
+</match>
+```
+
+The option `port 10514` shown above is unnecessary because Fluentd defaults to port 10514 if `use_ssl false` is used.
+
+{{% /tab %}}
+{{< /tabs >}}
+
+-------------------
+
+Datadog has successfully tested the shipper configurations on Windows Server 2012 R2, CentOS 7, and Ubuntu 16 with NXLog, Datadog Agent v6, and Fluentd.
+
 ## Using the Agent as a Proxy
 
 **This feature is only available for Agent v5**
@@ -471,7 +562,7 @@ It is recommended to use an actual proxy (a web proxy or HAProxy) to forward you
 to
     `dd_url: http://proxy-node:17123`
 
-6. Verify on the [Infrastructure page][3] that all nodes report data to Datadog.
+6. Verify on the [Infrastructure page][4] that all nodes report data to Datadog.
 
 ## Further Reading
 
@@ -479,4 +570,5 @@ to
 
 [1]: http://haproxy.1wt.eu
 [2]: http://www.haproxy.org/#perf
-[3]: https://app.datadoghq.com/infrastructure#overview
+[3]: https://www.nginx.com
+[4]: https://app.datadoghq.com/infrastructure#overview

--- a/content/agent/proxy.md
+++ b/content/agent/proxy.md
@@ -446,7 +446,7 @@ To verify that everything is working properly, review the HAProxy statistics at 
 
 ## Using NGINX as a Proxy
 
-[NGINX][3] is a web server which can also be used as a reverse proxy, load balancer, mail proxy, and HTTP cache. You can use NGINX as a Proxy to send logs to Datadog:
+[NGINX][3] is a web server which can also be used as a reverse proxy, load balancer, mail proxy, and HTTP cache. You can use NGINX as a proxy to send logs to Datadog:
 
 `agent ---> nginx ---> Datadog` or  
 `external log shipper ---> nginx ---> Datadog`


### PR DESCRIPTION
### What does this PR do?
- Migrate NGINX proxy for logs KB to docs - https://help.datadoghq.com/hc/en-us/articles/360001455791-Proxy-for-logs-collection-with-NGINX

### Motivation
KB site migration

### Preview link
https://docs-staging.datadoghq.com/ruth/nginx-proxy-logs/agent/proxy/#using-nginx-as-a-proxy

### Additional Notes
Redirect KB article after merge
