### PR TITLE
Add error code for rate limiting

### DIFF
--- a/content/en/api/errors/errors_code.md
+++ b/content/en/api/errors/errors_code.md
@@ -18,6 +18,7 @@ external_redirect: /api/#success-and-errors
 * `409 Conflict`
 * `413 Payload Too Large`
 * `422 Unprocessable`
+* `429 Too Many Requests`
 * `500 Server Error`
 
 ##### Example Error Response

--- a/content/fr/api/errors/errors_code.md
+++ b/content/fr/api/errors/errors_code.md
@@ -18,6 +18,7 @@ external_redirect: /api/#reussites-et-erreurs
 * `409 Conflict`
 * `413 Payload Too Large`
 * `422 Unprocessable`
+* `429 Too Many Requests`
 * `500 Server Error`
 
 ##### Exemple de réponse de type Error


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds 429 as the response code for rate limiting

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
