### PR TITLE
Interpolation wording update

### DIFF
--- a/content/en/graphing/faq/interpolation-the-fill-modifier-explained.md
+++ b/content/en/graphing/faq/interpolation-the-fill-modifier-explained.md
@@ -40,33 +40,32 @@ Interpolation occurs when more than one source corresponds to your graph query, 
 
 Interpolation is not needed when you graph one metric submitted from one source, for example `avg:net.bytes_rcvd{host:a}` assuming `host:a` always submits the metric `net.bytes_rcvd` with the same tags.
 
-Interpolation is not performed for multi-part queries, for example:  
-`avg:system.cpu.user{env:prod},avg:system.cpu.user{env:dev}`
+Interpolation is not performed for multi-part queries, for example: `avg:system.cpu.user{env:prod},avg:system.cpu.user{env:dev}`
 
 The type of interpolation described in this article is also not performed for arithmetic. When evaluating queries, Datadog's backend rolls data up into intervals (one for each point in a timeseries graph, see [this article][1] for more details). If a query involves arithmetic, and one of these intervals is missing data for part of a query, the query system substitutes 0 for that interval. This behavior cannot be controlled with the fill modifier.
 
 ## How to control interpolation?
 
-The default interpolation for gauge type metrics is linear and is performed up to 5 min after real samples. The default for count or rate type metrics is to disable interpolation.
+The default interpolation for all metric types is linear and is performed up to 5 min after real samples. Interpolation is disabled by the `.as_count()` and `.as_rate()` modifiers for when used on any metric type. Lean more about [metric types][2].
 
 The fill modifier controls interpolation parameters:
 
-* fill(linear, X) gives you a linear interpolation up to X seconds after real samples.
-* fill(last, X) just replicates the last sample value up to X secs.
-* fill(zero, X) inserts 0 where the interpolation is needed up to X secs.
-* fill(null, X) disables interpolation, the value of X doesn't matter.
+* `fill(linear, X)`: Gives you a linear interpolation up to X seconds after real samples.
+* `fill(last, X)`: Replicates the last sample value up to X secs.
+* `fill(zero, X)`: Inserts 0 where the interpolation is needed up to X secs.
+* `fill(null, X)`: Disables interpolation, the value of X doesn't matter.
 
 ## FAQ
 
-**There's a gap in my metric, fill(zero) doesn't do anything, I still have a long straight line on my graph.**  
+**There's a gap in my metric, fill(zero) doesn't do anything, I still have a long straight line on my graph.**
 Since graphs are just a series of data points joined by lines, a long period without any data translates into a long straight line and has no need for interpolation to fill values. Interpolation is about aligning series to make aggregation and multi-line graphs possible.
 
 In contrast, a monitor uses a rollup of a time frame to evaluate interpolated values and calculate averages.
 
-**I have disabled interpolation but I see my metrics dropping to 0 which is not expected.**  
-These artificial dips are caused by front-end visualization enhancement. [See this article for more information][2].
+**I have disabled interpolation but I see my metrics dropping to 0 which is not expected.**
+These artificial dips are caused by front-end visualization enhancement. [See this article for more information][3].
 
-**How to choose the interpolation method?**  
+**How to choose the interpolation method?**
 The default interpolation method (which is chosen based on a metric's type) is usually fine, but it is sometimes desirable to override these defaults.
 
 Linear interpolation is a great fit for metrics reported on a steady basis from the same sources. For sparse metrics or metrics reported from varying sources over time, it's often more interesting to disable interpolation. This makes sense if you send data points only when the value of the thing you measure changes.
@@ -74,4 +73,5 @@ Linear interpolation is a great fit for metrics reported on a steady basis from 
 Null prevents graphs from displaying interpolated values 5 min after the last real value.
 
 [1]: /graphing/functions
-[2]: /graphing/faq/i-see-unexpected-drops-to-zero-on-my-graph-why
+[2]: /developers/metrics
+[3]: /graphing/faq/i-see-unexpected-drops-to-zero-on-my-graph-why


### PR DESCRIPTION
### What does this PR do?
Updates the wording over the interpolation faq to clearly state that interpolation is disabled with the as_count and as_rate modifiers. The metric 2.0 PR includes this piece of info as well: https://github.com/DataDog/documentation/pull/5281

### Motivation
Support feedback.

### Preview link
