### PR TITLE
make sure there is a default card id to help avoid issues with corp u…

### DIFF
--- a/layouts/partials/integrations/integrations.html
+++ b/layouts/partials/integrations/integrations.html
@@ -84,7 +84,7 @@
         {{ if $indx }}
             {{ if $formatname }}
             <div id="mixid_{{$i}}" class="col-6 col-sm-4 col-md-3 col-lg-3 col-xl-2-4 mix text-center {{ range $i, $e := $v.Params.categories }} cat-{{ replace $e "/" "" | urlize }} {{ end }}" data-id="{{ $i }}" data-ref="item">
-                <div id="{{ $v.Params.name }}" class="card">
+                <div id="{{ $v.Params.name | default ($urlname | lower) }}" class="card">
                     <a class="card-img" href="{{ (print "integrations/" ($urlname | lower)) | absLangURL }}">
                         {{ $.Scratch.Set "url" ""}}
                         {{ if $indx }}


### PR DESCRIPTION
### What does this PR do?
This PR adds a default id to integration cards using the url name should the `Params.name` field be empty or non existent.

### Motivation
Helps avoid issues with corp site being able to share some of this data.

### Preview link
https://docs-staging.datadoghq.com/david.jones/default-card-id/integrations/

### Additional Notes

