### PR TITLE
[Widget Event] fixed broken link

### DIFF
--- a/content/en/graphing/widgets/event_timeline.md
+++ b/content/en/graphing/widgets/event_timeline.md
@@ -3,7 +3,7 @@ title: Event Timeline Widget
 kind: documentation
 description: "Display your Event Stream Timeline in a widget."
 further_reading:
-- link: "graphing/dashboards/Screenboard/"
+- link: "graphing/dashboards/screenboard/"
   tag: "Documentation"
   text: "Screenboard"
 - link: "graphing/graphing_json/"


### PR DESCRIPTION
### What does this PR do?
- Fix broken link on event timeline widget page

### Motivation
Top 404 URL graph

### Preview link
https://docs-staging.datadoghq.com/ruth/widget-event-link/graphing/widgets/event_timeline/#further-reading