### PR TITLE
Fix typo in browser log documentation

### DIFF
--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -26,7 +26,7 @@ further_reading:
 
 Send logs to Datadog from web browsers or other Javascript client thanks to the Datadog's `datadog-logs` client-side JavaScript logging library.
 
-With the `datadog-logs` library, you can send log directories to Datadog from JS clients and leverage the following features:
+With the `datadog-logs` library, you can send log directly to Datadog from JS clients and leverage the following features:
 
 * Use the library as a logger. Everything is forwarded to Datadog as JSON documents.
 * Add `context` and extra custom attributes to each log sent.


### PR DESCRIPTION
### What does this PR do?
Fix a typo

### Motivation
Directly instead of directories

### Preview link
https://docs-staging.datadoghq.com/nils/browser-log/logs/log_collection/javascript/?tab=us 
<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
