### PR TITLE
Remove font script tag

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,7 +10,7 @@
 
         gtag('config', 'UA-21102638-5');
     </script>
-    
+
     <meta charset="utf-8">
     {{ partial "prefetch.html" . }}
     {{ partial "preload.html" . }}
@@ -21,7 +21,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <link rel="icon" type="image/png" href="https://docs.datadoghq.com/favicon.ico">
     <link rel="stylesheet" href="{{ .Site.BaseURL }}css/{{ (index .Site.Data.manifests.css "main-dd.css" ) }}">
-    <link href="//fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet">
     {{- if ne $.Params.disable_opengraph_meta_tags true -}}
     {{- partial "meta.html" . -}}
     {{- end -}}


### PR DESCRIPTION
### What does this PR do?
Removes unused font being loaded in header. The `Source Code Pro` Google font had been replaced at some point with `monospace` but the reference to load the font and styles were still there. 

### Motivation
Looking at ways to improve load times on Docs site and cleanup old dependencies

### Preview link
https://docs-staging.datadoghq.com/nsollecito/remove-google-font-ref/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
