### PR TITLE
fixing the example of wildcards in log explorer search

### DIFF
--- a/content/en/logs/explorer/search.md
+++ b/content/en/logs/explorer/search.md
@@ -90,9 +90,9 @@ Wildcard searches work within facets with this syntax. This query returns all th
 
 Wildcard searches can also be used to search in the plain text of a log that is not part of a facet. This query returns all the logs that contain the string `NETWORK`:
 
-`"*NETWORK*"`
+`*NETWORK*`
 
-However, this search term does not return logs that contain the string `NETWORK` if it is in a facet.
+However, this search term does not return logs that contain the string `NETWORK` if it is in a facet and not part of the log message.
 
 ### Numerical values
 Use `<`,`>`, `<=`, or `>=` to perform a search on numerical attributes. For instance, retrieve all logs that have a response time over 100ms with:


### PR DESCRIPTION

### What does this PR do?
removes erroneous quotes from the facet search example for wild card searches

### Motivation
someone reached out because the documented misdirected them and they didn't know how to perform wildcard searches. 

### Preview link
https://docs-staging.datadoghq.com/estib/facet-search-example-remove-quotes/logs/explorer/search/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
thanks! go ahead and merge if you like it. 
