### PR TITLE
removing graphing primer link + clarifying `apm_non_local_traffic` apm param description

### DIFF
--- a/content/en/agent/apm/_index.md
+++ b/content/en/agent/apm/_index.md
@@ -84,7 +84,7 @@ Find below the list of all available parameters for your `datadog.yaml` configur
 | `log_file`                | string      | Location of the log file.                                                                                                                                          |
 | `replace_tags`            | list        | A list of tag replacement rules. See the [Scrubbing sensitive information](#scrubbing-sensitive-information) section.                                              |
 | `receiver_port`           | number      | Port that the Datadog Agent's trace receiver listen on. Default value is `8126`.                                                                                   |
-| `apm_non_local_traffic`   | boolean     | Allows the Agent to receive outside connections. It then listen on all interfaces.                                                                                 |
+| `apm_non_local_traffic`   | boolean     | Set to `true` to allow the Agent to receive outside connections, and then listen on all interfaces.                                                                                 |
 | `max_memory`              | float       | Maximum memory that the Agent is allowed to occupy. When this is exceeded the process is killed.                                                                   |
 | `max_cpu_percent`         | float       | Maximum CPU percentage that the Agent should use. The Agent automatically adjusts its pre-sampling rate to stay below this number.                                 |
   

--- a/content/en/graphing/dashboards/timeboard.md
+++ b/content/en/graphing/dashboards/timeboard.md
@@ -25,7 +25,7 @@ Event Correlation refers to overlaying events on top of a dashboard graph. You c
 
 {{< img src="graphing/dashboards/guides-eventcorrelation-screenboard.png" alt="guides-eventcorrelation-screenboard" responsive="true" style="width:90%;">}}
 
-Set up event correlation at design time by editing any graph on both Timeboards and Screenboards and adding events to the graph. To learn more about this, visit the [Graphing Primer][1]. You can find details about adding events [using the UI][2] or via the JSON interface further down the page.
+Set up event correlation at design time by editing any graph on both Timeboards and Screenboards and adding events to the graph. You can find details about adding events [using the UI][1] or via the JSON interface further down the page.
 
 ## Event Correlation at View Time
 
@@ -53,15 +53,15 @@ To define the most related logs, the following parameters are used:
 
 ## Read Only
 
-[An Administrator][1] or Timeboard creator can make a Timeboard read-only by clicking the gear icon (upper right corner of a Timeboard) and clicking the **Permissions** link:
+[An Administrator][2] or Timeboard creator can make a Timeboard read-only by clicking the gear icon (upper right corner of a Timeboard) and clicking the **Permissions** link:
 
 {{< img src="graphing/dashboards/timeboard/read_only.png" alt="Read Only" responsive="true" style="width:30%;">}}
 
 **Click "Yes" on the confirmation window to make the Timeboard read-only**
 
-Only account [administrators][1] and the Timeboard creator can activate read-only mode for a Timeboard. Any user in the organization, regardless of administrator privileges, can sign up to receive change notifications for a particular Timeboard.
+Only account [administrators][2] and the Timeboard creator can activate read-only mode for a Timeboard. Any user in the organization, regardless of administrator privileges, can sign up to receive change notifications for a particular Timeboard.
 
-If a user decides to track changes for a Timeboard, the following Timeboard changes are reported to the user through an event in the [event stream][2]:
+If a user decides to track changes for a Timeboard, the following Timeboard changes are reported to the user through an event in the [event stream][1]:
 
 1. Text changes (title, description)
 2. Tile changes
@@ -106,8 +106,8 @@ Special thanks to [Brightcove][4], [Shopify][5], and [Zendesk][6] for sharing th
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /account_management/team/#datadog-user-roles
-[2]: /graphing/event_stream
+[1]: /graphing/event_stream
+[2]: 
 [3]: /api
 [4]: https://www.brightcove.com
 [5]: https://www.shopify.com

--- a/content/en/graphing/dashboards/timeboard.md
+++ b/content/en/graphing/dashboards/timeboard.md
@@ -107,7 +107,7 @@ Special thanks to [Brightcove][4], [Shopify][5], and [Zendesk][6] for sharing th
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /graphing/event_stream
-[2]: 
+[2]: /account_management/team/#datadog-user-roles
 [3]: /api
 [4]: https://www.brightcove.com
 [5]: https://www.shopify.com


### PR DESCRIPTION
### What does this PR do?
Removing a link that doesn't make sense.

### Motivation
It's completely incorrect.

### Preview link

https://docs-staging.datadoghq.com/kaylyn/timeboard-graphing-primer/graphing/dashboards/timeboard/#event-correlation-at-design-time

