### PR TITLE
update history state when clicking a filter

### DIFF
--- a/layouts/partials/integrations/integrations.js
+++ b/layouts/partials/integrations/integrations.js
@@ -149,6 +149,11 @@ document.addEventListener('DOMContentLoaded', function () {
         var filter = button.getAttribute('data-filter');
         activateButton(button, filters);
         updateData(filter, false);
+
+        if (history.pushState) {
+            var href = button.getAttribute('href');
+            history.pushState({}, document.title, href);
+        }
     }
 
     function updateData(filter, isSearch) {


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug on the integrations page [where choosing a filter wasn't updating the url history](https://cl.ly/afb4dd6ae1ac).

### Motivation

It was reported in the websites channel

### Preview link

https://docs-staging.datadoghq.com/david.jones/add-history-integrations/integrations/

### Additional Notes
