### PR TITLE
Add missing information to status processor

### DIFF
--- a/content/en/logs/processing/processors.md
+++ b/content/en/logs/processing/processors.md
@@ -74,7 +74,7 @@ However, be aware that each incoming status value is mapped as follows:
 * Strings beginning with **n** (case-insensitive) map to **notice (5)**
 * Strings beginning with **i** (case-insensitive) map to **info (6)**
 * Strings beginning with **d**, **trace** or **verbose** (case-insensitive) map to **debug (7)**
-* Strings matching **OK** or **Success** (case-insensitive) map to **OK**
+* Strings beginning with **o** or matching **OK** or **Success** (case-insensitive) map to **OK**
 * All others map to **info (6)**
 
 ## Service Remapper


### PR DESCRIPTION
### What does this PR do?
While testing some logs configs for a customer I noticed that logs with the status "out" were being assigned the status "OK". After checking with the logs team I found that this is because the status string begins with "o" which is logical based on the other rules listed here but it isn't currently documented.

### Motivation
Hoping to avoid confusion/tickets from customers looking at the documentation and not seeing this bit of information.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/possum/status-remapper/content/en/logs/processing/processors.md