### PR TITLE
clean up some small issues in the forecast docs

### DIFF
--- a/content/en/graphing/functions/algorithms.md
+++ b/content/en/graphing/functions/algorithms.md
@@ -8,7 +8,7 @@ disable_toc: true
 
 | Function      | Description                                                                                | Example                                                    |
 | :----         | :-------                                                                                   | :---------                                                 |
-| `anomalies()` | Overlay a gray band on the metric showing the expected behavior of a series based on past. | `anomalies(avg:<METRIC_NAME>{*}, '<ALGORITHM>', <BOUNDS>)` |
+| `anomalies()` | Overlay a gray band on the metric showing the expected behavior of a series based on past. | `anomalies(METRIC_NAME>{*}, '<ALGORITHM>', <BOUNDS>)` |
 
 The `anomalies()` function has two parameters:
 
@@ -27,7 +27,7 @@ See the [Anomaly Monitor][1] page for more info.
 
 | Function     | Description                | Example                                                                    |
 | :----        | :-------                   | :---------                                                                 |
-| `outliers()` | Highlight outliers series. | `outliers(avg:<METRIC_NAME>{*}, '<ALGORITHM>', <TOLERANCE>, <PERCENTAGE>)` |
+| `outliers()` | Highlight outliers series. | `outliers(<METRIC_NAME>{*}, '<ALGORITHM>', <TOLERANCE>, <PERCENTAGE>)` |
 
 The `outliers()` function has three parameters:
 
@@ -43,7 +43,7 @@ See the [Outlier Monitor][2] page for more info.
 
 | Function     | Description                | Example                                                                    |
 | :----        | :-------                   | :---------                                                                 |
-| `forecast()`  | Predicts where a metric is heading in the future. | `forecast(avg:<METRIC_NAME>{*}, '<ALGORITHM>', <DEVIATIONS>)` |
+| `forecast()`  | Predicts where a metric is heading in the future. | `forecast(<METRIC_NAME>{*}, '<ALGORITHM>', <DEVIATIONS>)` |
 
 The `forecast()` function has two parameters:
 

--- a/content/en/graphing/functions/algorithms.md
+++ b/content/en/graphing/functions/algorithms.md
@@ -39,15 +39,15 @@ The `outliers()` function has three parameters:
 
 See the [Outlier Monitor][2] page for more info.
 
-## Forcast
+## Forecast
 
 | Function     | Description                | Example                                                                    |
 | :----        | :-------                   | :---------                                                                 |
-| `forcast()`  | Predicts where a metric is heading in the future. | `forcast(avg:<METRIC_NAME>{*}, '<FORECAST>', <DEVIATIONS>` |
+| `forecast()`  | Predicts where a metric is heading in the future. | `forecast(avg:<METRIC_NAME>{*}, '<ALGORITHM>', <DEVIATIONS>)` |
 
-The `forcasts()` function has two parameters:
+The `forecasts()` function has two parameters:
 
-* `FORECAST`: The outliers algorithm to use - select `linear` or `seasonal`. For more information about these algorithms, see the [Forcast Algorithms][3] section.
+* `ALGORITHM`: The forecasting algorithm to use - select `linear` or `seasonal`. For more information about these algorithms, see the [Forecast Algorithms][3] section.
 * `DEVIATIONS`: The width of the range of forecasted values. A value of 1 or 2 should be large enough to forecast most "normal" points accurately.
 
 A number of the graphing options disappear, as forecasts have a unique visualization. After successfully adding **Forecast**, your editor should show something like this:

--- a/content/en/graphing/functions/algorithms.md
+++ b/content/en/graphing/functions/algorithms.md
@@ -45,7 +45,7 @@ See the [Outlier Monitor][2] page for more info.
 | :----        | :-------                   | :---------                                                                 |
 | `forecast()`  | Predicts where a metric is heading in the future. | `forecast(avg:<METRIC_NAME>{*}, '<ALGORITHM>', <DEVIATIONS>)` |
 
-The `forecasts()` function has two parameters:
+The `forecast()` function has two parameters:
 
 * `ALGORITHM`: The forecasting algorithm to use - select `linear` or `seasonal`. For more information about these algorithms, see the [Forecast Algorithms][3] section.
 * `DEVIATIONS`: The width of the range of forecasted values. A value of 1 or 2 should be large enough to forecast most "normal" points accurately.

--- a/content/en/monitors/monitor_types/forecasts.md
+++ b/content/en/monitors/monitor_types/forecasts.md
@@ -2,7 +2,7 @@
 title: Forecasts monitor
 kind: documentation
 aliases:
-- /guides/forecasts/ 
+- /guides/forecasts/
 further_reading:
 - link: "monitors/notifications"
   tag: "Documentation"
@@ -41,7 +41,7 @@ There are three required options for setting up a forecast alert:
 
 Datadog automatically sets the **Advanced** options for you by analyzing your metric. Note that any changes in the **Define the metric** section could change the advanced options.
 
-* You can change the forecasting algorithm to be used here. See the [Forcast algorithms](#forecast-algorithms) section for tips on how to choose the best algorithm for your use case. Each algorithm also has additional settings is described in the next section.
+* You can change the forecasting algorithm to be used here. See the [Forecast algorithms](#forecast-algorithms) section for tips on how to choose the best algorithm for your use case. Each algorithm also has additional settings is described in the next section.
 * Datadog recommends using larger intervals between points to avoid having noise influence the forecast too much.
 * The number of deviations controls the width of the range of forecasted values. A value of 1 or 2 should be large enough to forecast most "normal" points accurately.
 


### PR DESCRIPTION
### What does this PR do?

1. Fixes "forcast" to "forecast".
2. The first param of `forecast()` should be called "algorithm."
3. Don't specify "avg" because any space aggregator can be used. Also, other function doc pages don't include this.

### Motivation

Clearer documentation for forecasts.

### Preview link

https://docs-staging.datadoghq.com/stephen/forecast-fixes/graphing/functions/algorithms/#forecast
