### PR TITLE
improve announcement banner loading, added inline js

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}" style="opacity:0">
+<html lang="{{ .Site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}" style="opacity:0" class="{{ if or $.Site.Params.announcement_banner.link $.Site.Params.announcement_banner.text }}banner{{ end }}">
 <head>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-21102638-5"></script>

--- a/layouts/partials/announcement_banner/announcement_banner.html
+++ b/layouts/partials/announcement_banner/announcement_banner.html
@@ -4,4 +4,11 @@
     <a href="{{.Site.Params.corp_url}}{{$announce.link}}">{{$announce.text | safeHTML }}</a>
     <i class="icon icon-small-x pull-right"></i>
 </div>
+<script>
+    var announcement_banner;
+    announcement_banner = sessionStorage.getItem('announcement_banner');
+    if (announcement_banner !== 'closed') {
+        document.getElementsByClassName('announcement_banner')[0].classList.add('open');
+    }
+</script>
 {{ end }}

--- a/layouts/partials/announcement_banner/announcement_banner.js
+++ b/layouts/partials/announcement_banner/announcement_banner.js
@@ -1,12 +1,4 @@
 $(document).ready(function () {
-    var announcement_banner;
-    announcement_banner = sessionStorage.getItem('announcement_banner');
-
-    if (announcement_banner !== 'closed') {
-        document.getElementsByClassName('announcement_banner')[0].classList.add('open');
-        $('html').addClass('banner');
-    }
-
     $('.announcement_banner .icon').on('click', function (e) {
         sessionStorage.setItem('announcement_banner', 'closed');
         $('.announcement_banner').removeClass('open');


### PR DESCRIPTION
### What does this PR do?
Adds inline js to load up the announcement banner immediately, so it doesn't 'flash' when the page loads.

### Preview link
https://docs-staging.datadoghq.com/zach/announce-banner-improve
Load the page, announcement banner should be visible immediately. 

### Trello Card
https://trello.com/c/d9kylnEf/3041-docs-announcement-banner-opens-after-page-load-causing-page-to-jump-down-on-refreshes
