### PR TITLE
CI fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 public/
 data/integrations/
 data/service_checks/
+integrations_data/
 
 # Ignoring all integrations file
 content/integrations/*.md

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 public/
 data/integrations/
 data/service_checks/
-integrations_data/
+/data/integrations_data
 
 # Ignoring all integrations file
 content/integrations/*.md

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 public/
 data/integrations/
 data/service_checks/
-/data/integrations_data
+data/integrations_data
 
 # Ignoring all integrations file
 content/integrations/*.md

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 public/
 data/integrations/
 data/service_checks/
-data/integrations_data
+integrations_data
 
 # Ignoring all integrations file
 content/integrations/*.md

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,6 @@ build_preview:
     MESSAGE: ":gift_heart: Your preview site is available!\nNow running tests..."
     CONFIGURATION_FILE: "./local/etc/pull_config_preview.yaml"
   script:
-    - mkdir ./integrations_data
     - post_dd_event "documentation deploy ${CI_COMMIT_REF_NAME} started" "${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}" "info"
     - version_static_assets
     - sync_integration_descriptions
@@ -114,7 +113,6 @@ build_live:
     UNTRACKED_EXTRAS: "data,content/en/integrations,content/en/agent/basic_agent_usage/heroku.md,content/en/developers/integrations"
     CONFIGURATION_FILE: "./local/etc/pull_config.yaml"
   script:
-    - mkdir ./integrations_data
     - post_dd_event "documentation deploy ${CI_COMMIT_REF_NAME} started" "${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}" "info"
     - notify_slack "<https://github.com/DataDog/documentation/commit/${CI_COMMIT_SHA}|${CI_COMMIT_SHA:0:8}> sent to gitlab for production deployment. <${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}|details>" "#FFD700"
     - version_static_assets

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,6 +56,8 @@ build_preview:
     paths:
       - ${ARTIFACT_RESOURCE}
       - ./integrations_data
+  only:
+    - /.+?\/[a-zA-Z0-9_-]+/
 
 evaluate_missing_metrics:
   <<: *base_template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,7 @@ build_preview:
   artifacts:
     paths:
       - ${ARTIFACT_RESOURCE}
-      - ./integrations_data
+      - ./data/integrations_data
 
 evaluate_missing_metrics:
   <<: *base_template
@@ -128,7 +128,7 @@ build_live:
     when: on_success
     paths:
       - ${ARTIFACT_RESOURCE}
-      - ./integrations_data
+      - ./data/integrations_data
     expire_in: 1 week
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,6 +55,16 @@ build_preview:
   artifacts:
     paths:
       - ${ARTIFACT_RESOURCE}
+      - /tmp
+  only:
+    - /.+?\/[a-zA-Z0-9_-]+/
+
+evaluate_missing_metrics:
+  <<: *base_template
+  stage: post-deploy
+  environment: "preview"
+  script:
+    - chmod +x ./local/bin/py/missing_metrics.py && ./local/bin/py/missing_metrics.py -k $(get_secret 'dd-demo-api-key') -p $(get_secret 'dd-demo-app-key') -a $(get_secret 'dd_api_key') -b $(get_secret 'dd-app-key')
   only:
     - /.+?\/[a-zA-Z0-9_-]+/
 
@@ -116,12 +126,12 @@ build_live:
     - push_site_to_s3
     - create_artifact
     - create_artifact_untracked
-    - chmod +x ./local/bin/py/missing_metrics.py && ./local/bin/py/missing_metrics.py -k $(get_secret 'dd-demo-api-key') -p $(get_secret 'dd-demo-app-key') -a $(get_secret 'dd_api_key') -b $(get_secret 'dd-app-key')
   artifacts:
     when: on_success
     paths:
       - local/etc/docsdatadoghq.json
       - ${ARTIFACT_RESOURCE}
+      - /tmp
     expire_in: 1 week
   only:
     - master
@@ -150,6 +160,16 @@ index_algolia:
   only:
     - schedules
 
+evaluate_missing_metrics_live:
+  <<: *base_template
+  stage: post-deploy
+  environment: "live"
+  script:
+    - chmod +x ./local/bin/py/missing_metrics.py && ./local/bin/py/missing_metrics.py -k $(get_secret 'dd-demo-api-key') -p $(get_secret 'dd-demo-app-key') -a $(get_secret 'dd_api_key') -b $(get_secret 'dd-app-key')
+  only:
+    - master
+
+
 manage_translations:on-schedule:
   <<: *base_template
   stage: post-deploy
@@ -162,6 +182,8 @@ manage_translations:on-schedule:
     - chmod +x ./local/bin/py/translate_metrics.py && ./local/bin/py/translate_metrics.py -k "${APIKEY}" -a $(get_secret 'dd_api_key')
   only:
     - schedules
+
+
 
 #push_translations:
 #  <<: *base_template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,6 +37,7 @@ build_preview:
     MESSAGE: ":gift_heart: Your preview site is available!\nNow running tests..."
     CONFIGURATION_FILE: "./local/etc/pull_config_preview.yaml"
   script:
+    - mkdir ./integrations_data
     - post_dd_event "documentation deploy ${CI_COMMIT_REF_NAME} started" "${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}" "info"
     - version_static_assets
     - sync_integration_descriptions
@@ -55,7 +56,7 @@ build_preview:
   artifacts:
     paths:
       - ${ARTIFACT_RESOURCE}
-      - /tmp/extracted/
+      - ./integrations_data
 
 evaluate_missing_metrics:
   <<: *base_template
@@ -113,6 +114,7 @@ build_live:
     UNTRACKED_EXTRAS: "data,content/en/integrations,content/en/agent/basic_agent_usage/heroku.md,content/en/developers/integrations"
     CONFIGURATION_FILE: "./local/etc/pull_config.yaml"
   script:
+    - mkdir ./integrations_data
     - post_dd_event "documentation deploy ${CI_COMMIT_REF_NAME} started" "${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}" "info"
     - notify_slack "<https://github.com/DataDog/documentation/commit/${CI_COMMIT_SHA}|${CI_COMMIT_SHA:0:8}> sent to gitlab for production deployment. <${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}|details>" "#FFD700"
     - version_static_assets
@@ -127,9 +129,8 @@ build_live:
   artifacts:
     when: on_success
     paths:
-      - local/etc/docsdatadoghq.json
       - ${ARTIFACT_RESOURCE}
-      - /tmp
+      - ./integrations_data
     expire_in: 1 week
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,7 +59,7 @@ build_preview:
   only:
     - /.+?\/[a-zA-Z0-9_-]+/
 
-evaluate_missing_metrics:
+evaluate_missing_metrics_preview:
   <<: *base_template
   stage: post-deploy
   environment: "preview"
@@ -68,7 +68,7 @@ evaluate_missing_metrics:
   only:
     - /.+?\/[a-zA-Z0-9_-]+/
 
-test_preview_link_checks:
+link_checks_preview:
   <<: *base_template
   stage: post-deploy
   environment: "preview"
@@ -80,7 +80,7 @@ test_preview_link_checks:
   only:
     - /.+?\/[a-zA-Z0-9_-]+/
 
-test_missing_tms_preview:
+missing_tms_preview:
   <<: *base_template
   stage: post-deploy
   environment: "preview"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,7 @@ build_preview:
   artifacts:
     paths:
       - ${ARTIFACT_RESOURCE}
-      - ./data/integrations_data
+      - ./integrations_data
 
 evaluate_missing_metrics:
   <<: *base_template
@@ -128,7 +128,7 @@ build_live:
     when: on_success
     paths:
       - ${ARTIFACT_RESOURCE}
-      - ./data/integrations_data
+      - ./integrations_data
     expire_in: 1 week
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -157,7 +157,7 @@ index_algolia:
   only:
     - schedules
 
-evaluate_missing_metrics_live:
+evaluate_missing_metrics:
   <<: *base_template
   stage: post-deploy
   environment: "live"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,9 +55,7 @@ build_preview:
   artifacts:
     paths:
       - ${ARTIFACT_RESOURCE}
-      - /tmp
-  only:
-    - /.+?\/[a-zA-Z0-9_-]+/
+      - /tmp/extracted/
 
 evaluate_missing_metrics:
   <<: *base_template

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ ifeq ($(wildcard $(CONFIG_FILE)),)
 endif
 include $(CONFIG_FILE)
 
-
 help:
 	@perl -nle'print $& if m{^[a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
 
@@ -43,6 +42,7 @@ clean-exe:  ## remove execs.
 	@rm -rf ${EXE_LIST}
 
 clean-integrations:  ## remove built integrations files.
+	@rm -rf ./integrations_data/
 	@if [ -d data/integrations ]; then \
 		find ./data/integrations -type f -maxdepth 1 \
 	    -a -not -name '*.fr.yaml' \

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ clean-exe:  ## remove execs.
 	@rm -rf ${EXE_LIST}
 
 clean-integrations:  ## remove built integrations files.
-	@rm -rf ./data/integrations_data/
+	@rm -rf ./integrations_data/
 	@if [ -d data/integrations ]; then \
 		find ./data/integrations -type f -maxdepth 1 \
 	    -a -not -name '*.fr.yaml' \
@@ -58,7 +58,7 @@ clean-integrations:  ## remove built integrations files.
 	    -a -not -name 'amazon_vpc.md' \
 	    -a -not -name 'amazon_cloudhsm.md' \
 	    -a -not -name 'cloud_foundry.md' \
-		-a -not -name 'cloudability.md' \
+		  -a -not -name 'cloudability.md' \
 	    -a -not -name 'cloudcheckr.md' \
 	    -a -not -name 'integration_sdk.md' \
 	    -a -not -name 'jenkins.md' \

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ clean-exe:  ## remove execs.
 	@rm -rf ${EXE_LIST}
 
 clean-integrations:  ## remove built integrations files.
-	@rm -rf ./integrations_data/
+	@rm -rf ./data/integrations_data/
 	@if [ -d data/integrations ]; then \
 		find ./data/integrations -type f -maxdepth 1 \
 	    -a -not -name '*.fr.yaml' \

--- a/local/bin/py/missing_metrics.py
+++ b/local/bin/py/missing_metrics.py
@@ -5,6 +5,7 @@ import time
 import glob
 import platform
 import csv
+import sys
 from optparse import OptionParser
 
 tempdir = (
@@ -102,3 +103,4 @@ if __name__ == '__main__':
     post_dd_metrics(metrics, options)
   else:
     print('\x1b[31mERROR\x1b[0m: List of metrics recovered was empty.')
+    sys.exit(1)

--- a/local/bin/py/missing_metrics.py
+++ b/local/bin/py/missing_metrics.py
@@ -9,7 +9,7 @@ import sys
 from optparse import OptionParser
 
 tempdir = (
-   "./data/integrations_data"
+   "./integrations_data"
 )
 
 

--- a/local/bin/py/missing_metrics.py
+++ b/local/bin/py/missing_metrics.py
@@ -9,9 +9,7 @@ import sys
 from optparse import OptionParser
 
 tempdir = (
-   "/tmp"
-   if platform.system() == "Darwin"
-   else tempfile.gettempdir()
+   "./integrations_data"
 )
 
 

--- a/local/bin/py/missing_metrics.py
+++ b/local/bin/py/missing_metrics.py
@@ -9,7 +9,7 @@ import sys
 from optparse import OptionParser
 
 tempdir = (
-   "./integrations_data"
+   "./data/integrations_data"
 )
 
 

--- a/local/bin/py/missing_metrics.py
+++ b/local/bin/py/missing_metrics.py
@@ -46,7 +46,7 @@ def get_dd_metrics(csv_metrics, keys):
   dd_metrics = {}
 
   try:
-    dd_metrics = api.Metric.list(from_time).get('metrics')
+    dd_metrics = api.Metric.list(from_time).get('metrics', {})
   except:
     print('\x1b[31mERROR\x1b[0m: There was an error with the Datadog API call, current value of dd_metrics is: \n {}'.format(dd_metrics))
 
@@ -84,7 +84,7 @@ def post_dd_metrics(metrics, keys):
 
 if __name__ == '__main__':
   print('\x1b[32mINFO\x1b[0m: Getting csv metrics from...')
-  print(tempdir)
+  #print(tempdir)
   csv_metrics = get_csv_metrics(tempdir)
   #print(csv_metrics)
   print('\x1b[32mINFO\x1b[0m: Parsing keys')
@@ -96,5 +96,9 @@ if __name__ == '__main__':
   options, args = parser.parse_args()
   print('\x1b[32mINFO\x1b[0m: Getting dd metrics...')
   metrics = get_dd_metrics(csv_metrics, options)
-  print('\x1b[32mINFO\x1b[0m: Posting dd metrics...')
-  post_dd_metrics(metrics, options)
+
+  if len(metrics) != 0:
+    print('\x1b[32mINFO\x1b[0m: Posting dd metrics...')
+    post_dd_metrics(metrics, options)
+  else:
+    print('\x1b[31mERROR\x1b[0m: List of metrics recovered was empty.')

--- a/local/bin/py/missing_metrics.py
+++ b/local/bin/py/missing_metrics.py
@@ -43,7 +43,13 @@ def get_dd_metrics(csv_metrics, keys):
   days = 5
   from_time = int(time.time()) - 60 * 60 * 24 * days
 
-  dd_metrics = api.Metric.list(from_time).get('metrics')
+  dd_metrics = {}
+
+  try:
+    dd_metrics = api.Metric.list(from_time).get('metrics')
+  except:
+    print('\x1b[31mERROR\x1b[0m: There was an error with the Datadog API call, current value of dd_metrics is: \n {}'.format(dd_metrics))
+
   metrics_send = []
   metrics_print = []
 

--- a/local/bin/py/update_pre_build.py
+++ b/local/bin/py/update_pre_build.py
@@ -178,9 +178,7 @@ class PreBuild:
         self.options = opts
         self.list_of_contents = []
         self.tempdir = (
-            "/tmp"
-            if platform.system() == "Darwin"
-            else tempfile.gettempdir()
+            "./integrations_data"
         )
         self.data_dir = "{0}{1}{2}".format(
             abspath(normpath(options.source)),

--- a/local/bin/py/update_pre_build.py
+++ b/local/bin/py/update_pre_build.py
@@ -178,7 +178,7 @@ class PreBuild:
         self.options = opts
         self.list_of_contents = []
         self.tempdir = (
-            "./integrations_data"
+            "./data/integrations_data"
         )
         self.data_dir = "{0}{1}{2}".format(
             abspath(normpath(options.source)),

--- a/local/bin/py/update_pre_build.py
+++ b/local/bin/py/update_pre_build.py
@@ -178,7 +178,7 @@ class PreBuild:
         self.options = opts
         self.list_of_contents = []
         self.tempdir = (
-            "./data/integrations_data"
+            "./integrations_data"
         )
         self.data_dir = "{0}{1}{2}".format(
             abspath(normpath(options.source)),


### PR DESCRIPTION
### What does this PR do?

* Fixes the `evaluate_missing_metrics` script in order to proper exit over exception.
* Removes the `evaluate_missing_metrics_live` script from the main build job and move it to a post build job.
* Instead of storing integrations data in `/tmp` folder it creates a dedicated `.integrations_data` folder in the gitlab working dir, allowing to pass it as artefact to the rest of the CI (mostly to `evaluate_missing_metrics` script
* adds new folder to `.gitignore` in order to not jam local builds.

### Motivation

It's breaking master build for now, preventing any post build script to run.

### Preview link

* https://docs-staging.datadoghq.com/gus/missing-metrics-script-fix/