### PR TITLE
Morgan.lupton/clarify cluster agent

### DIFF
--- a/content/en/agent/kubernetes/cluster.md
+++ b/content/en/agent/kubernetes/cluster.md
@@ -102,8 +102,8 @@ kubectl create configmap dca-yaml --from-file datadog-cluster.yaml
 
 Locate the following manifests, and replace `<DD_API_KEY>` with [your API key][4]:
 
-* `Dockerfiles/manifests/cluster-agent/datadog-cluster-agent_service.yaml`
-* `Dockerfiles/manifests/cluster-agent/cluster-agent.yaml`
+* `[Dockerfiles/manifests/cluster-agent/datadog-cluster-agent_service.yaml](https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/datadog-cluster-agent_service.yaml)`
+* `[Dockerfiles/manifests/cluster-agent/cluster-agent.yaml](https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/cluster-agent.yaml)`
 
 Then, run:
 

--- a/content/en/agent/kubernetes/cluster.md
+++ b/content/en/agent/kubernetes/cluster.md
@@ -102,8 +102,8 @@ kubectl create configmap dca-yaml --from-file datadog-cluster.yaml
 
 Locate the following manifests, and replace `<DD_API_KEY>` with [your API key][4]:
 
-* `[Dockerfiles/manifests/cluster-agent/datadog-cluster-agent_service.yaml](https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/datadog-cluster-agent_service.yaml)`
-* `[Dockerfiles/manifests/cluster-agent/cluster-agent.yaml](https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/cluster-agent.yaml)`
+* [`Dockerfiles/manifests/cluster-agent/datadog-cluster-agent_service.yaml`](https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/datadog-cluster-agent_service.yaml)
+* [`Dockerfiles/manifests/cluster-agent/cluster-agent.yaml`](https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/cluster-agent.yaml)
 
 Then, run:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds links to relevant manifests in GitHub for additional clarification.

### Motivation
Attempting to setup the Datadog cluster agent had me a bit confused at this step in the setup. 

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
