### PR TITLE
Fixing broken links and other small changes

### DIFF
--- a/content/en/api/metrics/metrics_querytime.md
+++ b/content/en/api/metrics/metrics_querytime.md
@@ -6,7 +6,7 @@ external_redirect: /api/#query-time-series-points
 ---
 
 ## Query timeseries points
-This endpoint allows you to query for metrics from any time period.
+This endpoint allows you to query for metrics from any time period. Use the query syntax described in [From the query to the graph][1].
 
 *Note:* In Python, `from` is a reserved word. So instead, the Python API uses the `start` and `end` parameters in the function call.
 
@@ -22,3 +22,5 @@ This endpoint allows you to query for metrics from any time period.
 * **`query`** [*required*]:  
     The query string
 
+
+[1]: /graphing/functions

--- a/content/en/api/rate_limiting/rate_limiting.md
+++ b/content/en/api/rate_limiting/rate_limiting.md
@@ -23,5 +23,5 @@ Regarding API rate limit policy:
 [2]: /api/#metrics
 [3]: /developers/metrics/custom_metrics
 [4]: /api/#query-time-series-points
-[5]: /api/?lang=bash#list-logs
+[5]: /api/?lang=bash#get-a-list-of-logs
 [6]: /api/#graphs

--- a/content/en/tracing/advanced/manual_instrumentation.md
+++ b/content/en/tracing/advanced/manual_instrumentation.md
@@ -23,9 +23,9 @@ Manual instrumentation allows programmatic creation of traces to send to Datadog
 
 If you aren't using a [supported framework instrumentation][1], or you would like additional depth in your application’s traces, you may want to manually instrument your code.
 
-Do this either using the Trace annotation for simple method call tracing, or with the [OpenTracing API][2] for complex tracing.
+Do this either using the Trace annotation for simple method call tracing, or with the OpenTracing API for complex tracing.
 
-Datadog's Trace annotation is provided by the [dd-trace-api dependency][3].
+Datadog's Trace annotation is provided by the [dd-trace-api dependency][2].
 
 **Example Usage**
 
@@ -42,8 +42,7 @@ public class MyClass {
 
 
 [1]: /tracing/languages/java/#compatibility
-[2]: #opentracing
-[3]: https://mvnrepository.com/artifact/com.datadoghq/dd-trace-api
+[2]: https://mvnrepository.com/artifact/com.datadoghq/dd-trace-api
 {{% /tab %}}
 {{% tab "Python" %}}
 

--- a/content/en/tracing/guide/configure_an_apdex_for_your_traces_with_datadog_apm.md
+++ b/content/en/tracing/guide/configure_an_apdex_for_your_traces_with_datadog_apm.md
@@ -15,7 +15,7 @@ Apdex is a numerical measure of user satisfaction with the performance of enterp
 * 0 = no users satisfied
 * 1 = all users satisfied
 
-To define your apdex, you need to be an administrator of your Datadog account. To define your apdex you need to first define a time threshold - **T** - separating satisfactory response times to unsatisfactory response time from your application or service. With one threshold you can then define three categories:
+To define your apdex, you need to be an administrator of your Datadog account. To define your apdex you need to first define a time threshold—**T**—separating satisfactory response times from unsatisfactory response times from your application or service. With one threshold you can then define three categories:
 
 * Satisfied requests have a response time below **T**
 * Tolerated requests have a response time equal to/above **T** and below/equal to **4T**

--- a/content/en/tracing/guide/configure_an_apdex_for_your_traces_with_datadog_apm.md
+++ b/content/en/tracing/guide/configure_an_apdex_for_your_traces_with_datadog_apm.md
@@ -15,7 +15,7 @@ Apdex is a numerical measure of user satisfaction with the performance of enterp
 * 0 = no users satisfied
 * 1 = all users satisfied
 
-To define your apdex you need to first define a time threshold - **T** - separating satisfactory response times to unsatisfactory response time from your application or service. With one threshold you can then define three categories:
+To define your apdex, you need to be an administrator of your Datadog account. To define your apdex you need to first define a time threshold - **T** - separating satisfactory response times to unsatisfactory response time from your application or service. With one threshold you can then define three categories:
 
 * Satisfied requests have a response time below **T**
 * Tolerated requests have a response time equal to/above **T** and below/equal to **4T**

--- a/content/en/tracing/guide/trace_sampling_and_storage.md
+++ b/content/en/tracing/guide/trace_sampling_and_storage.md
@@ -99,14 +99,14 @@ It is possible to disable the instrumentation for a percentage of transactions. 
 
 ## Trace storage
 
-Individual traces are stored for up to 6 months. To determine how long a particular trace will be stored, the Agent makes a sampling decision early in the trace's lifetime. In Datadog backend, sampled traces are retained according to time buckets:
+Individual traces are stored for up to 4 months. To determine how long a particular trace will be stored, the Agent makes a sampling decision early in the trace's lifetime. In Datadog backend, sampled traces are retained according to time buckets:
 
 | Retention bucket       |  % of stream kept |
 | :--------------------- | :---------------- |
 | 6 hours                |              100% |
 | Current day (UTC time) |               25% |
 | 6 days                 |               10% |
-| 6 months               |                1% |
+| 4 months               |                1% |
 
 That is to say, on a given day you would see in the UI:
 
@@ -114,7 +114,7 @@ That is to say, on a given day you would see in the UI:
 * **25%** of those from the previous hours of the current calendar day (starting at `00:00 UTC`)
 * **10%** from the previous six calendar days
 * **1%** of those from the previous six months (starting from the first day of the month six months ago)
-* **0%** of traces older than 6 months
+* **0%** of traces older than 4 months
 
 For example, at `9:00am UTC Wed, 12/20` you would see:
 

--- a/content/en/tracing/setup/java.md
+++ b/content/en/tracing/setup/java.md
@@ -49,7 +49,7 @@ Instrumentation may come from auto-instrumentation, the OpenTracing api, or a mi
 
 ## Compatibility
 
-Datadog officially supports the Java JRE 1.7 and higher of both Oracle JDK and OpenJDK.
+Datadog officially supports the Java JRE 1.7 and higher of both Oracle JDK and OpenJDK. Datadog does not officially support any early-access versions of Java.
 
 ### Integrations
 


### PR DESCRIPTION
### What does this PR do?
Fixing broken links and other small changes

### Motivation
Better docs for a better world

### Preview link

- Removing link `OpenTracing API` - https://docs-staging.datadoghq.com/kaylyn/typos/tracing/advanced/manual_instrumentation/?tab=java#opentracing
- Updating logs link - https://docs-staging.datadoghq.com/kaylyn/typos/api/?lang=python#rate-limiting
- Updating trace sampling from 4 to 6 months - https://docs-staging.datadoghq.com/kaylyn/typos/tracing/guide/trace_sampling_and_storage/#trace-storage
- Adding in link to info about query language - https://docs-staging.datadoghq.com/kaylyn/typos/api/?lang=python#query-timeseries-points
- Admin role clarification - https://docs-staging.datadoghq.com/kaylyn/typos/tracing/guide/configure_an_apdex_for_your_traces_with_datadog_apm/
- updating Java version - https://docs-staging.datadoghq.com/kaylyn/typos/tracing/setup/java/#compatibility