### PR TITLE
fix typo in log_collection code example

### DIFF
--- a/content/en/logs/log_collection/ruby.md
+++ b/content/en/logs/log_collection/ruby.md
@@ -81,7 +81,7 @@ config.lograge.enabled = true
 # We are asking here to log in RAW (which are actually ruby hashes). The Ruby logging is going to take care of the JSON formatting.
 config.lograge.formatter = Lograge::Formatters::Raw.new
 
-# This is is useful if you want to log query parameters
+# This is useful if you want to log query parameters
 config.lograge.custom_options = lambda do |event|
     { :ddsource => ["ruby"],
       :params => event.payload[:params].reject { |k| %w(controller action).include? k }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fixes a typo in a code example

### Motivation
<!-- What inspired you to submit this pull request?-->
I copied and pasted the code example and had the typo pointed out to me in a code review. I noticed that the typo is present in the documentation so I wanted to point it out.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
