### PR TITLE
update the header and footer navigation to match corp

### DIFF
--- a/data/partials/footer.yaml
+++ b/data/partials/footer.yaml
@@ -2,25 +2,28 @@ col1:
   - name: product
     link: "https://www.datadoghq.com/product/"
     title: "Features"
+  - name: integrations
+    link: "https://www.datadoghq.com/product/integrations/"
+    title: "Integrations"
   - name: apm
     link: "https://www.datadoghq.com/apm/"
     title: "APM"
   - name: logs
     link: "https://www.datadoghq.com/log-management/"
     title: "Log Management"
-  - name: integrations
-    link: "https://www.datadoghq.com/product/integrations/"
-    title: "Integrations"
+  - name: dashboards
+    link: "https://www.datadoghq.com/dashboarding/"
+    title: "Dashboards"
+  - name: synthetics
+    link: "https://www.datadoghq.com/synthetics/"
+    title: "Synthetics"
   - name: alerts
     link: "https://www.datadoghq.com/alerts/"
     title: "Alerts"
-  - name: api
-    link: "api/"
-    title: "API"
+col2:
   - name: pricing
     link: "https://www.datadoghq.com/pricing/"
     title: "Pricing"
-col2:
   - name: documentation
     link: "https://docs.datadoghq.com/"
     title: "Documentation"
@@ -33,6 +36,9 @@ col2:
   - name: security
     link: "https://www.datadoghq.com/security/"
     title: "Security"
+  - name: api
+    link: "api/"
+    title: "API"
 col3:
   - name: contact
     link: "https://www.datadoghq.com/about/contact/"
@@ -52,6 +58,9 @@ col3:
   - name: legal
     link: "https://www.datadoghq.com/legal/"
     title: "Legal"
+  - name: analyst
+    link: "https://www.datadoghq.com/about/analyst/"
+    title: "Analyst Reports"
 col4:
   - name: blog
     link: "https://www.datadoghq.com/blog/"

--- a/data/partials/header.yaml
+++ b/data/partials/header.yaml
@@ -18,6 +18,9 @@ left:
           - name: product_dashboards
             link: "https://www.datadoghq.com/dashboarding/"
             title: "Dashboards"
+          - name: product_synthetics
+            link: "https://www.datadoghq.com/synthetics/"
+            title: "Synthetics"
           - name: product_alerts
             link: "https://www.datadoghq.com/alerts/"
             title: "Alerts"
@@ -66,6 +69,9 @@ right:
           - name: blog_engineering
             link: "https://www.datadoghq.com/blog/engineering/"
             title: "Engineering"
+          - name: blog_community
+            link: "https://www.datadoghq.com/blog/community/"
+            title: "Community"
           - name: blog_pupculture
             link: "https://www.datadoghq.com/blog/pup-culture/"
             title: "Pup Culture"


### PR DESCRIPTION
### What does this PR do?
Updates the header and footer navigation to match corp site. We were missing the synthetics link and community blog section among other changes.

### Motivation
Just happened to notice today

### Preview link
https://docs-staging.datadoghq.com/david.jones/update-navigation/

