### PR TITLE
Updates for APM .NET Tracer v0.8

### DIFF
--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -1592,8 +1592,6 @@ Once the sampling priority has been set, it cannot be changed. This is done auto
 
 Priority sampling is enabled by default. The default sampler automatically assigns a value of `AutoReject` or `AutoKeep` to traces, depending on their service and volume.
 
-The ability to set a trace's sampling priority manually is coming soon.
-
 {{% /tab %}}
 {{% tab "PHP" %}}
 

--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -249,7 +249,7 @@ using Datadog.Trace;
 var scope = Tracer.Instance.ActiveScope;
 
 // add a tag to the span
-span?.SetTag("<TAG_KEY>", "<TAG_VALUE>");
+scope.Span.SetTag("<TAG_KEY>", "<TAG_VALUE>");
 ```
 
 **Note**: `Datadog.Trace.Tracer.Instance.ActiveScope` returns `null` if there is no active span.

--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -708,9 +708,9 @@ For more information on manual instrumentation, see the [API documentation][2].
 {{% /tab %}}
 {{% tab ".NET" %}}
 
-If you aren’t using libraries supported by automatic instrumentation (see [Library compatibility][1]), you should manually instrument your code.
+If you are not using libraries supported by automatic instrumentation (see [Integrations][1]), you can instrument your code manually.
 
-The following example uses the global Datadog Tracer and creates a span to trace a web request:
+The following example uses the global `Tracer` and creates a custom span to trace a web request:
 
 ```csharp
 using Datadog.Trace;
@@ -727,7 +727,7 @@ using(var scope = Tracer.Instance.StartActive("web.request"))
 ```
 
 
-[1]: /tracing/languages/dotnet/#runtime-compatibility
+[1]: /tracing/languages/dotnet/#integrations
 {{% /tab %}}
 
 {{% tab "PHP" %}}

--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -2275,4 +2275,3 @@ apm_config:
 [5]: /tracing/getting_further/trace_sampling_and_storage
 [6]: /logs/log_collection/?tab=tailexistingfiles#send-your-application-logs-in-json
 [7]: /logs/log_collection/?tab=tailexistingfiles#enabling-log-collection-from-integrations
-[8]:

--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -407,7 +407,7 @@ const tracer = require('dd-trace').init({
 {{% /tab %}}
 {{% tab ".NET" %}}
 
-The .NET Tracer automatically reads the environment variables `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`. The Agent endpoint can also be set when creating a new `Tracer` instance:
+The .NET Tracer automatically reads the environment variables `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` to set the Agent endpoint. The Agent endpoint can also be set when creating a new `Tracer` instance:
 
 ```csharp
 using Datadog.Trace;

--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -245,11 +245,8 @@ Add tags directly to a `Datadog.Trace.Span` object by calling `Span.SetTag()`. F
 ```csharp
 using Datadog.Trace;
 
-// get the global tracer
-var tracer = Tracer.Instance;
-
-// get the currently active span (can be null)
-var span = tracer.ActiveScope?.Span;
+// access the active scope through the global tracer (can return null)
+var scope = Tracer.Instance.ActiveScope;
 
 // add a tag to the span
 span?.SetTag("<TAG_KEY>", "<TAG_VALUE>");
@@ -405,6 +402,21 @@ const tracer = require('dd-trace').init({
   hostname: process.env.DD_AGENT_HOST,
   port: process.env.DD_TRACE_AGENT_PORT
 })
+```
+
+{{% /tab %}}
+{{% tab ".NET" %}}
+
+The .NET Tracer automatically reads the environment variables `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`. The Agent endpoint can also be set when creating a new `Tracer` instance:
+
+```csharp
+using Datadog.Trace;
+
+var uri = new Uri("htt://localhost:8126/");
+var tracer = Tracer.Create(agentEndpoint: uri);
+
+// optional: set the new tracer as the new default/global tracer
+Tracer.Instance = tracer;
 ```
 
 {{% /tab %}}
@@ -1114,11 +1126,12 @@ The following tags are available to override Datadog specific options:
 For OpenTracing support, add the [`Datadog.Trace.OpenTracing`][1] NuGet package to your application. During application start-up, initialize the OpenTracing library:
 
 ```csharp
+using Datadog.Trace.OpenTracing;
+
 public void ConfigureServices(IServiceCollection services)
 {
     // create an OpenTracing ITracer with default setting
-    OpenTracing.ITracer tracer =
-        Datadog.Trace.OpenTracing.OpenTracingTracerFactory.CreateTracer();
+    OpenTracing.ITracer tracer = OpenTracingTracerFactory.CreateTracer();
 
     // to use tracer with ASP.NET Core dependency injection
     services.AddSingleton<ITracer>(tracer);
@@ -1339,9 +1352,9 @@ Distributed tracing is enabled by default for all supported integrations (see [C
 {{% /tab %}}
 {{% tab ".NET" %}}
 
-Coming Soon. Reach out to [the Datadog support team][1] to be part of the beta.
+Distributed tracing is enabled by default for all supported integrations (see [Integrations][1]).
 
-[1]: /help
+[1]: /tracing/languages/dotnet/#integrations
 {{% /tab %}}
 {{% tab "PHP" %}}
 
@@ -1577,7 +1590,9 @@ Once the sampling priority has been set, it cannot be changed. This is done auto
 {{% /tab %}}
 {{% tab ".NET" %}}
 
-Coming Soon. Reach out to [the Datadog support team][1] to be part of the beta.
+Priority sampling is enabled by default. The default sampler automatically assigns a value of `AutoReject` or `AutoKeep` to traces, depending on their service and volume.
+
+The ability to set a trace's sampling priority manually is coming soon.
 
 [1]: /help
 {{% /tab %}}
@@ -2142,7 +2157,12 @@ For more tracer settings, check out the [API documentation][2].
 Debug mode is disabled by default. To enable it, set the `isDebugEnabled` argument to `true` when creating a new tracer instance:
 
 ```csharp
-var tracer = Datadog.Trace.Tracer.Create(isDebugEnabled: true);
+using Datadog.Trace;
+
+var tracer = Tracer.Create(isDebugEnabled: true);
+
+// optional: set the new tracer as the new default/global tracer
+Tracer.Instance = tracer;
 ```
 
 {{% /tab %}}
@@ -2255,3 +2275,4 @@ apm_config:
 [5]: /tracing/getting_further/trace_sampling_and_storage
 [6]: /logs/log_collection/?tab=tailexistingfiles#send-your-application-logs-in-json
 [7]: /logs/log_collection/?tab=tailexistingfiles#enabling-log-collection-from-integrations
+[8]:

--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -1594,7 +1594,6 @@ Priority sampling is enabled by default. The default sampler automatically assig
 
 The ability to set a trace's sampling priority manually is coming soon.
 
-[1]: /help
 {{% /tab %}}
 {{% tab "PHP" %}}
 

--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -715,7 +715,7 @@ using(var scope = Tracer.Instance.StartActive("web.request"))
 ```
 
 
-[1]: /tracing/languages/dotnet/#compatibility
+[1]: /tracing/languages/dotnet/#runtime-compatibility
 {{% /tab %}}
 
 {{% tab "PHP" %}}

--- a/content/en/tracing/languages/dotnet.md
+++ b/content/en/tracing/languages/dotnet.md
@@ -286,7 +286,7 @@ The .NET Tracer supports automatic instrumentation on the following runtimes:
 | .NET Framework         | 4.5+     | Windows        | Public Beta  |
 | .NET Core <sup>1</sup> | 2.0+     | Windows, Linux | Public Beta  |
 
-<sup>1</sup> There was an issue in .NET Core versions 2.1.0, 2.1.1, and 2.1.2 that could prevent profilers from working correctly. This issue was fixed in .NET Core 2.1.3. See [this GitHub issue][9] for more details.
+<sup>1</sup> There is an issue in .NET Core versions 2.1.0, 2.1.1, and 2.1.2 that can prevent profilers from working correctly. This issue is fixed in .NET Core 2.1.3. See [this GitHub issue][9] for more details.
 
 Don’t see your desired frameworks? Datadog is continually adding additional support. [Check with the Datadog team][3] for help.
 

--- a/content/en/tracing/languages/dotnet.md
+++ b/content/en/tracing/languages/dotnet.md
@@ -304,7 +304,7 @@ The .NET Tracer can instrument the following libraries automatically:
 | WCF                             | built-in                                 |                  | _Coming soon_             |                      |
 | ADO.NET <sup>3</sup>            | built-in                                 |                  | Public Beta               | `AdoNet`             |
 | WebClient / WebRequest          | built-in                                 |                  | Public Beta               | `WebRequest`         |
-| HttpClient / HttpClientHandler  | built-in or `System.Net.Http`            |                  | Public Beta               | `HttpMessageHandler` |
+| HttpClient / HttpClientHandler  | built-in or `System.Net.Http`            | 4.0+             | Public Beta               | `HttpMessageHandler` |
 | Redis (StackExchange client)    | `StackExchange.Redis`                    | 1.0.187+         | Public Beta               | `StackExchangeRedis` |
 | Redis (ServiceStack client)     | `ServiceStack.Redis`                     | 4.0.48+          | Public Beta               | `ServiceStackRedis`  |
 | Elasticsearch                   | `NEST` / `Elasticsearch.Net`             | 6.0.0+           | Public Beta               | `ElasticsearchNet`   |

--- a/content/en/tracing/languages/dotnet.md
+++ b/content/en/tracing/languages/dotnet.md
@@ -314,7 +314,7 @@ Notes:
 
 <sup>1</sup> The `AspNet` integration adds instrumentation to any application based on `Systme.Web.HttpApplication`, which can include applications developed with Web Forms, MVC, Web API, and other web frameworks.
 
-<sup>2</sup> The `AspNet` integration not enabled by default as in .NET Tracer 0.8. To enable it manually for testing purposes, see the [release notes for .NET Tracer 0.8][7].
+<sup>2</sup> The `AspNet` integration is not enabled by default in .NET Tracer 0.8. To enable it manually for testing purposes, see the [release notes for .NET Tracer 0.8][7].
 
 <sup>3</sup> The ADO.NET integration tries to instrument **all** ADO.NET providers. Support was tested with SQL Server (`System.Data.SqlClient`) and PostgreSQL (`Npgsql`). Other providers (e.g. MySQL, SQLite, Oracle) might work, but have not been tested yet.
 

--- a/content/en/tracing/languages/dotnet.md
+++ b/content/en/tracing/languages/dotnet.md
@@ -300,7 +300,7 @@ The .NET Tracer can instrument the following libraries automatically:
 | ASP.NET MVC 4                   | `Microsoft.AspNet.Mvc`                   | 4.0.40804        | Public Beta               | `AspNetMvc`          |
 | ASP.NET Web API 2               | `Microsoft.AspNet.WebApi.Core`           | 5.2+             | Public Beta               | `AspNetWebApi2`      |
 | ASP.NET Core MVC                | `Microsoft.AspNetCore.Mvc.Core`          | 2.0+             | Public Beta               | `AspNetCoreMvc2`     |
-| ASP.NET Web Forms<sup>1</sup>   | built-in                                 |                  | Experimental <sup>2</sup> | `AspNet`             |
+| ASP.NET Web Forms <sup>1</sup>  | built-in                                 |                  | Experimental<sup>2</sup>  | `AspNet`             |
 | WCF                             | built-in                                 |                  | _Coming soon_             |                      |
 | ADO.NET <sup>3</sup>            | built-in                                 |                  | Public Beta               | `AdoNet`             |
 | WebClient / WebRequest          | built-in                                 |                  | Public Beta               | `WebRequest`         |

--- a/content/en/tracing/languages/dotnet.md
+++ b/content/en/tracing/languages/dotnet.md
@@ -300,7 +300,7 @@ The .NET Tracer can instrument the following libraries automatically:
 | ASP.NET MVC 4                   | `Microsoft.AspNet.Mvc`                   | 4.0.40804        | Public Beta               | `AspNetMvc`          |
 | ASP.NET Web API 2               | `Microsoft.AspNet.WebApi.Core`           | 5.2+             | Public Beta               | `AspNetWebApi2`      |
 | ASP.NET Web Forms<sup>1</sup>   | included with .NET Framework             |                  | Experimental <sup>2</sup> | `AspNet`             |
-| ASP.NET Core MVC                |                                          | 2.0+             | Public Beta               | `AspNetCoreMvc2`     |
+| ASP.NET Core MVC                | `Microsoft.AspNetCore.Mvc.Core`          | 2.0+             | Public Beta               | `AspNetCoreMvc2`     |
 | WCF                             | included with .NET Framework             |                  | _Coming soon_             |                      |
 | ADO.NET <sup>3</sup>            | included / `System.Data.Common`          | 4.0+             | Public Beta               | `AdoNet`             |
 | HttpClient / HttpClientHandler  | included / `System.Net.Http`             | 4.0+             | Public Beta               | `HttpMessageHandler` |

--- a/content/en/tracing/languages/dotnet.md
+++ b/content/en/tracing/languages/dotnet.md
@@ -126,7 +126,7 @@ apk add libc6-compat
 
 **Note:** If your application runs on IIS and you used the MSI installer, you don't need to configure environment variables manually and you may skip this section.
 
-**Note:** The .NET runtime will try to load a profiler into _any_ .NET process that is started while these environment variables are set. You should limit profiling only to the applications that need to be traced. **Do not set these environment variables globally as this causes _all_ .NET processes on the host to be profiled.**
+**Note:** The .NET runtime tries to load a profiler into _any_ .NET process that is started while these environment variables are set. You should limit profiling only to the applications that need to be traced. **Do not set these environment variables globally as this causes _all_ .NET processes on the host to be profiled.**
 
 {{< tabs >}}
 

--- a/content/en/tracing/languages/dotnet.md
+++ b/content/en/tracing/languages/dotnet.md
@@ -36,7 +36,7 @@ Automatic instrumentation captures:
 - Unhandled exceptions, including stacktraces if available
 - A total count of traces (e.g. web requests) flowing through the system
 
-### Installing libraries
+### Installation
 
 There are three components needed to enable automatic instrumentation.
 
@@ -273,53 +273,50 @@ Environment Variable       | Description                                        
 `DD_AGENT_HOST`            | Sets the host where traces are sent (the host running the Agent). Can be a hostname or an IP address. | `localhost`   |
 `DD_TRACE_AGENT_PORT`      | Sets the port where traces are sent (the port where the Agent is listening for connections).              | `8126`        |
 `DD_ENV`                   | Adds the `env` tag with the specified value to generated spans. See [Agent configuration][2] for more details about the `env` tag. | _empty_ (no `env` tag) |
-`DD_SERVICE_NAME`          | Sets the default service name. If not set, the .NET Tracer tries to determine service name automatically from application name (e.g. IIS application name, entry assembly, or process name). | _empty_ (determine service name automatically) |
-`DD_DISABLED_INTEGRATIONS` | Sets a list of integrations to disable. All other integrations remain enabled. If not set, all integrations are enabled. Supports multiple values separated with semicolons. Valid values are: `AspNetCoreMvc2`, `AspNetMvc`, `AspNetWebApi2`, `ElasticsearchNet`, `ServiceStackRedis`, `SqlServer`, `StackExchangeRedis` | _empty_ (all integrations enabled) |
+`DD_SERVICE_NAME`          | Sets the default service name. If not set, the .NET Tracer tries to determine service name automatically from application name (e.g. IIS application name, process entry assembly, or process name). | _empty_ (determine service name automatically) |
+`DD_DISABLED_INTEGRATIONS` | Sets a list of integrations to disable. All other integrations remain enabled. If not set, all integrations are enabled. Supports multiple values separated with semicolons. Valid values are the integration names listed in the [Integrations][8] section below | _empty_ (all integrations enabled) |
 `DD_TRACE_LOG_PATH`        | Sets the path for the profiler's log file. | Windows: `%ProgramData%\Datadog .NET Tracer\logs\dotnet-profiler.log`<br><br>Linux: `/var/log/datadog/dotnet-profiler.log` | |
 
 ### Runtime Compatibility
 
 The .NET Tracer supports automatic instrumentation on the following runtimes:
 
-| Runtime        | Versions | OS      | Support Type |
-| -------------- | -------- | ------- | ------------ |
-| .NET Framework | 4.5+     | Windows | Public Beta  |
-| .NET Core      | 2.0+     | Windows | Public Beta  |
-| .NET Core      | 2.0+     | Linux   | Public Beta  |
+| Runtime                | Versions | OS             | Support type |
+| ---------------------- | -------- | ---------------| ------------ |
+| .NET Framework         | 4.5+     | Windows        | Public Beta  |
+| .NET Core <sup>1</sup> | 2.0+     | Windows, Linux | Public Beta  |
 
-**Note**: Libraries that target .NET Standard 2.0 are supported when running on either .NET Framework 4.6.1+ or .NET Core 2.0+.
-
-Don’t see your desired frameworks? Datadog is continually adding additional support. [Check with the Datadog team][3] for help.
-
-### Web Framework Integrations
-
-The .NET Tracer can instrument the following web frameworks automatically:
-
-| Web framework     | Versions  | Runtime             | OS      | Support Type  | Integration Name |
-| ----------------- | --------- | ------------------- | ------- | ------------- | ---------------- |
-| ASP.NET MVC 5     | 5.1.3+    | .NET Framework 4.5+ | Windows | Public Beta   | `AspNetMvc`      |
-| ASP.NET MVC 4     | 4.0.40804 | .NET Framework 4.5+ | Windows | Public Beta   | `AspNetMvc`      |
-| ASP.NET Web API 2 | 2.2+      | .NET Framework 4.5+ | Windows | Public Beta   | `AspNetWebApi2`  |
-| ASP.NET Web Forms | 4.5+      | .NET Framework 4.5+ | Windows | _Coming soon_ |                  |
-| ASP.NET Core MVC  | 2.0+      | .NET Framework 4.5+ | Windows | Public Beta   | `AspNetCoreMvc2` |
-| ASP.NET Core MVC  | 2.0+      | .NET Core 2.0+      | Windows | Public Beta   | `AspNetCoreMvc2` |
-| ASP.NET Core MVC  | 2.0+      | .NET Core 2.0+      | Linux   | Public Beta   | `AspNetCoreMvc2` |
+<sup>1</sup> There was an issue in .NET Core versions 2.1.0, 2.1.1, and 2.1.2 that could prevent profilers from working correctly. This issue was fixed in .NET Core 2.1.3. See [this GitHub issue][9] for more details.
 
 Don’t see your desired frameworks? Datadog is continually adding additional support. [Check with the Datadog team][3] for help.
 
-### Data Store Integrations
+### Integrations
 
-The .NET Tracer's ability to automatically instrument data store access depends on the client libraries used:
+The .NET Tracer can instrument the following libraries automatically:
 
-| Data store    | Library or NuGet package                  | Versions   | Support type  | Integration Name     |
-| ------------- | ----------------------------------------- | ---------- | ------------- | -------------------- |
-| ADO.NET       | `System.Data` / `System.Data.Common`      | 4.0+       | Public Beta   | `AdoNet`             |
-| Redis         | `StackExchange.Redis`                     | 1.0.187+   | Public Beta   | `StackExchangeRedis` |
-| Redis         | `ServiceStack.Redis`                      | 4.0.48+    | Public Beta   | `ServiceStackRedis`  |
-| Elasticsearch | `NEST` / `Elasticsearch.Net`              | 6.0.0+     | Public Beta   | `ElasticsearchNet`   |
-| MongoDB       | `MongoDB.Driver` / `MongoDB.Driver.Core`  | 2.2.0+     | Public Beta   | `MongoDb`            |
+| Framework or library            | NuGet package name                       | Package versions | Support Type              | Integration Name     |
+| ------------------------------- | ---------------------------------------- | ---------------- | ------------------------- | -------------------- |
+| ASP.NET MVC 5                   | `Microsoft.AspNet.Mvc`                   | 5.1.3+           | Public Beta               | `AspNetMvc`          |
+| ASP.NET MVC 4                   | `Microsoft.AspNet.Mvc`                   | 4.0.40804        | Public Beta               | `AspNetMvc`          |
+| ASP.NET Web API 2               | `Microsoft.AspNet.WebApi.Core`           | 5.2+             | Public Beta               | `AspNetWebApi2`      |
+| ASP.NET Web Forms<sup>1</sup>   | included with .NET Framework             |                  | Experimental <sup>2</sup> | `AspNet`             |
+| ASP.NET Core MVC                |                                          | 2.0+             | Public Beta               | `AspNetCoreMvc2`     |
+| WCF                             | included with .NET Framework             |                  | _Coming soon_             |                      |
+| ADO.NET <sup>3</sup>            | included / `System.Data.Common`          | 4.0+             | Public Beta               | `AdoNet`             |
+| HttpClient / HttpClientHandler  | included / `System.Net.Http`             | 4.0+             | Public Beta               | `HttpMessageHandler` |
+| WebClient / WebRequest          | included / `System.Net.Requests`         | 4.0+             | Public Beta               | `WebRequest`         |
+| Redis (StackExchange client)    | `StackExchange.Redis`                    | 1.0.187+         | Public Beta               | `StackExchangeRedis` |
+| Redis (ServiceStack client)     | `ServiceStack.Redis`                     | 4.0.48+          | Public Beta               | `ServiceStackRedis`  |
+| Elasticsearch                   | `NEST` / `Elasticsearch.Net`             | 6.0.0+           | Public Beta               | `ElasticsearchNet`   |
+| MongoDB                         | `MongoDB.Driver` / `MongoDB.Driver.Core` | 2.2.0+           | Public Beta               | `MongoDb`            |
 
-The ADO.NET integration tries to instrument **all** ADO.NET providers. Support was tested with SQL Server (`System.Data.SqlClient`) and PostgreSQL (`Npgsql`). Other providers (e.g. MySQL, SQLite, Oracle) might work, but have not been tested yet.
+Notes:
+
+<sup>1</sup> The `AspNet` integration adds instrumentation to any application based on `Systme.Web.HttpApplication`, which can include application developed with Web Forms, MVC, Web API, and other web frameworks.
+
+<sup>2</sup> The `AspNet` integration is experimental and not enabled by default as of v0.8. To enable it manually for testing purposes, see the [release notes for .NET Tracer v0.8][7].
+
+<sup>3</sup> The ADO.NET integration tries to instrument **all** ADO.NET providers. Support was tested with SQL Server (`System.Data.SqlClient`) and PostgreSQL (`Npgsql`). Other providers (e.g. MySQL, SQLite, Oracle) might work, but have not been tested yet.
 
 Don’t see your desired frameworks? Datadog is continually adding additional support. [Check with the Datadog team][3] for help.
 
@@ -351,3 +348,6 @@ For more details on supported platforms, see the [.NET Standard documentation][6
 [4]: https://www.nuget.org/packages/Datadog.Trace
 [5]: /tracing/advanced_usage/?tab=net
 [6]: https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support
+[7]: https://github.com/DataDog/dd-trace-dotnet/releases/tag/v0.8.0-beta
+[8]: #integrations
+[9]: https://github.com/dotnet/coreclr/issues/18448

--- a/content/en/tracing/languages/dotnet.md
+++ b/content/en/tracing/languages/dotnet.md
@@ -299,12 +299,12 @@ The .NET Tracer can instrument the following libraries automatically:
 | ASP.NET MVC 5                   | `Microsoft.AspNet.Mvc`                   | 5.1.3+           | Public Beta               | `AspNetMvc`          |
 | ASP.NET MVC 4                   | `Microsoft.AspNet.Mvc`                   | 4.0.40804        | Public Beta               | `AspNetMvc`          |
 | ASP.NET Web API 2               | `Microsoft.AspNet.WebApi.Core`           | 5.2+             | Public Beta               | `AspNetWebApi2`      |
-| ASP.NET Web Forms<sup>1</sup>   | included with .NET Framework             |                  | Experimental <sup>2</sup> | `AspNet`             |
 | ASP.NET Core MVC                | `Microsoft.AspNetCore.Mvc.Core`          | 2.0+             | Public Beta               | `AspNetCoreMvc2`     |
-| WCF                             | included with .NET Framework             |                  | _Coming soon_             |                      |
-| ADO.NET <sup>3</sup>            | included / `System.Data.Common`          | 4.0+             | Public Beta               | `AdoNet`             |
-| HttpClient / HttpClientHandler  | included / `System.Net.Http`             | 4.0+             | Public Beta               | `HttpMessageHandler` |
-| WebClient / WebRequest          | included / `System.Net.Requests`         | 4.0+             | Public Beta               | `WebRequest`         |
+| ASP.NET Web Forms<sup>1</sup>   | built-in                                 |                  | Experimental <sup>2</sup> | `AspNet`             |
+| WCF                             | built-in                                 |                  | _Coming soon_             |                      |
+| ADO.NET <sup>3</sup>            | built-in                                 | 4.0+             | Public Beta               | `AdoNet`             |
+| HttpClient / HttpClientHandler  | built-in                                 | 4.0+             | Public Beta               | `HttpMessageHandler` |
+| WebClient / WebRequest          | built-in                                 | 4.0+             | Public Beta               | `WebRequest`         |
 | Redis (StackExchange client)    | `StackExchange.Redis`                    | 1.0.187+         | Public Beta               | `StackExchangeRedis` |
 | Redis (ServiceStack client)     | `ServiceStack.Redis`                     | 4.0.48+          | Public Beta               | `ServiceStackRedis`  |
 | Elasticsearch                   | `NEST` / `Elasticsearch.Net`             | 6.0.0+           | Public Beta               | `ElasticsearchNet`   |

--- a/content/en/tracing/languages/dotnet.md
+++ b/content/en/tracing/languages/dotnet.md
@@ -314,7 +314,7 @@ Notes:
 
 <sup>1</sup> The `AspNet` integration adds instrumentation to any application based on `Systme.Web.HttpApplication`, which can include applications developed with Web Forms, MVC, Web API, and other web frameworks.
 
-<sup>2</sup> The `AspNet` integration is experimental and not enabled by default as of v0.8. To enable it manually for testing purposes, see the [release notes for .NET Tracer v0.8][7].
+<sup>2</sup> The `AspNet` integration not enabled by default as in .NET Tracer 0.8. To enable it manually for testing purposes, see the [release notes for .NET Tracer 0.8][7].
 
 <sup>3</sup> The ADO.NET integration tries to instrument **all** ADO.NET providers. Support was tested with SQL Server (`System.Data.SqlClient`) and PostgreSQL (`Npgsql`). Other providers (e.g. MySQL, SQLite, Oracle) might work, but have not been tested yet.
 

--- a/content/en/tracing/languages/dotnet.md
+++ b/content/en/tracing/languages/dotnet.md
@@ -312,7 +312,7 @@ The .NET Tracer can instrument the following libraries automatically:
 
 Notes:
 
-<sup>1</sup> The `AspNet` integration adds instrumentation to any application based on `Systme.Web.HttpApplication`, which can include application developed with Web Forms, MVC, Web API, and other web frameworks.
+<sup>1</sup> The `AspNet` integration adds instrumentation to any application based on `Systme.Web.HttpApplication`, which can include applications developed with Web Forms, MVC, Web API, and other web frameworks.
 
 <sup>2</sup> The `AspNet` integration is experimental and not enabled by default as of v0.8. To enable it manually for testing purposes, see the [release notes for .NET Tracer v0.8][7].
 

--- a/content/en/tracing/languages/dotnet.md
+++ b/content/en/tracing/languages/dotnet.md
@@ -302,9 +302,9 @@ The .NET Tracer can instrument the following libraries automatically:
 | ASP.NET Core MVC                | `Microsoft.AspNetCore.Mvc.Core`          | 2.0+             | Public Beta               | `AspNetCoreMvc2`     |
 | ASP.NET Web Forms<sup>1</sup>   | built-in                                 |                  | Experimental <sup>2</sup> | `AspNet`             |
 | WCF                             | built-in                                 |                  | _Coming soon_             |                      |
-| ADO.NET <sup>3</sup>            | built-in                                 | 4.0+             | Public Beta               | `AdoNet`             |
-| HttpClient / HttpClientHandler  | built-in                                 | 4.0+             | Public Beta               | `HttpMessageHandler` |
-| WebClient / WebRequest          | built-in                                 | 4.0+             | Public Beta               | `WebRequest`         |
+| ADO.NET <sup>3</sup>            | built-in                                 |                  | Public Beta               | `AdoNet`             |
+| WebClient / WebRequest          | built-in                                 |                  | Public Beta               | `WebRequest`         |
+| HttpClient / HttpClientHandler  | built-in or `System.Net.Http`            |                  | Public Beta               | `HttpMessageHandler` |
 | Redis (StackExchange client)    | `StackExchange.Redis`                    | 1.0.187+         | Public Beta               | `StackExchangeRedis` |
 | Redis (ServiceStack client)     | `ServiceStack.Redis`                     | 4.0.48+          | Public Beta               | `ServiceStackRedis`  |
 | Elasticsearch                   | `NEST` / `Elasticsearch.Net`             | 6.0.0+           | Public Beta               | `ElasticsearchNet`   |

--- a/content/en/tracing/languages/dotnet.md
+++ b/content/en/tracing/languages/dotnet.md
@@ -126,7 +126,7 @@ apk add libc6-compat
 
 **Note:** If your application runs on IIS and you used the MSI installer, you don't need to configure environment variables manually and you may skip this section.
 
-**Note:** The profiler tries to attach to _any_ .NET process that is started while these environment variables are set. You should limit profiling only to the applications that need to be traced. **Do not set these environment variables globally as this causes _all_ .NET processes on the host to be profiled.**
+**Note:** The .NET runtime will try to load a profiler into _any_ .NET process that is started while these environment variables are set. You should limit profiling only to the applications that need to be traced. **Do not set these environment variables globally as this causes _all_ .NET processes on the host to be profiled.**
 
 {{< tabs >}}
 

--- a/content/en/tracing/languages/dotnet.md
+++ b/content/en/tracing/languages/dotnet.md
@@ -316,7 +316,7 @@ Notes:
 
 <sup>2</sup> The `AspNet` integration is not enabled by default in .NET Tracer 0.8. To enable it manually for testing purposes, see the [release notes for .NET Tracer 0.8][7].
 
-<sup>3</sup> The ADO.NET integration tries to instrument **all** ADO.NET providers. Support was tested with SQL Server (`System.Data.SqlClient`) and PostgreSQL (`Npgsql`). Other providers (e.g. MySQL, SQLite, Oracle) might work, but have not been tested yet.
+<sup>3</sup> The ADO.NET integration tries to instrument **all** ADO.NET providers. Support was tested with SQL Server (`System.Data.SqlClient`) and PostgreSQL (`Npgsql`). Other providers (e.g. MySQL, SQLite, Oracle) might work, but have not been tested.
 
 Don’t see your desired frameworks? Datadog is continually adding additional support. [Check with the Datadog team][3] for help.
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
- APM > Languages > .NET
  - add new supported libraries
  - merge the two separate tables of supported libraries into one
- APM > Advanced Instrumentation
  - add .NET instructions to change Agent host and port
  - add .NET support for distributed tracing and sampling priority
  - improve .NET code samples slightly

### Motivation
We released [version 0.8](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v0.8.0-beta) of the .NET Tracer 

### Preview links
https://docs-staging.datadoghq.com/lpimentel/apm-dotnet-0.8/tracing/languages/dotnet/
https://docs-staging.datadoghq.com/lpimentel/apm-dotnet-0.8/tracing/advanced_usage/?tab=net

### Additional Notes
N/A

