### PR TITLE
APM guide index and frontmatter cleanup

### DIFF
--- a/content/en/tracing/guide/_index.md
+++ b/content/en/tracing/guide/_index.md
@@ -6,15 +6,19 @@ disable_toc: true
 ---
 
 
-{{< whatsnext desc="General Guides:" >}}
+{{< whatsnext desc="Onboarding Guides:" >}}
+    {{< nextlink href="tracing/guide/alert_anomalies_p99_database" >}}1. Alert on anomalies in database services p99 latency [3 mins]{{< /nextlink >}}
+    {{< nextlink href="tracing/guide/week_over_week_p50_comparison" >}}2. Compare p50 latency week over week for a service [2 mins]{{< /nextlink >}}
+    {{< nextlink href="tracing/guide/slowest_request_daily" >}}3. Debug the slowest trace on the slowest endpoint of a web service [3 mins]{{< /nextlink >}}
+    {{< nextlink href="tracing/guide/add_span_md_and_graph_it" >}}4. Add span tags and slice and dice your application performanc [7 mins]{{< /nextlink >}}
+{{< /whatsnext >}}
+<br>
+{{< whatsnext desc="Additional Guides:" >}}
     {{< nextlink href="tracing/guide/configure_an_apdex_for_your_traces_with_datadog_apm" >}}Configure Apdex score by service{{< /nextlink >}}
     {{< nextlink href="tracing/guide/security" >}}Scrub Sensitive information from your traces{{< /nextlink >}}
     {{< nextlink href="tracing/guide/resource_monitor" >}}Build monitor upon your resource metrics{{< /nextlink >}}
     {{< nextlink href="tracing/guide/trace_sampling_and_storage" >}}Trace Sampling and Storage{{< /nextlink >}}
     {{< nextlink href="tracing/guide/agent-obfuscation" >}}Agent Trace Obfuscation{{< /nextlink >}}
-    {{< nextlink href="tracing/guide/week_over_week_p50_comparison" >}}Compare p50 latency week over week for a service{{< /nextlink >}}
-    {{< nextlink href="tracing/guide/alert_anomalies_p99_database" >}}Alert on anomalies in database services p99 latency{{< /nextlink >}}
-    {{< nextlink href="tracing/guide/slowest_request_daily" >}}Debug the slowest trace on the slowest endpoint of a web service{{< /nextlink >}}
     {{< nextlink href="/api/?lang=python#tracing" >}}Trace API{{< /nextlink >}}
     {{< nextlink href="/developers/libraries/#apm-distributed-tracing-client-libraries" >}}Tracing Client Libraries{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/tracing/guide/add_span_md_and_graph_it.md
+++ b/content/en/tracing/guide/add_span_md_and_graph_it.md
@@ -1,20 +1,20 @@
 ---
-title: Add span tags and slice and dice your application performance.
+title: Add span tags and slice and dice your application performance
 kind: guide
 disable_toc: true
 further_reading:
-- link: "tracing/setup/"
-  tag: "Documentation"
-  text: "Learn how to setup APM tracing with your application"
-- link: "tracing/visualization/services_list/"
-  tag: "Documentation"
-  text: "Discover the list of services reporting to Datadog"
-- link: "tracing/visualization/resource"
-  tag: "Documentation"
-  text: "Dive into your resource performance and traces"
-- link: "tracing/visualization/trace"
-  tag: "Documentation"
-  text: "Understand how to read a Datadog Trace"
+- link: "/tracing/guide/alert_anomalies_p99_database/"
+  tag: "3 mins"
+  text: "Alert on anomalous p99 latency of a database service"
+- link: "tracing/guide/week_over_week_p50_comparison/"
+  tag: "2 mins"
+  text: "Compare a service’s latency to the previous week"
+- link: "/tracing/guide/slowest_request_daily/"
+  tag: "3 mins"
+  text: "Debug the slowest trace on the slowest endpoint of a web service"
+- link: "tracing/guide/"
+  tag: ""
+  text: "All guides"
 ---
 
 {{< img src="tracing/guide/add_span_md_and_graph_it/span_md_6.gif" alt="Analytics View" responsive="true" style="width:90%;">}}

--- a/content/en/tracing/guide/alert_anomalies_p99_database.md
+++ b/content/en/tracing/guide/alert_anomalies_p99_database.md
@@ -3,18 +3,18 @@ title: Alert on anomalous p99 latency of a database service
 kind: guide
 disable_toc: true
 further_reading:
-- link: "tracing/setup/"
-  tag: "Documentation"
-  text: "Learn how to setup APM tracing with your application"
-- link: "tracing/visualization/services_list/"
-  tag: "Documentation"
-  text: "Discover the list of services reporting to Datadog"
-- link: "tracing/visualization/resource"
-  tag: "Documentation"
-  text: "Dive into your resource performance and traces"
-- link: "tracing/visualization/trace"
-  tag: "Documentation"
-  text: "Understand how to read a Datadog Trace"
+- link: "tracing/guide/week_over_week_p50_comparison/"
+  tag: "2 mins"
+  text: "Compare a service’s latency to the previous week"
+- link: "/tracing/guide/slowest_request_daily/"
+  tag: "3 mins"
+  text: "Debug the slowest trace on the slowest endpoint of a web service"
+- link: "tracing/guide/add_span_md_and_graph_it/"
+  tag: "7 mins"
+  text: "Add span tags and slice and dice your application performance"
+- link: "tracing/guide/"
+  tag: ""
+  text: "All guides"
 ---
 
 {{< img src="tracing/guide/alert_anomalies_p99_database/alert_anomalies_full.gif" alt="Monitor view with ongoing alert" responsive="true" style="width:90%;">}}

--- a/content/en/tracing/guide/slowest_request_daily.md
+++ b/content/en/tracing/guide/slowest_request_daily.md
@@ -3,18 +3,18 @@ title: Debug the slowest trace on the slowest endpoint of a web service
 kind: guide
 disable_toc: true
 further_reading:
-- link: "tracing/setup/"
-  tag: "Documentation"
-  text: "Learn how to setup APM tracing with your application"
-- link: "tracing/visualization/services_list/"
-  tag: "Documentation"
-  text: "Discover the list of services reporting to Datadog"
-- link: "tracing/visualization/resource"
-  tag: "Documentation"
-  text: "Dive into your resource performance and traces"
-- link: "tracing/visualization/trace"
-  tag: "Documentation"
-  text: "Understand how to read a Datadog Trace"
+- link: "/tracing/guide/alert_anomalies_p99_database/"
+  tag: "3 mins"
+  text: "Alert on anomalous p99 latency of a database service"
+- link: "tracing/guide/week_over_week_p50_comparison/"
+  tag: "2 mins"
+  text: "Compare a service’s latency to the previous week"
+- link: "tracing/guide/add_span_md_and_graph_it/"
+  tag: "7 mins"
+  text: "Add span tags and slice and dice your application performance"
+- link: "tracing/guide/"
+  tag: ""
+  text: "All guides"
 ---
 
 {{< img src="tracing/guide/slowest_request_daily/slowest_trace_1.gif" alt="Identifying the slowest trace and finding the Host metrics for it" responsive="true" style="width:90%;">}}

--- a/content/en/tracing/guide/week_over_week_p50_comparison.md
+++ b/content/en/tracing/guide/week_over_week_p50_comparison.md
@@ -3,18 +3,18 @@ title: Compare a Service’s latency to the previous week
 kind: guide
 disable_toc: true
 further_reading:
-- link: "tracing/setup/"
-  tag: "Documentation"
-  text: "Learn how to setup APM tracing with your application"
-- link: "tracing/visualization/services_list/"
-  tag: "Documentation"
-  text: "Discover the list of services reporting to Datadog"
-- link: "tracing/visualization/resource"
-  tag: "Documentation"
-  text: "Dive into your resource performance and traces"
-- link: "tracing/visualization/trace"
-  tag: "Documentation"
-  text: "Understand how to read a Datadog Trace"
+- link: "/tracing/guide/alert_anomalies_p99_database/"
+  tag: "3 mins"
+  text: "Alert on anomalous p99 latency of a database service"
+- link: "/tracing/guide/slowest_request_daily/"
+  tag: "3 mins"
+  text: "Debug the slowest trace on the slowest endpoint of a web service"
+- link: "tracing/guide/add_span_md_and_graph_it/"
+  tag: "7 mins"
+  text: "Add span tags and slice and dice your application performance"
+- link: "tracing/guide/"
+  tag: ""
+  text: "All guides"
 ---
 
 {{< img src="tracing/guide/week_over_week_p50_comparison/wow_p50_comp_3.mp4" alt="comparaison video" video="true" responsive="true" style="width:90%;">}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Cleans up the frontmatter of the newly published APM guides as well as the index page for that folder. Finally removes a redundant period from a title.

### Motivation
Finishing up the APM Guide push.

### Preview link
/tracing/guide/
/tracing/guide/alert_anomalies_p99_database/
/tracing/guide/slowest_request_daily/
/tracing/guide/week_over_week_p50_comparison/
/tracing/guide/add_span_md_and_graph_it/


<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/omri/guide_cleanup/tracing/guide/
https://docs-staging.datadoghq.com/omri/guide_cleanup/tracing/guide/alert_anomalies_p99_database/
https://docs-staging.datadoghq.com/omri/guide_cleanup/tracing/guide/slowest_request_daily/
https://docs-staging.datadoghq.com/omri/guide_cleanup/tracing/guide/week_over_week_p50_comparison/
https://docs-staging.datadoghq.com/omri/guide_cleanup/tracing/guide/add_span_md_and_graph_it/


### Additional Notes
If it's possible to move the `[x mins]` notation from the text of the index page items and move them to a placement equivalent to the "tag" of the further reading that would be perfect (see example in the further readings of the guides here)!
