### PR TITLE
Tags API updates

### DIFF
--- a/content/en/api/tags/code_snippets/api-tags-add.py
+++ b/content/en/api/tags/code_snippets/api-tags-add.py
@@ -6,5 +6,11 @@ options = {
 }
 
 initialize(**options)
+
+# Add tags to a host
+hostname='<YOUR_HOSTNAME>'
 hosts = api.Hosts.search(q='hosts:')
-api.Tag.create(hosts['results']['hosts'][0], tags=["role:codesample"])
+
+for host in hosts['host_list']:
+    if host['name'] == hostname:
+        api.Tag.create(host['name'], tags=['<KEY>:<VALUE>'])

--- a/content/en/api/tags/code_snippets/api-tags-get-host.py
+++ b/content/en/api/tags/code_snippets/api-tags-get-host.py
@@ -7,7 +7,7 @@ options = {
 
 initialize(**options)
 
-# Get tags by hostname.
+# Get tags by hostname
 hostname='<YOUR_HOSTNAME>'
 hosts = api.Hosts.search(q='hosts:')
 

--- a/content/en/api/tags/code_snippets/api-tags-get-host.py
+++ b/content/en/api/tags/code_snippets/api-tags-get-host.py
@@ -7,6 +7,10 @@ options = {
 
 initialize(**options)
 
-# Get tags by host id.
+# Get tags by hostname.
+hostname='<YOUR_HOSTNAME>'
 hosts = api.Hosts.search(q='hosts:')
-print api.Tag.get(hosts['host_list'][0])
+
+for host in hosts['host_list']:
+    if host['name'] == hostname:
+        print(host['tags_by_source'])

--- a/content/en/api/tags/code_snippets/result.api-tags-add.py
+++ b/content/en/api/tags/code_snippets/result.api-tags-add.py
@@ -1,7 +1,9 @@
 {
-    'host': 'hostname',
-    'tags': [
-        'role:webserver',
-        'env:production'
-    ]
+  'Datadog': [
+    'host:dev-test',
+    'environment:test'
+  ],
+  'Users': [
+    'role:database'
+  ]
 }

--- a/content/en/api/tags/code_snippets/result.api-tags-get-host.py
+++ b/content/en/api/tags/code_snippets/result.api-tags-get-host.py
@@ -1,6 +1,9 @@
 {
-    'tags': [
-        'role:database',
-        'env:test'
-    ]
+  'Datadog': [
+    'host:dev-test',
+    'environment:test'
+  ],
+  'Users': [
+    'role:database'
+  ]
 }


### PR DESCRIPTION
### What does this PR do?
- Update API Python commands for `Get host tags` and `Add tags to a host`

### Motivation
- Trello request
- The old commands don't work

### Preview link
https://docs-staging.datadoghq.com/ruth/api-tags/api/?lang=python#get-host-tags

### Additional Notes
- Tested and confirmed
