### PR TITLE
Global processing rules for the Datadog Agent

### DIFF
--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -321,7 +321,12 @@ logs:
 
 ### Global processing rules
 
-Since Datadog Agent v6.10, the `exclude_at_match`, `include_at_match`, and `mask_sequences` rules can be defined globally in the `datadog.yaml`:
+Since Datadog Agent v6.10, the `exclude_at_match`, `include_at_match`, and `mask_sequences` rules can be defined globally.
+
+{{< tabs >}}
+{{% tab "Configuration files" %}}
+
+In the `datadog.yaml` file:
 
 ```
 logs_config:
@@ -334,7 +339,17 @@ logs_config:
        pattern: \w+@datadoghq.com
        replace_placeholder: "MASKED_EMAIL"
 ```
+{{% /tab %}}
+{{% tab "Environment Variable" %}}
 
+The `DD_LOGS_CONFIG_PROCESSING_RULES` can be used to configure global processing rules:
+
+```
+DD_LOGS_CONFIG_PROCESSING_RULES="[{"type": "mask_sequences", "name": "mask_user_email", "replace_placeholder": "MASKED_EMAIL", "pattern" : "\w+@datadoghq.com"}]
+```
+
+{{% /tab %}}
+{{< /tabs >}}
 All the logs collected by the Datadog Agent are impacted by those processing rules.
 
 **Note**: The Datadog Agent does not start the log collector if there is a format issue in the global processing rules. Run the [Status Command][9] to troubleshoot any issues.

--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -319,6 +319,26 @@ logs:
 
 [Refer to the Agent proxy documentation][8] to learn how to forward your Logs with a proxy.
 
+### Global processing rules
+
+Since Datadog Agent v6.10, the `exclude_at_match`, `include_at_match`, and `mask_sequences` rules can be defined globally in the `datadog.yaml`:
+
+```
+logs_config:
+  processing_rules:
+     - type: exclude_at_match
+       name: exclude_healthcheck
+       pattern: healtcheck
+     - type: mask_sequences
+       name: mask_user_email
+       pattern: \w+@datadoghq.com
+       replace_placeholder: "MASKED_EMAIL"
+```
+
+All the logs collected by the Datadog Agent are impacted by those processing rules.
+
+**Note**: The Datadog Agent does not start the log collector if there is a format issue in the global processing rules. Run the [Status Command][9] to troubleshoot any issues.
+
 ## How to get the most of your application logs
 
 When logging stack traces, there are specific attributes that have a dedicated UI display within your Datadog application such as the logger name, the current thread, the error type, and the stack trace itself.
@@ -358,3 +378,4 @@ Datadog automatically parses JSON-formatted logs. For this reason, if you have c
 [6]: /developers/metrics/custom_metrics
 [7]: /tagging
 [8]: /agent/proxy/#proxy-for-logs
+[9]: https://docs.datadoghq.com/agent/basic_agent_usage/windows/?tab=agentv6#agent-commands


### PR DESCRIPTION
### What does this PR do?
We released the ability to define global processing rule that impact all the logs going through the agent.

### Motivation

Scrubbing logs is usually something that you want to apply on all the logs, not just one specific source.

### Preview link
https://docs-staging.datadoghq.com/nils/logs-global-processing-rules/logs/log_collection/?tab=tailexistingfiles#advanced-log-collection-functions

<!-- This is the base preview link. Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
