### PR TITLE
Update journald instruction for log collection

### DIFF
--- a/content/logs/log_collection/_index.md
+++ b/content/logs/log_collection/_index.md
@@ -108,7 +108,7 @@ logs:
     path: /var/log/journal/
 ```
 
-Refer to the [journald integration][2] documentation for more details regarding the setup for containerised environment and units filtering.
+Refer to the [journald integration][2] documentation for more details regarding the setup for containerized environments and units filtering.
  
 
 [1]: /agent/faq/agent-configuration-files

--- a/content/logs/log_collection/_index.md
+++ b/content/logs/log_collection/_index.md
@@ -108,8 +108,13 @@ logs:
     path: /var/log/journal/
 ```
 
+Refer to the [journald integration][2] documentation for more details regarding the setup for containerised environment and units filtering.
+ 
 
 [1]: /agent/faq/agent-configuration-files
+[2]: /integrations/journald
+
+
 {{% /tab %}}
 {{% tab "Windows Events" %}}
 


### PR DESCRIPTION
### What does this PR do?
Add reference to journald integration setup in related log collection section.

### Motivation
Following support troubleshooting case
https://trello.com/c/9LUrlvzZ/936-unable-to-collect-journald-logs-through-kubernetes-agent

Using search bar, I landed on the log collection section ... and did not pay attention that there would be other good material to look at.

### Preview link
https://docs-staging.datadoghq.com/pcariou/logjournaldupdate/logs/log_collection/?tab=streamlogsfromjournald

