### PR TITLE
Update tracing docs re: meta field string requirements

### DIFF
--- a/content/en/api/tracing/send_trace.md
+++ b/content/en/api/tracing/send_trace.md
@@ -38,7 +38,7 @@ and each span is a dictionary with a `trace_id`, `span_id`, `resource`..
 *   **`duration`** - _required_ The duration of the request in nanoseconds.
 *   **`parent_id`** - _optional_ The span integer ID of the parent span.
 *   **`error`** - _optional_ Set this value to 1 to indicate if an error occured. If an error occurs, you should pass additional information, such as the error message, type and stack information in the `meta` property.
-*   **`meta`** - _optional_ A dictionary of key-value metadata. e.g. tags.
+*   **`meta`** - _optional_ A dictionary of key-value metadata. e.g. tags. NOTE: all keys and values must be strings
 
 [1]: /tracing/#instrument-your-application
 [2]: /tracing/visualization/trace

--- a/content/en/api/tracing/send_trace.md
+++ b/content/en/api/tracing/send_trace.md
@@ -38,7 +38,8 @@ and each span is a dictionary with a `trace_id`, `span_id`, `resource`..
 *   **`duration`** - _required_ The duration of the request in nanoseconds.
 *   **`parent_id`** - _optional_ The span integer ID of the parent span.
 *   **`error`** - _optional_ Set this value to 1 to indicate if an error occured. If an error occurs, you should pass additional information, such as the error message, type and stack information in the `meta` property.
-*   **`meta`** - _optional_ A dictionary of key-value metadata. e.g. tags. NOTE: all keys and values must be strings
+*   **`meta`** - _optional_ A set of key-value metadata. Keys and values must be strings.
+*   **`metrics`** - _optional_ A set of key-value metadata. Keys must be strings and values must be 64-bit floating point numbers.
 
 [1]: /tracing/#instrument-your-application
 [2]: /tracing/visualization/trace


### PR DESCRIPTION
The trace agent will respond with `json: cannot unmarshal number into Go struct field Span.meta of type string\n` if you try to send an integer as a meta field value.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds a note about what types you can pass for Span.meta key/values

### Motivation
<!-- What inspired you to submit this pull request?-->
I got the following error when exporting a span with an integer in a meta value: `json: cannot unmarshal number into Go struct field Span.meta of type string\n`

