### PR TITLE
Cswatt/synthetics network timings

### DIFF
--- a/content/synthetics/_index.md
+++ b/content/synthetics/_index.md
@@ -60,7 +60,6 @@ The Synthetics details page displays the following network timings:
 
 | Timing | Description |
 | ------ | ----------- |
-| Redirect | Sum of the time spent in redirects. The next 5 timings in this table are for the last request executed; all the time spent before the last request is aggregated here. When there is no redirect or `followRedirect` is explicitly set to false, this metric does not appear. |
 | DNS | Time spent resolving the DNS name of the last request. |
 | Connect | Time spent establishing a connection to the server. |
 | SSL | Time spent for the TLS handshake. If the last request is not over HTTPS, this metric does not appear. |

--- a/content/synthetics/_index.md
+++ b/content/synthetics/_index.md
@@ -54,6 +54,21 @@ Finally, the following characters are reserved: `-`, `(`, `)`, `"`, `~`, `*`, `:
 
 Select **Create a New check +** > **New Uptime Check** in the upper right corner of the Synthetics page to create an [Uptime Check][2].
 
+## Network timings
+
+The Synthetics details page displays the following network timings:
+
+| Timing | Description |
+| ------ | ----------- |
+| Redirect | Sum of the time spent in redirects. The next 5 timings in this table are for the last request executed; all the time spent before the last request is aggregated here. When there is no redirect or `followRedirect` is explicitly set to false, this metric does not appear. |
+| DNS | Time spent resolving the DNS name of the last request. |
+| Connect | Time spent establishing a connection to the server. |
+| SSL | Time spent for the TLS handshake. If the last request is not over HTTPS, this metric does not appear. |
+| TTFB (time to first byte) | Time spent waiting for the first byte of response to be received. |
+| Download | Time spent downloading the response. |
+
+Response time is the sum of these network timings.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/synthetics/_index.md
+++ b/content/synthetics/_index.md
@@ -58,13 +58,13 @@ Select **Create a New check +** > **New Uptime Check** in the upper right corner
 
 The Synthetics details page displays the following network timings:
 
-| Timing | Description |
-| ------ | ----------- |
-| DNS | Time spent resolving the DNS name of the last request. |
-| Connect | Time spent establishing a connection to the server. |
-| SSL | Time spent for the TLS handshake. If the last request is not over HTTPS, this metric does not appear. |
-| TTFB (time to first byte) | Time spent waiting for the first byte of response to be received. |
-| Download | Time spent downloading the response. |
+| Timing                    | Description                                                                                           |
+|---------------------------|-------------------------------------------------------------------------------------------------------|
+| DNS                       | Time spent resolving the DNS name of the last request.                                                |
+| Connect                   | Time spent establishing a connection to the server.                                                   |
+| SSL                       | Time spent for the TLS handshake. If the last request is not over HTTPS, this metric does not appear. |
+| TTFB (time to first byte) | Time spent waiting for the first byte of response to be received.                                     |
+| Download                  | Time spent downloading the response.                                                                  |
 
 Response time is the sum of these network timings.
 


### PR DESCRIPTION
### What does this PR do?
Adds network timings to Synthetics docs.

### Motivation
Trello request from eng

### Preview link
https://docs-staging.datadoghq.com/cswatt/synthetics-network-timings/synthetics/#network-timings
