### PR TITLE
fix manual log injection example missing the format

### DIFF
--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -1935,6 +1935,7 @@ Example using `console` as the underlying logger:
 
 ```javascript
 const tracer = require('dd-trace')
+const formats = require('dd-trace/ext/formats')
 
 class Logger {
   log (level, message) {
@@ -1943,7 +1944,7 @@ class Logger {
     const record = { time, level, message }
 
     if (span) {
-      tracer.inject(span.context(), record)
+      tracer.inject(span.context(), formats.LOG, record)
     }
 
     console.log(record)


### PR DESCRIPTION
### What does this PR do?

Add the missing format parameter for `tracer.inject()` in the manual log injection example.

### Motivation

Without the correct format, log injection will not work.

### Preview link

https://docs-staging.datadoghq.com/rochdev/fix-log-inject/tracing/advanced_usage/?tab=nodejs#logging

### Additional Notes
