### PR TITLE
APM Troubleshooting links

### DIFF
--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -1,6 +1,16 @@
 ---
-title: Troubleshooting
+title: APM Troubleshooting
 kind: documentation
+further_reading:
+- link: "/agent/docker/apm"
+  tag: "Documentation"
+  text: "Docker APM setup"
+- link: "/integrations/amazon_ecs/#trace-collection"
+  tag: "Documentation"
+  text: "ECS EC2 APM setup"
+- link: "/integrations/ecs_fargate/#trace-collection"
+  tag: "Documentation"
+  text: "ECS Fargate APM setup"
 ---
 
 ## Tracer debugging
@@ -151,3 +161,7 @@ make install
 
 {{% /tab %}}
 {{< /tabs >}}
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
### What does this PR do?
- Add Docker, ECS EC2, and ECS Fargate APM setup links to APM Troubleshooting
- Add `APM` to title

### Motivation
Trello request from support

### Preview link
https://docs-staging.datadoghq.com/ruth/apm-troubleshooting/tracing/troubleshooting/#further-reading

### Additional Notes
Wait until https://github.com/DataDog/integrations-core/pull/3667 is merged
