### PR TITLE
[users-api] Update Users API docs to use plural endpoints instead of singular

### DIFF
--- a/content/en/api/users/code_snippets/api-user-create.sh
+++ b/content/en/api/users/code_snippets/api-user-create.sh
@@ -3,5 +3,5 @@ app_key=<YOUR_APP_KEY>
 
 curl -X POST -H "Content-type: application/json" \
     -d '{"handle":"test@datadoghq.com","name":"test user", "access_role":"st"}' \
-    "https://api.datadoghq.com/api/v1/user?api_key=${api_key}&application_key=${app_key}"
+    "https://api.datadoghq.com/api/v1/users?api_key=${api_key}&application_key=${app_key}"
 

--- a/content/en/api/users/code_snippets/api-user-disable.sh
+++ b/content/en/api/users/code_snippets/api-user-disable.sh
@@ -2,5 +2,5 @@ api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 user_id=test@datadoghq.com
 
-curl -X DELETE "https://api.datadoghq.com/api/v1/user/${user_id}?api_key=${api_key}&application_key=${app_key}"
+curl -X DELETE "https://api.datadoghq.com/api/v1/users/${user_id}?api_key=${api_key}&application_key=${app_key}"
 

--- a/content/en/api/users/code_snippets/api-user-get-all.sh
+++ b/content/en/api/users/code_snippets/api-user-get-all.sh
@@ -1,5 +1,5 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -X GET "https://api.datadoghq.com/api/v1/user?api_key=${api_key}&application_key=${app_key}"
+curl -X GET "https://api.datadoghq.com/api/v1/users?api_key=${api_key}&application_key=${app_key}"
 

--- a/content/en/api/users/code_snippets/api-user-get.sh
+++ b/content/en/api/users/code_snippets/api-user-get.sh
@@ -2,5 +2,5 @@ api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 user_id=test@datadoghq.com
 
-curl -X GET "https://api.datadoghq.com/api/v1/user/${user_id}?api_key=${api_key}&application_key=${app_key}"
+curl -X GET "https://api.datadoghq.com/api/v1/users/${user_id}?api_key=${api_key}&application_key=${app_key}"
 

--- a/content/en/api/users/code_snippets/api-user-update.sh
+++ b/content/en/api/users/code_snippets/api-user-update.sh
@@ -4,5 +4,5 @@ user_id=test@datadoghq.com
 
 curl -X PUT -H "Content-type: application/json" \
     -d '{"email":"test+1@datadoghq.com","name":"alt user", "access_role":"ro"}' \
-    "https://api.datadoghq.com/api/v1/user/${user_id}?api_key=${api_key}&application_key=${app_key}"
+    "https://api.datadoghq.com/api/v1/users/${user_id}?api_key=${api_key}&application_key=${app_key}"
 

--- a/content/en/api/users/users_create_code.md
+++ b/content/en/api/users/users_create_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#create-user
 ---
 
 ##### Signature
-`POST /v1/user`
+`POST /v1/users`
 ##### Example Request
 {{< code-snippets basename="api-user-create" >}}
 ##### Example Response

--- a/content/en/api/users/users_delete_code.md
+++ b/content/en/api/users/users_delete_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#disable-user
 ---
 
 ##### Signature
-`DELETE /v1/user/<USER_ID>`
+`DELETE /v1/users/<USER_ID>`
 ##### Example Request
 {{< code-snippets basename="api-user-disable" >}}
 ##### Example Response

--- a/content/en/api/users/users_get_code.md
+++ b/content/en/api/users/users_get_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#get-user
 ---
 
 ##### Signature
-`GET /v1/user/<USER_ID>`
+`GET /v1/users/<USER_ID>`
 ##### Example Request
 {{< code-snippets basename="api-user-get" >}}
 ##### Example Response

--- a/content/en/api/users/users_getall_code.md
+++ b/content/en/api/users/users_getall_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#get-all-users
 ---
 
 ##### Signature
-`GET /v1/user`
+`GET /v1/users`
 ##### Example Request
 {{< code-snippets basename="api-user-get-all" >}}
 ##### Example Response

--- a/content/en/api/users/users_update_code.md
+++ b/content/en/api/users/users_update_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#update-user
 
 
 ##### Signature
-`PUT /v1/user/<USER_ID>`
+`PUT /v1/users/<USER_ID>`
 ##### Example Request
 {{< code-snippets basename="api-user-update" >}}
 ##### Example Response


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This change encourages users to use the new plural Users endpoints by changing code snippets and descriptions to use the new users instead of singular User

### Motivation
<!-- What inspired you to submit this pull request?-->
The end goal is to eventually move users to the plural endpoints completely, and deprecate the old endpoints.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nathan/plural-users-documentation

### Additional Notes
<!-- Anything else we should know when reviewing?-->
