### PR TITLE
Changed: Deprecated Ruby 1.9 support for Ruby APM

### DIFF
--- a/content/en/tracing/setup/ruby.md
+++ b/content/en/tracing/setup/ruby.md
@@ -105,15 +105,15 @@ Ruby APM includes support for the following Ruby interpreters:
 
 | Type                               | Version | Support type    |
 | ---------------------------------- | -----   | --------------- |
-| [MRI][10]  | 1.9.1   | Experimental    |
-|                                    | 1.9.3   | Fully Supported |
+| [MRI][10]                          | 1.9.1   | Deprecated      |
+|                                    | 1.9.3   | Deprecated      |
 |                                    | 2.0     | Fully Supported |
 |                                    | 2.1     | Fully Supported |
 |                                    | 2.2     | Fully Supported |
 |                                    | 2.3     | Fully Supported |
 |                                    | 2.4     | Fully Supported |
 |                                    | 2.5     | Fully Supported |
-| [JRuby][11]         | 9.1.5   | Experimental    |
+| [JRuby][11]                        | 9.1.5   | Experimental    |
 
 #### Web Server Compatibility
 
@@ -121,9 +121,9 @@ Ruby APM includes support for the following web servers:
 
 | Type                                           | Version      | Support type    |
 | ---------------------------------------------- | ------------ | --------------- |
-| [Puma][12]                        | 2.16+ / 3.6+ | Fully Supported |
-| [Unicorn][13]       | 4.8+ / 5.1+  | Fully Supported |
-| [Passenger][14] | 5.0+         | Fully Supported |
+| [Puma][12]                                     | 2.16+ / 3.6+ | Fully Supported |
+| [Unicorn][13]                                  | 4.8+ / 5.1+  | Fully Supported |
+| [Passenger][14]                                | 5.0+         | Fully Supported |
 
 #### Library Compatibility
 
@@ -162,6 +162,8 @@ Ruby APM includes support for the following libraries and frameworks:
 *Fully Supported* support indicates all tracer features are available.
 
 *Experimental* indicates most features should be available, but unverified.
+
+*Deprecated* indicates support will be removed in a future release.
 
 ## Configuration
 


### PR DESCRIPTION
### What does this PR do?

Updates APM Ruby documentation to reflect deprecated support for Ruby 1.9.

### Motivation

`dd-trace-rb` deprecated support for Ruby 1.9 in its latest 0.25.0 release. Support will be removed in 0.27.0.

### Preview link

https://docs-staging.datadoghq.com/delner/apm_ruby_deprecate_1.9_support/tracing/setup/ruby/

### Additional Notes

Timeline for deprecation and removal:

 - 0.25.0: Support for Ruby < 2.0 is deprecated; retains full feature support.
 - 0.26.0: Last version to support Ruby < 2.0; any new features will not support 1.9.
 - 0.27.0: Support for Ruby < 2.0 is removed.

Version 0.26.x will receive only critical bugfixes for 1 year following the release of 0.26.0.

https://github.com/DataDog/dd-trace-rb/pull/771
