### PR TITLE
add hreflang partial to template and sitemap. Keep disabled for now

### DIFF
--- a/layouts/_default/404-baseof.html
+++ b/layouts/_default/404-baseof.html
@@ -18,6 +18,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {{ if .Params.external_redirect }} {{ partial "meta-http-equiv.html" . }} {{ end }}
     {{- partial "noindex.html" . -}}
+    {{- partial "hreflang.html" . -}}
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <link rel="icon" type="image/png" href="https://docs.datadoghq.com/favicon.ico">
     <link rel="stylesheet" href="{{ .Site.BaseURL }}css/{{ (index .Site.Data.manifests.css "main-dd.css" ) }}">

--- a/layouts/_default/api-baseof.html
+++ b/layouts/_default/api-baseof.html
@@ -18,6 +18,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {{ if .Params.external_redirect }} {{ partial "meta-http-equiv.html" . }} {{ end }}
     {{- partial "noindex.html" . -}}
+    {{- partial "hreflang.html" . -}}
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <link rel="icon" type="image/png" href="https://docs.datadoghq.com/favicon.ico">
     <link rel="stylesheet" href="{{ .Site.BaseURL }}css/{{ (index .Site.Data.manifests.css "main-dd.css" ) }}">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -42,6 +42,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {{ if .Params.external_redirect }} {{ partial "meta-http-equiv.html" . }} {{ end }}
     {{- partial "noindex.html" . -}}
+    {{- partial "hreflang.html" . -}}
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <link rel="icon" type="image/png" href="https://docs.datadoghq.com/favicon.ico">
     <link rel="stylesheet" href="{{ .Site.BaseURL }}css/{{ (index .Site.Data.manifests.css "main-dd.css" ) }}">

--- a/layouts/partials/hreflang.html
+++ b/layouts/partials/hreflang.html
@@ -1,0 +1,7 @@
+{{/*
+{{ if .IsTranslated }}
+  {{ range .Translations }}
+    <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}"/>
+  {{ end}}
+{{ end }}
+*/}}

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,4 +1,4 @@
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range where (where .Data.Pages "Params.beta" "!=" true) ".Params.is_public" "!=" false }}
   	  {{ if (and (not .Params.private) (ne (.Language.Lang | default "en") "fr") (ne (.Language.Lang | default "en") "ja") ) }}
 	  <url>
@@ -8,6 +8,16 @@
       {{ end }}
       {{ with .Sitemap.ChangeFreq }}<changefreq>{{ . }}</changefreq>{{ end }}
       {{ if ge .Sitemap.Priority 0.0 }}<priority>{{ .Sitemap.Priority }}</priority>{{ end }}
+
+      {{/*
+      {{ if .IsTranslated }}
+        <xhtml:link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}"/>
+        {{ range .Translations }}
+            <xhtml:link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}"/>
+        {{ end}}
+      {{ end }}
+      */}}
+
 	  </url>
 	  {{ end }}
   {{ end }}

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -11,7 +11,6 @@
 
       {{/*
       {{ if .IsTranslated }}
-        <xhtml:link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}"/>
         {{ range .Translations }}
             <xhtml:link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}"/>
         {{ end}}


### PR DESCRIPTION
### What does this PR do?

This PR:
- adds hreflang to pages
- adds hreflang to sitemap
- both of these are setup but **DISABLED** for now until we want to enable it. To enable just remove `{{/*` and `*/}}` in `layouts/partials/hreflang.html` and `layouts/sitemap.xml`

### Motivation
https://trello.com/c/RTMfe4qN/3654-add-hreflang-to-doc-site

### Preview link
https://docs-staging.datadoghq.com/david.jones/hreflang/

### Additional Notes

