### PR TITLE
Update RPM upgrade instructions to trust both datadog GPG keys

### DIFF
--- a/content/en/agent/guide/upgrade-to-agent-v6.md
+++ b/content/en/agent/guide/upgrade-to-agent-v6.md
@@ -75,6 +75,7 @@ DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dat
     enabled=1
     gpgcheck=1
     gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+           https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
     ```
 
 2. Update your local Yum repo and install the Agent:
@@ -125,6 +126,7 @@ DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dat
     enabled=1
     gpgcheck=1
     gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+           https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
     ```
 
 2. Update your local Yum repo and install the Agent:
@@ -222,6 +224,7 @@ DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dat
     enabled=1
     gpgcheck=1
     gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+           https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
     ```
 
 2. Update your local Yum repo and install the Agent:
@@ -290,6 +293,7 @@ DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dat
     enabled=1
     gpgcheck=1
     gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+           https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
     ```
 
 2. Update your local Yum repo and install the Agent:
@@ -342,12 +346,14 @@ DD_UPGRADE=true bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dat
   gpgcheck=1
   repo_gpgcheck=0
   gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+         https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
   ```
 
 2. Update your local Zypper repo and install the Agent:
   ```
   sudo zypper refresh
   sudo rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+  sudo rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
   sudo zypper install datadog-agent
   ```
 

--- a/static/config/99datadog.config
+++ b/static/config/99datadog.config
@@ -27,6 +27,7 @@ files:
             enabled=1
             gpgcheck=1
             gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+                   https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
 
     "/datadog/hooks/99start_datadog.sh":
         mode: "000755"


### PR DESCRIPTION
### What does this PR do?

Updates the upgrade instructions on distributions using our `yum` repository so that the users trust our new signing key.

### Motivation

In the near future, we're going to sign our RPM packages with our newer GPG key. To minimise the number of upgrade problems our clients may run into, it's best that they start trusting our new key as soon as possible.

### Preview link

https://docs-staging.datadoghq.com/kylian.serrania/update-rpm-gpg-keys-trusted/agent/guide/upgrade-to-agent-v6/

### Additional Notes

Linked to [this Dogweb PR](https://github.com/DataDog/dogweb/pull/38720).