### PR TITLE
Add Go example for enabling Trace Analytics for DB

### DIFF
--- a/content/en/tracing/trace_search_and_analytics/_index.md
+++ b/content/en/tracing/trace_search_and_analytics/_index.md
@@ -298,7 +298,7 @@ Datadog.configure { |c| c.use :mongo, analytics_enabled: true }
 {{% /tab %}}
 {{% tab "Go" %}}
 
-Database tracing is not captured by Trace Search & Analytics by default and you must enable collection manually for each integration. For example:
+Database tracing is not captured by Trace Search & Analytics by default. Enable collection manually for each integration, for example:
 
 ```go
 // Register the database driver with Analytics enabled.

--- a/content/en/tracing/trace_search_and_analytics/_index.md
+++ b/content/en/tracing/trace_search_and_analytics/_index.md
@@ -298,7 +298,12 @@ Datadog.configure { |c| c.use :mongo, analytics_enabled: true }
 {{% /tab %}}
 {{% tab "Go" %}}
 
-Database tracing is not captured by Trace Search & Analytics by default and you must enable collection manually for each integration.
+Database tracing is not captured by Trace Search & Analytics by default and you must enable collection manually for each integration. For example:
+
+```go
+// Register the database driver with Analytics enabled.
+sqltrace.Register("mysql", &mysql.MySQLDriver{}, sqltrace.WithAnalytics(true))
+```
 
 {{% /tab %}}
 {{% tab "Node.js" %}}


### PR DESCRIPTION
### What does this PR do?
Adds small Go snippet for the Database Services section of Trace Search.

### Motivation
Docs improvement was suggested after troubleshooting the reason this wasn't working.

### Preview link
https://docs-staging.datadoghq.com/cgilmour/apm-go-example-for-analytics/tracing/trace_search_and_analytics/?tab=go#database-services
