### PR TITLE
Adding a note about leader election in Cluster Agent documentation

### DIFF
--- a/content/en/agent/kubernetes/cluster.md
+++ b/content/en/agent/kubernetes/cluster.md
@@ -245,6 +245,8 @@ In order to collect events, you need the following environment variables in your
 ```
 Enabling the leader election ensures that only one Agent collects the events.
 
+**Note**: You must disable leader election in the Datadog Agent on your nodes before enabling leader election in the Datadog Cluster Agent. Otherwise, leader election may fail and cluster-level metrics may become unavailable.
+
 #### Cluster metadata provider
 
 In the Node Agent, set the environment variable `DD_CLUSTER_AGENT_ENABLED` to true.

--- a/content/en/agent/kubernetes/cluster.md
+++ b/content/en/agent/kubernetes/cluster.md
@@ -245,7 +245,7 @@ In order to collect events, you need the following environment variables in your
 ```
 Enabling the leader election ensures that only one Agent collects the events.
 
-**Note**: You must disable leader election in the Datadog Agent on your nodes before enabling leader election in the Datadog Cluster Agent. Otherwise, leader election may fail and some features such as the External Metrics Provider or the Cluster Level Checks may not work.
+**Note**: You must disable leader election in the Datadog Agent on your nodes before enabling leader election in the Datadog Cluster Agent. Otherwise, leader election may fail and some features such as the external metrics provider or the cluster level checks may not work.
 
 #### Cluster metadata provider
 

--- a/content/en/agent/kubernetes/cluster.md
+++ b/content/en/agent/kubernetes/cluster.md
@@ -245,7 +245,7 @@ In order to collect events, you need the following environment variables in your
 ```
 Enabling the leader election ensures that only one Agent collects the events.
 
-**Note**: You must disable leader election in the Datadog Agent on your nodes before enabling leader election in the Datadog Cluster Agent. Otherwise, leader election may fail and cluster-level metrics may become unavailable.
+**Note**: You must disable leader election in the Datadog Agent on your nodes before enabling leader election in the Datadog Cluster Agent. Otherwise, leader election may fail and some features such as the External Metrics Provider or the Cluster Level Checks may not work.
 
 #### Cluster metadata provider
 


### PR DESCRIPTION
Following issue https://github.com/DataDog/datadog-agent/issues/3771 we wanted to note to users that disabling LE on the node agents is required before enabling LE on the cluster agents.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Following issue https://github.com/DataDog/datadog-agent/issues/3771 we wanted to note to users that disabling LE on the node agents is required before enabling LE on the cluster agents.

### Motivation
Improving user experience when using Datadog Cluster Agent

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/yair.cohen/k8_cluster_agent_le_note/agent/kubernetes/cluster/

### Additional Notes
This is my first PR for the documentation repository so apologies if I forgot something. Please verify.