### PR TITLE
Notes that kube-state-metrics collection is automatic

### DIFF
--- a/content/en/integrations/kubernetes.md
+++ b/content/en/integrations/kubernetes.md
@@ -52,6 +52,8 @@ To gather your kube-state metrics:
   kubectl apply -f <NAME_OF_THE_KUBE_STATE_MANIFESTS_FOLDER>
   ```
 
+Once done, the Kubernetes State integration automatically collects kube-state metrics.
+
 ## Setup Kubernetes DNS
 ### Configuration
 


### PR DESCRIPTION
### What does this PR do?
Notes on the Kubernetes State integration that kube-state metrics collection is automatic, i.e. gently guides users away from creating an extraneous conf.yaml which will make things double-count.

### Motivation
support h/t @jinmei612 

### Preview link

https://docs-staging.datadoghq.com/cswatt/kube-state-conf-warning/integrations/kubernetes/#setup-kubernetes-state

