### PR TITLE
add a line to service check query secion in monitor api page

### DIFF
--- a/content/en/api/monitors/monitors_create.md
+++ b/content/en/api/monitors/monitors_create.md
@@ -59,7 +59,7 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
 
     *   **`check`** name of the check, e.g. datadog.agent.up
     *   **`tags`** one or more quoted tags (comma-separated), or "*". e.g.: `.over("env:prod", "role:db")`
-    *   **`count`** must be at >= your max threshold (defined in the `options`). e.g. if you want to notify on 1 critical, 3 ok and 2 warn statuses count should be 3.
+    *   **`count`** must be at >= your max threshold (defined in the `options`). e.g. if you want to notify on 1 critical, 3 ok and 2 warn statuses count should be 3. It is limited to 10.
 
     ##### Event Alert Query
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Add a line to `count` in service check query section on monitor api page. 
https://cl.ly/3c109651f676

### Motivation
<!-- What inspired you to submit this pull request?-->
Monitor-app is adding a upper limit value to this field on monitor api creation. 
related PR: https://github.com/DataDog/dogweb/pull/39302

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->

https://docs-staging.datadoghq.com/zhengshi/api_monitor_service_check/api/?lang=python#create-a-monitor

### Additional Notes
<!-- Anything else we should know when reviewing?-->
