### PR TITLE
[agent] Add instructions to update repo file for GPG key rotation

### DIFF
--- a/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
+++ b/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
@@ -61,7 +61,7 @@ Then check if the new key is trusted by following the steps in [How to check if 
 
 ### Yum repository file update
 
-Alternatively, on CentOS, RHEL and Amazon Linux, if a Yum repository file is used to define the Datadog repository (usually called `datadog.repo`), such as the following:
+Alternatively, on CentOS, RHEL, and Amazon Linux, if your Yum repository file used to define the Datadog repository (usually called `datadog.repo`) looks like this:
 
 ```
 [datadog]

--- a/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
+++ b/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
@@ -43,21 +43,24 @@ Otherwise, the command returns a non-0 exit code and the following output:
 package gpg-pubkey-e09422b3 is not installed
 ```
 
-## How to manually trust the new GPG key
+## How to trust the new GPG key
 
-### Manual import command
+This step is not required if hosts already trust the new key or if a recent version of an official installation method listed above is used.
 
-To manually trust the new key, run the following command on the host:
+### Import command
+
+Run the following commands on the host:
 
 ```bash
-rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+curl -o /tmp/DATADOG_RPM_KEY_E09422B3.public https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+rpm --import /tmp/DATADOG_RPM_KEY_E09422B3.public
 ```
 
 Then check if the new key is trusted by following the steps in [How to check if a host trusts the new GPG key](#how-to-check-if-a-host-trusts-the-new-gpg-key).
 
 ### Yum repository file update
 
-Alternatively, on CentOS or RHEL, if a Yum repository file is used to define the Datadog repository (usually called `datadog.repo`), such as the following:
+Alternatively, on CentOS, RHEL and Amazon Linux, if a Yum repository file is used to define the Datadog repository (usually called `datadog.repo`), such as the following:
 
 ```
 [datadog]
@@ -80,6 +83,7 @@ gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
        https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
 ```
 
+This method doesn't work on SUSE-based systems. [Use the import command instead](#import-command).
 
 [1]: https://yum.datadoghq.com/
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
+++ b/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
@@ -52,8 +52,9 @@ This step is not required if hosts already trust the new key or if a recent vers
 Run the following commands on the host:
 
 ```bash
-curl -o /tmp/DATADOG_RPM_KEY_E09422B3.public https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-rpm --import /tmp/DATADOG_RPM_KEY_E09422B3.public
+$ curl -o /tmp/DATADOG_RPM_KEY_E09422B3.public https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+
+$ rpm --import /tmp/DATADOG_RPM_KEY_E09422B3.public
 ```
 
 Then check if the new key is trusted by following the steps in [How to check if a host trusts the new GPG key](#how-to-check-if-a-host-trusts-the-new-gpg-key).
@@ -71,7 +72,7 @@ gpgcheck=1
 gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
 ```
 
-update it to add the new key (`https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public`) as one of the trusted keys:
+update it to add the new key `https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public` as one of the trusted keys:
 
 ```
 [datadog]
@@ -83,7 +84,7 @@ gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
        https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
 ```
 
-This method doesn't work on SUSE-based systems. [Use the import command instead](#import-command).
+**Note**: This method doesn't work on SUSE-based systems. [Use the import command instead](#import-command).
 
 [1]: https://yum.datadoghq.com/
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
+++ b/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
@@ -45,6 +45,8 @@ package gpg-pubkey-e09422b3 is not installed
 
 ## How to manually trust the new GPG key
 
+### Manual import command
+
 To manually trust the new key, run the following command on the host:
 
 ```bash
@@ -52,6 +54,32 @@ rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
 ```
 
 Then check if the new key is trusted by following the steps in [How to check if a host trusts the new GPG key](#how-to-check-if-a-host-trusts-the-new-gpg-key).
+
+### Yum repository file update
+
+Alternatively, on CentOS or RHEL, if a Yum repository file is used to define the Datadog repository (usually called `datadog.repo`), such as the following:
+
+```
+[datadog]
+name = Datadog, Inc.
+baseurl = https://yum.datadoghq.com/stable/6/x86_64/
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+```
+
+update it to add the new key (`https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public`) as one of the trusted keys:
+
+```
+[datadog]
+name = Datadog, Inc.
+baseurl = https://yum.datadoghq.com/stable/6/x86_64/
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+```
+
 
 [1]: https://yum.datadoghq.com/
 [2]: https://app.datadoghq.com/account/settings#agent


### PR DESCRIPTION
### What does this PR do?

Add instructions on how to update the Datadog repository file to trust the new key. Only has an effect on distributions using `yum`. `zypper` (openSuSE, SLES) doesn't use the `gpgkey` field by default, the keys have to be manually installed anyway.

### Motivation

Agent RPM package key rotation.

### Preview link

https://docs-staging.datadoghq.com/kylian.serrania/update-gpg-rotation-doc/agent/faq/rpm-gpg-key-rotation-agent-6/
