### PR TITLE
corrects syntax in global log processing rule env var

### DIFF
--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -345,7 +345,7 @@ logs_config:
 The `DD_LOGS_CONFIG_PROCESSING_RULES` can be used to configure global processing rules:
 
 ```
-DD_LOGS_CONFIG_PROCESSING_RULES="[{"type": "mask_sequences", "name": "mask_user_email", "replace_placeholder": "MASKED_EMAIL", "pattern" : "\w+@datadoghq.com"}]
+DD_LOGS_CONFIG_PROCESSING_RULES='[{"type": "mask_sequences", "name": "mask_user_email", "replace_placeholder": "MASKED_EMAIL", "pattern" : "\\w+@datadoghq.com"}]'
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Corrects the syntax for applying global log processing rules with `DD_LOGS_CONFIG_PROCESSING_RULES`

### Motivation

Noticed the syntax issue in the environment variable method of applying global log processing rules

### Preview link

https://docs-staging.datadoghq.com/tj/correct_global_log_processing_rule_env_var_syntax/logs/log_collection/?tab=environmentvariable

### Additional Notes
<!-- Anything else we should know when reviewing?-->
