### PR TITLE
no header for browser test

### DIFF
--- a/content/en/synthetics/identify_synthetics_bots.md
+++ b/content/en/synthetics/identify_synthetics_bots.md
@@ -29,7 +29,7 @@ Some parts of your system might not be available to robots without the right ide
 
 Choose any or a variety of the following methods to identify the robots to make sure they are performing the actions you expect.
 
-1. You can use the [**headers set for APM integration**][1]. The `x-datadog-origin: synthetics` header, for instance, is added to all the requests launched for both API and browser tests. Using one of these headers allows you to filter these bot requests once in your analytics tool.
+1. You can use the [**headers set for APM integration**][1]. The `x-datadog-origin: synthetics` header, for instance, is added to all the requests launched for API tests. Using one of these headers allows you to filter these bot requests once in your analytics tool. For now, no headers are added for browser tests.
 
 If you want these requests to be completely removed, and not sent at all to your analytics tool, you can use the below JavaScript variable on your website, wrapped around your analytics tool code snippet:
 

--- a/content/en/synthetics/identify_synthetics_bots.md
+++ b/content/en/synthetics/identify_synthetics_bots.md
@@ -29,7 +29,7 @@ Some parts of your system might not be available to robots without the right ide
 
 Choose any or a variety of the following methods to identify the robots to make sure they are performing the actions you expect.
 
-1. You can use the [**headers set for APM integration**][1]. The `x-datadog-origin: synthetics` header, for instance, is added to all the requests launched for API tests. Using one of these headers allows you to filter these bot requests once in your analytics tool. For now, no headers are added for browser tests.
+1. You can use the [**headers set for APM integration**][1]. The `x-datadog-origin: synthetics` header, for instance, is added to all the requests launched for API tests. Using one of these headers allows you to filter these bot requests once in your analytics tool. No headers are added for browser tests.
 
 If you want these requests to be completely removed, and not sent at all to your analytics tool, you can use the below JavaScript variable on your website, wrapped around your analytics tool code snippet:
 


### PR DESCRIPTION
We no longer put any headers on browser tests following this PR https://github.com/DataDog/synthetics-browser-checks/pull/132/files#diff-c9e04ec7425907b6e727624ce58e05caL60

### What does this PR do?
Slightly modify the doc following up on an engineering PR