### PR TITLE
use long GPG key ID

### DIFF
--- a/content/en/agent/guide/upgrade-to-agent-v6.md
+++ b/content/en/agent/guide/upgrade-to-agent-v6.md
@@ -176,7 +176,7 @@ DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dat
 2. Set up the Datadog API repo on your system and import Datadog's APT key:
     ```shell
     sudo sh -c "echo 'deb https://apt.datadoghq.com/ stable 6' > /etc/apt/sources.list.d/datadog.list"
-    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE
+    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE
     ```
 
     Note: You might need to install `dirmngr` to import Datadog's APT key.
@@ -387,7 +387,7 @@ DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dat
 2. Set up the Datadog API repo on your system and import Datadog's APT key:
     ```shell
     sudo sh -c "echo 'deb https://apt.datadoghq.com/ stable 6' > /etc/apt/sources.list.d/datadog.list"
-    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE
+    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE
     ```
 
     Note: You might need to install `dirmngr` to import Datadog's APT key.


### PR DESCRIPTION
### What does this PR do?

This PR changes documentation and install scripts to use the long version of DataDog packaging GPG key instead of the short one.

### Motivation
https://github.com/DataDog/datadog-agent/pull/3754

### Preview link
