### PR TITLE
[apm] Fix Ruby manual tracing docs

### DIFF
--- a/content/en/tracing/guide/trace_sampling_and_storage.md
+++ b/content/en/tracing/guide/trace_sampling_and_storage.md
@@ -170,7 +170,7 @@ Manually keep a trace:
 Datadog.tracer.trace(name, options) do |span|
 
   # Always Keep the Trace
-  span.set_tag(Datadog::Ext::ForcedTracing::TAG_KEEP)
+  span.set_tag(Datadog::Ext::ManualTracing::TAG_KEEP)
   # method impl follows
 end
 ```
@@ -179,7 +179,7 @@ Manually drop a trace:
 ```ruby
 Datadog.tracer.trace(name, options) do |span|
   # Always Drop the Trace
-  span.set_tag(Datadog::Ext::ForcedTracing::TAG_DROP)
+  span.set_tag(Datadog::Ext::ManualTracing::TAG_DROP)
   # method impl follows
 end
 ```


### PR DESCRIPTION
### What does this PR do?
Fix the docs for Ruby manual tracing. It is called `ManualTracing` and not `ForcedTracing`.

### Motivation
We renamed the constant in `dd-trace-rb`

### Preview link
[Preview](https://docs-staging.datadoghq.com/brettlangdon/ruby.manual.tracing/tracing/guide/trace_sampling_and_storage/?tab=ruby#manually-control-trace-priority)