### PR TITLE
Prod: fix typo for agent 5 non_local_traffic

### DIFF
--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -117,7 +117,7 @@ Open the following ports in order to benefit from all the Agent functionalities:
 
 * **Inbound**:
 
-  * `8125/udp`: DogStatsd. Unless `dogstatsd_non_local_traffic` is set to true. This port is available on localhost:
+  * `8125/udp`: DogStatsd. Unless `non_local_traffic` is set to true. This port is available on localhost:
 
       * `127.0.0.1`
       * `::1`


### PR DESCRIPTION
### What does this PR do?

Fix typo for Agent 5 in the Network tab, related to `non_local_traffic`

Based on the config template file of Agent 5 
https://github.com/DataDog/dd-agent/blob/master/datadog.conf.example#L97-L102

(This came from Public Slack)

Screenshot: https://cl.ly/833d1f3a2aaa
