### PR TITLE
add k8s clustername autodetection documentation

### DIFF
--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -154,6 +154,17 @@ NAME            DESIRED   CURRENT   READY     UP-TO-DATE   AVAILABLE   NODE SELE
 datadog-agent   2         2         2         2            2           <none>          16h
 ```
 
+### Kubernetes cluster name auto detection
+
+Since version 6.5.0 of the Datadog agent, a cluster name attribute has been added to the agent configuration to be used in Kubernetes clusters so that host aliases are unique. It can be set using the `DD_CLUSTER_NAME` environment variable.
+
+Starting with version 6.11.0, the Datadog agent can auto detect the Kubernetes cluster name on Google GKE, Azure AKS and AWS EKS. The aim of this feature is to make it easier to identify nodes across Kubernetes clusters by adding an alias which contains the cluster name as a suffix on the node name.
+
+On Google GKE and Azure AKS, the cluster name is retrieved from the cloud provider API whereas for AWS EKS the cluster name is retrieved from EC2 instance tags.
+
+**Note**: On AWS it is required to add the `ec2:DescribeInstances` [permission][12] to your Datadog IAM policy so that the agent could query the EC2 instance tags.
+
+
 ## Enable capabilities
 
 ### Log Collection
@@ -260,3 +271,4 @@ The workaround in this case is to add `hostNetwork: true` in your Agent pod spec
 [9]: /logs/docker/#configuration-file-example
 [10]: /graphing/infrastructure/process/?tab=kubernetes#installation
 [11]: /agent/kubernetes/dogstatsd
+[12]: https://docs.datadoghq.com/integrations/amazon_ec2/#configuration

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -156,13 +156,13 @@ datadog-agent   2         2         2         2            2           <none>   
 
 ### Kubernetes cluster name auto detection
 
-Since version 6.5.0 of the Datadog agent, a cluster name attribute has been added to the agent configuration to be used in Kubernetes clusters so that host aliases are unique. It can be set using the `DD_CLUSTER_NAME` environment variable.
+Since version 6.5.0 of the Datadog Agent, the Agent configuration contains a cluster name attribute to be used in Kubernetes clusters, so that host aliases are unique. This attribute can be set using the `DD_CLUSTER_NAME` environment variable.
 
-Starting with version 6.11.0, the Datadog agent can auto detect the Kubernetes cluster name on Google GKE, Azure AKS and AWS EKS. The aim of this feature is to make it easier to identify nodes across Kubernetes clusters by adding an alias which contains the cluster name as a suffix on the node name.
+Starting with version 6.11.0, the Datadog Agent can auto-detect the Kubernetes cluster name on Google GKE, Azure AKS, and AWS EKS. This feature facilitates the identification of nodes across Kubernetes clusters by adding an alias which contains the cluster name as a suffix on the node name.
 
-On Google GKE and Azure AKS, the cluster name is retrieved from the cloud provider API whereas for AWS EKS the cluster name is retrieved from EC2 instance tags.
+On Google GKE and Azure AKS, the cluster name is retrieved from the cloud provider API. For AWS EKS, the cluster name is retrieved from EC2 instance tags.
 
-**Note**: On AWS it is required to add the `ec2:DescribeInstances` [permission][12] to your Datadog IAM policy so that the agent could query the EC2 instance tags.
+**Note**: On AWS, it is required to add the `ec2:DescribeInstances` [permission][12] to your Datadog IAM policy so that the Agent can query the EC2 instance tags.
 
 
 ## Enable capabilities


### PR DESCRIPTION

### What does this PR do?
document the feature of k8s cluster name auto detection

### Motivation
users should know that k8s cluster name could be provided in the config template or auto detected also by the agent 

### Preview link
https://docs-staging.datadoghq.com/ahmed/k8s-clustername-autodetection/agent/kubernetes/daemonset_setup/

