### PR TITLE
Removing reference to measure for Trace Search

### DIFF
--- a/content/en/tracing/trace_search_and_analytics/analytics.md
+++ b/content/en/tracing/trace_search_and_analytics/analytics.md
@@ -35,19 +35,19 @@ Switch between the Trace search and the Trace Analytics modes by clicking on the
 
 Use the query to control what's displayed in your Trace Analytic:
 
-1. Choose a [Measure][1] or [Facet][2] to analyze. [Measure][1] lets you choose the aggregation function whereas [Facet][2] displays the unique count.
+1. Choose the `Duration` metric or a [Facet][1] to analyze. Selecting the `Duration` metric lets you choose the aggregation function whereas [Facet][1] displays the unique count.
 
     {{< img src="tracing/trace_search_and_analytics/analytics/choose_measure_facet.png" alt="choose measure facet" responsive="true" style="width:50%;">}}
 
-2. Select the aggregation function for the [Measure][1] you want to graph:
+2. Select the aggregation function for the `Duration` metric:
 
     {{< img src="tracing/trace_search_and_analytics/analytics/agg_function.png" alt="aggregation function" responsive="true" style="width:50%;">}}
 
-3. Use [Tag][1] or [Facet][2] to split your Analytic.
+3. Use [Tag][2] or [Facet][1] to split your Analytic.
 
     {{< img src="tracing/trace_search_and_analytics/analytics/split_by.png" alt="split by" responsive="true" style="width:50%;">}}
 
-4. Choose to display either the *X* **top** or **bottom** values according to the selected [Measure][1].
+4. Choose to display either the *X* **top** or **bottom** values according to the selected [Facet][1] or `Duration`.
 
     {{< img src="tracing/trace_search_and_analytics/analytics/top_bottom_button.png" alt="top bottom button" responsive="true" style="width:20%;">}}
 
@@ -69,7 +69,7 @@ Available visualizations:
 
 ### Timeseries
 
-Visualize the evolution of a single [Measure][1] (or a [Facet][2] unique count of values) over a selected time frame, and (optionally) split by an available [Facet][2].
+Visualize the evolution of the `Duration` metric (or a [Facet][1] unique count of values) over a selected time frame, and (optionally) split by an available [Facet][1].
 
 The following timeseries Trace Analytic shows:
 The evolution of the **pc99** **duration** by steps of **5min** for each **Service**
@@ -78,7 +78,7 @@ The evolution of the **pc99** **duration** by steps of **5min** for each **Servi
 
 ### Top List
 
-Visualize the top values from a [Facet][2] according to the chosen [Measure][1]:
+Visualize the top values from a [Facet][1] according to their `Duration` (or a [Facet][1] unique count of values):
 
 The following Top List Trace Analytic shows:
 The top **pc99** **duration** of **Service**
@@ -112,8 +112,8 @@ Export [Trace Analytics][6] from the Trace search or build them directly in your
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/trace_search_and_analytics/search/#measures
-[2]: /tracing/trace_search_and_analytics/search/#facets
+[1]: /tracing/trace_search_and_analytics/search/#facets
+[2]: /tracing/trace_search_and_analytics/search/#measures
 [3]: /monitors/monitor_types/apm
 [4]: /graphing/dashboards/timeboard
 [5]: /help

--- a/content/en/tracing/trace_search_and_analytics/search.md
+++ b/content/en/tracing/trace_search_and_analytics/search.md
@@ -210,24 +210,6 @@ Use Facets to easily filters on your Traces. The search bar and url automaticall
 
 {{< img src="tracing/trace_search_and_analytics/search/facet_panel.png" alt="Facet panel" responsive="true" style="width:80%;">}}
 
-## Measures
-
-A Measure is a attribute with numerical value contained in your traces. Think of it as a "trace metric".
-
-### Create a Measure
-
-To start using an attribute as a measure, click on a numerical attribute of your trace:
-
-{{< img src="tracing/trace_search_and_analytics/search/create_a_mesure.png" alt="Create a measure" responsive="true" style="width:80%;">}}
-
-Once this is done, the value of this attribute is stored **for all new traces** and can be used in [the search bar](#search-bar), [the Facet Panel](#facet-panel), and in the [Trace graph query][8].
-
-### Select the Measure Unit
-
-All measure have their own unit that is then used for display in the Trace search columns, Trace stream widgets in dashboards, and in the Trace Graphs.
-
-{{< img src="tracing/trace_search_and_analytics/search/edit_a_measure.png" alt="Edit a measure" responsive="true" style="width:80%;">}}
-
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
### What does this PR do?
Removes references to measure with Trace Search since this feature is not yet implemented. 

### Preview link

* https://docs-staging.datadoghq.com/gus/trace-search-update/tracing/trace_search_and_analytics/search/

* https://docs-staging.datadoghq.com/gus/trace-search-update/tracing/trace_search_and_analytics/analytics/ 

### Additional Notes
Once this will be released (target end of Q2), we will just need to revert this PR.
