### PR TITLE
Adding alias for K8s

### DIFF
--- a/content/en/integrations/kubernetes.md
+++ b/content/en/integrations/kubernetes.md
@@ -11,6 +11,7 @@ aliases:
     - /tracing/api/
     - /integrations/kubernetes_state/
     - /integrations/kube_proxy/
+    - /integrations/Kubernetes
 public_title: Datadog-Kubernetes Integration
 short_description: "Capture Pod scheduling events, track the status of your Kublets, and more"
 categories:


### PR DESCRIPTION
### What does this PR do?
Adds an alias to the K8s page in order to account for the DD doc link on this article: 

https://www.padok.fr/en/blog/monitoring-tools-kubernetes?utm_sq=g61osa4uqj

### Preview link

* http://docs-staging.datadoghq.com/gus/k8-redirect/integrations/Kubernetes