### PR TITLE
fixing toc not reaching bottom of page

### DIFF
--- a/layouts/partials/table-of-contents/table-of-contents.scss
+++ b/layouts/partials/table-of-contents/table-of-contents.scss
@@ -33,10 +33,10 @@ body > header.scrolled ~ .container .mobile-toc-toggle {
     position:absolute;
     max-width: 266px;
     background: rgba(248, 248, 248, 0.8);
-    height: 94%;
+    height: 100%;
     right: 0px;
     z-index: 3;
-    
+
     // for left aligned ToC layout for large screens
     @media (min-width: 1720px){
       max-width: none !important;


### PR DESCRIPTION
### What does this PR do?

Makes toc reach bottom of the page to fix this behaviour.


![Open Tracing Section](https://cl.ly/776f4ebdc485/[d48af2a4f88b5f90989b891083a6062f]_Image%25202019-07-25%2520at%252010.46.31%2520AM.png)

### Preview link

* https://docs-staging.datadoghq.com/gus/fix-toc/tracing/setup/ruby/#opentracing