### PR TITLE
Changes for Internet Explorer

### DIFF
--- a/src/js/datadog-docs.js
+++ b/src/js/datadog-docs.js
@@ -268,7 +268,7 @@ $(document).ready(function () {
                         if (event.state.page) {
                             current_page = event.state.page;
                             changePage(current_page);
-                        } 
+                        }
                     };
 
                     function addHistory(page) {
@@ -419,6 +419,23 @@ $(document).ready(function () {
     // sticky polyfill trigger
     var elements = document.querySelectorAll('.sticky');
     Stickyfill.add(elements);
+
+    // Polyfill `includes` for Internet Explorer
+    if (!String.prototype.includes) {
+        Object.defineProperty(String.prototype, 'includes', {
+          value: function(search, start) {
+            if (typeof start !== 'number') {
+              start = 0
+            }
+
+            if (start + search.length > this.length) {
+              return false
+            } else {
+              return this.indexOf(search, start) !== -1
+            }
+          }
+        })
+      }
 
     // add targer-blank to external links
     var newLinks = document.getElementsByTagName("a");


### PR DESCRIPTION
### What does this PR do?
- Add polyfill for `includes` which does not work with Internet Explorer.

### Motivation
- Customers that use Internet Explorer could not see tabs.
Screenshot of current docs site in IE:
![image](https://user-images.githubusercontent.com/19349244/52543104-c836c680-2d74-11e9-8bc4-e239ba52b56b.png)

### Preview link
https://docs-staging.datadoghq.com/ruth/ie/

Screenshot of tabs fixed in IE on this branch:
![image](https://user-images.githubusercontent.com/19349244/52543077-7130f180-2d74-11e9-9a37-189a4177c063.png)
