### PR TITLE
add some clarifying documentation for downtimes

### DIFF
--- a/content/monitors/downtimes.md
+++ b/content/monitors/downtimes.md
@@ -71,7 +71,7 @@ The downtimes are scheduled and cancelled at the specified constraints—by canc
 
 ## Searching Downtimes
 
-Downtime history can be seen both on the Monitor Status Page as overlayed on the group transition history, as well as in the Event Stream by searching for: `tags:audit,downtime` or a specific downtime by id with `tags:audit,downtime_id:<downtime_id>`
+Downtime history can be seen both on the Monitor Status Page as overlaid on the group transition history, as well as in the Event Stream by searching for `tags:audit,downtime`, or a specific downtime by ID with `tags:audit,downtime_id:<downtime_id>`
 
 ## Further Reading
 

--- a/content/monitors/downtimes.md
+++ b/content/monitors/downtimes.md
@@ -71,7 +71,7 @@ This works by cancelling the existing downtime, and creating a new downtime with
 
 ## Searching Downtimes
 
-Downtime history can be seen both on the Monitor Status Page as overlaid on the group transition history, as well as in the Event Stream by searching for `tags:audit,downtime`, or a specific downtime by ID with `tags:audit,downtime_id:<downtime_id>`
+Downtime history can be seen both on the Monitor Status Page as overlaid on the group transition history, as well as in the Event Stream by searching for `tags:audit,downtime`, or a specific downtime by ID with `tags:audit,downtime_id:<DOWNTIME_ID>`
 
 ## Further Reading
 

--- a/content/monitors/downtimes.md
+++ b/content/monitors/downtimes.md
@@ -22,7 +22,7 @@ You can schedule downtimes and/or mute your Datadog monitors so that they do not
 
 Monitors trigger events when they change state between `ALERT`, `WARNING` (if enabled), `RESOLVED`, and `NO DATA` (if enabled). If a monitor has been silenced either by a downtime or muting, then any transition from `RESOLVED` to another state will **neither trigger an event**, nor activate any associated notification channels. 
 
-**Note**: Muting or un-muting a monitor via the UI deletes all scheduled downtimes associated with that monitor.
+**Note**: Muting or un-muting a monitor via the UI does not delete scheduled downtimes associated with that monitor. For that you should use the Manage Downtimes feature or directly use the API.
 
 {{< img src="monitors/downtimes/downtime_on_alert.png" alt="downtime on alert" responsive="true" style="width:80%;">}}
 
@@ -55,11 +55,23 @@ To schedule downtime, click the "Schedule Downtime" button in the upper right.
 
 2. Set a schedule.
   {{< img src="monitors/downtimes/downtime-schedule.png" alt="downtime-schedule" responsive="true" style="width:80%;">}}
-  You can set a start date and time or leave the field empty to immediately start the downtime. You may also set a repeating schedule to accommodate regularly scheduled downtimes.
+  You can set a start date and time or leave the field empty to immediately start the downtime. You may also set a [repeating schedule to accommodate regularly scheduled downtimes](#recurring-downtimes).
 
 3. Add an optional message to notify your team
   {{< img src="monitors/downtimes/downtime-notify.png" alt="downtime-notify" responsive="true" style="width:80%;">}}
   Enter a message to notify your team about this downtime. The message field allows standard [markdown formatting][5] as well as Datadog's @-notification syntax. The *Notify your team* field allows you to specify team members or send the message to a service [integration][6].
+
+## Recurring Downtimes
+
+Recurring downtimes allow you to create a downtime that is started and stopped and a recurring interval or pattern. 
+
+These are useful if you have for example a regularly scheduled maintenance window, non-peak or peak hours for which you have configured a different monitor to account for this change in behavior and want to suppress an otherwise noisy monitor.
+
+The downtimes will be scheduled and cancelled at the specified constraints, by cancelling the existing downtime and creating a new downtime with the same constraints associated to the user which configured this downtime.
+
+## Searching Downtimes
+
+Downtime history can be seen both on the Monitor Status Page as overlayed on the group transition history, as well as in the Event Stream by searching for: `tags:audit,downtime` or a specific downtime by id with `tags:audit,downtime_id:<downtime_id>`
 
 ## Further Reading
 

--- a/content/monitors/downtimes.md
+++ b/content/monitors/downtimes.md
@@ -22,7 +22,7 @@ You can schedule downtimes and/or mute your Datadog monitors so that they do not
 
 Monitors trigger events when they change state between `ALERT`, `WARNING` (if enabled), `RESOLVED`, and `NO DATA` (if enabled). If a monitor has been silenced either by a downtime or muting, then any transition from `RESOLVED` to another state will **neither trigger an event**, nor activate any associated notification channels. 
 
-**Note**: Muting or un-muting a monitor via the UI does not delete scheduled downtimes associated with that monitor. For that you should use the Manage Downtimes feature or directly use the API.
+**Note**: Muting or un-muting a monitor via the UI does not delete scheduled downtimes associated with that monitor. For that, use the Manage Downtimes feature or directly use the API.
 
 {{< img src="monitors/downtimes/downtime_on_alert.png" alt="downtime on alert" responsive="true" style="width:80%;">}}
 

--- a/content/monitors/downtimes.md
+++ b/content/monitors/downtimes.md
@@ -67,7 +67,7 @@ Recurring downtimes allow you to create a downtime that is started and stopped a
 
 One use case for this would be if you have regularly scheduled maintenance windows and want to suppress what might become a noisy monitor due to your changes.
 
-The downtimes are scheduled and cancelled at the specified constraints—by cancelling the existing downtime, and creating a new downtime with the same constraints associated to the user who configured this downtime.
+This works by cancelling the existing downtime, and creating a new downtime with the same constraints associated to the user who configured this downtime.
 
 ## Searching Downtimes
 

--- a/content/monitors/downtimes.md
+++ b/content/monitors/downtimes.md
@@ -67,7 +67,7 @@ Recurring downtimes allow you to create a downtime that is started and stopped a
 
 One use case for this would be if you have regularly scheduled maintenance windows and want to suppress what might become a noisy monitor due to your changes.
 
-The downtimes will be scheduled and cancelled at the specified constraints, by cancelling the existing downtime and creating a new downtime with the same constraints associated to the user which configured this downtime.
+The downtimes are scheduled and cancelled at the specified constraints—by cancelling the existing downtime, and creating a new downtime with the same constraints associated to the user who configured this downtime.
 
 ## Searching Downtimes
 

--- a/content/monitors/downtimes.md
+++ b/content/monitors/downtimes.md
@@ -67,7 +67,9 @@ Recurring downtimes allow you to create a downtime that is started and stopped a
 
 One use case for this would be if you have regularly scheduled maintenance windows and want to suppress what might become a noisy monitor due to your changes.
 
-This works by cancelling the existing downtime, and creating a new downtime with the same constraints associated to the user who configured this downtime.
+When a recurring downtime ends, the downtime is cancelled and a new downtime with the same constraints (with updated start and end times) is created in a rolling pattern. 
+
+**Note**: The original creator is associated to all of these newly created downtimes.
 
 ## Searching Downtimes
 

--- a/content/monitors/downtimes.md
+++ b/content/monitors/downtimes.md
@@ -63,7 +63,7 @@ To schedule downtime, click the "Schedule Downtime" button in the upper right.
 
 ## Recurring Downtimes
 
-Recurring downtimes allow you to create a downtime that is started and stopped and a recurring interval or pattern. 
+Recurring downtimes allow you to create a downtime that is started and stopped at a recurring interval or pattern. 
 
 These are useful if you have for example a regularly scheduled maintenance window, non-peak or peak hours for which you have configured a different monitor to account for this change in behavior and want to suppress an otherwise noisy monitor.
 

--- a/content/monitors/downtimes.md
+++ b/content/monitors/downtimes.md
@@ -65,7 +65,7 @@ To schedule downtime, click the "Schedule Downtime" button in the upper right.
 
 Recurring downtimes allow you to create a downtime that is started and stopped at a recurring interval or pattern. 
 
-These are useful if you have for example a regularly scheduled maintenance window, non-peak or peak hours for which you have configured a different monitor to account for this change in behavior and want to suppress an otherwise noisy monitor.
+One use case for this would be if you have regularly scheduled maintenance windows and want to suppress what might become a noisy monitor due to your changes.
 
 The downtimes will be scheduled and cancelled at the specified constraints, by cancelling the existing downtime and creating a new downtime with the same constraints associated to the user which configured this downtime.
 

--- a/content/monitors/faq/why-did-i-get-a-recovery-event-from-a-monitor-that-was-in-a-downtime-when-it-alerted.md
+++ b/content/monitors/faq/why-did-i-get-a-recovery-event-from-a-monitor-that-was-in-a-downtime-when-it-alerted.md
@@ -13,10 +13,10 @@ further_reading:
   text: "Learn more about downtimes"
 ---
 
-When a group is [downtimed][1] and transitions from **`OK`** to one of **`ALERT`**, **`WARNING`**, or **`NO DATA`** state, this event is suppressed from notifying you. 
+When a group is [downtimed][1] and transitions from **`OK`** to one of a **`ALERT`**, **`WARNING`**, or **`NO DATA`** state, this event is suppressed from notifying you. 
 When this downtime ends or is cancelled, this allows both re-notify events (if configured) and recovery events to then be sent. 
 
-An option is to resolve the monitor prior to cancelling the downtime to suppress recovery notifications. Though any groups that were in a non-**`OK`** state could switch back to their previous state resulting in another notification.
+An option is to resolve the monitor prior to cancelling the downtime to suppress recovery notifications. However, any groups that were in a non-**`OK`** state could switch back to their previous state, resulting in another notification.
 
 {{< partial name="whats-next/whats-next.html" >}}
 

--- a/content/monitors/faq/why-did-i-get-a-recovery-event-from-a-monitor-that-was-in-a-downtime-when-it-alerted.md
+++ b/content/monitors/faq/why-did-i-get-a-recovery-event-from-a-monitor-that-was-in-a-downtime-when-it-alerted.md
@@ -1,5 +1,5 @@
 ---
-title: Why did I get a Recovery Event from a Monitor that was in a Downtime when it Alerted?
+title: Why did I get a recovery event from a Monitor that was in a Downtime when it alerted?
 kind: faq
 further_reading:
 - link: "monitors/monitor_types"
@@ -13,8 +13,8 @@ further_reading:
   text: "Learn more about downtimes"
 ---
 
-When a group is [downtimed][1] and transitions from **`OK`** to one of (**`ALERT`**, **`WARNING`**, **`NO DATA`**), this event will be suppressed from notifying you. When this downtime ends or is cancelled, this allows both re-notify events (if configured) and recovery events to then be sent. This is expected behavior. 
-
+When a group is [downtimed][1] and transitions from **`OK`** to one of **`ALERT`**, **`WARNING`**, or **`NO DATA`** state, this event is suppressed from notifying you. 
+When this downtime ends or is cancelled, this allows both re-notify events (if configured) and recovery events to then be sent. 
 
 An option is to resolve the monitor prior to cancelling the downtime to suppress recovery notifications. Though any groups that were in a non-**`OK`** state could switch back to their previous state resulting in another notification.
 

--- a/content/monitors/faq/why-did-i-get-a-recovery-event-from-a-monitor-that-was-in-a-downtime-when-it-alerted.md
+++ b/content/monitors/faq/why-did-i-get-a-recovery-event-from-a-monitor-that-was-in-a-downtime-when-it-alerted.md
@@ -1,0 +1,23 @@
+---
+title: Why did I get a Recovery Event from a Monitor that was in a Downtime when it Alerted?
+kind: faq
+further_reading:
+- link: "monitors/monitor_types"
+  tag: "Documentation"
+  text: "Learn how to create a monitor"
+- link: "monitors/notifications"
+  tag: "Documentation"
+  text: "Configure your monitor notifications"
+- link: "monitors/downtimes"
+  tag: "Documentation"
+  text: "Learn more about downtimes"
+---
+
+When a group is [downtimed][1] and transitions from **`OK`** to one of (**`ALERT`**, **`WARNING`**, **`NO DATA`**), this event will be suppressed from notifying you. When this downtime ends or is cancelled, this allows both re-notify events (if configured) and recovery events to then be sent. This is expected behavior. 
+
+
+An option is to resolve the monitor prior to cancelling the downtime to suppress recovery notifications. Though any groups that were in a non-**`OK`** state could switch back to their previous state resulting in another notification.
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /monitors/downtimes


### PR DESCRIPTION
### What does this PR do?
add some clarifying documentation for downtimes

- Add some clarification on Recurring downtimes.
- Add info on how to search for downtimes in the event stream
- Add a FAQ for recovery notifications after downtime ends.

### Motivation
Downtime Clarification documentation improvements.

### Preview link
- https://docs-staging.datadoghq.com/downtime-docs-updates/monitors/downtimes/
- https://docs-staging.datadoghq.com/downtime-docs-updates/monitors/downtimes/faq/why-did-i-get-a-recovery-event-from-a-monitor-that-was-in-a-downtime-when-it-alerted

### Additional Notes
