### PR TITLE
Add examples for DD_APM_IGNORE_RESOURCES and DD_APM_ANALYZED_SPANS

### DIFF
--- a/content/en/agent/docker/apm.md
+++ b/content/en/agent/docker/apm.md
@@ -53,8 +53,8 @@ List of all environment variables available for tracing with the Docker Agent:
 | `DD_APM_DD_URL`            | Datadog API endpoint where traces are sent. For Datadog EU site set `DD_APM_DD_URL` to `https://trace.agent.datadoghq.eu` |
 | `DD_APM_RECEIVER_PORT`     | Port that the Datadog Agent's trace receiver listens on. Default value is `8126`.                                          |
 | `DD_APM_NON_LOCAL_TRAFFIC` | Allow non-local traffic when [tracing from other containers](#tracing-from-other-containers).                             |
-| `DD_APM_IGNORE_RESOURCES`  | Configure resources for the agent to ignore. Format should be comma seperated\* regular expressions. Example: `"GET /ignore-me,(GET|POST) /and-also-me"` |
-| `DD_APM_ANALYZED_SPANS`    | Configure the spans to analyze for transactions. Format should be comma seperated\* instances of `<service-name>|<span-name>=1` |
+| `DD_APM_IGNORE_RESOURCES`  | Configure resources for the agent to ignore. Format should be comma seperated\* regular expressions. i.e. `"GET /ignore-me,(GET|POST) /and-also-me"` |
+| `DD_APM_ANALYZED_SPANS`    | Configure the spans to analyze for transactions. Format should be comma seperated\* instances of `<SERVICE_NAME>|<OPERATION_NAME>=1`. i.e. `my-express-app|express.request=1,my-dotnet-app|aspnet_core_mvc.request=1` |
 | `DD_APM_ENV`               | Sets the default [environment][2] for your traces.                                                                        |
 | `DD_APM_MAX_EPS`           | Sets the maximum APM events per second.                                                                                   |
 | `DD_APM_MAX_TPS`           | Sets the maximum traces per second.                                                                                       |

--- a/content/en/agent/docker/apm.md
+++ b/content/en/agent/docker/apm.md
@@ -53,7 +53,7 @@ List of all environment variables available for tracing with the Docker Agent:
 | `DD_APM_DD_URL`            | Datadog API endpoint where traces are sent. For Datadog EU site set `DD_APM_DD_URL` to `https://trace.agent.datadoghq.eu` |
 | `DD_APM_RECEIVER_PORT`     | Port that the Datadog Agent's trace receiver listens on. Default value is `8126`.                                          |
 | `DD_APM_NON_LOCAL_TRAFFIC` | Allow non-local traffic when [tracing from other containers](#tracing-from-other-containers).                             |
-| `DD_APM_IGNORE_RESOURCES`  | Configure resources for the agent to ignore. Format should be comma seperated\* regular expressions. i.e. `"GET /ignore-me,(GET|POST) /and-also-me"` |
+| `DD_APM_IGNORE_RESOURCES`  | Configure resources for the agent to ignore. Format should be comma seperated, regular expressions. i.e. <code>"GET /ignore-me,(GET&#124;POST) /and-also-me"</code>. |
 | `DD_APM_ANALYZED_SPANS`    | Configure the spans to analyze for transactions. Format should be comma seperated\* instances of `<SERVICE_NAME>|<OPERATION_NAME>=1`. i.e. `my-express-app|express.request=1,my-dotnet-app|aspnet_core_mvc.request=1` |
 | `DD_APM_ENV`               | Sets the default [environment][2] for your traces.                                                                        |
 | `DD_APM_MAX_EPS`           | Sets the maximum APM events per second.                                                                                   |

--- a/content/en/agent/docker/apm.md
+++ b/content/en/agent/docker/apm.md
@@ -53,11 +53,13 @@ List of all environment variables available for tracing with the Docker Agent:
 | `DD_APM_DD_URL`            | Datadog API endpoint where traces are sent. For Datadog EU site set `DD_APM_DD_URL` to `https://trace.agent.datadoghq.eu` |
 | `DD_APM_RECEIVER_PORT`     | Port that the Datadog Agent's trace receiver listens on. Default value is `8126`.                                          |
 | `DD_APM_NON_LOCAL_TRAFFIC` | Allow non-local traffic when [tracing from other containers](#tracing-from-other-containers).                             |
-| `DD_APM_IGNORE_RESOURCES`   | A comma-separated list of endpoints and resources that the Agent should ignore (i.e. health checks endpoints).            |
-| `DD_APM_ANALYZED_SPANS`    | Configure the spans to analyze for transactions.                                                                          |
+| `DD_APM_IGNORE_RESOURCES`  | Configure resources for the agent to ignore. Format should be comma seperated\* regular expressions. Example: `"GET /ignore-me,(GET|POST) /and-also-me"` |
+| `DD_APM_ANALYZED_SPANS`    | Configure the spans to analyze for transactions. Format should be comma seperated\* instances of `<service-name>|<span-name>=1` |
 | `DD_APM_ENV`               | Sets the default [environment][2] for your traces.                                                                        |
 | `DD_APM_MAX_EPS`           | Sets the maximum APM events per second.                                                                                   |
 | `DD_APM_MAX_TPS`           | Sets the maximum traces per second.                                                                                       |
+
+**\****No additional characters such as spaces or newlines are allowed between commas*
 
 ## Tracing from other containers
 

--- a/content/en/agent/docker/apm.md
+++ b/content/en/agent/docker/apm.md
@@ -54,12 +54,10 @@ List of all environment variables available for tracing with the Docker Agent:
 | `DD_APM_RECEIVER_PORT`     | Port that the Datadog Agent's trace receiver listens on. Default value is `8126`.                                          |
 | `DD_APM_NON_LOCAL_TRAFFIC` | Allow non-local traffic when [tracing from other containers](#tracing-from-other-containers).                             |
 | `DD_APM_IGNORE_RESOURCES`  | Configure resources for the agent to ignore. Format should be comma seperated, regular expressions. i.e. <code>"GET /ignore-me,(GET&#124;POST) /and-also-me"</code>. |
-| `DD_APM_ANALYZED_SPANS`    | Configure the spans to analyze for transactions. Format should be comma seperated\* instances of `<SERVICE_NAME>|<OPERATION_NAME>=1`. i.e. `my-express-app|express.request=1,my-dotnet-app|aspnet_core_mvc.request=1` |
+| `DD_APM_ANALYZED_SPANS`    | Configure the spans to analyze for transactions. Format should be comma seperated instances of <code>\<SERVICE_NAME>&#124;\<OPERATION_NAME>=1</code>. i.e. <code>my-express-app&#124;express.request=1,my-dotnet-app&#124;aspnet_core_mvc.request=1</code>. |
 | `DD_APM_ENV`               | Sets the default [environment][2] for your traces.                                                                        |
 | `DD_APM_MAX_EPS`           | Sets the maximum APM events per second.                                                                                   |
 | `DD_APM_MAX_TPS`           | Sets the maximum traces per second.                                                                                       |
-
-**\****No additional characters such as spaces or newlines are allowed between commas*
 
 ## Tracing from other containers
 


### PR DESCRIPTION
### What does this PR do?
Adds config examples and supporting language for `DD_APM_IGNORE_RESOURCES` and `DD_APM_ANALYZED_SPANS` envvars. 

### Motivation
Docs specified intent of envvars but did not provide meaningful language as to the shape the configuration options could take or provide working examples

### Preview link
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/quotecenter/datadog-documentation/agent/docker/apm/?tab=java#docker-apm-environment-variables

### Additional Notes
Sourced info for `DD_APM_ANALYZED_SPANS` from https://docs.datadoghq.com/logs/log_collection/docker/?tab=containerinstallation#one-step-install-to-collect-all-the-container-logs and https://docs.datadoghq.com/agent/apm/?tab=agent630#trace-collection
Sourced info for `DD_APM_IGNORE_RESOURCES` from https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml#L804