### PR TITLE
Adds watchdog monitor to api

### DIFF
--- a/content/en/api/monitors/monitors_create.md
+++ b/content/en/api/monitors/monitors_create.md
@@ -29,6 +29,7 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
 | network      | `service check`      |
 | outlier      | `query alert`        |
 | process      | `service check`      |
+| watchdog     | `event alert`        |
     
 *   **`query`** [*required*]:  
     The query defines when the monitor triggers. Query syntax depends on what type of monitor you are creating:  


### PR DESCRIPTION
### What does this PR do?
Adds Watchdog Monitors to the list of monitors in the API

### Motivation
Trello card

### Preview link

https://docs-staging.datadoghq.com/cswatt/watchdog-monitor-api/api/?lang=python#create-a-monitor

