### PR TITLE
Update K8s log instructions to exclude agent logs by default

### DIFF
--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -211,8 +211,12 @@ To enable [Log collection][10] with your DaemonSet:
             value: "true"
         - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
             value: "true"
+        - name: DD_AC_EXCLUDE 
+            value: "name:datadog-agent"
     (...)
     ```
+    
+The `DD_AC_EXCLUDE` prevents the Datadog Agent from collecting and sending its own logs. Remove this parameter if you want to collect the Datadog Agent logs.
 
 2. Mount the Docker socket or logs directories (`/var/log/pods` and `/var/lib/docker/containers` if docker runtime)
 


### PR DESCRIPTION
### What does this PR do?
Prevent the Datadog Agent to collect its own log by default in K8s environment.

### Motivation
The Agent is generating a lot of logs that most of the times are used through a flare and not for real time debugging. Which is why we should suggest to exclude data collection for the agent container by default.

### Preview link

https://docs-staging.datadoghq.com/nils/k8s-log-agent-exclude/agent/kubernetes/daemonset_setup/?tab=k8sfile#log-collection

### Additional Notes
<!-- Anything else we should know when reviewing?-->
