### PR TITLE
David.jones/remove minify

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:david.jones_bump-hugo
   tags:
     - "runner:main"
     - "size:large"
@@ -43,7 +43,6 @@ build_preview:
     - placehold_translations
     - update_preview_baseurl
     - build_hugo_site_new
-    - minify_html
     - collect_static_assets
     # remove service_checks json as we don't need to s3 push that..
     - rm -rf data/service_checks
@@ -84,7 +83,6 @@ build_live:
     - sync_integration_metrics
     - placehold_translations
     - build_hugo_site_new
-    - minify_html
     - collect_static_assets
     - push_site_to_s3
     - create_artifact

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:david.jones_bump-hugo
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
   tags:
     - "runner:main"
     - "size:large"


### PR DESCRIPTION
### What does this PR do?

This PR removes the separate minify process we run and instead uses hugo's built in `--minify` command. 

### Motivation

- We use this on corp site.
- We don't need to maintain another script to do this

### Preview link
https://docs-staging.datadoghq.com/david.jones/remove-minify/

### Additional Notes
The usage of `--minify` is in the build image
