### PR TITLE
Autodiscovery ConfigMaps

### DIFF
--- a/content/en/agent/autodiscovery/integrations.md
+++ b/content/en/agent/autodiscovery/integrations.md
@@ -570,7 +570,7 @@ data:
         timeout: 1
 ```
 
-In the manifest, define the volumeMounts and volumes:
+In the manifest, define the `volumeMounts` and `volumes`:
 
 ```
 [...]

--- a/content/en/agent/autodiscovery/integrations.md
+++ b/content/en/agent/autodiscovery/integrations.md
@@ -176,7 +176,7 @@ See the [Autodiscovery Container Identifiers][1] documentation for information o
 {{% /tab %}}
 {{% tab "ConfigMap" %}}
 
-On Kubernetes, you can use [ConfigMaps][1]. Reference the template below and refer to the [Kubernetes Custom Integrations][2] documentation.
+On Kubernetes, you can use [ConfigMaps][1]. Reference the template below and the [Kubernetes Custom Integrations][2] documentation.
 
 ```
 kind: ConfigMap

--- a/content/en/agent/autodiscovery/integrations.md
+++ b/content/en/agent/autodiscovery/integrations.md
@@ -389,7 +389,7 @@ data:
       service: redis
 ```
 
-In the manifest, define the volumeMounts and volumes:
+In the manifest, define the `volumeMounts` and `volumes`:
 
 ```
 [...]


### PR DESCRIPTION
### What does this PR do?
- Add ConfigMap template and examples to the Autodiscovery page
- Rename tabs so they fit the width of the screen

### Motivation
- Trello request

### Preview link
https://docs-staging.datadoghq.com/ruth/config-map/agent/autodiscovery/integrations/?tab=configmap#configuration

### Additional Notes
Simon has reviewed this PR.
