### PR TITLE
Adding Heroku front matters

### DIFF
--- a/local/etc/pull_config.yaml
+++ b/local/etc/pull_config.yaml
@@ -59,6 +59,11 @@
       options:
         dest_path: '/agent/basic_agent_usage/'
         file_name: 'heroku.md'
+        front_matters:
+          title: Datadog Heroku Buildpack
+          kind: documentation
+          aliases:
+          - /developers/faq/how-do-i-collect-metrics-from-heroku-with-datadog
 
   - repo_name: dd-trace-rb
     contents:

--- a/local/etc/pull_config_preview.yaml
+++ b/local/etc/pull_config_preview.yaml
@@ -59,6 +59,12 @@
       options:
         dest_path: '/agent/basic_agent_usage/'
         file_name: 'heroku.md'
+        front_matters:
+          title: Datadog Heroku Buildpack
+          kind: documentation
+          aliases:
+          - /developers/faq/how-do-i-collect-metrics-from-heroku-with-datadog
+---
 
   - repo_name: dd-trace-rb
     contents:

--- a/local/etc/pull_config_preview.yaml
+++ b/local/etc/pull_config_preview.yaml
@@ -64,7 +64,6 @@
           kind: documentation
           aliases:
           - /developers/faq/how-do-i-collect-metrics-from-heroku-with-datadog
----
 
   - repo_name: dd-trace-rb
     contents:


### PR DESCRIPTION
### What does this PR do?

Adds Heroku front matters, it should be merged after those PR are merged:

https://github.com/DataDog/heroku-buildpack-datadog/pull/124
https://github.com/DataDog/documentation/pull/5063

### Motivation

Previously they were displayed in the heroku build pack repo, this PR includes them only in the doc side. 