### PR TITLE
Adding information about DD_DOGSTATSD_NON_LOCAL_TRAFFIC variable

### DIFF
--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -70,7 +70,7 @@ spec:
         ports:
           - containerPort: 8125
             ## Custom metrics via DogStatsD - uncomment this section to enable custom metrics collection
-            ## Set also DD_DOGSTATSD_NON_LOCAL_TRAFFIC to true to collect StatsD metrics from other containers.
+            ## Set DD_DOGSTATSD_NON_LOCAL_TRAFFIC to true to collect StatsD metrics from other containers.
             # hostPort: 8125
             name: dogstatsdport
             protocol: UDP

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -69,25 +69,31 @@ spec:
         name: datadog-agent
         ports:
           - containerPort: 8125
-            # Custom metrics via DogStatsD - uncomment this section to enable custom metrics collection
+            ## Custom metrics via DogStatsD - uncomment this section to enable custom metrics collection
+            ## Set also DD_DOGSTATSD_NON_LOCAL_TRAFFIC to true to collect StatsD metrics from other containers.
             # hostPort: 8125
             name: dogstatsdport
             protocol: UDP
           - containerPort: 8126
-            # Trace Collection (APM) - uncomment this section to enable APM
+            ## Trace Collection (APM) - uncomment this section to enable APM
             # hostPort: 8126
             name: traceport
             protocol: TCP
         env:
           - name: DD_API_KEY
-            # Kubernetes Secrets - uncomment this section to supply API Key with secrets
-#            valueFrom:
-#              secretKeyRef:
-#                name: datadog-secret
-#                key: api-key
+            ## Kubernetes Secrets - uncomment this section to supply API Key with secrets
+            # valueFrom:
+            #   secretKeyRef:
+            #     name: datadog-secret
+            #     key: api-key
+
+          ## Set DD_SITE to datadoghq.eu to send your Agent data to the Datadog EU site
           - name: DD_SITE
-            # Set DD_SITE to datadoghq.eu to send your Agent data to the Datadog EU site
             value: "datadoghq.com"
+
+          ## Set DD_DOGSTATSD_NON_LOCAL_TRAFFIC to true to allow StatsD collection.
+          - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
+            value: "false"
           - name: DD_COLLECT_KUBERNETES_EVENTS
             value: "true"
           - name: DD_LEADER_ELECTION
@@ -112,7 +118,7 @@ spec:
             mountPath: /var/run/docker.sock
           - name: logpodpath
             mountPath: /var/log/pods
-          # Docker runtime directory, replace this path with your container runtime logs directory, or remove this configuration if `/var/log/pods` is not a symlink to any other directory.
+          ## Docker runtime directory, replace this path with your container runtime logs directory, or remove this configuration if `/var/log/pods` is not a symlink to any other directory.
           - name: logcontainerpath
             mountPath: /var/lib/docker/containers
           - name: procdir
@@ -137,7 +143,7 @@ spec:
         - hostPath:
             path: /var/log/pods
           name: logpodpath
-        # Docker runtime directory, replace this path with your container runtime logs directory, or remove this configuration if `/var/log/pods` is not a symlink to any other directory.
+        ## Docker runtime directory, replace this path with your container runtime logs directory, or remove this configuration if `/var/log/pods` is not a symlink to any other directory.
         - hostPath:
             path: /var/lib/docker/containers
           name: logcontainerpath
@@ -222,7 +228,7 @@ Mount `/var/lib/docker/containers` as well, since `/var/log/pods` is symlink to 
           (...)
           - name: logpodpath
               mountPath: /var/log/pods
-          # Docker runtime directory, replace this path with your container runtime logs directory, or remove this configuration if `/var/log/pods` is not a symlink to any other directory.    
+          # Docker runtime directory, replace this path with your container runtime logs directory, or remove this configuration if `/var/log/pods` is not a symlink to any other directory.
           - name: logcontainerpath
             mountPath: /var/lib/docker/containers
       (...)

--- a/content/en/agent/kubernetes/dogstatsd.md
+++ b/content/en/agent/kubernetes/dogstatsd.md
@@ -14,7 +14,7 @@ To emit custom metrics from your Kubernetes application, use [DogStatsD][1], a m
 
 ## Use DogStatsD over a Unix Domain Socket
 
-You can use [DogStatsD over a Unix Domain Socket][3]. 
+You can use [DogStatsD over a Unix Domain Socket][3].
 
 ### Create a listening socket
 
@@ -63,27 +63,34 @@ For more details, see the [DogStatsD over a Unix Domain Socket documentation][3]
 
 ### Bind the DogStatsD port to a host port
 
-Add a `hostPort` to your `datadog-agent.yaml` file:
+1. Add a `hostPort` to your `datadog-agent.yaml` manifest:
 
-```yaml
-ports:
-  - containerPort: 8125
-    hostPort: 8125
-    name: dogstatsdport
-    protocol: UDP
-```
+      ```yaml
+      ports:
+        - containerPort: 8125
+          hostPort: 8125
+          name: dogstatsdport
+          protocol: UDP
+      ```
 
-This enables your applications to send metrics via DogStatsD on port `8125` on whichever node they happen to be running.
+    This enables your applications to send metrics via DogStatsD on port `8125` on whichever node they happen to be running.
 
-**Note**: `hostPort` functionality requires a networking provider that adheres to the [CNI specification][5], such as Calico, Canal, or Flannel. For more information, including a workaround for non-CNI network providers, consult the [Kubernetes documentation][6].
+    **Note**: `hostPort` functionality requires a networking provider that adheres to the [CNI specification][5], such as Calico, Canal, or Flannel. For more information, including a workaround for non-CNI network providers, consult the [Kubernetes documentation][6].
 
-To apply the change:
+2. Enable DogStatsD non local traffic to allow StatsD data collection, set `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` to `true` in your `datadog-agent.yaml` manifest:
 
-```bash
-kubectl apply -f datadog-agent.yaml
-```
+        - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
+          value: "true"
 
-**Warning**: The `hostPort` parameter opens a port on your host. Make sure your firewall only allows access from your applications or trusted sources.  Another word of caution: some network plugins don't support `hostPorts` yet, so this won't work. 
+    This allows collecting StatsD data from other containers than the one running the Agent.
+
+3. Apply the change:
+
+      ```
+      kubectl apply -f datadog-agent.yaml
+      ```
+
+**Warning**: The `hostPort` parameter opens a port on your host. Make sure your firewall only allows access from your applications or trusted sources.  Another word of caution: some network plugins don't support `hostPorts` yet, so this won't work.
 The workaround in this case is to add `hostNetwork: true` in your Agent pod specifications. This shares the network namespace of your host with the Datadog Agent. It also means that all ports opened on the container are also opened on the host. If a port is used both on the host and in your container, they conflict (since they share the same network namespace) and the pod will not start. Not all Kubernetes installations allow this.
 
 ### Pass the node's IP address to your application
@@ -106,7 +113,7 @@ Origin detection allows DogStatsD to detect where the container metrics come fro
 
 **Note**: An alternative to UDP is [Unix Domain Sockets][8].
 
-To enable origin detection over UDP, add the following lines to your application manifest: 
+To enable origin detection over UDP, add the following lines to your application manifest:
 
 ```yaml
 env:
@@ -127,13 +134,13 @@ Origin detection is supported in Agent 6.10.0+ and in the following client libra
 | [C#][13]     | 3.3.0   |
 | [Java][14]   | 2.6     |
 
-To set [tag cardinality][15] for the metrics collected using origin detection, use the environment variable `DD_DOGSTATSD_TAG_CARDINALITY`. 
+To set [tag cardinality][15] for the metrics collected using origin detection, use the environment variable `DD_DOGSTATSD_TAG_CARDINALITY`.
 
 There are two environment variables that set tag cardinality: `DD_CHECKS_TAG_CARDINALITY` and `DD_DOGSTATSD_TAG_CARDINALITY`—as DogStatsD is priced differently, its tag cardinality setting is separated in order to provide the opportunity for finer configuration. Otherwise, these variables function the same way: they can have values `low`, `orchestrator`, or `high`. They both default to `low`.
 
 ## Instrument your code to send metrics to DogStatsD
 
-Once your application can send metrics via DogStatsD on each node, you can instrument your application code to submit custom metrics. 
+Once your application can send metrics via DogStatsD on each node, you can instrument your application code to submit custom metrics.
 
 **[See the full list of Datadog DogStatsD Client Libraries][16]**
 


### PR DESCRIPTION
### What does this PR do?
Adds infos about `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` variable since it wasn't the case before. 

### Motivation
We got a fair amount of support ticket that could have been solved with a better documentation of this env variable.

### Preview link

* https://docs-staging.datadoghq.com/gus/dogstatsd-non-local-traffic/agent/kubernetes/daemonset_setup/?tab=k8sfile#create-manifest
* https://docs-staging.datadoghq.com/gus/dogstatsd-non-local-traffic/agent/kubernetes/dogstatsd/#bind-the-dogstatsd-port-to-a-host-port