### PR TITLE
Fix link redirection to configuration

### DIFF
--- a/content/en/integrations/faq/how-to-monitor-events-from-the-windows-event-logs.md
+++ b/content/en/integrations/faq/how-to-monitor-events-from-the-windows-event-logs.md
@@ -3,11 +3,12 @@ title: How to monitor events from the Windows Event Logs ?
 kind: faq
 ---
 
-With the Windows version of the Datadog Agent, it is possible to post Events to your [Event Stream][1] based on logs from the Windows Event Log.
+With the Windows version of the Datadog Agent, it is possible to post events to your [Event Stream][1] based on logs from the Windows Event Log.
 
-To do so, open the Datadog Agent Manager and on the left pane navigate to the Windows Event Log section.
+To do so, open the Datadog Agent Manager. On the left pane, navigate to the Windows Event Log section.
 
-Here defines filters that are matched against incoming events:
+The following defines filters that are matched against incoming events:
+
 ```yaml
 # init_config:
 #
@@ -30,16 +31,18 @@ Here defines filters that are matched against incoming events:
 #       - A list of message filters, using % as a wildcard.
 ```
 
-The most common way to visualize Event Logs in Windows is to use the Windows Event Viewer. Though it is a very convenient GUI tool, its main issue is to alter the details of a log entry to make it more user-friendly and readable, which is not helping when setting up filters.
+The most common way to visualize Event Logs in Windows is to use the Windows Event Viewer. Though it is a convenient GUI tool, its main purpose is to alter the details of a log entry to make it more user-friendly and readable, which does not necessarily help when setting up filters.
 
-As the Agent pulls log information from a WMI class, we use a Powershell commandlet to filter event logs and look into their internal structure. In this example we want to monitor events with ID 4776 from the Security log, which represent a successful authentication on the system.
+As the Agent pulls log information from a WMI class, use a Powershell commandlet to filter event logs and look into their internal structure. In this example, you want to monitor events with ID 4776 from the security log, which represent a successful authentication on the system.
 
-First we retrieve the last 100 entries from the Security log*:
+First, retrieve the last 100 entries from the security log*:
+
 ```
 $logs = Get-WmiObject -class Win32_NTLogEvent -filter "(logfile='Security')" | select -First 100
 ```
 
-Now we display the first event with an ID of 4776:
+Now, display the first event with an ID of 4776:
+
 ```
 $logs | where  { $_.EventCode -eq 4776} | select -First 1 | format-list
 
@@ -64,9 +67,10 @@ Type             : Audit Success
 UserName         :
 ```
 
-Note how the Type here is Audit Success, whereas this information is labeled as Keyword in the Event Viewer.
+Note how the `Type` here is Audit Success, whereas this information is labeled as "Keyword" in the Event Viewer.
 
-Based on this information we can create the following yaml file:
+Based on this information, you can create the following YAML file:
+
 ```yaml
 init_config:
 
@@ -88,9 +92,9 @@ instances:
 
 Save the configuration, enable the integration and [restart the Agent][2]. Now disconnect from the Windows machine and reconnect.
 
-You should see an Event appear on your [Event Stream][1] on the Datadog website.
+You should see an event appear on your [Event Stream][1] on the Datadog website.
 
-*Note that the -Get-WmiObject command outlined do not locate all of the event logs by default. If this command does not return any results when you input the Event Log filename you wish to monitor, you have to add it to the registry. For more on how to add it to the registry, [check out this article][3].
+*Note that the -Get-WmiObject command outlined does not locate all of the event logs by default. If this command does not return any results when you input the Event Log filename you wish to monitor, you have to add it to the registry. For more on how to add it to the registry, [check out this article][3].
 
 ** For convenience, reference [the YAML example][4] file to use as a template.
 

--- a/content/en/integrations/faq/how-to-monitor-events-from-the-windows-event-logs.md
+++ b/content/en/integrations/faq/how-to-monitor-events-from-the-windows-event-logs.md
@@ -10,23 +10,23 @@ To do so, open the Datadog Agent Manager and on the left pane navigate to the Wi
 Here defines filters that are matched against incoming events:
 ```yaml
 # init_config:
-# 
+#
 # instances:
 #   Each Event Log instance lets you define the type of events you want to
 #   match and how to tag those events. You can use the following filters:
-#   
-#   - 
-#     log_file: 
+#
+#   -
+#     log_file:
 #       - Application, System, Setup, Security
-#     source_name: 
+#     source_name:
 #       - Any available source name
-#     type: 
+#     type:
 #       - Warning, Error, Information...
-#     user: 
+#     user:
 #       - Any valid user name
-#     event_id: 
+#     event_id:
 #       - The Event ID can be found through http://www.eventid.net/ and viewed in the window event viewer.
-#     message_filters: 
+#     message_filters:
 #       - A list of message filters, using % as a wildcard.
 ```
 
@@ -34,7 +34,7 @@ The most common way to visualize Event Logs in Windows is to use the Windows Eve
 
 As the Agent pulls log information from a WMI class, we use a Powershell commandlet to filter event logs and look into their internal structure. In this example we want to monitor events with ID 4776 from the Security log, which represent a successful authentication on the system.
 
-First we retrieve the last 100 entries from the Security log*: 
+First we retrieve the last 100 entries from the Security log*:
 ```
 $logs = Get-WmiObject -class Win32_NTLogEvent -filter "(logfile='Security')" | select -First 100
 ```
@@ -47,7 +47,7 @@ Category         : 14336
 CategoryString   : Credential Validation
 EventCode        : 4776
 EventIdentifier  : 4776
-TypeEvent        : 
+TypeEvent        :
 InsertionStrings : {MICROSOFT_AUTHENTICATION_PACKAGE_V1_0, vagrant, WIN-5OU1M45KDAQ, 0x0}
 LogFile          : Security
 Message          : The computer attempted to validate the credentials for an account.
@@ -61,7 +61,7 @@ SourceName       : Microsoft-Windows-Security-Auditing
 TimeGenerated    : 20150522184549.469748-000
 TimeWritten      : 20150522184549.469748-000
 Type             : Audit Success
-UserName         : 
+UserName         :
 ```
 
 Note how the Type here is Audit Success, whereas this information is labeled as Keyword in the Event Viewer.
@@ -72,12 +72,12 @@ init_config:
 
 instances:
  ########################
-- 
+-
   log_file:
     - Security
   type:
     - Audit Success
-  event_id: 
+  event_id:
     - 4776
   source_name:
     - Microsoft-Windows-Security-Auditing
@@ -97,4 +97,4 @@ You should see an Event appear on your [Event Stream][1] on the Datadog website.
 [1]: /graphing/event_stream
 [2]: /agent/guide/agent-commands/#start-stop-restart-the-agent
 [3]: /integrations/faq/how-to-add-event-log-files-to-the-win32-ntlogevent-wmi-class
-[4]: https://github.com/DataDog/dd-agent/tree/master/conf.d
+[4]: https://github.com/DataDog/integrations-core/blob/master/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example


### PR DESCRIPTION
### What does this PR do?
Fix link to the windows event log YAML configuration file. Note that I only modified line `100`, unsure why other lines seem affected by this PR.

### Motivation
Read the documentation and found that it was redirecting to a jmx based integration instead.

### Preview link
https://docs-staging.datadoghq.com/davidb/windows-event-link/integrations/faq/how-to-monitor-events-from-the-windows-event-logs/
