### PR TITLE
Document tag autodiscovery from Pod annotations

### DIFF
--- a/content/en/agent/autodiscovery/_index.md
+++ b/content/en/agent/autodiscovery/_index.md
@@ -93,7 +93,20 @@ Note: Tags are only set when a container starts.
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 
-The Datadog Agent can extract pod labels and annotations as metric tags with the following configuration in your `datadog.yaml` file:
+The Datadog Agent can autodiscover tags from Pod annotations, allowing to
+associate tags to entire pods or individual containers. The expected format
+for annotation autodiscovery is the following one:
+
+```
+annotations:
+  ad.datadoghq.com/tags: '{"<TAG_NAME>": "<TAG_VALUE>", ...}'
+  ad.datadoghq.com/<container identifier>.tags: '{"<TAG_NAME>": "<TAG_VALUE>", ...}'
+```
+
+Note that autodiscovery identifies containers by _name_.
+
+The Datadog Agent can also extract pod labels and annotations as metric tags
+with the following configuration in your `datadog.yaml` file:
 
 ```
 kubernetes_pod_labels_as_tags:

--- a/content/en/agent/autodiscovery/_index.md
+++ b/content/en/agent/autodiscovery/_index.md
@@ -93,9 +93,9 @@ Note: Tags are only set when a container starts.
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 
-The Datadog Agent can autodiscover tags from Pod annotations, allowing to
-associate tags to entire pods or individual containers. The expected format
-for annotation autodiscovery is the following one:
+The Datadog Agent can autodiscover tags from Pod annotations, which allows it to
+associate tags to entire pods or individual containers. Use this format
+for annotation autodiscovery:
 
 ```
 annotations:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Document how to use Pod annotations autodiscovery.

### Motivation
<!-- What inspired you to submit this pull request?-->

Release of the feature in 6.10

### Preview link
<!-- Impacted pages preview links-->

https://docs-staging.datadoghq.com/xavier.lucas/ad-annotation-tagging/agent/autodiscovery/?tab=kubernetes#tag-extraction

<!-- This is the base preview link. Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
