### PR TITLE
Fixing disclaimer

### DIFF
--- a/content/en/agent/autodiscovery/_index.md
+++ b/content/en/agent/autodiscovery/_index.md
@@ -71,7 +71,7 @@ config_providers:
 {{< tabs >}}
 {{% tab "Docker" %}}
 
-**Note**: this feature is available for Agent v6.5+. See [Upgrading the Datadog Agent][1].
+**Note**: this feature is available for Agent v6.5+.
 
 The Datadog Agent can extract container labels and environment variables as metric tags with the following configuration in your `datadog.yaml` file:
 
@@ -92,11 +92,10 @@ docker_labels_as_tags:
 
 Note: Tags are only set when a container starts.
 
-[1]: 
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 
-**Note**: this feature is available for Agent v6.10+. See [Upgrading the Datadog Agent][1].
+**Note**: this feature is available for Agent v6.10+.
 
 The Datadog Agent can autodiscover tags from Pod annotations, which allows it to
 associate tags to entire pods or individual containers. Use this format
@@ -133,7 +132,6 @@ kubernetes_pod_annotations_as_tags:
 
 Note: Tags are only set when a pod starts.
 
-[1]: 
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/agent/autodiscovery/_index.md
+++ b/content/en/agent/autodiscovery/_index.md
@@ -68,10 +68,10 @@ config_providers:
 
 ### Tag extraction
 
-**Note**: this feature is available for Agent v6.10+. See [Upgrading the Datadog Agent][3].
-
 {{< tabs >}}
 {{% tab "Docker" %}}
+
+**Note**: this feature is available for Agent v6.5+. See [Upgrading the Datadog Agent][1].
 
 The Datadog Agent can extract container labels and environment variables as metric tags with the following configuration in your `datadog.yaml` file:
 
@@ -92,8 +92,11 @@ docker_labels_as_tags:
 
 Note: Tags are only set when a container starts.
 
+[1]: 
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
+
+**Note**: this feature is available for Agent v6.10+. See [Upgrading the Datadog Agent][1].
 
 The Datadog Agent can autodiscover tags from Pod annotations, which allows it to
 associate tags to entire pods or individual containers. Use this format
@@ -130,6 +133,7 @@ kubernetes_pod_annotations_as_tags:
 
 Note: Tags are only set when a pod starts.
 
+[1]: 
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -510,7 +514,7 @@ The [Cluster Checks feature][1] monitors non-containerized and out-of-cluster re
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note**: Some supported integrations require additional steps for Autodiscovery to work: [Ceph][4], [Varnish][5], [Postfix][6], [Cassandra Nodetools][7], and [Gunicorn][8]. Contact [Datadog support][9] for assistance.
+**Note**: Some supported integrations require additional steps for Autodiscovery to work: [Ceph][3], [Varnish][4], [Postfix][5], [Cassandra Nodetools][6], and [Gunicorn][7]. Contact [Datadog support][8] for assistance.
 
 ## Reference
 
@@ -531,7 +535,7 @@ The following template variables are handled by the Agent:
   - `"%%pid%%"`: retrieves the container process ID as returned by `docker inspect --format '{{.State.Pid}}' <container>`
 
 - Container hostname: `hostname` (added in Agent 6.4, Docker listener only)
-  - `"%%hostname%%"`: retrieves the `hostname` value from the container configuration. Only use it if the `"%%host%%"` variable cannot fetch a reliable IP (example: [ECS awsvpc mode][10]
+  - `"%%hostname%%"`: retrieves the `hostname` value from the container configuration. Only use it if the `"%%host%%"` variable cannot fetch a reliable IP (example: [ECS awsvpc mode][9]
 
 - Environment variable: `env` (added in Agent 6.1)
   - `"%%env_MYENVVAR%%"`: use the contents of the `$MYENVVAR` environment variable **as seen by the Agent process**
@@ -623,11 +627,10 @@ instances:
 
 [1]: /agent/faq/agent-5-autodiscovery
 [2]: https://github.com/DataDog/integrations-core/blob/master/go_expvar/datadog_checks/go_expvar/data/conf.yaml.example
-[3]: /agent/guide/upgrade-to-agent-v6
-[4]: /integrations/ceph
-[5]: /integrations/varnish/#autodiscovery
-[6]: /integrations/postfix
-[7]: /integrations/cassandra/#agent-check-cassandra-nodetool
-[8]: /integrations/gunicorn
-[9]: /help
-[10]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html
+[3]: /integrations/ceph
+[4]: /integrations/varnish/#autodiscovery
+[5]: /integrations/postfix
+[6]: /integrations/cassandra/#agent-check-cassandra-nodetool
+[7]: /integrations/gunicorn
+[8]: /help
+[9]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html


### PR DESCRIPTION
### What does this PR do?
Fixing disclaimer 

### Motivation

There was a disclaimer stating:

>**Note:** this feature is available for Agent v6.10+. See Upgrading the Datadog Agent.

However, this is only true for the Kubernetes tab. This does not apply to the Docker tab as extracting labels/envs as tags has been around since 6.5.x.

### Preview link
