### PR TITLE
synthetics: no second opinion tests

### DIFF
--- a/content/en/synthetics/_index.md
+++ b/content/en/synthetics/_index.md
@@ -58,7 +58,7 @@ Finally, the following characters are reserved: `-`, `(`, `)`, `"`, `~`, `*`, `:
 
 ## Create a check
 
-Select **Create a New check +** in the upper right corner of the Synthetics page to create an [API tests][2] or a [browser test][3].
+Select **Create a New check +** in the upper right corner of the Synthetics page to create an [API tests][2] or a [browser test][3]. When a test fails, the endpoint is not retested: the uptime directly considers the endpoint as `down`. 
 
 {{< img src="synthetics/create_a_check.png" alt="Create a check" responsive="true" style="width:80%;">}}
 

--- a/content/en/synthetics/api_test.md
+++ b/content/en/synthetics/api_test.md
@@ -113,6 +113,8 @@ A check is considered `FAILED` if it doesn't satisfy the assertions configured f
 | SSL             | The SSL connection couldn't be performed; see below for more detailed explanations.                                                                                                          |
 | TIMEOUT         | The request couldn't be completed in a reasonable time.                                                                                                                                      |
 
+If a test fails, the uptime directly considers the endpoint as `down`. It is not retested until the next test run.
+
 ### SSL errors
 
 | Error                              | Description                                                                                                                                                            |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
clarifies that no second opinion tests are run on synthetics

### Motivation
@MargotLepizzera 

### Preview link
https://docs-staging.datadoghq.com/cswatt/synthetics-second-opinion/synthetics

### Additional Notes
<!-- Anything else we should know when reviewing?-->
