### PR TITLE
Fixes typo and word choice on log file tailing FAQ

### DIFF
--- a/content/en/logs/faq/how-to-increase-the-number-of-log-files-tailed-by-the-agent.md
+++ b/content/en/logs/faq/how-to-increase-the-number-of-log-files-tailed-by-the-agent.md
@@ -14,7 +14,7 @@ further_reading:
   text: "How to investigate a log parsing issue?"
 ---
 
-By default the Agent can tail up to 100 log files. This limit is set to avoid performances issue when wildcards are set on huge repository.
+By default the Agent can tail up to 100 log files. This limit is set to avoid performances issue when wildcards are set on huge directories.
 
 To increase this limit, set the value of `open_files_limit` in the Agent's configuration file (`/etc/datadog-agent/datadog.yaml`) in the `logs_config` section:
 
@@ -23,5 +23,5 @@ logs_config:
   open_files_limit: 100
 ```
 
-**Note**: Increasing the tailed logs files limit might increase the ressource consumption of the Agent.
+**Note**: Increasing the tailed logs files limit might increase the resource consumption of the Agent.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Fixes a typo and changes the word "repository" to "directories"

### Motivation

Noticed the typo. 

### Preview link

Will add when available

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
