### PR TITLE
[dashboards] Copy change, add links to widget definitions

### DIFF
--- a/content/en/api/dashboards/dashboards.md
+++ b/content/en/api/dashboards/dashboards.md
@@ -8,7 +8,7 @@ external_redirect: /api/#dashboards
 ## Dashboards
 
 <div class="alert alert-info">
-This new endpoint replaces the timeboard and screenboard endpoints. The documentation for the old endpoints are available here:
+This new endpoint unifies the screenboard and timeboard APIs to allow you to manage all of your dashboards using a single format. The documentation for the old endpoints are available here:
     <ul>
         <li><a href="https://docs.datadoghq.com/graphing/faq/timeboard-api-doc"> Timeboard API doc</a></li>
         <li><a href="https://docs.datadoghq.com/graphing/faq/screenboard-api-doc"> Screenboard API doc</a></li>

--- a/content/en/api/dashboards/dashboards.md
+++ b/content/en/api/dashboards/dashboards.md
@@ -8,7 +8,7 @@ external_redirect: /api/#dashboards
 ## Dashboards
 
 <div class="alert alert-info">
-This new endpoint unifies the screenboard and timeboard APIs to allow you to manage all of your dashboards using a single format. The documentation for the old endpoints are available here:
+This new endpoint unifies screenboard and timeboard APIs to allow you to manage all of your dashboards using a single format. Documentation for old endpoints is available here:
     <ul>
         <li><a href="https://docs.datadoghq.com/graphing/faq/timeboard-api-doc"> Timeboard API doc</a></li>
         <li><a href="https://docs.datadoghq.com/graphing/faq/screenboard-api-doc"> Screenboard API doc</a></li>

--- a/content/en/api/dashboards/dashboards_create.md
+++ b/content/en/api/dashboards/dashboards_create.md
@@ -13,7 +13,7 @@ external_redirect: /api/#create-a-dashboard
 * **`widgets`** [*required*]:  
     List of widgets to display on the dashboard. Widget definitions follow this form:
     * **`definition`** [*required*]:  
-        Definition of the widget.
+        [Definition of the widget.][1]
     * **`id`** [*optional*, *default*=**auto-generated integer**]:  
         ID of the widget.
 * **`layout_type`** [*required*]:  
@@ -32,3 +32,5 @@ external_redirect: /api/#create-a-dashboard
         The default value for the template variable on dashboard load.
     * **`prefix`** [*optional*, *default*=**None**]:  
         The tag prefix associated with the variable. Only tags with this prefix appear in the variable dropdown.
+
+[1]: /graphing/widgets

--- a/content/en/api/dashboards/dashboards_update.md
+++ b/content/en/api/dashboards/dashboards_update.md
@@ -14,7 +14,7 @@ external_redirect: /api/#update-a-dashboard
 * **`widgets`** [*required*]:  
     List of widgets to display on the dashboard. Widget definitions follow this form:
     * **`definition`** [*required*]:  
-        Definition of the widget.
+        [Definition of the widget.][1]
     * **`id`** [*optional*, *default*=**auto-generated integer**]:  
         ID of the widget.
 * **`layout_type`** [*required*]:  
@@ -33,3 +33,5 @@ external_redirect: /api/#update-a-dashboard
         The default value for the template variable on dashboard load.
     * **`prefix`** [*optional*, *default*=**None**]:  
         The tag prefix associated with the variable. Only tags with this prefix appear in the variable dropdown.
+
+[1]: /graphing/widgets


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Does a copy change in the introduction of the new API and links widget definitions to the appropriate doc now that we have them.

### Motivation
Customers had no links to widget schemas

### Preview link
https://docs-staging.datadoghq.com/iddl/dashboards-api/api/?lang=python#create-a-dashboard

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->
