### PR TITLE
Fix YAML indentation on K8s Log instructions.

### DIFF
--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -257,7 +257,7 @@ The Docker API is optimized to get logs from one container at a time. When there
         (...)
         - hostPath:
             path: /opt/datadog-agent/run
-            name: pointdir
+          name: pointdir
       (...)
     ```
 

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -218,7 +218,7 @@ The Docker API is optimized to get logs from one container at a time. When there
         (...)
         - hostPath:
             path: /var/log/pods
-            name: logpath
+          name: logpath
       (...)
     ```
 
@@ -236,7 +236,7 @@ The Docker API is optimized to get logs from one container at a time. When there
         (...)
         - hostPath:
             path: /var/run/docker.sock
-            name: dockersocket
+          name: dockersocket
       (...)
     ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This fixes some errant indentation in the k8s daemonset install.

### Motivation
<!-- What inspired you to submit this pull request?-->
This will help prevent new users from encountering errors.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
