### PR TITLE
Remove incorrect example

### DIFF
--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -224,8 +224,6 @@ Other examples:
 | key:"/valueStr"         | `%{data::keyvalue(":", "/")}`       | {"key": "/valueStr"}           |
 | key:={valueStr}         | `%{data::keyvalue(":=", "", "{}")}` | {"key": "valueStr"}            |
 | key:=valueStr           | `%{data::keyvalue(":=", "")}`       | {"key": "valueStr"}            |
-| key1:=>val1,key2:=>val2 | `%{data::keyvalue(":=>", ",")}`     | {"key1": "val1","key2":"val2"} |
-
 
 ### Parsing dates
 


### PR DESCRIPTION
Removes an example from the keyvalue table that is incorrect. This example suggests that setting the second argument for `keyvalue()` will allow the user to change the character used as a splitter but, in fact, the second argument is for defining whitelisted characters (as per the example just above the table).

For more details see:
 - this ticket: https://datadog.zendesk.com/agent/tickets/217482
 - the trello card here: https://trello.com/c/rfJADqTE/398-processing-improve-the-keyvalue-parser