### PR TITLE
Fix hostname attributes in recommeneded config map/pod spec for nginx…

### DIFF
--- a/content/en/tracing/setup/nginx.md
+++ b/content/en/tracing/setup/nginx.md
@@ -127,7 +127,7 @@ data:
   # datadog-operation-name-override: "nginx.handle"
 ```
 
-Additionally, ensure that your nginx-ingress controller's pod spec has the `HOST_IP` environment variable set. Add this entry to the `env:` block that contains the environment variabeles `POD_NAME` and `POD_NAMESPACE`. 
+Additionally, ensure that your nginx-ingress controller's pod spec has the `HOST_IP` environment variable set. Add this entry to the `env:` block that contains the environment variables `POD_NAME` and `POD_NAMESPACE`. 
 
 ```yaml
 - name: HOST_IP

--- a/content/en/tracing/setup/nginx.md
+++ b/content/en/tracing/setup/nginx.md
@@ -120,12 +120,22 @@ metadata:
     app.kubernetes.io/part-of: ingress-nginx
 data:
   enable-opentracing: "true"
-  datadog-collector-host: datadogd.monitoring.svc.cluster.local
+  datadog-collector-host: $HOST_IP
   # Defaults
   # datadog-service-name: "nginx"
   # datadog-collector-port: "8126"
   # datadog-operation-name-override: "nginx.handle"
 ```
+
+Additionally, ensure that your nginx-ingress controller's pod spec has the `HOST_IP` environment variable set. Add this entry to the `env:` block that contains the environment variabeles `POD_NAME` and `POD_NAMESPACE`. 
+
+```yaml
+- name: HOST_IP
+  valueFrom:
+    fieldRef:
+      fieldPath: status.hostIP
+```
+  
 
 ## Further Reading
 


### PR DESCRIPTION
…-ingress controller

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
OpenTracing configuration steps for nginx-ingress controllers were unclear and did not result in a successful configuration. @cgilmour made the changes mentioned in this doc to successfully gather traces for this service. 

### Motivation
Issues were uncovered during an active POV with McKesson, and were replicated by myself with minikube. 

### Preview link
https://docs-staging.datadoghq.com/morgan.lupton/nginx-ingress-opentracing/tracing/setup/nginx/#nginx-ingress-controller-for-kubernetes

### Additional Notes
<!-- Anything else we should know when reviewing?-->
