### PR TITLE
Add missing `etc` to config paths

### DIFF
--- a/content/en/agent/guide/agent-configuration-files.md
+++ b/content/en/agent/guide/agent-configuration-files.md
@@ -52,7 +52,7 @@ Note: [A full example of the `datadog.yaml` file is available in the `datadog-ag
 
 ## Agent configuration directory
 
-Prior releases of Datadog Agent stored configuration files in `/dd-agent/conf.d/`. Starting with the 6.0 release, configuration files are stored in `/datadog-agent/conf.d/<CHECK_NAME>`.
+Prior releases of Datadog Agent stored configuration files in `/dd-agent/conf.d/`. Starting with the 6.0 release, configuration files are stored in `/etc/datadog-agent/conf.d/<CHECK_NAME>`.
 
 {{< tabs >}}
 {{% tab "Agent v6" %}}
@@ -76,14 +76,14 @@ Prior releases of Datadog Agent stored configuration files in `/dd-agent/conf.d/
 
 In order to provide a more flexible way to define the configuration for a check, from version 6.0.0, the Agent loads any valid YAML file contained in the folder:
 
-`/datadog-agent/conf.d/<CHECK_NAME>.d/`.
+`/etc/datadog-agent/conf.d/<CHECK_NAME>.d/`.
 
 Note: For log collection, to prevent duplicate logs from being sent to Datadog, the Agent does not accept multiple YAML files that point to the same log source. In the case where there is more than one YAML file that points to the same log source, the Agent considers the files in alphabetical order and uses the first file.
 
 This way, complex configurations can be broken down into multiple files. For example, a configuration for the `http_check` might look like this:
 
 ```
-/datadog-agent/conf.d/http_check.d/
+/etc/datadog-agent/conf.d/http_check.d/
 ├── backend.yaml
 └── frontend.yaml
 ```
@@ -91,12 +91,12 @@ This way, complex configurations can be broken down into multiple files. For exa
 Autodiscovery template files are stored in the configuration folder as well. For example, consider `redisdb`:
 
 ```
-/datadog-agent/conf.d/redisdb.d/
+/etc/datadog-agent/conf.d/redisdb.d/
 ├── auto_conf.yaml
 └── conf.yaml.example
 ```
 
-To preserve backwards compatibility, the Agent still picks up configuration files in the form `/datadog-agent/conf.d/<check_name>.yaml`, but migrating to the new layout is strongly recommended.
+To preserve backwards compatibility, the Agent still picks up configuration files in the form `/etc/datadog-agent/conf.d/<check_name>.yaml`, but migrating to the new layout is strongly recommended.
 
 {{% /tab %}}
 {{% tab "Agent v5" %}}


### PR DESCRIPTION
### What does this PR do?
Corrects configuration paths in the Agent Configuration Files page.

### Motivation
I noticed that the path did not match up with where the config files were actually located

### Preview link
This is the current page:
https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6

As far as I can tell, there's no way for me to link to a staging preview?

Thanks!