### PR TITLE
Estib/s3 archives tags not included

### DIFF
--- a/content/en/logs/archives/s3.md
+++ b/content/en/logs/archives/s3.md
@@ -56,12 +56,6 @@ From the moment that your archive settings are successfully configured in your D
 
 However, after creating or updating your archive configurations, it can take several minutes before the next archive upload is attempted, so **you should check back on your S3 bucket in 15 minutes** to make sure the archives have successfully been getting uploaded from your Datadog account. 
 
-## Server Side Encryption (SSE)
-
-To add server side encryption to your S3 log archives, go to the **Properties** tab in your S3 bucket and select **Default Encryption**. Select the `AES-256` option and **Save**.
-
-{{< img src="logs/archives/log_archives_s3_encryption.png" alt="Select the AES-256 option and Save." responsive="true" style="width:75%;">}}
-
 ## Format of the S3 Archives
 
 The log archives that Datadog forwards to your S3 bucket are in zipped (gzip) JSON format. Under whatever prefix you indicate (or `/` if there is none), the archives are stored in a directory structure that indicates on what date and at what time the archive files were generated, like so:
@@ -85,6 +79,8 @@ Within the zipped JSON file, each event's content is formatted as follows:
 }
 ```
 
+**Note:** At this time, archives do not include log tags (which are metadata about logs), but instead only log content. This includes the message, custom attributes, and reserved attributes of your log events.
+
 ## Multiple S3 Archives
 
 Admins can route specific logs to an archive by adding a query in the archive's `filter` field. Logs enter the first archive whose filter they match on, so it is important to order your archives carefully. 
@@ -92,6 +88,12 @@ Admins can route specific logs to an archive by adding a query in the archive's 
 For example, if you create a first archive filtered to the `env:prod` tag and a second archive without any filter (the equivalent of `*`), all your production logs would go to one S3 bucket/path and the rest would go to the other.
 
 {{< img src="logs/archives/log_archives_s3_multiple.png" alt="Logs enter the first archive whose filter they match on." responsive="true" style="width:75%;">}}
+
+## Server Side Encryption (SSE)
+
+To add server side encryption to your S3 log archives, go to the **Properties** tab in your S3 bucket and select **Default Encryption**. Select the `AES-256` option and **Save**.
+
+{{< img src="logs/archives/log_archives_s3_encryption.png" alt="Select the AES-256 option and Save." responsive="true" style="width:75%;">}}
 
 [1]: https://s3.console.aws.amazon.com/s3
 [2]: https://docs.aws.amazon.com/AmazonS3/latest/user-guide/create-bucket.html

--- a/content/en/logs/archives/s3.md
+++ b/content/en/logs/archives/s3.md
@@ -79,7 +79,7 @@ Within the zipped JSON file, each event's content is formatted as follows:
 }
 ```
 
-**Note:** At this time, archives do not include log tags (which are metadata about logs that help to connect your log data to related metrics and traces), but instead only log content. This includes the message, custom attributes, and reserved attributes of your log events.
+**Note:** Archives only include log content which consists of the message, custom attributes, and reserved attributes of your log events. The log tags (metadata that connects your log data to related metrics and traces) are not included.
 
 ## Multiple S3 Archives
 

--- a/content/en/logs/archives/s3.md
+++ b/content/en/logs/archives/s3.md
@@ -79,7 +79,7 @@ Within the zipped JSON file, each event's content is formatted as follows:
 }
 ```
 
-**Note:** At this time, archives do not include log tags (which are metadata about logs), but instead only log content. This includes the message, custom attributes, and reserved attributes of your log events.
+**Note:** At this time, archives do not include log tags (which are metadata about logs that help to connect your log data to related metrics and traces), but instead only log content. This includes the message, custom attributes, and reserved attributes of your log events.
 
 ## Multiple S3 Archives
 


### PR DESCRIPTION
### What does this PR do?
1. Explicitly says that tags are not included in log archive contents
2. Moves SSE section to end to emphasize it less (since it is, after all, optional).

### Motivation
To make sure customers are less likely to be surprised by the lack of tags in log archives. 

### Preview link
https://docs-staging.datadoghq.com/estib/s3_archives_tags_not_included/logs/archives/s3/
