### PR TITLE
Making API reference doc private to not mess with search

### DIFF
--- a/content/en/integrations/faq/list-of-api-source-attribute-value.md
+++ b/content/en/integrations/faq/list-of-api-source-attribute-value.md
@@ -1,6 +1,7 @@
 ---
 title: List of API source attribute values
 kind: faq
+private: true
 ---
 
 |Integration name | API source attribute|
@@ -263,6 +264,7 @@ kind: faq
 |Riakcs|RIAKCS|
 |Rollbar|ROLLBAR|
 |Ruby|RUBY|
+|Segment|SEGMENT|
 |Sentry|SENTRY|
 |Servicenow|SERVICENOW|
 |Sketch|SKETCH|
@@ -300,3 +302,4 @@ kind: faq
 |Yarn|YARN|
 |Zendesk|ZENDESK|
 |Zookeeper|ZOOKEEPER|
+

--- a/local/etc/pull_config.yaml
+++ b/local/etc/pull_config.yaml
@@ -6,10 +6,10 @@
 
     contents:
 
-    #- action: source
-    #  branch: prod
-    #  globs:
-    #  - dd/utils/context/source.py
+    # - action: source
+    #   branch: prod
+    #   globs:
+    #   - dd/utils/context/source.py
 
     - action: integrations
       branch: prod

--- a/local/etc/pull_config_preview.yaml
+++ b/local/etc/pull_config_preview.yaml
@@ -6,10 +6,10 @@
 
     contents:
 
-    #- action: source
-    #  branch: prod
-    #  globs:
-    #  - dd/utils/context/source.py
+    # - action: source
+    #   branch: prod
+    #   globs:
+    #   - dd/utils/context/source.py
 
     - action: integrations
       branch: prod


### PR DESCRIPTION
### What does this PR do?
Make this page private (and fix indentation of this page creation in the pull_configs files) 

The idea is to not mess with the search when looking for only an integration name.