### PR TITLE
update data collected in cf docs

### DIFF
--- a/content/en/integrations/cloud_foundry.md
+++ b/content/en/integrations/cloud_foundry.md
@@ -396,7 +396,7 @@ On the [Metrics explorer][22] page in Datadog, search for metrics beginning `clo
 
 The following metrics are sent by the Datadog Firehose Nozzle (`cloudfoundry.nozzle`). The Datadog Agent release does not send any special metrics of its own, just the usual metrics from any Agent checks you configure in the Director runtime config (and, by default, [system][23], [network][24], [disk][25], and [ntp][26] metrics).
 
-The Datadog Firehose Nozzle only collects CounterEvents (as metrics, not events) and ValueMetrics; it ignores LogMessages, Errors, and ContainerMetrics.
+The Datadog Firehose Nozzle only collects CounterEvents (as metrics, not events), ValueMetrics, and ContainerMetrics; it ignores LogMessages and Errors.
 
 {{< get-metrics-from-git "cloud_foundry">}}
 

--- a/ja/content/integrations/cloud_foundry.md
+++ b/ja/content/integrations/cloud_foundry.md
@@ -285,6 +285,6 @@ The BOSH Agent sets a severity for each alert it generates, and the Datadog Heal
 
 The following metrics are sent by the Datadog Firehose Nozzle (`cloudfoundry.nozzle`) and the BOSH Health Monitor Datadog plugin (`bosh.healthmonitor`). The Datadog Agent release does not send any special metrics of its own, just the usual metrics from any Agent checks you configure in the Director runtime config (and, by default, [system](/integrations/system/#metrics), [network](/integrations/network/#metrics), [disk](/integrations/disk/#metrics), and [ntp](/integrations/ntp/#metrics) metrics).
 
-The Datadog Firehose Nozzle only collects CounterEvents (as metrics, not events) and ValueMetrics; it ignores LogMessages, Errors, and ContainerMetrics.
+The Datadog Firehose Nozzle only collects CounterEvents (as metrics, not events), ValueMetrics, and ContainerMetrics; it ignores LogMessages and Errors.
 
 {{< get-metrics-from-git >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes the `Data Collected` part of the CF docs to indicate that `ContainerMetrics` do in fact get sent to the nozzle. 

### Motivation
Prospect asking about whether the CF integration collects `ContainerMetrics`

### Preview link
N/A
(I think it should be this: https://docs-staging.datadoghq.com/fanny-cf-doc/integrations/cloud_foundry, but I haven't built my branch)

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
See trello card for internal details on this PR: https://trello.com/c/kDrjBPG1/600-%F0%9F%9A%A8-error-fix-cloudfoundry-doc-metrics-collected 
