### PR TITLE
responsive table fix on bumped hugo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:david.jones_local-hugo
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
   tags:
     - "runner:main"
     - "size:large"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:david.jones_local-hugo
   tags:
     - "runner:main"
     - "size:large"

--- a/layouts/shortcodes/table.html
+++ b/layouts/shortcodes/table.html
@@ -1,3 +1,4 @@
+<span> </span>
 <div class="{{ if .Get "responsive"}}table-responsive-container{{ end }} {{ if .Get "wide" }}table-wide{{ end }} {{ if .Get "vertical-mobile" }}table-vertical-mobile{{ end }}">
 {{ if .Get "responsive"}}<div class="table-scroll">{{.Inner}}</div>{{ else }}{{.Inner}}{{ end }}
 </div>

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "gulp-rename": "1.3.0",
     "gulp-sass": "3.2.1",
     "gulp-uglify": "3.0.0",
-    "hugo-bin": "0.42.0",
+    "hugo-bin": "0.43.6",
     "jquery": "3.4.0",
     "jshint": "2.9.5",
     "jshint-stylish": "2.2.1",


### PR DESCRIPTION
### What does this PR do?
- bump the hugo version back up again
- fix the responsive table, strangely the render failed without tag prior to the table output
- fix the artifact pull failing sometimes (in updated image)

### Motivation
We updated hugo but saw some issues and rolled back this pr fixes the issues

### Preview link
https://docs-staging.datadoghq.com/david.jones/responsive-table-fix/tracing/setup/java/#configuration

### Additional Notes
We need to merge this PR first https://github.com/DataDog/corp-ci/pull/41