### PR TITLE
improving go apm page

### DIFF
--- a/content/tracing/languages/go.md
+++ b/content/tracing/languages/go.md
@@ -92,7 +92,7 @@ The Go tracer includes support for the following data stores and libraries.
 Packages must be imported, i.e.:
 
 ```go
-import "gopkg.in/DataDog/dd-trace-go.v1/contrib/<package_dir>/<package_name>
+import "gopkg.in/DataDog/dd-trace-go.v1/contrib/<package_dir>/<package_name>"
 ```
 
 ## Configuration

--- a/content/tracing/languages/go.md
+++ b/content/tracing/languages/go.md
@@ -97,7 +97,7 @@ import "gopkg.in/DataDog/dd-trace-go.v1/contrib/<package_dir>/<package_name>"
 
 ## Configuration
 
-The tracer is configured with options parameters when the `Start` function is called. An example for generating a trace:
+The tracer is configured with options parameters when the `Start` function is called. An example for generating a trace using the HTTP library:
 
 ```go
 package main


### PR DESCRIPTION
### What does this PR do?
Makes improvements to the Tracing Go Applications page. A note about importing libraries, and an improved config example. Also minor syntax updates.

### Motivation
Support request, h/t @dabcoder 

### Preview link

https://docs-staging.datadoghq.com/cswatt/go-apm-update/tracing/languages/go


### Additional Notes
<!-- Anything else we should know when reviewing?-->
