### PR TITLE
add info on where to find the mac trace agent

### DIFF
--- a/content/en/agent/basic_agent_usage/osx.md
+++ b/content/en/agent/basic_agent_usage/osx.md
@@ -21,9 +21,9 @@ further_reading:
 
 This page outlines the basic features of the Datadog Agent for macOS. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
-Unlike other agents, the agent tracing functionality is not included with the macOS Datadog agent out of the box and must be installed separately by downloading the darwin trace agent from our [Github trace agent repository][4].
+Unlike other Agents, the macOS Datadog Agent does not include Agent tracing functionality out of the box. This functionality can be installed separately by downloading the Darwin Trace Agent from the [Github trace agent repository][4].
 
-By default, the Agent is installed in a sandbox located at `/opt/datadog-agent`. You're free to move this folder wherever you like; however, his documentation assumes a default installation location.
+By default, the Agent is installed in a sandbox located at `/opt/datadog-agent`. You're free to move this folder wherever you like; however, this documentation assumes a default installation location.
 
 **Note**: macOS 10.12 and above are supported by the Agent v6, macOS 10.10 and above by the Agent v5.
 

--- a/content/en/agent/basic_agent_usage/osx.md
+++ b/content/en/agent/basic_agent_usage/osx.md
@@ -21,7 +21,7 @@ further_reading:
 
 This page outlines the basic features of the Datadog Agent for macOS. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
-Unlike other Agents, the macOS Datadog Agent does not include Agent tracing functionality out of the box. This functionality can be installed separately by downloading the Darwin Trace Agent from the [Github trace agent repository][4].
+Unlike other Agents, the macOS Datadog Agent does not include Agent tracing functionality out of the box. This functionality can be installed separately using [instructions in our Github agent repository][4].
 
 By default, the Agent is installed in a sandbox located at `/opt/datadog-agent`. You can move this folder wherever you like; however, this documentation assumes a default installation location.
 
@@ -110,4 +110,4 @@ See the instructions on how to [add packages to the embedded Agent][3] for more 
 [1]: https://app.datadoghq.com/account/settings#agent/mac
 [2]: /agent/troubleshooting
 [3]: /agent/faq/custom_python_package
-[4]: https://github.com/DataDog/datadog-trace-agent/releases
+[4]: https://github.com/DataDog/datadog-agent/blob/master/docs/trace-agent/README.md#run-on-macos

--- a/content/en/agent/basic_agent_usage/osx.md
+++ b/content/en/agent/basic_agent_usage/osx.md
@@ -21,7 +21,7 @@ further_reading:
 
 This page outlines the basic features of the Datadog Agent for macOS. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
-Unlike other agents, the agent tracing functionality is not included with the macOS Datadog agent out of the box and must be installed separately by downloading the darwin trace agent from our [Github trace agent repository](https://github.com/DataDog/datadog-trace-agent/releases).
+Unlike other agents, the agent tracing functionality is not included with the macOS Datadog agent out of the box and must be installed separately by downloading the darwin trace agent from our [Github trace agent repository][4].
 
 By default, the Agent is installed in a sandbox located at `/opt/datadog-agent`. You're free to move this folder wherever you like; however, his documentation assumes a default installation location.
 
@@ -110,3 +110,4 @@ See the instructions on how to [add packages to the embedded Agent][3] for more 
 [1]: https://app.datadoghq.com/account/settings#agent/mac
 [2]: /agent/troubleshooting
 [3]: /agent/faq/custom_python_package
+[4]: https://github.com/DataDog/datadog-trace-agent/releases

--- a/content/en/agent/basic_agent_usage/osx.md
+++ b/content/en/agent/basic_agent_usage/osx.md
@@ -23,7 +23,7 @@ This page outlines the basic features of the Datadog Agent for macOS. If you hav
 
 Unlike other Agents, the macOS Datadog Agent does not include Agent tracing functionality out of the box. This functionality can be installed separately by downloading the Darwin Trace Agent from the [Github trace agent repository][4].
 
-By default, the Agent is installed in a sandbox located at `/opt/datadog-agent`. You're free to move this folder wherever you like; however, this documentation assumes a default installation location.
+By default, the Agent is installed in a sandbox located at `/opt/datadog-agent`. You can move this folder wherever you like; however, this documentation assumes a default installation location.
 
 **Note**: macOS 10.12 and above are supported by the Agent v6, macOS 10.10 and above by the Agent v5.
 

--- a/content/en/agent/basic_agent_usage/osx.md
+++ b/content/en/agent/basic_agent_usage/osx.md
@@ -21,6 +21,8 @@ further_reading:
 
 This page outlines the basic features of the Datadog Agent for macOS. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
+Unlike other agents, the agent tracing functionality is not included with the macOS Datadog agent out of the box and must be installed separately by downloading the darwin trace agent from our [Github trace agent repository](https://github.com/DataDog/datadog-trace-agent/releases).
+
 By default, the Agent is installed in a sandbox located at `/opt/datadog-agent`. You're free to move this folder wherever you like; however, his documentation assumes a default installation location.
 
 **Note**: macOS 10.12 and above are supported by the Agent v6, macOS 10.10 and above by the Agent v5.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds info on where to find the mac trace agent.

### Motivation
Unlike other agents Mac agent does not include trace agent and this was not obvious in our docs.

### Preview link
https://docs.datadoghq.com/agent/basic_agent_usage/osx/?tab=agentv6
