### PR TITLE
Update certificate path for logs proxy

### DIFF
--- a/content/en/agent/logs/proxy.md
+++ b/content/en/agent/logs/proxy.md
@@ -40,20 +40,11 @@ The parameters above can also be set with the following environment variables:
     * For `app.datadoghq.com`: `agent-intake.logs.datadoghq.com` on port `10516` and activate SSL encryption.
     * For `app.datadoghq.eu`: `agent-intake.logs.datadoghq.eu` on port `443` and activate SSL encryption.
 
-* Use the public key for TLS encryption for the SSL encryption:
-    * For [app.datadoghq.com][1]
-    * For [app.datadoghq.eu][2]
+* Download the `CA certificates` for TLS encryption for the SSL encryption with the following command:
+    * `sudo apt-get install ca-certificates` (Debian, Ubuntu)
+    * `yum install ca-certificates` (CentOS, Redhat)
+  And use the certificate file located in `/etc/ssl/certs/ca-certificates.crt`(Debian, Ubuntu) or `/etc/ssl/certs/ca-bundle.crt` (CentOS, Redhat)
 
-    On some systems, the full certificate chain may be required. If so, use this public key instead:
-
-    * For [app.datadoghq.com][3]
-    * For [app.datadoghq.eu][4]
-
-
-[1]: /resources/crt/intake.logs.datadoghq.com.crt
-[2]: /resources/crt/intake.logs.datadoghq.eu.crt
-[3]: /resources/crt/FULL_intake.logs.datadoghq.com.crt
-[4]: /resources/crt/FULL_intake.logs.datadoghq.eu.crt
 {{% /tab %}}
 {{% tab "SOCKS5" %}}
 

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -212,14 +212,16 @@ backend datadog-logs
     balance roundrobin
     mode tcp
     option tcplog
-    server datadog agent-intake.logs.datadoghq.com:10516 ssl verify required ca-file /etc/ssl/certs/FULL_intake.logs.datadoghq.com.crt
+    server datadog agent-intake.logs.datadoghq.com:10516 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt
 ```
 
-**Note**: Download the `datadog-logs` backend certificate [FULL_intake.logs.datadoghq.com.crt][1] for the logs proxy configuration.
+**Note**: Download the certificate with the following command:
+        * `sudo apt-get install ca-certificates` (Debian, Ubuntu)
+        * `yum install ca-certificates` (CentOS, Redhat)
+The file might be located at `/etc/ssl/certs/ca-bundle.crt` for CentOS, Redhat.
 
 Once the HAProxy configuration is in place, you can reload it or restart HAProxy. **It is recommended to have a `cron` job that reloads HAProxy every 10 minutes** (usually doing something like `service haproxy reload`) to force a refresh of HAProxy's DNS cache, in case `app.datadoghq.com` fails over to another IP.
 
-[1]: /resources/crt/FULL_intake.logs.datadoghq.com.crt
 {{% /tab %}}
 {{% tab "Datadog EU site" %}}
 
@@ -304,14 +306,16 @@ backend datadog-logs
     balance roundrobin
     mode tcp
     option tcplog
-    server datadog agent-intake.logs.datadoghq.eu:443 ssl verify required ca-file /etc/ssl/certs/FULL_intake.logs.datadoghq.eu.crt
+    server datadog agent-intake.logs.datadoghq.eu:443 ssl verify required ca-file /etc/ssl/certs/ca-bundle.crt
 ```
 
-**Note**: Download the `datadog-logs` backend certificate [FULL_intake.logs.datadoghq.eu.crt][1] for the logs proxy configuration.
+**Note**: Download the certificate with the following command:
+        * `sudo apt-get install ca-certificates` (Debian, Ubuntu)
+        * `yum install ca-certificates` (CentOS, Redhat)
+The file might be located at `/etc/ssl/certs/ca-bundle.crt` for CentOS, Redhat.
 
 Once the HAProxy configuration is in place, you can reload it or restart HAProxy. **It is recommended to have a `cron` job that reloads HAProxy every 10 minutes** (usually doing something like `service haproxy reload`) to force a refresh of HAProxy's DNS cache, in case `app.datadoghq.eu` fails over to another IP.
 
-[1]: /resources/crt/FULL_intake.logs.datadoghq.eu.crt
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -462,10 +466,9 @@ To use the Datadog Agent v6 as the logs collector, instruct the Agent to use the
 ```yaml
 logs_config:
   logs_dd_url: myProxyServer.myDomain:10514
-  logs_no_ssl: true
 ```
 
-The `logs_no_ssl` parameter is set to `true` because establishing the SSL/TLS connection is handled by NGINX's `proxy_ssl on` option. **Note**: Set this option to `false` if you don't intend to use a proxy which can encrypt the connection to the logs intake.
+Do not change the `logs_no_ssl` parameter as Nginx is simply forwarding the traffic to Datadog and does not decrypt or encrypt the traffic.
 
 ## Using the Agent as a Proxy
 

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -468,7 +468,7 @@ logs_config:
   logs_dd_url: myProxyServer.myDomain:10514
 ```
 
-Do not change the `logs_no_ssl` parameter as Nginx is simply forwarding the traffic to Datadog and does not decrypt or encrypt the traffic.
+Do not change the `logs_no_ssl` parameter as NGINX is simply forwarding the traffic to Datadog and does not decrypt or encrypt the traffic.
 
 ## Using the Agent as a Proxy
 


### PR DESCRIPTION
### What does this PR do?
Update the certificate to use when configuring proxy for logs

### Motivation
The certificate we now we recommend to use is the CA certificates.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/log-proxy-update-certificate/agent/logs/proxy?tab=tcp
https://docs-staging.datadoghq.com/nils/log-proxy-update-certificate/agent/proxy/?tab=agentv6#using-haproxy-as-a-proxy
https://docs-staging.datadoghq.com/nils/log-proxy-update-certificate/agent/proxy/?tab=agentv6#using-nginx-as-a-proxy
### Additional Notes
<!-- Anything else we should know when reviewing?-->
