### PR TITLE
add note about hpa

### DIFF
--- a/content/agent/kubernetes/cluster.md
+++ b/content/agent/kubernetes/cluster.md
@@ -248,7 +248,9 @@ To enable the Custom Metrics Server:
 2. Configure the `<DD_APP_KEY>` as well as the `<DD_API_KEY>` in the Deployment of the Datadog Cluster Agent.
 3. Create a [service exposing the port 443][7] and [register it as an APIService for External Metrics][8].
 
-Refer to [the dedicated Custom metrics server guide][1] to configure the Custom Metrics Server and get more details about this feature.
+Refer to [the dedicated Custom metrics server guide][1] to configure the Custom Metrics Server and get more details about this feature. 
+
+**Note**: An [HPA][9] is required for values to be served on the external metrics route.
 
 ## Further Reading
 
@@ -263,3 +265,4 @@ Refer to [the dedicated Custom metrics server guide][1] to configure the Custom 
 [6]: https://golang.org/pkg/expvar
 [7]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/hpa-example/cluster-agent-hpa-svc.yaml
 [8]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/hpa-example/rbac-hpa.yaml
+[9]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale


### PR DESCRIPTION
### What does this PR do?
Add note that HPA is required for values to be served on the external metrics route

### Motivation
Engineering request from @CharlyF 

### Preview link
https://docs-staging.datadoghq.com/cswatt/cluster-hpa/agent/kubernetes/cluster/

