### PR TITLE
[Browser log] add a supported browsers section

### DIFF
--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -250,7 +250,7 @@ signupLogger.setContext({
 })
 ```
 
-## Supported Browsers
+## Supported browsers
 
 The `datadog-logs` library supports all modern desktop and mobile browsers, and legacy browsers IE10 and IE11.
 

--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -250,6 +250,10 @@ signupLogger.setContext({
 })
 ```
 
+## Supported Browsers
+
+The `datadog-logs` library supports all modern desktop and mobile browsers, and legacy browsers IE10 and IE11.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -252,7 +252,7 @@ signupLogger.setContext({
 
 ## Supported browsers
 
-The `datadog-logs` library supports all modern desktop and mobile browsers, and legacy browsers IE10 and IE11.
+The `datadog-logs` library supports all modern desktop and mobile browsers. IE10 and IE11 are also supported.
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Document which browsers are supported by the library.

### Motivation
<!-- What inspired you to submit this pull request?-->

Feature is GA and the info is asked by customers.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/bcaudan/browser-log-compatibility/logs/log_collection/javascript/?tab=us#pagetitle

### Additional Notes
<!-- Anything else we should know when reviewing?-->
