### PR TITLE
Fix 404 links

### DIFF
--- a/content/fr/agent/apm/_index.md
+++ b/content/fr/agent/apm/_index.md
@@ -212,7 +212,7 @@ Les tags primaires apparaissent en haut des pages APM. Utilisez ces sélecteurs 
 [13]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
 [14]: https://app.datadoghq.com/apm/services
 [15]: https://app.datadoghq.com/apm/docs/trace-search
-[16]: /fr/tracing/visualization/search/#apm-events
+[16]: /fr/tracing/trace_search_and_analytics/#apm-events
 [17]: /fr/tagging
 [18]: /fr/agent/faq/agent-configuration-files/?tab=agentv6
 [19]: /fr/tagging/assigning_tags/#traces

--- a/content/fr/tracing/visualization/analytics.md
+++ b/content/fr/tracing/visualization/analytics.md
@@ -21,7 +21,7 @@ further_reading:
   - link: tracing/visualization/trace
     tag: Documentation
     text: Comprendre comment lire une trace Datadog
-  - link: tracing/visualization/search
+  - link: tracing/trace_search_and_analytics
     tag: Documentation
     text: Recherche globale sur toutes vos traces avec des tags
 ---
@@ -110,8 +110,8 @@ Exportez les [analyses de traces][6] de la recherche de traces ou créez-les dir
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /fr/tracing/visualization/search/#measures
-[2]: /fr/tracing/visualization/search/#facets
+[1]: /fr/tracing/trace_search_and_analytics/#measures
+[2]: /fr/tracing/trace_search_and_analytics/#facets
 [3]: /fr/monitors/monitor_types/apm
 [4]: /fr/graphing/dashboards/timeboard
 [5]: /fr/help


### PR DESCRIPTION
### What does this PR do?
- Fix 404 links

### Motivation
- Docs 404 top list

### Preview link
N/A
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
N/A
