### PR TITLE
Adding agent obfuscation for traces guide

### DIFF
--- a/content/en/tracing/guide/_index.md
+++ b/content/en/tracing/guide/_index.md
@@ -12,4 +12,5 @@ disable_toc: true
     {{< nextlink href="tracing/guide/security" >}}Scrub Sensitive information from your traces{{< /nextlink >}}
     {{< nextlink href="tracing/guide/resource_monitor" >}}Build monitor upon your resource metrics{{< /nextlink >}}
     {{< nextlink href="tracing/guide/trace_sampling_and_storage" >}}Trace Sampling and Storage{{< /nextlink >}}
+    {{< nextlink href="tracing/guide/agent-obfuscation" >}}Agent Trace Obfuscation{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/tracing/guide/agent-5-tracing-setup.md
+++ b/content/en/tracing/guide/agent-5-tracing-setup.md
@@ -5,7 +5,6 @@ private: true
 disable_toc: true
 aliases:
   - /tracing/faq/agent-5-tracing-setup
-private: true
 ---
 
 ## Getting started

--- a/content/en/tracing/guide/agent-obfuscation.md
+++ b/content/en/tracing/guide/agent-obfuscation.md
@@ -8,12 +8,17 @@ disable_toc: true
 Agent trace obfuscation is disabled by default. Enable it in your `datadog.yaml` configuration file to obfuscate all information attached to your traces, the general format is:
 
 ```
-obfuscation:
-  <SERVICE_NAME>:
-    enabled: true
-    keep_values:
-      - <VALUE_1>
-      - <VALUE_2>
+apm_config:
+  enabled: true
+  
+  ## (...)
+  
+  obfuscation:
+    <SERVICE_NAME>:
+      enabled: true
+      keep_values:
+        - <VALUE_1>
+        - <VALUE_2>
 ```
 
 * `enabled` should be set to true to have obfuscation enabled for the specified `<SERVICE_NAME>`.
@@ -24,23 +29,33 @@ Find below some examples:
 **ElasticSearch obfuscation rules**. Applies to spans of type `elasticsearch`, more specifically, to the `elasticsearch.body` span metadata:
 
 ```
-obfuscation:
-  elasticsearch:
-    enabled: true
-    keep_values:
-      - user_id
-      - category_id
+apm_config:
+  enabled: true
+  
+  ## (...)
+  
+  obfuscation:
+    elasticsearch:
+      enabled: true
+      keep_values:
+        - user_id
+        - category_id
 ```
 
 **MongoDB obfuscation rules**. Applies to spans of type `mongodb`, more specifically: to the `mongodb.query` span metadata.
 
 ```
-obfuscation:
-  mongodb:
-    enabled: true
-    keep_values:
-      - uid
-      - cat_id
+apm_config:
+  enabled: true
+  
+  ## (...)
+  
+  obfuscation:
+    mongodb:
+      enabled: true
+      keep_values:
+        - uid
+        - cat_id
 ```
 
 For web services, there is a specific set of boolean parameters that can be applied:
@@ -51,8 +66,13 @@ For web services, there is a specific set of boolean parameters that can be appl
 For instance, find below an example of HTTP obfuscation rules for `http.url` metadata in spans of type `http`:
 
 ```
-obfuscation:
-  http:
-    remove_query_string: true
-    remove_paths_with_digits: true
+apm_config:
+  enabled: true
+  
+  ## (...)
+  
+  obfuscation:
+    http:
+      remove_query_string: true
+      remove_paths_with_digits: true
 ```

--- a/content/en/tracing/guide/agent-obfuscation.md
+++ b/content/en/tracing/guide/agent-obfuscation.md
@@ -36,7 +36,7 @@ apm_config:
         - cat_id
 ```
 
-* `keep_values` are a set of keys from which the values are not obfuscated.
+* `keep_values` - defines a set of keys to exclude from Agent trace obfuscation.
 
 {{% /tab %}}
 {{% tab "ElasticSearch" %}}
@@ -57,7 +57,7 @@ apm_config:
         - category_id
 ```
 
-* `keep_values` are a set of keys from which the values are not obfuscated.
+* `keep_values` - defines a set of keys to exclude from Agent trace obfuscation.
 
 {{% /tab %}}
 {{% tab "Redis" %}}
@@ -108,7 +108,7 @@ apm_config:
       remove_paths_with_digits: true
 ```
 
-* `remove_query_string`: If true, query strings in URLs are obfuscated.
+* `remove_query_string`: If true, obfuscates query strings in URLs.
 * `remove_paths_with_digits`: If true, path segments in URLs containing digits are replaced by "?".
 
 {{% /tab %}}

--- a/content/en/tracing/guide/agent-obfuscation.md
+++ b/content/en/tracing/guide/agent-obfuscation.md
@@ -1,0 +1,58 @@
+---
+title: Agent Trace Obfuscation
+kind: guide
+private: true
+disable_toc: true
+---
+
+Agent trace obfuscation is disabled by default. Enable it in your `datadog.yaml` configuration file to obfuscate all information attached to your traces, the general format is:
+
+```
+obfuscation:
+  <SERVICE_NAME>:
+    enabled: true
+    keep_values:
+      - <VALUE_1>
+      - <VALUE_2>
+```
+
+* `enabled` should be set to true to have obfuscation enabled for the specified `<SERVICE_NAME>`.
+* `keep_values` are a set of keys from which the values are not obfuscated.
+
+Find below some examples:
+
+**ElasticSearch obfuscation rules**. Applies to spans of type `elasticsearch`, more specifically, to the `elasticsearch.body` span metadata:
+
+```
+obfuscation:
+  elasticsearch:
+    enabled: true
+    keep_values:
+      - user_id
+      - category_id
+```
+
+**MongoDB obfuscation rules**. Applies to spans of type `mongodb`, more specifically: to the `mongodb.query` span metadata.
+
+```
+obfuscation:
+  mongodb:
+    enabled: true
+    keep_values:
+      - uid
+      - cat_id
+```
+
+For web services, there is a specific set of boolean parameters that can be applied:
+
+* `remove_query_string`: If true, query strings in URLs are obfuscated.
+* `remove_paths_with_digits`: If true, path segments in URLs containing digits are replaced by "?".
+
+For instance, find below an example of HTTP obfuscation rules for `http.url` metadata in spans of type `http`:
+
+```
+obfuscation:
+  http:
+    remove_query_string: true
+    remove_paths_with_digits: true
+```

--- a/content/en/tracing/guide/agent-obfuscation.md
+++ b/content/en/tracing/guide/agent-obfuscation.md
@@ -5,51 +5,29 @@ private: true
 disable_toc: true
 ---
 
-Agent trace obfuscation is disabled by default. Enable it in your `datadog.yaml` configuration file to obfuscate all information attached to your traces, the general format is:
+Agent trace obfuscation is disabled by default. Enable it in your `datadog.yaml` configuration file to obfuscate all information attached to your traces.
+
+Currently this options only works with the following services:
+
+* `mongodb`
+* `elasticsearch`
+* `redis`
+* `memcached`
+* `http`
+* `remove_stack_traces`
+
+
+{{< tabs >}}
+{{% tab "MongoDB" %}}
+
+Applies to spans of type `mongodb`, more specifically: to the `mongodb.query` span metadata.
 
 ```
 apm_config:
   enabled: true
-  
+
   ## (...)
-  
-  obfuscation:
-    <SERVICE_NAME>:
-      enabled: true
-      keep_values:
-        - <VALUE_1>
-        - <VALUE_2>
-```
 
-* `enabled` should be set to true to have obfuscation enabled for the specified `<SERVICE_NAME>`.
-* `keep_values` are a set of keys from which the values are not obfuscated.
-
-Find below some examples:
-
-**ElasticSearch obfuscation rules**. Applies to spans of type `elasticsearch`, more specifically, to the `elasticsearch.body` span metadata:
-
-```
-apm_config:
-  enabled: true
-  
-  ## (...)
-  
-  obfuscation:
-    elasticsearch:
-      enabled: true
-      keep_values:
-        - user_id
-        - category_id
-```
-
-**MongoDB obfuscation rules**. Applies to spans of type `mongodb`, more specifically: to the `mongodb.query` span metadata.
-
-```
-apm_config:
-  enabled: true
-  
-  ## (...)
-  
   obfuscation:
     mongodb:
       enabled: true
@@ -58,21 +36,94 @@ apm_config:
         - cat_id
 ```
 
-For web services, there is a specific set of boolean parameters that can be applied:
+* `keep_values` are a set of keys from which the values are not obfuscated.
 
-* `remove_query_string`: If true, query strings in URLs are obfuscated.
-* `remove_paths_with_digits`: If true, path segments in URLs containing digits are replaced by "?".
+{{% /tab %}}
+{{% tab "ElasticSearch" %}}
 
-For instance, find below an example of HTTP obfuscation rules for `http.url` metadata in spans of type `http`:
+Applies to spans of type `elasticsearch`, more specifically, to the `elasticsearch.body` span metadata:
 
 ```
 apm_config:
   enabled: true
-  
+
   ## (...)
-  
+
+  obfuscation:
+    elasticsearch:
+      enabled: true
+      keep_values:
+        - user_id
+        - category_id
+```
+
+* `keep_values` are a set of keys from which the values are not obfuscated.
+
+{{% /tab %}}
+{{% tab "Redis" %}}
+
+Applies to spans of type `redis`, more specifically, to the `redis.raw_command` span metadata:
+
+```
+apm_config:
+  enabled: true
+
+  ## (...)
+
+  obfuscation:
+    redis:
+      enabled: true
+```
+
+{{% /tab %}}
+{{% tab "MemCached" %}}
+
+Applies to spans of type `memcached`, more specifically, to the `memcached.command` span metadata:
+
+```
+apm_config:
+  enabled: true
+
+  ## (...)
+
+  obfuscation:
+    memcached:
+      enabled: true
+```
+
+{{% /tab %}}
+{{% tab "Http" %}}
+
+HTTP obfuscation rules for `http.url` metadata in spans of type `http`:
+
+```
+apm_config:
+  enabled: true
+
+  ## (...)
+
   obfuscation:
     http:
       remove_query_string: true
       remove_paths_with_digits: true
 ```
+
+* `remove_query_string`: If true, query strings in URLs are obfuscated.
+* `remove_paths_with_digits`: If true, path segments in URLs containing digits are replaced by "?".
+
+{{% /tab %}}
+{{% tab "Stack Traces" %}}
+
+Set the `remove_stack_traces` parameter to true, to remove stack traces and replace them with `?`.
+```
+apm_config:
+  enabled: true
+
+  ## (...)
+
+  obfuscation:
+    remove_stack_traces: true
+```
+
+{{% /tab %}}
+{{< /tabs >}}


### PR DESCRIPTION
### What does this PR do?
Adds a guide on how to obfuscate values associated to metadata for some spans with the DD Agent.

### Motivation
This parameter from the main `datadog.yaml` file was not documented yet

### Preview link

* https://docs-staging.datadoghq.com/gus/apm-obfuscation/tracing/guide/agent-obfuscation/