### PR TITLE
updating docs to reflect trace storage only for one month

### DIFF
--- a/content/en/tracing/guide/trace_sampling_and_storage.md
+++ b/content/en/tracing/guide/trace_sampling_and_storage.md
@@ -99,30 +99,30 @@ It is possible to disable the instrumentation for a percentage of transactions. 
 
 ## Trace storage
 
-Individual traces are stored for up to 4 months. To determine how long a particular trace will be stored, the Agent makes a sampling decision early in the trace's lifetime. In Datadog backend, sampled traces are retained according to time buckets:
+Individual traces are stored for up to 1 month. To determine how long a particular trace will be stored, the Agent makes a sampling decision early in the trace's lifetime. In Datadog backend, sampled traces are retained according to time buckets:
 
 | Retention bucket       |  % of stream kept |
 | :--------------------- | :---------------- |
 | 6 hours                |              100% |
 | Current day (UTC time) |               25% |
 | 6 days                 |               10% |
-| 4 months               |                1% |
+| 1 months               |                1% |
 
 That is to say, on a given day you would see in the UI:
 
 * **100%** of sampled traces from the last six hours
 * **25%** of those from the previous hours of the current calendar day (starting at `00:00 UTC`)
 * **10%** from the previous six calendar days
-* **1%** of those from the previous four months (starting from the first day of the month four months ago)
-* **0%** of traces older than four months
+* **1%** of those from the previous month (starting from the first day of the last month)
+* **0%** of traces older than a month
 
 For example, at `9:00am UTC Wed, 12/20` you would see:
 
 * **100%** of traces sampled on `Wed 12/20 03:00 - 09:00`
 * **25%** of traces sampled on `Wed 12/20 00:00` - `Wed 12/20 02:59`
 * **10%** of traces sampled on `Thurs 12/14 00:00` - `Tue 12/19 23:59`
-* **1%** of traces sampled on `9/1 00:00` - `12/13 23:59`
-* **0%** of traces before `9/1 00:00`
+* **1%** of traces sampled on `11/1 00:00` - `12/13 23:59`
+* **0%** of traces before  11/1 00:00`
 
 Once a trace has been viewed by opening a full page, it continues to be available by using its trace ID in the URL: `https://app.datadoghq.com/apm/trace/<TRACE_ID>`. This is true even if it "expires" from the UI. This behavior is independent of the UI retention time buckets.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

https://docs-staging.datadoghq.com/priyanshi/trace_storage/tracing/guide/trace_sampling_and_storage/#trace-storage

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
