### PR TITLE
Update Brower Log collection instructions

### DIFF
--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -163,6 +163,13 @@ This gives the following result:
 }  
 ```
 
+The logger adds the following information by default:
+
+* `http.url`
+* `session_id`
+* `http.useragent`
+* `network.client.ip`
+
 ## Advanced usage
 
 ### Filter by severity

--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -58,7 +58,7 @@ The Javascript logging library is in private beta. <a href="https://docs.datadog
 The following parameters can be used to configure the library to send logs to Datadog:
 
 * Set `isCollectingError` to `false` to turn off the automatic JS and console error collection.
-* Use `addGlobalContext` to add JSON attribute to all the generated logs
+* Use `addLoggerGlobalContext` to add JSON attribute to all the generated logs
 * Set `publicApiKey` to the value of the public API key (**only public API keys can be used in this library**)
 
 {{< tabs >}}
@@ -78,7 +78,7 @@ The following parameters can be used to configure the library to send logs to Da
 
       // OPTIONAL
       // add global metadata attributes
-      Datadog.addLoggerGlobalContext({'<META_KEY>': '<META_VALUE>'});
+      Datadog.addLoggerGlobalContext({<META_KEY>: '<META_VALUE>'});
     </script>
     ...
   </head>

--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -167,7 +167,7 @@ This gives the following result:
 
 ### Filter by severity
 
-In some cases, you might want to disable the debug mode or to only collect warning and errors. This can be achieved by changing the logging level thanks to the `logLevel` parameter to `debug`, `info`, `warn`, and `error` :
+In some cases, you might want to disable the debug mode or to only collect warning and errors. This can be achieved by changing the logging level thanks to the `logLevel` parameter to `debug` (default), `info`, `warn`, and `error` :
 
 ```
 Datadog.logger.setLogLevel('<SEVERITY_LEVEL>')
@@ -179,7 +179,7 @@ Only logs with a severity equal or higher to the specified one are sent.
 
 By default, the loggers are sending logs to Datadog. It is also possible to configure the logger to send logs to the console or to not send logs at all. This can be used in development environment to keep the logs locally.
 
-Use the `setLogHandler` function with the values `http`, `console`, or `silent`:
+Use the `setLogHandler` function with the values `http` (default), `console`, or `silent`:
 ```
 Datadog.logger.setLogHandler('<HANDLER>')
 ```

--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -78,7 +78,7 @@ The following parameters can be used to configure the library to send logs to Da
 
       // OPTIONAL
       // add global metadata attributes
-      Datadog.addLoggerGlobalContext({<META_KEY>: '<META_VALUE>'});
+      Datadog.addLoggerGlobalContext({<META_KEY>: <META_VALUE>});
     </script>
     ...
   </head>
@@ -201,7 +201,7 @@ createLogger (<LOGGER_NAME>, {
 ```
 
 Those parameters can also be set thanks to the `addContext`, `setLogLevel`, and `setLogHandler` functions.
-You can then get this logger in any part of your Javascript code thanks to the `getLogger` function:
+After the creation of this logger, you can then get it in any part of your Javascript code thanks to the `getLogger` function:
 
 ```
 const my_logger = getLogger('<LOGGER_NAME>') 

--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -68,7 +68,7 @@ The following parameters can be used to configure the library to send logs to Da
 <html>
   <head>
     <title>Example to send logs to Datadog</title>
-    <script type="text/javascript" src="<COMING_SOON>"></script>
+    <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-logs-us.js"></script>
     <script>
       // Set your Public API key
       Datadog.init({
@@ -78,7 +78,7 @@ The following parameters can be used to configure the library to send logs to Da
 
       // OPTIONAL
       // add global metadata attributes
-      Datadog.addGlobalContext({'<META_KEY>': '<META_VALUE>'});
+      Datadog.addLoggerGlobalContext({'<META_KEY>': '<META_VALUE>'});
     </script>
     ...
   </head>
@@ -93,7 +93,7 @@ The following parameters can be used to configure the library to send logs to Da
 <html>
   <head>
     <title>Example to send logs to Datadog</title>
-    <script type="text/javascript" src="<COMING_SOON>"></script>
+    <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-logs-eu.js"></script>
     <script>
       // Set your Public API key
       Datadog.init({
@@ -103,7 +103,7 @@ The following parameters can be used to configure the library to send logs to Da
 
       // OPTIONAL
       // add global metadata attributes
-      Datadog.addGlobalContext({'<META_KEY>': '<META_VALUE>'});
+      Datadog.addLoggerGlobalContext({<META_KEY>: '<META_VALUE>'});
     </script>
     ...
   </head>
@@ -119,7 +119,7 @@ The following parameters can be used to configure the library to send logs to Da
 Send a custom log entries directly to Datadog with the `log` function:
 
 ```
-Datadog.log(<MESSAGE>,<JSON_ATTRIBUTES>,<SEVERITY>)
+Datadog.logger.log(<MESSAGE>,<JSON_ATTRIBUTES>,<SEVERITY>)
 ```
 
 | Placehodler         | Description                                                                             |
@@ -128,13 +128,15 @@ Datadog.log(<MESSAGE>,<JSON_ATTRIBUTES>,<SEVERITY>)
 | `<JSON_ATTRIBUTES>` | A valid JSON object that includes all attributes attached to the `<MESSAGE>`            |
 | `<SEVERITY>`        | Status of your log; the accepted severity values are `debug`, `info`, `warn` or `error`. |
 
+Severity can also be used as a placeholder of the `log` function `Datadog.logger.debug(<MESSAGE>,<JSON_ATTRIBUTES>)`.
+
 **Example:**
 
 ```
 ...
 <script>
 ...
-Datadog.log('Button clicked', { name: 'buttonName' });
+Datadog.logger.info('Button clicked', { name: 'buttonName', id: 123 });
 ...
 </script>
 ...
@@ -147,6 +149,7 @@ This gives the following result:
   "severity": "info",
   "session_id": "1234", 
   "name": "buttonName",
+  "id": 123,
   "message": "Button clicked",
   http:{
     "url": "...",
@@ -159,6 +162,75 @@ This gives the following result:
   }
 }  
 ```
+
+## Advanced usage
+
+### Filter by severity
+
+In some cases, you might want to disable the debug mode or to only collect warning and errors. This can be achieved by changing the logging level thanks to the `logLevel` parameter to `debug`, `info`, `warn`, and `error` :
+
+```
+Datadog.logger.setLogLevel('<SEVERITY_LEVEL>')
+```
+
+Only logs with a severity equal or higher to the specified one are sent.
+
+### Change the destination
+
+By default, the loggers are sending logs to Datadog. It is also possible to configure the logger to send logs to the console or to not send logs at all. This can be used in development environment to keep the logs locally.
+
+Use the `setLogHandler` function with the values `http`, `console`, or `silent`:
+```
+Datadog.logger.setLogHandler('<HANDLER>')
+```
+
+### Define multiple loggers
+
+The library contains a default logger but it is also possible define different loggers which can be convenient when several team are working on the same project.
+
+Each logger can optionally be configure with its own log level, handler and context. Note that the `Global Context` is added on top of each logger context. 
+
+Use the following to define a custom logger:
+
+```
+createLogger (<LOGGER_NAME>, {
+    logLevel?: 'debug' | 'info' | 'warn' | 'error'
+    logHandler?: 'http' | 'console' | 'silent'
+    context?: { <KEY>:'<VALUE>'}
+})
+```
+
+Those parameters can also be set thanks to the `addContext`, `setLogLevel`, and `setLogHandler` functions.
+You can then get this logger in any part of your Javascript code thanks to the `getLogger` function:
+
+```
+const my_logger = getLogger('<LOGGER_NAME>') 
+```
+
+**Example:**
+
+
+Let's assume that there is a signup logger define with all the others logger:
+
+```
+# create a new logger
+const signupLogger = createLogger('signupLogger'})
+signupLogger.addContext({ env: 'staging'})
+```
+
+It can now be used in different part of the code with:
+
+```
+...
+<script>
+...
+const signupLogger = getLogger('signupLogger')
+signupLogger.info('Test sign up completed')
+...
+</script>
+...
+```
+
 
 ## Further Reading
 

--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -177,7 +177,7 @@ Only logs with a severity equal or higher to the specified one are sent.
 
 ### Change the destination
 
-By default, the loggers are sending logs to Datadog. It is also possible to configure the logger to send logs to the console or to not send logs at all. This can be used in development environment to keep the logs locally.
+By default, the loggers are sending logs to Datadog. It is also possible to configure the logger to send logs to the console or not to send logs at all. This can be used in the development environment to keep the logs locally.
 
 Use the `setLogHandler` function with the values `http` (default), `console`, or `silent`:
 ```
@@ -186,9 +186,9 @@ Datadog.logger.setLogHandler('<HANDLER>')
 
 ### Define multiple loggers
 
-The library contains a default logger but it is also possible define different loggers which can be convenient when several team are working on the same project.
+The library contains a default logger, but it is also possible to define different loggers which can be convenient when several teams are working on the same project.
 
-Each logger can optionally be configure with its own log level, handler and context. Note that the `Global Context` is added on top of each logger context. 
+Each logger can optionally be configured with its own log level, handler, and context. Note that the `Global Context` is added on top of each logger context. 
 
 Use the following to define a custom logger:
 
@@ -218,7 +218,7 @@ const signupLogger = createLogger('signupLogger'})
 signupLogger.addContext({ env: 'staging'})
 ```
 
-It can now be used in different part of the code with:
+It can now be used in a different part of the code with:
 
 ```
 ...


### PR DESCRIPTION
### What does this PR do?
Update the browser log instructions with the latest update

### Motivation
The url is now available to download the library and there was a couple changed in the definition of the loggers

### Preview link
https://docs-staging.datadoghq.com/nils/browser/logs/log_collection/javascript/?tab=us#pagetitle

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
