### PR TITLE
clarified requirement for query and name

### DIFF
--- a/content/en/api/monitors/monitors_edit.md
+++ b/content/en/api/monitors/monitors_edit.md
@@ -7,9 +7,9 @@ external_redirect: /api/#edit-a-monitor
 
 ## Edit A Monitor
 ##### ARGUMENTS
-* **`query`** [*required*]:
+* **`query`** [*required, optional on edit*]:
     The metric query to alert on.
-* **`name`** [*required*]:
+* **`name`** [*required, optional on edit*]:
     The name of the monitor.
 * **`message`** [*optional*, *default*=**dynamic, based on query**]:
     A message to include with notifications for this monitor. Email notifications can be sent to specific users by using the same '@username' notation as events.


### PR DESCRIPTION
### What does this PR do?
clarifying required params for monitor `edit` endpoint (`query` and `name` are required to create but not to edit)

### Motivation
Customer Inquiry

### Preview link
Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/bcon/update-monitor-requirement-clarity/api/monitors/monitors_edit.md

