### PR TITLE
Update short lived and multiline log instruction

### DIFF
--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -286,7 +286,7 @@ logs:
 {{% /tab %}}
 {{% tab "Docker" %}}
 
-In docker environment use the `com.datadoghq.ad.logs` labels as below on your container to make sure that the above log is properly collected:
+In a docker environment use the `com.datadoghq.ad.logs` labels on your container to make sure that the log is properly collected, for example:
 
 ```
  labels:
@@ -296,7 +296,7 @@ In docker environment use the `com.datadoghq.ad.logs` labels as below on your co
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 
-In Kubernetes environment use the `ad.datadoghq.com` pod annotations as below on your pods to make sure that the above log is properly collected:
+In a Kubernetes environment use the `ad.datadoghq.com` pod annotations on your pods to make sure that the log is properly collected, for example:
 
 ```
 apiVersion: extensions/v1beta1

--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -265,6 +265,10 @@ For example, every Java log line starts with a timestamp in `yyyy-dd-mm` format.
 2018-01-03T09:26:24.365Z UTC starting upload of /my/file.gz
 ```
 
+
+{{< tabs >}}
+{{% tab "Configuration file" %}}
+
 To achieve this, you need to use the following `log_processing_rules`:
 
 ```yaml
@@ -278,6 +282,43 @@ logs:
         name: new_log_start_with_date
         pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
 ```
+
+{{% /tab %}}
+{{% tab "Docker" %}}
+
+In docker environment use the `com.datadoghq.ad.logs` labels as below on your container to make sure that the above log is properly collected:
+
+```
+ labels:
+    com.datadoghq.ad.logs: '[{"source": "postgresql", "service": "database", "log_processing_rules": [{"type": "multi_line", "name": "log_start_with_date", "pattern" : "\\d{4}-(0?[1-9]|1[012])-(0?[1-9]|[12][0-9]|3[01])"}]}]'
+```
+
+{{% /tab %}}
+{{% tab "Kubernetes" %}}
+
+In Kubernetes environment use the `ad.datadoghq.com` pod annotations as below on your pods to make sure that the above log is properly collected:
+
+```
+apiVersion: extensions/v1beta1
+kind: ReplicaSet
+metadata:
+  name: postgres
+spec:
+  template:
+    metadata:
+      annotations:
+        ad.datadoghq.com/nginx.logs: '[{"source": "postgresql", "service": "database", "log_processing_rules": [{"type": "multi_line", "name": "log_start_with_date", "pattern" : "\\d{4}-(0?[1-9]|1[012])-(0?[1-9]|[12][0-9]|3[01])"}]}]'
+      labels:
+        app: database
+      name: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:latest
+```
+
+{{% /tab %}}
+{{< /tabs >}}
 
 More examples:
 

--- a/content/en/logs/log_collection/docker.md
+++ b/content/en/logs/log_collection/docker.md
@@ -229,18 +229,6 @@ Refer to the [Autodiscovery guide][1] for setup, examples, and more information 
 * Use the environment variable to collect logs from all containers and then override the default `source` and `service` values.
 * Add processing rules for the wanted subset of containers.
 
-#### Short lived containers
-
-To ensure their logs are properly collected, Autodiscovery detects short lived containers as soon as they are started. If you are using the host installation of the Agent, add this in your `datadog.yaml` file (it is automatically added for the containerized version):
-
-```
-listeners:
-  - name: docker
-config_providers:
-  - name: docker
-    polling: true
-```
-
 ### Filter containers
 
 It is possible to filter logs, metrics, and Autodiscovery using the following methods. This can be useful to prevent the collection of the Datadog Agent logs.


### PR DESCRIPTION
### What does this PR do?
Remove the short lived section which is outdated and misleading.
Also update the multiline section to better reflect container setup.

### Motivation
The container multiline setup was only explained in the docker log collection guide.

### Preview link
https://docs-staging.datadoghq.com/nils/log-container-short-lived-multiline/logs/log_collection/?tab=tailexistingfiles#multi-line-aggregation

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
