### PR TITLE
Fixing host api results

### DIFF
--- a/content/en/api/hosts/code_snippets/result.api-hosts-search.py
+++ b/content/en/api/hosts/code_snippets/result.api-hosts-search.py
@@ -1,11 +1,11 @@
 {
   'total_returned': 1,
-  "last_reported_time": 1560000000,
   'host_list': [
     {
       'name': 'i-deadbeef',
       'up': True,
       'is_muted': False,
+      "last_reported_time": 1560000000,
       'apps': [
         'agent'
       ],

--- a/content/en/api/hosts/code_snippets/result.api-hosts-search.rb
+++ b/content/en/api/hosts/code_snippets/result.api-hosts-search.rb
@@ -1,11 +1,11 @@
 ["200", {
   "total_returned": 1,
-  "last_reported_time": 1560000000,
   "host_list": [
     {
       "name": "i-deadbeef",
       "up": true,
       "is_muted": false,
+      "last_reported_time": 1560000000,
       "apps": [
         "agent"
       ],

--- a/content/en/api/hosts/code_snippets/result.api-hosts-search.sh
+++ b/content/en/api/hosts/code_snippets/result.api-hosts-search.sh
@@ -1,11 +1,11 @@
 {
   "total_returned": 1,
-  "last_reported_time": 1560000000,
   "host_list": [
     {
       "name": "i-deadbeef",
       "up": true,
       "is_muted": false,
+      "last_reported_time": 1560000000,
       "apps": [
         "agent"
       ],

--- a/content/en/api/hosts/code_snippets/result.api-hosts-totals.py
+++ b/content/en/api/hosts/code_snippets/result.api-hosts-totals.py
@@ -1,1 +1,1 @@
-{'total_up':1750,'total_active':1759, "last_reported_time": 1560000000}
+{'total_up':1750,'total_active':1759}

--- a/content/en/api/hosts/code_snippets/result.api-hosts-totals.rb
+++ b/content/en/api/hosts/code_snippets/result.api-hosts-totals.rb
@@ -1,1 +1,1 @@
-["200", {"total_up":1750,"total_active":1759, "last_reported_time": 1560000000}]
+["200", {"total_up":1750,"total_active":1759}]

--- a/content/en/api/hosts/code_snippets/result.api-hosts-totals.sh
+++ b/content/en/api/hosts/code_snippets/result.api-hosts-totals.sh
@@ -1,1 +1,1 @@
-{"total_up":1750,"total_active":1759, "last_reported_time": 1560000000}
+{"total_up":1750,"total_active":1759}


### PR DESCRIPTION
### What does this PR do?
Fixes host api results

### Motivation

1) The sample response for the totals endpoint shouldn't have changed. It should be reverted back to {'total_up':1750,'total_active':1759}

2) For the hosts response, the last_reported_time field belongs inside each individual object in the host list.

### Preview link

* https://docs-staging.datadoghq.com/gus/host-api/api/?lang=bash#host-totals
* https://docs-staging.datadoghq.com/gus/host-api/api/?lang=bash#search-hosts