### PR TITLE
Update Prometheus integration docs with the new OpenMetrics histograms param

### DIFF
--- a/content/en/developers/prometheus.md
+++ b/content/en/developers/prometheus.md
@@ -86,7 +86,7 @@ class KubeDNSCheck(OpenMetricsBaseCheck):
 #### Overriding `self.metrics_mapper`
 
 `metrics_mapper` is a dictionary where the key is the metric to capture and the value is the corresponding metric name in Datadog.
-The reason for the override is so metrics reported by the OpenMetrics checks are not counted as [custom metric][5]:
+The reason for the override is so that metrics reported by the OpenMetrics checks are not counted as [custom metric][5]:
 
 ```python
 from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck

--- a/content/en/developers/prometheus.md
+++ b/content/en/developers/prometheus.md
@@ -1,10 +1,10 @@
 ---
-title: Writing a custom Prometheus Check
+title: Writing a custom OpenMetrics Check
 kind: documentation
 further_reading:
 - link: "agent/prometheus"
   tag: "Documentation"
-  text: "Configuring a Prometheus Check"
+  text: "Configuring an OpenMetrics Check"
 - link: "developers/agent_checks"
   tag: "Documentation"
   text: "Write a Custom Check"
@@ -17,21 +17,21 @@ aliases:
 
 ## Overview
 
-This page dives into the `PrometheusCheck` interface for more advanced usage, including an example of a simple check that collects timing metrics and status events from [Kube DNS][1]. For information on configuring a basic Prometheus check, see the [Agent Documentation][2].
+This page dives into the `OpenMetricsBasicCheck` interface for more advanced usage, including an example of a simple check that collects timing metrics and status events from [Kube DNS][1]. For information on configuring a basic OpenMetrics check, see the [Agent Documentation][2].
 
-## Advanced usage: Prometheus check interface
+## Advanced usage: OpenMetrics check interface
 
-If you have more advanced needs than the generic check (metrics preprocessing for example) you can write a custom `PrometheusCheck`. It's [the base class][3] of the generic check and it provides a structure and some helpers to collect metrics, events, and service checks exposed via Prometheus. Minimal configuration for checks based on this class include:
+If you have more advanced needs than the generic check (metrics preprocessing for example) you can write a custom `OpenMetricsBaseCheck`. It's [the base class][3] of the generic check and it provides a structure and some helpers to collect metrics, events, and service checks exposed via Prometheus. Minimal configuration for checks based on this class include:
 
 - Overriding `self.NAMESPACE`
 - Overriding `self.metrics_mapper`
 - Implementing the `check()` method
 AND/OR
-- Create method named after the Prometheus metric they will handle (see `self.prometheus_metric_name`)
+- Create method named after the OpenMetric metric they will handle (see `self.prometheus_metric_name`)
 
 ## Writing a custom Prometheus check
 
-This is a simple example of writing a kube DNS check to illustrate the `PrometheusCheck` class usage. The example below replicates the functionality of the following generic Prometheus check:
+This is a simple example of writing a kube DNS check to illustrate the `OpenMetricsBaseCheck` class usage. The example below replicates the functionality of the following generic Prometheus check:
 
 ```yaml
 instances:
@@ -62,12 +62,12 @@ instances:
 ```
 
 ### Writing the check
-All Prometheus checks inherit from the `PrometheusCheck` class found in `checks/prometheus_check.py`:
+All OpenMetrics checks inherit from the `OpenMetricsBaseCheck` class found in `checks/openmetrics_check.py`:
 
 ```python
-from datadog_checks.checks.prometheus import PrometheusCheck
+from datadog_checks.checks.openmetrics import OpenMetricsBasicCheck
 
-class KubeDNSCheck(PrometheusCheck):
+class KubeDNSCheck(OpenMetricsBasicCheck):
 ```
 
 #### Overriding `self.NAMESPACE`
@@ -75,9 +75,9 @@ class KubeDNSCheck(PrometheusCheck):
 `NAMESPACE` is the prefix metrics will have. It needs to be hardcoded in your check class:
 
 ```python
-from datadog_checks.checks.prometheus import PrometheusCheck
+from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
 
-class KubeDNSCheck(PrometheusCheck):
+class KubeDNSCheck(OpenMetricsBaseCheck):
     def __init__(self, name, init_config, agentConfig, instances=None):
         super(KubeDNSCheck, self).__init__(name, init_config, agentConfig, instances)
         self.NAMESPACE = 'kubedns'
@@ -86,12 +86,12 @@ class KubeDNSCheck(PrometheusCheck):
 #### Overriding `self.metrics_mapper`
 
 `metrics_mapper` is a dictionary where the key is the metric to capture and the value is the corresponding metric name in Datadog.
-The reason for the override is so metrics reported by the Prometheus checks are not counted as [custom metric][5]:
+The reason for the override is so metrics reported by the OpenMetrics checks are not counted as [custom metric][5]:
 
 ```python
-from datadog_checks.checks.prometheus import PrometheusCheck
+from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
 
-class KubeDNSCheck(PrometheusCheck):
+class KubeDNSCheck(OpenMetricsBaseCheck):
     def __init__(self, name, init_config, agentConfig, instances=None):
         super(KubeDNSCheck, self).__init__(name, init_config, agentConfig, instances)
         self.NAMESPACE = 'kubedns'
@@ -107,7 +107,7 @@ class KubeDNSCheck(PrometheusCheck):
 
 #### Implementing the check method
 
-From `instance` we just need `endpoint` which is the Prometheus metrics endpoint to poll metrics from:
+From `instance` we just need `endpoint` which is the Prometheus or OpenMetrics metrics endpoint to poll metrics from:
 
 ```python
 def check(self, instance):
@@ -161,11 +161,11 @@ def check(self, instance):
 
 ```python
 from datadog_checks.errors import CheckException
-from datadog_checks.checks.prometheus import PrometheusCheck
+from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
 
-class KubeDNSCheck(PrometheusCheck):
+class KubeDNSCheck(OpenMetricsBaseCheck):
     """
-    Collect kube-dns metrics from Prometheus
+    Collect kube-dns metrics from Prometheus endpoint
     """
     def __init__(self, name, init_config, agentConfig, instances=None):
         super(KubeDNSCheck, self).__init__(name, init_config, agentConfig, instances)
@@ -197,7 +197,7 @@ class KubeDNSCheck(PrometheusCheck):
 
 ## Going further
 
-You can improve your Prometheus check with the following methods:
+You can improve your OpenMetrics check with the following methods:
 
 ### `self.ignore_metrics`
 
@@ -213,7 +213,7 @@ If the `labels_mapper` dictionary is provided, the metrics labels in `labels_map
 
 ### `self.type_overrides`
 
-`type_overrides` is a dictionary where the keys are Prometheus metric names and the values are a metric type (name as string) to use instead of the one listed in the payload. It can be used to force a type on untyped metrics.  
+`type_overrides` is a dictionary where the keys are Prometheus or OpenMetrics metric names and the values are a metric type (name as string) to use instead of the one listed in the payload. It can be used to force a type on untyped metrics.  
 Available types are: `counter`, `gauge`, `summary`, `untyped`, and `histogram`.
 
 **Note**: it is empty in the base class but needs to be overloaded/hardcoded in the final check not to be counted as custom metric.

--- a/content/en/developers/prometheus.md
+++ b/content/en/developers/prometheus.md
@@ -17,7 +17,7 @@ aliases:
 
 ## Overview
 
-This page dives into the `OpenMetricsBasicCheck` interface for more advanced usage, including an example of a simple check that collects timing metrics and status events from [Kube DNS][1]. For information on configuring a basic OpenMetrics check, see the [Agent Documentation][2].
+This page dives into the `OpenMetricsBaseCheck` interface for more advanced usage, including an example of a simple check that collects timing metrics and status events from [Kube DNS][1]. For information on configuring a basic OpenMetrics check, see the [Agent Documentation][2].
 
 ## Advanced usage: OpenMetrics check interface
 

--- a/content/en/developers/prometheus.md
+++ b/content/en/developers/prometheus.md
@@ -107,7 +107,7 @@ class KubeDNSCheck(OpenMetricsBaseCheck):
 
 #### Implementing the check method
 
-From `instance` we just need `endpoint` which is the Prometheus or OpenMetrics metrics endpoint to poll metrics from:
+From `instance`, use `endpoint`, which is the Prometheus or OpenMetrics metrics endpoint to poll metrics from:
 
 ```python
 def check(self, instance):
@@ -139,7 +139,7 @@ def check(self, instance):
         raise CheckException("Unable to find prometheus_endpoint in config file.")
 ```
 
-Then as soon as you have data available you just need to flush:
+Then as soon as you have data available, flush:
 
 ```python
 from datadog_checks.errors import CheckException
@@ -201,11 +201,11 @@ You can improve your OpenMetrics check with the following methods:
 
 ### `self.ignore_metrics`
 
-Some metrics are ignored because they are duplicates or introduce a very high cardinality. Metrics included in this list will be silently skipped without a `Unable to handle metric` debug line in the logs.
+Some metrics are ignored because they are duplicates or introduce a very high cardinality. Metrics included in this list are silently skipped without an `Unable to handle metric` debug line in the logs.
 
 ### `self.labels_mapper`
 
-If the `labels_mapper` dictionary is provided, the metrics labels in `labels_mapper` will use the corresponding value as tag name when sending the gauges.
+If the `labels_mapper` dictionary is provided, the metrics labels in `labels_mapper` use the corresponding value as tag name when sending the gauges.
 
 ### `self.exclude_labels`
 
@@ -213,10 +213,10 @@ If the `labels_mapper` dictionary is provided, the metrics labels in `labels_map
 
 ### `self.type_overrides`
 
-`type_overrides` is a dictionary where the keys are Prometheus or OpenMetrics metric names and the values are a metric type (name as string) to use instead of the one listed in the payload. It can be used to force a type on untyped metrics.  
+`type_overrides` is a dictionary where the keys are Prometheus or OpenMetrics metric names and the values are a metric type (name as string) to use instead of the one listed in the payload. This can be used to force a type on untyped metrics.  
 Available types are: `counter`, `gauge`, `summary`, `untyped`, and `histogram`.
 
-**Note**: it is empty in the base class but needs to be overloaded/hardcoded in the final check not to be counted as custom metric.
+**Note**: This value is empty in the base class, but needs to be overloaded/hardcoded in the final check in order to not be counted as a custom metric.
 
 ## Further Reading
 

--- a/content/en/developers/prometheus.md
+++ b/content/en/developers/prometheus.md
@@ -21,7 +21,7 @@ This page dives into the `OpenMetricsBaseCheck` interface for more advanced usag
 
 ## Advanced usage: OpenMetrics check interface
 
-If you have more advanced needs than the generic check (metrics preprocessing for example) you can write a custom `OpenMetricsBaseCheck`. It's [the base class][3] of the generic check and it provides a structure and some helpers to collect metrics, events, and service checks exposed via Prometheus. Minimal configuration for checks based on this class include:
+If you have more advanced needs than the generic check (metrics preprocessing for example) you can write a custom `OpenMetricsBaseCheck`. It's [the base class][3] of the generic check, and it provides a structure and some helpers to collect metrics, events, and service checks exposed via Prometheus. Minimal configuration for checks based on this class include:
 
 - Overriding `self.NAMESPACE`
 - Overriding `self.metrics_mapper`
@@ -31,7 +31,7 @@ AND/OR
 
 ## Writing a custom Prometheus check
 
-This is a simple example of writing a kube DNS check to illustrate the `OpenMetricsBaseCheck` class usage. The example below replicates the functionality of the following generic Prometheus check:
+This is a simple example of writing a Kube DNS check to illustrate usage of the `OpenMetricsBaseCheck` class. The example below replicates the functionality of the following generic Prometheus check:
 
 ```yaml
 instances:

--- a/content/en/getting_started/integrations/prometheus.md
+++ b/content/en/getting_started/integrations/prometheus.md
@@ -32,7 +32,7 @@ Starting with version 6.1.0, the Agent includes [OpenMetrics][3] and [Prometheus
 
 OpenMetrics is a newer standard for exposing metrics data, influeced by the Prometheus exposition format. The Agent's OpenMetrics check is recommended for text-format metrics and when configuring new checks. Additionaly, OpenMetrics check is recommended for Prometheus metrics end-points that use OpenMetrics format such as with  Kubernetes and many other Cloud Native Computing Foundation (CNCF) projects. OpenMetrics check also supports converting OpenMetrics historgams to Distribution metrics.
 
-Prometheus check is preffered when monitoring existing or legacy applications which use a protobuf format.
+Prometheus check is preferred when monitoring existing or legacy applications that use a protobuf format.
 
 ## Setup
 ### Installation
@@ -46,7 +46,7 @@ If running the Agent as a binary on a host, configure your OpenMetrics or Promet
 {{< tabs >}}
 {{% tab "Host" %}}
 
-First, edit the `openmetrics.d/conf.yaml` or `prometheus.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][1] to configure your Datadog-OpenMetrics or Datadog-Prometheus integrations. Then [restart the Agent][2] to start collecting your metrics. Find below the minimum required configuration needed to enable the integration and see the [sample openmetrics.d/conf.yaml][3] or [sample prometheus.d/conf.yaml][4] for all available configuration options.
+First, edit the `openmetrics.d/conf.yaml` or `prometheus.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][1] to configure your Datadog-OpenMetrics or Datadog-Prometheus integrations. Then [restart the Agent][2] to start collecting your metrics.  See the [sample openmetrics.d/conf.yaml][3] or [sample prometheus.d/conf.yaml][4] for all available configuration options. This is the minimum required configuration needed to enable the integration:
 
 ```yaml
 init_config:
@@ -151,7 +151,7 @@ Find below the full list of parameters that can be used for your `instances`:
 |`prometheus_timeout`|integer|optional|10| Set a timeout in seconds for the Prometheus/OpenMetrics query.|
 |`max_returned_metrics`|integer|optional|2000| The check limits itself to 2000 metrics by default. Increase this limit if needed.|
 
-Note: All parameters but `send_distribution_buckets` are supported by both OpenMetrics check and Prometheus check.
+**Note**: All parameters but `send_distribution_buckets` are supported by both OpenMetrics check and Prometheus check.
 
 ## From custom to official integration
 

--- a/content/en/getting_started/integrations/prometheus.md
+++ b/content/en/getting_started/integrations/prometheus.md
@@ -163,7 +163,7 @@ Official integrations have their own dedicated directories. There's a default in
 
 {{< partial name="whats-next/whats-next.html" >}}
 
- [1]: /integrations/openmetrics
+[1]: /integrations/openmetrics
 [2]: /integrations/prometheus
 [3]: https://github.com/DataDog/integrations-core/tree/master/openmetrics
 [4]: https://github.com/DataDog/integrations-core/tree/master/prometheus

--- a/content/en/getting_started/integrations/prometheus.md
+++ b/content/en/getting_started/integrations/prometheus.md
@@ -26,9 +26,9 @@ Collect your exposed Prometheus and OpenMetrics metrics from your application [r
 
 ## Overview
 
-Starting with version 6.1.0, the Agent includes [OpenMetrics][3] and [Prometheus][4] checks capable of scraping Prometheus endpoints with a few lines of configuration. This page explains the basic usage of these checks, which enable you to scrape custom metrics from Prometheus endpoints. 
+Starting with version 6.5.0, the Agent includes [OpenMetrics][3] and [Prometheus][4] checks capable of scraping Prometheus endpoints with a few lines of configuration. This page explains the basic usage of these checks, which enable you to scrape custom metrics from Prometheus endpoints. 
 
-We recommend using the OpenMetrics check by default, which is more efficient and offers advanced capabilities. Use the Prometheus check only when the metrics end-point does not support a text-format.
+We recommend using the OpenMetrics check since it is more efficient and fully supports Prometheus text format. Use the Prometheus check only when the metrics end-point does not support a text-format.
 
 For more advanced usage of the `OpenMetricsCheck` interface, including writing a custom check, see the [Developer Tools][5] section.
 

--- a/content/en/getting_started/integrations/prometheus.md
+++ b/content/en/getting_started/integrations/prometheus.md
@@ -1,5 +1,5 @@
 ---
-title: Prometheus metrics collection
+title: Prometheus and OpenMetrics metrics collection
 kind: documentation
 aliases:
     - /getting_started/prometheus
@@ -22,25 +22,31 @@ aliases:
   - /getting_started/prometheus
 ---
 
-Collect your exposed Prometheus metrics from your application [running inside containers](#container-auto-discovery) or directly [on your host](#host-agent) using the Datadog Agent and the [Datadog-Prometheus][1] integration.
+Collect your exposed Prometheus/OpenMetrics metrics from your application [running inside containers](#container-auto-discovery) or directly [on your host](#host-agent) using the Datadog Agent and the [Datadog-OpenMetrics][1] or [Datadog-Prometheus][2] integrations.
 
 ## Overview
 
-Starting with version 6.1.0, the Agent includes a [Prometheus][2] check capable of scraping Prometheus endpoints with a few lines of configuration. This page explains the basic usage of the generic `Prometheus` check, which enables you to scrape custom metrics from Prometheus endpoints. For more advanced usage of the `PrometheusCheck` interface, including writing a custom check, see the [Developer Tools][3] section.
+Starting with version 6.1.0, the Agent includes [OpenMetrics][3] and [Prometheus][4] checks capable of scraping Prometheus endpoints with a few lines of configuration. This page explains the basic usage of the generic `Prometheus` and `OpenMetrics` checks, which enable you to scrape custom metrics from Prometheus and OpenMetrics endpoints. For more advanced usage of the `PrometheusCheck` interface, including writing a custom check, see the [Developer Tools][5] section.
+
+## Choosing between OpenMetrics and Prometheus integrations
+
+OpenMetrics is a newer standard for exposing metrics data, influeced by the Prometheus exposition format. The Agent's OpenMetrics check is recommended for text-format metrics and when configuring new checks. Additionaly, OpenMetrics check is recommended for Prometheus metrics end-points that use OpenMetrics format such as with  Kubernetes and many other Cloud Native Computing Foundation (CNCF) projects. OpenMetrics check also supports converting OpenMetrics historgams to Distribution metrics.
+
+Prometheus check is preffered when monitoring existing or legacy applications which use a protobuf format.
 
 ## Setup
 ### Installation
 
-[Install the Datadog Agent for your corresponding operating system][4]. The Prometheus/OpenMetrics check is included in the [Datadog Agent][4] package, so you don't need to install anything else on your containers or hosts.
+[Install the Datadog Agent for your corresponding operating system][6]. OpenMetrics and Prometheus checks are included in the [Datadog Agent][7] package, so you don't need to install anything else on your containers or hosts.
 
 ### Configuration
 
-If running the Agent as a binary on a host, configure your Prometheus/OpenMetrics check as any [other Agent integration](?tab=host). If running the Agent as a DaemonSet in Kubernetes, configure your Prometheus/OpenMetrics check using [Autodiscovery](?tab=kubernetes).
+If running the Agent as a binary on a host, configure your OpenMetrics or Prometheus check as any [other Agent integration](?tab=host). If running the Agent as a DaemonSet in Kubernetes, configure your OpenMetrics or Prometheus check using [Autodiscovery](?tab=kubernetes).
 
 {{< tabs >}}
 {{% tab "Host" %}}
 
-First, edit the `prometheus.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][1] to configure your Datadog-Prometheus integration. Then [restart the Agent][2] to start collecting your metrics. Find below the minimum required configuration needed to enable the integration and see the [sample prometheus.d/conf.yaml][3] for all available configuration options.
+First, edit the `openmetrics.d/conf.yaml` or `prometheus.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][1] to configure your Datadog-OpenMetrics or Datadog-Prometheus integrations. Then [restart the Agent][2] to start collecting your metrics. Find below the minimum required configuration needed to enable the integration and see the [sample openmetrics.d/conf.yaml][3] or [sample prometheus.d/conf.yaml][4] for all available configuration options.
 
 ```yaml
 init_config:
@@ -54,15 +60,16 @@ instances:
 
 [1]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6#agent-configuration-directory
 [2]: /agent/guide/agent-commands/#start-stop-and-restart-the-agent
-[3]: https://github.com/DataDog/integrations-core/blob/master/prometheus/datadog_checks/prometheus/data/conf.yaml.example
+[3]: https://github.com/DataDog/integrations-core/blob/master/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+[4]: https://github.com/DataDog/integrations-core/blob/master/prometheus/datadog_checks/prometheus/data/conf.yaml.example
 {{% /tab %}}
 {{% tab "Docker" %}}
 
-The Agent detects if it's running on Docker and automatically searches all containers labels for Datadog-Prometheus labels. Autodiscovery expects labels to look like these examples, depending on the file type:
+The Agent detects if it's running on Docker and automatically searches all containers labels for Datadog-OpenMetrics labels. Autodiscovery expects labels to look like these examples, depending on the file type:
 
 **Dockerfile**
 ```
-LABEL "com.datadoghq.ad.check_names"='["prometheus"]'
+LABEL "com.datadoghq.ad.check_names"='["openmetrics"]'
 LABEL "com.datadoghq.ad.init_configs"='["{}"]'
 LABEL "com.datadoghq.ad.instances"='["{\"prometheus_url\":\"http://%%host%%:<PROMETHEUS_PORT>/<PROMETHEUS_ENDPOINT> \",\"namespace\":\"<METRICS_NAMESPACE_PREFIX_FOR_DATADOG>\",\"metrics\":[\"<PROMETHEUS_METRIC_TO_FETCH>: <DATADOG_NEW_METRIC_NAME>\"]}"]'
 ```
@@ -70,20 +77,20 @@ LABEL "com.datadoghq.ad.instances"='["{\"prometheus_url\":\"http://%%host%%:<PRO
 **docker-compose.yaml**
 ```yaml
 labels:
-  com.datadoghq.ad.check_names: '["prometheus"]'
+  com.datadoghq.ad.check_names: '["openmetrics"]'
   com.datadoghq.ad.init_configs: '["{}"]'
   com.datadoghq.ad.instances: '["{\"prometheus_url\":\"http://%%host%%:<PROMETHEUS_PORT>/<PROMETHEUS_ENDPOINT> \",\"namespace\":\"<METRICS_NAMESPACE_PREFIX_FOR_DATADOG>\",\"metrics\":[\"<PROMETHEUS_METRIC_TO_FETCH>: <DATADOG_NEW_METRIC_NAME>\"]}"]'
 ```
 
 **docker run command**
 ```
--l com.datadoghq.ad.check_names='["prometheus"]' -l com.datadoghq.ad.init_configs='["{}"]' -l com.datadoghq.ad.instances='["{\"prometheus_url\":\"http://%%host%%:<PROMETHEUS_PORT>/<PROMETHEUS_ENDPOINT> \",\"namespace\":\"<METRICS_NAMESPACE_PREFIX_FOR_DATADOG>\",\"metrics\":[\"<PROMETHEUS_METRIC_TO_FETCH>: <DATADOG_NEW_METRIC_NAME>\"]}"]'
+-l com.datadoghq.ad.check_names='["openmetrics"]' -l com.datadoghq.ad.init_configs='["{}"]' -l com.datadoghq.ad.instances='["{\"prometheus_url\":\"http://%%host%%:<PROMETHEUS_PORT>/<PROMETHEUS_ENDPOINT> \",\"namespace\":\"<METRICS_NAMESPACE_PREFIX_FOR_DATADOG>\",\"metrics\":[\"<PROMETHEUS_METRIC_TO_FETCH>: <DATADOG_NEW_METRIC_NAME>\"]}"]'
 ```
 
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 
-Like all [Datadog Agent integrations][1], the Datadog-Prometheus integration can be configured using [Autodiscovery][2]. This allows you to send a given container/pod exposed Prometheus metrics to Datadog by applying the following `annotations` to it:
+Like all [Datadog Agent integrations][1], the Datadog-OpenMetrics integration can be configured using [Autodiscovery][2]. This allows you to send a given container/pod exposed OpenMetrics or Prometheus metrics to Datadog by applying the following `annotations` to it:
 
 ```
 # (...)
@@ -91,7 +98,7 @@ metadata:
 #(...)
   annotations:
       ad.datadoghq.com/<CONTAINER_IDENTIFIER>.check_names: |
-        ["prometheus"]
+        ["openmetrics"]
       ad.datadoghq.com/<CONTAINER_IDENTIFIER>.init_configs: |
         [{}]
       ad.datadoghq.com/<CONTAINER_IDENTIFIER>.instances: |
@@ -124,40 +131,46 @@ Find below the full list of parameters that can be used for your `instances`:
 
 |Name | Type | Necessity | Default value | Description |
 |---| --- | --- | ------ |---|
-|`prometheus_url`|string|required|none| The URL where your application metrics are exposed by Prometheus.|
+|`prometheus_url`|string|required|none| The URL where your application metrics are exposed by Prometheus/OpenMetrics.|
 |`namespace`|string|required|none| The namespace to be appended before all metrics namespaces. Your metrics are collected in the form `namespace.metric_name`.|
 |`metrics`|list of key:value elements|required|none| List of `<METRIC_TO_FETCH>: <NEW_METRIC_NAME>` pairs for metrics to be fetched from the Prometheus endpoint.<br> `<NEW_METRIC_NAME>` is optional. It transforms the name in Datadog if set.<br> This list should contain at least one metric.|
-|`prometheus_metrics_prefix`|string|optional|none| Prefix for exposed Prometheus metrics.|
+|`prometheus_metrics_prefix`|string|optional|none| Prefix for exposed Prometheus/OpenMetrics metrics.|
 |`health_service_check`|boolean|optional|true| Send a service check reporting on the health of the Prometheus endpoint.<br> The check is named `<NAMESPACE>.prometheus.health`.|
 |`label_to_hostname`|string|optional|none| Override the hostname with the value of one label.|
 |`label_joins`|object|optional|none| The label join allows you to target a metric and retrieve its label via a 1:1 mapping.|
 |`labels_mapper`|list of key:value element|optional|none| The label mapper allows you to rename some labels.<br> Format: `<LABEL_TO_RENAME>: <NEW_LABEL_NAME>`.|
 |`type_overrides`|list of key:value element|optional|none| Type override allows you to override a type in the Prometheus payload<br> or type an untyped metric (they're ignored by default).<br> Supported `<METRIC_TYPE>`s are `gauge`, `counter`, `histogram`, and `summary`.|
 |`tags`|list of key:value element|optional|none| List of tags to attach to every metric, event, and service check emitted by this integration.<br><br> [Learn more about tagging][5].|
+|`send_distribution_buckets`|boolean|optional|false| Set `send_distribution_buckets` to `true` to send and convert OpenMetrics histograms to [Distribution metrics][8]. <br><br>`send_histograms_buckets` must be set to `true` (default value).| 
 |`send_histogram_buckets`|boolean|optional|true| Set `send_histograms_buckets` to `true` to send the histograms bucket.|
-|`send_monotonic_counter`|boolean|optional|true| To send counters as monotonic counter<br><br> see [the relevant issue][6] in GitHub. |
+|`send_monotonic_counter`|boolean|optional|true| To send counters as monotonic counter<br><br> see [the relevant issue][9] in GitHub. |
 |`exclude_labels`|list of string|optional|none| List of labels to be excluded.|
 |`ssl_cert`|string|optional|none| If your Prometheus endpoint is secured, here are the settings to configure it:<br> Can either be: only the path to the certificate and thus you should specify the private key<br>, or it can be the path to a file containing both the certificate and the private key.|
 |`ssl_private_key`|string|optional|none| Needed if the certificate does not include the private key.<br> **WARNING**: The private key to your local certificate must be unencrypted.|
 |`ssl_ca_cert`|string|optional|none| The path to the trusted CA used for generating custom certificates. Set this to false to disable SSL certificate<br> verification.|
-|`prometheus_timeout`|integer|optional|10| Set a timeout in seconds for the Prometheus query.|
+|`prometheus_timeout`|integer|optional|10| Set a timeout in seconds for the Prometheus/OpenMetrics query.|
 |`max_returned_metrics`|integer|optional|2000| The check limits itself to 2000 metrics by default. Increase this limit if needed.|
+
+Note: All parameters but `send_distribution_buckets` are supported by both OpenMetrics check and Prometheus check.
 
 ## From custom to official integration
 
-By default, all metrics retrieved by the generic Prometheus check are considered custom metrics. If you are monitoring off-the-shelf software and think it deserves an official integration, don't hesitate to [contribute][7]!
+By default, all metrics retrieved by the generic Prometheus check are considered custom metrics. If you are monitoring off-the-shelf software and think it deserves an official integration, don't hesitate to [contribute][10]!
 
-Official integrations have their own dedicated directories. There's a default instance mechanism in the generic check to hardcode the default configuration and metrics metadata. For example, reference the [kube-proxy][8] integration.
+Official integrations have their own dedicated directories. There's a default instance mechanism in the generic check to hardcode the default configuration and metrics metadata. For example, reference the [kube-proxy][11] integration.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /integrations/prometheus
-[2]: https://github.com/DataDog/integrations-core/tree/master/prometheus
-[3]: /developers/prometheus
-[4]: https://app.datadoghq.com/account/settings#agent
-[5]: https://docs.datadoghq.com/tagging
-[6]: https://github.com/DataDog/integrations-core/issues/1303
-[7]: /developers/prometheus
-[8]: https://github.com/DataDog/integrations-core/tree/master/kube_proxy
+ [1]: /integrations/openmetrics
+[2]: /integrations/prometheus
+[3]: https://github.com/DataDog/integrations-core/tree/master/openmetrics
+[4]: https://github.com/DataDog/integrations-core/tree/master/prometheus
+[5]: /developers/prometheus
+[6]: https://app.datadoghq.com/account/settings#agent
+[7]: https://docs.datadoghq.com/tagging
+[8]: /graphing/metrics/distributions
+[9]: https://github.com/DataDog/integrations-core/issues/1303
+[10]: /developers/prometheus
+[11]: https://github.com/DataDog/integrations-core/tree/master/kube_proxy

--- a/content/en/getting_started/integrations/prometheus.md
+++ b/content/en/getting_started/integrations/prometheus.md
@@ -28,7 +28,7 @@ Collect your exposed Prometheus and OpenMetrics metrics from your application [r
 
 Starting with version 6.5.0, the Agent includes [OpenMetrics][3] and [Prometheus][4] checks capable of scraping Prometheus endpoints with a few lines of configuration. This page explains the basic usage of these checks, which enable you to scrape custom metrics from Prometheus endpoints. 
 
-We recommend using the OpenMetrics check since it is more efficient and fully supports Prometheus text format. Use the Prometheus check only when the metrics end-point does not support a text-format.
+Datadog recommends using the OpenMetrics check since it is more efficient and fully supports Prometheus text format. Use the Prometheus check only when the metrics endpoint does not support a text format.
 
 For more advanced usage of the `OpenMetricsCheck` interface, including writing a custom check, see the [Developer Tools][5] section.
 
@@ -39,7 +39,7 @@ For more advanced usage of the `OpenMetricsCheck` interface, including writing a
 
 ### Configuration
 
-If running the Agent as a binary on a host, configure your OpenMetrics or Prometheus check as any [other Agent integration](?tab=host). If running the Agent as a DaemonSet in Kubernetes, configure your OpenMetrics or Prometheus check using [Autodiscovery](?tab=kubernetes).
+If you are running the Agent as a binary on a host, configure your OpenMetrics or Prometheus check as you would any [other Agent integration](?tab=host). If you are running the Agent as a DaemonSet in Kubernetes, configure your OpenMetrics or Prometheus check using [Autodiscovery](?tab=kubernetes).
 
 {{< tabs >}}
 {{% tab "Host" %}}

--- a/content/en/getting_started/integrations/prometheus.md
+++ b/content/en/getting_started/integrations/prometheus.md
@@ -26,13 +26,11 @@ Collect your exposed Prometheus and OpenMetrics metrics from your application [r
 
 ## Overview
 
-Starting with version 6.1.0, the Agent includes [OpenMetrics][3] and [Prometheus][4] checks capable of scraping Prometheus endpoints with a few lines of configuration. This page explains the basic usage of the generic `Prometheus` and `OpenMetrics` checks, which enable you to scrape custom metrics from Prometheus and OpenMetrics endpoints. For more advanced usage of the `PrometheusCheck` interface, including writing a custom check, see the [Developer Tools][5] section.
+Starting with version 6.1.0, the Agent includes [OpenMetrics][3] and [Prometheus][4] checks capable of scraping Prometheus endpoints with a few lines of configuration. This page explains the basic usage of these checks, which enable you to scrape custom metrics from Prometheus endpoints. 
 
-## Choosing between OpenMetrics and Prometheus integrations
+We recommend using the OpenMetrics check by default, which is more efficient and offers advanced capabilities. Use the Prometheus check only when the metrics end-point does not support a text-format.
 
-OpenMetrics is a newer standard for exposing metrics data, influeced by the Prometheus exposition format. The Agent's OpenMetrics check is recommended for text-format metrics and when configuring new checks. Additionaly, OpenMetrics check is recommended for Prometheus metrics end-points that use OpenMetrics format such as with  Kubernetes and many other Cloud Native Computing Foundation (CNCF) projects. OpenMetrics check also supports converting OpenMetrics historgams to Distribution metrics.
-
-Prometheus check is preferred when monitoring existing or legacy applications that use a protobuf format.
+For more advanced usage of the `OpenMetricsCheck` interface, including writing a custom check, see the [Developer Tools][5] section.
 
 ## Setup
 ### Installation

--- a/content/en/getting_started/integrations/prometheus.md
+++ b/content/en/getting_started/integrations/prometheus.md
@@ -22,7 +22,7 @@ aliases:
   - /getting_started/prometheus
 ---
 
-Collect your exposed Prometheus/OpenMetrics metrics from your application [running inside containers](#container-auto-discovery) or directly [on your host](#host-agent) using the Datadog Agent and the [Datadog-OpenMetrics][1] or [Datadog-Prometheus][2] integrations.
+Collect your exposed Prometheus and OpenMetrics metrics from your application [running inside containers](#container-auto-discovery) or directly [on your host](#host-agent) by using the Datadog Agent, and the [Datadog-OpenMetrics][1] or [Datadog-Prometheus][2] integrations.
 
 ## Overview
 


### PR DESCRIPTION
1. Add send_distribution_buckets parameter to the docs
2. Promote OpenMetrics check over Prometheus check in the integration page

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
https://docs-staging.datadoghq.com/yair.cohen/openmetrics-to-distributionmetrics-docs/getting_started/integrations/prometheus?tab=host

### Additional Notes
Please review the "Choosing between OpenMetrics and Prometheus integrations" section in particular to check accuracy. Thanks
