### PR TITLE
force-yes is deprecated

### DIFF
--- a/content/en/agent/faq/downgrade-datadog-agent.md
+++ b/content/en/agent/faq/downgrade-datadog-agent.md
@@ -13,7 +13,7 @@ For DEB or RPM packages of the Datadog Agent, find below instructions to downgra
 ### CLI
 
 ```
-sudo apt-get update && sudo apt-get install --force-yes datadog-agent=1:6.X.Y-1
+sudo apt-get update && sudo apt-get install --allow-downgrades datadog-agent=1:6.X.Y-1
 ```
 
 ### Configuration management tools


### PR DESCRIPTION
### What does this PR do?
`--force-yes` is now deprecated in favor of `--allow*` options. 

https://superuser.com/questions/1438031/ubuntu-18-command-apt-get-dist-upgrade-qq-force-yes-deprecated

### Page preview

https://docs-staging.datadoghq.com/davidb/force-yes-deprecated/

### Motivation
Testing