### PR TITLE
Update logs.md, disabled features section

### DIFF
--- a/content/en/security/logs.md
+++ b/content/en/security/logs.md
@@ -49,7 +49,7 @@ With the Docker Agent, pass in ```DD_LOGS_CONFIG_LOGS_DD_URL=tcp-encrypted-intak
 Additionally, certain features are not available at the moment to customers who have signed Datadog's BAA, notably:
 
 * Users cannot request support via chat
-* The logs Live Tail is disabled
+* The logs Live Tail, Rehydrate from Archives, and Generate Metrics features are disabled
 * Notifications from Log Monitors cannot include log samples
 * Log Monitors cannot be configured with a `group-by` clause
 


### PR DESCRIPTION
Add "Rehydrate from Archives" and "Generate Metrics" to list of unavailable features for HIPAA-enabled customers

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
