### PR TITLE
removing fr pages from sitemap for gsc

### DIFF
--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,6 +1,6 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {{ range where (where .Data.Pages "Params.beta" "!=" true) ".Params.is_public" "!=" false }}
-  	  {{ if not .Params.private }}
+  	  {{ if (and (not .Params.private) (ne (.Language.Lang | default "en") "fr") ) }}
 	  <url>
 	    <loc>{{ .Permalink }}</loc>
       {{ if not .Lastmod.IsZero }}

--- a/layouts/sitemapindex.xml
+++ b/layouts/sitemapindex.xml
@@ -1,0 +1,12 @@
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+	{{ range . }}
+  {{ if not (eq .Language.Lang "fr") }}
+	<sitemap>
+	  	<loc>{{ .SitemapAbsURL }}</loc>
+		{{ if not .LastChange.IsZero }}
+	   	<lastmod>{{ .LastChange.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</lastmod>
+		{{ end }}
+	</sitemap>
+  {{ end }}
+	{{ end }}
+</sitemapindex>


### PR DESCRIPTION
### What does this PR do?
This PR hides the french pages from `sitemap.xml` and `/fr/sitemap.xml` to improve the google search console.

### Motivation
The `noindex` we added [here](https://github.com/DataDog/documentation/pull/4390) is good but it actually causes more problems in google search console as the sitemap lists the pages for indexing but the pages say not to index 😬

### Preview link

Comparison of the preview sitemap against production you can see the changes:

https://docs-staging.datadoghq.com/david.jones/sitemap-fr/sitemap.xml
VS
https://docs.datadoghq.com/sitemap.xml

https://docs-staging.datadoghq.com/david.jones/sitemap-fr/fr/sitemap.xml
VS
https://docs.datadoghq.com/fr/sitemap.xml

### Additional Notes

