### PR TITLE
Updating examples to match K8s 1.16

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -221,7 +221,7 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 | [Ubuntu x86_64][3]                | Ubuntu 12.04+          |
 | [RedHat/CentOS x86_64][4]         | RedHat/CentOS 5+       |
 | [Docker][5]                       | Version 1.12+          |
-| [Kubernetes][6]                   | Version 1.3+           |
+| [Kubernetes][6]                   | Version 1.3 to 1.8     |
 | [SUSE Enterprise Linux x86_64][7] | SUSE 11 SP4+           |
 | [Fedora x86_64][8]                | Fedora 26+             |
 | [MacOS][9]                        | macOS 10.10+           |

--- a/content/en/agent/docker/log.md
+++ b/content/en/agent/docker/log.md
@@ -197,11 +197,14 @@ See the [multi-line processing rule documentation][1] to get more pattern exampl
 If you are running Kubernetes, pod annotations can be used.
 
 ```
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: nginx
 spec:
+  selector:
+    matchLabels:
+      app: webapp
   template:
     metadata:
       annotations:
@@ -281,7 +284,7 @@ ac_exclude = ["name:datadog-agent"]
 
 ## Short Lived containers
 
-For a Docker environment, the Agent receives container updates in real time through Docker events. The Agent extracts and updates the configuration from the container labels (Autodiscovery) every 1 seconds. 
+For a Docker environment, the Agent receives container updates in real time through Docker events. The Agent extracts and updates the configuration from the container labels (Autodiscovery) every 1 seconds.
 
  Since Agent v6.14+, the Agent collects logs for all containers (running or stopped) which means that short lived containers logs that have started and stopped in the past second are still collected as long as they are not removed.
 

--- a/content/en/agent/guide/agent-5-kubernetes-basic-agent-usage.md
+++ b/content/en/agent/guide/agent-5-kubernetes-basic-agent-usage.md
@@ -9,7 +9,7 @@ aliases:
 {{< img src="integrations/kubernetes/k8sdashboard.png" alt="Kubernetes Dashboard" responsive="true" >}}
 
 <div class="alert alert-warning">
-The Datadog Agent v5 is supported up to Kubernetes version 1.6, for latest version of Kubernetes use the Datadog Agent v6.
+The Datadog Agent v5 is supported up to Kubernetes version 1.8, for latest version of Kubernetes use the Datadog Agent v6.
 </div>
 
 ## Overview

--- a/content/en/agent/guide/agent-5-kubernetes-basic-agent-usage.md
+++ b/content/en/agent/guide/agent-5-kubernetes-basic-agent-usage.md
@@ -8,6 +8,10 @@ aliases:
 
 {{< img src="integrations/kubernetes/k8sdashboard.png" alt="Kubernetes Dashboard" responsive="true" >}}
 
+<div class="alert alert-warning">
+The Datadog Agent v5 is supported up to Kubernetes version 1.6, for latest version of Kubernetes use the Datadog Agent v6.
+</div>
+
 ## Overview
 
 Get metrics from Kubernetes in real time to:

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -58,11 +58,14 @@ echo -n <DD_API_KEY> | base64
 # data:
 #   api-key: "<YOUR_BASE64_ENCODED_DATADOG_API_KEY>"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: datadog-agent
 spec:
+  selector:
+    matchLabels:
+      app: datadog-agent
   template:
     metadata:
       labels:
@@ -211,11 +214,11 @@ To enable [Log collection][10] with your DaemonSet:
             value: "true"
         - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
             value: "true"
-        - name: DD_AC_EXCLUDE 
+        - name: DD_AC_EXCLUDE
             value: "name:datadog-agent"
     (...)
     ```
-    
+
 Setting `DD_AC_EXCLUDE` prevents the Datadog Agent from collecting and sending its own logs. Remove this parameter if you want to collect the Datadog Agent logs.
 
 2. Mount the Docker socket or logs directories (`/var/log/pods` and `/var/lib/docker/containers` if docker runtime)
@@ -318,7 +321,7 @@ For Agent v6.12+, short lived container logs (stopped or crashed) are automatica
 {{% /tab %}}
 {{% tab "Docker Socket" %}}
 
-For a Docker environment, the Agent receives container updates in real time through Docker events. The Agent extracts and updates the configuration from the container labels (Autodiscovery) every 1 seconds. 
+For a Docker environment, the Agent receives container updates in real time through Docker events. The Agent extracts and updates the configuration from the container labels (Autodiscovery) every 1 seconds.
 Since Agent v6.14+, the Agent collects logs for all containers (running or stopped) which means that short lived containers logs that have started and stopped in the past second are still collected as long as they are not removed.
 
 {{% /tab %}}

--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -152,11 +152,14 @@ In a Docker environment, use the label `com.datadoghq.ad.logs` on your container
 In a Kubernetes environment, use the pod annotation `ad.datadoghq.com` on your pod to specify the `log_processing_rules`, for example:
 
 ```
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: postgres
 spec:
+  selector:
+    matchLabels:
+      app: database
   template:
     metadata:
       annotations:

--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -54,12 +54,15 @@ To enable network performance monitoring with the Datadog Agent, use the followi
 To enable network performance monitoring with Kubernetes, use the following configuration:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: datadog-agent
   namespace: default
 spec:
+  selector:
+    matchLabels:
+      app: datadog-agent
   template:
     metadata:
       labels:

--- a/content/fr/agent/docker/log.md
+++ b/content/fr/agent/docker/log.md
@@ -196,11 +196,14 @@ Consultez la [documentation relative aux règles de traitement multiligne][1] po
 Si vous exécutez Kubernetes, vous pouvez utiliser les annotations de pod.
 
 ```
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: nginx
 spec:
+  selector:
+    matchLabels:
+      app: webapp
   template:
     metadata:
       annotations:

--- a/content/fr/agent/kubernetes/daemonset_setup.md
+++ b/content/fr/agent/kubernetes/daemonset_setup.md
@@ -14,7 +14,7 @@ further_reading:
 aliases:
   - /agent/kubernetes/apm
 ---
-Tirez profit des DaemonSets pour déployer l'Agent Datadog sur l'ensemble de vos nœuds (ou sur un nœud donné grâce [aux nodeSelectors][1]). 
+Tirez profit des DaemonSets pour déployer l'Agent Datadog sur l'ensemble de vos nœuds (ou sur un nœud donné grâce [aux nodeSelectors][1]).
 
 *Si vous ne pouvez pas utiliser de DaemonSets pour votre cluster Kubernetes, [installez l'Agent Datadog][2] en tant que déploiement sur chaque nœud Kubernetes.*
 
@@ -57,11 +57,14 @@ echo -n <CLÉ_API_DD> | base64
 # data:
 #   api-key: "<VOTRE_CLÉ_D_API_DATADOG_CHIFFRÉE_EN_BASE64>"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: datadog-agent
 spec:
+  selector:
+    matchLabels:
+      app: datadog-agent
   template:
     metadata:
       labels:
@@ -93,7 +96,7 @@ spec:
             #     name: datadog-secret
             #     key: api-key
 
-          ## Définissez DD_SITE sur datadoghq.eu pour envoyer les données de votre Agent au site européen de Datadog 
+          ## Définissez DD_SITE sur datadoghq.eu pour envoyer les données de votre Agent au site européen de Datadog
           - name: DD_SITE
             value: "datadoghq.com"
 
@@ -210,7 +213,7 @@ Pour activer la [collecte de logs][10] avec votre DaemonSet :
             value: "true"
         - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
             value: "true"
-        - name: DD_AC_EXCLUDE 
+        - name: DD_AC_EXCLUDE
             value: "name:datadog-agent"
     (...)
     ```

--- a/content/fr/logs/log_collection/docker.md
+++ b/content/fr/logs/log_collection/docker.md
@@ -193,11 +193,14 @@ Consultez la [documentation relative aux règles de traitement multiligne][1] po
 Si vous exécutez Kubernetes, vous pouvez utiliser les annotations de pod.
 
 ```
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: nginx
 spec:
+  selector:
+    matchLabels:
+      app: webapp
   template:
     metadata:
       annotations:
@@ -279,6 +282,6 @@ ac_exclude = ["name:datadog-agent"]
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /fr/integrations/journald/
+[1]: /fr/integrations/journald
 [2]: /fr/agent/autodiscovery
 [3]: /fr/agent/autodiscovery/integrations/?tab=kubernetes


### PR DESCRIPTION
### What does this PR do?

Updates examples in the documentation to match the new K8s 1.16 release breaking changes.

### Motivation
Current examples are broken for K8s 1.16

