### PR TITLE
Disabling JA translation pulling util we have a sufficient corpus

### DIFF
--- a/translate.yaml
+++ b/translate.yaml
@@ -37,6 +37,7 @@ github:
   pr_body: 'This is an automated PR created by the scheduled translation task pulling the latest translated files'
   pr_labels:
     - "Translation"
+  pr_preview_base_url: "https://docs-staging.datadoghq.com"
 reviewers:
   - name: 'David Jones'
     github_user: 'davidejones'

--- a/translate.yaml
+++ b/translate.yaml
@@ -27,8 +27,6 @@ filters:
 langs:
 - lang_country: "fr_FR"
   lang: "fr"
-- lang_country: "ja"
-  lang: "ja"
 github:
   org: 'DataDog'
   repo: 'documentation'


### PR DESCRIPTION
Some JA documentation are pulled from transifex, but the architecture is not yet ready for this. Disabling JA pulling for now.