### PR TITLE
migrates remaining info from secrets agent repo

### DIFF
--- a/content/en/agent/guide/secrets-management.md
+++ b/content/en/agent/guide/secrets-management.md
@@ -63,7 +63,10 @@ In the above example, the secret’s handle is the string `user_array[1234]`.
 Secrets are resolved after [Autodiscovery][1] template variables are resolved, i.e. you can use them in a secret handle. For instance:
 
 ```
-“ENC[db_prod_password_%%host%%]”
+instances:
+  - server: %%host%%
+    user: ENC[db_prod_user_%%host%%]
+    password: ENC[db_prod_password_%%host%%]
 ```
 
 ### Providing an executable
@@ -75,6 +78,13 @@ The Agent caches secrets internally in memory to reduce the number of calls (use
 Since APM and Process Monitoring run in their own process/service, and since processes don't share memory, each needs to be able to load/decrypt secrets. Thus, if `datadog.yaml` contains secrets, each process might call the executable once. For example, storing the `api_key` as a secret in the `datadog.yaml` file with APM and Process Monitoring enabled might result in 3 calls to the secret backend.
 
 By design, the user-provided executable needs to implement any error handling mechanism that a user might require. Conversely, the Agent needs to be restarted if a secret has to be refreshed in memory (e.g. revoked password).
+
+Relying on a user-provided executable has multiple benefits:
+
+* Guaranteeing that the Agent does not attempt to load in memory parameters for which there isn't a secret handle.
+* Ability for the user to limit the visibility of the Agent to secrets that it needs (e.g., by restraining the acessable list of secrets in the key management backend)
+* Freedom and flexibility in allowing users to use any secrets management backend without having to rebuild the Agent.
+* Enabling each user to solve the initial trust problem from the Agent to their secrets management backend. This occurs in a way that leverages each user's preferred authentication method and fits into their continuous integration workflow.
 
 #### Configuration
 


### PR DESCRIPTION

### What does this PR do?
all the last stuff from the agent repo is now in the corpsite docs

### Motivation
agent single-sourcing okr~

### Preview link

https://docs-staging.datadoghq.com/cswatt/secrets-migration/agent/guide/secrets-management

### Additional Notes
<!-- Anything else we should know when reviewing?-->
