### PR TITLE
update pa11y metric name

### DIFF
--- a/local/bin/js/pa11y.js
+++ b/local/bin/js/pa11y.js
@@ -75,7 +75,7 @@ const options = {
     baseUrl: 'https://docs.datadoghq.com', // site baseUrl to test
     outputFileName: 'docs-pa11y-output',
     outputFileType: 'csv', // csv or json
-    metricName: 'test.pa11y.num_errors' // metric name
+    metricName: 'docs.pa11y.num_errors' // metric name
 };
 
 runPa11y(options);


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
change metric name for pa11y accessibility errors to align with corpsite. 


