### PR TITLE
Revert "Readding Beta flag to distribution metric docs"

### DIFF
--- a/content/en/developers/metrics/distributions.md
+++ b/content/en/developers/metrics/distributions.md
@@ -11,11 +11,6 @@ further_reading:
   text: "Official and Community-contributed API and DogStatsD client libraries"
 ---
 
-<div class="alert alert-warning">
-This feature is in beta. <a href="https://docs.datadoghq.com/help/">Contact Datadog support</a> to enable distribution metrics for your account.
-</div>
-
-
 ## Overview
 
 Distributions are a new metric type in Agent 6 that aggregate the values that are sent from multiple hosts during a flush interval to measure statistical distributions across your entire infrastructure. This can be thought of as a global version of our existing [Histogram metric type][1], which measures the statistical distribution of values on a single host.

--- a/content/en/graphing/metrics/distributions.md
+++ b/content/en/graphing/metrics/distributions.md
@@ -10,10 +10,6 @@ further_reading:
     text: "Using Distributions in DogStatsD"
 ---
 
-<div class="alert alert-warning">
-This feature is in beta. <a href="https://docs.datadoghq.com/help/">Contact Datadog support</a> to enable distribution metrics for your account.
-</div>
-
 ## Overview
 
 Distributions are a metric type in Agent 6 that aggregate the values that are sent from multiple hosts during a flush interval to measure statistical distributions across your entire infrastructure server-side.  This can be thought of as a global version of the [Histogram metric][1], which measures at the Agent-level the statistical distribution of values on a single host.


### PR DESCRIPTION
Reverts DataDog/documentation#4816