### PR TITLE
Adding tagging conf example

### DIFF
--- a/content/en/developers/write_agent_check.md
+++ b/content/en/developers/write_agent_check.md
@@ -52,7 +52,7 @@ __version__ = "1.0.0"
 
 class HelloCheck(AgentCheck):
     def check(self, instance):
-        self.gauge('hello.world', 1)
+        self.gauge('hello.world', 1, tags=['TAG_KEY:TAG_VALUE'])
 ```
 
 For more details about the interface provided by the base class, browse the [API documentation][5].
@@ -139,7 +139,7 @@ class LSCheck(AgentCheck):
     def check(self, instance):
         files, err, retcode = get_subprocess_output(["ls", "."], self.log, raise_on_empty_output=True)
         file_count = len(files.split('\n') - 1  #len() returns an int by default
-        self.gauge("file.count", file_count)
+        self.gauge("file.count", file_count,tags=['TAG_KEY:TAG_VALUE'])
 ```
 
 

--- a/content/en/tagging/_index.md
+++ b/content/en/tagging/_index.md
@@ -46,7 +46,7 @@ Below are Datadog's tagging restrictions, requirements, and suggestions:
     * Colons
     * Periods
     * Slashes
-    
+
     Other special characters are converted to underscores.
 
     **Note**: A tag cannot end with a colon, for example `tag:`
@@ -54,7 +54,7 @@ Below are Datadog's tagging restrictions, requirements, and suggestions:
 2. Tags can be **up to 200 characters** long and support Unicode.
 3. Tags are converted to lowercase. Therefore, `CamelCase` tags are not recommended. Authentication (crawler) based integrations convert camel case tags to underscores, for example `TestTag` --> `test_tag`.
 4. A tag can be in the format `value` or `<KEY>:<VALUE>`. For optimal functionality, **we recommend constructing tags in the `<KEY>:<VALUE>` format.** Commonly used tag keys are `env`, `instance`, and `name`. The key always precedes the first colon of the global tag definition, for example:
-    
+
     | Tag                | Key           | Value          |
     |--------------------|---------------|----------------|
     | `env:staging:east` | `env`         | `staging:east` |


### PR DESCRIPTION
### What does this PR do?
Adds tagging example in the write a custom check doc. 

Note that it doesn't follow the "classic" placeholder logic on purpose in order to make the cp/cv of the example work right away since tags must start with a letter. 

### Preview
https://docs-staging.datadoghq.com/gus/enhance-example/developers/write_agent_check/