### PR TITLE
options clarification

### DIFF
--- a/content/en/api/monitors/code_snippets/api-monitor-create.py
+++ b/content/en/api/monitors/code_snippets/api-monitor-create.py
@@ -8,7 +8,7 @@ options = {
 initialize(**options)
 
 # Create a new monitor
-options = {
+monitor_options = {
     "notify_no_data": True,
     "no_data_timeframe": 20
 }
@@ -19,5 +19,5 @@ api.Monitor.create(
     name="Bytes received on host0",
     message="We may need to add web hosts if this is consistently high.",
     tags=tags,
-    options=options
+    options=monitor_options
 )


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
uses separate variables to set monitor options

### Motivation
<!-- What inspired you to submit this pull request?-->
We had a customer create a ton of monitors (20k+) with their API key as an option.  Adding some clarity here to make this more explicit.

### Preview link
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/bcon/options-monitor-api/api/?lang=python#monitors

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
