### PR TITLE
Change APM Ruby support for Mongo gem from < 2.5 to 2.5+.

### DIFF
--- a/content/en/tracing/setup/ruby.md
+++ b/content/en/tracing/setup/ruby.md
@@ -143,7 +143,7 @@ Ruby APM includes support for the following libraries and frameworks:
 | [Grape][33]                    | `>= 1.0`               | Fully Supported | *[Link][34]*     |
 | [GraphQL][35]                  | `>= 1.7.9`             | Fully Supported | *[Link][36]*     |
 | [gRPC][37]                     | `>= 1.10`              | Fully Supported | *[Link][38]*     |
-| [MongoDB][39]                  | `>= 2.0, < 2.5`        | Fully Supported | *[Link][40]*     |
+| [MongoDB][39]                  | `>= 2.0`               | Fully Supported | *[Link][40]*     |
 | [MySQL2][41]                   | `>= 0.3.10`            | Fully Supported | *[Link][42]*     |
 | [Net/HTTP][43]                 | *(Any Supported Ruby)* | Fully Supported | *[Link][44]*     |
 | [Racecar][45]                  | `>= 0.3.5`             | Fully Supported | *[Link][46]*     |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Updates versions of Mongo gem support from < 2.5 to 2.5+ to reflect the 0.21.2 release.

### Motivation

Keep documentation in sync with library.

### Preview link
https://docs-staging.datadoghq.com/delner/apm_ruby_update_mongo_support/tracing/setup/ruby/

### Additional Notes

Only relevant to versions of ddtrace >= 0.21.2.
