### PR TITLE
Remove the note about labels and annotations as tags

### DIFF
--- a/content/en/agent/autodiscovery/_index.md
+++ b/content/en/agent/autodiscovery/_index.md
@@ -129,6 +129,9 @@ kubernetes_pod_annotations_as_tags:
   app: kube_app
 ```
 
+Note: Tags are only set when a pod starts.
+Starting with version 6.12.0, the Datadog Agent will dynamically detect any changes in labels and annotations as tags, not only when a pod starts.
+
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/agent/autodiscovery/_index.md
+++ b/content/en/agent/autodiscovery/_index.md
@@ -129,7 +129,6 @@ kubernetes_pod_annotations_as_tags:
   app: kube_app
 ```
 
-Note: Tags are only set when a pod starts.
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
### What does this PR do?
Remove the note about labels and annotations as tags as they became dynamic in Agent 6.12 https://github.com/DataDog/datadog-agent/pull/3253

### Motivation
update

### Preview link
https://docs-staging.datadoghq.com/ahmed/revert-pod-labels-as-tags-note/agent/autodiscovery/