### PR TITLE
update client auth k8s faq

### DIFF
--- a/content/en/integrations/faq/client-authentication-against-the-apiserver-and-kubelet.md
+++ b/content/en/integrations/faq/client-authentication-against-the-apiserver-and-kubelet.md
@@ -13,7 +13,7 @@ kubelet_client_crt: /path/to/client.crt
 kubelet_client_key: /path/to/client.key
 ```
 
-## Server Authentication for API server and kubelet
+## Server authentication for API server and kubelet
 
 Datadog uses the default CA certificate of the Agent's service account to verify the API server's identity. To use custom certificates, specify the path in your configuration file.
 

--- a/content/en/integrations/faq/client-authentication-against-the-apiserver-and-kubelet.md
+++ b/content/en/integrations/faq/client-authentication-against-the-apiserver-and-kubelet.md
@@ -1,9 +1,9 @@
 ---
-title: Client Authentication against the apiserver and kubelet
+title: Client Authentication against the API server and kubelet
 kind: faq
 ---
 
-By default the Agent authenticates against the apiserver and kubelet with its service account bearer token. If you want to specify its path, set the options below. If X509 client certificates are set, either for the kubelet or apiserver, they will be used instead. The recommended way to [expose these files][1] to the Agent is by using [Kubernetes Secrets][2].
+By default the Agent authenticates against the API server and kubelet with its service account bearer token. If you want to specify its path, set the options below. If X509 client certificates are set, either for the kubelet or API server, they are used instead. The recommended way to [expose these files][1] to the Agent is by using [Kubernetes Secrets][2].
 
 ```
 bearer_token_path: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -13,13 +13,13 @@ kubelet_client_crt: /path/to/client.crt
 kubelet_client_key: /path/to/client.key
 ```
 
-## Server Authentication for apiserver and kubelet
+## Server Authentication for API server and kubelet
 
-We use the default CA certificate of the Agent's service account to verify the apiserver's identity. To use custom certificates, specify the path in your configuration file.
+Datadog uses the default CA certificate of the Agent's service account to verify the API server's identity. To use custom certificates, specify the path in your configuration file.
 
 ```
 apiserver_ca_cert: /path/to/cacert.crt
-kubelet_cert: /path/to/ca.pem
+kubelet_client_ca: /path/to/ca.pem
 ```
 
 The default for kubelet traffic is to first try to use the read-only port that doesn't require TLS and then to fall back to the HTTPS API with simple TLS validation. Providing a cert forces TLS validation on. Explicitly disabling tls_verify should be used with caution: if an attacker sniffs the Agent requests they will see the Agent's service account bearer token.
@@ -28,5 +28,16 @@ The default for kubelet traffic is to first try to use the read-only port that d
 kubelet_tls_verify: True
 ```
 
+## Alternate Option: kubeconfig
+
+Alternately, you can also use [kubeconfig][3] for API server authentication. Use the `DD_KUBERNETES_KUBECONFIG_PATH` environment variable to specify the path, or the equivalent option in [datadog.yaml][4]
+
+```
+kubernetes_kubeconfig_path: /path/to/file
+```
+
+
 [1]: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod
 [2]: https://kubernetes.io/docs/concepts/configuration/secret
+[3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig
+[4]: https://github.com/DataDog/datadog-agent/blob/a9e0c4f534482170817300edb3cce01df9abea4a/pkg/config/config_template.yaml#L687-L692

--- a/content/en/integrations/faq/client-authentication-against-the-apiserver-and-kubelet.md
+++ b/content/en/integrations/faq/client-authentication-against-the-apiserver-and-kubelet.md
@@ -28,7 +28,7 @@ The default for kubelet traffic is to first try to use the read-only port that d
 kubelet_tls_verify: True
 ```
 
-## Alternate Option: kubeconfig
+## Alternate option: kubeconfig
 
 Alternately, you can use [kubeconfig][3] for API server authentication. Use the `DD_KUBERNETES_KUBECONFIG_PATH` environment variable to specify the path, or the equivalent option in [datadog.yaml][4].
 

--- a/content/en/integrations/faq/client-authentication-against-the-apiserver-and-kubelet.md
+++ b/content/en/integrations/faq/client-authentication-against-the-apiserver-and-kubelet.md
@@ -30,7 +30,7 @@ kubelet_tls_verify: True
 
 ## Alternate Option: kubeconfig
 
-Alternately, you can also use [kubeconfig][3] for API server authentication. Use the `DD_KUBERNETES_KUBECONFIG_PATH` environment variable to specify the path, or the equivalent option in [datadog.yaml][4]
+Alternately, you can use [kubeconfig][3] for API server authentication. Use the `DD_KUBERNETES_KUBECONFIG_PATH` environment variable to specify the path, or the equivalent option in [datadog.yaml][4].
 
 ```
 kubernetes_kubeconfig_path: /path/to/file


### PR DESCRIPTION
### What does this PR do?
1. Documents the kubeconfig approach for API server validation.
2. Updates existing FAQ to use Agent 6 env vars.
3. Corrects existing FAQ's grammar/style.

### Motivation
Support request.

### Preview link

https://docs-staging.datadoghq.com/cswatt/kubeconfig-approach/integrations/faq/client-authentication-against-the-apiserver-and-kubelet/

