### PR TITLE
Making FAQ only accessible through direct link

### DIFF
--- a/content/en/integrations/faq/agent-5-amazon-ecs.md
+++ b/content/en/integrations/faq/agent-5-amazon-ecs.md
@@ -2,6 +2,7 @@
 title: Amazon Elastic Container Service with Agent v5
 kind: faq
 disable_toc: true
+beta: true
 ---
 
 <div class="alert alert-warning">


### PR DESCRIPTION
### What does this PR do?

Makes the Agent v5 instructions doc page private in order to not have it indexed by search. 


### Motivation
It ranks higher as the main AWS ECS page:

https://cl.ly/623a0d48592b
