### PR TITLE
[APM] Update framework support in the PHP tracer docs

### DIFF
--- a/content/en/tracing/setup/php.md
+++ b/content/en/tracing/setup/php.md
@@ -111,18 +111,18 @@ If the web framework that you use is not listed below, you can still see traces 
 | Module         | Versions           | Support Type    |
 |:---------------|:-------------------|:----------------|
 | CakePHP        | 2.x                | Fully Supported |
+| CodeIgniter    | 2.x                | PHP 7           |
 | Laravel        | 4.2, 5.x           | Fully Supported |
 | Lumen          | 5.2+               | Fully Supported |
 | Slim           | 3.x                | Fully Supported |
-| Symfony        | 3.3, 3.4, 4.x | Fully Supported |
+| Symfony        | 3.3, 3.4, 4.x      | Fully Supported |
+| WordPress      | 4.x                | PHP 7           |
 | Zend Framework | 1.12               | Fully Supported |
-| CakePHP        | 1.3, 3.x           | _Coming Soon_   |
-| CodeIgniter    | 2, 3               | _Coming Soon_   |
+| CodeIgniter    | 3.x                | _Coming Soon_   |
 | Drupal         |                    | _Coming Soon_   |
 | Magento        | 2                  | _Coming Soon_   |
 | Phalcon        | 1.3, 3.4           | _Coming Soon_   |
 | Slim           | 2.x                | _Coming Soon_   |
-| Wordpress      |                    | _Coming Soon_   |
 | Yii            | 1.1                | _Coming Soon_   |
 
 Don’t see your desired frameworks? Datadog is continually adding additional support. Check with the [Datadog team][13] for help.
@@ -144,7 +144,6 @@ Don’t see your desired CLI library? Datadog is continually adding additional s
 | Module                           | Versions                   | Support Type    |
 |:---------------------------------|:---------------------------|:----------------|
 | Amazon RDS (using PDO or MySQLi) | *(Any Supported PHP)*      | Fully Supported |
-| CakePHP Console                  | 2.x                        | Fully Supported |
 | Elasticsearch                    | 1.x                        | Fully Supported |
 | Eloquent                         | Laravel supported versions | Fully Supported |
 | Memcached                        | *(Any Supported PHP)*      | Fully Supported |


### PR DESCRIPTION
### What does this PR do?

Per the latest release, this PR updates the supported frameworks. I also moved `CakePHP Console` back to the CLI section. Not sure how that got moved. :)

### Preview link

https://docs-staging.datadoghq.com/sammyk/php-tracer-ci-wp-support/tracing/setup/php/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
