### PR TITLE
Add analyzed span and ignore resource examples

### DIFF
--- a/content/en/agent/docker/apm.md
+++ b/content/en/agent/docker/apm.md
@@ -53,13 +53,13 @@ List of all environment variables available for tracing with the Docker Agent:
 | `DD_APM_DD_URL`            | Datadog API endpoint where traces are sent. For Datadog EU site set `DD_APM_DD_URL` to `https://trace.agent.datadoghq.eu` |
 | `DD_APM_RECEIVER_PORT`     | Port that the Datadog Agent's trace receiver listens on. Default value is `8126`.                                          |
 | `DD_APM_NON_LOCAL_TRAFFIC` | Allow non-local traffic when [tracing from other containers](#tracing-from-other-containers).                             |
-| `DD_APM_IGNORE_RESOURCES`  | Configure resources for the agent to ignore. Format should comma seperated\* regular expressions. Example: `"GET /ignore-me,(GET|POST) /and-also-me"` |
-| `DD_APM_ANALYZED_SPANS`    | Configure the spans to analyze for transactions. Format should look like `<service-name>|<span-name>=1` with comma separated values\* i.e. `"your-express-serivce|express.request=1,your-dotnet-service|aspnet_core_mvc.request=1"`|
+| `DD_APM_IGNORE_RESOURCES`  | Configure resources for the agent to ignore. Format should be comma seperated\* regular expressions. Example: `"GET /ignore-me,(GET|POST) /and-also-me"` |
+| `DD_APM_ANALYZED_SPANS`    | Configure the spans to analyze for transactions. Format should be comma seperated\* instances of `<service-name>|<span-name>=1` |
 | `DD_APM_ENV`               | Sets the default [environment][2] for your traces.                                                                        |
 | `DD_APM_MAX_EPS`           | Sets the maximum APM events per second.                                                                                   |
 | `DD_APM_MAX_TPS`           | Sets the maximum traces per second.                                                                                       |
 
-\**No additional characters such as spaces or newlines are allowed between commas*
+**\****No additional characters such as spaces or newlines are allowed between commas*
 
 ## Tracing from other containers
 

--- a/content/en/agent/docker/apm.md
+++ b/content/en/agent/docker/apm.md
@@ -53,11 +53,13 @@ List of all environment variables available for tracing with the Docker Agent:
 | `DD_APM_DD_URL`            | Datadog API endpoint where traces are sent. For Datadog EU site set `DD_APM_DD_URL` to `https://trace.agent.datadoghq.eu` |
 | `DD_APM_RECEIVER_PORT`     | Port that the Datadog Agent's trace receiver listens on. Default value is `8126`.                                          |
 | `DD_APM_NON_LOCAL_TRAFFIC` | Allow non-local traffic when [tracing from other containers](#tracing-from-other-containers).                             |
-| `DD_APM_IGNORE_RESOURCES`   | A comma-separated list of endpoints and resources that the Agent should ignore (i.e. health checks endpoints).            |
-| `DD_APM_ANALYZED_SPANS`    | Configure the spans to analyze for transactions.                                                                          |
+| `DD_APM_IGNORE_RESOURCES`  | Configure resources for the agent to ignore. Format should comma seperated\* regular expressions. Example: `"GET /ignore-me,(GET|POST) /and-also-me"` |
+| `DD_APM_ANALYZED_SPANS`    | Configure the spans to analyze for transactions. Format should look like `<service-name>|<span-name>=1` with comma separated values\* i.e. `"your-express-serivce|express.request=1,your-dotnet-service|aspnet_core_mvc.request=1"`|
 | `DD_APM_ENV`               | Sets the default [environment][2] for your traces.                                                                        |
 | `DD_APM_MAX_EPS`           | Sets the maximum APM events per second.                                                                                   |
 | `DD_APM_MAX_TPS`           | Sets the maximum traces per second.                                                                                       |
+
+\**No additional characters such as spaces or newlines are allowed between commas*
 
 ## Tracing from other containers
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
