### PR TITLE
Host totals api update

### DIFF
--- a/content/en/api/hosts/code_snippets/result.api-hosts-search.py
+++ b/content/en/api/hosts/code_snippets/result.api-hosts-search.py
@@ -1,5 +1,6 @@
 {
   'total_returned': 1,
+  "last_reported_time": 1560000000,
   'host_list': [
     {
       'name': 'i-deadbeef',

--- a/content/en/api/hosts/code_snippets/result.api-hosts-search.rb
+++ b/content/en/api/hosts/code_snippets/result.api-hosts-search.rb
@@ -1,5 +1,6 @@
 ["200", {
   "total_returned": 1,
+  "last_reported_time": 1560000000,
   "host_list": [
     {
       "name": "i-deadbeef",

--- a/content/en/api/hosts/code_snippets/result.api-hosts-search.sh
+++ b/content/en/api/hosts/code_snippets/result.api-hosts-search.sh
@@ -1,5 +1,6 @@
 {
   "total_returned": 1,
+  "last_reported_time": 1560000000,
   "host_list": [
     {
       "name": "i-deadbeef",

--- a/content/en/api/hosts/code_snippets/result.api-hosts-totals.py
+++ b/content/en/api/hosts/code_snippets/result.api-hosts-totals.py
@@ -1,1 +1,1 @@
-{'total_up':1750,'total_active':1759}
+{'total_up':1750,'total_active':1759, "last_reported_time": "2019-06-08T13:20:00Z"}

--- a/content/en/api/hosts/code_snippets/result.api-hosts-totals.py
+++ b/content/en/api/hosts/code_snippets/result.api-hosts-totals.py
@@ -1,1 +1,1 @@
-{'total_up':1750,'total_active':1759, "last_reported_time": "2019-06-08T13:20:00Z"}
+{'total_up':1750,'total_active':1759, "last_reported_time": 1560000000}

--- a/content/en/api/hosts/code_snippets/result.api-hosts-totals.rb
+++ b/content/en/api/hosts/code_snippets/result.api-hosts-totals.rb
@@ -1,1 +1,1 @@
-["200", {"total_up":1750,"total_active":1759, "last_reported_time": "2019-06-08T13:20:00Z"}]
+["200", {"total_up":1750,"total_active":1759, "last_reported_time": 1560000000}]

--- a/content/en/api/hosts/code_snippets/result.api-hosts-totals.rb
+++ b/content/en/api/hosts/code_snippets/result.api-hosts-totals.rb
@@ -1,1 +1,1 @@
-["200", {"total_up":1750,"total_active":1759}]
+["200", {"total_up":1750,"total_active":1759, "last_reported_time": "2019-06-08T13:20:00Z"}]

--- a/content/en/api/hosts/code_snippets/result.api-hosts-totals.sh
+++ b/content/en/api/hosts/code_snippets/result.api-hosts-totals.sh
@@ -1,1 +1,1 @@
-{"total_up":1750,"total_active":1759}
+{"total_up":1750,"total_active":1759, "last_reported_time": "2019-06-08T13:20:00Z"}

--- a/content/en/api/hosts/code_snippets/result.api-hosts-totals.sh
+++ b/content/en/api/hosts/code_snippets/result.api-hosts-totals.sh
@@ -1,1 +1,1 @@
-{"total_up":1750,"total_active":1759, "last_reported_time": "2019-06-08T13:20:00Z"}
+{"total_up":1750,"total_active":1759, "last_reported_time": 1560000000}

--- a/content/en/api/hosts/hosts_search.md
+++ b/content/en/api/hosts/hosts_search.md
@@ -22,3 +22,5 @@ This endpoint allows searching for hosts by name, alias, or tag. Hosts live with
     Host result to start search from.
 * **`count`** [*optional*, *default*=**100**]:
     Number of host results to return. Max 100.
+* **`from`** [*optional*, *default*=**now - 2 hours**]:
+    Number of seconds since UNIX epoch from which you want to search your hosts.

--- a/content/en/api/hosts/hosts_totals.md
+++ b/content/en/api/hosts/hosts_totals.md
@@ -10,4 +10,5 @@ This endpoint returns the total number of active and up hosts in your Datadog ac
 
 ##### ARGUMENTS
 
-This endpoint takes no JSON arguments.
+* **`from`** [*optional*, *default*=**now - 2 hours**]:
+    Seconds since the UNIX epoch you want to get the total number of active and up hosts.

--- a/content/en/api/hosts/hosts_totals.md
+++ b/content/en/api/hosts/hosts_totals.md
@@ -11,4 +11,4 @@ This endpoint returns the total number of active and up hosts in your Datadog ac
 ##### ARGUMENTS
 
 * **`from`** [*optional*, *default*=**now - 2 hours**]:
-    Seconds since the UNIX epoch you want to get the total number of active and up hosts.
+    Number of seconds since UNIX epoch from which you want to get the total number of active and up hosts.


### PR DESCRIPTION
### What does this PR do?
Updates the host endpoint API to add the `from` parameter that can be passed as query param + adds the `last_reported_time` parameter from the result payload.

### Motivation
Update.

### Preview link

* https://docs-staging.datadoghq.com/gus/host-totals-api/api/?lang=python#host-totals
* https://docs-staging.datadoghq.com/gus/host-totals-api/api/?lang=python#search-hosts