### PR TITLE
Synthetics out of beta

### DIFF
--- a/content/en/synthetics/_index.md
+++ b/content/en/synthetics/_index.md
@@ -17,7 +17,7 @@ further_reading:
   text: "Configure a Browser Test"
 ---
 
-<div class="alert alert-warning">Synthetics is currently in beta for the Datadog US Site. To request access complete the <a href="https://app.datadoghq.com/synthetics/beta">Datadog Synthetics Request form</a>.</div>
+<div class="alert alert-warning">Synthetics is only available in the US. Browser tests are available in beta: to request access complete the <a href="https://app.datadoghq.com/synthetics/beta">Datadog Synthetics Request form</a>.</div>
 
 ## Overview
 

--- a/content/en/synthetics/api_test.md
+++ b/content/en/synthetics/api_test.md
@@ -17,7 +17,7 @@ further_reading:
   text: "Configure a Browser Test"
 ---
 
-<div class="alert alert-warning">Synthetics is in beta for the Datadog US Site. To request access, complete the <a href="https://app.datadoghq.com/synthetics/beta">Datadog Synthetics request form</a>.</div>
+<div class="alert alert-warning">Synthetics is only available in the US. Browser tests are available in beta: to request access complete the <a href="https://app.datadoghq.com/synthetics/beta">Datadog Synthetics Request form</a>.</div>
 
 ## Overview
 

--- a/content/en/synthetics/apm.md
+++ b/content/en/synthetics/apm.md
@@ -13,7 +13,7 @@ further_reading:
 
 ---
 
-<div class="alert alert-warning">Synthetics is in beta for the Datadog US Site. To request access, complete the <a href="https://app.datadoghq.com/synthetics/beta">Datadog Synthetics request form</a>.</div>
+<div class="alert alert-warning">Synthetics is only available in the US. Browser tests are available in beta: to request access complete the <a href="https://app.datadoghq.com/synthetics/beta">Datadog Synthetics Request form</a>.</div>
 
 {{< img src="synthetics/apm/synthetics-apm.gif" alt="APM and Synthetics" responsive="true" style="width:80%;">}}
 

--- a/content/en/synthetics/browser_test.md
+++ b/content/en/synthetics/browser_test.md
@@ -17,7 +17,7 @@ further_reading:
   text: "Configure an API Tests"
 ---
 
-<div class="alert alert-warning">Synthetics is in beta for the Datadog US Site. Request access via the <a href="https://app.datadoghq.com/synthetics/beta">Datadog Synthetics request form</a>.</div>
+<div class="alert alert-warning">Synthetics is only available in the US. Browser tests are available in beta: to request access complete the <a href="https://app.datadoghq.com/synthetics/beta">Datadog Synthetics Request form</a>.</div>
 
 ## Overview
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates the note box on top of all Synthetics pages to reflect that it's out of beta, but still only available in the US. Browser Tests are still in beta.

### Motivation
Request from @MargotLepizzera 

### Preview link

https://docs-staging.datadoghq.com/cswatt/synthetics-beta/synthetics
