### PR TITLE
Clarify Trace Agent environment variables

### DIFF
--- a/content/en/agent/docker/apm.md
+++ b/content/en/agent/docker/apm.md
@@ -36,9 +36,9 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -e DD_APM_ENABLED=true \
               datadog/agent:latest
 ```
-## Docker APM Environment Variables
+## Docker APM Agent Environment Variables
 
-List of all environment variables available for tracing with the Docker Agent:
+List of all environment variables available for tracing within the Docker Agent:
 
 | Environment variable       | Description                                                                                                               |
 | ------                     | ------                                                                                                                    |
@@ -94,7 +94,9 @@ docker run -d --name app \
 This exposes the hostname `datadog-agent` in your `app` container.
 If you're using `docker-compose`, `<NETWORK_NAME>` parameters are the ones defined under the `networks` section of your `docker-compose.yml`.
 
-Your application tracers must be configured to submit traces to this address. See the examples below for each supported language:
+Your application tracers must be configured to submit traces to this address. Set environment variables with the `DD_AGENT_HOST` as the Agent container name, and `DD_TRACE_AGENT_PORT` as the Agent Trace port. (In this example case, `datadog-agent` and `8126`, respectively.)
+
+Alternately, see the examples below to set the Agent host manually in each supported language:
 
 {{< tabs >}}
 {{% tab "Java" %}}

--- a/content/en/agent/docker/apm.md
+++ b/content/en/agent/docker/apm.md
@@ -94,7 +94,7 @@ docker run -d --name app \
 This exposes the hostname `datadog-agent` in your `app` container.
 If you're using `docker-compose`, `<NETWORK_NAME>` parameters are the ones defined under the `networks` section of your `docker-compose.yml`.
 
-Your application tracers must be configured to submit traces to this address. Set environment variables with the `DD_AGENT_HOST` as the Agent container name, and `DD_TRACE_AGENT_PORT` as the Agent Trace port. (In this example case, `datadog-agent` and `8126`, respectively.)
+Your application tracers must be configured to submit traces to this address. Set environment variables with the `DD_AGENT_HOST` as the Agent container name, and `DD_TRACE_AGENT_PORT` as the Agent Trace port in your application containers. (In this example case, `datadog-agent` and `8126`, respectively.)
 
 Alternately, see the examples below to set the Agent host manually in each supported language:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Makes the APM Docker docs more explicit. The APM Docker docs refer specifically to environment variables _within_ the Agent container, not outside of it.

Adds a note at the end about setting environment variables in your containers for connecting to the APM Agent.

### Motivation
<!-- What inspired you to submit this pull request?-->
Confusion over the proper environment variable name.

### Preview link
<!-- Impacted pages preview links-->

https://docs-staging.datadoghq.com/kirk.kaiser/clarify-trace-agent-hostname/agent/docker/apm/?tab=java

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
