### PR TITLE
Bcon/better alias

### DIFF
--- a/content/en/monitors/guide/as-count-in-monitor-evaluations.md
+++ b/content/en/monitors/guide/as-count-in-monitor-evaluations.md
@@ -2,7 +2,6 @@
 title: as_count() in Monitor Evaluations
 kind: guide
 aliases:
-  - /monitors/guide/as-count-in-monitor-evaluations
   - /monitors/guide/as-count-monitor-evaluation
 ---
 

--- a/content/en/monitors/guide/as-count-in-monitor-evaluations.md
+++ b/content/en/monitors/guide/as-count-in-monitor-evaluations.md
@@ -3,7 +3,7 @@ title: as_count() in Monitor Evaluations
 kind: guide
 aliases:
   - /monitors/guide/as-count-in-monitor-evaluations
-  - /monitors/guide/as-count-monitor-evaluations
+  - /monitors/guide/as-count-monitor-evaluation
 ---
 
 ## Overview

--- a/content/en/monitors/guide/as-count-in-monitor-evaluations.md
+++ b/content/en/monitors/guide/as-count-in-monitor-evaluations.md
@@ -3,6 +3,7 @@ title: as_count() in Monitor Evaluations
 kind: guide
 aliases:
   - /monitors/guide/as-count-in-monitor-evaluations
+  - /monitors/guide/as-count-monitor-evaluations
 ---
 
 ## Overview


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/bcon/better-alias/monitors/guide/as-count-in-monitor-evaluations/
https://docs-staging.datadoghq.com/bcon/better-alias/monitors/guide/as-count-monitor-evaluation/

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
