### PR TITLE
Update for Nav Links with Anchors

### DIFF
--- a/layouts/partials/sidenav/recursive-nav.html
+++ b/layouts/partials/sidenav/recursive-nav.html
@@ -27,7 +27,14 @@
         {{ end }}
         {{ $el_url := ($ctx.Scratch.Get "el_url") }}
         {{ $hash_list := split $element.URL "#" }}
-        {{ $hash_check := slicestr $element.URL 0 1 }}
+        {{ $ctx.Scratch.Set "nav_url" (print $element.URL | absLangURL) }}
+        {{ if in $element.URL "#" }}
+            {{ if eq (slicestr $element.URL 0 1) "#" }}
+                {{ $ctx.Scratch.Set "nav_url" (print $element.URL) }}
+            {{ else }}
+                {{ $ctx.Scratch.Set "nav_url" (print ($element.URL | absLangURL) "#" (index $hash_list 1)) }}
+            {{ end }}
+        {{ end }}
         {{ if gt (len $hash_list) 1 }}
             {{ $ctx.Scratch.Set "url_hash" (print "#" (index $hash_list 1)) }}
         {{ else }}
@@ -36,11 +43,12 @@
         {{ $url_first := ($ctx.Scratch.Get "url_first") }}
         {{ $url_first_second := ($ctx.Scratch.Get "url_first_second") }}
         {{ $url_first_second_third := ($ctx.Scratch.Get "url_first_second_third") }}
+        {{ $nav_url := ($ctx.Scratch.Get "nav_url") }}
         <!-- if url matches then active link or if second part in url and no children --->
         {{ $active_page := (or (eq $ctx.RelPermalink $el_url) (and (eq $url_first_second $el_url) (not $element.Children)) (and (eq $url_first "/integrations/") (eq $el_url "/integrations/") ) ) }}
         {{ $open_parent := (or (and (eq $url_first $el_url) (ne $el_url "/")) (eq $url_first_second $el_url) (eq $url_first_second_third $el_url) $active_page) }}
         <li class="{{if $open_parent }}open{{ end }}">
-            <a href="{{ if eq $hash_check "#" }}{{$element.URL}}{{ else }}{{ $element.URL | absLangURL}}{{ end }}" {{if $active_page }}class="active"{{ end }}>
+            <a href="{{ $nav_url }}" {{if $active_page }}class="active"{{ end }}>
                 {{ if $element.Pre }}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" ($element.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" ($element.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}{{ end }} <span>{{ $element.Name }}</span>
             </a>
             {{ if eq $element.Name "Integrations" }}


### PR DESCRIPTION
### What does this PR do?
- Update for Nav Links with Anchors

### Motivation
- Some nav links with anchors don't work. Example = "Other Integrations" link under `/logs/log_collection/`

### Preview link
https://docs-staging.datadoghq.com/ruth/side-nav/logs/log_collection/

### Additional notes
Staging branch looks good.
