### PR TITLE
data files are also owned by docs team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 *           @DataDog/baklava
 
 # Websites
-data/*      @DataDog/corpweb
+data/*      @DataDog/corpweb @DataDog/baklava
 local/*     @DataDog/corpweb
 layouts/*   @DataDog/corpweb
 src/*       @DataDog/corpweb


### PR DESCRIPTION
### What does this PR do?

Files in the data folder are owned by both websites and documentation. 
This PR adds Baklava to the codeowners so a PR changing a data file would require one (and only one) of the 2 teams to approve it before it could be merged.

### Motivation
Discussion with Kaylyn on a recent PR

### Preview link
N/A

### Additional Notes
