### PR TITLE
added support for listing traces in  trace search API

### DIFF
--- a/content/en/api/tracing/code_snippets/list_traces.py
+++ b/content/en/api/tracing/code_snippets/list_traces.py
@@ -1,0 +1,2 @@
+# This is not yet supported by the Python Client for Datadog API
+# Consult the curl example

--- a/content/en/api/tracing/code_snippets/list_traces.rb
+++ b/content/en/api/tracing/code_snippets/list_traces.rb
@@ -1,0 +1,2 @@
+# This is not yet supported by the Ruby Client for Datadog API
+# Consult the curl example 

--- a/content/en/api/tracing/code_snippets/list_traces.sh
+++ b/content/en/api/tracing/code_snippets/list_traces.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Make sure you replace the <DD_API_KEY> and <DD_APP_KEY> key below
+# with the ones for your account
+
+api_key=<DD_API_KEY>
+app_key=<DD_APP_KEY>
+
+curl -X POST \
+  'https://api.datadoghq.com/api/v1/traces-queries/list?api_key=${api_key}&application_key=${app_key}' \
+  -H 'content-type: application/json' \
+  -d '{"query": "service:nginx -@http.method:POST","time": {"from": "2019-03-20T09:00Z", "to": "2019-03-20T10:00Z"}, "sort": "desc", "limit": 50}'

--- a/content/en/api/tracing/code_snippets/result.list_traces.py
+++ b/content/en/api/tracing/code_snippets/result.list_traces.py
@@ -1,0 +1,2 @@
+# This is not yet supported by the Python Client for Datadog API
+# Consult the curl example

--- a/content/en/api/tracing/code_snippets/result.list_traces.rb
+++ b/content/en/api/tracing/code_snippets/result.list_traces.rb
@@ -1,0 +1,2 @@
+# This is not yet supported by the Ruby Client for Datadog API
+# Consult the curl example 

--- a/content/en/api/tracing/code_snippets/result.list_traces.sh
+++ b/content/en/api/tracing/code_snippets/result.list_traces.sh
@@ -1,0 +1,18 @@
+{
+    traces: [{
+        id: "AAAAAWgN8Xwgr1vKDQAAAABBV2dOOFh3ZzZobm1mWXJFYTR0OA",
+        content: {
+            timestamp: "2019-01-02T09:42:36.320Z",
+            tags: ['team:A'],
+            attributes: {
+                customAttribute: 123,
+                duration: 2345
+            },
+            host: 'i-123',
+            service: 'agent',
+            message: 'host connected to remote'
+        }
+    }],
+    nextLogId: "BBBBWgn...",
+    status: "ok"
+}

--- a/content/en/api/tracing/list_tracesearch.md
+++ b/content/en/api/tracing/list_tracesearch.md
@@ -1,0 +1,48 @@
+---
+title: Get a list of Traces
+type: apicontent
+order: 16.2
+external_redirect: /api/#list-traces
+---
+
+## Get a list of Traces
+
+List endpoint returns traces that match a trace search query. Results are paginated.
+
+
+##### ARGUMENTS
+
+* **`query`** [*required*]:  
+    The search query - following the [Trace search syntax][1] .
+* **`time.from`** [*required*]:  
+    Minimum timestamp for requested traces. Format can be either
+    - an ISO-8601 string
+    - a unix timestamp (number representing the elapsed millisec since epoch)
+* **`time.to`** [*required*]:  
+    Maximum timestamp for requested traces. Format can be either
+    - an ISO-8601 string with minute, second or millisecond precision 
+    - a unix timestamp (number representing the elapsed millisec since epoch)
+* **`time.timezone`** [*optional*, *default*=**None**]:
+   Can be specified both as an offset (e.g. "UTC+03:00") or a regional zone (e.g. "Europe/Paris")
+* **`time.offset`** [*optional*, *default*=**None**]:
+   Equivalent to `time.timezone`. But value in seconds.
+   If both timezone and offset are specified, timezone is ignored.
+* **`startAt`** [*optional*, *default*=**None**]:  
+   Hash identifier of the first trace to return in the list, available in a trace `id` attribute. This parameter is used for the [pagination feature](#pagination).
+   **Note**: this parameter is ignored if the corresponding trace is out of the scope of the specified time window. 
+* **`sort`** [*optional*, *default*=**desc**]:  
+    Time-ascending `asc` or time-descending `desc`results.
+* **`limit`** [*optional*, *default*=**10**]:  
+    Number of traces return in the response (maximum is 1000)
+
+##### PAGINATION
+
+Retrieve a trace list longer than the 1000 traces limit with the Trace List API Pagination feature:
+
+* for the first request, use no `startAt` parameter.
+* for the N-th request, use `nextTraceID` of N-1th request result as the `startAt` parameter value. 
+
+For better control over pagination results, you should use an absolute `time` parameter - don't use the`now` keyword.
+
+
+[1]: https://docs.datadoghq.com/tracing/visualization/search/#search-syntax

--- a/content/en/api/tracing/list_tracesearch_code.md
+++ b/content/en/api/tracing/list_tracesearch_code.md
@@ -1,0 +1,18 @@
+---
+title: List Traces
+type: apicode
+order: 16.2
+external_redirect: /api/#list-traces
+---
+
+##### Signature
+
+`POST api/v1/traces-queries/list`
+
+##### Example Request
+
+{{< code-snippets basename="list_traces" >}}
+
+##### Example Response
+
+{{< code-snippets basename="result.list_traces" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
adds support for listing traces in trace search API (similar to list-logs api)

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/api/?lang=python#tracing

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:


For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->
https://docs-staging.datadoghq.com/priyanshi/trace_search_api

### Additional Notes
<!-- Anything else we should know when reviewing?-->
