### PR TITLE
adding description to monitor notifications

### DIFF
--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -1,6 +1,7 @@
 ---
 title: Notifications
 kind: documentation
+description: Setting up monitor notifications
 aliases:
   - /monitors/faq/how-do-i-add-custom-template-variables-to-my-monitor-message
   - /monitors/faq/how-do-i-setup-conditional-contacts-and-messages-in-a-single-monitor


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adding a description section to Monitor Notifications

Onboarding Challenge

### Preview link
https://github.com/DataDog/documentation/blob/master/content/en/monitors/notifications.md

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/lauren/monitor_notifications_description

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
