### PR TITLE
Add FAQ about Agent 6.14.0 RPM packages key rotation

### DIFF
--- a/content/en/agent/faq/_index.md
+++ b/content/en/agent/faq/_index.md
@@ -18,7 +18,7 @@ aliases:
 * [How do I use Kubernetes secrets to set my API key?][9]
 * [Datadog Windows Agent user][10]
 * [How do I run the kubernetes_state check as a cluster check?][11]
-* [RPM GPG key rotation for Agent 6 packages][12]
+* [RPM GPG Key Rotation for Agent v6][12]
 
 [1]: /agent/faq/host-metrics-with-the-container-agent
 [2]: /agent/faq/downgrade-datadog-agent

--- a/content/en/agent/faq/_index.md
+++ b/content/en/agent/faq/_index.md
@@ -18,6 +18,7 @@ aliases:
 * [How do I use Kubernetes secrets to set my API key?][9]
 * [Datadog Windows Agent user][10]
 * [How do I run the kubernetes_state check as a cluster check?][11]
+* [RPM GPG key rotation for Agent 6 packages][12]
 
 [1]: /agent/faq/host-metrics-with-the-container-agent
 [2]: /agent/faq/downgrade-datadog-agent
@@ -30,3 +31,4 @@ aliases:
 [9]: /agent/faq/kubernetes-secrets
 [10]: /agent/faq/windows-agent-ddagent-user
 [11]: /agent/faq/kubernetes-state-cluster-check
+[12]: /agent/faq/rpm-gpg-key-rotation-agent-6

--- a/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
+++ b/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
@@ -1,23 +1,22 @@
 ---
 title: RPM GPG key rotation for Agent 6 packages
 kind: faq
-private: false
 ---
 
 Starting with the 6.14.0 release, the RPM packages of the Agent are signed with a new GPG key.
 
 Hosts which are using our RPM packages located in our [yum repository][1] and want to install or upgrade the Agent 6.14.0 or later are affected by this change and need to trust this new key by importing the associated public key in their hosts' keyrings.
 
-The fingerprint of the associated public key is: `A4C0B90D7443CF6E4E8AA341F1068E14E09422B3`.
-
 Trying to install or upgrade the Agent package without trusting the new key will result in `NOKEY` errors when installing the package.
 
+The fingerprint of the associated public key is: `A4C0B90D7443CF6E4E8AA341F1068E14E09422B3`.
+
 If you're using the latest version of one of the following officially supported install methods:
-- the [Agent installation page][2],
-- the `datadog` [chef cookbook][3],
-- the `Datadog.datadog` [ansible role][4],
-- the `datadog_agent` [puppet module][5],
-- the `datadog` [saltstack formula][6],
+* the [Agent installation page][2],
+* the `datadog` [chef cookbook][3],
+* the `Datadog.datadog` [ansible role][4],
+* the `datadog_agent` [puppet module][5],
+* the `datadog` [saltstack formula][6],
 
 then your hosts will automatically trust the new key, and no further action needs to be done to be able to install Agent 6 packages signed with the new key.
 

--- a/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
+++ b/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
@@ -1,6 +1,7 @@
 ---
 title: RPM GPG key rotation for Agent 6 packages
 kind: faq
+private: false
 ---
 
 Starting with the 6.14.0 release, the RPM packages of the Agent are signed with a new GPG key.

--- a/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
+++ b/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
@@ -5,6 +5,8 @@ kind: faq
 
 Starting with v6.14.0, the Agent RPM packages are signed with a new GPG key.
 
+The previous GPG key is over 4 years old, so to better follow security best practices we are rotating our key.
+
 Hosts using RPM packages located in the [Datadog Yum repository][1] to install or upgrade the Agent v6.14.0+ are affected by this change and need to trust this new key by importing the associated public key in their hosts' keyrings.
 
 Trying to install or upgrade the Agent package without trusting the new key results in `NOKEY` errors when installing the package.

--- a/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
+++ b/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
@@ -1,0 +1,55 @@
+---
+title: RPM GPG key rotation for Agent 6 packages
+kind: faq
+---
+
+Starting with the 6.14.0 release, the RPM packages of the Agent are signed with a new GPG key.
+
+Hosts which are using our RPM packages located in our [yum repository][1] and want to install or upgrade the Agent 6.14.0 or later are affected by this change and need to trust this new key by importing the associated public key in their hosts' keyrings.
+
+The fingerprint of the associated public key is: `A4C0B90D7443CF6E4E8AA341F1068E14E09422B3`.
+
+Trying to install or upgrade the Agent package without trusting the new key will result in `NOKEY` errors when installing the package.
+
+If you're using the latest version of one of the following officially supported install methods:
+- the [Agent installation page][2],
+- the `datadog` [chef cookbook][3],
+- the `Datadog.datadog` [ansible role][4],
+- the `datadog_agent` [puppet module][5],
+- the `datadog` [saltstack formula][6],
+
+then your hosts will automatically trust the new key, and no further action needs to be done to be able to install Agent 6 packages signed with the new key.
+
+## How to check if a host trusts the new GPG key
+
+To check that a particular host does trust the new key, run this command on the host:
+```bash
+rpm -q gpg-pubkey-e09422b3
+```
+
+If the new key is indeed trusted, the command has a 0 exit code and its output is:
+```bash
+gpg-pubkey-e09422b3-57744e9e
+```
+
+Otherwise, the command will return with a non-0 exit code and the following output:
+```bash
+package gpg-pubkey-e09422b3 is not installed
+```
+
+## How to manually trust the new GPG key
+
+If you want to manually make a host trust the new key, run the following command on the host:
+
+```bash
+rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+```
+
+You can then check that the new key is indeed trusted by following the steps in the [How to check if a host trusts the new GPG key](#how-to-check-if-a-host-trusts-the-new-GPG-key) section.
+
+[1]: https://yum.datadoghq.com/
+[2]: https://app.datadoghq.com/account/settings#agent
+[3]: https://github.com/DataDog/chef-datadog
+[4]: https://github.com/DataDog/ansible-datadog
+[5]: https://github.com/DataDog/puppet-datadog-agent
+[6]: https://github.com/DataDog/datadog-formula

--- a/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
+++ b/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
@@ -5,7 +5,7 @@ kind: faq
 
 Starting with v6.14.0, the Agent RPM packages are signed with a new GPG key.
 
-Hosts using RPM packages located in the [Datadog Yum repository][1] and want to install or upgrade the Agent v6.14.0+ are affected by this change and need to trust this new key by importing the associated public key in their hosts' keyrings.
+Hosts using RPM packages located in the [Datadog Yum repository][1] to install or upgrade the Agent v6.14.0+ are affected by this change and need to trust this new key by importing the associated public key in their hosts' keyrings.
 
 Trying to install or upgrade the Agent package without trusting the new key results in `NOKEY` errors when installing the package.
 

--- a/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
+++ b/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
@@ -12,10 +12,15 @@ Trying to install or upgrade the Agent package without trusting the new key will
 The fingerprint of the associated public key is: `A4C0B90D7443CF6E4E8AA341F1068E14E09422B3`.
 
 If you're using the latest version of one of the following officially supported install methods:
+
 * the [Agent installation page][2],
+
 * the `datadog` [chef cookbook][3],
+
 * the `Datadog.datadog` [ansible role][4],
+
 * the `datadog_agent` [puppet module][5],
+
 * the `datadog` [saltstack formula][6],
 
 then your hosts will automatically trust the new key, and no further action needs to be done to be able to install Agent 6 packages signed with the new key.

--- a/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
+++ b/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
@@ -1,29 +1,28 @@
 ---
-title: RPM GPG key rotation for Agent 6 packages
+title: RPM GPG Key Rotation for Agent v6
 kind: faq
 ---
 
-Starting with the 6.14.0 release, the RPM packages of the Agent are signed with a new GPG key.
+Starting with v6.14.0, the Agent RPM packages are signed with a new GPG key.
 
-Hosts which are using our RPM packages located in our [yum repository][1] and want to install or upgrade the Agent 6.14.0 or later are affected by this change and need to trust this new key by importing the associated public key in their hosts' keyrings.
+Hosts using RPM packages located in the [Datadog Yum repository][1] and want to install or upgrade the Agent v6.14.0+ are affected by this change and need to trust this new key by importing the associated public key in their hosts' keyrings.
 
-Trying to install or upgrade the Agent package without trusting the new key will result in `NOKEY` errors when installing the package.
+Trying to install or upgrade the Agent package without trusting the new key results in `NOKEY` errors when installing the package.
 
 The fingerprint of the associated public key is: `A4C0B90D7443CF6E4E8AA341F1068E14E09422B3`.
 
-If you're using the latest version of one of the following officially supported install methods:
+If you're using the latest version for one of the following officially supported install methods, then your hosts will automatically trust the new key and no further action is needed.
 
-* the [Agent installation page][2],
+* [Agent installation page][2]
 
-* the `datadog` [chef cookbook][3],
+* Datadog [Chef cookbook][3]
 
-* the `Datadog.datadog` [ansible role][4],
+* `Datadog.datadog` [Ansible role][4]
 
-* the `datadog_agent` [puppet module][5],
+* Datadog Agent [Puppet module][5]
 
-* the `datadog` [saltstack formula][6],
+* Datadog [SaltStack formula][6]
 
-then your hosts will automatically trust the new key, and no further action needs to be done to be able to install Agent 6 packages signed with the new key.
 
 ## How to check if a host trusts the new GPG key
 
@@ -32,25 +31,25 @@ To check that a particular host does trust the new key, run this command on the 
 rpm -q gpg-pubkey-e09422b3
 ```
 
-If the new key is indeed trusted, the command has a 0 exit code and its output is:
+If the new key is trusted, the command has a 0 exit code and outputs:
 ```bash
 gpg-pubkey-e09422b3-57744e9e
 ```
 
-Otherwise, the command will return with a non-0 exit code and the following output:
+Otherwise, the command returns a non-0 exit code and the following output:
 ```bash
 package gpg-pubkey-e09422b3 is not installed
 ```
 
 ## How to manually trust the new GPG key
 
-If you want to manually make a host trust the new key, run the following command on the host:
+To manually trust the new key, run the following command on the host:
 
 ```bash
 rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
 ```
 
-You can then check that the new key is indeed trusted by following the steps in the [How to check if a host trusts the new GPG key](#how-to-check-if-a-host-trusts-the-new-GPG-key) section.
+Then check if the new key is trusted by following the steps in [How to check if a host trusts the new GPG key](#how-to-check-if-a-host-trusts-the-new-gpg-key).
 
 [1]: https://yum.datadoghq.com/
 [2]: https://app.datadoghq.com/account/settings#agent


### PR DESCRIPTION
### What does this PR do?

Describes who is affected by the change, and how to prepare
the hosts before installing or upgrading to Agent 6.14.0+.

### Motivation

Give a link we can add to the Agent changelog and to customers that need help with the change.

### Preview link

https://docs-staging.datadoghq.com/kylian.serrania/add-rpm-6.14.0-key-faq/agent/faq/rpm-gpg-key-rotation-agent-6/

### Additional Notes

I'm open to ideas to find a better title, a better page layout and clearer explanations.
