### PR TITLE
.NET tracing compatiblity

### DIFF
--- a/content/en/tracing/languages/dotnet.md
+++ b/content/en/tracing/languages/dotnet.md
@@ -25,6 +25,8 @@ further_reading:
 
 To begin tracing applications written in any language, first [install and configure the Datadog Agent][1]. The .NET Tracer runs in-process to instrument your applications and sends traces to the Agent.
 
+Note that the .NET Tracer supports all .NET-based languages, i.e. C#, VB.Net, etc. If you need support for a particular framework, consider making an open-source contribution.
+
 ## Automatic Instrumentation
 
 Automatic instrumentation uses the Profiling API provided by .NET Framework and .NET Core to modify IL instructions at runtime and inject instrumentation code into your application. With zero code changes and minimal configuration, the .NET Tracer automatically instruments all supported libraries out of the box.

--- a/content/en/tracing/languages/dotnet.md
+++ b/content/en/tracing/languages/dotnet.md
@@ -25,7 +25,7 @@ further_reading:
 
 To begin tracing applications written in any language, first [install and configure the Datadog Agent][1]. The .NET Tracer runs in-process to instrument your applications and sends traces to the Agent.
 
-Note that the .NET Tracer supports all .NET-based languages, i.e. C#, VB.Net, etc. If you need support for a particular framework, consider making an open-source contribution.
+**Note**: The .NET Tracer supports all .NET-based languages (C#, VB.Net, etc). If you need support for a particular framework, consider making an open-source contribution.
 
 ## Automatic Instrumentation
 


### PR DESCRIPTION
### What does this PR do?

It is a template of the kind of wording I'd like to see added to the .NET tracing guide. I'd like something equivalent to this statement in the Java APM guide:

> Note that dd-trace-java’s artifacts (dd-java-agent.jar, dd-trace-api.jar, dd-trace-ot.jar) support all JVM-based languages, i.e. Scala, Groovy, Kotlin, Clojure, etc. If you need support for a particular framework, consider making an open-source contribution.

https://docs.datadoghq.com/tracing/languages/java/#installation-and-getting-started

### Motivation

Support often gets questions about what langauges are supported, a statement like this could clear things up, especially for those not as familiar with the language. When I was confused and asked in a support channel for clarification once about what languages were supported I received this answer:

> Scala and Java (languages) both running on a JVM (which executes Java Bytecode) is the exact analogy to C#, VB.Net, etc, (languages) running on a .Net runtime (which executes MSIL). 
> 
> Just like there are multiple JVMs (Oracle, OpenJDK, etc), there are multiple .Net runtimes (classic, Core, mono, etc)

Which I think is something we should communicate in the public docs.

### Preview link

https://docs.datadoghq.com/tracing/languages/dotnet/?tab=netframeworkonwindows

https://docs-staging.datadoghq.com/nicholas-devlin-patch-1//tracing/languages/dotnet/?tab=netframeworkonwindows

### Additional Notes

I don't believe this should be the exact phrasing, since I know next to nothing about .NET, but I would like something like this to be added.
