### PR TITLE
remove private beta functions from the docs

### DIFF
--- a/content/en/graphing/functions/beta.md
+++ b/content/en/graphing/functions/beta.md
@@ -19,18 +19,6 @@ Beta functions are available by editing the query JSON directly.
 |------------------|------------------------------------------------|------------------------------------------------|
 | `exclude_null()` | Remove N/A groups from your graph or top list. | `exclude_null(avg:system.load.1{*} by {host})` |
 
-## Lowess
-
-| Function   | Description                                                           | Example                        |
-|------------|-----------------------------------------------------------------------|--------------------------------|
-| `lowess()` | Smooth the metric by applying locally-weighted polynomial regression. | `lowess(avg:system.load.1{*})` |
-
-## Piecewise Linear
-
-| Function             | Description                                                          | Example                                  |
-|----------------------|----------------------------------------------------------------------|------------------------------------------|
-| `piecewise_linear()` | Approximate the metric with a piecewise function of linear segments. | `piecewise_linear(avg:system.load.1{*})` |
-
 ## Rolling Average
 
 | Function          | Description                                    | Example                           |
@@ -54,4 +42,3 @@ Beta functions are available by editing the query JSON directly.
     {{< nextlink href="/graphing/functions/smoothing" >}}Smoothing: Smooth your metric variations.{{< /nextlink >}}
     {{< nextlink href="/graphing/functions/timeshift" >}}Timeshift: Shift your metric data point along the timeline. {{< /nextlink >}}
 {{< /whatsnext >}}
-


### PR DESCRIPTION
### What does this PR do?

This PR removes the lowess() and piecewise_linear() from the docs. They are not exposed to customers in the UI and we'd like to keep it that way (we don't want to have to support these).

### Motivation

These were never intended to be released to customers, but snuck into the docs in https://github.com/DataDog/documentation/pull/3750.

### Preview link

https://docs-staging.datadoghq.com/stephen/no-beta/graphing/functions/beta/

