### PR TITLE
Update resource.md

### DIFF
--- a/content/en/tracing/visualization/resource.md
+++ b/content/en/tracing/visualization/resource.md
@@ -75,7 +75,7 @@ The displayed metrics represent, per span:
 | ------            | --------                                                                                                |
 | `Avg Span/trace`  | Average number of occurrences of the span, for traces including the current resource, where the span is present at least once. |
 | `% of traces`     | Percentage of traces including the current resource where the span is present at least once. |
-| `Avg duration`    | Average duration for which the span was active, for traces including the current resource, where the span is present at least once.                |
+| `Avg duration`    | Average duration of the span, for traces including the current resource, where the span is present at least once.                |
 | `Avg % Exec Time` | Average ratio of execution time for which the span was active, for traces including the current resource, where the span is present at least once. |
 
 **Note**: A span is considered active when it's not waiting for a child span to complete. The active spans at a given time, for a given trace, are all the leaf spans (i.e.: spans without children).


### PR DESCRIPTION
### What does this PR do?
Fix Avg Duration Description for Span Summary

### Motivation
The old description was explaining the avg execution time of the span while the code clearly compute the avg duration of the span.

### Old link
https://docs.datadoghq.com/tracing/visualization/resource/#span-summary

### Preview link

maybe: 
https://docs-staging.datadoghq.com/c%C3%A9cile/FixAvgDurationDEscription/tracing/visualization/resource/#span-summary

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
