### PR TITLE
Moving docker log collection into agent section

### DIFF
--- a/content/en/agent/autodiscovery/_index.md
+++ b/content/en/agent/autodiscovery/_index.md
@@ -509,7 +509,7 @@ services:
 ```
 
 
-[1]: /logs/docker
+[1]: /agent/docker/log
 {{% /tab %}}
 {{% tab "Cluster Checks" %}}
 

--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -12,7 +12,7 @@ further_reading:
 - link: "agent/faq/docker-jmx"
   tag: "FAQ"
   text: "Docker JMX"
-- link: "logs/docker"
+- link: "agent/docker/log"
   tag: "Documentation"
   text: Collect your Docker logs
 - link: "graphing/infrastructure/process"

--- a/content/en/agent/docker/apm.md
+++ b/content/en/agent/docker/apm.md
@@ -27,7 +27,7 @@ To make it available from *any host*, use `-p 8126:8126/tcp` instead.
 
 For example, the following command allows the Agent to receive traces from your host only:
 
-```bash
+```
 docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /proc/:/host/proc/:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \

--- a/content/en/agent/docker/log.md
+++ b/content/en/agent/docker/log.md
@@ -3,7 +3,8 @@ title: Docker Log collection
 kind: documentation
 aliases:
   - /logs/docker
-  - /logs/languages/docker/
+  - /logs/languages/docker
+  - /logs/log_collection/docker
 further_reading:
 - link: "logs/explorer"
   tag: "Documentation"
@@ -103,7 +104,7 @@ The source and service values can be overridden with Autodiscovery as described 
 
 * Logs coming from container `Stderr` have a default status of `Error`.
 
-* If using the journald logging driver instead of Docker's default json-file logging driver, see the [journald integration][1] documentation for details regarding the setup for containerized environments.
+* If using the *journald* logging driver instead of Docker's default json-file logging driver, see the [journald integration][1] documentation for details regarding the setup for containerized environments.
 
 ### Activate Log Integrations
 
@@ -143,6 +144,8 @@ Add the following label as a run command:
 
 {{% /tab %}}
 {{< /tabs >}}
+
+Where `<LOG_CONFIG>` is the log collection configuration you would find inside an integration configuration file. [See log collection configuration to learn more][4]
 
 #### Examples
 
@@ -280,6 +283,7 @@ ac_exclude = ["name:datadog-agent"]
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /integrations/journald/
+[1]: /integrations/journald
 [2]: /agent/autodiscovery
 [3]: /agent/autodiscovery/?tab=kubernetes#setting-up-check-templates
+[4]: /logs/log_collection/#custom-log-collection

--- a/content/en/graphing/infrastructure/livecontainers.md
+++ b/content/en/graphing/infrastructure/livecontainers.md
@@ -45,7 +45,7 @@ config_providers:
 * Logs are indexed by default, however [Exclusion Filters][2] are configurable for fine-grained controls over indexing and uniquely receiving Live Tail data.
 
 
-[1]: /logs/log_collection/docker/?tab=hostinstallation
+[1]: /agent/docker/log/?tab=hostinstallation
 [2]: /agent/guide/agent-configuration-files/?tab=agentv6
 {{% /tab %}}
 
@@ -60,7 +60,7 @@ Follow the instructions for the [Docker Agent][1], passing in the following attr
 
 **Note**: Logs are indexed by default, however [Exclusion Filters][2] are configurable for fine-grained controls over indexing and uniquely receiving Live Tail data.
 
-[1]: /logs/log_collection/docker/?tab=containerinstallation
+[1]: /agent/docker/log/?tab=containerinstallation
 [2]: /logs/logging_without_limits/#exclusion-filters
 {{% /tab %}}
 
@@ -235,7 +235,7 @@ ac_include: ["name:frontend.*"]
 [3]: /integrations/kubernetes
 [4]: /integrations/amazon_ecs
 [5]: /agent/docker/#run-the-docker-agent
-[6]: /logs/log_collection/docker/?tab=hostinstallation#activate-log-integrations
+[6]: /agent/docker/log/?tab=hostinstallation#activate-log-integrations
 [7]: /logs/live_tail
 [8]: /tagging
 [9]: https://gist.github.com/hkaj/404385619e5908f16ea3134218648237

--- a/content/en/logs/_index.md
+++ b/content/en/logs/_index.md
@@ -171,7 +171,7 @@ Your logs are collected and centralized into the [Log Explorer][3] view. You can
 [18]: /logs/log_collection/#filter-logs
 [19]: /logs/log_collection/#scrub-sensitive-data-in-your-logs
 [20]: /logs/log_collection/#multi-line-aggregation
-[21]: /logs/log_collection/docker
+[21]: /agent/docker/log
 [22]: /agent/basic_agent_usage/kubernetes/#log-collection-setup
 [23]: /integrations/amazon_web_services/#log-collection
 [24]: /integrations/amazon_web_services/#enable-logging-for-your-aws-service

--- a/content/en/logs/guide/integration-pipeline-reference.md
+++ b/content/en/logs/guide/integration-pipeline-reference.md
@@ -97,9 +97,9 @@ Datadog’s integration processing Pipelines are available for the `source` tag 
 [24]: /integrations/couch/#log-collection
 [25]: https://github.com/DataDog/integrations-core/blob/master/couch/datadog_checks/couch/data/conf.yaml.example
 [26]: /logs/log_collection/?tab=tailexistingfiles#custom-log-collection
-[27]: /logs/log_collection/docker
-[28]: /logs/log_collection/docker/?tab=environmentvariable#one-step-install-to-collect-all-the-container-logs
-[29]: /logs/log_collection/docker/?tab=hostinstallation#one-step-install-to-collect-all-the-container-logs
+[27]: /agent/docker/log
+[28]: /agent/docker/log/?tab=environmentvariable#one-step-install-to-collect-all-the-container-logs
+[29]: /agent/docker/log/?tab=hostinstallation#one-step-install-to-collect-all-the-container-logs
 [30]: /integrations/elastic/#log-collection
 [31]: https://github.com/DataDog/integrations-core/blob/master/elastic/datadog_checks/elastic/data/conf.yaml.example
 [32]: /logs/log_collection/go

--- a/content/en/logs/guide/log-collection-troubleshooting-guide.md
+++ b/content/en/logs/guide/log-collection-troubleshooting-guide.md
@@ -175,8 +175,8 @@ Check if logs appear in the [Datadog Live Tail][11]. If they appear in the Live 
 [3]: https://en.wikipedia.org/wiki/Chmod
 [4]: https://docs.datadoghq.com/integrations/journald/#pagetitle
 [5]: https://codebeautify.org/yaml-validator
-[6]: /logs/log_collection/docker/?tab=containerinstallation#filter-containers
-[7]: /logs/log_collection/docker/?tab=dockerfile#examples
+[6]: /agent/docker/log/?tab=containerinstallation#filter-containers
+[7]: /agent/docker/log/?tab=dockerfile#examples
 [8]: /agent/autodiscovery/?tab=kubernetes#setting-up-check-templates
 [9]: /integrations/amazon_web_services/?tab=allpermissions#set-up-the-datadog-lambda-function
 [10]: https://app.datadoghq.com/account/settings#api

--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -427,7 +427,7 @@ Datadog automatically parses JSON-formatted logs. For this reason, if you have c
 
 [1]: /agent
 [2]: /agent/kubernetes/daemonset_setup/#log-collection
-[3]: /logs/log_collection/docker
+[3]: /agent/docker/log
 [4]: /agent/guide/agent-configuration-files
 [5]: /agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [6]: /agent/guide/agent-commands/#agent-status-and-information

--- a/data/partials/mainnav.fr.yaml
+++ b/data/partials/mainnav.fr.yaml
@@ -57,6 +57,8 @@ main:
         children:
           - name: APM
             url: agent/docker/apm
+          - name: Log collection
+            url: agent/docker/log
       - name: Kubernetes
         url: agent/kubernetes/
         children:
@@ -254,7 +256,7 @@ main:
             url: tracing/setup/envoy/
           - name: NGINX
             url: tracing/setup/nginx/
-          - name: Istio 
+          - name: Istio
             url: tracing/setup/istio/
       - name: Enrichir vos Traces
         url: tracing/advanced/
@@ -313,7 +315,7 @@ main:
           - name: Browser
             url: logs/log_collection/javascript/
           - name: Docker
-            url: logs/log_collection/docker/
+            url: agent/docker/log/
           - name: Csharp
             url: logs/log_collection/csharp/
           - name: Go

--- a/data/partials/mainnav.yaml
+++ b/data/partials/mainnav.yaml
@@ -61,8 +61,10 @@ main:
       - name: "Docker"
         url: "agent/docker/"
         children:
-          - name: "APM"
-            url: "agent/docker/apm"
+          - name: APM
+            url: agent/docker/apm
+          - name: Log collection
+            url: agent/docker/log
       ## Kubernetes
       - name: "Kubernetes"
         url: "agent/kubernetes/"
@@ -385,7 +387,7 @@ main:
           - name: "Browser"
             url: "logs/log_collection/javascript/"
           - name: "Docker"
-            url: "logs/log_collection/docker/"
+            url: "agent/docker/log/"
           - name: "Csharp"
             url: "logs/log_collection/csharp/"
           - name: "Go"
@@ -605,4 +607,3 @@ main:
   - name: "Help"
     url: "help/"
     pre: "nav_help"
-


### PR DESCRIPTION
### What does this PR do?
Moves docker Log collection into the Agent/docker sub-section.

### Motivation

Centralising all agent related documentation for log collection within the Agent section since the agent is now one among many ways to collect logs and send them to Datadog. 

### Preview link

* https://docs-staging.datadoghq.com/gus/docker-log-in-agent-section/agent/docker/log/