### PR TITLE
updates to synthetics browser test

### DIFF
--- a/content/en/synthetics/browser_tests.md
+++ b/content/en/synthetics/browser_tests.md
@@ -92,6 +92,8 @@ The navigation action allow you to:
 * Refresh the current page of the scenario.
 * Follow a specific link.
 
+**Note**: In the "Enter link URL" box, users must prepend URLs with `http` or `https`.
+
 #### Hover
 
 This browser test step isn’t added through an actual hovering mechanism (otherwise each element you are hovering would be added as a step) but using a dedicated action with a click.
@@ -141,11 +143,11 @@ Common failure reasons include:
 
 | Error           | Description                                                                                                                                                                                    |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `CONNRESET`       | The connection was abruptly closed by the remote server. Possible causes include the webserver encountering an error or crashing while responding, loss of connectivity of the webserver, etc. |
-| `DNS`             | The DNS entry is not found for the check URL. Possible causes include misconfigured check URL, wrong configuration of your DNS entries, etc.                                                          |
-| `INVALID_REQUEST` | The configuration of the check is invalid.                                                                                                                             |
-| `SSL`             | The SSL connection couldn't be performed.                                                                                     |
-| `TIMEOUT`         | The request couldn't be completed in a reasonable time. Browser tests timeout in 60 seconds. |
+| `General test failure`       |  |
+| `Element located but it's invisible`             | The element is on the page but cannot be clicked on—for isntance, if another element is overlaid on top of it.                                                          |
+| `Cannot locate element` | Element cannot be not found in the HTML.                                                                                                                             |
+| `Select did not have option`             | The specified option is missing from the dropdown menu.                                                                                     |
+| `Forbidden URL`         | The test likely encountered a protocol that is not supported. Reach out to [Datadog support] for further details.  |
 
 ## Further Reading
 

--- a/content/en/synthetics/browser_tests.md
+++ b/content/en/synthetics/browser_tests.md
@@ -160,3 +160,4 @@ Common failure reasons include:
 [5]: https://www.google.com/chrome
 [6]: https://chrome.google.com/webstore/detail/datadog-test-recorder/kkbncfpddhdmkfmalecgnphegacgejoa
 [7]: /synthetics/settings/#secure-credential
+[8]: /help

--- a/content/en/synthetics/browser_tests.md
+++ b/content/en/synthetics/browser_tests.md
@@ -147,7 +147,7 @@ Common failure reasons include:
 | `Element located but it's invisible`             | The element is on the page but cannot be clicked on—for instance, if another element is overlaid on top of it.                                                          |
 | `Cannot locate element` | The element cannot be found in the HTML.                                                                                                                             |
 | `Select did not have option`             | The specified option is missing from the dropdown menu.                                                                                     |
-| `Forbidden URL`         | The test likely encountered a protocol that is not supported. Reach out to [Datadog support] for further details.  |
+| `Forbidden URL`         | The test likely encountered a protocol that is not supported. Reach out to [Datadog support][8] for further details.  |
 
 ## Further Reading
 

--- a/content/en/synthetics/browser_tests.md
+++ b/content/en/synthetics/browser_tests.md
@@ -145,7 +145,7 @@ Common failure reasons include:
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `General test failure`       |  |
 | `Element located but it's invisible`             | The element is on the page but cannot be clicked on—for instance, if another element is overlaid on top of it.                                                          |
-| `Cannot locate element` | Element cannot be not found in the HTML.                                                                                                                             |
+| `Cannot locate element` | The element cannot be found in the HTML.                                                                                                                             |
 | `Select did not have option`             | The specified option is missing from the dropdown menu.                                                                                     |
 | `Forbidden URL`         | The test likely encountered a protocol that is not supported. Reach out to [Datadog support] for further details.  |
 

--- a/content/en/synthetics/browser_tests.md
+++ b/content/en/synthetics/browser_tests.md
@@ -143,11 +143,11 @@ Common failure reasons include:
 
 | Error           | Description                                                                                                                                                                                    |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `General test failure`       |  |
 | `Element located but it's invisible`             | The element is on the page but cannot be clicked on—for instance, if another element is overlaid on top of it.                                                          |
 | `Cannot locate element` | The element cannot be found in the HTML.                                                                                                                             |
 | `Select did not have option`             | The specified option is missing from the dropdown menu.                                                                                     |
 | `Forbidden URL`         | The test likely encountered a protocol that is not supported. Reach out to [Datadog support][8] for further details.  |
+| `General test failure`       | A general error message. [Contact support][8] for further details. |
 
 ## Further Reading
 

--- a/content/en/synthetics/browser_tests.md
+++ b/content/en/synthetics/browser_tests.md
@@ -144,7 +144,7 @@ Common failure reasons include:
 | Error           | Description                                                                                                                                                                                    |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `General test failure`       |  |
-| `Element located but it's invisible`             | The element is on the page but cannot be clicked on—for isntance, if another element is overlaid on top of it.                                                          |
+| `Element located but it's invisible`             | The element is on the page but cannot be clicked on—for instance, if another element is overlaid on top of it.                                                          |
 | `Cannot locate element` | Element cannot be not found in the HTML.                                                                                                                             |
 | `Select did not have option`             | The specified option is missing from the dropdown menu.                                                                                     |
 | `Forbidden URL`         | The test likely encountered a protocol that is not supported. Reach out to [Datadog support] for further details.  |


### PR DESCRIPTION


### What does this PR do?

* updates test failure and errors section. previously it had the errors from API tests.
* caveat for navigation step that you must prepend URLs with `http` or `https`

### Motivation
requests from @MargotLepizzera 

### Preview link

https://docs-staging.datadoghq.com/cswatt/synthetics-browser-updates/synthetics/browser_tests

