### PR TITLE
Provide additional enablement guidance to HIPAA customers

### DIFF
--- a/content/en/security/logs.md
+++ b/content/en/security/logs.md
@@ -11,19 +11,19 @@ further_reading:
 
 This article is part of a [series on data security][1].
 
-The Log Management product supports multiple [environments and formats][2], allowing customers the flexibility to submit to Datadog nearly any data they choose. This article describes the main security guarantees and filtering controls available to users when submitting Logs to Datadog.
+The Log Management product supports multiple [environments and formats][2], allowing customers the flexibility to submit to Datadog nearly any data they choose. This article describes the main security guarantees and filtering controls available to users when submitting logs to Datadog.
 
 ## Information Security
 
-The Datadog Agent submits Logs to Datadog over a TLS-encrypted TCP connection, requiring an outbound communication over port `10516`. Datadog uses symmetric encryption at rest (AES-256) for indexed Logs. Indexed Logs are deleted from the Datadog platform once their retention period, as defined by the customer, expires.
+The Datadog Agent submits logs to Datadog over a TLS-encrypted TCP connection, requiring an outbound communication over port `10516`. Datadog uses symmetric encryption at rest (AES-256) for indexed logs. Indexed logs are deleted from the Datadog platform once their retention period, as defined by the customer, expires.
 
 ## Logs Filtering
 
-For customers using release 6, the Agent can be configured to filter Logs sent by the Agent to the Datadog application. To prevent the submission of specific Logs, use the `log_processing_rules` [setting][3], with the **exclude_at_match** or **include_at_match** `type`. This setting enables the creation of a list containing one or more regular expressions, which instructs the Agent to filter out Logs based on a whitelist or blacklist.
+For customers using release 6, the Agent can be configured to filter logs sent by the Agent to the Datadog application. To prevent the submission of specific logs, use the `log_processing_rules` [setting][3], with the **exclude_at_match** or **include_at_match** `type`. This setting enables the creation of a list containing one or more regular expressions, which instructs the Agent to filter out logs based on a whitelist or blacklist.
 
 ## Logs Obfuscation
 
-For customers using release 6, the Agent can be configured to obfuscate specific patterns within Logs sent by the Agent to the Datadog application. To mask sensitive sequences within your Logs, use the `log_processing_rules` [setting][4], with the  **mask_sequences** `type`. This setting enables the creation of a list containing one or more regular expressions, which instructs the Agent to redact sensitive data within your Logs.
+For customers using release 6, the Agent can be configured to obfuscate specific patterns within logs sent by the Agent to the Datadog application. To mask sensitive sequences within your logs, use the `log_processing_rules` [setting][4], with the  **mask_sequences** `type`. This setting enables the creation of a list containing one or more regular expressions, which instructs the Agent to redact sensitive data within your logs.
 
 ## Configuration Requirements for HIPAA-enabled Customers
 
@@ -47,7 +47,7 @@ logs_config:
 Additionally, certain features are not available at the moment to customers who have signed Datadog's BAA, notably:
 
 * Users cannot request support via chat
-* The Logs Live Tail is disabled
+* The logs Live Tail is disabled
 * Notifications from Log Monitors cannot include log samples
 * Log Monitors cannot be configured with a `group-by` clause
 

--- a/content/en/security/logs.md
+++ b/content/en/security/logs.md
@@ -32,8 +32,16 @@ Datadog will sign a Business Associate Agreement (BAA) with customers that trans
 Prior to executing a BAA, customers transmitting ePHI to the Datadog Log Management Service must implement the following configurations:
 
 * The Datadog agent must be configured to submit logs to `tcp-encrypted-intake.logs.datadoghq.com`
+* The Datadog [log collection AWS Lambda function][5] must be configured to submit logs to `lambda-tcp-encrypted-intake.logs.datadoghq.com` by setting the `DD_URL` environment variable
 * Other log sources besides the Datadog agent must be configured to submit logs to `http-encrypted-intake.logs.datadoghq.com`
-* A HIPAA-ready lambda function, provided by Datadog, must be used to submit logs. The default Datadog AWS lambda must not be used.
+
+The following sample configuration can be used with the Datadog agent to submit Logs to a HIPAA-ready endpoint directly (i.e. without a proxy):
+```
+logs_enabled: true
+logs_config:
+  logs_dd_url: tcp-encrypted-intake.logs.datadoghq.com:10516
+  logs_no_ssl: false
+```
 
 Additionally, certain features are not available at the moment to customers who have signed Datadog's BAA, notably:
 
@@ -52,3 +60,4 @@ If you have any questions about how the Log Management Service satisfies the app
 [2]: /logs/log_collection
 [3]: /logs/log_collection/#filter-logs
 [4]: /logs/log_collection/#scrub-sensitive-data-in-your-logs
+[5]: /integrations/amazon_lambda/#log-collection

--- a/content/en/security/logs.md
+++ b/content/en/security/logs.md
@@ -35,7 +35,8 @@ Prior to executing a BAA, customers transmitting ePHI to the Datadog Log Managem
 * The Datadog [log collection AWS Lambda function][5] must be configured to submit logs to `lambda-tcp-encrypted-intake.logs.datadoghq.com` by setting the `DD_URL` environment variable
 * Other log sources besides the Datadog agent must be configured to submit logs to `http-encrypted-intake.logs.datadoghq.com`
 
-The following sample configuration can be used with the Datadog agent to submit Logs to a HIPAA-ready endpoint directly (i.e. without a proxy):
+The following sample configuration can be used with the Datadog Agent to submit logs to a HIPAA-ready endpoint directly (i.e. without a proxy):
+
 ```
 logs_enabled: true
 logs_config:


### PR DESCRIPTION
### What does this PR do?
This PR clarifies configuration requirements for HIPAA-enabled customers.

### Motivation
Datadog will sign a Business Associate Agreement (BAA) with customers that transmit protected health information via Datadog’s Log Management Service. This PR provides additional information to customers regarding how their agents and lambdas should be configured.

### Preview link
https://docs-staging.datadoghq.com/marc.tremsal/hipaa-tweaks/security/logs/

### Additional Notes
Reviewed and approved by compliance and security