### PR TITLE
Adding list of Agent APM metrics

### DIFF
--- a/content/en/agent/faq/_index.md
+++ b/content/en/agent/faq/_index.md
@@ -9,46 +9,48 @@ aliases:
 
 * [Getting further with Docker][1]
 * [Docker JMX][2]
-* [Downgrade the Agent to a prior minor version][3]
-* [How does Datadog determine the Agent hostname?][4]
-* [Common Windows Agent Installation Error 1721][5]
-* [How do I install the Agent on a server with limited internet connectivity?][6]
-* [How to monitor SNMP devices?][7]
-* [I stopped my Agent but I'm still seeing the host in my Datadog account.][8]
-* [How do I uninstall the Agent?][9]
-* [Network Time Protocol (NTP) Offset Issues][10]
-* [How to solve Permission denied errors?][11]
-* [Error Restarting Agent: Already Listening on a Configured Port][12]
-* [Forwarder logs contain 599 response code][13]
-* [Starting Datadog Agent (using supervisord):Error: Cannot open an HTTP server: socket.error reported errno.EACCES (13)][14]
-* [Why don't I see the 'system.processes.open_file_descriptors' metric?][15]
-* [How is the 'system.mem.used' metric calculated?][16]
-* [Adding a custom Python package to the Agent][17]
-* [Why should I install the Datadog Agent on my cloud instances?][18]
-* [The Datadog Agent for Logs or Traces Only][19]
-* [Install the Agent with AWS SSM][20]
-* [How do I use Kubernetes secrets to set my API key?][21]
-* [Datadog Windows Agent user][22]
+* [ APM metrics send by the Datadog Agent][3]
+* [Downgrade the Agent to a prior minor version][4]
+* [How does Datadog determine the Agent hostname?][5]
+* [Common Windows Agent Installation Error 1721][6]
+* [How do I install the Agent on a server with limited internet connectivity?][7]
+* [How to monitor SNMP devices?][8]
+* [I stopped my Agent but I'm still seeing the host in my Datadog account.][9]
+* [How do I uninstall the Agent?][10]
+* [Network Time Protocol (NTP) Offset Issues][11]
+* [How to solve Permission denied errors?][12]
+* [Error Restarting Agent: Already Listening on a Configured Port][13]
+* [Forwarder logs contain 599 response code][14]
+* [Starting Datadog Agent (using supervisord):Error: Cannot open an HTTP server: socket.error reported errno.EACCES (13)][15]
+* [Why don't I see the 'system.processes.open_file_descriptors' metric?][16]
+* [How is the 'system.mem.used' metric calculated?][17]
+* [Adding a custom Python package to the Agent][18]
+* [Why should I install the Datadog Agent on my cloud instances?][19]
+* [The Datadog Agent for Logs or Traces Only][20]
+* [Install the Agent with AWS SSM][21]
+* [How do I use Kubernetes secrets to set my API key?][22]
+* [Datadog Windows Agent user][23]
 
 [1]: /agent/faq/getting-further-with-docker
 [2]: /agent/faq/docker-jmx
-[3]: /agent/faq/downgrade-datadog-agent
-[4]: /agent/faq/how-datadog-agent-determines-the-hostname
-[5]: /agent/faq/common-windows-agent-installation-error-1721
-[6]: /agent/faq/how-do-i-install-the-agent-on-a-server-with-limited-internet-connectivity
-[7]: /agent/faq/how-to-monitor-snmp-devices
-[8]: /agent/faq/i-stopped-my-agent-but-i-m-still-seeing-the-host
-[9]: /agent/faq/how-do-i-uninstall-the-agent
-[10]: /agent/faq/network-time-protocol-ntp-offset-issues
-[11]: /agent/faq/how-to-solve-permission-denied-errors
-[12]: /agent/faq/error-restarting-agent-already-listening-on-a-configured-port
-[13]: /agent/faq/forwarder-logs-contain-599-response-code
-[14]: /agent/faq/cannot-open-an-http-server-socket-error-reported-errno-eacces-13
-[15]: /agent/faq/why-don-t-i-see-the-system-processes-open-file-descriptors-metric
-[16]: /agent/faq/how-is-the-system-mem-used-metric-calculated
-[17]: /agent/faq/custom_python_package
-[18]: /agent/faq/why-should-i-install-the-agent-on-my-cloud-instances
-[19]: /agent/faq/the-datadog-agent-for-logs-or-traces-only
-[20]: /agent/faq/install-the-agent-with-aws-ssm
-[21]: /agent/faq/kubernetes-secrets
-[22]: /agent/faq/windows-agent-ddagent-user
+[3]: /agent/faq/agent-apm-metrics
+[4]: /agent/faq/downgrade-datadog-agent
+[5]: /agent/faq/how-datadog-agent-determines-the-hostname
+[6]: /agent/faq/common-windows-agent-installation-error-1721
+[7]: /agent/faq/how-do-i-install-the-agent-on-a-server-with-limited-internet-connectivity
+[8]: /agent/faq/how-to-monitor-snmp-devices
+[9]: /agent/faq/i-stopped-my-agent-but-i-m-still-seeing-the-host
+[10]: /agent/faq/how-do-i-uninstall-the-agent
+[11]: /agent/faq/network-time-protocol-ntp-offset-issues
+[12]: /agent/faq/how-to-solve-permission-denied-errors
+[13]: /agent/faq/error-restarting-agent-already-listening-on-a-configured-port
+[14]: /agent/faq/forwarder-logs-contain-599-response-code
+[15]: /agent/faq/cannot-open-an-http-server-socket-error-reported-errno-eacces-13
+[16]: /agent/faq/why-don-t-i-see-the-system-processes-open-file-descriptors-metric
+[17]: /agent/faq/how-is-the-system-mem-used-metric-calculated
+[18]: /agent/faq/custom_python_package
+[19]: /agent/faq/why-should-i-install-the-agent-on-my-cloud-instances
+[20]: /agent/faq/the-datadog-agent-for-logs-or-traces-only
+[21]: /agent/faq/install-the-agent-with-aws-ssm
+[22]: /agent/faq/kubernetes-secrets
+[23]: /agent/faq/windows-agent-ddagent-user

--- a/content/en/agent/faq/agent-apm-metrics.md
+++ b/content/en/agent/faq/agent-apm-metrics.md
@@ -3,11 +3,11 @@ title: APM metrics send by the Datadog Agent
 kind: faq
 ---
 
-Find below the list of out of the box metrics send by a Datadog Agent when [APM is enabled][1]:
+Find below the list of out-of-the-box metrics sent by the Datadog Agent when [APM is enabled][1]:
 
 | Metric Name                                           | Type  | Description                                                                                                                     |
 | ----------------------------------------------------- | ----- | -----                                                                                                                           |
-| `datadog.trace_agent.started`                         | Count | Increment by one every time the agent starts.                                                                                   |
+| `datadog.trace_agent.started`                         | Count | Increment by one every time the Agent starts.                                                                                   |
 | `datadog.trace_agent.panic`                           | Gauge | Increment by one on every code panic.                                                                                           |
 | `datadog.trace_agent.heartbeat`                       | Gauge | Increment by one every 10 seconds.                                                                                              |
 | `datadog.trace_agent.heap_alloc`                      | Gauge | Heap allocations as reported by the Go runtime.                                                                                 |
@@ -46,7 +46,7 @@ Find below the list of out of the box metrics send by a Datadog Agent when [APM 
 | `datadog.trace_agent.stats_writer.retries`            | Count | Number of retries on failures to the Datadog API                                                                                |
 | `datadog.trace_agent.stats_writer.splits`             | Count | Number of times a payload was split into multiple ones.                                                                         |
 | `datadog.trace_agent.stats_writer.errors`             | Count | Errors that could not be retried.                                                                                               |
-| `datadog.trace_agent.service_writer.services`         | Count | Number of services flushed                                                                                                      |
+| `datadog.trace_agent.service_writer.services`         | Count | Number of services flushed.                                                                                                      |
 | `datadog.trace_agent.events.max_eps.max_rate`         | Gauge | Same as the Agent config's `max_events_per_second` parameter.                                                                   |
 | `datadog.trace_agent.events.max_eps.reached_max`      | Gauge | Is set to `1` every time `max_events_per_second` is reached, otherwise it's `0`.                                                |
 | `datadog.trace_agent.events.max_eps.current_rate`     | Gauge | Count of APM Events per second received by the Agent                                                                            |

--- a/content/en/agent/faq/agent-apm-metrics.md
+++ b/content/en/agent/faq/agent-apm-metrics.md
@@ -48,8 +48,8 @@ Find below the list of out of the box metrics send by a Datadog Agent when [APM 
 | `datadog.trace_agent.stats_writer.errors`             | Count | Errors that could not be retried.                                                                                               |
 | `datadog.trace_agent.service_writer.services`         | Count | Number of services flushed                                                                                                      |
 | `datadog.trace_agent.events.max_eps.max_rate`         | Gauge | Same as the Agent config's `max_events_per_second` parameter.                                                                   |
-| `datadog.trace_agent.events.max_eps.reached_max`      | Gauge | Increment by one every time `max_events_per_second` was reached.                                                                |
-| `datadog.trace_agent.events.max_eps.current_rate`     | Gauge |                                                                                                                                 |
-| `datadog.trace_agent.events.max_eps.sample_rate`      | Gauge |                                                                                                                                 |
+| `datadog.trace_agent.events.max_eps.reached_max`      | Gauge | Is set to `1` every time `max_events_per_second` is reached, otherwise it's `0`.                                                |
+| `datadog.trace_agent.events.max_eps.current_rate`     | Gauge | Count of APM Events per second received by the Agent                                                                            |
+| `datadog.trace_agent.events.max_eps.sample_rate`      | Gauge | Sample rate applied by the Agent to Events it received                                                                          |
 
 [1]: /tracing/setup

--- a/content/en/agent/faq/agent-apm-metrics.md
+++ b/content/en/agent/faq/agent-apm-metrics.md
@@ -8,26 +8,25 @@ Find below the list of out of the box metrics send by a Datadog Agent when [APM 
 | Metric Name                                           | Type  | Description                                                                                                                     |
 | ----- ----------------------------------------------- | ----- | -----                                                                                                                           |
 | `datadog.trace_agent.started`                         | Count | Increment by one every time the agent starts.                                                                                   |
-| `datadog.trace_agent.panic`                           | Count | Increment by one on every code panic.                                                                                           |
-| `datadog.trace_agent.heartbeat`                       | Count | Increment by one every 10 seconds.                                                                                              |
+| `datadog.trace_agent.panic`                           | Gauge | Increment by one on every code panic.                                                                                           |
+| `datadog.trace_agent.heartbeat`                       | Gauge | Increment by one every 10 seconds.                                                                                              |
 | `datadog.trace_agent.heap_alloc`                      | Gauge | Heap allocations as reported by the Go runtime.                                                                                 |
 | `datadog.trace_agent.cpu_percent`                     | Gauge | CPU usage (in cores), e.g. 50 (half a core), 200 (two cores), 250 (2.5 cores)                                                   |
 | `datadog.trace_agent.presampler_rate`                 | Gauge | If lower than 1, it means payloads are being refused due to high resource usage (cpu or memory).                                |
-| `datadog.trace_agent.receiver.traces_received`        | Gauge | Number of traces received and accepted.                                                                                         |
-| `datadog.trace_agent.receiver.traces_dropped`         | Gauge | Traces dropped due to normalization errors.                                                                                     |
-| `datadog.trace_agent.receiver.traces_filtered`        | Gauge | Traces filtered by ignored resources (as defined in `datadog.yaml` file).                                                       |
-| `datadog.trace_agent.receiver.traces_priority`        | Gauge | Traces processed by priority sampler that have the `priority` tag.                                                              |
+| `datadog.trace_agent.receiver.traces_received`        | Count | Number of traces received and accepted.                                                                                         |
+| `datadog.trace_agent.receiver.traces_dropped`         | Count | Traces dropped due to normalization errors.                                                                                     |
+| `datadog.trace_agent.receiver.traces_filtered`        | Count | Traces filtered by ignored resources (as defined in `datadog.yaml` file).                                                       |
+| `datadog.trace_agent.receiver.traces_priority`        | Count | Traces processed by priority sampler that have the `priority` tag.                                                              |
 | `datadog.trace_agent.receiver.traces_bytes`           | Count | Total bytes of payloads accepted by the Agent.                                                                                  |
 | `datadog.trace_agent.receiver.spans_received`         | Count | Total bytes of payloads received by the Agent.                                                                                  |
 | `datadog.trace_agent.receiver.spans_dropped`          | Count | Total bytes of payloads dropped by the Agent.                                                                                   |
 | `datadog.trace_agent.receiver.spans_filtered`         | Count | Total bytes of payloads filtered by the Agent                                                                                   |
-| `datadog.trace_agent.receiver.services_received`      | Gauge | Services received in `/v0.x/` services endpoints.                                                                               |
-| `datadog.trace_agent.receiver.services_bytes`         | Gauge | Bytes accepted in `/v0.x/` services endpoints.                                                                                  |
+| `datadog.trace_agent.receiver.services_received`      | Count | Services received in `/v0.x/` services endpoints.                                                                               |
+| `datadog.trace_agent.receiver.services_bytes`         | Count | Bytes accepted in `/v0.x/` services endpoints.                                                                                  |
 | `datadog.trace_agent.receiver.events_extracted`       | Count | Total APM events sampled.                                                                                                       |
 | `datadog.trace_agent.receiver.events_sampled`         | Count | Total APM events sampled by the `max_events_per_second` parameter sampler.                                                      |
 | `datadog.trace_agent.receiver.payload_accepted`       | Count | Number of payloads accepted by the Agent.                                                                                       |
 | `datadog.trace_agent.receiver.payload_refused`        | Count | Number of payloads rejected by the receiver because of the sampling.                                                            |
-| `datadog.trace_agent.receiver.out_chan_fill`          | Gauge | Percentage of fill in receiver's out channel.                                                                                   |
 | `datadog.trace_agent.receiver.suicide`                | Count | Number of times the Agent killed itself due to excessive memory use (150% of max_memory).                                       |
 | `datadog.trace_agent.trace_writer.flush_duration`     | Gauge | Time it took to flush a payload to the Datadog API.                                                                             |
 | `datadog.trace_agent.trace_writer.payloads`           | Count | Number of payloads sent.                                                                                                        |
@@ -41,16 +40,16 @@ Find below the list of out of the box metrics send by a Datadog Agent when [APM 
 | `datadog.trace_agent.trace_writer.errors`             | Count | Errors that could not be retried.                                                                                               |
 | `datadog.trace_agent.trace_writer.single_max_size`    | Count | Increment by one when a single trace was flushed because it was bigger than the maximum allowed size by the Datadog API (3.2M). |
 | `datadog.trace_agent.stats_writer.flush_duration`     | Gauge | Time it took to flush a payload to the Datadog API.                                                                             |
-| `datadog.trace_agent.stats_writer.payloads`           | Gauge | Number of payloads sent.                                                                                                        |
-| `datadog.trace_agent.stats_writer.stats_buckets`      | Gauge | Number of stats buckets flushed.                                                                                                |
-| `datadog.trace_agent.stats_writer.bytes`              | Gauge | Number of bytes sent (calculated after Gzip).                                                                                   |
-| `datadog.trace_agent.stats_writer.retries`            | Gauge | Number of retries on failures to the Datadog API                                                                                |
+| `datadog.trace_agent.stats_writer.payloads`           | Count | Number of payloads sent.                                                                                                        |
+| `datadog.trace_agent.stats_writer.stats_buckets`      | Count | Number of stats buckets flushed.                                                                                                |
+| `datadog.trace_agent.stats_writer.bytes`              | Count | Number of bytes sent (calculated after Gzip).                                                                                   |
+| `datadog.trace_agent.stats_writer.retries`            | Count | Number of retries on failures to the Datadog API                                                                                |
 | `datadog.trace_agent.stats_writer.splits`             | Count | Number of times a payload was split into multiple ones.                                                                         |
-| `datadog.trace_agent.stats_writer.errors`             | Gauge | Errors that could not be retried.                                                                                               |
-| `datadog.trace_agent.service_writer.services`         | Gauge | Number of services flushed                                                                                                      |
-| `datadog.trace_agent.events.max_eps.max_rate`         | Rate  | Same as the Agent config's `max_events_per_second` parameter.                                                                   |
-| `datadog.trace_agent.events.max_eps.reached_max`      | Count | Increment by one every time `max_events_per_second` was reached.                                                                |
-| `datadog.trace_agent.events.max_eps.current_rate`     | Rate  |                                                                                                                                 |
-| `datadog.trace_agent.events.max_eps.sample_rate`      | Rate  |                                                                                                                                 |
+| `datadog.trace_agent.stats_writer.errors`             | Count | Errors that could not be retried.                                                                                               |
+| `datadog.trace_agent.service_writer.services`         | Count | Number of services flushed                                                                                                      |
+| `datadog.trace_agent.events.max_eps.max_rate`         | Gauge | Same as the Agent config's `max_events_per_second` parameter.                                                                   |
+| `datadog.trace_agent.events.max_eps.reached_max`      | Gauge | Increment by one every time `max_events_per_second` was reached.                                                                |
+| `datadog.trace_agent.events.max_eps.current_rate`     | Gauge |                                                                                                                                 |
+| `datadog.trace_agent.events.max_eps.sample_rate`      | Gauge |                                                                                                                                 |
 
 [1]: /tracing/setup

--- a/content/en/agent/faq/agent-apm-metrics.md
+++ b/content/en/agent/faq/agent-apm-metrics.md
@@ -1,0 +1,31 @@
+---
+title: APM metrics send by the Datadog Agent
+kind: faq
+---
+
+Find below the list of out of the box metrics send by a Datadog Agent when [APM is enabled][1]:
+
+| Metric Name | Type | Description|
+| ----- | ----- | ----- |
+| `datadog.trace_agent.service_writer.bytes` | Count | |
+| `datadog.trace_agent.service_writer.errors` | Count | |
+| `datadog.trace_agent.service_writer.payloads` | Count | |
+| `datadog.trace_agent.service_writer.retries` | Count| |
+| `datadog.trace_agent.service_writer.services` | Count| |
+| `datadog.trace_agent.stats_writer.bytes` | Count | |
+| `datadog.trace_agent.stats_writer.errors` | Count | |
+| `datadog.trace_agent.stats_writer.payloads` | Count | |
+| `datadog.trace_agent.stats_writer.retries` | Count |
+| `datadog.trace_agent.stats_writer.splits` | Count | |
+| `datadog.trace_agent.stats_writer.stats_buckets` | Count | |
+| `datadog.trace_agent.trace_writer.bytes` | Count | |
+| `datadog.trace_agent.trace_writer.bytes_estimated` | Count | |
+| `datadog.trace_agent.trace_writer.bytes_uncompressed` | Count | |
+| `datadog.trace_agent.trace_writer.errors` | Count | |
+| `datadog.trace_agent.trace_writer.events` | Count | |
+| `datadog.trace_agent.trace_writer.payloads` | Count | |
+| `datadog.trace_agent.trace_writer.retries` | Count | |
+| `datadog.trace_agent.trace_writer.single_max_size` | Count | |
+| `datadog.trace_agent.trace_writer.spans` | Count | |
+| `datadog.trace_agent.trace_writer.traces` | Count | |
+[1]: /tracing/setup

--- a/content/en/agent/faq/agent-apm-metrics.md
+++ b/content/en/agent/faq/agent-apm-metrics.md
@@ -6,7 +6,7 @@ kind: faq
 Find below the list of out of the box metrics send by a Datadog Agent when [APM is enabled][1]:
 
 | Metric Name                                           | Type  | Description                                                                                                                     |
-| ----- ----------------------------------------------- | ----- | -----                                                                                                                           |
+| ----------------------------------------------------- | ----- | -----                                                                                                                           |
 | `datadog.trace_agent.started`                         | Count | Increment by one every time the agent starts.                                                                                   |
 | `datadog.trace_agent.panic`                           | Gauge | Increment by one on every code panic.                                                                                           |
 | `datadog.trace_agent.heartbeat`                       | Gauge | Increment by one every 10 seconds.                                                                                              |

--- a/content/en/agent/faq/agent-apm-metrics.md
+++ b/content/en/agent/faq/agent-apm-metrics.md
@@ -5,27 +5,52 @@ kind: faq
 
 Find below the list of out of the box metrics send by a Datadog Agent when [APM is enabled][1]:
 
-| Metric Name | Type | Description|
-| ----- | ----- | ----- |
-| `datadog.trace_agent.service_writer.bytes` | Count | |
-| `datadog.trace_agent.service_writer.errors` | Count | |
-| `datadog.trace_agent.service_writer.payloads` | Count | |
-| `datadog.trace_agent.service_writer.retries` | Count| |
-| `datadog.trace_agent.service_writer.services` | Count| |
-| `datadog.trace_agent.stats_writer.bytes` | Count | |
-| `datadog.trace_agent.stats_writer.errors` | Count | |
-| `datadog.trace_agent.stats_writer.payloads` | Count | |
-| `datadog.trace_agent.stats_writer.retries` | Count |
-| `datadog.trace_agent.stats_writer.splits` | Count | |
-| `datadog.trace_agent.stats_writer.stats_buckets` | Count | |
-| `datadog.trace_agent.trace_writer.bytes` | Count | |
-| `datadog.trace_agent.trace_writer.bytes_estimated` | Count | |
-| `datadog.trace_agent.trace_writer.bytes_uncompressed` | Count | |
-| `datadog.trace_agent.trace_writer.errors` | Count | |
-| `datadog.trace_agent.trace_writer.events` | Count | |
-| `datadog.trace_agent.trace_writer.payloads` | Count | |
-| `datadog.trace_agent.trace_writer.retries` | Count | |
-| `datadog.trace_agent.trace_writer.single_max_size` | Count | |
-| `datadog.trace_agent.trace_writer.spans` | Count | |
-| `datadog.trace_agent.trace_writer.traces` | Count | |
+| Metric Name                                           | Type  | Description                                                                                                                     |
+| ----- ----------------------------------------------- | ----- | -----                                                                                                                           |
+| `datadog.trace_agent.started`                         | Count | Increment by one every time the agent starts.                                                                                   |
+| `datadog.trace_agent.panic`                           | Count | Increment by one on every code panic.                                                                                           |
+| `datadog.trace_agent.heartbeat`                       | Count | Increment by one every 10 seconds.                                                                                              |
+| `datadog.trace_agent.heap_alloc`                      | Gauge | Heap allocations as reported by the Go runtime.                                                                                 |
+| `datadog.trace_agent.cpu_percent`                     | Gauge | CPU usage (in cores), e.g. 50 (half a core), 200 (two cores), 250 (2.5 cores)                                                   |
+| `datadog.trace_agent.presampler_rate`                 | Gauge | If lower than 1, it means payloads are being refused due to high resource usage (cpu or memory).                                |
+| `datadog.trace_agent.receiver.traces_received`        | Gauge | Number of traces received and accepted.                                                                                         |
+| `datadog.trace_agent.receiver.traces_dropped`         | Gauge | Traces dropped due to normalization errors.                                                                                     |
+| `datadog.trace_agent.receiver.traces_filtered`        | Gauge | Traces filtered by ignored resources (as defined in `datadog.yaml` file).                                                       |
+| `datadog.trace_agent.receiver.traces_priority`        | Gauge | Traces processed by priority sampler that have the `priority` tag.                                                              |
+| `datadog.trace_agent.receiver.traces_bytes`           | Count | Total bytes of payloads accepted by the Agent.                                                                                  |
+| `datadog.trace_agent.receiver.spans_received`         | Count | Total bytes of payloads received by the Agent.                                                                                  |
+| `datadog.trace_agent.receiver.spans_dropped`          | Count | Total bytes of payloads dropped by the Agent.                                                                                   |
+| `datadog.trace_agent.receiver.spans_filtered`         | Count | Total bytes of payloads filtered by the Agent                                                                                   |
+| `datadog.trace_agent.receiver.services_received`      | Gauge | Services received in `/v0.x/` services endpoints.                                                                               |
+| `datadog.trace_agent.receiver.services_bytes`         | Gauge | Bytes accepted in `/v0.x/` services endpoints.                                                                                  |
+| `datadog.trace_agent.receiver.events_extracted`       | Count | Total APM events sampled.                                                                                                       |
+| `datadog.trace_agent.receiver.events_sampled`         | Count | Total APM events sampled by the `max_events_per_second` parameter sampler.                                                      |
+| `datadog.trace_agent.receiver.payload_accepted`       | Count | Number of payloads accepted by the Agent.                                                                                       |
+| `datadog.trace_agent.receiver.payload_refused`        | Count | Number of payloads rejected by the receiver because of the sampling.                                                            |
+| `datadog.trace_agent.receiver.out_chan_fill`          | Gauge | Percentage of fill in receiver's out channel.                                                                                   |
+| `datadog.trace_agent.receiver.suicide`                | Count | Number of times the Agent killed itself due to excessive memory use (150% of max_memory).                                       |
+| `datadog.trace_agent.trace_writer.flush_duration`     | Gauge | Time it took to flush a payload to the Datadog API.                                                                             |
+| `datadog.trace_agent.trace_writer.payloads`           | Count | Number of payloads sent.                                                                                                        |
+| `datadog.trace_agent.trace_writer.traces`             | Count | Number of traces processed.                                                                                                     |
+| `datadog.trace_agent.trace_writer.events`             | Count | Number of events processed.                                                                                                     |
+| `datadog.trace_agent.trace_writer.spans`              | Count | Number of spans processed.                                                                                                      |
+| `datadog.trace_agent.trace_writer.bytes`              | Count | Number of bytes sent (calculated after Gzip).                                                                                   |
+| `datadog.trace_agent.trace_writer.bytes_uncompressed` | Count | Number of bytes sent (calculated before Gzip).                                                                                  |
+| `datadog.trace_agent.trace_writer.bytes_estimated`    | Count | Number of bytes estimated by Agent internal algorithm.                                                                          |
+| `datadog.trace_agent.trace_writer.retries`            | Count | Number of retries on failures to the Datadog API.                                                                               |
+| `datadog.trace_agent.trace_writer.errors`             | Count | Errors that could not be retried.                                                                                               |
+| `datadog.trace_agent.trace_writer.single_max_size`    | Count | Increment by one when a single trace was flushed because it was bigger than the maximum allowed size by the Datadog API (3.2M). |
+| `datadog.trace_agent.stats_writer.flush_duration`     | Gauge | Time it took to flush a payload to the Datadog API.                                                                             |
+| `datadog.trace_agent.stats_writer.payloads`           | Gauge | Number of payloads sent.                                                                                                        |
+| `datadog.trace_agent.stats_writer.stats_buckets`      | Gauge | Number of stats buckets flushed.                                                                                                |
+| `datadog.trace_agent.stats_writer.bytes`              | Gauge | Number of bytes sent (calculated after Gzip).                                                                                   |
+| `datadog.trace_agent.stats_writer.retries`            | Gauge | Number of retries on failures to the Datadog API                                                                                |
+| `datadog.trace_agent.stats_writer.splits`             | Count | Number of times a payload was split into multiple ones.                                                                         |
+| `datadog.trace_agent.stats_writer.errors`             | Gauge | Errors that could not be retried.                                                                                               |
+| `datadog.trace_agent.service_writer.services`         | Gauge | Number of services flushed                                                                                                      |
+| `datadog.trace_agent.events.max_eps.max_rate`         | Rate  | Same as the Agent config's `max_events_per_second` parameter.                                                                   |
+| `datadog.trace_agent.events.max_eps.reached_max`      | Count | Increment by one every time `max_events_per_second` was reached.                                                                |
+| `datadog.trace_agent.events.max_eps.current_rate`     | Rate  |                                                                                                                                 |
+| `datadog.trace_agent.events.max_eps.sample_rate`      | Rate  |                                                                                                                                 |
+
 [1]: /tracing/setup


### PR DESCRIPTION
### What does this PR do?

Adds List of OOTB metrics that are send if APM is enabled for a given Datadog Agent.

### Motivation

Support request

### Preview link

* https://docs-staging.datadoghq.com/gus/trace-agent-metrics/agent/faq/agent-apm-metrics/