### PR TITLE
added faq and link from faq page

### DIFF
--- a/content/en/monitors/faq/_index.md
+++ b/content/en/monitors/faq/_index.md
@@ -20,4 +20,5 @@ private: true
     {{< nextlink href="monitors/faq/can-i-create-monitor-dependencies" >}}Can I create monitor dependencies?{{< /nextlink >}}
     {{< nextlink href="monitors/faq/how-to-update-anomaly-monitor-timezone" >}}How to update an anomaly detection monitor to account for local timezone?{{< /nextlink >}}
     {{< nextlink href="monitors/faq/what-are-recovery-thresholds" >}}What are recovery thresholds?{{< /nextlink >}}
+    {{< nextlink href="monitors/faq/why-did-my-monitor-settings-change-not-take-effect" >}}Why did my monitor settings change not take effect?{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/monitors/faq/why-did-my-monitor-settings-change-not-take-effect.md
+++ b/content/en/monitors/faq/why-did-my-monitor-settings-change-not-take-effect.md
@@ -6,7 +6,7 @@ kind: faq
 
 Datadog keeps monitor groups available in the UI for 24 hours.  If you do not have *No Data* alert settings enabled and your group for a metric monitor stops reporting data, it will persist on the monitor status page until it ages out, though that group will stop being evaluated after a short absence (specific timing depends on your settings).
 
-For event monitors, however, we will also keep groups for evaluations for at least 24 hours. This means that if a monitor is updated and the groups are changed in the query, some old groups may persist. If you must change the group settings on your event monitor, you may want clone or create a new monitor to reflect your new groups.  Alternatively, you can mute them if you'd like to maintain the monitor but silence any alerts that would result from the changes.
+For event monitors, however, Datadog also keeps groups for evaluations for at least 24 hours. This means that if a monitor is updated and the groups are changed in the query, some old groups may persist. If you must change the group settings on your event monitor, you may want clone or create a new monitor to reflect your new groups.  Alternatively, you can mute them if you would like to maintain the monitor but silence any alerts that would result from the changes.
 
 
 

--- a/content/en/monitors/faq/why-did-my-monitor-settings-change-not-take-effect.md
+++ b/content/en/monitors/faq/why-did-my-monitor-settings-change-not-take-effect.md
@@ -7,6 +7,3 @@ kind: faq
 Datadog keeps monitor groups available in the UI for 24 hours.  If you do not have *No Data* alert settings enabled and your group for a metric monitor stops reporting data, it will persist on the monitor status page until it ages out, though that group will stop being evaluated after a short absence (specific timing depends on your settings).
 
 For event monitors, however, Datadog also keeps groups for evaluations for at least 24 hours. This means that if a monitor is updated and the groups are changed in the query, some old groups may persist. If you must change the group settings on your event monitor, you may want clone or create a new monitor to reflect your new groups.  Alternatively, you can mute them if you would like to maintain the monitor but silence any alerts that would result from the changes.
-
-
-

--- a/content/en/monitors/faq/why-did-my-monitor-settings-change-not-take-effect.md
+++ b/content/en/monitors/faq/why-did-my-monitor-settings-change-not-take-effect.md
@@ -1,0 +1,12 @@
+---
+title: Why Did My Monitor Settings Change Not Take Effect?
+kind: faq
+
+---
+
+We will keep monitor groups available in the UI for 24 hours.  If you do not have "No Data" alert settings enabled and your group for a metric monitor stops reporting data, it will persist on the monitor status page until it ages out, though that group will stop being evaluated after a short absence (specific timing depends on your settings).
+
+For event monitors, however, we will also keep groups for evaluations for at least 24 hours. This means that if a monitor is updated and the groups are changed in the query, some old groups may persist. If you must change the group settings on your event monitor, you may want clone or create a new monitor to reflect your new groups.  Alternatively, you can mute them if you'd like to maintain the monitor but silence any alerts that would result from the changes.
+
+
+

--- a/content/en/monitors/faq/why-did-my-monitor-settings-change-not-take-effect.md
+++ b/content/en/monitors/faq/why-did-my-monitor-settings-change-not-take-effect.md
@@ -4,7 +4,7 @@ kind: faq
 
 ---
 
-We will keep monitor groups available in the UI for 24 hours.  If you do not have "No Data" alert settings enabled and your group for a metric monitor stops reporting data, it will persist on the monitor status page until it ages out, though that group will stop being evaluated after a short absence (specific timing depends on your settings).
+Datadog keeps monitor groups available in the UI for 24 hours.  If you do not have *No Data* alert settings enabled and your group for a metric monitor stops reporting data, it will persist on the monitor status page until it ages out, though that group will stop being evaluated after a short absence (specific timing depends on your settings).
 
 For event monitors, however, we will also keep groups for evaluations for at least 24 hours. This means that if a monitor is updated and the groups are changed in the query, some old groups may persist. If you must change the group settings on your event monitor, you may want clone or create a new monitor to reflect your new groups.  Alternatively, you can mute them if you'd like to maintain the monitor but silence any alerts that would result from the changes.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Added a FAQ page for a behavior that has been identified but will not be fixed in our current events setup.  (will be addressed likely with new backend in a few quarters)

### Motivation
<!-- What inspired you to submit this pull request?-->
https://trello.com/c/dsvOJQok/2775-group-not-excluded-from-event-monitor

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/bcon/add-faq-event-monitor-groups/monitors/faq/why-did-my-monitor-settings-change-not-take-effect

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
