### PR TITLE
we can't use hugo params in js

### DIFF
--- a/src/js/datadog-docs.js
+++ b/src/js/datadog-docs.js
@@ -39,14 +39,14 @@ $(document).ready(function () {
     $('.ds-hint').css('background', 'transparent');
     if (window.location.href.indexOf('/search/') > -1) {
 
-        var client = algoliasearch("{{ $.Site.Params.algolia.appId }}", '{{ $.Site.Params.algolia.apiKey }}');
+        var client = algoliasearch("EOIG7V0A2O", 'c7ec32b3838892b10610af30d06a4e42');
         var results = new RegExp('[\?&]' + "s" + '=([^&#]*)').exec(window.location.href);
         var $pagination = $('#tipue_search_content');
         var query = "";
         try {query = results[1];} catch (e) {}
 
         // get indexname by language
-        var indexName = "{{ $.Site.Params.algolia.indexName }}";
+        var indexName = "docsearch_docs_prod";
 
         var lang = 'en';
         if(window.location.pathname.indexOf("/fr/") > -1) {


### PR DESCRIPTION
### What does this PR do?

Fixes a bug with the detailed search page where we are using hugo params in a js file.

### Motivation

Issue reported

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/david.jones/algolia-search-bug/search/?s=docker

### Additional Notes

