### PR TITLE
Added APM glossary definitions to the first instance on every apm page

### DIFF
--- a/content/en/tracing/_index.md
+++ b/content/en/tracing/_index.md
@@ -28,7 +28,7 @@ disable_toc: true
 </br>
 ## What is Datadog APM?
 
- Datadog Application Performance Monitoring (APM or tracing) provides you with deep insight into your application's performance - from automatically generated dashboards for monitoring key metrics, like request volume and latency, to detailed traces of individual requests - side by side with your logs and infrastructure monitoring. When a request is made to an application, Datadog can see the traces across a distributed system, and we can show you systematic data about precisely what is happening to this request.
+ Datadog Application Performance Monitoring (APM or tracing) provides you with deep insight into your application's performance - from automatically generated dashboards for monitoring key metrics, like request volume and latency, to detailed traces of individual requests - side by side with your logs and infrastructure monitoring. When a request is made to an application, Datadog can see the [traces][1] across a distributed system, and we can show you systematic data about precisely what is happening to this request.
 
 ## Overview
 
@@ -46,3 +46,7 @@ disable_toc: true
 
 {{< partial name="whats-next/whats-next.html" >}}
 
+
+
+
+[1]: /tracing/visualization/#trace

--- a/content/en/tracing/advanced/adding_metadata_to_spans.md
+++ b/content/en/tracing/advanced/adding_metadata_to_spans.md
@@ -16,16 +16,16 @@ further_reading:
   text: "Explore your services, resources, and traces"
 ---
 
-Add tags in the form of key-value pairs to correlate traces with other Datadog products, which provides more details about specific spans. Tags can be added to a [single span](#adding-tags-to-a-span) or [globally to all spans](#adding-tags-globally-to-all-spans).
+Add [tags][1] in the form of key-value pairs to correlate traces with other Datadog products, which provides more details about specific spans. Tags can be added to a [single span](#adding-tags-to-a-span) or [globally to all spans](#adding-tags-globally-to-all-spans).
 
-**Note**: Tracing metadata is added via tags, but tags already have a specific meaning throughout [Datadog][1].
+**Note**: Tracing metadata is added via tags, but tags already have a specific meaning throughout [Datadog][2].
 
 ## Adding tags to a span
 
 {{< tabs >}}
 {{% tab "Java" %}}
 
-The Datadog UI uses tags to set span level metadata. A full list of these tags can be found in the [Datadog][1] and [OpenTracing][2] APIs.
+The Datadog UI uses [tags][1] to set [span][2] level metadata. A full list of these tags can be found in the [Datadog][3] and [OpenTracing][4] APIs.
 
 Custom tags may be set for auto-instrumentation by grabbing the active span out of the global tracer and setting a tag with `setTag`.
 
@@ -51,12 +51,14 @@ class ServletImpl extends AbstractHttpServlet {
 }
 ```
 
-[1]: https://github.com/DataDog/dd-trace-java/blob/master/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
-[2]: https://github.com/opentracing/opentracing-java/blob/master/opentracing-api/src/main/java/io/opentracing/tag/Tags.java
+[1]: /tracing/visualization/#span-tags
+[2]: /tracing/visualization/#spans
+[3]: https://github.com/DataDog/dd-trace-java/blob/master/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+[4]: https://github.com/opentracing/opentracing-java/blob/master/opentracing-api/src/main/java/io/opentracing/tag/Tags.java
 {{% /tab %}}
 {{% tab "Python" %}}
 
-Add tags directly to a span by calling `set_tag`. For example, with the following route handler:
+Add [tags][1] directly to a [span][2] by calling `set_tag`. For example, with the following route handler:
 
 ```python
 from ddtrace import tracer
@@ -81,10 +83,13 @@ def handle_customer(customer_id):
     current_span.set_tag('customer.id', customer_id)
 ```
 
+
+[1]: /tracing/visualization/#span-tags
+[2]: /tracing/visualization/#spans
 {{% /tab %}}
 {{% tab "Ruby" %}}
 
-Add tags directly to `Datadog::Span` objects by calling `#set_tag`:
+Add [tags][1] directly to `Datadog::Span` objects by calling `#set_tag`:
 
 ```ruby
 # An example of a Sinatra endpoint,
@@ -96,7 +101,7 @@ get '/posts' do
 end
 ```
 
-Access the current active span from any method within your code. **Note**: If the method is called and there is no span currently active, `active_span` is `nil`.
+Access the current active [span][2] from any method within your code. **Note**: If the method is called and there is no span currently active, `active_span` is `nil`.
 
 ```ruby
 # e.g. adding tag to active span
@@ -105,10 +110,13 @@ current_span = Datadog.tracer.active_span
 current_span.set_tag('<TAG_KEY>', '<TAG_VALUE>') unless current_span.nil?
 ```
 
+
+[1]: /tracing/visualization/#span-tags
+[2]: /tracing/visualization/#spans
 {{% /tab %}}
 {{% tab "Go" %}}
 
-Add tags directly to a `Span` interface by calling `SetTag`:
+Add [tags][1] directly to a `Span` interface by calling `SetTag`:
 
 ```go
 package main
@@ -137,7 +145,7 @@ func main() {
 }
 ```
 
-Datadog's integrations make use of the `Context` type to propagate the current active span.
+Datadog's integrations make use of the `Context` type to propagate the current active [span][2].
 If you want to add span tags attached to a `Context`, call the `SpanFromContext` function:
 
 ```go
@@ -158,11 +166,14 @@ func handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+
+[1]: /tracing/visualization/#span-tags
+[2]: /tracing/visualization/#spans
 {{% /tab %}}
 {{% tab "Node.js" %}}
 
 
-Add tags directly to span objects by calling `setTag` or `addTags`:
+Add [tags][1] directly to span objects by calling `setTag` or `addTags`:
 
 ```javascript
 // An example of an Express endpoint,
@@ -177,7 +188,7 @@ app.get('/posts', (req, res) => {
 })
 ```
 
-Access the current active span from any method within your code. **Note**: If the method is called and there is no span currently active, `tracer.scope().active()` returns `null`.
+Access the current active [span][2] from any method within your code. **Note**: If the method is called and there is no span currently active, `tracer.scope().active()` returns `null`.
 
 ```javascript
 // e.g. adding tag to active span
@@ -187,10 +198,13 @@ const span = tracer.scope().active()
 span.setTag('<TAG_KEY>', '<TAG_VALUE>')
 ```
 
+
+[1]: /tracing/visualization/#span-tags
+[2]: /tracing/visualization/#spans
 {{% /tab %}}
 {{% tab ".NET" %}}
 
-Add tags directly to a `Datadog.Trace.Span` object by calling `Span.SetTag()`. For example:
+Add [tags][1] directly to a `Datadog.Trace.Span` object by calling `Span.SetTag()`. For example:
 
 ```csharp
 using Datadog.Trace;
@@ -202,13 +216,16 @@ var scope = Tracer.Instance.ActiveScope;
 scope.Span.SetTag("<TAG_KEY>", "<TAG_VALUE>");
 ```
 
-**Note**: `Datadog.Trace.Tracer.Instance.ActiveScope` returns `null` if there is no active span.
+**Note**: `Datadog.Trace.Tracer.Instance.ActiveScope` returns `null` if there is no active [span][2].
 
+
+[1]: /tracing/visualization/#span-tags
+[2]: /tracing/visualization/#spans
 {{% /tab %}}
 {{% tab "PHP" %}}
 
 
-Add tags directly to a `DDTrace\Span` object by calling `Span::setTag()`. For example:
+Add [tags][1] directly to a `DDTrace\Span` object by calling `Span::setTag()`. For example:
 
 ```php
 // Get the currently active span (can be null)
@@ -219,8 +236,12 @@ if (null !== $span) {
 }
 ```
 
-**Note**: `Tracer::getActiveSpan()` returns `null` if there is no active span.
+**Note**: `Tracer::getActiveSpan()` returns `null` if there is no active [span][2].
 
+
+
+[1]: /tracing/visualization/#span-tags
+[2]: /tracing/visualization/#spans
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -229,18 +250,19 @@ if (null !== $span) {
 {{< tabs >}}
 {{% tab "Java" %}}
 
-Add tags to all spans by configuring the tracer with the system property `dd.trace.global.tags`:
+Add [tags][1] to all [spans][2] by configuring the tracer with the system property `dd.trace.global.tags`:
 
 ```bash
 java -javaagent:<DD-JAVA-AGENT-PATH>.jar \
      -dd.trace.global.tags='env:dev,<TAG_KEY>:<TAG_VALUE>' \
      -jar <YOUR_APPLICATION_PATH>.jar
 ```
-
+[1]: /tracing/visualization/#span-tags
+[2]: /tracing/visualization/#spans
 {{% /tab %}}
 {{% tab "Python" %}}
 
-Add tags to all spans by configuring the tracer with the `tracer.set_tags` method:
+Add [tags][1] to all [spans]span by configuring the tracer with the `tracer.set_tags` method:
 
 ```python
 from ddtrace import tracer
@@ -248,10 +270,12 @@ from ddtrace import tracer
 tracer.set_tags({ 'env': 'dev' })
 ```
 
+
+[1]: /tracing/visualization/#span-tags
 {{% /tab %}}
 {{% tab "Ruby" %}}
 
-Add tags to all spans by configuring the tracer with the `tags` option:
+Add [tags][1] to all [spans][2] by configuring the tracer with the `tags` option:
 
 ```ruby
 Datadog.configure do |c|
@@ -259,13 +283,16 @@ Datadog.configure do |c|
 end
 ```
 
-See the [API documentation][1] for more details.
+See the [API documentation][3] for more details.
 
-[1]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md#environment-and-tags
+
+[1]: /tracing/visualization/#span-tags
+[2]: /tracing/visualization/#spans
+[3]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md#environment-and-tags
 {{% /tab %}}
 {{% tab "Go" %}}
 
-Add tags to all spans by configuring the tracer with the `tags` option:
+Add [tags][1] to all [spans][2] by configuring the tracer with the `tags` option:
 
 ```go
 package main
@@ -281,10 +308,13 @@ func main() {
 }
 ```
 
+
+[1]: /tracing/visualization/#span-tags
+[2]: /tracing/visualization/#spans
 {{% /tab %}}
 {{% tab "Node.js" %}}
 
-Add tags to all spans by configuring the tracer with the `tags` parameter:
+Add [tags][1] to all [spans][2] by configuring the tracer with the `tags` parameter:
 
 ```js
 const tracer = require('dd-trace').init({
@@ -295,7 +325,8 @@ const tracer = require('dd-trace').init({
 })
 ```
 
-
+[1]: /tracing/visualization/#span-tags
+[2]: /tracing/visualization/#spans
 {{% /tab %}}
 {{% tab ".NET" %}}
 
@@ -305,18 +336,21 @@ Coming Soon. Reach out to [the Datadog support team][1] to learn more.
 {{% /tab %}}
 {{% tab "PHP" %}}
 
-Use the environment variable `DD_TRACE_GLOBAL_TAGS` to add tags to all the generated spans. See the [PHP configuration][1]
+Use the environment variable `DD_TRACE_GLOBAL_TAGS` to add [tags][1] to all the generated [spans][2]. See the [PHP configuration][3]
 section for details on how environment variables are set.
 
 ```ini
 DD_TRACE_GLOBAL_TAGS=key1:value1,key2:value2
 ```
 
-[1]: /tracing/setup/php/#configuration
+
+[1]: /tracing/visualization/#span-tags
+[2]: /tracing/visualization/#spans
+[3]: /tracing/setup/php/#configuration
 {{% /tab %}}
 {{% tab "C++" %}}
 
-Add tags directly to a span object by calling `Span::SetTag`. For example:
+Add [tags][1] directly to a [span][2] object by calling `Span::SetTag`. For example:
 
 ```cpp
 auto tracer = ...
@@ -325,13 +359,18 @@ span->SetTag("key must be string", "Values are variable types");
 span->SetTag("key must be string", 1234);
 ```
 
-Values are of [variable type][1] and can be complex objects. Values are serialized as JSON, with the exception of a string value being serialized bare (without extra quotation marks).
+Values are of [variable type][3] and can be complex objects. Values are serialized as JSON, with the exception of a string value being serialized bare (without extra quotation marks).
 
-[1]: https://github.com/opentracing/opentracing-cpp/blob/master/include/opentracing/value.h
+
+[1]: /tracing/visualization/#span-tags
+[2]: /tracing/visualization/#spans
+[3]: https://github.com/opentracing/opentracing-cpp/blob/master/include/opentracing/value.h
 {{% /tab %}}
 {{< /tabs >}}
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
-[1]: /tagging
+
+[1]: /tracing/visualization/#span-tags
+[2]: /tagging

--- a/content/en/tracing/advanced/connect_logs_and_traces.md
+++ b/content/en/tracing/advanced/connect_logs_and_traces.md
@@ -16,9 +16,9 @@ further_reading:
   text: "Correlate request logs with traces automatically"
 ---
 
-The correlation between Datadog APM and Datadog Log Management is improved by automatically adding a `trace_id` and `span_id` in your logs with the Tracing Libraries. This can then be used in the platform to show you the exact logs correlated to the observed trace.
+The correlation between Datadog APM and Datadog Log Management is improved by automatically adding a `trace_id` and `span_id` in your logs with the Tracing Libraries. This can then be used in the platform to show you the exact logs correlated to the observed [trace][1].
 
-Before correlating traces with logs, ensure your logs are either sent as JSON, or [parsed by the proper language level log processor][1].
+Before correlating traces with logs, ensure your logs are either sent as JSON, or [parsed by the proper language level log processor][2].
 
 Your language level logs *must* be turned into Datadog attributes in order for traces and logs correlation to work.
 
@@ -194,9 +194,9 @@ Coming Soon. Reach out to [the Datadog support team][1] to learn more.
 {{< tabs >}}
 {{% tab "Java" %}}
 
-If you prefer to manually correlate your traces with your logs, leverage the Datadog API to retrieve correlation identifiers:
+If you prefer to manually correlate your [traces][1] with your logs, leverage the Datadog API to retrieve correlation identifiers:
 
-* Use `CorrelationIdentifier#getTraceId()` and `CorrelationIdentifier#getSpanId()` API methods to inject identifiers at the beginning and end of each span to log (see examples below).
+* Use `CorrelationIdentifier#getTraceId()` and `CorrelationIdentifier#getSpanId()` API methods to inject identifiers at the beginning and end of each [span][2] to log (see examples below).
 * Configure MDC to use the injected Keys:
   * `dd.trace_id` Active Trace ID during the log statement (or `0` if no trace)
   * `dd.span_id` Active Span ID during the log statement (or `0` if no trace)
@@ -247,19 +247,21 @@ Then update your logger configuration to include `dd.trace_id` and `dd.span_id` 
 <Pattern>"%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %X{dd.trace_id:-0} %X{dd.span_id:-0} - %m%n"</Pattern>
 ```
 
-**Note**: If you are not using a [Datadog Log Integration][1] to parse your logs, custom log parsing rules need to ensure that `trace_id` and `span_id` are being parsed as a string. More information can be found in the [FAQ on this topic][2].
+**Note**: If you are not using a [Datadog Log Integration][3] to parse your logs, custom log parsing rules need to ensure that `trace_id` and `span_id` are being parsed as a string. More information can be found in the [FAQ on this topic][4].
 
-[See the Java logging documentation][1] for more details about specific logger implementation or to learn how to log in JSON.
+[See the Java logging documentation][3] for more details about specific logger implementation or to learn how to log in JSON.
 
 
-[1]: /logs/log_collection/java/#raw-format
-[2]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel
+[1]: /tracing/visualization/#trace
+[2]: /tracing/visualization/#spans
+[3]: /logs/log_collection/java/#raw-format
+[4]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel
 {{% /tab %}}
 {{% tab "Python" %}}
 
 **Manual Trace ID Injection with Standard Library Logging**
 
-If you prefer to manually correlate your traces with your logs, patch your `logging` module by updating your log formatter to include the ``dd.trace_id`` and ``dd.span_id`` attributes from the log record.
+If you prefer to manually correlate your [traces][1] with your logs, patch your `logging` module by updating your log formatter to include the ``dd.trace_id`` and ``dd.span_id`` attributes from the log record.
 
 The configuration below is used by the automatic injection method and is supported by default in the Python Log Integration:
 
@@ -320,13 +322,14 @@ Once the logger is configured, executing a traced function that logs an event yi
 {"event": "In tracer context", "trace_id": 9982398928418628468, "span_id": 10130028953923355146}
 ```
 
-**Note**: If you are not using a [Datadog Log Integration][1] to parse your logs, custom log parsing rules need to ensure that `trace_id` and `span_id` are being parsed as a string. More information can be found in the [FAQ on this topic][2].
+**Note**: If you are not using a [Datadog Log Integration][2] to parse your logs, custom log parsing rules need to ensure that `trace_id` and `span_id` are being parsed as a string. More information can be found in the [FAQ on this topic][3].
 
-[See the Python logging documentation][1] to ensure that the Python Log Integration is properly configured so that your Python logs are automatically parsed.
+[See the Python logging documentation][2] to ensure that the Python Log Integration is properly configured so that your Python logs are automatically parsed.
 
 
-[1]: /logs/log_collection/python/#configure-the-datadog-agent
-[2]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel
+[1]: /tracing/visualization/#trace
+[2]: /logs/log_collection/python/#configure-the-datadog-agent
+[3]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel
 {{% /tab %}}
 {{% tab "Ruby" %}}
 To add trace IDs to your own logger, add a log formatter which retrieves the trace IDs with `Datadog.tracer.active_correlation`, then add the trace IDs to the message.
@@ -369,7 +372,7 @@ See the [Ruby logging documentation][1] to verify the Ruby log integration is pr
 {{% /tab %}}
 {{% tab "Go" %}}
 
-The Go tracer exposes two API calls to allow printing trace and span identifiers along with log statements using exported methods from `SpanContext` type:
+The Go tracer exposes two API calls to allow printing [trace][1] and [span][2] identifiers along with log statements using exported methods from `SpanContext` type:
 
 ```go
 package main
@@ -396,11 +399,13 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 The above example illustrates how to use the span's context in the standard library's `log` package. Similar logic may be applied to 3rd party packages too.
 
-**Note**: If you are not using a [Datadog Log Integration][1] to parse your logs, custom log parsing rules need to ensure that `trace_id` and `span_id` are being parsed as a string. More information can be found in the [FAQ on this topic][2].
+**Note**: If you are not using a [Datadog Log Integration][3] to parse your logs, custom log parsing rules need to ensure that `trace_id` and `span_id` are being parsed as a string. More information can be found in the [FAQ on this topic][4].
 
 
-[1]: /logs/log_collection/go/#configure-your-logger
-[2]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel
+[1]: /tracing/visualization/#trace
+[2]: /tracing/visualization/#spans
+[3]: /logs/log_collection/go/#configure-your-logger
+[4]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel
 {{% /tab %}}
 {{% tab "Node.js" %}}
 
@@ -476,4 +481,5 @@ Coming Soon. Reach out to [the Datadog support team][1] to learn more.
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /agent/logs/#enabling-log-collection-from-integrations
+[1]: /tracing/visualization/#trace
+[2]: /agent/logs/#enabling-log-collection-from-integrations

--- a/content/en/tracing/advanced/manual_instrumentation.md
+++ b/content/en/tracing/advanced/manual_instrumentation.md
@@ -17,16 +17,16 @@ further_reading:
   text: "Explore your services, resources, and traces"
 ---
 
-Manual instrumentation allows programmatic creation of traces to send to Datadog. This is useful for tracing in-house code not captured by automatic instrumentation. Before instrumenting your application, review Datadog’s APM Terminology and familiarize yourself with the core concepts of Datadog APM.
+Manual instrumentation allows programmatic creation of traces to send to Datadog. This is useful for tracing in-house code not captured by automatic instrumentation. Before instrumenting your application, review Datadog’s [APM Terminology][1] and familiarize yourself with the core concepts of Datadog APM.
 
 {{< tabs >}}
 {{% tab "Java" %}}
 
-If you aren't using a [supported framework instrumentation][1], or you would like additional depth in your application’s traces, you may want to manually instrument your code.
+If you aren't using a [supported framework instrumentation][1], or you would like additional depth in your application’s [traces][2], you may want to manually instrument your code.
 
 Do this either using the Trace annotation for simple method call tracing, or with the OpenTracing API for complex tracing.
 
-Datadog's Trace annotation is provided by the [dd-trace-api dependency][2].
+Datadog's Trace annotation is provided by the [dd-trace-api dependency][3].
 
 **Example Usage**
 
@@ -42,8 +42,10 @@ public class MyJob {
 ```
 
 
+
 [1]: /tracing/setup/java/#compatibility
-[2]: https://mvnrepository.com/artifact/com.datadoghq/dd-trace-api
+[2]: /tracing/visualization/#trace
+[3]: https://mvnrepository.com/artifact/com.datadoghq/dd-trace-api
 {{% /tab %}}
 {{% tab "Python" %}}
 
@@ -87,7 +89,7 @@ Further API details can be found at [`ddtrace.Tracer()`][4]
 
 **Using the API**
 
-If the above methods are still not enough to satisfy your tracing needs, a manual API is provided which allows you to start and finish spans however you may require:
+If the above methods are still not enough to satisfy your tracing needs, a manual API is provided which allows you to start and finish [spans][5] however you may require:
 
 ```python
   span = tracer.trace('operations.of.interest')
@@ -101,8 +103,9 @@ If the above methods are still not enough to satisfy your tracing needs, a manua
 
 API details of the decorator can be found here:
 
-- [`ddtrace.Tracer.trace`][5]
-- [`ddtrace.Span.finish`][6]
+- [`ddtrace.Tracer.trace`][6]
+- [`ddtrace.Span.finish`][7]
+
 
 
 
@@ -110,8 +113,9 @@ API details of the decorator can be found here:
 [2]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtrace.Tracer.wrap
 [3]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtrace.Span
 [4]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#tracer
-[5]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtrace.Tracer.trace
-[6]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtrace.Span.finish
+[5]: /tracing/visualization/#spans
+[6]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtrace.Tracer.trace
+[7]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtrace.Span.finish
 {{% /tab %}}
 {{% tab "Ruby" %}}
 
@@ -174,7 +178,7 @@ func main() {
     span.SetTag("<TAG_KEY>", "<TAG_VALUE>")
 }
 ```
-**Create a distributed trace by manually propagating the tracing context:**
+**Create a distributed [trace][3] by manually propagating the tracing context:**
 
 ```go
 package main
@@ -198,7 +202,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
-**Then, on the server side, to continue the trace, start a new Span from the extracted `Context`:**
+**Then, on the server side, to continue the trace, start a new [Span][4] from the extracted `Context`:**
 
 ```go
 package main
@@ -222,14 +226,17 @@ func handler(w http.ResponseWriter, r *http.Request) {
 ```
 
 
+
 [1]: /tracing/setup/go/#compatibility
 [2]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer
+[3]: /tracing/visualization/#trace
+[4]: /tracing/visualization/#spans
 {{% /tab %}}
 {{% tab "Node.js" %}}
 
 If you aren’t using supported library instrumentation (see [Library compatibility][1]), you may want to manually instrument your code.
 
-The following example initializes a Datadog Tracer and creates a span called `web.request`:
+The following example initializes a Datadog Tracer and creates a [span][2] called `web.request`:
 
 ```javascript
 const tracer = require('dd-trace').init()
@@ -239,17 +246,19 @@ span.setTag('http.url', '/login')
 span.finish()
 ```
 
-For more information on manual instrumentation, see the [API documentation][2].
+For more information on manual instrumentation, see the [API documentation][3].
+
 
 
 [1]: /tracing/setup/nodejs/#compatibility
-[2]: https://datadog.github.io/dd-trace-js/#manual-instrumentation
+[2]: /tracing/visualization/#spans
+[3]: https://datadog.github.io/dd-trace-js/#manual-instrumentation
 {{% /tab %}}
 {{% tab ".NET" %}}
 
 If you are not using libraries supported by automatic instrumentation (see [Integrations][1]), you can instrument your code manually.
 
-The following example uses the global `Tracer` and creates a custom span to trace a web request:
+The following example uses the global `Tracer` and creates a custom [span][2] to [trace][3] a web request:
 
 ```csharp
 using Datadog.Trace;
@@ -267,13 +276,15 @@ using(var scope = Tracer.Instance.StartActive("web.request"))
 
 
 [1]: /tracing/setup/dotnet/#integrations
+[2]: /tracing/visualization/#spans
+[3]: /tracing/visualization/#trace
 {{% /tab %}}
 
 {{% tab "PHP" %}}
 
 Even if Datadog does not officially support your web framework, you may not need to perform any manual instrumentation. See [automatic instrumentation][1] for more details.
 
-If you really need manual instrumentation, e.g., because you want to trace specific custom methods in your application, first install the PHP tracer dependency with Composer:
+If you really need manual instrumentation, e.g., because you want to [trace][2] specific custom methods in your application, first install the PHP tracer dependency with Composer:
 
 ```bash
 $ composer require datadog/dd-trace
@@ -283,8 +294,8 @@ $ composer require datadog/dd-trace
 
 The `dd_trace()` function hooks into existing functions and methods to:
 
-* Open a span before the code executes
-* Set additional tags or errors on the span
+* Open a [span][3] before the code executes
+* Set additional [tags][4] or errors on the span
 * Close the span when it is done
 * Modify the arguments or the return value
 
@@ -330,7 +341,7 @@ $rootSpan->setTag(\DDTrace\Tag::HTTP_STATUS_CODE, 200);
 
 Zend Framework 1 is automatically instrumented by default, so you are not required to modify your ZF1 project. However, if automatic instrumentation is disabled, enable the tracer manually.
 
-First, [download the latest source code from the releases page][2]. Extract the zip file and copy the `src/DDTrace` folder to your application's `/library` folder. Then add the following to your `application/configs/application.ini` file:
+First, [download the latest source code from the releases page][5]. Extract the zip file and copy the `src/DDTrace` folder to your application's `/library` folder. Then add the following to your `application/configs/application.ini` file:
 
 ```ini
 autoloaderNamespaces[] = "DDTrace_"
@@ -342,19 +353,22 @@ resources.ddtrace = true
 
 Prior to PHP 7, some frameworks provided ways to compile PHP classes—e.g., through the Laravel's `php artisan optimize` command.
 
-While this [has been deprecated][3] if you are using PHP 7.x, you still may use this caching mechanism in your app prior to version 7.x. In this case, Datadog suggests you use the [OpenTracing][4] API instead of adding `datadog/dd-trace` to your Composer file.
+While this [has been deprecated][6] if you are using PHP 7.x, you still may use this caching mechanism in your app prior to version 7.x. In this case, Datadog suggests you use the [OpenTracing][7] API instead of adding `datadog/dd-trace` to your Composer file.
 
 
 
 
 [1]: /tracing/setup/php/#automatic-instrumentation
-[2]: https://github.com/DataDog/dd-trace-php/releases/latest
-[3]: https://laravel-news.com/laravel-5-6-removes-artisan-optimize
-[4]: /tracing/advanced/opentracing/?tab=php
+[2]: /tracing/visualization/#trace
+[3]: /tracing/visualization/#spans
+[4]: /tracing/visualization/#span-tags
+[5]: https://github.com/DataDog/dd-trace-php/releases/latest
+[6]: https://laravel-news.com/laravel-5-6-removes-artisan-optimize
+[7]: /tracing/advanced/opentracing/?tab=php
 {{% /tab %}}
 {{% tab "C++" %}}
 
-To manually instrument your code, install the tracer as in the setup examples, and then use the tracer object to create spans.
+To manually instrument your code, install the tracer as in the setup examples, and then use the tracer object to create [spans][1].
 
 ```cpp
 {
@@ -369,7 +383,7 @@ To manually instrument your code, install the tracer as in the setup examples, a
 } // ... or when they are destructed (root_span finishes here).
 ```
 
-Distributed tracing can be accomplished by [using the `Inject` and `Extract` methods on the tracer][1], which accept [generic `Reader` and `Writer` types][2]. Priority sampling (enabled by default) should be on to ensure uniform delivery of spans.
+Distributed tracing can be accomplished by [using the `Inject` and `Extract` methods on the tracer][2], which accept [generic `Reader` and `Writer` types][3]. Priority sampling (enabled by default) should be on to ensure uniform delivery of spans.
 
 ```cpp
 // Allows writing propagation headers to a simple map<string, string>.
@@ -408,11 +422,14 @@ void example() {
 ```
 
 
-[1]: https://github.com/opentracing/opentracing-cpp/#inject-span-context-into-a-textmapwriter
-[2]: https://github.com/opentracing/opentracing-cpp/blob/master/include/opentracing/propagation.h
+[1]: /tracing/visualization/#spans
+[2]: https://github.com/opentracing/opentracing-cpp/#inject-span-context-into-a-textmapwriter
+[3]: https://github.com/opentracing/opentracing-cpp/blob/master/include/opentracing/propagation.h
 {{% /tab %}}
 {{< /tabs >}}
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /tracing/visualization

--- a/content/en/tracing/advanced/opentracing.md
+++ b/content/en/tracing/advanced/opentracing.md
@@ -19,7 +19,7 @@ OpenTracing is a vendor-neutral, cross-language standard for tracing application
 {{< tabs >}}
 {{% tab "Java" %}}
 
-Use the [OpenTracing API][1] and the Datadog Tracer (dd-trace-ot) library to measure execution times for specific pieces of code. This lets you trace your application more precisely than you can with the Java Agent alone.
+Use the [OpenTracing API][1] and the Datadog Tracer (dd-trace-ot) library to measure execution times for specific pieces of code. This lets you [trace][2] your application more precisely than you can with the Java Agent alone.
 
 #### Setup
 
@@ -56,7 +56,7 @@ compile group: 'io.opentracing', name: 'opentracing-util', version: "0.31.0"
 compile group: 'com.datadoghq', name: 'dd-trace-ot', version: "${dd-trace-java.version}"
 ```
 
-Configure your application using environment variables or system properties as discussed in the [configuration][2] section.
+Configure your application using environment variables or system properties as discussed in the [configuration][3] section.
 
 #### Manual instrumentation with OpenTracing
 
@@ -96,7 +96,7 @@ class InstrumentedClass {
 }
 ```
 
-Alternatively, wrap the code you want to trace in a `try-with-resources` statement:
+Alternatively, wrap the code you want to [trace][2] in a `try-with-resources` statement:
 
 ```java
 import datadog.trace.api.DDTags;
@@ -157,7 +157,7 @@ public class Application {
 
 #### Manual instrumentation for async traces
 
-Create asynchronous traces with manual instrumentation using the OpenTracing API.
+Create asynchronous [traces][2] with manual instrumentation using the OpenTracing API.
 
 ```java
 // Step 1: start the Scope/Span on the work submission thread
@@ -243,7 +243,8 @@ public class MyHttpRequestExtractAdapter implements TextMap {
 Notice the above examples only use the OpenTracing classes. Check the [OpenTracing API][1] for more details and information.
 
 [1]: https://github.com/opentracing/opentracing-java
-[2]: /tracing/setup/java/#configuration
+[2]: /tracing/visualization/#trace
+[3]: /tracing/setup/java/#configuration
 {{% /tab %}}
 {{% tab "Python" %}}
 
@@ -310,9 +311,9 @@ It can also be configured by using `Datadog.configure` as described in the [Ruby
 
 **Activating and configuring integrations**
 
-By default, configuring OpenTracing with Datadog does not automatically activate any additional instrumentation provided by Datadog. You will only receive spans and traces from OpenTracing instrumentation you have in your application.
+By default, configuring OpenTracing with Datadog does not automatically activate any additional instrumentation provided by Datadog. You will only receive [spans][3] and [traces][4] from OpenTracing instrumentation you have in your application.
 
-However, additional instrumentation provided by Datadog can be activated alongside OpenTracing using `Datadog.configure`, which can be used to enhance your tracing further. To enable this, see [Ruby integration instrumentation][3] for more details.
+However, additional instrumentation provided by Datadog can be activated alongside OpenTracing using `Datadog.configure`, which can be used to enhance your tracing further. To enable this, see [Ruby integration instrumentation][5] for more details.
 
 **Supported serialization formats**
 
@@ -325,7 +326,9 @@ However, additional instrumentation provided by Datadog can be activated alongsi
 
 [1]: /tracing/setup/ruby/#quickstart-for-opentracing
 [2]: /tracing/setup/ruby/#tracer-settings
-[3]: /tracing/setup/ruby/#integration-instrumentation
+[3]: /tracing/visualization/#spans
+[4]: /tracing/visualization/#trace
+[5]: /tracing/setup/ruby/#integration-instrumentation
 {{% /tab %}}
 {{% tab "Go" %}}
 

--- a/content/en/tracing/advanced/runtime_metrics.md
+++ b/content/en/tracing/advanced/runtime_metrics.md
@@ -17,7 +17,7 @@ further_reading:
   text: "Explore your services, resources, and traces"
 ---
 
-Enable runtime metrics collection in the tracing client to gain additional insights into an application's performance. Runtime metrics can be viewed in the context of a service, correlated in the Trace View at the time of a given request, and utilized anywhere in the platform.
+Enable runtime metrics collection in the tracing client to gain additional insights into an application's performance. Runtime metrics can be viewed in the context of a [service][1], correlated in the Trace View at the time of a given request, and utilized anywhere in the platform.
 
 {{< img src="tracing/advanced/runtime_metrics/jvm_runtime_trace.png" alt="JVM Runtime Trace" responsive="true">}}
 
@@ -228,3 +228,5 @@ Coming Soon. Reach out to [the Datadog support team][1] to be part of the beta.
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /tracing/visualization/#services

--- a/content/en/tracing/advanced/setting_primary_tags_to_scope.md
+++ b/content/en/tracing/advanced/setting_primary_tags_to_scope.md
@@ -18,9 +18,9 @@ further_reading:
 
 ## Definition
 
-There are several dimensions available to scope an entire Datadog APM application. These include aggregate statistics (such as requests/second, latency, error rate, Apdex score) and visible traces. These dimensions are set up through primary tags that allow you to get an even finer view of your application's behavior. Use cases for primary tags include environment, availability zone, datacenter, etc.
+There are several dimensions available to scope an entire Datadog APM application. These include aggregate statistics (such as requests/second, latency, error rate, Apdex score) and visible [traces][1]. These dimensions are set up through primary tags that allow you to get an even finer view of your application's behavior. Use cases for primary tags include environment, availability zone, datacenter, etc.
 
-Primary tags must follow a different set of rules from those of conventional [Datadog tags][1].
+Primary tags must follow a different set of rules from those of conventional [Datadog tags][2].
 
 ## Setup
 ### Environment
@@ -32,7 +32,7 @@ There are several ways to specify an environment when reporting data:
   Use a host tag with the format `env:<ENVIRONMENT>` to tag all traces from that Agent accordingly.
 
 2. Agent configuration:
-  Override the default tag used by the Agent in [the Agent configuration file][2]. This tags all traces coming through the Agent, overriding the host tag value.
+  Override the default tag used by the Agent in [the Agent configuration file][3]. This tags all traces coming through the Agent, overriding the host tag value.
 
     ```
     apm_config:
@@ -40,7 +40,7 @@ There are several ways to specify an environment when reporting data:
     ```
 
 3. Per trace:
-  When submitting a single trace, specify an environment by tagging one of its spans with the metadata key `env`. This overrides the Agent configuration and the host tag's value (if any). Consult the [trace tagging documentation][3] to learn how to assign a tag to your traces.
+  When submitting a single trace, specify an environment by tagging one of its spans with the metadata key `env`. This overrides the Agent configuration and the host tag's value (if any). Consult the [trace tagging documentation][4] to learn how to assign a tag to your traces.
 
 #### Viewing Data by Environment
 
@@ -50,7 +50,7 @@ Environments appear at the top of APM pages. Use the dropdown to scope the data 
 
 ## Add a second primary tag in Datadog
 
-If you added a host tag other than `env:<ENVIRONMENT>` to your traces, it can be set as a primary tag along with the environment tag. Go to the [APM Settings][4] page to define, change, or remove your primary tags.
+If you added a host tag other than `env:<ENVIRONMENT>` to your traces, it can be set as a primary tag along with the environment tag. Go to the [APM Settings][5] page to define, change, or remove your primary tags.
 
 Note:
 
@@ -73,7 +73,8 @@ Primary tags appear at the top of APM pages. Use these selectors to slice the da
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tagging
-[2]: /agent/guide/agent-configuration-files/?tab=agentv6
-[3]: /tagging/assigning_tags/#traces
-[4]: https://app.datadoghq.com/apm/settings
+[1]: /tracing/visualization/#trace
+[2]: /tagging
+[3]: /agent/guide/agent-configuration-files/?tab=agentv6
+[4]: /tagging/assigning_tags/#traces
+[5]: https://app.datadoghq.com/apm/settings

--- a/content/en/tracing/faq/my-trace-agent-log-renders-empty-service-error.md
+++ b/content/en/tracing/faq/my-trace-agent-log-renders-empty-service-error.md
@@ -3,7 +3,7 @@ title: My trace-agent.log renders "empty `service`" error
 kind: faq
 ---
 
-If your Agent is not rendering your traces on the UI, the first place to look for errors is the `trace-agent.log`.
+If your Agent is not rendering your [traces][1] on the UI, the first place to look for errors is the `trace-agent.log`.
 
 You may see the following errors :
 
@@ -15,13 +15,13 @@ res:<your.request.name>]: span.normalize: empty `Service` (debug for more info)
 
 ### Check that the service was properly defined
 
-Note that this issue is more likely to happen when manual instrumentation is used, especially in languages such as Go. Refer to our documentations for further details: [this page][1] leads you to the specific languages libraries we use.
+Note that this issue is more likely to happen when manual instrumentation is used, especially in languages such as Go. Refer to our documentations for further details: [this page][2] leads you to the specific languages libraries we use.
 
 ### My service is defined properly
 
 The issue is probably linked to the actual location of your code instrumentation.
 
-The goal here is to always have a Root span define when a Child span is called when an application is running.
+The goal here is to always have a Root [span][3] define when a Child span is called when an application is running.
 
 A wrong instrumentation can lead to a dissociation of that Child span to its Rootspan, either at every span call, or in some specific path calls in the application.
 
@@ -35,9 +35,11 @@ If the Child span isn't associated directly to the Root span, you could end up w
 
 ### Nope, my code is properly instrumented
 
-It's time to contact [the Datadog support team][2]!
+It's time to contact [the Datadog support team][4]!
 
 Send your flare, and details about the language/library you're using, and a snippet of your code instrumentation.
 
-[1]: /tracing/setup
-[2]: /help
+[1]: /tracing/visualization/#trace
+[2]: /tracing/setup
+[3]: /tracing/visualization/#spans
+[4]: /help

--- a/content/en/tracing/faq/php-tracer-manual-installation.md
+++ b/content/en/tracing/faq/php-tracer-manual-installation.md
@@ -71,7 +71,7 @@ Datadog PHP tracer extension
 ...
 ```
 
-Visit a tracing-enabled endpoint of your application and view the [APM UI][5] to see the traces.
+Visit a tracing-enabled endpoint of your application and view the [APM UI][5] to see the [traces][6].
 
 **Note**: It might take a few minutes before traces appear in the UI.
 
@@ -80,3 +80,4 @@ Visit a tracing-enabled endpoint of your application and view the [APM UI][5] to
 [3]: #modify-the-ini-file
 [4]: https://github.com/DataDog/dd-trace-php/releases/latest
 [5]: https://app.datadoghq.com/apm/services
+[6]: /tracing/visualization/#trace

--- a/content/en/tracing/faq/resource-trace-doesn-t-show-up-under-correct-service.md
+++ b/content/en/tracing/faq/resource-trace-doesn-t-show-up-under-correct-service.md
@@ -5,7 +5,7 @@ kind: faq
 
 When using a custom instrumentation of your application, if you notice any resources/traces in the Datadog UI that aren't coupled the service you expect, the most likely scenario is explained below.
 
-A resource is connected to a service by more than the service Name - it is also done via the Name of the top-level span of the trace. This means that a service requires a top level name to be consistent across your resources.  
+A [resource][1] is connected to a [service][2] by more than the service Name - it is also done via the Name of the top-level [span][3] of the [trace][4]. This means that a service requires a top level name to be consistent across your resources.  
 See this in the following image in the address bar:
 
 {{< img src="tracing/faq/APM_service_name.png" alt="APM service Name" responsive="true" >}}
@@ -49,3 +49,8 @@ More examples and documentation can be found on our language-specific instrument
     {{< nextlink href="tracing/setup/dotnet" tag=".NET" >}}.NET language instrumentation.{{< /nextlink >}}
     {{< nextlink href="tracing/setup/php" tag="PHP" >}}PHP language instrumentation.{{< /nextlink >}}
 {{< /whatsnext >}}
+
+[1]: /tracing/visualization/#resources
+[2]: /tracing/visualization/#services
+[3]: /tracing/visualization/#spans
+[4]: /tracing/visualization/#trace

--- a/content/en/tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel.md
+++ b/content/en/tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel.md
@@ -7,14 +7,14 @@ further_reading:
   text: "Correlate Traces and Logs"
 ---
 
-Clicking on a trace opens a contextual panel that contains information about the trace, about the host and the correlated logs. However the log panel can be empty in some specific cases. Let's review how this can be fixed.
+Clicking on a [trace][1] opens a contextual panel that contains information about the trace, about the host and the correlated logs. However the log panel can be empty in some specific cases. Let's review how this can be fixed.
 
 {{< img src="tracing/faq/tracing_no_logs_in_trace.png" alt="Tracing missing logs" responsive="true" style="width:90%;">}}
 
 
 ## What logs are displayed in the trace panel?
 
-When looking at a trace, there are two types of logs that can be seen:
+When looking at a [trace][1], there are two types of logs that can be seen:
 
 * - `host`: Display logs from the trace's host within the trace timeframe
 * - `trace_id`: Display logs that have the corresponding trace id
@@ -29,15 +29,15 @@ If the log section is empty when the `host` option is set, go into the log explo
 
 - Logs are being sent from the host that emitted trace.
 - There are logs for that host within the trace timeframe.
-- The timestamp of the logs is properly set. Checkout [this specific guide][1] for more explanation about the log timestamp.
+- The timestamp of the logs is properly set. Checkout [this specific guide][2] for more explanation about the log timestamp.
 
 ### Trace_id option
 
-Make sure you have a `trace_id` standard attribute in your logs. You should see a trace icon next to the SERVICE name (black if trace is not sampled, grey if trace is sampled).
+Make sure you have a `trace_id` standard attribute in your logs. You should see a trace icon next to the [SERVICE][3] name (black if trace is not sampled, grey if trace is sampled).
 
 {{< img src="tracing/faq/trace_in_log_panel.png" alt="Trace icon in log panel" responsive="true" style="width:50%;">}}
 
-If your logs do not contain the `trace_id`, follow the guide on [correlating traces and logs][2].
+If your logs do not contain the `trace_id`, follow the guide on [correlating traces and logs][4].
 The idea is then on the log side to:
 
 1. Extract the trace id in a log attribute
@@ -46,13 +46,16 @@ The idea is then on the log side to:
 {{< tabs >}}
 {{% tab "JSON logs" %}}
 
-For JSON logs, step 1 and 2 are done automatically. The tracer inject the trace and span id automatically in the logs and it is remapped automatically thanks to the [reserved attribute remappers][1].
+For JSON logs, step 1 and 2 are done automatically. The tracer inject the [trace][1] and [span][2] id automatically in the logs and it is remapped automatically thanks to the [reserved attribute remappers][3].
 
-If this isn't working as expected, ensure the name of the logs attribute that contains the trace id is `dd.trace_id` and verify it is properly set in [reserved attributes][2].
+If this isn't working as expected, ensure the name of the logs attribute that contains the trace id is `dd.trace_id` and verify it is properly set in [reserved attributes][4].
 
 
-[1]: /logs/processing/#edit-reserved-attributes
-[2]: https://app.datadoghq.com/logs/pipelines/remapping
+
+[1]: /tracing/visualization/#trace
+[2]: /tracing/visualization/#spans
+[3]: /logs/processing/#edit-reserved-attributes
+[4]: https://app.datadoghq.com/logs/pipelines/remapping
 {{% /tab %}}
 {{% tab "With Log integration" %}}
 
@@ -68,13 +71,15 @@ Now it is possible that the log format is not covered by the integration pipelin
 {{% /tab %}}
 {{% tab "Custom" %}}
 
-For raw logs without any integration, make sure that the custom parsing rule is extracting the trace and span ids as a string as on the following example:
+For raw logs without any integration, make sure that the custom parsing rule is extracting the [trace][1] and [span][2] ids as a string as on the following example:
 
 {{< img src="tracing/faq/tracing_custom_parsing.png" alt="Custom parser" responsive="true" style="width:90%;">}}
 
-* Then define a [Trace remapper][1] on the extracted attribute to remap them to the official trace id of the logs.
+* Then define a [Trace remapper][3] on the extracted attribute to remap them to the official trace id of the logs.
 
-[1]: /logs/processing/processors/#trace-remapper
+[1]: /tracing/visualization/#trace
+[2]: /tracing/visualization/#spans
+[3]: /logs/processing/processors/#trace-remapper
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -86,5 +91,7 @@ Once the IDs are properly injected and remapped into your logs, you can make a d
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /logs/faq/why-do-my-logs-not-have-the-expected-timestamp/#pagetitle
-[2]: /tracing/advanced/connect_logs_and_traces
+[1]: /tracing/visualization/#trace
+[2]: /logs/faq/why-do-my-logs-not-have-the-expected-timestamp/#pagetitle
+[3]: /tracing/visualization/#services
+[4]: /tracing/advanced/connect_logs_and_traces

--- a/content/en/tracing/guide/add_span_md_and_graph_it.md
+++ b/content/en/tracing/guide/add_span_md_and_graph_it.md
@@ -23,17 +23,17 @@ _7 minutes to complete_
 
 {{< img src="tracing/guide/add_span_md_and_graph_it/span_md_6.mp4" alt="Analytics View" video="true" responsive="true" style="width:90%;">}}
 
-Datadog APM allows you to customize your traces to include any additional information you might need to maintain observability into your business. You can use this to identify a spike in the throughput of a certain enterprise customer, or the user suffering the highest latency, or to pinpoint the database shard generating the most errors.
+Datadog APM allows you to customize your [traces][1] to include any additional information you might need to maintain observability into your business. You can use this to identify a spike in the throughput of a certain enterprise customer, or the user suffering the highest latency, or to pinpoint the database shard generating the most errors.
 
-In this example, a customer ID is added to traces allowing the customers that have the slowest performance to be identified. Customization of traces is based on tags that seamlessly integrate APM with the rest of Datadog and come in the form of `key:value` pairs of metadata added to spans.
+In this example, a customer ID is added to traces allowing the customers that have the slowest performance to be identified. Customization of traces is based on tags that seamlessly integrate APM with the rest of Datadog and come in the form of `key:value` pairs of metadata added to [spans][2].
 
 ## Instrument your code with custom span tags
 
 1) **Follow the example to get your code instrumented**.
 
-Depending on the programming language you are you using, you’ll need to set the tags to add to your spans differently.
+Depending on the programming language you are you using, you’ll need to set the [tags][3] to add to your spans differently.
 
-**Note**: take note of the service and [resource names][1] you are working on, these will come in handy later. In this example, the service is the Ruby server `web-store` and the resource (endpoint) is `ShoppingCartController#checkout`.
+**Note**: take note of the service and [resource names][4] you are working on, these will come in handy later. In this example, the service is the Ruby server `web-store` and the resource (endpoint) is `ShoppingCartController#checkout`.
 
 {{< tabs >}}
 {{% tab "Java" %}}
@@ -223,7 +223,7 @@ class ShoppingCartController extends Controller
 
 ## Leverage the Datadog UI to search for your custom span tags
 
-2) **Go to the Services page** and click on the service that you added tags to. **Scroll down and click on the specific resource** where the tag was added in the Resource table. **Scroll down to the Traces table**
+2) **Go to the Services page** and click on the [service][5] that you added tags to. **Scroll down and click on the specific resource** where the tag was added in the [Resource][6] table. **Scroll down to the Traces table**
 
 {{< img src="tracing/guide/add_span_md_and_graph_it/span_md_3.png" alt="Resource Page" responsive="true" style="width:90%;">}}
 
@@ -243,9 +243,9 @@ The bottom part of the view includes additional information about the trace or a
 ## Leverage your custom span tags with Trace Search & Analytics
 <div class="alert alert-info">This section assumes that you have <a href="https://docs.datadoghq.com/tracing/trace_search_and_analytics/?tab=java" target=_blank>enabled Trace Search and Analytics</a></div>
 
-4) **Navigate to the [Trace Search page][2]**.
+4) **Navigate to the [Trace Search page][7]**.
 
-The Trace Search page allows you to identify specific [Traces][3] and APM Events you are interested in. Here you can filter by time a set of default tags (such as `Env`,`Service`, `Resource` and [many more][4]).
+The Trace Search page allows you to identify specific [Traces][8] and APM Events you are interested in. Here you can filter by time a set of default tags (such as `Env`,`Service`, `Resource` and [many more][9]).
 
 5) **Find a trace that has the new tag**. To do this use the facet explorer on the left to find the Resource name you set at the beginning of this guide and click into one of the rows you see there.
 
@@ -259,9 +259,9 @@ You can now determine the displayed name of your facet and where to place it in 
 
 You should now be able to see the facet you created in the Facet Explorer. The fastest way to find it is by using the `Search facets` box.
 
-6) **Navigate to the [Trace Analytics][5] page**
+6) **Navigate to the [Trace Analytics][10] page**
 
-The Trace Analytics page is a visual query building tool that allows you to conduct an investigation into your traces with infinite cardinality. It relies on facets to filter and scope the query, read more in the [Trace Analytics overview][6].
+The Trace Analytics page is a visual query building tool that allows you to conduct an investigation into your traces with infinite cardinality. It relies on facets to filter and scope the query, read more in the [Trace Analytics overview][11].
 
 7) **Choose the service** you’ve been working on from the service facet list, **choose Error** from the status facet and **select `customer_id`** (or any other tags you added to your spans) from the group by field.
 
@@ -269,7 +269,7 @@ The Trace Analytics page is a visual query building tool that allows you to cond
 
 8) **Remove Error** from the query, **change the `count *` measure to `Duration`** and **change the graph type to `Top List`**.
 
-You can now see the customers that have the slowest average requests. **Note**: If you’d like to make sure your customers never pass a certain threshold of performance, you can [export this query to a monitor][7], alternatively, you can save this visualization to a dashboard and keep an eye over it over time.
+You can now see the customers that have the slowest average requests. **Note**: If you’d like to make sure your customers never pass a certain threshold of performance, you can [export this query to a monitor][12], alternatively, you can save this visualization to a dashboard and keep an eye over it over time.
 
 {{< img src="tracing/guide/add_span_md_and_graph_it/span_md_7.mp4" alt="span md 7" video="true" responsive="true" style="width:90%;">}}
 
@@ -282,10 +282,16 @@ Finally, you can also see all the traces relevant to your query by clicking the 
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://docs.datadoghq.com/tracing/visualization/#resources
-[2]: https://app.datadoghq.com/apm/search
-[3]: https://docs.datadoghq.com/tracing/visualization/#trace
-[4]: https://docs.datadoghq.com/tracing/trace_search_and_analytics/search
-[5]: https://app.datadoghq.com/apm/search/analytics
-[6]: https://docs.datadoghq.com/tracing/trace_search_and_analytics/analytics
-[7]: https://docs.datadoghq.com/tracing/guide/alert_anomalies_p99_database
+
+[1]: /tracing/visualization/#trace
+[2]: /tracing/visualization/#spans
+[3]: /tracing/visualization/#span-tags
+[4]: https://docs.datadoghq.com/tracing/visualization/#resources
+[5]: /tracing/visualization/#services
+[6]: /tracing/visualization/#resources
+[7]: https://app.datadoghq.com/apm/search
+[8]: https://docs.datadoghq.com/tracing/visualization/#trace
+[9]: https://docs.datadoghq.com/tracing/trace_search_and_analytics/search
+[10]: https://app.datadoghq.com/apm/search/analytics
+[11]: https://docs.datadoghq.com/tracing/trace_search_and_analytics/analytics
+[12]: https://docs.datadoghq.com/tracing/guide/alert_anomalies_p99_database

--- a/content/en/tracing/guide/agent-5-tracing-setup.md
+++ b/content/en/tracing/guide/agent-5-tracing-setup.md
@@ -22,15 +22,15 @@ APM is enabled by default after Datadog Agent 5.13 (on Linux and Docker), but ca
 
 ### Installing the Agent
 
-Tracing metrics are sent to the Datadog through the Datadog Agent. To enable tracing:
+[Tracing metrics][4] are sent to the Datadog through the Datadog Agent. To enable tracing:
 
-Install the latest [Datadog Agent][4] (version 5.11.0+ is required).
+Install the latest [Datadog Agent][5] (version 5.11.0+ is required).
 
 ### Running the Agent in Docker
 
-To trace applications in Docker containers, use the [docker-dd-agent][5] image (tagged version 11.0.5110+) and enable tracing by passing `DD_APM_ENABLED=true` as an environment variable.
+To trace applications in Docker containers, use the [docker-dd-agent][6] image (tagged version 11.0.5110+) and enable tracing by passing `DD_APM_ENABLED=true` as an environment variable.
 
-For additional information, reference [the Docker page][6].
+For additional information, reference [the Docker page][7].
 
 ### Instrument your application
 
@@ -45,7 +45,7 @@ For additional information, reference [the Docker page][6].
     {{< nextlink href="tracing/setup/php" tag="PHP" >}}PHP language instrumentation.{{< /nextlink >}}
 {{< /whatsnext >}}
 
-To instrument an application written in a language that does not yet have official library support, reference the [Tracing API][7].
+To instrument an application written in a language that does not yet have official library support, reference the [Tracing API][8].
 
 ## Configuration
 
@@ -66,23 +66,24 @@ Additionally, some configuration options may be set as environment variables. No
 
 {{% /table %}}
 
-For more information about the Datadog Agent, see the [dedicated doc page][8] or refer to the [`datadog.conf.example` file][9].
+For more information about the Datadog Agent, see the [dedicated doc page][9] or refer to the [`datadog.conf.example` file][10].
 
 ### Trace search
-Trace search is available for Agent 5.25.0+. For more information, see the set up instructions in the main [APM documentation][10].
+Trace search is available for Agent 5.25.0+. For more information, see the set up instructions in the main [APM documentation][11].
 
 ## Troubleshooting
-Need help? Contact [Datadog support][11].
+Need help? Contact [Datadog support][12].
 
 
 [1]: https://github.com/DataDog/datadog-agent/tree/master/docs/trace-agent#run-on-macos
 [2]: https://github.com/DataDog/datadog-agent/tree/master/docs/trace-agent#run-on-windows
 [3]: /agent/faq/where-is-the-configuration-file-for-the-agent
-[4]: https://app.datadoghq.com/account/settings#agent
-[5]: https://hub.docker.com/r/datadog/docker-dd-agent
-[6]: /tracing/docker
-[7]: /api/?lang=console#traces
-[8]: /agent
-[9]: https://github.com/DataDog/dd-agent/blob/master/datadog.conf.example
-[10]: /tracing/setup/?tab=agent5250#trace-search
-[11]: /help
+[4]: /tracing/visualization/#trace-metrics
+[5]: https://app.datadoghq.com/account/settings#agent
+[6]: https://hub.docker.com/r/datadog/docker-dd-agent
+[7]: /tracing/docker
+[8]: /api/?lang=console#traces
+[9]: /agent
+[10]: https://github.com/DataDog/dd-agent/blob/master/datadog.conf.example
+[11]: /tracing/setup/?tab=agent5250#trace-search
+[12]: /help

--- a/content/en/tracing/guide/agent-obfuscation.md
+++ b/content/en/tracing/guide/agent-obfuscation.md
@@ -5,7 +5,7 @@ private: true
 disable_toc: true
 ---
 
-Agent trace obfuscation is disabled by default. Enable it in your `datadog.yaml` configuration file to obfuscate all information attached to your traces.
+Agent [trace][1] obfuscation is disabled by default. Enable it in your `datadog.yaml` configuration file to obfuscate all information attached to your traces.
 
 Currently this options only works with the following services:
 
@@ -20,7 +20,7 @@ Currently this options only works with the following services:
 {{< tabs >}}
 {{% tab "MongoDB" %}}
 
-Applies to spans of type `mongodb`, more specifically: to the `mongodb.query` span metadata.
+Applies to [spans][1] of type `mongodb`, more specifically: to the `mongodb.query` span metadata.
 
 ```
 apm_config:
@@ -37,11 +37,11 @@ apm_config:
 ```
 
 * `keep_values` - defines a set of keys to exclude from Agent trace obfuscation.
-
+[1]: /tracing/visualization/#spans
 {{% /tab %}}
 {{% tab "ElasticSearch" %}}
 
-Applies to spans of type `elasticsearch`, more specifically, to the `elasticsearch.body` span metadata:
+Applies to [spans][1] of type `elasticsearch`, more specifically, to the `elasticsearch.body` span metadata:
 
 ```
 apm_config:
@@ -58,11 +58,11 @@ apm_config:
 ```
 
 * `keep_values` - defines a set of keys to exclude from Agent trace obfuscation.
-
+[1]: /tracing/visualization/#spans
 {{% /tab %}}
 {{% tab "Redis" %}}
 
-Applies to spans of type `redis`, more specifically, to the `redis.raw_command` span metadata:
+Applies to [spans][1] of type `redis`, more specifically, to the `redis.raw_command` span metadata:
 
 ```
 apm_config:
@@ -74,11 +74,11 @@ apm_config:
     redis:
       enabled: true
 ```
-
+[1]: /tracing/visualization/#spans
 {{% /tab %}}
 {{% tab "MemCached" %}}
 
-Applies to spans of type `memcached`, more specifically, to the `memcached.command` span metadata:
+Applies to [spans][1] of type `memcached`, more specifically, to the `memcached.command` span metadata:
 
 ```
 apm_config:
@@ -90,11 +90,11 @@ apm_config:
     memcached:
       enabled: true
 ```
-
+[1]: /tracing/visualization/#spans
 {{% /tab %}}
 {{% tab "Http" %}}
 
-HTTP obfuscation rules for `http.url` metadata in spans of type `http`:
+HTTP obfuscation rules for `http.url` metadata in [spans][1] of type `http`:
 
 ```
 apm_config:
@@ -110,7 +110,7 @@ apm_config:
 
 * `remove_query_string`: If true, obfuscates query strings in URLs.
 * `remove_paths_with_digits`: If true, path segments in URLs containing digits are replaced by "?".
-
+[1]: /tracing/visualization/#spans
 {{% /tab %}}
 {{% tab "Stack Traces" %}}
 
@@ -127,3 +127,5 @@ apm_config:
 
 {{% /tab %}}
 {{< /tabs >}}
+
+[1]: /tracing/visualization/#trace

--- a/content/en/tracing/guide/alert_anomalies_p99_database.md
+++ b/content/en/tracing/guide/alert_anomalies_p99_database.md
@@ -29,9 +29,9 @@ Datadog allows you to set monitors to keep track of the health of your services 
 1. **Open the [New Monitor Page][2] and choose [APM][3]**.
 2. **Choose your environment** under Primary Tags and **Choose the database to monitor** under Service.
 
-    Under Resource, you can choose to monitor specific queries run in the database, but in this example, we’ll look at overall performance so leave it as `*`.
+    Under [Resource][4], you can choose to monitor specific queries run in the database, but in this example, we’ll look at overall performance so leave it as `*`.
 
-    Once you choose a service, the next step becomes available for you to set, and a chart appears at the top of the page showing the performance of the metric that the new monitor tracks.
+    Once you choose a [service][5], the next step becomes available for you to set, and a chart appears at the top of the page showing the performance of the metric that the new monitor tracks.
 
     {{< img src="tracing/guide/alert_anomalies_p99_database/alert_anomalies_2.png" alt="Monitor view with ongoing alert" responsive="true" style="width:90%;">}}
 
@@ -41,7 +41,7 @@ Datadog allows you to set monitors to keep track of the health of your services 
 
 4. **Set the *Alert when* field value to 100%**.
 
-    This means that all of the events for the selected duration have to be anomalous for the alert to trigger. This is a best practice for starting with Anomaly Detection. Over time, you’ll find the right values that fit your situation. You can find out more about Anomaly Detection Monitors in the [FAQ][4].
+    This means that all of the events for the selected duration have to be anomalous for the alert to trigger. This is a best practice for starting with Anomaly Detection. Over time, you’ll find the right values that fit your situation. You can find out more about Anomaly Detection Monitors in the [FAQ][6].
 
 5. **Change the alert notification**.
 
@@ -49,7 +49,7 @@ Datadog allows you to set monitors to keep track of the health of your services 
 
     {{< img src="tracing/guide/alert_anomalies_p99_database/alert_anomalies_3.png" alt="Monitor view with ongoing alert" responsive="true" style="width:90%;">}}
 
-    You can read more about the markup for notification text and what values and conditions you can set there in the [notifications overview][5].
+    You can read more about the markup for notification text and what values and conditions you can set there in the [notifications overview][7].
 
 6. **Make sure your username appears in the *Notify your team* box** and add any additional team members that should be notified in case of a database latency anomaly.
     **Note**: To add another user be sure to type `@` at the start. **Click on *Save***.
@@ -62,13 +62,13 @@ Datadog allows you to set monitors to keep track of the health of your services 
 
     Here you can see the current status of your monitor, mute it, or explore deeper into the specifics of a triggered alert.
 
-8. **Navigate back to the [Services Page][6]** and from there find the service you just set the monitor on, **click into the Service Page** and there **click on the Monitor bar** under the header.
+8. **Navigate back to the [Services Page][8]** and from there find the service you just set the monitor on, **click into the Service Page** and there **click on the Monitor bar** under the header.
 
     Here you should **see the new monitor** alongside any other monitor set for the service and suggested monitors that are recommended to set.
 
     {{< img src="tracing/guide/alert_anomalies_p99_database/alert_anomalies_5.png" alt="Monitor view with ongoing alert" responsive="true" style="width:90%;">}}
 
-    As you create monitors you’ll find more services, metrics and events to include and more complex conditions to set for these. Each of these monitors is connected to a service and can be accessed from the Service page as well as the [Service Map][7].
+    As you create monitors you’ll find more services, metrics and events to include and more complex conditions to set for these. Each of these monitors is connected to a service and can be accessed from the Service page as well as the [Service Map][9].
 
     {{< img src="tracing/guide/alert_anomalies_p99_database/alert_anomalies_6.png" alt="Service Map" responsive="true" style="width:90%;">}}
 
@@ -78,10 +78,13 @@ Datadog allows you to set monitors to keep track of the health of your services 
 
 {{< partial name="whats-next/whats-next.html" >}}
 
+
 [1]: https://docs.datadoghq.com/monitors/monitor_types/anomaly/#pagetitle
 [2]: https://app.datadoghq.com/monitors#/create
 [3]: https://app.datadoghq.com/monitors#create/apm
-[4]: https://docs.datadoghq.com/monitors/monitor_types/anomaly/#faq
-[5]: https://docs.datadoghq.com/monitors/notifications/?tab=is_alertis_warning
-[6]: https://app.datadoghq.com/apm/services
-[7]: https://app.datadoghq.com/service/map
+[4]: /tracing/visualization/#resources
+[5]: /tracing/visualization/#services
+[6]: https://docs.datadoghq.com/monitors/monitor_types/anomaly/#faq
+[7]: https://docs.datadoghq.com/monitors/notifications/?tab=is_alertis_warning
+[8]: https://app.datadoghq.com/apm/services
+[9]: https://app.datadoghq.com/service/map

--- a/content/en/tracing/guide/metrics_namespace.md
+++ b/content/en/tracing/guide/metrics_namespace.md
@@ -23,8 +23,9 @@ aliases:
 ---
 
 ## Overview
+The [trace metrics][1] namespace is `trace.<name>.<metrics>{<tags>}` where
 
-Tracing application metrics are collected after [enabling trace collection][1] and [instrumenting your application][2]. These metrics are available for dashboards and monitors.
+Tracing application metrics are collected after [enabling trace collection][2] and [instrumenting your application][3]. These metrics are available for dashboards and monitors.
 
 ### Metric names
 
@@ -60,5 +61,6 @@ Trace metrics come with a variety of tags. The possible tags are:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/send_traces
-[2]: /tracing/setup
+[1]: /tracing/visualization/#trace-metrics
+[2]: /tracing/send_traces
+[3]: /tracing/setup

--- a/content/en/tracing/guide/resource_monitor.md
+++ b/content/en/tracing/guide/resource_monitor.md
@@ -8,8 +8,8 @@ aliases:
 
 Datadog's Application Performance Monitoring component consists of a few key components: [services][1] and [resources][2] being the top most layers.
 
-Each graph within the APM service and resource Dashboards consist of some `trace.*` metrics.
-Use [the download button at the top of the graph][3] to save those Metrics to an existing Timeboard. This can be done for both service level and resource level metrics:
+Each graph within the APM [service][3] and [resource][4] Dashboards consist of some `trace.*` metrics.
+Use [the download button at the top of the graph][5] to save those Metrics to an existing Timeboard. This can be done for both service level and resource level metrics:
 
 {{< img src="tracing/faq/apm_save_1.png" alt="APM save" responsive="true" >}}
 
@@ -17,7 +17,7 @@ Use [the download button at the top of the graph][3] to save those Metrics to an
 
 ## Creating a Monitor from this
 
-While the current APM monitor has the ability to set up Alerts on a per [service basis][4], use the metric query taken from above to setup a Metric or even Anomaly monitor over a specific service or resource.
+While the current APM monitor has the ability to set up Alerts on a per [service basis][6], use the metric query taken from above to setup a Metric or even Anomaly monitor over a specific service or resource.
 
 Since these are regular Datadog Metrics and Tags, copy that query into a New Monitor.
 The downside here is that see the resource hash in the field, as opposed to the more readable name. However, to work around this, construct your Monitor message to send a link to the resource Page of the resource that caused the monitor to trigger. Each resource APM Page has the following format:
@@ -26,7 +26,7 @@ The downside here is that see the resource hash in the field, as opposed to the 
 /apm/resource/<Service>/<top_level_name>/<Resource_Name>?env=<env>
 ```
 
-Since each service contains a single Top Level Name and we can setup a multi alert by [environment][5] and resource and service, we only need to obtain the top level name to create the URL.
+Since each service contains a single Top Level Name and we can setup a multi alert by [environment][7] and resource and service, we only need to obtain the top level name to create the URL.
 This Top Level Name can be found by clicking on the service you are interested in. For example, for Datadog's Mcnulty-Web service, the Top Level Name is `pylons.request`:
 
 {{< img src="tracing/faq/top_level_name.png" alt="Top level name" responsive="true" >}}
@@ -35,8 +35,11 @@ Then the Monitor configuration would resemble the following:
 
 {{< img src="tracing/faq/top_level_monitor.png" alt="Top level monitor" responsive="true" >}}
 
+
 [1]: /tracing/visualization/service
 [2]: /tracing/visualization/resource
-[3]: /tracing/visualization/service/#export-to-timeboard
-[4]: /monitors/monitor_types/apm
-[5]: /tracing/advanced/setting_primary_tags_to_scope/#environment
+[3]: /tracing/visualization/#services
+[4]: /tracing/visualization/#resources
+[5]: /tracing/visualization/service/#export-to-timeboard
+[6]: /monitors/monitor_types/apm
+[7]: /tracing/advanced/setting_primary_tags_to_scope/#environment

--- a/content/en/tracing/guide/security.md
+++ b/content/en/tracing/guide/security.md
@@ -3,11 +3,11 @@ title: Security
 kind: documentation
 ---
 
-Sensitive information within your traces can be scrubbed [automatically](#automatic-scrubbing) or [manually](#replace-rules).
+Sensitive information within your [traces][1] can be scrubbed [automatically](#automatic-scrubbing) or [manually](#replace-rules).
 
 ## Automatic scrubbing
 
-Automatic scrubbing is available for some services, such as ElasticSearch, MongoDB, Redis, Memcached, and HTTP server and client request URLs. Below is an example configuration snippet documenting all the available options.
+Automatic scrubbing is available for some [services][2], such as ElasticSearch, MongoDB, Redis, Memcached, and HTTP server and client request URLs. Below is an example configuration snippet documenting all the available options.
 
 ```yaml
 apm_config:
@@ -52,7 +52,7 @@ apm_config:
 
 ## Replace rules
 
-To scrub sensitive data from your span's tags, use the `replace_tags` setting. It is a list containing one or more groups of parameters that describe how to perform replacements of sensitive data within your tags. These parameters are:
+To scrub sensitive data from your [span][3]'s tags, use the `replace_tags` setting. It is a list containing one or more groups of parameters that describe how to perform replacements of sensitive data within your tags. These parameters are:
 
 * `name`: The key of the tag to replace. To match all tags, use `*`. To match the resource, use `resource.name`.
 * `pattern`: The regexp pattern to match against.
@@ -75,3 +75,7 @@ apm_config:
     - name: "error.stack"
       pattern: "(?s).*"
 ```
+
+[1]: /tracing/visualization/#trace
+[2]: /tracing/visualization/#services
+[3]: /tracing/visualization/#spans

--- a/content/en/tracing/guide/slowest_request_daily.md
+++ b/content/en/tracing/guide/slowest_request_daily.md
@@ -23,11 +23,11 @@ _3 minutes to complete_
 
 {{< img src="tracing/guide/slowest_request_daily/slowest_trace_1.mp4" video="true" alt="Identifying the slowest trace and finding the Host metrics for it" responsive="true" style="width:90%;">}}
 
-With Datadog APM, you can easily investigate the performance of your endpoints, identify slow requests, and investigate the root cause of latency issues. This example shows the slowest trace of the day for an e-commerce checkout endpoint and how it slows down because of high CPU usage.
+With Datadog APM, you can easily investigate the performance of your endpoints, identify slow requests, and investigate the root cause of latency issues. This example shows the slowest [trace][1] of the day for an e-commerce checkout endpoint and how it slows down because of high CPU usage.
 
-1. **Open the [Services page][1]**.
+1. **Open the [Services page][2]**.
 
-    This page contains a list of all instrumented services available in Datadog APM. Note you can search for keywords, filter by `env-tag`, and set the timeline.
+    This page contains a list of all instrumented [services][3] available in Datadog APM. Note you can search for keywords, filter by `env-tag`, and set the timeline.
 
 2. **Search for a relevant and active web service and open the Service Page**.
 
@@ -40,7 +40,7 @@ With Datadog APM, you can easily investigate the performance of your endpoints, 
 3. **Sort the Resource table by p99 latency** and click into the slowest resource.
     **Note**: If you cannot see a p99 latency column, you can click on the cog icon `Change Columns` and flip the switch for `p99`.
 
-    The Resource page contains high-level metrics about this resource like throughput, latency, error rate, and a breakdown of the time spent on each downstream service from the resource. In addition, it contains the specific traces that pass through the resource and an aggregate view of the spans that make up these traces.
+    The [Resource][4] page contains high-level metrics about this resource like throughput, latency, error rate, and a breakdown of the time spent on each downstream service from the resource. In addition, it contains the specific [traces][1] that pass through the resource and an aggregate view of the [spans][5] that make up these traces.
 
      {{< img src="tracing/guide/slowest_request_daily/slowest_trace_3.png" alt="Identifying the slowest trace and finding the bottleneck causing it" responsive="true" style="width:90%;">}}
 
@@ -48,23 +48,28 @@ With Datadog APM, you can easily investigate the performance of your endpoints, 
 
     This is the Flamegraph and associated information. Here you can see the duration of each step in the trace and whether it is erroneous. This is useful in identifying slow components and error-prone ones. The Flamegraph can be zoomed, scrolled, and explored naturally. Under the Flamegraph you can see associated metadata, Logs, and Host information.
 
-    The Flamegraph is a great way of identifying the precise piece of your stack that is errneous or very latent. Errors are marked with red highlights and duration is represented by the horizontal length of the span, so very long spans are the slow ones. Learn more about using the Flamegraph in the [Trace View guide][2].
+    The Flamegraph is a great way of identifying the precise piece of your stack that is errneous or very latent. Errors are marked with red highlights and duration is represented by the horizontal length of the span, so very long spans are the slow ones. Learn more about using the Flamegraph in the [Trace View guide][6].
 
-    Under the Flamegraph you can see all of the tags (including [custom ones][3]). From here you can also see associated logs (if you [connected Logs to your Traces][4]), see Host-level information such as CPU and memory usage.
+    Under the Flamegraph you can see all of the tags (including [custom ones][7]). From here you can also see associated logs (if you [connected Logs to your Traces][8]), see Host-level information such as CPU and memory usage.
 
     {{< img src="tracing/guide/slowest_request_daily/slowest_trace_4.png" alt="Identifying the slowest trace and finding the bottleneck causing it" responsive="true" style="width:90%;">}}
 
 5. **Click into the Host tab**, observe the CPU and memory performance of the underlying host while the request was hitting it.
 6. **Click Open Host Dashboard** to view all relevant data about the host
 
-Datadog APM seamlessly integrates with the other Datadog metrics and information - like infrastructure metrics and Logs. Using the Flamegraph, this information is available to you as well as any [custom metadata][3] you are sending with your traces.
+Datadog APM seamlessly integrates with the other Datadog metrics and information - like infrastructure metrics and Logs. Using the Flamegraph, this information is available to you as well as any [custom metadata][7] you are sending with your traces.
 
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/apm/services
-[2]: https://docs.datadoghq.com/tracing/visualization/trace/?tab=spanmetadata
-[3]: https://docs.datadoghq.com/tracing/advanced/adding_metadata_to_spans
-[4]: https://docs.datadoghq.com/tracing/advanced/connect_logs_and_traces
+
+[1]: /tracing/visualization/#trace
+[2]: https://app.datadoghq.com/apm/services
+[3]: /tracing/visualization/#services
+[4]: /tracing/visualization/#resources
+[5]: /tracing/visualization/#spans
+[6]: https://docs.datadoghq.com/tracing/visualization/trace/?tab=spanmetadata
+[7]: https://docs.datadoghq.com/tracing/advanced/adding_metadata_to_spans
+[8]: https://docs.datadoghq.com/tracing/advanced/connect_logs_and_traces

--- a/content/en/tracing/guide/trace_sampling_and_storage.md
+++ b/content/en/tracing/guide/trace_sampling_and_storage.md
@@ -25,7 +25,7 @@ further_reading:
 
 ## Trace sampling
 
-Trace Sampling is applicable for high-volume web-scale applications, where a sampled proportion of traces is kept in Datadog based on the following rules.
+Trace Sampling is applicable for high-volume web-scale applications, where a sampled proportion of [traces][1] is kept in Datadog based on the following rules.
 
 Statistics (requests, errors, latency, etc.), are calculated based on the full volume of traces at the Agent level, and are therefore always accurate.
 
@@ -37,7 +37,7 @@ Datadog APM computes following aggregate statistics over all the traces instrume
 * Total errors and errors per second
 * Latency
 * Breakdown of time spent by service/type
-* [Apdex score][1] (web services only)
+* [Apdex score][2] (web services only)
 
 {{< img src="tracing/product_specs/trace_sampling_storage/sampling_stats.png" alt="Aggregate statistics are generated on un-sampled data." responsive="true" style="width:90%;">}}
 
@@ -79,7 +79,7 @@ For the lifecycle of a trace, decisions are made at Tracing Client, Agent, and B
 
     Moreover, the Agent provides a service-based rate to the prioritized traces from tracing client to ensure traces from low QPS services are prioritized to be kept.
 
-    Users can manually drop entire uninteresting resource endpoints at Agent level by using [resource filtering][2].
+    Users can manually drop entire uninteresting resource endpoints at Agent level by using [resource filtering][3].
 
 3. DD Backend/Server - The server receives traces from various Agents running on hosts and applies sampling to ensure representation from every reporting Agent. It does so by keeping traces on the basis of the signature marked by Agent.
 
@@ -368,7 +368,7 @@ Note that trace priority should be manually controlled only before any context p
 
 ## Trace Storage
 
-Individual traces are stored for up to 6 months. To determine how long a particular trace will be stored, the Agent makes a sampling decision early in the trace's lifetime. In Datadog backend, sampled traces are retained according to time buckets:
+Individual [traces][1] are stored for up to 6 months. To determine how long a particular trace will be stored, the Agent makes a sampling decision early in the trace's lifetime. In Datadog backend, sampled traces are retained according to time buckets:
 
 | Retention bucket       |  % of stream kept |
 | :--------------------- | :---------------- |
@@ -403,5 +403,7 @@ Once a trace has been viewed by opening a full page, it continues to be availabl
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/faq/how-to-configure-an-apdex-for-your-traces-with-datadog-apm
-[2]: https://docs.datadoghq.com/security/tracing/#resource-filtering
+
+[1]: /tracing/visualization/#trace
+[2]: /tracing/faq/how-to-configure-an-apdex-for-your-traces-with-datadog-apm
+[3]: https://docs.datadoghq.com/security/tracing/#resource-filtering

--- a/content/en/tracing/guide/week_over_week_p50_comparison.md
+++ b/content/en/tracing/guide/week_over_week_p50_comparison.md
@@ -28,14 +28,14 @@ Datadog can show you the latency of your application over time and how it compar
 
 1. **Open the [Service List page][1]**.
 
-    This page contains a list of all instrumented services available in Datadog APM. You can search over your services by keywords, filter them by `env` tag, and set the timeline.
+    This page contains a list of all instrumented [services][2] available in Datadog APM. You can search over your services by keywords, filter them by `env` tag, and set the timeline.
 2. **Search and open a relevant and active service**.
 
     The web-store service is used in this example because it’s a stable service that we want to double check that there hasn’t been any issues over the last month.
 
     {{< img src="tracing/guide/week_over_week_p50_comparison/wow_p50_comp_2.png" alt="comparaison 2" responsive="true" style="width:90%;">}}
 
-    The Service page comes out of the box for every service in your stack that’s available in Datadog APM. See in-depth analyses of throughput, latency (including percentile distribution) and errors as well as a summary of the active Datadog monitors for the service and breakdown of the resources made available by the service.
+    The Service page comes out of the box for every service in your stack that’s available in Datadog APM. See in-depth analyses of throughput, latency (including percentile distribution) and errors as well as a summary of the active Datadog monitors for the [service][2] and breakdown of the [resources][3] made available by the service.
 
 3. **Find the Latency graph** on the top of the Service Dashboard and deselect all the percentiles from the legend leaving only the p50 option, then **Expand the Latency graph** to view the full screen mode where you can conduct a more comprehensive analysis.
 
@@ -53,4 +53,7 @@ Datadog can show you the latency of your application over time and how it compar
 
 {{< partial name="whats-next/whats-next.html" >}}
 
+
 [1]: https://app.datadoghq.com/apm/services
+[2]: /tracing/visualization/#services
+[3]: /tracing/visualization/#resources

--- a/content/en/tracing/send_traces/_index.md
+++ b/content/en/tracing/send_traces/_index.md
@@ -23,12 +23,12 @@ further_reading:
   text: "ECS Fargate APM setup"
 ---
 
-To use APM, start by sending your traces to Datadog, and then [configure your environment](#configure-your-environment). You can send traces to Datadog in multiple different ways depending on your system setup: including using the [Datadog Agent locally](#datadog-agent), [on containers](#containers), and [several other ways](#-additional-environments). For the full overview of all of the steps to set up APM, see the [APM overview][1].
+To use APM, start by sending your [traces][1] to Datadog, and then [configure your environment](#configure-your-environment). You can send traces to Datadog in multiple different ways depending on your system setup: including using the [Datadog Agent locally](#datadog-agent), [on containers](#containers), and [several other ways](#-additional-environments). For the full overview of all of the steps to set up APM, see the [APM overview][2].
 
 ## Datadog Agent
 
-APM is enabled by default in Agent 6. Set `apm_non_local_traffic: true` in your main [`datadog.yaml` configuration file][2] if you are sending traces from a nonlocal environment (like a container).
-To get an overview of all the possible settings for APM, take a look at the Agent's [`datadog.example.yaml`][3] configuration file. For all of the metrics sent to Datadog by the Agent, see [APM metrics sent by the Datadog Agent][4]. For more information about the Datadog Agent, see the [Agent documentation][5] or refer to the [`datadog.yaml` configuration template][6].
+APM is enabled by default in Agent 6. Set `apm_non_local_traffic: true` in your main [`datadog.yaml` configuration file][3] if you are sending traces from a nonlocal environment (like a container).
+To get an overview of all the possible settings for APM, take a look at the Agent's [`datadog.example.yaml`][4] configuration file. For all of the metrics sent to Datadog by the Agent, see [APM metrics sent by the Datadog Agent][5]. For more information about the Datadog Agent, see the [Agent documentation][6] or refer to the [`datadog.yaml` configuration template][7].
 
 ## Containers
 
@@ -44,15 +44,15 @@ There are alternernates to the Agent and containers that you can use to collect 
 
 ### Lambda - X-Ray
 
-For more information setting up Lambda - X-Ray, see the [Amazon X-Ray integration documentation][7]
+For more information setting up Lambda - X-Ray, see the [Amazon X-Ray integration documentation][8]
 
 ### Heroku
 
-Tracing is enabled by default when monitoring with Heroku. For more information about configuring tracing for Heroku, see the [Heroku cloud documentation][8].
+Tracing is enabled by default when monitoring with Heroku. For more information about configuring tracing for Heroku, see the [Heroku cloud documentation][9].
 
 ### Cloud Foundry
 
-Tracing is enabled by default when monitoring with Cloud Foundry. For more information about configuring tracing for Cloud Foundry, see the [Cloud Foundry documentation][9].
+Tracing is enabled by default when monitoring with Cloud Foundry. For more information about configuring tracing for Cloud Foundry, see the [Cloud Foundry documentation][10].
 
 ### Other(GAE, AAS, Serverless)
 
@@ -60,7 +60,7 @@ Datadog APM currently requires sending trace data to a running Agent. A workarou
 
 ## Configure your environment
 
-There are several ways to specify [an environment][10] when reporting data:
+There are several ways to specify [an environment][11] when reporting data:
 
 1. **Host tag**: Use a host tag with the format `env:<ENVIRONMENT>` to tag all traces from that Agent accordingly.
 2. **Agent configuration**: Override the default tag used by the Agent in the Agent configuration file. This tags all traces coming through the Agent, overriding the host tag value.
@@ -68,25 +68,27 @@ There are several ways to specify [an environment][10] when reporting data:
   apm_config:
   env: <ENVIRONMENT>
   ```
-3. **Per trace**: When submitting a single trace, specify an environment by tagging one of its spans with the metadata key `env`. This overrides the Agent configuration and the host tag’s value (if any). Consult the [trace tagging documentation][11] to learn how to assign a tag to your traces.
+3. **Per trace**: When submitting a single [trace][1], specify an environment by tagging one of its [spans][12] with the metadata key `env`. This overrides the Agent configuration and the host tag’s value (if any). Consult the [trace tagging documentation][13] to learn how to assign a tag to your traces.
 
 ## Next steps
 
-Next, [Instrument your application][12]. For the full overview of all of the steps to set up APM, see the [APM overview][1].
+Next, [Instrument your application][14]. For the full overview of all of the steps to set up APM, see the [APM overview][2].
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing
-[2]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
-[3]: https://github.com/DataDog/datadog-trace-agent/blob/6.4.1/datadog.example.yaml
-[4]: /tracing/send_traces/agent-apm-metrics
-[5]: /agent
-[6]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
-[7]: /integrations/amazon_xray/#overview
-[8]: /agent/basic_agent_usage/heroku/#installation
-[9]: /integrations/cloud_foundry/#trace-collection
-[10]: /tracing/advanced/setting_primary_tags_to_scope/#definition
-[11]: /tracing/advanced/adding_metadata_to_spans/?tab=java
-[12]: /tracing/setup
+[1]: /tracing/visualization/#trace
+[2]: /tracing
+[3]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
+[4]: https://github.com/DataDog/datadog-trace-agent/blob/6.4.1/datadog.example.yaml
+[5]: /tracing/send_traces/agent-apm-metrics
+[6]: /agent
+[7]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
+[8]: /integrations/amazon_xray/#overview
+[9]: /agent/basic_agent_usage/heroku/#installation
+[10]: /integrations/cloud_foundry/#trace-collection
+[11]: /tracing/advanced/setting_primary_tags_to_scope/#definition
+[12]: /tracing/visualization/#spans
+[13]: /tracing/advanced/adding_metadata_to_spans/?tab=java
+[14]: /tracing/setup

--- a/content/en/tracing/setup/_index.md
+++ b/content/en/tracing/setup/_index.md
@@ -7,13 +7,15 @@ aliases:
 disable_toc: true
 ---
 
-After you have [enabled trace collection][1], configure your application to send traces using one of the following official Datadog tracing libraries:
+After you have [enabled trace collection][1], configure your application to send [traces][2] using one of the following official Datadog tracing libraries:
 
 ### Language setup
 
 {{< partial name="apm/apm-languages.html" >}}
 
-To instrument an application written in a language that does not yet have official library support, visit the list of [community tracing libraries][2].
+To instrument an application written in a language that does not yet have official library support, visit the list of [community tracing libraries][3].
+
 
 [1]: /tracing/send_traces
-[2]: /developers/libraries/#apm-tracing-client-libraries
+[2]: /tracing/visualization/#trace
+[3]: /developers/libraries/#apm-tracing-client-libraries

--- a/content/en/tracing/trace_search_and_analytics/_index.md
+++ b/content/en/tracing/trace_search_and_analytics/_index.md
@@ -475,10 +475,15 @@ span->SetTag(datadog::tags::analytics_event, 0.5);
 
 ## APM Event Filtering
 
-An APM event represents the top span for a service, including its metadata. Once enabled, APM events are sent at 100% throughput by default. For example, a Java service with 100 requests will generate 100 APM events from its `servlet.request` spans, as each `servlet.request` span generates an APM event. [Filtering APM events][3] has the benefit of reducing the number of billable APM events and has no effect on trace sampling. Once a service has been filtered lower than 100%, APM event analytics are upscaled to display an estimate by default, and you have the option to display the filtered value.
+An [APM event][3] represents the top [span][4] for a [service], including its metadata. Once enabled, APM events are sent at 100% throughput by default. For example, a Java service with 100 requests will generate 100 APM events from its `servlet.request` spans, as each `servlet.request` span generates an APM event. [Filtering APM events][5] has the benefit of reducing the number of billable APM events and has no effect on [trace][6] sampling. Once a service has been filtered lower than 100%, APM event analytics are upscaled to display an estimate by default, and you have the option to display the filtered value.
 
 {{< img src="tracing/trace_search_and_analytics/analytics/apm_event_filtering.png" alt="APM Event Filtering" responsive="true" style="width:100%;">}}
 
+
+
 [1]: https://app.datadoghq.com/apm/search
 [2]: /tracing/trace_search_and_analytics/agent_trace_search
-[3]: https://app.datadoghq.com/apm/settings
+[3]: /tracing/visualization/#apm-event
+[4]: /tracing/visualization/#spans
+[5]: https://app.datadoghq.com/apm/settings
+[6]: /tracing/visualization/#trace

--- a/content/en/tracing/trace_search_and_analytics/agent_trace_search.md
+++ b/content/en/tracing/trace_search_and_analytics/agent_trace_search.md
@@ -10,8 +10,8 @@ kind: Documentation
 
 **Note**: To enable trace search and analytics with the Agent, [services][1] must be already flowing into Datadog.
 
-1. Once [your services are set up][4], navigate to the [Trace Search & Analytics docs page][5] to find a list of services and resource names available for use in Trace Search.
-3. Select the `environment` and `services` from which to extract [APM events][6].
+1. Once [your services are set up][4], navigate to the [Trace Search & Analytics docs page][5] to find a list of [services][6] and [resource][7] names available for use in Trace Search.
+3. Select the `environment` and `services` from which to extract [APM events][8].
 2. Update your Datadog Agent configuration (based on Agent version) with the information below:
 
 {{< tabs >}}
@@ -52,13 +52,17 @@ DD_APM_ANALYZED_SPANS="<SERVICE_NAME_1>|<OPERATION_NAME_1>=1,<SERVICE_NAME_2>|<O
 
 In Datadog, every automatically instrumented service has an `<OPERATION_NAME>`, which is used to set the type of request being traced. For example, if you're tracing a Python Flask application, you might have a `flask.request` as your operation name. In a Node application using Express, you would have `express.request` ask your operation name.
 
-Replace both the `<SERVICE_NAME>` and `<OPERATION_NAME>` in your configuration with the service name and operation name of the traces you want to add to Trace Search.
+Replace both the `<SERVICE_NAME>` and `<OPERATION_NAME>` in your configuration with the service name and operation name of the [traces][9] you want to add to Trace Search.
 
 For example, if you have a Python service named `python-api`, and it's running Flask (operation name `flask.request`), your `<SERVICE_NAME>` would be `python-api`, and your `<OPERATION_NAME>` would be `flask.request`.
+
 
 [1]: https://app.datadoghq.com/apm/services
 [2]: /tracing/trace_search_and_analytics/#automatic-configuration
 [3]: /tracing/trace_search_and_analytics/#custom-instrumentation
 [4]: /tracing/setup
 [5]: https://app.datadoghq.com/apm/docs/trace-search
-[6]: /tracing/trace_search_and_analytics/search/#apm-events
+[6]: /tracing/visualization/#services
+[7]: /tracing/visualization/#resources
+[8]: /tracing/trace_search_and_analytics/search/#apm-events
+[9]: /tracing/visualization/#trace

--- a/content/en/tracing/trace_search_and_analytics/analytics.md
+++ b/content/en/tracing/trace_search_and_analytics/analytics.md
@@ -101,7 +101,7 @@ Visualize the top values from a [facet][1] according to a chosen [measure][2] (t
 
 ## Related Traces
 
-Select or click on a section of the graph to either zoom in the graph or see the list of traces corresponding to your selection:
+Select or click on a section of the graph to either zoom in the graph or see the list of [traces][3] corresponding to your selection:
 
 {{< img src="tracing/trace_search_and_analytics/analytics/view_traces.png" alt="view Traces" responsive="true" style="width:40%;">}}
 
@@ -111,16 +111,16 @@ Select or click on a section of the graph to either zoom in the graph or see the
 
 Export your Trace analytic:
 
-* To create a new [APM monitor][3]:
+* To create a new [APM monitor][4]:
     This feature is not available yet.
-* To an existing [Timeboard][4]:
-    This functionality is in beta, [contact the Datadog support team][5] to activate it for your organization.
+* To an existing [Timeboard][5]:
+    This functionality is in beta, [contact the Datadog support team][6] to activate it for your organization.
 
 ## Traces in Dashboard
 
-Export [Trace Analytics][6] from the Trace search or build them directly in your [Dashboard][7] alongside metrics and logs.
+Export [Trace Analytics][7] from the Trace search or build them directly in your [Dashboard][8] alongside metrics and logs.
 
-[Learn more about the timeseries widget][8]
+[Learn more about the timeseries widget][9]
 
 ## Further Reading
 
@@ -128,9 +128,10 @@ Export [Trace Analytics][6] from the Trace search or build them directly in your
 
 [1]: /tracing/trace_search_and_analytics/search/#facets
 [2]: /tracing/trace_search_and_analytics/search/#measures
-[3]: /monitors/monitor_types/apm
-[4]: /graphing/dashboards/timeboard
-[5]: /help
-[6]: /graphing/widgets/timeseries
-[7]: /graphing/dashboards
-[8]: /graphing/widgets/timeseries
+[3]: /tracing/visualization/#trace
+[4]: /monitors/monitor_types/apm
+[5]: /graphing/dashboards/timeboard
+[6]: /help
+[7]: /graphing/widgets/timeseries
+[8]: /graphing/dashboards
+[9]: /graphing/widgets/timeseries

--- a/content/en/tracing/trace_search_and_analytics/search.md
+++ b/content/en/tracing/trace_search_and_analytics/search.md
@@ -30,9 +30,9 @@ further_reading:
 
 ## Overview
 
-Use Trace Search & Analytics to filter application performance metrics and [APM Events](#apm-events) by user-defined tags. It allows deep exploration of the web requests flowing through your service.
+Use [Trace Search & Analytics][1] to filter application performance metrics and [APM Events](#apm-events) by user-defined tags. It allows deep exploration of the web requests flowing through your service.
 
-Trace Search & Analytics can be enabled per APM service and per host. A service on which it is enabled exposes all its APM Events to Datadog.
+Trace Search & Analytics can be enabled per APM [service][2] and per host. A service on which it is enabled exposes all its APM Events to Datadog.
 
 Downstream services like databases and cache layers aren't in the list of available services (as they don't generate traces on their own), but their information is picked up by the top level services that call them.
 
@@ -45,16 +45,16 @@ In the Trace Search view you can:
 
 ## APM Events
 
-When a request hits a service (e.g. webserver, database), the Datadog Agent creates an APM event. It's a record of the request including its duration, response code, and any [custom metadata][1].
-An APM event is represented by a single span with attached metadata for the handled request. For each service that receives a request, the agent creates an APM event. If a request runs through a web service, listing service, and database service, the request will generate 3 APM events. To reduce the amount of APM Events generated, [explicitly turn on/off any APM event collection for a specific service][2].
+When a request hits a [service][2] (e.g. webserver, database), the Datadog Agent creates an APM event. It's a record of the request including its duration, response code, and any [custom metadata][3].
+An APM event is represented by a single span with attached metadata for the handled request. For each service that receives a request, the agent creates an APM event. If a request runs through a web service, listing service, and database service, the request will generate 3 APM events. To reduce the amount of APM Events generated, [explicitly turn on/off any APM event collection for a specific service][4].
 
-To start collecting APM events, [enable Trace Search & Analytics for your services][3].
+To start collecting APM events, [enable Trace Search & Analytics for your services][5].
 
 ### Complete traces
 
 {{< img src="tracing/trace_search_and_analytics/search/complete_trace.png" alt="Trace list" responsive="true">}}
 
-If checked, APM Events listed in the trace stream have a trace associated with them, so you can display the full trace with all its associated spans.
+If checked, APM Events listed in the trace stream have a trace associated with them, so you can display the full [trace][6] with all its associated [span][7].
 
 ## Search bar
 
@@ -89,7 +89,7 @@ For instance, if your facet name is **url** and you want to filter on the **url*
 
 ### Tags search
 
-Your traces inherit tags from [hosts][4] and [integrations][5] that generate them. They can be used in the search and as facets as well:
+Your traces inherit tags from [hosts][8] and [integrations][9] that generate them. They can be used in the search and as facets as well:
 
 | Query                                                          | Match                                                                       |
 | :----                                                          | :---                                                                        |
@@ -97,7 +97,7 @@ Your traces inherit tags from [hosts][4] and [integrations][5] that generate the
 | `(service:srvA OR service:srvB)` or `(service:(srvA OR srvB))` | All traces that contain tags `#service:srvA` or `#service:srvB`.            |
 | `("env:prod" AND -"version:beta")`                             | All traces that contain `#env:prod` and that do not contain `#version:beta` |
 
-If your tags don't follow [tags best practices][6] and don't use the `key:value` syntax, use this search query:
+If your tags don't follow [tags best practices][10] and don't use the `key:value` syntax, use this search query:
 
 * `tags:<MY_TAG>`
 
@@ -198,7 +198,7 @@ To start using an attribute as a Facet or in the search, click on it and add it 
 
 {{< img src="tracing/trace_search_and_analytics/search/create_facet.png" style="width:50%;" alt="Create Facet" responsive="true" style="width:50%;">}}
 
-Once this is done, the value of this attribute is stored **for all new traces** and can be used in [the search bar](#search-bar), [the Facet Panel](#facet-panel), and in the [Trace graph query][7].
+Once this is done, the value of this attribute is stored **for all new traces** and can be used in [the search bar](#search-bar), [the Facet Panel](#facet-panel), and in the [Trace graph query][11].
 
 ### Facet Panel
 
@@ -210,10 +210,15 @@ Use Facets to easily filters on your Traces. The search bar and url automaticall
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/advanced/adding_metadata_to_spans/?tab=java
-[2]: /tracing/trace_search_and_analytics/?tab=java#configure-by-integration
-[3]: /tracing/trace_search_and_analytics/?tab=php#automatic-configuration
-[4]: /graphing/infrastructure
-[5]: /integrations
-[6]: /tagging/#tags-best-practices
-[7]: /tracing/trace_search_and_analytics/analytics
+
+[1]: /tracing/visualization/#trace-search-analytics
+[2]: /tracing/visualization/#services
+[3]: /tracing/advanced/adding_metadata_to_spans/?tab=java
+[4]: /tracing/trace_search_and_analytics/?tab=java#configure-by-integration
+[5]: /tracing/trace_search_and_analytics/?tab=php#automatic-configuration
+[6]: /tracing/visualization/#trace
+[7]: /tracing/visualization/#spans
+[8]: /graphing/infrastructure
+[9]: /integrations
+[10]: /tagging/#tags-best-practices
+[11]: /tracing/trace_search_and_analytics/analytics

--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -29,7 +29,7 @@ When experiencing unexpected behavior with Datadog APM, there are a few common i
 
     After having [enabled tracer debug mode](#tracer-debug-mode), check your Agent logs to see if there is more info about your issue.
 
-If there are errors that you don't understand, or traces are reported to be flushed to Datadog and you still cannot see them in the Datadog UI, [contact Datadog support][5] and provide the relevant log entries with [a flare][6].
+If there are errors that you don't understand, or [traces][5] are reported to be flushed to Datadog and you still cannot see them in the Datadog UI, [contact Datadog support][6] and provide the relevant log entries with [a flare][7].
 
 ## Tracer debug mode
 
@@ -194,9 +194,12 @@ make install
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
+
 [1]: /help
 [2]: /tracing/setup/#agent-configuration
 [3]: /agent/troubleshooting/?tab=agentv6#get-more-logging-from-the-agent
 [4]: /agent/guide/agent-log-files
-[5]: /help
-[6]: /agent/troubleshooting/#send-a-flare
+[5]: /tracing/visualization/#trace
+[6]: /help
+[7]: /agent/troubleshooting/#send-a-flare

--- a/content/en/tracing/visualization/resource.md
+++ b/content/en/tracing/visualization/resource.md
@@ -18,7 +18,7 @@ further_reading:
 
 {{< img src="tracing/visualization/resource/ressource.png" alt="Ressource" responsive="true" >}}
 
-A resource is a particular action for a given service (typically an individual endpoint or query). Read more about resources in [Getting Started with APM][1]. For each resource, APM automatically generates a dashboard page covering:
+A resource is a particular action for a given [service][1] (typically an individual endpoint or query). Read more about resources in [Getting Started with APM][2]. For each resource, APM automatically generates a dashboard page covering:
 
 * Key health metrics
 * Monitor status for all monitors associated with this service
@@ -39,7 +39,7 @@ Datadog provides out of the box graphs for any given resource:
     * The **% Error Rate**
 * Sub-Services: When there are multiple services involved, a fourth graph is available that breaks down your **Total time spent**/**%of time spent**/**Avg time per request** of your service by *services* or *type*.
 
-    This represents the total/relative/average time spent by traces from the current service to the other *services* or *type*.
+    This represents the total/relative/average time spent by [traces][3] from the current service to the other *services* or *type*.
 
     **Note**: For services like *Postgres* or *Redis*, which are "final" operations that do not call other services, there is no sub-services graph.
 
@@ -47,7 +47,7 @@ Datadog provides out of the box graphs for any given resource:
 
 ### Export to Timeboard
 
-On the upper-right corner of each graph click on the arrow in order to export your graph into a pre-existing [Timeboard][2]:
+On the upper-right corner of each graph click on the arrow in order to export your graph into a pre-existing [Timeboard][4]:
 
 {{< img src="tracing/visualization/resource/save_to_timeboard.png" alt="Save to timeboard" responsive="true" style="width:40%;">}}
 
@@ -65,7 +65,7 @@ Zoom on this graph to filter corresponding traces.
 
 ## Span Summary
 
-For a given resource, Datadog provides you a span analysis breakdown of all matching traces:
+For a given resource, Datadog provides you a [span][5] analysis breakdown of all matching traces:
 
 {{< img src="tracing/visualization/resource/span_stats.png" alt="Span statistics" responsive="true" style="width:80%;">}}
 
@@ -85,7 +85,7 @@ The displayed metrics represent, per span:
 
 Consult the list of traces associated with this resource. Filter/sort this list to see fast/slow and error/non-error traces:
 
-[Refer to the dedicated trace documentation to learn more][3].
+[Refer to the dedicated trace documentation to learn more][6].
 
 {{< img src="tracing/visualization/resource/traces_list.png" alt="Traces list" responsive="true" style="width:90%;">}}
 
@@ -93,6 +93,9 @@ Consult the list of traces associated with this resource. Filter/sort this list 
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/visualization
-[2]: /graphing/dashboards/timeboard
-[3]: /tracing/visualization/trace
+[1]: /tracing/visualization/#services
+[2]: /tracing/visualization
+[3]: /tracing/visualization/#trace
+[4]: /graphing/dashboards/timeboard
+[5]: /tracing/visualization/#spans
+[6]: /tracing/visualization/trace

--- a/content/en/tracing/visualization/service.md
+++ b/content/en/tracing/visualization/service.md
@@ -78,7 +78,7 @@ Use the top right selector of this graph to zoom on a given percentile of latenc
 
 ## Resources
 
-See the list of resources associated with your service. Resources are particular actions for your services (typically individual endpoints or queries). Read more about resources in [Getting Started with APM][1]. Sort the resources for this service by requests, latency, errors, and time, to identify areas of high traffic or potential trouble. Note that the these metric columns are configurable (see image below).
+See the list of [resources][6] associated with your service. Resources are particular actions for your services (typically individual endpoints or queries). Read more about resources in [Getting Started with APM][1]. Sort the resources for this service by requests, latency, errors, and time, to identify areas of high traffic or potential trouble. Note that the these metric columns are configurable (see image below).
 
 {{< img src="tracing/visualization/service/resources.png" alt="Resources" responsive="true" style="width:90%;">}}
 
@@ -110,3 +110,4 @@ Choose what to display in your resources list:
 [3]: /monitors/monitor_types/apm
 [4]: /tracing/guide/configure_an_apdex_for_your_traces_with_datadog_apm
 [5]: /graphing/dashboards/timeboard
+[6]: /tracing/visualization/#resources

--- a/content/en/tracing/visualization/services_list.md
+++ b/content/en/tracing/visualization/services_list.md
@@ -20,15 +20,15 @@ further_reading:
 
 ## Overview
 
-After you have [instrumented your application][1], your reporting services appear on [the APM services page][2]. The services list is a bird's eye view of all [services][3] reporting from your infrastructure.
-Select an individual service to view detailed performance insights. [Read the dedicated service documentation to learn more][3].
+After you have [instrumented your application][1], your reporting [services][2] appear on [the APM services page][3]. The services list is a bird's eye view of all [services][4] reporting from your infrastructure.
+Select an individual service to view detailed performance insights. [Read the dedicated service documentation to learn more][4].
 
 ## Filtering the service list
 
 Filter the services list depending on:
 
-* [Environment][4]
-* [Primary Tag][5]
+* [Environment][5]
+* [Primary Tag][6]
 * [Service type](#services-types)
 * A query (basic text filtering)
 
@@ -36,7 +36,7 @@ Filter the services list depending on:
 
 ### Services types
 
-Every service monitored by your application is associated with a "type". This type is automatically determined by Datadog based on the `span.type` attribute attached to your [spans][6]. The "type" specified the name of the application/framework the Datadog Agent is integrating with.
+Every service monitored by your application is associated with a "type". This type is automatically determined by Datadog based on the `span.type` attribute attached to your [spans][7]. The "type" specified the name of the application/framework the Datadog Agent is integrating with.
 
 For example, if you are using the official Flask Integration, the "Type" is set to "Web". If you are monitoring a custom application, the "Type" appears as "Custom".
 
@@ -51,7 +51,7 @@ We also have some aliases for Integrations such as Postgres, MySQL, and Cassandr
 
 ### Changing service color
 
-Service color is used in [trace visualizations][7]. Select your service color to change it:
+Service color is used in [trace visualizations][8]. Select your service color to change it:
 
 {{< img src="tracing/visualization/service_color.png" alt="Services colors" responsive="true" style="width:30%;">}}
 
@@ -62,8 +62,8 @@ Choose what to display in your services list:
 * **Requests**: Total amount of requests traced (per seconds)
 * **Avg/p75/p90/p95/p99/Max Latency**: Avg/p75/p90/p95/p99/Max latency of your traced requests
 * **Error Rate**: Amount of requests traced (per seconds) that ended with an error
-* **Apdex**: Apdex score of the service, [learn more on Apdex][8]
-* **Monitor status**: [Status of monitors][9] attached to a service
+* **Apdex**: Apdex score of the service, [learn more on Apdex][9]
+* **Monitor status**: [Status of monitors][10] attached to a service
 
 {{< img src="tracing/visualization/services_columns.png" alt="Services columns" responsive="true" style="width:40%;">}}
 
@@ -72,11 +72,12 @@ Choose what to display in your services list:
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /tracing/setup
-[2]: https://app.datadoghq.com/apm/services
-[3]: /tracing/visualization/service
-[4]: /tracing/advanced/setting_primary_tags_to_scope/#environment
-[5]: /tracing/advanced/setting_primary_tags_to_scope
-[6]: /tracing/visualization/trace/#spans
-[7]: /tracing/visualization/trace
-[8]: /tracing/faq/how-to-configure-an-apdex-for-your-traces-with-datadog-apm
-[9]: /tracing/visualization/service/#service-monitor
+[2]: /tracing/visualization/#services
+[3]: https://app.datadoghq.com/apm/services
+[4]: /tracing/visualization/service
+[5]: /tracing/advanced/setting_primary_tags_to_scope/#environment
+[6]: /tracing/advanced/setting_primary_tags_to_scope
+[7]: /tracing/visualization/trace/#spans
+[8]: /tracing/visualization/trace
+[9]: /tracing/faq/how-to-configure-an-apdex-for-your-traces-with-datadog-apm
+[10]: /tracing/visualization/service/#service-monitor

--- a/content/en/tracing/visualization/services_map.md
+++ b/content/en/tracing/visualization/services_map.md
@@ -16,13 +16,13 @@ further_reading:
   text: "Creating context with service maps (Datadog + Airbnb)"
 ---
 
-The Service Map decomposes your application into all its component services and draws the observed dependencies between these services in real time, so you can identify bottlenecks and understand how data flows through your architecture.
+The Service Map decomposes your application into all its component [services][1] and draws the observed dependencies between these services in real time, so you can identify bottlenecks and understand how data flows through your architecture.
 
 {{< img src="tracing/visualization/services_map/service_map_overview.png" alt="Service Map Overview" responsive="true">}}
 
 ## Setup
 
-The Service Map visualizes data collected by Datadog APM. Setup is not required to view services.
+The Service Map visualizes data collected by Datadog APM. Setup is not required to view [services][1].
 
 ## Ways to use it
 
@@ -32,7 +32,7 @@ The Service Map was built to provide an overview of your services and their heal
 
 The Service Map can be filtered based on the type of service (webserver, database, cache, etc.) or based on a fuzzy string match. This is particularly useful in a microservices environment with hundreds or thousands of nodes.
 
-Services are also scoped by `env`, and, optionally, a [first-class dimension][1].  Using the dropdowns to select a different scope draws an entirely different map consisting of the services within that scope. These services cannot call or be called by services in other environments.
+Services are also scoped by `env`, and, optionally, a [first-class dimension][2].  Using the dropdowns to select a different scope draws an entirely different map consisting of the services within that scope. These services cannot call or be called by services in other environments.
 
 ## Inspection
 
@@ -70,7 +70,7 @@ Additionally, monitors can be tagged by service in the “Say what’s happening
 
 ### Nodes and edges
 
-Nodes represent services exactly as instrumented in APM and match those in your [Services][2] page. Edges represent aggregate calls from one service to another. These interactions are shown on the flame graph for each individual trace.
+Nodes represent services exactly as instrumented in APM and match those in your [Services][3] page. Edges represent aggregate calls from one service to another. These interactions are shown on the flame graph for each individual [trace][4].
 
 New services or connections appear within moments of being instrumented and age out if there are no corresponding traces seen for two weeks.  This takes into account services that do work infrequently, but are an important part of a functioning system.
 
@@ -87,5 +87,7 @@ Monitors are not constrained to APM monitors. The service tag, described above, 
 {{< partial name="whats-next/whats-next.html" >}}
 
 
-[1]: /tracing/setup/first_class_dimensions
-[2]: https://app.datadoghq.com/apm/services
+[1]: /tracing/visualization/#services
+[2]: /tracing/setup/first_class_dimensions
+[3]: https://app.datadoghq.com/apm/services
+[4]: /tracing/visualization/#trace

--- a/content/en/tracing/visualization/trace.md
+++ b/content/en/tracing/visualization/trace.md
@@ -19,7 +19,7 @@ further_reading:
   text: "Understand how to read a Datadog Trace"
 ---
 
-View an individual trace to see all of its spans and associated metadata. Each trace can be viewed either as a flame graph or as a list (grouped by service or host).
+View an individual [trace][1] to see all of its [spans][2] and associated metadata. Each trace can be viewed either as a flame graph or as a list (grouped by [service][3] or host).
 
 {{< img src="tracing/visualization/trace/trace.png" alt="Trace" responsive="true" style="width:90%;">}}
 
@@ -31,7 +31,7 @@ To get a closer look at the flame graph, zoom in by scrolling:
 
 {{< img src="tracing/visualization/trace/trace_zoom.mp4" alt="Trace Error" video="true" responsive="true" width="90%" >}}
 
-The List view aggregates resources by service and sorts them according to their corresponding count of spans. Services are sorted per relative percentage of execution time spent by the trace in each service:
+The List view aggregates [resources][4] by [service][3] and sorts them according to their corresponding count of spans. Services are sorted per relative percentage of execution time spent by the trace in each service:
 
 {{< img src="tracing/visualization/trace/trace_list.png" alt="Trace list" responsive="true" style="width:90%;">}}
 
@@ -44,7 +44,7 @@ Click on a span in the flame graph to show its metadata below the graph. If ther
 
 {{< img src="tracing/visualization/trace/trace_error.png" alt="Trace Error" responsive="true" style="width:90%;">}}
 
-If you are analyzing a trace reporting an error, the error has a specific display if you follow the special meaning tags rules. When submitting your traces you can add attributes to the `meta` parameter.
+If you are analyzing a [trace][1] reporting an error, the error has a specific display if you follow the special meaning tags rules. When submitting your traces you can add attributes to the `meta` parameter.
 
 Some attributes have special meanings that lead to a dedicated display or specific behavior in Datadog:
 
@@ -57,6 +57,7 @@ Some attributes have special meanings that lead to a dedicated display or specif
 
 {{< img src="tracing/visualization/trace/trace_error_formating.png" alt="Error Formating" responsive="true" >}}
 
+[1]: /tracing/visualization/#trace
 {{% /tab %}}
 {{% tab "Host Info" %}}
 
@@ -79,3 +80,8 @@ See logs related to your service at the time of the trace. When you hover over a
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /tracing/visualization/#trace
+[2]: /tracing/visualization/#spans
+[3]: /tracing/visualization/#services
+[4]: /tracing/visualization/#resources


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds APM definitions to every APM related document page linking to the new trace definitions glossary page whenever relevant.

### Motivation
Adding a relevant definition link to the first instance it shows up on each page. 

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jasonmh/apm-definitions

### Additional Notes
<!-- Anything else we should know when reviewing?-->
