### PR TITLE
Agent Status Page

### DIFF
--- a/content/en/agent/guide/_index.md
+++ b/content/en/agent/guide/_index.md
@@ -9,7 +9,7 @@ disable_toc: true
     {{< nextlink href="agent/guide/agent-commands" >}}Agent Commands{{< /nextlink >}}
     {{< nextlink href="agent/guide/agent-configuration-files" >}}Agent Configuration Files{{< /nextlink >}}
     {{< nextlink href="agent/guide/agent-log-files" >}}Agent Log Files{{< /nextlink >}}
-    {{< nextlink href="agent/guide/agent-status-page" >}}Agent Status Page{{< /nextlink >}}
+    {{< nextlink href="agent/guide/agent-status-page" >}}Agent v6 Status Page{{< /nextlink >}}
     {{< nextlink href="agent/guide/integration-management" >}}Integration Management{{< /nextlink >}}
     {{< nextlink href="agent/guide/network" >}}Network Traffic{{< /nextlink >}}
     {{< nextlink href="agent/guide/secrets-management" >}}Secrets Management{{< /nextlink >}}

--- a/content/en/agent/guide/_index.md
+++ b/content/en/agent/guide/_index.md
@@ -9,6 +9,7 @@ disable_toc: true
     {{< nextlink href="agent/guide/agent-commands" >}}Agent Commands{{< /nextlink >}}
     {{< nextlink href="agent/guide/agent-configuration-files" >}}Agent Configuration Files{{< /nextlink >}}
     {{< nextlink href="agent/guide/agent-log-files" >}}Agent Log Files{{< /nextlink >}}
+    {{< nextlink href="agent/guide/agent-status-page" >}}Agent Status Page{{< /nextlink >}}
     {{< nextlink href="agent/guide/integration-management" >}}Integration Management{{< /nextlink >}}
     {{< nextlink href="agent/guide/network" >}}Network Traffic{{< /nextlink >}}
     {{< nextlink href="agent/guide/secrets-management" >}}Secrets Management{{< /nextlink >}}

--- a/content/en/agent/guide/agent-status-page.md
+++ b/content/en/agent/guide/agent-status-page.md
@@ -13,11 +13,9 @@ further_reading:
   text: "Agent Commands"
 ---
 
-## Overview
-
 The Agent status page displays information about your running Agent. See [Agent Commands][1] to find the status command for your environment. The sections below provide details on the contents of the status page.
 
-### Agent version
+## Agent version
 
 General information for Agent is displayed under the Agent version, for example:
 ```text
@@ -30,7 +28,7 @@ General information for Agent is displayed under the Agent version, for example:
   Log Level: info
 ```
 
-#### Paths
+### Paths
 
 This section displays the paths to the Datadog config file, `conf.d` directory, and `checks.d` directory, for example:
 ```text
@@ -39,7 +37,7 @@ This section displays the paths to the Datadog config file, `conf.d` directory, 
     checks.d: /etc/datadog-agent/checks.d
 ```
 
-#### Clocks
+### Clocks
 
 This section displays the [NTP offset][2] and system UTC time, for example:
 ```text
@@ -47,7 +45,7 @@ This section displays the [NTP offset][2] and system UTC time, for example:
     System UTC time: 2019-08-29 18:16:41.526203 UTC
 ```
 
-#### Host Info
+### Host Info
 
 This section displays information on the host the Agent is running on, for example:
 ```text
@@ -63,7 +61,7 @@ This section displays information on the host the Agent is running on, for examp
     virtualizationSystem: vbox
 ```
 
-#### Hostnames
+### Hostnames
 
 This section displays the hostnames found by the Agent, for example:
 ```text
@@ -77,8 +75,8 @@ This section displays the hostnames found by the Agent, for example:
       gce: unable to retrieve hostname from GCE: Get http://169.254.169.254/computeMetadata/v1/instance/hostname: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
 ```
 
-### Collector
-#### Running Checks
+## Collector
+### Running Checks
 
 This section displays a list of running check instances, for example:
 ```text
@@ -92,18 +90,20 @@ This section displays a list of running check instances, for example:
       Average Execution Time : 6ms
 ```
 
-##### Definitions
+Terms and descriptions:
 
-* **Instance ID**: The instance ID and the status of the check.
-* **Total Runs**: The total number of times the instance has run.
-* **Metric Samples**: The number of fetched metrics.
-* **Events**: The number of triggered events.
-* **Service Checks**: The number of service checks reported.
-* **Average Execution Time**: The average time taken to run the instance.
-* **Last Run**: The number during the last check run.
-* **Total**: The total number since the Agent's most recent start or restart.
+| Term                   | Description                                                      |
+|------------------------|------------------------------------------------------------------|
+| Instance ID            | The instance ID and the status of the check.                     |
+| Total Runs             | The total number of times the instance has run.                  |
+| Metric Samples         | The number of fetched metrics.                                   |
+| Events                 | The number of triggered events.                                  |
+| Service Checks         | The number of service checks reported.                           |
+| Average Execution Time | The average time taken to run the instance.                      |
+| Last Run               | The number during the last check run.                            |
+| Total                  | The total number since the Agent's most recent start or restart. |
 
-#### Config Errors
+### Config Errors
 
 This section only displays if there are checks with config errors, for example:
 ```text
@@ -112,7 +112,7 @@ This section only displays if there are checks with config errors, for example:
       Configuration file contains no valid instances
 ```
 
-#### Loading Errors
+### Loading Errors
 
 This section only displays if there are checks with loading errors, for example:
 ```text
@@ -128,7 +128,7 @@ This section only displays if there are checks with loading errors, for example:
         unable to import module 'test': No module named test
 ```
 
-### JMXFetch
+## JMXFetch
 
 This section displays a list of initialized and failed JMX checks even if there are no checks, for example:
 ```text
@@ -141,13 +141,13 @@ This section displays a list of initialized and failed JMX checks even if there 
     no checks
 ```
 
-### Forwarder
+## Forwarder
 
 The forwarder uses a number of workers to send payloads to Datadog.
 
 If you see the warning `the forwarder dropped transactions, there is probably an issue with your network`, this means that all the workers were busy. You should review your network performance and tune the `forwarder_num_workers` and `forwarder_timeout` options.
 
-#### Transactions
+### Transactions
 
 This section displays the transactions made by the forwarder, for example:
 ```text
@@ -169,21 +169,23 @@ This section displays the transactions made by the forwarder, for example:
     Errors: 1
 ```
 
-##### Definitions
+Terms and descriptions:
 
-* **CheckRunsV1**: The number of service check payloads sent.
-* **IntakeV1**: The number of event payloads sent.
-* **TimeseriesV1**: The number of metric payloads sent.
-* **Errors**: The number of errors while sending payloads.
+| Term         | Description                                  |
+|--------------|----------------------------------------------|
+| CheckRunsV1  | The number of service check payloads sent.   |
+| IntakeV1     | The number of event payloads sent.           |
+| TimeseriesV1 | The number of metric payloads sent.          |
+| Errors       | The number of errors while sending payloads. |
 
-#### API Keys status
+### API Keys status
 
 This sections shows the status of your configured API key, for example:
 ```text
     API key ending with ab123: API Key valid
 ```
 
-### Endpoints
+## Endpoints
 
 This section displays the list of endpoints in use by the Datadog Agent, for example:
 ```text
@@ -191,7 +193,7 @@ This section displays the list of endpoints in use by the Datadog Agent, for exa
       - ab123
 ```
 
-### Logs Agent
+## Logs Agent
 
 If the Logs Agent is enabled, this section displays information on the logs processed and sent, for example:
 ```text
@@ -199,7 +201,7 @@ If the Logs Agent is enabled, this section displays information on the logs proc
     LogsSent: 10
 ```
 
-### Aggregator
+## Aggregator
 
 This section displays information on the Agent's aggregator, for example:
 ```text
@@ -213,16 +215,18 @@ This section displays information on the Agent's aggregator, for example:
   Service Checks Flushed: 20
 ```
 
-##### Definitions
+Terms and descriptions:
 
-* **Checks Metric Sample**: The total number of metrics sent from the checks to the aggregator.
-* **Dogstatsd Metric Sample**: The total number of metrics sent from the DogStatsD server to the aggregator.
-* **Event**: The total number of events sent to the aggregator.
-* **Service Check**: The total number of service checks sent to the aggregator.
-* **Flush**: The aggregator stores data in a queue. The queue is emptied once per flush interval and the data is sent to the forwarder.
+| Term                    | Description                                                                                                                |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| Checks Metric Sample    | The total number of metrics sent from the checks to the aggregator.                                                        |
+| Dogstatsd Metric Sample | The total number of metrics sent from the DogStatsD server to the aggregator.                                              |
+| Event                   | The total number of events sent to the aggregator.                                                                         |
+| Service Check           | The total number of service checks sent to the aggregator.                                                                 |
+| Flush                   | The aggregator stores data in a queue. The queue is emptied once per flush interval and the data is sent to the forwarder. |
 
 
-### DogStatsD
+## DogStatsD
 
 This section displays the number of packets received by the DogStatsD server for each type of data and associated errors, for example:
 ```text

--- a/content/en/agent/guide/agent-status-page.md
+++ b/content/en/agent/guide/agent-status-page.md
@@ -1,0 +1,249 @@
+---
+title: Agent Status Page
+kind: guide
+further_reading:
+- link: "agent/troubleshooting/"
+  tag: "Documentation"
+  text: "Agent Troubleshooting"
+- link: "agent/guide/agent-configuration-files/"
+  tag: "Guide"
+  text: "Agent Configuration Files"
+- link: "agent/guide/agent-commands/"
+  tag: "Guide"
+  text: "Agent Commands"
+---
+
+## Overview
+
+The Agent status page displays information about your running Agent. See [Agent Commands][1] to find the status command for your environment. The sections below provide details on the contents of the status page.
+
+### Agent version
+
+General information for Agent is displayed under the Agent version, for example:
+```text
+  Status date: 2019-08-29 18:16:41.526203 UTC
+  Agent start: 2019-08-29 18:04:18.060507 UTC
+  Pid: 12141
+  Go Version: go1.11.5
+  Python Version: 2.7.16
+  Check Runners: 4
+  Log Level: info
+```
+
+#### Paths
+
+This section displays the paths to the Datadog config file, `conf.d` directory, and `checks.d` directory, for example:
+```text
+    Config File: /etc/datadog-agent/datadog.yaml
+    conf.d: /etc/datadog-agent/conf.d
+    checks.d: /etc/datadog-agent/checks.d
+```
+
+#### Clocks
+
+This section displays the [NTP offset][2] and system UTC time, for example:
+```text
+    NTP offset: 2.095ms
+    System UTC time: 2019-08-29 18:16:41.526203 UTC
+```
+
+#### Host Info
+
+This section displays information on the host the Agent is running on, for example:
+```text
+    bootTime: 2019-08-29 18:01:27.000000 UTC
+    kernelVersion: 4.4.0-109-generic
+    os: linux
+    platform: ubuntu
+    platformFamily: debian
+    platformVersion: 16.04
+    procs: 175
+    uptime: 2m53s
+    virtualizationRole: guest
+    virtualizationSystem: vbox
+```
+
+#### Hostnames
+
+This section displays the hostnames found by the Agent, for example:
+```text
+    hostname: ubuntu-xenial
+    socket-fqdn: ubuntu-xenial
+    socket-hostname: ubuntu-xenial
+    hostname provider: os
+    unused hostname providers:
+      aws: not retrieving hostname from AWS: the host is not an ECS instance, and other providers already retrieve non-default hostnames
+      configuration/environment: hostname is empty
+      gce: unable to retrieve hostname from GCE: Get http://169.254.169.254/computeMetadata/v1/instance/hostname: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
+```
+
+### Collector
+#### Running Checks
+
+This section displays a list of running check instances, for example:
+```text
+    load
+    ----
+      Instance ID: load [OK]
+      Total Runs: 4
+      Metric Samples: Last Run: 6, Total: 24
+      Events: Last Run: 0, Total: 0
+      Service Checks: Last Run: 0, Total: 0
+      Average Execution Time : 6ms
+```
+
+##### Definitions
+
+* **Instance ID**: The instance ID and the status of the check.
+* **Total Runs**: The total number of times the instance has run.
+* **Metric Samples**: The number of fetched metrics.
+* **Events**: The number of triggered events.
+* **Service Checks**: The number of service checks reported.
+* **Average Execution Time**: The average time taken to run the instance.
+* **Last Run**: The number during the last check run.
+* **Total**: The total number since the Agent's most recent start or restart.
+
+#### Config Errors
+
+This section only displays if there are checks with config errors, for example:
+```text
+    test
+    ----
+      Configuration file contains no valid instances
+```
+
+#### Loading Errors
+
+This section only displays if there are checks with loading errors, for example:
+```text
+    test
+    ----
+      Core Check Loader:
+        Check test not found in Catalog
+        
+      JMX Check Loader:
+        check is not a jmx check, or unable to determine if it's so
+        
+      Python Check Loader:
+        unable to import module 'test': No module named test
+```
+
+### JMXFetch
+
+This section displays a list of initialized and failed JMX checks even if there are no checks, for example:
+```text
+  Initialized checks
+  ==================
+    no checks
+    
+  Failed checks
+  =============
+    no checks
+```
+
+### Forwarder
+
+The forwarder uses a number of workers to send payloads to Datadog.
+
+If you see the warning `the forwarder dropped transactions, there is probably an issue with your network`, this means that all the workers were busy. You should review your network performance and tune the `forwarder_num_workers` and `forwarder_timeout` options.
+
+#### Transactions
+
+This section displays the transactions made by the forwarder, for example:
+```text
+    CheckRunsV1: 2
+    Dropped: 0
+    DroppedOnInput: 0
+    Events: 0
+    HostMetadata: 0
+    IntakeV1: 2
+    Metadata: 0
+    Requeued: 0
+    Retried: 0
+    RetryQueueSize: 0
+    Series: 0
+    ServiceChecks: 0
+    SketchSeries: 0
+    Success: 6
+    TimeseriesV1: 2
+    Errors: 1
+```
+
+##### Definitions
+
+* **CheckRunsV1**: The number of service check payloads sent.
+* **IntakeV1**: The number of event payloads sent.
+* **TimeseriesV1**: The number of metric payloads sent.
+* **Errors**: The number of errors while sending payloads.
+
+#### API Keys status
+
+This sections shows the status of your configured API key, for example:
+```text
+    API key ending with ab123: API Key valid
+```
+
+### Endpoints
+
+This section displays the list of endpoints in use by the Datadog Agent, for example:
+```text
+  https://app.datadoghq.com - API Key ending with:
+      - ab123
+```
+
+### Logs Agent
+
+If the Logs Agent is enabled, this section displays information on the logs processed and sent, for example:
+```text
+    LogsProcessed: 10
+    LogsSent: 10
+```
+
+### Aggregator
+
+This section displays information on the Agent's aggregator, for example:
+```text
+  Checks Metric Sample: 399
+  Dogstatsd Metric Sample: 123
+  Event: 1
+  Events Flushed: 1
+  Number Of Flushes: 2
+  Series Flushed: 273
+  Service Check: 20
+  Service Checks Flushed: 20
+```
+
+##### Definitions
+
+* **Checks Metric Sample**: The total number of metrics sent from the checks to the aggregator.
+* **Dogstatsd Metric Sample**: The total number of metrics sent from the DogStatsD server to the aggregator.
+* **Event**: The total number of events sent to the aggregator.
+* **Service Check**: The total number of service checks sent to the aggregator.
+* **Flush**: The aggregator stores data in a queue. The queue is emptied once per flush interval and the data is sent to the forwarder.
+
+
+### DogStatsD
+
+This section displays the number of packets received by the DogStatsD server for each type of data and associated errors, for example:
+```text
+  Event Packets: 0
+  Event Parse Errors: 0
+  Metric Packets: 122
+  Metric Parse Errors: 0
+  Service Check Packets: 0
+  Service Check Parse Errors: 0
+  Udp Bytes: 7,672
+  Udp Packet Reading Errors: 0
+  Udp Packets: 123
+  Uds Bytes: 0
+  Uds Origin Detection Errors: 0
+  Uds Packet Reading Errors: 0
+  Uds Packets: 0
+```
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /agent/guide/agent-commands/#agent-information
+[2]: /agent/troubleshooting/ntp

--- a/content/en/agent/guide/agent-status-page.md
+++ b/content/en/agent/guide/agent-status-page.md
@@ -1,5 +1,5 @@
 ---
-title: Agent Status Page
+title: Agent v6 Status Page
 kind: guide
 further_reading:
 - link: "agent/troubleshooting/"
@@ -13,7 +13,9 @@ further_reading:
   text: "Agent Commands"
 ---
 
-The Agent status page displays information about your running Agent. See [Agent Commands][1] to find the status command for your environment. The sections below provide details on the contents of the status page.
+The Agent v6 status page displays information about your running Agent. See [Agent Commands][1] to find the status command for your environment. The sections below provide details on the contents of the status page.
+
+**Note**: The status page may have minor differences between Agent versions. 
 
 ## Agent version
 
@@ -63,7 +65,7 @@ This section displays information on the host the Agent is running on, for examp
 
 ### Hostnames
 
-This section displays the hostnames found by the Agent, for example:
+This section displays the hostnames found by the Agent (see the example below). The `hostname` is the final hostname reported to the backend. For more information, see [How does Datadog determine the Agent hostname][3].
 ```text
     hostname: ubuntu-xenial
     socket-fqdn: ubuntu-xenial
@@ -171,12 +173,14 @@ This section displays the transactions made by the forwarder, for example:
 
 Terms and descriptions:
 
-| Term         | Description                                  |
-|--------------|----------------------------------------------|
-| CheckRunsV1  | The number of service check payloads sent.   |
-| IntakeV1     | The number of event payloads sent.           |
-| TimeseriesV1 | The number of metric payloads sent.          |
-| Errors       | The number of errors while sending payloads. |
+| Term           | Description                                                                  |
+|----------------|------------------------------------------------------------------------------|
+| Success        | The number of transactions successfully sent.                                |
+| Errors         | The number of times a transaction failed to be sent and was retried.         |
+| RetryQueueSize | The current number of transactions waiting to be retried.                    |
+| Retried        | The number of times a transaction was retried.                               |
+| DroppedOnInput | The number of transactions that were dropped because all workers were busy.  |
+| Dropped        | The number of transactions dropped because they were retried too many times. |
 
 ### API Keys status
 
@@ -217,13 +221,13 @@ This section displays information on the Agent's aggregator, for example:
 
 Terms and descriptions:
 
-| Term                    | Description                                                                                                                |
-|-------------------------|----------------------------------------------------------------------------------------------------------------------------|
-| Checks Metric Sample    | The total number of metrics sent from the checks to the aggregator.                                                        |
-| Dogstatsd Metric Sample | The total number of metrics sent from the DogStatsD server to the aggregator.                                              |
-| Event                   | The total number of events sent to the aggregator.                                                                         |
-| Service Check           | The total number of service checks sent to the aggregator.                                                                 |
-| Flush                   | The aggregator stores data in a queue. The queue is emptied once per flush interval and the data is sent to the forwarder. |
+| Term                    | Description                                                                              |
+|-------------------------|------------------------------------------------------------------------------------------|
+| Checks Metric Sample    | The total number of metrics sent from the checks to the aggregator.                      |
+| Dogstatsd Metric Sample | The total number of metrics sent from the DogStatsD server to the aggregator.            |
+| Event                   | The total number of events sent to the aggregator.                                       |
+| Service Check           | The total number of service checks sent to the aggregator.                               |
+| Flush                   | The number of times aggregated metrics were flushed to the forwarder to send to Datadog. |
 
 
 ## DogStatsD
@@ -251,3 +255,4 @@ This section displays the number of packets received by the DogStatsD server for
 
 [1]: /agent/guide/agent-commands/#agent-information
 [2]: /agent/troubleshooting/ntp
+[3]: /agent/faq/how-datadog-agent-determines-the-hostname


### PR DESCRIPTION
### What does this PR do?
- Add Agent Status Page to the public docs site

### Motivation
- Single source of the truth

### Preview link
https://docs-staging.datadoghq.com/ruth/agent-status/agent/guide/agent-status-page/

### Additional Notes
- Do not merge until Agent team reviews
- Remove page from the [datadog-agent](https://github.com/DataDog/datadog-agent/blob/master/docs/agent/status.md) repo after this is merged.
