### PR TITLE
Zach/add a11y package

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,19 +95,6 @@ index_algolia_preview:
   only:
     - /.+?\/[a-zA-Z0-9_-]+/
 
-test_pa11y:
-  <<: *base_template
-  stage: post-deploy
-  environment: "preview"
-  dependencies:
-    - build_preview
-  script:
-    - cp -r /etc/node_modules .
-    - node ./local/bin/js/pa11y.js --env preview --dd_api_key $(get_secret 'dd-demo-api-key')
-  only:
-    - /.+?\/[a-zA-Z0-9_-]+/
-
-
 # ================== live ================== #
 build_live:
   <<: *base_template
@@ -211,6 +198,18 @@ test_missing_tms_live:
     - check_missing_tms
   only:
     - master
+
+test_pa11y:
+  <<: *base_template
+  stage: post-deploy
+  environment: "live"
+  dependencies:
+    - build_live
+  script:
+    - cp -r /etc/node_modules .
+    - node ./local/bin/js/pa11y.js --env live --dd_api_key $(get_secret 'dd_api_key')
+  only:
+    - schedules
 
 #rollback_live:
 #  <<: *base_template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:zach_add-a11y-package
   tags:
     - "runner:main"
     - "size:large"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,6 +95,19 @@ index_algolia_preview:
   only:
     - /.+?\/[a-zA-Z0-9_-]+/
 
+test_pa11y:
+  <<: *base_template
+  stage: post-deploy
+  environment: "preview"
+  dependencies:
+    - build_preview
+  script:
+    - cp -r /etc/node_modules .
+    - node ./local/bin/js/pa11y.js --env preview --dd_api_key $(get_secret 'dd-demo-api-key')
+  only:
+    - /.+?\/[a-zA-Z0-9_-]+/
+
+
 # ================== live ================== #
 build_live:
   <<: *base_template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:zach_add-a11y-package
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
   tags:
     - "runner:main"
     - "size:large"

--- a/local/bin/js/pa11y.js
+++ b/local/bin/js/pa11y.js
@@ -1,5 +1,21 @@
 const runPa11y = require('a11y');
 
+// pa11y config options
+const pa11yConfig = {
+    chromeLaunchConfig: {
+        ignoreHTTPSErrors: false,
+        executablePath: process.env.CHROME_BIN || null, // allows puppeteer to be run in docker image alpine
+        args: ['--no-sandbox'] // for launching a "headless" chrome browser in CI
+    },
+    timeout: 200000,
+    ignore: [
+        'WCAG2AA.Principle1.Guideline1_3.1_3_1.H49.AlignAttr', // align="left" attribute added by hugo in md tables. can't remove.
+        'WCAG2AA.Principle3.Guideline3_2.3_2_2.H32.2', // for mkto forms without 'submit' attribute
+        'WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail', // color contrast issues, too many incorrect results
+        'WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputSearch.Name' // can't update Algolia's searchBox componenet to include this attribute
+    ]
+};
+
 // some html files in dist have weird characters, pa11y fails to read them, must exclude.
 // remove directories with many html files that share the same layout and add only single files from each to speed up pa11y process
 const directoryExclusions = [
@@ -46,9 +62,15 @@ const includeUrls = [
     'videos/anomaly_detection/index.html'
 ];
 
+// some results will contain errors from third parties, or should be excluded from pa11y output.
+// If you find an error from a 3rd party, exclude it by adding the string in this array from the issue.context result
+const filterBadResults = ['bid.g.doubleclick.net', '_hj'];
+
 const options = {
+    pa11yConfig,
     directoryExclusions, // any directories to exclude
-    includeUrls, // any specific html files to include
+    includeUrls, // any specific html files to include,
+    filterBadResults,
     publicDir: 'public', // output directory name
     baseUrl: 'https://docs.datadoghq.com', // site baseUrl to test
     outputFileName: 'docs-pa11y-output',

--- a/local/bin/js/pa11y.js
+++ b/local/bin/js/pa11y.js
@@ -1,139 +1,59 @@
-const pa11y = require('pa11y');
-const path = require('path');
-const fs = require('fs');
-const asyncPool = require('tiny-async-pool');
-const { Parser } = require('json2csv');
+const runPa11y = require('a11y');
 
-const fileArray = [];
-
-// some html files in public/ have weird characters, pa11y fails to read them, must exclude.
-const fileExclusions = [
-    // '&ap=434&fe=21625&dc=11210&at=GUdVQ18ZT08%3D&jsonp=NREUM.setToken',
-    // '%E2%80%8E',
-    // '%C2%A0%E2%80%A6',
-    // '%EF%BC%89%E4%B8%8A',
-    // '%20%5Bon%20our%20site%5D',
-    // 'content-assets'
+// some html files in dist have weird characters, pa11y fails to read them, must exclude.
+// remove directories with many html files that share the same layout and add only single files from each to speed up pa11y process
+const directoryExclusions = [
+    'api',
+    'fr',
+    'en',
+    'ja',
+    'config',
+    'account_management',
+    'agent',
+    'basic_agent_usage',
+    'developers',
+    'examples',
+    'getting_started',
+    'graphing',
+    'guides',
+    'infrastructure',
+    'integrations',
+    'logs',
+    'monitors',
+    'synthetics',
+    'tracing',
+    'videos'
 ];
 
-// create array of all html files in starting folder
-fromDir('./public', '.html');
-
-function fromDir(startPath, filter) {
-    // console.log('Starting from dir '+startPath+'/');
-
-    if (!fs.existsSync(startPath)) {
-        console.log('no dir ', startPath);
-        return;
-    }
-
-    const files = fs.readdirSync(startPath);
-    for (let i = 0; i < files.length; i++) {
-        const filename = path.join(startPath, files[i]);
-        const stat = fs.lstatSync(filename);
-        if (stat.isDirectory()) {
-            fromDir(filename, filter); // recurse
-        } else if (filename.indexOf(filter) >= 0) {
-            const absFilePath = `./${filename}`;
-
-            const isValidHTML = fileExclusions.every(function(
-                currVal,
-                index,
-                arr
-            ) {
-                // console.log('curr val: ', currVal);
-                if (absFilePath.includes(currVal)) {
-                    return false;
-                }
-                return true;
-            });
-
-            if (
-                filename &&
-                typeof filename === 'string' &&
-                fs.existsSync(absFilePath) &&
-                isValidHTML
-            ) {
-                fileArray.push(absFilePath);
-            }
-        }
-    }
-}
-
-const testUrls = [
-    './public/about/press/index.html',
-    './public/about/team/index.html'
+// html files to include
+const includeUrls = [
+    'api/index.html',
+    'account_management/api-app-keys/index.html',
+    'agent/apm/index.html',
+    'api/authentication/index.html',
+    'basic_agent_usage/index.html',
+    'developers/guide/index.html',
+    'examples/aws-metric/index.html',
+    'getting_started/agent/index.html',
+    'graphing/dashboards/index.html',
+    'guides/alerting/index.html',
+    'infrastructure/index.html',
+    'integrations/kubernetes/index.html',
+    'logs/analytics/index.html',
+    'monitors/check_summary/index.html',
+    'synthetics/api_tests/index.html',
+    'tracing/advanced/index.html',
+    'videos/anomaly_detection/index.html'
 ];
 
-const pa11yConfig = {
-    // rules to ignore
-    ignore: [
-        'WCAG2AA.Principle1.Guideline1_3.1_3_1.H49.AlignAttr', // align="left" attribute added by hugo in md tables. can't remove. 
-        'WCAG2AA.Principle3.Guideline3_2.3_2_2.H32.2', // for mkto forms without 'submit' attribute
-        'WCAG2AA.Principle2.Guideline2_4.2_4_1.G1,G123,G124.NoSuchID' // we use id hashes for filtering, should change to query params in future
-    ]
-}
+const options = {
+    directoryExclusions, // any directories to exclude
+    includeUrls, // any specific html files to include
+    publicDir: 'public', // output directory name
+    baseUrl: 'http://docs.datadoghq.com', // site baseUrl to test
+    outputFileName: 'docs-pa11y-output',
+    outputFileType: 'csv', // csv or json
+    metricName: 'test.pa11y.num_errors' // metric name
+};
 
-// takes each url and runs pa11y command with config options.
-function pally(url){
-    return pa11y(url, pa11yConfig)
-}
-
-
-/**
-* Promise pool function to run pa11y command (which returns a promise)
-* on array of urls
-*
-* @param {Number} - concurrency limit
-* @param {Array} - array of urls on whic to run pa11y
-* @param {Function} - Iterator function to be called for each url
-*/ 
-asyncPool(3, fileArray, pally).then(results => {
-
-    const cleanResults = removeBadResults(results);
-    const numIssues = cleanResults.reduce(
-        (accum, currVal) => accum + currVal.issues.length,
-        0
-    );
-
-    console.log(
-        'Number of accessibility issues across all pages are: ',
-        numIssues
-    );
-
-    const fields = [
-        'documentTitle',
-        'pageUrl',
-        'issues.type',
-        'issues.code',
-        'issues.message',
-        'issues.context',
-        'issues.selector'
-    ];
-    const json2csvParser = new Parser({ fields, unwind: ['issues'] });
-    const csv = json2csvParser.parse(cleanResults);
-
-    fs.writeFile('pa11y-output.csv', csv, function(err) {
-        // currently saves file to app's root directory
-        if (err) throw err;
-        console.log('file saved');
-    });
-}).catch(err => {
-    console.log(err);
-})
-
-// sometimes results come back with null issues and a chrome error, need to filter
-function removeBadResults(results) {
-    const cleanResults = [];
-    for (let i = 0; i <= results.length; i += 1) {
-        if (results[i]) {
-            if (results[i]['issues'].length !== 0) {
-                if (results[i]['pageUrl'] !== 'chrome-error://chromewebdata/') {
-                    cleanResults.push(results[i]);
-                }
-            }
-        }
-    }
-
-    return cleanResults;
-}
+runPa11y(options);

--- a/local/bin/js/pa11y.js
+++ b/local/bin/js/pa11y.js
@@ -50,7 +50,7 @@ const options = {
     directoryExclusions, // any directories to exclude
     includeUrls, // any specific html files to include
     publicDir: 'public', // output directory name
-    baseUrl: 'http://docs.datadoghq.com', // site baseUrl to test
+    baseUrl: 'https://docs.datadoghq.com', // site baseUrl to test
     outputFileName: 'docs-pa11y-output',
     outputFileType: 'csv', // csv or json
     metricName: 'test.pa11y.num_errors' // metric name

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@babel/polyfill": "^7.4.4",
-        "a11y": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/zach/add-pa11y-package/a11y-v1.0.11.tgz",
+        "a11y": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/zach/add-pa11y-package/a11y-v1.0.12.tgz",
         "algoliasearch": "3.33.0",
         "bootstrap": ">=4.1.2",
         "del": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     },
     "dependencies": {
         "@babel/polyfill": "^7.4.4",
+        "a11y": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/zach/add-pa11y-package/a11y-v1.0.11.tgz",
         "algoliasearch": "3.33.0",
         "bootstrap": ">=4.1.2",
         "del": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@babel/polyfill": "^7.4.4",
-        "a11y": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/zach/add-pa11y-package/a11y-v1.0.12.tgz",
+        "a11y": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/a11y-v1.0.0.tgz",
         "algoliasearch": "3.33.0",
         "bootstrap": ">=4.1.2",
         "del": "4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -916,9 +916,9 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"a11y@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/zach/add-pa11y-package/a11y-v1.0.12.tgz":
-  version "1.0.12"
-  resolved "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/zach/add-pa11y-package/a11y-v1.0.12.tgz#b30ce8f6c9a002bd5a3472bfcf72ed07c20eeac1"
+"a11y@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/a11y-v1.0.0.tgz":
+  version "1.0.0"
+  resolved "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/a11y-v1.0.0.tgz#da31141f85fda51a94b429d27652afe44280bce6"
   dependencies:
     aws-sdk "^2.531.0"
     dogapi "^2.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -916,6 +916,19 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"a11y@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/zach/add-pa11y-package/a11y-v1.0.11.tgz":
+  version "1.0.11"
+  resolved "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/zach/add-pa11y-package/a11y-v1.0.11.tgz#d1639018d907fb12410ebd0d63a2d94fffceee7a"
+  dependencies:
+    aws-sdk "^2.531.0"
+    dogapi "^2.8.3"
+    glob "^7.1.4"
+    json2csv "^4.5.3"
+    pa11y "^5.2.0"
+    request "^2.88.0"
+    tiny-async-pool "^1.0.4"
+    yargs "^14.0.0"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -1300,6 +1313,21 @@ autoprefixer@^9.6.1:
     postcss "^7.0.17"
     postcss-value-parser "^4.0.0"
 
+aws-sdk@^2.531.0:
+  version "2.534.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.534.0.tgz#72eac35c58651eb533044551e5fd06a7a8c8be79"
+  integrity sha512-0wm8mQg+N7vzOaFiM8wwvUXqWayf1ebqfi/SYVygASA79SnRe16pT73X2kEB/DbhXo+487Hf9p3hBGAsjoLcIA==
+  dependencies:
+    buffer "4.9.1"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -1405,6 +1433,11 @@ big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
+
+bignumber.js@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-1.1.1.tgz#1a415d9ac014c13256af1feed9d1a3e5717a8cf7"
+  integrity sha1-GkFdmsAUwTJWrx/u2dGj5XF6jPc=
 
 bin-check@^4.1.0:
   version "4.1.0"
@@ -1629,7 +1662,7 @@ buffer-xor@^1.0.3:
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
-buffer@^4.3.0:
+buffer@4.9.1, buffer@^4.3.0:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
   integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
@@ -2762,6 +2795,17 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dogapi@^2.8.3:
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/dogapi/-/dogapi-2.8.3.tgz#f7b2210bb03e17b54bd7c9fce7894152efc15481"
+  integrity sha512-CzJIllAcv17H8hylyuljldJv+2EGal5+Fa+gsXFrXDo1zl8cq9jk7FDCXDqH4C/tPNAusS9ckV8wuBFtCiuTUg==
+  dependencies:
+    extend "^3.0.0"
+    json-bigint "^0.1.4"
+    lodash "^4.17.10"
+    minimist "^1.1.1"
+    rc "^1.2.8"
+
 dom-serializer@0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.1.tgz#13650c850daffea35d8b626a4cfc4d3a17643fdb"
@@ -3281,7 +3325,7 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-events@^1.1.0:
+events@1.1.1, events@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
@@ -3443,7 +3487,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.2:
+extend@^3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -4331,7 +4375,7 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
   dependencies:
     postcss "^7.0.14"
 
-ieee754@^1.1.4:
+ieee754@1.1.13, ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
@@ -4852,6 +4896,11 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
+
 jquery@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
@@ -4921,6 +4970,13 @@ jshint@2.10.2:
     shelljs "0.3.x"
     strip-json-comments "1.0.x"
 
+json-bigint@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-0.1.4.tgz#b5d40b8a9009e92f157f7c079db097001830e01e"
+  integrity sha1-tdQLipAJ6S8Vf3wHnbCXABgw4B4=
+  dependencies:
+    bignumber.js "~1.1.1"
+
 json-buffer@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
@@ -4955,6 +5011,15 @@ json2csv@^4.5.2:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/json2csv/-/json2csv-4.5.2.tgz#75f0808cb89ed8ef7e338445a510a3cd3e385dfe"
   integrity sha512-Te2Knce3VfLKyurH3AolM6Y781ZE+R3jQ+0YQ0HYLiubyicST/19vML24e1dpScaaEQb+1Q1t5IcGXr6esM9Lw==
+  dependencies:
+    commander "^2.15.1"
+    jsonparse "^1.3.1"
+    lodash.get "^4.4.2"
+
+json2csv@^4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/json2csv/-/json2csv-4.5.3.tgz#74cdde618929317261dfe2b97677a5e891bdc263"
+  integrity sha512-tg5sm25TOwgMsPUixPFmmuOUFtVCj4p57XipoE8gi/ejNftce/0d8LBgWnCkjF4HsLDsFzszdbIEV6mnK0WfNg==
   dependencies:
     commander "^2.15.1"
     jsonparse "^1.3.1"
@@ -5216,7 +5281,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.15, lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@~4.17.10, lodash@~4.17.11:
+lodash@4.17.15, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@~4.17.10, lodash@~4.17.11:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -5497,7 +5562,7 @@ minimist@1.1.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.0.tgz#cdf225e8898f840a258ded44fc91776770afdc93"
   integrity sha1-zfIl6ImPhAolje1E/JF3Z3Cv3JM=
 
-minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
@@ -7340,7 +7405,7 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.2.7:
+rc@^1.2.7, rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -7792,7 +7857,12 @@ sass-loader@^7.1.0:
     pify "^4.0.1"
     semver "^6.3.0"
 
-sax@^1.2.4, sax@~1.2.4:
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0, sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -8831,6 +8901,14 @@ url-to-options@^1.0.1:
   resolved "https://registry.yarnpkg.com/url-to-options/-/url-to-options-1.0.1.tgz#1505a03a289a48cbd7a434efbaeec5055f5633a9"
   integrity sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -8875,6 +8953,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+uuid@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 uuid@^3.3.2:
   version "3.3.3"
@@ -9110,6 +9193,19 @@ ws@^6.0.0, ws@^6.1.0:
   dependencies:
     async-limiter "~1.0.0"
 
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
+
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
@@ -9152,7 +9248,7 @@ yaml-lint@^1.2.4:
     lodash.snakecase "^4.1.1"
     nconf "^0.10.0"
 
-yargs-parser@^13.1.0:
+yargs-parser@^13.1.0, yargs-parser@^13.1.1:
   version "13.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.1.tgz#d26058532aa06d365fe091f6a1fc06b2f7e5eca0"
   integrity sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==
@@ -9183,6 +9279,23 @@ yargs@13.2.4:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.0"
+
+yargs@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.0.0.tgz#ba4cacc802b3c0b3e36a9e791723763d57a85066"
+  integrity sha512-ssa5JuRjMeZEUjg7bEL99AwpitxU/zWGAGpdj0di41pOEmJti8NR6kyUIJBkR78DTYNPZOU08luUo0GTHuB+ow==
+  dependencies:
+    cliui "^5.0.0"
+    decamelize "^1.2.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^13.1.1"
 
 yargs@^3.19.0:
   version "3.32.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -916,9 +916,9 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"a11y@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/zach/add-pa11y-package/a11y-v1.0.11.tgz":
-  version "1.0.11"
-  resolved "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/zach/add-pa11y-package/a11y-v1.0.11.tgz#d1639018d907fb12410ebd0d63a2d94fffceee7a"
+"a11y@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/zach/add-pa11y-package/a11y-v1.0.12.tgz":
+  version "1.0.12"
+  resolved "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/zach/add-pa11y-package/a11y-v1.0.12.tgz#b30ce8f6c9a002bd5a3472bfcf72ed07c20eeac1"
   dependencies:
     aws-sdk "^2.531.0"
     dogapi "^2.8.3"


### PR DESCRIPTION
### What does this PR do?
Adds [pa11y](https://github.com/pa11y/pa11y) to Docs CI. Pa11y is a website accessibility (a11y) tool that uses [HTML Code Sniffer](https://squizlabs.github.io/HTML_CodeSniffer/) to scrape live urls and output errors and warnings in accordance with [WCAG](https://www.w3.org/TR/WCAG/) guidelines.

By default the pa11y script was written to read all html files from the `public` folder, but this would take the script way too long to complete and give redundant errors.  For example, pa11y doesn't need to run for every language directory (`/fr`, /`ja`) or every `agent/` page as they have similar layouts. For starters, we can check top-level pages, fixing those a11y errors, and add more pages as necessary. This can be adjusted in the pa11y.js script. 

A CSV file is generated that lives in s3 bucket `origin-static-assets` under `pa11y-output-docs` and contains the pa11y errors for specific urls, right down to the HTML element causing the error.

Some errors will be layout specific and need to be handled or approved by Websites. Other issues such as anchors tags with no corresponding ID, or img alt attributes, can be handled by Community.

This job will be run during the nightly master Docs build.

Note: pa11y is live currently on Corpsite and outputs a metric with the number of pa11y errors to DD, shown on the dashboard: https://dd-corpsite.datadoghq.com/dashboard/u3m-7ve-2yv/corpsite-accessibility-pa11y-issues?from_ts=1568212013417&live=true&tile_size=m&to_ts=1568816813417

### Motivation
This tool will help the Docs site to be ADA compliant by fixing accessibility issues sitewide



