### PR TITLE
updating language describing the replace_tag http.url rule

### DIFF
--- a/content/en/tracing/guide/security.md
+++ b/content/en/tracing/guide/security.md
@@ -63,7 +63,7 @@ For example:
 ```yaml
 apm_config:
   replace_tags:
-    # Replace all numbers following the `token/` string in the tag "http.url" with "?":
+    # Replace all characters starting at the `token/` string in the tag "http.url" with "?":
     - name: "http.url"
       pattern: "token/(.*)"
       repl: "?"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR updates the language describing the [`replace_tags` `http.url` rule](https://docs.datadoghq.com/tracing/guide/security/#replace-rules) to match the behavior of the rule.

### Motivation
<!-- What inspired you to submit this pull request?-->

A customer reached out via Zendesk (Ticket [216588](https://datadog.zendesk.com/agent/tickets/216588)) noting the following: 

>There seems to be an error in the documentation (page: https://docs.datadoghq.com/tracing/guide/security/). The example at the bottom says the following: 
>
> ``` 
># Replace all numbers following the `token/` string in the tag "http.url" with "?": 
>- name: "http.url" 
>pattern: "token/(.*)" 
>repl: "?" 
>```
>
>while the following rule: 
>``` 
>- name: "http.url" 
>pattern: "/api/v1/some_endpoint/([a-z0-9]+)" 
>repl: "AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD" 
>```
>
>results in tag becoming 
>http.url: www.oursite.com/AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD 
>instead of, what I understood from the logs: 
>http.url: www.oursite.com/api/v1/some_endpoint/AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD

We tested this on our end and were able to replicate the behavior as described by the customer: (_see trello card for additional details_: https://trello.com/c/t4X02uKn/1306-potential-update-to-scrubbing-rule-in-security-documentation

### Preview link
<!-- Impacted pages preview links-->
 
https://docs-staging.datadoghq.com/siobhan.mahoney/updating-language-for-replace_tag-http.url-rule/tracing/guide/security/ 

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
For reference, here is the link to relevant page in the live Datadog docs: https://docs.datadoghq.com/tracing/guide/security/