### PR TITLE
Document the host filtering parameter

### DIFF
--- a/content/en/api/metrics/code_snippets/api-metrics-list.sh
+++ b/content/en/api/metrics/code_snippets/api-metrics-list.sh
@@ -8,4 +8,4 @@ curl -G \
     -d "api_key=${api_key}" \
     -d "application_key=${app_key}" \
     -d "from=${from_time}"
-
+    -d "host=<HOSTNAME>"

--- a/content/en/api/metrics/metrics_list.md
+++ b/content/en/api/metrics/metrics_list.md
@@ -10,6 +10,6 @@ Get the list of actively reporting metrics from a given time until now. This end
 
 ##### ARGUMENTS
 * **`from`** [*required*]:
-    Seconds since the unix epoch
+    Seconds since the Unix epoch
 * **`host`** [*optional*]:
-    Hostname to to filter the list of metrics returned. If set, metrics retrieved are the one with the corresponding hostname tag.
+    Hostname for filtering the list of metrics returned. If set, metrics retrieved are those with the corresponding hostname tag.

--- a/content/en/api/metrics/metrics_list.md
+++ b/content/en/api/metrics/metrics_list.md
@@ -9,6 +9,7 @@ external_redirect: /api/#get-list-of-active-metrics
 Get the list of actively reporting metrics from a given time until now. This endpoint is not available in the Python and Ruby libraries.
 
 ##### ARGUMENTS
-* **`from`** [*required*]:  
+* **`from`** [*required*]:
     Seconds since the unix epoch
-
+* **`host`** [*optional*]:
+    Hostname to to filter the list of metrics returned. If set, metrics retrieved are the one with the corresponding hostname tag.


### PR DESCRIPTION
### What does this PR do?
Adds API parameter to filter the list of metrics retrieved by a given hostname.

### Motivation
It wasn't documented.

### Preview link
