### PR TITLE
APM > .NET > Trace Analytics configuration

### DIFF
--- a/content/en/tracing/trace_search_and_analytics/_index.md
+++ b/content/en/tracing/trace_search_and_analytics/_index.md
@@ -222,7 +222,7 @@ Integration names can be found on the [integrations table][1].
 {{% tab ".NET" %}}
 
 
-In addition to setting globally, you can enable or disable Trace Search & Analytics for individual integrations using the following setting:
+In addition to setting globally, you can enable or disable Trace Search & Analytics for individual integrations.
 
 * Environment Variable or AppSetting: `DD_<INTEGRATION>_ANALYTICS_ENABLED=true`
 
@@ -232,12 +232,14 @@ Or in code:
 Tracer.Instance.Settings.Integrations["<INTEGRATION>"].AnalyticsEnabled = true;
 ```
 
-Use this in addition to the global configuration for any integrations that submit custom services. For example, you can set the following to enable all ADO.NET spans in Trace Search & Analytics:
+For example, to enable Trace Search & Analytics for ASP.NET MVC:
 
-* Environment Variable or AppSetting: `DD_ADONET_ANALYTICS_ENABLED=true`
+* Environment Variable or AppSetting: `DD_ASPNETMVC_ANALYTICS_ENABLED=true`
+
+Or in code:
 
 ```csharp
-Tracer.Instance.Settings.Integrations["AdoNet"].AnalyticsEnabled = true;
+Tracer.Instance.Settings.Integrations["AspNetMvc"].AnalyticsEnabled = true;
 ```
 
 Integration names can be found on the [integrations table][1].

--- a/content/en/tracing/trace_search_and_analytics/_index.md
+++ b/content/en/tracing/trace_search_and_analytics/_index.md
@@ -310,6 +310,24 @@ tracer.use('mysql', {
 ```
 
 {{% /tab %}}
+{{% tab ".NET" %}}
+
+
+Database tracing is not captured by Trace Search & Analytics by default and you must enable collection manually for each integration. For example, to enable Trace Search & Analytics for ADO.NET:
+
+* Environment Variable or AppSetting: `DD_ADONET_ANALYTICS_ENABLED=true`
+
+Or in code:
+
+```csharp
+Tracer.Instance.Settings.Integrations["AdoNet"].AnalyticsEnabled = true;
+```
+
+Integration names can be found on the [integrations table][1].
+
+
+[1]: /tracing/setup/dotnet#integrations
+{{% /tab %}}
 {{% tab "PHP" %}}
 
 Database tracing is not captured by Trace Search & Analytics by default and you must enable collection manually for each integration. For example:
@@ -398,6 +416,22 @@ Applications with custom instrumentation can enable trace analytics by setting t
 const { ANALYTICS } = require('dd-trace/ext/tags')
 
 span.setTag(ANALYTICS, true)
+```
+
+{{% /tab %}}
+{{% tab ".NET" %}}
+
+Applications with custom instrumentation can enable trace analytics by setting the `Tags.Analytics` tag on the service root span:
+
+```csharp
+using Datadog.Trace;
+
+using(var scope = Tracer.Instance.StartActive("web.request"))
+{
+    // enable Analytics on this span
+    scope.span.SetTag(Tags.Analytics, "true");
+}
+
 ```
 
 {{% /tab %}}

--- a/content/en/tracing/trace_search_and_analytics/_index.md
+++ b/content/en/tracing/trace_search_and_analytics/_index.md
@@ -85,6 +85,24 @@ After enabling, the Trace Search & Analytics UI starts showing results. Visit [T
 
 [1]: https://app.datadoghq.com/apm/search
 {{% /tab %}}
+{{% tab ".NET" %}}
+
+Trace Search & Analytics can be enabled globally for all web integrations with one configuration parameter in the Tracing Client:
+
+* Environment Variable or AppSetting: `DD_TRACE_ANALYTICS_ENABLED=true`
+
+This setting can also be set in code:
+```csharp
+Tracer.Instance.Settings.AnalyticsEnabled = true;
+```
+
+
+
+After enabling, the Trace Search & Analytics UI starts showing results. Visit [Trace Search page][1] to get started.
+
+
+[1]: https://app.datadoghq.com/apm/search
+{{% /tab %}}
 {{% tab "PHP" %}}
 
 Trace Search & Analytics can be enabled globally for all web integrations with one configuration parameter in the Tracing Client:

--- a/content/en/tracing/trace_search_and_analytics/_index.md
+++ b/content/en/tracing/trace_search_and_analytics/_index.md
@@ -92,11 +92,10 @@ Trace Search & Analytics can be enabled globally for all web integrations with o
 * Environment Variable or AppSetting: `DD_TRACE_ANALYTICS_ENABLED=true`
 
 This setting can also be set in code:
+
 ```csharp
 Tracer.Instance.Settings.AnalyticsEnabled = true;
 ```
-
-
 
 After enabling, the Trace Search & Analytics UI starts showing results. Visit [Trace Search page][1] to get started.
 
@@ -219,6 +218,32 @@ Integration names can be found on the [integrations table][1].
 
 
 [1]: /tracing/languages/nodejs/#integrations
+{{% /tab %}}
+{{% tab ".NET" %}}
+
+
+In addition to setting globally, you can enable or disable Trace Search & Analytics for individual integrations using the following setting:
+
+* Environment Variable or AppSetting: `DD_<INTEGRATION>_ANALYTICS_ENABLED=true`
+
+Or in code:
+
+```csharp
+Tracer.Instance.Settings.Integrations["<INTEGRATION>"].AnalyticsEnabled = true;
+```
+
+Use this in addition to the global configuration for any integrations that submit custom services. For example, you can set the following to enable all ADO.NET spans in Trace Search & Analytics:
+
+* Environment Variable or AppSetting: `DD_ADONET_ANALYTICS_ENABLED=true`
+
+```csharp
+Tracer.Instance.Settings.Integrations["AdoNet"].AnalyticsEnabled = true;
+```
+
+Integration names can be found on the [integrations table][1].
+
+
+[1]: /tracing/setup/dotnet#integrations
 {{% /tab %}}
 {{% tab "PHP" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds .NET tabs for Trace Analytics configuration.

### Motivation
We added support for Trace Analytics configuration in [version 1.1](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v1.1.0).

### Preview link
https://docs-staging.datadoghq.com/lucas/apm-dotnet-trace-search/tracing/trace_search_and_analytics/?tab=net

### Additional Notes
N/A
