### PR TITLE
Allow doc to build even if one integration has an error

### DIFF
--- a/local/etc/pull_config.yaml
+++ b/local/etc/pull_config.yaml
@@ -25,10 +25,10 @@
     - action: integrations
       branch: master
       globs:
-      - "*[!}]/metadata.csv"
-      - "*[!}]/manifest.json"
-      - "*[!}]/service_checks.json"
-      - "*[!}]/README.md"
+      - "*/metadata.csv"
+      - "*/manifest.json"
+      - "*/service_checks.json"
+      - "*/README.md"
 
     - action: pull-and-push-folder
       branch: master
@@ -44,10 +44,10 @@
     - action: integrations
       branch: master
       globs:
-      - "*[!}]/metadata.csv"
-      - "*[!}]/manifest.json"
-      - "*[!}]/service_checks.json"
-      - "*[!}]/README.md"
+      - "*/metadata.csv"
+      - "*/manifest.json"
+      - "*/service_checks.json"
+      - "*/README.md"
 
   - repo_name: heroku-buildpack-datadog
     contents:

--- a/local/etc/pull_config.yaml
+++ b/local/etc/pull_config.yaml
@@ -44,10 +44,10 @@
     - action: integrations
       branch: master
       globs:
-      - "**/metadata.csv"
-      - "**/manifest.json"
-      - "**/service_checks.json"
-      - "**/README.md"
+      - "*[!}]/metadata.csv"
+      - "*[!}]/manifest.json"
+      - "*[!}]/service_checks.json"
+      - "*[!}]/README.md"
 
   - repo_name: heroku-buildpack-datadog
     contents:


### PR DESCRIPTION
### What does this PR do?

This Prevent the whole documentation build to fail if a manifest is not there for a given integration.
It also removes the `tqdm` logic and some not so necessary print.
 
If there is no manifest, no documentation page will be build, hence we can remove the discard action we had previously for "non-real" integrations.

### Motivation

More robust doc.