### PR TITLE
setup ability to set a custom body class from markdown

### DIFF
--- a/content/en/help.md
+++ b/content/en/help.md
@@ -1,6 +1,8 @@
 ---
+title: Help
 kind: documentation
 disable_toc: true
+customclass: help
 ---
 
 {{< partial name="support/support.html" >}}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -38,7 +38,8 @@
     </script>
 </head>
 {{- $bodyClass := $.Scratch.Get "bodyClass" -}}
-<body class="{{ .Site.Language.Lang }} {{ if .Kind }}kind-{{.Kind}}{{ end }} {{ if .IsPage }} {{ replace $.Type "/" "-" }} {{ else }} {{ .Section }} {{ end }} {{ $bodyClass }}">
+{{- $customClass := $.Params.customclass -}}
+<body class="{{ .Site.Language.Lang }} {{ if .Kind }}kind-{{.Kind}}{{ end }} {{ if .IsPage }} {{ replace $.Type "/" "-" }} {{ else }} {{ .Section }} {{ end }} {{ $bodyClass }} {{ $customClass }}">
 
     <div class="greyside">
         <div class="container h-100">

--- a/src/scss/pages/_help.scss
+++ b/src/scss/pages/_help.scss
@@ -1,0 +1,5 @@
+body.help {
+   #pagetitle {
+     display:none;
+   }
+}

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -15,6 +15,7 @@
 @import "pages/search";
 @import "pages/404";
 @import "pages/home";
+@import "pages/help";
 
 // for now just include ie fixes
 @import "ie";


### PR DESCRIPTION
### What does this PR do?
We can set a custom body class from layout files. This PR adds it to markdown files too and sets the help page title but sets up specific help css to hide the title per the existing design.

### Motivation
Setting the `title` front matter param on help.md caused the page title in the browser to change which was good. However it also caused the h1 to show on that page which wasn't wanted.

### Preview link
https://docs-staging.datadoghq.com/david.jones/custom-class/help/

### Additional Notes
