### PR TITLE
Adding Algolia index config update script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -109,6 +109,7 @@ index_algolia:
   stage: post-deploy
   environment: "live"
   script:
+    - chmod +x ./local/bin/py/algolia_index.py && ./local/bin/py/algolia_index.py -d "['js', 'images', 'fonts', 'en', 'css', 'search', 'json', 'error', 'matts quick tips', 'videos']" -l "['fr','ja']" -c "./local/etc/docsdatadoghq.json"
     - cp ./local/etc/docsdatadoghq.json /etc/
     - index_docsearch_algolia
   only:

--- a/local/bin/py/algolia_index.py
+++ b/local/bin/py/algolia_index.py
@@ -43,7 +43,7 @@ def update_algolia_private_url(docs_index_config,private_urls):
         for url in private_urls:
             config["stop_urls"].append(url)
 
-    print("Addition complete, updating Algolia main configuration file.")
+    print("Addition complete, updating Algolia main configuration file with the new one: \n {} \n".format(config))
 
     with open(docs_index_config, 'w+', encoding='utf-8') as json_file:
         json.dump(config, json_file)

--- a/local/bin/py/algolia_index.py
+++ b/local/bin/py/algolia_index.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+from bs4 import BeautifulSoup
+from optparse import OptionParser
+
+def find_private_url(path, exclusions):
+
+    private_urls=[]
+
+    if not os.path.exists(path):
+        raise ValueError('Content folder path incorrect')
+    else:
+        for (dirpath, dirnames, filenames) in os.walk(path):
+            dirnames[:] = [d for d in dirnames if d not in exclusions]
+            filenames[:] = [f for f in filenames if f.endswith('.html')]
+            for filename in filenames:
+                with open(os.path.join(dirpath, filename), 'rt', encoding='utf-8') as current_file:
+                        html = BeautifulSoup(current_file, "html.parser")
+
+                        if html.find_all('meta', {'name': 'robots', 'content': 'noindex, nofollow'}):
+                            print('skipping private: %s' % dirpath)
+                            private_urls.append(dirpath)
+
+    return private_urls
+
+def transform_url(private_urls):
+    new_private_urls = []
+
+    for url in private_urls:
+        new_private_urls.append(url.replace('public/','docs.datadoghq.com/'))
+
+    return new_private_urls
+
+def update_algolia_private_url(docs_index_config,private_urls):
+
+    with open(docs_index_config, 'rt', encoding='utf-8') as json_file:
+        print("Configuration file {} correctly loaded.".format(docs_index_config))
+        config = json.load(json_file)
+
+        print("Adding list of private URLs.")
+        for url in private_urls:
+            config["stop_urls"].append(url)
+
+    print("Addition complete, updating Algolia main configuration file.")
+
+    with open(docs_index_config, 'w+', encoding='utf-8') as json_file:
+        json.dump(config, json_file)
+
+if __name__ == "__main__":
+    parser = OptionParser(usage="usage: %prog [options] create placeholder pages for multi-language")
+    parser.add_option("-c", "--config_location", help="location of the doc search config")
+    parser.add_option("-d", "--excluded_directory", help="directories to skip from detecting private")
+    parser.add_option("-l", "--excluded_language", help="languages to skip from detecting private")
+
+    (options, args) = parser.parse_args()
+    options = vars(options)
+
+    print("Detecting the list of URL to not index:\n")
+    private_urls = find_private_url('public/', options["excluded_directory"] + options["excluded_language"])
+
+    print("Transforming links to make them match the algolia logic:\n")
+    private_urls=transform_url(private_urls)
+
+    print("List of URLs to not index with Algolia:\n {} \n".format(private_urls))
+
+    print("Updating Algolia docsearch configuration file:\n")
+    update_algolia_private_url(options["config_location"],private_urls)
+
+    print("Algolia docsearch config update \o/")

--- a/local/etc/docsdatadoghq.json
+++ b/local/etc/docsdatadoghq.json
@@ -1,262 +1,262 @@
 {
-  "index_name": "docsearch_docs_prod",
-  "start_urls": [
-    {
-      "url": "https://docs.datadoghq.com/api/",
-      "selectors_key": "api",
-      "tags": [
-        "api"
-      ],
-      "page_rank": 0
-    },
-    {
-      "url": "https://docs.datadoghq.com/fr/api/",
-      "selectors_key": "api",
-      "tags": [
-        "api"
-      ],
-      "page_rank": 0
-    },
-    {
-      "url": "https://docs.datadoghq.com/integrations/",
-      "selectors_key": "integrations",
-      "tags": [
-        "integrations"
-      ],
-      "page_rank": 90
-    },
-    {
-      "url": "https://docs.datadoghq.com/fr/integrations/",
-      "selectors_key": "integrations",
-      "tags": [
-        "integrations"
-      ],
-      "page_rank": 90
-    },
-    {
-      "url": "https://docs.datadoghq.com/",
-      "selectors_key": "docs",
-      "tags": [
-        "docs"
-      ],
-      "page_rank": 100
-    },
-    {
-      "url": "https://docs.datadoghq.com/(?P<section>.*?)/faq/",
-      "selectors_key": "faq",
-      "variables": {
-        "section": [
-          "agent",
-          "graphing",
-          "monitors",
-          "tracing",
-          "logs",
-          "developers",
-          "account_management",
-          "synthetics"
-        ]
-      },
-      "tags": [
-        "faq"
-      ],
-      "page_rank": -100
-    },
-    {
-      "url": "https://docs.datadoghq.com/fr/(?P<section>.*?)/faq/",
-      "selectors_key": "faq",
-      "variables": {
-        "section": [
-          "agent",
-          "graphing",
-          "monitors",
-          "tracing",
-          "logs",
-          "developers",
-          "account_management",
-          "synthetics"
-        ]
-      },
-      "tags": [
-        "faq"
-      ],
-      "page_rank": -100
-    },
-    {
-      "url": "https://docs.datadoghq.com/(?P<section>.*?)/guide/",
-      "selectors_key": "guide",
-      "variables": {
-        "section": [
-          "agent",
-          "graphing",
-          "monitors",
-          "tracing",
-          "logs",
-          "developers"
-        ]
-      },
-      "tags": [
-        "guide"
-      ],
-      "page_rank": 10
-    },
-    {
-      "url": "https://docs.datadoghq.com/fr/(?P<section>.*?)/guide/",
-      "selectors_key": "guide",
-      "variables": {
-        "section": [
-          "agent",
-          "graphing",
-          "monitors",
-          "tracing",
-          "logs",
-          "developers"
-        ]
-      },
-      "tags": [
-        "guide"
-      ],
-      "page_rank": 10
-    }
-  ],
-  "stop_urls": [
-    "docs.datadoghq.com/search/",
-    "docs.datadoghq.com/fr/search/",
-    "docs.datadoghq.com/videos/",
-    "docs.datadoghq.com/integrations/$",
-    "/faq/$",
-    "/guide/$",
-    "\\?",
-    "/api/.+",
-    "\\.json$"
-  ],
-  "sitemap_urls": [
-    "https://docs.datadoghq.com/en/sitemap.xml"
-  ],
-  "selectors": {
-    "docs": {
-      "lvl0": {
-        "selector": ".h-100 .sidenav-nav > ul >li.open > a",
-        "global": true,
-        "default_value": "Documentation"
-      },
-      "lvl1": ".main h1",
-      "lvl2": ".main h2",
-      "lvl3": ".main h3",
-      "lvl4": ".main h4",
-      "text": ".main p, .main ul > li, table tbody tr, code-tabs table tbody tr td",
-      "language": {
-        "selector": "/html/@lang",
-        "type": "xpath",
-        "global": true
-      }
-    },
-    "integrations": {
-      "lvl0": {
-        "selector": ".h-100 .sidenav-nav > ul >li.open > a",
-        "global": true,
-        "default_value": "Integrations"
-      },
-      "lvl1": ".main h1",
-      "lvl2": ".main h2",
-      "lvl3": ".main h3",
-      "lvl4": ".main h4",
-      "text": ".main p, .main ul > li, table tbody tr, .table-metrics tr",
-      "language": {
-        "selector": "/html/@lang",
-        "type": "xpath",
-        "global": true
-      }
-    },
-    "faq": {
-      "lvl0": {
-        "selector": ".h-100 .sidenav-nav > ul >li.open > a",
-        "global": true,
-        "default_value": "FAQ"
-      },
-      "lvl1": ".main h1",
-      "lvl2": ".main h2",
-      "text": ".main p, table tbody tr td, code-tabs table tbody tr td",
-      "language": {
-        "selector": "/html/@lang",
-        "type": "xpath",
-        "global": true
-      }
-    },
-    "guide": {
-      "lvl0": {
-        "selector": ".h-100 .sidenav-nav > ul >li.open > a",
-        "global": true,
-        "default_value": "Guide"
-      },
-      "lvl1": ".main h1",
-      "lvl2": ".main h2",
-      "lvl3": ".main h3",
-      "lvl4": ".main h4",
-      "text": ".main p, .main ul > li, table tbody tr td, code-tabs table tbody tr td",
-      "language": {
-        "selector": "/html/@lang",
-        "type": "xpath",
-        "global": true
-      }
-    },
-    "api": {
-      "lvl0": {
-        "selector": ".h-100 .sidenav-nav > ul > li > a.toc_open",
-        "global": true,
-        "default_value": "API"
-      },
-      "lvl1": ".main-api h2",
-      "text": ".main-api p, h5[id*='rate-limit'] + ul > li",
-      "language": {
-        "selector": "/html/@lang",
-        "type": "xpath",
-        "global": true
-      }
-    }
-  },
-  "keep_tags": [
-    "code"
-  ],
-  "selectors_exclude": [
-    ".whatsnext",
-    "#en-apprendre-plus",
-    "#further-reading",
-    ".alert-info",
-    ".announcement_banner"
-  ],
-  "conversation_id": [
-    "620036890"
-  ],
-  "custom_settings": {
-    "separatorsToIndex": "_@.",
-    "attributeForDistinct": "url_without_anchor",
-    "attributesForFaceting": [
-      "language",
-      "tags"
-    ],
-    "optionalWords": [
-      "the"
-    ],
-    "synonyms": [
-      [
-        "agent",
-        "datadog agent"
-      ],
-      [
-        "microsoft azure",
-        "azure"
-      ],
-      [
-        "gcp",
-        "google cloud platform"
-      ],
-      [
-        "aws",
-        "amazon web service"
-      ]
-    ]
-  },
-  "only_content_level": true,
-  "user_agent": "Googlebot",
-  "nb_hits": 55397
+	"index_name": "docsearch_docs_prod",
+	"start_urls": [
+		{
+			"url": "https://docs.datadoghq.com/api/",
+			"selectors_key": "api",
+			"tags": [
+				"api"
+			],
+			"page_rank": 0
+		},
+		{
+			"url": "https://docs.datadoghq.com/fr/api/",
+			"selectors_key": "api",
+			"tags": [
+				"api"
+			],
+			"page_rank": 0
+		},
+		{
+			"url": "https://docs.datadoghq.com/integrations/",
+			"selectors_key": "integrations",
+			"tags": [
+				"integrations"
+			],
+			"page_rank": 90
+		},
+		{
+			"url": "https://docs.datadoghq.com/fr/integrations/",
+			"selectors_key": "integrations",
+			"tags": [
+				"integrations"
+			],
+			"page_rank": 90
+		},
+		{
+			"url": "https://docs.datadoghq.com/",
+			"selectors_key": "docs",
+			"tags": [
+				"docs"
+			],
+			"page_rank": 100
+		},
+		{
+			"url": "https://docs.datadoghq.com/(?P<section>.*?)/faq/",
+			"selectors_key": "faq",
+			"variables": {
+				"section": [
+					"agent",
+					"graphing",
+					"monitors",
+					"tracing",
+					"logs",
+					"developers",
+					"account_management",
+					"synthetics"
+				]
+			},
+			"tags": [
+				"faq"
+			],
+			"page_rank": -100
+		},
+		{
+			"url": "https://docs.datadoghq.com/fr/(?P<section>.*?)/faq/",
+			"selectors_key": "faq",
+			"variables": {
+				"section": [
+					"agent",
+					"graphing",
+					"monitors",
+					"tracing",
+					"logs",
+					"developers",
+					"account_management",
+					"synthetics"
+				]
+			},
+			"tags": [
+				"faq"
+			],
+			"page_rank": -100
+		},
+		{
+			"url": "https://docs.datadoghq.com/(?P<section>.*?)/guide/",
+			"selectors_key": "guide",
+			"variables": {
+				"section": [
+					"agent",
+					"graphing",
+					"monitors",
+					"tracing",
+					"logs",
+					"developers"
+				]
+			},
+			"tags": [
+				"guide"
+			],
+			"page_rank": 10
+		},
+		{
+			"url": "https://docs.datadoghq.com/fr/(?P<section>.*?)/guide/",
+			"selectors_key": "guide",
+			"variables": {
+				"section": [
+					"agent",
+					"graphing",
+					"monitors",
+					"tracing",
+					"logs",
+					"developers"
+				]
+			},
+			"tags": [
+				"guide"
+			],
+			"page_rank": 10
+		}
+	],
+	"stop_urls": [
+		"docs.datadoghq.com/search/",
+		"docs.datadoghq.com/fr/search/",
+		"docs.datadoghq.com/videos/",
+		"docs.datadoghq.com/integrations/$",
+		"/faq/$",
+		"/guide/$",
+		"\\?",
+		"/api/.+",
+		"\\.json$"
+	],
+	"sitemap_urls": [
+		"https://docs.datadoghq.com/en/sitemap.xml"
+	],
+	"selectors": {
+		"docs": {
+			"lvl0": {
+				"selector": ".h-100 .sidenav-nav > ul >li.open > a",
+				"global": true,
+				"default_value": "Documentation"
+			},
+			"lvl1": ".main h1",
+			"lvl2": ".main h2",
+			"lvl3": ".main h3",
+			"lvl4": ".main h4",
+			"text": ".main p, .main ul > li, table tbody tr, code-tabs table tbody tr td",
+			"language": {
+				"selector": "/html/@lang",
+				"type": "xpath",
+				"global": true
+			}
+		},
+		"integrations": {
+			"lvl0": {
+				"selector": ".h-100 .sidenav-nav > ul >li.open > a",
+				"global": true,
+				"default_value": "Integrations"
+			},
+			"lvl1": ".main h1",
+			"lvl2": ".main h2",
+			"lvl3": ".main h3",
+			"lvl4": ".main h4",
+			"text": ".main p, .main ul > li, table tbody tr, .table-metrics tr",
+			"language": {
+				"selector": "/html/@lang",
+				"type": "xpath",
+				"global": true
+			}
+		},
+		"faq": {
+			"lvl0": {
+				"selector": ".h-100 .sidenav-nav > ul >li.open > a",
+				"global": true,
+				"default_value": "FAQ"
+			},
+			"lvl1": ".main h1",
+			"lvl2": ".main h2",
+			"text": ".main p, table tbody tr td, code-tabs table tbody tr td",
+			"language": {
+				"selector": "/html/@lang",
+				"type": "xpath",
+				"global": true
+			}
+		},
+		"guide": {
+			"lvl0": {
+				"selector": ".h-100 .sidenav-nav > ul >li.open > a",
+				"global": true,
+				"default_value": "Guide"
+			},
+			"lvl1": ".main h1",
+			"lvl2": ".main h2",
+			"lvl3": ".main h3",
+			"lvl4": ".main h4",
+			"text": ".main p, .main ul > li, table tbody tr td, code-tabs table tbody tr td",
+			"language": {
+				"selector": "/html/@lang",
+				"type": "xpath",
+				"global": true
+			}
+		},
+		"api": {
+			"lvl0": {
+				"selector": ".h-100 .sidenav-nav > ul > li > a.toc_open",
+				"global": true,
+				"default_value": "API"
+			},
+			"lvl1": ".main-api h2",
+			"text": ".main-api p, h5[id*='rate-limit'] + ul > li",
+			"language": {
+				"selector": "/html/@lang",
+				"type": "xpath",
+				"global": true
+			}
+		}
+	},
+	"keep_tags": [
+		"code"
+	],
+	"selectors_exclude": [
+		".whatsnext",
+		"#en-apprendre-plus",
+		"#further-reading",
+		".alert-info",
+		".announcement_banner"
+	],
+	"conversation_id": [
+		"620036890"
+	],
+	"custom_settings": {
+		"separatorsToIndex": "_@.",
+		"attributeForDistinct": "url_without_anchor",
+		"attributesForFaceting": [
+			"language",
+			"tags"
+		],
+		"optionalWords": [
+			"the"
+		],
+		"synonyms": [
+			[
+				"agent",
+				"datadog agent"
+			],
+			[
+				"microsoft azure",
+				"azure"
+			],
+			[
+				"gcp",
+				"google cloud platform"
+			],
+			[
+				"aws",
+				"amazon web service"
+			]
+		]
+	},
+	"only_content_level": true,
+	"user_agent": "Googlebot",
+	"nb_hits": 55397
 }


### PR DESCRIPTION
### What does this PR do?
Fixes issues with Algolia Search.

It creates a pre-script that looks across all public files that checks if a page is flagged as "noindex, nofollow" 

If so, then the url is stored to be finnaly added to the `stop_urls` list of our Algolia index config file.

### Motivation

* Documentation search was indexing files not index by goole. 
* Improve doc search

### Preview link
No preview are available.