### PR TITLE
Tj/fix mistake on qvw page v2

### DIFF
--- a/content/en/graphing/widgets/query_value.md
+++ b/content/en/graphing/widgets/query_value.md
@@ -22,8 +22,8 @@ The widget can display the latest value reported, or an aggregate computed from 
 
 1. Choose the data to graph:
     * Metric: See [the main graphing documentation][1] to configure a metric query.
-    * APM Events: See [the trace search documentation][2] to configure a log event query.
-    * Log Events: See [the log search documentation][3] to configure an APM event query.
+    * APM Events: See [the trace search documentation][2] to configure an APM event query.
+    * Log Events: See [the log search documentation][3] to configure a log event query.
 2. Choose the units and the formatting. 
 3. Optional: configure a conditional format depending on the value displayed.
 

--- a/content/en/graphing/widgets/query_value.md
+++ b/content/en/graphing/widgets/query_value.md
@@ -22,7 +22,7 @@ The widget can display the latest value reported, or an aggregate computed from 
 
 1. Choose the data to graph:
     * Metric: See [the main graphing documentation][1] to configure a metric query.
-    * APM Events: See [the trace search documentation][2] to configure an APM event query.
+    * APM Events: See [the trace search documentation][2] to configure a log event query.
     * Log Events: See [the log search documentation][3] to configure an APM event query.
 2. Choose the units and the formatting. 
 3. Optional: configure a conditional format depending on the value displayed.

--- a/content/en/logs/faq/log-collection-troubleshooting-guide.md
+++ b/content/en/logs/faq/log-collection-troubleshooting-guide.md
@@ -159,7 +159,7 @@ Check Datadog lambda configuration parameter:
 
 Check that Datadog lambda function is actually triggered by leveraging `aws.lambda.invocations` and `aws.lambda.errors` metrics with the `functionname` tag of your Datadog lambda function within Datadog, or check for errors in Datadog lambda logs in Cloudwatch.
 
-#### Expectedly droping logs
+#### Expectedly dropping logs
 
 Check if logs appear in the [Datadog Live Tail][11]. If they appear in the Live Tail, check the Indexes configuration page for any [exclusion filters][12] that could match your logs.
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes a mistake on the QVW page and a typo on the log collection troubleshooting guide

### Motivation

Fixing a couple of mistakes I noticed today

### Preview link

- https://docs-staging.datadoghq.com/tj/fix_mistake_on_qvw_page_v2/graphing/widgets/query_value/

- https://docs-staging.datadoghq.com/tj/fix_mistake_on_qvw_page_v2/logs/faq/log-collection-troubleshooting-guide/

### Additional Notes

There is a broken image on https://docs-staging.datadoghq.com/tj/fix_mistake_on_qvw_page_v2/graphing/widgets/query_value/

I will create a card for that since I'm not sure how to fix it. 