### PR TITLE
docs announcement banner config to match corpsite's

### DIFF
--- a/config/_default/params.en.yaml
+++ b/config/_default/params.en.yaml
@@ -4,6 +4,7 @@ meta_title: Getting Started with Datadog
 meta_description: Datadog, the leading service for cloud-scale monitoring.
 disclaimer: "This page is not yet available in English, we are working on its translation. <br> May you have any questions or feedback about our current translation project, <a href=\"https://docs.datadoghq.com/fr/help/\">feel free to reach out to us!</a>"
 announcement_banner:
-  text: "<span class='d-none d-sm-block'>New announcements for Serverless, Network, RUM, and more from Dash!</span><span class='d-block d-sm-none'>New announcements from Dash!</span>"
+  desktop_message: 'New announcements for Serverless, Network, RUM, and more from Dash!'
+  mobile_message: 'New announcements from Dash!'
   link: "https://www.datadoghq.com/blog/dash-2019-new-feature-roundup/"
   exclude: []

--- a/layouts/_default/404-baseof.html
+++ b/layouts/_default/404-baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}" style="opacity:0" class="{{ if or $.Site.Params.announcement_banner.link $.Site.Params.announcement_banner.text }}banner{{ end }}">
+<html lang="{{ .Site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}" style="opacity:0" class="{{ if or $.Site.Params.announcement_banner.link $.Site.Params.announcement_banner.desktop_message }}banner{{ end }}">
 <head>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-21102638-5"></script>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}" style="opacity:0" class="{{ if or $.Site.Params.announcement_banner.link $.Site.Params.announcement_banner.text }}banner{{ end }}">
+<html lang="{{ .Site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}" style="opacity:0" class="{{ if or $.Site.Params.announcement_banner.link $.Site.Params.announcement_banner.desktop_message }}banner{{ end }}">
 <head>
     <script>
       // Init browser logs when the lib is loaded.

--- a/layouts/partials/announcement_banner/announcement_banner.html
+++ b/layouts/partials/announcement_banner/announcement_banner.html
@@ -1,7 +1,18 @@
 {{ $announce := .Site.Params.announcement_banner }}
 {{ if not (in (slice "dg" "landing-page" "tshirt" "apm" "legal" "event" "webinar" "summit") .Type) }}
 <div class="announcement_banner text-center">
-    <a href="{{$announce.link}}">{{$announce.text | safeHTML }}</a>
+    <a href="{{$announce.link}}">
+        <span class="d-none d-md-block">
+            {{ $announce.desktop_message | safeHTML }}
+        </span>
+        <span class="d-block d-md-none">
+            {{ if $announce.mobile_message }}
+                {{ $announce.mobile_message | safeHTML }}
+            {{ else }}
+                {{ $announce.desktop_message | safeHTML }}
+            {{ end}}
+        </span>
+    </a>
     <i class="icon icon-small-x pull-right"></i>
 </div>
 <script>


### PR DESCRIPTION
### What does this PR do?
— Updating `params.en.yaml` config to have separate `mobile_message` and `desktop_message`
— Clean up `announcement_banner.html` for new config
— Both `params.en.yaml` and `announcement_banner.html` are now identical to corpsite so it's easier to update

### Motivation
Self initiated after working on https://dd.slack.com/archives/C3CT8QA11/p1563451202132200

### Preview link
https://docs-staging.datadoghq.com/won/201907-annc-banner-config-update/
