### PR TITLE
Add Colisweb community Scala tracer

### DIFF
--- a/data/libraries.yaml
+++ b/data/libraries.yaml
@@ -194,10 +194,6 @@ Classic:
       dogstatsd: true
       authors: Datadog
   - Scala:
-    - name: scala-opentracing
-      link: https://github.com/Colisweb/scala-opentracing
-      api: true
-      authors: Colisweb
     - name: datadog-scala
       link: https://github.com/gphat/datadog-scala
       api: true
@@ -269,3 +265,7 @@ Tracing:
       official: true
       authors: Datadog
       notes: gem is called 'ddtrace'.
+  - Scala:
+    - name: scala-opentracing                                                                       
+      link: https://github.com/Colisweb/scala-opentracing                                           
+      authors: Colisweb

--- a/data/libraries.yaml
+++ b/data/libraries.yaml
@@ -194,6 +194,10 @@ Classic:
       dogstatsd: true
       authors: Datadog
   - Scala:
+    - name: scala-opentracing
+      link: https://github.com/Colisweb/scala-opentracing
+      api: true
+      authors: Colisweb
     - name: datadog-scala
       link: https://github.com/gphat/datadog-scala
       api: true


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a Scala tracer to the community libraries page

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jeremy.g/community-scala/developers/libraries/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
