### PR TITLE
Making all link terminal

### DIFF
--- a/local/bin/py/algolia_index.py
+++ b/local/bin/py/algolia_index.py
@@ -29,7 +29,7 @@ def transform_url(private_urls):
     new_private_urls = []
 
     for url in private_urls:
-        new_private_urls.append(url.replace('public/','docs.datadoghq.com/'))
+        new_private_urls.append(url.replace('public/','docs.datadoghq.com/') + '/$')
 
     return new_private_urls
 


### PR DESCRIPTION
### What does this PR do?
Makes all link found by the private url script terminal because otherwise Algolia interprets them as regex.. hence no /faq/ link or /guide/ link are currently being indexed