### PR TITLE
adds caveat about apm on helm charts

### DIFF
--- a/content/en/agent/kubernetes/helm.md
+++ b/content/en/agent/kubernetes/helm.md
@@ -150,6 +150,8 @@ datadog:
 
 ### Enable APM and Distributed Tracing
 
+**Note**: If you want to deploy the Datadog Agent as a deployment instead of a DaemonSet, configuration of APM via Helm is not supported.
+
 Update your [datadog-values.yaml][7] file with the following APM configuration:
 
 ```


### PR DESCRIPTION

### What does this PR do?
adds a note that if you're deploying the dd-agent as a deployment instead of a daemonset, you can't configure apm via helm

### Motivation
support request

### Preview link

https://docs-staging.datadoghq.com/cswatt/helm-caveat/agent/kubernetes/helm/?tab=macoshomebrew#enable-apm-and-distributed-tracing

