### PR TITLE
Update on exclusion filter behaviour

### DIFF
--- a/content/en/logs/logging_without_limits.md
+++ b/content/en/logs/logging_without_limits.md
@@ -83,6 +83,8 @@ To configure an exclusion filter:
 3. Save the filter
 
     {{< img src="logs/logging_without_limits/index_filter_details.png" alt="" responsive="true" style="width:80%;">}}
+    
+**Note**: If a log matches several exclusion filters, only the first exclusion filter rule is applied. A log is not sampled or excluded multiple times by different exclusion filters. 
 
 ### Example
 


### PR DESCRIPTION
### What does this PR do?
Clarify the behaviour of exclusion filters

### Motivation
Customer were wondering why it was not working with several exclusion filter on the same query

### Preview link
https://docs-staging.datadoghq.com/nils/exclusion-filters-log/logs/logging_without_limits/#exclusion-filters

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
