### PR TITLE
adding oregon and london datacenter locations

### DIFF
--- a/content/en/synthetics/api_test.md
+++ b/content/en/synthetics/api_test.md
@@ -46,6 +46,8 @@ Define the request you want to be executed by Datadog:
 5. Pick locations to run the test from. Available locations are:
     * Frankfurt (Request made from an AWS Datacenter)
     * Tokyo (Request made from an AWS Datacenter)
+    * Oregon (Request made from an AWS Datacenter)
+    * London (Request made from an AWS Datacenter)
 
 6. Choose a check frequency between "1 run per minute" and "1 run per week".
 7. Finish by clicking on **Test URL** to try out the request configuration. You should see a response preview show up in the right side of your screen.

--- a/content/en/synthetics/browser_test.md
+++ b/content/en/synthetics/browser_test.md
@@ -38,6 +38,8 @@ Define the configuration of your browser test.
 5. Pick-up locations to run the test from. Available locations are:
     * Frankfurt (Request made from an AWS Datacenter)
     * Tokyo (Request made from an AWS Datacenter)
+    * Oregon (Request made from an AWS Datacenter)
+    * London (Request made from an AWS Datacenter)
 6. Choose a Check frequency between "1 run per 5 minute interval" to "1 run per week":
 
     {{< img src="synthetics/browser_test/check_frequency.png" alt="Check frequency" responsive="true" style="width:80%;">}}


### PR DESCRIPTION
### What does this PR do?
Adds Oregon and London locations.

In the future, after we have more than 4 locations, we might want to have a reference guide in a `guide` section under Synthetics that just lists all available locations. Right now, as there are 4 locations, I think that'd look a bit weird and underwhelming, so let's sit tight for now.

### Motivation
h/t @MargotLepizzera 

### Preview link
https://docs-staging.datadoghq.com/cswatt/oregon-datacenter/synthetics/browser_test/
https://docs-staging.datadoghq.com/cswatt/oregon-datacenter/synthetics/api_test/

