### PR TITLE
Update source in custom file log collection

### DIFF
--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -64,7 +64,7 @@ logs:
   - type: file
     path: <PATH_LOG_FILE>/<LOG_FILE_NAME>.log
     service: <APP_NAME>
-    source: custom
+    source: <SOURCE>
 ```
 
 **Note**: When tailing files for logs, the Datadog Agent v6 for **Windows** requires the log files have UTF8 encoding.


### PR DESCRIPTION
### What does this PR do?
Add a default placeholder for the source on custom file log collection

### Motivation
Users send logs with a `custom` source.

### Preview link
https://docs-staging.datadoghq.com/nils/log-custom-file/agent/logs/?tab=tailexistingfiles#custom-log-collection

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

### Additional Notes
<!-- Anything else we should know when reviewing?-->
