### PR TITLE
Fixes search

### DIFF
--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -19,10 +19,10 @@ further_reading:
   text: "Control the volume of logs indexed by Datadog"
 ---
 
-## Overview 
+## Overview
 
-If your logs are JSON-formatted, Datadog automatically parses them, but for other formats, Datadog allows you to enrich your logs with the help of Grok Parser.    
-The Grok syntax provides an easier way to parse logs than pure regular expressions.  
+If your logs are JSON-formatted, Datadog automatically parses them, but for other formats, Datadog allows you to enrich your logs with the help of Grok Parser.
+The Grok syntax provides an easier way to parse logs than pure regular expressions.
 The main usage of the Grok Parser is to extract attributes from semi-structured text messages.
 
 Grok comes with a lot of reusable patterns to parse integers, ip addresses, hostnames, etc...
@@ -35,7 +35,7 @@ Parsing rules can be written with the `%{MATCHER:EXTRACT:FILTER}` syntax:
 
 * **Filter** (optional): a post-processor of the match to transform it
 
-Example for this classic unstructured log:  
+Example for this classic unstructured log:
 ```
 john connected on 11/08/2017
 ```
@@ -49,7 +49,9 @@ You would have at the end this structured log:
 
 {{< img src="logs/processing/parsing/parsing_example_1.png" alt="Parsing example 1" responsive="true" style="width:80%;">}}
 
-**Note**: If you have multiple parsing rules in a single Grok parser, only one can match any given log. The first one that matches from top to bottom is the one that does the parsing. 
+**Note**: If you have multiple parsing rules in a single Grok parser, only one can match any given log. The first one that matches from top to bottom is the one that does the parsing.
+
+### Matcher and Filter
 
 Here is the list of all the matchers and filters natively implemented by Datadog:
 
@@ -127,7 +129,7 @@ At the bottom of your grok processor tiles there is an Advanced Settings section
 
 * Use the **Helper Rules** field to define tokens for your parsing rules. Helper rules helps you factorize grok patterns across your parsing rules which is useful when you have several rules in the same grok parser that uses the same tokens.
 
-Example for this classic unstructured log:  
+Example for this classic unstructured log:
 
 ```
 john id:12345 connected on 11/08/2017 on server XYZ in production
@@ -161,9 +163,9 @@ This is the key value core filter : `keyvalue([separatorStr[, characterWhiteList
 * `characterWhiteList`: defines additional non escaped value chars. Default `\\w.\\-_@`
 * `quotingStr` : defines quotes. Default behavior detects quotes (`<>`, `"\"\""`, ...). When defined default behavior is replaced by allowing only defined quoting char. For example `<>` matches *test=<toto sda> test2=test*.
 
-Use filters such as **keyvalue()** to more-easily map strings to attributes: 
+Use filters such as **keyvalue()** to more-easily map strings to attributes:
 
-log: 
+log:
 
 ```
 user=john connect_date=11/08/2017 id=123 action=click
@@ -184,7 +186,7 @@ If you add an **extract** attribute `my_attribute` in your rule pattern you woul
 
 If `=` is not the default separator between your key and values, add a parameter in your parsing rule with the wanted splitter.
 
-log: 
+log:
 
 ```
 user: john connect_date: 11/08/2017 id: 123 action: click
@@ -200,7 +202,7 @@ rule %{data::keyvalue(": ")}
 
 If logs contain specials characters in an attribute value such as `/` in a url for instance, add it to the white-list in the parsing rule:
 
-log: 
+log:
 
 ```
 url=https://app.datadoghq.com/event/stream user=john
@@ -269,13 +271,13 @@ MyParsingRule (%{integer:user.id}|%{word:user.firstname}) connected on %{date("M
 
 {{< img src="logs/processing/parsing/parsing_example_4_bis.png" alt="Parsing example 4 bis" responsive="true" style="width:80%;" >}}
 
-### Optional attribute 
+### Optional attribute
 
 Some logs contain values that only appear part of the time. In those cases, you can make attribute extraction optional with `()?` extracting it only when the attribute is contained in your log.
 
 **Log**:
 ```
-john 1234 connected on 11/08/2017 
+john 1234 connected on 11/08/2017
 ```
 
 **Rule**:
@@ -289,7 +291,7 @@ MyParsingRule %{word:user.firstname} (%{integer:user.id} )?connected on %{date("
 
 {{< img src="logs/processing/parsing/parsing_example_5_bis.png" alt="Parsing example 5 bis" responsive="true" style="width:80%;" >}}
 
-### Regex 
+### Regex
 Use the regex matcher to match any substring of your log message based on literal regex rules.
 
 **Log**:

--- a/local/etc/docsdatadoghq.json
+++ b/local/etc/docsdatadoghq.json
@@ -119,7 +119,8 @@
     }
   ],
   "stop_urls": [
-    "/search/",
+    "docs.datadoghq.com/search/",
+    "docs.datadoghq.com/fr/search/",
     "/videos/",
     "/integrations/$",
     "/faq/$",
@@ -142,7 +143,7 @@
       "lvl2": ".main h2",
       "lvl3": ".main h3",
       "lvl4": ".main h4",
-      "text": ".main p, .main ul > li > table tbody tr td",
+      "text": ".main p, .main ul > li, table tbody tr, code-tabs table tbody tr td",
       "language": {
         "selector": "/html/@lang",
         "type": "xpath",
@@ -159,7 +160,7 @@
       "lvl2": ".main h2",
       "lvl3": ".main h3",
       "lvl4": ".main h4",
-      "text": ".main p, .main ul > li > table tbody tr td > .table-metrics tr td",
+      "text": ".main p, .main ul > li, table tbody tr, .table-metrics tr",
       "language": {
         "selector": "/html/@lang",
         "type": "xpath",
@@ -174,7 +175,7 @@
       },
       "lvl1": ".main h1",
       "lvl2": ".main h2",
-      "text": ".main p, table tbody tr td",
+      "text": ".main p, table tbody tr td, code-tabs table tbody tr td",
       "language": {
         "selector": "/html/@lang",
         "type": "xpath",
@@ -191,7 +192,7 @@
       "lvl2": ".main h2",
       "lvl3": ".main h3",
       "lvl4": ".main h4",
-      "text": ".main p, .main ul > li > table tbody tr td",
+      "text": ".main p, .main ul > li, table tbody tr td, code-tabs table tbody tr td",
       "language": {
         "selector": "/html/@lang",
         "type": "xpath",
@@ -257,5 +258,5 @@
   },
   "only_content_level": true,
   "user_agent": "Googlebot",
-  "nb_hits": 20672
+  "nb_hits": 55397
 }


### PR DESCRIPTION
### What does this PR do?
Fixes the search. 

The previous PR about this didn't helped the ranking, it just removed the table from being indexed.. fixing the indexing strategy that we had for sure but creating more harm than good.

### Motivation
A search that indexes all content expecially here table in doc pages and metrics table in integrations page.

### Additional Notes
I think moving forward ranking problems needs to be address case by case, playing with the global scrapping strategy is too dangerous.

It's easier to work on the wording for some specific search rather than changing the whole indexing strategy.
