### PR TITLE
enable collect assets

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,7 @@ build_preview:
     - build_hugo_site
     - build_hugo_site_ja
     - minify_html
-    #- collect_static_assets
+    - collect_static_assets
     # remove service_checks json as we don't need to s3 push that..
     - rm -rf data/service_checks
     - push_site_to_s3


### PR DESCRIPTION
### What does this PR do?

This PR enables the asset upload part of preview sites. I had mistakenly disabled it during some updates that were for speeding up preview site builds. Causing new images to not show because they weren't uploaded 🤦‍♂ 

### Motivation

An issue in a recent preview site build

### Preview link
N/A

### Additional Notes

