### PR TITLE
APP key not needed

### DIFF
--- a/content/en/api/metrics/code_snippets/api-metrics-post.py
+++ b/content/en/api/metrics/code_snippets/api-metrics-post.py
@@ -2,8 +2,7 @@ from datadog import initialize, api
 import time
 
 options = {
-    'api_key': '<YOUR_API_KEY>',
-    'app_key': '<YOUR_APP_KEY>'
+    'api_key': '<YOUR_API_KEY>'
 }
 
 initialize(**options)

--- a/content/en/api/metrics/code_snippets/api-metrics-post.rb
+++ b/content/en/api/metrics/code_snippets/api-metrics-post.rb
@@ -2,9 +2,8 @@ require 'rubygems'
 require 'dogapi'
 
 api_key = '<YOUR_API_KEY>'
-app_key = '<YOUR_APP_KEY>'
 
-dog = Dogapi::Client.new(api_key, app_key)
+dog = Dogapi::Client.new(api_key)
 
 # Submit one metric value.
 dog.emit_point('some.metric.name', 50.0, :host => "my_host.example.com")


### PR DESCRIPTION
### What does this PR do?
- Remove App key from post timeseries Python and Ruby examples 

### Motivation
- Trello request from support
- App key is not necessary to post timeseries

### Preview link
https://docs-staging.datadoghq.com/ruth/api-app-key/api/?lang=python#post-timeseries-points

### Additional Notes
- Tested and confirmed
