### PR TITLE
only run manage translations on weekdays

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -120,7 +120,7 @@ manage_translations:on-schedule:
     URL: ${PREVIEW_DOMAIN}
     CONFIG: ${PREVIEW_CONFIG}
   script:
-    - manage_translations "${APIKEY}"
+    - if [[ $(date +%u) -lt 6 ]]; then manage_translations "${APIKEY}"; fi
   only:
     - schedules
 


### PR DESCRIPTION
### What does this PR do?

This will only run the translations push/pull on weekdays. This helps to avoid PR's building up at the weekend when we can have just one on the monday morning.

### Motivation
Lots or PR's for the same changes

### Preview link
N/A 

### Additional Notes

