### PR TITLE
Update short lived container for Agent 6.14

### DIFF
--- a/content/en/agent/docker/log.md
+++ b/content/en/agent/docker/log.md
@@ -279,6 +279,14 @@ ac_exclude = ["name:datadog-agent"]
 {{% /tab %}}
 {{< /tabs >}}
 
+## Short Lived containers
+
+For a Docker environment, the Agent receives container updates in real time through Docker events. The Agent extracts and updates the configuration from the container labels (Autodiscovery) every 1 seconds. 
+
+ Since Agent v6.14+, the Agent collects logs for all containers (running or stopped) which means that short lived containers logs that have started and stopped in the past second are still collected as long as they are not removed.
+
+For Kubernetes environements, refer to the [Kubernetes short lived container documentation][5]
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -287,3 +295,4 @@ ac_exclude = ["name:datadog-agent"]
 [2]: /agent/autodiscovery
 [3]: /agent/autodiscovery/integrations/?tab=kubernetespodannotations#configuration
 [4]: /agent/logs/#custom-log-collection
+[5]: https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile#short-lived-containers

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -318,11 +318,8 @@ For Agent v6.12+, short lived container logs (stopped or crashed) are automatica
 {{% /tab %}}
 {{% tab "Docker Socket" %}}
 
-For a Docker environment, the Agent receives container updates in real time through Docker events. The Agent extracts and updates the configuration from the container labels (Autodiscovery) every 10 seconds. Therefore, by default, the Agent does not collect data for any container with a shorter life.
-
-You can override the polling interval by setting the `ad_config_poll_interval` parameter, which is equivalent to the `DD_AD_CONFIG_POLL_INTERVAL` environment variable.
-
-For a Kubernetes environment, use the `K8s file` collection method that supports init, stopped, and short lived containers. No additional setup is required.
+For a Docker environment, the Agent receives container updates in real time through Docker events. The Agent extracts and updates the configuration from the container labels (Autodiscovery) every 1 seconds. 
+Since Agent v6.14+, the Agent collects logs for all containers (running or stopped) which means that short lived containers logs that have started and stopped in the past second are still collected as long as they are not removed.
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
### What does this PR do?
Update short lived container documentation to reflect 6.14 update

### Motivation
Short lived container are now properly collected for pure docker environment as well.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/short-lived/agent/kubernetes/daemonset_setup/?tab=dockersocket#short-lived-containers

### Additional Notes
<!-- Anything else we should know when reviewing?-->
