### PR TITLE
Update log instruction for K8s

### DIFF
--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -261,9 +261,9 @@ The Docker API is optimized to get logs from one container at a time. When there
       (...)
     ```
     
-The `pointdir` is used to store a file with a pointer on all the container that the agent is collecting log from to make sure none are lost when the agent is restarted or in case of network issue.
+The `pointdir` is used to store a file with a pointer to all the containers that the Agent is collecting logs from. This is to make sure none are lost when the Agent is restarted, or in the case of na etwork issue.
 
-Use the [Autodiscovery with Pod Annotations][14] to configure the log collection to add multiline processing rules or customise the `source` and `service` attribute.
+Use [Autodiscovery with Pod Annotations][14] to configure log collection to add multiline processing rules, or to customize the `source` and `service` attributes.
 
 ### APM and Distributed Tracing
 

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -250,14 +250,14 @@ The Docker API is optimized to get logs from one container at a time. When there
       (...)
         volumeMounts:
           (...)
-          - name: pointerdir
+          - name: pointdir
               mountPath: /opt/datadog-agent/run
       (...)
       volumes:
         (...)
         - hostPath:
             path: /opt/datadog-agent/run
-            name: pointerdir
+            name: pointdir
       (...)
     ```
     

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -195,13 +195,14 @@ To enable [Log collection][10] with your DaemonSet:
 
 2. Mount the Docker socket or `/var/log/pods`
 
-The Agent has two ways to collect logs, from the Docker socket or the Kubernetes log files (automatically handled by Kubernetes). 
-You should use the log file collection when:
+The Agent has two ways to collect logs: from the Docker socket, and from the Kubernetes log files (automatically handled by Kubernetes). 
+
+Use log file collection when:
 
 * Docker is not the runtime
 * More than 10 containers are used within each pod 
 
-Indeed when there are many containers in the same pod, collecting logs through the Docker socket might be consuming much more resources than going through the files as the Docker API is optimised to get logs from one container at a time.
+The Docker API is optimized to get logs from one container at a time. When there are many containers in the same pod, collecting logs through the Docker socket might be consuming much more resources than going through the files.
 
 {{< tabs >}}
 {{% tab "K8s File" %}}

--- a/content/en/agent/kubernetes/host_setup.md
+++ b/content/en/agent/kubernetes/host_setup.md
@@ -37,13 +37,13 @@ Note: these metrics are unavailable for Azure Kubernetes Service (AKS).
 
 There are two ways to collect logs from containers running in Kubernetes:
 
-- Through the Docker socket
-- Through the Kubernetes log files 
+- Through the Docker socket.
+- Through the Kubernetes log files.
 
-We recommend using the Kubernetes log files approach when you are either not using Docker or using more than 10 containers per pod.
+Datadog recommends using the Kubernetes log files approach when you are either not using Docker, or are using more than 10 containers per pod.
 
-We also recommend to take advantage of DaemonSets to [automatically deploy the Datadog Agent on all your nodes][4]. 
-Otherwise to manually enable log collection from one specific node, add the following parameters in the `datadog.yaml`:
+Datadog also recommends that you take advantage of DaemonSets to [automatically deploy the Datadog Agent on all your nodes][4]. 
+Otherwise, to manually enable log collection from one specific node, add the following parameters in the `datadog.yaml`:
 
 ```
 logs_enabled: true
@@ -58,7 +58,7 @@ logs_config:
 
 [Restart the Agent][7].
 
-Use the [Autodiscovery with Pod Annotations][8] to configure the log collection to add multiline processing rules or customise the `source` and `service` attribute.
+Use [Autodiscovery with Pod Annotations][8] to configure log collection to add multiline processing rules, or to customize the `source` and `service` attributes.
 
 ## Further Reading
 To get a better idea of how (or why) to integrate your Kubernetes service, see the related series of [Datadog blog posts][6].

--- a/content/en/agent/kubernetes/host_setup.md
+++ b/content/en/agent/kubernetes/host_setup.md
@@ -35,12 +35,30 @@ Note: these metrics are unavailable for Azure Kubernetes Service (AKS).
 
 **Available for Agent >6.0**
 
-Two installations are possible:
+There are two ways to collect logs from containers running in Kubernetes:
 
-- On the node where the Agent is external to the Docker environment
-- Deployed with its containerized version in the Docker environment
+- Through the Docker socket
+- Through the Kubernetes log files 
 
-Take advantage of DaemonSets to [automatically deploy the Datadog Agent on all your nodes][4]. Otherwise follow the [container log collection steps][5] to start collecting logs from all your containers.
+We recommend using the Kubernetes log files approach when you are either not using Docker or using more than 10 containers per pod.
+
+We also recommend to take advantage of DaemonSets to [automatically deploy the Datadog Agent on all your nodes][4]. 
+Otherwise to manually enable log collection from one specific node, add the following parameters in the `datadog.yaml`:
+
+```
+logs_enabled: true
+listeners:
+  - name: kubelet
+config_providers:
+  - name: kubelet
+    polling: true
+logs_config:
+  container_collect_all: true
+```
+
+[Restart the Agent][7].
+
+Use the [Autodiscovery with Pod Annotations][8] to configure the log collection to add multiline processing rules or customise the `source` and `service` attribute.
 
 ## Further Reading
 To get a better idea of how (or why) to integrate your Kubernetes service, see the related series of [Datadog blog posts][6].
@@ -51,3 +69,5 @@ To get a better idea of how (or why) to integrate your Kubernetes service, see t
 [4]: https://app.datadoghq.com/account/settings#agent/kubernetes
 [5]: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup
 [6]: https://www.datadoghq.com/blog/monitoring-kubernetes-era
+[7]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#start-stop-and-restart-the-agent
+[8]: https://docs.datadoghq.com/agent/autodiscovery/?tab=kubernetes#setting-up-check-templates


### PR DESCRIPTION
### What does this PR do?
Update the log instruction for Kubernetes to reflect the two possibilities (docker socket and log files).

### Motivation
The file tailing method is now used by default if `/var/log/pods` is mounted.

### Preview link
https://docs-staging.datadoghq.com/nils/kubernetes-log-collection/agent/kubernetes/daemonset_setup/#log-collection

https://docs-staging.datadoghq.com/nils/kubernetes-log-collection/agent/kubernetes/host_setup/#collect-container-logs

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
