### PR TITLE
Evaluate missing metrics

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,15 +59,6 @@ build_preview:
   only:
     - /.+?\/[a-zA-Z0-9_-]+/
 
-evaluate_missing_metrics_preview:
-  <<: *base_template
-  stage: post-deploy
-  environment: "preview"
-  script:
-    - chmod +x ./local/bin/py/missing_metrics.py && ./local/bin/py/missing_metrics.py -k $(get_secret 'dd-demo-api-key') -p $(get_secret 'dd-demo-app-key') -a $(get_secret 'dd_api_key') -b $(get_secret 'dd-app-key')
-  only:
-    - /.+?\/[a-zA-Z0-9_-]+/
-
 link_checks_preview:
   <<: *base_template
   stage: post-deploy


### PR DESCRIPTION

### What does this PR do?
- Don't run evaluate missing metrics on preview site builds

### Motivation
- Only show metrics from prod branches

### Preview link
N/A

### Additional Notes
N/A
