### PR TITLE
small additions to k8s index

### DIFF
--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -24,12 +24,16 @@ further_reading:
 
 **Note**: Agent version 6.0 and above only support versions of Kubernetes higher than 1.7.6. For prior versions of Kubernetes, consult the [Legacy Kubernetes versions section][1].
 
+There are a number of different ways to monitor your Kubernetes system using Datadog. Choosing one depends on how your system is structured and the type of monitoring you desire. There are four options for installing the Datadog Agent for Kubernetes: DaemonSets, Helm charts, installing the Agent directly on the host, and the Datadog Cluster Agent.
+
 ## Installation
 
-To gather metrics, traces, and logs from your Kubernetes clusters, there are two options:
+To gather metrics, traces, and logs from your Kubernetes clusters, there are four options:
 
-1. [Container installation][2] (**recommended**) -  The Agent runs inside a Pod. This implementation is sufficient for the majority of use cases, but note that it does not grant visibility into components of the system that exist outside Kubernetes. This method also does not monitor the starting phase of your Kubernetes cluster.
-2. [Host installation][3] (optional) - Installing the Agent on the host provides additional visibility into your ecosystem, independent of Kubernetes.
+* [Container installation][2] (**recommended**) -  The Agent runs inside a Pod. This implementation is sufficient for the majority of use cases, but does not monitor the starting phase of your Kubernetes cluster.
+* [Helm installation][3] - [Helm][4] is a package manger for Kubernetes that allows you to easily install the Datadog Agent and enable its various capabilities.
+* [Host installation][5] - If the kubelet runs into an issue, and the Agent as a container dies, you will lose visibility into the node. However, if the Agent runs *on* the node, you can monitor the kubelet throughout its lifecycle. If this is a significant concern for you, install the Agent as a host.
+* [Cluster Agent][6] - For systems with very large Kubernetes clusters, the Datadog Cluster Agent can help to alleviate server load.
 
 **Note**: Only one Datadog Agent shound run on each node; a sidecar per node is not generally recommended and may not function as expected.
 
@@ -41,21 +45,21 @@ You must allow the Agent to perform a few actions:
 
 - `get` and `update` the `Configmaps` named `datadogtoken` to update and query the most up-to-date version token corresponding to the latest event stored in ETCD.
 - `list` and `watch` the `Events` to pull the events from the API Server, format, and submit them.
-- `get`, `update`, and `create` for the `Endpoint`. The Endpoint used by the Agent for the [Leader election][4] feature is named `datadog-leader-election`.
+- `get`, `update`, and `create` for the `Endpoint`. The Endpoint used by the Agent for the [Leader election][7] feature is named `datadog-leader-election`.
 - `list` the `componentstatuses` resource, in order to submit service checks for the Control Plane's components status.
 
-You can find the templates in `manifests/rbac` in the [datadog-agent GitHub repository][5]. This creates a Service Account in the default namespace, a Cluster Role with the above rights, and a Cluster Role Binding.
+You can find the templates in `manifests/rbac` in the [datadog-agent GitHub repository][8]. This creates a Service Account in the default namespace, a Cluster Role with the above rights, and a Cluster Role Binding.
 
 ## Custom Integrations
 
-For details on the usage of ConfigMaps in Kubernetes, consult [Datadog's Kubernetes Custom Integrations documentation][6].
+For details on the usage of ConfigMaps in Kubernetes, consult [Datadog's Kubernetes Custom Integrations documentation][9].
 
 ## Troubleshooting
 
-* [Can I install the Agent on my Kubernetes master node(s)][7]
-* [Why is the Kubernetes check failing with a ConnectTimeout error to port 10250?][8]
-* [Client Authentication against the apiserver and kubelet][9]
-* [Using RBAC permission with your Kubernetes integration][10]
+* [Can I install the Agent on my Kubernetes master node(s)][10]
+* [Why is the Kubernetes check failing with a ConnectTimeout error to port 10250?][11]
+* [Client Authentication against the apiserver and kubelet][12]
+* [Using RBAC permission with your Kubernetes integration][13]
 
 ## Further Reading
 
@@ -63,11 +67,14 @@ For details on the usage of ConfigMaps in Kubernetes, consult [Datadog's Kuberne
 
 [1]: /agent/kubernetes/legacy
 [2]: /agent/kubernetes/daemonset_setup
-[3]: /agent/kubernetes/host_setup
-[4]: /agent/kubernetes/event_collection#leader-election
-[5]: https://github.com/DataDog/datadog-agent/tree/0bef169d4e80e838ec6b303f5ad1da716b424b0f/Dockerfiles/manifests/rbac
-[6]: /agent/kubernetes/integrations
-[7]: /integrations/faq/can-i-install-the-agent-on-my-kubernetes-master-node-s
-[8]: /integrations/faq/why-is-the-kubernetes-check-failing-with-a-connecttimeout-error-to-port-10250
-[9]: /integrations/faq/client-authentication-against-the-apiserver-and-kubelet
-[10]: /integrations/faq/using-rbac-permission-with-your-kubernetes-integration
+[3]: /agent/kubernetes/helm
+[4]: https://helm.
+[5]: /agent/kubernetes/host_setup
+[6]: /agent/kubernetes/cluster
+[7]: /agent/kubernetes/event_collection#leader-election
+[8]: https://github.com/DataDog/datadog-agent/tree/0bef169d4e80e838ec6b303f5ad1da716b424b0f/Dockerfiles/manifests/rbac
+[9]: /agent/kubernetes/integrations
+[10]: /integrations/faq/can-i-install-the-agent-on-my-kubernetes-master-node-s
+[11]: /integrations/faq/why-is-the-kubernetes-check-failing-with-a-connecttimeout-error-to-port-10250
+[12]: /integrations/faq/client-authentication-against-the-apiserver-and-kubelet
+[13]: /integrations/faq/using-rbac-permission-with-your-kubernetes-integration

--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -68,7 +68,7 @@ For details on the usage of ConfigMaps in Kubernetes, consult [Datadog's Kuberne
 [1]: /agent/kubernetes/legacy
 [2]: /agent/kubernetes/daemonset_setup
 [3]: /agent/kubernetes/helm
-[4]: https://helm.
+[4]: https://helm.sh
 [5]: /agent/kubernetes/host_setup
 [6]: /agent/kubernetes/cluster
 [7]: /agent/kubernetes/event_collection#leader-election


### PR DESCRIPTION
### What does this PR do?
improves clarity for daemonset installation, adds helm and DCA as install options

### Motivation
support

### Preview link

https://docs-staging.datadoghq.com/cswatt/k8s-restructure/agent/kubernetes
