### PR TITLE
various updates for speed improvements during preview builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,21 +35,23 @@ build_preview:
     URL: ${PREVIEW_DOMAIN}
     CONFIG: ${PREVIEW_CONFIG}
     MESSAGE: ":gift_heart: Your preview site is available!\nNow running tests..."
-    UNTRACKED_EXTRAS: "data,content/en/integrations"
   script:
     - post_dd_event "documentation deploy ${CI_COMMIT_REF_NAME} started" "${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}" "info"
     - version_static_assets
-    - sync_integration_descriptions
+    #- sync_integration_descriptions
+    - sync_integration_descriptions_cached
     - placehold_translations
     - build_hugo_site
     - build_hugo_site_ja
     - minify_html
-    - collect_static_assets
+    #- collect_static_assets
+    # remove service_checks json as we don't need to s3 push that..
+    - rm -rf data/service_checks
     - push_site_to_s3
     - notify_slack "<https://github.com/DataDog/documentation/commit/${CI_COMMIT_SHA}|${CI_COMMIT_REF_NAME}> is ready for preview. <${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}| checks running>." "#31b834"
-    - remove_static_from_repo
-    - create_artifact
-    - create_artifact_untracked
+    #- remove_static_from_repo
+    #- create_artifact
+    #- create_artifact_untracked
   only:
     - /.+?\/[a-zA-Z0-9_-]+/
 

--- a/layouts/partials/sidenav/sidenav-m.html
+++ b/layouts/partials/sidenav/sidenav-m.html
@@ -26,7 +26,7 @@
             </form>
 
             <div class="sidenav-nav">
-                {{ partial "sidenav/nav.html" . }}
+                <!-- This is placed with js now for build speed increase -->
             </div>
         </div>
     </div>

--- a/src/js/datadog-docs.js
+++ b/src/js/datadog-docs.js
@@ -1,5 +1,8 @@
 $(document).ready(function () {
 
+    var sidenavHTML = $('.container .sidenav-nav').clone();
+    $('header .sidenav-nav').html(sidenavHTML);
+
     // ie
     document.createElement('picture');
 


### PR DESCRIPTION
### What does this PR do?
This PR makes a number of changes to the preview site build in an attempt to increase the speed of the build.

So far with these changes the build takes roughly 3mins versus the 6mins it has been lately.

The changes involve:
- downloading the automated files from the last master artifact instead of building from scratch
- removing some duplicate s3 calls
- removing creating artifacts during previews (not needed)
- reduce hugo build time by moving nav generation for mobile

### Motivation
To speed up preview site builds

### Preview link
https://docs-staging.datadoghq.com/david.jones/updatedeploy/

### Additional Notes
This just needs some QA to make sure the preview still works as normal

