### PR TITLE
add what happens to api, app keys when user account is disabled

### DIFF
--- a/content/en/account_management/api-app-keys.md
+++ b/content/en/account_management/api-app-keys.md
@@ -36,6 +36,9 @@ To remove a Datadog API key or application key or client token, navigate to [Int
 
 {{< img src="account_management/api_app_keys/application_keys.png" alt="Application Keys" responsive="true" >}}
 
+## Disabling a User Account
+If a user's account is disabled, any application keys that the user created are deleted. Any API keys that were created by the disabled account are not deleted, and are still valid.
+
 ## Transferring API/Application Keys
 Due to security reasons, Datadog does not transfer API/application keys from one user to another. The recommended best practice is to keep track of API/application keys and rotate those keys once a user has left the company. This way, a user that has left the company no longer has access to your account and Datadog’s API. Transferring the API/application key allows a user that no longer remains with the company to continue to send and receive data from the Datadog API. Customers have also asked to change the handle that the API/application keys are associated with. This, however, does not resolve the inherent issue: that a user that no longer remains with the company continues to have the ability to send and retrieve data from the Datadog API.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds information on what happens to API and application keys when a user's account is disabled

### Motivation
Customer request

### Preview link
https://docs-staging.datadoghq.com/laura.hampton/delete-user-api-app-keys/account_management/api-app-keys/#disabling-a-user-account


