### PR TITLE
More visibility for Reserved attributes in logs

### DIFF
--- a/content/en/logs/log_collection/ruby.md
+++ b/content/en/logs/log_collection/ruby.md
@@ -89,7 +89,7 @@ config.lograge.custom_options = lambda do |event|
 end
 ```
 
-**Note**:You can also ask Lograge to add contextual information to your logs. Refer to the official doc if you are interested: [Lograge documentation][1]
+**Note**:You can also ask Lograge to add contextual information to your logs. Refer to the official doc if you are interested: [Lograge documentation][2]
 
 ## Disable log coloration
 As it would be weirdly displayed in your Datadog application, disable your log coloration:
@@ -130,7 +130,7 @@ Logging.appenders.file(
 )
 ```
 
-If you want to tweak the log layout, all items available can be found directly from the [source repository][2]
+If you want to tweak the log layout, all items available can be found directly from the [source repository][3]
 
 ## Configure your Datadog Agent.
 
@@ -165,7 +165,7 @@ That's it! Now, all the rails calls are going to be in proper JSON automatically
 
 ### Inject trace IDs in your logs
 
-If APM is enabled for this application and you wish to improve the correlation between application logs and traces, [follow these instructions][3] to automatically add trace and span ids in your logs.
+If APM is enabled for this application and you wish to improve the correlation between application logs and traces, [follow these instructions][4] to automatically add trace and span ids in your logs.
 
 Once this is done, the log should have the following (for JSON format):
 
@@ -277,3 +277,4 @@ end
 [1]: https://docs.datadoghq.com/logs/?tab=ussite#reserved-attributes)
 [2]: https://github.com/roidrage/lograge#installation
 [3]: https://github.com/TwP/logging/blob/master/lib/logging/layouts/parseable.rb#L100
+[4]: 

--- a/content/en/logs/log_collection/ruby.md
+++ b/content/en/logs/log_collection/ruby.md
@@ -21,7 +21,7 @@ further_reading:
   text: "Log Collection Troubleshooting Guide"
 ---
 
-It's recommended to use `lograge` here as it helps to bring some sanity to logs that are noisy and hardly parseable. 
+It's recommended to use `lograge` here as it helps to bring some sanity to logs that are noisy and hardly parseable. When setting up logging with Ruby, make sure to keep in mind the [reserved attributes][1].
 
 Instead of having a Rail logging output like this:
 
@@ -274,6 +274,6 @@ end
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/roidrage/lograge#installation
-[2]: https://github.com/TwP/logging/blob/master/lib/logging/layouts/parseable.rb#L100
-[3]: https://docs.datadoghq.com/tracing/advanced_usage/?tab=ruby#correlate-traces-and-logs
+[1]: https://docs.datadoghq.com/logs/?tab=ussite#reserved-attributes)
+[2]: https://github.com/roidrage/lograge#installation
+[3]: https://github.com/TwP/logging/blob/master/lib/logging/layouts/parseable.rb#L100

--- a/content/en/logs/log_collection/ruby.md
+++ b/content/en/logs/log_collection/ruby.md
@@ -277,4 +277,4 @@ end
 [1]: https://docs.datadoghq.com/logs/?tab=ussite#reserved-attributes)
 [2]: https://github.com/roidrage/lograge#installation
 [3]: https://github.com/TwP/logging/blob/master/lib/logging/layouts/parseable.rb#L100
-[4]: 
+[4]: https://docs.datadoghq.com/tracing/advanced_usage/?tab=ruby#correlate-traces-and-logs


### PR DESCRIPTION
### What does this PR do?
Adds info about reserved attributes in the ruby log collection docs.

### Motivation
Support request

### Preview link
https://docs-staging.datadoghq.com/kaylyn/ruby-log-reserved-atts/logs/log_collection/ruby/
