### PR TITLE
Add an alias to rehydration log page

### DIFF
--- a/content/en/logs/archives/rehydrating.md
+++ b/content/en/logs/archives/rehydrating.md
@@ -2,6 +2,8 @@
 title: Rehydrating from Archives
 kind: Documentation
 description: "Capture log events from your archives back into Datadog."
+aliases:
+  - /logs/historical-views
 ---
 
 <div class="alert alert-warning">


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
add a redirect: hottest fix for bad link in app, but it's not harmful to keep this redirect on long-term.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/estib/fixroute_logrehydration/logs/historical-views/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
