### PR TITLE
fix link to template variables

### DIFF
--- a/content/en/agent/autodiscovery/clusterchecks.md
+++ b/content/en/agent/autodiscovery/clusterchecks.md
@@ -260,6 +260,6 @@ The Agent `status` command should show the check instance running and reporting 
 [5]: /developers/write_agent_check
 [6]: /integrations/mysql
 [7]: /agent/autodiscovery/?tab=kubernetes#template-source-kubernetes-pod-annotations
-[8]: /autodiscovery/?tab=kubernetes#supported-template-variables
+[8]: /agent/autodiscovery/?tab=kubernetes#supported-template-variables
 [9]: /integrations/http_check
 [10]: /integrations/nginx


### PR DESCRIPTION
### What does this PR do?
Fix a link to the template variables on page `agent/autodiscovery/clusterchecks/`

### Motivation
Error in link checker

### Preview link
https://docs-staging.datadoghq.com/david.jones/fix-templatevar-link/agent/autodiscovery/clusterchecks/

Click on link that says template variable.

### Additional Notes

