### PR TITLE
As count wording update.

### DIFF
--- a/content/en/monitors/faq/as-count-monitor-evaluation.md
+++ b/content/en/monitors/faq/as-count-monitor-evaluation.md
@@ -89,13 +89,13 @@ Since this special behavior is tied to the `as_count` modifier, replace `as_coun
 
 *Example:* Suppose you wish to monitor the error rate of a service:
 
-If you want to be alerted when the error rate is above 50% in total during the past 5 min. You might have this query like:
+If you want to be alerted when the error rate is above 50% in total during the past 5 min. You might have a query like:
 `sum(last_5m):sum:requests.error{*}.as_count() / sum:requests.total{*}.as_count() > 0.5 `
 
 To correctly rewrite it in the explicit format, the query can be rewritten like:
 
 `sum(last_5m): ( default(sum:requests.error{*}.as_rate(),0) / sum:requests.total{*}.as_rate() )`
 
-[Reach out to the Datadog support team][1] if you have any questions regarding these logic.
+[Reach out to the Datadog support team][1] if you have any questions regarding this logic.
 
 [1]: /help

--- a/content/en/monitors/faq/as-count-monitor-evaluation.md
+++ b/content/en/monitors/faq/as-count-monitor-evaluation.md
@@ -9,18 +9,18 @@ Monitors involving arithmetic division and at least 1 `as_count` modifier use a 
 
 ## Example
 
-Let's say that you have 2 metrics, *A* and *B*:
+You have 2 metrics, *A* and *B*:
 
 * *A* has datapoints (a0, a1, ..., ax)
 * *B* has datapoints (b0, b1, ..., bx)
 
-Let's call now the current evaluation path for `as_count` monitors with division queries `as_count_eval_path` and all other monitors evaluation path `classic_eval_path`.
+Call the current evaluation path for `as_count` monitors with division query `as_count_eval_path` and all other monitors evaluation path `classic_eval_path`.
 
 Suppose Datadog monitors an error rate, which is calculated as:
 
 `sum:requests.error{*}.as_count() / sum:requests.total{*}.as_count()`
 
-Let's take this query for the time frame between *11:00:00* and *11:05:00*:
+Take this query for the time frame between *11:00:00* and *11:05:00*:
 
 `sum(last_5m): sum:requests.error{*}.as_count() / sum:requests.total{*}.as_count()`
 


### PR DESCRIPTION
### What does this PR do?
It seems that monitors queries with a division and as as-count modifier still follow a dedicated evaluation path.

This PR updates the content to match the new logic and make it intemporal.

### Motivation
Support request.

### Preview link

* https://docs-staging.datadoghq.com/gus/as_count/monitors/faq/as-count-monitor-evaluation/