### PR TITLE
Update logs HTTP limits

### DIFF
--- a/content/en/api/logs/logs.md
+++ b/content/en/api/logs/logs.md
@@ -11,9 +11,9 @@ external_redirect: /api/#logs
 
 Send your logs to your Datadog platform over HTTP. Limits per HTTP request are:
 
-* Maximum content size per payload: 2MB
+* Maximum content size per payload: 5MB
 * Maximum size for a single log: 256kB
-* Maximum array size if sending multiple logs in an array: 50 entries
+* Maximum array size if sending multiple logs in an array: 500 entries
 
 **Note**: If you are in the Datadog EU site (`app.datadoghq.eu`), the HTTP log endpoint is: `http-intake.logs.datadoghq.eu`.
 


### PR DESCRIPTION
### What does this PR do?
Update the batch size limits for the Logs HTTP API

### Motivation
The limits were updated to support bigger batches

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/http-logs-batch-size/api/?lang=python#send-logs-over-http

### Additional Notes
<!-- Anything else we should know when reviewing?-->
