### PR TITLE
[Tracing PHP] Add link to blog post

### DIFF
--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -5,6 +5,9 @@ aliases:
 - /tracing/setup/php
 - /agent/apm/php/
 further_reading:
+- link: "https://www.datadoghq.com/blog/monitor-php-performance/"
+  tag: "Blog"
+  text: "PHP monitoring with Datadog APM and distributed tracing"
 - link: "https://github.com/DataDog/dd-trace-php"
   tag: "GitHub"
   text: "Source code"


### PR DESCRIPTION
### What does this PR do?
- Add link to new PHP blog post

### Motivation
- Email about new blog post

### Preview link
https://docs-staging.datadoghq.com/ruth/php-blog/tracing/languages/php/#further-reading
