### PR TITLE
Fix Grape Logging code reference

### DIFF
--- a/content/en/logs/log_collection/ruby.md
+++ b/content/en/logs/log_collection/ruby.md
@@ -250,16 +250,15 @@ end
 Add the grape_logging gem:
 
 ```ruby
-gem 'grape_logging', git: "git://github.com/guizmaii/grape_logging.git", branch: "master"
+gem 'grape_logging'
 ```
 
 Pass additional configuration to Grape:
 
 ```ruby
 use GrapeLogging::Middleware::RequestLogger,
-      instrumentation_key: 'grape', # (cette clé devra matcher avec la config du point 2.3)
+      instrumentation_key: 'grape', 
       include: [ GrapeLogging::Loggers::Response.new,
-                 GrapeLogging::Loggers::DatabaseTime.new,
                  GrapeLogging::Loggers::FilterParameters.new ]
 ```
 


### PR DESCRIPTION
### What does this PR do?
Cleans up the Ruby Grape Logging docs

### Motivation
The Gem reference is incorrect, the repository no longer exists

### Preview link
https://docs.datadoghq.com/logs/log_collection/ruby/#grape-s-suggested-logging-configuration

https://docs-staging.datadoghq.com/zparnold/logs/log_collection/ruby

### Additional Notes
I also removed a parameter that is unsupported in the correct `grape_logging` gem
