### PR TITLE
Update pagerduty_add_services_code.md

### DIFF
--- a/content/en/api/integrations_pagerduty/pagerduty_add_services_code.md
+++ b/content/en/api/integrations_pagerduty/pagerduty_add_services_code.md
@@ -6,7 +6,7 @@ external_redirect: /api/#add-new-services-and-schedules
 ---
 
 ##### Signature
-`PUT /v1/integration/pagerduty`
+`POST /v1/integration/pagerduty`
 
 ##### Example Request
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes a discrepancy between the `Signature` and `Example Request` sections of a code example for the Pagerduty integration API.

Currently, the code example shows a `POST` requests, whereas the `Signature` section shows a `PUT` request. It should be a `POST` request, so this updates the `Signature` section from `PUT` to `POST`.

https://docs.datadoghq.com/api/?lang=bash#add-new-services-and-schedules

![image](https://user-images.githubusercontent.com/7545301/63895130-475fb500-c9bc-11e9-8206-b88f0fc6006d.png)
