### PR TITLE
Adding naming precision for folder name

### DIFF
--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -54,7 +54,7 @@ If an integration does not support logs by default, use the custom file configur
 
 Datadog Agent v6 can collect logs and forward them to Datadog from files, the network (TCP or UDP), journald, and Windows channels:
 
-1. Create a new folder in the `conf.d/` directory at the root of your [Agent's configuration directory][4] named after your log source.
+1. Create a new `<CUSTOM_LOG_SOURCE>.d/` folder in the `conf.d/` directory at the root of your [Agent's configuration directory][4] named after your log source.
 2. Create a new `conf.yaml` file in this new folder.
 3. Add a custom log collection configuration group with the parameters below.
 4. [Restart your Agent][5] to take into account this new configuration.


### PR DESCRIPTION
### What does this PR do?
Adds folder name precision for the custom log collection section.

### Motivation
If there is no .d it doesn't work

### Preview link

* https://docs-staging.datadoghq.com/gus/log-folder-name/logs/log_collection/?tab=tailexistingfiles#custom-log-collection