### PR TITLE
[Go Logs] add blog link

### DIFF
--- a/content/en/logs/log_collection/go.md
+++ b/content/en/logs/log_collection/go.md
@@ -4,6 +4,9 @@ kind: documentation
 aliases:
   - /logs/languages/go
 further_reading:
+- link: "https://www.datadoghq.com/blog/go-logging/"
+  tag: "Blog"
+  text: "How to collect, standardize, and centralize Golang logs"
 - link: "logs/processing"
   tag: "Documentation"
   text: "Learn how to process your logs"


### PR DESCRIPTION
### What does this PR do?
- Add blog post link to Go Logs page

### Motivation
- New blog bost

### Preview link
https://docs-staging.datadoghq.com/ruth/go-log-blog/logs/log_collection/go/#further-reading
