### PR TITLE
add documentation on the invalid monitor option API error response

### DIFF
--- a/content/en/api/monitors/monitors_create.md
+++ b/content/en/api/monitors/monitors_create.md
@@ -154,6 +154,13 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
 
             Example: `{'ok': 1, 'critical': 1, 'warning': 1}`
 
+    ##### Errors and Validation
+    If an invalid monitor option is included in the request, the response will be:
+
+        ```Error: 400 - ["Invalid monitor option:<invalid option>"]```
+
+
+
 [1]: /monitors/#export-your-monitor
 [2]: /monitors/monitor_types
 [3]: /monitors/monitor_types/#define-the-conditions

--- a/content/en/api/monitors/monitors_create.md
+++ b/content/en/api/monitors/monitors_create.md
@@ -157,7 +157,7 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
     ##### Errors and Validation
     If an invalid monitor option is included in the request, the response will be:
 
-        ```Error: 400 - ["Invalid monitor option:<invalid option>"]```
+            Error: 400 - ["Invalid monitor option:<invalid option>"]
 
 
 


### PR DESCRIPTION
### What does this PR do?
This PR documents the `Invalid monitor option:` error response to the create monitor API request. 

### Motivation
Customer request, request from the monitors team. 

### Preview link
https://docs-staging.datadoghq.com/laura.hampton/add-monitor-options-API-error-docs/api/?lang=python#create-a-monitor

###Additional note: 

I'm not sure if this is the best place to document this error message; if you have thoughts on this, I'm open to hearing them. 


