### PR TITLE
add missing args to aws delete integration API

### DIFF
--- a/content/en/api/integrations_aws/aws_delete.md
+++ b/content/en/api/integrations_aws/aws_delete.md
@@ -11,4 +11,15 @@ Delete a given Datadog-AWS integration.
 
 ##### Arguments
 
-This endpoint takes no JSON arguments.
+* **`account_id`** [*required*]:
+
+    Your AWS Account ID without dashes.
+    [Consult the Datadog AWS integration to learn more][1] about your AWS account ID.
+
+* **`role_name`** [*required*]:
+
+    Your Datadog role delegation name.
+    For more information about you AWS account Role name, [see the Datadog AWS integration configuration info][2].
+
+[1]: /integrations/amazon_web_services/#configuration
+[2]: /integrations/amazon_web_services/#installation


### PR DESCRIPTION
### What does this PR do?
adding some missing args to AWS delete integration endpoint in the API

### Motivation
PM request

### Preview link

https://docs-staging.datadoghq.com/cswatt/api-aws-args/api/?lang=bash#delete-an-aws-integration
