### PR TITLE
SOCKS5 tab says 'SOCK5' instead of 'SOCKS5', this fixes the typo

### DIFF
--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -150,7 +150,7 @@ Those parameters can also be set with the following environment variables:
 [3]: /crt/FULL_intake.logs.datadoghq.com.crt
 [4]: /crt/FULL_intake.logs.datadoghq.eu.crt
 {{% /tab %}}
-{{% tab "SOCK5" %}}
+{{% tab "SOCKS5" %}}
 
 To send your logs to your Datadog account via a SOCKS5 proxy server use the following settings in your `datadog.yaml` configuration file:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Fixes typo in tab under proxy configuration. Should read "SOCKS5" reads "SOCK5" instead.

### Motivation

Saw the typo on our public-facing docs side and figured it would be worthwhile to submit the PR

### Preview link

https://cl.ly/b6cebc922dd1 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
