### PR TITLE
[API] rate limit for metric retrieval

### DIFF
--- a/content/en/api/rate_limiting/rate_limiting.md
+++ b/content/en/api/rate_limiting/rate_limiting.md
@@ -13,10 +13,11 @@ Rate limits can be increased from defaults by [contacting the Datadog support te
 
 Regarding API rate limit policy:
 
-* We **do not rate limit** on datapoint/metric submission (see [metrics section][2] for more info on how metric submission rate is handled) - limits encounter would be the quantity of [custom metrics][3] based on your agreement
-* Rate limit for event submission is 1000 per aggregate per day per organization. An aggregate is a group of similar events.
-* Rate limit for the [query_batch API][4] call is 300 per hour per organization, it can be extended on demand
-* Rate limit for the [graph_snapshot API][5] call is 60 per hour per organization, it can be extended on demand
+* Datadog **does not rate limit** on data point/metric submission (see [metrics section][2] for more info on how metric submission rate is handled). Limits encounter is dependent on the quantity of [custom metrics][3] based on your agreement.
+* The rate limit for metric **retrieval** is `100` per hour per organization.
+* The rate limit for event submission is `1000` per aggregate per day per organization. An aggregate is a group of similar events.
+* The rate limit for the [query_batch API][4] call is `300` per hour per organization. This can be extended on demand.
+* The rate limit for the [graph_snapshot API][5] call is `60` per hour per organization. This can be extended on demand.
 
 [1]: /help
 [2]: /api/#metrics


### PR DESCRIPTION
### What does this PR do?
- Add rate limit for metric retrieval through the API
- Wording updates

### Motivation
- Trello request

### Preview link
https://docs-staging.datadoghq.com/ruth/metric-api/api/#rate-limiting
