### PR TITLE
PHP docs: CLI, Artisan and new env var

### DIFF
--- a/content/en/tracing/setup/php.md
+++ b/content/en/tracing/setup/php.md
@@ -100,8 +100,8 @@ PHP APM supports the following SAPI's:
 | SAPI           | Support type    |
 |:---------------|:----------------|
 | apache2handler | Fully Supported |
+| cli            | Fully Supported |
 | fpm            | Fully Supported |
-| cli            | _Coming Soon_   |
 
 ### Integrations
 
@@ -109,22 +109,33 @@ PHP APM supports the following SAPI's:
 
 If the web framework that you use is not listed below, you can still see traces for your web requests in the UI. However, some metadata and spans that are very specific to that particular web framework may not display.
 
-| Module         | Versions      | Support Type    |
-|:---------------|:--------------|:----------------|
-| Laravel        | 4.2, 5.x      | Fully Supported |
+| Module         | Versions           | Support Type    |
+|:---------------|:-------------------|:----------------|
+| Laravel        | 4.2, 5.x           | Fully Supported |
+| Lumen          | 5.2+               | Fully Supported |
 | Symfony        | 2.x, 3.3, 3.4, 4.x | Fully Supported |
-| Zend Framework | 1.12          | Fully Supported |
-| CakePHP        | 1.3, 2.8, 3.x | _Coming Soon_   |
-| CodeIgniter    | 2, 3          | _Coming Soon_   |
-| Drupal         |               | _Coming Soon_   |
-| Lumen          | 5.2+          | _Coming Soon_   |
-| Magento        | 2             | _Coming Soon_   |
-| Phalcon        | 1.3, 3.4      | _Coming Soon_   |
-| Slim           | 2, 3          | _Coming Soon_   |
-| Wordpress      |               | _Coming Soon_   |
-| Yii            | 1.1           | _Coming Soon_   |
+| Zend Framework | 1.12               | Fully Supported |
+| CakePHP        | 1.3, 2.8, 3.x      | _Coming Soon_   |
+| CodeIgniter    | 2, 3               | _Coming Soon_   |
+| Drupal         |                    | _Coming Soon_   |
+| Magento        | 2                  | _Coming Soon_   |
+| Phalcon        | 1.3, 3.4           | _Coming Soon_   |
+| Slim           | 2, 3               | _Coming Soon_   |
+| Wordpress      |                    | _Coming Soon_   |
+| Yii            | 1.1                | _Coming Soon_   |
 
 Don’t see your desired frameworks? Datadog is continually adding additional support. Check with the [Datadog team][11] for help.
+
+#### CLI Library Compatibility
+
+Tracing from the CLI SAPI is disabled by default. To enable tracing of PHP CLI scripts, set `DD_TRACE_CLI_ENABLED=true`.
+
+| Module          | Versions           | Support Type    |
+|:----------------|:-------------------|:----------------|
+| Laravel Artisan | 5.x                | Fully Supported |
+| Symfony Console |                    | _Coming Soon_   |
+
+Don’t see your desired CLI library? Datadog is continually adding additional support. Check with the [Datadog team][11] for help.
 
 #### Datastore Compatibility
 
@@ -190,10 +201,13 @@ Set in the command line to start the server.
 DD_TRACE_DEBUG=true php -S localhost:8888
 ```
 
+### Environment Variable Configuration
+
 | Env variable                         | Default     | Note                                                                        |
 |:-------------------------------------|:------------|:----------------------------------------------------------------------------|
 | `DD_AGENT_HOST`                      | `localhost` | The Agent host name                                                         |
 | `DD_AUTOFINISH_SPANS`                | `false`     | Whether spans are automatically finished when the tracer is flushed         |
+| `DD_TRACE_CLI_ENABLED`               | `false`     | Enable tracing of PHP scripts from the CLI                                  |
 | `DD_DISTRIBUTED_TRACING`             | `true`      | Whether to enable [distributed tracing][14]                                 |
 | `DD_INTEGRATIONS_DISABLED`           | `null`      | CSV list of disabled extensions; e.g., `curl,mysqli`                        |
 | `DD_PRIORITY_SAMPLING`               | `true`      | Whether to enable priority sampling.                                   |


### PR DESCRIPTION
### What does this PR do?

This PR updates the PHP docs to mention tracing support for CLI, Artisan, and a new env var to enable CLI tracing.

### Motivation

To sync with [today's release of the PHP tracer](https://github.com/DataDog/dd-trace-php/releases/tag/0.23.0).

### Preview link

[Preview link](https://docs-staging.datadoghq.com/sammyk/php-docs-lumen-cli-support/tracing/setup/php/#compatibility)

### Additional Notes

N/A
