### PR TITLE
Add a new beta banner for javascript library

### DIFF
--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -1,6 +1,7 @@
 ---
 title: Browser Log Collection
 kind: documentation
+beta: true
 aliases:
   - /logs/log_collection/web_browser
 further_reading:

--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -50,6 +50,10 @@ Read the [Public API keys documentation][2] to learn more about the restrictions
 
 ## Configure the JavaScript logger
 
+<div class="alert alert-warning">
+The Javascript logging library is in private beta. <a href="https://docs.datadoghq.com/help/">Reach out to support</a> to turn on this feature for your account.
+</div>
+
 The following parameters can be used to configure the library to send logs to Datadog:
 
 * Set `isCollectingError` to `false` to turn off the automatic JS and console error collection.

--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -52,7 +52,7 @@ Read the [Public API keys documentation][2] to learn more about the restrictions
 ## Configure the JavaScript logger
 
 <div class="alert alert-warning">
-The Javascript logging library is in private beta. <a href="https://docs.datadoghq.com/help/">Reach out to support</a> to turn on this feature for your account.
+The Javascript logging library is in private beta. <a href="https://docs.datadoghq.com/help/">Reach out to Datadog support team</a> to enable this feature for your account.
 </div>
 
 The following parameters can be used to configure the library to send logs to Datadog:


### PR DESCRIPTION
### What does this PR do?
Add a new beta banner in the javascript logging section


### Motivation
Users assumed that only the public key were in beta. It was misleading

### Preview link
https://docs-staging.datadoghq.com/nils/browser-logs-beta/logs/log_collection/javascript/?tab=us#pagetitle

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
