### PR TITLE
Add alias for old faq article

### DIFF
--- a/content/en/agent/troubleshooting.md
+++ b/content/en/agent/troubleshooting.md
@@ -5,6 +5,7 @@ aliases:
     - /agent/faq/send-logs-and-configs-to-datadog-via-flare-command
     - /agent/faq/how-to-get-more-logging-from-the-agent
     - /agent/faq/agent-5-container-more-log
+    - /agent/faq/agent-s-are-no-longer-reporting-data
 further_reading:
 - link: "/agent/guide/agent-commands/?tab=agentv6"
   tag: "FAQ"


### PR DESCRIPTION
### What does this PR do?
- Add alias for old faq article

### Motivation
- Docs 404 top list

### Preview link
https://docs-staging.datadoghq.com/ruth/404-links-5-2/agent/faq/agent-s-are-no-longer-reporting-data/
