### PR TITLE
Updated the doc for the env DD_PROCESS_AGENT_ENABLED when set to false

### DIFF
--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -79,7 +79,7 @@ Optional collection Agents are disabled by default for security or performance r
 |----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `DD_APM_ENABLED`           | Enable [trace collection][7] with the trace Agent.                                                                                                        |
 | `DD_LOGS_ENABLED`          | Enable [log collection][8] with the logs Agent.                                                                                                            |
-| `DD_PROCESS_AGENT_ENABLED` | Enable [live process collection][9] with the process Agent. The [live container view][10] is already enabled by default if the Docker socket is available. If set to `false`, will disable the live process collection][9] and the [live container view][10]|
+| `DD_PROCESS_AGENT_ENABLED` | Enable [live process collection][9] with the process Agent. The [live container view][10] is already enabled by default if the Docker socket is available. If set to `false`, the [live process collection][9] and the [live container view][10] are disabled.|
 
 ##### DogStatsD (custom metrics)
 

--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -79,7 +79,7 @@ Optional collection Agents are disabled by default for security or performance r
 |----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `DD_APM_ENABLED`           | Enable [trace collection][7] with the trace Agent.                                                                                                        |
 | `DD_LOGS_ENABLED`          | Enable [log collection][8] with the logs Agent.                                                                                                            |
-| `DD_PROCESS_AGENT_ENABLED` | Enable [live process collection][9] with the process Agent. The [live container view][10] is already enabled by default if the Docker socket is available. |
+| `DD_PROCESS_AGENT_ENABLED` | Enable [live process collection][9] with the process Agent. The [live container view][10] is already enabled by default if the Docker socket is available. If set to `false`, will disable the live process collection][9] and the [live container view][10]|
 
 ##### DogStatsD (custom metrics)
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
It updates the doc for the env DD_PROCESS_AGENT_ENABLED when set to false

### Motivation
https://github.com/DataDog/datadog-agent/issues/4077

### Additional Notes
<!-- Anything else we should know when reviewing?-->
