### PR TITLE
Readding Beta flag to distribution metric docs

### DIFF
--- a/content/en/developers/metrics/distributions.md
+++ b/content/en/developers/metrics/distributions.md
@@ -11,6 +11,11 @@ further_reading:
   text: "Official and Community-contributed API and DogStatsD client libraries"
 ---
 
+<div class="alert alert-warning">
+This feature is in beta. <a href="https://docs.datadoghq.com/help/">Contact Datadog support</a> to enable distribution metrics for your account.
+</div>
+
+
 ## Overview
 
 Distributions are a new metric type in Agent 6 that aggregate the values that are sent from multiple hosts during a flush interval to measure statistical distributions across your entire infrastructure. This can be thought of as a global version of our existing [Histogram metric type][1], which measures the statistical distribution of values on a single host.

--- a/content/en/graphing/metrics/distributions.md
+++ b/content/en/graphing/metrics/distributions.md
@@ -10,6 +10,10 @@ further_reading:
     text: "Using Distributions in DogStatsD"
 ---
 
+<div class="alert alert-warning">
+This feature is in beta. <a href="https://docs.datadoghq.com/help/">Contact Datadog support</a> to enable distribution metrics for your account.
+</div>
+
 ## Overview
 
 Distributions are a metric type in Agent 6 that aggregate the values that are sent from multiple hosts during a flush interval to measure statistical distributions across your entire infrastructure server-side.  This can be thought of as a global version of the [Histogram metric][1], which measures at the Agent-level the statistical distribution of values on a single host.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Turns out we still want to keep the distributions beta feature request information on the public docs UNTIL DASH but not any earlier 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
