### PR TITLE
Replace help article link

### DIFF
--- a/content/fr/integrations/active_directory.md
+++ b/content/fr/integrations/active_directory.md
@@ -53,4 +53,4 @@ Le check Active Directory n'inclut actuellement aucun check de service.
 
 
 [1]: https://github.com/DataDog/integrations-core/blob/master/active_directory/conf.yaml.example
-[2]: /agent/guide/agent-commands/#agent-status-and-information
+[2]: https://docs.datadoghq.com/fr/agent/faq/agent-commands/#agent-status-and-information

--- a/content/fr/integrations/active_directory.md
+++ b/content/fr/integrations/active_directory.md
@@ -53,6 +53,4 @@ Le check Active Directory n'inclut actuellement aucun check de service.
 
 
 [1]: https://github.com/DataDog/integrations-core/blob/master/active_directory/conf.yaml.example
-[2]: https://help.datadoghq.com/hc/en-us/articles/203764635-Agent-Status-and-Information
-[3]: https://github.com/DataDog/integrations-core/blob/master/active_directory/metadata.csv
-
+[2]: /agent/guide/agent-commands/#agent-status-and-information


### PR DESCRIPTION

### What does this PR do?
- Replace help article link

### Motivation
`help.datadoghq.com` is deprecated

### Preview link
N/A

### Additional Notes
- Link checker removed 3rd link because it is not used
