### PR TITLE
Update monitor integration type to show service check

### DIFF
--- a/content/en/api/monitors/monitors_create.md
+++ b/content/en/api/monitors/monitors_create.md
@@ -22,7 +22,7 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
 | event        | `event alert`                   |
 | forecast     | `query alert`                   |
 | host         | `service check`                 |
-| integration  | `query alert or service check`  |
+| integration  | `query alert` or `service check`  |
 | live process | `process alert`                 |
 | logs         | `log alert`                     |
 | metric       | `query alert`                   |

--- a/content/en/api/monitors/monitors_create.md
+++ b/content/en/api/monitors/monitors_create.md
@@ -13,23 +13,23 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
 *   **`type`** [*required*]:
     The [type of the monitor][2], chosen from:
 
-| Monitor Type | type attribute value |
-| :--------    | :-------             |
-| anomaly      | `query alert`        |
-| apm          | `query alert`        |
-| composite    | `composite`          |
-| custom       | `service check`      |
-| event        | `event alert`        |
-| forecast     | `query alert`        |
-| host         | `service check`      |
-| integration  | `query alert`        |
-| live process | `process alert`      |
-| logs         | `log alert`          |
-| metric       | `query alert`        |
-| network      | `service check`      |
-| outlier      | `query alert`        |
-| process      | `service check`      |
-| watchdog     | `event alert`        |
+| Monitor Type | type attribute value            |
+| :--------    | :-------                        |
+| anomaly      | `query alert`                   |
+| apm          | `query alert`                   |
+| composite    | `composite`                     |
+| custom       | `service check`                 |
+| event        | `event alert`                   |
+| forecast     | `query alert`                   |
+| host         | `service check`                 |
+| integration  | `query alert or service check`  |
+| live process | `process alert`                 |
+| logs         | `log alert`                     |
+| metric       | `query alert`                   |
+| network      | `service check`                 |
+| outlier      | `query alert`                   |
+| process      | `service check`                 |
+| watchdog     | `event alert`                   |
 
 *   **`query`** [*required*]:
     The query defines when the monitor triggers. Query syntax depends on what type of monitor you are creating:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates the API documentation for the monitor type table to reflect that an integration monitor could be either `query alert` or `service check`

### Motivation
Depending on what the monitor is looking at, it could either be a service check or query alert. Service check if you're monitoring an integration service check, or a query alert if you're using a metric/arithmetic. 

The Monitor tab for `Integration` in the UI allows you to make either, so this mapping should show both to avoid confusion. 

### Preview link

https://docs-staging.datadoghq.com/nick/monitor_type/api/monitors/monitors_create/


