### PR TITLE
typo in link

### DIFF
--- a/content/en/monitors/guide/_index.md
+++ b/content/en/monitors/guide/_index.md
@@ -4,7 +4,7 @@ kind: guide
 ---
 
 {{< whatsnext desc="General Guides:" >}}
-    {{< nextlink href="monitors/guide/monitor-arithmetic-and-sparse-metric" >}}Monitor Arithmetic and Sparse Metrics{{< /nextlink >}}
+    {{< nextlink href="monitors/guide/monitor-arithmetic-and-sparse-metrics" >}}Monitor Arithmetic and Sparse Metrics{{< /nextlink >}}
     {{< nextlink href="monitors/guide/as-count-in-monitor-evaluations" >}}as_count() Monitor Evaluations{{< /nextlink >}}
     {{< nextlink href="monitors/guide/visualize-your-service-check-in-the-datadog-ui" >}}Visualize your service check in the Datadog UI{{< /nextlink >}}
 {{< /whatsnext >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fixes a typo on the TOC for monitors guides

### Motivation
<!-- What inspired you to submit this pull request?-->
Checked my pages and found the bad link after deploy

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/bcon/link-typo/monitors/guide

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
