### PR TITLE
Fix Redhat link

### DIFF
--- a/content/agent/basic_agent_usage/redhat.md
+++ b/content/agent/basic_agent_usage/redhat.md
@@ -108,7 +108,7 @@ See the instructions on how to [add packages to the embedded Agent][4] for more 
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/account/settings#agent/redhat
+[1]: https://app.datadoghq.com/account/settings#agent/centos
 [2]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md#service-lifecycle-commands
 [3]: /agent/troubleshooting
 [4]: /agent/faq/custom_python_package


### PR DESCRIPTION
### What does this PR do?
- The in-app instructions for Redhat and Centos are under the same link (`#centos`). Updating the instruction link to point to centos.

### Motivation
Trello request

### Preview link
https://docs-staging.datadoghq.com/ruth/redhat-link/agent/basic_agent_usage/redhat/
