### PR TITLE
Add documentation for GET /v1/monitor pagination arguments.

### DIFF
--- a/content/en/api/monitors/monitors_showall.md
+++ b/content/en/api/monitors/monitors_showall.md
@@ -18,6 +18,6 @@ external_redirect: /api/#get-all-monitor-details
 * **`with_downtimes`** [*optional*, *default* = **true**]:
     If this argument is set to `true`, then the returned data includes all current downtimes for each monitor.
 * **`page`** [*optional*, *default* = **0**]:
-    Page to start paginating from. If this argument is not specified, the request will return all monitors without pagination.
+    The page to start paginating from. If this argument is not specified, the request returns all monitors without pagination.
 * **`per_page`** [*optional*, *default*=**100**]:
     The number of monitors to return per page. If the `page` argument is not specified, the default behavior returns all monitors without a `per_page` limit. However, if `page` is specified and `per_page` is not, the argument defaults to `100`.

--- a/content/en/api/monitors/monitors_showall.md
+++ b/content/en/api/monitors/monitors_showall.md
@@ -17,3 +17,7 @@ external_redirect: /api/#get-all-monitor-details
     A comma separated list indicating what service and/or custom tags, if any, should be used to filter the list of monitors. Tags created in the Datadog UI automatically have the **service** key prepended (e.g. `service:my-app`)
 * **`with_downtimes`** [*optional*, *default* = **true**]:
     If this argument is set to `true`, then the returned data includes all current downtimes for each monitor.
+* **`page`** [*optional*, *default* = **0**]:
+    Page to start paginating from. If this argument is not specified, the request will return all monitors without pagination.
+* **`per_page`** [*optional*, *default*=**100**]:
+    Number of monitors to return per page. If the `page` argument is not specified, the default behavior will be to return all monitors without a `per_page` limit. However, if `page` is specified and `per_page` is not, the argument will default to `100`.

--- a/content/en/api/monitors/monitors_showall.md
+++ b/content/en/api/monitors/monitors_showall.md
@@ -20,4 +20,4 @@ external_redirect: /api/#get-all-monitor-details
 * **`page`** [*optional*, *default* = **0**]:
     Page to start paginating from. If this argument is not specified, the request will return all monitors without pagination.
 * **`per_page`** [*optional*, *default*=**100**]:
-    Number of monitors to return per page. If the `page` argument is not specified, the default behavior will be to return all monitors without a `per_page` limit. However, if `page` is specified and `per_page` is not, the argument will default to `100`.
+    The number of monitors to return per page. If the `page` argument is not specified, the default behavior returns all monitors without a `per_page` limit. However, if `page` is specified and `per_page` is not, the argument defaults to `100`.


### PR DESCRIPTION
### What does this PR do?
Adds documentation for `GET /v1/monitor` endpoint by documenting the `page` and `per_page` pagination arguments.

### Preview link
https://docs-staging.datadoghq.com/armcburney/add_documentation_for_get_all_monitors_api/api/?lang=python#get-all-monitor-details