### PR TITLE
moving the trace search alias

### DIFF
--- a/content/en/tracing/trace_search_and_analytics/_index.md
+++ b/content/en/tracing/trace_search_and_analytics/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Trace Search and Analytics
 kind: documentation
+aliases:
+  - tracing/visualization/search/
 ---
 
 {{< vimeo 278748711 >}}

--- a/content/en/tracing/trace_search_and_analytics/search.md
+++ b/content/en/tracing/trace_search_and_analytics/search.md
@@ -8,7 +8,6 @@ aliases:
   - tracing/trace_search/
   - tracing/search
   - /tracing/getting_further/apm_events/
-  - tracing/visualization/search
 further_reading:
 - link: "tracing/setup/"
   tag: "Documentation"


### PR DESCRIPTION
### What does this PR do?
APM refactor - updates where the old trace search alias goes

### Motivation
It's not going quite to the right place.
