### PR TITLE
[web-platform] update tagdex disappearance duration to 12 hours

### DIFF
--- a/content/en/graphing/faq/how-do-i-delete-a-host-or-metric-from-the-ui.md
+++ b/content/en/graphing/faq/how-do-i-delete-a-host-or-metric-from-the-ui.md
@@ -5,7 +5,7 @@ kind: faq
 
 ### Metrics/Tags
 
-There is no way to immediately delete a metric/tag. Unused metrics/tags "age out" of the UI naturally after 24 hours.
+There is no way to immediately delete a metric/tag. Unused metrics/tags "age out" of the UI naturally after 12 hours.
 
 With respect to monitors, the metric stream will stop being considered after that age-out period.
 
@@ -13,7 +13,7 @@ With respect to dashboards, the metric/tag will still appear in the visualizatio
 
 ### Hosts
 
-If you're running the Agent, and assuming you've intentionally [stopped][2] or [removed][3] your host, all hosts and metrics that have not seen new data in 24 hours will disappear from the UI. You may still [query against them][4], however, they will not appear in drop downs, nor in the infrastructure or host map views.
+If you're running the Agent, and assuming you've intentionally [stopped][2] or [removed][3] your host, all hosts and metrics that have not seen new data in 12 hours will disappear from the UI. You may still [query against them][4], however, they will not appear in drop downs, nor in the infrastructure or host map views.
 
 [1]: /graphingjson
 [2]: /agent/faq/agent-commands/#start-stop-restart-the-agent


### PR DESCRIPTION
### What does this PR do?

- Updates the time it takes for tags to disappear from 24 to 12 hours
- It's possible this value will change in Q2 after a new OKR is completed, so this may change soonish.

- Trello: https://trello.com/c/2bCxOm6R/608-tag-autocompletion-in-ui-components

### Motivation

- Investigating 2 support tickets in the past 48 hours which both originated from confusion about what the proper duration is

### Preview link

- https://docs-staging.datadoghq.com/cameron.yick/update-metric-tags-disappear-duration/

