### PR TITLE
[doc] Fix annotations in Kubernetes Pod  section in Apache HTTP

### DIFF
--- a/content/en/agent/autodiscovery/integrations.md
+++ b/content/en/agent/autodiscovery/integrations.md
@@ -380,7 +380,7 @@ kind: Pod
 metadata:
   name: apache
   annotations:
-    ad.datadoghq.com/apache.check_names: ["apache","http_check"]
+    ad.datadoghq.com/apache.check_names: '["apache","http_check"]'
     ad.datadoghq.com/apache.init_configs: [{},{}]
     ad.datadoghq.com/apache.instances: |
       [


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
adding single quote in  `["apache","http_check"]` to `'["apache","http_check"]'` 

`ad.datadoghq.com/apache.check_names: ["apache","http_check"]`  is
given as array need to be wrapped in single quote. Otherwise k8s will reject the values as it expects annotations to be  strings.

### Motivation
<!-- What inspired you to submit this pull request?-->

https://datadog.zendesk.com/agent/tickets/244279

### Preview link
<!-- Impacted pages preview links-->

https://docs.datadoghq.com/agent/autodiscovery/integrations/?tab=kubernetespodannotations#datadog-apache-and-http-check-integrations

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 




### Additional Notes
<!-- Anything else we should know when reviewing?-->
