### PR TITLE
add base64 encoding note to k8s daemonset page

### DIFF
--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -34,6 +34,13 @@ kubectl create -f "https://raw.githubusercontent.com/DataDog/datadog-agent/maste
 
 ## Create manifest
 Create the following `datadog-agent.yaml` manifest.
+
+Remember to encode your API key using `base64`:
+
+```
+echo -n <DD_API_KEY> | base64
+```
+
 **Note**: If you are using KMS or have high DogStatsD usage, you may need a higher memory limit.
 
 ```yaml


### PR DESCRIPTION
### What does this PR do?
Adds a quick note about base64 encoding. There's also a faq on this, but it doesn't provide a ton more information so I'm not linking to it here.

### Motivation
support request

### Preview link

https://docs-staging.datadoghq.com/cswatt/k8s-daemonset-base64-2/agent/kubernetes/daemonset_setup

