### PR TITLE
Fix tag to enable trace search and analytics

### DIFF
--- a/content/en/tracing/trace_search_and_analytics/_index.md
+++ b/content/en/tracing/trace_search_and_analytics/_index.md
@@ -368,7 +368,7 @@ class MyClass {
     // Span provided by @Trace annotation.
     if (span != null) {
       span.setTag(DDTags.SERVICE_NAME, "my-custom-service");
-      span.setTag(DDTags.ANALYTICS_KEY, true);
+      span.setTag(DDTags.ANALYTICS_SAMPLE_RATE, true);
     }
   }
 }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
It changes the docs to use the tag `DDTags.ANALYTICS_SAMPLE_RATE` instead of `DDTags.ANALYTICS_KEY` for java as the latter doesn't exist.
`  public static final String ANALYTICS_SAMPLE_RATE = "_dd1.sr.eausr";` [defined here](https://github.com/DataDog/dd-trace-java/blob/d3266e9215e631bc4f2799a1379962210bd99800/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java#L17)

### Motivation
I got confused while reading the docs and had to look into the code and other language examples to know which tag was needed.

### Preview link
https://docs-staging.datadoghq.com/jannik.steinmann/fix-trace-search-tag/tracing/trace_search_and_analytics/?tab=java

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/jannik.steinmann/fix-trace-search-tag/content/en/tracing/trace_search_and_analytics/_index.md

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
-
