### PR TITLE
Arithmetic processor - rounding

### DIFF
--- a/content/en/logs/processing/processors.md
+++ b/content/en/logs/processing/processors.md
@@ -166,7 +166,7 @@ An attribute is missing if it is not found in the log attributes, or if it canno
 
 * The operator `-` needs to be space split in the formula as it can also be contained in attribute names.
 * If the target attribute already exists, it is overwritten by the result of the formula.
-* Results are rounded up to the 9th decimal. For example, if the result of the formula is `1.1234567891`, the actual value of the attribute will be `1.123456789`.
+* Results are rounded up to the 9th decimal. For example, if the result of the formula is `0.1234567891`, the actual value stored for the attribute is `0.123456789`.
 
 ## Trace Remapper
 

--- a/content/en/logs/processing/processors.md
+++ b/content/en/logs/processing/processors.md
@@ -166,6 +166,7 @@ An attribute is missing if it is not found in the log attributes, or if it canno
 
 * The operator `-` needs to be space split in the formula as it can also be contained in attribute names.
 * If the target attribute already exists, it is overwritten by the result of the formula.
+* Results are rounded up to the 9th decimal. For example, if the result of the formula is `1.1234567891`, the actual value of the attribute will be `1.123456789`.
 
 ## Trace Remapper
 


### PR DESCRIPTION
### What does this PR do?
The arithmetic processors apply a rounding on the result and support up to 9 decimal numbers.

### Motivation
This was not documented and a customer hit this case.

### Preview link
https://docs-staging.datadoghq.com/nils/arithmetic-rounding-logs//logs/processing/processors/#arithmetic-processor

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
