### PR TITLE
Update Logs HIPAA instruction for Lambda function

### DIFF
--- a/content/en/security/logs.md
+++ b/content/en/security/logs.md
@@ -32,7 +32,7 @@ Datadog will sign a Business Associate Agreement (BAA) with customers that trans
 Prior to executing a BAA, customers transmitting ePHI to the Datadog Log Management Service must implement the following configurations:
 
 * The Datadog Agent must be configured to submit logs to `tcp-encrypted-intake.logs.datadoghq.com`
-* The Datadog [log collection AWS Lambda function][5] must be configured to submit logs to `lambda-tcp-encrypted-intake.logs.datadoghq.com` by setting the `DD_URL` environment variable
+* The Datadog [log collection AWS Lambda function][5] must be configured to submit logs to `lambda-tcp-encrypted-intake.logs.datadoghq.com` by setting the `DD_URL` environment variable as well as setting `DD_USE_TCP` to `true`.
 * Other log sources besides the Datadog Agent must be configured to submit logs to `http-encrypted-intake.logs.datadoghq.com`
 
 The following sample configuration can be used with the Datadog Agent to submit logs to a HIPAA-ready endpoint directly (i.e. without a proxy):


### PR DESCRIPTION
### What does this PR do?
Update the instruction to send logs for HIPAA customers with the Lambda function

### Motivation
The Lambda function was recently modified to send logs in HTTPS by default. But this breaks the HIPAA compliancy. So we need to force the use of TCP.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/logs-hipaa-lambda/security/logs/#configuration-requirements-for-hipaa-enabled-customers

### Additional Notes
<!-- Anything else we should know when reviewing?-->
