### PR TITLE
specify cpp 11+ for opentracing

### DIFF
--- a/content/en/tracing/setup/cpp.md
+++ b/content/en/tracing/setup/cpp.md
@@ -166,9 +166,11 @@ int main(int argc, char* argv[]) {
 Just link against `libopentracing`, making sure that `libopentracing.so` is in your `LD_LIBRARY_PATH`:
 
 ```bash
-g++ -o tracer_example tracer_example.cpp -lopentracing
+g++ -std=c++11 -o tracer_example tracer_example.cpp -lopentracing
 ./tracer_example
 ```
+
+**Note**: OpenTracing requires C++ 11 or higher.
 
 ### Change Agent Hostname
 


### PR DESCRIPTION

### What does this PR do?
Adds `-std=c++11` to dynamic loading example. Adds a note to explain that this is because OpenTracing requires C++ 11+.

### Motivation
support

### Preview link

https://docs-staging.datadoghq.com/cswatt/cpp-dynamic-loading/tracing/setup/cpp/#dynamic-loading


