### PR TITLE
Removing confusing term

### DIFF
--- a/content/en/logs/explorer/_index.md
+++ b/content/en/logs/explorer/_index.md
@@ -69,7 +69,7 @@ The Logstream is the list of logs that match the selected context. A context is 
 
 ### Logs Table
 
-The logstream is displayed in the logs table. 
+The logstream is displayed in the logs table.
 
 Configure the logs table content according to your needs and preferences with the "Options" button. Among your custom attributes, only faceted or measures attributes are available for columns.
 
@@ -97,7 +97,7 @@ Interact with the attributes names and values in the lower JSON section to:
 
 Interact with the upper reserved attributes section:
 
-* with **Host**, to access the host dashboard or append the search request with the `host` of the log. 
+* with **Host**, to access the host dashboard or append the search request with the `host` of the log.
 * with **Service**, to see the trace in APM, append the search request with the trace ID (both require a `trace_id` attribute in the log: refer to [trace injection in logs][3]) or append search request with the `service` of the log.
 * with **Source**, to append the search request with the `source` of the log.
 
@@ -171,7 +171,7 @@ Once this is done, the value of this attribute is stored **for all new logs** an
 
 {{% tab "Measures" %}}
 
-A measure is a attribute with a numerical value contained in your logs. Think of it as a "log metric".
+A measure is a attribute with a numerical value contained in your logs.
 
 **Create a Measure**:
 


### PR DESCRIPTION
### What does this PR do?
Log metric is now confusing with the log to metric beta functionality. This PR removes the wording since it's not necessary now.

### Motivation
Customer feedback.

### Preview link
