### PR TITLE
removing NPM from infra section

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -453,10 +453,6 @@ main:
     url: "graphing/infrastructure/process/"
     parent: "graphing_infrastructure"
     weight: 604
-  - name: "Network Performance Monitor"
-    url: "graphing/infrastructure/network_performance_monitor/"
-    parent: "graphing_infrastructure"
-    weight: 605
   - name: "Serverless"
     url: "graphing/infrastructure/serverless/"
     parent: "graphing_infrastructure"


### PR DESCRIPTION
### What does this PR do?
removing NPM from infra section in the toc

### Motivation
broken link

### Preview link

https://docs-staging.datadoghq.com/kaylyn/toc-bug/graphing/infrastructure/network_performance_monitor/ should now redirect to https://docs-staging.datadoghq.com/kaylyn/toc-bug/network_performance_monitoring/

