### PR TITLE
 Update githook to ignore riak_repl integration

### DIFF
--- a/local/githooks/pre-commit.d/integration-logos
+++ b/local/githooks/pre-commit.d/integration-logos
@@ -10,6 +10,7 @@ int_ignore = ['_index.png',
               'dotnetclr.png',
               'integration.png',
               'integrations-extras.png',
+              'riak_repl.png'
               'sortdb.png',
               'snmpwalk.png',
               'stunnel.png',

--- a/local/githooks/pre-commit.d/integration-logos
+++ b/local/githooks/pre-commit.d/integration-logos
@@ -10,7 +10,7 @@ int_ignore = ['_index.png',
               'dotnetclr.png',
               'integration.png',
               'integrations-extras.png',
-              'riak_repl.png'
+              'riak_repl.png',
               'sortdb.png',
               'snmpwalk.png',
               'stunnel.png',


### PR DESCRIPTION
### What does this PR do?
Update githook to ignore riak_repl integration. This is a community integration with no logo.

### Motivation
githook shows logo is missing
