### PR TITLE
Updating the get all monitors response

### DIFF
--- a/content/en/api/monitors/code_snippets/result.api-monitor-show-all.sh
+++ b/content/en/api/monitors/code_snippets/result.api-monitor-show-all.sh
@@ -1,38 +1,90 @@
-[
-  {
-    "id": 91879,
-    "message": "We may need to add web hosts if this is consistently high.",
-    "name": "Bytes received on host0",
-    "options": {
-      "notify_audit": false,
-      "notify_no_data": false,
-      "silenced": {}
-    },
-    "org_id": 1499,
-    "query": "avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 100",
-    "type": "metric alert",
-    "multi": false,
-    "created": "2015-12-18T16:34:14.014039+00:00",
-    "modified": "2015-12-18T16:34:14.014039+00:00"
-  },
-  {
-    "id": 91875,
-    "message": "",
-    "name": "**system.net.bytes_rcvd** over **host:host0** was **> 100** on average during the **last 1h**.",
-    "options": {
-      "escalation_message": "",
-      "no_data_timeframe": false,
-      "notify_audit": true,
-      "notify_no_data": false,
-      "renotify_interval": null,
-      "silenced": {},
-      "timeout_h": null
-    },
-    "org_id": 1499,
-    "query": "avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 100",
-    "type": "metric alert",
-    "multi": false,
-    "created": "2015-12-18T16:34:14.014039+00:00",
-    "modified": "2015-12-18T16:34:14.014039+00:00"
-  }
+[  
+   {  
+      "tags":[  
+
+      ],
+      "deleted":null,
+      "query":"change(avg(last_5m),last_1m):avg:apache.net.hits{*} by {host} > 500",
+      "message":"Host {{host.name}} with IP {{host.ip}} is under heavy load.",
+      "matching_downtimes":[  
+
+      ],
+      "id":1111111,
+      "multi":true,
+      "name":"example title",
+      "created":"2019-03-11T17:20:45.414125+00:00",
+      "created_at":1552324845000,
+      "creator":{  
+         "id":1111111,
+         "handle":"example@example.com",
+         "name":"Jane Doe",
+         "email":"example@example.com"
+      },
+      "org_id":1111111,
+      "modified":"2019-03-11T17:20:45.414125+00:00",
+      "overall_state_modified":"2019-03-19T12:55:48.320241+00:00",
+      "overall_state":"No Data",
+      "type":"query alert",
+      "options":{  
+         "notify_audit":false,
+         "locked":false,
+         "timeout_h":0,
+         "silenced":{  
+
+         },
+         "include_tags":true,
+         "no_data_timeframe":null,
+         "require_full_window":true,
+         "new_host_delay":300,
+         "notify_no_data":false,
+         "renotify_interval":0,
+         "escalation_message":"",
+         "thresholds":{  
+            "critical":500,
+            "warning":250
+         }
+      }
+   },
+   {  
+      "tags":[  
+
+      ],
+      "deleted":null,
+      "query":"avg(last_1m):outliers(avg:apache.net.hits{*} by {host}, 'DBSCAN', 3) > 0",
+      "message":"@example@example.com",
+      "matching_downtimes":[  
+
+      ],
+      "id":1111111,
+      "multi":true,
+      "name":"example title",
+      "created":"2019-03-11T18:10:09.957865+00:00",
+      "created_at":1552327809000,
+      "creator":{  
+         "id":111111,
+         "handle":"example@example.com",
+         "name":"Jane Doe",
+         "email":"example@example.com"
+      },
+      "org_id":1111111,
+      "modified":"2019-03-11T18:11:25.217705+00:00",
+      "overall_state_modified":"2019-03-20T12:50:45.684420+00:00",
+      "overall_state":"No Data",
+      "type":"query alert",
+      "options":{  
+         "notify_audit":false,
+         "locked":false,
+         "timeout_h":0,
+         "silenced":{  
+
+         },
+         "include_tags":true,
+         "no_data_timeframe":null,
+         "require_full_window":true,
+         "new_host_delay":300,
+         "notify_no_data":false,
+         "renotify_interval":0,
+         "escalation_message":""
+      }
+   }
 ]


### PR DESCRIPTION
### What does this PR do?
Updates the `GET /v1/monitor` method response. 

### Motivation
Response currently documented is out of date.

### Preview link

https://docs-staging.datadoghq.com/kaylyn/get-monitor-response/api/?lang=bash#get-all-monitor-details

### Additional Notes
@ruthnaebeck - I somehow always manage to miss removing personal/proprietary details when I copy/paste my API responses into the docs, so please especially double check that.
