### PR TITLE
ECS EC2 and Fargate links

### DIFF
--- a/content/en/agent/apm/_index.md
+++ b/content/en/agent/apm/_index.md
@@ -10,19 +10,13 @@ aliases:
 further_reading:
 - link: "/agent/docker/apm"
   tag: "Documentation"
-  text: Docker setup
-- link: "tracing/languages/go"
+  text: "Docker setup"
+- link: "/integrations/amazon_ecs/#trace-collection"
   tag: "Documentation"
-  text: Go language instrumentation
-- link: "tracing/languages/java"
+  text: "ECS EC2 setup"
+- link: "/integrations/ecs_fargate/#trace-collection"
   tag: "Documentation"
-  text: Java language instrumentation
-- link: "tracing/languages/python"
-  tag: "Documentation"
-  text: Python language instrumentation
-- link: "tracing/languages/ruby"
-  tag: "Documentation"
-  text: Ruby language instrumentation
+  text: "ECS Fargate setup"
 ---
 
 This documentation covers Agent v6 only, to know how to set up APM tracing with Agent v5, [refer to the dedicated APM with Agent v5 doc][1].

--- a/content/en/agent/apm/_index.md
+++ b/content/en/agent/apm/_index.md
@@ -10,13 +10,13 @@ aliases:
 further_reading:
 - link: "/agent/docker/apm"
   tag: "Documentation"
-  text: "Docker setup"
+  text: "Docker APM setup"
 - link: "/integrations/amazon_ecs/#trace-collection"
   tag: "Documentation"
-  text: "ECS EC2 setup"
+  text: "ECS EC2 APM setup"
 - link: "/integrations/ecs_fargate/#trace-collection"
   tag: "Documentation"
-  text: "ECS Fargate setup"
+  text: "ECS Fargate APM setup"
 ---
 
 This documentation covers Agent v6 only, to know how to set up APM tracing with Agent v5, [refer to the dedicated APM with Agent v5 doc][1].


### PR DESCRIPTION
### What does this PR do?
- Remove duplicate language links from the Further Reading section
- Add links to ECS EC2 and Fargate APM setups

### Motivation
Trello request

### Preview link
https://docs-staging.datadoghq.com/ruth/apm-setup-links/agent/apm/#further-reading

### Additional Notes
Wait until https://github.com/DataDog/integrations-core/pull/3667 is merged
