### PR TITLE
changes to allow fr to be indexed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,7 +115,7 @@ build_live:
     - build_hugo_site_new
     - collect_static_assets
     - push_site_to_s3
-    - chmod +x ./local/bin/py/algolia_index.py && ./local/bin/py/algolia_index.py -d "['js', 'images', 'fonts', 'en', 'css', 'search', 'json', 'error', 'matts quick tips', 'videos']" -l "['fr','ja']" -c "./local/etc/algolia/docs_datadoghq.json"
+    - chmod +x ./local/bin/py/algolia_index.py && ./local/bin/py/algolia_index.py -d "['js', 'images', 'fonts', 'en', 'css', 'search', 'json', 'error', 'matts quick tips', 'videos']" -l "['ja']" -c "./local/etc/algolia/docs_datadoghq.json"
     - create_artifact
     - create_artifact_untracked
     - chmod +x ./local/bin/py/missing_metrics.py && ./local/bin/py/missing_metrics.py -k $(get_secret 'dd-demo-api-key') -p $(get_secret 'dd-demo-app-key') -a $(get_secret 'dd_api_key') -b $(get_secret 'dd-app-key')

--- a/layouts/partials/hreflang.html
+++ b/layouts/partials/hreflang.html
@@ -1,7 +1,7 @@
-{{/*
 {{ if .IsTranslated }}
   {{ range .Translations }}
-    <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}"/>
+    {{ if in (slice "fr") .Lang }}
+      <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}"/>
+    {{ end }}
   {{ end}}
 {{ end }}
-*/}}

--- a/layouts/partials/noindex.html
+++ b/layouts/partials/noindex.html
@@ -1,3 +1,3 @@
-{{ if (or (eq .Params.beta true) (eq .Params.private true) (eq .Params.placeholder true) (eq .Site.Params.environment "preview") (eq .Params.noindex true) (in (slice "fr" "ja") (.Language.Lang | default "en") )) }}
+{{ if (or (eq .Params.beta true) (eq .Params.private true) (eq .Params.placeholder true) (eq .Site.Params.environment "preview") (eq .Params.noindex true) (in (slice "ja") (.Language.Lang | default "en") )) }}
 <meta name="robots" content="noindex, nofollow">
 {{ end }}

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,6 +1,6 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range where (where .Data.Pages "Params.beta" "!=" true) ".Params.is_public" "!=" false }}
-  	  {{ if (and (not .Params.private) (ne (.Language.Lang | default "en") "fr") (ne (.Language.Lang | default "en") "ja") ) }}
+  	  {{ if (and (not .Params.private) (ne (.Language.Lang | default "en") "ja") ) }}
 	  <url>
 	    <loc>{{ .Permalink }}</loc>
       {{ if not .Lastmod.IsZero }}
@@ -9,13 +9,13 @@
       {{ with .Sitemap.ChangeFreq }}<changefreq>{{ . }}</changefreq>{{ end }}
       {{ if ge .Sitemap.Priority 0.0 }}<priority>{{ .Sitemap.Priority }}</priority>{{ end }}
 
-      {{/*
       {{ if .IsTranslated }}
         {{ range .Translations }}
-            <xhtml:link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}"/>
+            {{ if in (slice "fr") .Lang }}
+              <xhtml:link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}"/>
+            {{ end }}
         {{ end}}
       {{ end }}
-      */}}
 
 	  </url>
 	  {{ end }}

--- a/layouts/sitemapindex.xml
+++ b/layouts/sitemapindex.xml
@@ -1,6 +1,6 @@
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 	{{ range . }}
-  {{ if not (or (eq .Language.Lang "fr") (eq .Language.Lang "ja")) }}
+  {{ if not (eq .Language.Lang "ja") }}
 	<sitemap>
 	  	<loc>{{ .SitemapAbsURL }}</loc>
 		{{ if not .LastChange.IsZero }}


### PR DESCRIPTION
### What does this PR do?

This PR is to:

- Stop french pages from having the noindex meta
- Enable the alternate hreflang for french pages
- Update the sitemap to list the fr pages

### Motivation
Discussions with Kaylyn and Gus

### Preview link
https://docs-staging.datadoghq.com/david.jones/google-index-fr/

### Additional Notes

