### PR TITLE
Add note about needing attributes for log correlation to work

### DIFF
--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -1481,6 +1481,13 @@ another_span->SetTag("sampling.priority", 0); // Discard this span.
 
 The correlation between Datadog APM and Datadog Log Management is improved by automatically adding a `trace_id` and `span_id` in your logs with the Tracing Libraries. This can then be used in the platform to show you the exact logs correlated to the observed trace.
 
+Before correlating traces with logs, ensure your logs are either [sent as JSON][1], or [parsed by the proper language level log processor][2]. 
+
+Your language level logs *must* be turned into Datadog attributes in order for traces and logs correlation to work.
+
+[1]: /logs/log_collection/?tab=tailexistingfiles#send-your-application-logs-in-json
+[2]: /logs/log_collection/?tab=tailexistingfiles#enabling-log-collection-from-integrations
+
 {{< img src="tracing/trace_id_injection.png" alt="Logs in Traces" responsive="true" style="width:100%;">}}
 
 {{< tabs >}}

--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -1481,12 +1481,9 @@ another_span->SetTag("sampling.priority", 0); // Discard this span.
 
 The correlation between Datadog APM and Datadog Log Management is improved by automatically adding a `trace_id` and `span_id` in your logs with the Tracing Libraries. This can then be used in the platform to show you the exact logs correlated to the observed trace.
 
-Before correlating traces with logs, ensure your logs are either [sent as JSON][1], or [parsed by the proper language level log processor][2]. 
+Before correlating traces with logs, ensure your logs are either [sent as JSON][6], or [parsed by the proper language level log processor][7]. 
 
 Your language level logs *must* be turned into Datadog attributes in order for traces and logs correlation to work.
-
-[1]: /logs/log_collection/?tab=tailexistingfiles#send-your-application-logs-in-json
-[2]: /logs/log_collection/?tab=tailexistingfiles#enabling-log-collection-from-integrations
 
 {{< img src="tracing/trace_id_injection.png" alt="Logs in Traces" responsive="true" style="width:100%;">}}
 
@@ -2141,3 +2138,5 @@ apm_config:
 [3]: http://opentracing.io
 [4]: #priority-sampling
 [5]: /tracing/getting_further/trace_sampling_and_storage
+[6]: /logs/log_collection/?tab=tailexistingfiles#send-your-application-logs-in-json
+[7]: /logs/log_collection/?tab=tailexistingfiles#enabling-log-collection-from-integrations


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Clarify that trace / log correlation only works if we're extracting attributes from the logs.

### Motivation
<!-- What inspired you to submit this pull request?-->
I was trying to correlate logs and traces, and didn't see it working until I was extracting attributes from my logs.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
