### PR TITLE
Fixes small mistake for k8s multi-line rule

### DIFF
--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -307,7 +307,7 @@ spec:
   template:
     metadata:
       annotations:
-        ad.datadoghq.com/nginx.logs: '[{"source": "postgresql", "service": "database", "log_processing_rules": [{"type": "multi_line", "name": "log_start_with_date", "pattern" : "\\d{4}-(0?[1-9]|1[012])-(0?[1-9]|[12][0-9]|3[01])"}]}]'
+        ad.datadoghq.com/postgres.logs: '[{"source": "postgresql", "service": "database", "log_processing_rules": [{"type": "multi_line", "name": "log_start_with_date", "pattern" : "\\d{4}-(0?[1-9]|1[012])-(0?[1-9]|[12][0-9]|3[01])"}]}]'
       labels:
         app: database
       name: postgres


### PR DESCRIPTION
### What does this PR do?

Changed "nginx" to "postgres" on kubernetes multi-line aggregation example

### Motivation

Noticed the mistake

### Preview link

https://docs-staging.datadoghq.com/tj/fix_mistake_for_log_collection_page/logs/log_collection/?tab=kubernetes

### Additional Notes
