### PR TITLE
change java function to not hardcode customer_id

### DIFF
--- a/content/en/tracing/advanced/adding_metadata_to_spans.md
+++ b/content/en/tracing/advanced/adding_metadata_to_spans.md
@@ -44,7 +44,7 @@ class ServletImpl extends AbstractHttpServlet {
     final Span span = GlobalTracer.get().activeSpan();
     if (span != null) {
       span.setTag("customer.id", req.getParameter("customer_id"));
-      span.setTag("http.url", "/login");
+      span.setTag("<TAG_KEY>", "<TAG_VALUE>");
     }
     // servlet impl
   }

--- a/content/en/tracing/advanced/adding_metadata_to_spans.md
+++ b/content/en/tracing/advanced/adding_metadata_to_spans.md
@@ -43,7 +43,7 @@ class ServletImpl extends AbstractHttpServlet {
   void doGet(HttpServletRequest req, HttpServletResponse resp) {
     final Span span = GlobalTracer.get().activeSpan();
     if (span != null) {
-      span.setTag("customer.id", 12345);
+      span.setTag("customer.id", req.getParameter("customer_id"));
       span.setTag("http.url", "/login");
     }
     // servlet impl


### PR DESCRIPTION

### What does this PR do?

Change the java customer id `12345` to pull from the request parameters instead

### Motivation

it looks a bit silly to hardcode the customer id as 12345, especially when the other example functions all show variables used

### Additional Notes

PHP and .Net don't use examples and leave it as <TAG_KEY> and <TAG_VALUE>, they should probably be updated to match the other examples, but i don't know those language well and don't want to make a mistake, so i'm just leaving them alone