### PR TITLE
remove note about UBlock because it's no longer true

### DIFF
--- a/content/en/graphing/dashboards/_index.md
+++ b/content/en/graphing/dashboards/_index.md
@@ -32,8 +32,6 @@ Search across your Dashboard with the search bar at the top of the page. Dashboa
 
 A Dashboard's popularity is relative. An organization's most popular Dashboard appears as 5 bars; all other Dashboards are relative to that. Popularity is based upon the amount of traffic a Dashboard is getting and is updated daily, so new Dashboards have 0 popularity bars for up to the first 24 hours.
 
-If you are using uBlock or a similar browser plugin to block web beacons, your traffic won't impact a Dashboard's popularity.
-
 **Note**: Traffic to the public URLs of public Dashboards is ignored.
 
 ## Create a Dashboard list

--- a/content/fr/graphing/dashboards/_index.md
+++ b/content/fr/graphing/dashboards/_index.md
@@ -31,8 +31,6 @@ Effectuez des recherches dans votre dashboard grâce à la barre de recherche en
 
 La popularité d'un dashboard est relative. Le dashboard le plus populaire d'une entreprise est représenté par cinq barres, et la popularité de tous les autres dashboards dépend de ce dernier. La popularité est basée sur le trafic d'un dashboard et est mise à jour quotidiennement. Par conséquent, les nouveaux dashboards n'ont aucune barre de popularité pendant les 24 premières heures.
 
-Si vous utilisez uBlock ou un plug-in de navigateur similaire pour bloquer les balises Web, votre trafic n'aura aucune incidence sur la popularité d'un dashboard.
-
 **Remarque** : le trafic vers des URL publiques de dashboards publics n'est pas pris en compte.
 
 ## Créer une liste de dashboards


### PR DESCRIPTION
### What does this PR do?

UBlock no longer prevents us from capturing app usage data, so the note in the docs about users being excluded if they use an ad blocker is no longer true. Remove the note!

### Preview link

https://docs-staging.datadoghq.com/stephen/no-ublock/graphing/dashboards/#popularity

