### PR TITLE
Misspelled Lambda

### DIFF
--- a/content/en/tracing/send_traces/_index.md
+++ b/content/en/tracing/send_traces/_index.md
@@ -42,9 +42,9 @@ Note: After having instrumented your application, the tracing client sends trace
 
 There are alternernates to the Agent and containers that you can use to collect traces.
 
-### Lamda - X-Ray
+### Lambda - X-Ray
 
-For more information abut setting up Lamda - X-Ray, see the [Amazon X-Ray integration documentation][6]
+For more information abut setting up Lambda - X-Ray, see the [Amazon X-Ray integration documentation][6]
 
 ### Heroku
 

--- a/content/en/tracing/send_traces/_index.md
+++ b/content/en/tracing/send_traces/_index.md
@@ -44,15 +44,15 @@ There are alternernates to the Agent and containers that you can use to collect 
 
 ### Lambda - X-Ray
 
-For more information abut setting up Lambda - X-Ray, see the [Amazon X-Ray integration documentation][6]
+For more information setting up Lambda - X-Ray, see the [Amazon X-Ray integration documentation][6]
 
 ### Heroku
 
-Tracing is enabled by default when monitoring with Heroku. For more information abut configuring tracing for Heroku, see the [Heroku cloud documentation][7].
+Tracing is enabled by default when monitoring with Heroku. For more information about configuring tracing for Heroku, see the [Heroku cloud documentation][7].
 
 ### Cloud Foundry
 
-Tracing is enabled by default when monitoring with Cloud Foundry. For more information abut configuring tracing for Cloud Foundry, see the [Cloud Foundry documentation][8].
+Tracing is enabled by default when monitoring with Cloud Foundry. For more information about configuring tracing for Cloud Foundry, see the [Cloud Foundry documentation][8].
 
 ### Other(GAE, AAS, Serverless)
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes the misspelling of Lambda. AWS X-Ray pulls in Lambda Traces
see: https://aws.amazon.com/lambda/

### Motivation
See above

### Preview link

### Additional Notes
