### PR TITLE
[Agent Configuration Files] Fixing folder name and wording

### DIFF
--- a/content/en/agent/guide/agent-configuration-files.md
+++ b/content/en/agent/guide/agent-configuration-files.md
@@ -52,7 +52,7 @@ Note: [A full example of the `datadog.yaml` file is available in the `datadog-ag
 
 ## Agent configuration directory
 
-Prior releases of Datadog Agent stored configuration files in `/dd-agent/conf.d/`. Starting with the 6.0 release, configuration files are stored in `/etc/datadog-agent/conf.d/<CHECK_NAME>`.
+Prior releases of Datadog Agent stored configuration files in `/dd-agent/conf.d/`. Starting with the 6.0 release, configuration files are stored in `/etc/datadog-agent/conf.d/<CHECK_NAME>.d/`.
 
 {{< tabs >}}
 {{% tab "Agent v6" %}}
@@ -74,13 +74,7 @@ Prior releases of Datadog Agent stored configuration files in `/dd-agent/conf.d/
 
 ### Checks configuration files for Agent 6
 
-In order to provide a more flexible way to define the configuration for a check, from version 6.0.0, the Agent loads any valid YAML file contained in the folder:
-
-`/etc/datadog-agent/conf.d/<CHECK_NAME>.d/`.
-
-Note: For log collection, to prevent duplicate logs from being sent to Datadog, the Agent does not accept multiple YAML files that point to the same log source. In the case where there is more than one YAML file that points to the same log source, the Agent considers the files in alphabetical order and uses the first file.
-
-This way, complex configurations can be broken down into multiple files. For example, a configuration for the `http_check` might look like this:
+An example for each Agent check configuration files can be found in the `conf.yaml.example` file in the corresponding `<CHECK_NAME>.d/` folder. Rename this file to `conf.yaml` in order to enable the associated check. Note that the Agent loads any valid YAML file contained in the folder: `/etc/datadog-agent/conf.d/<CHECK_NAME>.d/`. This way, complex configurations can be broken down into multiple files. For example, a configuration for the `http_check` might look like this:
 
 ```
 /etc/datadog-agent/conf.d/http_check.d/
@@ -88,13 +82,15 @@ This way, complex configurations can be broken down into multiple files. For exa
 └── frontend.yaml
 ```
 
-Autodiscovery template files are stored in the configuration folder as well. For example, consider `redisdb`:
+Autodiscovery template files are stored in the configuration folder as well as a `auto_conf.yaml` file. For example, consider the Redis check, its configuration in `redisdb.d/` are:
 
 ```
 /etc/datadog-agent/conf.d/redisdb.d/
 ├── auto_conf.yaml
 └── conf.yaml.example
 ```
+
+**Note**: For log collection, to prevent duplicate logs from being sent to Datadog, the Agent does not accept multiple YAML files that point to the same log source. In the case where there is more than one YAML file that points to the same log source, the Agent considers the files in alphabetical order and uses the first file.
 
 To preserve backwards compatibility, the Agent still picks up configuration files in the form `/etc/datadog-agent/conf.d/<check_name>.yaml`, but migrating to the new layout is strongly recommended.
 

--- a/content/en/agent/guide/agent-configuration-files.md
+++ b/content/en/agent/guide/agent-configuration-files.md
@@ -82,7 +82,7 @@ An example for each Agent check configuration files can be found in the `conf.ya
 └── frontend.yaml
 ```
 
-Autodiscovery template files are stored in the configuration folder as well as a `auto_conf.yaml` file. For example, consider the Redis check, its configuration in `redisdb.d/` are:
+Autodiscovery template files are stored in the configuration folder with the `auto_conf.yaml` file. For example, for the Redis check, here is the configuration in `redisdb.d/`:
 
 ```
 /etc/datadog-agent/conf.d/redisdb.d/
@@ -90,7 +90,7 @@ Autodiscovery template files are stored in the configuration folder as well as a
 └── conf.yaml.example
 ```
 
-**Note**: For log collection, to prevent duplicate logs from being sent to Datadog, the Agent does not accept multiple YAML files that point to the same log source. In the case where there is more than one YAML file that points to the same log source, the Agent considers the files in alphabetical order and uses the first file.
+**Note**: For log collection, the Agent does not accept multiple YAML files that point to the same log source to prevent duplicate logs from being sent to Datadog. In the case where there is more than one YAML file that points to the same log source, the Agent considers the files in alphabetical order and uses the first file.
 
 To preserve backwards compatibility, the Agent still picks up configuration files in the form `/etc/datadog-agent/conf.d/<check_name>.yaml`, but migrating to the new layout is strongly recommended.
 


### PR DESCRIPTION
### What does this PR do?
Fixes the Agent configuration file name and wording.

### Motivation
Hotjar feedbak.

### Preview link

* https://docs-staging.datadoghq.com/gus/glitch-fix/agent/guide/agent-configuration-files/?tab=agentv6#checks-configuration-files-for-agent-6