### PR TITLE
Side nav fix for hidden item

### DIFF
--- a/layouts/partials/sidenav/nav.html
+++ b/layouts/partials/sidenav/nav.html
@@ -37,7 +37,7 @@
     -->
 
     <!-- For Rule (A) -->
-    {{ $plink := replace $dot.Page.RelPermalink (print "/" $ctx.Site.Language.Lang) "" }}
+    {{ $plink := replace $dot.Page.RelPermalink (print "/" $ctx.Site.Language.Lang "/") "/" }}
     {{ $spacedWords := (replace $plink "/" " ") }}
     {{ $currentUrlPartsLength := countwords $spacedWords }}
     {{ $url_part1 := index (split $plink "/") 1 }}


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue with the left navigation where it wasn't expanding correctly for certain subpages.

Why?
We do some comparison on the url paths. These url paths have the language code stripped from them. The code used to strip the language code wasn't good enough which caused a url like

`/agent/autodiscovery/endpointschecks/` to be stripped to `/agent/autodiscoverydpointschecks/`

Which caused any subsequent comparisons to fail.
This pr strips the language code if it looks like `/en/` or `/fr/` not just `/en` or `/fr` as these could be parts of a word in the url.

### Motivation
Discussion in `#documentation` channel

### Preview link
https://docs-staging.datadoghq.com/david.jones/leftnav-fix-hiddenitem/

### Additional Notes

