### PR TITLE
use generic private beta alert for runtime metrics

### DIFF
--- a/content/en/tracing/advanced/runtime_metrics.md
+++ b/content/en/tracing/advanced/runtime_metrics.md
@@ -48,9 +48,8 @@ In Kubernetes, [bind the DogstatsD port to a host port][5]; in ECS, [set the app
 {{% /tab %}}
 {{% tab "Python" %}}
 
-<div class="alert alert-info">
-This feature is currently in <strong>BETA</strong>.
-Reach out to <a href="/help">the Datadog support team</a> to be part of the beta.
+<div class="alert alert-warning">
+This feature is currently in private beta. <a href="https://docs.datadoghq.com/help/">Reach out to support</a> to turn on this feature for your account.
 </div>
 
 Runtime metrics collection can be enabled with the `DD_RUNTIME_METRICS_ENABLED=true` environment parameter when running with `ddtrace-run`:
@@ -73,9 +72,8 @@ In Kubernetes, [bind the DogstatsD port to a host port][5]; in ECS, [set the app
 {{% /tab %}}
 {{% tab "Ruby" %}}
 
-<div class="alert alert-info">
-This feature is currently in <strong>BETA</strong>.
-Reach out to <a href="/help">the Datadog support team</a> to be part of the beta.
+<div class="alert alert-warning">
+This feature is currently in private beta. <a href="https://docs.datadoghq.com/help/">Reach out to support</a> to turn on this feature for your account.
 </div>
 
 Runtime metrics collection uses the [`dogstatsd-ruby`][1] gem to send metrics via DogStatsD to the Agent. To collect runtime metrics, you must add this gem to your Ruby application, and make sure that [DogStatsD is enabled for the Agent][2].
@@ -123,9 +121,8 @@ Coming Soon. Reach out to [the Datadog support team][1] to be part of the beta.
 {{% /tab %}}
 {{% tab "Node.js" %}}
 
-<div class="alert alert-info">
-This feature is currently in <strong>BETA</strong>.
-Reach out to <a href="/help">the Datadog support team</a> to be part of the beta.
+<div class="alert alert-warning">
+This feature is currently in private beta. <a href="https://docs.datadoghq.com/help/">Reach out to support</a> to turn on this feature for your account.
 </div>
 
 Runtime metrics collection can be enabled with one configuration parameter in the tracing client either through the tracer option: `tracer.init({ runtimeMetrics: true })` or through the environment variable: `DD_RUNTIME_METRICS_ENABLED=true`


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
https://docs-staging.datadoghq.com/priyanshi/update_beta_text/tracing/advanced/runtime_metrics/?tab=python
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:


For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
