### PR TITLE
Clarify format of DD_APM_ANALYZED_SPANS

### DIFF
--- a/content/en/agent/apm/_index.md
+++ b/content/en/agent/apm/_index.md
@@ -128,14 +128,15 @@ In `datadog.conf`, add `[trace.analyzed_spans]`. For example:
 
 {{% /tab %}}
 {{% tab "Docker" %}}
-Add `DD_APM_ANALYZED_SPANS` to the Agent container environment (compatible with version 12.6.5250+). For example:
+Add `DD_APM_ANALYZED_SPANS` to the Agent container environment (compatible with version 12.6.5250+). Format should be comma-separated regular expressions without spaces. For example:
 
 ```
 DD_APM_ANALYZED_SPANS="<SERVICE_NAME_1>|<OPERATION_NAME_1>=1,<SERVICE_NAME_2>|<OPERATION_NAME_2>=1"
 ```
-<div class="alert alert-info">
-Make sure there are no spaces between your services. If you have spaces, not all of your services will report correctly.
-</div>
+
+```
+`my-express-app|express.request=1,my-dotnet-app|aspnet_core_mvc.request=1`
+```
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/agent/apm/_index.md
+++ b/content/en/agent/apm/_index.md
@@ -133,6 +133,9 @@ Add `DD_APM_ANALYZED_SPANS` to the Agent container environment (compatible with 
 ```
 DD_APM_ANALYZED_SPANS="<SERVICE_NAME_1>|<OPERATION_NAME_1>=1,<SERVICE_NAME_2>|<OPERATION_NAME_2>=1"
 ```
+<div class="alert alert-info">
+Make sure there are no spaces between your services. If you have spaces, not all of your services will report correctly.
+</div>
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/agent/apm/_index.md
+++ b/content/en/agent/apm/_index.md
@@ -128,7 +128,7 @@ In `datadog.conf`, add `[trace.analyzed_spans]`. For example:
 
 {{% /tab %}}
 {{% tab "Docker" %}}
-Add `DD_APM_ANALYZED_SPANS` to the Agent container environment (compatible with version 12.6.5250+). Format should be comma-separated regular expressions without spaces. For example:
+Add `DD_APM_ANALYZED_SPANS` to the Agent container environment (compatible with version 12.6.5250+). Format should be a comma-separated regular expressions without spaces. For example:
 
 ```
 DD_APM_ANALYZED_SPANS="<SERVICE_NAME_1>|<OPERATION_NAME_1>=1,<SERVICE_NAME_2>|<OPERATION_NAME_2>=1"


### PR DESCRIPTION
### What does this PR do?

It clarifies that you can't have spacing in between services in Docker `DD_APM_ANALYZED_SPANS`.

### Motivation

Customer confusion.

### Preview link

https://docs-staging.datadoghq.com/kaylyn/trace-search-spaces/agent/apm/?tab=docker#trace-search

### Additional Notes
<!-- Anything else we should know when reviewing?-->
