### PR TITLE
removed note about broken feature

### DIFF
--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -36,8 +36,6 @@ Notifications are a key component of any [monitor][1]. You want to make sure the
 
 3. Optionally enable **monitor renotification**. This option is useful to remind your team that a problem is not solved until the monitor is marked as [resolved][3]. If enabled, an escalation message can be configured to send any time the monitor renotifies. The original message is included as well.
 
-***Note:*** *To avoid notification storms, Datadog groups notifications with the same monitor ID and alert type in 20 second buckets. The first two notifications in the group within a 20 second bucket are sent as normal. All additional notifications within that 20 second window are sent as a single message.*
-
 ## Variables
 
 Use variables to customize your monitor notifications, the available variables are:


### PR DESCRIPTION
### What does this PR do?
Removes a note about the avalanche feature that is broken and won't be fixed near term.  Will add back with updated language when it's repaired/redesigned.

### Motivation
Customer pointed it out 

### Preview link
https://docs-staging.datadoghq.com/bcon/remove-avalanche-note/monitors/notifications.md