### PR TITLE
change the push translations to not run during triggers or schedules

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -134,6 +134,9 @@ push_translations:
     - push_changed_translations
   only:
     - master
+  except:
+    - triggers
+    - schedules
 
 #rollback_live:
 #  <<: *base_template


### PR DESCRIPTION
### What does this PR do?

This PR updates the push translations job to only run during master deploys not during schedules or triggers.

### Motivation

I don't want this to run the same time as the scheduled "manage_translations" task

### Preview link
N/A

### Additional Notes

