### PR TITLE
only show alternate when its not a placeholder, also only output on s…

### DIFF
--- a/layouts/partials/hreflang.html
+++ b/layouts/partials/hreflang.html
@@ -1,7 +1,9 @@
 {{ if .IsTranslated }}
   {{ range .Translations }}
     {{ if in (slice "fr") .Lang }}
-      <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}"/>
+      {{ if ne .Params.placeholder true }}
+        <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}"/>
+      {{ end }}
     {{ end }}
   {{ end}}
 {{ end }}

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,6 +1,6 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range where (where .Data.Pages "Params.beta" "!=" true) ".Params.is_public" "!=" false }}
-  	  {{ if (and (not .Params.private) (ne (.Language.Lang | default "en") "ja") ) }}
+  	  {{ if (and (not .Params.private) (not .Params.placeholder) (ne (.Language.Lang | default "en") "ja") ) }}
 	  <url>
 	    <loc>{{ .Permalink }}</loc>
       {{ if not .Lastmod.IsZero }}


### PR DESCRIPTION
### What does this PR do?

This PR stops placeholders from being part of the indexing as they aren't translated.

- only shows hreflang alternate when its not a placeholder
- only output on sitemap when not a placeholder

### Motivation
Discussion and Google search console errors

### Preview link
https://docs-staging.datadoghq.com/david.jones/update-indexing/

### Additional Notes
Follow on from https://github.com/DataDog/documentation/pull/5332
