### PR TITLE
Fixing instructions for Amazon linux AMI original and Agent v5

### DIFF
--- a/content/en/integrations/faq/agent-5-amazon-ecs.md
+++ b/content/en/integrations/faq/agent-5-amazon-ecs.md
@@ -1,6 +1,7 @@
 ---
 title: Amazon Elastic Container Service with Agent v5
 kind: faq
+disable_toc: true
 ---
 
 <div class="alert alert-warning">

--- a/content/en/integrations/faq/agent-5-amazon-ecs.md
+++ b/content/en/integrations/faq/agent-5-amazon-ecs.md
@@ -25,9 +25,10 @@ You may either configure the task using the [AWS CLI tools][2] or using the Amaz
 
 ##### AWS CLI
 
-1. Download [dd-agent-ecs.json][3].
-1. Edit dd-agent-ecs.json and update it with the [API_KEY][4] for your account.
-1. Execute the following command:
+1. Download [datadog-agent-ecs.json][3] ([datadog-agent-ecs1.json][4] if you are using an original Amazon Linux AMI).
+2. Edit `datadog-agent-ecs.json` and set `<YOUR_DATADOG_API_KEY>` with the [Datadog API key][5] for your account.
+3. Execute the following command:
+
 ```
 Amazon Elastic Container Service register-task-definition --cli-input-json file://path/to/dd-agent-ecs.json
 ```
@@ -37,40 +38,40 @@ Amazon Elastic Container Service register-task-definition --cli-input-json file:
 1. Log in to your AWS Console and navigate to the EC2 Container Service section.
 2. Click on the cluster you wish to add Datadog to.
 3. Click on **Task Definitions** on the left side and click the button **Create new Task Definition**.
-4. Enter a **Task Definition Name**, such as ```dd-agent-task```.
+4. Enter a **Task Definition Name**, such as `dd-agent-task`.
 5. Click on the **Add volume** link.
-6. For **Name** enter ```docker_sock```. For **Source Path**, enter ```/var/run/docker.sock```. Click **Add**.
-7. Add another volume with the name ```proc``` and source path of ```/proc/```.
-8. Add another volume with the name ```cgroup``` and source path of ```/cgroup/```.
+6. For **Name** enter `docker_sock`. For **Source Path**, enter `/var/run/docker.sock`. Click **Add**.
+7. Add another volume with the name `proc` and source path of `/proc/`.
+8. Add another volume with the name `cgroup` and source path of `/cgroup/` (Use `/sys/fs/cgroup/`if you are using an original Amazon Linux AMI)
 9. Click the large **Add container** button.
-10. For **Container name** enter ```dd-agent```.
-11. For **Image** enter ```datadog/docker-dd-agent:latest```.
-12. For **Maximum memory** enter ```256```. **Note**: For high resource usage, you may need a higher memory limit.
-13. Scroll down to the **Advanced container configuration** section and enter ```10``` in **CPU units**.
-14. For **Env Variables**, add a **Key** of ```API_KEY``` and enter your Datadog API Key in the value. *If you feel more comfortable storing secrets like this in s3, take a [look at the ECS Configuration guide][5].*
-15. Add another Environment Variable for any tags you want to add using the key ```TAGS```.
+10. For **Container name** enter `dd-agent`.
+11. For **Image** enter `datadog/docker-dd-agent:latest`.
+12. For **Maximum memory** enter `256`. **Note**: For high resource usage, you may need a higher memory limit.
+13. Scroll down to the **Advanced container configuration** section and enter `10` in **CPU units**.
+14. For **Env Variables**, add a **Key** of `API_KEY` and enter your Datadog API Key in the value. *If you feel more comfortable storing secrets like this in s3, take a [look at the ECS Configuration guide][6].*
+15. Add another Environment Variable for any tags you want to add using the key `TAGS`.
 16. Scroll down to the **Storage and Logging** section.
-17. In **Mount points** select the **docker_sock** source volume and enter ```/var/run/docker.sock``` in the Container path. Leave the **Read only** checkbox un-checked.
-18. Add another mount point for **proc** and enter ```/host/proc/``` in the Container path. Check the **Read only** checkbox.
-19. Add a third mount point for **cgroup** and enter ```/host/sys/fs/cgroup``` in the Container path. Check the **Read only** checkbox.
+17. In **Mount points** select the **docker_sock** source volume and enter `/var/run/docker.sock` in the Container path. Leave the **Read only** checkbox un-checked.
+18. Add another mount point for **proc** and enter `/host/proc/` in the Container path. Check the **Read only** checkbox.
+19. Add a third mount point for **cgroup** and enter `/host/sys/fs/cgroup` in the Container path. Check the **Read only** checkbox.
 
 #### Create or Modify your IAM Policy
 
-1. Add those permissions to your [Datadog IAM policy][6] in order to collect Amazon ECS metrics:
+1. Add those permissions to your [Datadog IAM policy][7] in order to collect Amazon ECS metrics:
 
   * `ecs:ListClusters`: List available clusters.
   * `ecs:ListContainerInstances`: List instances of a cluster.
   * `ecs:DescribeContainerInstances`: Describe instances to add metrics on resources and tasks running, adds cluster tag to ec2 instances.
 
-  For more information on ECS policies, [review the documentation on the AWS website][7].
+  For more information on ECS policies, [review the documentation on the AWS website][8].
 
-2. Using the Identity and Access Management (IAM) console, create a new role called ```dd-agent-ecs```.
+2. Using the Identity and Access Management (IAM) console, create a new role called `dd-agent-ecs`.
 3. Select **Amazon EC2 Role for EC2 Container Service**. On the next screen do not check any checkboxes and click **Next Step**.
 4. Click **Create Role**.
 5. Click on the newly created role.
 6. Expand the **Inline Policies** section. Click the link to create a new inline policy.
 7. Choose **Custom Policy** and press the button.
-8. For **Policy Name** enter ```dd-agent-policy```. Copy the following text into the **Policy Document**:
+8. For **Policy Name** enter `dd-agent-policy`. Copy the following text into the **Policy Document**:
 
   ```json
    {
@@ -99,7 +100,7 @@ Amazon Elastic Container Service register-task-definition --cli-input-json file:
 
 #### Run the Agent as a Daemon Service
 
-Ideally you want the Datadog Agent to load on one container on each EC2 instance. The easiest way to achieve this is to run the Datadog Agent as a [Daemon Service][8].
+Ideally you want the Datadog Agent to load on one container on each EC2 instance. The easiest way to achieve this is to run the Datadog Agent as a [Daemon Service][9].
 
 ##### Schedule a Daemon Service in AWS using Our ECS Task
 
@@ -114,14 +115,15 @@ If you're not using APM or Logs, you are finished. Otherwise, point your applica
 
 ##### Dynamic detection and monitoring of running services
 
-Datadog's [Autodiscovery][9] can be used in conjunction with ECS and Docker to automatically discover and monitor running tasks in your environment.
+Datadog's [Autodiscovery][10] can be used in conjunction with ECS and Docker to automatically discover and monitor running tasks in your environment.
 
 [1]: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_GetStarted.html
 [2]: https://aws.amazon.com/cli
-[3]: /resources/json/dd-agent-ecs.json
-[4]: https://app.datadoghq.com/account/settings#api
-[5]: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html#ecs-config-s3
-[6]: /integrations/amazon_web_services/#installation
-[7]: https://docs.aws.amazon.com/IAM/latest/UserGuide/list_ecs.html
-[8]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html#service_scheduler_daemon
-[9]: /agent/autodiscovery
+[3]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs.json
+[4]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs1.json
+[5]: https://app.datadoghq.com/account/settings#api
+[6]: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html#ecs-config-s3
+[7]: /integrations/amazon_web_services/#installation
+[8]: https://docs.aws.amazon.com/IAM/latest/UserGuide/list_ecs.html
+[9]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html#service_scheduler_daemon
+[10]: /agent/autodiscovery

--- a/content/en/integrations/faq/agent-5-amazon-ecs.md
+++ b/content/en/integrations/faq/agent-5-amazon-ecs.md
@@ -30,7 +30,7 @@ You may either configure the task using the [AWS CLI tools][2] or using the Amaz
 3. Execute the following command:
 
 ```
-Amazon Elastic Container Service register-task-definition --cli-input-json file://path/to/dd-agent-ecs.json
+Amazon Elastic Container Service register-task-definition --cli-input-json file:<PATH_TO_JSON_DD_AGENT_ECS>.json
 ```
 
 ##### Web UI

--- a/content/en/integrations/faq/agent-5-amazon-ecs.md
+++ b/content/en/integrations/faq/agent-5-amazon-ecs.md
@@ -119,8 +119,8 @@ Datadog's [Autodiscovery][10] can be used in conjunction with ECS and Docker to 
 
 [1]: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_GetStarted.html
 [2]: https://aws.amazon.com/cli
-[3]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs.json
-[4]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs1.json
+[3]: /resources/json/dd-agent-ecs.json
+[4]: /resources/json/dd-agent-ecs1.json
 [5]: https://app.datadoghq.com/account/settings#api
 [6]: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html#ecs-config-s3
 [7]: /integrations/amazon_web_services/#installation

--- a/static/resources/json/dd-agent-ecs1.json
+++ b/static/resources/json/dd-agent-ecs1.json
@@ -1,0 +1,58 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "dd-agent",
+      "image": "datadog/docker-dd-agent:latest",
+      "cpu": 10,
+      "memory": 256,
+      "essential": true,
+      "mountPoints": [
+        {
+          "containerPath": "/var/run/docker.sock",
+          "sourceVolume": "docker_sock"
+        },
+        {
+          "containerPath": "/host/sys/fs/cgroup",
+          "sourceVolume": "cgroup",
+          "readOnly": true
+        },
+        {
+          "containerPath": "/host/proc",
+          "sourceVolume": "proc",
+          "readOnly": true
+        }
+      ],
+      "environment": [
+        {
+          "name": "API_KEY",
+          "value": "INSERT_API_KEY"
+        },
+        {
+      	  "name": "SD_BACKEND",
+	  "value": "docker"
+        }
+      ]
+    }
+  ],
+  "volumes": [
+    {
+      "host": {
+        "sourcePath": "/var/run/docker.sock"
+      },
+      "name": "docker_sock"
+    },
+    {
+      "host": {
+        "sourcePath": "/proc/"
+      },
+      "name": "proc"
+    },
+    {
+      "host": {
+        "sourcePath": "/sys/fs/cgroup/"
+      },
+      "name": "cgroup"
+    }
+  ],
+  "family": "dd-agent-task"
+}


### PR DESCRIPTION
### What does this PR do?
Fixes instructions for Agent v5 and Amazon ECS with original AMI.

### Motivation
Customer feedback.

### Preview link

* https://docs-staging.datadoghq.com/gus/ecs-agent-5-update/integrations/faq/agent-5-amazon-ecs/