### PR TITLE
[Browser log] add checks on window.DD_LOGS

### DIFF
--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -98,6 +98,8 @@ The following parameters can be used to configure the library to send logs to Da
 {{% /tab %}}
 {{< /tabs >}}
 
+**Note:** `window.DD_LOGS` check is added to prevent any issues in case of a loading failure of the library.
+
 ## Send a custom log entry
 
 Send a custom log entry directly to Datadog with the `log` function:
@@ -154,6 +156,8 @@ The logger adds the following information by default:
 * `http.useragent`
 * `network.client.ip`
 
+**Note:** `window.DD_LOGS` check is added to prevent any issues in case of a loading failure of the library.
+
 ## Advanced usage
 
 ### Filter by status
@@ -166,6 +170,8 @@ window.DD_LOGS && DD_LOGS.logger.setLevel('<LEVEL>')
 
 Only logs with a status equal to or higher than the specified level are sent.
 
+**Note:** `window.DD_LOGS` check is added to prevent any issues in case of a loading failure of the library.
+
 ### Change the destination
 
 By default, the loggers are sending logs to Datadog. It is also possible to configure the logger to send logs to the console, or to not send logs at all. This can be used in the development environment to keep the logs locally.
@@ -174,6 +180,8 @@ Use the `setHandler` function with the values `http` (default), `console`, or `s
 ```
 window.DD_LOGS && DD_LOGS.logger.setHandler('<HANDLER>')
 ```
+
+**Note:** `window.DD_LOGS` check is added to prevent any issues in case of a loading failure of the library.
 
 ### Define multiple loggers
 
@@ -228,6 +236,8 @@ if (window.DD_LOGS) {
 ...
 ```
 
+**Note:** `window.DD_LOGS` check is added to prevent any issues in case of a loading failure of the library.
+
 ### Overwrite context
 
 It is possible to set the entire context in one call. This also overrides previously set attributes, if any:
@@ -253,6 +263,8 @@ if (window.DD_LOGS) {
     })
 }
 ```
+
+**Note:** `window.DD_LOGS` check is added to prevent any issues in case of a loading failure of the library.
 
 ## Supported browsers
 

--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -55,14 +55,14 @@ The following parameters can be used to configure the library to send logs to Da
     <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-logs-us.js"></script>
     <script>
       // Set your client token
-      DD_LOGS.init({
+      window.DD_LOGS && DD_LOGS.init({
         clientToken: '<CLIENT_TOKEN>',
         forwardErrorsToLogs: true,
       });
 
       // OPTIONAL
       // add global metadata attribute--one attribute can be added at a time
-      DD_LOGS.addLoggerGlobalContext('<META_KEY>', <META_VALUE>);
+      window.DD_LOGS && DD_LOGS.addLoggerGlobalContext('<META_KEY>', <META_VALUE>);
     </script>
     ...
   </head>
@@ -80,14 +80,14 @@ The following parameters can be used to configure the library to send logs to Da
     <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-logs-eu.js"></script>
     <script>
       // Set your client token
-      DD_LOGS.init({
+      window.DD_LOGS && DD_LOGS.init({
         clientToken: '<CLIENT_TOKEN>',
         forwardErrorsToLogs: true,
       });
 
       // OPTIONAL
       // add global metadata attribute--one attribute can be added at a time
-      DD_LOGS.addLoggerGlobalContext('<META_KEY>', <META_VALUE>);
+      window.DD_LOGS && DD_LOGS.addLoggerGlobalContext('<META_KEY>', <META_VALUE>);
     </script>
     ...
   </head>
@@ -103,7 +103,7 @@ The following parameters can be used to configure the library to send logs to Da
 Send a custom log entry directly to Datadog with the `log` function:
 
 ```
-DD_LOGS.logger.log(<MESSAGE>,<JSON_ATTRIBUTES>,<STATUS>)
+window.DD_LOGS && DD_LOGS.logger.log(<MESSAGE>,<JSON_ATTRIBUTES>,<STATUS>)
 ```
 
 | Placeholder         | Description                                                                             |
@@ -120,7 +120,7 @@ Status can also be used as a placeholder for the `log` function `DD_LOGS.logger.
 ...
 <script>
 ...
-DD_LOGS.logger.info('Button clicked', { name: 'buttonName', id: 123 });
+window.DD_LOGS && DD_LOGS.logger.info('Button clicked', { name: 'buttonName', id: 123 });
 ...
 </script>
 ...
@@ -161,7 +161,7 @@ The logger adds the following information by default:
 In some cases, you might want to disable the debug mode or to only collect warnings and errors. This can be achieved by changing the logging level: set the `level` parameter to `debug` (default), `info`, `warn`, or `error` :
 
 ```
-DD_LOGS.logger.setLevel('<LEVEL>')
+window.DD_LOGS && DD_LOGS.logger.setLevel('<LEVEL>')
 ```
 
 Only logs with a status equal to or higher than the specified level are sent.
@@ -172,7 +172,7 @@ By default, the loggers are sending logs to Datadog. It is also possible to conf
 
 Use the `setHandler` function with the values `http` (default), `console`, or `silent`:
 ```
-DD_LOGS.logger.setHandler('<HANDLER>')
+window.DD_LOGS && DD_LOGS.logger.setHandler('<HANDLER>')
 ```
 
 ### Define multiple loggers
@@ -184,7 +184,7 @@ Each logger can optionally be configured with its own log level, handler, and co
 Use the following to define a custom logger:
 
 ```
-DD_LOGS.createLogger (<LOGGER_NAME>, {
+window.DD_LOGS && DD_LOGS.createLogger (<LOGGER_NAME>, {
     level?: 'debug' | 'info' | 'warn' | 'error'
     handler?: 'http' | 'console' | 'silent'
     context?: <JSON_ATTRIBUTES>
@@ -195,7 +195,9 @@ Those parameters can also be set with the `setContext`, `setLevel`, and `setHand
 After the creation of this logger, you can then access it in any part of your JavaScript code with the `getLogger` function:
 
 ```
-const my_logger = DD_LOGS.getLogger('<LOGGER_NAME>')
+if (window.DD_LOGS) {
+    const my_logger = DD_LOGS.getLogger('<LOGGER_NAME>')
+}
 ```
 
 **Example:**
@@ -205,8 +207,10 @@ Assume that there is a signup logger, defined with all the other loggers:
 
 ```
 # create a new logger
-const signupLogger = DD_LOGS.createLogger('signupLogger')
-signupLogger.addContext('env', 'staging')
+if (window.DD_LOGS) {
+    const signupLogger = DD_LOGS.createLogger('signupLogger')
+    signupLogger.addContext('env', 'staging')
+}
 ```
 
 It can now be used in a different part of the code with:
@@ -215,8 +219,10 @@ It can now be used in a different part of the code with:
 ...
 <script>
 ...
-const signupLogger = DD_LOGS.getLogger('signupLogger')
-signupLogger.info('Test sign up completed')
+if (window.DD_LOGS) {
+    const signupLogger = DD_LOGS.getLogger('signupLogger')
+    signupLogger.info('Test sign up completed')
+}
 ...
 </script>
 ...
@@ -228,20 +234,24 @@ It is possible to set the entire context in one call. This also overrides previo
 
 ```
 # For one logger
-my_logger.setContext(<JSON_ATTRIBUTES>)
+if (window.DD_LOGS) {
+    my_logger.setContext(<JSON_ATTRIBUTES>)
+}
 
 # For the global context
-DD_LOGS.setLoggerGlobalContext(<JSON_ATTRIBUTES>)
+window.DD_LOGS && DD_LOGS.setLoggerGlobalContext(<JSON_ATTRIBUTES>)
 ```
 
 **Example:**
 
 ```
-const signupLogger = DD_LOGS.getLogger('signupLogger')
-signupLogger.setContext({
-  env: 'staging',
-  team: 'user-account'
-})
+if (window.DD_LOGS) {
+    const signupLogger = DD_LOGS.getLogger('signupLogger')
+    signupLogger.setContext({
+      env: 'staging',
+      team: 'user-account'
+    })
+}
 ```
 
 ## Supported browsers

--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -58,7 +58,7 @@ The following parameters can be used to configure the library to send logs to Da
       DD_LOGS.init({
         clientToken: '<CLIENT_TOKEN>',
         forwardErrorsToLogs: true,
-    });
+      });
 
       // OPTIONAL
       // add global metadata attribute--one attribute can be added at a time
@@ -83,7 +83,7 @@ The following parameters can be used to configure the library to send logs to Da
       DD_LOGS.init({
         clientToken: '<CLIENT_TOKEN>',
         forwardErrorsToLogs: true,
-    });
+      });
 
       // OPTIONAL
       // add global metadata attribute--one attribute can be added at a time

--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -98,7 +98,7 @@ The following parameters can be used to configure the library to send logs to Da
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note:** `window.DD_LOGS` check is added to prevent any issues in case of a loading failure of the library.
+**Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the library.
 
 ## Send a custom log entry
 
@@ -156,7 +156,7 @@ The logger adds the following information by default:
 * `http.useragent`
 * `network.client.ip`
 
-**Note:** `window.DD_LOGS` check is added to prevent any issues in case of a loading failure of the library.
+**Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the library.
 
 ## Advanced usage
 
@@ -170,7 +170,7 @@ window.DD_LOGS && DD_LOGS.logger.setLevel('<LEVEL>')
 
 Only logs with a status equal to or higher than the specified level are sent.
 
-**Note:** `window.DD_LOGS` check is added to prevent any issues in case of a loading failure of the library.
+**Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the library.
 
 ### Change the destination
 
@@ -181,7 +181,7 @@ Use the `setHandler` function with the values `http` (default), `console`, or `s
 window.DD_LOGS && DD_LOGS.logger.setHandler('<HANDLER>')
 ```
 
-**Note:** `window.DD_LOGS` check is added to prevent any issues in case of a loading failure of the library.
+**Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the library.
 
 ### Define multiple loggers
 
@@ -236,7 +236,7 @@ if (window.DD_LOGS) {
 ...
 ```
 
-**Note:** `window.DD_LOGS` check is added to prevent any issues in case of a loading failure of the library.
+**Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the library.
 
 ### Overwrite context
 
@@ -264,7 +264,7 @@ if (window.DD_LOGS) {
 }
 ```
 
-**Note:** `window.DD_LOGS` check is added to prevent any issues in case of a loading failure of the library.
+**Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the library.
 
 ## Supported browsers
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add extra checks to ensure that our library is defined before trying to interact with it.
It can be undefined if:
- There is an error during the initialization of our library
- Some users are blocking the loading of our library (ad blockers)
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->
Customer feedback:
https://trello.com/c/rkzsKFOj/526-cant-find-variable-ddlogs-error
Investigation task:
https://trello.com/c/wo9trTeh/527-investigate-avoid-errors-when-library-is-blocked

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/bcaudan/add-checks/logs/log_collection/javascript/?tab=us#pagetitle

