### PR TITLE
Update _index.md

### DIFF
--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -26,10 +26,7 @@ further_reading:
 
 ## Installation
 
-To gather metrics, traces, and logs from your Kubernetes clusters, there are two options:
-
-1. [Container installation][2] (**recommended**) -  The Agent runs inside a Pod. This implementation is sufficient for the majority of use cases, but note that it does not grant visibility into components of the system that exist outside Kubernetes. This method also does not monitor the starting phase of your Kubernetes cluster.
-2. [Host installation][3] (optional) - Installing the Agent on the host provides additional visibility into your ecosystem, independent of Kubernetes.
+To gather metrics, traces, and logs from your Kubernetes clusters, you should run the datadog agent as a [Daemonset][2]. This method does not monitor the starting phase of your Kubernetes cluster. The other option is to use the normal [host installation][3] on each of your nodes.
 
 **Note**: Only one Datadog Agent shound run on each node; a sidecar per node is not generally recommended and may not function as expected.
 


### PR DESCRIPTION
### What does this PR do?
removes language around limitations that running the kubernetes agent previously had, as our engineering team has bridged this gap and it is no longer accurate

### Motivation
A client that I am working with was having concerns here and confused, and suggested changing the docs. After posting in cake, a T2 (grant) said that this language was very misleading and not accurate

### Preview link
https://github.com/DataDog/documentation/blob/mikelaning/kubernetes-installation/content/en/agent/kubernetes/_index.md

