### PR TITLE
Add page for explaining how to identify synthetics probes

### DIFF
--- a/content/en/synthetics/_index.md
+++ b/content/en/synthetics/_index.md
@@ -15,6 +15,9 @@ further_reading:
 - link: "synthetics/browser_test"
   tag: "Documentation"
   text: "Configure a Browser Test"
+- link: "synthetics/identify_our_bots"
+  tag: "Documentation"
+  text: "Identify Our Bots"
 ---
 
 <div class="alert alert-warning">Synthetics is only available in the US. Browser tests are available in beta: to request access complete the <a href="https://app.datadoghq.com/synthetics/beta">Datadog Synthetics Request form</a>.</div>

--- a/content/en/synthetics/_index.md
+++ b/content/en/synthetics/_index.md
@@ -15,9 +15,9 @@ further_reading:
 - link: "synthetics/browser_test"
   tag: "Documentation"
   text: "Configure a Browser Test"
-- link: "synthetics/identify_our_bots"
+- link: "synthetics/identify_synthetics_bots"
   tag: "Documentation"
-  text: "Identify Our Bots"
+  text: "Identify Synthetics Bots"
 ---
 
 <div class="alert alert-warning">Synthetics is only available in the US. Browser tests are available in beta: to request access complete the <a href="https://app.datadoghq.com/synthetics/beta">Datadog Synthetics Request form</a>.</div>

--- a/content/en/synthetics/identify_our_bots.md
+++ b/content/en/synthetics/identify_our_bots.md
@@ -1,0 +1,37 @@
+---
+title: Identify our bots
+kind: documentation
+beta: true
+description: Identify incoming Synthetics requests
+further_reading:
+- link: "https://www.datadoghq.com/blog/introducing-synthetic-monitoring/"
+  tag: "Blog"
+  text: "Introducing Datadog Synthetics"
+- link: "synthetics/"
+  tag: "Documentation"
+  text: "Manage your checks"
+- link: "synthetics/browser_test"
+  tag: "Documentation"
+  text: "Configure a Browser Test"
+- link: "synthetics/api_test"
+  tag: "Documentation"
+  text: "Configure an API Test"
+
+---
+
+<div class="alert alert-warning">Synthetics is only available in the US. Browser tests are available in beta: to request access complete the <a href="https://app.datadoghq.com/synthetics/beta">Datadog Synthetics Request form</a>.</div>
+
+## Overview
+
+Some parts of your system might not be available to robots without the right identification. Datadog provides you with a variety of ways to identify the robots and make sure they can perform the actions you expect them to do.
+
+## Solutions
+
+1. You can use the [**headers we set for APM integration**][1]. It will work for all the tests (both browser and API).
+
+2. You can use the **shared headers** to set any header to any value for all your API tests at once.
+
+3. You can locally add **cookies, headers or basic auth** to your API tests.
+
+4. You can use our **IP ranges** provided by this URL https://ip-ranges.datadoghq.com/, in the section "synthetics".
+[1]: ../apm/#how-are-traces-linked-to-checks

--- a/content/en/synthetics/identify_synthetics_bots.md
+++ b/content/en/synthetics/identify_synthetics_bots.md
@@ -1,5 +1,5 @@
 ---
-title: Identify our bots
+title: Identify Synthetics Bots
 kind: documentation
 beta: true
 description: Identify incoming Synthetics requests
@@ -23,11 +23,19 @@ further_reading:
 
 ## Overview
 
-Some parts of your system might not be available to robots without the right identification. Datadog provides you with a variety of ways to identify the robots and make sure they can perform the actions you expect them to do.
+Some parts of your system might not be available to robots without the right identification or you might want to avoid collecting analytics from our robots. Datadog provides you with a variety of ways to identify the robots and make sure they can perform the actions you expect them to do.
 
 ## Solutions
 
-1. You can use the [**headers we set for APM integration**][1]. It will work for all the tests (both browser and API).
+1. You can use the [**headers we set for APM integration**][1]. The `x-datadog-origin: synthetics` header for instance is being added to all the requests launched for both API & Browser tests. Using one of these headers will allow you to filter these bot requests once in your analytics tool.
+
+If you want these requests to be completely removed, and not sent at all to your analytics tool, you can use the below JavaScript variable on your website, wrapped around your analytics tool code snippet:
+
+```
+if (window._DATADOG_SYNTHETICS_BROWSER === undefined) {
+  initializeAnalytics()
+}
+```
 
 2. You can use the **shared headers** to set any header to any value for all your API tests at once.
 

--- a/content/en/synthetics/identify_synthetics_bots.md
+++ b/content/en/synthetics/identify_synthetics_bots.md
@@ -23,11 +23,13 @@ further_reading:
 
 ## Overview
 
-Some parts of your system might not be available to robots without the right identification or you might want to avoid collecting analytics from our robots. Datadog provides you with a variety of ways to identify the robots and make sure they can perform the actions you expect them to do.
+Some parts of your system might not be available to robots without the right identification, or you might want to avoid collecting analytics from Datadog robots.
 
 ## Solutions
 
-1. You can use the [**headers we set for APM integration**][1]. The `x-datadog-origin: synthetics` header for instance is being added to all the requests launched for both API & Browser tests. Using one of these headers will allow you to filter these bot requests once in your analytics tool.
+Choose any or a variety of the following methods to identify the robots to make sure they are performing the actions you expect.
+
+1. You can use the [**headers set for APM integration**][1]. The `x-datadog-origin: synthetics` header, for instance, is added to all the requests launched for both API and browser tests. Using one of these headers allows you to filter these bot requests once in your analytics tool.
 
 If you want these requests to be completely removed, and not sent at all to your analytics tool, you can use the below JavaScript variable on your website, wrapped around your analytics tool code snippet:
 
@@ -41,5 +43,7 @@ if (window._DATADOG_SYNTHETICS_BROWSER === undefined) {
 
 3. You can locally add **cookies, headers or basic auth** to your API tests.
 
-4. You can use our **IP ranges** provided by this URL https://ip-ranges.datadoghq.com/, in the section "synthetics".
-[1]: ../apm/#how-are-traces-linked-to-checks
+4. You can use Datadog's [**IP ranges**][2], provided in the section "synthetics".
+
+[1]: /synthetics/apm/#how-are-traces-linked-to-checks
+[2]: https://ip-ranges.datadoghq.com/

--- a/data/partials/mainnav.yaml
+++ b/data/partials/mainnav.yaml
@@ -486,8 +486,8 @@ main:
         url: "synthetics/browser_test"
       - name: "APM Integration"
         url: "synthetics/apm"
-      - name: "Identify our bots"
-        url: "synthetics/identify_our_bots"
+      - name: "Identify Synthetics Bots"
+        url: "synthetics/identify_synthetics_bots"
 
   # DEVELOPERS
   - name: "Developer Tools"

--- a/data/partials/mainnav.yaml
+++ b/data/partials/mainnav.yaml
@@ -486,6 +486,8 @@ main:
         url: "synthetics/browser_test"
       - name: "APM Integration"
         url: "synthetics/apm"
+      - name: "Identify our bots"
+        url: "synthetics/identify_our_bots"
 
   # DEVELOPERS
   - name: "Developer Tools"


### PR DESCRIPTION
Add page for explaining how to identify synthetics probes.

Preview is here: https://docs-staging.datadoghq.com/gabin/identify-synthetics-bots/synthetics/identify_our_bots/