### PR TITLE
fix formats for DD_AC_EXCLUDE and DD_AC_INCLUDE

### DIFF
--- a/content/en/agent/autodiscovery/management.md
+++ b/content/en/agent/autodiscovery/management.md
@@ -63,7 +63,7 @@ DD_AC_EXCLUDE = "name:dd-agent"
 Another example, the following configuration instructs the Agent to ignore some containers from Docker Cloud:
 
 ```shell
-DD_AC_EXCLUDE = "image:dockercloud/network-daemon, image:dockercloud/cleanup, image:dockercloud/logrotate, image:dockercloud/events, image:dockercloud/ntpd"
+DD_AC_EXCLUDE = "image:dockercloud/network-daemon image:dockercloud/cleanup image:dockercloud/logrotate image:dockercloud/events image:dockercloud/ntpd"
 ```
 
 **Note**: You can also use a regex to ignore them all: `DD_AC_EXCLUDE = "image:dockercloud/*"`
@@ -114,7 +114,7 @@ For example, if you only want to monitor `ubuntu` or `debian` images, and exclud
 
 ```
 DD_AC_EXCLUDE = "image:.*"
-DD_AC_INCLUDE = "image:ubuntu, image:debian"
+DD_AC_INCLUDE = "image:ubuntu image:debian"
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
fix formats on the autodiscovery management page

### Motivation
support

### Preview link

https://docs-staging.datadoghq.com/cswatt/dd-ac-format/agent/autodiscovery/management/?tab=containerizedagent

