### PR TITLE
adding missing curl command

### DIFF
--- a/content/en/api/logs_pipelines/code_snippets/get_all_pipelines.sh
+++ b/content/en/api/logs_pipelines/code_snippets/get_all_pipelines.sh
@@ -4,3 +4,5 @@
 
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
+
+curl -X GET "https://api.datadoghq.com/api/v1/logs/config/pipelines?api_key=${api_key}&application_key=${app_key}"


### PR DESCRIPTION
### What does this PR do?
Adds missing curl example for the get all log pipelines endpoint

### Motivation
Customer feedback.

### Preview link

* https://docs-staging.datadoghq.com/gus/curl-example/api/?lang=bash#get-all-pipelines