### PR TITLE
remove unsupported syntax

### DIFF
--- a/content/en/graphing/event_stream/_index.md
+++ b/content/en/graphing/event_stream/_index.md
@@ -44,9 +44,6 @@ To combine multiple terms into a complex query, use any of the following Boolean
 | `OR`     | **Union**: either term is contained in the selected events. Use a comma (`,`) for tags.                                                    | `sources:nagios,chef directory OR Mixlib`    |
 | `NOT`    | **Exclusion**: the following term is NOT in the event. This operator works for strings only—use `-` in front of tags. | `-tags:<KEY>:<VALUE> NOT "<STRING>"` |
 
-In the example below, a full text search is performed to find all open chef or Nagios errors that mention one or more Redis instances that are currently down.
-
-`sources:nagios,chef status:error redis_* AND down`
 
 **Note**: some of the advanced query language features (e.g. boolean logic) work only in the event stream page, and do not work in graph tiles or in screen board widgets.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
There is a section of our doc that explains how to use both AND and OR queries at the same time.  We don't currently support this (likely due to a regression) so I want to remove the example from the docs for clarity.  We will support this again in a few quarters.

### Motivation
<!-- What inspired you to submit this pull request?-->
Conversation here: https://trello.com/c/piSug6gi/1223-feature-request-be-able-to-use-and-with-or-logic-when-filtering-events

### Preview link
https://docs-staging.datadoghq.com/bcon/remove-unsupported-event-query-syntax/graphing/event_stream/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
