### PR TITLE
Update for keyboard interaction on copy-log from log slide panel

### DIFF
--- a/content/en/logs/explorer/_index.md
+++ b/content/en/logs/explorer/_index.md
@@ -104,7 +104,7 @@ Interact with the upper reserved attributes section:
 
 The **View in context** button updates the search request in order to show you the log lines dated just before and after a selected log—even if they don't match your filter. This context is different according to the situation, as Datadog uses the `Hostname`, `Service`, `filename`, and `container_id` attributes, along with tags, in order find the appropriate context for your logs.
 
-Copy the log content JSON to the clipboard through the **Export** button, or through (Ctrl+C/Cmd+C) keyboard interaction.
+Copy the JSON log content to the clipboard through the **Export** button or keyboard interaction (Ctrl+C/Cmd+C).
 
 {{< img src="logs/explorer/upper_log_panel.png" alt="configure display table" responsive="true" style="width:50%;">}}
 

--- a/content/en/logs/explorer/_index.md
+++ b/content/en/logs/explorer/_index.md
@@ -104,7 +104,7 @@ Interact with the upper reserved attributes section:
 
 The **View in context** button updates the search request in order to show you the log lines dated just before and after a selected log—even if they don't match your filter. This context is different according to the situation, as Datadog uses the `Hostname`, `Service`, `filename`, and `container_id` attributes, along with tags, in order find the appropriate context for your logs.
 
-Copy the log content JSON to the clipboard through the **Export** button.
+Copy the log content JSON to the clipboard through the **Export** button, or through (Ctrl+C/Cmd+C) keyboard interaction.
 
 {{< img src="logs/explorer/upper_log_panel.png" alt="configure display table" responsive="true" style="width:50%;">}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update for keyboard interaction on copy-log from log slide panel

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
