### PR TITLE
Changing link to extension

### DIFF
--- a/content/en/synthetics/browser_test.md
+++ b/content/en/synthetics/browser_test.md
@@ -140,4 +140,4 @@ To use your variables in one of your assertions, hit *Use Variable* and select t
 [2]: /integrations/#cat-notification
 [3]: http://daringfireball.net/projects/markdown/syntax
 [4]: https://www.google.com/chrome
-[5]: https://chrome.google.com/webstore/detail/datadog-test-recorder-sta/bfgpghinhlklmedgkkpnhphfgdliceel
+[5]: https://chrome.google.com/webstore/detail/datadog-test-recorder/kkbncfpddhdmkfmalecgnphegacgejoa


### PR DESCRIPTION
### What does this PR do?
This PR changes the link to direct to the correct extension (it was previously pointing at our staging extension).

### Motivation
Discussion with @GJSafar and @m-rousse 

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
