### PR TITLE
double/single quote formatting for curl commands in the API

### DIFF
--- a/content/en/api/checks/code_snippets/api-checks-post.sh
+++ b/content/en/api/checks/code_snippets/api-checks-post.sh
@@ -8,4 +8,4 @@ curl  -X POST -H "Content-type: application/json" \
       \"status\": 0,
       \"tags\": [\"env:test\"]
 }" \
-'https://api.datadoghq.com/api/v1/check_run?api_key=<YOUR_API_KEY>'
+"https://api.datadoghq.com/api/v1/check_run?api_key=<YOUR_API_KEY>"

--- a/content/en/api/comments/code_snippets/api-comment-delete.sh
+++ b/content/en/api/comments/code_snippets/api-comment-delete.sh
@@ -1,6 +1,5 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
-# comment_id=1382559936236196216
 
 # Create a comment to delete. Use jq (http://stedolan.github.io/jq/download/) to get the comment id.
 comment_id=$(curl -X POST -H "Content-type: application/json" \

--- a/content/en/api/comments/code_snippets/api-comment-edit.sh
+++ b/content/en/api/comments/code_snippets/api-comment-edit.sh
@@ -1,6 +1,6 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
-comment_id=1382557387240472966
+comment_id=<COMMENT_ID>
 
 # Create a comment to edit. Use jq (http://stedolan.github.io/jq/download/) to get the comment id.
 comment_id=$(curl -X POST -H "Content-type: application/json" -d '{"message" : "This comment was submitted and will be edited by the api."}' "https://api.datadoghq.com/api/v1/comments?api_key=${api_key}&application_key=${app_key}" | jq -r '.comment.resource|ltrimstr("/api/v1/comments/")')

--- a/content/en/api/events/code_snippets/api-events-post.sh
+++ b/content/en/api/events/code_snippets/api-events-post.sh
@@ -8,5 +8,5 @@ curl  -X POST -H "Content-type: application/json" \
       "tags": ["environment:test"],
       "alert_type": "info"
 }' \
-'https://api.datadoghq.com/api/v1/events?api_key=<YOUR_API_KEY>'
+"https://api.datadoghq.com/api/v1/events?api_key=<YOUR_API_KEY>"
 

--- a/content/en/api/events/code_snippets/api-events-stream.sh
+++ b/content/en/api/events/code_snippets/api-events-stream.sh
@@ -10,4 +10,4 @@ curl -G -H "Content-type: application/json" \
     -d "unaggregated=true"\
     -d "api_key=<YOUR_API_KEY>" \
     -d "application_key=<YOUR_APP_KEY>" \
-    'https://api.datadoghq.com/api/v1/events'
+    "https://api.datadoghq.com/api/v1/events"

--- a/content/en/api/graphs/code_snippets/api-graph-snapshot.sh
+++ b/content/en/api/graphs/code_snippets/api-graph-snapshot.sh
@@ -8,5 +8,5 @@ curl -G -H "Content-type: application/json" \
     -d "end=${currenttime}" \
     -d "api_key=<YOUR_API_KEY>" \
     -d "application_key=<YOUR_APP_KEY>" \
-    'https://api.datadoghq.com/api/v1/graph/snapshot'
+    "https://api.datadoghq.com/api/v1/graph/snapshot"
 

--- a/content/en/api/integrations_aws/code_snippets/aws_generate_new_external_id.sh
+++ b/content/en/api/integrations_aws/code_snippets/aws_generate_new_external_id.sh
@@ -12,4 +12,4 @@ curl -X PUT -H "Content-type: application/json"
     "role_name": "DatadogAWSIntegrationRole"
     }'
 
-"https://dd.datadoghq.com/api/v1/integration/aws/generate_new_external_id?${api_key}&application_key=${app_key}
+"https://dd.datadoghq.com/api/v1/integration/aws/generate_new_external_id?${api_key}&application_key=${app_key}"

--- a/content/en/api/metrics/code_snippets/api-metrics-post.sh
+++ b/content/en/api/metrics/code_snippets/api-metrics-post.sh
@@ -12,5 +12,5 @@ curl  -X POST -H "Content-type: application/json" \
           \"tags\":[\"environment:test\"]}
         ]
 }" \
-'https://api.datadoghq.com/api/v1/series?api_key=<YOUR_API_KEY>'
+"https://api.datadoghq.com/api/v1/series?api_key=<YOUR_API_KEY>"
 

--- a/content/en/api/synthetics/code_snippets/post_test.sh
+++ b/content/en/api/synthetics/code_snippets/post_test.sh
@@ -4,7 +4,7 @@ api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
 curl -X POST \
-  'https://api.datadoghq.com/api/v1/synthetics/tests?api_key=${api_key}&application_key=${app_key}' \
+  "https://api.datadoghq.com/api/v1/synthetics/tests?api_key=${api_key}&application_key=${app_key}" \
   -H 'Content-Type: application/json' \
   -d '{
    "config":{


### PR DESCRIPTION
### What does this PR do?
audited all the curl commands where it's single quotes instead of double 
and exchanged them for double quotes

also some other typos

### Motivation
don't let dreams be dreams

### Preview link

https://docs-staging.datadoghq.com/cswatt/api-single-quotes/api


