### PR TITLE
Update api-metrics-list.sh

### DIFF
--- a/content/en/api/metrics/code_snippets/api-metrics-list.sh
+++ b/content/en/api/metrics/code_snippets/api-metrics-list.sh
@@ -7,5 +7,5 @@ curl -G \
     "https://api.datadoghq.com/api/v1/metrics" \
     -d "api_key=${api_key}" \
     -d "application_key=${app_key}" \
-    -d "from=${from_time}"
+    -d "from=${from_time}" \
     -d "host=<HOSTNAME>"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

adds a correction to the sample curl command for getting list of active metrics.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
