### PR TITLE
Upudate PHP tracing docs with DD_SERVICE_NAME config env

### DIFF
--- a/content/en/tracing/setup/php.md
+++ b/content/en/tracing/setup/php.md
@@ -198,12 +198,12 @@ DD_TRACE_DEBUG=true php -S localhost:8888
 | `DD_INTEGRATIONS_DISABLED`           | `null`      | CSV list of disabled extensions; e.g., `curl,mysqli`                        |
 | `DD_PRIORITY_SAMPLING`               | `true`      | Whether to enable priority sampling.                                   |
 | `DD_SAMPLING_RATE`                   | `1.0`       | The sampling rate for the traces. Between `0.0` and `1.0` (default)         |
+| `DD_SERVICE_NAME`                    | ``          | The default app name                                                        |
 | `DD_TRACE_AGENT_PORT`                | `8126`      | The Agent port number                                                       |
-| `DD_TRACE_APP_NAME`                  | ``          | The default app name                                                        |
+| `DD_TRACE_ANALYTICS_ENABLED`         | `false`     | Flag to enable trace analytics for relevant spans in web integrations       |
 | `DD_TRACE_DEBUG`                     | `false`     | Enable [debug mode][15] for the tracer                                      |
 | `DD_TRACE_ENABLED`                   | `true`      | Enable the tracer globally                                                  |
 | `DD_TRACE_GLOBAL_TAGS`               | ``          | Tags to be set on all spans: e.g.: `key1:value1,key2:value2`                |
-| `DD_TRACE_ANALYTICS_ENABLED`         | `false`     | Flag to enable trace analytics for relevant spans in web integrations       |
 | `DD_<INTEGRATION>_ANALYTICS_ENABLED` | `false`     | Flag to enable trace analytics for relevant spans in a specific integration |
 
 ## Further Reading


### PR DESCRIPTION
### What does this PR do?
This PR updates the name of a configuration parameters after it has been renamed in version `0.23.0` of the PHP tracer.

### Preview link
[Preview](https://docs-staging.datadoghq.com/apm/php/service-name/tracing/setup/php/)
