### PR TITLE
Agent community integrations installation.

### DIFF
--- a/content/en/agent/guide/_index.md
+++ b/content/en/agent/guide/_index.md
@@ -11,6 +11,7 @@ disable_toc: true
     {{< nextlink href="agent/guide/agent-log-files" >}}Agent Log Files{{< /nextlink >}}
     {{< nextlink href="agent/guide/integration-management" >}}Integration Management{{< /nextlink >}}
     {{< nextlink href="agent/guide/network" >}}Network Traffic{{< /nextlink >}}
+    {{< nextlink href="agent/guide/community-integrations-installation-with-docker-agent" >}}Use a community integration with the Agent{{< /nextlink >}}
 {{< /whatsnext >}}
 <br>
 {{< whatsnext desc="Agent 5 Guides:" >}}

--- a/content/en/agent/guide/_index.md
+++ b/content/en/agent/guide/_index.md
@@ -11,7 +11,7 @@ disable_toc: true
     {{< nextlink href="agent/guide/agent-log-files" >}}Agent Log Files{{< /nextlink >}}
     {{< nextlink href="agent/guide/integration-management" >}}Integration Management{{< /nextlink >}}
     {{< nextlink href="agent/guide/network" >}}Network Traffic{{< /nextlink >}}
-    {{< nextlink href="agent/guide/community-integrations-installation-with-docker-agent" >}}Use a community integration with the Agent{{< /nextlink >}}
+    {{< nextlink href="agent/guide/community-integrations-installation-with-docker-agent" >}}Community integration installation{{< /nextlink >}}
 {{< /whatsnext >}}
 <br>
 {{< whatsnext desc="Agent 5 Guides:" >}}

--- a/content/en/agent/guide/agent-commands.md
+++ b/content/en/agent/guide/agent-commands.md
@@ -1,6 +1,6 @@
 ---
 title: Agent Commands
-kind: faq
+kind: guide
 aliases:
     - /agent/faq/agent-status-and-information
     - /agent/faq/start-stop-restart-the-datadog-agent
@@ -15,7 +15,7 @@ further_reading:
 For Linux based systems where the <code>service</code> wrapper command is not available, <a href="https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md#service-lifecycle-commands">consult the list of alternatives</a>.
 </div>
 
-## Start, Stop, and Restart the Agent 
+## Start, Stop, and Restart the Agent
 
 ### Start the Agent
 
@@ -89,7 +89,7 @@ List of commands to stop the Datadog Agent:
 {{% /tab %}}
 {{< /tabs >}}
 
-### Restart the Agent 
+### Restart the Agent
 
 List of commands to restart the Datadog Agent:
 

--- a/content/en/agent/guide/agent-configuration-files.md
+++ b/content/en/agent/guide/agent-configuration-files.md
@@ -1,6 +1,6 @@
 ---
 title: Agent Configuration Files
-kind: faq
+kind: guide
 aliases:
   - /agent/faq/agent-configuration-files
 ---

--- a/content/en/agent/guide/agent-log-files.md
+++ b/content/en/agent/guide/agent-log-files.md
@@ -1,6 +1,6 @@
 ---
 title: Agent Log Files
-kind: faq
+kind: guide
 disable_toc: true
 aliases:
   - /agent/faq/agent-log-files

--- a/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
+++ b/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
@@ -14,23 +14,26 @@ further_reading:
   text: "Agent commands"
 ---
 
-Datadog community integrations are stored in the [Integrations-extra][1] Github repository. Since they are non-officially supported by Datadog, they are not packaged with the Datadog Agent and needs to be built locally in order to be included in the Agent. Find below how to install them with your Datadog Agent running as a binary on a host or as a container.
+Datadog community integrations are hosted in the [Integrations-extra][1] Github repository. As non-officially supported by Datadog, they are not packaged with the Datadog Agent and need to be built locally and installed in order to be included in the Agent. Find below how to install one community integration with your Datadog Agent running as a binary on a host or as a container.
 
 {{< tabs >}}
 {{% tab "Agent above v6.8" %}}
 
 To install the `<INTEGRATION_NAME>` check on your host:
 
-1. Install the [developer toolkit][1] on one host.
-2. Run `ddev -e release build <INTEGRATION_NAME>` to build the `<INTEGRATION_NAME>` package.
-3. [Download the Datadog Agent][2].
-4. Upload the build artifact of step 2. to any host with an Agent and run `datadog-agent integration install -w <PATH_OF_INTEGRATION_NAME_PACKAGE>/<ARTIFACT_NAME>.whl`.
-5. Configure your integration like any other packaged integration.
-6. [Restart the Agent][3].
+1. Install the [developer toolkit][1].
+2. Clone the integrations-extras repository: `git clone https://github.com/DataDog/integrations-extras.git`.
+3. Update your `ddev` config with the `integrations-extras/` path: `ddev config set extras ./integrations-extras`.
+4. Run `ddev -e release build <INTEGRATION_NAME>` to build the `<INTEGRATION_NAME>` package.
+5. [Download and launch the Datadog Agent][2].
+6. Run `datadog-agent integration install -w <PATH_OF_INTEGRATION_NAME_PACKAGE>/<ARTIFACT_NAME>.whl`.
+7. Configure your integration like [any other packaged integration][3].
+8. [Restart the Agent][4].
 
 [1]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [2]: https://app.datadoghq.com/account/settings#agent
-[3]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
+[3]: /getting_started/integrations
+[4]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
 {{% /tab %}}
 {{% tab "Docker" %}}
 
@@ -49,7 +52,7 @@ COPY --from=wheel_builder /wheels/integrations-extras/<INTEGRATION_NAME>/dist/ /
 RUN agent integration install -r -w /dist/*.whl
 ```
 
-The use this new Agent image in combination with [Autodiscovery][1] in order to enable the `<INTEGRATION_NAME>` check.
+Then use this new Agent image in combination with [Autodiscovery][1] in order to enable the `<INTEGRATION_NAME>` check.
 
 [1]: agent/autodiscovery
 {{% /tab %}}

--- a/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
+++ b/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
@@ -16,7 +16,6 @@ further_reading:
 
 Datadog community integrations are stored in the [Integrations-extra][1] Github repository. Since they are non-officially supported by Datadog, they are not packaged with the Datadog Agent and needs to be build locally in order to be included in the Agent. Find below how to install them with your Datadog Agent running as a binary on a host or as a container.
 
-
 {{< tabs >}}
 {{% tab "Agent 6.8+" %}}
 
@@ -37,7 +36,7 @@ To install the `<INTEGRATION_NAME>` check on your host:
 
 The best way to use an integration from integrations-extra with the Docker Agent is to build the Agent with this integration installed. Use the following Dockerfile to build an updated version of the Agent that includes the `<INTEGRATION_NAME>` integration from integrations-extras.
 
-```
+```dockerfile
 FROM python:2.7 AS wheel_builder
 WORKDIR /wheels
 RUN pip install "datadog-checks-dev[cli]"
@@ -50,8 +49,13 @@ COPY --from=wheel_builder /wheels/integrations-extras/<INTEGRATION_NAME>/dist/ /
 RUN agent integration install -r -w /dist/*.whl
 ```
 
+The use this new Agent image in combination with [Autodiscovery][1] in order to enable the `<INTEGRATION_NAME>` check.
+
+[1]: agent/autodiscovery
 {{% /tab %}}
 {{% tab "Agent 6.8-" %}}
+
+To install the `<INTEGRATION_NAME>` check on your host:
 
 1. [Download the Datadog Agent][1] on your host.
 2. Download the `<INTEGRATION_NAME>.py` file in the `<INTEGRATION_NAME>/datadog_checks/<INTEGRATION_NAME>/` folder from the [integrations-extra repository][2]

--- a/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
+++ b/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
@@ -1,0 +1,72 @@
+---
+title: Install a community integration with the Agent
+kind: guide
+disable_toc: true
+further_reading:
+- link: "agent/troubleshooting/"
+  tag: "Documentation"
+  text: "Agent Troubleshooting"
+- link: "agent/guide/agent-configuration-files/"
+  tag: "FAQ"
+  text: "Agent configuration files"
+- link: "agent/guide/agent-commands/"
+  tag: "FAQ"
+  text: "Agent commands"
+---
+
+Datadog community integrations are stored in the [Integrations-extra][1] Github repository. Since they are non-officially supported by Datadog, they are not packaged with the Datadog Agent and needs to be build locally in order to be included in the Agent. Find below how to install them with your Datadog Agent running as a binary on a host or as a container.
+
+
+{{< tabs >}}
+{{% tab "Agent 6.8+" %}}
+
+To install the `<INTEGRATION_NAME>` check on your host:
+
+1. Install the [developer toolkit][1] on one host.
+2. Run `ddev -e release build <INTEGRATION_NAME>` to build the `<INTEGRATION_NAME>` package.
+3. [Download the Datadog Agent][2].
+4. Upload the build artifact of step 2. to any host with an Agent and run `datadog-agent integration install -w <PATH_OF_INTEGRATION_NAME_PACKAGE>/<ARTIFACT_NAME>.whl`.
+5. Configure your integration like any other packaged integration.
+6. [Restart the Agent][3].
+
+[1]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
+[2]: https://app.datadoghq.com/account/settings#agent
+[3]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
+{{% /tab %}}
+{{% tab "Docker" %}}
+
+The best way to use an integration from integrations-extra with the Docker Agent is to build the Agent with this integration installed. Use the following Dockerfile to build an updated version of the Agent that includes the `<INTEGRATION_NAME>` integration from integrations-extras.
+
+```
+FROM python:2.7 AS wheel_builder
+WORKDIR /wheels
+RUN pip install "datadog-checks-dev[cli]"
+RUN git clone https://github.com/DataDog/integrations-extras.git
+RUN ddev config set extras ./integrations-extras
+RUN ddev -e release build <INTEGRATION_NAME>
+
+FROM datadog/agent:latest
+COPY --from=wheel_builder /wheels/integrations-extras/<INTEGRATION_NAME>/dist/ /dist
+RUN agent integration install -r -w /dist/*.whl
+```
+
+{{% /tab %}}
+{{% tab "Agent 6.8-" %}}
+
+1. [Download the Datadog Agent][1] on your host.
+2. Download the `<INTEGRATION_NAME>.py` file in the `<INTEGRATION_NAME>/datadog_checks/<INTEGRATION_NAME>/` folder from the [integrations-extra repository][2]
+3. Place it in the Agent's `checks.d` directory.
+4. Download the `conf.yaml.example` file in the `<INTEGRATION_NAME>/datadog_checks/<INTEGRATION_NAME>/data/` folder from the [integrations-extra repository][2]
+5. Rename this file into `conf.yaml`.
+6. Create a new `<INTEGRATION_NAME>.d/` folder in your [Agent configuration directory][3].
+7. Place the `conf.yaml` file in the directory created in step 6.
+8. Configure your integration like any other packaged integration.
+9. [Restart the Agent][4].
+
+[1]: https://app.datadoghq.com/account/settings#agent
+[2]: https://github.com/DataDog/integrations-extras
+[3]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6#agent-configuration-directory
+[4]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
+{{% /tab %}}
+{{< /tabs >}}
+[1]: https://github.com/DataDog/integrations-extras

--- a/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
+++ b/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
@@ -1,5 +1,5 @@
 ---
-title: Install a community integration with the Agent
+title: Community integration installation
 kind: guide
 disable_toc: true
 further_reading:
@@ -14,7 +14,7 @@ further_reading:
   text: "Agent commands"
 ---
 
-Datadog community integrations are hosted in the [Integrations-extra][1] Github repository. As non-officially supported by Datadog, they are not packaged with the Datadog Agent and need to be built locally and installed in order to be included in the Agent. Find below how to install one community integration with your Datadog Agent running as a binary on a host or as a container.
+Datadog community integrations are hosted in the [Integrations-extra][1] Github repository. As non-officially supported by Datadog, they are not packaged with the Datadog Agent and need to be built locally and installed in order to be included in the Agent. Find below how to install one community integration with your Datadog Agent running as a binary on a host or as a container prior to use it as a normal Agent Check.
 
 {{< tabs >}}
 {{% tab "Agent above v6.8" %}}

--- a/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
+++ b/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
@@ -17,7 +17,7 @@ further_reading:
 Datadog community integrations are stored in the [Integrations-extra][1] Github repository. Since they are non-officially supported by Datadog, they are not packaged with the Datadog Agent and needs to be build locally in order to be included in the Agent. Find below how to install them with your Datadog Agent running as a binary on a host or as a container.
 
 {{< tabs >}}
-{{% tab "Agent 6.8+" %}}
+{{% tab "Agent above v6.8" %}}
 
 To install the `<INTEGRATION_NAME>` check on your host:
 
@@ -36,7 +36,7 @@ To install the `<INTEGRATION_NAME>` check on your host:
 
 The best way to use an integration from integrations-extra with the Docker Agent is to build the Agent with this integration installed. Use the following Dockerfile to build an updated version of the Agent that includes the `<INTEGRATION_NAME>` integration from integrations-extras.
 
-```dockerfile
+```
 FROM python:2.7 AS wheel_builder
 WORKDIR /wheels
 RUN pip install "datadog-checks-dev[cli]"
@@ -53,7 +53,7 @@ The use this new Agent image in combination with [Autodiscovery][1] in order to 
 
 [1]: agent/autodiscovery
 {{% /tab %}}
-{{% tab "Agent 6.8-" %}}
+{{% tab "Agent prior to 6.8" %}}
 
 To install the `<INTEGRATION_NAME>` check on your host:
 

--- a/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
+++ b/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
@@ -73,4 +73,9 @@ To install the `<INTEGRATION_NAME>` check on your host:
 [4]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
 {{% /tab %}}
 {{< /tabs >}}
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
 [1]: https://github.com/DataDog/integrations-extras

--- a/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
+++ b/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
@@ -14,7 +14,7 @@ further_reading:
   text: "Agent commands"
 ---
 
-Datadog community integrations are stored in the [Integrations-extra][1] Github repository. Since they are non-officially supported by Datadog, they are not packaged with the Datadog Agent and needs to be build locally in order to be included in the Agent. Find below how to install them with your Datadog Agent running as a binary on a host or as a container.
+Datadog community integrations are stored in the [Integrations-extra][1] Github repository. Since they are non-officially supported by Datadog, they are not packaged with the Datadog Agent and needs to be built locally in order to be included in the Agent. Find below how to install them with your Datadog Agent running as a binary on a host or as a container.
 
 {{< tabs >}}
 {{% tab "Agent above v6.8" %}}
@@ -64,13 +64,14 @@ To install the `<INTEGRATION_NAME>` check on your host:
 5. Rename this file into `conf.yaml`.
 6. Create a new `<INTEGRATION_NAME>.d/` folder in your [Agent configuration directory][3].
 7. Place the `conf.yaml` file in the directory created in step 6.
-8. Configure your integration like any other packaged integration.
-9. [Restart the Agent][4].
+8. Configure your integration like [any other packaged integration][4].
+9. [Restart the Agent][5].
 
 [1]: https://app.datadoghq.com/account/settings#agent
 [2]: https://github.com/DataDog/integrations-extras
 [3]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6#agent-configuration-directory
-[4]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
+[4]: /getting_started/integrations
+[5]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
+++ b/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
@@ -14,7 +14,7 @@ further_reading:
   text: "Agent commands"
 ---
 
-Datadog community integrations are hosted in the [Integrations-extra][1] Github repository. As non-officially supported by Datadog, they are not packaged with the Datadog Agent and need to be built locally and installed in order to be included in the Agent. Find below how to install one community integration with your Datadog Agent running as a binary on a host or as a container prior to use it as a normal Agent Check.
+Community developed integrations for the Datadog Agent are stored in the [Integrations-extra][1] Github repository. They are not packaged and built into the Datadog Agent, but can be installed as add-ons by following these instructions:
 
 {{< tabs >}}
 {{% tab "Agent above v6.8" %}}

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -31,7 +31,7 @@ further_reading:
 
 This decision was taken after the POODLE problem. Versioned endpoints start with Agent v5.2.0, where each version of the Agent calls a different endpoint based on the version of the *Forwarder*. For example, Agent v5.2.0 calls `5-2-0-app.agent.datadoghq.com`. Therefore you must whitelist `*.agent.datadoghq.com` in your firewall(s).
 
-These domains are **CNAME** records pointing to a set of static IP addresses. These addresses can be found at:  
+These domains are **CNAME** records pointing to a set of static IP addresses. These addresses can be found at:
 
 * **[https://ip-ranges.datadoghq.com][4]**, or
 * **[https://ip-ranges.datadoghq.eu][5]** for Datadog EU
@@ -74,14 +74,14 @@ You should whitelist all of these IPs. While only a subset are active at any giv
 
 **All outbound traffic is sent over SSL via TCP / UDP.**
 
-Open the following ports in order to benefit from all the Agent functionalities: 
+Open the following ports in order to benefit from all the Agent functionalities:
 
 {{< tabs >}}
 {{% tab "Agent v6" %}}
 
 * **Outbound**:
 
-  * `443/tcp`: port for most Agent data. (Metrics, APM, Live Processes/Containers) 
+  * `443/tcp`: port for most Agent data. (Metrics, APM, Live Processes/Containers)
   * `123/udp`: NTP - [More details on the importance of NTP][1].
   * `10516/tcp`: port for the [Log collection][2]
   * `10255/tcp`: port for the [Kubernetes http kubelet][3]
@@ -92,12 +92,12 @@ Open the following ports in order to benefit from all the Agent functionalities:
   * `5000/tcp`: port for the [go_expvar server][4]
   * `5001/tcp`: port on which the IPC api listens
   * `5002/tcp`: port for [the Agent browser GUI to be served][5]
-  * `8125/udp`: dogstatsd. Unless `dogstatsd_non_local_traffic` is set to true. This port is available on localhost: 
+  * `8125/udp`: dogstatsd. Unless `dogstatsd_non_local_traffic` is set to true. This port is available on localhost:
 
       * `127.0.0.1`
-      * `::1` 
+      * `::1`
       * `fe80::1`
-  
+
   * `8126/tcp`: port for the [APM Receiver][6]
 
 
@@ -112,15 +112,15 @@ Open the following ports in order to benefit from all the Agent functionalities:
 
 * **Outbound**:
 
-  * `443/tcp`: port for most Agent data. (Metrics, APM, Live Processes/Containers) 
+  * `443/tcp`: port for most Agent data. (Metrics, APM, Live Processes/Containers)
   * `123/udp`: NTP - [More details on the importance of NTP][1].
 
 * **Inbound**:
 
-  * `8125/udp`: DogStatsd. Unless `dogstatsd_non_local_traffic` is set to true. This port is available on localhost: 
+  * `8125/udp`: DogStatsd. Unless `dogstatsd_non_local_traffic` is set to true. This port is available on localhost:
 
       * `127.0.0.1`
-      * `::1` 
+      * `::1`
       * `fe80::1`
 
   * `8126/tcp`: port for the [APM Receiver][2]


### PR DESCRIPTION
### What does this PR do?
Adds instructions to use integrations from integrations-extra with the Agent.

### Motivation
A better onboarding over the Agent and its usage.

### Preview link

* https://docs-staging.datadoghq.com/gus/agent-community-integrations/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker