### PR TITLE
Updating Distributions UI section in Assigning Tags 

### DIFF
--- a/content/en/tagging/assigning_tags.md
+++ b/content/en/tagging/assigning_tags.md
@@ -253,9 +253,9 @@ When creating a monitor, assign monitor tags under step 4 *Say what's happening*
 {{% /tab %}}
 {{% tab "Distribution Metrics" %}}
 
-Create percentile aggregations within [Distribution Metrics][1] by applying sets of tags to a metric, for which a timeseries is created for every potentially queryable combination of tag values. For more information on counting custom metrics/timeseries emitted from distribution metrics, see [2].
+Create percentile aggregations within [Distribution Metrics][1] by applying a whitelist of up to 10 tags to a metric, for which a timeseries is created for every potentially queryable combination of tag values. For more information on counting custom metrics/timeseries emitted from distribution metrics, see [2].
 
-** Apply up to ten tags **:
+** Apply up to ten tags. Exclusionary tags will not be accepted **:
 [REPLACE WITH THIS IMAGE HERE]
 
 

--- a/content/en/tagging/assigning_tags.md
+++ b/content/en/tagging/assigning_tags.md
@@ -253,7 +253,7 @@ When creating a monitor, assign monitor tags under step 4 *Say what's happening*
 {{% /tab %}}
 {{% tab "Distribution Metrics" %}}
 
-Create percentile aggregations within [Distribution Metrics][1] by applying a whitelist of up to 10 tags to a metric, for which a timeseries is created for every potentially queryable combination of tag values. For more information on counting custom metrics/timeseries emitted from distribution metrics, see [2].
+Create percentile aggregations within [Distribution Metrics][1] by applying a whitelist of up to ten tags to a metric -  this creates a timeseries for every potentially queryable combination of tag values. For more information on counting custom metrics and timeseries emitted from distribution metrics, see [Custom Metrics][2].
 
 ** Apply up to ten tags. Exclusionary tags will not be accepted **:
 [REPLACE WITH THIS IMAGE HERE]

--- a/content/en/tagging/assigning_tags.md
+++ b/content/en/tagging/assigning_tags.md
@@ -253,14 +253,14 @@ When creating a monitor, assign monitor tags under step 4 *Say what's happening*
 {{% /tab %}}
 {{% tab "Distribution Metrics" %}}
 
-Assign tag keys within [Distribution Metrics][1] (Beta) to create aggregate timeseries by applying sets of tags to a metric, for which a timeseries is created for every combination of tag values within the set.
+Create percentile aggregations within [Distribution Metrics][1] by applying sets of tags to a metric, for which a timeseries is created for every potentially queryable combination of tag values. For more information on counting custom metrics/timeseries emitted from distribution metrics, see [2].
 
-**Sets of tags are limited to groups of four**:
-
-{{< img src="tagging/assigning_tags/distributionmetricstags.png" alt="Distribution Metrics Tags" responsive="true" style="width:80%;">}}
+** Apply up to ten tags **:
+[REPLACE WITH THIS IMAGE HERE]
 
 
 [1]: /graphing/metrics/distributions
+[2]: /developers/metrics/custom_metrics/
 {{% /tab %}}
 {{% tab "Integrations" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
We've updated the Distributions UI and are no longer limiting the number of tags that a customer can apply to create percentile aggregations to 4. It is now 10.


### Preview link
https://docs-staging.datadoghq.com/kathy.lin/dist_tags/

