### PR TITLE
update next link to learn about Datadog UI (en)

### DIFF
--- a/content/en/getting_started/agent/_index.md
+++ b/content/en/getting_started/agent/_index.md
@@ -106,7 +106,7 @@ For help troubleshooting the Agent:
 ## Next Steps
 {{< whatsnext desc="After the Agent is installed:">}}
     {{< nextlink href="/getting_started/integrations" tag="Documentation" >}}Learn about Integrations{{< /nextlink >}}
-    {{< nextlink href="/getting_started" tag="Documentation" >}}Learn about the Datadog UI{{< /nextlink >}}
+    {{< nextlink href="/getting_started/application" tag="Documentation" >}}Learn about the Datadog UI{{< /nextlink >}}
 {{< /whatsnext >}}
 
 [1]: /integrations


### PR DESCRIPTION
### What does this PR do?

It updates the whatsnext link at https://docs.datadoghq.com/getting_started/agent/ for the Application UI

<img width="896" alt="imagen" src="https://user-images.githubusercontent.com/3729517/63271973-83e43000-c29b-11e9-97d0-8d38432b06b5.png">


### Motivation
I clicked on the Datadog UI link and got me to the initial Getting Started page https://docs.datadoghq.com/getting_started/ instead of https://docs.datadoghq.com/getting_started/application/

### Preview link
I'm working off a fork 😅 