### PR TITLE
update some autodiscovery guide links

### DIFF
--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -419,7 +419,7 @@ The workaround in this case is to add `hostNetwork: true` in your Agent pod spec
 [8]: /agent/autodiscovery/?tab=agent#how-to-set-it-up
 [9]: /integrations/amazon_ec2/#configuration
 [10]: /logs
-[11]: /agent/autodiscovery/?tab=kubernetes#setting-up-check-templates
+[11]: /agent/autodiscovery/integrations/?tab=kubernetes
 [12]: /tracing/setup
 [13]: /graphing/infrastructure/process/?tab=kubernetes#installation
 [14]: /agent/kubernetes/dogstatsd

--- a/content/en/agent/kubernetes/host_setup.md
+++ b/content/en/agent/kubernetes/host_setup.md
@@ -29,7 +29,7 @@ To gather your kube-state metrics:
 
 Since [Agent v6][2], Kubernetes DNS integration works automatically with the [Autodiscovery][3].
 
-Note: these metrics are unavailable for Azure Kubernetes Service (AKS). 
+Note: these metrics are unavailable for Azure Kubernetes Service (AKS).
 
 ## Collect container logs
 
@@ -42,7 +42,7 @@ There are two ways to collect logs from containers running in Kubernetes:
 
 Datadog recommends using the Kubernetes log files approach when you are either not using Docker, or are using more than 10 containers per pod.
 
-Datadog also recommends that you take advantage of DaemonSets to [automatically deploy the Datadog Agent on all your nodes][4]. 
+Datadog also recommends that you take advantage of DaemonSets to [automatically deploy the Datadog Agent on all your nodes][4].
 Otherwise, to manually enable log collection from one specific node, add the following parameters in the `datadog.yaml`:
 
 ```
@@ -70,4 +70,4 @@ To get a better idea of how (or why) to integrate your Kubernetes service, see t
 [5]: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup
 [6]: https://www.datadoghq.com/blog/monitoring-kubernetes-era
 [7]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#start-stop-and-restart-the-agent
-[8]: https://docs.datadoghq.com/agent/autodiscovery/?tab=kubernetes#setting-up-check-templates
+[8]: https://docs.datadoghq.com/agent/autodiscovery/integrations/?tab=kubernetes

--- a/content/fr/agent/kubernetes/host_setup.md
+++ b/content/fr/agent/kubernetes/host_setup.md
@@ -28,7 +28,7 @@ Pour recueillir vos métriques kube-state :
 
 Depuis l'[Agent v6][2], l'intégration Kubernetes DNS fonctionne automatiquement avec l'[Autodiscovery][3].
 
-Remarque : ces métriques ne sont pas disponibles pour Azure Kubernetes Service (AKS). 
+Remarque : ces métriques ne sont pas disponibles pour Azure Kubernetes Service (AKS).
 
 ## Recueillir des logs de conteneur
 
@@ -41,7 +41,7 @@ Vous pouvez recueillir vos logs depuis des conteneurs s'exécutant dans Kubernet
 
 Si vous n'utilisez pas Docker ou si vous utilisez plus de 10 conteneurs par pod, il est conseillé de passer par les fichiers de log Kubernetes.
 
-Nous vous recommandons également de tirer parti des DaemonSets pour [déployer automatiquement l'Agent Datadog sur l'ensemble de vos nœuds][4]. 
+Nous vous recommandons également de tirer parti des DaemonSets pour [déployer automatiquement l'Agent Datadog sur l'ensemble de vos nœuds][4].
 Vous pouvez également activer manuellement la collecte de logs à partir d'un nœud spécifique en ajoutant les paramètres suivants dans le fichier `datadog.yaml` :
 
 ```
@@ -69,4 +69,4 @@ Pour mieux comprendre comment (et pourquoi) intégrer votre service Kubernetes, 
 [5]: https://docs.datadoghq.com/fr/agent/basic_agent_usage/kubernetes/#log-collection-setup
 [6]: https://www.datadoghq.com/blog/monitoring-kubernetes-era
 [7]: https://docs.datadoghq.com/fr/agent/guide/agent-commands/?tab=agentv6#start-stop-and-restart-the-agent
-[8]: https://docs.datadoghq.com/fr/agent/autodiscovery/?tab=kubernetes#setting-up-check-templates
+[8]: https://docs.datadoghq.com/fr/agent/autodiscovery/integrations/?tab=kubernetes

--- a/content/fr/integrations/java.md
+++ b/content/fr/integrations/java.md
@@ -128,7 +128,7 @@ instances:
             - <NOM_REGEX_BEAN_EXCLU>
       - include:
           bean_regex: regex_topic=(.*?)
-          attribute: 
+          attribute:
             attribute1:
               metric_type: gauge
               alias: jmx.<NOM_ATTRIBUT_AVEC_TAG_REGEX>
@@ -172,7 +172,7 @@ Pour lancer un check JMX sur l'un de vos conteneurs :
 [5]: https://github.com/DataDog/integrations-core/blob/master/solr/datadog_checks/solr/data/conf.yaml.example
 [6]: https://github.com/DataDog/integrations-core/blob/master/tomcat/datadog_checks/tomcat/data/conf.yaml.example
 [7]: https://github.com/DataDog/integrations-core/blob/master/kafka/datadog_checks/kafka/data/conf.yaml.example
-[8]: https://docs.datadoghq.com/fr/agent/autodiscovery/?tab=files#setting-up-check-templates
+[8]: https://docs.datadoghq.com/fr/agent/autodiscovery/integrations/?tab=kubernetes
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/fr/logs/log_collection/docker.md
+++ b/content/fr/logs/log_collection/docker.md
@@ -215,7 +215,7 @@ spec:
 Consultez le [guide Autodiscovery][1] pour consulter des exemples et en savoir plus sur la configuration et le fonctionnement d'Autodiscovoery.
 
 
-[1]: /fr/agent/autodiscovery/?tab=kubernetes#setting-up-check-templates
+[1]: /fr/agent/autodiscovery/integrations/?tab=kubernetes
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -281,4 +281,4 @@ ac_exclude = ["name:datadog-agent"]
 
 [1]: /fr/integrations/journald/
 [2]: /fr/agent/autodiscovery
-[3]: /fr/agent/autodiscovery/?tab=kubernetes#setting-up-check-templates
+[3]: /fr/agent/autodiscovery/integrations/?tab=kubernetes


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Some links were pointing to an expired anchor, updating them to point to the new, multi-page autodiscovery guide.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/haissam/update-ad-logs-link

### Additional Notes
<!-- Anything else we should know when reviewing?-->
