### PR TITLE
add python3 migration guide

### DIFF
--- a/content/en/agent/guide/_index.md
+++ b/content/en/agent/guide/_index.md
@@ -14,6 +14,7 @@ disable_toc: true
     {{< nextlink href="agent/guide/secrets-management" >}}Secrets Management{{< /nextlink >}}
     {{< nextlink href="agent/guide/community-integrations-installation-with-docker-agent" >}}Community integration installation{{< /nextlink >}}
     {{< nextlink href="agent/guide/datadog-agent-manager-windows" >}}Datadog Agent Manager for Windows{{< /nextlink >}}
+    {{< nextlink href="agent/guide/python-3" >}}Python 2 to 3 Custom Check Migration{{< /nextlink >}}
 {{< /whatsnext >}}
 <br>
 {{< whatsnext desc="Agent 5 Guides:" >}}

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -5,7 +5,7 @@ kind: guide
 
 ## Overview
 
-This guide is meant to provide information about the changes between Python 2 and 3, as well as tips and best practices on how to convert checks to support Python 3.
+This guide provides information and best practices on migrating checks between Python 2 and 3.
 
 To provide flexibility in allowing code to run multiple on versions of the Agent, this guide focuses on retaining backwards compatibility.
 

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -97,7 +97,7 @@ In Python 3, the `dict.iterkeys()`, `dict.iteritems()` and `dict.itervalues()` m
 | `for key, value in mydict.iteritems():`<br/> &nbsp;&nbsp;`  ...` | `from six import iteritems` <br/><br/> `for key, value in iteritems(mydict):`<br/> &nbsp;&nbsp;`  ...`|
 | `for value in mydict.itervalues():`<br/> &nbsp;&nbsp;`  ...` | `from six import itervalues` <br/><br/> `for value in itervalues(mydict):`<br/> &nbsp;&nbsp;`  ...` |
 
-Also, in Python 3, the `dict.keys()`, `dict.items()`, `dict.values()` methods return iterators. To retrieve a dictionary’s keys/items/values as a list:
+Also, in Python 3, the `dict.keys()`, `dict.items()`, `dict.values()` methods return iterators. Therefore, if the dictionary needs to be modified during iteration, it's necessary to make a copy first. To retrieve a dictionary’s keys/items/values as a list:
 
 | Python 2 | Python 2 and 3 |
 | --- | --- |

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -86,7 +86,7 @@ from datadog_checks.base.checks import AgentCheck
 
 ### Six
 
-[Six][5] is a Python 2/3 compatibility library intended to allow developers to ship ubiquitous Python code. Some of the examples below make use of six to make legacy Python 2 code compatible with Python 3.
+[Six][5] is a Python 2/3 compatibility library intended to allow developers to ship Python code that works in both Python 2 and Python3. Some of the examples below make use of six to make legacy Python 2 code compatible with Python 3.
 
 ### Dictionary methods
 

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -42,7 +42,7 @@ File ~/dev/my-check.py:
   Line 850, column 25: division w/o __future__ statement
 ```
 
-After addressing the incompatibilities, the same command would show:
+After addressing the incompatibilities, the same command returns:
 
 ```bash
 $ ddev validate py3 ~/dev/my-check.py  

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -1,0 +1,271 @@
+---
+title: Python 3 Custom Check Migration
+kind: guide
+---
+
+## Overview
+
+This guide is meant to provide information about the changes between Python 2 and 3, as well as tips and best practices on how to convert checks to support Python 3.
+
+To provide flexibility in allowing code to run multiple on versions of the Agent, this guide focuses on retaining backwards compatibility.
+
+## Editors and Tools
+
+### ddev
+
+The Datadog developer package, also known as ddev, contains functions that can help you verify that your custom checks are compatible with Python 3. 
+
+#### Installation
+
+```bash
+$ pip install "datadog-checks-dev[cli]"
+```
+
+#### Usage
+
+Run the `validate` command to verify that a custom check or integration will run on Python 3. CHECK must be a valid path to a Python module or package folder:
+
+```bash
+$ ddev validate py3 [OPTIONS] CHECK
+```
+
+For example:
+
+```bash
+$ ddev validate py3 ~/dev/my-check.py  
+Validating python3 compatibility of ~/dev/my-check.py...
+Incompatibilities were found for ~/dev/my-check.py:
+File ~/dev/my-check.py:
+  Line 2, column 0: print statement used
+  Line 834, column 21: division w/o __future__ statement
+  Line 850, column 25: division w/o __future__ statement
+```
+
+After addressing the incompatibilities, the same command would show:
+
+```bash
+$ ddev validate py3 ~/dev/my-check.py  
+Validating python3 compatibility of ~/dev/my-check.py…
+~/dev/foo.py is compatible with python3
+```
+
+While ddev catches any issue that could prevent the Python 3 interpreter from running code at all, it cannot check for logical validity. After code changes are made, make sure to run the check and validate the output.
+
+For more details about ddev, refer to the [ddev documentation][1].
+
+### 2to3
+
+[2to3][2] is a tool that converts Python 2 code to Python 3 code. If you have a custom check that is named `foo.py`, run 2to3:
+
+```bash
+$ 2to3 foo.py
+```
+
+This prints a diff against the original source file. For more details about 2to3, refer to the official [2to3 documentation][2].
+
+### Editors
+
+Most modern IDEs and editors provide advanced linting automatically. Make sure that they are pointed to a Python 3 executable, so that when you open a legacy Python 2–only file, any syntax/import/etc. errors or warnings show up on the side as a colorful tick in [PyCharm][3] or as a clickable box on the bottom in [Visual Studio Code][4].
+
+## Python Migration
+
+### Package Imports
+
+In an effort to standardize Datadog package namespacing, all resources now live under the base subpackage. So for example,
+
+```python
+from datadog_checks.checks import AgentCheck
+```
+
+would become
+
+```python
+from datadog_checks.base.checks import AgentCheck
+```
+
+### Six
+
+[Six][5] is a Python 2/3 compatibility library intended to allow developers to ship ubiquitous Python code. Some of the examples below make use of six to make legacy Python 2 code compatible with Python 3.
+
+### Dictionary methods
+
+In Python 3, the `dict.iter[keys|items|values]` methods are not available.
+
+| Python 2 | Python 2 and 3 |
+| --- | --- |
+| `for key in mydict.iterkeys():` <br/> &nbsp;&nbsp;`  ...` | `for key in mydict:`<br/> &nbsp;&nbsp;`  ...` |
+| `for key, value in mydict.iteritems():`<br/> &nbsp;&nbsp;`  ...` | `from six import iteritems` <br/><br/> `for key, value in iteritems(mydict):`<br/> &nbsp;&nbsp;`  ...`|
+| `for value in mydict.itervalues():`<br/> &nbsp;&nbsp;`  ...` | `from six import itervalues` <br/><br/> `for value in itervalues(mydict):`<br/> &nbsp;&nbsp;`  ...` |
+
+Also, in Python 3, the `dict.[keys|items|values]` methods are iterators. To retrieve a dictionary’s keys/items/values as a list:
+
+| Python 2 | Python 2 and 3 |
+| --- | --- |
+| `mykeylist = mydict.keys()` | `mykeylist = list(mydict)` |
+| `myitemlist = list(mydict.items())` | `// The Python 2 syntax works in Python 3, but if the dictionary needs to be modified during iteration, it's necessary to make a copy first.` <br/><br/> `from six import iteritems` <br/><br/> `myitemlist = list(iteritems(mydict))` |
+| `myvaluelist = mydict.values()` | `from six import itervalues`<br/><br/> `myvaluelist = list(itervalues(mydict))` |
+
+The `dict.has_key()` method is deprecated in Python 2 and is removed in Python 3. Use the `in` operator instead.
+
+| Python 2 | Python 2 and 3 |
+| --- | --- |
+| `mydict.has_key('foo') //deprecated` | `foo in mydict` |
+
+### Standard Library Changes
+
+Python 3 features a reorganized standard library, where a number of modules and functions were renamed or moved. Importing moved modules through `six.moves` works on both Python versions.
+
+| Python 2 | Python 3 | Python 2 and 3 |
+| --- | --- | --- |
+| `import HTMLParser` | `import html.parser` | `from six.moves import html_parser` |
+
+Consult the [six documentation][6] for the list of renamed modules. Note that the `urllib`, `urllib2`, and `urlparse` modules have been heavily reorganized.
+
+### Unicode
+
+Python 2 treats unicode text and binary-encoded data in the same manner, and tries to automatically convert between bytes and strings as needed. This works as long as all characters are ASCII, but leads to unexpected behavior when non-ASCII characters are encountered.
+
+| type | literal | Python 2 | Python 3 |
+| --- | --- | --- | --- |
+| bytes | b'...' | binary | binary |
+| str | '...' | binary | text |
+| unicode | u'...' | text | text |
+
+For string literals, it might be better to always use Unicode explicitly in Python 2, so they will work exactly the same when running in Python 3:
+
+```python
+s = u'This string will be the same in Python 2 and 3'
+```
+
+Text data are Unicode code points; you must encode with `.encode(encoding)` for storage or transmission. Binary data are encoded code points represented as a sequence of bytes that must be decoded with `.decode(encoding)` back to text. When reading text from a file, the `open` function from the `io` package is handy because the data read is already decoded into Unicode:
+
+```python
+from io import open
+
+f = open('textfile.txt', encoding='utf-8')
+contents = f.read()  ;; contents will be decoded to unicode using ‘utf-8’; these are not bytes!
+```
+
+Consult Ned Batchelder’s [Pragmatic Unicode][7] for further details.
+
+### Print
+
+In Python 3, print is explicitly treated as a function; to turn print into a function regardless of the Python version, put `from __future__ import print_function` at the top of any file using the old print statement and add parentheses to perform the function call.
+
+| Python 2 | Python 2 and 3 |
+| --- | --- |
+| `print "foo"` | `from __future__ import print_function` <br/><br/> `print("foo")` |
+
+
+### Integer Division
+
+In Python 2, the `/` operator performs floor division on integers.
+
+#### Python 2:
+
+```
+>> 5/2
+2
+```
+
+In Python 3, the `/` operator performs float division. The `//` operator performs floor division.
+
+#### Python 3:
+
+```
+>> 5/2
+2.5
+>> 5//2
+2
+```
+
+To replicate the same behavior of Python 3 regardless of the Python version, put `from __future__ import division` at the top of any file that uses division and use `//` for flooring division results.
+
+### Rounding
+
+In Python 2 the standard library round method uses the Round Half Up Strategy while Python 3 uses the Round To Even strategy. 
+ 
+#### Python 2:
+
+```
+>> round(2.5)
+3
+>> round(3.5)
+4
+```
+
+#### Python 3:
+
+```
+>> round(2.5)
+2
+>> round(3.5)
+5
+```
+ 
+Datadog provides a utility function, `round_value`, in `datadog_checks_base` to allow the replication of the Python 2 behavior in both Python 2 and 3. 
+
+### Exceptions
+
+Python 3 features different syntax for except and raise.
+
+| Python 2 | Python 2 and 3 |
+| --- | --- |
+| `try:` <br/> &nbsp;&nbsp; `...` <br/> `except Exception, variable:` <br/> &nbsp;&nbsp; `...` | `try:` <br/> &nbsp;&nbsp; `...` <br/> `except Exception as variable:` <br/> &nbsp;&nbsp; `...` |
+| `raise Exception, args` | `raise Exception(args)` |
+
+
+### Relative Imports
+
+In Python 3, relative imports must be made explicit, using the dot (`.`) syntax.
+
+Suppose your package is structured like this:
+
+```
+mypackage/
+	__init__.py
+	math.py
+	foo.py
+```
+
+Suppose also that `math.py` contains a function called `gcd`—which contains subtleties distinct from the standard library `math` module’s `gcd` function—and you want to use the `gcd` function from your local package, not the one from the standard library.
+
+In Python 2, if you are inside a package, this package’s own modules take precedence before global modules. Using `from math import gcd` imports the `gcd` from `mypackage/math.py`. 
+
+In Python 3, import forms not starting with `.` are interpreted as absolute imports. Using `from math import gcd` imports the `gcd` from the standard library.
+
+| Python 2 | Python 2 and 3 |
+| --- | --- |
+| `from math import gcd` | `from .math import gcd` |
+
+Or, for extra readability:
+
+| Python 2 | Python 2 and 3 |
+| --- | --- |
+| `from math import gcd` | `from mypackage.math import gcd` |
+
+
+### Iterators
+
+Several functions in Python 2 that return lists now return iterators in Python 3. These include `map`, `filter`, and `zip`. 
+
+The simplest fix to retain Python 2 behavior is to wrap these functions with a call to `list`:
+
+| Python 2 | Python 2 and 3 |
+| --- | --- |
+| `map(myfunction, myiterable)`| `list(map(myfunction, myiterable))` |
+| `filter(myfunction, myiterable)` | `list(filter(myfunction, myiterable))` |
+| `zip(myiterable1, myiterable2)` | `list(zip(myiterable1, myiterable2))` |
+
+The `xrange` function is removed in Python 3; instead, the `range` function returns an iterable `range` object. Import `range` with `from six.moves import range`.
+
+Use the built-in `next` function instead of calling the `next` method. For instance, rewrite `iterator.next()` as `next(iterator)`.
+
+
+[1]: https://datadog-checks-base.readthedocs.io/en/latest/datadog_checks_dev.cli.html
+[2]: https://docs.python.org/3.1/library/2to3.html
+[3]: https://www.jetbrains.com/help/pycharm/install-and-set-up-pycharm.html
+[4]: https://code.visualstudio.com/docs/setup/setup-overview
+[5]: https://pythonhosted.org/six/#
+[6]: https://pythonhosted.org/six/#module-six.moves
+[7]: https://nedbatchelder.com/text/unipain.html

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -62,7 +62,7 @@ For more details about ddev, refer to the [ddev documentation][1].
 $ 2to3 foo.py
 ```
 
-This prints a diff against the original source file. For more details about 2to3, refer to the official [2to3 documentation][2].
+Running 2to3 prints a diff against the original source file. For more details about 2to3, refer to the official [2to3 documentation][2].
 
 ### Editors
 

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -131,12 +131,6 @@ Python 2 treats unicode text and binary-encoded data in the same manner, and tri
 | str | '...' | binary | text |
 | unicode | u'...' | text | text |
 
-For string literals, it might be better to always use Unicode explicitly in Python 2, so they will work exactly the same when running in Python 3:
-
-```python
-s = u'This string will be the same in Python 2 and 3'
-```
-
 Text data are Unicode code points; you must encode with `.encode(encoding)` for storage or transmission. Binary data are encoded code points represented as a sequence of bytes that must be decoded with `.decode(encoding)` back to text. When reading text from a file, the `open` function from the `io` package is handy because the data read is already decoded into Unicode:
 
 ```python

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -132,7 +132,7 @@ Python 2 treats unicode text and binary-encoded data in the same manner, and tri
 | str | '...' | binary | text |
 | unicode | u'...' | text | text |
 
-Text data are Unicode code points; you must encode with `.encode(encoding)` for storage or transmission. Binary data are encoded code points represented as a sequence of bytes that must be decoded with `.decode(encoding)` back to text. When reading text from a file, the `open` function from the `io` package is handy because the data read is already decoded into Unicode:
+Text data is Unicode code points; you must encode with `.encode(encoding)` for storage or transmission. Binary data is encoded code points represented as a sequence of bytes that must be decoded with `.decode(encoding)` back to text. When reading text from a file, the `open` function from the `io` package is handy because the data read is already decoded into Unicode:
 
 ```python
 from io import open

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -97,7 +97,7 @@ In Python 3, the `dict.iterkeys()`, `dict.iteritems()` and `dict.itervalues()` m
 | `for key, value in mydict.iteritems():`<br/> &nbsp;&nbsp;`  ...` | `from six import iteritems` <br/><br/> `for key, value in iteritems(mydict):`<br/> &nbsp;&nbsp;`  ...`|
 | `for value in mydict.itervalues():`<br/> &nbsp;&nbsp;`  ...` | `from six import itervalues` <br/><br/> `for value in itervalues(mydict):`<br/> &nbsp;&nbsp;`  ...` |
 
-Also, in Python 3, the `dict.keys()`, `dict.items()`, `dict.values()` methods are [view objects](https://docs.python.org/3/library/stdtypes.html#dictionary-view-objects). To retrieve a dictionary’s keys/items/values as a list:
+Also, in Python 3, the `dict.keys()`, `dict.items()`, `dict.values()` methods return iterators. To retrieve a dictionary’s keys/items/values as a list:
 
 | Python 2 | Python 2 and 3 |
 | --- | --- |

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -13,7 +13,7 @@ To provide flexibility in allowing code to run multiple on versions of the Agent
 
 ### ddev
 
-The Datadog developer package, also known as ddev, contains functions that can help you verify that your custom checks are compatible with Python 3. 
+The Datadog developer package,`ddev`, contains functions to help you [verify that your custom checks are compatible with Python 3][8]. 
 
 #### Installation
 
@@ -264,3 +264,4 @@ Use the built-in `next` function instead of calling the `next` method. For insta
 [5]: https://pythonhosted.org/six/#
 [6]: https://pythonhosted.org/six/#module-six.moves
 [7]: https://nedbatchelder.com/text/unipain.html
+[8]: /developers/integrations/new_check_howto/#building

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -78,7 +78,7 @@ To standardize Datadog package namespacing, with Python3, all resources live und
 from datadog_checks.checks import AgentCheck
 ```
 
-would become
+becomes
 
 ```python
 from datadog_checks.base.checks import AgentCheck
@@ -98,7 +98,7 @@ In Python 3, the `dict.iterkeys()`, `dict.iteritems()` and `dict.itervalues()` m
 | `for key, value in mydict.iteritems():`<br/> &nbsp;&nbsp;`  ...` | `from six import iteritems` <br/><br/> `for key, value in iteritems(mydict):`<br/> &nbsp;&nbsp;`  ...`|
 | `for value in mydict.itervalues():`<br/> &nbsp;&nbsp;`  ...` | `from six import itervalues` <br/><br/> `for value in itervalues(mydict):`<br/> &nbsp;&nbsp;`  ...` |
 
-Also, in Python 3, the `dict.keys()`, `dict.items()`, `dict.values()` methods return iterators. Therefore, if the dictionary needs to be modified during iteration, it's necessary to make a copy first. To retrieve a dictionary’s keys/items/values as a list:
+Also, in Python 3, the `dict.keys()`, `dict.items()`, `dict.values()` methods return iterators. Therefore, if the dictionary needs to be modified during iteration, make a copy first. To retrieve a dictionary’s keys/items/values as a list:
 
 | Python 2 | Python 2 and 3 |
 | --- | --- |

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -17,6 +17,7 @@ The Datadog developer package, also known as ddev, contains functions that can h
 
 #### Installation
 
+Start by installing the developer toolkit:
 ```bash
 $ pip install "datadog-checks-dev[cli]"
 ```

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -97,7 +97,7 @@ In Python 3, the `dict.iterkeys()`, `dict.iteritems()` and `dict.itervalues()` m
 | `for key, value in mydict.iteritems():`<br/> &nbsp;&nbsp;`  ...` | `from six import iteritems` <br/><br/> `for key, value in iteritems(mydict):`<br/> &nbsp;&nbsp;`  ...`|
 | `for value in mydict.itervalues():`<br/> &nbsp;&nbsp;`  ...` | `from six import itervalues` <br/><br/> `for value in itervalues(mydict):`<br/> &nbsp;&nbsp;`  ...` |
 
-Also, in Python 3, the `dict.[keys|items|values]` methods are iterators. To retrieve a dictionary’s keys/items/values as a list:
+Also, in Python 3, the `dict.keys()`, `dict.items()`, `dict.values()` methods are [view objects](https://docs.python.org/3/library/stdtypes.html#dictionary-view-objects). To retrieve a dictionary’s keys/items/values as a list:
 
 | Python 2 | Python 2 and 3 |
 | --- | --- |

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -56,7 +56,7 @@ For more details about ddev, refer to the [ddev documentation][1].
 
 ### 2to3
 
-[2to3][2] is a tool that converts Python 2 code to Python 3 code. If you have a custom check that is named `foo.py`, run 2to3:
+[2to3][2] converts Python 2 code to Python 3 code. If you have a custom check that is named `foo.py`, run 2to3:
 
 ```bash
 $ 2to3 foo.py

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -50,7 +50,7 @@ Validating python3 compatibility of ~/dev/my-check.py…
 ~/dev/foo.py is compatible with python3
 ```
 
-While ddev catches any issue that could prevent the Python 3 interpreter from running code at all, it cannot check for logical validity. After code changes are made, make sure to run the check and validate the output.
+While `ddev` catches any issue that could prevent the Python 3 interpreter from running code at all, it cannot check for logical validity. After code changes are made, make sure to run the check and validate the output.
 
 For more details about ddev, refer to the [ddev documentation][1].
 

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -102,7 +102,7 @@ Also, in Python 3, the `dict.[keys|items|values]` methods are iterators. To retr
 | Python 2 | Python 2 and 3 |
 | --- | --- |
 | `mykeylist = mydict.keys()` | `mykeylist = list(mydict)` |
-| `myitemlist = list(mydict.items())` | `// The Python 2 syntax works in Python 3, but if the dictionary needs to be modified during iteration, it's necessary to make a copy first.` <br/><br/> `from six import iteritems` <br/><br/> `myitemlist = list(iteritems(mydict))` |
+| `myitemlist = mydict.items()` | `// The Python 2 syntax works in Python 3, but if the dictionary needs to be modified during iteration, it's necessary to make a copy first.` <br/><br/> `from six import iteritems` <br/><br/> `myitemlist = list(iteritems(mydict))` |
 | `myvaluelist = mydict.values()` | `from six import itervalues`<br/><br/> `myvaluelist = list(itervalues(mydict))` |
 
 The `dict.has_key()` method is deprecated in Python 2 and is removed in Python 3. Use the `in` operator instead.

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -124,7 +124,7 @@ Consult the [six documentation][6] for the list of renamed modules. Note that th
 
 ### Unicode
 
-Python 2 treats unicode text and binary-encoded data in the same manner, and tries to automatically convert between bytes and strings as needed. This works as long as all characters are ASCII, but leads to unexpected behavior when non-ASCII characters are encountered.
+Python 2 treats Unicode text and binary-encoded data the same, and tries to automatically convert between bytes and strings. This works as long as all characters are ASCII, but leads to unexpected behavior when it encounters non-ASCII characters.
 
 | type | literal | Python 2 | Python 3 |
 | --- | --- | --- | --- |

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -102,8 +102,8 @@ Also, in Python 3, the `dict.keys()`, `dict.items()`, `dict.values()` methods re
 | Python 2 | Python 2 and 3 |
 | --- | --- |
 | `mykeylist = mydict.keys()` | `mykeylist = list(mydict)` |
-| `myitemlist = mydict.items()` | `// The Python 2 syntax works in Python 3, but if the dictionary needs to be modified during iteration, it's necessary to make a copy first.` <br/><br/> `from six import iteritems` <br/><br/> `myitemlist = list(iteritems(mydict))` |
-| `myvaluelist = mydict.values()` | `from six import itervalues`<br/><br/> `myvaluelist = list(itervalues(mydict))` |
+| `myitemlist = mydict.items()` | `myitemlist = list(mydict.items())` |
+| `myvaluelist = mydict.values()` | `myvaluelist = list(mydict.values()` |
 
 The `dict.has_key()` method is deprecated in Python 2 and is removed in Python 3. Use the `in` operator instead.
 

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -66,7 +66,7 @@ This prints a diff against the original source file. For more details about 2to3
 
 ### Editors
 
-Most modern IDEs and editors provide advanced linting automatically. Make sure that they are pointed to a Python 3 executable, so that when you open a legacy Python 2–only file, any syntax/import/etc. errors or warnings show up on the side as a colorful tick in [PyCharm][3] or as a clickable box on the bottom in [Visual Studio Code][4].
+Most modern IDEs and editors provide advanced linting automatically. Make sure that they are pointed to a Python 3 executable, so that when you open a legacy Python 2–only file, any linting errors or warnings show up on the side as a colorful tick in [PyCharm][3] or as a clickable box on the bottom in [Visual Studio Code][4].
 
 ## Python Migration
 

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -24,7 +24,7 @@ $ pip install "datadog-checks-dev[cli]"
 
 #### Usage
 
-Run the `validate` command to verify that a custom check or integration will run on Python 3. CHECK must be a valid path to a Python module or package folder:
+Run the `validate` command to verify that your custom check or integration runs on Python 3. Replace `CHECK` with a valid path to a Python module or package folder:
 
 ```bash
 $ ddev validate py3 [OPTIONS] CHECK

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -89,7 +89,7 @@ from datadog_checks.base.checks import AgentCheck
 
 ### Dictionary methods
 
-In Python 3, the `dict.iter[keys|items|values]` methods are not available.
+In Python 3, the `dict.iterkeys()`, `dict.iteritems()` and `dict.itervalues()` methods are not available.
 
 | Python 2 | Python 2 and 3 |
 | --- | --- |

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -143,7 +143,7 @@ Text data are Unicode code points; you must encode with `.encode(encoding)` for 
 from io import open
 
 f = open('textfile.txt', encoding='utf-8')
-contents = f.read()  ;; contents will be decoded to unicode using ‘utf-8’; these are not bytes!
+contents = f.read()  # contents will be decoded to unicode using ‘utf-8’; these are not bytes!
 ```
 
 Consult Ned Batchelder’s [Pragmatic Unicode][7] for further details.

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -72,7 +72,7 @@ Most modern IDEs and editors provide advanced linting automatically. Make sure t
 
 ### Package Imports
 
-In an effort to standardize Datadog package namespacing, all resources now live under the base subpackage. So for example,
+To standardize Datadog package namespacing, with Python3, all resources live under the base subpackage. For example:
 
 ```python
 from datadog_checks.checks import AgentCheck


### PR DESCRIPTION
### What does this PR do?
Adds a guide on migrating custom checks from Python 2 to Python 3

### Motivation
PM request

### Preview link

https://docs-staging.datadoghq.com/cswatt/py3/agent/guide/python-3/


