### PR TITLE
Fix broken aliases

### DIFF
--- a/content/en/graphing/dashboards/shared_graph.md
+++ b/content/en/graphing/dashboards/shared_graph.md
@@ -2,8 +2,8 @@
 title: Shared Graphs
 kind: documentation
 aliases:
-    - graphing/faq/is-there-a-way-to-share-graphs
-    - graphing/faq/is-there-a-way-to-share-or-revoke-previously-shared-graphs
+    - /graphing/faq/is-there-a-way-to-share-graphs
+    - /graphing/faq/is-there-a-way-to-share-or-revoke-previously-shared-graphs
 further_reading:
 - link: "graphing/dashboards/"
   tag: "Documentation"

--- a/content/en/graphing/dashboards/template_variables.md
+++ b/content/en/graphing/dashboards/template_variables.md
@@ -2,8 +2,8 @@
 title: Template Variables
 kind: documentation
 aliases:
-    - graphing/dashboards/template_variables/correlate-metrics-and-events-using-dashboard-template-variables
-    - graphing/dashboards/template_variables/how-do-i-overlay-events-onto-my-dashboards
+    - /graphing/dashboards/template_variables/correlate-metrics-and-events-using-dashboard-template-variables
+    - /graphing/dashboards/template_variables/how-do-i-overlay-events-onto-my-dashboards
 further_reading:
 - link: "graphing/dashboards/"
   tag: "Documentation"

--- a/content/en/graphing/metrics/summary.md
+++ b/content/en/graphing/metrics/summary.md
@@ -3,7 +3,7 @@ title: Metrics Summary
 kind: documentation
 description: "Consult the full list of metrics reporting to Datadog."
 aliases:
-  - graphing/faq/how-can-i-set-up-custom-units-for-custom-metrics
+  - /graphing/faq/how-can-i-set-up-custom-units-for-custom-metrics
 further_reading:
   - link: "graphing/metrics/explorer"
     tag: "Documentation"

--- a/content/en/logs/logging_without_limits.md
+++ b/content/en/logs/logging_without_limits.md
@@ -3,7 +3,7 @@ title: Logging without Limits
 kind: documentation
 description: Control the volume of logs indexed by Datadog
 aliases:
-  - logs/dynamic_volume_control
+  - /logs/dynamic_volume_control
 further_reading:
 - link: "logs/explorer/analytics"
   tag: "Documentation"

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -3,7 +3,7 @@ title: Parsing
 kind: documentation
 description: "Parse your logs using the Grok Processor"
 aliases:
-    - logs/parsing/
+    - /logs/parsing/
 further_reading:
 - link: "logs/processing/processors"
   tag: "Documentation"

--- a/content/en/tracing/trace_search_and_analytics/analytics.md
+++ b/content/en/tracing/trace_search_and_analytics/analytics.md
@@ -3,9 +3,9 @@ title: Trace Analytics
 kind: documentation
 description: "Analytics on your APM data at infinite cardinality"
 aliases:
-  - tracing/trace_search_analytics/analytics
-  - tracing/analytics
-  - tracing/visualization/analytics
+  - /tracing/trace_search_analytics/analytics
+  - /tracing/analytics
+  - /tracing/visualization/analytics
 further_reading:
 - link: "tracing/setup/"
   tag: "Documentation"

--- a/content/en/tracing/trace_search_and_analytics/search.md
+++ b/content/en/tracing/trace_search_and_analytics/search.md
@@ -3,9 +3,9 @@ title: Trace Search
 kind: documentation
 description: "Global search of all your traces with tags"
 aliases:
-  - tracing/trace_search_analytics/
-  - tracing/trace_search/
-  - tracing/search
+  - /tracing/trace_search_analytics/
+  - /tracing/trace_search/
+  - /tracing/search
   - /tracing/getting_further/apm_events/
 further_reading:
 - link: "tracing/setup/"

--- a/content/fr/agent/kubernetes/daemonset_setup.md
+++ b/content/fr/agent/kubernetes/daemonset_setup.md
@@ -12,7 +12,7 @@ further_reading:
     tag: documentation
     text: Intégrations personnalisées
 aliases:
-  - /agent/kubernetes/apm
+  - /fr/agent/kubernetes/apm
 ---
 Tirez profit des DaemonSets pour déployer l'Agent Datadog sur l'ensemble de vos nœuds (ou sur un nœud donné grâce [aux nodeSelectors][1]). 
 


### PR DESCRIPTION
## What does this PR do?
Fix broken aliases

### Motivation
- Docs 404 top-list

### Preview link
N/A
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
N/A
