### PR TITLE
file upload note on synthetics browser tests

### DIFF
--- a/content/en/synthetics/browser_tests.md
+++ b/content/en/synthetics/browser_tests.md
@@ -61,7 +61,7 @@ Tests can be only recorded from **[Google Chrome][5]**. To record your test, dow
 
 1. Optionally, select **Open in a pop-up** at the upper right of the page to open your test recording in a separate pop-up window in order to avoid sizing issues in the displayed window within Datadog's interface.
 2. Click on **Start recording** to begin recording your browser test.
-3. Your actions are recorded and used to create steps within your browser test scenario.
+3. Your actions are recorded and used to create steps within your browser test scenario. You can record the uploading of files as an action, though this is limited to 10 files, with a limit of 5MB each.
 4. Use the actions available in the upper left corner to enrich your scenario:
     {{< img src="synthetics/browser_tests/browser_check_assertions.png" alt="Browser Test assertions" responsive="true" style="width:80%;">}}
 


### PR DESCRIPTION
### What does this PR do?
adds a note to synthetics browser tests that you can upload files. adds limitations - 10 files, 5mb each.

### Motivation
trello

### Preview link

https://docs-staging.datadoghq.com/cswatt/synthetics-upload/synthetics/browser_tests/#actions
