### PR TITLE
network performance monitoring iterations, apm name change

### DIFF
--- a/content/en/graphing/infrastructure/network_performance_monitor.md
+++ b/content/en/graphing/infrastructure/network_performance_monitor.md
@@ -45,18 +45,19 @@ To enable network performance monitoring with the Datadog Agent, use these confi
 3. Optionally uncomment the `@param system_probe_config` to add a custom object:
 `## @param system_probe_config - custom object - optional`
 4. Enter specific configurations for your System Probe data collection:
-```
-system_probe_config:
+  ```
+  system_probe_config:
 
-  ## @param enabled - boolean - optional - default: false
-  ## Set to true to enable the System Probe.
-  #
-  enabled: true
-```
+    ## @param enabled - boolean - optional - default: false
+    ## Set to true to enable the System Probe.
+    #
+    enabled: true
+  ```
 5. Start the system-probe:
 `sudo service datadog-agent-sysprobe start`
 6. Restart the main datadog-agent:
 `sudo service datadog-agent restart `
+
 **Note**: This command works for Linux, for a full list of Agent commands, see the [full list of Agent commands][1].
 
 

--- a/content/en/graphing/infrastructure/network_performance_monitor.md
+++ b/content/en/graphing/infrastructure/network_performance_monitor.md
@@ -38,38 +38,29 @@ Network performance monitoring requires Datadog Agent v6.12+. To enable network 
 
 To enable network performance monitoring with the Datadog Agent, use these configurations:
 
+1. Copy the system-probe example configuration:
+`sudo -u dd-agent cp /etc/datadog-agent/system-probe.yaml.example /etc/datadog-agent/system-probe.yaml`
+2. Modify the system-probe configuration file to set the enable flag to `true`:
+`sudo -u dd-agent vim /etc/datadog-agent/system-probe.yaml`
+3. Optionally uncomment the `@param system_probe_config` to add a custom object:
+`## @param system_probe_config - custom object - optional`
+4. Enter specific configurations for your System Probe data collection:
 ```
-# Copy the system-probe example configuration
-$ sudo -u dd-agent cp /etc/datadog-agent/system-probe.yaml.example /etc/datadog-agent/system-probe.yaml
-
-# Modify the system-probe configuration file to set the enable flag to true
-$ sudo -u dd-agent vim /etc/datadog-agent/system-probe.yaml
-
-
-##################################
-## System Probe Configuration ##
-##################################
-
-## @param system_probe_config - custom object - optional
-## Beta Agent
-## Enter specific configurations for your System Probe data collection.
-## Uncomment this parameter and the one below to enable them.
-#
-# system_probe_config:
+system_probe_config:
 
   ## @param enabled - boolean - optional - default: false
   ## Set to true to enable the System Probe.
   #
   enabled: true
-
-
-# Start the system-probe
-$ sudo service datadog-agent-sysprobe start
-
-# Restart the main datadog-agent
-$ sudo service datadog-agent-sysprobe restart
 ```
+5. Start the system-probe:
+`sudo service datadog-agent-sysprobe start`
+6. Restart the main datadog-agent:
+`sudo service datadog-agent restart `
+**Note**: This command works for Linux, for a full list of Agent commands, see the [full list of Agent commands][1].
 
+
+[1]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 

--- a/content/en/graphing/infrastructure/network_performance_monitor.md
+++ b/content/en/graphing/infrastructure/network_performance_monitor.md
@@ -38,20 +38,25 @@ Network performance monitoring requires Datadog Agent v6.12+. To enable network 
 
 To enable network performance monitoring with the Datadog Agent, use these configurations:
 
-1. Copy the system-probe example configuration:
+1. Copy the system-probe example configuration:<br>
 `sudo -u dd-agent cp /etc/datadog-agent/system-probe.yaml.example /etc/datadog-agent/system-probe.yaml`
-2. Modify the system-probe configuration file to set the enable flag to `true`:
+2. Modify the system-probe configuration file to set the enable flag to `true`:<br>
 `sudo -u dd-agent vim /etc/datadog-agent/system-probe.yaml`
-3. Optionally uncomment the `@param system_probe_config` to add a custom object:
-`## @param system_probe_config - custom object - optional`
+3. Optionally uncomment the `system_probe_config` parameter to add a custom object:
+  ```
+  ## @param system_probe_config - custom object - optional
+  ## (...)
+  #
+  system_probe_config:
+  ```
+
 4. Enter specific configurations for your System Probe data collection:
   ```
   system_probe_config:
-
-    ## @param enabled - boolean - optional - default: false
-    ## Set to true to enable the System Probe.
-    #
-    enabled: true
+      ## @param enabled - boolean - optional - default: false
+      ## Set to true to enable the System Probe.
+      #
+      enabled: true
   ```
 5. Start the system-probe:
 `sudo service datadog-agent-sysprobe start`
@@ -59,7 +64,6 @@ To enable network performance monitoring with the Datadog Agent, use these confi
 `sudo service datadog-agent restart `
 
 **Note**: This command works for Linux, for a full list of Agent commands, see the [full list of Agent commands][1].
-
 
 [1]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
 {{% /tab %}}

--- a/content/en/tracing/visualization/resource.md
+++ b/content/en/tracing/visualization/resource.md
@@ -59,7 +59,7 @@ Use the top right selector of this graph to zoom on a given percentile of latenc
 
 Zoom on this graph to filter corresponding traces.
 
-## Span Statistics
+## Span Summary
 
 For a given resource, Datadog provides you a span analysis breakdown of all matching traces:
 


### PR DESCRIPTION
### What does this PR do?
Iterates the network performance monitoring Agent example and changes a name in APM docs to match the UI.

### Preview link

- [network performance monitoring Agent example](https://docs-staging.datadoghq.com/kaylyn/apm-small-updates/graphing/infrastructure/network_performance_monitor/?tab=agent#installation)
- [span summary](https://docs-staging.datadoghq.com/kaylyn/apm-small-updates/tracing/visualization/resource/#span-statistics)


