### PR TITLE
tracing/setup/java.md

### DIFF
--- a/content/en/tracing/setup/java.md
+++ b/content/en/tracing/setup/java.md
@@ -35,7 +35,11 @@ Finally, add the following JVM argument when starting your application in your I
 -javaagent:/path/to/the/dd-java-agent.jar
 ```
 
-Note that `dd-trace-java`'s artifacts (`dd-java-agent.jar`, `dd-trace-api.jar`, `dd-trace-ot.jar`) support all JVM-based languages, i.e. Scala, Groovy, Kotlin, Clojure, etc. If you need support for a particular framework, consider making an [open-source contribution][4].
+**Note**:
+
+* The `-javaagent` needs to be run before the `-jar` file, adding it as a jvm option, not as an application argument, more info [here][16].
+
+* `dd-trace-java`'s artifacts (`dd-java-agent.jar`, `dd-trace-api.jar`, `dd-trace-ot.jar`) support all JVM-based languages, i.e. Scala, Groovy, Kotlin, Clojure, etc. If you need support for a particular framework, consider making an [open-source contribution][4].
 
 ## Automatic Instrumentation
 
@@ -342,3 +346,4 @@ java -javaagent:<DD-JAVA-AGENT-PATH>.jar \
 [13]: /agent/docker/#dogstatsd-custom-metrics
 [14]: /agent/kubernetes/dogstatsd/#bind-the-dogstatsd-port-to-a-host-port
 [15]: /integrations/amazon_ecs/?tab=python#create-an-ecs-task
+[16]: https://docs.oracle.com/javase/7/docs/technotes/tools/solaris/java.html

--- a/content/en/tracing/setup/java.md
+++ b/content/en/tracing/setup/java.md
@@ -37,7 +37,7 @@ Finally, add the following JVM argument when starting your application in your I
 
 **Note**:
 
-* The `-javaagent` needs to be run before the `-jar` file, adding it as a jvm option, not as an application argument, more info [here][16].
+* The `-javaagent` needs to be run before the `-jar` file, adding it as a JVM option, not as an application argument. For more information, see the [Oracle documentation][16].
 
 * `dd-trace-java`'s artifacts (`dd-java-agent.jar`, `dd-trace-api.jar`, `dd-trace-ot.jar`) support all JVM-based languages, i.e. Scala, Groovy, Kotlin, Clojure, etc. If you need support for a particular framework, consider making an [open-source contribution][4].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds note in setup about running `-javaagent` before `-jar` file.

### Motivation
<!-- What inspired you to submit this pull request?-->
Support ticket.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/andrew/update-java-installation/tracing/setup/java/#installation-and-getting-started

### Additional Notes
<!-- Anything else we should know when reviewing?-->
