### PR TITLE
suppressing roles API instead of deleting

### DIFF
--- a/content/en/account_management/rbac/_index.md
+++ b/content/en/account_management/rbac/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Role Based Access Control
 kind: documentation
-disable_toc: true
+private: true
 beta: true
 aliases:
   - /guides/rbac

--- a/content/en/account_management/rbac/_index.md
+++ b/content/en/account_management/rbac/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Role Based Access Control
 kind: documentation
+disable_toc: true
 beta: true
 aliases:
   - /guides/rbac

--- a/content/en/account_management/rbac/log_management.md
+++ b/content/en/account_management/rbac/log_management.md
@@ -1,6 +1,7 @@
 ---
 title: Role Based Access Control for Log Management
 kind: documentation
+disable_toc: true
 beta: true
 further_reading:
 - link: "account_management/rbac/role_api"

--- a/content/en/account_management/rbac/log_management.md
+++ b/content/en/account_management/rbac/log_management.md
@@ -1,7 +1,7 @@
 ---
 title: Role Based Access Control for Log Management
 kind: documentation
-disable_toc: true
+private: true
 beta: true
 further_reading:
 - link: "account_management/rbac/role_api"

--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -1,6 +1,7 @@
 ---
 title: Role API
 kind: documentation
+disable_toc: true
 beta: true
 further_reading:
 - link: "account_management/rbac/log_management/"

--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -1,7 +1,7 @@
 ---
 title: Role API
 kind: documentation
-disable_toc: true
+private: true
 beta: true
 further_reading:
 - link: "account_management/rbac/log_management/"

--- a/content/fr/account_management/rbac/_index.md
+++ b/content/fr/account_management/rbac/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Contrôle d'accès à base de rôles (RBAC)
 kind: documentation
-disable_toc: true
+private: true
 beta: true
 aliases:
   - /fr/guides/rbac

--- a/content/fr/account_management/rbac/_index.md
+++ b/content/fr/account_management/rbac/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Contrôle d'accès à base de rôles (RBAC)
 kind: documentation
+disable_toc: true
 beta: true
 aliases:
   - /fr/guides/rbac

--- a/data/partials/mainnav.fr.yaml
+++ b/data/partials/mainnav.fr.yaml
@@ -450,8 +450,6 @@ main:
             url: account_management/saml/safenet
       - name: Comptes multi-organisations
         url: account_management/multi_organization/
-      - name: Contrôle d'accès à base de rôles (RBAC)
-        url: account_management/rbac/
         children:
           - name: Log Management
             url: account_management/rbac/log_management

--- a/data/partials/mainnav.yaml
+++ b/data/partials/mainnav.yaml
@@ -565,11 +565,6 @@ main:
       - name: "Role Based Access Control"
         url: "account_management/rbac/"
         children:
-          # RBAC subnav
-          - name: "Log Management"
-            url: "account_management/rbac/log_management"
-          - name: "Role API"
-            url: "account_management/rbac/role_api"
       - name: "Switching between orgs"
         url: "account_management/org_switching/"
       - name: "Billing"

--- a/data/partials/mainnav.yaml
+++ b/data/partials/mainnav.yaml
@@ -562,9 +562,6 @@ main:
             url: "account_management/saml/safenet"
       - name: "Multi-org accounts"
         url: "account_management/multi_organization/"
-      - name: "Role Based Access Control"
-        url: "account_management/rbac/"
-        children:
       - name: "Switching between orgs"
         url: "account_management/org_switching/"
       - name: "Billing"


### PR DESCRIPTION
### What does this PR do?
suppresses the roles API documentation because it is closed beta

### Motivation
Better docs for a better world

### Preview link

https://docs-staging.datadoghq.com/kaylyn/suppress-roles/
