### PR TITLE
Update K8s log collection logic

### DIFF
--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -246,8 +246,8 @@ The Docker API is optimized to get logs from one container at a time. When there
 
 The Datadog Agent follows the below logic to know where logs should be picked up from:
 
-1. The Agent looks for the Docker socket, if available it collects logs from there
-2. If not available, it looks for `/var/log/pods` and if available collects logs from there.
+1. The Agent looks for the Docker socket, if available it collects logs from there.
+2. If Docker socket is not available, the Agent looks for `/var/log/pods` and if available collects logs from there.
 
 If you do want to collect logs from `/var/log/pods` even if the Docker socket is mounted, the environment variable `DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE` can be used (or `logs_config.k8s_container_use_file` in `datadog.yaml`) to force the Agent to go for the file collection mode.
 

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -204,6 +204,7 @@ Use log file collection when:
 
 The Docker API is optimized to get logs from one container at a time. When there are many containers in the same pod, collecting logs through the Docker socket might be consuming much more resources than going through the files.
 
+
 {{< tabs >}}
 {{% tab "K8s File" %}}
 
@@ -242,6 +243,13 @@ The Docker API is optimized to get logs from one container at a time. When there
 
 {{% /tab %}}
 {{< /tabs >}}
+
+The Datadog Agent follows the below logic to know where logs should be picked up from:
+
+1. The Agent looks for the Docker socket, if available it collects logs from there
+2. If not available, it looks for `/var/log/pods` and if available collects logs from there.
+
+If you do want to collect logs from `/var/log/pods` even if the Docker socket is mounted, the environment variable `DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE` can be used (or `logs_config.k8s_container_use_file` in `datadog.yaml`) to force the Agent to go for the file collection mode.
 
 
 3. Mount the `pointdir` volume in *volumeMounts*:


### PR DESCRIPTION
### What does this PR do?
Explain what logic the agent uses to choose between the docker socket and `/var/log/pods` to collect logs from.

### Motivation
The logic was changed lately and we added an extra flag to force the use of the files even if the docker socket is mounted.

### Preview link
https://docs-staging.datadoghq.com/nils/kubernetes-new-logic-log-collection/agent/kubernetes/daemonset_setup/?tab=k8sfile#log-collection

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
