### PR TITLE
a11y fixes

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -105,24 +105,11 @@ The recommended number of open file descriptors is 1024. You can see this value 
 minfds = 100  # Your hard limit
 ```
 
-### The Collector
-The collector gathers all standard metrics every 15 seconds. It also supports the execution of python-based, user-provided checks, stored in `/etc/dd-agent/checks.d`. User-provided checks must inherit from the AgentCheck abstract class defined in `checks/init.py`. See [Writing a custom Agent check][6] for more details.
-
-### The Forwarder
-The Agent forwarder listens for incoming requests over HTTP to send metrics over HTTPS to Datadog. Buffering prevents network splits from affecting metric reporting. Metrics are buffered in memory until a limit in size or number of outstanding send requests are reached. Afterwards, the oldest metrics are discarded to keep the forwarder's memory footprint manageable.
-
-### DogStatsD
-DogStatsD is a python implementation of [Etsy's StatsD][7] metric aggregation daemon. It is used to receive and roll up arbitrary metrics over UDP, thus allowing custom code to be instrumented without adding latency to the mix. Learn more about [DogStatsD][8].
-
-
 [1]: /integrations
 [2]: /developers/metrics/custom_metrics
 [3]: /agent/guide/network/?tab=agentv5v4#open-ports
 [4]: /agent/proxy/?tab=agentv5
 [5]: /agent/faq/network
-[6]: /developers/write_agent_check/?tab=agentv5
-[7]: https://github.com/etsy/statsd
-[8]: /developers/dogstatsd
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -245,9 +232,9 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 {{% /tab %}}
 {{% tab "Unix Agent" %}}
 
-| OS                                | Supported versions                        |
-|-----------------------------------|-------------------------------------------|
-| [AIX][1]                          | AIX 6.1 TL9 SP6, 7.1 TL5 SP3, 7.2 TL3 SP0 |
+| OS       | Supported versions                        |
+|----------|-------------------------------------------|
+| [AIX][1] | AIX 6.1 TL9 SP6, 7.1 TL5 SP3, 7.2 TL3 SP0 |
 
 
 

--- a/content/en/agent/faq/how-do-i-uninstall-the-agent.md
+++ b/content/en/agent/faq/how-do-i-uninstall-the-agent.md
@@ -7,23 +7,49 @@ further_reading:
   text: "Learn more about the Datadog Agent"
 ---
 
-To uninstall the Datadog Agent, run:
+Choose your platform to see dedicated instructions to uninstall the Agent:
+
+### Debian/Ubuntu
 
 {{< tabs >}}
 {{% tab "Agent v6" %}}
 
-### Debian/Ubuntu
 ```
 sudo apt-get --purge remove datadog-agent -y
 ```
 
+{{% /tab %}}
+{{% tab "Agent v5" %}}
+
+```
+sudo apt-get --purge remove datadog-agent -y
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ### CentOS/RHEL/Fedora/Amazon Linux
+
+{{< tabs >}}
+{{% tab "Agent v6" %}}
 
 ```
 sudo yum remove datadog-agent
 ```
 
+{{% /tab %}}
+{{% tab "Agent v5" %}}
+
+```
+sudo yum remove datadog-agent
+```
+{{% /tab %}}
+{{< /tabs >}}
+
 ### Mac OS
+
+{{< tabs >}}
+{{% tab "Agent v6" %}}
 
 1. Stop and close the Datadog Agent via the bone icon in the tray.
 2. Drag the Datadog application from the application folder to the trash bin.
@@ -36,34 +62,11 @@ sudo rm -rf ~/.datadog-agent/**​ #to remove broken symlinks
 ```
 Then, reboot your machine for changes to take effect.
 
-### Windows
-
-**It's important that the original account used to install the Agent is also used to remove it, otherwise it's possible remnants are left behind and it won't be cleanly removed.**
-
-Uninstall the Agent using Add/Remove Programs; alternatively, it's possible to to use Powershell as well. Here is a one-liner:
-
-```
-(Get-WmiObject -Class Win32_Product -Filter "Name='Datadog Agent'" -ComputerName . ).Uninstall()
-```
-
 {{% /tab %}}
 {{% tab "Agent v5" %}}
 
-### Debian/Ubuntu
 
-```
-sudo apt-get --purge remove datadog-agent -y
-```
-
-### CentOS/RHEL/Fedora/Amazon Linux
-
-```
-sudo yum remove datadog-agent
-```
-
-### Mac OS
-
-1. Stop and close the Datadog Agent: via the bone icon in the tray.
+1. Stop and close the Datadog Agent via the bone icon in the tray.
 2. Drag the Datadog application from the application folder to the trash bin.
 3. Run:
 
@@ -80,9 +83,24 @@ sudo launchctl unload -w /Library/LaunchDaemons/com.datadoghq.agent.plist
 sudo rm /Library/LaunchDaemons/com.datadoghq.agent.plist
 ```
 
+{{% /tab %}}
+{{< /tabs >}}
+
 ### Windows
 
 **It's important that the original account used to install the Agent is also used to remove it, otherwise it's possible remnants are left behind and it won't be cleanly removed.**
+
+{{< tabs >}}
+{{% tab "Agent v6" %}}
+
+Uninstall the Agent using Add/Remove Programs; alternatively, it's possible to to use Powershell as well. Here is a one-liner:
+
+```
+(Get-WmiObject -Class Win32_Product -Filter "Name='Datadog Agent'" -ComputerName . ).Uninstall()
+```
+
+{{% /tab %}}
+{{% tab "Agent v5" %}}
 
 Uninstall the Agent using Add/Remove Programs, alternatively, it's possible to to use Powershell as well. Here is a one-liner:
 
@@ -92,4 +110,3 @@ Uninstall the Agent using Add/Remove Programs, alternatively, it's possible to t
 
 {{% /tab %}}
 {{< /tabs >}}
-

--- a/content/en/api/integrations_aws/aws_get_available_log_services.md
+++ b/content/en/api/integrations_aws/aws_get_available_log_services.md
@@ -1,5 +1,5 @@
 ---
-title: Get a list of AWS log ready services
+title: Get list of AWS log ready services
 type: apicontent
 order: 15.07
 external_redirect: /api/#get-list-of-aws-log-ready-services

--- a/content/en/api/integrations_aws/aws_get_available_log_services_code.md
+++ b/content/en/api/integrations_aws/aws_get_available_log_services_code.md
@@ -1,5 +1,5 @@
 ---
-title: Get a list of AWS log ready services
+title: Get list of AWS log ready services
 type: apicode
 order: 15.07
 external_redirect: /api/#get-list-of-aws-log-ready-services

--- a/content/en/api/monitors/monitors_showall.md
+++ b/content/en/api/monitors/monitors_showall.md
@@ -14,7 +14,7 @@ external_redirect: /api/#get-all-monitor-details
 * **`name`** [*optional*, default=**None**]:
     A string to filter monitors by name
 * **`tags`** [*optional*, *default*=**None**]:
-    A comma separated list indicating what tags, if any, should be used to filter the list of monitorsby scope, e.g. `host:host0`. For more information, see the `tags` parameter for the appropriate `query` argument in the [Create a monitor](#monitor-create) section above.
+    A comma separated list indicating what tags, if any, should be used to filter the list of monitorsby scope, e.g. `host:host0`. For more information, see the `tags` parameter for the appropriate `query` argument in the [Create a monitor](#create-a-monitor) section above.
 * **`monitor_tags`** [*optional*, *default*=**None**]:
     A comma separated list indicating what service and/or custom tags, if any, should be used to filter the list of monitors. Tags created in the Datadog UI automatically have the **service** key prepended (e.g. `service:my-app`)
 * **`with_downtimes`** [*optional*, *default* = **true**]:

--- a/content/en/logs/log_collection/php.md
+++ b/content/en/logs/log_collection/php.md
@@ -26,13 +26,16 @@ further_reading:
 
 ## Overview
 
-Write your PHP logs into a file, then [use the Agent][1] to forward them to Datadog, choose between the following libraries:
+Write your PHP logs into a file, then [use the Agent][1] to forward them to Datadog, choose between the Monolog, Zend-Log, or Symfony logging libraries.
+
+## Setup
+### Installation
 
 {{< tabs >}}
 {{% tab "PHP Monolog" %}}
 
-Use Composer to add Monolog as a dependency:  
- 
+Use Composer to add Monolog as a dependency:
+
 ```
 composer require "monolog/monolog"
 ```
@@ -50,10 +53,51 @@ Alternatively, install it manually:
     // load Monolog library
     use Monolog\Logger;
     use Monolog\Handler\StreamHandler;
-    use Monolog\Formatter\JsonFormatter;    
+    use Monolog\Formatter\JsonFormatter;
     ```
 
-## Setup - Log into a file with Monolog
+{{% /tab %}}
+{{% tab "PHP Zend-Log" %}}
+
+Zend-log is a part of the Zend framework. Use [Composer][1] to add Zend-Log:
+
+```
+composer require "zendframework/zend-log"
+```
+
+Alternatively, install it manually:
+
+1. Download the source from the repository and include it to the libraries
+2. Initialize the instance in the application's bootstrap
+
+```php
+<?php
+require __DIR__ . '/vendor/autoload.php';
+
+use Zend\Log\Logger;
+use Zend\Log\Writer\Stream;
+use Zend\Log\Formatter\JsonFormatter;
+```
+
+[1]: https://getcomposer.org
+{{% /tab %}}
+{{% tab "PHP Symfony" %}}
+
+Declare a Monolog JSON formatter as a service:
+
+```yaml
+services:
+    monolog.json_formatter:
+        class: Monolog\Formatter\JsonFormatter
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### Logger Configuration
+
+{{< tabs >}}
+{{% tab "PHP Monolog" %}}
 
 The following configuration enables the JSON formatting and writes the logs and events into the `application-json.log` file. Edit your code, right after the initialization of the Monolog instance and add a new handler:
 
@@ -84,7 +128,56 @@ $log->pushHandler($stream);
 $log->info('Adding a new user', array('username' => 'Seldaek'));
 ```
 
-## Configure your Datadog Agent
+{{% /tab %}}
+{{% tab "PHP Zend-Log" %}}
+
+The following configuration enables the JSON formatting and writes the logs and events into the `application-json.log` file. Edit your code, right after the initialization of the Zend-Log instance and add a new handler.
+
+```php
+<?php
+
+use Zend\Log\Logger;
+use Zend\Log\Writer\Stream;
+use Zend\Log\Formatter\JsonFormatter;
+
+
+// create a logger
+$logger = new Logger();
+
+// create a writer
+$writer = new Stream('file://' . __DIR__ . '/application-json.log');
+
+// create a Json formatter
+$formatter = new JsonFormatter();
+$writer->setFormatter($formatter);
+
+// bind
+$logger->addWriter($writer);
+Zend\Log\Logger::registerErrorHandler($logger);
+```
+
+Then [Stream your log files to Datadog][1]
+
+[1]: /logs/log_collection
+{{% /tab %}}
+{{% tab "PHP Symfony" %}}
+
+Configure the formatter in your Monolog configuration: declare the formatter field as follows:
+
+```yaml
+ monolog:
+    handlers:
+        main:
+            type:   stream
+            path:   "%kernel.logs_dir%/%kernel.environment%.log"
+            level:  debug
+            formatter: monolog.json_formatter
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### Agent Configuration
 
 Create a `php.d/conf.yaml` file in your `conf.d/` folder with the following content:
 
@@ -92,7 +185,7 @@ Create a `php.d/conf.yaml` file in your `conf.d/` folder with the following cont
 init_config:
 
 instances:
-    
+
 ## Log section
 logs:
 
@@ -110,10 +203,12 @@ logs:
     sourcecategory: sourcecode
 ```
 
-## Add meta field and context
+## Adding more context
 
-It's useful to add additional context data to your logs and events.  
-Monolog makes this convenient by providing methods for setting thread-local context data that is then submitted automatically with all events. At any moment, log an event with contextual data:
+{{< tabs >}}
+{{% tab "PHP Monolog" %}}
+
+It's useful to add additional context data to your logs and events. Monolog makes this convenient by providing methods for setting thread-local context data that is then submitted automatically with all events. At any moment, log an event with contextual data:
 
 ```php
 $logger->info('Adding a new user', array('username' => 'Seldaek'));
@@ -122,8 +217,8 @@ $logger->info('Adding a new user', array('username' => 'Seldaek'));
 Monolog comes with a pre-processor feature. It's a simple callback that enriches your events with metadata you can set (e.g., the session id, the request id, etc.):
 
 ```php
- <?php 
-    
+ <?php
+
 $log->pushProcessor(function ($record) {
 
     // record the current user
@@ -144,239 +239,44 @@ $log->pushProcessor(function ($record) {
 });
 ```
 
-## Framework integration 
+{{% /tab %}}
+{{% tab "PHP Zend-Log" %}}
 
-Monolog is a part of the following frameworks:
-
-* [Symfony2, Symfony3][1]
-* [PPI][2]
-* [Laravel 4 & 5][3]
-* [Silex][4]
-* [Lumen][5]
-* [CakePHP][6]
-
-
-Integrate Monolog with your framework then configure your logger: 
- 
-```php
- <?php
-// Check if the Monolog library is well loaded
-//use Monolog\Logger;
-//use Monolog\Handler\StreamHandler;
-//use Monolog\Formatter\JsonFormatter;
-  
-// with the monolog instance
-$monolog = ...
-  
-///// Log shipper configuration
-
-$formatter = new JsonFormatter();
-$stream = new StreamHandler(__DIR__.'/application-json.log', Logger::DEBUG);
-$stream->setFormatter($formatter);
-
-$monolog->pushHandler($stream);
-return $r;
-```
-
-### Symfony (v2+, v3+)
-
-In your configuration directory `/path/to/config/directory/`, edit the `config_dev.yml` and `config_prod.yml` to configure log management to suit your needs for development and production environments.
-
-```yaml
-# app/config/config.yml
-monolog:
-
-# Uncomment this section, if you want to use a Processor 
-#       Processor : 
-#           session_processor:
-#               class: Acme\Bundle\MonologBundle\Log\SessionRequestProcessor
-#            arguments:  [ @session ]
-#            tags:
-#               - { name: monolog.processor, method: processRecord }
-          
-          
-    json_formatter:
-        class: Monolog\Formatter\JsonFormatter
-          
-    handlers:
-    
-        # Log shipper configuration
-        to_json_files:
-            # log to var/logs/(environment).log
-            type: stream
-            path: "%kernel.logs_dir%/%kernel.environment%.log"
-            # inclues all channels (doctrine, errors, etc.)
-            channels: ~
-            # use json formatter
-            formatter: monolog.json_formatter
-            # logs alls events (debug trought fatal)
-            level: debug
-```
-
-### PPI
-
-In your configuration directory `/path/to/config/directory/`, edit the `config_dev.yml` and `config_prod.yml` to configure log management to suit your needs for development and production environments.
-
-```yaml
-monolog:
-    handlers:
-    
-        # Log shipper configuration
-        to_json_files:
-            # log to var/logs/(environment).log
-            type: stream
-            path: "%kernel.logs_dir%/%kernel.environment%.log"
-            # use json formatter
-            formatter: monolog.json_formatter
-            # logs alls events (debug trought fatal)
-            level: debug
-```
-
-### Laravel
+Much of the useful information comes from additional context data that you can add to your logs and your events. Zend-Log makes this very convenient by providing methods to set thread local context data that is then submitted automatically with all events. At any moment, log an event with contextual data:
 
 ```php
-//file: bootstrap/app.php
-$app->configureMonologUsing(function($monolog) {
-    $monolog->pushHandler(...);
-    
-  // configure your logger below
-});
-
-return $app;
+$logger->info('Adding a new user', array('username' => 'Seldaek'));
 ```
 
-### Silex
+But, most importantly, the library comes with a Processor feature. Processors allow you to provide additional information to logs in an automated fashion. They are called from the logger before the event is passed to the writers; they receive the event array, and return an event array on completion.
+
+Use cases include:
+
+* Providing exception backtrace information.
+* Injecting substitutions into the message.
+* Injecting a request identifier (in order to later inspect logs for a specific identifier).
+
+Take a peek to this code if you want to use it:
 
 ```php
-// file: bootstrap
-$app->extend('monolog', function($monolog, $app) {
-    $monolog->pushHandler(...);
-    // configure your logger below
-    return $monolog;
-});
+$logger->addProcessor(new Zend\Log\Processor\Backtrace());
+$logger->addProcessor(new Zend\Log\Processor\PsrPlaceholder());
+$logger->addProcessor(new Zend\Log\Processor\ReferenceId());
+$logger->addProcessor(new Zend\Log\Processor\RequestId());
 ```
 
-### Lumen
+If you want to develop yours, [refer the Zend documentation][1].
 
-```php
-//file: bootstrap/app.php
-$app->configureMonologUsing(function($monolog) {
-    $monolog->pushHandler(...);
-    // configure your logger below
-});
 
-return $app;
-```
 
-### CakePHP
-
-First, add this dependency to the `composer.json` file and
-run `composer update`.
-
-```json
-{
-    "require": {
-        "cakephp/monolog": "*"
-    }
-}
-```
-
-Then, start by creating a logging configuration file (i.e., `app/Config/log.php`) that you includes your `app/Config/bootstrap.php`:
-
-```php
-include 'log.php';
-```
-
-A basic configuration, to replicate what Cake does but using Monolog would look something like this:
-
-```
-CakePlugin::load('Monolog');
-```
-
-Finally log into a file:
-
-```
-CakeLog::config('debug', array(
-  'engine' => 'Monolog.Monolog',
-  'channel' => 'app',
-  'handlers' => array(
-    'Stream' => array(
-      LOGS . 'application-json.log',
-      'formatters' => array(
-        'Json' => array("")
-      )
-    )
-  )
-));
-```
-
-[1]: /logs/log_collection/php/#symfony-v2-v3
-[2]: /logs/log_collection/php/#ppi
-[3]: /logs/log_collection/php/#laravel
-[4]: /logs/log_collection/php/#silex
-[5]: /logs/log_collection/php/#lumen
-[6]: /logs/log_collection/php/#cakephp
+[1]: https://docs.zendframework.com/zend-log/processors
 {{% /tab %}}
 {{% tab "PHP Symfony" %}}
 
-This section is about:
+Add a session Processor to add variable context within your logs:
 
-* How to send your logs to Datadog from a Symfony 2 environment
-* How to configure Monolog to send logs in JSON
-* How to enrich your Log events with session contextual data
-
-## Setup - Log into files with Monolog
-
-1. Declare a Monolog JSON formatter as a service:
-
-    ```yaml
-    services:
-        monolog.json_formatter:
-            class: Monolog\Formatter\JsonFormatter
-    ```
-
-2. Configure the formatter in your Monolog configuration: declare the formatter field as follows:
-
-    ```yaml
-     monolog:
-        handlers:
-            main:
-                type:   stream
-                path:   "%kernel.logs_dir%/%kernel.environment%.log"
-                level:  debug
-                formatter: monolog.json_formatter
-    ```
-
-## Configure your Datadog Agent
-
-Create a `php.d/conf.yaml` file in your `conf.d/` folder with the following content:
-
-```yaml
-init_config:
-
-instances:
-    
-## Log section
-logs:
-
-    ## - type: file (mandatory) type of log input source (tcp / udp / file)
-    ##   port / path: (mandatory) Set port if type is tcp or udp. Set path if type is file
-    ##   service: (mandatory) name of the service owning the log
-    ##   source: (mandatory) attribute that defines which integration is sending the logs
-    ##   sourcecategory: (optional) Multiple value attribute. Can be used to refine the source attribute
-    ##   tags: (optional) add tags to each logs collected
-
-  - type: file
-    path: /path/to/your/php/application-json.log
-    service: php
-    source: php
-    sourcecategory: sourcecode
-```
-
-## Adding a session Processor to add variable context in your logs
-
-1. Implement your session Processor:  
-  This is an example of such a Processor. It knows the current session and it enriches the content of the log record with valuable information such as the `requestId`, `sessionId`, ...  
+1. Implement your session Processor:
+  This is an example of such a Processor. It knows the current session and it enriches the content of the log record with valuable information such as the `requestId`, `sessionId`, ...
 
     ```php
     <?php
@@ -448,7 +348,7 @@ logs:
     }
     ```
 
-2. Wire the Processor with Symfony:  
+2. Wire the Processor with Symfony:
   ```yaml
    services:
       monolog.processor.session_request:
@@ -461,124 +361,185 @@ logs:
 3. [Stream generated JSON file to Datadog][1]
 
 
+
 [1]: /logs/log_collection
 {{% /tab %}}
-{{% tab "PHP Zend-Log" %}}
+{{< /tabs >}}
 
-Zend-log is a part of the Zend framework. Use [Composer][1] to add Zend-Log:
+## Monolog Framework integration
 
-```
-composer require "zendframework/zend-log"
-```
+Monolog is a part of the following frameworks:
 
-Alternatively, install it manually:
+* [Symfony2, Symfony3][2]
+* [PPI][3]
+* [Laravel 4 & 5][4]
+* [Silex][5]
+* [Lumen][6]
+* [CakePHP][7]
 
-1. Download the source from the repository and include it to the libraries
-2. Initialize the instance in the application's bootstrap
 
-```php
-<?php
-require __DIR__ . '/vendor/autoload.php';
-
-use Zend\Log\Logger;
-use Zend\Log\Writer\Stream;
-use Zend\Log\Formatter\JsonFormatter;
-```
-
-## Setup - Log into files with Zend-log
-
-The following configuration enables the JSON formatting and writes the logs and events into the `application-json.log` file. Edit your code, right after the initialization of the Zend-Log instance and add a new handler.
+Integrate Monolog with your framework then configure your logger:
 
 ```php
-<?php
+ <?php
+// Check if the Monolog library is well loaded
+//use Monolog\Logger;
+//use Monolog\Handler\StreamHandler;
+//use Monolog\Formatter\JsonFormatter;
 
-use Zend\Log\Logger;
-use Zend\Log\Writer\Stream;
-use Zend\Log\Formatter\JsonFormatter;
+// with the monolog instance
+$monolog = ...
 
-  
-// create a logger
-$logger = new Logger();
+///// Log shipper configuration
 
-// create a writer
-$writer = new Stream('file://' . __DIR__ . '/application-json.log');
-
-// create a Json formatter
 $formatter = new JsonFormatter();
-$writer->setFormatter($formatter);
+$stream = new StreamHandler(__DIR__.'/application-json.log', Logger::DEBUG);
+$stream->setFormatter($formatter);
 
-// bind
-$logger->addWriter($writer);
-Zend\Log\Logger::registerErrorHandler($logger);
+$monolog->pushHandler($stream);
+return $r;
 ```
 
-Then [Stream your log files to Datadog][2]
+### Symfony (v2+, v3+)
 
-## Configure your Datadog Agent
-
-Create a `php.d/conf.yaml` file in your `conf.d/` folder with the following content:
+In your configuration directory `/path/to/config/directory/`, edit the `config_dev.yml` and `config_prod.yml` to configure log management to suit your needs for development and production environments.
 
 ```yaml
-init_config:
+# app/config/config.yml
+monolog:
 
-instances:
-    
-## Log section
-logs:
+# Uncomment this section, if you want to use a Processor
+#       Processor :
+#           session_processor:
+#               class: Acme\Bundle\MonologBundle\Log\SessionRequestProcessor
+#            arguments:  [ @session ]
+#            tags:
+#               - { name: monolog.processor, method: processRecord }
 
-    ## - type: file (mandatory) type of log input source (tcp / udp / file)
-    ##   port/path: (mandatory) Set port if type is tcp or udp. Set path if type is file
-    ##   service: (mandatory) name of the service owning the log
-    ##   source: (mandatory) attribute that defines which integration is sending the logs
-    ##   sourcecategory: (optional) Multiple value attribute. Can be used to refine the source attribute
-    ##   tags: (optional) add tags to each logs collected
 
-  - type: file
-    path: /path/to/your/php/application-json.log
-    service: php
-    source: php
-    sourcecategory: sourcecode
+    json_formatter:
+        class: Monolog\Formatter\JsonFormatter
+
+    handlers:
+
+        # Log shipper configuration
+        to_json_files:
+            # log to var/logs/(environment).log
+            type: stream
+            path: "%kernel.logs_dir%/%kernel.environment%.log"
+            # inclues all channels (doctrine, errors, etc.)
+            channels: ~
+            # use json formatter
+            formatter: monolog.json_formatter
+            # logs alls events (debug trought fatal)
+            level: debug
 ```
 
-## Add meta field and context
+### PPI
 
-Much of the useful information comes from additional context data that you can add to your logs and your events. Zend-Log makes this very convenient by providing methods to set thread local context data that is then submitted automatically with all events. At any moment, log an event with contextual data:  
+In your configuration directory `/path/to/config/directory/`, edit the `config_dev.yml` and `config_prod.yml` to configure log management to suit your needs for development and production environments.
+
+```yaml
+monolog:
+    handlers:
+
+        # Log shipper configuration
+        to_json_files:
+            # log to var/logs/(environment).log
+            type: stream
+            path: "%kernel.logs_dir%/%kernel.environment%.log"
+            # use json formatter
+            formatter: monolog.json_formatter
+            # logs alls events (debug trought fatal)
+            level: debug
+```
+
+### Laravel
 
 ```php
-$logger->info('Adding a new user', array('username' => 'Seldaek'));
+//file: bootstrap/app.php
+$app->configureMonologUsing(function($monolog) {
+    $monolog->pushHandler(...);
+
+  // configure your logger below
+});
+
+return $app;
 ```
 
-But, most importantly, the library comes with a Processor feature. Processors allow you to provide additional information to logs in an automated fashion. They are called from the logger before the event is passed to the writers; they receive the event array, and return an event array on completion.
-
-Use cases include:
-
-* Providing exception backtrace information.
-* Injecting substitutions into the message.
-* Injecting a request identifier (in order to later inspect logs for a specific identifier).
-
-Take a peek to this code if you want to use it:
+### Silex
 
 ```php
-$logger->addProcessor(new Zend\Log\Processor\Backtrace());
-$logger->addProcessor(new Zend\Log\Processor\PsrPlaceholder());
-$logger->addProcessor(new Zend\Log\Processor\ReferenceId());
-$logger->addProcessor(new Zend\Log\Processor\RequestId());
+// file: bootstrap
+$app->extend('monolog', function($monolog, $app) {
+    $monolog->pushHandler(...);
+    // configure your logger below
+    return $monolog;
+});
 ```
 
-If you want to develop yours, [refer the Zend documentation][3].
+### Lumen
 
+```php
+//file: bootstrap/app.php
+$app->configureMonologUsing(function($monolog) {
+    $monolog->pushHandler(...);
+    // configure your logger below
+});
 
-[1]: https://getcomposer.org
-[2]: /logs/log_collection
-[3]: https://docs.zendframework.com/zend-log/processors
-{{% /tab %}}
-{{< /tabs >}}
+return $app;
+```
+
+### CakePHP
+
+First, add this dependency to the `composer.json` file and
+run `composer update`.
+
+```json
+{
+    "require": {
+        "cakephp/monolog": "*"
+    }
+}
+```
+
+Then, start by creating a logging configuration file (i.e., `app/Config/log.php`) that you includes your `app/Config/bootstrap.php`:
+
+```php
+include 'log.php';
+```
+
+A basic configuration, to replicate what Cake does but using Monolog would look something like this:
+
+```
+CakePlugin::load('Monolog');
+```
+
+Finally log into a file:
+
+```
+CakeLog::config('debug', array(
+  'engine' => 'Monolog.Monolog',
+  'channel' => 'app',
+  'handlers' => array(
+    'Stream' => array(
+      LOGS . 'application-json.log',
+      'formatters' => array(
+        'Json' => array("")
+      )
+    )
+  )
+));
+```
+
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
-
-
-
-
-[1]: /logs
+[1]: /agent/logs
+[2]: /logs/log_collection/php/#symfony-v2-v3
+[3]: /logs/log_collection/php/#ppi
+[4]: /logs/log_collection/php/#laravel
+[5]: /logs/log_collection/php/#silex
+[6]: /logs/log_collection/php/#lumen
+[7]: /logs/log_collection/php/#cakephp

--- a/content/en/synthetics/identify_synthetics_bots.md
+++ b/content/en/synthetics/identify_synthetics_bots.md
@@ -23,7 +23,7 @@ Some parts of your system might not be available to robots without the right ide
 * The [headers](#headers) attached to all Datadog robot requests.
 * Datadog's [**Synthetics IP ranges**][1].
 * The **Advanced options** configuration to set custom headers for your API and browser tests. You can also locally add **cookies, headers, or basic auth** to your API tests and **cookies and headers** to your browser tests.
-* The `window._DATADOG_SYNTHETICS_BROWSER` [JavaScript variable in your application code](#_datadog_synthetics_browser-variable).
+* The `window._DATADOG_SYNTHETICS_BROWSER` [JavaScript variable in your application code](#datadog-synthetics-browser-variable).
 
 #### Headers
 

--- a/content/en/tracing/advanced/opentracing.md
+++ b/content/en/tracing/advanced/opentracing.md
@@ -294,8 +294,6 @@ For more advanced usage and configuration information see [Datadog Python Opentr
 {{% /tab %}}
 {{% tab "Ruby" %}}
 
-### Setup
-
 To set up Datadog with OpenTracing, see the Ruby [Quickstart for OpenTracing][1] for details.
 
 **Configuring Datadog tracer settings**
@@ -317,11 +315,11 @@ However, additional instrumentation provided by Datadog can be activated alongsi
 
 **Supported serialization formats**
 
-| Type                           | Supported? | Additional information |
-| ------------------------------ | ---------- | ---------------------- |
-| `OpenTracing::FORMAT_TEXT_MAP` | Yes        |                        |
+| Type                           | Supported? | Additional information                                                                                                                                                                                                                                                                                        |
+|--------------------------------|------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `OpenTracing::FORMAT_TEXT_MAP` | Yes        |                                                                                                                                                                                                                                                                                                               |
 | `OpenTracing::FORMAT_RACK`     | Yes        | Because of the loss of resolution in the Rack format, note that baggage items with names containing either upper case characters or `-` are be converted to lower case and `_` in a round-trip, respectively. Datadog recommends avoiding these characters or accommodating accordingly on the receiving end. |
-| `OpenTracing::FORMAT_BINARY`   | No         |                        |
+| `OpenTracing::FORMAT_BINARY`   | No         |                                                                                                                                                                                                                                                                                                               |
 
 
 [1]: /tracing/setup/ruby/#quickstart-for-opentracing

--- a/content/en/tracing/trace_search_and_analytics/search.md
+++ b/content/en/tracing/trace_search_and_analytics/search.md
@@ -66,7 +66,7 @@ A query is composed of *terms* and *operators*.
 
 There are two types of *terms*:
 
-* A [**Facet**](#facets-search)
+* A [**Facet**](#facet-search)
 
 * A [**Tag**](#tags-search)
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes the last a11y issues we are facing with the Documentation Content.

Two fixes are bigger than the other one:

* Refactor of the Uninstall the Agent page in order to avoid duplication of anchors.
* Refactor of the PHP Log collection page in order to avoid duplication of anchors

The content is the same in both cases, it's the tab logic that changed in order to have unique anchors on the page allowing for a better accessibility.

The content that is removed in the basic_agent_usage page is actually duplicated content from 15lines above.. since it created conflict with the Agent v6 content i just removed it. 

### Preview link

* https://docs-staging.datadoghq.com/gus/a11y-final-fix/agent/faq/how-do-i-uninstall-the-agent/?tab=agentv6#pagetitle

* https://docs-staging.datadoghq.com/gus/a11y-final-fix/logs/log_collection/php/?tab=phpmonolog