### PR TITLE
adding agent repo migration info to FAQ

### DIFF
--- a/content/en/tracing/faq/_index.md
+++ b/content/en/tracing/faq/_index.md
@@ -13,4 +13,5 @@ disable_toc: true
     {{< nextlink href="tracing/faq/distributed-tracing" >}} Example of distributed tracing{{< /nextlink >}}
     {{< nextlink href="tracing/faq/terminology" >}}Terminology{{< /nextlink >}}
     {{< nextlink href="tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel" >}}Why can't I see my correlated logs in the Trace ID panel?{{< /nextlink >}}
+    {{< nextlink href="tracing/faq/trace-agent-from-source" >}}Installing the trace Agent from source and on Windows{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/tracing/faq/trace-agent-from-source.md
+++ b/content/en/tracing/faq/trace-agent-from-source.md
@@ -1,0 +1,49 @@
+---
+title: Installing the trace Agent from source and on Windows
+kind: faq
+---
+
+## Run on Windows
+
+The Windows trace agent is in beta and some manual steps are required.
+
+On Windows, the trace agent is shipped together with the Datadog Agent 5.19.0 or above.
+
+1. Install the Datadog Agent.
+2. Update your config file to include:
+    ```
+    [Main]
+    apm_enabled: yes
+    [trace.config]
+    log_file = C:\ProgramData\Datadog\logs\trace-agent.log
+    ```
+3. Restart the datadogagent service:
+    ```
+    net stop datadogagent
+    net start datadogagent
+    ```
+4. To see the trace agent status, either use the Service tab of the Task Manager, or run:
+    ```
+    sc.exe query datadog-trace-agent
+    ``` 
+    Check that the status is "running".
+
+## Install from source
+
+This is beta functionality.
+
+1. Install `Go 1.11+` is installed. For more information, see the steps on the [official website][1].
+After cloning the repo, simply run the following command in the root of the `datadog-agent` repository:
+2. Clone the [Datadog Agent repo][2]
+3. Run this command in the root of the `datadog-agent` repository:
+    ```bash
+    go install ./cmd/trace-agent
+    ```
+4. Run the agent using `trace-agent` (considering the path `$GOPATH/bin` is in your system's `$PATH`). 
+
+### Troubleshooting
+
+Check the agent output or logs (`/var/log/datadog/trace-agent.log` on Linux) to ensure that traces seem correct 
+and that they are reaching the Datadog API.
+[1]: https://golang.org/dl
+[2]: 

--- a/content/en/tracing/faq/trace-agent-from-source.md
+++ b/content/en/tracing/faq/trace-agent-from-source.md
@@ -1,39 +1,11 @@
 ---
-title: Installing the trace Agent from source and on Windows
+title: Installing the trace Agent from source
 kind: faq
 ---
 
-## Run on Windows
-
-The Windows trace agent is in beta and some manual steps are required.
-
-On Windows, the trace agent is shipped together with the Datadog Agent 5.19.0 or above.
-
-1. Install the Datadog Agent.
-2. Update your config file to include:
-    ```
-    [Main]
-    apm_enabled: yes
-    [trace.config]
-    log_file = C:\ProgramData\Datadog\logs\trace-agent.log
-    ```
-3. Restart the datadogagent service:
-    ```
-    net stop datadogagent
-    net start datadogagent
-    ```
-4. To see the trace agent status, either use the Service tab of the Task Manager, or run:
-    ```
-    sc.exe query datadog-trace-agent
-    ``` 
-    Check that the status is "running".
-
 ## Install from source
 
-This is beta functionality.
-
-1. Install `Go 1.11+` is installed. For more information, see the steps on the [official website][1].
-After cloning the repo, simply run the following command in the root of the `datadog-agent` repository:
+1. Install `Go 1.11+`. For more information, see the steps on the [official website][1].
 2. Clone the [Datadog Agent repo][2]
 3. Run this command in the root of the `datadog-agent` repository:
     ```bash
@@ -46,4 +18,4 @@ After cloning the repo, simply run the following command in the root of the `dat
 Check the agent output or logs (`/var/log/datadog/trace-agent.log` on Linux) to ensure that traces seem correct 
 and that they are reaching the Datadog API.
 [1]: https://golang.org/dl
-[2]: 
+[2]: https://github.com/DataDog/datadog-agent

--- a/content/en/tracing/faq/trace-agent-from-source.md
+++ b/content/en/tracing/faq/trace-agent-from-source.md
@@ -5,17 +5,17 @@ kind: faq
 
 ## Install from source
 
-1. Install `Go 1.11+`. For more information, see the steps on the [official website][1].
+1. Install `Go 1.11+`. For more information, see the steps on the [official Go website][1].
 2. Clone the [Datadog Agent repo][2]
 3. Run this command in the root of the `datadog-agent` repository:
     ```bash
     go install ./cmd/trace-agent
     ```
-4. Run the agent using `trace-agent` (considering the path `$GOPATH/bin` is in your system's `$PATH`). 
+4. Run the Agent using `trace-agent` (assuming the path `$GOPATH/bin` is in your system's `$PATH`). 
 
 ### Troubleshooting
 
-Check the agent output or logs (`/var/log/datadog/trace-agent.log` on Linux) to ensure that traces seem correct 
+Check the Agent output or logs (`/var/log/datadog/trace-agent.log` on Linux) to ensure that traces seem correct 
 and that they are reaching the Datadog API.
 [1]: https://golang.org/dl
 [2]: https://github.com/DataDog/datadog-agent

--- a/content/en/tracing/send_traces/_index.md
+++ b/content/en/tracing/send_traces/_index.md
@@ -28,6 +28,7 @@ To use APM, start by sending your [traces][1] to Datadog, and then [configure yo
 ## Datadog Agent
 
 APM is enabled by default in Agent 6. Set `apm_non_local_traffic: true` in your main [`datadog.yaml` configuration file][3] if you are sending traces from a nonlocal environment (like a container).
+
 To get an overview of all the possible settings for APM, take a look at the Agent's [`datadog.example.yaml`][4] configuration file. For all of the metrics sent to Datadog by the Agent, see [APM metrics sent by the Datadog Agent][5]. For more information about the Datadog Agent, see the [Agent documentation][6] or refer to the [`datadog.yaml` configuration template][7].
 
 ## Containers


### PR DESCRIPTION
### What does this PR do?
Adds trace agent from source and windows beta info to a tracing FAq

https://docs-staging.datadoghq.com/kaylyn/trace-agent-migration/tracing/faq/trace-agent-from-source

