### PR TITLE
added note about downtime creation timing

### DIFF
--- a/content/en/monitors/downtimes.md
+++ b/content/en/monitors/downtimes.md
@@ -20,14 +20,14 @@ You may occasionally need to shut systems down or take them off-line to perform 
 
 You can schedule downtimes and/or mute your Datadog monitors so that they do not alert at specific times when you do not want them to.
 
-Monitors trigger events when they change state between `ALERT`, `WARNING` (if enabled), `RESOLVED`, and `NO DATA` (if enabled). If a monitor has been silenced either by a downtime or muting, then any transition from `RESOLVED` to another state will **neither trigger an event**, nor activate any associated notification channels. 
+Monitors trigger events when they change state between `ALERT`, `WARNING` (if enabled), `RESOLVED`, and `NO DATA` (if enabled). If a monitor has been silenced either by a downtime or muting, then any transition from `RESOLVED` to another state will **neither trigger an event**, nor activate any associated notification channels.
 
 **Note**: Muting or un-muting a monitor via the UI does not delete scheduled downtimes associated with that monitor. For that, use the Manage Downtimes feature or directly use the API.
 
 {{< img src="monitors/downtimes/downtime_on_alert.png" alt="downtime on alert" responsive="true" style="width:80%;">}}
 
-If a monitor transitions states during downtime (such as from `OK` to `ALERT`, `WARNING`, or `NO DATA`) and remains in that state once a scheduled downtime expires, it will **NOT** trigger a notification. 
-**However, it WILL trigger a recovery event once data returns for that scope or the monitor returns to an `OK` state.** 
+If a monitor transitions states during downtime (such as from `OK` to `ALERT`, `WARNING`, or `NO DATA`) and remains in that state once a scheduled downtime expires, it will **NOT** trigger a notification.
+**However, it WILL trigger a recovery event once data returns for that scope or the monitor returns to an `OK` state.**
 
 This behavior is designed to prevent spammy `NO DATA` state alerts when using the *Autoresolve* feature. If you would prefer that the monitor trigger a `NO DATA` state event at the time that the silencing expires, [reach out to the Datadog support team][1] to request that this feature is enabled for your account. This will only affect instances when a monitor exits a downtime period in a `NO DATA` state.
 
@@ -50,9 +50,9 @@ To schedule downtime, click the "Schedule Downtime" button in the upper right.
 
 1. Choose what to silence.
    {{< img src="monitors/downtimes/choose-what-to-silence.png" alt="downtime-silence" responsive="true" style="width:80%;">}}
-   **Silencing by monitor name**  
-   You must select at least one monitor. If you choose to leave the selection field empty, all monitors are silenced by default. You can also select a scope to constrain your downtime to a specific host, device, or arbitrary tag. Refer to the [scope section][3] of the Graphing Primer using JSON for further information about scope.  
-   **Silencing by monitor tags**  
+   **Silencing by monitor name**
+   You must select at least one monitor. If you choose to leave the selection field empty, all monitors are silenced by default. You can also select a scope to constrain your downtime to a specific host, device, or arbitrary tag. Refer to the [scope section][3] of the Graphing Primer using JSON for further information about scope.
+   **Silencing by monitor tags**
    You can select one or more [monitor tags][4] to schedule downtimes on, but you must select at least one using this method. There is a limit of 32 tags, and each tag can be at most 256 characters long. Only monitors that have **ALL selected tags** are silenced. You can also select scopes for additional constraints.  <br/><br/>
    For either method, if you choose to silence all monitors constrained by a scope, clicking *Preview affected monitors* shows which monitors are affected. Any monitors within your scope that are created or edited after the downtime is scheduled are also silenced. Note that if a multi-alert is included, it is only silenced for groups covered by the scope. For example, if a downtime is scoped for `host:X` and a multi-alert is triggered on both `host:X` and `host:Y`, Datadog will generate a monitor notification for `host:Y`, but not `host:X`.
 
@@ -64,13 +64,15 @@ To schedule downtime, click the "Schedule Downtime" button in the upper right.
   {{< img src="monitors/downtimes/downtime-notify.png" alt="downtime-notify" responsive="true" style="width:80%;">}}
   Enter a message to notify your team about this downtime. The message field allows standard [markdown formatting][5] as well as Datadog's @-notification syntax. The *Notify your team* field allows you to specify team members or send the message to a service [integration][6].
 
+**Note**: Your downtime should be created in advance of the monitor or the appearance of a group being silenced.
+
 ## Recurring Downtimes
 
-Recurring downtimes allow you to create a downtime that is started and stopped at a recurring interval or pattern. 
+Recurring downtimes allow you to create a downtime that is started and stopped at a recurring interval or pattern.
 
 One use case for this would be if you have regularly scheduled maintenance windows and want to suppress what might become a noisy monitor due to your changes.
 
-When a recurring downtime ends, the downtime is cancelled and a new downtime with the same constraints (with updated start and end times) is created in a rolling pattern. 
+When a recurring downtime ends, the downtime is cancelled and a new downtime with the same constraints (with updated start and end times) is created in a rolling pattern.
 
 **Note**: The original creator is associated to all of these newly created downtimes.
 

--- a/content/en/monitors/downtimes.md
+++ b/content/en/monitors/downtimes.md
@@ -64,7 +64,7 @@ To schedule downtime, click the "Schedule Downtime" button in the upper right.
   {{< img src="monitors/downtimes/downtime-notify.png" alt="downtime-notify" responsive="true" style="width:80%;">}}
   Enter a message to notify your team about this downtime. The message field allows standard [markdown formatting][5] as well as Datadog's @-notification syntax. The *Notify your team* field allows you to specify team members or send the message to a service [integration][6].
 
-**Note**: Your downtime should be created in advance of the monitor or the appearance of a group being silenced.
+**Note**: Create the downtime before you create the monitor or before you mute the group.
 
 ## Recurring Downtimes
 


### PR DESCRIPTION
### What does this PR do?
In title.  Downtime creation needs to happen in advance of monitor creation (or new group) to allow sufficient time for matching.

### Motivation
Monitor escalation

### Preview link
https://docs-staging.datadoghq.com/bcon/downtime-clarification/monitors/downtimes