### PR TITLE
Short lived container - docker socket update

### DIFF
--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -300,10 +300,10 @@ For Agent v6.12+, short lived container logs (stopped or crashed) are automatica
 {{% /tab %}}
 {{% tab "Docker Socket" %}}
 
-By default the Agent receive updates on container in real time through Docker Events. However the configuration that is extracted from the container labels (autodiscovery) is updated every 10 seconds by the Agent. So any container with a shorter duration life might not have any data collected by the Agent.
+By default, the Agent receives container updates in real time through Docker events. However, the configuration that is extracted from the container labels (Autodiscovery) is updated every 10 seconds by the Agent. Therefore, any container with a shorter life may not have any data collected by the Agent.
 
-You can override this interval with a shorter one by setting the `ad_config_poll_interval` parameter which correspond to the `DD_AD_CONFIG_POLL_INTERVAL` environment variable.
-The expected value is a integer in seconds or you can specify the unit as in the below example:
+You can override this interval with a shorter one by setting the `ad_config_poll_interval` parameter, which is equivalent to the `DD_AD_CONFIG_POLL_INTERVAL` environment variable.
+The expected value is a integer in seconds or you can specify the unit, for example:
 
 ```
 config_providers:

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -300,19 +300,11 @@ For Agent v6.12+, short lived container logs (stopped or crashed) are automatica
 {{% /tab %}}
 {{% tab "Docker Socket" %}}
 
-By default, the Agent receives container updates in real time through Docker events. However, the configuration that is extracted from the container labels (Autodiscovery) is updated every 10 seconds by the Agent. Therefore, any container with a shorter life may not have any data collected by the Agent.
+For Docker environment (no Kubernetes), the Agent receives container updates in real time through Docker events. However, the configuration that is extracted from the container labels (Autodiscovery) is updated every 10 seconds by the Agent. Therefore, any container with a shorter life may not have any data collected by the Agent.
 
 You can override this interval with a shorter one by setting the `ad_config_poll_interval` parameter, which is equivalent to the `DD_AD_CONFIG_POLL_INTERVAL` environment variable.
-The expected value is a integer in seconds or you can specify the unit, for example:
 
-```
-config_providers:
-  - name: docker
-    polling: true
-    poll_interval: 500ms
-```
-
-The other option is to use the `K8s file` collection method that supports init, stopped, and short lived containers collection without any extra setup.
+In Kubernetes environment, we recommend to use the `K8s file` collection method that supports init, stopped, and short lived containers collection without any extra setup.
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -300,11 +300,11 @@ For Agent v6.12+, short lived container logs (stopped or crashed) are automatica
 {{% /tab %}}
 {{% tab "Docker Socket" %}}
 
-For Docker environment (not Kubernetes), the Agent receives container updates in real time through Docker events. However, the configuration that is extracted from the container labels (Autodiscovery) is updated every 10 seconds by the Agent. Therefore, any container with a shorter life may not have any data collected by the Agent.
+For a Docker environment, the Agent receives container updates in real time through Docker events. The Agent extracts and updates the configuration from the container labels (Autodiscovery) every 10 seconds. Therefore, by default, the Agent does not collect data for any container with a shorter life.
 
-You can override this interval with a shorter one by setting the `ad_config_poll_interval` parameter, which is equivalent to the `DD_AD_CONFIG_POLL_INTERVAL` environment variable.
+You can override the polling interval by setting the `ad_config_poll_interval` parameter, which is equivalent to the `DD_AD_CONFIG_POLL_INTERVAL` environment variable.
 
-For a Kubernetes environment, use the `K8s file` collection method that supports init, stopped, and short lived containers collection without any extra setup.
+For a Kubernetes environment, use the `K8s file` collection method that supports init, stopped, and short lived containers. No additional setup is required.
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -300,10 +300,17 @@ For Agent v6.12+, short lived container logs (stopped or crashed) are automatica
 {{% /tab %}}
 {{% tab "Docker Socket" %}}
 
-By default the Agent looks every 5 seconds for new containers. Any container with a shorter duration life does not have any data collected by the Agent.
+By default the Agent receive updates on container in real time through Docker Events. However the configuration that is extracted from the container labels (autodiscovery) is updated every 10 seconds by the Agent. So any container with a shorter duration life might not have any data collected by the Agent.
 
- You can override this autodiscovery interval with a shorter one by setting the `ad_config_poll_interval` parameter which correspond to the `DD_AD_CONFIG_POLL_INTERVAL` environment variable.
-The expected value is a integer in seconds.
+You can override this interval with a shorter one by setting the `ad_config_poll_interval` parameter which correspond to the `DD_AD_CONFIG_POLL_INTERVAL` environment variable.
+The expected value is a integer in seconds or you can specify the unit as in the below example:
+
+```
+config_providers:
+  - name: docker
+    polling: true
+    poll_interval: 500ms
+```
 
 The other option is to use the `K8s file` collection method that supports init, stopped, and short lived containers collection without any extra setup.
 

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -300,11 +300,11 @@ For Agent v6.12+, short lived container logs (stopped or crashed) are automatica
 {{% /tab %}}
 {{% tab "Docker Socket" %}}
 
-For Docker environment (no Kubernetes), the Agent receives container updates in real time through Docker events. However, the configuration that is extracted from the container labels (Autodiscovery) is updated every 10 seconds by the Agent. Therefore, any container with a shorter life may not have any data collected by the Agent.
+For Docker environment (not Kubernetes), the Agent receives container updates in real time through Docker events. However, the configuration that is extracted from the container labels (Autodiscovery) is updated every 10 seconds by the Agent. Therefore, any container with a shorter life may not have any data collected by the Agent.
 
 You can override this interval with a shorter one by setting the `ad_config_poll_interval` parameter, which is equivalent to the `DD_AD_CONFIG_POLL_INTERVAL` environment variable.
 
-In Kubernetes environment, we recommend to use the `K8s file` collection method that supports init, stopped, and short lived containers collection without any extra setup.
+For a Kubernetes environment, use the `K8s file` collection method that supports init, stopped, and short lived containers collection without any extra setup.
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
Add more details about how the Short lived container information can be collected with the Datadog Agent

### What does this PR do?
Explain a bit more precisely how data from short lived containers can be collected when using the Docker socket.

### Motivation
It was not clear for users that it was possible to achieve this with the Docker socket as well.

### Preview link
https://docs-staging.datadoghq.com/nils/short-lived-docker-socket/agent/kubernetes/daemonset_setup/?tab=k8sfile#short-lived-containers

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
