### PR TITLE
DogStatsD x Containerized Environments

### DIFF
--- a/content/en/developers/dogstatsd/datagram_shell.md
+++ b/content/en/developers/dogstatsd/datagram_shell.md
@@ -140,6 +140,8 @@ sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) # UDP
 sock.sendto("custom_metric:60|g|#shell", ("localhost", 8125))
 ```
 
+To send metrics on containerized environments, refer to the [DogStatsD on Kubernetes][4] documentation, in conjunction with the instructions for configuring APM on Kubernetes using [DaemonSets][5] or [Helm][6], depending on your installation. The [Docker APM][7] documentation may also be helpful.
+
 ### Sending events
 
 The format for sending events is:
@@ -172,4 +174,8 @@ PS C:\vagrant> .\send-statsd.ps1 "_e{$($title.length),$($text.Length)}:$title|$t
 
 [1]: /developers/libraries/#api-and-dogstatsd-client-libraries
 [2]: /developers/metrics/#naming-metrics
-[3]: https://github.com/joehack3r/powershell-statsd/blob/master/send-statsd.ps1
+[3]: https://github.com/joehack3r/powershell-statsd/blob/master/send-statsd.
+[4]: /agent/kubernetes/dogstatsd
+[5]: /agent/kubernetes/daemonset_setup/#apm-and-distributed-tracing
+[6]: /agent/kubernetes/helm/enable-apm-and-distributed-tracing
+[7]: /agent/docker/apm

--- a/content/en/developers/dogstatsd/datagram_shell.md
+++ b/content/en/developers/dogstatsd/datagram_shell.md
@@ -177,5 +177,5 @@ PS C:\vagrant> .\send-statsd.ps1 "_e{$($title.length),$($text.Length)}:$title|$t
 [3]: https://github.com/joehack3r/powershell-statsd/blob/master/send-statsd.
 [4]: /agent/kubernetes/dogstatsd
 [5]: /agent/kubernetes/daemonset_setup/#apm-and-distributed-tracing
-[6]: /agent/kubernetes/helm/enable-apm-and-distributed-tracing
+[6]: /agent/kubernetes/helm/#enable-apm-and-distributed-tracing
 [7]: /agent/docker/apm


### PR DESCRIPTION
### What does this PR do?
Support requested that we add instructions from an internal doc for Containers x APM to the Datagram > Sending Metrics section. These instructions already exist for Kubernetes x APM (DaemonSet install and Helm install) as well as Docker x APM, so I'm linking those at the bottom of the Sending Metrics section.

### Motivation
support request

### Preview link
https://docs-staging.datadoghq.com/cswatt/dsd-container-metrics/developers/dogstatsd/datagram_shell/#sending-metrics


