### PR TITLE
[dashboard] Fix indentation

### DIFF
--- a/content/api/dashboards/dashboards_create.md
+++ b/content/api/dashboards/dashboards_create.md
@@ -12,13 +12,13 @@ external_redirect: /api/#create-a-dashboard
     Title of the dashboard.
 * **`widgets`** [*required*]:  
     List of widgets to display on the dashboard. Widget definitions follow this form:
-    * **`id`** [*optional*, *default*=**auto-generated integer**]:  
-        ID of the widget.
     * **`definition`** [*required*]:  
         Definition of the widget.
-* **`layout_type`** [*required*]:
-  Layout type of the dashboard (for now, only `ordered` layout - current timeboard layout - is supported).
-  * **`description`** [*optional*, *default*=**None**]:  
+    * **`id`** [*optional*, *default*=**auto-generated integer**]:  
+        ID of the widget.
+* **`layout_type`** [*required*]:  
+  Layout type of the dashboard (for now, only `ordered` layout - previous timeboard layout - is supported).
+* **`description`** [*optional*, *default*=**None**]:  
   Description of the dashboard.
 * **`is_read_only`** [*optional*, *default*=**False**]:  
   Whether this dashboard is read-only. If `True`, only the author and admins can make changes to it.

--- a/content/api/dashboards/dashboards_update.md
+++ b/content/api/dashboards/dashboards_update.md
@@ -13,13 +13,13 @@ external_redirect: /api/#update-a-dashboard
     Title of the dashboard.
 * **`widgets`** [*required*]:  
     List of widgets to display on the dashboard. Widget definitions follow this form:
-    * **`id`** [*optional*, *default*=**auto-generated integer**]:  
-        ID of the widget.
     * **`definition`** [*required*]:  
         Definition of the widget.
-* **`layout_type`** [*required*]:
-  Layout type of the dashboard (for now, only `ordered` layout - current timeboard layout - is supported).
-  * **`description`** [*optional*, *default*=**None**]:  
+    * **`id`** [*optional*, *default*=**auto-generated integer**]:  
+        ID of the widget.
+* **`layout_type`** [*required*]:  
+  Layout type of the dashboard (for now, only `ordered` layout - previous timeboard layout - is supported).
+* **`description`** [*optional*, *default*=**None**]:  
   Description of the dashboard.
 * **`is_read_only`** [*optional*, *default*=**False**]:  
   Whether this dashboard is read-only. If `True`, only the author and admins can make changes to it.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- Fixes indentation for the `description` attribute in the new Dashboard API docs.
- Moves `definition` in the widget section before `id` to show required attributes before optional ones.
- Change `current timeboard layout` to `previous timeboard layout`

### Preview link
Impacted pages:
https://docs.datadoghq.com/api/?lang=ruby#create-a-dashboard
https://docs.datadoghq.com/api/?lang=ruby#update-a-dashboard

This is the base preview link. Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/marielaure/fix_dashboard_docs_indentation/api/#dashboards
