### PR TITLE
APM - dotnet tracer - expand supported library versions

### DIFF
--- a/content/en/tracing/setup/dotnet.md
+++ b/content/en/tracing/setup/dotnet.md
@@ -321,8 +321,8 @@ The .NET Tracer can instrument the following libraries automatically:
 
 | Framework or library            | NuGet package name                       | Package versions     | Integration Name     |
 | ------------------------------- | ---------------------------------------- | -------------------- | -------------------- |
-| ASP.NET MVC                     | `Microsoft.AspNet.Mvc`                   | 5.1.3+ and 4.0.40804 | `AspNetMvc`          |
-| ASP.NET Web API                 | `Microsoft.AspNet.WebApi.Core`           | 5.2+                 | `AspNetWebApi2`      |
+| ASP.NET MVC                     | `Microsoft.AspNet.Mvc`                   | 5.1.0+ and 4.0.40804 | `AspNetMvc`          |
+| ASP.NET Web API 2               | `Microsoft.AspNet.WebApi.Core`           | 5.2+                 | `AspNetWebApi2`      |
 | ASP.NET Core MVC                | `Microsoft.AspNetCore.Mvc.Core`          | 2.0+                 | `AspNetCoreMvc2`     |
 | ASP.NET Web Forms <sup>1</sup>  | built-in                                 |                      | `AspNet`             |
 | WCF                             | built-in                                 |                      | `Wcf`                |
@@ -331,8 +331,8 @@ The .NET Tracer can instrument the following libraries automatically:
 | HttpClient / HttpClientHandler  | built-in or `System.Net.Http`            | 4.0+                 | `HttpMessageHandler` |
 | Redis (StackExchange client)    | `StackExchange.Redis`                    | 1.0.187+             | `StackExchangeRedis` |
 | Redis (ServiceStack client)     | `ServiceStack.Redis`                     | 4.0.48+              | `ServiceStackRedis`  |
-| Elasticsearch                   | `NEST` / `Elasticsearch.Net`             | 6.0.0+               | `ElasticsearchNet`   |
-| MongoDB                         | `MongoDB.Driver` / `MongoDB.Driver.Core` | 2.2.0+               | `MongoDb`            |
+| Elasticsearch                   | `NEST` / `Elasticsearch.Net`             | 5.3.0+               | `ElasticsearchNet`   |
+| MongoDB                         | `MongoDB.Driver` / `MongoDB.Driver.Core` | 2.1.0+               | `MongoDb`            |
 
 Notes:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Expands the supported versions numbers for

- ASP.NET MVC
- MongoDB
- Elasticsearch

### Motivation
[Release 1.2](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v1.2.0) of the .NET Tracer added supports for older versions of this libraries.

### Preview link
https://docs-staging.datadoghq.com/lucas.p/apm-dotnet-supported-versions/tracing/setup/dotnet#integrations

### Additional Notes
N/A
