### PR TITLE
adding troubleshooting section to secrets

### DIFF
--- a/content/en/agent/guide/secrets-management.md
+++ b/content/en/agent/guide/secrets-management.md
@@ -219,13 +219,180 @@ instances:
     password: decrypted_db_prod_password
 ```
 
-## Troubleshooting secrets
+## Troubleshooting
 
-The Agent's public repository contains additional guidance on [troubleshooting secrets management][2].
+### Listing detected secrets
+
+The `secret` command in the Agent CLI shows any errors related to your setup—for example, if the rights on the executable are incorrect. It also lists all handles found, as well as where they are located.
+
+On Linux, the command outputs file mode, owner and group for the executable. On Windows, ACL rights are listed.
+
+Example on Linux:
+
+```shell
+$> datadog-agent secret
+=== Checking executable rights ===
+Executable path: /path/to/you/executable
+Check Rights: OK, the executable has the correct rights
+
+Rights Detail:
+file mode: 100700
+Owner username: dd-agent
+Group name: dd-agent
+
+=== Secrets stats ===
+Number of secrets decrypted: 3
+Secrets handle decrypted:
+- api_key: from datadog.yaml
+- db_prod_user: from postgres.yaml
+- db_prod_password: from postgres.yaml
+```
+
+Example on Windows (from an Administrator Powershell):
+```powershell
+PS C:\> & 'C:\Program Files\Datadog\Datadog Agent\embedded\agent.exe' secret
+=== Checking executable rights ===
+Executable path: C:\path\to\you\executable.exe
+Check Rights: OK, the executable has the correct rights
+
+Rights Detail:
+Acl list:
+stdout:
+
+
+Path   : Microsoft.PowerShell.Core\FileSystem::C:\path\to\you\executable.exe
+Owner  : BUILTIN\Administrators
+Group  : WIN-ITODMBAT8RG\None
+Access : NT AUTHORITY\SYSTEM Allow  FullControl
+         BUILTIN\Administrators Allow  FullControl
+         WIN-ITODMBAT8RG\ddagentuser Allow  ReadAndExecute, Synchronize
+Audit  :
+Sddl   : O:BAG:S-1-5-21-2685101404-2783901971-939297808-513D:PAI(A;;FA;;;SY)(A;;FA;;;BA)(A;;0x1200
+         a9;;;S-1-5-21-2685101404-2783901971-939297808-1001)
+
+=== Secrets stats ===
+Number of secrets decrypted: 3
+Secrets handle decrypted:
+- api_key: from datadog.yaml
+- db_prod_user: from sqlserver.yaml
+- db_prod_password: from sqlserver.yaml
+```
+
+### Seeing configurations after secrets were injected
+
+To quickly see how the check's configurations are resolved, you can use the `configcheck` command :
+
+```shell
+sudo -u dd-agent -- datadog-agent configcheck
+
+=== a check ===
+Source: File Configuration Provider
+Instance 1:
+host: <decrypted_host>
+port: <decrypted_port>
+password: <decrypted_password>
+~
+===
+
+=== another check ===
+Source: File Configuration Provider
+Instance 1:
+host: <decrypted_host2>
+port: <decrypted_port2>
+password: <decrypted_password2>
+~
+===
+```
+
+**Note**:  The Agent needs to be restarted to pick up changes on configuration files.
+
+### Debugging your secret_backend_command
+
+To test or debug outside of the Agent, you can mimic how the Agent runs it:
+
+#### Linux
+
+```bash
+sudo su dd-agent - bash -c "echo '{\"version\": \"1.0\", \"secrets\": [\"secret1\", \"secret2\"]}'" | /path/to/the/secret_backend_command
+```
+
+The `dd-agent` user is created when you install the Datadog Agent.
+
+#### Windows
+
+##### Rights related errors
+
+If you encounter one of the following errors, then something is missing in your setup. See the [Windows intructions](#windows).
+
+1. If any other group or user than needed has rights on the executable, a similar error to the following is logged:
+   ```
+   error while decrypting secrets in an instance: Invalid executable 'C:\decrypt.exe': other users/groups than LOCAL_SYSTEM, Administrators or ddagentuser have rights on it
+   ```
+
+2. If `ddagentuser` doesn't have read and execute right on the file, a similar error logged:
+   ```
+   error while decrypting secrets in an instance: could not query ACLs for C:\decrypt.exe
+   ```
+
+3. Your executable needs to be a valid Win32 application. If not, the following error is logged:
+   ```
+   error while running 'C:\decrypt.py': fork/exec C:\decrypt.py: %1 is not a valid Win32 application.
+   ```
+
+##### Testing your executable
+
+Your executable is executed by the Agent when fetching your secrets. The Datadog Agent runs using the `ddagentuser`. This user has no specific rights, but it is part of the `Performance Monitor Users` group. The password for this user is randomly generated at install time and is never saved anywhere.
+
+This means that your executable might work with your default user or development user—but not when it's run by the Agent, since `ddagentuser` has more restricted rights.
+
+To test your executable in the same conditions as the Agent, update the password of the `ddagentuser` on your dev box. This way, you can authenticate as `ddagentuser` and run your executable in the same context the Agent would.
+
+To do so, follow those steps:
+
+1. Remove `ddagentuser` from the `Local Policies/User Rights Assignement/Deny Log on locally` list in the `Local Security Policy`.
+2. Set a new password for `ddagentuser` (since the one generated at install time is never saved anywhere). In Powershell, run:
+
+   ```powershell
+   $user = [ADSI]"WinNT://./ddagentuser";
+   $user.SetPassword("a_new_password")
+   ```
+
+3. Update the password to be used by `DatadogAgent` service in the Service Control Manager. In Powershell, run:
+
+   ```powershell
+   sc.exe config DatadogAgent password= "a_new_password"
+   ```
+
+You can now login as `ddagentuser` to test your executable. Datadog has a [Powershell script][2] to help you test your
+executable as another user. It switches user contexts and mimics how the Agent runs your executable.
+
+Example on how to use it:
+
+```powershell
+.\secrets_tester.ps1 -user ddagentuser -password a_new_password -executable C:\path\to\your\executable.exe -payload '{"version": "1.0", "secrets": ["secret_ID_1", "secret_ID_2"]}'
+Creating new Process with C:\path\to\your\executable.exe
+Waiting a second for the process to be up and running
+Writing the payload to Stdin
+Waiting a second so the process can fetch the secrets
+stdout:
+{"secret_ID_1":{"value":"secret1"},"secret_ID_2":{"value":"secret2"}}
+stderr: None
+exit code:
+0
+```
+
+### Agent refusing to start
+
+The first thing the Agent does on startup is to load `datadog.yaml` and decrypt any secrets in it. This is done before setting up the logging. This means that on platforms like Windows, errors occurring when loading `datadog.yaml` aren't written in the logs, but on `stderr`. This can occur when the executable given to the Agent for secrets returns an error.
+
+If you have secrets in `datadog.yaml` and the Agent refuses to start: 
+
+* Try to start the Agent manually to be able to see `stderr`.
+* Remove the secrets from `datadog.yaml` and test with secrets in a check configuration file first.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /agent/autodiscovery
-[2]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/secrets.md#troubleshooting
+[2]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/secrets_scripts/secrets_tester.ps1


### PR DESCRIPTION
### What does this PR do?
Integrates remaining content from https://github.com/DataDog/datadog-agent/blob/master/docs/agent/secrets.md to the Secrets Management guide

### Motivation
dev request

### Preview link

https://docs-staging.datadoghq.com/cswatt/secrets-troubleshooting/agent/guide/secrets-management

