### PR TITLE
update archive instructions since archiving with roles in the US is n…

### DIFF
--- a/content/en/logs/archives/s3.md
+++ b/content/en/logs/archives/s3.md
@@ -17,12 +17,57 @@ This guide shows you how to set up an archive for forwarding ingested logs to yo
 
 Go into your [AWS Console][2] and [create an S3 bucket][3] to send your archives to. Be careful not to make your bucket publicly readable. 
 
-Next, grant Datadog permissions to write log archives to your S3 bucket. You can grant those permissions either from your bucket policy or with role delegation. 
-
-**Note**: To [rehydrate logs from your archive back into Datadog][1], the role delegation setup is required. 
+Next, grant Datadog permissions to write log archives to your S3 bucket. Users of the US Site do this via role delegation, users of the EU Site do this via the bucket policy.
 
 {{< tabs >}}
-{{% tab "Bucket Policy" %}}
+{{% tab "US Site" %}}
+
+1. Set up the [AWS integration][1] for the AWS account that holds your S3 bucket. This involves [creating a role][2] that Datadog can use to integrate with AWS Cloudwatch. 
+
+2. Add the following permission statement to the IAM policies of your Datadog role (be sure to edit the bucket names and, if desired, specify the paths that contain your log archives). The `GetObject` and `ListBucket` permissions allow for [Rehydrating from Archives][3]. The `PutObject` permissions is sufficient for uploading archives.
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "DatadogUploadAndRehydrateLogArchives",
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:GetObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::<MY_BUCKET_NAME_1_/_MY_OPTIONAL_BUCKET_PATH_1>/*",
+                "arn:aws:s3:::<MY_BUCKET_NAME_2_/_MY_OPTIONAL_BUCKET_PATH_2>/*"
+            ]
+        },
+        {
+            "Sid": "DatadogRehydrateLogArchivesListBucket",
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": [
+                "arn:aws:s3:::<MY_BUCKET_NAME_1>",
+                "arn:aws:s3:::<MY_BUCKET_NAME_2>"
+            ]
+        }
+    ]
+}
+```
+
+3. Go to your [Pipelines page in Datadog][4], and select the **Add archive** option at the bottom. Only Datadog users with admin status can complete this and the following step.
+
+4. Select the appropriate AWS account + role combination for your S3 bucket. Input your bucket name. Optionally input a prefix directory for all the content of your log archives. Save your archive, and you are finished. 
+
+    {{< img src="logs/archives/log_archives_s3_datadog_settings_role_delegation.png" alt="Set your S3 bucket info in Datadog" responsive="true" style="width:75%;">}}
+    
+[1]: https://app.datadoghq.com/account/settings#integrations/amazon-web-services
+[2]: /integrations/amazon_web_services/?tab=allpermissions#installation
+[3]: /logs/archives/rehydrating
+[4]: https://app.datadoghq.com/logs/pipelines
+{{% /tab %}}
+
+{{% tab "EU Site" %}}
 
 1. Modify your bucket to grant write-only access to the Datadog AWS user. Do this by editing your bucket's **permissions**, and setting the **bucket policy** with the following content (replace `<MY_BUCKET_NAME>` with the name of your bucket):
 
@@ -57,56 +102,6 @@ Next, grant Datadog permissions to write log archives to your S3 bucket. You can
     {{< img src="logs/archives/log_archives_s3_datadog_settings.png" alt="Set your S3 bucket info in Datadog" responsive="true" style="width:75%;">}}
 
 [1]: https://app.datadoghq.com/logs/pipelines
-{{% /tab %}}
-
-{{% tab "Role Delegation" %}}
-
-**Use of role delegation for writing log archives is in beta. Contact [Datadog support][1] to have it enabled for your account.**
-
-1. Set up the [AWS integration][2] for the AWS account that holds your S3 bucket. This involves [creating a role][3] that Datadog can use to integrate with AWS Cloudwatch. 
-
-2. Add the following permission statement to the IAM policies of your Datadog role (be sure to edit the bucket names and, if desired, specify the paths that contain your log archives). The `GetObject` and `ListBucket` permissions allow for [Rehydrating from Archives][4]. The `PutObject` permissions is sufficient for uploading archives.
-
-```
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "DatadogUploadAndRehydrateLogArchives",
-            "Effect": "Allow",
-            "Action": [
-                "s3:PutObject",
-                "s3:GetObject"
-            ],
-            "Resource": [
-                "arn:aws:s3:::<MY_BUCKET_NAME_1_/_MY_OPTIONAL_BUCKET_PATH_1>/*",
-                "arn:aws:s3:::<MY_BUCKET_NAME_2_/_MY_OPTIONAL_BUCKET_PATH_2>/*"
-            ]
-        },
-        {
-            "Sid": "DatadogRehydrateLogArchivesListBucket",
-            "Effect": "Allow",
-            "Action": "s3:ListBucket",
-            "Resource": [
-                "arn:aws:s3:::<MY_BUCKET_NAME_1>",
-                "arn:aws:s3:::<MY_BUCKET_NAME_2>"
-            ]
-        }
-    ]
-}
-```
-
-3. Go to your [Pipelines page in Datadog][5], and select the **Add archive** option at the bottom. Only Datadog users with admin status can complete this and the following step.
-
-4. Select the appropriate AWS account + role combination for your S3 bucket. Input your bucket name. Optionally input a prefix directory for all the content of your log archives. Save your archive, and you are finished. 
-
-    {{< img src="logs/archives/log_archives_s3_datadog_settings_role_delegation.png" alt="Set your S3 bucket info in Datadog" responsive="true" style="width:75%;">}}
-    
-[1]: /help
-[2]: https://app.datadoghq.com/account/settings#integrations/amazon-web-services
-[3]: /integrations/amazon_web_services/?tab=allpermissions#installation
-[4]: /logs/archives/rehydrating
-[5]: https://app.datadoghq.com/logs/pipelines
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/logs/archives/s3.md
+++ b/content/en/logs/archives/s3.md
@@ -26,34 +26,34 @@ Next, grant Datadog permissions to write log archives to your S3 bucket. US site
 
 2. Add the following permission statement to the IAM policies of your Datadog role (be sure to edit the bucket names and, if desired, specify the paths that contain your log archives). The `GetObject` and `ListBucket` permissions allow for [Rehydrating from Archives][3]. The `PutObject` permission is sufficient for uploading archives.
 
-```
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "DatadogUploadAndRehydrateLogArchives",
-            "Effect": "Allow",
-            "Action": [
-                "s3:PutObject",
-                "s3:GetObject"
-            ],
-            "Resource": [
-                "arn:aws:s3:::<MY_BUCKET_NAME_1_/_MY_OPTIONAL_BUCKET_PATH_1>/*",
-                "arn:aws:s3:::<MY_BUCKET_NAME_2_/_MY_OPTIONAL_BUCKET_PATH_2>/*"
-            ]
-        },
-        {
-            "Sid": "DatadogRehydrateLogArchivesListBucket",
-            "Effect": "Allow",
-            "Action": "s3:ListBucket",
-            "Resource": [
-                "arn:aws:s3:::<MY_BUCKET_NAME_1>",
-                "arn:aws:s3:::<MY_BUCKET_NAME_2>"
-            ]
-        }
-    ]
-}
-```
+    ```
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "DatadogUploadAndRehydrateLogArchives",
+                "Effect": "Allow",
+                "Action": [
+                    "s3:PutObject",
+                    "s3:GetObject"
+                ],
+                "Resource": [
+                    "arn:aws:s3:::<MY_BUCKET_NAME_1_/_MY_OPTIONAL_BUCKET_PATH_1>/*",
+                    "arn:aws:s3:::<MY_BUCKET_NAME_2_/_MY_OPTIONAL_BUCKET_PATH_2>/*"
+                ]
+            },
+            {
+                "Sid": "DatadogRehydrateLogArchivesListBucket",
+                "Effect": "Allow",
+                "Action": "s3:ListBucket",
+                "Resource": [
+                    "arn:aws:s3:::<MY_BUCKET_NAME_1>",
+                    "arn:aws:s3:::<MY_BUCKET_NAME_2>"
+                ]
+            }
+        ]
+    }
+    ```
 
 3. Go to your [Pipelines page in Datadog][4], and select the **Add archive** option at the bottom. Only Datadog users with admin status can complete this and the following step.
 

--- a/content/en/logs/archives/s3.md
+++ b/content/en/logs/archives/s3.md
@@ -17,14 +17,14 @@ This guide shows you how to set up an archive for forwarding ingested logs to yo
 
 Go into your [AWS Console][2] and [create an S3 bucket][3] to send your archives to. Be careful not to make your bucket publicly readable. 
 
-Next, grant Datadog permissions to write log archives to your S3 bucket. Users of the US Site do this via role delegation, users of the EU Site do this via the bucket policy.
+Next, grant Datadog permissions to write log archives to your S3 bucket. US site users do this with role delegation. EU site users do this with the bucket policy.
 
 {{< tabs >}}
 {{% tab "US Site" %}}
 
 1. Set up the [AWS integration][1] for the AWS account that holds your S3 bucket. This involves [creating a role][2] that Datadog can use to integrate with AWS Cloudwatch. 
 
-2. Add the following permission statement to the IAM policies of your Datadog role (be sure to edit the bucket names and, if desired, specify the paths that contain your log archives). The `GetObject` and `ListBucket` permissions allow for [Rehydrating from Archives][3]. The `PutObject` permissions is sufficient for uploading archives.
+2. Add the following permission statement to the IAM policies of your Datadog role (be sure to edit the bucket names and, if desired, specify the paths that contain your log archives). The `GetObject` and `ListBucket` permissions allow for [Rehydrating from Archives][3]. The `PutObject` permission is sufficient for uploading archives.
 
 ```
 {
@@ -69,7 +69,7 @@ Next, grant Datadog permissions to write log archives to your S3 bucket. Users o
 
 {{% tab "EU Site" %}}
 
-1. Modify your bucket to grant write-only access to the Datadog AWS user. Do this by editing your bucket's **permissions**, and setting the **bucket policy** with the following content (replace `<MY_BUCKET_NAME>` with the name of your bucket):
+1. Modify your bucket to grant write-only access to the Datadog AWS user by editing your bucket's **permissions**, and setting the **bucket policy** with the following content (update `<MY_BUCKET_NAME>`):
 
     ```
     {
@@ -97,7 +97,7 @@ Next, grant Datadog permissions to write log archives to your S3 bucket. Users o
 
 2. Go to your [Pipelines page in Datadog][1], and select the **Add archive** option at the bottom. Only Datadog users with admin status can complete this and the following step.
 
-3. Input your bucket name. Optionally input a prefix directory for all the content of your log archives. Save your archive, and you are finished. 
+3. Input your bucket name. Optionally input a prefix directory for all the content of your log archives. Save your archive.
 
     {{< img src="logs/archives/log_archives_s3_datadog_settings.png" alt="Set your S3 bucket info in Datadog" responsive="true" style="width:75%;">}}
 


### PR DESCRIPTION
…ow the default.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Makes the default log archive setup instructions be for "role delegation" for users of the US site, and offers a tab for the EU site to show bucket policy instructions. 

### Motivation
<!-- What inspired you to submit this pull request?-->
To keep documentation up to date with what our application supports. 

### Preview link
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/estib/archives-role-delegation-default-us/logs/archives/s3/?tab=ussite

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Thanks!