### PR TITLE
[doc] use double quotes for variable interpolation

### DIFF
--- a/content/en/api/logs/code_snippets/list_logs.sh
+++ b/content/en/api/logs/code_snippets/list_logs.sh
@@ -6,6 +6,6 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 curl -X POST \
-  'https://api.datadoghq.com/api/v1/logs-queries/list?api_key=${api_key}&application_key=${app_key}' \
+  "https://api.datadoghq.com/api/v1/logs-queries/list?api_key=${api_key}&application_key=${app_key}" \
   -H 'content-type: application/json' \
   -d '{"query": "service:nginx -@http.method:POST","time": {"from": "now - 1h", "to": "now"}, "sort": "desc", "limit": 50}'


### PR DESCRIPTION

### What does this PR do?
Bash scripts need to use double quotes for variable interpolation, this example was previously using single quotes

### Motivation
this was causing the example command to fail

### Preview link

https://docs-staging.datadoghq.com/ericmustin/update-string-formatting/api/?lang=bash#get-a-list-of-logs
