### PR TITLE
Fix broken tables

### DIFF
--- a/content/en/developers/metrics/counts.md
+++ b/content/en/developers/metrics/counts.md
@@ -32,6 +32,7 @@ Counters are used to count things.
 ### DogStatsD
 
 {{% table responsive="true" %}}
+
 | Method | Overview |
 | :----- | :------- |
 | dog.increment(...) | Used to increment a counter of events: <ul><li>Stored as a RATE type in the Datadog web application. Each value in the stored timeseries is a time-normalized delta of the counter's value over that StatsD flush period.</li></ul> |

--- a/content/en/developers/metrics/distributions.md
+++ b/content/en/developers/metrics/distributions.md
@@ -30,6 +30,7 @@ Under this model, the total number of timeseries created is based on the set of 
 ### DogStatsD
 
 {{% table responsive="true" %}}
+
 | Method | Overview |
 | :----- | :------- |
 | dog.distribution(...) | Track the statistical distribution of a set of values over one or more hosts.<ul><li>Required: metric name and value.</li><li>Optional: tag(s)</li></ul> |

--- a/content/en/developers/metrics/gauges.md
+++ b/content/en/developers/metrics/gauges.md
@@ -19,6 +19,7 @@ Gauges measure the value of a particular thing over time:
 ### Agent check
 
 {{% table responsive="true" %}}
+
 |Method | Overview |
 |:---|:---|
 |self.gauge(...)|<ul><li>If called multiple times during a check's execution for a metric only the last sample is used.</li><li>Stored as a Web Application GAUGE type</li></ul>|
@@ -27,6 +28,7 @@ Gauges measure the value of a particular thing over time:
 ### DogStatsD
 
 {{% table responsive="true" %}}
+
 |Method | Overview |
 |:---|:---|
 |dog.gauge(...)|Stored as a GAUGE type in the Datadog web application. Each value in the stored timeseries is the last gauge value submitted for that metric during the StatsD flush period.|

--- a/content/en/developers/metrics/rates.md
+++ b/content/en/developers/metrics/rates.md
@@ -19,6 +19,7 @@ Rates represent the derivative of a metric, it's the value variation of a metric
 ### Agent check
 
 {{% table responsive="true" %}}
+
 |Method | Overview |
 |:---|:---|
 |self.rate(...)|Submit the sampled raw value of your counter. Don't normalize the values to a rate, or calculate the deltas before submitting - the Agent does both for you:<ul><li>Should only be called once during a check.</li><li>Throws away any value that is less than a previously submitted value. IE the counter should be monotonically increasing.</li><li>Stored as a GAUGE type in the Datadog web application. Each value in the stored timeseries is a time-normalized delta of the counter's value between samples.</li></ul>|

--- a/content/en/developers/metrics/sets.md
+++ b/content/en/developers/metrics/sets.md
@@ -19,6 +19,7 @@ Sets are used to count the number of unique elements in a group.
 ### Agent check
 
 {{% table responsive="true" %}}
+
 |Method | Overview |
 |:---|:---|
 |self.set(...)|Used count the number of unique elements in a group:<ul><li>Should be called multiple times during an Agent check.</li><li>Stored as a GAUGE type in the Datadog web application.</li></ul>|
@@ -27,6 +28,7 @@ Sets are used to count the number of unique elements in a group.
 ### DogStatsD
 
 {{% table responsive="true" %}}
+
 |Method | Overview |
 |:---|:---|
 |dog.set(...)|Used count the number of unique elements in a group:<ul><li>Stored as GAUGE type in the Datadog web application. Each value in the stored timeseries is the count of unique values submitted to StatsD for a metric over that flush period.</li></ul>|

--- a/content/en/monitors/monitor_types/composite.md
+++ b/content/en/monitors/monitor_types/composite.md
@@ -157,6 +157,7 @@ Consider a scenario where monitor A is a multi-alert monitor grouped by `host`. 
 The previous table showed the composite monitor status across four points in time, but in this example, the table shows the status of each multi-alert case, all at one point in time:
 
 {{% table responsive="true" %}}
+
 |source | monitor A    | monitor B| monitor C | composite status (A && B && C) | alert triggered? |
 |-------|--------------|----------|-----------|--------------------------------|-------------------------|
 | web01 | Alert        | Warn     | Alert     | Alert                          |<i class="fa fa-check" aria-hidden="true"></i>|

--- a/content/fr/developers/metrics/counts.md
+++ b/content/fr/developers/metrics/counts.md
@@ -31,6 +31,7 @@ Les totaux servent à compter des éléments.
 ### DogStatsD
 
 {{% table responsive="true" %}}
+
 | Méthode | Présentation |
 | :----- | :------- |
 | dog.increment(...) | Permet d'incrémenter un compteur d'événements : <ul><li>Stocké en tant que RATE dans l'application Web de Datadog. Chaque valeur de la série temporelle stockée correspond à un delta normalisé temporellement de la valeur du compteur sur cette période de transmission de Statsd.</li></ul> |

--- a/content/fr/developers/metrics/distributions.md
+++ b/content/fr/developers/metrics/distributions.md
@@ -29,6 +29,7 @@ Dans ce modèle, le nombre total de séries temporelles créées repose sur l'en
 ### DogStatsD
 
 {{% table responsive="true" %}}
+
 | Méthode | Présentation |
 | :----- | :------- |
 | dog.distribution(...) | Surveillez la distribution statistique d'un ensemble de valeurs pour un ou plusieurs hosts.<ul><li>Obligatoire : la valeur et le nom de la métrique.</li><li>Facultatif : tag(s)</li></ul> |

--- a/content/fr/developers/metrics/gauges.md
+++ b/content/fr/developers/metrics/gauges.md
@@ -18,6 +18,7 @@ Les gauges mesurent la valeur d'un élément précis au fil du temps :
 ### Check de l'Agent
 
 {{% table responsive="true" %}}
+
 |Méthode | Présentation |
 |:---|:---|
 |self.gauge(...)|<ul><li>Si cette méthode est appelée plusieurs fois lors de l'exécution du check pour une métrique, seul le dernier échantillon est utilisé.</li><li>Stocké en tant que GAUGE dans une application Web.</li></ul>|
@@ -26,6 +27,7 @@ Les gauges mesurent la valeur d'un élément précis au fil du temps :
 ### DogStatsD
 
 {{% table responsive="true" %}}
+
 |Méthode | Présentation |
 |:---|:---|
 |dog.gauge(...)|Stocké en tant que GAUGE dans l'application Web de Datadog. Chaque valeur de la série temporelle stockée correspond à la dernière valeur gauge envoyée pour cette métrique durant la période de transmission de StatsD.|

--- a/content/fr/monitors/monitor_types/composite.md
+++ b/content/fr/monitors/monitor_types/composite.md
@@ -156,6 +156,7 @@ Mettons que le monitor A soit caractérisé par des alertes multiples et regroup
 Le tableau précédent indiquait le statut du monitor composite pour quatre occurrences. À l'inverse, dans cet exemple, le tableau indique le statut de chaque situation à alertes multiples, pour une seule occurrence :
 
 {{% table responsive="true" %}}
+
 |source | monitor A    | monitor B| monitor C | statut du monitor composite (A && B && C) | alerte déclenchée ? |
 |-------|--------------|----------|-----------|--------------------------------|-------------------------|
 | web01 | Alert        | Warn     | Alert     | Alert                          |<i class="fa fa-check" aria-hidden="true"></i>|


### PR DESCRIPTION
### What does this PR do?

This PR fixes such tables that are not interpreted as tables by the markdown processor.

#### Before

![スクリーンショット 2019-06-26 11 27 15](https://user-images.githubusercontent.com/1477130/60147243-aad83580-9807-11e9-8b2f-065996a00801.png)

#### After
![スクリーンショット 2019-06-26 11 27 02](https://user-images.githubusercontent.com/1477130/60147268-be839c00-9807-11e9-9da7-dfa36422d776.png)

### Motivation

It is hard to read some pages with the broken tables. 😵

### Preview link

There are no preview links because this PR is sent from a fork.
This PR modifies these pages.

- http://localhost:1313/developers/metrics/counts/
- http://localhost:1313/developers/metrics/distributions/
- http://localhost:1313/developers/metrics/gauges/
- http://localhost:1313/developers/metrics/rates/
- http://localhost:1313/developers/metrics/sets/
- http://localhost:1313/monitors/monitor_types/composite/
- http://localhost:1313/fr/developers/metrics/counts/
- http://localhost:1313/fr/developers/metrics/distributions/
- http://localhost:1313/fr/developers/metrics/gauges/
- http://localhost:1313/fr/monitors/monitor_types/composite/

