### PR TITLE
Adding new use case for DD_KUBERNETES_POD_LABELS_AS_TAGS

### DIFF
--- a/content/en/agent/autodiscovery/tag.md
+++ b/content/en/agent/autodiscovery/tag.md
@@ -105,7 +105,7 @@ kubernetes_pod_labels_as_tags:
   app: kube_app
 ```
 
-To add all pod labels as tags to your metrics where tags names are prefixed by `<PREFIX>_`, you can use the following environment variable:
+Use the following environment variable configuration to add all pod labels as tags to your metrics. In this example the tags names are prefixed by `<PREFIX>_`:
 
 ```yaml
 kubernetes_pod_labels_as_tags:
@@ -131,7 +131,7 @@ For example, you could set up:
 DD_KUBERNETES_POD_LABELS_AS_TAGS='{"app":"kube_app"}'
 ```
 
-To add all pod labels as tags to your metrics where tags names are prefixed by `<PREFIX>_`, you can use the following environment variable:
+Use the following environment variable configuration to add all pod labels as tags to your metrics. In this example the tags names are prefixed by `<PREFIX>_`:
 
 ```shell
 DD_KUBERNETES_POD_LABELS_AS_TAGS='{"*":"<PREFIX>_%%label%%"}'

--- a/content/en/agent/autodiscovery/tag.md
+++ b/content/en/agent/autodiscovery/tag.md
@@ -105,14 +105,14 @@ kubernetes_pod_labels_as_tags:
   app: kube_app
 ```
 
-Use the following environment variable configuration to add all pod labels as tags to your metrics. In this example the tags names are prefixed by `<PREFIX>_`:
+For Agent v6.8.0+, use the following environment variable configuration to add all pod labels as tags to your metrics. In this example, the tag names are prefixed by `<PREFIX>_`:
 
 ```yaml
 kubernetes_pod_labels_as_tags:
   *: <PREFIX>_%%label%%
 ```
 
-**Note**: Doing so may infinitely [increase the number of metrics][2] for your organization and impact your billing.
+**Note**: Using this method may [increase the number of metrics][2] for your organization and impact your billing.
 
 [1]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
 [2]: /developers/metrics/custom_metrics/#how-is-a-custom-metric-defined
@@ -131,13 +131,13 @@ For example, you could set up:
 DD_KUBERNETES_POD_LABELS_AS_TAGS='{"app":"kube_app"}'
 ```
 
-Use the following environment variable configuration to add all pod labels as tags to your metrics. In this example the tags names are prefixed by `<PREFIX>_`:
+For Agent v6.8.0+, use the following environment variable configuration to add all pod labels as tags to your metrics. In this example, the tags names are prefixed by `<PREFIX>_`:
 
 ```shell
 DD_KUBERNETES_POD_LABELS_AS_TAGS='{"*":"<PREFIX>_%%label%%"}'
 ```
 
-**Note**: Doing so may infinitely [increase the number of metrics][1] for your organization and impact your billing.
+**Note**: Using this method may [increase the number of metrics][2] for your organization and impact your billing.
 
 [1]: /developers/metrics/custom_metrics/#how-is-a-custom-metric-defined
 {{% /tab %}}

--- a/content/en/agent/autodiscovery/tag.md
+++ b/content/en/agent/autodiscovery/tag.md
@@ -105,7 +105,17 @@ kubernetes_pod_labels_as_tags:
   app: kube_app
 ```
 
+To add all pod labels as tags to your metrics where tags names are prefixed by `<PREFIX>_`, you can use the following environment variable:
+
+```yaml
+kubernetes_pod_labels_as_tags:
+  *: <PREFIX>_%%label%%
+```
+
+**Note**: Doing so may infinitely [increase the number of metrics][2] for your organization and impact your billing.
+
 [1]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
+[2]: /developers/metrics/custom_metrics/#how-is-a-custom-metric-defined
 {{% /tab %}}
 {{% tab "Containerized Agent" %}}
 
@@ -121,6 +131,15 @@ For example, you could set up:
 DD_KUBERNETES_POD_LABELS_AS_TAGS='{"app":"kube_app"}'
 ```
 
+To add all pod labels as tags to your metrics where tags names are prefixed by `<PREFIX>_`, you can use the following environment variable:
+
+```shell
+DD_KUBERNETES_POD_LABELS_AS_TAGS='{"*":"<PREFIX>_%%label%%"}'
+```
+
+**Note**: Doing so may infinitely [increase the number of metrics][1] for your organization and impact your billing.
+
+[1]: /developers/metrics/custom_metrics/#how-is-a-custom-metric-defined
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
### What does this PR do?
This PR documents the behaviour introduced in 6.8: 

https://github.com/DataDog/datadog-agent/pull/2525/files#diff-31ed38738104d02ea513b533285f6534R81

### Motivation
Support request

### Preview link

* https://docs-staging.datadoghq.com/gus/ad-tags/agent/autodiscovery/tag/?tab=hostagent#extract-pod-labels-as-tags