### PR TITLE
add missing arguments for Events.create

### DIFF
--- a/content/en/api/events/events_post.md
+++ b/content/en/api/events/events_post.md
@@ -33,6 +33,10 @@ This endpoint allows you to post events to the stream. Tag them, set priority an
     The type of event being posted.
     Options: **nagios**, **hudson**, **jenkins**, **my_apps**, **chef**, **puppet**, **git**, **bitbucket**...
     [Complete list of source attribute values][3]
+* **`related_event_id`** [*optional*, *default*=**None**]:
+    ID of the parent event. Must be sent as an integer (i.e. no quotes).
+* **`device_name`** [*optional*, *default*=**None**]:
+    A list of device names to post the event with.
 
 [1]: https://github.com/DataDog/dogapi-rb
 [2]: /graphing/event_stream/#markdown-events


### PR DESCRIPTION
### What does this PR do?
Adds missing arguments for Events.create

### Motivation
There were params in https://datadogpy.readthedocs.io/en/latest/#datadog.api.Event that weren't in these docs. Community member raised an issue in datadogpy.

### Preview link

https://docs-staging.datadoghq.com/cswatt/related-event-id/api/?lang=python#post-an-event


