### PR TITLE
[PHP] Prepare for GA release

### DIFF
--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -102,7 +102,7 @@ not show up.
 | Wordpress      |               | _Coming Soon_   |
 | Yii            | 1.1           | _Coming Soon_   |
 
-Datadog is continually adding additional support. Contact [Datadog support][11] if you need help.
+Don’t see your desired frameworks? Datadog is continually adding additional support. Check with the [Datadog team][11] for help.
 
 #### Datastore Compatibility
 
@@ -124,7 +124,7 @@ Datadog is continually adding additional support. Contact [Datadog support][11] 
 | PHPredis                         | 4                          | _Coming Soon_   |
 | Solarium                         | 4.2                        | _Coming Soon_   |
 
-Datadog is continually adding additional support. Contact [Datadog support][11] if you need help.
+Don’t see your desired datastores? Datadog is continually adding additional support. Check with the [Datadog team][11] for help.
 
 #### Library Compatibility
 
@@ -135,7 +135,7 @@ Datadog is continually adding additional support. Contact [Datadog support][11] 
 | Guzzle   | 6.x                   | Fully Supported |
 | ReactPHP |                       | _Coming Soon_   |
 
-Datadog is continually adding additional support. Contact [Datadog support][11] if you need help.
+Don’t see your desired libraries? Datadog is continually adding additional support. Check with the [Datadog team][11] for help.
 
 ## Configuration
 

--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -103,7 +103,7 @@ not show up.
 | Yii            | 1.1           | _Coming Soon_   |
 | Zend Framework | 1.12          | Fully Supported |
 
-Datadog is continually adding additional support. Contact [Datadog support][11] support if you need help.
+Datadog is continually adding additional support. Contact [Datadog support][11] if you need help.
 
 #### Datastore Compatibility
 
@@ -123,7 +123,7 @@ Datadog is continually adding additional support. Contact [Datadog support][11] 
 | phpredis        | 4                          | _Coming Soon_   |
 | Predis          | 1.1                        | Beta            |
 
-Datadog is continually adding additional support. Contact [Datadog support][11] support if you need help.
+Datadog is continually adding additional support. Contact [Datadog support][11] if you need help.
 
 #### Library Compatibility
 
@@ -134,7 +134,7 @@ Datadog is continually adding additional support. Contact [Datadog support][11] 
 | Guzzle   | 6.x                   | Fully Supported |
 | ReactPHP |                       | _Coming Soon_   |
 
-Datadog is continually adding additional support. Contact [Datadog support][11] support if you need help.
+Datadog is continually adding additional support. Contact [Datadog support][11] if you need help.
 
 ## Configuration
 

--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -98,7 +98,7 @@ not show up.
 | Drupal         |               | _Coming Soon_   |
 | Magento        | 2             | _Coming Soon_   |
 | Phalcon        | 1.3, 3.4      | _Coming Soon_   |
-| slim           | 2, 3          | _Coming Soon_   |
+| Slim           | 2, 3          | _Coming Soon_   |
 | Wordpress      |               | _Coming Soon_   |
 | Yii            | 1.1           | _Coming Soon_   |
 
@@ -121,7 +121,7 @@ Datadog is continually adding additional support. Contact [Datadog support][11] 
 | AWS Elasticache                  | AWS PHP SDK 3              | _Coming Soon_   |
 | Doctrine ORM                     | 2                          | _Coming Soon_   |
 | ODBC                             | *(Any Supported PHP)*      | _Coming Soon_   |
-| phpredis                         | 4                          | _Coming Soon_   |
+| PHPredis                         | 4                          | _Coming Soon_   |
 | Solarium                         | 4.2                        | _Coming Soon_   |
 
 Datadog is continually adding additional support. Contact [Datadog support][11] if you need help.

--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -113,7 +113,7 @@ Don’t see your desired frameworks? Datadog is continually adding additional su
 | Eloquent                         | Laravel supported versions | Fully Supported |
 | Memcached                        | *(Any Supported PHP)*      | Fully Supported |
 | MongoDB                          | 1.4.x                      | Fully Supported |
-| Mysqli                           | *(Any Supported PHP)*      | Fully Supported |
+| MySQLi                           | *(Any Supported PHP)*      | Fully Supported |
 | PDO (MySQL, PostgreSQL, MariaDB) | *(Any Supported PHP)*      | Fully Supported |
 | Predis                           | 1.1                        | Fully Supported |
 | AWS Couchbase                    | AWS PHP SDK 3              | _Coming Soon_   |

--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -90,17 +90,17 @@ not show up.
 
 | Module         | Versions      | Support Type    |
 |:---------------|:--------------|:----------------|
+| Laravel        | 4.2, 5.x      | Fully Supported |
+| Symfony        | 3.3, 3.4, 4.x | Fully Supported |
+| Zend Framework | 1.12          | Fully Supported |
 | CakePHP        | 1.3, 2.8, 3.x | _Coming Soon_   |
 | CodeIgniter    | 2, 3          | _Coming Soon_   |
 | Drupal         |               | _Coming Soon_   |
-| Laravel        | 4.2, 5.x      | Fully Supported |
 | Magento        | 2             | _Coming Soon_   |
 | Phalcon        | 1.3, 3.4      | _Coming Soon_   |
 | slim           | 2, 3          | _Coming Soon_   |
-| Symfony        | 3.3, 3.4, 4.x | Fully Supported |
 | Wordpress      |               | _Coming Soon_   |
 | Yii            | 1.1           | _Coming Soon_   |
-| Zend Framework | 1.12          | Fully Supported |
 
 Datadog is continually adding additional support. Contact [Datadog support][11] if you need help.
 
@@ -108,19 +108,19 @@ Datadog is continually adding additional support. Contact [Datadog support][11] 
 
 | Module          | Versions                   | Support Type    |
 |:----------------|:---------------------------|:----------------|
-| AWS Couchbase   | AWS PHP SDK 3              | _Coming Soon_   |
-| AWS DynamoDB    | AWS PHP SDK 3              | _Coming Soon_   |
-| AWS Elasticache | AWS PHP SDK 3              | _Coming Soon_   |
-| Doctrin ORM     | 2                          | _Coming Soon_   |
 | Elasticsearch   | 1.x                        | Fully Supported |
 | Eloquent        | Laravel supported versions | Fully Supported |
 | Memcached       | *(Any Supported PHP)*      | Fully Supported |
 | MongoDB         | 1.4.x                      | Fully Supported |
 | Mysqli          | *(Any Supported PHP)*      | Fully Supported |
+| PDO             | *(Any Supported PHP)*      | Fully Supported |
+| Predis          | 1.1                        | Fully Supported |
+| AWS Couchbase   | AWS PHP SDK 3              | _Coming Soon_   |
+| AWS DynamoDB    | AWS PHP SDK 3              | _Coming Soon_   |
+| AWS Elasticache | AWS PHP SDK 3              | _Coming Soon_   |
+| Doctrin ORM     | 2                          | _Coming Soon_   |
 | ODBC            | *(Any Supported PHP)*      | _Coming Soon_   |
-| PDO             | *(Any Supported PHP)*      | Beta            |
 | phpredis        | 4                          | _Coming Soon_   |
-| Predis          | 1.1                        | Beta            |
 
 Datadog is continually adding additional support. Contact [Datadog support][11] if you need help.
 

--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -16,10 +16,6 @@ further_reading:
   text: "Advanced Usage"
 ---
 
-<div class="alert alert-warning">
-The APM tracer for PHP applications is in Open Public Beta.
-</div>
-
 ## Installation and Getting Started
 
 For descriptions of terminology used in APM, take a look at the [official documentation][1].
@@ -76,13 +72,13 @@ Automatic instrumentation captures:
 
 PHP APM supports the following PHP versions:
 
-| Version | Support type |
-| :------ | :----------- |
-| 7.2.x   | Beta         |
-| 7.1.x   | Beta         |
-| 7.0.x   | Beta         |
-| 5.6.x   | Beta         |
-| 5.4.x   | Beta         |
+| Version | Support type    |
+| :------ | :-------------  |
+| 7.2.x   | Fully Supported |
+| 7.1.x   | Fully Supported |
+| 7.0.x   | Fully Supported |
+| 5.6.x   | Fully Supported |
+| 5.4.x   | Fully Supported |
 
 ### Integrations
 
@@ -92,30 +88,29 @@ Please note that if the web framework that you use is not listed below you will 
 in the UI. The only caveat is that some metadata and spans which are very specific to a particular web framework will
 not show up.
 
-| Module         | Versions | Support Type |
-| :------------- | :------- | :----------- |
-| Laravel        | 5.x      | Beta         |
-| Laravel        | 4.2      | Beta         |
-| Symfony        | 4.x      | Beta         |
-| Symfony        | >= 3.3   | Beta         |
-| Zend Framework | 1.12     | Beta         |
+| Module         | Versions      | Support Type    |
+|:---------------|:--------------|:----------------|
+| Laravel        | 4.2, 5.x      | Fully Supported |
+| Symfony        | 3.3, 3.4, 4.x | Fully Supported |
+| Wordpress      | 5.x           | _Coming soon_   |
+| Zend Framework | 1.12          | Fully Supported |
 
 Don't see your desired web frameworks? Let Datadog know more about your needs through [this survey][11].
 
 #### Library Compatibility
 
-| Module        | Versions                   | Support Type |
-| :------------ | :------------------------- | :----------- |
-| Curl          | *(Any Supported PHP)*      | Beta         |
-| Elasticsearch | 1.x                        | Beta         |
-| Eloquent      | Laravel supported versions | Beta         |
-| Guzzle        | 6.x                        | Beta         |
-| Guzzle        | 5.x                        | Beta         |
-| Memcached     | *(Any Supported PHP)*      | Beta         |
-| MongoDB       | 1.4.x                      | Beta         |
-| Mysqli        | *(Any Supported PHP)*      | Beta         |
-| PDO           | *(Any Supported PHP)*      | Beta         |
-| Predis        | 1.1                        | Beta         |
+| Module        | Versions                   | Support Type    |
+| :------------ | :------------------------- | :-------------- |
+| Curl          | *(Any Supported PHP)*      | Fully Supported |
+| Elasticsearch | 1.x                        | Fully Supported |
+| Eloquent      | Laravel supported versions | Fully Supported |
+| Guzzle        | 6.x                        | Fully Supported |
+| Guzzle        | 5.x                        | Fully Supported |
+| Memcached     | *(Any Supported PHP)*      | Fully Supported |
+| MongoDB       | 1.4.x                      | Fully Supported |
+| Mysqli        | *(Any Supported PHP)*      | Fully Supported |
+| PDO           | *(Any Supported PHP)*      | Fully Supported |
+| Predis        | 1.1                        | Fully Supported |
 
 Don't see your desired libraries? Let Datadog know more about your needs through [this survey][11].
 

--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -108,17 +108,17 @@ Don’t see your desired frameworks? Datadog is continually adding additional su
 
 | Module                           | Versions                   | Support Type    |
 |:---------------------------------|:---------------------------|:----------------|
-| Amazon RDS (using PDO or mysqli) | *(Any Supported PHP)*      | Fully Supported |
+| Amazon RDS (using PDO or MySQLi) | *(Any Supported PHP)*      | Fully Supported |
 | Elasticsearch                    | 1.x                        | Fully Supported |
 | Eloquent                         | Laravel supported versions | Fully Supported |
 | Memcached                        | *(Any Supported PHP)*      | Fully Supported |
 | MongoDB                          | 1.4.x                      | Fully Supported |
 | Mysqli                           | *(Any Supported PHP)*      | Fully Supported |
-| PDO (mysql, postgresql, mariadb) | *(Any Supported PHP)*      | Fully Supported |
+| PDO (MySQL, PostgreSQL, MariaDB) | *(Any Supported PHP)*      | Fully Supported |
 | Predis                           | 1.1                        | Fully Supported |
 | AWS Couchbase                    | AWS PHP SDK 3              | _Coming Soon_   |
 | AWS DynamoDB                     | AWS PHP SDK 3              | _Coming Soon_   |
-| AWS Elasticache                  | AWS PHP SDK 3              | _Coming Soon_   |
+| AWS ElastiCache                  | AWS PHP SDK 3              | _Coming Soon_   |
 | Doctrine ORM                     | 2                          | _Coming Soon_   |
 | ODBC                             | *(Any Supported PHP)*      | _Coming Soon_   |
 | PHPredis                         | 4                          | _Coming Soon_   |

--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -99,7 +99,6 @@ not show up.
 | slim           | 2, 3          | _Coming Soon_   |
 | Symfony        | 3.3, 3.4, 4.x | Fully Supported |
 | Wordpress      |               | _Coming Soon_   |
-| Wordpress      | 5.x           | _Coming soon_   |
 | Yii            | 1.1           | _Coming Soon_   |
 | Zend Framework | 1.12          | Fully Supported |
 

--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -106,21 +106,23 @@ Datadog is continually adding additional support. Contact [Datadog support][11] 
 
 #### Datastore Compatibility
 
-| Module          | Versions                   | Support Type    |
-|:----------------|:---------------------------|:----------------|
-| Elasticsearch   | 1.x                        | Fully Supported |
-| Eloquent        | Laravel supported versions | Fully Supported |
-| Memcached       | *(Any Supported PHP)*      | Fully Supported |
-| MongoDB         | 1.4.x                      | Fully Supported |
-| Mysqli          | *(Any Supported PHP)*      | Fully Supported |
-| PDO             | *(Any Supported PHP)*      | Fully Supported |
-| Predis          | 1.1                        | Fully Supported |
-| AWS Couchbase   | AWS PHP SDK 3              | _Coming Soon_   |
-| AWS DynamoDB    | AWS PHP SDK 3              | _Coming Soon_   |
-| AWS Elasticache | AWS PHP SDK 3              | _Coming Soon_   |
-| Doctrin ORM     | 2                          | _Coming Soon_   |
-| ODBC            | *(Any Supported PHP)*      | _Coming Soon_   |
-| phpredis        | 4                          | _Coming Soon_   |
+| Module                           | Versions                   | Support Type    |
+|:---------------------------------|:---------------------------|:----------------|
+| Amazon RDS (using PDO or mysqli) | *(Any Supported PHP)*      | Fully Supported |
+| Elasticsearch                    | 1.x                        | Fully Supported |
+| Eloquent                         | Laravel supported versions | Fully Supported |
+| Memcached                        | *(Any Supported PHP)*      | Fully Supported |
+| MongoDB                          | 1.4.x                      | Fully Supported |
+| Mysqli                           | *(Any Supported PHP)*      | Fully Supported |
+| PDO (mysql, postgresql, mariadb) | *(Any Supported PHP)*      | Fully Supported |
+| Predis                           | 1.1                        | Fully Supported |
+| AWS Couchbase                    | AWS PHP SDK 3              | _Coming Soon_   |
+| AWS DynamoDB                     | AWS PHP SDK 3              | _Coming Soon_   |
+| AWS Elasticache                  | AWS PHP SDK 3              | _Coming Soon_   |
+| Doctrine ORM                     | 2                          | _Coming Soon_   |
+| ODBC                             | *(Any Supported PHP)*      | _Coming Soon_   |
+| phpredis                         | 4                          | _Coming Soon_   |
+| Solarium                         | 4.2                        | _Coming Soon_   |
 
 Datadog is continually adding additional support. Contact [Datadog support][11] if you need help.
 

--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -128,12 +128,13 @@ Don’t see your desired datastores? Datadog is continually adding additional su
 
 #### Library Compatibility
 
-| Module   | Versions              | Support Type    |
-|:---------|:----------------------|:----------------|
-| Curl     | *(Any Supported PHP)* | Fully Supported |
-| Guzzle   | 5.x                   | Fully Supported |
-| Guzzle   | 6.x                   | Fully Supported |
-| ReactPHP |                       | _Coming Soon_   |
+| Module     | Versions              | Support Type    |
+|:-----------|:----------------------|:----------------|
+| Curl       | *(Any Supported PHP)* | Fully Supported |
+| Guzzle     | 5.x                   | Fully Supported |
+| Guzzle     | 6.x                   | Fully Supported |
+| Beanstalkd |                       | _Coming Soon_   |
+| ReactPHP   |                       | _Coming Soon_   |
 
 Don’t see your desired libraries? Datadog is continually adding additional support. Check with the [Datadog team][11] for help.
 

--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -90,29 +90,51 @@ not show up.
 
 | Module         | Versions      | Support Type    |
 |:---------------|:--------------|:----------------|
+| CakePHP        | 1.3, 2.8, 3.x | _Coming Soon_   |
+| CodeIgniter    | 2, 3          | _Coming Soon_   |
+| Drupal         |               | _Coming Soon_   |
 | Laravel        | 4.2, 5.x      | Fully Supported |
+| Magento        | 2             | _Coming Soon_   |
+| Phalcon        | 1.3, 3.4      | _Coming Soon_   |
+| slim           | 2, 3          | _Coming Soon_   |
 | Symfony        | 3.3, 3.4, 4.x | Fully Supported |
+| Wordpress      |               | _Coming Soon_   |
 | Wordpress      | 5.x           | _Coming soon_   |
+| Yii            | 1.1           | _Coming Soon_   |
 | Zend Framework | 1.12          | Fully Supported |
 
-Don't see your desired web frameworks? Let Datadog know more about your needs through [this survey][11].
+Datadog is continually adding additional support. Contact [Datadog support][11] support if you need help.
+
+#### Datastore Compatibility
+
+| Module          | Versions                   | Support Type    |
+|:----------------|:---------------------------|:----------------|
+| AWS Couchbase   | AWS PHP SDK 3              | _Coming Soon_   |
+| AWS DynamoDB    | AWS PHP SDK 3              | _Coming Soon_   |
+| AWS Elasticache | AWS PHP SDK 3              | _Coming Soon_   |
+| Doctrin ORM     | 2                          | _Coming Soon_   |
+| Elasticsearch   | 1.x                        | Fully Supported |
+| Eloquent        | Laravel supported versions | Fully Supported |
+| Memcached       | *(Any Supported PHP)*      | Fully Supported |
+| MongoDB         | 1.4.x                      | Fully Supported |
+| Mysqli          | *(Any Supported PHP)*      | Fully Supported |
+| ODBC            | *(Any Supported PHP)*      | _Coming Soon_   |
+| PDO             | *(Any Supported PHP)*      | Beta            |
+| phpredis        | 4                          | _Coming Soon_   |
+| Predis          | 1.1                        | Beta            |
+
+Datadog is continually adding additional support. Contact [Datadog support][11] support if you need help.
 
 #### Library Compatibility
 
-| Module        | Versions                   | Support Type    |
-| :------------ | :------------------------- | :-------------- |
-| Curl          | *(Any Supported PHP)*      | Fully Supported |
-| Elasticsearch | 1.x                        | Fully Supported |
-| Eloquent      | Laravel supported versions | Fully Supported |
-| Guzzle        | 6.x                        | Fully Supported |
-| Guzzle        | 5.x                        | Fully Supported |
-| Memcached     | *(Any Supported PHP)*      | Fully Supported |
-| MongoDB       | 1.4.x                      | Fully Supported |
-| Mysqli        | *(Any Supported PHP)*      | Fully Supported |
-| PDO           | *(Any Supported PHP)*      | Fully Supported |
-| Predis        | 1.1                        | Fully Supported |
+| Module   | Versions              | Support Type    |
+|:---------|:----------------------|:----------------|
+| Curl     | *(Any Supported PHP)* | Fully Supported |
+| Guzzle   | 5.x                   | Fully Supported |
+| Guzzle   | 6.x                   | Fully Supported |
+| ReactPHP |                       | _Coming Soon_   |
 
-Don't see your desired libraries? Let Datadog know more about your needs through [this survey][11].
+Datadog is continually adding additional support. Contact [Datadog support][11] support if you need help.
 
 ## Configuration
 
@@ -172,7 +194,7 @@ DD_TRACE_DEBUG=true php -S localhost:8888
 [8]: https://app.datadoghq.com/apm/services
 [9]: /tracing/languages/php/manual-installation
 [10]: #library-compatibility
-[11]: https://docs.google.com/forms/d/e/1FAIpQLSemTVTCdqzXkfzemJSr8wuEllxfqbGVj00flmRvKA17f0lyFg/viewform
+[11]: https://docs.datadoghq.com/help
 [12]: https://httpd.apache.org/docs/2.4/mod/mod_env.html#setenv
 [13]: http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_param
 [14]: /tracing/advanced_usage/?tab=php#distributed-tracing


### PR DESCRIPTION
### What does this PR do?
This PR changes definitions from `Beta` to `Fully Supported` for all the integrations that we support and remove all the `beta` warnings now that we go GA.

### Preview link
[https://docs-staging.datadoghq.com/php/labbati/lets-go-GA/tracing/languages/php/](https://docs-staging.datadoghq.com/php/labbati/lets-go-GA/tracing/languages/php/)
