### PR TITLE
make sure we don't index fr pages yet

### DIFF
--- a/layouts/partials/noindex.html
+++ b/layouts/partials/noindex.html
@@ -1,3 +1,3 @@
-{{ if (or (eq .Params.beta true) (eq .Params.private true) (eq .Params.placeholder true) (eq .Site.Params.environment "preview") (eq .Params.noindex true) ) }}
+{{ if (or (eq .Params.beta true) (eq .Params.private true) (eq .Params.placeholder true) (eq .Site.Params.environment "preview") (eq .Params.noindex true) (eq (.Language.Lang | default "en") "fr")) }}
 <meta name="robots" content="noindex, nofollow">
 {{ end }}


### PR DESCRIPTION
### What does this PR do?

Currently `noindex` is only being added to placeholder generated french pages. We need to make sure its on all french pages until we are ready for it to be released.

### Motivation
Per discovery with Kaylyn.

### Preview link
https://docs-staging.datadoghq.com/david.jones/no-index-update/

### Additional Notes
This is hard to check on a preview site as we set `noindex` to everything on a preview site. During my local testing this seemed fine.

**Please check after release that noindex appears on french pages only and not on the English site.**

