### PR TITLE
php apm added support for symfony2

### DIFF
--- a/content/en/tracing/languages/php.md
+++ b/content/en/tracing/languages/php.md
@@ -92,7 +92,7 @@ If the web framework that you use is not listed below, you can still see traces 
 | Module         | Versions      | Support Type    |
 |:---------------|:--------------|:----------------|
 | Laravel        | 4.2, 5.x      | Fully Supported |
-| Symfony        | 3.3, 3.4, 4.x | Fully Supported |
+| Symfony        | 2.x, 3.3, 3.4, 4.x | Fully Supported |
 | Zend Framework | 1.12          | Fully Supported |
 | CakePHP        | 1.3, 2.8, 3.x | _Coming Soon_   |
 | CodeIgniter    | 2, 3          | _Coming Soon_   |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Documents support for Symfony 2.x PHP APM

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/tracing/languages/php/#web-framework-compatibility

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/priyanshi/addSymfony2/tracing/languages/php/#web-framework-compatibility

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
