### PR TITLE
add envvar for nodejs autoconfig

### DIFF
--- a/content/en/tracing/trace_search_and_analytics/_index.md
+++ b/content/en/tracing/trace_search_and_analytics/_index.md
@@ -83,6 +83,10 @@ tracer.init({
 })
 ```
 
+You can also use the following configuration parameter:
+
+* Environment Variable: `DD_TRACE_ANALYTICS_ENABLED=true`
+
  After enabling, the Trace Search & Analytics UI starts showing results. Visit [Trace Search page][1] to get started.
 
 


### PR DESCRIPTION
### What does this PR do?
Adds `DD_TRACE_ANALYTICS_ENABLED=true` to node autoconfig docs

### Motivation
it's available now

### Preview link

https://docs-staging.datadoghq.com/cswatt/trace-analytics-node/tracing/trace_search_and_analytics/?tab=nodejs#automatic-configuration
