### PR TITLE
Algolia Sitemap

### DIFF
--- a/local/etc/algolia/docs_datadoghq_preview.json
+++ b/local/etc/algolia/docs_datadoghq_preview.json
@@ -154,11 +154,6 @@
 		"https://docs.datadoghq.com/developers/metrics/distributions/$",
 		"https://docs.datadoghq.com/developers/faq/$"
 	],
-	"sitemap_urls": [
-		"https://docs.datadoghq.com/en/sitemap.xml",
-		"https://docs.datadoghq.com/ja/sitemap.xml",
-		"https://docs.datadoghq.com/fr/sitemap.xml"
-	],
 	"selectors": {
 		"docs": {
 			"lvl0": {


### PR DESCRIPTION
### What does this PR do?
This PR tweaks the Algolia Sitemap parameter in order to correctly index documentation pages.
It removes Sitemap parameter since it conflicts with the start_urls configuration.

As stated in Algolia documentation: https://community.algolia.com/docsearch/config-file.html#sitemap_urls-optional

```
DocSearch will try to read URLs from your sitemap(s) instead of following every link of your starts_urls.
```

### Motivation
Better search.

### Preview link

* https://docs-staging.datadoghq.com/gus/algolia-sitemaps/