### PR TITLE
enableGitInfo so lastmod in sitemap.xml is based off git

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,8 @@
 title: "Docs"
 baseURL: "http://localhost:1313/"
 metadataformat: "yaml"
-
+# enableGitInfo so lastmod in sitemap.xml is based off git
+enableGitInfo: true
 canonifyURLs: true
 pygmentsuseclasses: true
 pygmentsCodeFences: true


### PR DESCRIPTION
### What does this PR do?
For some reason enablegitinfo was removed here https://github.com/DataDog/documentation/commit/1af9e36648f50d24afa08290a0b6024eca457064

We actually need it for the sitemap.xml to output lastmod entries. 
If EnableGitInfo is true, lastmod will always equal the latest Git revision for that file.

### Motivation
Checking a recent card before we moved to done. 
https://trello.com/c/goFDL30c/2830-last-modified-times-on-translations-sitemap-is-incorrect

### Preview link
https://docs-staging.datadoghq.com/david.jones/enable-git-info/fr/sitemap.xml
VS
https://docs.datadoghq.com/fr/sitemap.xml
