### PR TITLE
Removing ja entries from the sitemap

### DIFF
--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,6 +1,6 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {{ range where (where .Data.Pages "Params.beta" "!=" true) ".Params.is_public" "!=" false }}
-  	  {{ if (and (not .Params.private) (ne (.Language.Lang | default "en") "fr") ) }}
+  	  {{ if (and (not .Params.private) (ne (.Language.Lang | default "en") "fr") (ne (.Language.Lang | default "en") "ja") ) }}
 	  <url>
 	    <loc>{{ .Permalink }}</loc>
       {{ if not .Lastmod.IsZero }}

--- a/layouts/sitemapindex.xml
+++ b/layouts/sitemapindex.xml
@@ -1,6 +1,6 @@
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 	{{ range . }}
-  {{ if not (eq .Language.Lang "fr") }}
+  {{ if not (or (eq .Language.Lang "fr") (eq .Language.Lang "ja")) }}
 	<sitemap>
 	  	<loc>{{ .SitemapAbsURL }}</loc>
 		{{ if not .LastChange.IsZero }}


### PR DESCRIPTION
### What does this PR do?
Removes JA from the sitemap until it's fully released.

### Motivation
It's not ready yet.

### Preview

https://docs-staging.datadoghq.com/gus/ja-no-index