### PR TITLE
Logs - update docker host installation instructions

### DIFF
--- a/content/en/logs/log_collection/docker.md
+++ b/content/en/logs/log_collection/docker.md
@@ -83,13 +83,8 @@ listeners:
 config_providers:
   - name: docker
     polling: true
-```
-
-To collect logs from all your containers without any filtering, add the following at the end of `docker.d/conf.yaml` in your Agent's `conf.d` directory:
-
-```
-logs:
-    - type: docker
+logs_config:
+  container_collect_all: true
 ```
 
 [Restart the Agent][3] to see all your container logs in Datadog.


### PR DESCRIPTION
### What does this PR do?
Update host installation instruction for docker logs

### Motivation
no need to build a custom yaml file anymore.

### Preview link
https://docs-staging.datadoghq.com/nils/docker-host-logs/logs/log_collection/docker/?tab=containerinstallation

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
