### PR TITLE
PHP APM - explain agent connection timeout settings, and clarify how agent hostname can be correctly set

### DIFF
--- a/content/en/tracing/setup/php.md
+++ b/content/en/tracing/setup/php.md
@@ -211,10 +211,12 @@ DD_TRACE_DEBUG=true php -S localhost:8888
 | `DD_TRACE_CLI_ENABLED`               | `false`     | Enable tracing of PHP scripts from the CLI                                  |
 | `DD_DISTRIBUTED_TRACING`             | `true`      | Whether to enable [distributed tracing][14]                                 |
 | `DD_INTEGRATIONS_DISABLED`           | `null`      | CSV list of disabled extensions; e.g., `curl,mysqli`                        |
-| `DD_PRIORITY_SAMPLING`               | `true`      | Whether to enable priority sampling.                                   |
+| `DD_PRIORITY_SAMPLING`               | `true`      | Whether to enable priority sampling.                                        |
 | `DD_SAMPLING_RATE`                   | `1.0`       | The sampling rate for the traces. Between `0.0` and `1.0` (default)         |
 | `DD_SERVICE_NAME`                    | ``          | The default app name                                                        |
 | `DD_TRACE_AGENT_PORT`                | `8126`      | The Agent port number                                                       |
+| `DD_TRACE_AGENT_TIMEOUT`             | `500`       | Maximum time the agent is allowed to take (in milliseconds)                 |
+| `DD_TRACE_AGENT_CONNECT_TIMEOUT`     | `100`       | Maximum time the allowed for agent connection setup (in milliseconds)       |
 | `DD_TRACE_ANALYTICS_ENABLED`         | `false`     | Flag to enable trace analytics for relevant spans in web integrations       |
 | `DD_TRACE_DEBUG`                     | `false`     | Enable [debug mode][15] for the tracer                                      |
 | `DD_TRACE_ENABLED`                   | `true`      | Enable the tracer globally                                                  |

--- a/content/en/tracing/setup/php.md
+++ b/content/en/tracing/setup/php.md
@@ -212,8 +212,8 @@ DD_TRACE_DEBUG=true php -S localhost:8888
 | `DD_SAMPLING_RATE`                   | `1.0`       | The sampling rate for the traces. Between `0.0` and `1.0` (default)         |
 | `DD_SERVICE_NAME`                    | ``          | The default app name                                                        |
 | `DD_TRACE_AGENT_PORT`                | `8126`      | The Agent port number                                                       |
-| `DD_TRACE_AGENT_TIMEOUT`             | `500`       | Maximum time the agent is allowed to take (in milliseconds)                 |
-| `DD_TRACE_AGENT_CONNECT_TIMEOUT`     | `100`       | Maximum time the allowed for agent connection setup (in milliseconds)       |
+| `DD_TRACE_AGENT_TIMEOUT`             | `500`       | Maximum time the Agent is allowed to take (in milliseconds)                 |
+| `DD_TRACE_AGENT_CONNECT_TIMEOUT`     | `100`       | Maximum time the allowed for Agent connection setup (in milliseconds)       |
 | `DD_TRACE_ANALYTICS_ENABLED`         | `false`     | Flag to enable trace analytics for relevant spans in web integrations       |
 | `DD_TRACE_DEBUG`                     | `false`     | Enable [debug mode][15] for the tracer                                      |
 | `DD_TRACE_ENABLED`                   | `true`      | Enable the tracer globally                                                  |

--- a/content/en/tracing/setup/php.md
+++ b/content/en/tracing/setup/php.md
@@ -75,12 +75,9 @@ Automatic instrumentation captures:
 
 Configure your application level tracers to submit traces to a custom Agent hostname:
 
-The PHP tracer automatically looks for and initializes with the ENV variables `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`
+The PHP tracer automatically looks for and initializes with the ENV variables `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`.
 
-```php
-putenv('DD_AGENT_HOST=localhost');
-putenv('DD_TRACE_AGENT_PORT=8126');
-```
+See [tracer configuration][16] for more information how to correctly set these variables.
 
 ## Compatibility
 
@@ -242,3 +239,4 @@ DD_TRACE_DEBUG=true php -S localhost:8888
 [13]: http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_param
 [14]: /tracing/guide/distributed_tracing/?tab=php
 [15]: /tracing/troubleshooting
+[16]: #configuration

--- a/content/en/tracing/setup/php.md
+++ b/content/en/tracing/setup/php.md
@@ -77,7 +77,7 @@ Configure your application level tracers to submit traces to a custom Agent host
 
 The PHP tracer automatically looks for and initializes with the ENV variables `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`.
 
-See [tracer configuration][16] for more information how to correctly set these variables.
+See [tracer configuration][16] for more information on how to set these variables.
 
 ## Compatibility
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
List and explain agent connection timeout settings.

Clarify how agent hostname can be correctly set - since the order of execution matters and we already have configuration documentation that covers that topic - so instead of adding incomplete example. Lets link to that relevant part of PHP tracer documentation.


### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
