### PR TITLE
Temporarily remove application logs section for PHP tracer

### DIFF
--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -2029,17 +2029,7 @@ var tracer = Datadog.Trace.Tracer.Create(isDebugEnabled: true);
 Debug mode is disabled by default. To enable it, set the environment variable `DD_TRACE_DEBUG=true`. See the PHP [configuration docs][1] for details about how and when this environment variable value should be set in order
 to be properly handled by the tracer.
 
-**Application Logs**:
-
-By default, logging from the PHP tracer is disabled. In order to get debugging information and errors sent to logs,
-set a [PSR-3 logger][2] singleton.
-
-```php
-\DDTrace\Log\Logger::set(
-    new \DDTrace\Log\PsrLogger($logger)
-);
-```
-
+The location of the log file depends on your setup: it can be either ErrorLog directive (apache), error_log directive (nginx) or error_log ini param in php/php-fpm.
 
 [1]: 
 [2]: https://www.php-fig.org/psr/psr-3

--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -2029,11 +2029,11 @@ var tracer = Datadog.Trace.Tracer.Create(isDebugEnabled: true);
 Debug mode is disabled by default. To enable it, set the environment variable `DD_TRACE_DEBUG=true`. See the PHP [configuration docs][1] for details about how and when this environment variable value should be set in order
 to be properly handled by the tracer.
 
-In order to tell PHP where it should put error_log messages you can either set it at the server level or as a PHP `ini` parameter, which is the standard way to configure php behavior.
+In order to tell PHP where it should put `error_log` messages, you can either set it at the server level, or as a PHP `ini` parameter, which is the standard way to configure PHP behavior.
 
-If you are using Apache as a server, then you can use the Apache's `ErrorLog` directive.
-If you are using nginx as a server, then you can use the nginx's `error_log` directive.
-If you are configuring instead at php level, you can use the php's `error_log` ini parameter.
+If you are using Apache as a server, use the `ErrorLog` directive.
+If you are using NGINX as a server, use the `error_log` directive.
+If you are configuring instead at the PHP level, use PHP's `error_log` ini parameter.
 
 [1]: 
 [2]: https://www.php-fig.org/psr/psr-3

--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -2029,7 +2029,11 @@ var tracer = Datadog.Trace.Tracer.Create(isDebugEnabled: true);
 Debug mode is disabled by default. To enable it, set the environment variable `DD_TRACE_DEBUG=true`. See the PHP [configuration docs][1] for details about how and when this environment variable value should be set in order
 to be properly handled by the tracer.
 
-The location of the log file depends on your setup: it can be either ErrorLog directive (apache), error_log directive (nginx) or error_log ini param in php/php-fpm.
+In order to tell PHP where it should put error_log messages you can either set it at the server level or as a PHP `ini` parameter, which is the standard way to configure php behavior.
+
+If you are using Apache as a server, then you can use the Apache's `ErrorLog` directive.
+If you are using nginx as a server, then you can use the nginx's `error_log` directive.
+If you are configuring instead at php level, you can use the php's `error_log` ini parameter.
 
 [1]: 
 [2]: https://www.php-fig.org/psr/psr-3

--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -2031,8 +2031,8 @@ to be properly handled by the tracer.
 
 In order to tell PHP where it should put `error_log` messages, you can either set it at the server level, or as a PHP `ini` parameter, which is the standard way to configure PHP behavior.
 
-If you are using Apache as a server, use the `ErrorLog` directive.
-If you are using NGINX as a server, use the `error_log` directive.
+If you are using an Apache server, use the `ErrorLog` directive.
+If you are using an NGINX server, use the `error_log` directive.
 If you are configuring instead at the PHP level, use PHP's `error_log` ini parameter.
 
 [1]: 


### PR DESCRIPTION
### What does this PR do?
Temporarily remove application logs section for PHP tracer until it's ready

### Motivation
Setting a specific logger works but the logs coming from auto instrumentation will not be in it.
Remove the feature until we're able to get all the logs in it.
Without it, all dd tracer logs go to nginx, apache of php logs. 

https://trello.com/c/1s3jJS3k/1030-php-no-getting-any-traces
+ 
discussion with @labbati 

### Preview link
https://docs-staging.datadoghq.com/cecile/tracing/advanced_usage/?tab=php#debugging

### Additional Notes

