### PR TITLE
add note to k8s manifest about resource requests

### DIFF
--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -106,6 +106,7 @@ spec:
                 fieldPath: status.hostIP
           - name: DD_APM_ENABLED
             value: "true"
+        ## Note these are the minimum suggested values for requests and limits. The amount of resources required by the Agent varies depending on the number of checks, integrations, and features enabled.
         resources:
           requests:
             memory: "256Mi"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a note to the example `datadog-agent.yaml` manifest calling out certain values that may need adjustment depending on usage.

### Motivation
support request, customers weren't realizing these values may need to be changed

### Preview link

https://docs-staging.datadoghq.com/cswatt/k8s-minvals/agent/kubernetes/daemonset_setup/?tab=k8sfile


