### PR TITLE
update syslog-ng for TLS instructions

### DIFF
--- a/content/en/integrations/syslog_ng.md
+++ b/content/en/integrations/syslog_ng.md
@@ -77,7 +77,7 @@ Configure Syslog-ng to gather logs from your host, containers, & services.
 
 4. (Optional) TLS Encryption:  
 
-    * Download the ca-certificate:
+    * Download the CA certificate:
     
      ```
     sudo apt-get install ca-certificates

--- a/content/en/integrations/syslog_ng.md
+++ b/content/en/integrations/syslog_ng.md
@@ -148,7 +148,7 @@ Configure Syslog-ng to gather logs from your host, containers, & services.
 
 4. (Optional) TLS Encryption:  
 
-    * Download the ca-certificate:
+    * Download the CA certificate:
       
      ```
     sudo apt-get install ca-certificates

--- a/content/en/integrations/syslog_ng.md
+++ b/content/en/integrations/syslog_ng.md
@@ -76,14 +76,17 @@ Configure Syslog-ng to gather logs from your host, containers, & services.
     ```
 
 4. (Optional) TLS Encryption:  
-    To activate TLS encryption:
 
-    1. Download Datadog's [certificate][1] and save it to `/etc/syslog-ng/certs.d/datadoghq.crt`.
-
-    2. Change the definition of the destination to the following:
-
+    * Download the ca-certificate:
+    
+     ```
+    sudo apt-get install ca-certificates
+     ```
+            
+    * Change the definition of the destination to the following:
+    
         ```
-        destination d_datadog { tcp("intake.logs.datadoghq.com" port(10516)     tls(peer-verify(required-untrusted) ca_dir('/etc/syslog-ng/certs.d/')) template(DatadogFormat)); };
+        destination d_datadog { tcp("intake.logs.datadoghq.com" port(10516)     tls(peer-verify(required-untrusted)) template(DatadogFormat)); };
         ```
 
     More information about the TLS parameters and possibilities for syslog-ng available in the [official documentation][2].
@@ -144,14 +147,17 @@ Configure Syslog-ng to gather logs from your host, containers, & services.
     ```
 
 4. (Optional) TLS Encryption:  
-    To activate TLS encryption:
 
-    1. Download Datadog's [certificate][1] and save it to `/etc/syslog-ng/certs.d/datadoghq.crt`.
-
-    2. Change the definition of the destination to the following:
-
+    * Download the ca-certificate:
+      
+     ```
+    sudo apt-get install ca-certificates
+      ```
+      
+    * Change the definition of the destination to the following:
+    
         ```
-        destination d_datadog { tcp("tcp-intake.logs.datadoghq.eu" port(443)     tls(peer-verify(required-untrusted) ca_dir('/etc/syslog-ng/certs.d/')) template(DatadogFormat)); };
+        destination d_datadog { tcp("tcp-intake.logs.datadoghq.com" port(443)     tls(peer-verify(required-untrusted)) template(DatadogFormat)); };
         ```
 
     More information about the TLS parameters and possibilities for syslog-ng available in their [official documentation][2].
@@ -159,7 +165,6 @@ Configure Syslog-ng to gather logs from your host, containers, & services.
 5. Restart syslog-ng.
 
 
-[1]: /resources/crt/FULL_intake.logs.datadoghq.eu.crt
 [2]: https://syslog-ng.com/documents/html/syslog-ng-ose-latest-guides/en/syslog-ng-ose-guide-admin/html/tlsoptions.html
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/integrations/syslog_ng.md
+++ b/content/en/integrations/syslog_ng.md
@@ -157,7 +157,7 @@ Configure Syslog-ng to gather logs from your host, containers, & services.
     * Change the definition of the destination to the following:
     
         ```
-        destination d_datadog { tcp("tcp-intake.logs.datadoghq.com" port(443)     tls(peer-verify(required-untrusted)) template(DatadogFormat)); };
+        destination d_datadog { tcp("tcp-intake.logs.datadoghq.eu" port(443)     tls(peer-verify(required-untrusted)) template(DatadogFormat)); };
         ```
 
     More information about the TLS parameters and possibilities for syslog-ng available in their [official documentation][2].


### PR DESCRIPTION
### What does this PR do?
Update instructions to send logs in TLS with syslog-ng

### Motivation
There was issues with certificate so we wanted to provide a setup with the CA trusted certificates instead of Datadog custom ones.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/syslog-ng-tls-instruction/integrations/syslog_ng/?tab=datadogussite#pagetitle

### Additional Notes
<!-- Anything else we should know when reviewing?-->
