### PR TITLE
Removing outdated dashboards docs

### DIFF
--- a/content/en/glossary.md
+++ b/content/en/glossary.md
@@ -34,9 +34,9 @@ See the [Libraries documentation][3] for more information.
 
 Dashboards are one of the primary ways to visualize your data. There are two types of dashboards: Screenboards and Timeboards.
 
-[Screenboards][4] are dashboards with free-form layouts that can include a variety of objects, such as images, graphs, and logs. They are commonly used as status boards or storytelling tableaux, and can either update in real-time, or represent one or more fixed points in the past.
+[Screenboards][4] are dashboards with free-form layouts that can include a variety of objects, such as images, graphs, and logs. They are commonly used as status boards or storytelling views, and can either update in real-time, or represent one or more fixed points in the past.
 
-[Timeboards][5] have a more structured automatic layout, and represent a single point in time—either fixed or real-time—across the entire dashboard. They are commonly used for troubleshooting, correlation, and general data exploration.
+[Timeboards][5] have automatic layouts, and represent a single point in time—either fixed or real-time—across the entire dashboard. They are commonly used for troubleshooting, correlation, and general data exploration.
 
 #### DogStatsD
 

--- a/content/en/graphing/dashboards/screenboard.md
+++ b/content/en/graphing/dashboards/screenboard.md
@@ -13,7 +13,7 @@ further_reading:
   text: "Discover all available Widgets for your Dashboard"
 ---
 
-Screenboards are dashboards with free-form layouts which can include a variety of objects such as images, graphs, and logs. They are commonly used as status boards or storytelling tableaux, and can either update in real-time, or represent one or more fixed points in the past.
+Screenboards are dashboards with free-form layouts which can include a variety of objects such as images, graphs, and logs. They are commonly used as status boards or storytelling views, and can either update in real-time, or represent one or more fixed points in the past.
 
 ## Read Only
 

--- a/content/en/graphing/dashboards/timeboard.md
+++ b/content/en/graphing/dashboards/timeboard.md
@@ -13,7 +13,7 @@ further_reading:
   text: "Discover all available Widgets for your Dashboard"
 ---
 
-Timeboards have a more structured automatic layout, and represent a single point in time—either fixed or real-time—across the entire dashboard. They are commonly used for troubleshooting, correlation, and general data exploration.
+Timeboards have automatic layouts, and represent a single point in time—either fixed or real-time—across the entire dashboard. They are commonly used for troubleshooting, correlation, and general data exploration.
 
 ## Event correlation
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates descriptions of timeboards and screenboards to be consistent with glossary. Removes outdated documentation on how to edit dashboard titles (graphics and instructions both outdates).

### Motivation
Periodic check to make sure everything is up-to-date!

### Preview links
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/Stephanie_Niu/dashboardcleanup/content/en/glossary.md
https://docs-staging.datadoghq.com/Stephanie_Niu/dashboardcleanup/content/en/graphing/dashboards/screenboard.md
https://docs-staging.datadoghq.com/Stephanie_Niu/dashboardcleanup/content/en/graphing/dashboards/timeboard.md

### Additional Notes
Multiple commits were to unstage some unrelated doc changes.
