### PR TITLE
clarify remove tags api call

### DIFF
--- a/content/en/api/tags/tags_delete.md
+++ b/content/en/api/tags/tags_delete.md
@@ -6,7 +6,7 @@ external_redirect: /api/#remove-host-tags
 ---
 
 ## Remove host tags
-This endpoint allows you to remove all tags for a single host.
+This endpoint allows you to remove all user-assigned tags for a single host.
 
 ##### ARGUMENTS
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds the phrase "user-assigned" to clarify that this call only removes user-assigned tags, not _all_ tags.

### Motivation
support request

### Preview link

https://docs-staging.datadoghq.com/cswatt/tags-api/api/?lang=python#remove-host-tags

