### PR TITLE
Document Config API permission in Roles API

### DIFF
--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -213,7 +213,7 @@ The UUIDs for the permissions are as follows:
 | logs_write_pipelines         | 4fc43656-dd15-11e8-9308-f3e2bb5e31b4 | Update a subset of the log pipelines         |
 | logs_write_processors        | 505f4538-dd15-11e8-9308-47a4732f715f | Update the log processors in an index        |
 | logs_write_archives          | 505fd138-dd15-11e8-9308-afd2db62791e | Update the external archives configuration   |
-| logs_public_config_api       | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | Access the Logs Public Config API (r/w)      |
+| logs_public_config_api       | bd837a80-6cb2-11e9-8fc4-339b4b012214 | Access the Logs Public Config API (r/w)      |
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -197,6 +197,8 @@ The UUIDs for the permissions are as follows:
 | logs_write_pipelines         | 811ac4ca-dd12-11e8-9e57-676a7f0beef9 | Update a subset of the log pipelines         |
 | logs_write_processors        | 84aa3ae4-dd12-11e8-9e58-a373a514ccd0 | Update the log processors in an index        |
 | logs_write_archives          | 87b00304-dd12-11e8-9e59-cbeb5f71f72f | Update the external archives configuration   |
+| logs_public_config_api       | 1a92ede2-6cb2-11e9-99c6-2b3a4a0cdf0a | Access the Logs Public Config API (r/w)      |
+
 {{% /tab %}}
 {{% tab "Datadog EU site" %}}
 |             name             |                 uuid                 |                 description                  |
@@ -211,6 +213,8 @@ The UUIDs for the permissions are as follows:
 | logs_write_pipelines         | 4fc43656-dd15-11e8-9308-f3e2bb5e31b4 | Update a subset of the log pipelines         |
 | logs_write_processors        | 505f4538-dd15-11e8-9308-47a4732f715f | Update the log processors in an index        |
 | logs_write_archives          | 505fd138-dd15-11e8-9308-afd2db62791e | Update the external archives configuration   |
+| logs_public_config_api       | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | Access the Logs Public Config API (r/w)      |
+
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
### What does this PR do?
Document permissions for Config API in Roles API

### Motivation
Catch-up a missing element in the doc

### Preview link
https://docs-staging.datadoghq.com/pcariou/config-api_roles-api/account_management/rbac/role_api/?tab=datadogeusite#permission-uuids

### Additional Notes
<!-- Anything else we should know when reviewing?-->
