### PR TITLE
Update GCP integration API doc.

### DIFF
--- a/content/en/api/integrations/code_snippets/api-integrations-gcp.sh
+++ b/content/en/api/integrations/code_snippets/api-integrations-gcp.sh
@@ -27,15 +27,25 @@ curl -X POST -H "Content-type: application/json" \
     }' \
 "https://app.datadoghq.com/api/v1/integration/gcp?api_key=${api_key}&application_key=${app_key}"
 
+# Update a GCP Service Account's automute option in Datadog
+# project_id and client_email are required
+curl -X PUT -H "Content-type: application/json" \
+-d '{
+        "project_id": "<GCP_PROJECT_ID>",
+        "client_email": "<CLIENT_EMAIL>",
+        "automute": <AUTOMUTE> # true or false
+    }' \
+"https://app.datadoghq.com/api/v1/integration/gcp?api_key=${api_key}&application_key=${app_key}"
+
 # Update a GCP Service Account's host filters in Datadog
 # project_id and client_email are required
-curl -X POST -H "Content-type: application/json" \
+curl -X PUT -H "Content-type: application/json" \
 -d '{
         "project_id": "<GCP_PROJECT_ID>",
         "client_email": "<CLIENT_EMAIL>",
         "host_filters": "<KEY_1>:<VALUE_1>,<KEY_2>:<VALUE_2>"
     }' \
-"https://app.datadoghq.com/api/v1/integration/gcp/host_filters?api_key=${api_key}&application_key=${app_key}"
+"https://app.datadoghq.com/api/v1/integration/gcp?api_key=${api_key}&application_key=${app_key}"
 
 # Delete a GCP Service Account in Datadog
 # project_id and client_email are required

--- a/content/en/api/integrations/gcp.md
+++ b/content/en/api/integrations/gcp.md
@@ -14,6 +14,8 @@ Configure your Datadog-Google Cloud Platform integration directly through the Da
 
 * Using the `POST` method updates your integration configuration by **adding** your new configuration to the existing one in your Datadog organization. 
 
+* Using the `PUT` method updates the existing integration configuration in your Datadog organization.
+
 ##### ARGUMENTS
 
 All of the following fields' values are provided by the JSON service account key file created in the [GCP Console for service accounts][2]; Refer to the [Datadog-Google Cloud Platform integration installation instructions][3] to see how to generate one for your organization. 
@@ -62,6 +64,10 @@ For further references, consult the [Google Cloud service account documentation]
 * **`host_filters`** [*optional*]:
 
     Limit the GCE instances that are pulled into Datadog by using tags. Only hosts that match one of the defined tags are imported into Datadog.
+
+* **`automute`** [*optional*, *default*=**false**]:
+
+    Silence monitors for expected GCE instance shutdowns.
 
 [1]: /integrations/google_cloud_platform
 [2]: https://console.cloud.google.com/iam-admin/serviceaccounts


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates GCP integration API documentation with the newly added `PUT` method, which allows customers to update certain settings, such as `automute`, of an existing integration.
Updates GCP integration API code examples.

### Motivation
GCP integration API now supports updating an existing interation using the `PUT` method.
GCP integration now supports "automuting".

### Preview link
https://docs-staging.datadoghq.com/tian.chu/gcp-int-api-put-automute/api/?lang=bash#google-cloud-platform
