### PR TITLE
added missing semicolon to php instruction

### DIFF
--- a/content/en/tracing/advanced/manual_instrumentation.md
+++ b/content/en/tracing/advanced/manual_instrumentation.md
@@ -309,7 +309,7 @@ dd_trace("CustomDriver", "doWork", function (...$args) {
         // Inform the tracer that there was an exception thrown
         $span->setError($e);
         // Bubble up the exception
-        throw $e
+        throw $e;
     } finally {
         // Close the span
         $span->finish();


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes an error in the PHP script reported by @wantsui on slack.

### Motivation
Script was erroring.

### Preview link
/tracing/advanced/manual_instrumentation/?tab=php

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/omri/php_typo_fix/tracing/advanced/manual_instrumentation/?tab=php

### Additional Notes
<!-- Anything else we should know when reviewing?-->
