### PR TITLE
clarified uptime calculation

### DIFF
--- a/content/en/monitors/slo_widget.md
+++ b/content/en/monitors/slo_widget.md
@@ -40,6 +40,8 @@ Optionally, you can view uptime by monitor groups in three different ways:
 
 You can view the uptime percentage for the overall monitor, by selected groups, or both. For calculation, the total uptime percentage when selected by group can be calculated, as well as on the total of the monitors (all groups regardless of what’s selected) or for only the selected groups.
 
+**Note**: The overall uptime value represents the proportion of time that none of the groups in the widget's scope were in an alert state.  
+
 {{< img src="monitors/slo_widget/slo_uptime-view_mode.png" alt="View Mode" responsive="true" >}}
 
 You can also query multiple monitors and use the monitor search query to select your specific monitors.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds clarification about how the overall uptime is calculated

### Motivation
<!-- What inspired you to submit this pull request?-->
Several support tickets

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/bcon/uptime-calculation-clarification/monitors/slo_widget

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
