### PR TITLE
Update for docker-compose.yaml and Swarm mode

### DIFF
--- a/content/en/tagging/assigning_tags.md
+++ b/content/en/tagging/assigning_tags.md
@@ -77,6 +77,11 @@ When installing the containerized Datadog Agent, set your host tags using the en
 DD_KUBERNETES_POD_LABELS_AS_TAGS='{"app":"kube_app","release":"helm_release"}'
 DD_DOCKER_LABELS_AS_TAGS='{"com.docker.compose.service":"service_name"}'
 ```
+For the above DD_DOCKER_LABELS_AS_TAGS variable, if using within Docker Swarm in a docker-compose.yaml file DO NOT wrap the {} block in apostrophes instead leave without as below:
+
+```shell
+DD_DOCKER_LABELS_AS_TAGS={"com.docker.compose.service":"service_name"}
+```
 
 Either define the variables in your custom `datadog.yaml`, or set them as JSON maps in these environment variables. The map key is the source (`label/envvar`) name, and the map value is the Datadog tag name.
 

--- a/content/en/tagging/assigning_tags.md
+++ b/content/en/tagging/assigning_tags.md
@@ -77,7 +77,7 @@ When installing the containerized Datadog Agent, set your host tags using the en
 DD_KUBERNETES_POD_LABELS_AS_TAGS='{"app":"kube_app","release":"helm_release"}'
 DD_DOCKER_LABELS_AS_TAGS='{"com.docker.compose.service":"service_name"}'
 ```
-For the above DD_DOCKER_LABELS_AS_TAGS variable, if using within Docker Swarm in a docker-compose.yaml file DO NOT wrap the {} block in apostrophes instead leave without as below:
+When using the `DD_DOCKER_LABELS_AS_TAGS` variable within a Docker Swarm `docker-compose.yaml file`, remove the apostrophes, for example:
 
 ```shell
 DD_DOCKER_LABELS_AS_TAGS={"com.docker.compose.service":"service_name"}


### PR DESCRIPTION
This was found as part of the Broadridge POV

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
