### PR TITLE
haproxy's backend server checks didn't match ports

### DIFF
--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -194,25 +194,25 @@ backend datadog-metrics
     balance roundrobin
     mode tcp
     option tcplog
-    server mothership haproxy-app.agent.datadoghq.com:443 check port 80
+    server mothership haproxy-app.agent.datadoghq.com:443 check port 443
 
 backend datadog-traces
     balance roundrobin
     mode tcp
     option tcplog
-    server mothership trace.agent.datadoghq.com:443 check port 80
+    server mothership trace.agent.datadoghq.com:443 check port 443
 
 backend datadog-processes
     balance roundrobin
     mode tcp
     option tcplog
-    server mothership process.datadoghq.com:443 check port 80
+    server mothership process.datadoghq.com:443 check port 443
 
 backend datadog-logs
     balance roundrobin
     mode tcp
     option tcplog
-    server datadog agent-intake.logs.datadoghq.com:10516 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt
+    server datadog agent-intake.logs.datadoghq.com:10516 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt check port 10516
 ```
 
 **Note**: Download the certificate with the following command:
@@ -288,32 +288,32 @@ backend datadog-metrics
     balance roundrobin
     mode tcp
     option tcplog
-    server mothership haproxy-app.agent.datadoghq.eu:443 check port 80
+    server mothership haproxy-app.agent.datadoghq.eu:443 check port 443
 
 backend datadog-traces
     balance roundrobin
     mode tcp
     option tcplog
-    server mothership trace.agent.datadoghq.eu:443 check port 80
+    server mothership trace.agent.datadoghq.eu:443 check port 443
 
 backend datadog-processes
     balance roundrobin
     mode tcp
     option tcplog
-    server mothership process.datadoghq.eu:443 check port 80
+    server mothership process.datadoghq.eu:443 check port 443
 
 backend datadog-logs
     balance roundrobin
     mode tcp
     option tcplog
-    server datadog agent-intake.logs.datadoghq.eu:443 ssl verify required ca-file /etc/ssl/certs/ca-bundle.crt
+    server datadog agent-intake.logs.datadoghq.eu:443 ssl verify required ca-file /etc/ssl/certs/ca-bundle.crt check port 443
 ```
 
 **Note**: Download the certificate with the following command:
 
         * `sudo apt-get install ca-certificates` (Debian, Ubuntu)
         * `yum install ca-certificates` (CentOS, Redhat)
-        
+
 The file might be located at `/etc/ssl/certs/ca-bundle.crt` for CentOS, Redhat.
 
 Once the HAProxy configuration is in place, you can reload it or restart HAProxy. **It is recommended to have a `cron` job that reloads HAProxy every 10 minutes** (usually doing something like `service haproxy reload`) to force a refresh of HAProxy's DNS cache, in case `app.datadoghq.eu` fails over to another IP.

--- a/content/fr/agent/proxy.md
+++ b/content/fr/agent/proxy.md
@@ -86,7 +86,7 @@ Sur les hosts Unix, un proxy sur l'ensemble du système peut être défini avec 
 
 L'Agent utilise les valeurs suivantes par ordre de priorité :
 
-1. Les variables d'environnement `DD_PROXY_HTTPS`, `DD_PROXY_HTTP` et `DD_PROXY_NO_PROXY` 
+1. Les variables d'environnement `DD_PROXY_HTTPS`, `DD_PROXY_HTTP` et `DD_PROXY_NO_PROXY`
 2. Les variables d'environnement `HTTPS_PROXY`, `HTTP_PROXY` et `NO_PROXY`
 3. Les valeurs spécifiées dans `datadog.yaml`
 
@@ -193,25 +193,25 @@ backend datadog-metrics
     balance roundrobin
     mode tcp
     option tcplog
-    server mothership haproxy-app.agent.datadoghq.com:443 check port 80
+    server mothership haproxy-app.agent.datadoghq.com:443 check port 443
 
 backend datadog-traces
     balance roundrobin
     mode tcp
     option tcplog
-    server mothership trace.agent.datadoghq.com:443 check port 80
+    server mothership trace.agent.datadoghq.com:443 check port 443
 
 backend datadog-processes
     balance roundrobin
     mode tcp
     option tcplog
-    server mothership process.datadoghq.com:443 check port 80
+    server mothership process.datadoghq.com:443 check port 443
 
 backend datadog-logs
     balance roundrobin
     mode tcp
     option tcplog
-    server datadog agent-intake.logs.datadoghq.com:10516 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt
+    server datadog agent-intake.logs.datadoghq.com:10516 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt check port 10516
 ```
 
 Une fois la configuration HAProxy effectuée, vous pouvez la recharger ou redémarrer HAProxy.
@@ -284,25 +284,25 @@ backend datadog-metrics
     balance roundrobin
     mode tcp
     option tcplog
-    server mothership haproxy-app.agent.datadoghq.eu:443 check port 80
+    server mothership haproxy-app.agent.datadoghq.eu:443 check port 443
 
 backend datadog-traces
     balance roundrobin
     mode tcp
     option tcplog
-    server mothership trace.agent.datadoghq.eu:443 check port 80
+    server mothership trace.agent.datadoghq.eu:443 check port 443
 
 backend datadog-processes
     balance roundrobin
     mode tcp
     option tcplog
-    server mothership process.datadoghq.eu:443 check port 80
+    server mothership process.datadoghq.eu:443 check port 443
 
 backend datadog-logs
     balance roundrobin
     mode tcp
     option tcplog
-    server datadog agent-intake.logs.datadoghq.eu:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt
+    server datadog agent-intake.logs.datadoghq.eu:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt check port 443
 ```
 
 Une fois la configuration HAProxy effectuée, vous pouvez la recharger ou redémarrer HAProxy.

--- a/content/ja/agent/proxy.md
+++ b/content/ja/agent/proxy.md
@@ -143,7 +143,7 @@ logs_config:
     * `app.datadoghq.eu` の場合: `agent-intake.logs.datadoghq.eu` のポート `443`。SSL 暗号化をアクティブにします。
 
 * SSL 暗号化には、TLS 暗号化の公開鍵を使用します。
-    * [app.datadoghq.com][1] の場合 
+    * [app.datadoghq.com][1] の場合
     * [app.datadoghq.eu][2] の場合
 
     一部のシステムでは、証明書チェーン全体が必要になることがあります。その場合は、代わりにこの公開鍵を使用します。
@@ -227,7 +227,7 @@ frontend metrics-forwarder
     default_backend datadog-metrics
 
 # Agent がトレースを送信するために接続する
-# エンドポイントを宣言します (例: APM 構成セクションの "endpoint" 
+# エンドポイントを宣言します (例: APM 構成セクションの "endpoint"
 # の値)。
 frontend traces-forwarder
     bind *:3835
@@ -235,7 +235,7 @@ frontend traces-forwarder
     default_backend datadog-traces
 
 # Agent がプロセスを送信するために接続する
-# エンドポイントを宣言します (例: プロセス構成セクションの "url" 
+# エンドポイントを宣言します (例: プロセス構成セクションの "url"
 # の値)。
 frontend processes-forwarder
     bind *:3836
@@ -256,25 +256,25 @@ backend datadog-metrics
     balance roundrobin
     mode tcp
     option tcplog
-    server mothership haproxy-app.agent.datadoghq.com:443 check port 80
+    server mothership haproxy-app.agent.datadoghq.com:443 check port 443
 
 backend datadog-traces
     balance roundrobin
     mode tcp
     option tcplog
-    server mothership trace.agent.datadoghq.com:443 check port 80
+    server mothership trace.agent.datadoghq.com:443 check port 443
 
 backend datadog-processes
     balance roundrobin
     mode tcp
     option tcplog
-    server mothership process.datadoghq.com:443 check port 80
+    server mothership process.datadoghq.com:443 check port 443
 
 backend datadog-logs
     balance roundrobin
     mode tcp
     option tcplog
-    server datadog agent-intake.logs.datadoghq.com:10516 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt
+    server datadog agent-intake.logs.datadoghq.com:10516 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt check port 10516
 ```
 
 HAProxy 構成が完成したら、リロードするか、HAProxy を再起動できます。
@@ -318,7 +318,7 @@ frontend metrics-forwarder
     default_backend datadog-metrics
 
 # Agent がトレースを送信するために接続する
-# エンドポイントを宣言します (例: APM 構成セクションの "endpoint" 
+# エンドポイントを宣言します (例: APM 構成セクションの "endpoint"
 # の値)。
 frontend traces-forwarder
     bind *:3835
@@ -326,7 +326,7 @@ frontend traces-forwarder
     default_backend datadog-traces
 
 # Agent がプロセスを送信するために接続する
-# エンドポイントを宣言します (例: プロセス構成セクションの "url" 
+# エンドポイントを宣言します (例: プロセス構成セクションの "url"
 # の値)。
 frontend processes-forwarder
     bind *:3836
@@ -347,25 +347,25 @@ backend datadog-metrics
     balance roundrobin
     mode tcp
     option tcplog
-    server mothership haproxy-app.agent.datadoghq.eu:443 check port 80
+    server mothership haproxy-app.agent.datadoghq.eu:443 check port 443
 
 backend datadog-traces
     balance roundrobin
     mode tcp
     option tcplog
-    server mothership trace.agent.datadoghq.eu:443 check port 80
+    server mothership trace.agent.datadoghq.eu:443 check port 443
 
 backend datadog-processes
     balance roundrobin
     mode tcp
     option tcplog
-    server mothership process.datadoghq.eu:443 check port 80
+    server mothership process.datadoghq.eu:443 check port 443
 
 backend datadog-logs
     balance roundrobin
     mode tcp
     option tcplog
-    server datadog agent-intake.logs.datadoghq.eu:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt
+    server datadog agent-intake.logs.datadoghq.eu:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt check port 443
 ```
 
 HAProxy 構成が完成したら、リロードするか、HAProxy を再起動できます。
@@ -473,7 +473,7 @@ skip_ssl_validation: yes
 user nginx;
 worker_processes auto;
 error_log /var/log/nginx/error.log;
-pid /run/nginx.pid; 
+pid /run/nginx.pid;
 
 include /usr/share/nginx/modules/*.conf;
 events {
@@ -496,7 +496,7 @@ stream {
 user nginx;
 worker_processes auto;
 error_log /var/log/nginx/error.log;
-pid /run/nginx.pid; 
+pid /run/nginx.pid;
 
 include /usr/share/nginx/modules/*.conf;
 events {
@@ -541,7 +541,7 @@ SSL/TLS 接続の確立は NGINX の `proxy_ssl on` オプションによって�
     curl -v https://app.datadoghq.com/account/login 2>&1 | grep "200 OK"
     ```
 
-3. `proxy-node` 上の非ローカルトラフィックを許可するために、`datadog.conf` の 
+3. `proxy-node` 上の非ローカルトラフィックを許可するために、`datadog.conf` の
      `# non_local_traffic: no` の行を `non_local_traffic: yes` に変更します。
 
 4. ポート 17123 経由で他のノードから `proxy-node` に到達できることを確認します。`proxy-node` で Agent を起動し、他のノードでも Agent を実行します。


### PR DESCRIPTION
Health checks for backend servers didn't check the exact port data is to be shipped to.
While this doesn't necessarily cause issues on its own for very restricted environments where outbound ports have to be allowed explicitly using "check port 80" may result in health check failures even if the backends are up - simply because outbound 80 wasn't permitted

