### PR TITLE
Updating max number of resources

### DIFF
--- a/content/en/synthetics/apm/browser_tests.md
+++ b/content/en/synthetics/apm/browser_tests.md
@@ -35,7 +35,7 @@ A resource corresponds to the combination of requests and assets. The Resources 
 | % Total Time | The resource duration over the total interaction time           |
 | Size         | The size of the request response                                |
 
-The maximum number of resources that can be displayed is 15. Typically, the resources with the longest duration (slowest to load) are displayed first.
+The maximum number of resources that can be displayed is 50. Typically, the resources with the longest duration (slowest to load) are displayed first.
 
 #### Filter and Search
 Resources can be filtered by resource type. Also, a search can be performed over the displayed URLs.


### PR DESCRIPTION
### What does this PR do?

This PR modifies the maximum number of resources on the context panel that opens on the right when looking for a browser test step resources. I'm changing it from 15 to 50.

### Motivation

Discussion with @m-rousse 

### Preview link

https://docs-staging.datadoghq.com/margot.lepizzera/browser_test_resources/synthetics/apm/browser_tests/#resources