### PR TITLE
Python runtime metrics

### DIFF
--- a/content/en/tracing/advanced/runtime_metrics.md
+++ b/content/en/tracing/advanced/runtime_metrics.md
@@ -49,9 +49,18 @@ By default, JVM metrics from your application are sent to the Datadog Agent over
 {{% /tab %}}
 {{% tab "Python" %}}
 
-Coming Soon. Reach out to [the Datadog support team][1] to be part of the beta.
+Python metrics collection can be enabled with one environment parameter when running with `ddtrace-run`:
 
-[1]: /help
+* Environment Variable: `DD_RUNTIME_METRICS_ENABLED=true`
+
+Python metrics can be viewed in correlation with your Python services. See the [Service page][1] in Datadog.
+
+{{< img src="tracing/advanced/runtime_metrics/python-runtime.png" alt="Python Runtime" responsive="true" >}}
+
+**Note**: For the runtime UI, `ddtrace` >= [`0.24.0`][2] is supported.
+
+[1]: https://app.datadoghq.com/apm/services
+[2]: https://github.com/DataDog/dd-trace-py/releases/tag/v0.24.0
 {{% /tab %}}
 {{% tab "Ruby" %}}
 
@@ -108,9 +117,11 @@ Additional JMX metrics can be added using configuration files that are passed to
 {{% /tab %}}
 {{% tab "Python" %}}
 
-Coming Soon. Reach out to [the Datadog support team][1] to be part of the beta.
+{{< get-metrics-from-git "python" >}}
 
-[1]: /help
+Along with displaying these metrics in your APM Service Page, Datadog provides a [default Python Runtime Metrics Dashboard][1] with the `service` and `runtime-id` tags that are applied to these metrics.
+
+[1]: https://app.datadoghq.com/dash/integration/xyz/python-runtime-metrics
 {{% /tab %}}
 {{% tab "Ruby" %}}
 

--- a/content/en/tracing/advanced/runtime_metrics.md
+++ b/content/en/tracing/advanced/runtime_metrics.md
@@ -124,7 +124,7 @@ Additional JMX metrics can be added using configuration files that are passed to
 
 Along with displaying these metrics in your APM Service Page, Datadog provides a [default Python Runtime Metrics Dashboard][1] with the `service` and `runtime-id` tags that are applied to these metrics.
 
-[1]: https://app.datadoghq.com/dash/integration/xyz/python-runtime-metrics
+[1]: https://app.datadoghq.com/dash/integration/30267/python-runtime-metrics
 {{% /tab %}}
 {{% tab "Ruby" %}}
 

--- a/content/en/tracing/advanced/runtime_metrics.md
+++ b/content/en/tracing/advanced/runtime_metrics.md
@@ -49,11 +49,13 @@ By default, JVM metrics from your application are sent to the Datadog Agent over
 {{% /tab %}}
 {{% tab "Python" %}}
 
-Python metrics collection can be enabled with one environment parameter when running with `ddtrace-run`:
+This feature is currently in **BETA**. Reach out to the [the Datadog support team][1] to be part of the beta.
+
+Runtime metrics collection can be enabled with one environment parameter when running with `ddtrace-run`:
 
 * Environment Variable: `DD_RUNTIME_METRICS_ENABLED=true`
 
-Python metrics can be viewed in correlation with your Python services. See the [Service page][1] in Datadog.
+Runtime metrics can be viewed in correlation with your Python services. See the [Service page][1] in Datadog.
 
 **Note**: For the runtime UI, `ddtrace` >= [`0.24.0`][2] is supported.
 

--- a/content/en/tracing/advanced/runtime_metrics.md
+++ b/content/en/tracing/advanced/runtime_metrics.md
@@ -49,7 +49,10 @@ By default, JVM metrics from your application are sent to the Datadog Agent over
 {{% /tab %}}
 {{% tab "Python" %}}
 
-This feature is currently in **BETA**. Reach out to the [the Datadog support team][1] to be part of the beta.
+<div class="alert alert-info">
+This feature is currently in <strong>BETA</strong>.
+Reach out to <a href="/help">the Datadog support team</a> to be part of the beta.
+</div>
 
 Runtime metrics collection can be enabled with one environment parameter when running with `ddtrace-run`:
 

--- a/content/en/tracing/advanced/runtime_metrics.md
+++ b/content/en/tracing/advanced/runtime_metrics.md
@@ -55,8 +55,6 @@ Python metrics collection can be enabled with one environment parameter when run
 
 Python metrics can be viewed in correlation with your Python services. See the [Service page][1] in Datadog.
 
-{{< img src="tracing/advanced/runtime_metrics/python-runtime.png" alt="Python Runtime" responsive="true" >}}
-
 **Note**: For the runtime UI, `ddtrace` >= [`0.24.0`][2] is supported.
 
 [1]: https://app.datadoghq.com/apm/services


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/majorgreys/python-runtime-metrics/tracing/advanced/runtime_metrics/?tab=python

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
