### PR TITLE
downgrade hugo-bin to 0.43.3 which is hugo version 0.55.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "bootstrap": ">=4.1.2",
         "del": "4.1.1",
         "fancy-log": "^1.3.3",
-        "hugo-bin": "0.45.2",
+        "hugo-bin": "0.43.3",
         "jquery": "^3.4.1",
         "jshint": "2.10.2",
         "jshint-stylish": "2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4307,14 +4307,14 @@ https-proxy-agent@^2.2.1:
     agent-base "^4.3.0"
     debug "^3.1.0"
 
-hugo-bin@0.45.2:
-  version "0.45.2"
-  resolved "https://registry.yarnpkg.com/hugo-bin/-/hugo-bin-0.45.2.tgz#6c12202191c4b8ccebe40f0f42166544b2106c30"
-  integrity sha512-UzWyqKuPTRzXdDPAGs35OrHO5GmQlDIqUzQbDKmvtzTg2gXNIK7LITZ4VPHTCgBZIW+pp9ugGLtmyrc57n9EsA==
+hugo-bin@0.43.3:
+  version "0.43.3"
+  resolved "https://registry.yarnpkg.com/hugo-bin/-/hugo-bin-0.43.3.tgz#29d3b348cd03d6f5be99e127cf253a1e9f9e91c2"
+  integrity sha512-E+Xb+WH0Rvr8BQ9tLQ1CcClIEn1Bjd0LOOM0cRgz0M2aHunn7WDwRJs5oJYL3I2oWYXcdf8a0AVS/QgSCgupCQ==
   dependencies:
     bin-wrapper "^4.1.0"
     pkg-conf "^3.1.0"
-    rimraf "^3.0.0"
+    rimraf "^2.6.3"
     signale "^1.4.0"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
@@ -7708,13 +7708,6 @@ rimraf@2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.0.tgz#614176d4b3010b75e5c390eb0ee96f6dc0cebb9b"
-  integrity sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==
   dependencies:
     glob "^7.1.3"
 


### PR DESCRIPTION
### What does this PR do?

There seems to be issues changing files with the local hugo server causing a segfault. When downgrading to another hugo version this seemed to resolve itself.

This will likely need some qa effort to make sure it hasn't introduced any new bugs.

### Motivation
Issues running locally

### Preview link
https://docs-staging.datadoghq.com/david.jones/hugo-version/

### Additional Notes
Do not merge until @l0k0ms reviews