### PR TITLE
Fix bad path for agent configs

### DIFF
--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -208,7 +208,7 @@ To add integrations using Autodiscovery, see the [Autodiscovery Integration Temp
 
 ### Mounting conf.d
 
-Your integration configuration files can be copied to `/etc/datadog-agent/conf.d/` when starting the Docker Agent by mounting a `/conf.d` folder.
+Your integration configuration files can be copied to `/etc/dd-agent/conf.d/` when starting the Docker Agent by mounting a `/conf.d` folder.
 
 1. Create a configuration folder on the host with your YAML files:
     ```shell
@@ -227,9 +227,9 @@ Your integration configuration files can be copied to `/etc/datadog-agent/conf.d
                   datadog/agent:latest
     ```
 
-When the container starts, all files on the host in `/opt/datadog-agent-conf.d` with a `.yaml` extension are copied to `/etc/datadog-agent/conf.d/`. **Note**: If you add new YAML files to `/opt/datadog-agent-conf.d`, restart the Docker Agent.
+When the container starts, all files on the host in `/opt/datadog-agent-conf.d` with a `.yaml` extension are copied to `/etc/dd-agent/conf.d/`. **Note**: If you add new YAML files to `/opt/datadog-agent-conf.d`, restart the Docker Agent.
 
-The same can be done for the `/checks.d` folder. Any Python files in the `/checks.d` folder are automatically copied to `/etc/datadog-agent/checks.d/` when starting the Docker Agent.
+The same can be done for the `/checks.d` folder. Any Python files in the `/checks.d` folder are automatically copied to `/etc/dd-agent/checks.d/` when starting the Docker Agent.
 
 
 ## Further Reading


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fixing the agent configs path for the dockerized agent.
On 6.14.1 of the containerized agent I found:
```
root@7f87c589a59c:/# ls -la /etc/datadog-agent/
ls: cannot access '/etc/datadog-agent/': No such file or directory

root@7f87c589a59c:/# ls -la /etc/dd-agent/
total 24
drwxr-xr-x 1 root root 4096 Oct  2 16:11 .
drwxr-xr-x 1 root root 4096 Oct  2 16:11 ..
drwxr-xr-x 2 root root 4096 May 24 08:51 checks.d
drwxr-xr-x 1 root root 4096 May 27 12:03 conf.d
-rw-r--r-- 1 root root  271 Oct  2 16:11 datadog.conf
-rw-r--r-- 1 root root 2131 Oct  2 16:11 supervisor.conf
root@7f87c589a59c:/#
```

### Motivation
<!-- What inspired you to submit this pull request?-->
I was testing something and looked at the docs to find the config location, I found it was wrong.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ckelner/fix-agent-path/agent/docker

### Additional Notes
<!-- Anything else we should know when reviewing?-->
