### PR TITLE
adds note about journald logging driver

### DIFF
--- a/content/en/logs/log_collection/docker.md
+++ b/content/en/logs/log_collection/docker.md
@@ -103,7 +103,7 @@ The source and service values can be overridden with Autodiscovery as described 
 
 * Logs coming from container `Stderr` have a default status of `Error`.
 
-* Refer to the [journald integration][1] documentation for details regarding the setup for containerized environments if using the journald logging driver instead of Docker's default json-file logging driver.
+* If using the journald logging driver instead of Docker's default json-file logging driver, see the [journald integration][1] documentation for details regarding the setup for containerized environments.
 
 ### Activate Log Integrations
 

--- a/content/en/logs/log_collection/docker.md
+++ b/content/en/logs/log_collection/docker.md
@@ -103,11 +103,13 @@ The source and service values can be overridden with Autodiscovery as described 
 
 * Logs coming from container `Stderr` have a default status of `Error`.
 
+* Refer to the [journald integration][1] documentation for details regarding the setup for containerized environments if using the journald logging driver instead of Docker's default json-file logging driver.
+
 ### Activate Log Integrations
 
 In Datadog Agent 6.8+, `source` and `service` default to the `short_image` tag value. This allows Datadog to identify the log source for each container and automatically install the corresponding integration.
 
-The container short image name might not match the integration name for custom images, and can be overwritten to better reflect the name of your application. This can be done with [Datadog Autodiscovery][1] and [pod annotations in Kubernetes][2] or container labels.
+The container short image name might not match the integration name for custom images, and can be overwritten to better reflect the name of your application. This can be done with [Datadog Autodiscovery][2] and [pod annotations in Kubernetes][3] or container labels.
 
 Autodiscovery expects labels to follow this format, depending on the file type:
 
@@ -278,5 +280,6 @@ ac_exclude = ["name:datadog-agent"]
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /agent/autodiscovery
-[2]: /agent/autodiscovery/?tab=kubernetes#setting-up-check-templates
+[1]: /integrations/journald/
+[2]: /agent/autodiscovery
+[3]: /agent/autodiscovery/?tab=kubernetes#setting-up-check-templates


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Adds a note linking to the journald integration documentation.

### Motivation

This is for situations when containers are configured to use Docker's journald logging driver instead of the default json-file logging driver.  Adding a note to the Docker log collection documentation can help point users to the journald integration doc, which has the configuration information they should follow instead.

### Preview link

https://docs-staging.datadoghq.com/tj/add_journald_note_to_docker_logs_doc/logs/log_collection/docker/

<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
