### PR TITLE
Moving the note on log processing rule to highlight it more

### DIFF
--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -176,6 +176,9 @@ List of all available parameters for log collection:
 | `tags`           | No       | Add tags to each log collected ([learn more about tagging][7]).                                                                                                                                                                                                                                                                                    |
 
 ## Advanced log collection functions
+
+If you set up multiple processing rules, they are applied sequentially. Each rule is applied on the result of the previous one.
+
 ### Filter logs
 
 To send only a specific subset of logs to Datadog use the `log_processing_rules` parameter in your configuration file with the **exclude_at_match** or **include_at_match** `type`.
@@ -226,8 +229,6 @@ logs:
 
 {{% /tab %}}
 {{< /tabs >}}
-
-**Note**: If you set up multiple processing rules, they are applied sequentially. Each rule is applied on the result of the previous one.
 
 ### Scrub sensitive data in your logs
 


### PR DESCRIPTION
### What does this PR do?
Highlight the fact that there can be several processing rules applied on the agent and those are applied sequentially.

### Motivation

Clarification on the behaviour.

### Preview link
https://docs-staging.datadoghq.com/nils/log-processing-rule-note/logs/log_collection/?tab=tailexistingfiles#advanced-log-collection-functions

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
