### PR TITLE
Update K8s documentation with short lived container.

### DIFF
--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -265,6 +265,29 @@ The `pointdir` is used to store a file with a pointer to all the containers that
 
 Use [Autodiscovery with Pod Annotations][11] to configure log collection to add multiline processing rules, or to customize the `source` and `service` attributes.
 
+#### Short lived containers
+
+{{< tabs >}}
+{{% tab "K8s File" %}}
+
+By default the Agent looks every 5 seconds for new containers.
+
+Since Agent version 6.12+, short lived containers logs (stopped, or crashed) are automatically collected when using the K8s file log collection method (through `/var/log/pods`). This also includes the collection init container logs.
+
+{{% /tab %}}
+{{% tab "Docker Socket" %}}
+
+By default the Agent looks every 5 seconds for new containers, any container with a shorter duration life won't have any data collected by the Agent.
+
+ You can override this autodiscovery interval with a shorter one by setting `ad_config_poll_interval` parameter which correspond to the `DD_AD_CONFIG_POLL_INTERVAL` environment variable.
+The expected value is a integer in seconds.
+
+The other option is to use the `K8s file` collection method that supports init, stopped and short lived containers collection without any extra setup.
+
+{{% /tab %}}
+{{< /tabs >}}
+
+
 ### APM and Distributed Tracing
 
 To enable APM by allowing incoming data from port 8126, set the `DD_APM_NON_LOCAL_TRAFFIC` variable to true in your *env* section:

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -272,17 +272,17 @@ Use [Autodiscovery with Pod Annotations][11] to configure log collection to add 
 
 By default the Agent looks every 5 seconds for new containers.
 
-Since Agent version 6.12+, short lived containers logs (stopped, or crashed) are automatically collected when using the K8s file log collection method (through `/var/log/pods`). This also includes the collection init container logs.
+For Agent v6.12+, short lived container logs (stopped or crashed) are automatically collected when using the K8s file log collection method (through `/var/log/pods`). This also includes the collection init container logs.
 
 {{% /tab %}}
 {{% tab "Docker Socket" %}}
 
-By default the Agent looks every 5 seconds for new containers, any container with a shorter duration life won't have any data collected by the Agent.
+By default the Agent looks every 5 seconds for new containers. Any container with a shorter duration life does not have any data collected by the Agent.
 
- You can override this autodiscovery interval with a shorter one by setting `ad_config_poll_interval` parameter which correspond to the `DD_AD_CONFIG_POLL_INTERVAL` environment variable.
+ You can override this autodiscovery interval with a shorter one by setting the `ad_config_poll_interval` parameter which correspond to the `DD_AD_CONFIG_POLL_INTERVAL` environment variable.
 The expected value is a integer in seconds.
 
-The other option is to use the `K8s file` collection method that supports init, stopped and short lived containers collection without any extra setup.
+The other option is to use the `K8s file` collection method that supports init, stopped, and short lived containers collection without any extra setup.
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
### What does this PR do?
Describe how short lived containers logs can be collected.


### Motivation
Agent 6.12 release

### Preview link
https://docs-staging.datadoghq.com/nils/K8s-short-lived-containers/agent/kubernetes/daemonset_setup/?tab=k8sfile#log-collection

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Merge for 6.12 release