### PR TITLE
update dogstatsd example to be valid go

### DIFF
--- a/content/en/agent/kubernetes/dogstatsd.md
+++ b/content/en/agent/kubernetes/dogstatsd.md
@@ -122,9 +122,8 @@ func main(){
 
   // other main() code omitted for brevity
 
-  var err error
   // use host IP and port to define endpoint
-  dogstatsd, err = statsd.New(os.Getenv("DOGSTATSD_HOST_IP") + ":8125")
+  dogstatsd, err := statsd.New(os.Getenv("DOGSTATSD_HOST_IP") + ":8125")
   // alternatively, use the unix socket path
   // dogstatsd, err = statsd.New(os.Getenv("DD_DOGSTATSD_SOCKET"))
   if err != nil{
@@ -134,7 +133,7 @@ func main(){
     dogstatsd.Namespace = "My Application"
 
     // post an event to Datadog at app startup
-    dogstatsd.Event(*statsd.Event{
+    dogstatsd.Event(&statsd.Event{
       Title: "My application started.",
       Text: "My application started.",
       })


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Modifes the example code to be valid go code. Currently, the code is invalid since:

- `dogstatsdgo` is never declared
- invalid indirect of statsd.Event literal (type statsd.Event)

### Motivation
<!-- What inspired you to submit this pull request?-->
Had to modify the example before I could utilize it for testing.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

I also removed the `var err error` line since it is redundant. 