### PR TITLE
roles api plural doc update

### DIFF
--- a/content/en/account_management/rbac/_index.md
+++ b/content/en/account_management/rbac/_index.md
@@ -11,7 +11,7 @@ further_reading:
   text: "RBAC for Log Management"
 - link: "account_management/rbac/role_api"
   tag: "Documentation"
-  text: "Manage Roles and Permissions with the Role API"
+  text: "Manage Roles and Permissions with the Roles API"
 ---
 
 <div class="alert alert-warning">
@@ -38,9 +38,9 @@ The following roles are available out of the box. By default, users are associat
 
 Custom roles are imported via SAML integrations from identity providers. Datadog receives the user groups from your IdP and automatically generates roles to match those user groups. In this case, users who sign in via the IdP are automatically associated with those roles and have the permissions that are granted to those roles. 
 
-Alternatively, use [the Role API][1] to create roles, and associate users with those roles.
+Alternatively, use [the Roles API][1] to create roles, and associate users with those roles.
 
-For existing roles, you can grant/revoke permissions to/from via [the Role API][1] to manage the access of users associated with those roles.
+For existing roles, you can grant/revoke permissions to/from via [the Roles API][1] to manage the access of users associated with those roles.
 
 ## Further Reading
 

--- a/content/en/account_management/rbac/log_management.md
+++ b/content/en/account_management/rbac/log_management.md
@@ -6,7 +6,7 @@ beta: true
 further_reading:
 - link: "account_management/rbac/role_api"
   tag: "Documentation"
-  text: "Manage Roles and Permissions with the Role API"
+  text: "Manage Roles and Permissions with the Roles API"
 ---
 
 <div class="alert alert-warning">
@@ -33,23 +33,23 @@ The following permissions can be granted to manage read access on subsets of log
 
 {{< img src="account_management/rbac/logs_read_index_data.png" alt="Grant read access for indexes to specific roles" responsive="true" style="width:75%;" >}}
 
-* **logs_live_tail**: Grants a role the ability to use the live tail feature. This permission can be granted or revoked from a role via [the Role API][3].
+* **logs_live_tail**: Grants a role the ability to use the live tail feature. This permission can be granted or revoked from a role via [the Roles API][3].
 
 The following permissions can be granted to manage write access on various log-related account assets:
 
-* **logs_modify_indexes**: Grants a role the ability to modify log indexes. This includes setting inclusion filters for which logs should be routed into an index, limiting which roles have read access on that index (logs_read_index_data), and which roles can modify exclusion filters for that index (logs_write_exclusion_filters). This permission can be granted or revoked from a role via [the Role API][3]. **Note:** This permission also grants read access on all log indexes and write permissions on all index exclusion filters, since any role that can modify indexes also can grant itself these additional permissions. 
+* **logs_modify_indexes**: Grants a role the ability to modify log indexes. This includes setting inclusion filters for which logs should be routed into an index, limiting which roles have read access on that index (logs_read_index_data), and which roles can modify exclusion filters for that index (logs_write_exclusion_filters). This permission can be granted or revoked from a role via [the Roles API][3]. **Note:** This permission also grants read access on all log indexes and write permissions on all index exclusion filters, since any role that can modify indexes also can grant itself these additional permissions. 
 
 * **logs_write_exclusion_filters**: Grants a role the ability to create or modify exclusion filters within an index. This permission can be granted to a role in [the Processing Pipelines page of the Datadog app][2] by editing an index and adding a role to the "Grant editing Exclusion Filters of this index to" field (screenshot below).
 
 {{< img src="account_management/rbac/logs_write_exclusion_filters.png" alt="Grant write access on index exclusion filters to specific roles" responsive="true" style="width:75%;" >}}
 
-* **logs_write_pipelines**: Grants a role the ability to create and modify log processing pipelines. This includes setting matching filters for what logs should enter the processing pipeline, setting the name of the pipeline, and limiting which roles have write access on the processors within that pipeline (`logs_write_processors`). This permission can be granted or revoked from a role via [the Role API][3].
+* **logs_write_pipelines**: Grants a role the ability to create and modify log processing pipelines. This includes setting matching filters for what logs should enter the processing pipeline, setting the name of the pipeline, and limiting which roles have write access on the processors within that pipeline (`logs_write_processors`). This permission can be granted or revoked from a role via [the Roles API][3].
 
 * **logs_write_processors**: Grants a role the ability to create or modify the processors within a processing pipeline. This permission can be granted to a role in [the Processing Pipelines page of the Datadog app][2] by editing a processing pipeline and adding a role to the "Grant editing Processors of this index to" field (screenshot below).
 
 {{< img src="account_management/rbac/logs_write_processors.png" alt="Grant write access for processors to specific roles" responsive="true" style="width:75%;" >}}
 
-* **logs_write_archives**: Grants the ability to create or modify log archives. This permission can be granted or revoked from a role via [the Role API][3].
+* **logs_write_archives**: Grants the ability to create or modify log archives. This permission can be granted or revoked from a role via [the Roles API][3].
 
 ## Getting Started with RBAC
 
@@ -57,11 +57,11 @@ By default, existing users are already associated with one of the three out-of-t
 
 To start limiting these permissions for existing users, create custom roles and assign existing users to those roles. Then you can take any of the following actions to limit their permissions to those of the custom roles:
 
-* Remove users from the Datadog Standard or Read-Only Roles via [the Role API][3].
+* Remove users from the Datadog Standard or Read-Only Roles via [the Roles API][3].
 
-* Remove permissions from the Datadog Standard or Read-Only Roles via [the Role API][3].
+* Remove permissions from the Datadog Standard or Read-Only Roles via [the Roles API][3].
 
-* Delete the Datadog Standard or Read-Only Roles via [the Role API][3].
+* Delete the Datadog Standard or Read-Only Roles via [the Roles API][3].
 
 ## Further Reading
 

--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -1,5 +1,5 @@
 ---
-title: Role API
+title: Roles API
 kind: documentation
 private: true
 beta: true
@@ -21,7 +21,7 @@ Permissions related to specific account assets can be granted to roles in the Da
 
 Description: Returns all roles, including their names and uuids.  
 Method: GET  
-Endpoint: `api/v1/role`  
+Endpoint: `api/v1/roles`  
 Required Payload: No Payload
 
 ##### ARGUMENTS
@@ -41,7 +41,7 @@ Required Payload: No Payload
 Example:
 
 ```sh
-curl -X GET "https://app.datadoghq.com/api/v1/role?api_key=${API_KEY}&application_key=${APP_KEY}"
+curl -X GET "https://app.datadoghq.com/api/v1/roles?api_key=${API_KEY}&application_key=${APP_KEY}"
 
 # Response:
 # [{
@@ -55,12 +55,12 @@ curl -X GET "https://app.datadoghq.com/api/v1/role?api_key=${API_KEY}&applicatio
 
 Description: Returns a specific role, including its name and uuid.  
 Method: GET  
-Endpoint: `api/v1/role/$ROLE_UUID`  
+Endpoint: `api/v1/roles/$ROLE_UUID`  
 Required Payload: No Payload  
 Example:
 
 ```sh
-curl -X GET "https://app.datadoghq.com/api/v1/role/${ROLEUUID}?api_key=${API_KEY}&application_key=${APP_KEY}"
+curl -X GET "https://app.datadoghq.com/api/v1/roles/${ROLEUUID}?api_key=${API_KEY}&application_key=${APP_KEY}"
 
 # Response:
 # {
@@ -74,48 +74,48 @@ curl -X GET "https://app.datadoghq.com/api/v1/role/${ROLEUUID}?api_key=${API_KEY
 
 Description: Creates a new role. Returns role name and uuid.  
 Method: POST  
-Endpoint: `api/v1/role`  
+Endpoint: `api/v1/roles`  
 Required Payload: "name"  
 Example:
 
 ```sh
-curl -X POST -H "Content-type: application/json" -d "{\"name\":\"${ROLENAME}\"}" "https://app.datadoghq.com/api/v1/role?api_key=${API_KEY}&application_key=${APP_KEY}"
+curl -X POST -H "Content-type: application/json" -d "{\"name\":\"${ROLENAME}\"}" "https://app.datadoghq.com/api/v1/roles?api_key=${API_KEY}&application_key=${APP_KEY}"
 ```
 
 ### Update Role
 
 Description: Updates an existing role's name. Returns role name and uuid.  
 Method: PUT  
-Endpoint: `api/v1/role/$ROLE_UUID`  
+Endpoint: `api/v1/roles/$ROLE_UUID`  
 Required Payload: "name"  
 Example:
 
 ```sh
-curl -X PUT -H "Content-type: application/json" -d "{\"name\":\"${ROLENAME}\"}" "https://app.datadoghq.com/api/v1/role/${ROLEUUID}?api_key=${API_KEY}&application_key=${APP_KEY}"
+curl -X PUT -H "Content-type: application/json" -d "{\"name\":\"${ROLENAME}\"}" "https://app.datadoghq.com/api/v1/roles/${ROLEUUID}?api_key=${API_KEY}&application_key=${APP_KEY}"
 ```
 
 ### Delete Role
 
 Description: Deletes a role.  
 Method: DELETE  
-Endpoint: `api/v1/role/$ROLE_UUID`  
+Endpoint: `api/v1/roles/$ROLE_UUID`  
 Required Payload: No Payload  
 Example:
 
 ```sh
-curl -X DELETE "https://app.datadoghq.com/api/v1/role/${ROLEUUID}?api_key=${API_KEY}&application_key=${APP_KEY}"
+curl -X DELETE "https://app.datadoghq.com/api/v1/roles/${ROLEUUID}?api_key=${API_KEY}&application_key=${APP_KEY}"
 ```
 
 ### Get Permissions
 
 Description: Returns a list of all permissions, including name, description, uuid.  
 Method: GET  
-Endpoint: `api/v1/permission`  
+Endpoint: `api/v1/permissions`  
 Required Payload: No Payload  
 Example:
 
 ```sh
-curl -X GET "https://app.datadoghq.com/api/v1/permission?api_key=${API_KEY}&application_key=${APP_KEY}"
+curl -X GET "https://app.datadoghq.com/api/v1/permissions?api_key=${API_KEY}&application_key=${APP_KEY}"
 
 # Response:
 # [{
@@ -131,48 +131,48 @@ curl -X GET "https://app.datadoghq.com/api/v1/permission?api_key=${API_KEY}&appl
 
 Description: Adds a permission to a role.  
 Method: POST  
-Endpoint: `api/v1/role/$ROLE_UUID/permission/$PERMISSION_UUID`  
+Endpoint: `api/v1/roles/$ROLE_UUID/permissions/$PERMISSION_UUID`  
 Required Payload: Empty (`{}`)  
 Example:
 
 ```sh
-curl -X POST -H "Content-type: application/json" -d "{}" "https://app.datadoghq.com/api/v1/role/${ROLEUUID}/permission/${PERMISSION}?api_key=${API_KEY}&application_key=${APP_KEY}"
+curl -X POST -H "Content-type: application/json" -d "{}" "https://app.datadoghq.com/api/v1/roles/${ROLEUUID}/permissions/${PERMISSION}?api_key=${API_KEY}&application_key=${APP_KEY}"
 ```
 
 ### Revoke Permission from Role
 
 Description: Removes a permission from a role.  
 Method: DELETE  
-Endpoint: `api/v1/role/$ROLE_UUID/permission/$PERMISSION_UUID`  
+Endpoint: `api/v1/roles/$ROLE_UUID/permissions/$PERMISSION_UUID`  
 Required Payload: Empty (`{}`)  
 Example:
 
 ```sh
-curl -X DELETE -H "Content-type: application/json" -d "{}" "https://app.datadoghq.com/api/v1/role/${ROLEUUID}/permission/${PERMISSION}?api_key=${API_KEY}&application_key=${APP_KEY}"
+curl -X DELETE -H "Content-type: application/json" -d "{}" "https://app.datadoghq.com/api/v1/roles/${ROLEUUID}/permissions/${PERMISSION}?api_key=${API_KEY}&application_key=${APP_KEY}"
 ```
 
 ### Add User to Role
 
 Description: Adds a user to a role.  
 Method: POST  
-Endpoint: `api/v1/role/$ROLE_UUID/user/$USER_HANDLE`  
+Endpoint: `api/v1/roles/$ROLE_UUID/users/$USER_HANDLE`  
 Required Payload: Empty (`{}`)  
 Example:
 
 ```sh
-curl -X POST -H "Content-type: application/json" -d "{}" "https://app.datadoghq.com/api/v1/role/${ROLEUUID}/user/${USER}?api_key=${API_KEY}&application_key=${APP_KEY}"
+curl -X POST -H "Content-type: application/json" -d "{}" "https://app.datadoghq.com/api/v1/roles/${ROLEUUID}/users/${USER}?api_key=${API_KEY}&application_key=${APP_KEY}"
 ```
 
 ### Remove User from Role
 
 Description: Removes a user from a role.  
 Method: DELETE  
-Endpoint: `api/v1/role/$ROLE_UUID/user/$USER_HANDLE`  
+Endpoint: `api/v1/roles/$ROLE_UUID/users/$USER_HANDLE`  
 Required Payload: Empty (`{}`)  
 Example:
 
 ```sh
-curl -X DELETE -H "Content-type: application/json" -d "{}" "https://app.datadoghq.com/api/v1/role/${ROLEUUID}/user/${USER}?api_key=${API_KEY}&application_key=${APP_KEY}"
+curl -X DELETE -H "Content-type: application/json" -d "{}" "https://app.datadoghq.com/api/v1/roles/${ROLEUUID}/users/${USER}?api_key=${API_KEY}&application_key=${APP_KEY}"
 ```
 
 ## Permission UUIDs


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR attempts to help encourage users to switch to using the new plural duplicated endpoints for the Roles API by updating the documentation. This also changes other instances of "Role API" to "Roles API"

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
