### PR TITLE
correcting firehose permissions

### DIFF
--- a/content/en/integrations/cloud_foundry.md
+++ b/content/en/integrations/cloud_foundry.md
@@ -321,10 +321,10 @@ uaa:
   clients:
     datadog-firehose-nozzle:
       access-token-validity: 1209600
-      authorities: doppler.firehose
+      authorities: doppler.firehose,cloud_controller.admin_read_only
       authorized-grant-types: client_credentials
       override: true
-      scope: doppler.firehose
+      scope: doppler.firehose,cloud_controller.admin_read_only
       secret: <YOUR_SECRET>
 ```
 


### PR DESCRIPTION
added cloud_controller.admin_read_only permissions to match what is asked for in PCF Tile

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes inconsistent permissions from Docs to PCF Tile.

### Motivation
Accurate docs

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
