### PR TITLE
Slack API endpoint fix

### DIFF
--- a/content/en/api/integrations_slack/code_snippets/slack_add_channels.sh
+++ b/content/en/api/integrations_slack/code_snippets/slack_add_channels.sh
@@ -8,16 +8,16 @@ app_key=<DD_APP_KEY>
 curl -X POST -H "Content-type: application/json" \
 -d '{
     "channels": [
-      {
-        "channel_name": "<CHANNEL_NAME_3>",
-        "transfer_all_user_comments": "false",
-        "account": "<SLACK_ACCOUNT_1>"
-      },
-      {
-        "channel_name": "<CHANNEL_NAME_4>",
-        "transfer_all_user_comments": "false",
-        "account": "<SLACK_ACCOUNT_2>"
-      }
+        {
+          "channel_name": "#channel_name_main_account",
+          "transfer_all_user_comments": "false",
+          "account": "Main_Account"
+        },
+        {
+          "channel_name": "#channel_name_doghouse",
+          "transfer_all_user_comments": "false",
+          "account": "doghouse"
+        }
     ]
-  }' \
+}' \
 "https://api.datadoghq.com/api/v1/integration/slack?api_key=${api_key}&application_key=${app_key}"

--- a/content/en/api/integrations_slack/code_snippets/slack_create.sh
+++ b/content/en/api/integrations_slack/code_snippets/slack_create.sh
@@ -9,24 +9,12 @@ curl -v -X POST -H "Content-type: application/json" \
 -d '{
     "service_hooks": [
       {
-        "account": "<SLACK_ACCOUNT_1>",
-        "url": "https://hooks.slack.com/services/1/1"
+        "account": "Main_Account",
+        "url": "https://hooks.slack.com/services/1/1/1"
       },
       {
-        "account": "<SLACK_ACCOUNT_2>",
-        "url": "https://hooks.slack.com/services/2/2"
-      }
-    ],
-    "channels": [
-      {
-        "channel_name": "<CHANNEL_NAME_1>",
-        "transfer_all_user_comments": "false",
-        "account": "<SLACK_ACCOUNT_1>"
-      },
-      {
-        "channel_name": "<CHANNEL_NAME_2>",
-        "transfer_all_user_comments": "false",
-        "account": "<SLACK_ACCOUNT_2>"
+        "account": "doghouse",
+        "url": "https://hooks.slack.com/services/2/2/2"
       }
     ]
   }' \

--- a/content/en/api/integrations_slack/slack_create.md
+++ b/content/en/api/integrations_slack/slack_create.md
@@ -7,7 +7,8 @@ external_redirect: /api/#create-a-slack-integration
 
 ## Create a Slack integration
 
-Create a Datadog-Slack integration.
+Create a Datadog-Slack integration. Once created, add channel to it with the [Add channels to Slack integration endpoint](#add-channels-to-slack-integration).
+
 
 **Note**:
 
@@ -27,16 +28,3 @@ Create a Datadog-Slack integration.
 
 **Note**: **`service_hooks`** are not required in the payload when adding (POST) or updating (PUT) an existing Slack configuration.
 
-* **`channels`** [*required*]:
-    Array of slack channel objects to post to. A slack channel object is composed by:
-
-    * **`channel_name`** [*required*]:
-        Your channel name e.g: `#general`, `#private`
-
-    * **`transfer_all_user_comments`** [*optional*, *default*=**False**]:
-        To be notified for every comment on a graph, set it to `true`. If set to `False` use the `@slack-channel_name` syntax [for comments to be posted to slack][1].
-
-    * **`account`** [*required*]:
-        Account to which the channel belongs to.
-
-[1]: /monitors/notifications/#slack-integration

--- a/content/en/api/integrations_slack/slack_create.md
+++ b/content/en/api/integrations_slack/slack_create.md
@@ -7,7 +7,7 @@ external_redirect: /api/#create-a-slack-integration
 
 ## Create a Slack integration
 
-Create a Datadog-Slack integration. Once created, add channel to it with the [Add channels to Slack integration endpoint](#add-channels-to-slack-integration).
+Create a Datadog-Slack integration. Once created, add a channel to it with the [Add channels to Slack integration endpoint](#add-channels-to-slack-integration).
 
 
 **Note**:

--- a/static/resources/json/datadog_collection.json
+++ b/static/resources/json/datadog_collection.json
@@ -6784,7 +6784,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"service_hooks\": [\n        {\n            \"account\": \"Main_Account\",\n            \"url\": \"https://hooks.slack.com/services/1/1\"\n        },\n        {\n            \"account\": \"doghouse\",\n            \"url\": \"https://hooks.slack.com/services/2/2\"\n        }\n    ],\n    \"channels\": [\n        {\n            \"channel_name\": \"#private\",\n            \"transfer_all_user_comments\": \"false\",\n            \"account\": \"Main_Account\"\n        },\n        {\n            \"channel_name\": \"#heresachannel\",\n            \"transfer_all_user_comments\": \"false\",\n            \"account\": \"doghouse\"\n        }\n    ]\n}"
+									"raw": "{\n    \"service_hooks\": [\n        {\n            \"account\": \"Main_Account\",\n            \"url\": \"https://hooks.slack.com/services/1/1/1\"\n        },\n        {\n            \"account\": \"doghouse\",\n            \"url\": \"https://hooks.slack.com/services/2/2/2\"\n        }\n    ]\n}"
 								},
 								"url": {
 									"raw": "https://api.datadoghq.{{datadog_site}}/api/v1/integration/slack?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",
@@ -6874,7 +6874,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"channels\": [\n        {\n            \"channel_name\": \"<CHANNEL_NAME_3>\",\n            \"transfer_all_user_comments\": \"false\",\n            \"account\": \"<SLACK_ACCOUNT_1>\"\n        },\n        {\n            \"channel_name\": \"<CHANNEL_NAME_4>\",\n            \"transfer_all_user_comments\": \"false\",\n            \"account\": \"<SLACK_ACCOUNT_2>\"\n        }\n    ]\n}"
+									"raw": "{\n    \"channels\": [\n        {\n            \"channel_name\": \"#channel_name_main_account\",\n            \"transfer_all_user_comments\": \"false\",\n            \"account\": \"Main_Account\"\n        },\n        {\n            \"channel_name\": \"#channel_name_doghouse\",\n            \"transfer_all_user_comments\": \"false\",\n            \"account\": \"doghouse\"\n        }\n    ]\n}"
 								},
 								"url": {
 									"raw": "https://api.datadoghq.{{datadog_site}}/api/v1/integration/slack?api_key={{datadog_api_key}}&application_key={{datadog_application_key}}",


### PR DESCRIPTION
### What does this PR do?
Fixes the slack create endpoint, since channels can't be passed upon Datadog-Slack integration creation. They need to be configured into another API call.

### Motivation
Support feedback.

### Preview link

* https://docs-staging.datadoghq.com/gus/slack-fix/api/?lang=python#create-a-slack-integration