### PR TITLE
Add paperplane to the Connect Logs and Traces guide

### DIFF
--- a/content/en/tracing/advanced/connect_logs_and_traces.md
+++ b/content/en/tracing/advanced/connect_logs_and_traces.md
@@ -115,7 +115,7 @@ const tracer = require('dd-trace').init({
 })
 ```
 
-This enables automatic trace ID injection for `winston`, `bunyan`, and `pino`.
+This enables automatic trace ID injection for `bunyan`, `paperplane`, `pino`, and `winston`.
 
 **Note**: Automatic injection only works for logs formatted as JSON.
 

--- a/content/fr/tracing/advanced/connect_logs_and_traces.md
+++ b/content/fr/tracing/advanced/connect_logs_and_traces.md
@@ -75,7 +75,7 @@ end
 
 **Injection automatique d'ID de trace pour les applications Rails par défaut**
 
-Les applications Rails qui sont configurées avec un enregistreur `ActiveSupport::TaggedLogging` peuvent ajouter des ID de trace en tant que tags à la sortie du log. L'enregistreur Rails par défaut applique cette journalisation avec des tags, ce qui simplifie l'ajout de tags de trace. 
+Les applications Rails qui sont configurées avec un enregistreur `ActiveSupport::TaggedLogging` peuvent ajouter des ID de trace en tant que tags à la sortie du log. L'enregistreur Rails par défaut applique cette journalisation avec des tags, ce qui simplifie l'ajout de tags de trace.
 
 Dans le fichier de configuration de votre environnement Rails (p. ex., `config/environments/production.rb`), ajoutez le code suivant :
 
@@ -114,7 +114,7 @@ const tracer = require('dd-trace').init({
 })
 ```
 
-Cela active l'injection automatique d'ID de trace pour `winston`, `bunyan` et `pino`.
+Cela active l'injection automatique d'ID de trace pour `bunyan`, `paperplane`, `pino`, et `winston`.
 
 **Remarque** : l'injection automatique fonctionne uniquement pour les logs au format JSON.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR adds `paperplane` to the list of supported `node.js` loggers in the `Connect Logs and Traces` guide.

### Motivation
<!-- What inspired you to submit this pull request?-->
I missed this spot when I made this PR:  https://github.com/DataDog/documentation/pull/5093

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. -->

Since this PR is from a fork, I guess this is best way to preview:

https://github.com/articulate/documentation/blob/connect-logs-guide-add-paperplane/content/en/tracing/advanced/connect_logs_and_traces.md

https://github.com/articulate/documentation/blob/connect-logs-guide-add-paperplane/content/fr/tracing/advanced/connect_logs_and_traces.md

### Additional Notes
<!-- Anything else we should know when reviewing?-->
