### PR TITLE
Adding URL param to drive new lang_pref logic

### DIFF
--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -65,7 +65,7 @@
                         <p>Language</p>
                         <ul class="list-unstyled">
                             {{ range .Translations }}
-                                <li><a class="button is-small is-danger is-rounded" href="{{ .Permalink }}">{{ .Site.Language.LanguageName }}</a></li>
+                                <li><a class="button is-small is-danger is-rounded" href="{{ .Permalink }}?lang_pref={{ .Site.Language.Lang }}">{{ .Site.Language.LanguageName }}</a></li>
                             {{ end }}
                         </ul>
                     </div>


### PR DESCRIPTION
### What does this PR do?
Introduces lang_pref URL param to Footer language toggle. This helps drive language preferences for returning users

### Motivation
https://trello.com/c/NC3KcZYt

### Preview link
https://docs-staging.datadoghq.com/nsollecito/lang-redirects/

### Additional Notes
This is a complex change that spans 3 different repos and has exceptions and custom logic to account for preview sites. Proper testing involves changing Accept-Language headers to 'ja' and clearing / monitoring cookies on request and response. 

