### PR TITLE
add trace search & analytics client configuration docs for node

### DIFF
--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -133,10 +133,40 @@ Coming Soon. Reach out to [the Datadog support team][1] to be part of the beta.
 {{% /tab %}}
 {{% tab "Node.js" %}}
 
-Coming Soon. Reach out to [the Datadog support team][1] to be part of the beta.
+### Automatic Configuration
 
+Trace Search & Analytics can be enabled globally for all web integrations with one configuration parameter in the tracing client:
 
-[1]: /help
+```javascript
+tracer.init({
+  analytics: true
+})
+```
+
+After enabling, the Trace Search & Analytics UI will now populate, you can get started [here][1].
+
+### Configure Additional Services (optional)
+
+**Configure By Integration**
+
+In addition to setting globally, you can enable or disable Trace Search & Analytics for individual integrations.
+
+For example, to enable Trace Search & Analytics for Express:
+
+```javascript
+tracer.use('express', {
+  analytics: true
+})
+```
+
+**Configure Sample Rate of APM Events**
+
+When enabling Trace Search & Analytics, the default sample rate is to collect analytics for 100% of APM events. For any services that have been enabled for Trace Search & Analytics in the Tracing Client, you can adjusted the sampling rate for APM Events in your [APM settings][2].
+
+{{< img src="tracing/trace_sampling_ui.png" alt="Trace Sampling UI" responsive="true" style="width:100%;">}}
+
+[1]: https://app.datadoghq.com/apm/search
+[2]: https://app.datadoghq.com/apm/settings
 {{% /tab %}}
 {{% tab ".NET" %}}
 

--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -105,6 +105,16 @@ Integration names can be found on the [integrations table][2].
 
 Note several integrations require non-standard configuration due to the integration-specific implementation of the tracer. Consult the library documentation on [Trace Search & Analytics][3] for details.
 
+### Custom Instrumentation
+
+Applications with custom instrumentation can enable trace analytics by setting the `ANALYTICS` tag on the span:
+
+```javascript
+const { ANALYTICS } = require('dd-trace/ext/tags')
+
+span.setTag(ANALYTICS, true)
+```
+
 ### Configure Sample Rate of APM Events
 
 When enabling Trace Search & Analytics, the default sample rate is to collect 100% of APM Events. For any services that have been enabled for Trace Search & Analytics in the Tracing Client, you can adjusted the sampling rate for APM Events in your [APM settings][4].

--- a/content/en/tracing/advanced_usage/_index.md
+++ b/content/en/tracing/advanced_usage/_index.md
@@ -105,16 +105,6 @@ Integration names can be found on the [integrations table][2].
 
 Note several integrations require non-standard configuration due to the integration-specific implementation of the tracer. Consult the library documentation on [Trace Search & Analytics][3] for details.
 
-### Custom Instrumentation
-
-Applications with custom instrumentation can enable trace analytics by setting the `ANALYTICS` tag on the span:
-
-```javascript
-const { ANALYTICS } = require('dd-trace/ext/tags')
-
-span.setTag(ANALYTICS, true)
-```
-
 ### Configure Sample Rate of APM Events
 
 When enabling Trace Search & Analytics, the default sample rate is to collect 100% of APM Events. For any services that have been enabled for Trace Search & Analytics in the Tracing Client, you can adjusted the sampling rate for APM Events in your [APM settings][4].
@@ -167,6 +157,16 @@ For example, to enable Trace Search & Analytics for Express:
 tracer.use('express', {
   analytics: true
 })
+```
+
+**Custom Instrumentation**
+
+Applications with custom instrumentation can enable trace analytics by setting the `ANALYTICS` tag on the span:
+
+```javascript
+const { ANALYTICS } = require('dd-trace/ext/tags')
+
+span.setTag(ANALYTICS, true)
 ```
 
 **Configure Sample Rate of APM Events**


### PR DESCRIPTION
### What does this PR do?

Add Trace Search & Analytics client configuration documentation.

### Motivation

The feature should be documented for every language.

### Preview link

https://docs-staging.datadoghq.com/rochdev/trace-analytics-client-config/tracing/advanced_usage/?tab=nodejs#trace-search-analytics

### Additional Notes
