### PR TITLE
updating gin link

### DIFF
--- a/content/en/tracing/setup/go.md
+++ b/content/en/tracing/setup/go.md
@@ -172,7 +172,7 @@ func main() {
 [5]: /tracing/setup
 [6]: /tracing/setup/docker
 [7]: /agent/kubernetes/daemonset_setup/#trace-collection
-[8]: https://gin-gonic.github.io/gin
+[8]: https://gin-gonic.com/
 [9]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/gin-gonic/gin
 [10]: http://www.gorillatoolkit.org/pkg/mux
 [11]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/gorilla/mux


### PR DESCRIPTION
### What does this PR do?
Updates an outdated link

### Motivation
It is broken.

### Preview link

https://docs-staging.datadoghq.com/kaylyn/gin-link-broken/tracing/setup/go/#framework-compatibility


