### PR TITLE
Update nginx example to correctly propagate traces

### DIFF
--- a/content/en/tracing/setup/nginx.md
+++ b/content/en/tracing/setup/nginx.md
@@ -75,6 +75,7 @@ The `location` block within the server where tracing is desired should add the f
 ```nginx
             opentracing_operation_name "$request_method $uri";
             opentracing_tag "resource.name" "/";
+            opentracing_propagate_context;
 ```
 
 A config file for the Datadog tracing implementation is also required:


### PR DESCRIPTION
### What does this PR do?
Updates one line in nginx example documentation.

### Motivation
The fix for Datadog/dd-opentracing-cpp#97 was adding this line.

### Preview link
https://docs-staging.datadoghq.com/cgilmour/nginx-docfix/tracing/setup/nginx/