### PR TITLE
Fixes wrong URL for Dashboards API

### DIFF
--- a/content/graphing/faq/timeboard-api-doc.md
+++ b/content/graphing/faq/timeboard-api-doc.md
@@ -4,7 +4,7 @@ kind: faq
 ---
 
 <div class="alert alert-danger">
-This endpoint is outdated. Use the <a href="https://github.com/DataDog/datadog-agent/blob/master/docs/agent/upgrade.md"> new Dashboard endpoint</a> instead. 
+This endpoint is outdated. Use the <a href="https://docs.datadoghq.com/api/?lang=python#dashboards"> new Dashboard endpoint</a> instead. 
 </div>
 
 The Timeboard endpoint allows you to programmatically create, update delete and query Timeboards. [Find more about Timeboard][1].


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes a bad URL

### Motivation
I was reviewing new docs and noticed this was a bad URL that went to upgrading to agent 6.

### Preview link
https://docs-staging.datadoghq.com/ckelner/fix-dashboards-api-url/graphing/faq/timeboard-api-doc/?tab=python


