### PR TITLE
updating doc about agent ports

### DIFF
--- a/content/en/agent/guide/upgrade-to-agent-v6.md
+++ b/content/en/agent/guide/upgrade-to-agent-v6.md
@@ -19,23 +19,27 @@ Agent 6 is the latest major version of the Datadog Agent. The big difference bet
   * It uses fewer file descriptors
   * It has an all around decreased footprint
 
-* Agent 6 uses ports `5000` to expose its runtime metrics and `5001` for [its CLI/GUI commands][1]. You can specify different ports for `expvar_port` and `cmd_port` in the `datadog.yaml` file.
+* Agent 6 uses [two additional ports][1]:
+    * `5000` to expose its runtime metrics
+    * `5001` for [its CLI/GUI commands][2].
 
-* Custom build your Agent v6 and [DogStatsD][2] much easier and with many more configuration options, to include or exclude almost anything.
+    **Note**: You can specify different ports for `expvar_port` and `cmd_port` in the `datadog.yaml` file.
+
+* Custom build your Agent v6 and [DogStatsD][3] much easier and with many more configuration options, to include or exclude almost anything.
 
 ### Agent v6 new functionalities
 
-To see all changes between Agent v5 and v6, consult the [Datadog Agent dedicated changes][3] documentation, but here are the key differentiators:
+To see all changes between Agent v5 and v6, consult the [Datadog Agent dedicated changes][4] documentation, but here are the key differentiators:
 
-* [Distributions metrics][4] can be performed on the server directly to calculate real, effective global percentiles. (NOTE: this feature is in BETA. Contact support for details on how to have it enabled for your account.)
+* [Distributions metrics][5] can be performed on the server directly to calculate real, effective global percentiles. (NOTE: this feature is in BETA. Contact support for details on how to have it enabled for your account.)
 
-* [DogStatsD][2] can be used over a Unix socket instead of over UDP.
+* [DogStatsD][3] can be used over a Unix socket instead of over UDP.
 
-* [Live Process monitoring is available for Windows][5].
+* [Live Process monitoring is available for Windows][6].
 
-* [Prometheus OpenMetrics is supported natively][6].
+* [Prometheus OpenMetrics is supported natively][7].
 
-* [All your logs can be sent to Datadog for alerting, analysis, and correlation with metrics][7].
+* [All your logs can be sent to Datadog for alerting, analysis, and correlation with metrics][8].
 
 ## Upgrade to Agent 6
 
@@ -258,7 +262,7 @@ DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dat
 
 #### Manual Upgrade
 
-1. Download the DMG package of the latest Agent version, use the latest macOS release listed on the [release page][8] of the repository
+1. Download the DMG package of the latest Agent version, use the latest macOS release listed on the [release page][9] of the repository
 2. Install the DMG package
 3. Add your API key to `/opt/datadog-agent/etc/datadog.yaml`
 4. Transition your Agent configuration paths and formats from Agent v5 to Agent v6, with the `import` command. The command parses an existing v5 `datadog.conf` and converts the configuration options to the new v6 `datadog.yaml` format. It also copies configuration files for checks that are currently enabled:
@@ -419,7 +423,7 @@ DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dat
 
 ### Windows
 
-Download the latest version available [from here][9] and run the installation package.
+Download the latest version available [from here][10] and run the installation package.
 
 Transition your Agent configuration paths and formats from Agent v5 to Agent v6, with the `import` command. The command parses an existing v5 `datadog.conf` and converts the configuration options to the new v6 `datadog.yaml` format. It also copies configuration files for checks that are currently enabled.:
 
@@ -432,12 +436,13 @@ With:
 
 **Note**: `datadog.conf` is automatically upgraded to `datadog.yaml` on upgrade.
 
-[1]: /agent/guide/agent-commands
-[2]: /developers/dogstatsd/unix_socket
-[3]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md
-[4]: /developers/metrics/distributions
-[5]: /graphing/infrastructure/process
-[6]: https://www.datadoghq.com/blog/monitor-prometheus-metrics
-[7]: /logs
-[8]: https://github.com/DataDog/datadog-agent/releases
-[9]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-6-latest.amd64.msi
+[1]: /agent/?tab=agentv6#agent-architecture
+[2]: /agent/guide/agent-commands
+[3]: /developers/dogstatsd/unix_socket
+[4]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md
+[5]: /developers/metrics/distributions
+[6]: /graphing/infrastructure/process
+[7]: https://www.datadoghq.com/blog/monitor-prometheus-metrics
+[8]: /logs
+[9]: https://github.com/DataDog/datadog-agent/releases
+[10]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-6-latest.amd64.msi

--- a/content/en/agent/guide/upgrade-to-agent-v6.md
+++ b/content/en/agent/guide/upgrade-to-agent-v6.md
@@ -20,8 +20,8 @@ Agent 6 is the latest major version of the Datadog Agent. The big difference bet
   * It has an all around decreased footprint
 
 * Agent 6 uses [two additional ports][1]:
-    * `5000` to expose its runtime metrics
-    * `5001` for [its CLI/GUI commands][2].
+    * `5000` to expose its runtime metrics.
+    * `5001` for the [Agent CLI/GUI commands][2].
 
     **Note**: You can specify different ports for `expvar_port` and `cmd_port` in the `datadog.yaml` file.
 

--- a/content/en/agent/guide/upgrade-to-agent-v6.md
+++ b/content/en/agent/guide/upgrade-to-agent-v6.md
@@ -19,23 +19,23 @@ Agent 6 is the latest major version of the Datadog Agent. The big difference bet
   * It uses fewer file descriptors
   * It has an all around decreased footprint
 
-* Agent 6 uses ports `5000` and `5001` by default. You can specify different ports for `expvar_port` and `cmd_port` in the `datadog.yaml` file.
+* Agent 6 uses ports `5000` to expose its runtime metrics and `5001` for [its CLI/GUI commands][1]. You can specify different ports for `expvar_port` and `cmd_port` in the `datadog.yaml` file.
 
-* Custom build your Agent v6 and [DogStatsD][1] much easier and with many more configuration options, to include or exclude almost anything.
+* Custom build your Agent v6 and [DogStatsD][2] much easier and with many more configuration options, to include or exclude almost anything.
 
 ### Agent v6 new functionalities
 
-To see all changes between Agent v5 and v6, consult the [Datadog Agent dedicated changes][2] documentation, but here are the key differentiators:
+To see all changes between Agent v5 and v6, consult the [Datadog Agent dedicated changes][3] documentation, but here are the key differentiators:
 
-* [Distributions metrics][3] can be performed on the server directly to calculate real, effective global percentiles. (NOTE: this feature is in BETA. Contact support for details on how to have it enabled for your account.)
+* [Distributions metrics][4] can be performed on the server directly to calculate real, effective global percentiles. (NOTE: this feature is in BETA. Contact support for details on how to have it enabled for your account.)
 
-* [DogStatsD][1] can be used over a Unix socket instead of over UDP.
+* [DogStatsD][2] can be used over a Unix socket instead of over UDP.
 
-* [Live Process monitoring is available for Windows][4].
+* [Live Process monitoring is available for Windows][5].
 
-* [Prometheus OpenMetrics is supported natively][5].
+* [Prometheus OpenMetrics is supported natively][6].
 
-* [All your logs can be sent to Datadog for alerting, analysis, and correlation with metrics][6].
+* [All your logs can be sent to Datadog for alerting, analysis, and correlation with metrics][7].
 
 ## Upgrade to Agent 6
 
@@ -258,7 +258,7 @@ DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dat
 
 #### Manual Upgrade
 
-1. Download the DMG package of the latest Agent version, use the latest macOS release listed on the [release page][7] of the repository
+1. Download the DMG package of the latest Agent version, use the latest macOS release listed on the [release page][8] of the repository
 2. Install the DMG package
 3. Add your API key to `/opt/datadog-agent/etc/datadog.yaml`
 4. Transition your Agent configuration paths and formats from Agent v5 to Agent v6, with the `import` command. The command parses an existing v5 `datadog.conf` and converts the configuration options to the new v6 `datadog.yaml` format. It also copies configuration files for checks that are currently enabled:
@@ -419,7 +419,7 @@ DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dat
 
 ### Windows
 
-Download the latest version available [from here][8] and run the installation package.
+Download the latest version available [from here][9] and run the installation package.
 
 Transition your Agent configuration paths and formats from Agent v5 to Agent v6, with the `import` command. The command parses an existing v5 `datadog.conf` and converts the configuration options to the new v6 `datadog.yaml` format. It also copies configuration files for checks that are currently enabled.:
 
@@ -432,11 +432,12 @@ With:
 
 **Note**: `datadog.conf` is automatically upgraded to `datadog.yaml` on upgrade.
 
-[1]: /developers/dogstatsd/unix_socket
-[2]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md
-[3]: /developers/metrics/distributions
-[4]: /graphing/infrastructure/process
-[5]: https://www.datadoghq.com/blog/monitor-prometheus-metrics
-[6]: /logs
-[7]: https://github.com/DataDog/datadog-agent/releases
-[8]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-6-latest.amd64.msi
+[1]: /agent/guide/agent-commands
+[2]: /developers/dogstatsd/unix_socket
+[3]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md
+[4]: /developers/metrics/distributions
+[5]: /graphing/infrastructure/process
+[6]: https://www.datadoghq.com/blog/monitor-prometheus-metrics
+[7]: /logs
+[8]: https://github.com/DataDog/datadog-agent/releases
+[9]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-6-latest.amd64.msi


### PR DESCRIPTION
### What does this PR do?
Adds precisions about agent v6 ports usage.

### Motivation
A customer was confused by the wording.

### Preview link

* https://docs-staging.datadoghq.com/gus/agent-ports/agent/guide/upgrade-to-agent-v6/#what-is-the-agent-v6