### PR TITLE
Add docs for Datadog APM with Istio service mesh

### DIFF
--- a/content/en/tracing/setup/_index.md
+++ b/content/en/tracing/setup/_index.md
@@ -12,7 +12,7 @@ After you have [installed the Datadog Agent][1], [enabled trace collection][2], 
 **Note**: If you're using Kubernetes, make sure to [enable APM in your Daemonset setup][4]. If you're using Docker, [enable the Trace Agent in your application][5].
 
 
-{{< whatsnext desc="Select one of the following supported languages or proxy configurations to start instrumenting your application:">}}
+{{< whatsnext desc="Select one of the following supported languages, proxy or service mesh configurations to start instrumenting your application:">}}
   {{< nextlink href="tracing/languages/java" tag="Java" >}}Java language instrumentation.{{< /nextlink >}}
   {{< nextlink href="tracing/languages/python" tag="Python" >}}Python language instrumentation.{{< /nextlink >}}
   {{< nextlink href="tracing/languages/ruby" tag="Ruby" >}}Ruby language instrumentation{{< /nextlink >}}
@@ -22,7 +22,8 @@ After you have [installed the Datadog Agent][1], [enabled trace collection][2], 
   {{< nextlink href="tracing/languages/php" tag="PHP" >}}PHP language instrumentation.{{< /nextlink >}}
   {{< nextlink href="tracing/languages/cpp" tag="C++" >}}C++ language instrumentation.{{< /nextlink >}}
   {{< nextlink href="/tracing/setup/envoy/" tag="envoy" >}}Envoy proxy configuration.{{< /nextlink >}}
-  {{< nextlink href="/tracing/setup/nginx/" tag="nginix" >}}NGINX proxy configuration.{{< /nextlink >}}
+  {{< nextlink href="/tracing/setup/nginx/" tag="nginx" >}}NGINX proxy configuration.{{< /nextlink >}}
+  {{< nextlink href="/tracing/setup/istio/" tag="istio" >}}Istio service mesh configuration.{{< /nextlink >}}
 {{< /whatsnext >}}
 
 [1]: /agent

--- a/content/en/tracing/setup/istio.md
+++ b/content/en/tracing/setup/istio.md
@@ -24,7 +24,7 @@ Datadog APM is available for Istio v1.1.3+ on Kubernetes clusters.
 
 1. [Install the Agent][1]
 2. [Make sure APM is enabled for your Agent][2].
-3. Set the `apm_non_local_traffic` parameter to `true` and uncomment the `hostPort` setting so that Istio sidecars can connect to the Agent and submit traces.
+3. Uncomment the `hostPort` setting so that Istio sidecars can connect to the Agent and submit traces.
 
 **Note**: The Agent pods fails to start up if Istio's automatic sidecar injection is enabled on the namespace that Datadog Agent runs in. To avoid this:
 

--- a/content/en/tracing/setup/istio.md
+++ b/content/en/tracing/setup/istio.md
@@ -1,0 +1,102 @@
+---
+title: Istio
+kind: documentation
+further_reading:
+- link: "tracing/visualization/"
+  tag: "Use the APM UI"
+  text: "Explore your services, resources and traces"
+- link: "https://istio.io/"
+  tag: "Documentation"
+  text: "Istio website"
+- link: "https://istio.io/docs/"
+  tag: "Documentation"
+  text: "Istio documentation"
+- link: "https://github.com/DataDog/dd-opentracing-cpp"
+  tag: "Source Code"
+  text: "Datadog OpenTracing C++ Client"
+aliases:
+  - /tracing/servicemesh/istio
+---
+
+Support for Datadog APM is available for Istio on Kubernetes clusters.
+This was first available in Istio v1.1.3.
+
+## Configuration
+
+### Datadog Agent Installation
+
+The Datadog Agent must be [installed][k8s-install] and [APM enabled][apm-enabled].
+The `hostPort` setting needs to be uncommented for Istio sidecars to connect to the agent and submit traces.
+
+If Istio's automatic sidecar injection is enabled on the namespace that Datadog Agent runs in, then the Datadog Agent pods will fail to start up.
+This can be corrected in one of two ways:
+
+- disable sidecar injection for the Datadog Agent
+- create a headless service for the Datadog Agent
+
+#### Disabling Sidecar Injection for the Datadog Agent
+
+Add the `sidecar.istio.io/inject: "false"` annotation to the `datadog-agent` daemonset.
+```yaml
+...
+spec:
+  ...
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    ...
+
+```
+
+This can also be done with the `kubectl patch` command.
+```
+kubectl patch daemonset datadog-agent -p '{"spec":{"template":{"metadata":{"annotations":{"sidecar.istio.io/inject":"false"}}}}}'
+```
+
+#### Create a Headless Service for the Datadog Agent
+
+Create a service using the YAML specified below.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: datadog-agent
+  name: datadog-agent
+spec:
+  clusterIP: None
+  ports:
+  - name: dogstatsdport
+    port: 8125
+    protocol: UDP
+    targetPort: 8125
+  - name: traceport
+    port: 8126
+    protocol: TCP
+    targetPort: 8126
+  selector:
+    app: datadog-agent
+```
+
+### Istio Configuration and Installation
+
+To enable Datadog APM, a [custom installation][istio-custom] is required, to add two extra options before Istio is installed.
+These options are passed at the final `helm template` or `helm install` step:
+
+- `--set pilot.traceSampling=100.0`
+- `--set global.proxy.tracer=datadog`
+
+Eg: an installation using the `default` configuration profile will use the following command:
+```
+helm template install/kubernetes/helm/istio --name istio --namespace istio-system --set pilot.traceSampling=100.0 --set global.proxy.tracer=datadog | kubectl apply -f -
+```
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[k8s-install]: /agent/kubernetes/daemonset_setup/
+[apm-enabled]: /agent/kubernetes/daemonset_setup/#apm-and-distributed-tracing
+[istio-custom]: https://istio.io/docs/setup/kubernetes/install/helm/

--- a/content/en/tracing/setup/istio.md
+++ b/content/en/tracing/setup/istio.md
@@ -14,29 +14,27 @@ further_reading:
 - link: "https://github.com/DataDog/dd-opentracing-cpp"
   tag: "Source Code"
   text: "Datadog OpenTracing C++ Client"
-aliases:
-  - /tracing/servicemesh/istio
 ---
 
-Support for Datadog APM is available for Istio on Kubernetes clusters.
-This was first available in Istio v1.1.3.
+Datadog APM is available for Istio v1.1.3+ on Kubernetes clusters.
 
 ## Configuration
 
 ### Datadog Agent Installation
 
-The Datadog Agent must be [installed][k8s-install] and [APM enabled][apm-enabled].
-The `hostPort` setting needs to be uncommented for Istio sidecars to connect to the agent and submit traces.
+1. [Install the Agent][1]
+2. [Make sure APM is enabled for your Agent][2].
+3. Set the `apm_non_local_traffic` parameter to `true` and uncomment the `hostPort` setting so that Istio sidecars can connect to the Agent and submit traces.
 
-If Istio's automatic sidecar injection is enabled on the namespace that Datadog Agent runs in, then the Datadog Agent pods will fail to start up.
-This can be corrected in one of two ways:
+**Note**: The Agent pods fails to start up if Istio's automatic sidecar injection is enabled on the namespace that Datadog Agent runs in. To avoid this:
 
-- disable sidecar injection for the Datadog Agent
-- create a headless service for the Datadog Agent
+- [Disabling Sidecar Injection for the Datadog Agent](#disabling-sidecar-injection-for-the-datadog-agent)
+- [Create a Headless Service for the Datadog Agent](#create-a-headless-service-for-the-datadog-agent)
 
 #### Disabling Sidecar Injection for the Datadog Agent
 
-Add the `sidecar.istio.io/inject: "false"` annotation to the `datadog-agent` daemonset.
+Add the `sidecar.istio.io/inject: "false"` annotation to the `datadog-agent` daemonset:
+
 ```yaml
 ...
 spec:
@@ -50,7 +48,8 @@ spec:
 ```
 
 This can also be done with the `kubectl patch` command.
-```
+
+```shell
 kubectl patch daemonset datadog-agent -p '{"spec":{"template":{"metadata":{"annotations":{"sidecar.istio.io/inject":"false"}}}}}'
 ```
 
@@ -82,14 +81,14 @@ spec:
 
 ### Istio Configuration and Installation
 
-To enable Datadog APM, a [custom installation][istio-custom] is required, to add two extra options before Istio is installed.
-These options are passed at the final `helm template` or `helm install` step:
+To enable Datadog APM, a [custom Istio installation][3] is required to add two extra options before Istio is installed. These options are passed at the final `helm template` or `helm install` step:
 
 - `--set pilot.traceSampling=100.0`
 - `--set global.proxy.tracer=datadog`
 
-Eg: an installation using the `default` configuration profile will use the following command:
-```
+Eg: an installation using the `default` configuration profile would use the following command:
+
+```shell
 helm template install/kubernetes/helm/istio --name istio --namespace istio-system --set pilot.traceSampling=100.0 --set global.proxy.tracer=datadog | kubectl apply -f -
 ```
 
@@ -97,6 +96,6 @@ helm template install/kubernetes/helm/istio --name istio --namespace istio-syste
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[k8s-install]: /agent/kubernetes/daemonset_setup/
-[apm-enabled]: /agent/kubernetes/daemonset_setup/#apm-and-distributed-tracing
-[istio-custom]: https://istio.io/docs/setup/kubernetes/install/helm/
+[1]: /agent/kubernetes/daemonset_setup
+[2]: /agent/kubernetes/daemonset_setup/#apm-and-distributed-tracing
+[3]: https://istio.io/docs/setup/kubernetes/install/helm

--- a/content/en/tracing/setup/istio.md
+++ b/content/en/tracing/setup/istio.md
@@ -28,10 +28,10 @@ Datadog APM is available for Istio v1.1.3+ on Kubernetes clusters.
 
 **Note**: The Agent pods fails to start up if Istio's automatic sidecar injection is enabled on the namespace that Datadog Agent runs in. To avoid this:
 
-- [Disabling Sidecar Injection for the Datadog Agent](#disabling-sidecar-injection-for-the-datadog-agent)
+- [Disable Sidecar Injection for the Datadog Agent](#disable-sidecar-injection-for-the-datadog-agent)
 - [Create a Headless Service for the Datadog Agent](#create-a-headless-service-for-the-datadog-agent)
 
-#### Disabling Sidecar Injection for the Datadog Agent
+#### Disable Sidecar Injection for the Datadog Agent
 
 Add the `sidecar.istio.io/inject: "false"` annotation to the `datadog-agent` daemonset:
 
@@ -55,7 +55,7 @@ kubectl patch daemonset datadog-agent -p '{"spec":{"template":{"metadata":{"anno
 
 #### Create a Headless Service for the Datadog Agent
 
-Create a service using the YAML specified below.
+Create a headless service for the Datadog Agent using the YAML configuration specified below.
 
 ```yaml
 apiVersion: v1

--- a/content/en/tracing/setup/java.md
+++ b/content/en/tracing/setup/java.md
@@ -105,7 +105,7 @@ Don't see your desired web frameworks? Datadog is continually adding additional 
 | HttpURLConnection        | all         | Fully Supported | `httpurlconnection`, `urlconnection`           |
 | Kafka-Clients            | 0.11+       | Fully Supported | `kafka`                                        |
 | Kafka-Streams            | 0.11+       | Fully Supported | `kafka`, `kafka-streams`                       |
-| Jax RS Clients           | 1.11+       | Fully Supported | `jax-rs`, `jaxrs`, `jax-rs-client`             |
+| Jax RS Clients           | 2.0+        | Fully Supported | `jax-rs`, `jaxrs`, `jax-rs-client`             |
 | JMS                      | 1 and 2     | Fully Supported | `jms`                                          |
 | Rabbit AMQP              | 2.7+        | Fully Supported | `amqp`, `rabbitmq`                             |
 | OkHTTP                   | 3.0+        | Fully Supported | `okhttp`, `okhttp-3`                           |

--- a/data/partials/mainnav.fr.yaml
+++ b/data/partials/mainnav.fr.yaml
@@ -254,6 +254,8 @@ main:
             url: tracing/setup/envoy/
           - name: NGINX
             url: tracing/setup/nginx/
+          - name: Istio 
+            url: tracing/setup/istio/
       - name: Enrichir vos Traces
         url: tracing/advanced/
         children:

--- a/data/partials/mainnav.yaml
+++ b/data/partials/mainnav.yaml
@@ -302,6 +302,8 @@ main:
             url: "tracing/setup/envoy/"
           - name: "NGINX"
             url: "tracing/setup/nginx/"
+          - name: "Istio"
+            url: "tracing/setup/istio/"
 
       # Enrich Tracing
 


### PR DESCRIPTION
### What does this PR do?
Adds docs for users to configure their Istio service mesh and collect traces with Datadog.

### Motivation
The feature is available and user-facing documentation is missing.

### Preview link
https://docs-staging.datadoghq.com/cgilmour/istio-docs/tracing/setup/istio/