### PR TITLE
Add Aliases for 404 links

### DIFF
--- a/content/en/getting_started/_index.md
+++ b/content/en/getting_started/_index.md
@@ -4,6 +4,7 @@ kind: documentation
 aliases:
   - /overview
   - /guides/overview/
+  - /getting_started/faq/
 further_reading:
 - link: "https://learn.datadoghq.com/course/view.php?id=2"
   tag: "Learning Center"

--- a/content/en/tagging/_index.md
+++ b/content/en/tagging/_index.md
@@ -6,6 +6,7 @@ aliases:
     - /guides/tagging/
     - /developers/tagging/
     - /getting_started/tagging
+    - /tagging/faq/
 further_reading:
 - link: "tagging/assigning_tags"
   tag: "Documentation"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add Aliases for 404 links

### Motivation
404 Top list

### Preview link
N/A
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
