### PR TITLE
[apm] Python distributed tracing enabled by default

### DIFF
--- a/content/tracing/advanced_usage/_index.md
+++ b/content/tracing/advanced_usage/_index.md
@@ -1115,9 +1115,7 @@ public class MyHttpRequestExtractAdapter implements TextMap {
 {{% /tab %}}
 {{% tab "Python" %}}
 
-Distributed tracing is disabled by default. Refer to the configuration documentation for each framework to enable it.
-
-Distributed tracing is supported in the following frameworks:
+Distributed tracing is enabled by default and supported in the following frameworks:
 
 | Framework/Library | API Documentation                                                   |
 | ----------------- | :------------------------------------------------------------------ |


### PR DESCRIPTION
With our next release (`0.21.0`) `dd-trace-py` will enable distributed tracing by default OOTB!

### Preview link
https://docs-staging.datadoghq.com/brettlangdon-patch-1/tracing/advanced_usage/?tab=python#distributed-tracing