### PR TITLE
[php] Specify when config env variable should be available

### DIFF
--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -2015,13 +2015,19 @@ var tracer = Datadog.Trace.Tracer.Create(isDebugEnabled: true);
 
 Debug mode is disabled by default. To enable it, set the environment variable `DD_TRACE_DEBUG=true`.
 
+*An important note*: If you use code auto-instrumentation (the recommended approach) please be aware that the
+instrumenting code is executed before any user code. So the environment variables below must be set at the server
+level and be available to the PHP runtime before any user code is executed. So, for example, `putenv()` and `.env`
+files would not work.
+
 ```php
-putenv('DD_TRACE_DEBUG=true');
+DD_TRACE_DEBUG=true
 ```
 
 **Application Logs**:
 
-By default, logging from the PHP tracer is disabled. In order to get debugging information and errors sent to logs, set a [PSR-3 logger][1] singleton.
+By default, logging from the PHP tracer is disabled. In order to get debugging information and errors sent to logs,
+set a [PSR-3 logger][1] singleton.
 
 ```php
 \DDTrace\Log\Logger::set(

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -2013,8 +2013,7 @@ var tracer = Datadog.Trace.Tracer.Create(isDebugEnabled: true);
 {{% /tab %}}
 {{% tab "PHP" %}}
 
-Debug mode is disabled by default. To enable it, set the environment variable `DD_TRACE_DEBUG=true`. Please see at
-the PHP [configuration docs][6] for details about how and when this environment variable value should be set in order
+Debug mode is disabled by default. To enable it, set the environment variable `DD_TRACE_DEBUG=true`. See the PHP [configuration docs][6] for details about how and when this environment variable value should be set in order
 to be properly handled by the tracer.
 
 **Application Logs**:
@@ -2028,8 +2027,8 @@ set a [PSR-3 logger][1] singleton.
 );
 ```
 
-
 [1]: https://www.php-fig.org/psr/psr-3
+
 {{% /tab %}}
 {{% tab "C++" %}}
 

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -2013,16 +2013,9 @@ var tracer = Datadog.Trace.Tracer.Create(isDebugEnabled: true);
 {{% /tab %}}
 {{% tab "PHP" %}}
 
-Debug mode is disabled by default. To enable it, set the environment variable `DD_TRACE_DEBUG=true`.
-
-*An important note*: If you use code auto-instrumentation (the recommended approach) be aware that the
-instrumenting code is executed before any user code. As a result, the environment variables below must be set at the server
-level and be available to the PHP runtime before any user code is executed. For example, `putenv()` and `.env`
-files would not work.
-
-```php
-DD_TRACE_DEBUG=true
-```
+Debug mode is disabled by default. To enable it, set the environment variable `DD_TRACE_DEBUG=true`. Please see at
+the PHP [configuration docs][6] for details about how and when this environment variable value should be set in order
+to be properly handled by the tracer.
 
 **Application Logs**:
 
@@ -2132,3 +2125,4 @@ apm_config:
 [3]: http://opentracing.io
 [4]: #priority-sampling
 [5]: /tracing/getting_further/trace_sampling_and_storage
+[6]: /tracing/languages/php/#configuration

--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -2015,9 +2015,9 @@ var tracer = Datadog.Trace.Tracer.Create(isDebugEnabled: true);
 
 Debug mode is disabled by default. To enable it, set the environment variable `DD_TRACE_DEBUG=true`.
 
-*An important note*: If you use code auto-instrumentation (the recommended approach) please be aware that the
-instrumenting code is executed before any user code. So the environment variables below must be set at the server
-level and be available to the PHP runtime before any user code is executed. So, for example, `putenv()` and `.env`
+*An important note*: If you use code auto-instrumentation (the recommended approach) be aware that the
+instrumenting code is executed before any user code. As a result, the environment variables below must be set at the server
+level and be available to the PHP runtime before any user code is executed. For example, `putenv()` and `.env`
 files would not work.
 
 ```php

--- a/content/tracing/languages/php.md
+++ b/content/tracing/languages/php.md
@@ -220,9 +220,35 @@ dd_trace("CustomDriver", "doWork", function (...$args) {
 The PHP tracer can be configured using environment variables.
 
 *An important note*: If you use code auto-instrumentation (the recommended approach) please be aware that the
-instrumenting code is executed before any user code. So the environment variables below must be set at the server
-level and be available to the PHP runtime before any user code is executed. So, for example, `putenv()` and `.env`
+instrumenting code is executed before any user code. As a result, the environment variables below must be set at the
+server level and be available to the PHP runtime before any user code is executed. For example, `putenv()` and `.env`
 files would not work.
+
+### Apache
+
+Set using [`SetEnv`](https://httpd.apache.org/docs/2.4/mod/mod_env.html#setenv) from the server config, virtual host,
+directory, or **.htaccess** file.
+
+```
+SetEnv DD_TRACE_DEBUG true
+```
+
+### nginx
+
+Set using [`fastcgi_param`](http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_param) from the `http`,
+`server`, or `location` contexts.
+
+```
+fastcgi_param DD_TRACE_DEBUG true;
+```
+
+### PHP CLI server
+
+Set in the command line to start the server.
+
+```
+DD_TRACE_DEBUG=true php -S localhost:8888
+```
 
 | Env variable               | Default     | Note                                                                |
 | :------------------------- | :---------- | :------------------------------------------------------------------ |
@@ -234,7 +260,7 @@ files would not work.
 | `DD_SAMPLING_RATE`         | `1.0`       | The sampling rate for the traces. Between `0.0` and `1.0` (default) |
 | `DD_TRACE_AGENT_PORT`      | `8126`      | The Agent port number                                               |
 | `DD_TRACE_APP_NAME`        | ``          | The default app name                                                |
-| `DD_TRACE_DEBUG`           | `false`     | Enable debug mode for the tracer                                    |
+| `DD_TRACE_DEBUG`           | `false`     | Enable [debug mode][17] for the tracer                              |
 | `DD_TRACE_ENABLED`         | `true`      | Enable the tracer globally                                          |
 | `DD_TRACE_GLOBAL_TAGS`     | ``          | Tags to be set on all spans: e.g.: `key1:value1,key2:value2`        |
 
@@ -289,3 +315,4 @@ Don't see your desired libraries? Let Datadog know more about your needs through
 [14]: /tracing/advanced_usage/?tab=php#distributed-tracing
 [15]: /tracing/advanced_usage/?tab=php#priority-sampling
 [16]: https://docs.google.com/forms/d/e/1FAIpQLSemTVTCdqzXkfzemJSr8wuEllxfqbGVj00flmRvKA17f0lyFg/viewform
+[17]: /tracing/advanced_usage/?tab=php#debugging

--- a/content/tracing/languages/php.md
+++ b/content/tracing/languages/php.md
@@ -36,7 +36,7 @@ Make sure the Agent has **[APM enabled][6]**.
 
 ### Install the extension
 
-Install the PHP extension using one of the [precompiled packages for supported distributions][7]. If you can't find your distribution, you can install the PHP extension [from PECL][8] or [from source][9].
+Install the PHP extension using one of the [precompiled packages for supported distributions][7]. If you can't find your distribution, install the PHP extension [from PECL][8] or [from source][9].
 
 Once downloaded, install the package with one of the commands below.
 
@@ -219,10 +219,7 @@ dd_trace("CustomDriver", "doWork", function (...$args) {
 
 The PHP tracer can be configured using environment variables.
 
-*An important note*: If you use code auto-instrumentation (the recommended approach) please be aware that the
-instrumenting code is executed before any user code. As a result, the environment variables below must be set at the
-server level and be available to the PHP runtime before any user code is executed. For example, `putenv()` and `.env`
-files would not work.
+**Note**: If you use code auto-instrumentation (the recommended approach) be aware that the instrumenting code is executed before any user code. As a result, the environment variables below must be set at the server level and be available to the PHP runtime before any user code is executed. For example, `putenv()` and `.env` files would not work.
 
 ### Apache
 

--- a/content/tracing/languages/php.md
+++ b/content/tracing/languages/php.md
@@ -217,7 +217,12 @@ dd_trace("CustomDriver", "doWork", function (...$args) {
 
 ## Configuration
 
-Configure the Agent connection parameters via environment variables.
+The PHP tracer can be configured using environment variables.
+
+*An important note*: If you use code auto-instrumentation (the recommended approach) please be aware that the
+instrumenting code is executed before any user code. So the environment variables below must be set at the server
+level and be available to the PHP runtime before any user code is executed. So, for example, `putenv()` and `.env`
+files would not work.
 
 | Env variable               | Default     | Note                                                                |
 | :------------------------- | :---------- | :------------------------------------------------------------------ |


### PR DESCRIPTION
### What does this PR do?
This PR adds important details about when the configuration variables are read by the php tracer and when the user should properly set them.

### Motivation
We were involved with a customer trying to debug an issue and the problem was that he was setting an env variable when it is too late.

### Preview link
[Preview](https://docs-staging.datadoghq.com/php/specify-env-variable/tracing/languages/php/)
