### PR TITLE
logs pipeline caveats need admin app keys

### DIFF
--- a/content/en/api/logs_pipelines/logs_pipelines.md
+++ b/content/en/api/logs_pipelines/logs_pipelines.md
@@ -14,6 +14,8 @@ Pipelines and processors operate on incoming logs, parsing and transforming them
 * See the [Pipelines Configuration Page][2] for a list of the pipelines and processors currently configured in our UI.
 * For more information about Pipelines, see the [Pipeline documentation][3].
 
+**Note**: These endpoints are only available for admin users. Make sure to use an application key created by an admin.
+
 [1]: /help
 [2]: https://app.datadoghq.com/logs/pipelines
 [3]: https://docs.datadoghq.com/logs/processing


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a note to the logs pipeline portion of the API reference.

### Motivation
support

### Preview link

https://docs-staging.datadoghq.com/cswatt/pipeline-api-perms/api/?lang=python#logs-pipelines

