### PR TITLE
Adding note about Case Sensitive metrics names

### DIFF
--- a/content/en/developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags.md
+++ b/content/en/developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags.md
@@ -24,6 +24,8 @@ Datadog recommends certain best practices for naming metrics and tags.
 
 Metrics reported by the Agent are in a pseudo-hierarchical dotted format (e.g. `http.nginx.response_time`). This is described as pseudo-hierarchical because a hierarchy is not actually enforced, but the structure is used to infer certain relationships (e.g. "I see hostA and hostB are reporting 'http.nginx.\*', those must be web frontends").
 
+**Note**: Metric names are case sensitive in Datadog.
+
 **Rules and best practices for naming tags**:
 
 * Tags must start with a letter.
@@ -35,4 +37,3 @@ Metrics reported by the Agent are in a pseudo-hierarchical dotted format (e.g. `
 Examples of commonly used metric tag keys are `env`, `instance`, `name`, and `role`.
 
 {{< partial name="whats-next/whats-next.html" >}}
-

--- a/content/en/developers/metrics/_index.md
+++ b/content/en/developers/metrics/_index.md
@@ -49,6 +49,8 @@ There are a few rules regarding metric names:
 
 Metrics reported by the Agent are in a pseudo-hierarchical dotted format (e.g. `http.nginx.response_time`). The hierarchy is neither enforced nor interpreted, but it can be used to infer things about servers. For example, if `hostA` and `hostB` are both reporting `http.nginx.*` those must be web frontends.
 
+**Note**: Metric names are case sensitive in Datadog.
+
 ## Metric Types
 
 The "Datadog in-app type" affects how a given metric is interpreted in query results and graph visualizations across the application. This type is visible and can be changed on the [metric summary page][12]. Be aware that changing the metric type may render historical data nonsensical.
@@ -100,7 +102,7 @@ is interpreted properly.
 
 If you are not willing to lose the historical data submitted as a `gauge`, create a new metric name with the new type, leaving the type of `app.requests.served` unchanged.
 
-**Note**: For the AgentCheck, `self.increment` does not calculate the delta for a monotonically increasing counter, rather it reports the value passed in at the check run. To send the delta value on a monotonically increasing counter, use `self.monotonic_count`. 
+**Note**: For the AgentCheck, `self.increment` does not calculate the delta for a monotonically increasing counter, rather it reports the value passed in at the check run. To send the delta value on a monotonically increasing counter, use `self.monotonic_count`.
 
 ## Units
 


### PR DESCRIPTION
### What does this PR do?

Metric names are case sensitive.

### Preview link

* https://docs-staging.datadoghq.com/gus/metric-name/developers/metrics/#naming-metrics