### PR TITLE
[doc] Corrected monitor search curl command

### DIFF
--- a/content/en/api/monitors/code_snippets/api-monitor-search.sh
+++ b/content/en/api/monitors/code_snippets/api-monitor-search.sh
@@ -10,5 +10,5 @@ page=<PAGE_NUMBER>
 per_page=<PER_PAGE>
 sort=<SORT>
 
-curl -X GET -H "Content-type: application/json" -d \
-    "https://api.datadoghq.com/api/v1/monitor/search?api_key=${api_key}&application_key=${app_key}&query=${query}&page=${page}&pre_page=${per_page}&sort=${sort}"
+curl -X GET \
+    "https://api.datadoghq.com/api/v1/monitor/search?api_key=${api_key}&application_key=${app_key}&query=${query}&page=${page}&per_page=${per_page}&sort=${sort}"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Corrected a typo and removed the `-d` and `-H` options from curl command for consistency

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/tanjiehui-patch-1/api/?lang=bash#monitors-search