### PR TITLE
APM > .NET > fix url typo in sample code

### DIFF
--- a/content/en/tracing/setup/dotnet.md
+++ b/content/en/tracing/setup/dotnet.md
@@ -370,7 +370,7 @@ The .NET Tracer automatically reads the environment variables `DD_AGENT_HOST` an
 ```csharp
 using Datadog.Trace;
 
-var uri = new Uri("htt://localhost:8126/");
+var uri = new Uri("http://localhost:8126/");
 var tracer = Tracer.Create(agentEndpoint: uri);
 
 // optional: set the new tracer as the new default/global tracer


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fix a small typo in sample code where a URL that reads `htt://` instead of `http://` (missing `p`).

### Motivation
Customer noticed the typo and reported it.

### Preview link
https://docs-staging.datadoghq.com/lucas/apm-dotnet-http-typo/tracing/languages/dotnet/
