### PR TITLE
.NET profiler log

### DIFF
--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -166,10 +166,10 @@ Tracer.Instance = tracer;
 
 Location of the profiler log:
 
-| Platform | Path                                                        |
-|----------|-------------------------------------------------------------|
-| Linux    | /var/log/datadog/dotnet-profiler.log                        |
-| Windows  | C:\ProgramData\Datadog .NET Tracer\logs\dotnet-profiler.log |
+| Platform | Path                                                          |
+|----------|---------------------------------------------------------------|
+| Linux    | `/var/log/datadog/dotnet-profiler.log`                        |
+| Windows  | `C:\ProgramData\Datadog .NET Tracer\logs\dotnet-profiler.log` |
 
 
 {{% /tab %}}

--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -164,6 +164,14 @@ var tracer = Tracer.Create(isDebugEnabled: true);
 Tracer.Instance = tracer;
 ```
 
+Location of the profiler log:
+
+| Platform | Path                                                        |
+|----------|-------------------------------------------------------------|
+| Linux    | /var/log/datadog/dotnet-profiler.log                        |
+| Windows  | C:\ProgramData\Datadog .NET Tracer\logs\dotnet-profiler.log |
+
+
 {{% /tab %}}
 {{% tab "PHP" %}}
 


### PR DESCRIPTION

### What does this PR do?
- Add profiler log locations for .NET tracer debug

### Motivation
- Trello request

### Preview link
https://docs-staging.datadoghq.com/ruth/dotnet-logs/tracing/troubleshooting/?tab=net#tracer-debug-mode

### Additional Notes
N/A
