### PR TITLE
clarified value only available in query alert

### DIFF
--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -42,7 +42,7 @@ Use variables to customize your monitor notifications, the available variables a
 
 | Variable                | Description                                                                                    |
 |-------------------------|------------------------------------------------------------------------------------------------|
-| `{{value}}`             | Display the value that breached the alert.                                                     |
+| `{{value}}`             | Display the value that breached the alert. (query alerts)                                      |
 | `{{threshold}}`         | Display the alert threshold selected in the monitor's *Set alert conditions* section.          |
 | `{{warn_threshold}}`    | Display the warning threshold selected in the monitor's *Set alert conditions* section if any. |
 | `{{ok_threshold}}`      | Display the value that recovered the monitor.                                                  |

--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -42,7 +42,7 @@ Use variables to customize your monitor notifications, the available variables a
 
 | Variable                | Description                                                                                    |
 |-------------------------|------------------------------------------------------------------------------------------------|
-| `{{value}}`             | Display the value that breached the alert. (query alerts)                                      |
+| `{{value}}`             | Display the value that breached the alert for metrics based query monitors.                                      |
 | `{{threshold}}`         | Display the alert threshold selected in the monitor's *Set alert conditions* section.          |
 | `{{warn_threshold}}`    | Display the warning threshold selected in the monitor's *Set alert conditions* section if any. |
 | `{{ok_threshold}}`      | Display the value that recovered the monitor.                                                  |


### PR DESCRIPTION
### What does this PR do?
Clarifies that `{{value}}` is available only in query alerts.  Variables such as `{{a.value}}` work for composites as well but that is clear on the composites page

### Motivation
Support Escalation.  There will be a FR created for other monitor types.

### Preview link
https://docs-staging.datadoghq.com/bcon/clarify-notif-value-availability/monitors/notifications

