### PR TITLE
Updated the log format for java trace id in logs.

### DIFF
--- a/content/logs/log_collection/java.md
+++ b/content/logs/log_collection/java.md
@@ -69,7 +69,7 @@ If APM is enabled for this application and you wish to improve the correlation b
 Once this is done, the `ConversionPattern` to use becomes:
 
 ```xml
-<param name="ConversionPattern" value="%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %X{dd.trace_id} %X{dd.span_id} - %m%n" />
+<param name="ConversionPattern" value="%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - dd.trace_id=%X{dd.trace_id} dd.span_id=%X{dd.span_id} - %m%n" />
 ```
 
 [1]: https://docs.datadoghq.com/tracing/advanced_usage/?tab=java#logging


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fix the log format for the trace_id in logs for java apps. With the current format, no way to know which number is what in the generated logs.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/loic.raucy/updating-java-trace-id-collection/logs/log_collection/java/?tab=log4j

<!-- This is the base preview link. Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/loic.raucy/updated-java-trace-id-collection/logs/log_collection/java/?tab=log4j

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
