### PR TITLE
Remove misspelling and change phrasing in a java log doc

### DIFF
--- a/content/en/logs/log_collection/java.md
+++ b/content/en/logs/log_collection/java.md
@@ -42,7 +42,7 @@ By asking your logging library to log into JSON, you will:
 
 **To send your logs to Datadog, we recommend logging to a file and then tailing that file with your Datadog Agent.**
 
-We also strongly encourage you to setup your logging libraries to produce your logs in JSON format to avoid sustaning [custom parsing rules][2].
+We also strongly encourage you to setup your logging libraries to produce your logs in JSON format to avoid the need for [custom parsing rules][2].
 
 Here are setup examples for the `log4j`, `slf4j` and `log4j2` logging libraries:
 

--- a/content/en/logs/log_collection/java.md
+++ b/content/en/logs/log_collection/java.md
@@ -42,7 +42,7 @@ By asking your logging library to log into JSON, you will:
 
 **To send your logs to Datadog, we recommend logging to a file and then tailing that file with your Datadog Agent.**
 
-We also strongly encourage you to setup your logging libraries to produce your logs in JSON format to avoid the need for [custom parsing rules][2].
+Datadog strongly recommends setting up your logging libraries to produce your logs in JSON format to avoid the need for [custom parsing rules][2].
 
 Here are setup examples for the `log4j`, `slf4j` and `log4j2` logging libraries:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Replaces a misspelling (i.e. "sustaning") with the phrase "the need for"

### Motivation

Noticed the spelling error and chose to change the phrasing while fixing to avoid using the word "sustaining"

### Preview link

https://docs-staging.datadoghq.com/tj/change_word_choice_while_fixing_misspelling/logs/log_collection/java/?tab=log4j

<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
