### PR TITLE
Correcting the env DD_APM_IGNORE_RESOURCES

### DIFF
--- a/content/agent/docker/apm.md
+++ b/content/agent/docker/apm.md
@@ -53,7 +53,7 @@ List of all environment variables available for tracing with the Docker Agent:
 | `DD_APM_DD_URL`            | Datadog API endpoint where traces are sent. For Datadog EU site set `DD_APM_DD_URL` to `https://trace.agent.datadoghq.eu` |
 | `DD_APM_RECEIVER_PORT`     | Port that the Datadog Agent's trace receiver listen on. Default value is `8126`.                                          |
 | `DD_APM_NON_LOCAL_TRAFFIC` | Allow non-local traffic when [tracing from other containers](#tracing-from-other-containers).                             |
-| `DD_APM_IGNORE_RESOURCE`   | A comma-separated list of endpoints and resources that the Agent should ignore (i.e. health checks endpoints).            |
+| `DD_APM_IGNORE_RESOURCES`   | A comma-separated list of endpoints and resources that the Agent should ignore (i.e. health checks endpoints).            |
 | `DD_APM_ANALYZED_SPANS`    | Configure the spans to analyze for transactions.                                                                          |
 | `DD_APM_ENV`               | Sets the default [environment][2] for your traces.                                                                        |
 | `DD_APM_MAX_EPS`           | Sets the maximum APM events per second.                                                                                   |


### PR DESCRIPTION
### What does this PR do?
Changing the name of an ENV variable for APM

### Motivation
The real name can be seen here : 
 https://github.com/DataDog/datadog-agent/blob/master/pkg/trace/config/env.go#L48

