### PR TITLE
go back to corp-ci master now its updated

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:david.jones_latest-hugo
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
   tags:
     - "runner:main"
     - "size:large"


### PR DESCRIPTION
### What does this PR do?
Now that the content dir changes have gone live the corp-ci master image has been updated too.
So we can switch the gitlab image back to master.

### Motivation
motivation is consistency

### Preview link
https://docs-staging.datadoghq.com/david.jones/ci-image/

