### PR TITLE
removed some visible tag that appeared on APM Guide index

### DIFF
--- a/content/en/tracing/guide/_index.md
+++ b/content/en/tracing/guide/_index.md
@@ -14,6 +14,5 @@ disable_toc: true
     {{< nextlink href="tracing/guide/agent-obfuscation" >}}Agent Trace Obfuscation{{< /nextlink >}}
     {{< nextlink href="tracing/guide/week_over_week_p50_comparison" >}}Compare p50 latency week over week for a service{{< /nextlink >}}
     {{< nextlink href="tracing/guide/alert_anomalies_p99_database" >}}Alert on anomalies in database services p99 latency{{< /nextlink >}}
-    {{< nextlink href="tracing/guide/slowest_request_daily" >}}Debug the slowest trace on the slowest endpoint of a web service
-kind: guide{{< /nextlink >}}
+    {{< nextlink href="tracing/guide/slowest_request_daily" >}}Debug the slowest trace on the slowest endpoint of a web service{{< /nextlink >}}
 {{< /whatsnext >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes text "type: guide" that was visible on the index page and shouldn't be.

### Motivation
Found a mistake in the index page, am fixing.

### Preview link
/tracing/guide

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/omri/index_typo/tracing/guide

### Additional Notes
<!-- Anything else we should know when reviewing?-->
