### PR TITLE
reduces mark message period to 20 seconds

### DIFF
--- a/content/en/integrations/rsyslog.md
+++ b/content/en/integrations/rsyslog.md
@@ -263,7 +263,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
     Some Rsyslog versions are not able to reconnect properly when necessary. To mitigate this issue, use time markers so the connection never stops. To achieve this, add the following 2 lines in your Rsyslog configuration:  
     ```
     $ModLoad immark
-    $MarkMessagePeriod 45
+    $MarkMessagePeriod 20
     ```
     And don't forget to restart:
     ```

--- a/content/en/integrations/rsyslog.md
+++ b/content/en/integrations/rsyslog.md
@@ -139,7 +139,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
     Some Rsyslog versions are not able to reconnect properly when necessary. To mitigate this issue, use time markers so the connection never stops. To achieve this, add the following 2 lines in your Rsyslog configuration:
     ```
     $ModLoad immark
-    $MarkMessagePeriod 45
+    $MarkMessagePeriod 20
     ```
     And don't forget to restart:
     ```


### PR DESCRIPTION
### What does this PR do?

We previously suggested that users could optionally set their MarkMessagePeriod to 45 seconds to avoid having the connection broken during periods of inactivity, but 45 seconds is too long.  Based on feedback from Nils, we are updating this to 20 seconds

### Motivation

Originally came up during a support investigation that showed the MarkMessagePeriod needed to be reduced to avoid having the connection to logs intake broken during periods of inactivity.  Confirmed with logs-intake that the doc should be updated, and then got input from Nils on what to update the number to. 

### Preview link

Will update when available 

- https://docs-staging.datadoghq.com/tj/change_rsyslog_MarkMessagePeriod/integrations/rsyslog/?tab=datadogussite

### Additional Notes

