### PR TITLE
Update instruction for short lived container

### DIFF
--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -108,6 +108,17 @@ Exclude containers from logs collection, metrics collection, and Autodiscovery. 
 
 **Note**: The `docker.containers.running`, `.stopped`, `.running.total` and `.stopped.total` metrics are not affected by these settings and always count all containers. This does not affect your per-container billing.
 
+
+#### Short Lived containers
+
+By default, the agent looks for new containers every 5 seconds. Therefore any container that has a shorter duration life might not be picked up by the agent autodiscovery.
+
+One option to solve that situation is to override this value thanks to the `ad_config_poll_interval` parameter which correspond to the `DD_AD_CONFIG_POLL_INTERVAL` environment variable.
+The expected value is a integer in seconds.
+
+A workaround could also be to configure the container to wait for at least the poll interval before starting.
+This can be achieved by adding a sleep period that is as long as the poll interval:`sh -c 'sleep 5; exec yourcommand --etc`
+
 #### Misc
 
 | Env Variable                        | Description                                                                                                      |

--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -111,7 +111,7 @@ Exclude containers from logs collection, metrics collection, and Autodiscovery. 
 
 #### Short Lived containers
 
-By default, the agent looks for new containers every 5 seconds. Therefore any container that has a shorter duration life might not be picked up by the agent autodiscovery.
+By default the Agent looks every 5 seconds for new containers, any container with a shorter duration life won't have any data collected by the Agent.
 
 One option to solve that situation is to override this value thanks to the `ad_config_poll_interval` parameter which correspond to the `DD_AD_CONFIG_POLL_INTERVAL` environment variable.
 The expected value is a integer in seconds.

--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -113,7 +113,7 @@ Exclude containers from logs collection, metrics collection, and Autodiscovery. 
 
 By default the Agent looks every 5 seconds for new containers, any container with a shorter duration life won't have any data collected by the Agent.
 
-One option to solve that situation is to override this value thanks to the `ad_config_poll_interval` parameter which correspond to the `DD_AD_CONFIG_POLL_INTERVAL` environment variable.
+You can override this autodiscovery interval with a shorter one by setting `ad_config_poll_interval` parameter which correspond to the `DD_AD_CONFIG_POLL_INTERVAL` environment variable.
 The expected value is a integer in seconds.
 
 A workaround could also be to configure the container to wait for at least the poll interval before starting.

--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -116,7 +116,7 @@ By default the Agent looks every 5 seconds for new containers, any container wit
 You can override this autodiscovery interval with a shorter one by setting `ad_config_poll_interval` parameter which correspond to the `DD_AD_CONFIG_POLL_INTERVAL` environment variable.
 The expected value is a integer in seconds.
 
-A workaround could also be to configure the container to wait for at least the poll interval before starting.
+A better workaround would be to configure your containers to wait for at least the poll interval before starting.
 This can be achieved by adding a sleep period that is as long as the poll interval:`sh -c 'sleep 5; exec yourcommand --etc`
 
 #### Misc

--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -117,7 +117,7 @@ You can override this autodiscovery interval with a shorter one by setting `ad_c
 The expected value is a integer in seconds.
 
 A better workaround would be to configure your containers to wait for at least the poll interval before starting.
-This can be achieved by adding a sleep period that is as long as the poll interval:`sh -c 'sleep 5; exec yourcommand --etc`
+This can be achieved by adding a sleep period that is as long as the poll interval:`sh -c 'sleep 5; exec <COMMAND> --etc`
 
 #### Misc
 

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -258,7 +258,7 @@ The workaround in this case is to add `hostNetwork: true` in your Agent pod spec
 
 ### Short Lived containers
 
-By default, the agent looks for new containers every 5 seconds. Therefore any container that has a shorter duration life might not be picked up by the agent autodiscovery.
+By default the Agent looks every 5 seconds for new containers, any container with a shorter duration life won't have any data collected by the Agent.
 
 You can override this autodiscovery interval with a shorter one by setting `ad_config_poll_interval` parameter which correspond to the `DD_AD_CONFIG_POLL_INTERVAL` environment variable.
 The expected value is a integer in seconds.

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -256,6 +256,16 @@ To send custom metrics via DogStatsD from your application pods, uncomment the `
 Another word of caution: some network plugins don't support `hostPorts` yet, so this won't work.
 The workaround in this case is to add `hostNetwork: true` in your Agent pod specifications. This shares the network namespace of your host with the Datadog Agent. It also means that all ports opened on the container are also opened on the host. If a port is used both on the host and in your container, they conflict (since they share the same network namespace) and the pod will not start. Not all Kubernetes installations allow this.
 
+### Short Lived containers
+
+By default, the agent looks for new containers every 5 seconds. Therefore any container that has a shorter duration life might not be picked up by the agent autodiscovery.
+
+One option to solve that situation is to override this value thanks to the `ad_config_poll_interval` parameter which correspond to the `DD_AD_CONFIG_POLL_INTERVAL` environment variable.
+The expected value is a integer in seconds.
+
+A workaround could also be to configure the container to wait for at least the poll interval before starting.
+This can be achieved by adding a sleep period that is as long as the poll interval:`sh -c 'sleep 5; exec yourcommand --etc`
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -260,7 +260,7 @@ The workaround in this case is to add `hostNetwork: true` in your Agent pod spec
 
 By default, the agent looks for new containers every 5 seconds. Therefore any container that has a shorter duration life might not be picked up by the agent autodiscovery.
 
-One option to solve that situation is to override this value thanks to the `ad_config_poll_interval` parameter which correspond to the `DD_AD_CONFIG_POLL_INTERVAL` environment variable.
+You can override this autodiscovery interval with a shorter one by setting `ad_config_poll_interval` parameter which correspond to the `DD_AD_CONFIG_POLL_INTERVAL` environment variable.
 The expected value is a integer in seconds.
 
 A workaround could also be to configure the container to wait for at least the poll interval before starting.

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -264,7 +264,7 @@ You can override this autodiscovery interval with a shorter one by setting `ad_c
 The expected value is a integer in seconds.
 
 A better workaround would be to configure your containers to wait for at least the poll interval before starting.
-This can be achieved by adding a sleep period that is as long as the poll interval:`sh -c 'sleep 5; exec yourcommand --etc`
+This can be achieved by adding a sleep period that is as long as the poll interval:`sh -c 'sleep 5; exec <COMMAND> --etc`
 
 ## Further Reading
 

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -263,7 +263,7 @@ By default the Agent looks every 5 seconds for new containers, any container wit
 You can override this autodiscovery interval with a shorter one by setting `ad_config_poll_interval` parameter which correspond to the `DD_AD_CONFIG_POLL_INTERVAL` environment variable.
 The expected value is a integer in seconds.
 
-A workaround could also be to configure the container to wait for at least the poll interval before starting.
+A better workaround would be to configure your containers to wait for at least the poll interval before starting.
 This can be achieved by adding a sleep period that is as long as the poll interval:`sh -c 'sleep 5; exec yourcommand --etc`
 
 ## Further Reading


### PR DESCRIPTION
### What does this PR do?
Add instruction for short lived container while we do not officially have a solution for it.

### Motivation
There was no instructions on how to handle short lived containers with the Agent.

### Preview link
https://docs-staging.datadoghq.com/nils/short-lived/agent/kubernetes/daemonset_setup/

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>
