### PR TITLE
Add note about auto-discovery in a cluster

### DIFF
--- a/content/en/agent/prometheus.md
+++ b/content/en/agent/prometheus.md
@@ -28,7 +28,9 @@ Starting with version 6.1.0, the Agent includes a new [Prometheus][2] check capa
 
 ### Configuration
 
-Edit the `prometheus.yaml` file to add the different instances you want to retrieve custom metrics from.
+If running the Agent as a DaemonSet in Kubernetes, configure the Prometheus check using [auto-discovery][7].
+
+If running the Agent as a binary on a host, edit the `prometheus.yaml` file to add the different instances you want to retrieve custom metrics from.
 
 The minimal configuration of an instance includes:
 
@@ -97,3 +99,4 @@ Official integrations have their own dedicated directories. There's a default in
 [4]: /agent/autodiscovery
 [5]: https://github.com/DataDog/integrations-core/blob/master/prometheus/datadog_checks/prometheus/data/conf.yaml.example#L34
 [6]: https://github.com/DataDog/integrations-core/tree/master/kube_proxy
+[7]: /agent/prometheus/#auto-discovery


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds a note about  using auto-discovery to configure Prometheus when running the Agent as a DaemonSet.

### Motivation
<!-- What inspired you to submit this pull request?-->
Most users will be running the Agent as a DaemonSet, so make it obvious how the configuration should happen in that use case.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
