### PR TITLE
Global tags examples

### DIFF
--- a/content/en/tracing/advanced/adding_metadata_to_spans.md
+++ b/content/en/tracing/advanced/adding_metadata_to_spans.md
@@ -302,7 +302,7 @@ func main() {
 {{% /tab %}}
 {{% tab "Node.js" %}}
 
-Add metadata to all spans by configuring the tracer with the `tags` option:
+Add metadata to all spans by configuring the tracer with the `tags` parameter:
 
 ```js
 const tracer = require('dd-trace').init({

--- a/content/en/tracing/advanced/adding_metadata_to_spans.md
+++ b/content/en/tracing/advanced/adding_metadata_to_spans.md
@@ -247,10 +247,14 @@ if (null !== $span) {
 {{< tabs >}}
 {{% tab "Java" %}}
 
-Coming Soon. Reach out to [the Datadog support team][1] to learn more.
+Add metadata to all spans by configuring the tracer with the system property `dd.trace.global.tags`:
 
+```bash
+java -javaagent:<DD-JAVA-AGENT-PATH>.jar \
+     -dd.trace.global.tags='env:dev,<TAG_KEY>:<TAG_VALUE>' \
+     -jar <YOUR_APPLICATION_PATH>.jar
+```
 
-[1]: /help
 {{% /tab %}}
 {{% tab "Python" %}}
 
@@ -259,7 +263,7 @@ Add metadata to all spans by configuring the tracer with the `tracer.set_tags` m
 ```python
 from ddtrace import tracer
 
-tracer.set_tags({ 'env': 'prod' })
+tracer.set_tags({ 'env': 'dev' })
 ```
 
 {{% /tab %}}
@@ -269,7 +273,7 @@ Add metadata to all spans by configuring the tracer with the `tags` option:
 
 ```ruby
 Datadog.configure do |c|
-  c.tracer tags: { 'env' => 'prod' }
+  c.tracer tags: { 'env' => 'dev' }
 end
 ```
 
@@ -289,7 +293,7 @@ import "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 func main() {
     tracer.Start(
         tracer.WithGlobalTag("datacenter", "us-1"),
-        tracer.WithGlobalTag("env", "prod"),
+        tracer.WithGlobalTag("env", "dev"),
     )
     defer tracer.Stop()
 }
@@ -298,9 +302,15 @@ func main() {
 {{% /tab %}}
 {{% tab "Node.js" %}}
 
-Coming Soon. Reach out to [the Datadog support team][1] to learn more.
+Add metadata to all spans by configuring the tracer with the `tags` option:
 
-[1]: /help
+```js
+const tracer = require('dd-trace').init({
+  tags: 'env:dev,<TAG_KEY>:<TAG_VALUE>'
+})
+```
+
+
 {{% /tab %}}
 {{% tab ".NET" %}}
 

--- a/content/en/tracing/setup/java.md
+++ b/content/en/tracing/setup/java.md
@@ -171,7 +171,7 @@ To improve visibility into applications using unsupported frameworks, consider:
 ## Configuration
 
 The tracer is configured using System Properties and Environment Variables as follows:
-(See integration specific config in the [integrations][7] section above.)
+(See integration specific config in the [integrations](#integrations) section above.)
 
 {{% table responsive="true" %}}
 
@@ -182,13 +182,13 @@ The tracer is configured using System Properties and Environment Variables as fo
 | `dd.service.name`                      | `DD_SERVICE_NAME`                      | `unnamed-java-app`   | The name of a set of processes that do the same job. Used for grouping stats for your application.                                                                                                                      |
 | `dd.service.mapping`                   | `DD_SERVICE_MAPPING`                   | `null`               | (Example: `key1:value1,key2:value2`) Dynamically rename services via configuration. Useful for making databases have distinct names across different services.                                                          |
 | `dd.writer.type`                       | `DD_WRITER_TYPE`                       | `DDAgentWriter`      | Default value sends traces to the Agent. Configuring with `LoggingWriter` instead writes traces out to the console.                                                                                                     |
-| `dd.agent.host`                        | `DD_AGENT_HOST`                        | `localhost`          | Hostname for where to send traces to. If using a containerized environment, configure this to be the host IP.  See [Tracing Docker Applications][2] for more details.                                                   |
+| `dd.agent.host`                        | `DD_AGENT_HOST`                        | `localhost`          | Hostname for where to send traces to. If using a containerized environment, configure this to be the host IP.  See [Tracing Docker Applications][1] for more details.                                                   |
 | `dd.trace.agent.port`                  | `DD_TRACE_AGENT_PORT`                  | `8126`               | Port number the Agent is listening on for configured host.                                                                                                                                                              |
 | `dd.trace.global.tags`                 | `DD_TRACE_GLOBAL_TAGS`                 | `null`               | (Example: `key1:value1,key2:value2`) A list of default tags to be added to every span and every JMX metric. This value is merged into `trace.span.tags` and `trace.jmx.tags` to provide single place to configure both. |
 | `dd.trace.span.tags`                   | `DD_TRACE_SPAN_TAGS`                   | `null`               | (Example: `key1:value1,key2:value2`) A list of default tags to be added to every span. Tags of the same name added directly to a span overwrite the defaults provided here.                                             |
 | `dd.trace.jmx.tags`                    | `DD_TRACE_JMX_TAGS`                    | `null`               | (Example: `key1:value1,key2:value2`) A list of default tags to be added to every JMX metric. Tags of the same name added in JMX metrics configuration overwrite the defaults provided here.                             |
 | `dd.trace.header.tags`                 | `DD_TRACE_HEADER_TAGS`                 | `null`               | (Example: `CASE-insensitive-Header:my-tag-name,User-ID:userId`) A map of header keys to tag names.  Automatically apply header values as tags on traces.                                                                |
-| `dd.trace.annotations`                 | `DD_TRACE_ANNOTATIONS`                 | ([listed here][2])   | (Example: `com.some.Trace;io.other.Trace`) A list of method annotations to treat as `@Trace`.                                                                                                                           |
+| `dd.trace.annotations`                 | `DD_TRACE_ANNOTATIONS`                 | ([listed here][1])   | (Example: `com.some.Trace;io.other.Trace`) A list of method annotations to treat as `@Trace`.                                                                                                                           |
 | `dd.trace.methods`                     | `DD_TRACE_METHODS`                     | `null`               | (Example: `package.ClassName[method1,method2,...];AnonymousClass$1[call]`) List of class/interface and methods to trace.  Similar to adding `@Trace`, but without changing code.                                        |
 | `dd.trace.partial.flush.min.spans`     | `DD_TRACE_PARTIAL_FLUSH_MIN_SPANS`     | `1000`               | Set a number of partial spans to flush on. Useful to reduce memory overhead when dealing with heavy traffic or long running traces.                                                                                     |
 | `dd.trace.report-hostname`             | `DD_TRACE_REPORT_HOSTNAME`             | `false`              | When enabled, it adds the detected hostname to trace metadata                                                                                                                                                           |
@@ -201,11 +201,10 @@ The tracer is configured using System Properties and Environment Variables as fo
 | `dd.jmxfetch.refresh-beans-period`     | `DD_JMXFETCH_REFRESH_BEANS_PERIOD`     | `600`                | How often to refresh list of avalable JMX beans (in seconds).                                                                                                                                                           |
 | `dd.jmxfetch.statsd.host`              | `DD_JMXFETCH_STATSD_HOST`              | same as `agent.host` | Statsd host to send JMX metrics to.                                                                                                                                                                                     |
 | `dd.jmxfetch.statsd.port`              | `DD_JMXFETCH_STATSD_PORT`              | 8125                 | Statsd port to send JMX metrics to.                                                                                                                                                                                     |
-| `dd.logs.injection`                    | `DD_LOGS_INJECTION`                    | false                | Enabled automatic MDC key injection for Datadog trace and span ids. See [Advanced Usage][3] for details                                                                                                                 |
+| `dd.logs.injection`                    | `DD_LOGS_INJECTION`                    | false                | Enabled automatic MDC key injection for Datadog trace and span ids. See [Advanced Usage][2] for details                                                                                                                 |
 
-[1]: /tracing/setup/docker
-[2]: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java#L37
-[3]: /tracing/advanced/connect_logs_and_traces/?tab=java
+[1]: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java#L37
+[2]: /tracing/advanced/connect_logs_and_traces/?tab=java
 {{% /table %}}
 
 **Note**:
@@ -322,7 +321,7 @@ java -javaagent:<DD-JAVA-AGENT-PATH>.jar \
 [4]: https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md
 [5]: https://docs.oracle.com/javase/8/docs/api/java/lang/instrument/package-summary.html
 [6]: http://bytebuddy.net
-[7]: /help
+[7]: 
 [8]: /help
 [9]: https://github.com/DataDog/documentation#outside-contributors
 [10]: https://github.com/openzipkin/b3-propagation

--- a/content/en/tracing/setup/java.md
+++ b/content/en/tracing/setup/java.md
@@ -90,7 +90,7 @@ Beta integrations are disabled by default but can be enabled individually.
 *Note:* Many application servers are Servlet compatible and are automatically covered by that instrumentation, such as Tomcat, Jetty, Websphere, Weblogic, etc.
 Also, frameworks like Spring Boot inherently work because it uses a Servlet compatible embedded application server.
 
-Don't see your desired web frameworks? Datadog is continually adding additional support. Contact [Datadog support][8] if you need help.
+Don't see your desired web frameworks? Datadog is continually adding additional support. Contact [Datadog support][7] if you need help.
 
 #### Networking Framework Compatibility
 
@@ -112,7 +112,7 @@ Don't see your desired web frameworks? Datadog is continually adding additional 
 
 **Networking tracing provides:** timing request to response, tags for the request (e.g. response code), error and stacktrace capturing, and distributed tracing.
 
-Don't see your desired networking framework? Datadog is continually adding additional support. Contact [Datadog support][8] if you need help.
+Don't see your desired networking framework? Datadog is continually adding additional support. Contact [Datadog support][7] if you need help.
 
 #### Data Store Compatibility
 
@@ -146,7 +146,7 @@ Don't see your desired networking framework? Datadog is continually adding addit
 
 **Datastore tracing provides:** timing request to response, query info (e.g. a sanitized query string), and error and stacktrace capturing.
 
-Don't see your desired datastores? Datadog is continually adding additional support. Contact [Datadog support][8] if you need help.
+Don't see your desired datastores? Datadog is continually adding additional support. Contact [Datadog support][7] if you need help.
 
 #### Other Framework Compatibility
 
@@ -160,13 +160,13 @@ Don't see your desired datastores? Datadog is continually adding additional supp
 | Hystrix          | 1.4+     | Fully Supported | `hystrix`                                      |
 | Twilio SDK       | 0+       | Fully Supported | `twilio-sdk`                                   |
 
-Don't see your desired framework? Datadog is continually adding additional support. Contact [Datadog support][8] if you need help.
+Don't see your desired framework? Datadog is continually adding additional support. Contact [Datadog support][7] if you need help.
 
 To improve visibility into applications using unsupported frameworks, consider:
 
 * Adding custom instrumentation (with OpenTracing or the `@Trace` annotation).
-* [Submitting a pull request][9] with instrumentation for inclusion in a future release.
-* Contacting [Datadog support][8] and submitting a feature request.
+* [Submitting a pull request][8] with instrumentation for inclusion in a future release.
+* Contacting [Datadog support][7] and submitting a feature request.
 
 ## Configuration
 
@@ -214,7 +214,7 @@ The tracer is configured using System Properties and Environment Variables as fo
 
 ### B3 Headers Extraction and Injection
 
-Datadog APM tracer supports [B3 headers extraction][10] and injection for
+Datadog APM tracer supports [B3 headers extraction][9] and injection for
 distributed tracing.
 
 Distributed headers injection and extraction is controlled by
@@ -322,6 +322,5 @@ java -javaagent:<DD-JAVA-AGENT-PATH>.jar \
 [5]: https://docs.oracle.com/javase/8/docs/api/java/lang/instrument/package-summary.html
 [6]: http://bytebuddy.net
 [7]: /help
-[8]: /help
-[9]: https://github.com/DataDog/documentation#outside-contributors
-[10]: https://github.com/openzipkin/b3-propagation
+[8]: https://github.com/DataDog/documentation#outside-contributors
+[9]: https://github.com/openzipkin/b3-propagation

--- a/content/en/tracing/setup/java.md
+++ b/content/en/tracing/setup/java.md
@@ -321,7 +321,7 @@ java -javaagent:<DD-JAVA-AGENT-PATH>.jar \
 [4]: https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md
 [5]: https://docs.oracle.com/javase/8/docs/api/java/lang/instrument/package-summary.html
 [6]: http://bytebuddy.net
-[7]: 
+[7]: /help
 [8]: /help
 [9]: https://github.com/DataDog/documentation#outside-contributors
 [10]: https://github.com/openzipkin/b3-propagation


### PR DESCRIPTION
### What does this PR do?

Adds configuration examples for adding global tags to all traces collected in java and node.

### Motivation
It was missing.

### Preview link

* [NodeJS](https://docs-staging.datadoghq.com/gus/global-tags/tracing/advanced/adding_metadata_to_spans/?tab=nodejs#adding-metadata-globally-to-all-spans)
* [Java](https://docs-staging.datadoghq.com/gus/global-tags/tracing/advanced/adding_metadata_to_spans/?tab=java#adding-metadata-globally-to-all-spans)