### PR TITLE
use direct url to create RBACs to not use outdated RBACs: one source of truth

### DIFF
--- a/content/agent/kubernetes/daemonset_setup.md
+++ b/content/agent/kubernetes/daemonset_setup.md
@@ -20,84 +20,16 @@ Take advantage of DaemonSets to deploy the Datadog Agent on all your nodes (or o
 *If DaemonSets are not an option for your Kubernetes cluster, [install the Datadog Agent][2] as a deployment on each Kubernetes node.*
 
 ## Configure RBAC permissions
-If your Kubernetes has role-based access control (RBAC) enabled, configure RBAC permissions for your Datadog Agent service account. Create the file `datadog-serviceaccount.yaml`:
+If your Kubernetes has role-based access control (RBAC) enabled, configure RBAC permissions for your Datadog Agent service account.
 
-```yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: datadog-agent
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - services
-  - events
-  - endpoints
-  - pods
-  - nodes
-  - componentstatuses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  resourceNames:
-  - datadogtoken             # Kubernetes event collection state
-  - datadog-leader-election  # Leader election token
-  verbs:
-  - get
-  - update
-- apiGroups:  # To create the leader election token
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - create
-- nonResourceURLs:
-  - "/version"
-  - "/healthz"
-  verbs:
-  - get
-- apiGroups:  # Kubelet connectivity
-  - ""
-  resources:
-  - nodes/metrics
-  - nodes/spec
-  - nodes/proxy
-  verbs:
-  - get
----
-# You need to use that account for your dd-agent DaemonSet
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: datadog-agent
-  namespace: default
----
-# Your admin user needs the same permissions to be able to grant them
-# Easiest way is to bind your user to the cluster-admin role
-# See https://cloud.google.com/container-engine/docs/role-based-access-control#setting_up_role-based_access_control
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: datadog-agent
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: datadog-agent
-subjects:
-- kind: ServiceAccount
-  name: datadog-agent
-  namespace: default
-```
 Create the appropriate ClusterRole, ServiceAccount, and ClusterRoleBinding:
 
 ```
-kubectl create -f datadog-serviceaccount.yaml
+kubectl create -f k create --dry-run -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/rbac/clusterrole.yaml"
+
+kubectl create -f k create --dry-run -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/rbac/serviceaccount.yaml"
+
+kubectl create -f k create --dry-run -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/rbac/clusterrolebinding.yaml"
 ```
 
 ## Create manifest

--- a/content/agent/kubernetes/daemonset_setup.md
+++ b/content/agent/kubernetes/daemonset_setup.md
@@ -25,11 +25,11 @@ If your Kubernetes has role-based access control (RBAC) enabled, configure RBAC 
 Create the appropriate ClusterRole, ServiceAccount, and ClusterRoleBinding:
 
 ```
-kubectl create -f k create --dry-run -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/rbac/clusterrole.yaml"
+kubectl create -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/rbac/clusterrole.yaml"
 
-kubectl create -f k create --dry-run -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/rbac/serviceaccount.yaml"
+kubectl create -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/rbac/serviceaccount.yaml"
 
-kubectl create -f k create --dry-run -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/rbac/clusterrolebinding.yaml"
+kubectl create -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/rbac/clusterrolebinding.yaml"
 ```
 
 ## Create manifest


### PR DESCRIPTION
### What does this PR do?
Update the RBAC definition for kubernetes to use direct url. We don't want the customers to use outdated RBACs: one source of truth

### Motivation
Issue with RBAC for openshift that has not been updated in the docs: https://trello.com/c/DcLpar0y/1019-error-while-integrating-openshift-cluster