### PR TITLE
Update text to be in line with documentation in flare code.

### DIFF
--- a/content/en/agent/troubleshooting/send_a_flare.md
+++ b/content/en/agent/troubleshooting/send_a_flare.md
@@ -18,7 +18,9 @@ If you are running Agent 5.3+, you can send necessary troubleshooting informatio
 **Confirm the upload of the archive to immediately send it to Datadog support**.
 Datadog Agent is completely open source, which allows you to [verify the code's behavior][1]. If needed, the flare can be reviewed prior to sending since the flare prompts a confirmation before uploading it.
 
-In the commands below, replace `<CASE_ID>` with your Datadog support case ID, if you don't specify a case ID, the command asks for an email address that is used to login in your organization and creates a new support case.
+In the commands below, replace `<CASE_ID>` with your Datadog support case ID. In all cases, you will be asked for an email address. It is used verify your case ID. If you don't specify a case ID, the email address is used to login in your organization and create a new support case.
+
+
 
 {{< tabs >}}
 {{% tab "Agent v6" %}}

--- a/content/en/agent/troubleshooting/send_a_flare.md
+++ b/content/en/agent/troubleshooting/send_a_flare.md
@@ -18,7 +18,8 @@ If you are running Agent 5.3+, you can send necessary troubleshooting informatio
 **Confirm the upload of the archive to immediately send it to Datadog support**.
 Datadog Agent is completely open source, which allows you to [verify the code's behavior][1]. If needed, the flare can be reviewed prior to sending since the flare prompts a confirmation before uploading it.
 
-In the commands below, replace `<CASE_ID>` with your Datadog support case ID. In all cases, you will be asked for an email address. It is used verify your case ID. If you don't specify a case ID, the email address is used to login in your organization and create a new support case.
+In the commands below, replace `<CASE_ID>` with your Datadog support case ID if you have one, then enter the email address associated with it. 
+If you don't have a case ID, just enter your email address used to login in Datadog to create a new support case.
 
 
 


### PR DESCRIPTION
The text made it look like, to me, that only in the event of not providing a case id, then would you be asked for an email address. Then and **only** then.

Whereas the source code for the flare has a comment: https://github.com/DataDog/dd-agent/blob/7318fc0/utils/flare.py#L703-L704

That says:

```
 # We ask everytime now, as it is also the 'id' to check
 # that the case is the good one if it exists
```

I feel this changed text more accurately reflects the actual behavior of the code and will avoid confusion for users.

### What does this PR do?
Improve clarity.

### Motivation
I myself was confused by the case at hand.

### Preview link
<!-- Impacted pages preview links-->
N/A
