### PR TITLE
update Node APM docs for 0.10.0 release

### DIFF
--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -225,7 +225,7 @@ app.get('/posts', (req, res) => {
 
 **Adding tags to a current active span**
 
-Access the current active span from any method within your code. Note, however, that if the method is called and there is no span currently active, `tracer.scope().active()` returns `null`.
+Access the current active span from any method within your code. **Note**: If the method is called and there is no span currently active, `tracer.scope().active()` returns `null`.
 
 ```javascript
 // e.g. adding tag to active span
@@ -300,8 +300,8 @@ section for details on how environment variables should be set.
 DD_TRACE_GLOBAL_TAGS=key1:value1,key2:value2
 ```
 
-[1]: /tracing/languages/php/#configuration
 
+[1]: /tracing/languages/php/#configuration
 {{% /tab %}}
 {{% tab "C++" %}}
 
@@ -436,11 +436,11 @@ JVM metrics collection can be enabled with one configuration parameter in the tr
 * System Property: `-Ddd.jmxfetch.enabled=true`
 * Environment Variable: `DD_JMXFETCH_ENABLED=true`
 
-JVM metrics can be viewed in correlation with your Java services. You can get started [here][1].
+JVM metrics can be viewed in correlation with your Java services. See the [Service page][1] in Datadog.
 
 {{< img src="tracing/jvm-runtime.png" alt="JVM Runtime" responsive="true" style="width:100%;">}}
 
-**Note**: For the runtime UI, `dd-trace-java` >= [`0.24.0`][5] is supported.
+**Note**: For the runtime UI, `dd-trace-java` >= [`0.24.0`][2] is supported.
 
 ### Data Collected
 
@@ -448,23 +448,23 @@ The following metrics are collected by default after enabling JVM metrics.
 
 {{< get-metrics-from-git "java" >}}
 
-Along with displaying these metrics in your APM Service Page, Datadog provides a [default JVM Runtime Dashboard][4] with the `service` and `runtime-id` tags that are applied to these metrics.
+Along with displaying these metrics in your APM Service Page, Datadog provides a [default JVM Runtime Dashboard][3] with the `service` and `runtime-id` tags that are applied to these metrics.
 
-Additional JMX metrics can be added using configuration files that are passed to `jmxfetch.metrics-configs`. You can also enable existing Datadog JMX integrations individually with the `dd.integration.<name>` parameter. This auto-embeds configuration from Datadog's [existing JMX configuration files][2]. See the [JMX Integration][3] for further details on configuration.
+Additional JMX metrics can be added using configuration files that are passed to `jmxfetch.metrics-configs`. You can also enable existing Datadog JMX integrations individually with the `dd.integration.<name>` parameter. This auto-embeds configuration from Datadog's [existing JMX configuration files][4]. See the [JMX Integration][5] for further details on configuration.
 
 ### Collecting JVM Metrics in Containerized Environments
 
 By default, JVM metrics from your application are sent to the Datadog Agent over port 8125. If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to true][6], and that port 8125 is open on the Agent. For example: in Kubernetes, [bind the DogstatsD port to a host port][7]; in ECS, [set the approriate flags in your task definition][8].
 
+
 [1]: https://app.datadoghq.com/apm/services
-[2]: https://github.com/DataDog/integrations-core/search?q=jmx_metrics&unscoped_q=jmx_metrics
-[3]: /integrations/java/#configuration
-[4]: https://app.datadoghq.com/dash/integration/256/jvm-runtime-metrics
-[5]: https://github.com/DataDog/dd-trace-java/releases/tag/v0.24.0
+[2]: https://github.com/DataDog/dd-trace-java/releases/tag/v0.24.0
+[3]: https://app.datadoghq.com/dash/integration/256/jvm-runtime-metrics
+[4]: https://github.com/DataDog/integrations-core/search?q=jmx_metrics&unscoped_q=jmx_metrics
+[5]: /integrations/java/#configuration
 [6]: https://docs.datadoghq.com/agent/docker/#dogstatsd-custom-metrics
 [7]: https://docs.datadoghq.com/agent/kubernetes/dogstatsd/#bind-the-dogstatsd-port-to-a-host-port
 [8]: https://docs.datadoghq.com/integrations/amazon_ecs/?tab=python#create-an-ecs-task
-
 {{% /tab %}}
 {{% tab "Python" %}}
 
@@ -482,29 +482,29 @@ Coming Soon. Reach out to [the Datadog support team][1] to be part of the beta.
 
 Coming Soon. Reach out to [the Datadog support team][1] to be part of the beta.
 
-[1]: /help
 
+[1]: /help
 {{% /tab %}}
 {{% tab "Node.js" %}}
 
 Coming Soon. Reach out to [the Datadog support team][1] to be part of the beta.
 
-[1]: /help
 
+[1]: /help
 {{% /tab %}}
 {{% tab ".NET" %}}
 
 Coming Soon. Reach out to [the Datadog support team][1] to be part of the beta.
 
-[1]: /help
 
+[1]: /help
 {{% /tab %}}
 {{% tab "PHP" %}}
 
 Coming Soon. Reach out to [the Datadog support team][1] to be part of the beta.
 
-[1]: /help
 
+[1]: /help
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -794,11 +794,11 @@ Prior to PHP 7, some frameworks provided ways to compile PHP classes—e.g., thr
 While this [has been deprecated][3] if you are using PHP 7.x, you still may use this caching mechanism in your app prior to version 7.x. In this case, Datadog suggests you use the [OpenTracing][4] API instead of adding `datadog/dd-trace` to your Composer file.
 
 
+
 [1]: /tracing/languages/php/#automatic-instrumentation
 [2]: https://github.com/DataDog/dd-trace-php/releases/latest
 [3]: https://laravel-news.com/laravel-5-6-removes-artisan-optimize
 [4]: #opentracing
-
 {{% /tab %}}
 {{% tab "C++" %}}
 
@@ -2158,7 +2158,6 @@ If you are using an NGINX server, use the `error_log` directive.
 If you are configuring instead at the PHP level, use PHP's `error_log` ini parameter.
 
 [1]: http://php.net/manual/en/install.php
-[2]: https://www.php-fig.org/psr/psr-3
 {{% /tab %}}
 {{% tab "C++" %}}
 

--- a/content/en/tracing/languages/nodejs.md
+++ b/content/en/tracing/languages/nodejs.md
@@ -100,14 +100,14 @@ For details about how to how to toggle and configure plugins, check out the [API
 
 | Module                 | Versions    | Support Type    |  Notes              |
 | :----------            | :---------- | :-------------- | :------------------ |
-| [cassandra-driver][18] |             | Coming Soon     |                     |
+| [cassandra-driver][18] | `>=3`       | Fully Supported |                     |
 | [elasticsearch][19]    | `>=10`      | Fully Supported |                     |
 | [ioredis][20]          | `>=2`       | Fully Supported |                     |
 | [memcached][21]        | `>=2.2`     | Fully Supported |                     |
 | [mongodb-core][22]     | `>=2`       | Fully Supported | Supports Mongoose   |
 | [mysql][23]            | `>=2`       | Fully Supported |                     |
 | [mysql2][24]           | `>=1`       | Fully Supported |                     |
-| [pg][25]               | `>=4`       | Fully Supported | `pg-native` support coming soon |
+| [pg][25]               | `>=4`       | Fully Supported | Supports `pg-native` when used with `pg` |
 | [redis][26]            | `>=0.12`    | Fully Supported |                     |
 
 #### Worker Compatibility

--- a/content/en/tracing/languages/nodejs.md
+++ b/content/en/tracing/languages/nodejs.md
@@ -79,62 +79,62 @@ For details about how to how to toggle and configure plugins, check out the [API
 
 #### Web Framework Compatibility
 
-| Module        | Versions    | Support Type    | Notes                        |
-| :----------   | :---------- | :-------------- | :--------------------------- |
-| [express][10] | `>=4`       | Fully Supported | Supports Sails, Loopback, and [more][11] |
-| [graphql][12] | `>=0.10`    | Fully Supported | Supports Apollo Server and express-graphql |
-| [hapi][13]    | `>=2`       | Fully Supported |                              |
-| [koa][14]     | `>=2`       | Fully Supported |                              |
-| [restify][15] | `>=3`       | Fully Supported |                              |
+| Module        | Versions | Support Type    | Notes                                      |
+|---------------|----------|-----------------|--------------------------------------------|
+| [express][10] | `>=4`    | Fully Supported | Supports Sails, Loopback, and [more][11]   |
+| [graphql][12] | `>=0.10` | Fully Supported | Supports Apollo Server and express-graphql |
+| [hapi][13]    | `>=2`    | Fully Supported |                                            |
+| [koa][14]     | `>=2`    | Fully Supported |                                            |
+| [restify][15] | `>=3`    | Fully Supported |                                            |
 
 #### Native Module Compatibility
 
-| Module               | Support Type    |
-| :------------------- | :-------------- |
-| [dns][37]            | Fully Supported |
-| [http][16]           | Fully Supported |
-| [https][17]          | Fully Supported |
-| [net][38]            | Fully Supported |
+| Module      | Support Type    |
+|-------------|-----------------|
+| [dns][16]   | Fully Supported |
+| [http][17]  | Fully Supported |
+| [https][18] | Fully Supported |
+| [net][19]   | Fully Supported |
 
 #### Data Store Compatibility
 
-| Module                 | Versions    | Support Type    |  Notes              |
-| :----------            | :---------- | :-------------- | :------------------ |
-| [cassandra-driver][18] | `>=3`       | Fully Supported |                     |
-| [elasticsearch][19]    | `>=10`      | Fully Supported |                     |
-| [ioredis][20]          | `>=2`       | Fully Supported |                     |
-| [memcached][21]        | `>=2.2`     | Fully Supported |                     |
-| [mongodb-core][22]     | `>=2`       | Fully Supported | Supports Mongoose   |
-| [mysql][23]            | `>=2`       | Fully Supported |                     |
-| [mysql2][24]           | `>=1`       | Fully Supported |                     |
-| [pg][25]               | `>=4`       | Fully Supported | Supports `pg-native` when used with `pg` |
-| [redis][26]            | `>=0.12`    | Fully Supported |                     |
+| Module                 | Versions | Support Type    | Notes                                    |
+|------------------------|----------|-----------------|------------------------------------------|
+| [cassandra-driver][20] | `>=3`    | Fully Supported |                                          |
+| [elasticsearch][21]    | `>=10`   | Fully Supported |                                          |
+| [ioredis][22]          | `>=2`    | Fully Supported |                                          |
+| [memcached][23]        | `>=2.2`  | Fully Supported |                                          |
+| [mongodb-core][24]     | `>=2`    | Fully Supported | Supports Mongoose                        |
+| [mysql][25]            | `>=2`    | Fully Supported |                                          |
+| [mysql2][26]           | `>=1`    | Fully Supported |                                          |
+| [pg][27]               | `>=4`    | Fully Supported | Supports `pg-native` when used with `pg` |
+| [redis][28]            | `>=0.12` | Fully Supported |                                          |
 
 #### Worker Compatibility
 
-| Module             | Versions    | Support Type    | Notes                   |
-| :----------        | :---------- | :-------------- | :---------------------- |
-| [amqp10][27]       | `>=3`       | Fully Supported | Supports AMQP 1.0 brokers (i.e. ActiveMQ, Apache Qpid) |
-| [amqplib][28]      | `>=0.5`     | Fully Supported | Supports AMQP 0.9 brokers (i.e. RabbitMQ, Apache Qpid) |
-| [generic-pool][39] | `>=2`       | Fully Supported |                         |
-| [kafka-node][29]   |             | Coming Soon     |                         |
-| [rhea][30]         |             | Coming Soon     |                         |
+| Module             | Versions | Support Type    | Notes                                                  |
+|--------------------|----------|-----------------|--------------------------------------------------------|
+| [amqp10][29]       | `>=3`    | Fully Supported | Supports AMQP 1.0 brokers (i.e. ActiveMQ, Apache Qpid) |
+| [amqplib][30]      | `>=0.5`  | Fully Supported | Supports AMQP 0.9 brokers (i.e. RabbitMQ, Apache Qpid) |
+| [generic-pool][31] | `>=2`    | Fully Supported |                                                        |
+| [kafka-node][32]   |          | Coming Soon     |                                                        |
+| [rhea][33]         |          | Coming Soon     |                                                        |
 
 #### Promise Library Compatibility
 
-| Module           | Versions    | Support Type    |
-| :----------      | :---------- | :-------------- |
-| [bluebird][31]   | `>=2`       | Fully Supported |
-| [q][32]          | `>=1`       | Fully Supported |
-| [when][33]       | `>=3`       | Fully Supported |
+| Module         | Versions | Support Type    |
+|----------------|----------|-----------------|
+| [bluebird][34] | `>=2`    | Fully Supported |
+| [q][35]        | `>=1`    | Fully Supported |
+| [when][36]     | `>=3`    | Fully Supported |
 
 #### Logger Compatibility
 
-| Module                 | Versions    | Support Type    |
-| :----------            | :---------- | :-------------- |
-| [bunyan][34]           | `>=1`       | Fully Supported |
-| [pino][35]             | `>=2`       | Fully Supported |
-| [winston][36]          | `>=1`       | Fully Supported |
+| Module        | Versions | Support Type    |
+|---------------|----------|-----------------|
+| [bunyan][37]  | `>=1`    | Fully Supported |
+| [pino][38]    | `>=2`    | Fully Supported |
+| [winston][39] | `>=1`    | Fully Supported |
 
 ## Further Reading
 
@@ -155,27 +155,27 @@ For details about how to how to toggle and configure plugins, check out the [API
 [13]: https://hapijs.com
 [14]: https://koajs.com
 [15]: http://restify.com
-[16]: https://nodejs.org/api/http.html
-[17]: https://nodejs.org/api/https.html
-[18]: https://github.com/datastax/nodejs-driver
-[19]: https://github.com/elastic/elasticsearch-js
-[20]: https://github.com/luin/ioredis
-[21]: https://github.com/3rd-Eden/memcached
-[22]: http://mongodb.github.io/node-mongodb-native/core
-[23]: https://github.com/mysqljs/mysql
-[24]: https://github.com/sidorares/node-mysql2
-[25]: https://node-postgres.com
-[26]: https://github.com/NodeRedis/node_redis
-[27]: https://github.com/noodlefrenzy/node-amqp10
-[28]: https://github.com/squaremo/amqp.node
-[29]: https://github.com/SOHU-Co/kafka-node
-[30]: https://github.com/amqp/rhea
-[31]: https://github.com/petkaantonov/bluebird
-[32]: https://github.com/kriskowal/q
-[33]: https://github.com/cujojs/when
-[34]: https://github.com/trentm/node-bunyan
-[35]: http://getpino.io
-[36]: https://github.com/winstonjs/winston
-[37]: https://nodejs.org/api/dns.html
-[38]: https://nodejs.org/api/net.html
-[39]: https://github.com/coopernurse/node-pool
+[16]: https://nodejs.org/api/dns.html
+[17]: https://nodejs.org/api/http.html
+[18]: https://nodejs.org/api/https.html
+[19]: https://nodejs.org/api/net.html
+[20]: https://github.com/datastax/nodejs-driver
+[21]: https://github.com/elastic/elasticsearch-js
+[22]: https://github.com/luin/ioredis
+[23]: https://github.com/3rd-Eden/memcached
+[24]: http://mongodb.github.io/node-mongodb-native/core
+[25]: https://github.com/mysqljs/mysql
+[26]: https://github.com/sidorares/node-mysql2
+[27]: https://node-postgres.com
+[28]: https://github.com/NodeRedis/node_redis
+[29]: https://github.com/noodlefrenzy/node-amqp10
+[30]: https://github.com/squaremo/amqp.node
+[31]: https://github.com/coopernurse/node-pool
+[32]: https://github.com/SOHU-Co/kafka-node
+[33]: https://github.com/amqp/rhea
+[34]: https://github.com/petkaantonov/bluebird
+[35]: https://github.com/kriskowal/q
+[36]: https://github.com/cujojs/when
+[37]: https://github.com/trentm/node-bunyan
+[38]: http://getpino.io
+[39]: https://github.com/winstonjs/winston


### PR DESCRIPTION
### What does this PR do?

This PR updates the documentation with the following changes:

* Add `cassandra-driver` and `pg-native` to the list of integrations.
* Update all references to the scope manager with the new API.
* Fix trailing spaces (was done automatically by my editor).
* Remove the default value of `0` for log injection since it's no longer required.

### Motivation

`dd-trace-js` 0.10.0 was released with changes that should be documented.

### Preview link

https://docs-staging.datadoghq.com/rochdev/v0.10.0/tracing/languages/nodejs/#data-store-compatibility
https://docs-staging.datadoghq.com/rochdev/v0.10.0/tracing/advanced_usage/?tab=nodejs

### Additional Notes

