### PR TITLE
Add Account Management FAQ to Account Management subnav

### DIFF
--- a/data/partials/mainnav.yaml
+++ b/data/partials/mainnav.yaml
@@ -574,6 +574,8 @@ main:
         url: "account_management/org_switching/"
       - name: "Billing"
         url: "account_management/billing/"
+      - name: "FAQ"
+        url: "account_management/faq/"
 
 
       #- #  name: "FAQ"


### PR DESCRIPTION
### What does this PR do?
Adds Account Management FAQ to Account Management subnav.

### Motivation
When looking for documentation on API/Application key management I was able to find the Account Management FAQ by searching, but it was not available on the menu. It seems like having the FAQ for a subject under the subject's menu would be extremely helpful for users when they don't really know what to search for.

### Preview link
Technically affects all pages because it's a change to the main nav but it's primarily to facilitate access to this page:

https://docs-staging.datadoghq.com/chris.linstid/add-acct-mgmt-faq-to-subnav/account_management/faq/

Preview: https://docs-staging.datadoghq.com/chris.linstid/add-acct-mgmt-faq-to-subnav/