### PR TITLE
[Browser log] fix misleading capability

### DIFF
--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -29,7 +29,7 @@ With the `datadog-logs` library, you can send logs directly to Datadog from JS c
 * Use the library as a logger. Everything is forwarded to Datadog as JSON documents.
 * Add `context` and extra custom attributes to each log sent.
 * Wrap and forward every JavaScript error automatically.
-* Forward JavaScript console logs.
+* Forward JavaScript errors.
 * Record real client IP addresses and user agents.
 * Optimized network usage with automatic bulk posts.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
fix misleading capability

### Motivation
<!-- What inspired you to submit this pull request?-->
Customer request: https://trello.com/c/mx7DeIyt/31-missing-browser-logs-specifically-consolelogs

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/bcaudan/browser-log-fix/logs/log_collection/javascript/?tab=us#pagetitle

### Additional Notes
<!-- Anything else we should know when reviewing?-->
