### PR TITLE
re-enabling snowplow pageviews tracking

### DIFF
--- a/layouts/partials/footer_scripts/snowplow.html
+++ b/layouts/partials/footer_scripts/snowplow.html
@@ -20,4 +20,5 @@
       });
       window.snowplow('enableActivityTracking', 5, 5);
       window.snowplow('enableLinkClickTracking');
+      window.snowplow('trackPageView');
     </script>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR enable snowplow pageview tracking. This was removed by mistake in the following PR: https://github.com/DataDog/documentation/pull/4170 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
