### PR TITLE
alter DCA RBAC instructions to use a direct url

### DIFF
--- a/content/agent/kubernetes/cluster.md
+++ b/content/agent/kubernetes/cluster.md
@@ -36,7 +36,9 @@ Using the Datadog Cluster Agent helps you to:
 2. Enter the `datadog-agent` directory, and run:
 
   ```
-  kubectl apply -f Dockerfiles/manifests/cluster-agent/rbac/rbac-cluster-agent.yaml
+  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/rbac/clusterrole.yaml"
+  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/rbac/serviceaccount.yaml"
+  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/rbac/clusterrolebinding.yaml"
   ```
 
   This creates the appropriate ServiceAccount, ClusterRole, and ClusterRoleBinding.


### PR DESCRIPTION
### What does this PR do?
Same as 3951, update the RBAC definition for DCA to use the direct URL

### Motivation
we don't want customers to use outdated RBACs. 

### Preview link

https://docs-staging.datadoghq.com/cswatt/dca-rbac/agent/kubernetes/cluster/
