### PR TITLE
Fix open tracing link

### DIFF
--- a/content/en/tracing/advanced/manual_instrumentation.md
+++ b/content/en/tracing/advanced/manual_instrumentation.md
@@ -303,7 +303,7 @@ While this [has been deprecated][3] if you are using PHP 7.x, you still may use 
 [1]: /tracing/languages/php/#automatic-instrumentation
 [2]: https://github.com/DataDog/dd-trace-php/releases/latest
 [3]: https://laravel-news.com/laravel-5-6-removes-artisan-optimize
-[4]: #opentracing
+[4]: /tracing/advanced/opentracing/?tab=php
 {{% /tab %}}
 {{% tab "C++" %}}
 


### PR DESCRIPTION
### What does this PR do?
Fix `OpenTracing` link in PHP section

### Motivation
Trello request

### Preview link
https://docs-staging.datadoghq.com/ruth/open-tracing-link/tracing/advanced/manual_instrumentation/?tab=php
