### PR TITLE
Update Documentation for Upload Idp Metadata API

### DIFF
--- a/content/en/api/org/code_snippets/api-idp-upload.sh
+++ b/content/en/api/org/code_snippets/api-idp-upload.sh
@@ -2,5 +2,14 @@ api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 public_id=axd2s
 
-curl -X POST -H "Content-Type: multipart/form-data" -F "idp_file=@metadata.xml" \
-"https://api.datadoghq.com/api/v1/org/${public_id}/idp_metadata?api_key=${api_key}&application_key=${app_key}"
+# Upload IdP file using multipart/form-data
+curl -X POST -H "Content-Type: multipart/form-data" \
+    -F "idp_file=@metadata.xml" \
+    "https://api.datadoghq.com/api/v1/org/${public_id}/idp_metadata?api_key=${api_key}&application_key=${app_key}"
+
+# OR
+
+# Upload IdP file using application/xml
+curl -X POST -H "Content-Type: application/xml" \
+    --data-binary "@metadata.xml" \
+    "https://api.datadoghq.com/api/v1/org/${public_id}/idp_metadata?api_key=${api_key}&application_key=${app_key}"

--- a/content/en/api/org/code_snippets/api-idp-upload.sh
+++ b/content/en/api/org/code_snippets/api-idp-upload.sh
@@ -1,6 +1,6 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
-public_id=axd2s
+public_id=<DD_APP_PUBLIC_ID>
 
 # Upload IdP file using multipart/form-data
 curl -X POST -H "Content-Type: multipart/form-data" \

--- a/content/en/api/org/idp_update.md
+++ b/content/en/api/org/idp_update.md
@@ -7,7 +7,24 @@ external_redirect: /api/#upload-idp-metadata
 
 ## Upload IdP metadata
 
+There are a couple of options for updating the Identity Provider (IdP) metadata from your SAML IdP.
+
+* **Multipart Form-Data**: Post the IdP metadata file using a form post.
+* **XML Body**: Post the IdP metadata file as the body of the request.
+
+### Multipart Form-Data
+
+##### HEADERS
+* **`Content-Type: multipart/form-data`**
+
 ##### ARGUMENTS
-* **`idp_file`** [*required*]:  
+* **`idp_file`** [*required*]:
      The path to the XML metadata file you wish to upload.
 
+### XML Body
+
+##### HEADERS
+* **`Content-Type: application/xml`**
+
+##### ARGUMENTS
+The body must contain the contents of your IdP metadata XML file.

--- a/content/en/api/org/idp_update_code.md
+++ b/content/en/api/org/idp_update_code.md
@@ -8,7 +8,7 @@ external_redirect: /api/#upload-idp-metadata
 ##### Signature
 `POST https://api.datadoghq.com/api/v1/org/<PUBLIC_ID>/idp_metadata`
 ##### Example Request
-{{< code-snippets basename="api-org-update" >}}
+{{< code-snippets basename="api-idp-upload" >}}
 ##### Example Response
-{{< code-snippets basename="result.api-org-update" >}}
+{{< code-snippets basename="result.api-idp-upload" >}}
 


### PR DESCRIPTION
### What does this PR do?
Documents support for using the Upload IdP Metadata API endpoint to upload a SAML Identity Provider Metadata XML file using XML in the body of the request. It also fixes the existing documentation to show the correct response format.

### Motivation
Document new support in the API and fix the existing documentation.

### Preview link
https://docs-staging.datadoghq.com/chris.linstid/upload-idp-metadata/api/?lang=bash#upload-idp-metadata