### PR TITLE
Update windows agent install commands

### DIFF
--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -39,12 +39,12 @@ Optionally, install the Agent with the command line to add custom settings.
 
 Command prompt:
 ```cmd
-msiexec /qn /i datadog-agent-6-latest.amd64.msi APIKEY="<YOUR_DATADOG_API_KEY>"
+start /wait msiexec /qn /i datadog-agent-6-latest.amd64.msi APIKEY="<YOUR_DATADOG_API_KEY>"
 ```
 
 Powershell:
 ```powershell
-Start-Process msiexec -ArgumentList '/qn /i datadog-agent-6-latest.amd64.msi APIKEY="<YOUR_DATADOG_API_KEY>"'
+Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-6-latest.amd64.msi APIKEY="<YOUR_DATADOG_API_KEY>"'
 ```
 
 Each configuration item is added as a property to the command line. The following configuration command line options are available when installing the Agent on Windows:


### PR DESCRIPTION
### What does this PR do?

Changes the Windows agent command-line instructions to add /wait (-Wait in powershell) option, so that the agent is actually installed when the installation command returns.

### Motivation

The commands given launch the installation, but return immediately. To the user, this may look like the command didn't do anything (since the agent is still installing when the command finishes).

### Preview link

https://docs-staging.datadoghq.com/kylian.serrania/update-agent-windows-install-instructions/agent/basic_agent_usage/windows/?tab=agentv6
