### PR TITLE
[Forecasts Monitors] Adding note about full window of data for evalua…

### DIFF
--- a/content/en/monitors/monitor_types/forecasts.md
+++ b/content/en/monitors/monitor_types/forecasts.md
@@ -62,6 +62,8 @@ Datadog automatically sets the **Advanced** options for you by analyzing your me
 * We recommend using larger intervals between points to avoid having noise influence the forecast too much.
 * The number of deviations controls the width of the range of forecasted values. A value of 1 or 2 should be large enough to accurately forecast most "normal" points.
 
+Then, you can choose if the monitor requires a full window of data for evaluation. Setting it to "Requires" might result in evaluations getting skipped. Indeed, evaluations will get skipped if the data is sparse or if the past data in the evaluation window has some missing values. 
+
 Complete all steps in the New Monitor form (**Say what's happening**, etc.) and click **Save** to create the Forecast monitor.
 
 Both the Monitor Edit page and the Monitor Status pages provide "Historical Context" so that you can see how the metric behaved in the past. This should provide some insight into what the forecast algorithm takes into account when predicting future values.

--- a/content/en/monitors/monitor_types/forecasts.md
+++ b/content/en/monitors/monitor_types/forecasts.md
@@ -62,7 +62,7 @@ Datadog automatically sets the **Advanced** options for you by analyzing your me
 * We recommend using larger intervals between points to avoid having noise influence the forecast too much.
 * The number of deviations controls the width of the range of forecasted values. A value of 1 or 2 should be large enough to accurately forecast most "normal" points.
 
-Then, you can choose if the monitor requires a full window of data for evaluation. Setting it to "Requires" will force the monitor to ignore (i.e., show "No Data" as the monitor state) any series that doesn't have data going back all the way to the start of the time range shown in the Evaluation Window graph.
+Then, you can choose if the monitor requires a full window of data for evaluation. Setting it to "Requires" will force the monitor to ignore (i.e., show "No Data" as the monitor state) any series that doesn't have data going back to the start of the time range shown in the Evaluation Window graph.
 
 Complete all steps in the New Monitor form (**Say what's happening**, etc.) and click **Save** to create the Forecast monitor.
 

--- a/content/en/monitors/monitor_types/forecasts.md
+++ b/content/en/monitors/monitor_types/forecasts.md
@@ -62,7 +62,7 @@ Datadog automatically sets the **Advanced** options for you by analyzing your me
 * We recommend using larger intervals between points to avoid having noise influence the forecast too much.
 * The number of deviations controls the width of the range of forecasted values. A value of 1 or 2 should be large enough to accurately forecast most "normal" points.
 
-Then, you can choose if the monitor requires a full window of data for evaluation. Setting it to "Requires" might result in evaluations getting skipped. Indeed, evaluations will get skipped if the data is sparse or if the past data in the evaluation window has some missing values. 
+Then, you can choose if the monitor requires a full window of data for evaluation. Setting it to "Requires" will force the monitor to ignore (i.e., show "No Data" as the monitor state) any series that doesn't have data going back all the way to the start of the time range shown in the Evaluation Window graph.
 
 Complete all steps in the New Monitor form (**Say what's happening**, etc.) and click **Save** to create the Forecast monitor.
 


### PR DESCRIPTION
…tion

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR adds a short paragraph about full window of data for evaluation for forecast monitors.

### Motivation
<!-- What inspired you to submit this pull request?-->
[Trello Support ticket](https://trello.com/c/d7OKg3w0/90-forecast-monitor-is-not-showing-all-the-groups
@DataDog/butter 
)
### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
