### PR TITLE
Add service checks to supported monitor types

### DIFF
--- a/content/en/monitors/slo_widget.md
+++ b/content/en/monitors/slo_widget.md
@@ -54,7 +54,7 @@ You can select up to 20 monitors.
 
 ### Supported monitor types
 
-Currently only [metric monitor types][2] and synthetics are supported in the widget. Only supported monitors will be available to select within the widget. All other monitor types are not currently supported. 
+Currently only [metric monitor types][2], service checks, and synthetics are supported in the widget. Only supported monitors will be available to select within the widget. All other monitor types are not currently supported. 
 
 Supported metric monitor types include: metric, anomaly, APM, forecast, outlier, and integration metrics. For more info, see [here][2] for monitor types.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates the Supported monitor type section in docs 

### Motivation
We added supported for service checks (in beta) but they will be available in the monitor list in the widget 

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
