### PR TITLE
Prometheus Autodiscovery: l5d is a container name

### DIFF
--- a/content/en/agent/prometheus.md
+++ b/content/en/agent/prometheus.md
@@ -50,7 +50,7 @@ For a comprehensive list of settings refer to the [example configuration][3].
 
 You can configure the Prometheus check using [Autodiscovery][4] to quickly collect Prometheus metrics exposed by a container or pod.
 
-Example of Autodiscovery using pod annotations on a `linkerd` pod:
+Example of Autodiscovery using pod annotations `linkerd` pod, retrieving metrics from its `l5d` container:
 
 ```
 annotations:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Make clear that `l5d` is a container name inside the pod definition. This may be obvious to users of linkerd, but not easily discoverable for someone reading this page for the first time. 

### Motivation
<!-- What inspired you to submit this pull request?-->

Confused user: https://datadoghq.slack.com/archives/C4JREERCY/p1557932737130200

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->