### PR TITLE
Removing API code file from the list of stop URL in Algolia

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -142,7 +142,7 @@ index_algolia:
   stage: post-deploy
   environment: "live"
   script:
-    - chmod +x ./local/bin/py/algolia_index.py && ./local/bin/py/algolia_index.py -d "['config', 'error', 'examples', 'fonts', 'images', 'resources', 'static', 'videos']" -l "['ja']" -c "./local/etc/algolia/docs_datadoghq.json"
+    - chmod +x ./local/bin/py/algolia_index.py && ./local/bin/py/algolia_index.py -d "['config', 'api', 'error', 'examples', 'fonts', 'images', 'resources', 'static', 'videos']" -l "['ja']" -c "./local/etc/algolia/docs_datadoghq.json"
     - cp ./local/etc/algolia/docs_datadoghq.json /etc/docs_datadoghq.com
     - cat /etc/docs_datadoghq.com
     - index_docsearch_algolia

--- a/local/bin/py/algolia_index.py
+++ b/local/bin/py/algolia_index.py
@@ -41,9 +41,9 @@ def transform_url(private_urls):
     new_private_urls = []
     for url in private_urls:
 
-        ## We check if the url is not a localised FAQ url, if so we don't include it in list of stopped url
-        ## Since Localised FAQs are not indexed anyway.
-        if not (re.match(r"public/fr/.*/faq.*", url) or re.match(r"public/ja/.*/faq.*", url)):
+        ## We check if the url is not a localised FAQ url, or an API page if so we don't include it in list of stopped url
+        ## Since Localised FAQs are not indexed anyway and the API page is indexed as a whole
+        if not (re.match(r"public/fr/.*/faq/.*", url) or re.match(r"public/ja/.*/faq/.*", url) or re.match(r"public/ja/api/.*", url) or re.match(r"public/fr/api/.*", url)):
 
           ## We add /$ to all links in order to make them all "final", in fact
           ## Algolia stop_url parameter uses regex and not "perfect matching" link logic


### PR DESCRIPTION
### What does this PR do?

Removes the API link from the Algolia index update since those are not indexed anyway