### PR TITLE
added note for No Data

### DIFF
--- a/content/en/monitors/monitor_types/metric.md
+++ b/content/en/monitors/monitor_types/metric.md
@@ -76,6 +76,7 @@ further_reading:
 5. Select your **evaluation_delay** Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min), the time frame is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55. This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
 
 6. Optionally **notify on no data** after a configurable time frame. At the minimum, your chosen time frame must be greater than 2x the alerting window. For example, if you are alerting over the last 5 minutes then you would need to wait at least 10 minutes before notifying on missing data.
+*Note:* No Data Alerts have a default max of 24 hours. Please reach out to support to discuss increasing this value.
 
 7. Opt to **automatically resolve the monitor from a triggered state**.
     In general you'll want to leave this option off as you only want an alert to be resolved when it's fixed.

--- a/content/en/monitors/monitor_types/metric.md
+++ b/content/en/monitors/monitor_types/metric.md
@@ -76,7 +76,8 @@ further_reading:
 5. Select your **evaluation_delay** Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min), the time frame is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55. This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
 
 6. Optionally **notify on no data** after a configurable time frame. At the minimum, your chosen time frame must be greater than 2x the alerting window. For example, if you are alerting over the last 5 minutes then you would need to wait at least 10 minutes before notifying on missing data.
-*Note:* No Data Alerts have a default max of 24 hours. Please reach out to support to discuss increasing this value.
+
+**Note:** No Data Alerts have a default max of 24 hours. Reach out to support to discuss increasing this value.
 
 7. Opt to **automatically resolve the monitor from a triggered state**.
     In general you'll want to leave this option off as you only want an alert to be resolved when it's fixed.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a clarifying note about the default value for No Data alerting

### Motivation
Internal suggestion

### Preview link
Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/bcon/no-data-time-clarification/monitors/monitor_types/metric/
