### PR TITLE
Made it clear that logs agent whitelisting is for TCP traffic

### DIFF
--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -24,7 +24,7 @@ further_reading:
 * The destination for:
     * [APM][1] data is `trace.agent.datadoghq.com`
     * [Live Containers][2] data is `process.datadoghq.com`
-    * [Logs][3] data is `agent-intake.logs.datadoghq.com `
+    * [Logs][3] data is `agent-intake.logs.datadoghq.com ` for TCP traffic
     * All other Agent data:
         * **Agents < 5.2.0** `app.datadoghq.com`
         *  **Agents >= 5.2.0** `<version>-app.agent.datadoghq.com`
@@ -61,8 +61,8 @@ The information is structured as JSON following this schema:
 
 Each section has a dedicated endpoint at `https://ip-ranges.datadoghq.com/<section>.json` or `https://ip-ranges.datadoghq.eu/<section>.json`, for example:
 
-* [https://ip-ranges.datadoghq.com/logs.json][6] for the IPs used to receive logs data
-* [https://ip-ranges.datadoghq.eu/logs.json][7] for the IPs used to receive logs data for Datadog EU
+* [https://ip-ranges.datadoghq.com/logs.json][6] for the IPs used to receive logs data over TCP
+* [https://ip-ranges.datadoghq.eu/logs.json][7] for the IPs used to receive logs data over TCP for Datadog EU
 * [https://ip-ranges.datadoghq.com/apm.json][8] for the IPs used to receive APM data
 * [https://ip-ranges.datadoghq.eu/apm.json][9] for the IPs used to receive APM data for Datadog EU
 
@@ -83,7 +83,7 @@ Open the following ports in order to benefit from all the Agent functionalities:
 
   * `443/tcp`: port for most Agent data. (Metrics, APM, Live Processes/Containers)
   * `123/udp`: NTP - [More details on the importance of NTP][1].
-  * `10516/tcp`: port for the [Log collection][2]
+  * `10516/tcp`: port for the [Log collection][2] over TCP
   * `10255/tcp`: port for the [Kubernetes http kubelet][3]
   * `10250/tcp`: port for the [Kubernetes https kubelet][3]
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Specified that whitelisting, port `10516` and `agent-intake.logs.datadoghq.com` are used for TCP traffic to avoid confusion for customers.

### Motivation
As we are rolling out new load balancers and changing the whitelisting, we want customer to understand when they are impacted.

### Preview link
<!-- Impacted pages preview links-->


<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ajacquemot/logs_agent_network_tcp_traffic/agent/guide/network

### Additional Notes
<!-- Anything else we should know when reviewing?-->
