### PR TITLE
Fix APM broken link

### DIFF
--- a/content/en/tracing/send_traces/_index.md
+++ b/content/en/tracing/send_traces/_index.md
@@ -81,7 +81,7 @@ Next, [Instrument your application][12]. For the full overview of all of the ste
 [1]: /tracing
 [2]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
 [3]: https://github.com/DataDog/datadog-trace-agent/blob/6.4.1/datadog.example.yaml
-[4]: tracing/send_traces/agent-apm-metrics
+[4]: /tracing/send_traces/agent-apm-metrics
 [5]: /agent
 [6]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
 [7]: /integrations/amazon_xray/#overview


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fix APM broken link

### Motivation
CI link checker

### Preview link
N/A
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
N/A
