### PR TITLE
Tweaking redirects

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -6,6 +6,7 @@ aliases:
   - /guides/
   - /faq/
   - /docs/
+  - /guides/overview/
 disable_toc: true
 ---
 

--- a/content/en/getting_started/_index.md
+++ b/content/en/getting_started/_index.md
@@ -3,7 +3,6 @@ title: Getting started
 kind: documentation
 aliases:
   - /overview
-  - /guides/overview/
   - /getting_started/faq/
 further_reading:
 - link: "https://learn.datadoghq.com/course/view.php?id=2"


### PR DESCRIPTION
### What does this PR do?
Updates so that https://docs.datadoghq.com/guides/overview/ redirects to https://docs.datadoghq.com/

For staging,
https://docs-staging.datadoghq.com/kaylyn/redirects/guides/overview/ should now go to https://docs-staging.datadoghq.com/kaylyn/redirects/

