### PR TITLE
Fixes inconsistency in path to cert in syslog-ng doc

### DIFF
--- a/content/en/integrations/syslog_ng.md
+++ b/content/en/integrations/syslog_ng.md
@@ -83,7 +83,7 @@ Configure Syslog-ng to gather logs from your host, containers, & services.
     2. Change the definition of the destination to the following:
 
         ```
-        destination d_datadog { tcp("intake.logs.datadoghq.com" port(10516)     tls(peer-verify(required-untrusted) ca_dir('/opt/syslog-ng/certs.d/')) template(DatadogFormat)); };
+        destination d_datadog { tcp("intake.logs.datadoghq.com" port(10516)     tls(peer-verify(required-untrusted) ca_dir('/etc/syslog-ng/certs.d/')) template(DatadogFormat)); };
         ```
 
     More information about the TLS parameters and possibilities for syslog-ng available in the [official documentation][2].
@@ -151,7 +151,7 @@ Configure Syslog-ng to gather logs from your host, containers, & services.
     2. Change the definition of the destination to the following:
 
         ```
-        destination d_datadog { tcp("tcp-intake.logs.datadoghq.eu" port(443)     tls(peer-verify(required-untrusted) ca_dir('/opt/syslog-ng/certs.d/')) template(DatadogFormat)); };
+        destination d_datadog { tcp("tcp-intake.logs.datadoghq.eu" port(443)     tls(peer-verify(required-untrusted) ca_dir('/etc/syslog-ng/certs.d/')) template(DatadogFormat)); };
         ```
 
     More information about the TLS parameters and possibilities for syslog-ng available in their [official documentation][2].


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Changes `/opt/syslog-ng/certs.d/` to `/etc/syslog-ng/certs.d/` in order to align with the instruction in step 1 for setting up TLS encryption.  Change was made for both US and EU tabs. 

### Motivation

Support ticket

### Preview link

https://docs-staging.datadoghq.com/tj/fixes_an_inconsistency_in_syslog-ng_doc/integrations/syslog_ng/?tab=datadogeusite

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
