### PR TITLE
fix clarification on timezone ids and add links to reference material

### DIFF
--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -244,7 +244,7 @@ The date matcher transforms your timestamp in the EPOCH format.
 | Thu Jun 16 08:29:03 2016<sup>1</sup> | `%{date("EEE MMM dd HH:mm:ss yyyy","Europe/Paris"):date}` | {"date": 1466058543000} |
 | 2007-08-31 19:22:22.427 ADT              | `%{date("yyyy-MM-dd HH:mm:ss.SSS z"):date}`               | {"date": 1188675889244} |
 
-<sup>1</sup> Use this format if you perform your own localizations and your timestamps are _not_ in UTC. Timezone IDs are pulled from the TZ Database. See the [TZ database names here][2]
+<sup>1</sup> Use this format if you perform your own localizations and your timestamps are _not_ in UTC. Timezone IDs are pulled from the TZ Database. For more information, see the [TZ database names][2].
 
 **Note**: Parsing a date **doesn't** set its value as the log official date, for this use the Log Date Remapper [Log Date Remapper][1] in a subsequent Processor.
 

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -241,10 +241,10 @@ The date matcher transforms your timestamp in the EPOCH format.
 | 2016-11-29T16:21:36.431+0000             | `%{date("yyyy-MM-dd'T'HH:mm:ss.SSSZ"):date}`              | {"date": 1480436496431} |
 | 2016-11-29T16:21:36.431+00:00            | `%{date("yyyy-MM-dd'T'HH:mm:ss.SSSZZ"):date}`             | {"date": 1480436496431} |
 | 06/Feb/2009:12:14:14.655                 | `%{date("dd/MMM/yyyy:HH:mm:ss.SSS"):date}`                | {"date": 1233922454655} |
-| {{<sup>†</sup>}}Thu Jun 16 08:29:03 2016 | `%{date("EEE MMM dd HH:mm:ss yyyy","Europe/Paris"):date}` | {"date": 1466058543000} |
+| {{< sup >†< /sup >}}Thu Jun 16 08:29:03 2016 | `%{date("EEE MMM dd HH:mm:ss yyyy","Europe/Paris"):date}` | {"date": 1466058543000} |
 | 2007-08-31 19:22:22.427 ADT              | `%{date("yyyy-MM-dd HH:mm:ss.SSS z"):date}`               | {"date": 1188675889244} |
 
-**{{<sup>†</sup>}}** _Use this format if you perform your own localizations and your timestamps are _not_ in UTC. Timezone IDs are pulled from the TZ Database. See the [TZ database names here][https://en.wikipedia.org/wiki/List_of_tz_database_time_zones]_
+{{< sup >†</ sup >}} _Use this format if you perform your own localizations and your timestamps are _not_ in UTC. Timezone IDs are pulled from the TZ Database. See the [TZ database names here][https://en.wikipedia.org/wiki/List_of_tz_database_time_zones]_
 
 **Note**: Parsing a date **doesn't** set its value as the log official date, for this use the Log Date Remapper [Log Date Remapper][1] in a subsequent Processor.
 

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -231,18 +231,20 @@ Other examples:
 
 The date matcher transforms your timestamp in the EPOCH format.
 
-| **Raw string**                | **Parsing rule**                                          | **Result**              |
-| :---                          | :----                                                     | :----                   |
-| 14:20:15                      | `%{date("HH:mm:ss"):date}`                                | {"date": 51615000}      |
-| 11/10/2014                    | `%{date("dd/MM/yyyy"):date}`                              | {"date": 1412978400000} |
-| Thu Jun 16 08:29:03 2016      | `%{date("EEE MMM dd HH:mm:ss yyyy"):date}`                | {"date": 1466065743000} |
-| Tue Nov 1 08:29:03 2016       | `%{date("EEE MMM d HH:mm:ss yyyy"):date}`                 | {"date": 1466065743000} |
-| 06/Mar/2013:01:36:30 +0900    | `%{date("dd/MMM/yyyy:HH:mm:ss Z"):date}`                  | {"date": 1362501390000} |
-| 2016-11-29T16:21:36.431+0000  | `%{date("yyyy-MM-dd'T'HH:mm:ss.SSSZ"):date}`              | {"date": 1480436496431} |
-| 2016-11-29T16:21:36.431+00:00 | `%{date("yyyy-MM-dd'T'HH:mm:ss.SSSZZ"):date}`             | {"date": 1480436496431} |
-| 06/Feb/2009:12:14:14.655      | `%{date("dd/MMM/yyyy:HH:mm:ss.SSS"):date}`                | {"date": 1233922454655} |
-| Thu Jun 16 08:29:03 2016      | `%{date("EEE MMM dd HH:mm:ss yyyy","Europe/Paris"):date}` | {"date": 1466058543000} |
-| 2007-08-31 19:22:22.427 ADT   | `%{date("yyyy-MM-dd HH:mm:ss.SSS z"):date}`               | {"date": 1188675889244} |
+| **Raw string**                   | **Parsing rule**                                          | **Result**              |
+| :---                             | :----                                                     | :----                   |
+| 14:20:15                         | `%{date("HH:mm:ss"):date}`                                | {"date": 51615000}      |
+| 11/10/2014                       | `%{date("dd/MM/yyyy"):date}`                              | {"date": 1412978400000} |
+| Thu Jun 16 08:29:03 2016         | `%{date("EEE MMM dd HH:mm:ss yyyy"):date}`                | {"date": 1466065743000} |
+| Tue Nov 1 08:29:03 2016          | `%{date("EEE MMM d HH:mm:ss yyyy"):date}`                 | {"date": 1466065743000} |
+| 06/Mar/2013:01:36:30 +0900       | `%{date("dd/MMM/yyyy:HH:mm:ss Z"):date}`                  | {"date": 1362501390000} |
+| 2016-11-29T16:21:36.431+0000     | `%{date("yyyy-MM-dd'T'HH:mm:ss.SSSZ"):date}`              | {"date": 1480436496431} |
+| 2016-11-29T16:21:36.431+00:00    | `%{date("yyyy-MM-dd'T'HH:mm:ss.SSSZZ"):date}`             | {"date": 1480436496431} |
+| 06/Feb/2009:12:14:14.655         | `%{date("dd/MMM/yyyy:HH:mm:ss.SSS"):date}`                | {"date": 1233922454655} |
+| Thu Jun 16 08:29:03 2016[^1][^2] | `%{date("EEE MMM dd HH:mm:ss yyyy","Europe/Paris"):date}` | {"date": 1466058543000} |
+| 2007-08-31 19:22:22.427 ADT      | `%{date("yyyy-MM-dd HH:mm:ss.SSS z"):date}`               | {"date": 1188675889244} |
+[^1]: Use this format if you perform your own localizations and your timestamps are _not_ in UTC
+[^2]: Timezone IDs are pulled from the TZ Database. See the [TZ database names here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
 
 **Note**: Parsing a date **doesn't** set its value as the log official date, for this use the Log Date Remapper [Log Date Remapper][1] in a subsequent Processor.
 

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -244,7 +244,7 @@ The date matcher transforms your timestamp in the EPOCH format.
 | Thu Jun 16 08:29:03 2016<sup>1</sup> | `%{date("EEE MMM dd HH:mm:ss yyyy","Europe/Paris"):date}` | {"date": 1466058543000} |
 | 2007-08-31 19:22:22.427 ADT              | `%{date("yyyy-MM-dd HH:mm:ss.SSS z"):date}`               | {"date": 1188675889244} |
 
-<sup>1</sup> _Use this format if you perform your own localizations and your timestamps are _not_ in UTC. Timezone IDs are pulled from the TZ Database. See the [TZ database names here][https://en.wikipedia.org/wiki/List_of_tz_database_time_zones]_
+<sup>1</sup> Use this format if you perform your own localizations and your timestamps are _not_ in UTC. Timezone IDs are pulled from the TZ Database. See the [TZ database names here][https://en.wikipedia.org/wiki/List_of_tz_database_time_zones]_
 
 **Note**: Parsing a date **doesn't** set its value as the log official date, for this use the Log Date Remapper [Log Date Remapper][1] in a subsequent Processor.
 

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -241,10 +241,10 @@ The date matcher transforms your timestamp in the EPOCH format.
 | 2016-11-29T16:21:36.431+0000             | `%{date("yyyy-MM-dd'T'HH:mm:ss.SSSZ"):date}`              | {"date": 1480436496431} |
 | 2016-11-29T16:21:36.431+00:00            | `%{date("yyyy-MM-dd'T'HH:mm:ss.SSSZZ"):date}`             | {"date": 1480436496431} |
 | 06/Feb/2009:12:14:14.655                 | `%{date("dd/MMM/yyyy:HH:mm:ss.SSS"):date}`                | {"date": 1233922454655} |
-| {{<sup>1</sup>}}Thu Jun 16 08:29:03 2016 | `%{date("EEE MMM dd HH:mm:ss yyyy","Europe/Paris"):date}` | {"date": 1466058543000} |
+| Thu Jun 16 08:29:03 2016<sup>1</sup> | `%{date("EEE MMM dd HH:mm:ss yyyy","Europe/Paris"):date}` | {"date": 1466058543000} |
 | 2007-08-31 19:22:22.427 ADT              | `%{date("yyyy-MM-dd HH:mm:ss.SSS z"):date}`               | {"date": 1188675889244} |
 
-{{<sup>1</sup>}} _Use this format if you perform your own localizations and your timestamps are _not_ in UTC. Timezone IDs are pulled from the TZ Database. See the [TZ database names here][https://en.wikipedia.org/wiki/List_of_tz_database_time_zones]_
+<sup>1</sup> _Use this format if you perform your own localizations and your timestamps are _not_ in UTC. Timezone IDs are pulled from the TZ Database. See the [TZ database names here][https://en.wikipedia.org/wiki/List_of_tz_database_time_zones]_
 
 **Note**: Parsing a date **doesn't** set its value as the log official date, for this use the Log Date Remapper [Log Date Remapper][1] in a subsequent Processor.
 

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -241,10 +241,10 @@ The date matcher transforms your timestamp in the EPOCH format.
 | 2016-11-29T16:21:36.431+0000             | `%{date("yyyy-MM-dd'T'HH:mm:ss.SSSZ"):date}`              | {"date": 1480436496431} |
 | 2016-11-29T16:21:36.431+00:00            | `%{date("yyyy-MM-dd'T'HH:mm:ss.SSSZZ"):date}`             | {"date": 1480436496431} |
 | 06/Feb/2009:12:14:14.655                 | `%{date("dd/MMM/yyyy:HH:mm:ss.SSS"):date}`                | {"date": 1233922454655} |
-| {{< sup >†< /sup >}}Thu Jun 16 08:29:03 2016 | `%{date("EEE MMM dd HH:mm:ss yyyy","Europe/Paris"):date}` | {"date": 1466058543000} |
+| {{<sup>1</sup>}}Thu Jun 16 08:29:03 2016 | `%{date("EEE MMM dd HH:mm:ss yyyy","Europe/Paris"):date}` | {"date": 1466058543000} |
 | 2007-08-31 19:22:22.427 ADT              | `%{date("yyyy-MM-dd HH:mm:ss.SSS z"):date}`               | {"date": 1188675889244} |
 
-{{< sup >†</ sup >}} _Use this format if you perform your own localizations and your timestamps are _not_ in UTC. Timezone IDs are pulled from the TZ Database. See the [TZ database names here][https://en.wikipedia.org/wiki/List_of_tz_database_time_zones]_
+{{<sup>1</sup>}} _Use this format if you perform your own localizations and your timestamps are _not_ in UTC. Timezone IDs are pulled from the TZ Database. See the [TZ database names here][https://en.wikipedia.org/wiki/List_of_tz_database_time_zones]_
 
 **Note**: Parsing a date **doesn't** set its value as the log official date, for this use the Log Date Remapper [Log Date Remapper][1] in a subsequent Processor.
 

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -244,7 +244,7 @@ The date matcher transforms your timestamp in the EPOCH format.
 | Thu Jun 16 08:29:03 2016<sup>1</sup> | `%{date("EEE MMM dd HH:mm:ss yyyy","Europe/Paris"):date}` | {"date": 1466058543000} |
 | 2007-08-31 19:22:22.427 ADT              | `%{date("yyyy-MM-dd HH:mm:ss.SSS z"):date}`               | {"date": 1188675889244} |
 
-<sup>1</sup> Use this format if you perform your own localizations and your timestamps are _not_ in UTC. Timezone IDs are pulled from the TZ Database. See the [TZ database names here][https://en.wikipedia.org/wiki/List_of_tz_database_time_zones]_
+<sup>1</sup> Use this format if you perform your own localizations and your timestamps are _not_ in UTC. Timezone IDs are pulled from the TZ Database. See the [TZ database names here][2]
 
 **Note**: Parsing a date **doesn't** set its value as the log official date, for this use the Log Date Remapper [Log Date Remapper][1] in a subsequent Processor.
 
@@ -313,3 +313,4 @@ MyParsingRule %{regex("[a-z]*"):user.firstname}_%{regex("[a-zA-Z0-9]*"):user.id}
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /logs/processing/processors/#log-date-remapper
+[2]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -231,21 +231,20 @@ Other examples:
 
 The date matcher transforms your timestamp in the EPOCH format.
 
-| **Raw string**                    | **Parsing rule**                                          | **Result**              |
-| :---                              | :----                                                     | :----                   |
-| 14:20:15                          | `%{date("HH:mm:ss"):date}`                                | {"date": 51615000}      |
-| 11/10/2014                        | `%{date("dd/MM/yyyy"):date}`                              | {"date": 1412978400000} |
-| Thu Jun 16 08:29:03 2016          | `%{date("EEE MMM dd HH:mm:ss yyyy"):date}`                | {"date": 1466065743000} |
-| Tue Nov 1 08:29:03 2016           | `%{date("EEE MMM d HH:mm:ss yyyy"):date}`                 | {"date": 1466065743000} |
-| 06/Mar/2013:01:36:30 +0900        | `%{date("dd/MMM/yyyy:HH:mm:ss Z"):date}`                  | {"date": 1362501390000} |
-| 2016-11-29T16:21:36.431+0000      | `%{date("yyyy-MM-dd'T'HH:mm:ss.SSSZ"):date}`              | {"date": 1480436496431} |
-| 2016-11-29T16:21:36.431+00:00     | `%{date("yyyy-MM-dd'T'HH:mm:ss.SSSZZ"):date}`             | {"date": 1480436496431} |
-| 06/Feb/2009:12:14:14.655          | `%{date("dd/MMM/yyyy:HH:mm:ss.SSS"):date}`                | {"date": 1233922454655} |
-| [^1] [^2]Thu Jun 16 08:29:03 2016 | `%{date("EEE MMM dd HH:mm:ss yyyy","Europe/Paris"):date}` | {"date": 1466058543000} |
-| 2007-08-31 19:22:22.427 ADT       | `%{date("yyyy-MM-dd HH:mm:ss.SSS z"):date}`               | {"date": 1188675889244} |
+| **Raw string**                           | **Parsing rule**                                          | **Result**              |
+| :---                                     | :----                                                     | :----                   |
+| 14:20:15                                 | `%{date("HH:mm:ss"):date}`                                | {"date": 51615000}      |
+| 11/10/2014                               | `%{date("dd/MM/yyyy"):date}`                              | {"date": 1412978400000} |
+| Thu Jun 16 08:29:03 2016                 | `%{date("EEE MMM dd HH:mm:ss yyyy"):date}`                | {"date": 1466065743000} |
+| Tue Nov 1 08:29:03 2016                  | `%{date("EEE MMM d HH:mm:ss yyyy"):date}`                 | {"date": 1466065743000} |
+| 06/Mar/2013:01:36:30 +0900               | `%{date("dd/MMM/yyyy:HH:mm:ss Z"):date}`                  | {"date": 1362501390000} |
+| 2016-11-29T16:21:36.431+0000             | `%{date("yyyy-MM-dd'T'HH:mm:ss.SSSZ"):date}`              | {"date": 1480436496431} |
+| 2016-11-29T16:21:36.431+00:00            | `%{date("yyyy-MM-dd'T'HH:mm:ss.SSSZZ"):date}`             | {"date": 1480436496431} |
+| 06/Feb/2009:12:14:14.655                 | `%{date("dd/MMM/yyyy:HH:mm:ss.SSS"):date}`                | {"date": 1233922454655} |
+| {{<sup>†</sup>}}Thu Jun 16 08:29:03 2016 | `%{date("EEE MMM dd HH:mm:ss yyyy","Europe/Paris"):date}` | {"date": 1466058543000} |
+| 2007-08-31 19:22:22.427 ADT              | `%{date("yyyy-MM-dd HH:mm:ss.SSS z"):date}`               | {"date": 1188675889244} |
 
-[^1]: Use this format if you perform your own localizations and your timestamps are _not_ in UTC
-[^2]: Timezone IDs are pulled from the TZ Database. See the [TZ database names here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+**{{<sup>†</sup>}}** _Use this format if you perform your own localizations and your timestamps are _not_ in UTC. Timezone IDs are pulled from the TZ Database. See the [TZ database names here][https://en.wikipedia.org/wiki/List_of_tz_database_time_zones]_
 
 **Note**: Parsing a date **doesn't** set its value as the log official date, for this use the Log Date Remapper [Log Date Remapper][1] in a subsequent Processor.
 

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -231,18 +231,19 @@ Other examples:
 
 The date matcher transforms your timestamp in the EPOCH format.
 
-| **Raw string**                   | **Parsing rule**                                          | **Result**              |
-| :---                             | :----                                                     | :----                   |
-| 14:20:15                         | `%{date("HH:mm:ss"):date}`                                | {"date": 51615000}      |
-| 11/10/2014                       | `%{date("dd/MM/yyyy"):date}`                              | {"date": 1412978400000} |
-| Thu Jun 16 08:29:03 2016         | `%{date("EEE MMM dd HH:mm:ss yyyy"):date}`                | {"date": 1466065743000} |
-| Tue Nov 1 08:29:03 2016          | `%{date("EEE MMM d HH:mm:ss yyyy"):date}`                 | {"date": 1466065743000} |
-| 06/Mar/2013:01:36:30 +0900       | `%{date("dd/MMM/yyyy:HH:mm:ss Z"):date}`                  | {"date": 1362501390000} |
-| 2016-11-29T16:21:36.431+0000     | `%{date("yyyy-MM-dd'T'HH:mm:ss.SSSZ"):date}`              | {"date": 1480436496431} |
-| 2016-11-29T16:21:36.431+00:00    | `%{date("yyyy-MM-dd'T'HH:mm:ss.SSSZZ"):date}`             | {"date": 1480436496431} |
-| 06/Feb/2009:12:14:14.655         | `%{date("dd/MMM/yyyy:HH:mm:ss.SSS"):date}`                | {"date": 1233922454655} |
-| Thu Jun 16 08:29:03 2016[^1][^2] | `%{date("EEE MMM dd HH:mm:ss yyyy","Europe/Paris"):date}` | {"date": 1466058543000} |
-| 2007-08-31 19:22:22.427 ADT      | `%{date("yyyy-MM-dd HH:mm:ss.SSS z"):date}`               | {"date": 1188675889244} |
+| **Raw string**                    | **Parsing rule**                                          | **Result**              |
+| :---                              | :----                                                     | :----                   |
+| 14:20:15                          | `%{date("HH:mm:ss"):date}`                                | {"date": 51615000}      |
+| 11/10/2014                        | `%{date("dd/MM/yyyy"):date}`                              | {"date": 1412978400000} |
+| Thu Jun 16 08:29:03 2016          | `%{date("EEE MMM dd HH:mm:ss yyyy"):date}`                | {"date": 1466065743000} |
+| Tue Nov 1 08:29:03 2016           | `%{date("EEE MMM d HH:mm:ss yyyy"):date}`                 | {"date": 1466065743000} |
+| 06/Mar/2013:01:36:30 +0900        | `%{date("dd/MMM/yyyy:HH:mm:ss Z"):date}`                  | {"date": 1362501390000} |
+| 2016-11-29T16:21:36.431+0000      | `%{date("yyyy-MM-dd'T'HH:mm:ss.SSSZ"):date}`              | {"date": 1480436496431} |
+| 2016-11-29T16:21:36.431+00:00     | `%{date("yyyy-MM-dd'T'HH:mm:ss.SSSZZ"):date}`             | {"date": 1480436496431} |
+| 06/Feb/2009:12:14:14.655          | `%{date("dd/MMM/yyyy:HH:mm:ss.SSS"):date}`                | {"date": 1233922454655} |
+| [^1] [^2]Thu Jun 16 08:29:03 2016 | `%{date("EEE MMM dd HH:mm:ss yyyy","Europe/Paris"):date}` | {"date": 1466058543000} |
+| 2007-08-31 19:22:22.427 ADT       | `%{date("yyyy-MM-dd HH:mm:ss.SSS z"):date}`               | {"date": 1188675889244} |
+
 [^1]: Use this format if you perform your own localizations and your timestamps are _not_ in UTC
 [^2]: Timezone IDs are pulled from the TZ Database. See the [TZ database names here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Cleared up some confusion around time zone localization that was experienced while working with a customer today. Also included links to timezone ids as they appear in the TZ database on wikipedia. 

### Preview link

https://docs-staging.datadoghq.com/morgan.lupton/locale-clarification/logs/processing/parsing/?tab=matcher#parsing-dates

### Additional Notes
I used the [Markdown extended syntax](https://www.markdownguide.org/extended-syntax/) to make footnotes within the table, although I'm not sure if this is the best course of action. Please let me know if there's another way that you would recommend I convey this information.