### PR TITLE
tm job force pass

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,7 +74,6 @@ test_missing_tms_preview:
   <<: *base_template
   stage: post-deploy
   environment: "preview"
-  allow_failure: true
   dependencies:
     - build_preview
   script:
@@ -180,7 +179,6 @@ test_missing_tms_live:
   <<: *base_template
   stage: post-deploy
   environment: "live"
-  allow_failure: true
   dependencies:
     - build_live
   script:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This forces the trademark check to pass in the gitlab pipeline
### Motivation
<!-- What inspired you to submit this pull request?-->
https://trello.com/c/xWshocfr/3915-do-not-allow-gitlab-trademark-check-job-to-fail
### Preview link
https://docs-staging.datadoghq.com/eric.fraese/trademark-pipeline-job-force-pass/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
If the tm job fails, the user will be notified on slack.
The following monitor has been setup for master builds: https://dd-corpsite.datadoghq.com/monitors/10949858

Merge the corp-ci pr first: https://github.com/DataDog/corp-ci/pull/53