### PR TITLE
Update roles page to have pagination and sorting docs

### DIFF
--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -22,7 +22,22 @@ Permissions related to specific account assets can be granted to roles in the Da
 Description: Returns all roles, including their names and uuids.  
 Method: GET  
 Endpoint: `api/v1/role`  
-Required Payload: No Payload  
+Required Payload: No Payload
+
+##### ARGUMENTS
+
+
+* **`sort_field`** [*optional*, *default*=**name**]:
+    Sort roles by the given field.
+    Options: **name**
+* **`sort_dir`** [*optional*, *default*=**asc**]:
+    Direction of sort.
+    Options: **asc**, **desc**
+* **`start`** [*optional*, *default*=**0**]:
+    Roles result to start search from.
+* **`count`** [*optional*, *default*=**10**]:
+    Number of roles results to return. 
+
 Example:
 
 ```sh


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This updates the roles page to show new arguments for the api

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
