### PR TITLE
Fix typo in config name for B3 headers extraction

### DIFF
--- a/content/en/tracing/setup/java.md
+++ b/content/en/tracing/setup/java.md
@@ -230,8 +230,8 @@ injection. By default only Datadog injection style is enabled.
 
 Extraction styles can be configured using:
 
-* System Property: `-Ddd.propagation.style.extraction=Datadog,B3`
-* Environment Variable: `DD_PROPAGATION_STYLE_EXTRACTION=Datadog,B3`
+* System Property: `-Ddd.propagation.style.extract=Datadog,B3`
+* Environment Variable: `DD_PROPAGATION_STYLE_EXTRACT=Datadog,B3`
 
 The value of the property or environment variable is a comma (or
 space) separated list of header styles that are enabled for


### PR DESCRIPTION
### What does this PR do?
Fix typo in config name for B3 headers extraction. The correct name is taken from https://github.com/DataDog/dd-trace-java/blob/69e8aab4b17a963d3221f6e7b1f60196a0faff4e/dd-trace-api/src/main/java/datadog/trace/api/Config.java#L60

[Preview](https://docs-staging.datadoghq.com/labbati/fix-java-b3-config/tracing/setup/java/#b3-headers-extraction-and-injection)
