### PR TITLE
changed API_KEY to DD_API_KEY

### DIFF
--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -133,7 +133,7 @@ If you mount YAML configuration files in the `/conf.d` folder, they are automati
       -v /proc/:/host/proc/:ro \
       -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
       -v /opt/datadog-agent-conf.d:/conf.d:ro \
-      -e API_KEY={your_api_key_here} \
+      -e DD_API_KEY={your_api_key_here} \
        datadog/agent:latest
     ```
 


### PR DESCRIPTION
### What does this PR do?
There was a mistake, the env var API_KEY was used instead of DD_API_KEY

### Motivation
A customer reported it

### Preview link
https://docs-staging.datadoghq.com/update_docker_api_key/agent/docker

