### PR TITLE
Update checks_post.md

### DIFF
--- a/content/en/api/checks/checks_post.md
+++ b/content/en/api/checks/checks_post.md
@@ -22,12 +22,13 @@ external_redirect: /api/#post-a-check-run
     * 2 : CRITICAL
     * 3 : UNKNOWN
 
-
+* **`tags`** *[required]*:
+    A list of key:val tags for this check
+    
 * **`timestamp`** *[optional]*:
     POSIX timestamp of the event.
 
 * **`message`** *[optional]*:
     A description of why this status occurred
 
-* **`tags`** *[optional]*:
-    A list of key:val tags for this check
+


### PR DESCRIPTION
The tags field is required.

Datadog endpoint accepts a request without this field, but the monitor does not get it.
