### PR TITLE
unclebconnor-at_mention_clarification

### DIFF
--- a/content/monitors/notifications.md
+++ b/content/monitors/notifications.md
@@ -263,6 +263,8 @@ After having installed the Slack integration, type `@slack` in your notification
 
 **@-mentions in Slack from monitor alert**:
 
+*Please note that there must be a space between a closing curly brace `}` and `@`.  As `}` is a legal email character, we do not handle @-mentions immediately following them.
+
 Wrap the `@username` in `< >` as seen below in your monitors message template to **@ notify** the defined user within slack notifications.
 For example this configuration:
 

--- a/content/monitors/notifications.md
+++ b/content/monitors/notifications.md
@@ -256,7 +256,7 @@ Send the monitor notification to the appropriate endpoint:
 * Notify any non-Datadog users via email by adding `@<EMAIL>` to the notification message.
 * Install Slack or Hipchat integration to send your notifications directly in the appropriate channel.
 
-**Note**: A @-mentions must have a space between it and the last line character: `{{value}}@slack-channel` is invalid `{{value}} @slack-channel` is valid.
+**Note**: A @-mention must have a space between it and the last line character: `{{value}}@slack-channel` is invalid `{{value}} @slack-channel` is valid.
 
 {{< tabs >}}
 {{% tab "Slack Integration" %}}

--- a/content/monitors/notifications.md
+++ b/content/monitors/notifications.md
@@ -256,14 +256,14 @@ Send the monitor notification to the appropriate endpoint:
 * Notify any non-Datadog users via email by adding `@<EMAIL>` to the notification message.
 * Install Slack or Hipchat integration to send your notifications directly in the appropriate channel.
 
+**Note**: A @-mentions must have a space between it and the last line character: `{{value}}@slack-channel` is invalid `{{value}} @slack-channel` is valid.
+
 {{< tabs >}}
 {{% tab "Slack Integration" %}}
 
 After having installed the Slack integration, type `@slack` in your notification message to see the available list of channels to send your notification to.
 
 **@-mentions in Slack from monitor alert**:
-
-*Please note that there must be a space between a closing curly brace `}` and `@`.  As `}` is a legal email character, we do not handle @-mentions immediately following them.
 
 Wrap the `@username` in `< >` as seen below in your monitors message template to **@ notify** the defined user within slack notifications.
 For example this configuration:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Clarifies a common issue about not handling `@-mentions` immediately after curly braces `}`

### Motivation
<!-- What inspired you to submit this pull request?-->
This issue comes up quite often in escalations to the monitors team.

### Preview link
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/unclebconnor/at_mention_clarification/monitors/notifications/
*Not working :-/ . Maybe because I used a slash?

<!-- This is the base preview link. Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
