### PR TITLE
Table support code blocks

### DIFF
--- a/layouts/shortcodes/get-metrics-from-git.html
+++ b/layouts/shortcodes/get-metrics-from-git.html
@@ -51,7 +51,7 @@
           <tr>
             <td>
             <strong>{{$v.metric_name}}</strong><br>({{$v.metric_type}})</td>
-            <td>{{$v.description}}{{if $v.unit_name}}<br><em>shown as {{$v.unit_name}}</em>{{end}}
+            <td>{{$v.description | safeHTML }}{{if $v.unit_name}}<br><em>Shown as {{$v.unit_name}}</em>{{end}}
             </td>
           </tr>
 
@@ -73,7 +73,7 @@
     <tr>
       <td>
       <strong>{{$v.metric_name}}</strong><br>({{$v.metric_type}})</td>
-      <td>{{$v.description}}{{if $v.unit_name}}<br><em>shown as {{$v.unit_name}}</em>{{end}}
+      <td>{{$v.description | safeHTML }}{{if $v.unit_name}}<br><em>Shown as {{$v.unit_name}}</em>{{end}}
       </td>
     </tr>
   {{ end }}

--- a/local/bin/py/update_pre_build.py
+++ b/local/bin/py/update_pre_build.py
@@ -12,6 +12,8 @@ import shutil
 import requests
 import yaml
 import pickle
+import markdown2
+
 from collections import OrderedDict
 from functools import partial, wraps
 from itertools import chain, zip_longest
@@ -342,7 +344,7 @@ class PreBuild:
         )
 
     @staticmethod
-    def csv_to_yaml(key_name, csv_filename, yml_filename):
+    def metric_csv_to_yaml(key_name, csv_filename, yml_filename):
         """
         Given a file path to a single csv file convert it to a yaml file
 
@@ -357,6 +359,11 @@ class PreBuild:
                 dict(line) for line in reader
             ]
         if yaml_data[key_name]:
+            # Transforming the metric description to html in order to interpret markdown in
+            # integrations metrics table.
+            # the char strip is to compensate for the lib adding <p> </p><br> tags
+            for metric in yaml_data[key_name]:
+                metric['description'] = str(markdown2.markdown(metric['description']))[3:-5]
             with open(
                 file=yml_filename,
                 mode="w",
@@ -817,7 +824,7 @@ class PreBuild:
         new_file_name = "{}{}.yaml".format(
             self.data_integrations_dir, key_name
         )
-        self.csv_to_yaml(key_name, file_name, new_file_name)
+        self.metric_csv_to_yaml(key_name, file_name, new_file_name)
 
     def process_integration_manifest(self, file_name):
         """

--- a/local/etc/requirements3.txt
+++ b/local/etc/requirements3.txt
@@ -13,3 +13,4 @@ PyYAML==4.2b1
 tqdm==4.14.0
 Pygments==2.2.0
 datadog==0.16.0
+markdown2==2.3.8


### PR DESCRIPTION
### What does this PR do?

* Transforms the markdown metric description to html prior to passing it to the metrics table partial in order to allow markdown interpretation (mostly code blocks)

* It also renames the function use in order to enforce the fact that it's only applied to metrics 

### Motivation
https://github.com/DataDog/documentation/pull/5307

### Preview link
