### PR TITLE
Replace program files with variable %PROGRAMFILES%

### DIFF
--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -67,7 +67,7 @@ Each configuration item is added as a property to the command line. The followin
 | `DDAGENTUSER_NAME`         | String | Override the default `ddagentuser` username used during Agent installation _(v6.11.0+)_. [Learn more about the Datadog Windows Agent User][3].                                                                                     |
 | `DDAGENTUSER_PASSWORD`     | String | Override the cryptographically secure password generated for the `ddagentuser` user during Agent installation _(v6.11.0+)_. Must be provided for installs on domain servers. [Learn more about the Datadog Windows Agent User][3]. |
 | `APPLICATIONDATADIRECTORY` | Path   | Override the directory to use for the configuration file directory tree. May only be provided on initial install; not valid for upgrades. Default: `C:\ProgramData\Datadog`. _(v6.11.0+)_                                          |
-| `PROJECTLOCATION`          | Path   | Override the directory to use for the binary file directory tree. May only be provided on initial install; not valid for upgrades. Default: `C:\Program Files\Datadog\Datadog Agent`. _(v6.11.0+)_                                 |
+| `PROJECTLOCATION`          | Path   | Override the directory to use for the binary file directory tree. May only be provided on initial install; not valid for upgrades. Default: `%PROGRAMFILES%\Datadog\Datadog Agent`. _(v6.11.0+)_                                 |
 
 **Note**: If a valid `datadog.yaml` is found and has an API key configured, that file takes precedence over all specified command line options.
 
@@ -83,7 +83,7 @@ The execution of the Agent is controlled by the Windows Service Control Manager.
 
 * The main executable name is `agent.exe`.
 * The configuration GUI is a browser-based configuration application (for Windows 64-bit only).
-* Commands can be run from the command line `"C:\Program Files\Datadog\Datadog Agent\bin\agent.exe" <command>` for Agent versions >= 6.12 or `"C:\Program Files\Datadog\Datadog Agent\embedded\agent.exe" <command>` for Agent versions <= 6.11. Command-line options are below:
+* Commands can be run from the command line `"%PROGRAMFILES%\Datadog\Datadog Agent\bin\agent.exe" <command>` for Agent versions >= 6.12 or `"%PROGRAMFILES%\Datadog\Datadog Agent\embedded\agent.exe" <command>` for Agent versions <= 6.11. Command-line options are below:
 
 | Command         | Description                                                                      |
 |-----------------|----------------------------------------------------------------------------------|
@@ -165,19 +165,19 @@ To verify the Agent is running, check if the `DatadogAgent` service in the Servi
 To receive more information about the Agent's state, start the Datadog Agent Manager:
 
 * Right click on the Datadog Agent system tray icon -> Configure, or
-* Run  `& "C:\Program Files\Datadog\Datadog Agent\bin\agent.exe" launch-gui` for agent version >= 6.12 or `& "C:\Program Files\Datadog\Datadog Agent\embedded\agent.exe" launch-gui` for agent version <= 6.11 from an admin Powershell prompt
+* Run  `& "%PROGRAMFILES%\Datadog\Datadog Agent\bin\agent.exe" launch-gui` for agent version >= 6.12 or `& "%PROGRAMFILES%\Datadog\Datadog Agent\embedded\agent.exe" launch-gui` for agent version <= 6.11 from an admin Powershell prompt
 
 Then, open the status page by going to *Status* -> *General*.
 Get more information on running checks in *Status* -> *Collector* and *Checks* -> *Summary*.
 
 The status command is available for Powershell:
 ```powershell
-& "C:\Program Files\Datadog\Datadog Agent\embedded\agent.exe" status
+& "%PROGRAMFILES%\Datadog\Datadog Agent\embedded\agent.exe" status
 ```
 
 or cmd.exe:
 ```cmd
-"C:\Program Files\Datadog\Datadog Agent\embedded\agent.exe" status
+"%PROGRAMFILES%\Datadog\Datadog Agent\embedded\agent.exe" status
 ```
 
 {{% /tab %}}
@@ -195,16 +195,16 @@ For the status of Agent v3.9.1 to v5.1, navigate to `http://localhost:17125/stat
 The info command is available for Powershell:
 
 ```
-& "C:\Program Files\Datadog\Datadog Agent\embedded<PYTHON_MAJOR_VERSION>\python.exe" "C:\Program Files\Datadog\Datadog Agent\agent\agent.py" info
+& "%PROGRAMFILES%\Datadog\Datadog Agent\embedded<PYTHON_MAJOR_VERSION>\python.exe" "%PROGRAMFILES%\Datadog\Datadog Agent\agent\agent.py" info
 ```
 
 or cmd.exe:
 
 ```
-"C:\Program Files\Datadog\Datadog Agent\embedded<PYTHON_MAJOR_VERSION>\python.exe" "C:\Program Files\Datadog\Datadog Agent\agent\agent.py" info
+"%PROGRAMFILES%\Datadog\Datadog Agent\embedded<PYTHON_MAJOR_VERSION>\python.exe" "%PROGRAMFILES%\Datadog\Datadog Agent\agent\agent.py" info
 ```
 
-**Note**: For Agent versions <= 6.11 the path should be `C:\Program Files\Datadog\Datadog Agent\embedded\python.exe` instead.
+**Note**: For Agent versions <= 6.11 the path should be `%PROGRAMFILES%\Datadog\Datadog Agent\embedded\python.exe` instead.
 
 
 {{% /tab %}}
@@ -272,11 +272,11 @@ To send Datadog support a copy of your Windows logs and configurations, do the f
 The flare command is available for Powershell:
 
 ```
-& "C:\Program Files\Datadog\Datadog Agent\embedded\python.exe" "C:\Program Files\Datadog\Datadog Agent\agent\agent.py" flare <CASE_ID>
+& "%PROGRAMFILES%\Datadog\Datadog Agent\embedded\python.exe" "%PROGRAMFILES%\Datadog\Datadog Agent\agent\agent.py" flare <CASE_ID>
 ```
 or cmd.exe:
 ```
-"C:\Program Files\Datadog\Datadog Agent\embedded\python.exe" "C:\Program Files\Datadog\Datadog Agent\agent\agent.py" flare <CASE_ID>
+"%PROGRAMFILES%\Datadog\Datadog Agent\embedded\python.exe" "%PROGRAMFILES%\Datadog\Datadog Agent\agent\agent.py" flare <CASE_ID>
 ```
 
 #### Flare fails to upload
@@ -288,10 +288,10 @@ For Windows, you can find the location of this file by running the following fro
 **Step 1**:
 
 * Agent v5.12+:
-    `"C:\Program Files\Datadog\Datadog Agent\dist\shell.exe" since`
+    `"%PROGRAMFILES%\Datadog\Datadog Agent\dist\shell.exe" since`
 
 * Older Agent versions:
-    `"C:\Program Files (x86)\Datadog\Datadog Agent\files\shell.exe"`
+    `"%PROGRAMFILES%\Datadog\Datadog Agent\files\shell.exe"`
 
 **Step 2**:
 

--- a/content/en/agent/faq/agent-v6-changes.md
+++ b/content/en/agent/faq/agent-v6-changes.md
@@ -255,7 +255,7 @@ The major changes for Agent v6 on Windows are:
 
 * The Agent v5 Windows Agent Manager GUI was replaced with a browser-based, cross-platform manager. For details, see the [Datadog Agent Manager for Windows][1].
 * The main executable file is `agent.exe` (previously `ddagent.exe`).
-* Commands should be run with the command line `"C:\Program Files\datadog\datadog agent\embedded\agent.exe" <COMMAND>` from an **Administrator** command prompt.
+* Commands should be run with the command line `"%PROGRAMFILES%\datadog\datadog agent\embedded\agent.exe" <COMMAND>` from an **Administrator** command prompt.
 * The Windows service is now started as "Automatic-Delayed". It is started automatically on boot, but after all other services. This results in a small delay in reporting metrics after a reboot.
 * The Windows GUI and Windows system tray icon are now implemented separately. See the [Datadog Agent Manager for Windows][1] for more details.
 

--- a/content/en/agent/guide/datadog-agent-manager-windows.md
+++ b/content/en/agent/guide/datadog-agent-manager-windows.md
@@ -29,7 +29,7 @@ From the Windows start menu:
 
 From an elevated Powershell prompt:
 ```powershell
-& "C:\Program Files\Datadog\Datadog Agent\embedded\agent.exe" launch-gui
+& "%PROGRAMFILES%\Datadog\Datadog Agent\embedded\agent.exe" launch-gui
 ```
 
 The Datadog Agent Manager launches in your default web browser. The web address is `http://127.0.0.1:5002`.

--- a/content/en/agent/guide/integration-management.md
+++ b/content/en/agent/guide/integration-management.md
@@ -48,7 +48,7 @@ sudo -u dd-agent -- datadog-agent integration install datadog-vsphere==3.6.0
 ```
 Windows:
 ```
-"C:\Program Files\Datadog\Datadog Agent\embedded\agent.exe" integration install datadog-vsphere==3.6.0
+"%PROGRAMFILES%\Datadog\Datadog Agent\embedded\agent.exe" integration install datadog-vsphere==3.6.0
 ```
 
 The command installs the Python package of the integration and copies the configuration files (`conf.yaml.example`, `conf.yaml.default`, `auto_conf.yaml`) to the `conf.d` directory, overwriting the existing ones. The same thing is done during a full Agent upgrade. If a failure occurs while copying of the files, the command exits with a failure, but the version of the integration you specified still gets installed.
@@ -75,7 +75,7 @@ sudo -u dd-agent -- datadog-agent integration remove datadog-vsphere
 ```
 Windows:
 ```
-"C:\Program Files\Datadog\Datadog Agent\embedded\agent.exe" integration remove datadog-vsphere
+"%PROGRAMFILES%\Datadog\Datadog Agent\embedded\agent.exe" integration remove datadog-vsphere
 ```
 
 Removing an integration does not remove the corresponding configuration folder in the `conf.d` directory.
@@ -92,7 +92,7 @@ sudo -u dd-agent -- datadog-agent integration show datadog-vsphere
 ```
 Windows:
 ```
-"C:\Program Files\Datadog\Datadog Agent\embedded\agent.exe" integration show datadog-vsphere
+"%PROGRAMFILES%\Datadog\Datadog Agent\embedded\agent.exe" integration show datadog-vsphere
 ```
 
 ### Freeze
@@ -105,7 +105,7 @@ sudo -u dd-agent -- datadog-agent integration freeze
 ```
 Windows:
 ```
-"C:\Program Files\Datadog\Datadog Agent\embedded\agent.exe" integration freeze
+"%PROGRAMFILES%\Datadog\Datadog Agent\embedded\agent.exe" integration freeze
 ```
 
 [1]: https://github.com/DataDog/integrations-core

--- a/content/en/agent/guide/secrets-management.md
+++ b/content/en/agent/guide/secrets-management.md
@@ -260,7 +260,7 @@ Secrets handle decrypted:
 
 Example on Windows (from an Administrator Powershell):
 ```
-PS C:\> & 'C:\Program Files\Datadog\Datadog Agent\embedded\agent.exe' secret
+PS C:\> & '%PROGRAMFILES%\Datadog\Datadog Agent\embedded\agent.exe' secret
 === Checking executable rights ===
 Executable path: C:\path\to\you\executable.exe
 Check Rights: OK, the executable has the correct rights
@@ -314,7 +314,7 @@ password: <decrypted_password2>
 ===
 ```
 
-**Note**: The Agent needs to be [restarted][3] to pick up changes on configuration files.
+**Note**: The Agent needs to be [restarted][2] to pick up changes on configuration files.
 
 ### Debugging your secret_backend_command
 
@@ -371,7 +371,7 @@ To do so, follow those steps:
   sc.exe config DatadogAgent password= "a_new_password"
   ```
 
-You can now login as `ddagentuser` to test your executable. Datadog has a [Powershell script][2] to help you test your
+You can now login as `ddagentuser` to test your executable. Datadog has a [Powershell script][3] to help you test your
 executable as another user. It switches user contexts and mimics how the Agent runs your executable.
 
 Example on how to use it:
@@ -403,5 +403,5 @@ If you have secrets in `datadog.yaml` and the Agent refuses to start:
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /agent/autodiscovery
-[2]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/secrets_scripts/secrets_tester.ps1
-[3]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
+[2]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
+[3]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/secrets_scripts/secrets_tester.ps1

--- a/content/en/agent/troubleshooting/agent_check_status.md
+++ b/content/en/agent/troubleshooting/agent_check_status.md
@@ -62,13 +62,13 @@ Run the following script, with the proper `<CHECK_NAME>`:
 For Agent versions >= 6.12:
 
 ```
-C:\Program Files\Datadog\Datadog Agent\bin\agent.exe check <CHECK_NAME>
+%PROGRAMFILES%\Datadog\Datadog Agent\bin\agent.exe check <CHECK_NAME>
 ```
 
 For Agent versions <= 6.11:
 
 ```
-C:\Program Files\Datadog\Datadog Agent\embedded\agent.exe check <CHECK_NAME>
+%PROGRAMFILES%\Datadog\Datadog Agent\embedded\agent.exe check <CHECK_NAME>
 ```
 
 {{% /tab %}}

--- a/content/en/developers/dogstatsd/datagram_shell.md
+++ b/content/en/developers/dogstatsd/datagram_shell.md
@@ -132,7 +132,7 @@ PS C:\vagrant> .\send-statsd.ps1 "custom_metric:123|g|#shell"
 PS C:\vagrant>
 ```
 
-On any platform with Python (on Windows, the Agent's embedded Python interpreter can be used, which is located at `C:\Program Files\Datadog\Datadog Agent\embedded\python.exe` for Agent versions <= 6.11 and in `C:\Program Files\Datadog\Datadog Agent\embedded<PYTHON_MAJOR_VERSION>\python.exe` for Agent versions >= 6.12):
+On any platform with Python (on Windows, the Agent's embedded Python interpreter can be used, which is located at `%PROGRAMFILES%\Datadog\Datadog Agent\embedded\python.exe` for Agent versions <= 6.11 and in `%PROGRAMFILES%\Datadog\Datadog Agent\embedded<PYTHON_MAJOR_VERSION>\python.exe` for Agent versions >= 6.12):
 
 ```python
 import socket

--- a/content/en/developers/guide/custom-python-package.md
+++ b/content/en/developers/guide/custom-python-package.md
@@ -46,17 +46,17 @@ Custom Python packages can be installed using the Agent's embedded Python using 
 
 For Agent versions <= 6.11:
 ```
-C:\"Program Files"\Datadog\"Datadog Agent"\embedded\python -m pip install <PACKAGE_NAME>
+%PROGRAMFILES%\Datadog\"Datadog Agent"\embedded\python -m pip install <PACKAGE_NAME>
 ```
 
 For Agent versions >= 6.12:
 ```
-C:\"Program Files"\Datadog\"Datadog Agent"\embedded<PYTHON_MAJOR_VERSION>\python -m pip install <PACKAGE_NAME>
+%PROGRAMFILES%\Datadog\"Datadog Agent"\embedded<PYTHON_MAJOR_VERSION>\python -m pip install <PACKAGE_NAME>
 ```
 
 Or the package can be added in the library zipped folder that can be found at
 ```
-C:\Program Files (x86)\Datadog\Datadog Agent\files
+%PROGRAMFILES%\Datadog\Datadog Agent\files
 ```
 
 then [restart your Agent][1].

--- a/content/en/integrations/faq/how-to-run-jmx-commands-in-windows.md
+++ b/content/en/integrations/faq/how-to-run-jmx-commands-in-windows.md
@@ -7,14 +7,14 @@ If you are monitoring a JMX application with a Windows Agent, you can get access
 
 If java is in your path, from a command prompt you should be able to run:
 ```
-java -Xms50m -Xmx200m -classpath "C:\Program Files (x86)\Datadog\Datadog Agent\files\jmxfetch\jmxfetch-0.7.0-jar-with-dependencies.jar" org.datadog.jmxfetch.App --check tomcat.yaml --conf_directory "C:\ProgramData\Datadog\conf.d" --log_level DEBUG --reporter console [collect, list_everything, list_collected_attributes, list_matching_attributes, list_not_matching_attributes, list_limited_attributes, help]
+java -Xms50m -Xmx200m -classpath "%PROGRAMFILES%\Datadog\Datadog Agent\files\jmxfetch\jmxfetch-0.7.0-jar-with-dependencies.jar" org.datadog.jmxfetch.App --check tomcat.yaml --conf_directory "C:\ProgramData\Datadog\conf.d" --log_level DEBUG --reporter console [collect, list_everything, list_collected_attributes, list_matching_attributes, list_not_matching_attributes, list_limited_attributes, help]
 ```
 
 Make sure that the JMXFetch version is the same as the one that ships with your version of the Agent.
 
 Here is a subset of the output from the list_matching_attributes command:
 ```
-java -Xms50m -Xmx200m -classpath "C:\Program Files (x86)\Datadog\Datadog Agent\files\jmxfetch\jmxfe
+java -Xms50m -Xmx200m -classpath "%PROGRAMFILES%\Datadog\Datadog Agent\files\jmxfetch\jmxfe
 tch-0.7.0-jar-with-dependencies.jar" org.datadog.jmxfetch.App --check tomcat.yaml --conf_directory "C:\ProgramData\Datad
 og\conf.d" --log_level DEBUG --reporter console list_matching_attributes
 Log location is not set, not logging to file

--- a/content/en/tracing/setup/dotnet.md
+++ b/content/en/tracing/setup/dotnet.md
@@ -151,8 +151,8 @@ If you did not use the MSI installer, set all four environment variables:
 ```
 COR_ENABLE_PROFILING=1
 COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
-COR_PROFILER_PATH=C:\Program Files\Datadog\.NET Tracer\Datadog.Trace.ClrProfiler.Native.dll
-DD_INTEGRATIONS=C:\Program Files\Datadog\.NET Tracer\integrations.json
+COR_PROFILER_PATH=%PROGRAMFILES%\Datadog\.NET Tracer\Datadog.Trace.ClrProfiler.Native.dll
+DD_INTEGRATIONS=%PROGRAMFILES%\Datadog\.NET Tracer\integrations.json
 ```
 
 For example, to set them from a batch file before starting your application:
@@ -161,8 +161,8 @@ For example, to set them from a batch file before starting your application:
 rem Set environment variables
 SET COR_ENABLE_PROFILING=1
 SET COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
-SET COR_PROFILER_PATH=C:\Program Files\Datadog\.NET Tracer\Datadog.Trace.ClrProfiler.Native.dll
-SET DD_INTEGRATIONS=C:\Program Files\Datadog\.NET Tracer\integrations.json
+SET COR_PROFILER_PATH=%PROGRAMFILES%\Datadog\.NET Tracer\Datadog.Trace.ClrProfiler.Native.dll
+SET DD_INTEGRATIONS=%PROGRAMFILES%\Datadog\.NET Tracer\integrations.json
 
 rem Start application
 example.exe
@@ -190,8 +190,8 @@ If you did not use the MSI installer, set all four environment variables:
 ```
 CORECLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
-CORECLR_PROFILER_PATH=C:\Program Files\Datadog\.NET Tracer\Datadog.Trace.ClrProfiler.Native.dll
-DD_INTEGRATIONS=C:\Program Files\Datadog\.NET Tracer\integrations.json
+CORECLR_PROFILER_PATH=%PROGRAMFILES%\Datadog\.NET Tracer\Datadog.Trace.ClrProfiler.Native.dll
+DD_INTEGRATIONS=%PROGRAMFILES%\Datadog\.NET Tracer\integrations.json
 ```
 
 For example, to set them from a batch file before starting your application:
@@ -200,8 +200,8 @@ For example, to set them from a batch file before starting your application:
 rem Set environment variables
 SET CORECLR_ENABLE_PROFILING=1
 SET CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
-SET CORECLR_PROFILER_PATH=C:\Program Files\Datadog\.NET Tracer\Datadog.Trace.ClrProfiler.Native.dll
-SET DD_INTEGRATIONS=C:\Program Files\Datadog\.NET Tracer\integrations.json
+SET CORECLR_PROFILER_PATH=%PROGRAMFILES%\Datadog\.NET Tracer\Datadog.Trace.ClrProfiler.Native.dll
+SET DD_INTEGRATIONS=%PROGRAMFILES%\Datadog\.NET Tracer\integrations.json
 
 rem Start application
 dotnet.exe example.dll


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR changes every occurences of 'C:\Program Files' to the variable %PROGRAMFILES%.

### Motivation
`c:\program files\datadog\....` is the default location the vast majority of the time, but may not be correct if either (a) the system drive isn't `c:` or (b) one has explicitly chosen another install directory.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/julien-lebot/replace_program_files_with_variable

### Additional Notes
<!-- Anything else we should know when reviewing?-->
