### PR TITLE
Fix `site` configuration info in Agent doc.

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -68,9 +68,9 @@ Manage the Datadog Agent and [Integrations][1] using configuration management to
 
 ### Datadog site
 
-To send your Agent data to the [Datadog EU site][3], edit your [Agent main configuration file][4] `datadog.yaml` and set the `dd_site` parameter to:
+To send your Agent data to the [Datadog EU site][3], edit your [Agent main configuration file][4] `datadog.yaml` and set the `site` parameter to:
 
-`dd_site:datadoghq.eu`
+`site:datadoghq.eu`
 
 ### Log location
 

--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -70,7 +70,7 @@ Manage the Datadog Agent and [Integrations][1] using configuration management to
 
 To send your Agent data to the [Datadog EU site][3], edit your [Agent main configuration file][4] `datadog.yaml` and set the `site` parameter to:
 
-`site:datadoghq.eu`
+`site: datadoghq.eu`
 
 ### Log location
 

--- a/content/fr/agent/basic_agent_usage/_index.md
+++ b/content/fr/agent/basic_agent_usage/_index.md
@@ -67,9 +67,9 @@ Gérez l'Agent Datadog et les [intégrations][1] grâce aux outils de gestion de
 
 ### Site de Datadog
 
-Pour envoyer vos données de l'Agent au [site Datadog Europe][3], modifiez le [principal fichier de configuration de l'Agent][4] `datadog.yaml` et définissez le paramètre `dd_site` sur :
+Pour envoyer vos données de l'Agent au [site Datadog Europe][3], modifiez le [principal fichier de configuration de l'Agent][4] `datadog.yaml` et définissez le paramètre `site` sur :
 
-`dd_site:datadoghq.eu`
+`site:datadoghq.eu`
 
 ### Emplacement des logs
 

--- a/content/fr/agent/basic_agent_usage/_index.md
+++ b/content/fr/agent/basic_agent_usage/_index.md
@@ -69,7 +69,7 @@ Gérez l'Agent Datadog et les [intégrations][1] grâce aux outils de gestion de
 
 Pour envoyer vos données de l'Agent au [site Datadog Europe][3], modifiez le [principal fichier de configuration de l'Agent][4] `datadog.yaml` et définissez le paramètre `site` sur :
 
-`site:datadoghq.eu`
+`site: datadoghq.eu`
 
 ### Emplacement des logs
 


### PR DESCRIPTION
### What does this PR do?
The wrong  parameter was indicated to use the `site` feature in the Agent configuration.

### Preview link
https://docs-staging.datadoghq.com/remeh/site-config/agent/basic_agent_usage

