### PR TITLE
Refactoring the monitor notifications desc

### DIFF
--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -305,25 +305,19 @@ For example, if the rendered variable is setup as a channel in the Slack integra
 
 ## Test monitor notifications
 
+**Testing notifications are supported for the following monitor types: Host, Metric, Anomaly, Outlier, Forecast, Integration (check only), Process (check only), Network (check only), Custom check, and Event.**
+
 After you define your monitor, test what your monitor's notification would look like in any applicable state with the *Test Notifications* button at the bottom right of the monitor page:
 
-1. Choose which monitor case you want to test in the following pop-up:
+1. Choose which monitor case you want to test in the following pop-up. You can only test states that are available in the monitor’s configuration and test for thresholds specified in the alerting conditions. [Recovery thresholds][4] are an exception, as Datadog sends a recovery notification once the monitor is no longer in alert or has no warn conditions.
 
-  {{< img src="monitors/notifications/test-notif-select.png" alt="Test the notifications for this monitor" responsive="true" style="width:50%;" >}}
+    {{< img src="monitors/notifications/test-notif-select.png" alt="Test the notifications for this monitor" responsive="true" style="width:50%;" >}}
 
-2. Click **Run test** to send the notification.
+2. Click **Run test** to send the notification to any notification handle available in the message box.
 
 **Notes**:
 
 * Test notifications produce events that can be searched for within the event stream. These notifications also indicate who initiated the test in the message body, and `[TEST]` is added into the test notification title.
-
-* You can only test states that are available in the monitor’s configuration and test for thresholds specified in the alerting conditions. [Recovery thresholds][4] are an exception, as Datadog sends a recovery notification once the monitor is no longer in alert or has no warn conditions.
-
-* Your test notifications are sent to any notification handle available in the message box.
-
-* You do not need to save the monitor to run the notification test.
-
-* Testing notifications are currently supported for the following monitor types: Host, Metric, Anomaly, Outlier, Forecast, Integration (check only), Process (check only), Network (check only), Custom check, and Event.
 
 * Message variables auto-populate with an available randomly selected group based on the scope of your monitor's definition.
 

--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -309,7 +309,7 @@ For example, if the rendered variable is setup as a channel in the Slack integra
 
 After you define your monitor, test what your monitor's notification would look like in any applicable state with the *Test Notifications* button at the bottom right of the monitor page:
 
-1. Choose which monitor case you want to test in the following pop-up. You can only test states that are available in the monitor’s configuration and test for thresholds specified in the alerting conditions. [Recovery thresholds][4] are an exception, as Datadog sends a recovery notification once the monitor is no longer in alert or has no warn conditions.
+1. Choose which monitor case you want to test in the following pop-up. You can only test states that are available in the monitor’s configuration, and only for thresholds specified in the alerting conditions. [Recovery thresholds][4] are an exception, as Datadog sends a recovery notification once the monitor either is no longer in alert, or it has no warn conditions.
 
     {{< img src="monitors/notifications/test-notif-select.png" alt="Test the notifications for this monitor" responsive="true" style="width:50%;" >}}
 

--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -305,7 +305,7 @@ For example, if the rendered variable is setup as a channel in the Slack integra
 
 ## Test monitor notifications
 
-**Testing notifications are supported for the following monitor types: Host, Metric, Anomaly, Outlier, Forecast, Integration (check only), Process (check only), Network (check only), Custom check, and Event.**
+**Testing notifications are supported for the following monitor types**: host, metric, anomaly, outlier, forecast, integration (check only), process (check only), network (check only), custom check, and event.
 
 After you define your monitor, test what your monitor's notification would look like in any applicable state with the *Test Notifications* button at the bottom right of the monitor page:
 

--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -305,35 +305,27 @@ For example, if the rendered variable is setup as a channel in the Slack integra
 
 ## Test monitor notifications
 
-After you define your monitor, you can test what your monitor's notification would look like in any applicable state. You can test what's specified in the "Say What's Happening" field by selecting "Select all" or selecting specific states.
+After you define your monitor, test what your monitor's notification would look like in any applicable state with the *Test Notifications* button at the bottom right of the monitor page. Choose which monitor case you want to test in the following pop-up:
 
 {{< img src="monitors/notifications/test-notif-select.png" alt="Test the notifications for this monitor" responsive="true" style="width:50%;" >}}
 
-You can only test states that are available in the monitor’s configuration and test for thresholds specified in the alerting conditions. [Recovery thresholds][4] are an exception, as Datadog sends a recovery notification once the monitor is no longer in alert or has no warn conditions.
+Then click **Run test** to send the notification.
 
-In the following, you are only able to test for ALERT because only an alert threshold has been specified:
+**Notes**:
 
-{{< img src="monitors/notifications/test-notif-alert.png" alt="Set alert conditions" responsive="true" >}}
+* Test notifications produce events that can be searched for within the event stream. These notifications also indicate who initiated the test in the message body, and `[TEST]` is added into the test notification title.
 
-In this next example, you can test for both ALERT and NO DATA:
+* You can only test states that are available in the monitor’s configuration and test for thresholds specified in the alerting conditions. [Recovery thresholds][4] are an exception, as Datadog sends a recovery notification once the monitor is no longer in alert or has no warn conditions.
 
-{{< img src="monitors/notifications/test-notif-alert-nodata.png" alt="Test the notifications for this monitor" responsive="true"  >}}
+* Your test notifications are sent to any notification handle available in the message box.
 
-Message variables auto-populate with an available randomly selected group based on the scope of your monitor's definition.
+* You do not need to save the monitor to run the notification test.
 
-{{< img src="monitors/notifications/test-notif-message.png" alt="Say what's happening" responsive="true" style="width:50%;" >}}
+* Testing notifications are currently supported for the following monitor types: Host, Metric, Anomaly, Outlier, Forecast, Integration (check only), Process (check only), Network (check only), Custom check, and Event.
 
-### Managing test notifications
+* Message variables auto-populate with an available randomly selected group based on the scope of your monitor's definition.
 
-Test notifications produce events that can be searched for within the event stream. These notifications also indicate who initiated the test in the message body, and [TEST] is added into the test notification title. 
-
-Your test notifications are sent to any notification handle available in the message box. You can also test webhooks.  
-
-**TIP**: Datadog recommends that you test using a test notification channel if you do not want to add these notifications to your on-call channels. 
-
-You do not need to save the monitor to run the notification test. Clicking **Run test** sends the notification, and you can continue to edit the monitor and notification box before saving. 
-
-Testing notifications are currently supported for the following monitor types: Host, Metric, Anomaly, Outlier, Forecast, Integration (check only), Process (check only), Network (check only), Custom check, and Event.
+  {{< img src="monitors/notifications/test-notif-message.png" alt="Say what's happening" responsive="true" style="width:50%;" >}}
 
 ## Advanced notification configuration
 ### Include links to appropriate dashboards

--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -305,11 +305,13 @@ For example, if the rendered variable is setup as a channel in the Slack integra
 
 ## Test monitor notifications
 
-After you define your monitor, test what your monitor's notification would look like in any applicable state with the *Test Notifications* button at the bottom right of the monitor page. Choose which monitor case you want to test in the following pop-up:
+After you define your monitor, test what your monitor's notification would look like in any applicable state with the *Test Notifications* button at the bottom right of the monitor page:
 
-{{< img src="monitors/notifications/test-notif-select.png" alt="Test the notifications for this monitor" responsive="true" style="width:50%;" >}}
+1. Choose which monitor case you want to test in the following pop-up:
 
-Then click **Run test** to send the notification.
+  {{< img src="monitors/notifications/test-notif-select.png" alt="Test the notifications for this monitor" responsive="true" style="width:50%;" >}}
+
+2. Click **Run test** to send the notification.
 
 **Notes**:
 


### PR DESCRIPTION
### What does this PR do?
Refactors the test monitor notifications desc

### Motivation

Screenshots were not really use-full and it was confusing since useful info was split over two different sections

### Preview link

https://docs-staging.datadoghq.com/gus/test-monitor/monitors/notifications/?tab=is_alertis_warning#test-monitor-notifications