### PR TITLE
Adding link to main aws doc

### DIFF
--- a/content/en/logs/archives/s3.md
+++ b/content/en/logs/archives/s3.md
@@ -9,13 +9,13 @@ aliases:
 
 ## Overview
 
-Keeping your logs in a storage-optimized archive for longer periods of time is a great way to meet compliance requirements and retain auditability for ad-hoc investigations within budget. Once your logs are being archived for the long-term, you always [have access to them][1] should you ever need to investigate something unexpected or that might have happened a long time ago. 
+Keeping your logs in a storage-optimized archive for longer periods of time is a great way to meet compliance requirements and retain auditability for ad-hoc investigations within budget. Once your logs are being archived for the long-term, you always [have access to them][1] should you ever need to investigate something unexpected or that might have happened a long time ago.
 
 This guide shows you how to set up an archive for forwarding ingested logs to your own Amazon S3 bucket.
- 
+
 ## Create and Configure an S3 Bucket
 
-Go into your [AWS Console][2] and [create an S3 bucket][3] to send your archives to. Be careful not to make your bucket publicly readable. 
+Go into your [AWS Console][2] and [create an S3 bucket][3] to send your archives to. Be careful not to make your bucket publicly readable.
 
 Next, grant Datadog permissions to write log archives to your S3 bucket. US site users do this with role delegation. EU site users do this with the bucket policy.
 
@@ -24,7 +24,7 @@ Next, grant Datadog permissions to write log archives to your S3 bucket. US site
 
 1. Set up the [AWS integration][1] for the AWS account that holds your S3 bucket. This involves [creating a role][2] that Datadog can use to integrate with AWS Cloudwatch.
 
-2. Add the following permission statement to the IAM policies of your Datadog role (be sure to edit the bucket names and, if desired, specify the paths that contain your log archives). The `GetObject` and `ListBucket` permissions allow for [Rehydrating from Archives][3]. The `PutObject` permission is sufficient for uploading archives.
+2. Add the following two permission statements to [the IAM policies of your Datadog role][3] (be sure to edit the bucket names and, if desired, specify the paths that contain your log archives). The `GetObject` and `ListBucket` permissions allow for [Rehydrating from Archives][4]. The `PutObject` permission is sufficient for uploading archives.
 
     ```
     {
@@ -55,16 +55,17 @@ Next, grant Datadog permissions to write log archives to your S3 bucket. US site
     }
     ```
 
-3. Go to your [Archives page][4] in Datadog, and select the **Add a new archive** option at the bottom. Only Datadog users with admin status can complete this and the following step.
+3. Go to your [Archives page][5] in Datadog, and select the **Add a new archive** option at the bottom. Only Datadog users with admin status can complete this and the following step.
 
-4. Select the appropriate AWS account + role combination for your S3 bucket. Input your bucket name. Optionally input a prefix directory for all the content of your log archives. Save your archive, and you are finished. 
+4. Select the appropriate AWS account + role combination for your S3 bucket. Input your bucket name. Optionally input a prefix directory for all the content of your log archives. Save your archive, and you are finished.
 
     {{< img src="logs/archives/log_archives_s3_datadog_settings_role_delegation.png" alt="Set your S3 bucket info in Datadog" responsive="true" style="width:75%;">}}
-    
+
 [1]: https://app.datadoghq.com/account/settings#integrations/amazon-web-services
 [2]: /integrations/amazon_web_services/?tab=allpermissions#installation
-[3]: /logs/archives/rehydrating
-[4]: https://app.datadoghq.eu/logs/pipelines/archives
+[3]: /integrations/amazon_web_services/?tab=allpermissions#installation
+[4]: /logs/archives/rehydrating
+[5]: https://app.datadoghq.eu/logs/pipelines/archives
 {{% /tab %}}
 
 {{% tab "EU Site" %}}
@@ -111,7 +112,7 @@ Next, grant Datadog permissions to write log archives to your S3 bucket. US site
 
 From the moment that your archive settings are successfully configured in your Datadog account, all the logs that Datadog ingests are enriched by your processing Pipelines and subsequently forwarded to your S3 bucket for archiving.
 
-However, after creating or updating your archive configurations, it can take several minutes before the next archive upload is attempted, so **you should check back on your S3 bucket in 15 minutes** to make sure the archives have successfully been getting uploaded from your Datadog account. 
+However, after creating or updating your archive configurations, it can take several minutes before the next archive upload is attempted, so **you should check back on your S3 bucket in 15 minutes** to make sure the archives have successfully been getting uploaded from your Datadog account.
 
 ## Format of the S3 Archives
 
@@ -119,7 +120,7 @@ The log archives that Datadog forwards to your S3 bucket are in zipped (gzip) JS
 
 `/my/s3/prefix/dt=20180515/hour=14/archive_143201.1234.7dq1a9mnSya3bFotoErfxl.json.gz`
 
-This directory structure simplifies the process of querying your historical log archives based on their date. 
+This directory structure simplifies the process of querying your historical log archives based on their date.
 
 Within the zipped JSON file, each event's content is formatted as follows:
 
@@ -140,7 +141,7 @@ Within the zipped JSON file, each event's content is formatted as follows:
 
 ## Multiple S3 Archives
 
-Admins can route specific logs to an archive by adding a query in the archive's `filter` field. Logs enter the first archive whose filter they match on, so it is important to order your archives carefully. 
+Admins can route specific logs to an archive by adding a query in the archive's `filter` field. Logs enter the first archive whose filter they match on, so it is important to order your archives carefully.
 
 For example, if you create a first archive filtered to the `env:prod` tag and a second archive without any filter (the equivalent of `*`), all your production logs would go to one S3 bucket/path and the rest would go to the other.
 


### PR DESCRIPTION
### What does this PR do?

Adds link to main AWS integration tile in order to streamline more AWS S3 archives configuration instructions.

### Motivation
Customer feedback.

### Preview link

* https://docs-staging.datadoghq.com/gus/aws-s3-policy/logs/archives/s3/?tab=ussite#create-and-configure-an-s3-bucket