### PR TITLE
Update vmware billing doc

### DIFF
--- a/content/en/account_management/billing/vsphere.md
+++ b/content/en/account_management/billing/vsphere.md
@@ -5,7 +5,7 @@ kind: faq
 
 ## Overview
 
-Datadog bills for each Agent installed on a vCenter server.
+Datadog bills for each Agent installed on a vCenter server and each VM monitored.
 
 ### VM exclusion
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update billing doc to mention VMs

### Motivation
<!-- What inspired you to submit this pull request?-->
Set customer expecations

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/marcweisman/vmware-billing//account_management/billing/vsphere/#overview

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
