### PR TITLE
clarify that watchdog is only for apm

### DIFF
--- a/content/en/monitors/monitor_types/watchdog.md
+++ b/content/en/monitors/monitor_types/watchdog.md
@@ -13,9 +13,11 @@ further_reading:
 
 ## Overview
 
-[Watchdog][1] is an algorithmic feature that automatically detects application and infrastructure issues, by continuously observing trends and patterns in application metrics—like error rate, request rate, and latency—and looking for unexpected behavior. 
+[Watchdog][1] is an algorithmic feature for APM that automatically detects application and infrastructure issues, by continuously observing trends and patterns in application metrics—like error rate, request rate, and latency—and looking for unexpected behavior. 
 
 Watchdog monitors allow you to set up monitors and receive alert notifications when Watchdog detects a potential problem in your systems.
+
+**Note**: Watchdog is an APM feature, and Watchdog monitors are only available to APM customers.
 
 ## Creating a Watchdog Monitor
 * Choose "Watchdog" on the [New Monitor][2] page.

--- a/content/en/watchdog.md
+++ b/content/en/watchdog.md
@@ -20,7 +20,7 @@ further_reading:
 
 ## Overview
 
-Watchdog is an algorithmic feature that automatically detects potential application and infrastructure issues. Watchdog observes trends and patterns in application metrics - like error rate, request rate, and latency—and unexpected behavior. Watchdog evaluates all services and resources without the need to configure a monitor for each service.
+Watchdog is an algorithmic feature for APM that automatically detects potential application and infrastructure issues. Watchdog observes trends and patterns in application metrics—like error rate, request rate, and latency—and unexpected behavior. Watchdog evaluates all services and resources without the need to configure a monitor for each service.
 
 Watchdog looks for irregularities in metrics, like a sudden spike in hit rate. For each irregularity, the [Watchdog page][1] displays a Watchdog story. Each story includes a graph of the detected metric irregularity and gives more information about the relevant timeframe and endpoint or endpoints. To avoid false alarms, Watchdog only reports issues after observing your data for a sufficient amount of time to establish a high degree of confidence.
 


### PR DESCRIPTION
### What does this PR do?
watchdog is an apm feature for apm that is for apm customers only

apm apologies to all non-apm customers. apm

### Motivation
lior

### Preview link

https://docs-staging.datadoghq.com/cswatt/watchdog-apm/watchdog
https://docs-staging.datadoghq.com/cswatt/watchdog-apm/monitors/monitor_types/watchdog

