### PR TITLE
update docsearch config in different job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,6 +90,12 @@ build_live:
     - create_artifact
     - create_artifact_untracked
     - chmod +x ./local/bin/py/missing_metrics.py && ./local/bin/py/missing_metrics.py -k $(get_secret 'dd-demo-api-key') -p $(get_secret 'dd-demo-app-key') -a $(get_secret 'dd_api_key') -b $(get_secret 'dd-app-key')
+    - chmod +x ./local/bin/py/algolia_index.py && ./local/bin/py/algolia_index.py -d "['js', 'images', 'fonts', 'en', 'css', 'search', 'json', 'error', 'matts quick tips', 'videos']" -l "['fr','ja']" -c "./local/etc/docsdatadoghq.json"
+  artifacts:
+    when: on_success
+    paths:
+      - local/etc/docsdatadoghq.json
+    expire_in: 1 week
   only:
     - master
 
@@ -109,9 +115,10 @@ index_algolia:
   stage: post-deploy
   environment: "live"
   script:
-    - chmod +x ./local/bin/py/algolia_index.py && ./local/bin/py/algolia_index.py -d "['js', 'images', 'fonts', 'en', 'css', 'search', 'json', 'error', 'matts quick tips', 'videos']" -l "['fr','ja']" -c "./local/etc/docsdatadoghq.json"
     - cp ./local/etc/docsdatadoghq.json /etc/
     - index_docsearch_algolia
+  dependencies:
+    - build_live
   only:
     - schedules
 


### PR DESCRIPTION
### What does this PR do?

Fixes issues with running algolia_index

The `public` files don't exist to search through in the algolia job. So this changes the work to be run in the build job and pass along the updated json file to the algolia job

### Motivation
issues running the updated index algolia

### Preview link
N/A

### Additional Notes

