### PR TITLE
Reorganize the APM Docs

### DIFF
--- a/content/en/tracing/_index.md
+++ b/content/en/tracing/_index.md
@@ -8,38 +8,37 @@ further_reading:
   text: "Introduction to Application Performance Monitoring"
 ---
 
-## Setup
+Datadog APM provides you with deep insight into your application's performance-from automatically generated dashboards monitoring key metrics, such as request volume and latency, to detailed traces of individual requests-side by side with your logs and infrastructure monitoring.
+
+{{< whatsnext desc="Setup">}}
     {{< nextlink href="/agent/apm/" >}}Enable APM in the Datadog Agent{{< /nextlink >}}
     {{< nextlink href="/tracing/languages" >}}Instrument Your Application{{< /nextlink >}}
     {{< nextlink href="/agent/apm#enable-trace-search-analytics" >}}Enable Trace Search & Analytics{{< /nextlink >}}
+{{< /whatsnext >}}
 
-## Enrich Tracing
-    {{< nextlink href="/agent/apm" >}}Connect Logs & Traces{{< /nextlink >}}
-    {{< nextlink href="/tracing/languages" >}}Adding Unique Metadata to Spans{{< /nextlink >}}
-    {{< nextlink href="https://datadoghq.slack.com/messages/apm" >}}Runtime Metrics{{< /nextlink >}}
-    {{< nextlink href="https://datadoghq.slack.com/messages/apm" >}}Opentracing{{< /nextlink >}}
-    {{< nextlink href="https://datadoghq.slack.com/messages/apm" >}}Manual Instrumentation{{< /nextlink >}}
+{{< whatsnext desc="Enrich Tracing">}}
+    {{< nextlink href="/tracing/advanced_usage/correlate-traces-and-logs" >}}Connect Logs & Traces{{< /nextlink >}}
+    {{< nextlink href="/tracing/advanced_usage/#custom-tagging" >}}Adding Unique Metadata to Spans{{< /nextlink >}}
+    {{< nextlink href="/tracing/advanced_usage#runtime-metrics" >}}Runtime Metrics{{< /nextlink >}}
+    {{< nextlink href="/tracing/advanced_usage/#opentracing" >}}Opentracing{{< /nextlink >}}
+    {{< nextlink href="/tracing" >}}Manual Instrumentation{{< /nextlink >}}
+    {{< nextlink href="/tracing" >}}Setting Primary Tags to Group Services{{< /nextlink >}}
+{{< /whatsnext >}}
 
-## Use the APM UI
+{{< whatsnext desc="Use the APM UI">}}
     {{< nextlink href="/agent/apm" >}}Service List{{< /nextlink >}}
     {{< nextlink href="/tracing/languages" >}}Serice Page{{< /nextlink >}}
-    {{< nextlink href="https://datadoghq.slack.com/messages/apm" >}}Resource Page{{< /nextlink >}}
-    {{< nextlink href="https://datadoghq.slack.com/messages/apm" >}}Trace View{{< /nextlink >}}
-    {{< nextlink href="https://datadoghq.slack.com/messages/apm" >}}Trace Search{{< /nextlink >}}
-    {{< nextlink href="https://datadoghq.slack.com/messages/apm" >}}Trace Analytics{{< /nextlink >}}
-    {{< nextlink href="https://datadoghq.slack.com/messages/apm" >}}Service Map{{< /nextlink >}}
+    {{< nextlink href="/tracing" >}}Resource Page{{< /nextlink >}}
+    {{< nextlink href="/tracing" >}}Trace View{{< /nextlink >}}
+    {{< nextlink href="/tracing" >}}Trace Search{{< /nextlink >}}
+    {{< nextlink href="/tracing" >}}Trace Analytics{{< /nextlink >}}
+    {{< nextlink href="/tracing" >}}Service Map{{< /nextlink >}}
+{{< /whatsnext >}}
 
-## Proxy Instrumentation
-    {{< nextlink href="/agent/apm" >}}Envoy{{< /nextlink >}}
-    {{< nextlink href="/tracing/languages" >}}Nginx{{< /nextlink >}}
-
-## Guides
+{{< whatsnext desc="Guides">}}
     {{< nextlink href="/agent/apm" >}}How Distributed Tracing Works{{< /nextlink >}}
     {{< nextlink href="/tracing/languages" >}}Monitoring APM{< /nextlink >}}
-    {{< nextlink href="https://datadoghq.slack.com/messages/apm" >}}Trace Metrics{{< /nextlink >}}
+    {{< nextlink href="/tracing" >}}Trace Metrics{{< /nextlink >}}
+{{< /whatsnext >}}
 
-## Further Reading
 
-{{< partial name="whats-next/whats-next.html" >}}
-
-[1]: https://app.datadoghq.com/apm/home

--- a/content/en/tracing/_index.md
+++ b/content/en/tracing/_index.md
@@ -8,21 +8,35 @@ further_reading:
   text: "Introduction to Application Performance Monitoring"
 ---
 
-{{< vimeo 203196972 >}}
+## Setup
+    {{< nextlink href="/agent/apm/" >}}Enable APM in the Datadog Agent{{< /nextlink >}}
+    {{< nextlink href="/tracing/languages" >}}Instrument Your Application{{< /nextlink >}}
+    {{< nextlink href="/agent/apm#enable-trace-search-analytics" >}}Enable Trace Search & Analytics{{< /nextlink >}}
 
-## What is APM?
+## Enrich Tracing
+    {{< nextlink href="/agent/apm" >}}Connect Logs & Traces{{< /nextlink >}}
+    {{< nextlink href="/tracing/languages" >}}Adding Unique Metadata to Spans{{< /nextlink >}}
+    {{< nextlink href="https://datadoghq.slack.com/messages/apm" >}}Runtime Metrics{{< /nextlink >}}
+    {{< nextlink href="https://datadoghq.slack.com/messages/apm" >}}Opentracing{{< /nextlink >}}
+    {{< nextlink href="https://datadoghq.slack.com/messages/apm" >}}Manual Instrumentation{{< /nextlink >}}
 
-Datadog APM provides you with deep insight into your application's performance-from automatically generated dashboards monitoring key metrics, such as request volume and latency, to detailed traces of individual requests-side by side with your logs and infrastructure monitoring.
+## Use the APM UI
+    {{< nextlink href="/agent/apm" >}}Service List{{< /nextlink >}}
+    {{< nextlink href="/tracing/languages" >}}Serice Page{{< /nextlink >}}
+    {{< nextlink href="https://datadoghq.slack.com/messages/apm" >}}Resource Page{{< /nextlink >}}
+    {{< nextlink href="https://datadoghq.slack.com/messages/apm" >}}Trace View{{< /nextlink >}}
+    {{< nextlink href="https://datadoghq.slack.com/messages/apm" >}}Trace Search{{< /nextlink >}}
+    {{< nextlink href="https://datadoghq.slack.com/messages/apm" >}}Trace Analytics{{< /nextlink >}}
+    {{< nextlink href="https://datadoghq.slack.com/messages/apm" >}}Service Map{{< /nextlink >}}
 
-Datadog APM is offered as an upgrade to the Pro and Enterprise plans. A free 14-day trial is available. Registered users can visit the [APM page of the Datadog application][1] to get started.
+## Proxy Instrumentation
+    {{< nextlink href="/agent/apm" >}}Envoy{{< /nextlink >}}
+    {{< nextlink href="/tracing/languages" >}}Nginx{{< /nextlink >}}
 
-{{< whatsnext desc="Get started with Datadog APM">}}
-    {{< nextlink href="/agent/apm" >}}Configure your Agent to collect your Application Traces{{< /nextlink >}}
-    {{< nextlink href="/tracing/languages" >}}Set up your Application to send traces to your Datadog Agent{{< /nextlink >}}
-    {{< nextlink href="/tracing/visualization" >}}Visualize services, resources, and traces in Datadog {{< /nextlink >}}
-    {{< nextlink href="/tracing/getting_further" >}}Learn more about Datadog APM product specificities{{< /nextlink >}}
-    {{< nextlink href="https://datadoghq.slack.com/messages/apm" >}}Join the APM channel in the Public Datadog Slack for additional help from Datadog staff{{< /nextlink >}}
-{{< /whatsnext >}}
+## Guides
+    {{< nextlink href="/agent/apm" >}}How Distributed Tracing Works{{< /nextlink >}}
+    {{< nextlink href="/tracing/languages" >}}Monitoring APM{< /nextlink >}}
+    {{< nextlink href="https://datadoghq.slack.com/messages/apm" >}}Trace Metrics{{< /nextlink >}}
 
 ## Further Reading
 

--- a/content/en/tracing/languages/java.md
+++ b/content/en/tracing/languages/java.md
@@ -35,6 +35,25 @@ Finally, add the following JVM argument when starting your application in your I
 
 Note that `dd-trace-java`'s artifacts (`dd-java-agent.jar`, `dd-trace-api.jar`, `dd-trace-ot.jar`) support all JVM-based languages, i.e. Scala, Groovy, Kotlin, Clojure, etc. If you need support for a particular framework, consider making an [open-source contribution][4].
 
+### Containerized Setup
+
+Once your application is instrumented with the tracing client, by default traces will be sent to `localhost:8126`. Please see the [Agent Setup instructions][] to enable trace collection, below is an example on how to adjust the Agent hostname in your application:
+
+The Java Tracing Module automatically looks for and initializes with the ENV variables `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`.
+
+```bash
+java -javaagent:<DD-JAVA-AGENT-PATH>.jar -jar <YOUR_APPLICATION_PATH>.jar
+```
+
+You can also use system properties:
+
+```bash
+java -javaagent:<DD-JAVA-AGENT-PATH>.jar \
+     -Ddd.agent.host=$DD_AGENT_HOST \
+     -Ddd.agent.port=$DD_TRACE_AGENT_PORT \
+     -jar <YOUR_APPLICATION_PATH>.jar
+```
+
 ## Automatic Instrumentation
 
 Automatic instrumentation for Java uses the `java-agent` instrumentation capabilities [provided by the JVM][5]. When a `java-agent` is registered, it has the ability to modify class files at load time.
@@ -245,3 +264,4 @@ Java APM has minimal impact on the overhead of an application:
 [6]: http://bytebuddy.net
 [7]: /help
 [8]: https://github.com/DataDog/documentation#outside-contributors
+[9]: agent/apm/#containerized-setup

--- a/data/partials/platforms_apm_containers.yaml
+++ b/data/partials/platforms_apm_containers.yaml
@@ -1,0 +1,14 @@
+platforms_apm_containers:
+  - name: docker
+    link: "agent/docker/"
+    image: "platform_docker.png"
+  - name: kubernetes
+    link: "agent/kubernetes/"
+    image: "platform_kubernetes.png"
+  - name: ecs
+    link: "integrations/amazon_ecs/#metric-collection"
+    image: "platform_macosx.png"
+  - name: fargate
+    link: "integrations/ecs_fargate/#agent-setup"
+    image: "platform_redhat.png"
+  


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR updates the layout, format of the APM documentation. 

### Motivation
<!-- What inspired you to submit this pull request?-->
Confusion on how to configure Datadog Agent when setting up APM.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->
https://docs-staging.datadoghq.com/andrew/update-landing-page/tracing

### Additional Notes
<!-- Anything else we should know when reviewing?-->
As tagged, this is a WIP.