### PR TITLE
Mikelaning/containerizedagent and hostagent tab fix

### DIFF
--- a/content/en/agent/autodiscovery/_index.md
+++ b/content/en/agent/autodiscovery/_index.md
@@ -50,7 +50,7 @@ The overall process of Datadog Agent Autodiscovery is:
 
 ## How to set it up
 
-If running the Agent as a binary on a host, enable Autodiscovery with the [Host Agent](?tab=host-agent) tab instructions. If running the Agent as a container, enable Autodiscovery with the  [Containerized Agent Tab](?tab=containerized-agent) instructions.
+If running the Agent as a binary on a host, enable Autodiscovery with the [Host Agent](?tab=host-agent) tab instructions. If running the Agent as a container, enable Autodiscovery with the  [Containerized Agent Tab](?tab=containerizedagent) instructions.
 
 ### Docker Autodiscovery
 
@@ -114,7 +114,7 @@ KUBERNETES=true
 {{< tabs >}}
 {{% tab "Host Agent" %}}
 
-ECS Fargate can't be monitored with the Datadog Agent running as a binary on a host, see to the [Containerized Agent Tab](?tab=containerized-agent#ecs-fargate-autodiscovery) instructions.
+ECS Fargate can't be monitored with the Datadog Agent running as a binary on a host, see the [Containerized Agent Tab](?tab=containerizedagent#ecs-fargate-autodiscovery) instructions.
 
 {{% /tab %}}
 {{% tab "Containerized Agent" %}}

--- a/content/en/agent/autodiscovery/_index.md
+++ b/content/en/agent/autodiscovery/_index.md
@@ -50,7 +50,7 @@ The overall process of Datadog Agent Autodiscovery is:
 
 ## How to set it up
 
-If running the Agent as a binary on a host, enable Autodiscovery with the [Host Agent](?tab=host-agent) tab instructions. If running the Agent as a container, enable Autodiscovery with the  [Containerized Agent Tab](?tab=containerizedagent) instructions.
+If running the Agent as a binary on a host, enable Autodiscovery with the [Host Agent](?tab=hostagent) tab instructions. If running the Agent as a container, enable Autodiscovery with the  [Containerized Agent Tab](?tab=containerizedagent) instructions.
 
 ### Docker Autodiscovery
 

--- a/content/en/agent/autodiscovery/management.md
+++ b/content/en/agent/autodiscovery/management.md
@@ -14,7 +14,7 @@ Datadog Agent auto-discovers all containers available by default. To restrict it
 
 **Note**: The `docker.containers.running`, `.stopped`, `.running.total`, and `.stopped.total` metrics are not affected by these settings and always count all containers. This does not affect your per-container billing.
 
-If running the Agent as a binary on a host, configure your Autodiscovery perimeter with the [Host Agent](?tab=host-agent) tab instructions. If running the Agent as a container, configure your Autodiscovery perimeter with the [Containerized Agent Tab](?tab=containerized-agent) instructions.
+If running the Agent as a binary on a host, configure your Autodiscovery perimeter with the [Host Agent](?tab=hostagent) tab instructions. If running the Agent as a container, configure your Autodiscovery perimeter with the [Containerized Agent Tab](?tab=containerizedagent) instructions.
 
 ## Exclude containers
 

--- a/content/en/agent/autodiscovery/tag.md
+++ b/content/en/agent/autodiscovery/tag.md
@@ -22,7 +22,7 @@ further_reading:
 The Datadog Agent can create and assign tags to all metrics, traces, and logs emitted by a container based on its labels or environment variables.
 If you are working with a Kubernetes environment, the Agent can create and assign tags to all metrics, traces, and logs emitted by a Pod, based on its labels or annotations.
 
-If running the Agent as a binary on a host, configure your tag extractions with the [Host Agent](?tab=host-agent) tab instructions. If running the Agent as a container configure your tag extraction with the  [Containerized Agent Tab](?tab=containerized-agent) instructions.
+If running the Agent as a binary on a host, configure your tag extractions with the [Host Agent](?tab=hostagent) tab instructions. If running the Agent as a container configure your tag extraction with the  [Containerized Agent Tab](?tab=containerizedagent) instructions.
 
 ## Kubernetes
 


### PR DESCRIPTION
These hyperlinks do not send to the correct url. they send to ?tab=host-agent and ?tab=containerized-agent. The correct ones are hostagent and containerizedagent. 

See video of url changing incorrectly and refreshing to the default url
https://cl.ly/1624427f211d