### PR TITLE
Fix link on Docker APM page

### DIFF
--- a/content/en/agent/docker/apm.md
+++ b/content/en/agent/docker/apm.md
@@ -61,7 +61,7 @@ List of all environment variables available for tracing within the Docker Agent:
 
 ## Tracing from other containers
 
-As with DogStatsD, traces can be submitted to the Agent from other containers either using [Docker networks](#docker-network) or with the [Docker host IP](#host-ip).
+As with DogStatsD, traces can be submitted to the Agent from other containers either using [Docker networks](#docker-network) or with the [Docker host IP](#docker-host-ip ).
 
 ### Docker Network
 

--- a/content/en/agent/docker/apm.md
+++ b/content/en/agent/docker/apm.md
@@ -61,7 +61,7 @@ List of all environment variables available for tracing within the Docker Agent:
 
 ## Tracing from other containers
 
-As with DogStatsD, traces can be submitted to the Agent from other containers either using [Docker networks](#docker-network) or with the [Docker host IP](#docker-host-ip ).
+As with DogStatsD, traces can be submitted to the Agent from other containers either using [Docker networks](#docker-network) or with the [Docker host IP](#docker-host-ip).
 
 ### Docker Network
 


### PR DESCRIPTION
### What does this PR do?
- Fix link on Docker APM page

### Motivation
- Trello request

### Preview link
https://docs-staging.datadoghq.com/ruth/docker-apm-link/agent/docker/apm/?tab=java#tracing-from-other-containers
