### PR TITLE
Simplify PHP span metadata examples. Cleanup trace search PHP docs

### DIFF
--- a/content/en/tracing/advanced/adding_metadata_to_spans.md
+++ b/content/en/tracing/advanced/adding_metadata_to_spans.md
@@ -210,23 +210,7 @@ scope.Span.SetTag("<TAG_KEY>", "<TAG_VALUE>");
 {{% tab "PHP" %}}
 
 
-Add metadata directly to a `DDTrace\Span` object by calling `Span::setTag()`.
-
-```php
-dd_trace('<FUNCTION_NAME>', function () {
-    $scope = \DDTrace\GlobalTracer::get()
-      ->startActiveSpan('<FUNCTION_NAME>');
-    $span = $scope->getSpan();
-    $span->setTag('<TAG_KEY>', '<TAG_VALUE>');
-
-    $result = <FUNCTION_NAME>();
-
-    $scope->close();
-    return $result;
-});
-```
-
-Access the current active span from any method within your code:
+Add metadata directly to a `DDTrace\Span` object by calling `Span::setTag()`. For example:
 
 ```php
 // Get the currently active span (can be null)
@@ -313,7 +297,6 @@ const tracer = require('dd-trace').init({
 })
 ```
 
-
 {{% /tab %}}
 {{% tab ".NET" %}}
 
@@ -329,6 +312,7 @@ section for details on how environment variables should be set.
 ```ini
 DD_TRACE_GLOBAL_TAGS=key1:value1,key2:value2
 ```
+
 
 [1]: /tracing/setup/php/#configuration
 {{% /tab %}}

--- a/content/en/tracing/advanced/adding_metadata_to_spans.md
+++ b/content/en/tracing/advanced/adding_metadata_to_spans.md
@@ -297,6 +297,7 @@ const tracer = require('dd-trace').init({
 })
 ```
 
+
 {{% /tab %}}
 {{% tab ".NET" %}}
 
@@ -312,7 +313,6 @@ section for details on how environment variables should be set.
 ```ini
 DD_TRACE_GLOBAL_TAGS=key1:value1,key2:value2
 ```
-
 
 [1]: /tracing/setup/php/#configuration
 {{% /tab %}}

--- a/content/en/tracing/advanced/manual_instrumentation.md
+++ b/content/en/tracing/advanced/manual_instrumentation.md
@@ -300,8 +300,8 @@ dd_trace("CustomDriver", "doWork", function (...$args) {
     $span->setTag(Tags\RESOURCE_NAME, $this->workToDo);
 
     try {
-        // Execute the original method
-        $result = $this->doWork(...$args);
+        // Execute the original method. Note: dd_trace_forward_call() - will handle any parameters automatically
+        $result = dd_trace_forward_call();
         // Set a tag based on the return value
         $span->setTag('doWork.size', count($result));
         return $result;

--- a/content/en/tracing/advanced/manual_instrumentation.md
+++ b/content/en/tracing/advanced/manual_instrumentation.md
@@ -300,7 +300,7 @@ dd_trace("CustomDriver", "doWork", function (...$args) {
     $span->setTag(Tags\RESOURCE_NAME, $this->workToDo);
 
     try {
-        // Execute the original method. Note: dd_trace_forward_call() - will handle any parameters automatically
+        // Execute the original method. Note: dd_trace_forward_call() - handles any parameters automatically
         $result = dd_trace_forward_call();
         // Set a tag based on the return value
         $span->setTag('doWork.size', count($result));

--- a/content/en/tracing/trace_search_and_analytics/_index.md
+++ b/content/en/tracing/trace_search_and_analytics/_index.md
@@ -253,13 +253,11 @@ Integration names can be found on the [integrations table][1].
 
 In addition to setting globally, you can enable or disable Trace Search & Analytics for individual integrations using the following setting:
 
-* System Property: `-Ddd.<INTEGRATION>.analytics.enabled=true`
 * Environment Variable: `DD_<INTEGRATION>_ANALYTICS_ENABLED=true`
 
-Use this in addition to the global configuration for any integrations that submit custom services. For example, for JMS spans which comes in as a custom service, you can set the following to enable all JMS Tracing in Trace Search & Analytics:
+Use this in addition to the global configuration for any integrations that submit custom services. For example, for Symfony spans which comes in as a custom service, you can set the following to enable all Symfony Tracing in Trace Search & Analytics:
 
-* System Property: `-Ddd.jms.analytics.enabled=true`
-* Environment Variable: `DD_JMS_ANALYTICS_ENABLED=true`
+* Environment Variable: `DD_SYMFONY_ANALYTICS_ENABLED=true`
 
 Integration names can be found on the [integrations table][1].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

<!-- A brief description of the change being made with this pull request.-->

### Motivation
Current span metadata example, could be a bit confusing. And it was much more (unnecessarily?) extensive than similar examples for e.g. .NET.

PHP examples how to enable analytics contained Java specific examples :)
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
