### PR TITLE
Improve PHP docs consistency

### DIFF
--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -261,44 +261,6 @@ span?.SetTag("<TAG_KEY>", "<TAG_VALUE>");
 {{% /tab %}}
 {{% tab "PHP" %}}
 
-**Tracing a custom function or method**
-
-The `dd_trace()` function hooks into existing functions and methods to:
-
-* Open a span before the code executes
-* Set additional tags or errors on the span
-* Close the span when it is done
-* Modify the arguments or the return value
-
-For example, the following snippet traces the `CustomDriver::doWork()` method, adds custom tags, reports any exceptions as errors on the span, and then re-throws the exceptions.
-
-```php
-dd_trace("CustomDriver", "doWork", function (...$args) {
-    // Start a new span
-    $scope = GlobalTracer::get()->startActiveSpan('CustomDriver.doWork');
-    $span = $scope->getSpan();
-
-    // Access object members via $this
-    $span->setTag(Tags\RESOURCE_NAME, $this->workToDo);
-
-    try {
-        // Execute the original method
-        $result = $this->doWork(...$args);
-        // Set a tag based on the return value
-        $span->setTag('doWork.size', count($result));
-        return $result;
-    } catch (Exception $e) {
-        // Inform the tracer that there was an exception thrown
-        $span->setError($e);
-        // Bubble up the exception
-        throw $e
-    } finally {
-        // Close the span
-        $span->finish();
-    }
-});
-```
-
 **Adding tags to a span**
 
 Add tags directly to a `DDTrace\Span` object by calling `Span::setTag()`.
@@ -332,19 +294,14 @@ if (null !== $span) {
 
 **Adding tags globally to all spans**
 
-Not supported with automatic instrumentation.
+Use the environment variable `DD_TRACE_GLOBAL_TAGS` to add tags to all the generated spans. Please see at the [PHP configuration][1]
+section for details on how environment variables should be set.
 
-Manual instrumentations of the tracer can set an associative array of global tags via the `global_tags` configuration key.
-
-```php
-$config = [
-    'global_tags' => [
-        '<TAG_KEY>' => '<TAG_VALUE>',
-    ]
-];
-$tracer = new \DDTrace\Tracer(null, null, $config);
-\DDTrace\GlobalTracer::set($tracer);
+```ini
+DD_TRACE_GLOBAL_TAGS=key1:value1,key2:value2
 ```
+
+[1]: /tracing/languages/php/#configuration
 
 {{% /tab %}}
 {{% tab "C++" %}}
@@ -673,33 +630,55 @@ using(var scope = Tracer.Instance.StartActive("web.request"))
 
 [1]: /tracing/languages/dotnet/#compatibility
 {{% /tab %}}
+
 {{% tab "PHP" %}}
 
-If you aren’t using a [framework supported by automatic instrumentation][1], manually instrument your code.
+Even if we do not officially support your web framework, most probably you won't need to perform any manual instrumentation.
+See [automatic instrumentation][1] for more details.
 
-First install the PHP tracer dependency with Composer:
+If you really need manual instrumentation, e.g because you want to trace specific custom methods in your application,
+first install the PHP tracer dependency with Composer:
 
 ```bash
 $ composer require datadog/dd-trace
 ```
 
-Then use the PHP tracer bootstrap to initialize the global tracer and create a root span to start the trace:
+#### Trace a custom function or method
+
+The `dd_trace()` function hooks into existing functions and methods to:
+
+* Open a span before the code executes
+* Set additional tags or errors on the span
+* Close the span when it is done
+* Modify the arguments or the return value
+
+For example, the following snippet traces the `CustomDriver::doWork()` method, adds custom tags, reports any exceptions as errors on the span, and then re-throws the exceptions.
 
 ```php
-// The existing Composer autoloader
-require __DIR__ . '/../vendor/autoload.php';
+dd_trace("CustomDriver", "doWork", function (...$args) {
+    // Start a new span
+    $scope = GlobalTracer::get()->startActiveSpan('CustomDriver.doWork');
+    $span = $scope->getSpan();
 
-// Add the PHP tracer bootstrap
-require __DIR__ . '/../vendor/datadog/dd-trace/bridge/dd_init.php';
+    // Access object members via $this
+    $span->setTag(Tags\RESOURCE_NAME, $this->workToDo);
 
-$span = \DDTrace\GlobalTracer::get()
-    ->startRootSpan('web.request')
-    ->getSpan();
-$span->setResource($_SERVER['REQUEST_URI']);
-$span->setTag(\DDTrace\Tag::SPAN_TYPE, \DDTrace\Type::WEB_SERVLET);
-$span->setTag(\DDTrace\Tag::HTTP_METHOD, $_SERVER['REQUEST_METHOD']);
-
-// Run the app here...
+    try {
+        // Execute the original method
+        $result = $this->doWork(...$args);
+        // Set a tag based on the return value
+        $span->setTag('doWork.size', count($result));
+        return $result;
+    } catch (Exception $e) {
+        // Inform the tracer that there was an exception thrown
+        $span->setError($e);
+        // Bubble up the exception
+        throw $e
+    } finally {
+        // Close the span
+        $span->finish();
+    }
+});
 ```
 
 The root span an be accessed later on directly from the global tracer via `Tracer::getRootScope()`. This is useful in contexts where the metadata to be added to the root span does not exist in early script execution.
@@ -711,8 +690,33 @@ $rootSpan = \DDTrace\GlobalTracer::get()
 $rootSpan->setTag(\DDTrace\Tag::HTTP_STATUS_CODE, 200);
 ```
 
+#### Zend Framework 1 manual instrumentation
 
-[1]: /tracing/languages/php/#framework-compatibility
+Zend Framework 1 is automatically instrumented by default, so you are not required to modify your ZF1 project. However, if automatic instrumentation is disabled, enable the tracer manually.
+
+First, [download the latest source code from the releases page][2]. Extract the zip file and copy the `src/DDTrace` folder to your application's `/library` folder. Then add the following to your `application/configs/application.ini` file:
+
+```ini
+autoloaderNamespaces[] = "DDTrace_"
+pluginPaths.DDTrace = APPLICATION_PATH "/../library/DDTrace/Integrations/ZendFramework/V1"
+resources.ddtrace = true
+```
+
+#### Manual instrumentation and php code optimization
+
+Prior to PHP 7 some frameworks provided ways to compile php classes, e.g. through the Laravel's `php artisan optimize`
+command.
+
+While this [has been deprecated][3] if you are using php 7.x, you still may use this caching mechanism in your app prior
+to version 7.x. In this case we suggest to use [OpenTracing][4] api instead of adding `datadog/dd-trace` to your
+composer file.
+
+
+[1]: /tracing/languages/php/#automatic-instrumentation
+[2]: https://github.com/DataDog/dd-trace-php/releases/latest
+[3]: https://laravel-news.com/laravel-5-6-removes-artisan-optimize
+[4]: #opentracing
+
 {{% /tab %}}
 {{% tab "C++" %}}
 

--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -702,12 +702,11 @@ resources.ddtrace = true
 
 #### Manual instrumentation and php code optimization
 
-Prior to PHP 7 some frameworks provided ways to compile php classes, e.g. through the Laravel's `php artisan optimize`
-command.
+Prior to PHP 7, some frameworks provided ways to compile PHP classes—e.g., through the Laravel's `php artisan optimize` command.
 
-While this [has been deprecated][3] if you are using php 7.x, you still may use this caching mechanism in your app prior
-to version 7.x. In this case we suggest to use [OpenTracing][4] api instead of adding `datadog/dd-trace` to your
-composer file.
+While this [has been deprecated][3] if you are using PHP 7.x, you still may use this caching mechanism in your app prior
+to version 7.x. In this case, Datadog suggests you use the [OpenTracing][4] API instead of adding `datadog/dd-trace` to your
+Composer file.
 
 
 [1]: /tracing/languages/php/#automatic-instrumentation

--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -633,11 +633,9 @@ using(var scope = Tracer.Instance.StartActive("web.request"))
 
 {{% tab "PHP" %}}
 
-Even if we do not officially support your web framework, most probably you won't need to perform any manual instrumentation.
-See [automatic instrumentation][1] for more details.
+Even if Datdog does not officially support your web framework, you may not need to perform any manual instrumentation. See [automatic instrumentation][1] for more details.
 
-If you really need manual instrumentation, e.g because you want to trace specific custom methods in your application,
-first install the PHP tracer dependency with Composer:
+If you really need manual instrumentation, e.g., because you want to trace specific custom methods in your application, first install the PHP tracer dependency with Composer:
 
 ```bash
 $ composer require datadog/dd-trace

--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -294,7 +294,7 @@ if (null !== $span) {
 
 **Adding tags globally to all spans**
 
-Use the environment variable `DD_TRACE_GLOBAL_TAGS` to add tags to all the generated spans. Please see at the [PHP configuration][1]
+Use the environment variable `DD_TRACE_GLOBAL_TAGS` to add tags to all the generated spans. See the [PHP configuration][1]
 section for details on how environment variables should be set.
 
 ```ini

--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -704,9 +704,7 @@ resources.ddtrace = true
 
 Prior to PHP 7, some frameworks provided ways to compile PHP classes—e.g., through the Laravel's `php artisan optimize` command.
 
-While this [has been deprecated][3] if you are using PHP 7.x, you still may use this caching mechanism in your app prior
-to version 7.x. In this case, Datadog suggests you use the [OpenTracing][4] API instead of adding `datadog/dd-trace` to your
-Composer file.
+While this [has been deprecated][3] if you are using PHP 7.x, you still may use this caching mechanism in your app prior to version 7.x. In this case, Datadog suggests you use the [OpenTracing][4] API instead of adding `datadog/dd-trace` to your Composer file.
 
 
 [1]: /tracing/languages/php/#automatic-instrumentation

--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -126,17 +126,15 @@ The PHP tracer can be configured using environment variables.
 
 ### Apache
 
-Set using [`SetEnv`][12] from the server config, virtual host,
-directory, or **.htaccess** file.
+Set using [`SetEnv`][12] from the server config, virtual host, directory, or **.htaccess** file.
 
 ```
 SetEnv DD_TRACE_DEBUG true
 ```
 
-### nginx
+### NGINX
 
-Set using [`fastcgi_param`][13] from the `http`,
-`server`, or `location` contexts.
+Set using [`fastcgi_param`][13] from the `http`, `server`, or `location` contexts.
 
 ```
 fastcgi_param DD_TRACE_DEBUG true;

--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -88,8 +88,9 @@ PHP APM supports the following PHP versions:
 
 #### Web Framework Compatibility
 
-Please not that if the web framework that you use is not listed below you will still see traces for your web requests
-in the UI. The only caveat is that some metadata and spans which are very specific to a particular web fr
+Please note that if the web framework that you use is not listed below you will still see traces for your web requests
+in the UI. The only caveat is that some metadata and spans which are very specific to a particular web framework will
+not show up.
 
 | Module         | Versions | Support Type |
 | :------------- | :------- | :----------- |

--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -36,7 +36,7 @@ Make sure the Agent has **[APM enabled][6]**.
 
 ### Install the extension
 
-Install the PHP extension using one of the [precompiled packages for supported distributions][7]. If you can't find your distribution, install the PHP extension [from source][9].
+Install the PHP extension using one of the [precompiled packages for supported distributions][7].
 
 Once downloaded, install the package with one of the commands below.
 
@@ -49,53 +49,13 @@ $ dpkg -i datadog-php-tracer.deb
 
 # using APK package (Alpine)
 $ apk add datadog-php-tracer.apk --allow-untrusted
-
-# using tar.gz archive (Other distributions using libc6)
-$ tar -xf datadog-php-tracer.tar.gz -C /
-  /opt/datadog-php/bin/post-install.sh
 ```
 
-### Install from source
+You are all set, now visit a tracing-enabled endpoint of your application and view the [APM UI][8] to see the traces.
 
-[Download the source code `tar.gz` or `.zip` file][7] from the releases page and unzip the file. Then compile and install the extension with the commands below.
+**Note**: It might take a few minutes before traces appear in the UI.
 
-```bash
-$ cd /path/to/dd-trace-php
-$ phpize
-$ ./configure --enable-ddtrace
-$ make
-$ sudo make install
-```
-
-#### Modify the INI file
-
-Modify the `php.ini` configuration file to make the **ddtrace** extension available in the PHP runtime. To find out where the INI file is, run the following command:
-
-```bash
-$ php --ini
-
-Configuration File (php.ini) Path: /usr/local/etc/php/7.2
-Loaded Configuration File:         /usr/local/etc/php/7.2/php.ini
-...
-```
-
-Add the following line to the `php.ini` file.
-
-```ini
-extension=ddtrace.so
-```
-
-After restarting the web server/PHP SAPI (e.g., `$ sudo apachectl restart`, `$ sudo service php-fpm restart`, etc.) the extension is enabled. To confirm that the extension is loaded, run:
-
-```bash
-$ php --ri=ddtrace
-
-ddtrace
-
-
-Datadog PHP tracer extension
-...
-```
+If you can't find your distribution, you can [manually install][9] the PHP extension.
 
 ## Compatibility
 
@@ -113,7 +73,7 @@ PHP APM supports the following PHP versions:
 
 Tracing is automatically instrumented by default. Once the extension is installed, **ddtrace** traces your application and sends traces to the Agent.
 
-Automatic instrumentation works by modifying PHP's runtime to wrap certain functions and methods in order to trace them. The PHP tracer supports automatic instrumentation for [several libraries][12].
+Automatic instrumentation works by modifying PHP's runtime to wrap certain functions and methods in order to trace them. The PHP tracer supports automatic instrumentation for [several libraries][10].
 
 Automatic instrumentation captures:
 
@@ -197,12 +157,6 @@ pluginPaths.DDTrace = APPLICATION_PATH "/../library/DDTrace/Integrations/ZendFra
 resources.ddtrace = true
 ```
 
-## View the trace
-
-Assuming the Agent is running with APM enabled and it is configured with your API key, and assuming the **ddtrace** extension is installed and instrumented properly into your application, visit a tracing-enabled endpoint of your application and view the [APM UI][13] to see the traces.
-
-**Note**: It might take a few minutes before traces appear in the UI.
-
 ## Configuration
 
 The PHP tracer can be configured using environment variables.
@@ -211,7 +165,7 @@ The PHP tracer can be configured using environment variables.
 
 ### Apache
 
-Set using [`SetEnv`][14] from the server config, virtual host,
+Set using [`SetEnv`][11] from the server config, virtual host,
 directory, or **.htaccess** file.
 
 ```
@@ -220,7 +174,7 @@ SetEnv DD_TRACE_DEBUG true
 
 ### nginx
 
-Set using [`fastcgi_param`][15] from the `http`,
+Set using [`fastcgi_param`][12] from the `http`,
 `server`, or `location` contexts.
 
 ```
@@ -239,13 +193,13 @@ DD_TRACE_DEBUG=true php -S localhost:8888
 | :------------------------- | :---------- | :------------------------------------------------------------------ |
 | `DD_AGENT_HOST`            | `localhost` | The Agent host name                                                 |
 | `DD_AUTOFINISH_SPANS`      | `false`     | Whether spans are automatically finished when the tracer is flushed |
-| `DD_DISTRIBUTED_TRACING`   | `true`      | Whether to enable [distributed tracing][16]                         |
+| `DD_DISTRIBUTED_TRACING`   | `true`      | Whether to enable [distributed tracing][13]                         |
 | `DD_INTEGRATIONS_DISABLED` | `null`      | CSV list of disabled extensions; e.g., `curl,mysqli`                |
-| `DD_PRIORITY_SAMPLING`     | `true`      | Whether to enable [priority sampling][17]                           |
+| `DD_PRIORITY_SAMPLING`     | `true`      | Whether to enable [priority sampling][14]                           |
 | `DD_SAMPLING_RATE`         | `1.0`       | The sampling rate for the traces. Between `0.0` and `1.0` (default) |
 | `DD_TRACE_AGENT_PORT`      | `8126`      | The Agent port number                                               |
 | `DD_TRACE_APP_NAME`        | ``          | The default app name                                                |
-| `DD_TRACE_DEBUG`           | `false`     | Enable [debug mode][18] for the tracer                              |
+| `DD_TRACE_DEBUG`           | `false`     | Enable [debug mode][15] for the tracer                              |
 | `DD_TRACE_ENABLED`         | `true`      | Enable the tracer globally                                          |
 | `DD_TRACE_GLOBAL_TAGS`     | ``          | Tags to be set on all spans: e.g.: `key1:value1,key2:value2`        |
 
@@ -261,7 +215,7 @@ DD_TRACE_DEBUG=true php -S localhost:8888
 | Symfony        | >= 3.4   | Beta         |
 | Zend Framework | 1.12     | Beta         |
 
-Don't see your desired web frameworks? Let Datadog know more about your needs through [this survey][19].
+Don't see your desired web frameworks? Let Datadog know more about your needs through [this survey][16].
 
 #### Library Compatibility
 
@@ -278,7 +232,7 @@ Don't see your desired web frameworks? Let Datadog know more about your needs th
 | PDO           | *(Any Supported PHP)*      | Beta         |
 | Predis        | 1.1                        | Beta         |
 
-Don't see your desired libraries? Let Datadog know more about your needs through [this survey][19].
+Don't see your desired libraries? Let Datadog know more about your needs through [this survey][16].
 
 ## Further Reading
 
@@ -291,14 +245,12 @@ Don't see your desired libraries? Let Datadog know more about your needs through
 [5]: /agent/kubernetes/daemonset_setup/#trace-collection
 [6]: /agent/apm/?tab=agent630#agent-configuration
 [7]: https://github.com/DataDog/dd-trace-php/releases/latest
-[9]: #install-from-source
-[10]: https://pecl.php.net/package/datadog_trace
-[11]: #modify-the-ini-file
-[12]: #library-compatibility
-[13]: https://app.datadoghq.com/apm/services
-[14]: https://httpd.apache.org/docs/2.4/mod/mod_env.html#setenv
-[15]: http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_param
-[16]: /tracing/advanced_usage/?tab=php#distributed-tracing
-[17]: /tracing/advanced_usage/?tab=php#priority-sampling
-[18]: /tracing/advanced_usage/?tab=php#debugging
-[19]: https://docs.google.com/forms/d/e/1FAIpQLSemTVTCdqzXkfzemJSr8wuEllxfqbGVj00flmRvKA17f0lyFg/viewform
+[8]: https://app.datadoghq.com/apm/services
+[9]: /tracing/languages/php/manual-installation
+[10]: #library-compatibility
+[11]: https://httpd.apache.org/docs/2.4/mod/mod_env.html#setenv
+[12]: http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_param
+[13]: /tracing/advanced_usage/?tab=php#distributed-tracing
+[14]: /tracing/advanced_usage/?tab=php#priority-sampling
+[15]: /tracing/advanced_usage/?tab=php#debugging
+[16]: https://docs.google.com/forms/d/e/1FAIpQLSemTVTCdqzXkfzemJSr8wuEllxfqbGVj00flmRvKA17f0lyFg/viewform

--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -51,7 +51,7 @@ $ dpkg -i datadog-php-tracer.deb
 $ apk add datadog-php-tracer.apk --allow-untrusted
 ```
 
-You are all set, now visit a tracing-enabled endpoint of your application and view the [APM UI][8] to see the traces.
+Visit a tracing-enabled endpoint of your application and view the [APM UI][8] to see the traces.
 
 **Note**: It might take a few minutes before traces appear in the UI.
 

--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -88,9 +88,7 @@ PHP APM supports the following PHP versions:
 
 #### Web Framework Compatibility
 
-Please note that if the web framework that you use is not listed below you will still see traces for your web requests
-in the UI. The only caveat is that some metadata and spans which are very specific to a particular web framework will
-not show up.
+If the web framework that you use is not listed below, you can still see traces for your web requests in the UI. However, some metadata and spans that are very specific to that particular web framework may not display.
 
 | Module         | Versions | Support Type |
 | :------------- | :------- | :----------- |

--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -61,9 +61,7 @@ If you can't find your distribution, you can [manually install][9] the PHP exten
 
 Tracing is automatically instrumented by default. Once the extension is installed, **ddtrace** traces your application and sends traces to the Agent.
 
-Even if we do not officially support your web framework, most probably you won't need any manual instrumentation as we record
-generic web request and create generic traces for them. On the other hand, if you use one of the frameworks that we support,
-we will set more relevant metadata which makes easier to navigate through your services.
+Even if Datadog does not officially support your web framework, you may not need any manual instrumentation. Datadog records generic web requests and creates generic traces for them. If you use one of the supported frameworks, however, Datadog sets more relevant metadata, which makes it easier to navigate through your services.
 
 Automatic instrumentation works by modifying PHP's runtime to wrap certain functions and methods in order to trace them. The PHP tracer supports automatic instrumentation for [several libraries][10].
 

--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -36,7 +36,7 @@ Make sure the Agent has **[APM enabled][6]**.
 
 ### Install the extension
 
-Install the PHP extension using one of the [precompiled packages for supported distributions][7]. If you can't find your distribution, install the PHP extension [from PECL][8] or [from source][9].
+Install the PHP extension using one of the [precompiled packages for supported distributions][7]. If you can't find your distribution, install the PHP extension [from source][9].
 
 Once downloaded, install the package with one of the commands below.
 
@@ -54,20 +54,6 @@ $ apk add datadog-php-tracer.apk --allow-untrusted
 $ tar -xf datadog-php-tracer.tar.gz -C /
   /opt/datadog-php/bin/post-install.sh
 ```
-
-### Install from PECL
-
-<div class="alert alert-warning">
-Installing the PHP tracer via PECL is an experimental feature.
-</div>
-
-Alternatively install the extension from the [PECL package **datadog_trace**][10].
-
-```bash
-$ sudo pecl install datadog_trace-beta
-```
-
-Next, [modify the `php.ini` file][11] to add the extension to the PHP runtime.
 
 ### Install from source
 
@@ -305,7 +291,6 @@ Don't see your desired libraries? Let Datadog know more about your needs through
 [5]: /agent/kubernetes/daemonset_setup/#trace-collection
 [6]: /agent/apm/?tab=agent630#agent-configuration
 [7]: https://github.com/DataDog/dd-trace-php/releases/latest
-[8]: #install-from-pecl
 [9]: #install-from-source
 [10]: https://pecl.php.net/package/datadog_trace
 [11]: #modify-the-ini-file

--- a/content/en/tracing/languages/php/manual-installation.md
+++ b/content/en/tracing/languages/php/manual-installation.md
@@ -15,12 +15,11 @@ further_reading:
 
 ## Before you start
 
-We strongly encourage you to install the PHP extension through our [pre-built packages][1].
-If you still prefer to manually install the PHP tracer please follow the steps below.
+Datadog strongly encourages you to install the PHP extension through the [pre-built packages][1]. If you still prefer to manually install the PHP tracer, follow the steps below.
 
 ### Install from the .tar.gz archive
 
-You can download the latest `.tar.gz` from our [release page][2].
+Download the latest `.tar.gz` from the [release page][2].
 
 From the location you downloaded the package:
 
@@ -61,7 +60,7 @@ Add the following line to the `php.ini` file.
 extension=ddtrace.so
 ```
 
-Depending on how you manually installed the PHP tracer, you also need to add this line to the php.ini file.
+Depending on how you manually installed the PHP tracer, you also need to add this line to the `php.ini` file.
 
 ```ini
 # If you installed from .tar.gz
@@ -82,7 +81,7 @@ Datadog PHP tracer extension
 ...
 ```
 
-You are now all set, now visit a tracing-enabled endpoint of your application and view the [APM UI][5] to see the traces.
+Visit a tracing-enabled endpoint of your application and view the [APM UI][5] to see the traces.
 
 **Note**: It might take a few minutes before traces appear in the UI.
 

--- a/content/en/tracing/languages/php/manual-installation.md
+++ b/content/en/tracing/languages/php/manual-installation.md
@@ -1,0 +1,93 @@
+---
+title: PHP tracer manual Installation
+kind: Documentation
+aliases:
+- /tracing/setup/php/manual-installation
+- /agent/apm/php/manual-installation
+further_reading:
+- link: "tracing/languages/php"
+  tag: "Documentation"
+  text: "PHP Language Documentation"
+- link: "tracing/advanced_usage/?tab=php"
+  tag: "Documentation"
+  text: "Advanced Usage"
+---
+
+## Before you start
+
+We strongly encourage you to install the PHP extension through our [pre-built packages][1].
+If you still prefer to manually install the PHP tracer please follow the steps below.
+
+### Install from the .tar.gz archive
+
+You can download the latest `.tar.gz` from our [release page][2].
+
+From the location you downloaded the package:
+
+```bash
+$ tar -xf datadog-php-tracer.tar.gz -C /
+  /opt/datadog-php/bin/post-install.sh
+```
+
+Next, [modify the `php.ini` file][3] to add the extension to the PHP runtime.
+
+### Install from source
+
+[Download the source code `tar.gz` or `.zip` file][4] from the releases page and unzip the file. Then compile and install the extension with the commands below.
+
+```bash
+$ cd /path/to/dd-trace-php
+$ phpize
+$ ./configure --enable-ddtrace
+$ make
+$ sudo make install
+```
+
+#### Modify the INI file
+
+Modify the `php.ini` configuration file to make the **ddtrace** extension available in the PHP runtime. To find out where the INI file is, run the following command:
+
+```bash
+$ php --ini
+
+Configuration File (php.ini) Path: /usr/local/etc/php/7.2
+Loaded Configuration File:         /usr/local/etc/php/7.2/php.ini
+...
+```
+
+Add the following line to the `php.ini` file.
+
+```ini
+extension=ddtrace.so
+```
+
+Depending on how you manually installed the PHP tracer, you also need to add this line to the php.ini file.
+
+```ini
+# If you installed from .tar.gz
+ddtrace.request_init_hook=<PATH_TO_EXTRACTED_TAR_GZ>/dd-trace-sources/bridge/dd_wrap_autoloader.php
+
+# If you installed from source
+ddtrace.request_init_hook=<PATH_TO_SOURCES>/bridge/dd_wrap_autoloader.php
+```
+
+After restarting the web server/PHP SAPI (e.g., `$ sudo apachectl restart`, `$ sudo service php-fpm restart`, etc.) the extension is enabled. To confirm that the extension is loaded, run:
+
+```bash
+$ php --ri=ddtrace
+
+ddtrace
+
+Datadog PHP tracer extension
+...
+```
+
+You are now all set, now visit a tracing-enabled endpoint of your application and view the [APM UI][5] to see the traces.
+
+**Note**: It might take a few minutes before traces appear in the UI.
+
+[1]: /tracing/languages/php/#install-the-extension
+[2]: https://github.com/DataDog/dd-trace-php/releases
+[3]: #modify-the-ini-file
+[4]: https://github.com/DataDog/dd-trace-php/releases/latest
+[5]: https://app.datadoghq.com/apm/services


### PR DESCRIPTION
### What does this PR do?

This PR slightly changes the PHP trace documentation and makes it more consistent with the Java tracer.

Furthermore, it tries to simplify on-boarding, focusing on automatic installation rather then manual installation.

### Preview link
[Preview](https://docs-staging.datadoghq.com/labbati/docs-consistency/tracing/languages/php/)
