### PR TITLE
Puppy agent

### DIFF
--- a/content/en/agent/guide/_index.md
+++ b/content/en/agent/guide/_index.md
@@ -11,6 +11,7 @@ disable_toc: true
     {{< nextlink href="agent/guide/agent-log-files" >}}Agent Log Files{{< /nextlink >}}
     {{< nextlink href="agent/guide/integration-management" >}}Integration Management{{< /nextlink >}}
     {{< nextlink href="agent/guide/network" >}}Network Traffic{{< /nextlink >}}
+    {{< nextlink href="agent/guide/puppy-agent" >}}Puppy Agent{{< /nextlink >}}
 {{< /whatsnext >}}
 <br>
 {{< whatsnext desc="Agent 5 Guides:" >}}

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -31,7 +31,7 @@ further_reading:
 
 This decision was taken after the POODLE problem. Versioned endpoints start with Agent v5.2.0, where each version of the Agent calls a different endpoint based on the version of the *Forwarder*. For example, Agent v5.2.0 calls `5-2-0-app.agent.datadoghq.com`. Therefore you must whitelist `*.agent.datadoghq.com` in your firewall(s).
 
-These domains are **CNAME** records pointing to a set of static IP addresses. These addresses can be found at:  
+These domains are **CNAME** records pointing to a set of static IP addresses. These addresses can be found at:
 
 * **[https://ip-ranges.datadoghq.com][4]**, or
 * **[https://ip-ranges.datadoghq.eu][5]** for Datadog EU
@@ -74,14 +74,14 @@ You should whitelist all of these IPs. While only a subset are active at any giv
 
 **All outbound traffic is sent over SSL via TCP / UDP.**
 
-Open the following ports in order to benefit from all the Agent functionalities: 
+Open the following ports in order to benefit from all the Agent functionalities:
 
 {{< tabs >}}
 {{% tab "Agent v6" %}}
 
 * **Outbound**:
 
-  * `443/tcp`: port for most Agent data. (Metrics, APM, Live Processes/Containers) 
+  * `443/tcp`: port for most Agent data. (Metrics, APM, Live Processes/Containers)
   * `123/udp`: NTP - [More details on the importance of NTP][1].
   * `10516/tcp`: port for the [Log collection][2]
   * `10255/tcp`: port for the [Kubernetes http kubelet][3]
@@ -92,12 +92,12 @@ Open the following ports in order to benefit from all the Agent functionalities:
   * `5000/tcp`: port for the [go_expvar server][4]
   * `5001/tcp`: port on which the IPC api listens
   * `5002/tcp`: port for [the Agent browser GUI to be served][5]
-  * `8125/udp`: dogstatsd. Unless `dogstatsd_non_local_traffic` is set to true. This port is available on localhost: 
+  * `8125/udp`: dogstatsd. Unless `dogstatsd_non_local_traffic` is set to true. This port is available on localhost:
 
       * `127.0.0.1`
-      * `::1` 
+      * `::1`
       * `fe80::1`
-  
+
   * `8126/tcp`: port for the [APM Receiver][6]
 
 
@@ -112,15 +112,15 @@ Open the following ports in order to benefit from all the Agent functionalities:
 
 * **Outbound**:
 
-  * `443/tcp`: port for most Agent data. (Metrics, APM, Live Processes/Containers) 
+  * `443/tcp`: port for most Agent data. (Metrics, APM, Live Processes/Containers)
   * `123/udp`: NTP - [More details on the importance of NTP][1].
 
 * **Inbound**:
 
-  * `8125/udp`: DogStatsd. Unless `dogstatsd_non_local_traffic` is set to true. This port is available on localhost: 
+  * `8125/udp`: DogStatsd. Unless `dogstatsd_non_local_traffic` is set to true. This port is available on localhost:
 
       * `127.0.0.1`
-      * `::1` 
+      * `::1`
       * `fe80::1`
 
   * `8126/tcp`: port for the [APM Receiver][2]

--- a/content/en/agent/guide/puppy-agent.md
+++ b/content/en/agent/guide/puppy-agent.md
@@ -1,0 +1,87 @@
+---
+title: Puppy Agent
+kind: guide
+disable_toc: true
+further_reading:
+- link: "logs/"
+  tag: "Documentation"
+  text: "Collect your logs"
+---
+
+## Overview
+
+The Puppy Agent is a lightweight version of the Datadog Agent that can be compiled to different platforms. The main use case for the puppy agent is IoT devices or other devices with limited resource availability.
+
+The Puppy Agent is [building the core Agent binary][1] with the `--puppy` flag that only installs a limited number of modules into the Agent. The Puppy Agent only installs [the `zlib` module][2].
+
+Here is the command that would be used to build the puppy agent:
+
+```
+invoke agent.build --puppy
+```
+
+Features included (not an exhaustive list):
+
+* [Core checks][3]
+* [Log Collection][4]
+* [DogStatsD][5]
+
+Note: Python is not included by default in the Puppy Agent and thus any python-based integrations aren't available.
+
+## Custom Puppy Agent
+
+To create a custom Puppy Agent, the following modules are available when building the Agent according yo your needs:
+
+| Module    | Description                                            |
+| -----     | ---------                                              |
+| `apm`     | Make the APM agent execution available.                |
+| `consul`  | Enable consul as a configuration store.                |
+| `python`  | Embed the Python interpreter.                          |
+| `docker`  | Add Docker support (required by AutoDiscovery).        |
+| `ec2`     | Enable EC2 hostname detection and metadata collection. |
+| `etcd`    | Enable Etcd as a configuration store.                  |
+| `gce`     | Enable GCE hostname detection and metadata collection. |
+| `jmx`     | Enable the JMX-fetch bridge.                           |
+| `kubelet` | Enable kubelet tag collection.                         |
+| `log`     | Enable the Agent log collection.                       |
+| `process` | Enable the Agent process data collection.              |
+| `zk`      | Enable Zookeeper as a configuration store.             |
+| `zstd`    | Use Zstandard instead of Zlib.                         |
+| `systemd` | Enable systemd journal log collection.                 |
+
+
+Choose at build time which components of the Agent you want to find in the final artifact. By default, all the components are picked up, so if you want to replicate the same configuration of the Agent distributed via system packages, run `invoke agent.build`.
+
+To pick only certain components invoke the task like this:
+
+```
+invoke agent.build --build-include=<MODULE_NAME_1>,<MODULE_NAME_2>
+```
+
+For instance to include `zstd`, `etcd`, and `python` modules, run:
+
+```
+invoke agent.build --build-include=zstd,etcd,python
+```
+
+You can also exclude only a subset of modules:
+
+```
+invoke agent.build --build-exclude=<MODULE_NAME_1>,<MODULE_NAME_2>
+```
+
+Note: You may need to provide some extra dependencies in your dev environment to build certain bits (see the [development environment][6] documentation to learn more).
+
+### Additional details
+
+The Agent build uses `pkg-config` to make compilers and linkers aware of Python. If you need to adjust the build for your specific configuration, add or edit the files within the `pkg-config` folder.
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+[1]: /agent/basic_agent_usage/source/?tab=agentv6
+[2]: https://github.com/DataDog/datadog-agent/blob/6.11.x/tasks/build_tags.py#L32
+[3]: /getting_started/agent/?tab=datadogussite#metrics
+[4]: /logs/log_collection
+[5]: /developers/dogstatsd
+[6]: https://github.com/DataDog/datadog-agent/blob/master/docs/dev/agent_dev_env.md


### PR DESCRIPTION
### What does this PR do?
Creates a Guide for the Puppy Agent. 


### Motivation
Better document how to build lightweight version of the DD agent in order to accommodate new use-cases like IoT for instance.

### Preview link

* https://docs-staging.datadoghq.com/gus/puppy-agent/agent/guide/puppy-agent/