### PR TITLE
update to use master image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:zach_upgrade-docs-webpack
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
   tags:
     - "runner:main"
     - "size:large"


### PR DESCRIPTION
### What does this PR do?

Update docs to use master image of corp-ci, which is set to not delete assets on sync

### Motivation

 Fixing an issue with referencing deleted assets

### Preview link

https://docs-staging.datadoghq.com/david.jones/update-image/

### Additional Notes

