### PR TITLE
Add APM Ruby runtime metrics documentation

### DIFF
--- a/content/en/tracing/advanced/runtime_metrics.md
+++ b/content/en/tracing/advanced/runtime_metrics.md
@@ -55,9 +55,44 @@ Coming Soon. Reach out to [the Datadog support team][1] to be part of the beta.
 {{% /tab %}}
 {{% tab "Ruby" %}}
 
-Coming Soon. Reach out to [the Datadog support team][1] to be part of the beta.
+<div class="alert alert-info">
+This feature is currently in <strong>BETA</strong>.
+Reach out to <a href="/help">the Datadog support team</a> to be part of the beta.
+</div>
 
-[1]: /help
+Ruby runtime metrics collection uses the [`dogstatsd-ruby`][1] gem to send metrics to the Statsd agent. To collect runtime metrics, you must add this gem to your Ruby application.
+
+Metrics collection is disabled by default. You can enable it by setting the `DD_RUNTIME_METRICS_ENABLED` environment variable to `true`, or by setting the following configuration in your Ruby application:
+
+```ruby
+# config/initializers/datadog.rb
+require 'datadog/statsd'
+require 'ddtrace'
+
+Datadog.configure do |c|
+  # To enable runtime metrics collection, set `true`. Defaults to `false`
+  # You can also set DD_RUNTIME_METRICS_ENABLED=true to configure this.
+  c.runtime_metrics_enabled = true
+
+  # Optionally, you can configure the Statsd instance used for sending runtime metrics.
+  # Statsd is automatically configured with default settings if `dogstatsd-ruby` is available.
+  # You can configure with host and port of Datadog agent; defaults to 'localhost:8125'.
+  c.runtime_metrics statsd: Datadog::Statsd.new
+end
+```
+
+Ruby metrics can be viewed in correlation with your Ruby services. See the [Service page][1] in Datadog.
+
+**Collecting Ruby Metrics in Containerized Environments**
+
+ By default, Ruby metrics from your application are sent to the Datadog Agent over port 8125. If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to true][2], and that port 8125 is open on the Agent. For example: in Kubernetes, [bind the DogstatsD port to a host port][3]; in ECS, [set the appropriate flags in your task definition][4].
+
+[1]: https://rubygems.org/gems/dogstatsd-ruby
+[2]: https://app.datadoghq.com/apm/services
+[3]: /agent/docker/#dogstatsd-custom-metrics
+[4]: /agent/kubernetes/dogstatsd/#bind-the-dogstatsd-port-to-a-host-port
+[5]: /integrations/amazon_ecs/?tab=python#create-an-ecs-task
+
 {{% /tab %}}
 {{% tab "Go" %}}
 

--- a/content/en/tracing/advanced/runtime_metrics.md
+++ b/content/en/tracing/advanced/runtime_metrics.md
@@ -60,7 +60,7 @@ This feature is currently in <strong>BETA</strong>.
 Reach out to <a href="/help">the Datadog support team</a> to be part of the beta.
 </div>
 
-Ruby runtime metrics collection uses the [`dogstatsd-ruby`][1] gem to send metrics to the Statsd agent. To collect runtime metrics, you must add this gem to your Ruby application.
+Runtime runtime metrics collection uses the [`dogstatsd-ruby`][1] gem to send metrics to the Statsd agent. To collect runtime metrics, you must add this gem to your Ruby application.
 
 Metrics collection is disabled by default. You can enable it by setting the `DD_RUNTIME_METRICS_ENABLED` environment variable to `true`, or by setting the following configuration in your Ruby application:
 
@@ -81,11 +81,11 @@ Datadog.configure do |c|
 end
 ```
 
-Ruby metrics can be viewed in correlation with your Ruby services. See the [Service page][1] in Datadog.
+Runtime metrics can be viewed in correlation with your Ruby services. See the [Service page][1] in Datadog.
 
-**Collecting Ruby Metrics in Containerized Environments**
+**Collecting Runtime Metrics in Containerized Environments**
 
- By default, Ruby metrics from your application are sent to the Datadog Agent over port 8125. If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to true][2], and that port 8125 is open on the Agent. For example: in Kubernetes, [bind the DogstatsD port to a host port][3]; in ECS, [set the appropriate flags in your task definition][4].
+ By default, Runtime metrics from your application are sent to the Datadog Agent over port 8125. If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to true][2], and that port 8125 is open on the Agent. For example: in Kubernetes, [bind the DogstatsD port to a host port][3]; in ECS, [set the appropriate flags in your task definition][4].
 
 [1]: https://rubygems.org/gems/dogstatsd-ruby
 [2]: https://app.datadoghq.com/apm/services

--- a/content/en/tracing/advanced/runtime_metrics.md
+++ b/content/en/tracing/advanced/runtime_metrics.md
@@ -60,7 +60,7 @@ This feature is currently in <strong>BETA</strong>.
 Reach out to <a href="/help">the Datadog support team</a> to be part of the beta.
 </div>
 
-Runtime runtime metrics collection uses the [`dogstatsd-ruby`][1] gem to send metrics to the Statsd agent. To collect runtime metrics, you must add this gem to your Ruby application.
+Runtime metrics collection uses the [`dogstatsd-ruby`][1] gem to send metrics to the Statsd agent. To collect runtime metrics, you must add this gem to your Ruby application.
 
 Metrics collection is disabled by default. You can enable it by setting the `DD_RUNTIME_METRICS_ENABLED` environment variable to `true`, or by setting the following configuration in your Ruby application:
 

--- a/content/en/tracing/advanced/runtime_metrics.md
+++ b/content/en/tracing/advanced/runtime_metrics.md
@@ -155,7 +155,7 @@ The following metrics are collected by default after enabling Runtime metrics.
 
 Along with displaying these metrics in your APM Service Page, Datadog provides a [default Ruby Runtime Dashboard][1] with the `service` and `runtime-id` tags that are applied to these metrics.
 
-[1]: https://app.datadoghq.com/dash/integration/XYZ/ruby-runtime-metrics
+[1]: https://app.datadoghq.com/dash/integration/30193/ruby-runtime-metrics
 
 {{% /tab %}}
 {{% tab "Go" %}}

--- a/content/en/tracing/advanced/runtime_metrics.md
+++ b/content/en/tracing/advanced/runtime_metrics.md
@@ -149,9 +149,14 @@ Coming Soon. Reach out to [the Datadog support team][1] to be part of the beta.
 {{% /tab %}}
 {{% tab "Ruby" %}}
 
-Coming Soon. Reach out to [the Datadog support team][1] to be part of the beta.
+The following metrics are collected by default after enabling Runtime metrics.
 
-[1]: /help
+{{< get-metrics-from-git "ruby" >}}
+
+Along with displaying these metrics in your APM Service Page, Datadog provides a [default Ruby Runtime Dashboard][1] with the `service` and `runtime-id` tags that are applied to these metrics.
+
+[1]: https://app.datadoghq.com/dash/integration/XYZ/ruby-runtime-metrics
+
 {{% /tab %}}
 {{% tab "Go" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Adds documentation describing the setup and use of runtime metrics with `dd-trace-rb`.

### Motivation

Cover the basic setup of runtime metrics with Ruby APM.

### Preview link

https://docs-staging.datadoghq.com/delner/apm_ruby_runtime_metrics/tracing/advanced/runtime_metrics

### Additional Notes

Documentation only applies to the unmerged/unreleased https://github.com/DataDog/dd-trace-rb/pull/677 feature expected to be released with 0.22.0.
