### PR TITLE
Moving dashboard back-up to libraries page

### DIFF
--- a/content/en/developers/libraries.md
+++ b/content/en/developers/libraries.md
@@ -25,139 +25,165 @@ The following table lists Datadog-official and community contributed [Trace][2] 
 
 Using Datadog [APIs][3] it's possible to write a script to backup your Dashboard definitions as code. See the following projects as examples of how these backups can be accomplished:
 
-* https://github.com/brightcove/dog-watcher
-* https://github.com/Shopify/doggy
-* https://github.com/grosser/kennel
+| Language   | Library                                                  | Author          |
+| ---        | ---                                                      | ---             |
+| JavaScript | [dog-watcher][4] | [Brightcove][5] |
+| Ruby       | [doggy][6]                | [Shopify][7]    |
+| Ruby       | [kennel][8]              | [Zendesk][9]    |
 
-Special thanks to [Brightcove][4], [Shopify][5], and [Zendesk][6] for sharing these projects!
+
+### Managing Monitors
+
+There are multiple community projects available to maintain, manage, or backup monitors by using the Datadog [API][3]:
+
+| Language  | Library                                                                     | Author                                              |
+| ---       | ---                                                                         | ---                                                 |
+| Python    | [DogPush][10]                            | [TrueAccord][11]         |
+| Ruby      | [barkdog][12]                        | [codenize-tools][13] |
+| Ruby      | [interferon][14]                          | [Airnb][15]                  |
+| Ruby      | [dogwatch][16]                              | [Rapid7][17]                 |
+| Terraform | [Terraform][18] | [Terraform][19]              |
 
 ## Community Integrations
 
 ### Ansible
-In addition to the official Ansible integration, the [monitoring section][7] of the [ansible-modules-extras][8] repository contains modules that interact with Datadog.
+In addition to the official Ansible integration, the [monitoring section][20] of the [ansible-modules-extras][21] repository contains modules that interact with Datadog.
 
 ### Aptible
-Enclave delivers your metrics to a Datadog account. [Consult the dedicated Aptible help center to learn how][9].
+Enclave delivers your metrics to a Datadog account. [Consult the dedicated Aptible help center to learn how][22].
 
 ### Auth0
-[This extension][10] takes your Auth0 logs and ships them to Datadog.
+[This extension][23] takes your Auth0 logs and ships them to Datadog.
 
 ### CLI Management
-A [set of tools][11] to backup/restore dashboards and monitors, and configure users via a command line interface.
+A [set of tools][24] to backup/restore dashboards and monitors, and configure users via a command line interface.
 
 ### Consul
-Publish consul service counts into Datadog via [DogStatsD][1] with [this library][12].
+Publish consul service counts into Datadog via [DogStatsD][1] with [this library][25].
 
 ### Dogscaler
-Scale up auto-scale groups based on the results of a Datadog query with [Dogscaler][13].
+Scale up auto-scale groups based on the results of a Datadog query with [Dogscaler][26].
 
 ### Dynatrace
-This [plugin][14] sends any Dynatrace measure from a chart to Datadog.
+This [plugin][27] sends any Dynatrace measure from a chart to Datadog.
 
 ### FreeSwitch
-This is for a [FreeSwitch ESL][15] application to export statistics to Datadog using the DogStatsD API and is written by [WiMacTel][16].
+This is for a [FreeSwitch ESL][28] application to export statistics to Datadog using the DogStatsD API and is written by [WiMacTel][29].
 
 ### Google Analytics
-You can get data into Datadog from Google Analytics via the Datadog API with [this library][17] from [Bithaus][18].
+You can get data into Datadog from Google Analytics via the Datadog API with [this library][30] from [Bithaus][31].
 
 ### Heroku
-Heroku emits dyno metrics via logs. To convert these logs into metrics and send them to Datadog, use one of the following log drains. To send your Heroku logs to Datadog, see [the documentation][19].
+Heroku emits dyno metrics via logs. To convert these logs into metrics and send them to Datadog, use one of the following log drains. To send your Heroku logs to Datadog, see [the documentation][32].
 
-  * [Heroku Datadog Log Drain][20] written in Nodejs by [Oz][21].
-  * [Heroku Datadog Log Drain][22] written in Go by [Apiary][23].
+  * [Heroku Datadog Log Drain][33] written in Nodejs by [Oz][34].
+  * [Heroku Datadog Log Drain][35] written in Go by [Apiary][36].
 
 
 ### Jira
-A [tool][24] to poll data from Jira and upload it as metrics to Datadog.
+A [tool][37] to poll data from Jira and upload it as metrics to Datadog.
 
 ### Logstash Output
-  * [Logstash Output for Datadog][25]
-  * [Logstash Output for DogStatsD][26]
+  * [Logstash Output for Datadog][38]
+  * [Logstash Output for DogStatsD][39]
 
 ### Moogsoft
-A Moogsoft [listener][27] that ingests Datadog notifications.
+A Moogsoft [listener][40] that ingests Datadog notifications.
 
 ### NGINX LUA
-  * Emit [custom metrics][28] directly from NGINX configurations using the [nginx_lua_datadog][29] module in your LUA scripts.
-  * [lua-resty-dogstatsd][30] is an extension developed by  [mediba inc][31], which enables emiting metrics, events, and service checks to [DogStatsD][1] protocol. lua-resty-dogstatsd is released as GPLv3 and relies on the nginx cosocket API.
+  * Emit [custom metrics][41] directly from NGINX configurations using the [nginx_lua_datadog][42] module in your LUA scripts.
+  * [lua-resty-dogstatsd][43] is an extension developed by  [mediba inc][44], which enables emiting metrics, events, and service checks to [DogStatsD][1] protocol. lua-resty-dogstatsd is released as GPLv3 and relies on the nginx cosocket API.
 
 ### OpenVPN
-  * Send OpenVPN [bandwidth usage][32] and the count of active connections to Datadog.
-  * Send OpenVPN [licensing information][33] to Datadog.
+  * Send OpenVPN [bandwidth usage][45] and the count of active connections to Datadog.
+  * Send OpenVPN [licensing information][46] to Datadog.
 
 ### Phusion Passenger
-Send health metrics from Phusion's Passenger server using the [passenger-datadog-monitor][34] written by [Stevenson Jean-Pierre][35]
+Send health metrics from Phusion's Passenger server using the [passenger-datadog-monitor][47] written by [Stevenson Jean-Pierre][48]
 
 ### Pid-stats
-This [library][36] allows you to generate process information from StatsD, given pid files. It was created by [GitterHQ][37].
+This [library][49] allows you to generate process information from StatsD, given pid files. It was created by [GitterHQ][50].
 
 ### Saltstack
-  * [Datadog Saltstack Formula][38]
-  * [Datadog Saltstack][39] written by [Luca Cipriani][40].
+  * [Datadog Saltstack Formula][51]
+  * [Datadog Saltstack][52] written by [Luca Cipriani][53].
 
 ### Sensu
-Use these Sensu [handlers][41] to automatically send both metrics and events to Datadog.
+Use these Sensu [handlers][54] to automatically send both metrics and events to Datadog.
 
 ### StackStorm
 
-This StackStorm Datadog [integration pack][42] supplies action integration for Datadog.
+This StackStorm Datadog [integration pack][55] supplies action integration for Datadog.
 
 ### Winston
-A Winston Datadog [transport][43].
+A Winston Datadog [transport][56].
 
 ## Community Agent Ports
 
 ### FreeBSD
-  * [FreeBSD dd-agent port][44]
+  * [FreeBSD dd-agent port][57]
 
 ### NixOS
-  * [dd-agent nixpkg][45]
+  * [dd-agent nixpkg][58]
 
-If you've written a Datadog library and would like to add it to this page, send an email to [code@datadoghq.com][46].
+If you've written a Datadog library and would like to add it to this page, send an email to [code@datadoghq.com][59].
 
 [1]: /developers/dogstatsd
 [2]: /tracing
 [3]: /api
-[4]: https://www.brightcove.com
-[5]: https://www.shopify.com
-[6]: https://www.zendesk.com
-[7]: https://docs.ansible.com/ansible/list_of_monitoring_modules.html
-[8]: https://github.com/ansible/ansible-modules-extras
-[9]: https://www.aptible.com/documentation/enclave/reference/metrics/metric-drains/datadog.html
-[10]: https://github.com/BetaProjectWave/auth0-logs-to-datadog
-[11]: https://github.com/keirans/datadog-management
-[12]: https://github.com/zendesk/consul2dogstats
-[13]: https://github.com/cvent/dogscaler
-[14]: https://github.com/Dynatrace/Dynatrace-AppMon-Datadog-Plugin
-[15]: https://github.com/wimactel/FreeSwitch-DataDog-Metrics
-[16]: https://github.com/wimactel
-[17]: https://github.com/bithauschile/datadog-ga
-[18]: https://blog.bithaus.cl/2016/04/20/realtime-google-analytics-metrics-in-datadog
-[19]: /logs/guide/collect-heroku-logs
-[20]: https://github.com/ozinc/heroku-datadog-drain
-[21]: https://corp.oz.com
-[22]: https://github.com/apiaryio/heroku-datadog-drain-golang
-[23]: https://apiary.io
-[24]: https://github.com/evernote/jiradog
-[25]: https://www.elastic.co/guide/en/logstash/current/plugins-outputs-datadog.html
-[26]: https://github.com/brigade/logstash-output-dogstatsd
-[27]: https://docs.moogsoft.com/display/060102/Datadog+Solution+Pak
-[28]: /developers/metrics/custom_metrics
-[29]: https://github.com/simplifi/ngx_lua_datadog
-[30]: https://github.com/mediba-system/lua-resty-dogstatsd
-[31]: http://www.mediba.jp
-[32]: https://github.com/byronwolfman/dd-openvpn
-[33]: https://github.com/denniswebb/datadog-openvpn
-[34]: https://github.com/Sjeanpierre/passenger-datadog-monitor
-[35]: https://github.com/Sjeanpierre
-[36]: https://github.com/gitterHQ/pid-stats
-[37]: https://github.com/gitterHQ
-[38]: https://github.com/DataDog/datadog-formula
-[39]: https://gist.github.com/mastrolinux/6175280
-[40]: https://gist.github.com/mastrolinux
-[41]: https://github.com/sensu-plugins/sensu-plugins-datadog
-[42]: https://github.com/StackStorm-Exchange/stackstorm-datadog
-[43]: https://github.com/sparkida/winston-datadog
-[44]: https://github.com/urosgruber/dd-agent-FreeBSD
-[45]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/tools/networking/dd-agent
-[46]: mailto:code@datadoghq.com
+[4]: https://github.com/brightcove/dog-watcher
+[5]: https://www.brightcove.com
+[6]: https://github.com/Shopify/doggy
+[7]: https://www.shopify.com
+[8]: https://github.com/grosser/kennel
+[9]: https://www.zendesk.com
+[10]: https://github.com/trueaccord/DogPush
+[11]: https://github.com/trueaccord
+[12]: https://github.com/codenize-tools/barkdog
+[13]: https://github.com/codenize-tools
+[14]: https://github.com/airbnb/interferon
+[15]: https://github.com/airbnb
+[16]: https://github.com/rapid7/dogwatch
+[17]: https://github.com/rapid7
+[18]: https://www.terraform.io/docs/providers/datadog/r/monitor.html
+[19]: https://www.terraform.io
+[20]: https://docs.ansible.com/ansible/list_of_monitoring_modules.html
+[21]: https://github.com/ansible/ansible-modules-extras
+[22]: https://www.aptible.com/documentation/enclave/reference/metrics/metric-drains/datadog.html
+[23]: https://github.com/BetaProjectWave/auth0-logs-to-datadog
+[24]: https://github.com/keirans/datadog-management
+[25]: https://github.com/zendesk/consul2dogstats
+[26]: https://github.com/cvent/dogscaler
+[27]: https://github.com/Dynatrace/Dynatrace-AppMon-Datadog-Plugin
+[28]: https://github.com/wimactel/FreeSwitch-DataDog-Metrics
+[29]: https://github.com/wimactel
+[30]: https://github.com/bithauschile/datadog-ga
+[31]: https://blog.bithaus.cl/2016/04/20/realtime-google-analytics-metrics-in-datadog
+[32]: /logs/guide/collect-heroku-logs
+[33]: https://github.com/ozinc/heroku-datadog-drain
+[34]: https://corp.oz.com
+[35]: https://github.com/apiaryio/heroku-datadog-drain-golang
+[36]: https://apiary.io
+[37]: https://github.com/evernote/jiradog
+[38]: https://www.elastic.co/guide/en/logstash/current/plugins-outputs-datadog.html
+[39]: https://github.com/brigade/logstash-output-dogstatsd
+[40]: https://docs.moogsoft.com/display/060102/Datadog+Solution+Pak
+[41]: /developers/metrics/custom_metrics
+[42]: https://github.com/simplifi/ngx_lua_datadog
+[43]: https://github.com/mediba-system/lua-resty-dogstatsd
+[44]: http://www.mediba.jp
+[45]: https://github.com/byronwolfman/dd-openvpn
+[46]: https://github.com/denniswebb/datadog-openvpn
+[47]: https://github.com/Sjeanpierre/passenger-datadog-monitor
+[48]: https://github.com/Sjeanpierre
+[49]: https://github.com/gitterHQ/pid-stats
+[50]: https://github.com/gitterHQ
+[51]: https://github.com/DataDog/datadog-formula
+[52]: https://gist.github.com/mastrolinux/6175280
+[53]: https://gist.github.com/mastrolinux
+[54]: https://github.com/sensu-plugins/sensu-plugins-datadog
+[55]: https://github.com/StackStorm-Exchange/stackstorm-datadog
+[56]: https://github.com/sparkida/winston-datadog
+[57]: https://github.com/urosgruber/dd-agent-FreeBSD
+[58]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/tools/networking/dd-agent
+[59]: mailto:code@datadoghq.com

--- a/content/en/developers/libraries.md
+++ b/content/en/developers/libraries.md
@@ -23,7 +23,7 @@ The following table lists Datadog-official and community contributed [Trace][2] 
 
 ### Dashboards Backup
 
-Using Datadog [APIs][3] it's possible to write a script to backup your Dashboard definitions as code. See the following projects as examples of how these backups can be accomplished:
+Using Datadog [APIs][3], it's possible to write a script to backup your Dashboard definitions as code. See the following projects as examples of how these backups can be accomplished:
 
 | Language   | Library          | Author          |
 | ---        | ---              | ---             |
@@ -34,7 +34,7 @@ Using Datadog [APIs][3] it's possible to write a script to backup your Dashboard
 
 ### Managing Monitors
 
-There are multiple community projects available to maintain, manage, or backup monitors by using the Datadog [API][3]:
+There are multiple community projects available to maintain, manage, or backup monitors using the Datadog [API][3]:
 
 | Language  | Library          | Author               |
 | ---       | ---              | ---                  |

--- a/content/en/developers/libraries.md
+++ b/content/en/developers/libraries.md
@@ -25,24 +25,24 @@ The following table lists Datadog-official and community contributed [Trace][2] 
 
 Using Datadog [APIs][3] it's possible to write a script to backup your Dashboard definitions as code. See the following projects as examples of how these backups can be accomplished:
 
-| Language   | Library                                                  | Author          |
-| ---        | ---                                                      | ---             |
+| Language   | Library          | Author          |
+| ---        | ---              | ---             |
 | JavaScript | [dog-watcher][4] | [Brightcove][5] |
-| Ruby       | [doggy][6]                | [Shopify][7]    |
-| Ruby       | [kennel][8]              | [Zendesk][9]    |
+| Ruby       | [doggy][6]       | [Shopify][7]    |
+| Ruby       | [kennel][8]      | [Zendesk][9]    |
 
 
 ### Managing Monitors
 
 There are multiple community projects available to maintain, manage, or backup monitors by using the Datadog [API][3]:
 
-| Language  | Library                                                                     | Author                                              |
-| ---       | ---                                                                         | ---                                                 |
-| Python    | [DogPush][10]                            | [TrueAccord][11]         |
-| Ruby      | [barkdog][12]                        | [codenize-tools][13] |
-| Ruby      | [interferon][14]                          | [Airnb][15]                  |
-| Ruby      | [dogwatch][16]                              | [Rapid7][17]                 |
-| Terraform | [Terraform][18] | [Terraform][19]              |
+| Language  | Library          | Author               |
+| ---       | ---              | ---                  |
+| Python    | [DogPush][10]    | [TrueAccord][11]     |
+| Ruby      | [barkdog][12]    | [codenize-tools][13] |
+| Ruby      | [interferon][14] | [Airnb][15]          |
+| Ruby      | [dogwatch][16]   | [Rapid7][17]         |
+| Terraform | [Terraform][18]  | [Terraform][19]      |
 
 ## Community Integrations
 

--- a/content/en/developers/libraries.md
+++ b/content/en/developers/libraries.md
@@ -19,129 +19,145 @@ The following table lists Datadog-official and community contributed [Trace][2] 
 
 {{< tracing-libraries-table >}}
 
+## Datadog Client Community Libraries
+
+### Dashboards Backup
+
+Using Datadog [APIs][3] it's possible to write a script to backup your Dashboard definitions as code. See the following projects as examples of how these backups can be accomplished:
+
+* https://github.com/brightcove/dog-watcher
+* https://github.com/Shopify/doggy
+* https://github.com/grosser/kennel
+
+Special thanks to [Brightcove][4], [Shopify][5], and [Zendesk][6] for sharing these projects!
+
 ## Community Integrations
 
 ### Ansible
-In addition to the official Ansible integration, the [monitoring section][3] of the [ansible-modules-extras][4] repository contains modules that interact with Datadog.
+In addition to the official Ansible integration, the [monitoring section][7] of the [ansible-modules-extras][8] repository contains modules that interact with Datadog.
 
 ### Aptible
-Enclave delivers your metrics to a Datadog account. [Consult the dedicated Aptible help center to learn how][5].
+Enclave delivers your metrics to a Datadog account. [Consult the dedicated Aptible help center to learn how][9].
 
 ### Auth0
-[This extension][6] takes your Auth0 logs and ships them to Datadog.
+[This extension][10] takes your Auth0 logs and ships them to Datadog.
 
 ### CLI Management
-A [set of tools][7] to backup/restore dashboards and monitors, and configure users via a command line interface.
+A [set of tools][11] to backup/restore dashboards and monitors, and configure users via a command line interface.
 
 ### Consul
-Publish consul service counts into Datadog via [DogStatsD][1] with [this library][8].
+Publish consul service counts into Datadog via [DogStatsD][1] with [this library][12].
 
 ### Dogscaler
-Scale up auto-scale groups based on the results of a Datadog query with [Dogscaler][9].
+Scale up auto-scale groups based on the results of a Datadog query with [Dogscaler][13].
 
 ### Dynatrace
-This [plugin][10] sends any Dynatrace measure from a chart to Datadog.
+This [plugin][14] sends any Dynatrace measure from a chart to Datadog.
 
 ### FreeSwitch
-This is for a [FreeSwitch ESL][11] application to export statistics to Datadog using the DogStatsD API and is written by [WiMacTel][12].
+This is for a [FreeSwitch ESL][15] application to export statistics to Datadog using the DogStatsD API and is written by [WiMacTel][16].
 
 ### Google Analytics
-You can get data into Datadog from Google Analytics via the Datadog API with [this library][13] from [Bithaus][14].
+You can get data into Datadog from Google Analytics via the Datadog API with [this library][17] from [Bithaus][18].
 
 ### Heroku
-Heroku emits dyno metrics via logs. To convert these logs into metrics and send them to Datadog, use one of the following log drains. To send your Heroku logs to Datadog, see [the documentation][41].
+Heroku emits dyno metrics via logs. To convert these logs into metrics and send them to Datadog, use one of the following log drains. To send your Heroku logs to Datadog, see [the documentation][19].
 
-  * [Heroku Datadog Log Drain][37] written in Nodejs by [Oz][38].
-  * [Heroku Datadog Log Drain][39] written in Go by [Apiary][40].
+  * [Heroku Datadog Log Drain][20] written in Nodejs by [Oz][21].
+  * [Heroku Datadog Log Drain][22] written in Go by [Apiary][23].
 
 
 ### Jira
-A [tool][42] to poll data from Jira and upload it as metrics to Datadog.
+A [tool][24] to poll data from Jira and upload it as metrics to Datadog.
 
 ### Logstash Output
-  * [Logstash Output for Datadog][15]
-  * [Logstash Output for DogStatsD][16]
+  * [Logstash Output for Datadog][25]
+  * [Logstash Output for DogStatsD][26]
 
 ### Moogsoft
-A Moogsoft [listener][17] that ingests Datadog notifications.
+A Moogsoft [listener][27] that ingests Datadog notifications.
 
 ### NGINX LUA
-  * Emit [custom metrics][18] directly from NGINX configurations using the [nginx_lua_datadog][19] module in your LUA scripts.
-  * [lua-resty-dogstatsd][20] is an extension developed by  [mediba inc][21], which enables emiting metrics, events, and service checks to [DogStatsD][1] protocol. lua-resty-dogstatsd is released as GPLv3 and relies on the nginx cosocket API.
+  * Emit [custom metrics][28] directly from NGINX configurations using the [nginx_lua_datadog][29] module in your LUA scripts.
+  * [lua-resty-dogstatsd][30] is an extension developed by  [mediba inc][31], which enables emiting metrics, events, and service checks to [DogStatsD][1] protocol. lua-resty-dogstatsd is released as GPLv3 and relies on the nginx cosocket API.
 
 ### OpenVPN
-  * Send OpenVPN [bandwidth usage][22] and the count of active connections to Datadog.
-  * Send OpenVPN [licensing information][23] to Datadog.
+  * Send OpenVPN [bandwidth usage][32] and the count of active connections to Datadog.
+  * Send OpenVPN [licensing information][33] to Datadog.
 
 ### Phusion Passenger
-Send health metrics from Phusion's Passenger server using the [passenger-datadog-monitor][24] written by [Stevenson Jean-Pierre][25]
+Send health metrics from Phusion's Passenger server using the [passenger-datadog-monitor][34] written by [Stevenson Jean-Pierre][35]
 
 ### Pid-stats
-This [library][26] allows you to generate process information from StatsD, given pid files. It was created by [GitterHQ][27].
+This [library][36] allows you to generate process information from StatsD, given pid files. It was created by [GitterHQ][37].
 
 ### Saltstack
-  * [Datadog Saltstack Formula][28]
-  * [Datadog Saltstack][29] written by [Luca Cipriani][30].
+  * [Datadog Saltstack Formula][38]
+  * [Datadog Saltstack][39] written by [Luca Cipriani][40].
 
 ### Sensu
-Use these Sensu [handlers][31] to automatically send both metrics and events to Datadog.
+Use these Sensu [handlers][41] to automatically send both metrics and events to Datadog.
 
 ### StackStorm
 
-This StackStorm Datadog [integration pack][32] supplies action integration for Datadog.
+This StackStorm Datadog [integration pack][42] supplies action integration for Datadog.
 
 ### Winston
-A Winston Datadog [transport][33].
+A Winston Datadog [transport][43].
 
 ## Community Agent Ports
 
 ### FreeBSD
-  * [FreeBSD dd-agent port][34]
+  * [FreeBSD dd-agent port][44]
 
 ### NixOS
-  * [dd-agent nixpkg][35]
+  * [dd-agent nixpkg][45]
 
-If you've written a Datadog library and would like to add it to this page, send an email to [code@datadoghq.com][36].
+If you've written a Datadog library and would like to add it to this page, send an email to [code@datadoghq.com][46].
 
 [1]: /developers/dogstatsd
 [2]: /tracing
-[3]: https://docs.ansible.com/ansible/list_of_monitoring_modules.html
-[4]: https://github.com/ansible/ansible-modules-extras
-[5]: https://www.aptible.com/documentation/enclave/reference/metrics/metric-drains/datadog.html
-[6]: https://github.com/BetaProjectWave/auth0-logs-to-datadog
-[7]: https://github.com/keirans/datadog-management
-[8]: https://github.com/zendesk/consul2dogstats
-[9]: https://github.com/cvent/dogscaler
-[10]: https://github.com/Dynatrace/Dynatrace-AppMon-Datadog-Plugin
-[11]: https://github.com/wimactel/FreeSwitch-DataDog-Metrics
-[12]: https://github.com/wimactel
-[13]: https://github.com/bithauschile/datadog-ga
-[14]: https://blog.bithaus.cl/2016/04/20/realtime-google-analytics-metrics-in-datadog
-[15]: https://www.elastic.co/guide/en/logstash/current/plugins-outputs-datadog.html
-[16]: https://github.com/brigade/logstash-output-dogstatsd
-[17]: https://docs.moogsoft.com/display/060102/Datadog+Solution+Pak
-[18]: /developers/metrics/custom_metrics
-[19]: https://github.com/simplifi/ngx_lua_datadog
-[20]: https://github.com/mediba-system/lua-resty-dogstatsd
-[21]: http://www.mediba.jp
-[22]: https://github.com/byronwolfman/dd-openvpn
-[23]: https://github.com/denniswebb/datadog-openvpn
-[24]: https://github.com/Sjeanpierre/passenger-datadog-monitor
-[25]: https://github.com/Sjeanpierre
-[26]: https://github.com/gitterHQ/pid-stats
-[27]: https://github.com/gitterHQ
-[28]: https://github.com/DataDog/datadog-formula
-[29]: https://gist.github.com/mastrolinux/6175280
-[30]: https://gist.github.com/mastrolinux
-[31]: https://github.com/sensu-plugins/sensu-plugins-datadog
-[32]: https://github.com/StackStorm-Exchange/stackstorm-datadog
-[33]: https://github.com/sparkida/winston-datadog
-[34]: https://github.com/urosgruber/dd-agent-FreeBSD
-[35]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/tools/networking/dd-agent
-[36]: mailto:code@datadoghq.com
-[37]: https://github.com/ozinc/heroku-datadog-drain
-[38]: https://corp.oz.com/
-[39]: https://github.com/apiaryio/heroku-datadog-drain-golang
-[40]: https://apiary.io/
-[41]: /logs/guide/collect-heroku-logs
-[42]: https://github.com/evernote/jiradog
+[3]: /api
+[4]: https://www.brightcove.com
+[5]: https://www.shopify.com
+[6]: https://www.zendesk.com
+[7]: https://docs.ansible.com/ansible/list_of_monitoring_modules.html
+[8]: https://github.com/ansible/ansible-modules-extras
+[9]: https://www.aptible.com/documentation/enclave/reference/metrics/metric-drains/datadog.html
+[10]: https://github.com/BetaProjectWave/auth0-logs-to-datadog
+[11]: https://github.com/keirans/datadog-management
+[12]: https://github.com/zendesk/consul2dogstats
+[13]: https://github.com/cvent/dogscaler
+[14]: https://github.com/Dynatrace/Dynatrace-AppMon-Datadog-Plugin
+[15]: https://github.com/wimactel/FreeSwitch-DataDog-Metrics
+[16]: https://github.com/wimactel
+[17]: https://github.com/bithauschile/datadog-ga
+[18]: https://blog.bithaus.cl/2016/04/20/realtime-google-analytics-metrics-in-datadog
+[19]: /logs/guide/collect-heroku-logs
+[20]: https://github.com/ozinc/heroku-datadog-drain
+[21]: https://corp.oz.com
+[22]: https://github.com/apiaryio/heroku-datadog-drain-golang
+[23]: https://apiary.io
+[24]: https://github.com/evernote/jiradog
+[25]: https://www.elastic.co/guide/en/logstash/current/plugins-outputs-datadog.html
+[26]: https://github.com/brigade/logstash-output-dogstatsd
+[27]: https://docs.moogsoft.com/display/060102/Datadog+Solution+Pak
+[28]: /developers/metrics/custom_metrics
+[29]: https://github.com/simplifi/ngx_lua_datadog
+[30]: https://github.com/mediba-system/lua-resty-dogstatsd
+[31]: http://www.mediba.jp
+[32]: https://github.com/byronwolfman/dd-openvpn
+[33]: https://github.com/denniswebb/datadog-openvpn
+[34]: https://github.com/Sjeanpierre/passenger-datadog-monitor
+[35]: https://github.com/Sjeanpierre
+[36]: https://github.com/gitterHQ/pid-stats
+[37]: https://github.com/gitterHQ
+[38]: https://github.com/DataDog/datadog-formula
+[39]: https://gist.github.com/mastrolinux/6175280
+[40]: https://gist.github.com/mastrolinux
+[41]: https://github.com/sensu-plugins/sensu-plugins-datadog
+[42]: https://github.com/StackStorm-Exchange/stackstorm-datadog
+[43]: https://github.com/sparkida/winston-datadog
+[44]: https://github.com/urosgruber/dd-agent-FreeBSD
+[45]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/tools/networking/dd-agent
+[46]: mailto:code@datadoghq.com

--- a/content/en/graphing/dashboards/screenboard.md
+++ b/content/en/graphing/dashboards/screenboard.md
@@ -13,7 +13,7 @@ further_reading:
   text: "Discover all available Widgets for your Dashboard"
 ---
 
-## Change Screenboard name 
+## Change Screenboard name
 
 1. Click on Edit Board at the top of the Screenboard
     {{< img src="graphing/dashboards/screenboard/screenboard_name.png" alt="Screenboard name" responsive="true" style="width:75%;">}}
@@ -28,7 +28,7 @@ further_reading:
 
 **Click "Yes" on the confirmation window to make the Screenboard read-only**
 
-Only [account Administrators][1] and the Screenboard creator can activate read-only mode for a Screenboard.  
+Only [account Administrators][1] and the Screenboard creator can activate read-only mode for a Screenboard.
 Any user in the organization, regardless of administrator privileges, can sign up to receive change notifications for a particular Screenboard.
 
 If a user decides to track changes for a Screenboard, the following Screenboard changes are reported to the user through an event in the [event stream][2]:
@@ -42,12 +42,12 @@ If a user decides to track changes for a Screenboard, the following Screenboard 
 
 4. Screenboard deletion
 
-In order to prevent the above listed changes, an administrator (account admins + Screenboard creator) can activate read-only view disabling all non-administrators user edits to any tiles or text in the Screenboard, as well as Screenboard deletion.  
+In order to prevent the above listed changes, an administrator (account admins + Screenboard creator) can activate read-only view disabling all non-administrators user edits to any tiles or text in the Screenboard, as well as Screenboard deletion.
 Even in read-only mode, non-administrator users can still clone the Screenboard, rearrange the tiles, snapshot each tile, and view the tile in full-screen. Any tile rearrangement by a non-administrator user do not persist if the Screenboard is set to read-only.
 
 ## Global Time Selector
 
-Screenboards feature a global time option, which sets the same timeframe for all time-based widgets on the same screenboard. The global time selector can be set to a moving window in the past ("The Past Hour," "The Past 3 Months," etc.) or to a fixed period between two dates. If a moving window is chosen, all widgets update their timeframes every few milliseconds to move along with that window. 
+Screenboards feature a global time option, which sets the same timeframe for all time-based widgets on the same screenboard. The global time selector can be set to a moving window in the past ("The Past Hour," "The Past 3 Months," etc.) or to a fixed period between two dates. If a moving window is chosen, all widgets update their timeframes every few milliseconds to move along with that window.
 
 {{< img src="graphing/dashboards/screenboard/global_time_screenboard.png" alt="Global Time Selector" responsive="true" style="width:50%;">}}
 
@@ -82,23 +82,9 @@ This feature can be enabled by following these simple steps:
 2. Select **Notifications** option and enable the notifications:
     {{< img src="graphing/dashboards/faq/notifications_pop_up.png" alt=" notifications pop up" responsive="true" style="width:40%;">}}
 
-## Backup my Screenboard
-
-Using Datadog [APIs][3] it's possible to write a script to backup your Screenboard definitions as code. See the following projects as examples of how these backups can be accomplished:
-
-* https://github.com/brightcove/dog-watcher
-* https://github.com/Shopify/doggy
-* https://github.com/grosser/kennel
-
-Special thanks to [Brightcove][4], [Shopify][5], and [Zendesk][6] for sharing these projects!
-
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /account_management/team/#datadog-user-roles
 [2]: /graphing/event_stream
-[3]: /api
-[4]: https://www.brightcove.com
-[5]: https://www.shopify.com
-[6]: https://www.zendesk.com

--- a/content/en/graphing/dashboards/timeboard.md
+++ b/content/en/graphing/dashboards/timeboard.md
@@ -68,7 +68,7 @@ If a user decides to track changes for a Timeboard, the following Timeboard chan
 3. Timeboard cloning
 4. Timeboard deletion
 
-In order to prevent the above listed changes, an administrator (account administrators or Timeboard creator) can activate read-only view disabling all non-administrator user edits to any tiles or text in the Timeboard, as well as Timeboard deletion.  
+In order to prevent the above listed changes, an administrator (account administrators or Timeboard creator) can activate read-only view disabling all non-administrator user edits to any tiles or text in the Timeboard, as well as Timeboard deletion.
 
 Even in read-only mode, non-administrator users can still clone the Timeboard, rearrange the tiles, snapshot each tile, and view the tile in full screen. Any tile rearrangement by a non-administrator user does not persist if the Timeboard is set to read-only.
 
@@ -92,23 +92,9 @@ This feature can be enabled by following these steps:
 2. Select **Notifications** option and enable the notifications:
     {{< img src="graphing/dashboards/faq/notifications_pop_up.png" alt=" notifications pop up" responsive="true" style="width:30%;">}}
 
-## Backup my Timeboard
-
-Using Datadog [APIs][3], it's possible to write a script to backup your Timeboard definitions as code. See the following projects as examples of how these backups can be accomplished:
-
-* https://github.com/brightcove/dog-watcher
-* https://github.com/Shopify/doggy
-* https://github.com/grosser/kennel
-
-Special thanks to [Brightcove][4], [Shopify][5], and [Zendesk][6] for sharing these projects!
-
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /graphing/event_stream
 [2]: /account_management/team/#datadog-user-roles
-[3]: /api
-[4]: https://www.brightcove.com
-[5]: https://www.shopify.com
-[6]: https://www.zendesk.com

--- a/content/en/monitors/_index.md
+++ b/content/en/monitors/_index.md
@@ -77,16 +77,6 @@ Manually *Resolve*-ing a monitor is appropriate for cases where data is reported
 
 Typical use case: monitor based on error metrics that are not generated when there are no errors (e.g. `aws.elb.httpcode_elb_5xx`, or any DogStatsD counter in your code reporting an error _only when there is an error_)
 
-## Managing Monitors
-
-There are multiple community projects available to maintain, manage, or backup monitors by using the Datadog API:
-
-* https://github.com/trueaccord/DogPush
-* https://github.com/winebarrel/barkdog
-* https://github.com/airbnb/interferon
-* https://github.com/rapid7/dogwatch
-* https://www.terraform.io/docs/providers/datadog/r/monitor.html
-
 [1]: /graphing/event_stream
 [2]: https://app.datadoghq.com/monitors/triggered
 [3]: https://app.datadoghq.com/monitors


### PR DESCRIPTION
### What does this PR do?
Moves Dashboard Back up to libraries page.

### Motivation
It's community based

### Preview link

https://docs-staging.datadoghq.com/gus/dashboard-back-up/developers/libraries/#datadog-client-community-libraries