### PR TITLE
Autodiscovery Auto-conf documentation

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -225,28 +225,28 @@ main:
     identifier: "agent_autodiscovery"
     parent: "agent"
     weight: 4
+  - name: "Auto-Configuration"
+    url: "agent/autodiscovery/auto_conf/"
+    parent: "agent_autodiscovery"
+    weight: 401
   - name: "Integrations Templates"
     url: "agent/autodiscovery/integrations/"
     parent: "agent_autodiscovery"
-    weight: 401
+    weight: 402
   - name: "Container Identifier"
     url: "agent/autodiscovery/ad_identifiers/"
     parent: "agent_autodiscovery"
-    weight: 402
+    weight: 403
   - name: "Template Variables"
     url: "agent/autodiscovery/template_variables/"
     parent: "agent_autodiscovery"
-    weight: 403
+    weight: 404
   - name: "Tag Extraction"
     url: "agent/autodiscovery/tag/"
     parent: "agent_autodiscovery"
-    weight: 404
+    weight: 405
   - name: "Discovery Management"
     url: "agent/autodiscovery/management/"
-    parent: "agent_autodiscovery"
-    weight: 405
-  - name: "Troubleshooting"
-    url: "agent/autodiscovery/troubleshooting/"
     parent: "agent_autodiscovery"
     weight: 406
   - name: "Endpoints Checks"
@@ -257,6 +257,10 @@ main:
     url: "agent/autodiscovery/clusterchecks/"
     parent: "agent_autodiscovery"
     weight: 408
+  - name: "Troubleshooting"
+    url: "agent/autodiscovery/troubleshooting/"
+    parent: "agent_autodiscovery"
+    weight: 409
 
   ## AGENT - LOGS
 

--- a/content/en/agent/autodiscovery/_index.md
+++ b/content/en/agent/autodiscovery/_index.md
@@ -39,14 +39,15 @@ The configuration files are static, and any network-related options configured w
 
 The overall process of Datadog Agent Autodiscovery is:
 
-1. **Create and Load Integration template**: When the Agent starts with Autodiscovery enabled, it loads integration templates from all [available template sources][2]; along with the [Autodiscovery container identifiers][3]. Static configuration files aren't suitable for checks that collect data from ever-changing network endpoints like host or ports, so Autodiscovery uses [**Template Variables**][4] for integration template configuration. Those integration template configurations can be loaded into the Agent in 4 main ways:
+1. **Create and Load Integration template**: When the Agent starts with Autodiscovery enabled, it loads integration templates from all [available template sources][2]; along with the [Autodiscovery container identifiers][3]. Static configuration files aren't suitable for checks that collect data from ever-changing network endpoints like host or ports, so Autodiscovery uses [**Template Variables**][4] for integration template configuration. Those integration template configurations can be loaded into the Agent in 5 main ways:
 
-  * [Using a configuration file mounted within the Agent][5]
-  * [Using Key-Value Store][6]
-  * [Using Kubernetes Annotations][7]
-  * [Using Docker Labels][8]
+  * [Using auto-configuration file shipped with the Agent][5]
+  * [Using a configuration file mounted within the Agent][6]
+  * [Using Key-Value Store][7]
+  * [Using Kubernetes Annotations][8]
+  * [Using Docker Labels][9]
 
-2. **Apply an integration template to a specific container**: Unlike in a traditional Agent setup, the Agent doesn't run all checks all the time; it decides which checks to enable by inspecting all containers running on the same host as the Agent and the corresponding loaded integration templates. The Agent then watches for Kubernetes/Docker events&mdash;container creation, destruction, starts, and stops&mdash;and enables, disables, and regenerates static check configurations on such events. As the Agent inspects each running container, it checks if the container matches any of the [Autodiscovery container identifiers][3] from any loaded integration templates. For each match, the Agent generates a static check configuration by substituting the [Template Variables][9] with the matching container's specific values. Then it enables the check using the static configuration.
+2. **Apply an integration template to a specific container**: Unlike in a traditional Agent setup, the Agent doesn't run all checks all the time; it decides which checks to enable by inspecting all containers running on the same host as the Agent and the corresponding loaded integration templates. The Agent then watches for Kubernetes/Docker events&mdash;container creation, destruction, starts, and stops&mdash;and enables, disables, and regenerates static check configurations on such events. As the Agent inspects each running container, it checks if the container matches any of the [Autodiscovery container identifiers][3] from any loaded integration templates. For each match, the Agent generates a static check configuration by substituting the [Template Variables][10] with the matching container's specific values. Then it enables the check using the static configuration.
 
 ## How to set it up
 
@@ -107,7 +108,7 @@ KUBERNETES=true
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note**: For Kubernetes users, both a [CRI integration][10] and a [CRI-O integration][11] are available.
+**Note**: For Kubernetes users, both a [CRI integration][11] and a [CRI-O integration][12] are available.
 
 ### ECS Fargate Autodiscovery
 
@@ -136,10 +137,11 @@ ECS_FARGATE=true
 [2]: /agent/autodiscovery/integrations
 [3]: /agent/autodiscovery/ad_identifiers
 [4]: /agent/autodiscovery/template_variables
-[5]: /agent/autodiscovery/integrations/?tab=file#configuration
-[6]: /agent/autodiscovery/integrations/?tab=keyvaluestore#configuration
-[7]: /agent/autodiscovery/integrations/?tab=kubernetespodannotations#configuration
-[8]: /agent/autodiscovery/integrations/?tab=dockerlabel#configuration
-[9]: /agent/autodiscovery/template_variables
-[10]: /integrations/cri
-[11]: /integrations/crio
+[5]: /agent/autodiscovery/auto_conf
+[6]: /agent/autodiscovery/integrations/?tab=file#configuration
+[7]: /agent/autodiscovery/integrations/?tab=keyvaluestore#configuration
+[8]: /agent/autodiscovery/integrations/?tab=kubernetespodannotations#configuration
+[9]: /agent/autodiscovery/integrations/?tab=dockerlabel#configuration
+[10]: /agent/autodiscovery/template_variables
+[11]: /integrations/cri
+[12]: /integrations/crio

--- a/content/en/agent/autodiscovery/auto_conf.md
+++ b/content/en/agent/autodiscovery/auto_conf.md
@@ -1,0 +1,83 @@
+---
+title: Auto-Configuration
+kind: documentation
+disable_toc: true
+further_reading:
+- link: "/agent/autodiscovery/integrations"
+  tag: "Documentation"
+  text: "Create and load an Autodiscovery Integration Template"
+- link: "/agent/autodiscovery/management"
+  tag: "Documentation"
+  text: "Manage which Container to include in the Agent Autodiscovery"
+---
+
+The Agent, when running as a container, is trying by default to auto-discover other containers around it thanks to the `auto_conf.yaml` integrations configuration file shipped with it.
+
+**Note**: The auto-configurations only support default configuration for the integrations below. If you want to customize your Datadog-integration configuration, refer to the Integrations Templates documentation to learn how to configure your Autodiscovery:
+
+* [Using a configuration file mounted within the Agent][1]
+* [Using Key-Value Store][2]
+* [Using Kubernetes Annotations][3]
+* [Using Docker Labels][4]
+
+The following integrations are automatically discovered thanks to the `auto_conf.yaml` files shipped with the Agent:
+
+| Integration | Auto-configuration file |
+| ------ | -------- |
+| [Apache][5]  | [auto_conf.yaml][6] |
+| [Consul][7] | [auto_conf.yaml][8] |
+| [Coredns][9] | [auto_conf.yaml][10] |
+| [Couch][11] | [auto_conf.yaml][12] |
+| [Couchbase][13] | [auto_conf.yaml][14] |
+| [Elastic][15] | [auto_conf.yaml][16] |
+| [Etcd][17] | [auto_conf.yaml][18] |
+| [Harbor][19] | [auto_conf.yaml][20] |
+| [Kube APIserver][21] | [auto_conf.yaml][22] |
+| [KubeDNS][21] | [auto_conf.yaml][23] |
+| [Kubernetes State][21] | [auto_conf.yaml][24] |
+| [Kyototycoon][25] | [auto_conf.yaml][26] |
+| [MemCached][27] | [auto_conf.yaml][28] |
+| [Presto][29] | [auto_conf.yaml][30] |
+| [Redis][31] | [auto_conf.yaml][32] |
+| [Riak][33] | [auto_conf.yaml][34] |
+| [Tomcat][35] | [auto_conf.yaml][36] |
+
+For a given integration, the `auto_conf.yaml` covers all required parameters to setup an integration and the corresponding [autodiscovery templates variables][37] are already in place to take into account the containerized environment.
+
+[1]: /agent/autodiscovery/integrations/?tab=file#configuration
+[2]: /agent/autodiscovery/integrations/?tab=keyvaluestore#configuration
+[3]: /agent/autodiscovery/integrations/?tab=kubernetespodannotations#configuration
+[4]: /agent/autodiscovery/integrations/?tab=dockerlabel#configuration
+[5]: /integrations/apache
+[6]: https://github.com/DataDog/integrations-core/tree/master/apache/datadog_checks/apache/data
+[7]: /integrations/consul
+[8]: https://github.com/DataDog/integrations-core/blob/master/consul/datadog_checks/consul/data/auto_conf.yaml
+[9]: /integrations/coredns
+[10]: https://github.com/DataDog/integrations-core/blob/master/coredns/datadog_checks/coredns/data/auto_conf.yaml
+[11]: /integrations/couch
+[12]: https://github.com/DataDog/integrations-core/blob/master/couch/datadog_checks/couch/data/auto_conf.yaml
+[13]: /integrations/couchbase
+[14]: https://github.com/DataDog/integrations-core/tree/master/couchbase/datadog_checks/couchbase/data/auto_conf.yaml
+[15]: /integrations/elastic
+[16]: https://github.com/DataDog/integrations-core/blob/master/elastic/datadog_checks/elastic/data/auto_conf.yaml
+[17]: /integrations/etcd
+[18]: https://github.com/DataDog/integrations-core/blob/master/etcd/datadog_checks/etcd/data/auto_conf.yaml
+[19]: /integrations/harbor
+[20]: https://github.com/DataDog/integrations-core/blob/master/harbor/datadog_checks/harbor/data/auto_conf.yaml
+[21]: /integrations/kubernetes
+[22]: https://github.com/DataDog/integrations-core/blob/master/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/auto_conf.yaml
+[23]: https://github.com/DataDog/integrations-core/blob/master/kube_dns/datadog_checks/kube_dns/data/auto_conf.yaml
+[24]: https://github.com/DataDog/integrations-core/blob/master/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
+[25]: /integrations/kyototycoon
+[26]: https://github.com/DataDog/integrations-core/blob/master/kyototycoon/datadog_checks/kyototycoon/data/auto_conf.yaml
+[27]: /integrations/mcache
+[28]: https://github.com/DataDog/integrations-core/blob/master/mcache/datadog_checks/mcache/data/auto_conf.yaml
+[29]: /integrations/presto
+[30]: https://github.com/DataDog/integrations-core/blob/master/presto/datadog_checks/presto/data/auto_conf.yaml
+[31]: /integrations/redisdb
+[32]: https://github.com/DataDog/integrations-core/blob/master/redisdb/datadog_checks/redisdb/data/auto_conf.yaml
+[33]: /integrations/riak
+[34]: https://github.com/DataDog/integrations-core/blob/master/riak/datadog_checks/riak/data/auto_conf.yaml
+[35]: /integrations/tomcat
+[36]: https://github.com/DataDog/integrations-core/blob/master/tomcat/datadog_checks/tomcat/data/auto_conf.yaml
+[37]: /agent/autodiscovery/template_variables


### PR DESCRIPTION
### What does this PR do?
Adds autodiscovery auto-configuration documentation explaining:

* what is auto-conf
* which integrations are auto-conf ready
* how to override auto-conf
* how to disable auto-conf

### Motivation
Be more container focus moving foward.

### Preview link
