### PR TITLE
include payload limits

### DIFF
--- a/content/en/api/metrics/metrics_timeseries.md
+++ b/content/en/api/metrics/metrics_timeseries.md
@@ -6,7 +6,7 @@ external_redirect: /api/#post-time-series-points
 ---
 
 ## Post timeseries points
-The metrics end-point allows you to post time-series data that can be graphed on Datadog's dashboards.
+The metrics end-point allows you to post time-series data that can be graphed on Datadog's dashboards. As of this writing, the limit is 3.2 megabytes (3200000) for compressed payloads, and 62 megabytes (62914560) for the decompressed payloads.
 
 #### ARGUMENTS
 

--- a/content/en/api/metrics/metrics_timeseries.md
+++ b/content/en/api/metrics/metrics_timeseries.md
@@ -6,7 +6,7 @@ external_redirect: /api/#post-time-series-points
 ---
 
 ## Post timeseries points
-The metrics end-point allows you to post time-series data that can be graphed on Datadog's dashboards. As of this writing, the limit is 3.2 megabytes (3200000) for compressed payloads, and 62 megabytes (62914560) for the decompressed payloads.
+The metrics end-point allows you to post time-series data that can be graphed on Datadog's dashboards. The limit for compressed payloads is 3.2 megabytes (3200000), and 62 megabytes (62914560) for decompressed payloads.
 
 #### ARGUMENTS
 


### PR DESCRIPTION
### What does this PR do?

Include information about the payload limits for the series endpoint in the api.

### Motivation

we have an internal doc that describes this: https://github.com/DataDog/se-docs/wiki/Payload-size-limits-for-the--api-v1-series-endpoint

And it's a question that support gets sometimes. There is no reason it shouldn't be public.

### Preview link

https://docs.datadoghq.com/api/?lang=bash#post-timeseries-points