### PR TITLE
typo and minor mistake fix

### DIFF
--- a/content/en/tracing/guide/_index.md
+++ b/content/en/tracing/guide/_index.md
@@ -10,7 +10,7 @@ disable_toc: true
     {{< nextlink href="tracing/guide/alert_anomalies_p99_database" >}}1. Alert on anomalies in database services p99 latency [3 mins]{{< /nextlink >}}
     {{< nextlink href="tracing/guide/week_over_week_p50_comparison" >}}2. Compare p50 latency week over week for a service [2 mins]{{< /nextlink >}}
     {{< nextlink href="tracing/guide/slowest_request_daily" >}}3. Debug the slowest trace on the slowest endpoint of a web service [3 mins]{{< /nextlink >}}
-    {{< nextlink href="tracing/guide/add_span_md_and_graph_it" >}}4. Add span tags and slice and dice your application performanc [7 mins]{{< /nextlink >}}
+    {{< nextlink href="tracing/guide/add_span_md_and_graph_it" >}}4. Add span tags and slice and dice your application performance [7 mins]{{< /nextlink >}}
 {{< /whatsnext >}}
 <br>
 {{< whatsnext desc="Additional Guides:" >}}

--- a/content/en/tracing/guide/slowest_request_daily.md
+++ b/content/en/tracing/guide/slowest_request_daily.md
@@ -46,7 +46,7 @@ With Datadog APM, you can easily investigate the performance of your endpoints, 
 
     The Flamegraph is a great way of identifying the precise piece of your stack that is errneous or very latent. Errors are marked with red highlights and duration is represented by the horizontal length of the span, so very long spans are the slow ones. Learn more about using the Flamegraph in the [Trace View guide][2].
 
-    Under the Flamegraph you can see all of the metadata (including [custom metadata][3]) and create facets for searches. From here you can also see associated logs (if you [connected Logs to your Traces][4]), see Host-level information such as CPU and memory usage. 
+    Under the Flamegraph you can see all of the tags (including [custom ones][3]). From here you can also see associated logs (if you [connected Logs to your Traces][4]), see Host-level information such as CPU and memory usage. 
 
     {{< img src="tracing/guide/slowest_request_daily/slowest_trace_4.png" alt="Identifying the slowest trace and finding the bottleneck causing it" responsive="true" style="width:90%;">}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes a typo on the APM Guide index and removes an incorrect sentence part on the slowest trace guide.

### Motivation
Mistakes should be fixed.

### Preview link
/tracing/guide
/tracing/guide/slowest_request_daily

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/omri/typo_fixes/tracing/guide
https://docs-staging.datadoghq.com/omri/typo_fixes/tracing/guide/slowest_request_daily

### Additional Notes
N/A
