### PR TITLE
make sure the search endpoint is language relative

### DIFF
--- a/layouts/partials/algolia.html
+++ b/layouts/partials/algolia.html
@@ -37,7 +37,7 @@ var search_desktop = docsearch({
 var desktop_enable_enter = true;
 search_desktop.autocomplete.on('keyup', function(e) {
    if(e.keyCode === 13 && desktop_enable_enter) {
-       window.location = '{{ .Site.BaseURL }}search/?s='+$(this).val();
+       window.location = '{{ absLangURL "search/" }}?s='+$(this).val();
    }
 });
 search_desktop.autocomplete.on('autocomplete:cursorchanged', function(e) {
@@ -64,7 +64,7 @@ var search_mobile = docsearch({
 var mobile_enable_enter = true;
 search_mobile.autocomplete.on('keyup', function(e) {
    if(e.keyCode === 13 && mobile_enable_enter) {
-       window.location = '{{ .Site.BaseURL }}search/?s='+$(this).val();
+       window.location = '{{ absLangURL "search/" }}?s='+$(this).val();
    }
 });
 search_mobile.autocomplete.on('autocomplete:cursorchanged', function(e) {


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue where entering a search word and hitting enter would always take you to the english `/?search` results even if you were on french or japanese.

### Motivation

A bug that was discovered when testing a release

### Preview link

https://docs-staging.datadoghq.com/david.jones/search-endpoint/fr/
- enter docker in the search box on the left and press enter
- note that it takes you to `/fr/?search=docker` instead of `/?search=docker`

### Additional Notes

