### PR TITLE
Add a date-parsing example for AM/PM

### DIFF
--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -241,7 +241,7 @@ The date matcher transforms your timestamp in the EPOCH format.
 | **Raw string**                           | **Parsing rule**                                          | **Result**              |
 | :---                                     | :----                                                     | :----                   |
 | 14:20:15                                 | `%{date("HH:mm:ss"):date}`                                | {"date": 51615000}      |
-| 12:48:45,669 AM                          | `%{date("hh:mm:ss,SSS a"):date}`                          | {"date": 1570063725669} |
+| 02:20:15 PM                              | `%{date("hh:mm:ss a"):date}`                              | {"date": 51615000}      |
 | 11/10/2014                               | `%{date("dd/MM/yyyy"):date}`                              | {"date": 1412978400000} |
 | Thu Jun 16 08:29:03 2016                 | `%{date("EEE MMM dd HH:mm:ss yyyy"):date}`                | {"date": 1466065743000} |
 | Tue Nov 1 08:29:03 2016                  | `%{date("EEE MMM d HH:mm:ss yyyy"):date}`                 | {"date": 1466065743000} |

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -241,6 +241,7 @@ The date matcher transforms your timestamp in the EPOCH format.
 | **Raw string**                           | **Parsing rule**                                          | **Result**              |
 | :---                                     | :----                                                     | :----                   |
 | 14:20:15                                 | `%{date("HH:mm:ss"):date}`                                | {"date": 51615000}      |
+| 12:48:45,669 AM                          | `%{date("hh:mm:ss,SSS a"):date}`                          | {"date": 1570063725669} |
 | 11/10/2014                               | `%{date("dd/MM/yyyy"):date}`                              | {"date": 1412978400000} |
 | Thu Jun 16 08:29:03 2016                 | `%{date("EEE MMM dd HH:mm:ss yyyy"):date}`                | {"date": 1466065743000} |
 | Tue Nov 1 08:29:03 2016                  | `%{date("EEE MMM d HH:mm:ss yyyy"):date}`                 | {"date": 1466065743000} |


### PR DESCRIPTION
### What does this PR do?
Adds an example to show how a customer can parse dates in 12-hour format (AM or PM).

### Motivation
Customers occasionally reach out about this and currently even SEs have to do a bit of digging to find out what symbols are supported in the Grok Parser for dates. 

### Preview link
https://docs-staging.datadoghq.com/possum/date-example/logs/processing/parsing/?tab=matcher#parsing-dates

### Additional Notes
Our Grok Parsers are capable of handling any of the symbols listed in these links: 

- https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html
- https://www.joda.org/joda-time/key_format.html

Customers aren't likely to need most of these (nobody is sending logs in BC, for example) but it might be worth putting a link at some point.