### PR TITLE
APM > .NET > consolidate and move "Configuration" sections

### DIFF
--- a/content/en/tracing/setup/dotnet.md
+++ b/content/en/tracing/setup/dotnet.md
@@ -391,7 +391,9 @@ dotnet MyApplication.dll
 
 {{% tab "web.config" %}}
 
-.NET Framework only: To configure the Tracer using an `app.config` or `web.config` file, use the `<appSettings>` section. For example:
+_This section applies only applications running on .NET Framework._
+
+To configure the Tracer using an `app.config` or `web.config` file, use the `<appSettings>` section. For example:
 ```xml
 <configuration>
   <appSettings>

--- a/content/en/tracing/setup/dotnet.md
+++ b/content/en/tracing/setup/dotnet.md
@@ -423,9 +423,11 @@ To configure the Tracer using an JSON file, create `datadog.json` in the instrum
 
 ### Configuration Variables
 
-The following tables list the supported configuration variables. In each table, the first column, _Setting Name_, indicates the variable name used when using environment variables or configuration files. The second column, _Propery Name_, indicates the name of the propery on the `TracerSettings` class when changing the equivalent setting in code.
+The following tables list the supported configuration variables. In each table, the first column, _Setting Name_, indicates the variable name used when using environment variables or configuration files. The second column, _Propery Name_, indicates the name of the equivalent propery on the `TracerSettings` class when changing settings in the code.
 
-The first table below lists configuration variables that are available for both automatic and manual instrumentation.
+#### Automatic and Manual Instrumentation
+
+The following table lists configuration variables that are available for both automatic and manual instrumentation.
 
 Setting Name          | Property Name          | Description                                                                                                                                                                                                    |
 --------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -436,7 +438,9 @@ Setting Name          | Property Name          | Description                    
 `DD_SERVICE_NAME`     | `ServiceName`          | Sets the default service name. If not set (default), the .NET Tracer tries to determine service name automatically from application name (e.g. IIS application name, process entry assembly, or process name). |
 `DD_LOGS_INJECTION`   | `LogsInjectionEnabled` | Enables or disables automatic injection of correlation identifiers into application logs.                                                                                                                      |
 
-#### Automatic instrumentation
+#### Automatic Instrumentation Only
+
+The following table lists configuration variables that are available only when using automatic instrumentation.
 
 Setting Name                 | Property Name              | Description                                                                                                                                                                                                                                                                                  |
 -----------------------------| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -446,7 +450,7 @@ Setting Name                 | Property Name              | Description         
 `DD_DISABLED_INTEGRATIONS`   | `DisabledIntegrationNames` | Sets a list of integrations to disable. All other integrations remain enabled. If not set, all integrations are enabled. Supports multiple values separated with semicolons. Valid values are the integration names listed in the [Integrations][4] section above.                           |
 `DD_TRACE_ANALYTICS_ENABLED` | `AnalyticsEnabled`         | Shorthand that enables default Trace Search and Analytics settings for web framework integrations. Valid values are: `true` or `false` (default).                                                                                                                                            |
 
-The following table lists settings that can be set for each integration. The first column, _Setting Name_, indicates the variable name used when using environment variables or configuration files. The second column, _Propery Name_, indicates the name of the propery on the `IntegrationSettings` class when changing the equivalent setting in the code. Access these properties through the `TracerSettings.Integrations[string integrationName]` indexer. Integration names are listed in the [Integrations][4] section above.
+The following table lists settings that can be set for each integration. The first column, _Setting Name_, indicates the variable name used when using environment variables or configuration files. The second column, _Propery Name_, indicates the name of the equivalent propery on the `IntegrationSettings` class when changing settings in the code. Access these properties through the `TracerSettings.Integrations[string integrationName]` indexer. Integration names are listed in the [Integrations][4] section above.
 
 Setting Name                             | Property Name              | Description                                                                                                                        |
 ---------------------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |

--- a/content/en/tracing/setup/dotnet.md
+++ b/content/en/tracing/setup/dotnet.md
@@ -458,30 +458,6 @@ Setting Name                             | Property Name              | Descript
 `DD_<INTEGRATION>_ANALYTICS_ENABLED`     | `AnalyticsEnabled`         | Enables or disable Trace Search and Analytics for a specific integration. Valid values are: `true` or `false` (default).           |
 `DD_<INTEGRATION>_ANALYTICS_SAMPLE_RATE` | `AnalyticsSampleRate`      | Sets the Trace Search and Analytics sampling rate for a specific integration. A floating number between `0.0` and `1.0` (default). |
 
-## Change Agent Hostname
-
-Configure your application level tracers to submit traces to a custom Agent endpoint:
-
-The .NET Tracer automatically reads environment variables and configuration files to set the Agent endpoint. See [Configuration][11] for more details.
-
-To set the Agent endpoint in code, create a `TracerSettings` from the default configuration source, set `TracerSettings.AgentUri`, and create a new `Tracer` using these settings:
-
-```csharp
-using Datadog.Trace;
-
-// read default configuration sources (env vars, web.config, datadog.json)
-var settings = TracerSettings.FromDefaultSources();
-
-// change the Agent endpoint
-settings.AgentUri = new Uri("http://localhost:8126/");
-
-// create a new Tracer using these settings
-var tracer = new Tracer(settings);
-
-// set the global tracer
-Tracer.Instance = tracer;
-```
-
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/tracing/setup/dotnet.md
+++ b/content/en/tracing/setup/dotnet.md
@@ -425,20 +425,16 @@ To configure the Tracer using an JSON file, create `datadog.json` in the instrum
 
 The following tables list the supported configuration variables. In each table, the first column, _Setting Name_, indicates the variable name used when using environment variables or configuration files. The second column, _Propery Name_, indicates the name of the equivalent propery on the `TracerSettings` class when changing settings in the code.
 
-#### Automatic and Manual Instrumentation
+The first table below lists configuration variables that are available for both automatic and manual instrumentation.
 
-The following table lists configuration variables that are available for both automatic and manual instrumentation.
-
-Setting Name          | Property Name          | Description                                                                                                                                                                                                    |
---------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-`DD_TRACE_AGENT_URL`  | `AgentUri`             | Sets the URL endpoint where traces are sent. Overrides `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` if set. Default value is `http://<DD_AGENT_HOST>:<DD_TRACE_AGENT_PORT>`.                                      |
-`DD_AGENT_HOST`       | N/A                    | Sets the host where traces are sent (the host running the Agent). Can be a hostname or an IP address. Ignored if `DD_TRACE_AGENT_URL` is set. Default is value `localhost`.                                    |
-`DD_TRACE_AGENT_PORT` | N/A                    | Sets the port where traces are sent (the port where the Agent is listening for connections). Ignored if `DD_TRACE_AGENT_URL` is set. Default value is `8126`.                                                  |
-`DD_ENV`              | `Environment`          | Adds the `env` tag with the specified value to generated spans. See [Agent configuration][2] for more details about the `env` tag. If not set, the `env` tag is not set automatically on all spans.            |
-`DD_SERVICE_NAME`     | `ServiceName`          | Sets the default service name. If not set (default), the .NET Tracer tries to determine service name automatically from application name (e.g. IIS application name, process entry assembly, or process name). |
-`DD_LOGS_INJECTION`   | `LogsInjectionEnabled` | Enables or disables automatic injection of correlation identifiers into application logs.                                                                                                                      |
-
-#### Automatic Instrumentation Only
+Setting Name          | Property Name          | Description                                                                                                                                                                                                       |
+--------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+`DD_TRACE_AGENT_URL`  | `AgentUri`             | Sets the URL endpoint where traces are sent. Overrides `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` if set. Default value is `http://<DD_AGENT_HOST>:<DD_TRACE_AGENT_PORT>`.                                         |
+`DD_AGENT_HOST`       | N/A                    | Sets the host where traces are sent (the host running the Agent). Can be a hostname or an IP address. Ignored if `DD_TRACE_AGENT_URL` is set. Default is value `localhost`.                                       |
+`DD_TRACE_AGENT_PORT` | N/A                    | Sets the port where traces are sent (the port where the Agent is listening for connections). Ignored if `DD_TRACE_AGENT_URL` is set. Default value is `8126`.                                                     |
+`DD_ENV`              | `Environment`          | If specified, adds the `env` tag with the specified value to all generated spans. See [Agent configuration][2] for more details about the `env` tag.                                                              |
+`DD_SERVICE_NAME`     | `ServiceName`          | If specified, sets the default service name. Otherwise, the .NET Tracer tries to determine service name automatically from application name (e.g. IIS application name, process entry assembly, or process name). |
+`DD_LOGS_INJECTION`   | `LogsInjectionEnabled` | Enables or disables automatic injection of correlation identifiers into application logs.                                                                                                                         |
 
 The following table lists configuration variables that are available only when using automatic instrumentation.
 
@@ -450,7 +446,7 @@ Setting Name                 | Property Name              | Description         
 `DD_DISABLED_INTEGRATIONS`   | `DisabledIntegrationNames` | Sets a list of integrations to disable. All other integrations remain enabled. If not set, all integrations are enabled. Supports multiple values separated with semicolons. Valid values are the integration names listed in the [Integrations][4] section above.                           |
 `DD_TRACE_ANALYTICS_ENABLED` | `AnalyticsEnabled`         | Shorthand that enables default Trace Search and Analytics settings for web framework integrations. Valid values are: `true` or `false` (default).                                                                                                                                            |
 
-The following table lists settings that can be set for each integration. The first column, _Setting Name_, indicates the variable name used when using environment variables or configuration files. The second column, _Propery Name_, indicates the name of the equivalent propery on the `IntegrationSettings` class when changing settings in the code. Access these properties through the `TracerSettings.Integrations[string integrationName]` indexer. Integration names are listed in the [Integrations][4] section above.
+The following table lists configuration variables that are available only when using automatic instrumentation and can be set for each integration. The first column, _Setting Name_, indicates the variable name used when using environment variables or configuration files. The second column, _Propery Name_, indicates the name of the equivalent propery on the `IntegrationSettings` class when changing settings in the code. Access these properties through the `TracerSettings.Integrations[string integrationName]` indexer. Integration names are listed in the [Integrations][4] section above.
 
 Setting Name                             | Property Name              | Description                                                                                                                        |
 ---------------------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
### What does this PR do?
- consolidate several configuration subheader into one top-level header
- move the new configuration header so comes after installation instructions, not before
- remove the "Change Agent Hostname" section, since this is already explained (with examples) in the "Configuration" section

### Motivation
- having configuration be the first section (before even installation) seemed weird (users need to install the Tracer before they can configure it)
- having all configuration variable in a single top-level section makes them easier to find

### Preview link
https://docs-staging.datadoghq.com/lucas/apm-dotnet-configuration-redux/tracing/setup/dotnet/
