### PR TITLE
fr + ja announcement banner config updates

### DIFF
--- a/config/_default/params.fr.yaml
+++ b/config/_default/params.fr.yaml
@@ -4,6 +4,7 @@ meta_title: Débuter avec Datadog
 meta_description: 'Datadog, le principal prestataire de services de surveillance à l''échelle du cloud.'
 disclaimer: 'Cette page n''est pas encore disponible en français, sa traduction est en cours. <br> Si vous avez des questions ou des retours sur notre projet  de traduction actuel, <a href="https://docs.datadoghq.com/fr/help/">n''hésitez pas à nous contacter</a>.'
 announcement_banner:
-  text: 'Rejoignez-nous à la conférence Dash, le 16 et 17 juillet à New York !'
+  desktop_message: 'Rejoignez-nous à la conférence Dash, le 16 et 17 juillet à New York !'
+  mobile_message: 'Rejoignez-nous à la conférence Dash, le 16 et 17 juillet à New York !'
   link: 'https://www.dashcon.io/?utm_source=Trade+Show&utm_medium=DatadogOrganized&utm_campaign=Tradeshow-201907DashBanner'
   exclude: []

--- a/config/_default/params.ja.yaml
+++ b/config/_default/params.ja.yaml
@@ -4,6 +4,7 @@ meta_title: Datadogを始めてみましょう
 meta_description: Datadogが大規模なクラウドのモニタリングサービスをリードします。
 disclaimer: このページは英語では対応しておりません。随時翻訳に取り組んでいます。翻訳に関してご質問やご意見ございましたら、お気軽にご連絡ください。
 announcement_banner:
-  text: 7月16日〜17日にニューヨークで開催されるDashカンファレンスにご参加ください。
+  desktop_message: '7月16日〜17日にニューヨークで開催されるDashカンファレンスにご参加ください。'
+  mobile_message: '7月16日〜17日にニューヨークで開催されるDashカンファレンスにご参加ください。'
   link: 'https://www.dashcon.io/?utm_source=Trade+Show&utm_medium=DatadogOrganized&utm_campaign=Tradeshow-201907DashBanner'
   exclude: []


### PR DESCRIPTION
### What does this PR do?
— Fixing `fr` `ja` announcement banner config updates (currently, they are broken since we changed the k:v for the configuration.

### Motivation
Saw broken announcement banner for `fr` and `ja` docs sites

### Preview link
https://docs-staging.datadoghq.com/won/201907-annc-banner-for-frja/fr/
https://docs-staging.datadoghq.com/won/201907-annc-banner-for-frja/ja/

### Additional Notes
Although this branch fixes the problem of "empty announcement banner" problem for `fr` `ja` sites, they still are displaying old messaging, and they need to be updated
