### PR TITLE
update for 0.13.0 release of Node APM

### DIFF
--- a/content/en/tracing/setup/nodejs.md
+++ b/content/en/tracing/setup/nodejs.md
@@ -84,7 +84,7 @@ const tracer = require('dd-trace').init({
 
 Node `>=8` is supported by this library. Only even versions like 8.x and 10.x are officially supported. Odd versions like 9.x and 11.x should work but are not officially supported.
 
-If you need support for Node 4 or Node 6, these versions are supported by version 0.13 of the tracer. We will support this version until *April 30th, 2020* to give you time to update, but no new feature will be added.
+If you need support for Node 4 or Node 6, these versions are supported by version 0.13 of the tracer. We will support this version until **April 30th, 2020** to give you time to update, but no new feature will be added.
 
 Our policy on Node support is 1 year after a release reached end-of-life, and only for bug fixes.
 

--- a/content/en/tracing/setup/nodejs.md
+++ b/content/en/tracing/setup/nodejs.md
@@ -100,6 +100,7 @@ For details about how to how to toggle and configure plugins, check out the [API
 |------------------|----------|-----------------|--------------------------------------------|
 | [connect][45]    | `>=2`    | Fully Supported |                                            |
 | [express][10]    | `>=4`    | Fully Supported | Supports Sails, Loopback, and [more][11]   |
+| [fastify][47]    | `>=1`    | Fully Supported |                                            |
 | [graphql][12]    | `>=0.10` | Fully Supported | Supports Apollo Server and express-graphql |
 | [hapi][13]       | `>=2`    | Fully Supported |                                            |
 | [koa][14]        | `>=2`    | Fully Supported |                                            |
@@ -209,3 +210,4 @@ For details about how to how to toggle and configure plugins, check out the [API
 [44]: https://github.com/kevincennis/promise
 [45]: https://github.com/senchalabs/connect
 [46]: http://tediousjs.github.io/tedious/
+[47]: https://www.fastify.io/

--- a/content/en/tracing/setup/nodejs.md
+++ b/content/en/tracing/setup/nodejs.md
@@ -77,7 +77,7 @@ The NodeJS Tracing Module automatically looks for and initializes with the ENV v
 DD_AGENT_HOST=myhost DD_TRACE_AGENT_PORT=6218 node server
 ```
 
-To use a different protocol, specify the entire URL as a single ENV variable `DD_TRACE_AGENT_URL`.
+To use a different protocol such as UDS, specify the entire URL as a single ENV variable `DD_TRACE_AGENT_URL`.
 
 ```sh
 DD_TRACE_AGENT_URL=unix:/path/to/somesocket.sock node server

--- a/content/en/tracing/setup/nodejs.md
+++ b/content/en/tracing/setup/nodejs.md
@@ -73,11 +73,14 @@ Configure your application level tracers to submit traces to a custom Agent host
 
 The NodeJS Tracing Module automatically looks for and initializes with the ENV variables `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`
 
-```js
-const tracer = require('dd-trace').init({
-  hostname: process.env.DD_AGENT_HOST,
-  port: process.env.DD_TRACE_AGENT_PORT
-})
+```sh
+DD_AGENT_HOST=myhost DD_TRACE_AGENT_PORT=6218 node server
+```
+
+To use a different protocol, specify the entire URL as a single ENV variable `DD_TRACE_AGENT_URL`.
+
+```sh
+DD_TRACE_AGENT_URL=unix:/path/to/somesocket.sock node server
 ```
 
 ## Compatibility

--- a/content/en/tracing/setup/nodejs.md
+++ b/content/en/tracing/setup/nodejs.md
@@ -74,22 +74,22 @@ Configure your application level tracers to submit traces to a custom Agent host
 The NodeJS Tracing Module automatically looks for and initializes with the ENV variables `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`
 
 ```sh
-DD_AGENT_HOST=myhost DD_TRACE_AGENT_PORT=6218 node server
+DD_AGENT_HOST=<HOSTNAME> DD_TRACE_AGENT_PORT=<PORT> node server
 ```
 
 To use a different protocol such as UDS, specify the entire URL as a single ENV variable `DD_TRACE_AGENT_URL`.
 
 ```sh
-DD_TRACE_AGENT_URL=unix:/path/to/somesocket.sock node server
+DD_TRACE_AGENT_URL=unix:<SOCKET_PATH> node server
 ```
 
 ## Compatibility
 
 Node `>=8` is supported by this library. Only even versions like 8.x and 10.x are officially supported. Odd versions like 9.x and 11.x should work but are not officially supported.
 
-If you need support for Node 4 or Node 6, these versions are supported by version 0.13 of the tracer. We will support this version until **April 30th, 2020** to give you time to update, but no new feature will be added.
+Node 4 or Node 6 versions are supported by version 0.13 of the `dd-trace-js` tracer. This version will be supported until **April 30th, 2020**, but no new feature will be added.
 
-Our policy on Node support is 1 year after a release reached end-of-life, and only for bug fixes.
+**Note**: The global policy is that the Datadog JS tracer supports (only for bug fixes) a Node version until 1 year after its release reached its end-of-life.
 
 ### Integrations
 

--- a/content/en/tracing/setup/nodejs.md
+++ b/content/en/tracing/setup/nodejs.md
@@ -82,7 +82,11 @@ const tracer = require('dd-trace').init({
 
 ## Compatibility
 
-Node `^4.7`, `^6.9` and `>=8` are supported by this library. However, it benefits significantly from the performance improvements introduced in Node `>=8.3`.
+Node `>=8` is supported by this library. Only even versions like 8.x and 10.x are officially supported. Odd versions like 9.x and 11.x should work but are not officially supported.
+
+If you need support for Node 4 or Node 6, these versions are supported by version 0.13 of the tracer. We will support this version until *April 30th, 2020* to give you time to update, but no new feature will be added.
+
+Our policy on Node support is 1 year after a release reached end-of-life, and only for bug fixes.
 
 ### Integrations
 
@@ -94,6 +98,7 @@ For details about how to how to toggle and configure plugins, check out the [API
 
 | Module           | Versions | Support Type    | Notes                                      |
 |------------------|----------|-----------------|--------------------------------------------|
+| [connect][45]    | `>=2`    | Fully Supported |                                            |
 | [express][10]    | `>=4`    | Fully Supported | Supports Sails, Loopback, and [more][11]   |
 | [graphql][12]    | `>=0.10` | Fully Supported | Supports Apollo Server and express-graphql |
 | [hapi][13]       | `>=2`    | Fully Supported |                                            |
@@ -124,6 +129,7 @@ For details about how to how to toggle and configure plugins, check out the [API
 | [mysql2][26]           | `>=1`    | Fully Supported |                                                  |
 | [pg][27]               | `>=4`    | Fully Supported | Supports `pg-native` when used with `pg`         |
 | [redis][28]            | `>=0.12` | Fully Supported |                                                  |
+| [tedious][46]          | `>=1`    | Fully Supported | SQL Server driver for `mssql` and `sequelize`    |
 
 #### Worker Compatibility
 
@@ -201,3 +207,5 @@ For details about how to how to toggle and configure plugins, check out the [API
 [42]: https://github.com/articulate/paperplane/blob/master/docs/API.md#serverless-deployment
 [43]: https://github.com/then/promise
 [44]: https://github.com/kevincennis/promise
+[45]: https://github.com/senchalabs/connect
+[46]: http://tediousjs.github.io/tedious/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds `connect` and `tedious` to the list of integrations, and drops support for Node 4 and Node 6.

### Motivation
<!-- What inspired you to submit this pull request?-->

We have added the 2 integrations above in this version. We are also applying our deprecation policy of 1 years after EOL to Node.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

https://docs-staging.datadoghq.com/rochdev/dd-trace-js-0.13.0/tracing/setup/nodejs/#compatibility

### Additional Notes
<!-- Anything else we should know when reviewing?-->
