### PR TITLE
Removing outdated config

### DIFF
--- a/content/en/logs/log_collection/docker.md
+++ b/content/en/logs/log_collection/docker.md
@@ -90,8 +90,6 @@ To collect logs from all your containers without any filtering, add the followin
 ```
 logs:
     - type: docker
-      service: docker
-      source: docker
 ```
 
 [Restart the Agent][3] to see all your container logs in Datadog.


### PR DESCRIPTION
### What does this PR do?
Remove outdated configuration that would force the logs to have the docker source and service when setting it up from the host

### Motivation
We automatically set service and source to the short image now.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
