### PR TITLE
Update serilog instruction 

### DIFF
--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -309,7 +309,7 @@ var log = new LoggerConfiguration()
 
 **Note**: To send logs to Datadog EU site, set the `url` property to `https://http-intake.logs.datadoghq.eu`
 
-You can also override the default behaviour and forward logs in TCP by manually specifying the following required properties: `url`, `port`, `useSSL` and `useTCP`. Optionally, specify the `source`, `service`, `host`, and custom tags.
+You can also override the default behaviour and forward logs in TCP by manually specifying the following required properties: `url`, `port`, `useSSL`, and `useTCP`. Optionally, specify the `source`, `service`, `host`, and custom tags.
 For instance to forward logs to the Datadog US site in TCP you would use the following sink configuration:
 
 ```

--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -292,7 +292,7 @@ It is possible to stream logs from your application to Datadog or to the Datadog
 {{< tabs >}}
 {{% tab "SeriLog" %}}
 
-Install the Datadog [Serilog sink][1], which send events and logs to Datadog. By default the sink uses a TCP connection over SSL.
+Install the Datadog [Serilog sink][1], which send events and logs to Datadog. By default the sink forwards logs through HTTPS on port 443.
 Run the following command in the Package Manager Console: 
 
 ```
@@ -307,10 +307,11 @@ var log = new LoggerConfiguration()
     .CreateLogger();
 ```
 
-You can override the default behavior by manually specifying the following properties in the parameters: `endpoint`, `port`, `useSSL`. You can also specify the `source`, `service`, `host`, and custom tags:
+Logs can be sent to the EU site by setting the `url` property to `https://http-intake.logs.datadoghq.eu`
+You can also override the default behavior and forward logs in TCP by manually specifying the following properties in the parameters: `url`, `port`, `useSSL` and `useTCP`. You can also specify the `source`, `service`, `host`, and custom tags:
 
 ```
-var config = new DatadogConfiguration("intake.logs.datadoghq.com", 10516, true);
+var config = new DatadogConfiguration(url: "intake.logs.datadoghq.com", port: 10516, useSSL: true, useTCP: true);
 var log = new LoggerConfiguration()
     .WriteTo.DatadogLogs(
         "<API_KEY>",

--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -309,7 +309,8 @@ var log = new LoggerConfiguration()
 
 **Note**: To send logs to Datadog EU site, set the `url` property to `https://http-intake.logs.datadoghq.eu`
 
-You can also override the default behavior and forward logs in TCP by manually specifying the following properties in the parameters: `url`, `port`, `useSSL` and `useTCP`. You can also specify the `source`, `service`, `host`, and custom tags:
+You can also override the default behaviour and forward logs in TCP by manually specifying the following required properties: `url`, `port`, `useSSL` and `useTCP`. Optionally, specify the `source`, `service`, `host`, and custom tags.
+For instance to forward logs to the Datadog US site in TCP you would use the following sink configuration:
 
 ```
 var config = new DatadogConfiguration(url: "intake.logs.datadoghq.com", port: 10516, useSSL: true, useTCP: true);

--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -307,7 +307,8 @@ var log = new LoggerConfiguration()
     .CreateLogger();
 ```
 
-Logs can be sent to the EU site by setting the `url` property to `https://http-intake.logs.datadoghq.eu`
+**Note**: To send logs to Datadog EU site, set the `url` property to `https://http-intake.logs.datadoghq.eu`
+
 You can also override the default behavior and forward logs in TCP by manually specifying the following properties in the parameters: `url`, `port`, `useSSL` and `useTCP`. You can also specify the `source`, `service`, `host`, and custom tags:
 
 ```


### PR DESCRIPTION
### What does this PR do?
Better reflect the possible configuration setup between HTTPS and TCP.

### Motivation
The serilog sink was updated to support HTTPS

### Preview link
https://docs-staging.datadoghq.com/nils/serilog/logs/log_collection/csharp/?tab=serilog#agentless-logging

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
