### PR TITLE
Added containerized env instructions for JVM Metric collection

### DIFF
--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -453,11 +453,18 @@ Along with displaying these metrics in your APM Service Page, Datadog provides a
 
 Additional JMX metrics can be added using configuration files that are passed to `jmxfetch.metrics-configs`. You can also enable existing Datadog JMX integrations individually with the `dd.integration.<name>` parameter. This auto-embeds configuration from Datadog's [existing JMX configuration files][2]. See the [JMX Integration][3] for further details on configuration. 
 
+### Collecting JVM Metrics in Containerized Environments
+
+By default, JVM metrics from your Application are sent to the Datadog Agent over port 8125. If you are running the Agent as a container, ensure that DD_DOGSTATSD_NON_LOCAL_TRAFFIC [is set to true][6], and that port 8125 is open on the Agent. For example, in Kubernetes [bind the DogstatsD port to a host port][7], and in ECS you would have to [set the approriate flags in your task definition][8].
+
 [1]: https://app.datadoghq.com/apm/services
 [2]: https://github.com/DataDog/integrations-core/search?q=jmx_metrics&unscoped_q=jmx_metrics
 [3]: /integrations/java/#configuration
 [4]: https://app.datadoghq.com/dash/integration/256/jvm-runtime-metrics
 [5]: https://github.com/DataDog/dd-trace-java/releases/tag/v0.24.0
+[6]: https://docs.datadoghq.com/agent/docker/#dogstatsd-custom-metrics
+[7]: https://docs.datadoghq.com/agent/kubernetes/dogstatsd/#bind-the-dogstatsd-port-to-a-host-port
+[8]: https://docs.datadoghq.com/integrations/amazon_ecs/?tab=python#create-an-ecs-task
 
 {{% /tab %}}
 {{% tab "Python" %}}

--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -455,7 +455,7 @@ Additional JMX metrics can be added using configuration files that are passed to
 
 ### Collecting JVM Metrics in Containerized Environments
 
-By default, JVM metrics from your Application are sent to the Datadog Agent over port 8125. If you are running the Agent as a container, ensure that DD_DOGSTATSD_NON_LOCAL_TRAFFIC [is set to true][6], and that port 8125 is open on the Agent. For example, in Kubernetes [bind the DogstatsD port to a host port][7], and in ECS you would have to [set the approriate flags in your task definition][8].
+By default, JVM metrics from your application are sent to the Datadog Agent over port 8125. If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to true][6], and that port 8125 is open on the Agent. For example: in Kubernetes, [bind the DogstatsD port to a host port][7]; in ECS, [set the approriate flags in your task definition][8].
 
 [1]: https://app.datadoghq.com/apm/services
 [2]: https://github.com/DataDog/integrations-core/search?q=jmx_metrics&unscoped_q=jmx_metrics


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->
The Runtime Metrics section was missing critical instructions if you were running in a containerized environment.

### Preview link
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/andrew/jmx-container-apm/tracing/advanced_usage/?tab=java#runtime-metrics
<!-- This is the base preview link. Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
