### PR TITLE
Remove unsupported framework

### DIFF
--- a/content/en/tracing/setup/java.md
+++ b/content/en/tracing/setup/java.md
@@ -83,7 +83,6 @@ Beta integrations are disabled by default but can be enabled individually.
 | Spark Java                   | 2.3+       | [Beta][7]       | `sparkjava` (requires `jetty`)                 |
 | Spring Web (MVC)             | 4.0+       | Fully Supported | `spring-web`                                   |
 | Spring WebFlux               | 5.0+       | Fully Supported | `spring-webflux`                               |
-| Vert.x-Web                   | 4.1.0+     | Fully Supported | (requires `netty`)                             |
 
 **Web Framework tracing provides:** timing HTTP request to response, tags for the HTTP request (status code, method, etc), error and stacktrace capturing, linking work created within a web request and Distributed Tracing.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- Remove unsupported Java web framework Vert.x-Web

### Motivation
- Trello request from support

### Preview link
https://docs-staging.datadoghq.com/ruth/vertx-web/tracing/setup/java/#web-framework-compatibility

### Additional Notes
N/A
