### PR TITLE
David.jones/fix screenboards error

### DIFF
--- a/content/en/api/screenboards/code_snippets/api-screenboard-get-all.py
+++ b/content/en/api/screenboards/code_snippets/api-screenboard-get-all.py
@@ -1,0 +1,10 @@
+from datadog import initialize, api
+
+options = {
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
+}
+
+initialize(**options)
+
+api.Screenboard.get_all()

--- a/content/en/api/screenboards/code_snippets/api-screenboard-get-all.rb
+++ b/content/en/api/screenboards/code_snippets/api-screenboard-get-all.rb
@@ -1,0 +1,9 @@
+require 'rubygems'
+require 'dogapi'
+
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
+
+dog = Dogapi::Client.new(api_key, app_key)
+
+result = dog.get_all_screenboards()

--- a/content/en/api/screenboards/code_snippets/api-screenboard-get-all.sh
+++ b/content/en/api/screenboards/code_snippets/api-screenboard-get-all.sh
@@ -1,0 +1,5 @@
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
+
+curl -X GET "https://api.datadoghq.com/api/v1/screen?api_key=${api_key}&application_key=${app_key}"
+

--- a/content/en/api/screenboards/code_snippets/result.api-screenboard-get-all.py
+++ b/content/en/api/screenboards/code_snippets/result.api-screenboard-get-all.py
@@ -1,0 +1,22 @@
+{
+    'screenboards': [
+        {
+            'description': 'This has all the new hotness.',
+            'id': '2551',
+            'resource': '/api/v1/screen/2551',
+            'title': 'New and Improved Screenboard',
+            'created': '2015-12-17T21:29:40.890824+00:00',
+            'modified': '2015-12-17T21:39:20.770834+00:00',
+            'read_only': False
+        },
+        {
+            'description': 'And they are marvelous.',
+            'id': '2552',
+            'resource': '/api/v1/screen/2552',
+            'title': 'My First Metrics',
+            'created': '2015-12-17T21:29:40.890824+00:00',
+            'modified': '2015-12-17T21:39:20.770834+00:00',
+            'read_only': False
+        }
+    ]
+}

--- a/content/en/api/screenboards/code_snippets/result.api-screenboard-get-all.rb
+++ b/content/en/api/screenboards/code_snippets/result.api-screenboard-get-all.rb
@@ -1,0 +1,19 @@
+[
+    "200", {
+        "screenboards" => [{
+            "created" => "2015-12-17T20:00:25.050990+00:00",
+            "resource" => "/api/v1/screen/6334",
+            "id" => 6334,
+            "modified" => "2015-12-17T20:00:25.051176+00:00",
+            "title" => "dogapi test",
+            "read_only" => false
+        }, {
+            "created" => "2015-12-17T20:00:25.868731+00:00",
+            "resource" => "/api/v1/screen/2",
+            "id" => 2,
+            "modified" => "2015-12-17T20:00:25.868752+00:00",
+            "title" => "Database Screenboard",
+            "read_only" => false
+        }]
+    }
+]

--- a/content/en/api/screenboards/code_snippets/result.api-screenboard-get-all.sh
+++ b/content/en/api/screenboards/code_snippets/result.api-screenboard-get-all.sh
@@ -1,0 +1,21 @@
+
+[
+  {
+    'description': 'This has all the new hotness.',
+    'id': '2551',
+    'resource': '/api/v1/screen/2551',
+    'title': 'New and Improved Screenboard',
+    'created': '2015-12-17T23:06:06.703087+00:00',
+    'modified': '2015-12-17T23:12:26.726234+00:00',
+    'read_only': 'false'
+  },
+  {
+    'description': 'And they are marvelous.',
+    'id': '2552',
+    'resource': '/api/v1/screen/2552',
+    'title': 'My First Metrics',
+    'created': '2015-12-17T23:06:06.703087+00:00',
+    'modified': '2015-12-17T23:12:26.726234+00:00',
+    'read_only': 'false'
+  }
+]

--- a/layouts/section/api.html
+++ b/layouts/section/api.html
@@ -48,7 +48,7 @@
             </div>
             {{ $item := (index $codeList $index) | default (dict "Content" "")}}
             {{ $content := $item.Content | default "" }}
-            {{ $codelen := (len $content | default 0 }}
+            {{ $codelen := len $content | default 0 }}
             <div class="col-12 col-lg-6 api-code {{ if eq $codelen 0 }}empty{{ end }}">
                 {{ if gt $codelen 0 }}
                     <div class="code-container">

--- a/layouts/section/api.html
+++ b/layouts/section/api.html
@@ -46,7 +46,8 @@
             <div class="col-12 col-lg-6 api-content">
                 {{ $element.Content }}
             </div>
-            {{ $codelen := (len (index $codeList $index).Content)}}
+            {{ $item := (index $codeList $index) | default ""}}
+            {{ $codelen := (len (index $codeList $index).Content) | default 0 }}
             <div class="col-12 col-lg-6 api-code {{ if eq $codelen 0 }}empty{{ end }}">
                 {{ if gt $codelen 0 }}
                     <div class="code-container">

--- a/layouts/section/api.html
+++ b/layouts/section/api.html
@@ -46,8 +46,9 @@
             <div class="col-12 col-lg-6 api-content">
                 {{ $element.Content }}
             </div>
-            {{ $item := (index $codeList $index) | default ""}}
-            {{ $codelen := (len (index $codeList $index).Content) | default 0 }}
+            {{ $item := (index $codeList $index) | default (dict "Content" "")}}
+            {{ $content := $item.Content | default "" }}
+            {{ $codelen := (len $content | default 0 }}
             <div class="col-12 col-lg-6 api-code {{ if eq $codelen 0 }}empty{{ end }}">
                 {{ if gt $codelen 0 }}
                     <div class="code-container">


### PR DESCRIPTION
### What does this PR do?
I just noticed the docs master build is broken due to a recent translation pr merge.

This file `fr/api/screenboards/screenboards_getall_code.md` that was recently merged is trying to access code snippets that were deleted in this commit https://github.com/DataDog/documentation/commit/55c0116ddc2f525bfd4697eb5b0d3bdc577b94a1#diff-a62729bcecde8f963fe815d21bece0ae

This PR is just a bandaid to fix the hugo build error by putting in the code snippets the french file is referencing.

### Motivation
Noticed a build error in documentation-ci channel

