### PR TITLE
Correct 2 references of Agent versions with win embedded dir change

### DIFF
--- a/content/en/agent/troubleshooting/agent_check_status.md
+++ b/content/en/agent/troubleshooting/agent_check_status.md
@@ -59,6 +59,14 @@ If your issue continues, [reach out to the Datadog support team][1] with a [flar
 
 Run the following script, with the proper `<CHECK_NAME>`:
 
+For Agent versions >= 6.12:
+
+```
+C:\Program Files\Datadog\Datadog agent\bin\agent.exe check <CHECK_NAME>
+```
+
+For Agent versions <= 6.11:
+
 ```
 C:\Program Files\Datadog\Datadog agent\embedded\agent.exe check <CHECK_NAME>
 ```
@@ -84,14 +92,8 @@ Run the following script, with the proper `<CHECK_NAME>`:
 
 For example, to run the disk check:
 
-For Agent versions <= 6.11:
 ```
 C:\Program' 'Files\Datadog\Datadog' 'Agent\embedded\python.exe C:\Program' 'Files\Datadog\Datadog' 'Agent\agent\agent.py check disk
-```
-
-For Agent versions >= 6.12:
-```
-C:\Program' 'Files\Datadog\Datadog' 'Agent\embedded2\python.exe C:\Program' 'Files\Datadog\Datadog' 'Agent\agent\agent.py check disk
 ```
 
 {{% /tab %}}

--- a/content/en/agent/troubleshooting/agent_check_status.md
+++ b/content/en/agent/troubleshooting/agent_check_status.md
@@ -89,7 +89,7 @@ For Agent versions <= 6.11:
 C:\Program' 'Files\Datadog\Datadog' 'Agent\embedded\python.exe C:\Program' 'Files\Datadog\Datadog' 'Agent\agent\agent.py check disk
 ```
 
-For Agent versions <= 6.12:
+For Agent versions >= 6.12:
 ```
 C:\Program' 'Files\Datadog\Datadog' 'Agent\embedded2\python.exe C:\Program' 'Files\Datadog\Datadog' 'Agent\agent\agent.py check disk
 ```

--- a/content/en/agent/troubleshooting/agent_check_status.md
+++ b/content/en/agent/troubleshooting/agent_check_status.md
@@ -62,13 +62,13 @@ Run the following script, with the proper `<CHECK_NAME>`:
 For Agent versions >= 6.12:
 
 ```
-C:\Program Files\Datadog\Datadog agent\bin\agent.exe check <CHECK_NAME>
+C:\Program Files\Datadog\Datadog Agent\bin\agent.exe check <CHECK_NAME>
 ```
 
 For Agent versions <= 6.11:
 
 ```
-C:\Program Files\Datadog\Datadog agent\embedded\agent.exe check <CHECK_NAME>
+C:\Program Files\Datadog\Datadog Agent\embedded\agent.exe check <CHECK_NAME>
 ```
 
 {{% /tab %}}

--- a/content/en/developers/dogstatsd/datagram_shell.md
+++ b/content/en/developers/dogstatsd/datagram_shell.md
@@ -132,7 +132,7 @@ PS C:\vagrant> .\send-statsd.ps1 "custom_metric:123|g|#shell"
 PS C:\vagrant>
 ```
 
-On any platform with Python (on Windows, the Agent's embedded Python interpreter can be used, which is located at `C:\Program Files\Datadog\Datadog Agent\embedded\python.exe` for Agent versions <= 6.12 and in `C:\Program Files\Datadog\Datadog Agent\embedded2\python.exe` for Agent versions >= 6.13):
+On any platform with Python (on Windows, the Agent's embedded Python interpreter can be used, which is located at `C:\Program Files\Datadog\Datadog Agent\embedded\python.exe` for Agent versions <= 6.11 and in `C:\Program Files\Datadog\Datadog Agent\embedded2\python.exe` for Agent versions >= 6.12):
 
 ```python
 import socket


### PR DESCRIPTION
### What does this PR do?

Follow-up to #5020: couple of corrections to the Agent versions that include the Windows `embedded` dir changes.
