### PR TITLE
Added trace id correlation faq doc and updated index.md

### DIFF
--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1557,11 +1557,14 @@ Then update your logger configuration to include `dd.trace_id` and `dd.span_id` 
 <Pattern>"%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %X{dd.trace_id:-0} %X{dd.span_id:-0} - %m%n"</Pattern>
 ```
 
+**Note**: If you are not using a [Datadog Log Integration][3] to parse your logs, custom log parsing rules need to ensure that `trace_id` and `span_id` are being parsed as a string. More information can be found in our [FAQ on this topic][4].
+
 [See our Java logging documentation][3] for more details about specific logger implementation or to learn how to log in JSON.
 
 [1]: https://logback.qos.ch/manual/mdc.html
 [2]: https://docs.datadoghq.com/tracing/languages/java/#configuration
 [3]: https://docs.datadoghq.com/logs/log_collection/java/?tab=log4j#raw-format
+[4]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/
 {{% /tab %}}
 {{% tab "Python" %}}
 
@@ -1637,9 +1640,12 @@ Once the logger is configured, executing a traced function that logs an event yi
 {"event": "In tracer context", "trace_id": 9982398928418628468, "span_id": 10130028953923355146}
 ```
 
+**Note**: If you are not using a [Datadog Log Integration][1] to parse your logs, custom log parsing rules need to ensure that `trace_id` and `span_id` are being parsed as a string. More information can be found in our [FAQ on this topic][2].
+
 [See our Python logging documentation][1] to ensure that the Python Log Integration is properly configured so that your Python logs are automatically parsed.
 
 [1]: https://docs.datadoghq.com/logs/log_collection/python/#configure-the-datadog-agent
+[2]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/
 {{% /tab %}}
 {{% tab "Ruby" %}}
 
@@ -1719,10 +1725,13 @@ Datadog.tracer.trace('my.operation') { logger.warn('This is a traced operation.'
 # [2019-01-16 18:38:41 +0000][my_app][WARN][dd.trace_id=8545847825299552251 dd.span_id=3711755234730770098] This is a traced operation.
 ```
 
+**Note**: If you are not using a [Datadog Log Integration][2] to parse your logs, custom log parsing rules need to ensure that `trace_id` and `span_id` are being parsed as a string. More information can be found in our [FAQ on this topic][3].
+
 See our [Ruby logging documentation][2] to verify the Ruby log integration is properly configured and your ruby logs are automatically parsed.
 
 [1]: https://docs.datadoghq.com/logs/log_collection/ruby
 [2]: https://docs.datadoghq.com/logs/log_collection/ruby/#configure-the-datadog-agent
+[3]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/
 {{% /tab %}}
 {{% tab "Go" %}}
 
@@ -1756,6 +1765,8 @@ func handler(w http.ResponseWriter, r *http.Request) {
 ```
 
 The above example illustrates how to use the span's context in the standard library's `log` package. Similar logic may be applied to 3rd party packages too.
+
+**Note**: If you are not using a [Datadog Log Integration][7] to parse your logs, custom log parsing rules need to ensure that `trace_id` and `span_id` are being parsed as a string. More information can be found in our [FAQ on this topic][8].
 
 {{% /tab %}}
 {{% tab "Node.js" %}}
@@ -1839,11 +1850,15 @@ class Logger {
 module.exports = Logger
 ```
 
+**Note**: If you are not using a [Datadog Log Integration][1] to parse your logs, custom log parsing rules need to ensure that `trace_id` and `span_id` are being parsed as a string. More information can be found in our [FAQ on this topic][2].
+
+[1]: https://docs.datadoghq.com/logs/log_collection/nodejs/
+[2]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/
+
 {{% /tab %}}
 {{% tab ".NET" %}}
 
 Coming Soon. Reach out to [the Datadog support team][1] to be part of the beta.
-
 
 [1]: /help
 {{% /tab %}}
@@ -1880,8 +1895,11 @@ $logger->pushProcessor(function ($record) {
 });
 ```
 
+**Note**: If you are not using a [Datadog Log Integration][2] to parse your logs, custom log parsing rules need to ensure that `trace_id` and `span_id` are being parsed as a string. More information can be found in our [FAQ on this topic][3].
 
 [1]: https://github.com/Seldaek/monolog
+[2]: https://docs.datadoghq.com/logs/log_collection/php/
+[3]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/tracing/faq/_index.md
+++ b/content/tracing/faq/_index.md
@@ -10,5 +10,6 @@ private: true
     {{< nextlink href="tracing/faq/if-i-instrument-a-database-with-datadog-apm-will-there-be-sensitive-database-data-sent-to-datadog" >}}If I instrument a database with Datadog APM, will there be sensitive database data sent to Datadog?{{< /nextlink >}}
     {{< nextlink href="tracing/faq/distributed-tracing" >}} Example of distributed tracing{{< /nextlink >}}
     {{< nextlink href="tracing/faq/terminology" >}}Terminology{{< /nextlink >}}
+    {{< nextlink href="tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel" >}}Why can't I see my correlated logs in the Trace ID panel?{{< /nextlink >}}    
 {{< /whatsnext >}}
 

--- a/content/tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel.md
+++ b/content/tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel.md
@@ -1,19 +1,27 @@
 ---
 title: Why can't I see my correlated logs in the Trace ID panel?
 kind: faq
+further_reading:
+- link: "/tracing/advanced_usage/#correlate-traces-and-logs"
+  tag: "Documentation"
+  text: "Correlate Traces and Logs"
 ---
 
-When injecting trace identifiers into your logs, if you are using a [Log Integration][1] in Datadog, you can correlate traces and logs by following our guide [here][2]. Our Log Integrations include automatic log parsing rules to ensure that your attributes including `trace_id` and `span_id` are parsed correctly and you are able to view correlated traces with their logs.
+When injecting trace identifiers into your logs, if you are using a [Log Integration][1] in Datadog, follow the guide on [correlating traces and logs][2]. Datadog log integrations include automatic log parsing rules to ensure that your attributes (`trace_id` and `span_id`) are parsed correctly and you are able to view correlated traces with their logs.
 
-If you are not using a Log Integration and are building custom log parsing rules instead, please ensure that the `trace_id` and `span_id` values are being parsed as a string in the rules you have written, similar to the below: 
+If you are building custom log parsing rules instead, verify the `trace_id` and `span_id` values are parsed as a string in your rules, for example: 
 
 ```
 dd.trace_id=%{word:dd.trace_id} dd.span_id=%{word:dd.span_id}
 ```
 
-If these attributes are not being parsed out of a string due to a custom parsing rule outside of our Log Integration, this would prevent logs from being displayed in the trace view similar to the below. Once these values are being parsed correctly, you can make a direct correlation similar to the below:
+If these attributes are not parsed as a string due to a custom parsing rule, this prevents logs from being displayed in the trace view (see below). Once these values are being parsed correctly, you can make a direct trace to log correlation:
 
 {{< img src="tracing/trace_id_injection.png" alt="Tracing id injection" responsive="true" style="width:90%;">}}
 
-[1]: logs/log_collection
-[2]: tracing/advanced_usage/#correlate-traces-and-logs
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /logs/log_collection
+[2]: /tracing/advanced_usage/#correlate-traces-and-logs

--- a/content/tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel.md
+++ b/content/tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel.md
@@ -1,0 +1,19 @@
+---
+title: Why can't I see my correlated logs in the Trace ID panel?
+kind: faq
+---
+
+When injecting trace identifiers into your logs, if you are using a [Log Integration][1] in Datadog, you can correlate traces and logs by following our guide [here][2]. Our Log Integrations include automatic log parsing rules to ensure that your attributes including `trace_id` and `span_id` are parsed correctly and you are able to view correlated traces with their logs.
+
+If you are not using a Log Integration and are building custom log parsing rules instead, please ensure that the `trace_id` and `span_id` values are being parsed as a string in the rules you have written, similar to the below: 
+
+```
+dd.trace_id=%{word:dd.trace_id} dd.span_id=%{word:dd.span_id}
+```
+
+If these attributes are not being parsed out of a string due to a custom parsing rule outside of our Log Integration, this would prevent logs from being displayed in the trace view similar to the below. Once these values are being parsed correctly, you can make a direct correlation similar to the below:
+
+{{< img src="tracing/trace_id_injection.png" alt="Tracing id injection" responsive="true" style="width:90%;">}}
+
+[1]: logs/log_collection
+[2]: tracing/advanced_usage/#correlate-traces-and-logs


### PR DESCRIPTION
Fixed link title in index.md

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This creates an FAQ Tracing doc regarding what to do if a customer is using a custom log parsing rule.

### Motivation
<!-- What inspired you to submit this pull request?-->
This is a rare use case we discovered that we want to be documented.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->
https://docs-staging.datadoghq.com/andrew/correlate-log-faq/tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/
https://docs-staging.datadoghq.com/andrew/correlate-log-faq/tracing/faq/
https://docs-staging.datadoghq.com/andrew/correlate-log-faq/tracing/advanced_usage/#correlate-traces-and-logs

### Additional Notes
<!-- Anything else we should know when reviewing?-->
