### PR TITLE
Add trace search auto instrumentation back in

### DIFF
--- a/content/en/tracing/trace_search_and_analytics/_index.md
+++ b/content/en/tracing/trace_search_and_analytics/_index.md
@@ -26,7 +26,7 @@ To enable it, first configure your services to emit the relevant analytics eithe
  After enabling, the Trace Search & Analytics UI starts showing results. Visit [Trace Search page][1] to get started.	
 
 
- 	[1]: https://app.datadoghq.com/apm/search
+[1]: https://app.datadoghq.com/apm/search
 {{% /tab %}}	
 {{% tab "Python" %}}	
 
@@ -38,7 +38,7 @@ To enable it, first configure your services to emit the relevant analytics eithe
  After enabling, the Trace Search & Analytics UI starts showing results. Visit [Trace Search page][1] to get started.	
 
 
- 	[1]: https://app.datadoghq.com/apm/search
+[1]: https://app.datadoghq.com/apm/search
 {{% /tab %}}	
 {{% tab "Ruby" %}}	
 
@@ -56,7 +56,7 @@ Datadog.configure { |c| c.analytics_enabled = true }
  After enabling, the [Trace Search & Analytics][1] page populates.	
 
 
- 	[1]: https://app.datadoghq.com/apm/search
+[1]: https://app.datadoghq.com/apm/search
 {{% /tab %}}	
 {{% tab "Go" %}}	
 
@@ -69,7 +69,7 @@ tracer.Start(tracer.WithAnalytics(true))
  After enabling, the Trace Search & Analytics UI starts showing results. Visit [Trace Search page][2] to get started.	
 
 
-		[1]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#WithAnalytics
+[1]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#WithAnalytics
 [2]: https://app.datadoghq.com/apm/search
 {{% /tab %}}	
 {{% tab "Node.js" %}}	
@@ -85,7 +85,7 @@ tracer.init({
  After enabling, the Trace Search & Analytics UI starts showing results. Visit [Trace Search page][1] to get started.	
 
 
-	[1]: https://app.datadoghq.com/apm/search
+[1]: https://app.datadoghq.com/apm/search
 {{% /tab %}}	
 {{% tab ".NET" %}}	
 
@@ -102,7 +102,7 @@ Tracer.Instance.Settings.AnalyticsEnabled = true;
  After enabling, the Trace Search & Analytics UI starts showing results. Visit [Trace Search page][1] to get started.	
 
 
- 	[1]: https://app.datadoghq.com/apm/search
+[1]: https://app.datadoghq.com/apm/search
 {{% /tab %}}	
 {{% tab "PHP" %}}	
 
@@ -113,7 +113,7 @@ Tracer.Instance.Settings.AnalyticsEnabled = true;
  After enabling, the Trace Search & Analytics UI starts showing results. Visit [Trace Search page][1] to get started.	
 
 
-	[1]: https://app.datadoghq.com/apm/search
+[1]: https://app.datadoghq.com/apm/search
 {{% /tab %}}	
 {{< /tabs >}}
 

--- a/content/en/tracing/trace_search_and_analytics/_index.md
+++ b/content/en/tracing/trace_search_and_analytics/_index.md
@@ -13,6 +13,109 @@ To enable it, first configure your services to emit the relevant analytics eithe
 
 **Note**: to use Trace Search, you must be using Agent v6.7+ and have logs enabled.
 
+## Automatic Configuration
+
+{{< tabs >}}	
+{{% tab "Java" %}}	
+
+ Trace Search & Analytics can be enabled globally for all web integrations with one configuration parameter in the Tracing Client:	
+
+* System Property: `-Ddd.trace.analytics.enabled=true`	
+* Environment Variable: `DD_TRACE_ANALYTICS_ENABLED=true`	
+
+ After enabling, the Trace Search & Analytics UI starts showing results. Visit [Trace Search page][1] to get started.	
+
+
+ 	[1]: https://app.datadoghq.com/apm/search
+{{% /tab %}}	
+{{% tab "Python" %}}	
+
+ Enable Trace Search & Analytics globally for all web integrations with one configuration parameter in the Tracing Client:	
+
+* Tracer Configuration: `ddtrace.config.analytics_enabled = True`	
+* Environment Variable: `DD_ANALYTICS_ENABLED=true`	
+
+ After enabling, the Trace Search & Analytics UI starts showing results. Visit [Trace Search page][1] to get started.	
+
+
+ 	[1]: https://app.datadoghq.com/apm/search
+{{% /tab %}}	
+{{% tab "Ruby" %}}	
+
+ Trace search & analytics can be enabled for all web integrations with a global flag.	
+
+ To do so, set either `DD_TRACE_ANALYTICS_ENABLED=true` in your environment, or configure with:	
+
+ ```ruby	
+Datadog.configure { |c| c.analytics_enabled = true }	
+```	
+
+ - `true` enables analytics for all web frameworks.	
+- `false` or `nil` disables analytics, except for integrations that explicitly enable it. (Default)	
+
+ After enabling, the [Trace Search & Analytics][1] page populates.	
+
+
+ 	[1]: https://app.datadoghq.com/apm/search
+{{% /tab %}}	
+{{% tab "Go" %}}	
+
+ Trace Search & Analytics can be enabled globally for all web integrations using the [`WithAnalytics`][1] tracer start option. For example:	
+
+ ```go	
+tracer.Start(tracer.WithAnalytics(true))	
+```	
+
+ After enabling, the Trace Search & Analytics UI starts showing results. Visit [Trace Search page][2] to get started.	
+
+
+		[1]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#WithAnalytics
+[2]: https://app.datadoghq.com/apm/search
+{{% /tab %}}	
+{{% tab "Node.js" %}}	
+
+ Trace Search & Analytics can be enabled globally for all web integrations with one configuration parameter in the tracing client:	
+
+ ```javascript	
+tracer.init({	
+  analytics: true	
+})	
+```	
+
+ After enabling, the Trace Search & Analytics UI starts showing results. Visit [Trace Search page][1] to get started.	
+
+
+	[1]: https://app.datadoghq.com/apm/search
+{{% /tab %}}	
+{{% tab ".NET" %}}	
+
+ Trace Search & Analytics can be enabled globally for all web integrations with one configuration parameter in the Tracing Client:	
+
+ * Environment Variable or AppSetting: `DD_TRACE_ANALYTICS_ENABLED=true`	
+
+ This setting can also be set in code:	
+
+ ```csharp	
+Tracer.Instance.Settings.AnalyticsEnabled = true;	
+```	
+
+ After enabling, the Trace Search & Analytics UI starts showing results. Visit [Trace Search page][1] to get started.	
+
+
+ 	[1]: https://app.datadoghq.com/apm/search
+{{% /tab %}}	
+{{% tab "PHP" %}}	
+
+ Trace Search & Analytics can be enabled globally for all web integrations with one configuration parameter in the Tracing Client:	
+
+ * Environment Variable: `DD_TRACE_ANALYTICS_ENABLED=true`	
+
+ After enabling, the Trace Search & Analytics UI starts showing results. Visit [Trace Search page][1] to get started.	
+
+
+	[1]: https://app.datadoghq.com/apm/search
+{{% /tab %}}	
+{{< /tabs >}}
 
 ## Configure Additional Services (optional)
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds back in instructions for trace search auto instrumentation.


### Motivation
<!-- What inspired you to submit this pull request?-->
I accidentally got rid of it. 😬 

### Preview link

https://docs-staging.datadoghq.com/kirk.kaiser/add-trace-search-back-in/tracing/trace_search_and_analytics/
