### PR TITLE
remove unsupported raw log correlation from node documentation

### DIFF
--- a/content/en/tracing/advanced/connect_logs_and_traces.md
+++ b/content/en/tracing/advanced/connect_logs_and_traces.md
@@ -405,43 +405,9 @@ module.exports = Logger
 
 **Manual Trace ID Injection for Raw Formatted Logs**
 
-To ensure proper log correlation, verify the following is present in each log entry:
+Coming Soon. Reach out to [the Datadog support team][1] to learn more.
 
-- `dd.trace_id=<TRACE_ID>`: Where `<TRACE_ID>` is equal to `tracer.scope().active().context().toTraceId()`.
-- `dd.span_id=<SPAN_ID>`: Where `<SPAN_ID>` is equal to `tracer.scope().active().context().toSpanId()`.
-
-You should append or prepend these 2 strings directly to the message part of the log entry. This allows you to correlate trace and logs without having to alter your parsing rules.
-
-Example using `console` as the underlying logger:
-
-```javascript
-const tracer = require('dd-trace').init()
-
-class Logger {
-  log (level, message) {
-    const span = tracer.scope().active()
-    const time = (new Date()).toISOString()
-    const format = '[%s] [%s] - dd.trace_id=%s dd.span_id=%s %s'
-
-    let traceId = ''
-    let spanId = ''
-
-    if (span) {
-      traceId = span.context().toTraceId()
-      spanId = span.context().toSpanId()
-    }
-
-    console.log(format, time, level.toUpperCase(), traceId, spanId, message)
-  }
-}
-
-module.exports = Logger
-```
-
-**Note**: If you are not using a [Datadog Log Integration][1] to parse your logs, custom log parsing rules need to ensure that `trace_id` and `span_id` are being parsed as a string. More information can be found in the [FAQ on this topic][2].
-
-[1]: /logs/log_collection/nodejs
-[2]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel
+[1]: /help
 {{% /tab %}}
 {{% tab "PHP" %}}
 


### PR DESCRIPTION
### What does this PR do?

Remove the documentation about manual ID injection for raw formatted logs in Node APM.

### Motivation

The feature was never implemented in the Logs backend. Users are following the documentation and the feature doesn't work.

### Preview link

https://docs-staging.datadoghq.com/rochdev/remove-raw-log-correlation/tracing/advanced/connect_logs_and_traces/?tab=nodejs#manual-trace-id-injection

### Additional Notes