### PR TITLE
Mention restarting PHP after installing the PHP tracer

### DIFF
--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -50,7 +50,7 @@ $ dpkg -i datadog-php-tracer.deb
 $ apk add datadog-php-tracer.apk --allow-untrusted
 ```
 
-Visit a tracing-enabled endpoint of your application and view the [APM UI][8] to see the traces.
+Restart PHP (PHP-FPM or the Apache SAPI) and visit a tracing-enabled endpoint of your application and view the [APM UI][8] to see the traces.
 
 **Note**: It might take a few minutes before traces appear in the UI.
 

--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -50,7 +50,7 @@ $ dpkg -i datadog-php-tracer.deb
 $ apk add datadog-php-tracer.apk --allow-untrusted
 ```
 
-Restart PHP (PHP-FPM or the Apache SAPI) then visit a tracing-enabled endpoint of your application. View the [APM UI][8] to see the traces.
+Restart PHP (PHP-FPM or the Apache SAPI) and then visit a tracing-enabled endpoint of your application. View the [APM UI][8] to see the traces.
 
 **Note**: It might take a few minutes before traces appear in the UI.
 

--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -50,7 +50,7 @@ $ dpkg -i datadog-php-tracer.deb
 $ apk add datadog-php-tracer.apk --allow-untrusted
 ```
 
-Restart PHP (PHP-FPM or the Apache SAPI) and visit a tracing-enabled endpoint of your application and view the [APM UI][8] to see the traces.
+Restart PHP (PHP-FPM or the Apache SAPI) then visit a tracing-enabled endpoint of your application. View the [APM UI][8] to see the traces.
 
 **Note**: It might take a few minutes before traces appear in the UI.
 


### PR DESCRIPTION
### What does this PR do?
Per a [request from the community](https://github.com/DataDog/dd-trace-php/issues/358), this PR adds instructions to restart PHP after installing.

### Motivation
Community request.

### Preview link
[Preview of the PHP tracer page](https://docs-staging.datadoghq.com/sammyk/php-docs-update/tracing/languages/php/)

### Additional Notes
N/A
