### PR TITLE
Fix link

### DIFF
--- a/content/en/agent/kubernetes/dogstatsd.md
+++ b/content/en/agent/kubernetes/dogstatsd.md
@@ -104,7 +104,7 @@ With this, any pod running your application is able to send DogStatsD metrics vi
 
 Origin detection allows DogStatsD to detect where the container metrics come from, and tag metrics automatically. When this mode is enabled, all metrics received via UDP are tagged by the same container tags as Autodiscovery metrics.
 
-**Note**: An alternative to UDP is [Unix Domain Sockets][18].
+**Note**: An alternative to UDP is [Unix Domain Sockets][8].
 
 To enable origin detection over UDP, add the following lines to your application manifest: 
 
@@ -120,14 +120,14 @@ Origin detection is supported in Agent 6.10.0+ and in the following client libra
 
 | Library      | Version |
 | ------------ | ------- |
-| [Go][8]      | 2.2     |
-| [PHP][9]     | 1.4.0   |
-| [Python][10] | 0.28.0  |
-| [Ruby][11]   | 4.2.0   |
-| [C#][12]     | 3.3.0   |
-| [Java][13]   | 2.6     |
+| [Go][9]      | 2.2     |
+| [PHP][10]     | 1.4.0   |
+| [Python][11] | 0.28.0  |
+| [Ruby][12]   | 4.2.0   |
+| [C#][13]     | 3.3.0   |
+| [Java][14]   | 2.6     |
 
-To set [tag cardinality][14] for the metrics collected using origin detection, use the environment variable `DD_DOGSTATSD_TAG_CARDINALITY`. 
+To set [tag cardinality][15] for the metrics collected using origin detection, use the environment variable `DD_DOGSTATSD_TAG_CARDINALITY`. 
 
 There are two environment variables that set tag cardinality: `DD_CHECKS_TAG_CARDINALITY` and `DD_DOGSTATSD_TAG_CARDINALITY`—as DogStatsD is priced differently, its tag cardinality setting is separated in order to provide the opportunity for finer configuration. Otherwise, these variables function the same way: they can have values `low`, `orchestrator`, or `high`. They both default to `low`.
 
@@ -135,15 +135,15 @@ There are two environment variables that set tag cardinality: `DD_CHECKS_TAG_CAR
 
 Once your application can send metrics via DogStatsD on each node, you can instrument your application code to submit custom metrics. 
 
-**[See the full list of Datadog DogStatsD Client Libraries][15]**
+**[See the full list of Datadog DogStatsD Client Libraries][16]**
 
-For instance, if your application is written in Go, import Datadog's [Go library][16], which provides a DogStatsD client library:
+For instance, if your application is written in Go, import Datadog's [Go library][17], which provides a DogStatsD client library:
 
 ```
 import "github.com/DataDog/datadog-go/statsd"
 ```
 
-Before you can add custom counters, gauges, etc., [initialize the StatsD client][17] with the location of the DogStatsD service, depending on the method you have chosen:
+Before you can add custom counters, gauges, etc., [initialize the StatsD client][18] with the location of the DogStatsD service, depending on the method you have chosen:
 
 - Unix Domain Socket: `$DD_DOGSTATSD_SOCKET`
 - hostPort: `$DOGSTATSD_HOST_IP`
@@ -194,14 +194,14 @@ func InfoHandler(rw http.ResponseWriter, req *http.Request) {
 [5]: https://github.com/containernetworking/cni
 [6]: https://kubernetes.io/docs/setup/independent/troubleshooting-kubeadm/#hostport-services-do-not-work
 [7]: https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information
-[8]: https://github.com/DataDog/datadog-go
-[9]: https://github.com/DataDog/php-datadogstatsd
-[10]: https://github.com/DataDog/datadogpy
-[11]: https://github.com/DataDog/dogstatsd-ruby
-[12]: https://github.com/DataDog/dogstatsd-csharp-client
-[13]: https://github.com/DataDog/java-dogstatsd-client
-[14]: tagging/assigning_tags/#environment-variables
-[15]: /developers/libraries/#api-and-dogstatsd-client-libraries
-[16]: https://github.com/DataDog/datadog-go
-[17]: https://gist.github.com/johnaxel/fe50c6c73442219c48bf2bebb1154f91
-[18]: /developers/dogstatsd/unix_socket/#using-origin-detection-for-container-tagging
+[8]: /developers/dogstatsd/unix_socket/#using-origin-detection-for-container-tagging
+[9]: https://github.com/DataDog/datadog-go
+[10]: https://github.com/DataDog/php-datadogstatsd
+[11]: https://github.com/DataDog/datadogpy
+[12]: https://github.com/DataDog/dogstatsd-ruby
+[13]: https://github.com/DataDog/dogstatsd-csharp-client
+[14]: https://github.com/DataDog/java-dogstatsd-client
+[15]: /tagging/assigning_tags/#environment-variables
+[16]: /developers/libraries/#api-and-dogstatsd-client-libraries
+[17]: https://github.com/DataDog/datadog-go
+[18]: https://gist.github.com/johnaxel/fe50c6c73442219c48bf2bebb1154f91


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Change `tagging/assigning_tags/#environment-variables` to `/tagging/assigning_tags/#environment-variables`

### Motivation
Documentation pipelines - link checker

### Preview link
N/A
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
