### PR TITLE
APM > .NET > Update setup instructions

### DIFF
--- a/content/en/tracing/setup/dotnet.md
+++ b/content/en/tracing/setup/dotnet.md
@@ -156,7 +156,7 @@ DD_INTEGRATIONS=%PROGRAMFILES%\Datadog\.NET Tracer\integrations.json
 DD_DOTNET_TRACER_HOME=%PROGRAMFILES%\Datadog\.NET Tracer
 ```
 
-For example, to set them from a batch file before starting your application:
+For example, to set the environment variables from a batch file before starting your application:
 
 ```bat
 rem Set environment variables
@@ -185,7 +185,7 @@ CORECLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 ```
 
-`CORECLR_PROFILER_PATH` is not required because the MSI installer registers the native COM library's path in the Windows Registry, and environment variables `DD_INTEGRATIONS` and `DD_DOTNET_TRACER_HOME` set globally for all processes.
+`CORECLR_PROFILER_PATH` is not required because the MSI installer registers the native COM library's path in the Windows Registry, and environment variables `DD_INTEGRATIONS` and `DD_DOTNET_TRACER_HOME` are set globally for all processes.
 
 If you did not use the MSI installer, set all five environment variables:
 
@@ -217,7 +217,7 @@ dotnet.exe example.dll
 
 {{% tab ".NET Core on Linux" %}}
 
-On Linux, these five environment variables are required to enable automatic instrumentation:
+On Linux, the following environment variables are required to enable automatic instrumentation:
 
 ```
 CORECLR_ENABLE_PROFILING=1

--- a/content/en/tracing/setup/dotnet.md
+++ b/content/en/tracing/setup/dotnet.md
@@ -53,7 +53,7 @@ How these components are installed on the host depends on the runtime environmen
 
 {{% tab ".NET Framework on Windows" %}}
 
-Install the .NET Tracer on the host using the [MSI installer for Windows][1]. Choose the platform that matches your application: x64 for 64-bits or x86 for 32-bits. You can install both side-by-side if needed.
+Install the .NET Tracer on the host using the [MSI installer for Windows][1]. Choose the platform that matches the OS architecture.
 
 - Native library: deployed into `Program Files` by default and registered as a COM library in the Windows Registry by the MSI installer.
 - Managed libraries: deployed into the Global Assembly Cache (GAC) by the MSI installer, where any .NET Framework application can access them.
@@ -65,7 +65,7 @@ Install the .NET Tracer on the host using the [MSI installer for Windows][1]. Ch
 
 {{% tab ".NET Core on Windows" %}}
 
-Install the .NET Tracer on the host using the [MSI installer for Windows][1]. Choose the platform that matches your application: x64 for 64-bits or x86 for 32-bits. You can install both side-by-side if needed.
+Install the .NET Tracer on the host using the [MSI installer for Windows][1]. Choose the platform that matches the OS architecture.
 
 Add the `Datadog.Trace.ClrProfiler.Managed` [NuGet package][2] to your application, matching the package version to the MSI installer above. Refer to the [NuGet documentation][3] for instructions on how to add a NuGet package to your application.
 

--- a/content/en/tracing/setup/dotnet.md
+++ b/content/en/tracing/setup/dotnet.md
@@ -144,15 +144,16 @@ COR_ENABLE_PROFILING=1
 COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 ```
 
-`COR_PROFILER_PATH` is not required because the MSI installer registers the native COM library's path in the Windows Registry, and `DD_INTEGRATIONS` is set globally for all processes.
+`COR_PROFILER_PATH` is not required because the MSI installer registers the native COM library's path in the Windows Registry, and environment variables `DD_INTEGRATIONS` and `DD_DOTNET_TRACER_HOME` are set globally for all processes.
 
-If you did not use the MSI installer, set all four environment variables:
+If you did not use the MSI installer, set all five environment variables:
 
 ```
 COR_ENABLE_PROFILING=1
 COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 COR_PROFILER_PATH=%PROGRAMFILES%\Datadog\.NET Tracer\Datadog.Trace.ClrProfiler.Native.dll
 DD_INTEGRATIONS=%PROGRAMFILES%\Datadog\.NET Tracer\integrations.json
+DD_DOTNET_TRACER_HOME=%PROGRAMFILES%\Datadog\.NET Tracer
 ```
 
 For example, to set them from a batch file before starting your application:
@@ -163,6 +164,7 @@ SET COR_ENABLE_PROFILING=1
 SET COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 SET COR_PROFILER_PATH=%PROGRAMFILES%\Datadog\.NET Tracer\Datadog.Trace.ClrProfiler.Native.dll
 SET DD_INTEGRATIONS=%PROGRAMFILES%\Datadog\.NET Tracer\integrations.json
+set DD_DOTNET_TRACER_HOME=%PROGRAMFILES%\Datadog\.NET Tracer
 
 rem Start application
 example.exe
@@ -183,15 +185,16 @@ CORECLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 ```
 
-`CORECLR_PROFILER_PATH` is not required because the MSI installer registers the native COM library's path in the Windows Registry, and `DD_INTEGRATIONS` is set globally for all processes.
+`CORECLR_PROFILER_PATH` is not required because the MSI installer registers the native COM library's path in the Windows Registry, and environment variables `DD_INTEGRATIONS` and `DD_DOTNET_TRACER_HOME` set globally for all processes.
 
-If you did not use the MSI installer, set all four environment variables:
+If you did not use the MSI installer, set all five environment variables:
 
 ```
 CORECLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 CORECLR_PROFILER_PATH=%PROGRAMFILES%\Datadog\.NET Tracer\Datadog.Trace.ClrProfiler.Native.dll
 DD_INTEGRATIONS=%PROGRAMFILES%\Datadog\.NET Tracer\integrations.json
+DD_DOTNET_TRACER_HOME=%PROGRAMFILES%\Datadog\.NET Tracer
 ```
 
 For example, to set them from a batch file before starting your application:
@@ -202,6 +205,7 @@ SET CORECLR_ENABLE_PROFILING=1
 SET CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 SET CORECLR_PROFILER_PATH=%PROGRAMFILES%\Datadog\.NET Tracer\Datadog.Trace.ClrProfiler.Native.dll
 SET DD_INTEGRATIONS=%PROGRAMFILES%\Datadog\.NET Tracer\integrations.json
+SET DD_DOTNET_TRACER_HOME=%PROGRAMFILES%\Datadog\.NET Tracer
 
 rem Start application
 dotnet.exe example.dll
@@ -213,13 +217,14 @@ dotnet.exe example.dll
 
 {{% tab ".NET Core on Linux" %}}
 
-On Linux, these four environment variables are required to enable automatic instrumentation:
+On Linux, these five environment variables are required to enable automatic instrumentation:
 
 ```
 CORECLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
 DD_INTEGRATIONS=/opt/datadog/integrations.json
+DD_DOTNET_TRACER_HOME=/opt/datadog
 ```
 
 For example, to set them from a bash file before starting your application:
@@ -230,6 +235,7 @@ export CORECLR_ENABLE_PROFILING=1
 export CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 export CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
 export DD_INTEGRATIONS=/opt/datadog/integrations.json
+export DD_DOTNET_TRACER_HOME=/opt/datadog
 
 # Start your application
 dotnet example.dll
@@ -248,6 +254,7 @@ Environment=CORECLR_ENABLE_PROFILING=1
 Environment=CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 Environment=CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
 Environment=DD_INTEGRATIONS=/opt/datadog/integrations.json
+Environment=DD_DOTNET_TRACER_HOME=/opt/datadog
 
 [Install]
 WantedBy=multi-user.target
@@ -260,6 +267,7 @@ ENV CORECLR_ENABLE_PROFILING=1
 ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
 ENV DD_INTEGRATIONS=/opt/datadog/integrations.json
+ENV DD_DOTNET_TRACER_HOME=/opt/datadog
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- "Tracing .NET Applications" page
  - Update Windows MSI instructions to recommend installing only one MSI that matches the operation system's architecture
  - Add setup instructions for the newly added `DD_DOTNET_TRACER_HOME` environment variable

### Motivation
The .NET Tracer 1.8.0 introduces changes that simplify the Windows installation and utilize the new environment variable.

### Preview link
<!-- Impacted pages preview links-->
- [Tracing .NET Applications](https://docs-staging.datadoghq.com/zach.montoya/update_dotnet_tracer_env_variables/tracing/setup/dotnet/)

### Additional notes
Merge is pending release
