### PR TITLE
adding more logging + removing sitemap from prod config

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -153,6 +153,7 @@ index_algolia:
   script:
     - chmod +x ./local/bin/py/algolia_index.py && ./local/bin/py/algolia_index.py -d "['config', 'error', 'examples', 'fonts', 'images', 'resources', 'static', 'videos']" -l "['ja']" -c "./local/etc/algolia/docs_datadoghq.json"
     - cp ./local/etc/algolia/docs_datadoghq.json /etc/docs_datadoghq.com
+    - cat /etc/docs_datadoghq.com
     - index_docsearch_algolia
   dependencies:
     - build_live

--- a/local/bin/py/algolia_index.py
+++ b/local/bin/py/algolia_index.py
@@ -63,10 +63,12 @@ def update_algolia_private_url(docs_index_config,private_urls):
         for url in private_urls:
             config["stop_urls"].append(url)
 
+    print("\x1b[32mINFO\x1b[0m: current config is: \n\n {} \n\n".format(json.dump(config)))
     print("\x1b[32mINFO\x1b[0m: Addition complete, updating Algolia main configuration file with the new one.")
 
     with open(docs_index_config, 'w+', encoding='utf-8') as json_file:
         json.dump(config, json_file)
+
 
 if __name__ == "__main__":
     parser = OptionParser(usage="usage: %prog [options] create placeholder pages for multi-language")

--- a/local/etc/algolia/docs_datadoghq.json
+++ b/local/etc/algolia/docs_datadoghq.json
@@ -113,11 +113,6 @@
 		"/api/.+",
 		"\\.json$"
 	],
-	"sitemap_urls": [
-		"https://docs.datadoghq.com/en/sitemap.xml",
-		"https://docs.datadoghq.com/ja/sitemap.xml",
-		"https://docs.datadoghq.com/fr/sitemap.xml"
-	],
 	"selectors": {
 		"docs": {
 			"lvl0": {


### PR DESCRIPTION
### What does this PR do?
Follow up on https://github.com/DataDog/documentation/pull/5383

It actually applies preview changes to the prod one + add more logging to doublecheck if everything run smoothly.
