### PR TITLE
Fixing the postman collection endpoints

### DIFF
--- a/static/resources/json/datadog_collection.json
+++ b/static/resources/json/datadog_collection.json
@@ -4991,7 +4991,7 @@
 							]
 						},
 						{
-							"name": "Create an AWS Account in Datadog",
+							"name": "Create an AWS integration",
 							"request": {
 								"method": "POST",
 								"header": [
@@ -5031,7 +5031,7 @@
 										}
 									]
 								},
-								"description": "### Overview\n\nConfigure your Datadog-AWS integration directly through Datadog API. [Read more about Datadog-AWS integration][1].\n\n**Note**:\n\n* Using the `POST` method updates your integration configuration by **adding** your new configuration to the existing one in your Datadog organization.\n* Using the `PUT` method updates your integration configuration by **replacing** your current configuration with the new one sent to your Datadog organization.\n\n### Arguments\n\n* **`account_id`** [*required*]: Your AWS Account ID without dashes. [Consult the Datadog AWS integration to learn more][2] about your AWS account ID.\n\n* **`access_key_id`** [*optional*, *default*=**None**]: If your AWS account is a GovCloud or China account, enter the corresponding Access Key ID.\n\n* **`role_name`** [*required*]: Your Datadog role delegation name. [Consult the Datadog AWS integration to learn more][3] about your AWS account Role name.\n\n* **`filter_tags`** [*optional*, *default*=**None**]: Array of EC2 tags (in the form `key:value`) defines a filter that Datadog use when collecting metrics from EC2. Wildcards, such as `?` (for single characters) and `*` (for multiple characters) can also be used.\n    Only hosts that match one of the defined tags will be imported into Datadog. The rest will be ignored. Host matching a given tag can also be excluded by adding `!` before the tag.\n    e.x. `env:production,instance-type:c1.*,!region:us-east-1`\n    [Read more about EC2 tagging in AWS tagging documentation][4].\n\n* **`host_tags`** [*optional*, *default*=**None**]: Array of tags (in the form `key:value`) to add to all hosts and metrics reporting through this integration.\n\n* **`account_specific_namespace_rules`** [*optional*, *default*=**None**]: An object (in the form `{\"namespace1\":true/false, \"namespace2\":true/false}`) that enables or disables metric collection for specific AWS namespaces for this AWS account only. A list of namespaces can be found at the `https://api.datadoghq.com/api/v1/integration/aws/available_namespace_rules` endpoint.\n\n[1]: https://docs.datadoghq.com/integrations/amazon_web_services\n[2]: https://docs.datadoghq.com/integrations/amazon_web_services/#configuration\n[3]: https://docs.datadoghq.com/integrations/amazon_web_services/#installation\n[4]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html"
+								"description": "### Overview\n\nCreate a Datadog-Amazon Web Services integration.\n\n**Note**: Using the `POST` method updates your integration configuration by **adding** your new configuration to the existing one in your Datadog organization.\n\n### Arguments\n\n* **`account_id`** [*required*]:\n\n    Your AWS Account ID without dashes.\n    [Consult the Datadog AWS integration to learn more][1] about your AWS account ID.\n\n* **`access_key_id`** [*optional*, *default*=**None**]:\n\n    If your AWS account is a GovCloud or China account, enter the corresponding Access Key ID.\n\n* **`role_name`** [*required*]:\n\n    Your Datadog role delegation name.\n    For more information about you AWS account Role name, [see the Datadog AWS integration configuration info][2].\n\n* **`filter_tags`** [*optional*, *default*=**None**]:\n\n    The array of EC2 tags (in the form `key:value`) defines a filter that Datadog uses when collecting metrics from EC2. Wildcards, such as `?` (for single characters) and `*` (for multiple characters) can also be used.\n    Only hosts that match one of the defined tags will be imported into Datadog. The rest will be ignored. Host matching a given tag can also be excluded by adding `!` before the tag.\n    e.x. `env:production,instance-type:c1.*,!region:us-east-1`\n    For more information on EC2 tagging, see the [AWS tagging documentation][3].\n\n* **`host_tags`** [*optional*, *default*=**None**]:\n\n    Array of tags (in the form `key:value`) to add to all hosts and metrics reporting through this integration.\n\n* **`account_specific_namespace_rules`** [*optional*, *default*=**None**]:\n\n    An object (in the form `{\"namespace1\":true/false, \"namespace2\":true/false}`) that enables or disables metric collection for specific AWS namespaces for this AWS account only. A list of namespaces can be found at the `https://api.datadoghq.com/api/v1/integration/aws/available_namespace_rules` endpoint.\n\n[1]: /integrations/amazon_web_services/#configuration\n[2]: /integrations/amazon_web_services/#installation\n[3]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html"
 							},
 							"response": [
 								{
@@ -5673,6 +5673,163 @@
 								"description": "Delete a Datadog-AWS Filtering rule"
 							},
 							"response": []
+						},
+						{
+							"name": "Generate new External IDs",
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"account_id\": \"<YOUR_AWS_ACCOUNT_ID>\",\n    \"role_name\": \"DatadogAWSIntegrationRole\"\n}"
+								},
+								"url": {
+									"raw": "https://api.datadoghq.{{datadog_site}}/api/v1/integration/aws/generate_new_external_id?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
+									"protocol": "https",
+									"host": [
+										"api",
+										"datadoghq",
+										"{{datadog_site}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"integration",
+										"aws",
+										"generate_new_external_id"
+									],
+									"query": [
+										{
+											"key": "api_key",
+											"value": "{{datadog_api_key}}",
+											"description": "Your Datadog API key"
+										},
+										{
+											"key": "application_key",
+											"value": "{{datadog_application_key}}",
+											"description": "Your Datadog application key"
+										}
+									]
+								},
+								"description": "### Overview\n\nGenerate a new AWS external id for a given AWS account id and role name pair.\n\n### Arguments\n\n\n* **`account_id`** [*required*]:\n\n    Your AWS Account ID without dashes.\n    [Consult the Datadog AWS integration to learn more][1] about your AWS account ID.\n\n* **`role_name`** [*required*]:\n\n    Your Datadog role delegation name.\n    For more information about you AWS account Role name, [see the Datadog AWS integration configuration info][2].\n\n[1]: /integrations/amazon_web_services/#configuration\n[2]: /integrations/amazon_web_services/#installation"
+							},
+							"response": [
+								{
+									"name": "Creating an account",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"account_id\": \"<YOUR_AWS_ACCOUNT_ID>\",\n    \"filter_tags\": [\n        \"<TAG_KEY>:<TAG_VALUE>\"\n    ],\n    \"host_tags\": [\n        \"<TAG_KEY>:<TAG_VALUE>\"\n    ],\n    \"role_name\": \"DatadogAWSIntegrationRole\",\n    \"account_specific_namespace_rules\": {\n        \"auto_scaling\": false,\n        \"opsworks\": false\n    }\n}"
+										},
+										"url": {
+											"raw": "https://api.datadoghq.com/api/v1/integration/aws?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
+											"protocol": "https",
+											"host": [
+												"api",
+												"datadoghq",
+												"com"
+											],
+											"path": [
+												"api",
+												"v1",
+												"integration",
+												"aws"
+											],
+											"query": [
+												{
+													"key": "api_key",
+													"value": "{{datadog_api_key}}",
+													"description": "Your Datadog API key"
+												},
+												{
+													"key": "application_key",
+													"value": "{{datadog_application_key}}",
+													"description": "Your Datadog application key"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Date",
+											"value": "Mon, 06 May 2019 15:25:25 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Transfer-Encoding",
+											"value": "chunked"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "Vary",
+											"value": "Accept-Encoding"
+										},
+										{
+											"key": "Pragma",
+											"value": "no-cache"
+										},
+										{
+											"key": "Cache-Control",
+											"value": "no-cache"
+										},
+										{
+											"key": "Set-Cookie",
+											"value": "DD-PSHARD=193; Max-Age=604800; Path=/; expires=Mon, 13-May-2019 15:25:21 GMT; secure; HttpOnly"
+										},
+										{
+											"key": "X-DD-VERSION",
+											"value": "35.1295692"
+										},
+										{
+											"key": "X-DD-Debug",
+											"value": "c4aq40z3KDGIu7BkYTlUd0iZ+hCVqUX2FQHrdHjK4gPuZVw/LYvbdogVHHOtojAR"
+										},
+										{
+											"key": "Content-Encoding",
+											"value": "gzip"
+										},
+										{
+											"key": "DD-POOL",
+											"value": "dogweb_sameorig"
+										},
+										{
+											"key": "X-Frame-Options",
+											"value": "SAMEORIGIN"
+										},
+										{
+											"key": "X-Content-Type-Options",
+											"value": "nosniff"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=15724800;"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"external_id\": \"1234567890\"\n}"
+								}
+							]
 						}
 					],
 					"description": "Configure your Datadog-AWS integration directly through Datadog API.\n\nMore Details Here: https://docs.datadoghq.com/integrations/amazon_web_services/",
@@ -6254,10 +6411,10 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "https://app.datadoghq.{{datadog_site}}/api/v1/integration/pagerduty?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
+									"raw": "https://api.datadoghq.{{datadog_site}}/api/v1/integration/pagerduty?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
 									"protocol": "https",
 									"host": [
-										"app",
+										"api",
 										"datadoghq",
 										"{{datadog_site}}"
 									],
@@ -6398,10 +6555,10 @@
 									"raw": "{\n    \"services\": [\n        {\n            \"service_name\": \"<SERVICE_NAME_1>\",\n            \"service_key\": \"<PAGERDUTY_SERVICE_KEY>\"\n        },\n        {\n            \"service_name\": \"<SERVICE_NAME_2>\",\n            \"service_key\": \"<PAGERDUTY_SERVICE_KEY>\"\n        }\n    ],\n    \"subdomain\": \"<PAGERDUTY_SUB_DOMAIN>\",\n    \"schedules\": [\n        \"<SCHEDULE_1>\",\n        \"<SCHEDULE_2>\"\n    ],\n    \"api_token\": \"<PAGERDUTY_TOKEN>\"\n}"
 								},
 								"url": {
-									"raw": "https://app.datadoghq.{{datadog_site}}/api/v1/integration/pagerduty?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
+									"raw": "https://api.datadoghq.{{datadog_site}}/api/v1/integration/pagerduty?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
 									"protocol": "https",
 									"host": [
-										"app",
+										"api",
 										"datadoghq",
 										"{{datadog_site}}"
 									],
@@ -6443,10 +6600,10 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "https://app.datadoghq.{{datadog_site}}/api/v1/integration/pagerduty?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
+									"raw": "https://api.datadoghq.{{datadog_site}}/api/v1/integration/pagerduty?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
 									"protocol": "https",
 									"host": [
-										"app",
+										"api",
 										"datadoghq",
 										"{{datadog_site}}"
 									],
@@ -6488,10 +6645,10 @@
 									"raw": "{\n    \"services\": [\n        {\n            \"service_name\": \"<SERVICE_NAME_1>\",\n            \"service_key\": \"<PAGERDUTY_SERVICE_KEY>\"\n        },\n        {\n            \"service_name\": \"<SERVICE_NAME_2>\",\n            \"service_key\": \"<PAGERDUTY_SERVICE_KEY>\"\n        }\n    ],\n    \"schedules\": [\n        \"<SCHEDULE_1>\",\n        \"<SCHEDULE_2>\"\n    ]\n}"
 								},
 								"url": {
-									"raw": "https://app.datadoghq.{{datadog_site}}/api/v1/integration/pagerduty?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
+									"raw": "https://api.datadoghq.{{datadog_site}}/api/v1/integration/pagerduty?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
 									"protocol": "https",
 									"host": [
-										"app",
+										"api",
 										"datadoghq",
 										"{{datadog_site}}"
 									],
@@ -6543,10 +6700,10 @@
 									"raw": "{\n    \"service_hooks\": [\n        {\n            \"account\": \"Main_Account\",\n            \"url\": \"https://hooks.slack.com/services/1/1\"\n        },\n        {\n            \"account\": \"doghouse\",\n            \"url\": \"https://hooks.slack.com/services/2/2\"\n        }\n    ],\n    \"channels\": [\n        {\n            \"channel_name\": \"#private\",\n            \"transfer_all_user_comments\": \"false\",\n            \"account\": \"Main_Account\"\n        },\n        {\n            \"channel_name\": \"#heresachannel\",\n            \"transfer_all_user_comments\": \"false\",\n            \"account\": \"doghouse\"\n        }\n    ]\n}"
 								},
 								"url": {
-									"raw": "https://app.datadoghq.{{datadog_site}}/api/v1/integration/slack?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
+									"raw": "https://api.datadoghq.{{datadog_site}}/api/v1/integration/slack?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
 									"protocol": "https",
 									"host": [
-										"app",
+										"api",
 										"datadoghq",
 										"{{datadog_site}}"
 									],
@@ -6687,10 +6844,10 @@
 									"raw": "{\n    \"service_hooks\": [\n        {\n            \"account\": \"Main_Account\",\n            \"url\": \"https://hooks.slack.com/services/1/1\"\n        },\n        {\n            \"account\": \"doghouse\",\n            \"url\": \"https://hooks.slack.com/services/2/2\"\n        }\n    ],\n    \"channels\": [\n        {\n            \"channel_name\": \"#private\",\n            \"transfer_all_user_comments\": \"false\",\n            \"account\": \"Main_Account\"\n        },\n        {\n            \"channel_name\": \"#heresachannel\",\n            \"transfer_all_user_comments\": \"false\",\n            \"account\": \"doghouse\"\n        }\n    ]\n}"
 								},
 								"url": {
-									"raw": "https://app.datadoghq.{{datadog_site}}/api/v1/integration/slack?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
+									"raw": "https://api.datadoghq.{{datadog_site}}/api/v1/integration/slack?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
 									"protocol": "https",
 									"host": [
-										"app",
+										"api",
 										"datadoghq",
 										"{{datadog_site}}"
 									],
@@ -6732,10 +6889,10 @@
 									"raw": "{\n    \"service_hooks\": [\n        {\n            \"account\": \"Main_Account\",\n            \"url\": \"https://hooks.slack.com/services/1/1\"\n        },\n        {\n            \"account\": \"doghouse\",\n            \"url\": \"https://hooks.slack.com/services/2/2\"\n        }\n    ],\n    \"channels\": [\n        {\n            \"channel_name\": \"#private\",\n            \"transfer_all_user_comments\": \"false\",\n            \"account\": \"Main_Account\"\n        },\n        {\n            \"channel_name\": \"#heresachannel\",\n            \"transfer_all_user_comments\": \"false\",\n            \"account\": \"doghouse\"\n        }\n    ]\n}"
 								},
 								"url": {
-									"raw": "https://app.datadoghq.{{datadog_site}}/api/v1/integration/slack?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
+									"raw": "https://api.datadoghq.{{datadog_site}}/api/v1/integration/slack?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
 									"protocol": "https",
 									"host": [
-										"app",
+										"api",
 										"datadoghq",
 										"{{datadog_site}}"
 									],
@@ -6777,10 +6934,10 @@
 									"raw": "{\n    \"channels\": [\n        {\n            \"channel_name\": \"<CHANNEL_NAME_3>\",\n            \"transfer_all_user_comments\": \"false\",\n            \"account\": \"<SLACK_ACCOUNT_1>\"\n        },\n        {\n            \"channel_name\": \"<CHANNEL_NAME_4>\",\n            \"transfer_all_user_comments\": \"false\",\n            \"account\": \"<SLACK_ACCOUNT_2>\"\n        }\n    ]\n}"
 								},
 								"url": {
-									"raw": "https://app.datadoghq.{{datadog_site}}/api/v1/integration/slack?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
+									"raw": "https://api.datadoghq.{{datadog_site}}/api/v1/integration/slack?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
 									"protocol": "https",
 									"host": [
-										"app",
+										"api",
 										"datadoghq",
 										"{{datadog_site}}"
 									],
@@ -6832,10 +6989,10 @@
 									"raw": "{\n    \"hooks\": [\n        {\n            \"name\": \"somehook\",\n            \"url\": \"http://requestb.in/v1srg7v1\",\n            \"use_custom_payload\": \"false\",\n            \"custom_payload\": \"\",\n            \"encode_as_form\": \"false\",\n            \"headers\": \"\"\n        }\n    ]\n}"
 								},
 								"url": {
-									"raw": "https://app.datadoghq.{{datadog_site}}/api/v1/integration/webhooks?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
+									"raw": "https://api.datadoghq.{{datadog_site}}/api/v1/integration/webhooks?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
 									"protocol": "https",
 									"host": [
-										"app",
+										"api",
 										"datadoghq",
 										"{{datadog_site}}"
 									],
@@ -6874,10 +7031,10 @@
 									"raw": "{\n    \"hooks\": [\n      {\n        \"name\": \"<WEBHOOK_NAME>\",\n        \"url\": \"<WEBHOOK_URL>\",\n        \"use_custom_payload\": \"false\",\n        \"encode_as_form\": \"false\"\n      }\n    ]\n}"
 								},
 								"url": {
-									"raw": "https://app.datadoghq.{{datadog_site}}/api/v1/integration/webhooks?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
+									"raw": "https://api.datadoghq.{{datadog_site}}/api/v1/integration/webhooks?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
 									"protocol": "https",
 									"host": [
-										"app",
+										"api",
 										"datadoghq",
 										"{{datadog_site}}"
 									],
@@ -6917,10 +7074,10 @@
 									"raw": "{\n    \"hooks\": [\n        {\n            \"name\": \"somehook\",\n            \"url\": \"http://requestb.in/v1srg7v1\",\n            \"use_custom_payload\": \"false\",\n            \"custom_payload\": \"\",\n            \"encode_as_form\": \"false\",\n            \"headers\": \"\"\n        }\n    ]\n}"
 								},
 								"url": {
-									"raw": "https://app.datadoghq.{{datadog_site}}/api/v1/integration/webhooks?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
+									"raw": "https://api.datadoghq.{{datadog_site}}/api/v1/integration/webhooks?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
 									"protocol": "https",
 									"host": [
-										"app",
+										"api",
 										"datadoghq",
 										"{{datadog_site}}"
 									],
@@ -6959,10 +7116,10 @@
 									"raw": "{\n    \"hooks\": [\n        {\n            \"name\": \"anotherone\",\n            \"url\": \"http://requestb.in/v1srg7v1\"\n        }\n    ]\n}"
 								},
 								"url": {
-									"raw": "https://app.datadoghq.{{datadog_site}}/api/v1/integration/webhooks?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
+									"raw": "https://api.datadoghq.{{datadog_site}}/api/v1/integration/webhooks?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
 									"protocol": "https",
 									"host": [
-										"app",
+										"api",
 										"datadoghq",
 										"{{datadog_site}}"
 									],
@@ -9041,7 +9198,7 @@
 								}
 							]
 						},
-						"description": "### Overview\n\nCreate a Synthetics test to initiate and configure the tests you want Datadog to send to your API endpoints or to your browser app. You can configure the endpoints being tested, the number of tests, and where they are coming from. The parameters required are different for API and browser tests and they are marked accordingly—if a parameter is marked as _required_, it is required for both types of tests. Once you create a test, it shows up in the UI in your [Synthetics list][1]\n\nA browser test is treated like a GET API test. This method gives you the ability to create the browser test, but you have to use the UI to [record your test][2].\n\n##### Arguments\n\n*   **`assertions`** - _required_ - This is where you are defining exactly what should happen for a test to be considered passed. Each assertion has a: `type`, `operator`, `target`, and possibly a `property`.\n    *   **`type`** - _required API test_ - The part of the response that you want to assess. Possible types are `header`, `body`, `responseTime`, and `statusCode`. When you define a header, you must specify the header parameter key in the `property` parameter, and the header parameter value with the `target` parameter. For all other types, use the `target` to specify the body, the response time, and the error messages. For example, a `\"type\":\"statusCode\"` might have a `\"target\":403`.\n    *   **`operator`** - _required API test_ - Defines how to compare the target and the actual value from the response. Valid operators depend on the `type` of assertions. This is the list of valid operators per type:\n\n<table>\n <tr>\n    <th><code>type</code></th>\n    <th>Valid <code>operator</code></th>\n    <th>Value type</th>\n  </tr>\n  <tr>\n    <td>Status Code</td>\n    <td><code>is</code>, <code>is not</code></td>\n    <td>Integer</td>\n  </tr>\n  <tr>\n    <td>Response time</td>\n    <td><code>less than</code></td>\n    <td>Integer</td>\n  </tr>\n  <tr>\n    <td>Headers</td>\n    <td><code>contains</code>, <code>does not contain</code>, <code>is</code>, <code>is not</code>, <code>matches</code>, <code>does not match</code></td>\n    <td>for <code>contains</code>/<code>does not contain</code>/<code>is</code>/<code>is not</code>: String for <code>matches</code>/<code>does not match</code>: <a href=\"https://docs.datadoghq.com/tagging/using_tags\">RegexString</a></td>\n  </tr>\n  <tr>\n    <td>Body</td>\n    <td><code>contains</code>, <code>does not contain</code>, <code>is</code>, <code>is not</code>, <code>matches</code>, <code>does not match</code></td>\n    <td>for <code>contains</code>/<code>does not contain/<code>is</code>/<code>is not</code>: String for <code>matches</code>/<code>does not match</code>: <a href=\"https://docs.datadoghq.com/tagging/using_tags\">RegexString</a></td>\n  </tr>\n</table>\n\n   *   **`target`** - _required API test_ - The expected value for the assertion. For `header`, valid values are any of the valid values for the header key that you define in `property`. For `statusCode`, valid values are valid status codes. For `responseTime`, valid values are the expected response times.\n   *   **`property`** - _optional_ - When you are setting up a `header` `type`, this is required to define the headers parameter key. Valid values are any header keys, like `Content-Type` or `Authorization`.\n*   **`request`** - _required API test_ - An object containing all the necessary information to perform the request to your endpoint.\n   *   **`method`** - _required_ - The method of the API to test. Valid values are `GET`, `POST`, `PUT`, `PATCH`, and `DELETE`. Use `GET` for a browser test.\n   *   **`url`** - _required_ - The endpoint for the API Datadog is testing. For a browser test, the URL for the website Datadog is testing.\n   *   **`timeout`** - _optional_ - When the API request will timeout.\n   *   **`headers`** - _optional_ - Headers in the API request.\n   *   **`body`** - _optional_ - The body for the API request. Accepts text strings (including a JSON as a text string). Specify the type using `Content-Type` `property` parameter and the type (like `application/json` or `text/plain` in the `headers` paramater.\n*   **`locations`** - _required_ - A list of the locations that you want the tests to be sent from. At least one value is required, and you can use all locations. For a list of valid locations, use the `GET available locations` method. At least one value is required, and you can use all locations.\n*   **`message`** - _required_ - A description of the test.\n*   **`name`** - _required_ - A unique name for the test.\n*   **`options`** - _required_ - Use advanced options to specify custom request headers, authentication credentials, body content, cookies, or to have the test follow redirects. All optional parameters take their default value if you don't specify a value. Valid values in the request object are:\n    *  ** `tick_every`:** - _required_ -  How often the test should run (in seconds - current possible values are 60, 300, 900, 1800, 3600, 21600, 43200, 86400, 604800).\n    *  **`min_failure_duration`** - _optional_ - How long the test should be in failure before alerting (integer, number of seconds, max 7200). Default is 0.\n    *  **`min_location_failed`** - _optional_ - The minimum number of locations that must have been in failure at the same time during at least one moment in the `min_failure_duration` period (min_location_failed and min_failure_duration are part of the advanced alerting rules  - integer, >= 1. Default is 1.\n    *  **`follow_redirects`** - _optional_ - boolean - whether to follow redirects or not (max ten redirects can be followed before triggering a \"Too many redirects\" error). Valid values are `true` or `false`. Default value is `false`.\n    *  **`device_ids`** - _required browser test_ - The type of device you want to use to test. To get a list of available devices, use the `GET devices for browser checkes` method and use the `id` from the response. At least one device is required.\n*   **`tags`** - _optional_ - Tags you want to use to filter your test when you are viewing it in Datadog. For more info on custom tags, see [Using tags][3].\n*   **`type`** - _required_ - The type of test. Valid values are `api` and `browser`.\n\n[1]: https://app.datadoghq.com/synthetics/list\n[2]: https://docs.datadoghq.com/synthetics/browser_tests/#record-test\n[3]: https://docs.datadoghq.com/tagging/using_tags"
+						"description": "### Overview\n\nCreate a Synthetics test to initiate and configure the tests you want Datadog to send to your API endpoints or to your browser app. You can configure the endpoints being tested, the number of tests, and where they are coming from. The parameters required are different for API and browser tests and they are marked accordingly—if a parameter is marked as _required_, it is required for both types of tests. Once you create a test, it shows up in the UI in your [Synthetics list][1]\n\nA browser test is treated like a GET API test. This method gives you the ability to create the browser test, but you have to use the UI to [record your test][2].\n\n##### Arguments\n\n*   **`assertions`** - _required_ - This is where you are defining exactly what should happen for a test to be considered passed. Each assertion has a: `type`, `operator`, `target`, and possibly a `property`.\n    *   **`type`** - _required API test_ - The part of the response that you want to assess. Possible types are `header`, `body`, `responseTime`, and `statusCode`. When you define a header, you must specify the header parameter key in the `property` parameter, and the header parameter value with the `target` parameter. For all other types, use the `target` to specify the body, the response time, and the error messages. For example, a `\"type\":\"statusCode\"` might have a `\"target\":403`.\n    *   **`operator`** - _required API test_ - Defines how to compare the target and the actual value from the response. Valid operators depend on the `type` of assertions. This is the list of valid operators per type:\n\n<table>\n <tr>\n    <th><code>type</code></th>\n    <th>Valid <code>operator</code></th>\n    <th>Value type</th>\n  </tr>\n  <tr>\n    <td>Status Code</td>\n    <td><code>is</code>, <code>is not</code></td>\n    <td>Integer</td>\n  </tr>\n  <tr>\n    <td>Response time</td>\n    <td><code>less than</code></td>\n    <td>Integer</td>\n  </tr>\n  <tr>\n    <td>Headers</td>\n    <td><code>contains</code>, <code>does not contain</code>, <code>is</code>, <code>is not</code>, <code>matches</code>, <code>does not match</code></td>\n    <td>for <code>contains</code>/<code>does not contain</code>/<code>is</code>/<code>is not</code>: String for <code>matches</code>/<code>does not match</code>: <a href=\"https://docs.datadoghq.com/tagging/using_tags\">RegexString</a></td>\n  </tr>\n  <tr>\n    <td>Body</td>\n    <td><code>contains</code>, <code>does not contain</code>, <code>is</code>, <code>is not</code>, <code>matches</code>, <code>does not match</code></td>\n    <td>for <code>contains</code>/<code>does not contain/<code>is</code>/<code>is not</code>: String for <code>matches</code>/<code>does not match</code>: <a href=\"https://docs.datadoghq.com/tagging/using_tags\">RegexString</a></td>\n  </tr>\n</table>\n\n   *   **`target`** - _required API test_ - The expected value for the assertion. For `header`, valid values are any of the valid values for the header key that you define in `property`. For `statusCode`, valid values are valid status codes. For `responseTime`, valid values are the expected response times.\n   *   **`property`** - _optional_ - When you are setting up a `header` `type`, this is required to define the headers parameter key. Valid values are any header keys, like `Content-Type` or `Authorization`.\n*   **`request`** - _required API test_ - An object containing all the necessary information to perform the request to your endpoint.\n   *   **`method`** - _required_ - The method of the API to test. Valid values are `GET`, `POST`, `PUT`, `PATCH`, and `DELETE`. Use `GET` for a browser test.\n   *   **`url`** - _required_ - The endpoint for the API Datadog is testing. For a browser test, the URL for the website Datadog is testing.\n   *   **`timeout`** - _optional_ - When the API request will timeout.\n   *   **`headers`** - _optional_ - Headers in the API request.\n   *   **`body`** - _optional_ - The body for the API request. Accepts text strings (including a JSON as a text string). Specify the type using `Content-Type` `property` parameter and the type (like `application/json` or `text/plain` in the `headers` paramater.\n*   **`locations`** - _required_ - A list of the locations that you want the tests to be sent from. At least one value is required, and you can use all locations. For a list of valid locations, use the `GET available locations` method. At least one value is required, and you can use all locations.\n*   **`message`** - _required_ - A description of the test.\n*   **`name`** - _required_ - A unique name for the test.\n*   **`options`** - _required_ - Use advanced options to specify custom request headers, authentication credentials, body content, cookies, or to have the test follow redirects. All optional parameters take their default value if you don't specify a value. Valid values in the request object are:\n    *  ** `tick_every`:** - _required_ -  How often the test should run (in seconds - current possible values are 60, 300, 900, 1800, 3600, 21600, 43200, 86400, 604800).\n    *  **`min_failure_duration`** - _optional_ - How long the test should be in failure before alerting (integer, number of seconds, max 7200). Default is 0.\n    *  **`min_location_failed`** - _optional_ - The minimum number of locations that must have been in failure at the same time during at least one moment in the `min_failure_duration` period (min_location_failed and min_failure_duration are part of the advanced alerting rules  - integer, >= 1. Default is 1.\n    *  **`follow_redirects`** - _optional_ - boolean - whether to follow redirects or not (max ten redirects can be followed before triggering a \"Too many redirects\" error). Valid values are `true` or `false`. Default value is `false`.\n    *  **`device_ids`** - _required browser test_ - The type of device you want to use to test. To get a list of available devices, use the `GET devices for browser checkes` method and use the `id` from the response. At least one device is required.\n*   **`tags`** - _optional_ - Tags you want to use to filter your test when you are viewing it in Datadog. For more info on custom tags, see [Using tags][3].\n*   **`type`** - _required_ - The type of test. Valid values are `api` and `browser`.\n\n[1]: https://app.datadoghq.com/synthetics/list\n[2]: https://docs.datadoghq.com/synthetics/browser_test/#record-test\n[3]: https://docs.datadoghq.com/tagging/using_tags"
 					},
 					"response": []
 				},
@@ -9150,7 +9307,7 @@
 								}
 							]
 						},
-						"description": "### Overview\n\nUse this method to update an existing Synthetics test. In order to update a test, you have to submit the same payload as creating a test.\n\nThe parameters required are different for API and browser tests and they are marked accordingly—if a parameter is marked as _required_, it is required for both types of tests.\n\nA browser test is treated like a GET API test. This method gives you the ability to update the browser test, but you have to use the UI to [record your test][1].\n\nIn order to update a request, you have to submit a full object, but only these parameters are editable: `name`, `tags`, `config` (anything defined in the `assertions` and anything defined in the `request`), `message`, `options`, `locations`, and `status`.\n\n### Arguments\n\n*   **`assertions`** - _required_ - This is where you are defining exactly what should happen for a test to be considered passed. Each assertion has a: `type`, `operator`, `target`, and possibly a `property`.\n    *   **`type`** - _required API test_ - The part of the response that you want to assess. Possible types are `header`, `body`, `responseTime`, and `statusCode`. When you define a header, you must specify the header parameter key in the `property` parameter, and the header parameter value with the `target` parameter. For all other types, use the `target` to specify the body, the response time, and the error messages. For example, a `\"type\":\"statusCode\"` might have a `\"target\":403`.\n    *   **`operator`** - _required API test_ - Defines how to compare the target and the actual value from the response. Valid operators depend on the `type` of assertions. This is the list of valid operators per type:\n\n<table>\n <tr>\n    <th><code>type</code></th>\n    <th>Valid <code>operator</code></th>\n    <th>Value type</th>\n  </tr>\n  <tr>\n    <td>Status Code</td>\n    <td><code>is</code>, <code>is not</code></td>\n    <td>Integer</td>\n  </tr>\n  <tr>\n    <td>Response time</td>\n    <td><code>less than</code></td>\n    <td>Integer</td>\n  </tr>\n  <tr>\n    <td>Headers</td>\n    <td><code>contains</code>, <code>does not contain</code>, <code>is</code>, <code>is not</code>, <code>matches</code>, <code>does not match</code></td>\n    <td>for <code>contains</code>/<code>does not contain</code>/<code>is</code>/<code>is not</code>: String for <code>matches</code>/<code>does not match</code>: <a href=\"https://docs.datadoghq.com/tagging/using_tags\">RegexString</a></td>\n  </tr>\n  <tr>\n    <td>Body</td>\n    <td><code>contains</code>, <code>does not contain</code>, <code>is</code>, <code>is not</code>, <code>matches</code>, <code>does not match</code></td>\n    <td>for <code>contains</code>/<code>does not contain/<code>is</code>/<code>is not</code>: String for <code>matches</code>/<code>does not match</code>: <a href=\"https://docs.datadoghq.com/tagging/using_tags\">RegexString</a></td>\n  </tr>\n</table>\n\n   *   **`target`** - _required API test_ - The expected value for the assertion. For `header`, valid values are any of the valid values for the header key that you define in `property`. For `statusCode`, valid values are valid status codes. For `responseTime`, valid values are the expected response times.\n   *   **`property`** - _optional_ - When you are setting up a `header` `type`, this is required to define the headers parameter key. Valid values are any header keys, like `Content-Type` or `Authorization`.\n*   **`request`** - _required API test_ - An object containing all the necessary information to perform the request to your endpoint.\n   *   **`method`** - _required_ - The method of the API to test. Valid values are `GET`, `POST`, `PUT`, `PATCH`, and `DELETE`. Use `GET` for a browser test.\n   *   **`url`** - _required_ - The endpoint for the API Datadog is testing. For a browser test, the URL for the website Datadog is testing.\n   *   **`timeout`** - _optional_ - When the API request will timeout.\n   *   **`headers`** - _optional_ - Headers in the API request.\n   *   **`body`** - _optional_ The body for the API request. Accepts text strings (including a JSON as a text string). Specify the type using `Content-Type` `property` parameter and the type (like `application/json` or `text/plain` in the `headers` paramater.\n*   **`locations`** - _required_ - A list of the locations that you want the tests to be sent from. At least one value is required, and you can use all locations. For a list of valid locations, use the `GET available locations` method. At least one value is required, and you can use all locations.\n*   **`message`** - _required_ - A description of the test.\n*   **`name`** - _required_ - A unique name for the test.\n*   **`options`** - _required_ - Use advanced options to specify custom request headers, authentication credentials, body content, cookies, or to have the test follow redirects. All optional parameters take their default value if you don't specify a value. Valid values in the request object are:\n    *  **`tick_every`:** - _required_ -  How often the test should run (in seconds - current possible values are 60, 300, 900, 1800, 3600, 21600, 43200, 86400, 604800).\n    *  **`min_failure_duration`** - _optional_ - How long the test should be in failure before alerting (integer, number of seconds, max 7200). Default is 0.\n    *  **`min_location_failed`** - _optional_ - The minimum number of locations that must have been in failure at the same time during at least one moment in the `min_failure_duration` period (min_location_failed and min_failure_duration are part of the advanced alerting rules  - integer, >= 1. Default is 1.\n    *  **`follow_redirects`** - _optional_ - boolean - whether to follow redirects or not (max ten redirects can be followed before triggering a \"Too many redirects\" error). Valid values are `true` or `false`. Default value is `false`.\n    *  **`device_ids`** - _required browser test_ - The type of device you want to use to test. To get a list of available devices, use the `GET devices for browser checkes` method and use the `id` from the response. At least one device is required.\n*   **`tags`** - _optional_ - Tags you want to use to filter your test when you are viewing it in Datadog. For more info on custom tags, see [Using tags][2].\n*   **`type`** - _required_ - The type of test. Valid values are `api` and `browser`.\n\n[1]: https://docs.datadoghq.com/synthetics/browser_tests/#record-test\n[2]: https://docs.datadoghq.com/tagging/using_tags"
+						"description": "### Overview\n\nUse this method to update an existing Synthetics test. In order to update a test, you have to submit the same payload as creating a test.\n\nThe parameters required are different for API and browser tests and they are marked accordingly—if a parameter is marked as _required_, it is required for both types of tests.\n\nA browser test is treated like a GET API test. This method gives you the ability to update the browser test, but you have to use the UI to [record your test][1].\n\nIn order to update a request, you have to submit a full object, but only these parameters are editable: `name`, `tags`, `config` (anything defined in the `assertions` and anything defined in the `request`), `message`, `options`, `locations`, and `status`.\n\n### Arguments\n\n*   **`assertions`** - _required_ - This is where you are defining exactly what should happen for a test to be considered passed. Each assertion has a: `type`, `operator`, `target`, and possibly a `property`.\n    *   **`type`** - _required API test_ - The part of the response that you want to assess. Possible types are `header`, `body`, `responseTime`, and `statusCode`. When you define a header, you must specify the header parameter key in the `property` parameter, and the header parameter value with the `target` parameter. For all other types, use the `target` to specify the body, the response time, and the error messages. For example, a `\"type\":\"statusCode\"` might have a `\"target\":403`.\n    *   **`operator`** - _required API test_ - Defines how to compare the target and the actual value from the response. Valid operators depend on the `type` of assertions. This is the list of valid operators per type:\n\n<table>\n <tr>\n    <th><code>type</code></th>\n    <th>Valid <code>operator</code></th>\n    <th>Value type</th>\n  </tr>\n  <tr>\n    <td>Status Code</td>\n    <td><code>is</code>, <code>is not</code></td>\n    <td>Integer</td>\n  </tr>\n  <tr>\n    <td>Response time</td>\n    <td><code>less than</code></td>\n    <td>Integer</td>\n  </tr>\n  <tr>\n    <td>Headers</td>\n    <td><code>contains</code>, <code>does not contain</code>, <code>is</code>, <code>is not</code>, <code>matches</code>, <code>does not match</code></td>\n    <td>for <code>contains</code>/<code>does not contain</code>/<code>is</code>/<code>is not</code>: String for <code>matches</code>/<code>does not match</code>: <a href=\"https://docs.datadoghq.com/tagging/using_tags\">RegexString</a></td>\n  </tr>\n  <tr>\n    <td>Body</td>\n    <td><code>contains</code>, <code>does not contain</code>, <code>is</code>, <code>is not</code>, <code>matches</code>, <code>does not match</code></td>\n    <td>for <code>contains</code>/<code>does not contain/<code>is</code>/<code>is not</code>: String for <code>matches</code>/<code>does not match</code>: <a href=\"https://docs.datadoghq.com/tagging/using_tags\">RegexString</a></td>\n  </tr>\n</table>\n\n   *   **`target`** - _required API test_ - The expected value for the assertion. For `header`, valid values are any of the valid values for the header key that you define in `property`. For `statusCode`, valid values are valid status codes. For `responseTime`, valid values are the expected response times.\n   *   **`property`** - _optional_ - When you are setting up a `header` `type`, this is required to define the headers parameter key. Valid values are any header keys, like `Content-Type` or `Authorization`.\n*   **`request`** - _required API test_ - An object containing all the necessary information to perform the request to your endpoint.\n   *   **`method`** - _required_ - The method of the API to test. Valid values are `GET`, `POST`, `PUT`, `PATCH`, and `DELETE`. Use `GET` for a browser test.\n   *   **`url`** - _required_ - The endpoint for the API Datadog is testing. For a browser test, the URL for the website Datadog is testing.\n   *   **`timeout`** - _optional_ - When the API request will timeout.\n   *   **`headers`** - _optional_ - Headers in the API request.\n   *   **`body`** - _optional_ The body for the API request. Accepts text strings (including a JSON as a text string). Specify the type using `Content-Type` `property` parameter and the type (like `application/json` or `text/plain` in the `headers` paramater.\n*   **`locations`** - _required_ - A list of the locations that you want the tests to be sent from. At least one value is required, and you can use all locations. For a list of valid locations, use the `GET available locations` method. At least one value is required, and you can use all locations.\n*   **`message`** - _required_ - A description of the test.\n*   **`name`** - _required_ - A unique name for the test.\n*   **`options`** - _required_ - Use advanced options to specify custom request headers, authentication credentials, body content, cookies, or to have the test follow redirects. All optional parameters take their default value if you don't specify a value. Valid values in the request object are:\n    *  **`tick_every`:** - _required_ -  How often the test should run (in seconds - current possible values are 60, 300, 900, 1800, 3600, 21600, 43200, 86400, 604800).\n    *  **`min_failure_duration`** - _optional_ - How long the test should be in failure before alerting (integer, number of seconds, max 7200). Default is 0.\n    *  **`min_location_failed`** - _optional_ - The minimum number of locations that must have been in failure at the same time during at least one moment in the `min_failure_duration` period (min_location_failed and min_failure_duration are part of the advanced alerting rules  - integer, >= 1. Default is 1.\n    *  **`follow_redirects`** - _optional_ - boolean - whether to follow redirects or not (max ten redirects can be followed before triggering a \"Too many redirects\" error). Valid values are `true` or `false`. Default value is `false`.\n    *  **`device_ids`** - _required browser test_ - The type of device you want to use to test. To get a list of available devices, use the `GET devices for browser checkes` method and use the `id` from the response. At least one device is required.\n*   **`tags`** - _optional_ - Tags you want to use to filter your test when you are viewing it in Datadog. For more info on custom tags, see [Using tags][2].\n*   **`type`** - _required_ - The type of test. Valid values are `api` and `browser`.\n\n[1]: https://docs.datadoghq.com/synthetics/browser_test/#record-test\n[2]: https://docs.datadoghq.com/tagging/using_tags"
 					},
 					"response": []
 				},


### PR DESCRIPTION
### What does this PR do?
Some endpoints in the collection still refered the old `app.datadoghq.*` endpoint. This PR fixes this into `api.datadoghq.*`

### Motivation
Consistency