### PR TITLE
[PROD] Change Java client version to correct value

### DIFF
--- a/content/en/agent/kubernetes/dogstatsd.md
+++ b/content/en/agent/kubernetes/dogstatsd.md
@@ -132,7 +132,7 @@ Origin detection is supported in Agent 6.10.0+ and in the following client libra
 | [Python][11] | 0.28.0  |
 | [Ruby][12]   | 4.2.0   |
 | [C#][13]     | 3.3.0   |
-| [Java][14]   | 2.6     |
+| [Java][14]   | 2.8     |
 
 To set [tag cardinality][15] for the metrics collected using origin detection, use the environment variable `DD_DOGSTATSD_TAG_CARDINALITY`.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
The Java client version that supports origin detection over UDP was incorrect so I changed it to the correct value.

### Motivation

https://datadog.zendesk.com/agent/tickets/249919
### Preview link
https://docs.datadoghq.com/agent/kubernetes/dogstatsd/#origin-detection-over-udp

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/zach-groves-change-java-client-version-to-correct-value/content/en/agent/kubernetes/dogstatsd.md

### Additional Notes
Here is a link to the PR for adding this functionality: https://github.com/DataDog/java-dogstatsd-client/pull/73

DD_ENTITY_ID envar was only added in Java client version 2.8 which is how you configure this feature.
Here is a link to the release: https://github.com/DataDog/java-dogstatsd-client/releases
