### PR TITLE
make nav dropdowns fit text

### DIFF
--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -26,7 +26,7 @@
                         <li class="nav-item {{ if .children }}dropdown{{ end }}">
                             <a class="nav-link {{ if .children }}dropdown-toggle{{ end }}" href="{{ if in .link "http"}}{{ .link }}{{ else }}{{ .link | absLangURL }}{{ end }}">{{ .title }}</a>
                             {{ if .children }}
-                                <div class="dropdown-menu" aria-labelledby="navbarDropdown" {{ if eq .name "solutions" }}style="min-width:210px;"{{ end }}>
+                                <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                                     {{ range .children }}
                                         <a class="dropdown-item" href="{{ if in .link "http"}}{{ .link }}{{ else }}{{ .link | absLangURL }}{{ end }}">{{ .title }}</a>
                                     {{ end }}

--- a/layouts/partials/header/header.scss
+++ b/layouts/partials/header/header.scss
@@ -158,6 +158,10 @@ body > header {
     }
   }
 
+  .mainnav li.dropdown:nth-child(4) .dropdown-menu {
+    min-width: 210px;
+  }
+
   // mobile
   .navbar {
     padding-left:0;

--- a/src/scss/pages/_fr.scss
+++ b/src/scss/pages/_fr.scss
@@ -1,0 +1,7 @@
+body.fr {
+
+  &> header .mainnav li.dropdown:nth-child(4) .dropdown-menu {
+    min-width: 280px;
+  }
+
+}

--- a/src/scss/pages/_ja.scss
+++ b/src/scss/pages/_ja.scss
@@ -1,0 +1,11 @@
+body.ja {
+
+  &> header .mainnav li.dropdown:nth-child(1) .dropdown-menu {
+    min-width: 200px;
+  }
+
+  &> header .mainnav li.dropdown:nth-child(4) .dropdown-menu {
+    min-width: 300px;
+  }
+
+}

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -8,6 +8,9 @@
 
 // global to all pages
 @import "pages/global";
+// language specific
+@import "pages/ja";
+@import "pages/fr";
 
 // page specific styles that aren't partials go here
 // partial css lives with partial


### PR DESCRIPTION
### What does this PR do?

Make the header nav dropdowns fit the text they are holding in different languages.

### Motivation
text was going outside dropdown

### Preview link
mouse over the header nav and see dropdowns fit text
https://docs-staging.datadoghq.com/david.jones/nav-cleanup/
https://docs-staging.datadoghq.com/david.jones/nav-cleanup/fr/
https://docs-staging.datadoghq.com/david.jones/nav-cleanup/ja/

### Additional Notes

