### PR TITLE
synthetics: Update minimum interval

### DIFF
--- a/content/en/synthetics/api_tests/_index.md
+++ b/content/en/synthetics/api_tests/_index.md
@@ -49,7 +49,7 @@ Define the request you want to be executed by Datadog:
 3. **Name**: The name of your API test.
 4. **Select your tags**: The tags attached to your browser test. Use the `<KEY>:<VALUE>` format to filter on a `<VALUE>` for a given `<KEY>` on the [Synthetics page][2].
 5. **Locations**: The locations to run the test from. Many AWS locations from around the world are available. The full list is retrievable through the [Datadog API][3].
-6. **How often should Datadog run the test?** Intervals are available between every five minutes to once per week.
+6. **How often should Datadog run the test?** Intervals are available between every one minute to once per week.
 7. Click on **Test URL** to try out the request configuration. You should see a response preview show up on the right side of your screen.
 
 [1]: /synthetics/identify_synthetics_bots


### PR DESCRIPTION
### What does this PR do?
Update the minimum interval for synthetics checks to 1min.

### Motivation
According to the API and UI the minimum interval is one minute, rather
than five minutes. I nearly discounted using this service because we
needed 1min and this was the first page that I read.

### Preview link
N/A: This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

### Additional Notes
Maybe the actual intervals values shouldn't be listed here in future if
they are likely to change again?
