### PR TITLE
make the forms default go to the search results page.

### DIFF
--- a/layouts/partials/sidenav/sidenav-m.html
+++ b/layouts/partials/sidenav/sidenav-m.html
@@ -19,9 +19,9 @@
     <div class="row sticky">
         <div class="col">
             <a href="{{ "" | absLangURL }}"><h4>{{ i18n "datadog_docs" }}</h4></a>
-            <form class="docssearch">
+            <form class="docssearch" method="GET" action="{{ "/search/" | absLangURL }}">
                 <div id="docssearchWrapper">
-                    <input class="docssearch-input-m" type="docssearch" placeholder="Search documentation...">
+                    <input class="docssearch-input-m" name="s" type="docssearch" placeholder="Search documentation...">
                 </div>
             </form>
 

--- a/layouts/partials/sidenav/sidenav-m.html
+++ b/layouts/partials/sidenav/sidenav-m.html
@@ -19,7 +19,7 @@
     <div class="row sticky">
         <div class="col">
             <a href="{{ "" | absLangURL }}"><h4>{{ i18n "datadog_docs" }}</h4></a>
-            <form class="docssearch" method="GET" action="{{ "/search/" | absLangURL }}">
+            <form class="docssearch" method="GET" action="{{ "search/" | absLangURL }}">
                 <div id="docssearchWrapper">
                     <input class="docssearch-input-m" name="s" type="docssearch" placeholder="Search documentation...">
                 </div>

--- a/layouts/partials/sidenav/sidenav.html
+++ b/layouts/partials/sidenav/sidenav.html
@@ -19,9 +19,9 @@
     <div class="row sticky">
         <div class="col">
             <a href="{{ "" | absLangURL }}"><h4>{{ i18n "datadog_docs" }}</h4></a>
-            <form class="docssearch">
+            <form class="docssearch" method="GET" action="{{ "/search/" | absLangURL }}">
                 <div id="docssearchWrapper">
-                    <input class="docssearch-input" type="docssearch" placeholder="Search documentation...">
+                    <input class="docssearch-input" name="s" type="docssearch" placeholder="Search documentation...">
                 </div>
             </form>
 

--- a/layouts/partials/sidenav/sidenav.html
+++ b/layouts/partials/sidenav/sidenav.html
@@ -19,7 +19,7 @@
     <div class="row sticky">
         <div class="col">
             <a href="{{ "" | absLangURL }}"><h4>{{ i18n "datadog_docs" }}</h4></a>
-            <form class="docssearch" method="GET" action="{{ "/search/" | absLangURL }}">
+            <form class="docssearch" method="GET" action="{{ "search/" | absLangURL }}">
                 <div id="docssearchWrapper">
                     <input class="docssearch-input" name="s" type="docssearch" placeholder="Search documentation...">
                 </div>


### PR DESCRIPTION
### What does this PR do?
This PR makes the sidebar search form go to the search results page by default if JS fails.

### Motivation
https://cl.ly/9a99ed910673
https://cl.ly/0d06dca2f23c

If a JS bug happens or intermittent connection happens causing a js library to fail to load (like docsearch). The html forms defaults/fallback is to go to the search results page anyway. At which point we would hope it will load on that attempt.

### Preview link
https://docs-staging.datadoghq.com/david.jones/search-update/

### Additional Notes

