### PR TITLE
Add comment when using automatic and manual instrumentation for the p…

### DIFF
--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -153,7 +153,8 @@ Then, include the PHP tracer boostrap file right after the Composer autoloader a
 require '<APP_ROOT>/vendor/autoload.php';
 
 // Add the PHP tracer bootstrap
-// Don't add this line if you have also installed the dd tracer in another way than with Composer 
+// Don't add this line if you have also installed the dd tracer 
+// in another way than with Composer 
 require '<APP_ROOT>/vendor/datadog/dd-trace/bridge/dd_init.php';
 
 // Create the first span in the trace

--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -153,6 +153,7 @@ Then, include the PHP tracer boostrap file right after the Composer autoloader a
 require '<APP_ROOT>/vendor/autoload.php';
 
 // Add the PHP tracer bootstrap
+// Don't add this line if you have also installed the dd tracer in another way than with Composer 
 require '<APP_ROOT>/vendor/datadog/dd-trace/bridge/dd_init.php';
 
 // Create the first span in the trace


### PR DESCRIPTION

### What does this PR do?
Add comment when using automatic and manual instrumentation for the php tracer

### Motivation
Luca's comment in 
https://trello.com/c/S3Q5MmXz/960-customer-cant-install-the-php-tracer


### Preview link
https://docs-staging.datadoghq.com/cécile/PHPTracerBootstrap/tracing/advanced_usage/?tab=php#manual-instrumentation



### Additional Notes
Feel free to say it in another way if you think that's unclear.
the idea is that your app won't start if you add this line and have installed the "manual" tracer with composer but also the "auto" tracer 