### PR TITLE
[PROD]add logs collection to ac_exclude ac_include scope

### DIFF
--- a/content/agent/docker/_index.md
+++ b/content/agent/docker/_index.md
@@ -99,7 +99,7 @@ DD_DOCKER_LABELS_AS_TAGS='{"com.docker.compose.service":"service_name"}'
 
 #### Ignore containers
 
-Exclude containers from logs collection, metrics collection and Autodiscovery. Datadog excludes Kubernetes and OpenShift `pause` containers by default. See the `datadog.yaml.example` file for more documentation, and examples:
+Exclude containers from logs collection, metrics collection, and Autodiscovery. Datadog excludes Kubernetes and OpenShift `pause` containers by default. See the `datadog.yaml.example` file for more documentation, and examples:
 
 | Env Variable    | Description                                                                                                             |
 |-----------------|-------------------------------------------------------------------------------------------------------------------------|

--- a/content/agent/docker/_index.md
+++ b/content/agent/docker/_index.md
@@ -99,7 +99,7 @@ DD_DOCKER_LABELS_AS_TAGS='{"com.docker.compose.service":"service_name"}'
 
 #### Ignore containers
 
-Exclude containers from metrics collection and Autodiscovery. Datadog excludes Kubernetes and OpenShift `pause` containers by default. See the `datadog.yaml.example` file for more documentation, and examples:
+Exclude containers from logs collection, metrics collection and Autodiscovery. Datadog excludes Kubernetes and OpenShift `pause` containers by default. See the `datadog.yaml.example` file for more documentation, and examples:
 
 | Env Variable    | Description                                                                                                             |
 |-----------------|-------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
### What does this PR do?
Modify https://docs.datadoghq.com/agent/docker/#ignore-containers to reflect that log collection is also in the scope of ac_include/exclude

### Motivation
Discrepancy with reality and https://docs.datadoghq.com/logs/log_collection/docker/?tab=containerinstallation#filter-containers