### PR TITLE
added some info from sparse metric macro

### DIFF
--- a/content/en/monitors/faq/why-am-i-getting-so-many-no-data-alerts.md
+++ b/content/en/monitors/faq/why-am-i-getting-so-many-no-data-alerts.md
@@ -11,10 +11,14 @@ further_reading:
 ---
 
 For the AWS No Data errors, the issue here has to do with how frequently we
-receive AWS metrics.  
-Because our crawlers are rate-limited by the Cloudwatch APIs, data is often delayed by 10 or more minutes, so we generally recommend that an alert for an AWS metric be set to have a threshold window of at least 30 minutes or an hour (you can see this in step 3 of alert creation, "during the last...").  
+receive AWS metrics.
+Because our crawlers are rate-limited by the Cloudwatch APIs, data is often delayed by 10 or more minutes, so we generally recommend that an alert for an AWS metric be set to have a threshold window of at least 30 minutes or an hour (you can see this in step 3 of alert creation, "during the last...").
 
-Switching the time frame on this alert will resolve this issue, or you can install the Agent on some AWS hosts to get more up-to-date data to alert on. Overall, we're always working towards getting data more efficiently from AWS.
+We suggest using the "Do not require a full window of data" option so that evaluations are not skipped when data points for this metric are sparse.
+
+Furthermore, for AWS metrics, you can use the delay evaluation parameter to offset any delays related to Cloudwatch. We recommend that you set a delay of 900 seconds on AWS monitors, using the "Delay evaluation by" option. If you set a delay of 900 seconds and a threshold window of 30 minutes as suggested, the monitor will evaluate data from 15 minutes in the past and look back at the 30 minutes prior to that.
+
+Adjusting these settings on this alert will resolve the no data notifications, or you can install the Agent on some AWS hosts to get more up-to-date data to alert on. Overall, we're always working towards getting data more efficiently from AWS.
 
 {{< partial name="whats-next/whats-next.html" >}}
 

--- a/content/en/monitors/faq/why-am-i-getting-so-many-no-data-alerts.md
+++ b/content/en/monitors/faq/why-am-i-getting-so-many-no-data-alerts.md
@@ -10,15 +10,15 @@ further_reading:
   text: "Schedule a downtime to mute a monitor"
 ---
 
-For the AWS No Data errors, the issue here has to do with how frequently we
-receive AWS metrics.
-Because our crawlers are rate-limited by the Cloudwatch APIs, data is often delayed by 10 or more minutes, so we generally recommend that an alert for an AWS metric be set to have a threshold window of at least 30 minutes or an hour (you can see this in step 3 of alert creation, "during the last...").
+For the AWS No Data errors, the issue here has to do with how frequently Datadog receives AWS metrics.
+Because Datadog crawlers are rate-limited by the Cloudwatch APIs, data is often delayed by 10 or more minutes, so when configuring an alert for an AWS metric, you should set a threshold window of at least 30 minutes or an hour (you can see this in step 3 of alert creation, "during the last...").
 
-We suggest using the "Do not require a full window of data" option so that evaluations are not skipped when data points for this metric are sparse.
+You should also select the *Do not require a full window of data* option so that evaluations are not skipped when data points for this metric are sparse.
 
-Furthermore, for AWS metrics, you can use the delay evaluation parameter to offset any delays related to Cloudwatch. We recommend that you set a delay of 900 seconds on AWS monitors, using the "Delay evaluation by" option. If you set a delay of 900 seconds and a threshold window of 30 minutes as suggested, the monitor will evaluate data from 15 minutes in the past and look back at the 30 minutes prior to that.
+Furthermore, for AWS metrics, you can use the delay evaluation parameter to offset any delays related to Cloudwatch. Set a delay of 900 seconds on AWS monitors, using the *Delay evaluation by* option. 
+If you set a delay of 900 seconds and a threshold window of 30 minutes as suggested, the monitor evaluates data from 15 minutes in the past and look back at the 30 minutes prior to that.
 
-Adjusting these settings on this alert will resolve the no data notifications, or you can install the Agent on some AWS hosts to get more up-to-date data to alert on. Overall, we're always working towards getting data more efficiently from AWS.
+Adjusting these settings on this alert resolve the no data notifications issues, or you can install the Datadog Agent on some AWS hosts to get more up-to-date data to alert on.
 
 {{< partial name="whats-next/whats-next.html" >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds information about settings for AWS metric monitors to the monitors FAQ. 

### Motivation
<!-- What inspired you to submit this pull request?-->

Information about setting "Do not require full window of data for evaluation" and how to set the delay evaluation parameter were missing. 

### Preview link
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/laura.hampton/aws-metric-monitors-faq/monitors/faq/why-am-i-getting-so-many-no-data-alerts/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
