### PR TITLE
Tanguy.lebarzic/synthetics errors

### DIFF
--- a/content/synthetics/_index.md
+++ b/content/synthetics/_index.md
@@ -59,20 +59,6 @@ Select **Create a New check +** in the upper right corner of the Synthetics page
 
 {{< img src="synthetics/create_a_check.png" alt="Create a check" responsive="true" style="width:80%;">}}
 
-## Network timings
-
-The Synthetics details page displays the following network timings:
-
-| Timing                    | Description                                                                                           |
-|---------------------------|-------------------------------------------------------------------------------------------------------|
-| DNS                       | Time spent resolving the DNS name of the last request.                                                |
-| Connect                   | Time spent establishing a connection to the server.                                                   |
-| SSL                       | Time spent for the TLS handshake. If the last request is not over HTTPS, this metric does not appear. |
-| TTFB (time to first byte) | Time spent waiting for the first byte of response to be received.                                     |
-| Download                  | Time spent downloading the response.                                                                  |
-
-Response time is the sum of these network timings.
-
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/synthetics/uptime_check.md
+++ b/content/synthetics/uptime_check.md
@@ -83,6 +83,20 @@ Notifications example:
 
 {{< img src="synthetics/uptime_check/uptime_check_notifications.png" alt="Assertions" responsive="true" style="width:80%;">}}
 
+## Network timings
+
+The Synthetics details page displays the following network timings:
+
+| Timing                    | Description                                                                                           |
+|---------------------------|-------------------------------------------------------------------------------------------------------|
+| DNS                       | Time spent resolving the DNS name of the last request.                                                |
+| Connect                   | Time spent establishing a connection to the server.                                                   |
+| SSL                       | Time spent for the TLS handshake. If the last request is not over HTTPS, this metric does not appear. |
+| TTFB (time to first byte) | Time spent waiting for the first byte of response to be received.                                     |
+| Download                  | Time spent downloading the response.                                                                  |
+
+Response time is the sum of these network timings.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/synthetics/uptime_check.md
+++ b/content/synthetics/uptime_check.md
@@ -97,6 +97,50 @@ The Synthetics details page displays the following network timings:
 
 Response time is the sum of these network timings.
 
+## Failures
+
+A check is considered `FAILED` if it doesn't satisfy the assertions configured for this check, or if the request failed for another reason. These reasons include:
+
+| Error           | Description                                                                                                                                                                                  |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CONNRESET       | The connection was abruptly closed by the remote server. Possible causes include the webserver encountering an error or crashing while responding, loss of connectivity of the webserver... |
+| DNS             | DNS entry not found for %example.com%. Possible causes include misconfigured check URL, wrong configuration of your DNS entries...                                                          |
+| INVALID_REQUEST | The configuration of the check is invalid (eg. typo in the URL).                                                                                                                             |
+| SSL             | The SSL connection couldn't be performed, see below for more detailed explanations.                                                                                                          |
+| TIMEOUT         | The request couldn't be completed in a reasonable time.                                                                                                                                      |
+
+### SSL errors
+
+| Error                              | Description                                                                                                                                                            |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CERT_CHAIN_TOO_LONG                | The certificate chain length is greater than the supplied maximum depth.                                                                                               |
+| CERT_HAS_EXPIRED                   | The certificate has expired.                                                                                                                                           |
+| CERT_NOT_YET_VALID                 | The certificate is not valid until a future date.                                                                                                                      |
+| CERT_REJECTED                      | The root CA is marked to reject the purpose specified.                                                                                                                 |
+| CERT_REVOKED                       | The certificate was revoked by the issuer.                                                                                                                             |
+| CERT_UNTRUSTED                     | The root CA is not marked as trusted for its intended purpose.                                                                                                         |
+| CERT_SIGNATURE_FAILURE             | The signature of the certificate is not valid.                                                                                                                         |
+| CRL_HAS_EXPIRED                    | The certificate revocation list (CRL) has expired.                                                                                                                     |
+| CRL_NOT_YET_VALID                  | The certificate revocation list (CRL) is not valid until a future date.                                                                                                |
+| CRL_SIGNATURE_FAILURE              | The CRL signature of the certificate is not valid.                                                                                                                     |
+| DEPTH_ZERO_SELF_SIGNED_CERT        | The passed certificate is self-signed and the same certificate cannot be found in the list of trusted certificates.                                                    |
+| ERROR_IN_CERT_NOT_AFTER_FIELD      | There is a format error in the notAfter field in the certificate.                                                                                                      |
+| ERROR_IN_CERT_NOT_BEFORE_FIELD     | There is a format error in the notBefore field in the certificate.                                                                                                     |
+| ERROR_IN_CRL_LAST_UPDATE_FIELD     | The CRL lastUpdate field contains an invalid time.                                                                                                                     |
+| ERROR_IN_CRL_NEXT_UPDATE_FIELD     | The CRL nextUpdate field contains an invalid time.                                                                                                                     |
+| INVALID_CA                         | A CA certificate is not valid because it is not a CA or its extensions are not consistent with the intended purpose.                                                   |
+| INVALID_PURPOSE                    | The certificate that was provided cannot be used for its intended purpose.                                                                                             |
+| OUT_OF_MEM                         | An error occurred while allocating memory.                                                                                                                             |
+| PATH_LENGTH_EXCEEDED               | The basicConstraints pathlength parameter was exceeded.                                                                                                                |
+| SELF_SIGNED_CERT_IN_CHAIN          | A self-signed certificate exists in the certificate chain. The certificate chain can be built using the untrusted certificates, but the root CA was not found locally. |
+| UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY | The public key in the certificate could not be read.                                                                                                                   |
+| UNABLE_TO_DECRYPT_CERT_SIGNATURE   | Unable to decrypt the signature of the certificate.                                                                                                                    |
+| UNABLE_TO_DECRYPT_CRL_SIGNATURE    | The CRL signature could not be decrypted. (The actual signature value could not be determined.)                                                                        |
+| UNABLE_TO_GET_CRL                  | The certificate revocation list (CRL) was not found.                                                                                                                   |
+| UNABLE_TO_GET_ISSUER_CERT          | Unable to find the certificate for one of the certificate authorities (CAs) in the signing hierarchy, and that CA is not trusted by the local application.             |
+| UNABLE_TO_GET_ISSUER_CERT_LOCALLY  | The issuer certificate of a locally found certificate was not found. This usually means that the list of trusted certificates is not complete.                         |
+| UNABLE_TO_VERIFY_LEAF_SIGNATURE    | No signatures were verified because the certificate chain contains only one certificate, which is not self-signed, and the issuer is not trusted.                      |
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/synthetics/uptime_check.md
+++ b/content/synthetics/uptime_check.md
@@ -103,10 +103,10 @@ A check is considered `FAILED` if it doesn't satisfy the assertions configured f
 
 | Error           | Description                                                                                                                                                                                  |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CONNRESET       | The connection was abruptly closed by the remote server. Possible causes include the webserver encountering an error or crashing while responding, loss of connectivity of the webserver... |
-| DNS             | DNS entry not found for %example.com%. Possible causes include misconfigured check URL, wrong configuration of your DNS entries...                                                          |
-| INVALID_REQUEST | The configuration of the check is invalid (eg. typo in the URL).                                                                                                                             |
-| SSL             | The SSL connection couldn't be performed, see below for more detailed explanations.                                                                                                          |
+| CONNRESET       | The connection was abruptly closed by the remote server. Possible causes include the webserver encountering an error or crashing while responding, loss of connectivity of the webserver, etc. |
+| DNS             | DNS entry not found for the check URL. Possible causes include misconfigured check URL, wrong configuration of your DNS entries, etc.                                                        |
+| INVALID_REQUEST | The configuration of the check is invalid (e.g., typo in the URL).                                                                                                                             |
+| SSL             | The SSL connection couldn't be performed; see below for more detailed explanations.                                                                                                          |
 | TIMEOUT         | The request couldn't be completed in a reasonable time.                                                                                                                                      |
 
 ### SSL errors
@@ -114,7 +114,7 @@ A check is considered `FAILED` if it doesn't satisfy the assertions configured f
 | Error                              | Description                                                                                                                                                            |
 | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | CERT_CHAIN_TOO_LONG                | The certificate chain length is greater than the supplied maximum depth.                                                                                               |
-| CERT_HAS_EXPIRED                   | The certificate has expired.                                                                                                                                           |
+| CERT_HAS_EXPIRED                   | The certificate is expired.                                                                                                                                           |
 | CERT_NOT_YET_VALID                 | The certificate is not valid until a future date.                                                                                                                      |
 | CERT_REJECTED                      | The root CA is marked to reject the purpose specified.                                                                                                                 |
 | CERT_REVOKED                       | The certificate was revoked by the issuer.                                                                                                                             |
@@ -132,14 +132,14 @@ A check is considered `FAILED` if it doesn't satisfy the assertions configured f
 | INVALID_PURPOSE                    | The certificate that was provided cannot be used for its intended purpose.                                                                                             |
 | OUT_OF_MEM                         | An error occurred while allocating memory.                                                                                                                             |
 | PATH_LENGTH_EXCEEDED               | The basicConstraints pathlength parameter was exceeded.                                                                                                                |
-| SELF_SIGNED_CERT_IN_CHAIN          | A self-signed certificate exists in the certificate chain. The certificate chain can be built using the untrusted certificates, but the root CA was not found locally. |
-| UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY | The public key in the certificate could not be read.                                                                                                                   |
+| SELF_SIGNED_CERT_IN_CHAIN          | A self-signed certificate exists in the certificate chain. The certificate chain can be built using the untrusted certificates, but the root CA cannot be found locally. |
+| UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY | The public key in the certificate cannot be read.                                                                                                                   |
 | UNABLE_TO_DECRYPT_CERT_SIGNATURE   | Unable to decrypt the signature of the certificate.                                                                                                                    |
-| UNABLE_TO_DECRYPT_CRL_SIGNATURE    | The CRL signature could not be decrypted. (The actual signature value could not be determined.)                                                                        |
-| UNABLE_TO_GET_CRL                  | The certificate revocation list (CRL) was not found.                                                                                                                   |
+| UNABLE_TO_DECRYPT_CRL_SIGNATURE    | The CRL signature cannot be decrypted. (The actual signature value cannot be determined.)                                                                        |
+| UNABLE_TO_GET_CRL                  | The certificate revocation list (CRL) is not found.                                                                                                                   |
 | UNABLE_TO_GET_ISSUER_CERT          | Unable to find the certificate for one of the certificate authorities (CAs) in the signing hierarchy, and that CA is not trusted by the local application.             |
-| UNABLE_TO_GET_ISSUER_CERT_LOCALLY  | The issuer certificate of a locally found certificate was not found. This usually means that the list of trusted certificates is not complete.                         |
-| UNABLE_TO_VERIFY_LEAF_SIGNATURE    | No signatures were verified because the certificate chain contains only one certificate, which is not self-signed, and the issuer is not trusted.                      |
+| UNABLE_TO_GET_ISSUER_CERT_LOCALLY  | The issuer certificate of a locally found certificate is not found. This usually means that the list of trusted certificates is not complete.                         |
+| UNABLE_TO_VERIFY_LEAF_SIGNATURE    | No signatures are verified because the certificate chain contains only one certificate, which is not self-signed, and the issuer is not trusted.                      |
 
 ## Further Reading
 


### PR DESCRIPTION
Move the network timings section to the 'uptime check' page, and add a description of the possible errors that can cause a 'FAILED' check.

Visible on https://docs-staging.datadoghq.com/tanguy.lebarzic/synthetics-errors/synthetics/uptime_check/