### PR TITLE
fixing nginx status link for AD

### DIFF
--- a/content/en/agent/autodiscovery/endpointschecks.md
+++ b/content/en/agent/autodiscovery/endpointschecks.md
@@ -138,7 +138,7 @@ metadata:
       [
         {
           "name": "My Nginx Service Endpoints",
-          "nginx_status_url": "http://%%host%%/nginx_status/"
+          "nginx_status_url": "http://%%host%%:%%port%%/nginx_status"
         }
       ]
 spec:

--- a/content/en/agent/guide/agent-5-autodiscovery.md
+++ b/content/en/agent/guide/agent-5-autodiscovery.md
@@ -318,7 +318,7 @@ EXPOSE 8080
 COPY nginx.conf /etc/nginx/nginx.conf
 LABEL "com.datadoghq.ad.check_names"='["nginx"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'
-LABEL "com.datadoghq.ad.instances"='[{"nginx_status_url": "http://%%host%%/nginx_status:%%port%%"}]'
+LABEL "com.datadoghq.ad.instances"='[{"nginx_status_url": "http://%%host%%:%%port%%/nginx_status"}]'
 ```
 
 ## Reference


### PR DESCRIPTION
### What does this PR do?

Fixes Nginx status URL with DD AD.

Real status url is: https://github.com/DataDog/integrations-core/blob/master/nginx/datadog_checks/nginx/data/conf.yaml.example#L18

`http://localhost:81/nginx_status/`

### Motivation
Customer feedback

### Preview link
