### PR TITLE
fix typo in automatic instrumentation section for java

### DIFF
--- a/content/en/tracing/languages/java.md
+++ b/content/en/tracing/languages/java.md
@@ -44,7 +44,7 @@ Instrumentation may come from auto-instrumentation, the OpenTracing api, or a mi
 
 * Timing duration is captured using the JVM's nanotime clock unless a timestamp is provided from the OpenTracing api
 * Key/value tag pairs
-* Errors and stacktraces which are unhanded by the application
+* Errors and stacktraces which are unhandled by the application
 * A total count of traces (requests) flowing through the system
 
 ## Compatibility


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes "unhandled" typo in Java automatic instrumentation section in APM docs. 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
