### PR TITLE
Update broken links in tabs for logs and traces

### DIFF
--- a/content/en/tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel.md
+++ b/content/en/tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel.md
@@ -42,10 +42,13 @@ The idea is then on the log side to:
 {{< tabs >}}
 {{% tab "JSON logs" %}}
 
-For JSON logs, step 1 and 2 are done automatically. The tracer inject the trace and span id automatically in the logs and it is remapped automatically thanks to the [reserved attribute remappers](https://docs.datadoghq.com/logs/processing/#edit-reserved-attributes).
+For JSON logs, step 1 and 2 are done automatically. The tracer inject the trace and span id automatically in the logs and it is remapped automatically thanks to the [reserved attribute remappers][1].
 
-In case of issue, double check in your logs the name of the attribute that contains the trace id (should be `dd.trace_id`) and double check in your [reserved attributes](https://app.datadoghq.com/logs/pipelines/remapping) that it is properly set.
+In case of issue, double check in your logs the name of the attribute that contains the trace id (should be `dd.trace_id`) and double check in your [reserved attributes][2] that it is properly set.
 
+
+[1]: /logs/processing/#edit-reserved-attributes
+[2]: https://app.datadoghq.com/logs/pipelines/remapping
 {{% /tab %}}
 {{% tab "With Log integration" %}}
 

--- a/content/en/tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel.md
+++ b/content/en/tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel.md
@@ -42,12 +42,10 @@ The idea is then on the log side to:
 {{< tabs >}}
 {{% tab "JSON logs" %}}
 
-For JSON logs, step 1 and 2 are done automatically. The tracer inject the trace and span id automatically in the logs and it is remapped automatically thanks to the [reserved attribute remappers][1].
+For JSON logs, step 1 and 2 are done automatically. The tracer inject the trace and span id automatically in the logs and it is remapped automatically thanks to the [reserved attribute remappers](https://docs.datadoghq.com/logs/processing/#edit-reserved-attributes).
 
-In case of issue, double check in your logs the name of the attribute that contains the trace id (should be `dd.trace_id`) and double check in your [reserved attributes][2] that it is properly set.
+In case of issue, double check in your logs the name of the attribute that contains the trace id (should be `dd.trace_id`) and double check in your [reserved attributes](https://app.datadoghq.com/logs/pipelines/remapping) that it is properly set.
 
-[1]: 
-[2]: https://app.datadoghq.com/logs/pipelines/remapping
 {{% /tab %}}
 {{% tab "With Log integration" %}}
 
@@ -67,7 +65,7 @@ For raw logs without any integration, make sure that the custom parsing rule is 
 
 {{< img src="tracing/tracing_custom_parsing.png" alt="Custom parser" responsive="true" style="width:90%;">}}
 
-Then define a [Trace remapper][1] on the extracted attribute to remap them to the official trace id of the logs.
+* Then define a [Trace remapper][1] on the extracted attribute to remap them to the official trace id of the logs.
 
 [1]: https://docs.datadoghq.com/logs/processing/processors/#trace-remapper
 {{% /tab %}}


### PR DESCRIPTION
### What does this PR do?
Fix broken links in the article due to tabs

### Motivation
Empty links do not really look well on a troubleshooting article

### Preview link
https://docs-staging.datadoghq.com/nils/log-traces-kb-links/tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/?tab=custom#pagetitle


### Additional Notes
<!-- Anything else we should know when reviewing?-->
