### PR TITLE
fix office hours URL and clarify timing

### DIFF
--- a/content/en/developers/office_hours.md
+++ b/content/en/developers/office_hours.md
@@ -11,8 +11,8 @@ Office hours will be held in #integrations in the [Datadog Community Slack][1] (
 
 ### When
 
-* 2nd Wednesday of each month at 10:00 AM Eastern Time.
-* 4th Wednesday of each month at 3:00 PM Eastern Time.
+* 2nd Wednesday of each month at 10:00 AM Eastern Time (New York).
+* 4th Wednesday of each month at 3:00 PM Eastern Time (New York).
 
 ### Guidelines and Caveats
 
@@ -31,6 +31,6 @@ Discover the full list of [Datadog open-source projects at GitHub][5].
 
 [1]: https://datadoghq.slack.com
 [2]: http://chat.datadoghq.com
-[3]: https://plus.google.com/hangouts/_/datadoghq.com/dd-officehours
+[3]: https://datadog.zoom.us/j/312430886
 [4]: /help
 [5]: https://github.com/DataDog

--- a/content/fr/developers/office_hours.md
+++ b/content/fr/developers/office_hours.md
@@ -10,8 +10,8 @@ Les heures de permanence sont assurées sur le canal #integrations du [Slack dé
 
 ### Date
 
-* Chaque deuxième mercredi du mois, à 16 h (UTC+2).
-* Chaque quatrième mercredi du mois, à 21 h (UTC+2).
+* Chaque deuxième mercredi du mois, à 10h00 (New York).
+* Chaque quatrième mercredi du mois, à 15h00 (New York).
 
 ### Conseils et mises en garde
 
@@ -30,6 +30,6 @@ Découvrez la liste complète des [projets Datadog open source sur GitHub][5].
 
 [1]: https://datadoghq.slack.com
 [2]: http://chat.datadoghq.com
-[3]: https://plus.google.com/hangouts/_/datadoghq.com/dd-officehours
+[3]: https://datadog.zoom.us/j/312430886
 [4]: /fr/help
 [5]: https://github.com/DataDog

--- a/content/ja/developers/office_hours.md
+++ b/content/ja/developers/office_hours.md
@@ -30,6 +30,6 @@ Datadog は、Datadog [オープンソースプロジェクト](#list-of-open-so
 
 [1]: https://datadoghq.slack.com
 [2]: http://chat.datadoghq.com
-[3]: https://plus.google.com/hangouts/_/datadoghq.com/dd-officehours
+[3]: https://datadog.zoom.us/j/312430886
 [4]: /ja/help
 [5]: https://github.com/DataDog


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

* Update the Community Office Hours URL
* Clarify exactly when the meeting happens (the fr_FR conversion was wrong for half of the year).
  * I have _no idea_ what the jp_JP page says though…

### Motivation

Fixing errors!

### Preview link

https://docs-staging.datadoghq.com/phrawzty/comm_office_hours_url/developers/office_hours/

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

cc @jeremy-lq 