### PR TITLE
Autodiscovery tag extraction: add version note

### DIFF
--- a/content/en/agent/autodiscovery/_index.md
+++ b/content/en/agent/autodiscovery/_index.md
@@ -68,6 +68,8 @@ config_providers:
 
 ### Tag extraction
 
+**Note**: this feature is available for Agent v6.10+. See [Upgrading the Datadog Agent][3].
+
 {{< tabs >}}
 {{% tab "Docker" %}}
 
@@ -508,7 +510,7 @@ The [Cluster Checks feature][1] monitors non-containerized and out-of-cluster re
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note**: Some supported integrations require additional steps for Autodiscovery to work: [Ceph][3], [Varnish][4], [Postfix][5], [Cassandra Nodetools][6], and [Gunicorn][7]. Contact [Datadog support][8] for assistance.
+**Note**: Some supported integrations require additional steps for Autodiscovery to work: [Ceph][4], [Varnish][5], [Postfix][6], [Cassandra Nodetools][7], and [Gunicorn][8]. Contact [Datadog support][9] for assistance.
 
 ## Reference
 
@@ -529,7 +531,7 @@ The following template variables are handled by the Agent:
   - `%%pid%%`: retrieves the container process ID as returned by `docker inspect --format '{{.State.Pid}}' <container>`
 
 - Container hostname: `hostname` (added in Agent 6.4, Docker listener only)
-  - `%%hostname%%`: retrieves the `hostname` value from the container configuration. Only use it if the `%%host%%` variable cannot fetch a reliable IP (example: [ECS awsvpc mode][9]
+  - `%%hostname%%`: retrieves the `hostname` value from the container configuration. Only use it if the `%%host%%` variable cannot fetch a reliable IP (example: [ECS awsvpc mode][10]
 
 - Environment variable: `env` (added in Agent 6.1)
   - `%%env_MYENVVAR%%`: use the contents of the `$MYENVVAR` environment variable **as seen by the Agent process**
@@ -621,10 +623,11 @@ instances:
 
 [1]: /agent/faq/agent-5-autodiscovery
 [2]: https://github.com/DataDog/integrations-core/blob/master/go_expvar/datadog_checks/go_expvar/data/conf.yaml.example
-[3]: /integrations/ceph
-[4]: /integrations/varnish/#autodiscovery
-[5]: /integrations/postfix
-[6]: /integrations/cassandra/#agent-check-cassandra-nodetool
-[7]: /integrations/gunicorn
-[8]: /help
-[9]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html
+[3]: /agent/guide/upgrade-to-agent-v6
+[4]: /integrations/ceph
+[5]: /integrations/varnish/#autodiscovery
+[6]: /integrations/postfix
+[7]: /integrations/cassandra/#agent-check-cassandra-nodetool
+[8]: /integrations/gunicorn
+[9]: /help
+[10]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html


### PR DESCRIPTION
### What does this PR do?
Adds version note to tag extraction.

### Motivation
Requested by @ziquanmiao 

### Preview link

https://docs-staging.datadoghq.com/cswatt/k8s-tag-extraction-version/agent/autodiscovery/?tab=kubernetes#tag-extraction
