### PR TITLE
fix broken link to tracing docker applications

### DIFF
--- a/content/en/tracing/setup/java.md
+++ b/content/en/tracing/setup/java.md
@@ -327,7 +327,7 @@ java -javaagent:<DD-JAVA-AGENT-PATH>.jar \
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/setup
+[1]: /agent/docker/apm
 [2]: /tracing/setup/docker
 [3]: /agent/kubernetes/daemonset_setup/#trace-collection
 [4]: https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md


### PR DESCRIPTION

### What does this PR do?
fix broken link to go to https://docs.datadoghq.com/agent/docker/apm/

