### PR TITLE
adding info on mssql error

### DIFF
--- a/content/en/integrations/guide/collect-sql-server-custom-metrics.md
+++ b/content/en/integrations/guide/collect-sql-server-custom-metrics.md
@@ -181,6 +181,10 @@ You can also specify:
 
 **Note**: The `proc_only_if` guard condition is useful for HA scenarios where a database can move between servers.
 
+If your custom metrics are not appearing in Datadog, check the agent log file. If you see the following error: `Could not call procedure <PROCEDURE_NAME>: You must supply -1 parameters for this stored procedure`, it could be one of the following issues:
+* The `<PROCEDURE_NAME>` is typed incorrectly.
+* The database username specified in the configuration may not have permission to run the stored procedure. 
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/integrations/guide/collect-sql-server-custom-metrics.md
+++ b/content/en/integrations/guide/collect-sql-server-custom-metrics.md
@@ -182,8 +182,9 @@ You can also specify:
 **Note**: The `proc_only_if` guard condition is useful for HA scenarios where a database can move between servers.
 
 If your custom metrics are not appearing in Datadog, check the agent log file. If you see the following error: `Could not call procedure <PROCEDURE_NAME>: You must supply -1 parameters for this stored procedure`, it could be one of the following issues:
-* The `<PROCEDURE_NAME>` is typed incorrectly.
-* The database username specified in the configuration may not have permission to run the stored procedure. 
+
+- The `<PROCEDURE_NAME>` is typed incorrectly.
+- The database username specified in the configuration may not have permission to run the stored procedure. 
 
 ## Further Reading
 

--- a/content/en/integrations/guide/collect-sql-server-custom-metrics.md
+++ b/content/en/integrations/guide/collect-sql-server-custom-metrics.md
@@ -181,6 +181,8 @@ You can also specify:
 
 **Note**: The `proc_only_if` guard condition is useful for HA scenarios where a database can move between servers.
 
+### Troubleshooting
+
 If your custom metrics are not appearing in Datadog, check the Agent log file. If you see the following error: `Could not call procedure <PROCEDURE_NAME>: You must supply -1 parameters for this stored procedure`, it could be one of the following issues:
 
 - The `<PROCEDURE_NAME>` is typed incorrectly.

--- a/content/en/integrations/guide/collect-sql-server-custom-metrics.md
+++ b/content/en/integrations/guide/collect-sql-server-custom-metrics.md
@@ -181,7 +181,7 @@ You can also specify:
 
 **Note**: The `proc_only_if` guard condition is useful for HA scenarios where a database can move between servers.
 
-If your custom metrics are not appearing in Datadog, check the agent log file. If you see the following error: `Could not call procedure <PROCEDURE_NAME>: You must supply -1 parameters for this stored procedure`, it could be one of the following issues:
+If your custom metrics are not appearing in Datadog, check the Agent log file. If you see the following error: `Could not call procedure <PROCEDURE_NAME>: You must supply -1 parameters for this stored procedure`, it could be one of the following issues:
 
 - The `<PROCEDURE_NAME>` is typed incorrectly.
 - The database username specified in the configuration may not have permission to run the stored procedure. 


### PR DESCRIPTION
### What does this PR do?
Adds info on what may cause custom mssql metrics fail to appear in Datadog due to an error. 

### Motivation
I recently experienced this exact error. 

### Preview link
https://docs-staging.datadoghq.com/justin.massey/sql-server-changes/integrations/guide/collect-sql-server-custom-metrics/#update-the-sql-server-integration-configuration