### PR TITLE
Clarify types of a point in post timeseries points api call

### DIFF
--- a/content/en/api/metrics/metrics_timeseries.md
+++ b/content/en/api/metrics/metrics_timeseries.md
@@ -22,7 +22,7 @@ The metrics end-point allows you to post time-series data that can be graphed on
     * **`points`** [*required*]:
         A JSON array of points. Each point is of the form:
         `[[POSIX_timestamp, numeric_value], ...]`
-        **Note**: The timestamp should be in seconds, current, and its format should be a 32bit float gauge-type value.
+        **Note**: The timestamp should be in seconds, current. The numeric value format should be a 32bit float gauge-type value.
         Current is defined as not more than 10 minutes in the future or more than 1 hour in the past.
     * **`host`** [*optional*]:
         The name of the host that produced the metric.


### PR DESCRIPTION
### What does this PR do?
The way the doc reads now is as if you have to use a 32 bit float to store the timestamp which is incorrect. I'm kind of assuming this is meant for the numeric_value so I've changed it to be clearer. If it's not meant to be for the numeric value it should be deleted.

### Motivation
When I realized that the 32 bit float section can't be talking about the timestamp:
https://randomascii.wordpress.com/2012/02/13/dont-store-that-in-a-float/

### Preview link
https://docs.datadoghq.com/api/?lang=python#post-timeseries-points

https://docs-staging.datadoghq.com/julian.kozianski/clarify_api_points_value_types/api/?lang=python#post-timeseries-points


