### PR TITLE
Agent hostname resolution

### DIFF
--- a/content/en/agent/faq/how-datadog-agent-determines-the-hostname.md
+++ b/content/en/agent/faq/how-datadog-agent-determines-the-hostname.md
@@ -6,28 +6,10 @@ aliases:
 comments: <!–– Original flowchart is in lucidchart. Search Trello for link or ask Grant. ––>
 ---
 
-{{< tabs >}}
-{{% tab "Agent v6" %}}
+## Potential host names
 
-For Agent 6, there are differences in hostname resolution. For more information, see [differences in hostname resolution between Agent v5 and Agent v6][1].
-
-**Note**: Starting from the Agent v6.3 a configuration option called `hostname_fqdn` has been introduced that allows Agent v6 to have the same behavior as Agent v5. This flag is disabled by default on version 6.3+. See the [example datadog.yaml][2] for enabling this option.
-
-
-[1]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/hostname-resolution.md
-[2]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
-{{% /tab %}}
-{{% tab "Agent v5" %}}
-
-{{< img src="agent/faq/agent_hostname.jpeg" alt="Agent hostname scheme" responsive="true" >}}
-
-{{% /tab %}}
-{{< /tabs >}}
-
-### Potential host names
-
-The Datadog Agent collects potential host names from many different sources. To see all the names the Agent is detecting, run the Agent's [status subcommand][1].
-```
+The Datadog Agent collects potential host names from many different sources. Run the Agent's [status subcommand][1] to see all names the Agent is detecting.
+```text
 ...
 Hostnames
 =========
@@ -41,20 +23,20 @@ Hostnames
 ...
 ```
 
-From these names, a canonical name is picked for the host. This is the name the Agent primarily uses to identify itself to Datadog. The other names are submitted as well, but only as candidates for aliasing.
+From these names, a canonical name is chosen for the host. The Agent uses this name to identify itself to Datadog. The other names are submitted as well, but only as candidates for aliasing.
 
-The canonical hostname is picked according to the following rules. The first match is selected.
+The canonical hostname is chosen according to the following rules. The first match is selected.
 
-* **agent-hostname**: A hostname explicitly set in the Agent configuration file.
+* **agent-hostname**: A hostname explicitly set in the [Agent configuration file][2].
 * **hostname**: If the DNS hostname is not an EC2 default (e.g. ip-192-0-0-1).
 * **instance-id**: If the Agent can reach the EC2 metadata endpoint from the host.
 * **hostname**: Fall back on the DNS hostname even if it is an EC2 default.
 
-If the name is recognized as obviously non-unique (like localhost.localdomain), the current rule fails and passes through to the next.
+If the name is recognized as obviously non-unique (example: `localhost.localdomain`), the current rule fails and passes through to the next.
 
-#### AWS hosts
+### AWS hosts
 
-When pulling information on your AWS hosts from the [Datadog API][2], the following attributes display based on availability:
+When pulling information on your AWS hosts from the [Datadog API][3], the following attributes display based on availability:
 
 | Attribute      | Description                                         |
 |----------------|-----------------------------------------------------|
@@ -64,14 +46,76 @@ When pulling information on your AWS hosts from the [Datadog API][2], the follow
 
 ### Host Aliases
 
-A single host running in EC2 might have an instance ID (i-abcd1234), a generic hostname provided by EC2 based on the host's IP address (ip-192-0-0-1), and a meaningful hostname provided by an internal DNS server or a config-managed hosts file (myhost.mydomain). Datadog creates aliases for hostnames when there are multiple uniquely identifiable names for a single host.
+A single host running in EC2 might have an instance ID (i-abcd1234), a generic hostname provided by EC2 based on the host's IP address (ip-192-0-0-1), and a meaningful hostname provided by an internal DNS server or a config-managed hosts file (myhost.mydomain). Datadog creates aliases for host names when there are multiple uniquely identifiable names for a single host.
 
 The names collected by the Agent (detailed above) are added as aliases for the chosen canonical name.
 
-See a list of all the hosts in your account from the [Infrastructure List][3]. See the list of aliases associated with each host in the Inspect panel, which is accessed by clicking the "Inspect" button while hovering over a host row:
+See the list of all hosts in your account from the [Infrastructure List][4]. The aliases associated with each host are available in the inspect panel, which is accessed by clicking the **Inspect** button while hovering over a host row:
 
 {{< img src="agent/faq/host_aliases.png" alt="Host aliases" responsive="true" >}}
 
+## Agent versions
+
+{{< tabs >}}
+{{% tab "Agent v6" %}}
+
+There are differences in hostname resolution between Agent v5 and Agent v6.
+
+### Linux/MacOS
+
+When upgrading from Agent v5 to Agent v6, there might be a difference in the hostname reported by your Agent. To resolve the system hostname Agent v5 uses the `hostname -f` command while Agent v6 uses the Golang API `os.Hostname()`. On upgrades, the Agent hostname could change from a Fully-Qualified Domain Name (FQDN) to a short hostname, for example:
+
+`sub.domain.tld` --> `sub`
+
+**Note**: Starting from Agent v6.3, a configuration option called `hostname_fqdn` was introduced that allows Agent v6 to have the same behavior as Agent v5. This flag is disabled by default on version 6.3+. See the [example datadog.yaml][1] for enabling this option.
+
+#### Determine if you're affected
+
+Starting with v6.3.0, the Agent logs the warning below if you’re affected by the change:
+```text
+DEPRECATION NOTICE: The agent resolved your hostname as <HOSTNAME>. However in a future version, it will be resolved as <FQDN> by default. To enable the future behavior, please enable the `hostname_fqdn` flag in the configuration.
+```
+
+You are not affected if any of the following are true:
+
+* You are running the Agent in GCE.
+* You are setting the hostname in the [Agent's main configuration][2] file or through the `DD_HOSTNAME` environment variable.
+* You are running the Agent in a container with access to the Docker or Kubernetes API.
+* The hostname output of `cat /proc/sys/kernel/hostname` and `hostname -f` are the same.
+
+#### Recommended action
+
+If you're affected by this change, Datadog recommends taking the following action when you upgrade your Agent:
+
+* **Upgrading from Agent v5 to Agent v < 6.3**: Hardcode your hostname in the [Agent's main configuration][2] file.
+* **Upgrading from Agent v5 to Agent >= v6.3**: enable the `hostname_fqdn` option in the [Agent's main configuration][2] file. This ensures that you keep the same hostname.
+* **Upgrading from Agent v5 to Agent v6 (a future version which uses the fqdn by default)**: you don’t need to take any action.
+* If you want to ensure the current default behavior of Agent v6 is preserved when you upgrade the Agent in the future, set `hostname_fqdn` to `false`. That said, Datadog recommends you switch `hostname_fqdn` to `true` whenever possible.
+
+### Windows
+
+On Agent v5, the Windows Agent reported the unqualified hostname by default. To maintain backward compatibility, this behavior is preserved with Agent v6. The new flag `hostname_fqdn` remains disabled by default on Windows, and will remain disabled by default on future **v6** versions.
+
+The Windows Agent honors the configuration flag starting with v6.5. Setting `hostname_fqdn` to true results in the Windows Agent reporting the fully qualified hostname.
+
+#### Recommended action
+
+By default, the recommended action is to do nothing. This preserves the existing behavior, especially if upgrading from Agent v5.
+
+If you want to have Windows hosts specifically report fully qualified host names, then add the `hostname_fqdn` flag to the configuration file.
+
+
+[1]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
+[2]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
+{{% /tab %}}
+{{% tab "Agent v5" %}}
+
+{{< img src="agent/faq/agent_hostname.jpeg" alt="Agent hostname scheme" responsive="true" >}}
+
+{{% /tab %}}
+{{< /tabs >}}
+
 [1]: /agent/guide/agent-commands/#agent-status-and-information
-[2]: /api/#hosts
-[3]: https://app.datadoghq.com/infrastructure
+[2]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
+[3]: /api/#hosts
+[4]: https://app.datadoghq.com/infrastructure


### PR DESCRIPTION

### What does this PR do?
- Add Agent hostname resolution changes to the main documentation
- Organize content

### Motivation
- Single source for Agent docs

### Preview link
https://docs-staging.datadoghq.com/ruth/hostname-resolution/agent/faq/how-datadog-agent-determines-the-hostname/

### Additional Notes
N/A
