### PR TITLE
changing directory to file

### DIFF
--- a/content/en/integrations/journald.md
+++ b/content/en/integrations/journald.md
@@ -90,7 +90,7 @@ Tags are critical for finding information in highly dynamic containerized enviro
 
 This works automatically when the Agent is running from the host. If you are using the containerized version of the Datadog Agent, mount your journal path and the following file:
 
-- `/etc/machine-id`: this ensure that the Agent can query the journald that is stored on the host.
+- `/etc/machine-id`: this ensures that the Agent can query the journal that is stored on the host.
 
 Finally, [restart the agent][2].
 

--- a/content/en/integrations/journald.md
+++ b/content/en/integrations/journald.md
@@ -88,7 +88,7 @@ logs:
 
 Tags are critical for finding information in highly dynamic containerized environments, which is why the Agent can collect container tags in journald logs.
 
-This works automatically when the Agent is running from the host. If you are using the containerized version of the Datadog Agent, mount your journald path and the following file:
+This works automatically when the Agent is running from the host. If you are using the containerized version of the Datadog Agent, mount your journal path and the following file:
 
 - `/etc/machine-id`: this ensure that the Agent can query the journald that is stored on the host.
 

--- a/content/en/integrations/journald.md
+++ b/content/en/integrations/journald.md
@@ -88,7 +88,7 @@ logs:
 
 Tags are critical for finding information in highly dynamic containerized environments, which is why the Agent can collect container tags in journald logs.
 
-This works automatically when the Agent is running from the host. If you are using the containerized version of the Datadog Agent, mount your journald path and the following directory:
+This works automatically when the Agent is running from the host. If you are using the containerized version of the Datadog Agent, mount your journald path and the following file:
 
 - `/etc/machine-id`: this ensure that the Agent can query the journald that is stored on the host.
 


### PR DESCRIPTION
### What does this PR do?

This PR changes the wording for the `etc/machine-id` which is currently referred to as a directory although it seems to be a file.

### Motivation
Support ticket

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
