### PR TITLE
Agent container memory limit

### DIFF
--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -34,7 +34,7 @@ kubectl create -f "https://raw.githubusercontent.com/DataDog/datadog-agent/maste
 
 ## Create manifest
 Create the following `datadog-agent.yaml` manifest.  
-**Note**: If you are using KMS or have a high DogStatsD usage, consider using a higher memory limit.
+**Note**: If you are using KMS or have high DogStatsD usage, you may need a higher memory limit.
 
 ```yaml
 # datadog-agent.yaml

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -33,7 +33,8 @@ kubectl create -f "https://raw.githubusercontent.com/DataDog/datadog-agent/maste
 ```
 
 ## Create manifest
-Create the following `datadog-agent.yaml` manifest:
+Create the following `datadog-agent.yaml` manifest.  
+**Note**: If you are using KMS or have a high DogStatsD usage, consider using a higher memory limit.
 
 ```yaml
 # datadog-agent.yaml

--- a/content/en/integrations/faq/agent-5-amazon-ecs.md
+++ b/content/en/integrations/faq/agent-5-amazon-ecs.md
@@ -45,7 +45,7 @@ Amazon Elastic Container Service register-task-definition --cli-input-json file:
 9. Click the large **Add container** button.
 10. For **Container name** enter ```dd-agent```.
 11. For **Image** enter ```datadog/docker-dd-agent:latest```.
-12. For **Maximum memory** enter ```256```.
+12. For **Maximum memory** enter ```256```. **Note**: For high resource usage, you may need a higher memory limit.
 13. Scroll down to the **Advanced container configuration** section and enter ```10``` in **CPU units**.
 14. For **Env Variables**, add a **Key** of ```API_KEY``` and enter your Datadog API Key in the value. *If you feel more comfortable storing secrets like this in s3, take a [look at the ECS Configuration guide][5].*
 15. Add another Environment Variable for any tags you want to add using the key ```TAGS```.


### PR DESCRIPTION
### What does this PR do?
- Add notes about possible memory limit increase needed for Agent container.

### Motivation
Trello request from support

### Preview links
- https://docs-staging.datadoghq.com/ruth/memory-limit/agent/kubernetes/daemonset_setup/#create-manifest
- https://docs-staging.datadoghq.com/ruth/memory-limit/integrations/faq/agent-5-amazon-ecs/#web-ui

### Additional Notes
Related PR - https://github.com/DataDog/dogweb/pull/36546
