### PR TITLE
Add paperplane

### DIFF
--- a/content/en/tracing/setup/nodejs.md
+++ b/content/en/tracing/setup/nodejs.md
@@ -98,6 +98,7 @@ For details about how to how to toggle and configure plugins, check out the [API
 | [graphql][12] | `>=0.10` | Fully Supported | Supports Apollo Server and express-graphql |
 | [hapi][13]    | `>=2`    | Fully Supported |                                            |
 | [koa][14]     | `>=2`    | Fully Supported |                                            |
+| [paperplane][41] | `>=2.3` | Fully Supported | Not currently supported in [serverless-mode](https://github.com/articulate/paperplane/blob/master/docs/API.md#serverless-deployment) |
 | [restify][15] | `>=3`    | Fully Supported |                                            |
 
 #### Native Module Compatibility
@@ -194,3 +195,4 @@ For details about how to how to toggle and configure plugins, check out the [API
 [38]: http://getpino.io
 [39]: https://github.com/winstonjs/winston
 [40]: https://knexjs.org/
+[41]: https://github.com/articulate/paperplane

--- a/content/en/tracing/setup/nodejs.md
+++ b/content/en/tracing/setup/nodejs.md
@@ -98,7 +98,7 @@ For details about how to how to toggle and configure plugins, check out the [API
 | [graphql][12] | `>=0.10` | Fully Supported | Supports Apollo Server and express-graphql |
 | [hapi][13]    | `>=2`    | Fully Supported |                                            |
 | [koa][14]     | `>=2`    | Fully Supported |                                            |
-| [paperplane][41] | `>=2.3` | Fully Supported | Not currently supported in [serverless-mode](https://github.com/articulate/paperplane/blob/master/docs/API.md#serverless-deployment) |
+| [paperplane][41] | `>=2.3` | Fully Supported | Not supported in [serverless-mode][42] |
 | [restify][15] | `>=3`    | Fully Supported |                                            |
 
 #### Native Module Compatibility
@@ -196,3 +196,4 @@ For details about how to how to toggle and configure plugins, check out the [API
 [39]: https://github.com/winstonjs/winston
 [40]: https://knexjs.org/
 [41]: https://github.com/articulate/paperplane
+[42]: https://github.com/articulate/paperplane/blob/master/docs/API.md#serverless-deployment

--- a/content/en/tracing/setup/nodejs.md
+++ b/content/en/tracing/setup/nodejs.md
@@ -92,14 +92,14 @@ For details about how to how to toggle and configure plugins, check out the [API
 
 #### Web Framework Compatibility
 
-| Module        | Versions | Support Type    | Notes                                      |
-|---------------|----------|-----------------|--------------------------------------------|
-| [express][10] | `>=4`    | Fully Supported | Supports Sails, Loopback, and [more][11]   |
-| [graphql][12] | `>=0.10` | Fully Supported | Supports Apollo Server and express-graphql |
-| [hapi][13]    | `>=2`    | Fully Supported |                                            |
-| [koa][14]     | `>=2`    | Fully Supported |                                            |
-| [paperplane][41] | `>=2.3` | Fully Supported | Not supported in [serverless-mode][42] |
-| [restify][15] | `>=3`    | Fully Supported |                                            |
+| Module           | Versions | Support Type    | Notes                                      |
+|------------------|----------|-----------------|--------------------------------------------|
+| [express][10]    | `>=4`    | Fully Supported | Supports Sails, Loopback, and [more][11]   |
+| [graphql][12]    | `>=0.10` | Fully Supported | Supports Apollo Server and express-graphql |
+| [hapi][13]       | `>=2`    | Fully Supported |                                            |
+| [koa][14]        | `>=2`    | Fully Supported |                                            |
+| [paperplane][41] | `>=2.3`  | Fully Supported | Not supported in [serverless-mode][42]     |
+| [restify][15]    | `>=3`    | Fully Supported |                                            |
 
 #### Native Module Compatibility
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a listing for the [`paperplane`](https://github.com/articulate/paperplane) integration.

### Motivation

I just submitted [this PR](https://github.com/DataDog/dd-trace-js/pull/582) to add `paperplane` integration, and wanted to include it in the docs when it ships.

### Preview link

Since this PR is from a fork, I guess this is best way to preview:
https://github.com/articulate/documentation/blob/902d28584d7e3a5fafcc3a9b2556a07ed9d05e58/content/en/tracing/setup/nodejs.md

### Additional Notes

I just guessed on the `Support Type`.  I've seen on other pages that some integrations are in `Beta` instead of `Fully Supported`.  Please let me know which is most appropriate.  Thanks!
