### PR TITLE
adding secrets instructions

### DIFF
--- a/content/en/agent/faq/_index.md
+++ b/content/en/agent/faq/_index.md
@@ -25,6 +25,7 @@ private: true
 * [Why should I install the Datadog Agent on my cloud instances?][19]
 * [The Datadog Agent for Logs or Traces Only][20]
 * [Install the Agent with AWS SSM][21]
+* [How do I use Kubernetes secrets to set my APi key?][22]
 
 
 [1]: /agent/faq/getting-further-with-docker
@@ -48,3 +49,4 @@ private: true
 [19]: /agent/faq/why-should-i-install-the-agent-on-my-cloud-instances
 [20]: /agent/faq/the-datadog-agent-for-logs-or-traces-only
 [21]: /agent/faq/install-the-agent-with-aws-ssm
+[22]: /agent/faq/kubernetes-secrets

--- a/content/en/agent/faq/_index.md
+++ b/content/en/agent/faq/_index.md
@@ -25,7 +25,7 @@ private: true
 * [Why should I install the Datadog Agent on my cloud instances?][19]
 * [The Datadog Agent for Logs or Traces Only][20]
 * [Install the Agent with AWS SSM][21]
-* [How do I use Kubernetes secrets to set my APi key?][22]
+* [How do I use Kubernetes secrets to set my API key?][22]
 
 
 [1]: /agent/faq/getting-further-with-docker

--- a/content/en/agent/faq/kubernetes-secrets.md
+++ b/content/en/agent/faq/kubernetes-secrets.md
@@ -1,0 +1,43 @@
+---
+title: How do I use Kubernetes secrets to set my API key?
+kind: faq
+---
+
+In Kubernetes, a `secret` object enables you to store sensitive information, such as an API key. 
+
+To use Kubernetes `secret`s to set your API key, first create the secret:
+
+1. Encode your plaintext API key using `base_64`.
+
+```
+echo -n <DD_API_KEY> | base64
+```
+
+This command generates the value for `<YOUR_BASE64_ENCODED_DATADOG_API_KEY>`
+
+2. Uncomment the "Secret" manifest section and the `valueFrom` section of the `DD_API_KEY` environment variable of the DaemonSet.
+
+Secret manifest section:
+
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: datadog-secret
+  labels:
+    app: "datadog"
+type: Opaque
+data:
+  api-key: "<YOUR_BASE64_ENCODED_DATADOG_API_KEY>"
+```
+
+`valueFrom` section of the `DD_API_KEY` environment variable:
+
+```
+valueFrom:
+  secretKeyRef:
+    name: datadog-secret
+    key: api-key
+```
+
+3. Replace `<YOUR_BASE64_ENCODED_DATADOG_API_KEY>` with the value you generated in step 1.

--- a/content/en/agent/faq/kubernetes-secrets.md
+++ b/content/en/agent/faq/kubernetes-secrets.md
@@ -5,9 +5,7 @@ kind: faq
 
 In Kubernetes, a `secret` object enables you to store sensitive information, such as an API key. 
 
-To use Kubernetes `secret`s to set your API key, first create the secret:
-
-1. Encode your plaintext API key using `base_64`.
+To use Kubernetes `secret`s to set your API key, first encode your plaintext API key using `base_64`:
 
 ```
 echo -n <DD_API_KEY> | base64
@@ -15,7 +13,7 @@ echo -n <DD_API_KEY> | base64
 
 This command generates the value for `<YOUR_BASE64_ENCODED_DATADOG_API_KEY>`
 
-2. Uncomment the "Secret" manifest section and the `valueFrom` section of the `DD_API_KEY` environment variable of the DaemonSet.
+Then, uncomment the "Secret" manifest section and the `valueFrom` section of the `DD_API_KEY` environment variable of the DaemonSet.
 
 Secret manifest section:
 
@@ -40,4 +38,4 @@ valueFrom:
     key: api-key
 ```
 
-3. Replace `<YOUR_BASE64_ENCODED_DATADOG_API_KEY>` with the value you generated in step 1.
+Finally, replace `<YOUR_BASE64_ENCODED_DATADOG_API_KEY>` with the value you generated with `base_64`.

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -79,7 +79,7 @@ spec:
             protocol: TCP
         env:
           - name: DD_API_KEY
-            # Kubernetes Secrets - uncomment this section to use Kubernetes Secrets to supply the API key
+            # Kubernetes Secrets - uncomment this section to supply API Key with secrets
 #            valueFrom:
 #              secretKeyRef:
 #                name: datadog-secret

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -38,15 +38,17 @@ Create the following `datadog-agent.yaml` manifest:
 ```yaml
 # datadog-agent.yaml
 
-apiVersion: v1
-kind: Secret
-metadata:
-  name: datadog-secret
-  labels:
-    app: "datadog"
-type: Opaque
-data:
-  api-key: "<YOUR_BASE64_ENCODED_DATADOG_API_KEY>"
+# Uncomment this section to use Kubernetes secrets to configure your Datadog API key
+
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: datadog-secret
+#   labels:
+#     app: "datadog"
+# type: Opaque
+# data:
+#   api-key: "<YOUR_BASE64_ENCODED_DATADOG_API_KEY>"
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
@@ -77,10 +79,11 @@ spec:
             protocol: TCP
         env:
           - name: DD_API_KEY
-            valueFrom:
-              secretKeyRef:
-                name: datadog-secret
-                key: api-key
+            # Kubernetes Secrets - uncomment this section to use Kubernetes Secrets to supply the API key
+#            valueFrom:
+#              secretKeyRef:
+#                name: datadog-secret
+#                key: api-key
           - name: DD_SITE
             # Set DD_SITE to datadoghq.eu to send your Agent data to the Datadog EU site 
             value: "datadoghq.com"
@@ -130,14 +133,14 @@ spec:
           name: cgroups
 ```
 
-Replace `<YOUR_API_KEY>` with [your Datadog API key][3] or use [Kubernetes secrets][4] to set your API key as an [environment variable][5]. Consult the [Docker integration][6] to discover all of the configuration options.
+Replace `<YOUR_API_KEY>` with [your Datadog API key][3] or use [Kubernetes secrets][4] to set your API key as an [environment variable][5]. If you opt to use Kubernetes secrets, refer to Datadog's [instructions for setting an API key with Kubernetes secrets][6]. Consult the [Docker integration][7] to discover all of the configuration options.
 
 Deploy the DaemonSet with the command:
 ```
 kubectl create -f datadog-agent.yaml
 ```
 
-**Note**:  This manifest enables Autodiscovery's auto configuration feature. To learn how to configure Autodiscovery, see the [dedicated Autodiscovery documentation][7].
+**Note**:  This manifest enables Autodiscovery's auto configuration feature. To learn how to configure Autodiscovery, see the [dedicated Autodiscovery documentation][8].
 
 ### Verification
 
@@ -162,14 +165,14 @@ Starting with version 6.11.0, the Datadog Agent can auto-detect the Kubernetes c
 
 On Google GKE and Azure AKS, the cluster name is retrieved from the cloud provider API. For AWS EKS, the cluster name is retrieved from EC2 instance tags.
 
-**Note**: On AWS, it is required to add the `ec2:DescribeInstances` [permission][12] to your Datadog IAM policy so that the Agent can query the EC2 instance tags.
+**Note**: On AWS, it is required to add the `ec2:DescribeInstances` [permission][9] to your Datadog IAM policy so that the Agent can query the EC2 instance tags.
 
 
 ## Enable capabilities
 
 ### Log Collection
 
-To enable [Log collection][8] with your DaemonSet:
+To enable [Log collection][10] with your DaemonSet:
 
 1. Set the `DD_LOGS_ENABLED` and `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL` variable to true in your *env* section:
 
@@ -201,7 +204,7 @@ To enable [Log collection][8] with your DaemonSet:
       (...)
     ```
 
-Learn more about this in [the Docker log collection documentation][9].
+Learn more about this in [the Docker log collection documentation][11].
 
 ### Trace Collection
 
@@ -233,7 +236,7 @@ To enable trace collection with your DaemonSet:
 
 ### Process Collection
 
-See [Process collection for Kubernetes][10].
+See [Process collection for Kubernetes][12].
 
 ### DogStatsD
 
@@ -248,7 +251,7 @@ To send custom metrics via DogStatsD, set the `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` v
 (...)
 ```
 
-Learn more about this in the [Kubernetes DogStatsD documentation][11]
+Learn more about this in the [Kubernetes DogStatsD documentation][13]
 
 To send custom metrics via DogStatsD from your application pods, uncomment the `# hostPort: 8125` line in your `datadog-agent.yaml` manifest. This exposes the DogStatsD port on each of your Kubernetes nodes.
 
@@ -265,10 +268,11 @@ The workaround in this case is to add `hostNetwork: true` in your Agent pod spec
 [3]: https://app.datadoghq.com/account/settings#api
 [4]: https://kubernetes.io/docs/concepts/configuration/secret
 [5]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information
-[6]: /agent/docker/#environment-variables
-[7]: https://docs.datadoghq.com/agent/autodiscovery
-[8]: /logs
-[9]: /logs/docker/#configuration-file-example
-[10]: /graphing/infrastructure/process/?tab=kubernetes#installation
-[11]: /agent/kubernetes/dogstatsd
-[12]: https://docs.datadoghq.com/integrations/amazon_ec2/#configuration
+[6]: /agent/faq/kubernetes-secrets
+[7]: /agent/docker/#environment-variables
+[8]: https://docs.datadoghq.com/agent/autodiscovery
+[9]: https://docs.datadoghq.com/integrations/amazon_ec2/#configuration
+[10]: /logs
+[11]: /logs/docker/#configuration-file-example
+[12]: /graphing/infrastructure/process/?tab=kubernetes#installation
+[13]: /agent/kubernetes/dogstatsd


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds instructions for setting API key in the daemonset manifest using k8s secrets

### Motivation
support request

### Preview link
https://docs-staging.datadoghq.com/cswatt/k8s-secrets/agent/kubernetes/daemonset_setup
https://docs-staging.datadoghq.com/cswatt/k8s-secrets/agent/faq/kubernetes-secrets
