### PR TITLE
Update missing metrics script

### DIFF
--- a/local/bin/py/missing_metrics.py
+++ b/local/bin/py/missing_metrics.py
@@ -30,7 +30,7 @@ def get_csv_metrics(tempdir):
 
 def get_dd_metrics(csv_metrics, keys):
   cloud = ('aws','azure', 'gcp') # tuple
-  ignore = ['isatap', '.p90', '.p95', '.p99', 'gcp.logging.user.', 'gcp.custom.']
+  ignore = ['isatap', '.p90', '.p95', '.p99', 'gcp.logging.user.', 'gcp.custom.','aws.ec2.iam_credentials_expiration_seconds']
 
   # Datadog Demo account
   options = {


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- Update missing metrics script to ignore custom metric used by Datadog devops

### Motivation
- Updating EC2 missing metrics

### Preview link
N/A
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
N/A
<!-- Anything else we should know when reviewing?-->
