### PR TITLE
Adding details on prerequisites

### DIFF
--- a/content/en/synthetics/apm/_index.md
+++ b/content/en/synthetics/apm/_index.md
@@ -27,7 +27,7 @@ Statements on this page apply to both [API][1] and [browser tests][2] for APM ex
 
 ### Prerequisites
 
-* Your service is [traced on the APM side][3].
+* Your service, and the endpoint your test is running on, is [traced on the APM side][3].
 * Your service uses an HTTP server.
 * Your HTTP server is using a library that supports distributed tracing.
 


### PR DESCRIPTION
### What does this PR do?
This PR clarifies that in order to have a Synthetics test result be correlated to an APM trace, users need to make sure the endpoint the test is running on, is actually being traced.

### Motivation
https://trello.com/c/3S0227r4/471-apm-browser-test-this-trace-is-not-available
