### PR TITLE
Zach/add eslint webpack

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,11 @@
+# Ignore all js directories, delete each as eslint errors are fixed
+src/scripts/datadog-docs.js
+src/scripts/main-dd-js.js
+src/scripts/helpers/moveToAnchor.js
+src/scripts/components/codenav.js
+src/scripts/components/global-modals.js
+src/scripts/components/header.js
+src/scripts/components/integrations.js
+src/scripts/components/platforms.js
+src/scripts/components/sidenav.js
+src/scripts/components/table-of-contents.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,7 @@
 # Ignore all js directories, delete each as eslint errors are fixed
 src/scripts/datadog-docs.js
 src/scripts/main-dd-js.js
-src/scripts/helpers/moveToAnchor.js
+# src/scripts/helpers/moveToAnchor.js
 src/scripts/components/codenav.js
 src/scripts/components/global-modals.js
 src/scripts/components/header.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,7 @@
 # Ignore all js directories, delete each as eslint errors are fixed
 src/scripts/datadog-docs.js
 src/scripts/main-dd-js.js
-# src/scripts/helpers/moveToAnchor.js
+src/scripts/helpers/moveToAnchor.js
 src/scripts/components/codenav.js
 src/scripts/components/global-modals.js
 src/scripts/components/header.js

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:zach_add-eslint-webpack
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
   tags:
     - "runner:main"
     - "size:large"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:zach_add-eslint-webpack
   tags:
     - "runner:main"
     - "size:large"

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
         "eslint-config-airbnb": "^17.1.1",
         "eslint-config-prettier": "^6.0.0",
         "eslint-config-standard": "^13.0.1",
+        "eslint-loader": "^3.0.2",
         "eslint-plugin-import": "^2.18.2",
         "eslint-plugin-node": "^9.1.0",
         "eslint-plugin-prettier": "^3.1.0",

--- a/src/scripts/components/announcement_banner.js
+++ b/src/scripts/components/announcement_banner.js
@@ -1,5 +1,5 @@
 $(document).ready(function () {
-    $('.announcement_banner .icon').on('click', function (e) {
+    $('.announcement_banner .icon').on('click', function () {
         sessionStorage.setItem('announcement_banner', 'closed');
         $('.announcement_banner').removeClass('open');
         $('html').removeClass('banner');

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -19,31 +19,6 @@ const commonConfig = env => {
             sortManifest: true,
             publicPath: 'static/'
         })
-        // new CopyPlugin([
-        //     {
-        //         from: 'images/',
-        //         to: '../images/[path][name].[contenthash:5].[ext]'
-        //     }
-        // ]),
-
-        // create manifest for images with hashes
-        // new StatsWriterPlugin({
-        //     fields  : ['assetsByChunkName', 'assets'],
-        //     filename: '../../data/image_manifest.json',
-        //     transform(stats) {
-        //         console.log('stats: ', stats);
-        //         const manifest = {};
-        //         stats.assets
-        //             .map(asset => asset.name)
-        //             .sort()
-        //             .forEach(file => {
-        //                 manifest[file.replace(/\.[a-f0-9]{5}\./, '.')] = file;
-        //                 // 5 is length of hash
-        //             });
-        //         return JSON.stringify(manifest, null, 2) + '\n';
-        //     }
-        // }),
-        // manifest2
     ];
 
     // check if the analyze script was run and add BundleAnalyzer plugin if true
@@ -67,6 +42,14 @@ const commonConfig = env => {
         context: path.join(__dirname, 'src'),
         module: {
             rules: [
+                {
+                    test: /\.js$/,
+                    exclude: /node_modules/,
+                    loader: 'eslint-loader',
+                    options: {
+                        // eslint options (if necessary)
+                    }
+                },
                 {
                     test: /\.(ttf|eot|svg|gif|png|jpg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
                     loader: 'file-loader?name=[path][name].[hash].[ext]'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3121,6 +3121,17 @@ eslint-import-resolver-node@^0.3.2:
     debug "^2.6.9"
     resolve "^1.5.0"
 
+eslint-loader@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-loader/-/eslint-loader-3.0.2.tgz#5a627316a51d6f41d357b9f6f0554e91506cdd6e"
+  integrity sha512-S5VnD+UpVY1PyYRqeBd/4pgsmkvSokbHqTXAQMpvCyRr3XN2tvSLo9spm2nEpqQqh9dezw3os/0zWihLeOg2Rw==
+  dependencies:
+    fs-extra "^8.1.0"
+    loader-fs-cache "^1.0.2"
+    loader-utils "^1.2.3"
+    object-hash "^1.3.1"
+    schema-utils "^2.2.0"
+
 eslint-module-utils@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz#7b4675875bf96b0dbf1b21977456e5bb1f5e018c"
@@ -3685,6 +3696,15 @@ finalhandler@~1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
+find-cache-dir@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-0.1.1.tgz#c8defae57c8a52a8a784f9e31c57c742e993a0b9"
+  integrity sha1-yN765XyKUqinhPnjHFfHQumToLk=
+  dependencies:
+    commondir "^1.0.1"
+    mkdirp "^0.5.1"
+    pkg-dir "^1.0.0"
+
 find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
@@ -3828,6 +3848,15 @@ fs-extra@^5.0.0:
   integrity sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==
   dependencies:
     graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
@@ -4092,7 +4121,7 @@ got@^8.3.1:
     url-parse-lax "^3.0.0"
     url-to-options "^1.0.1"
 
-graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
+graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
   integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
@@ -5201,6 +5230,14 @@ load-script@^1.0.0:
   resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
   integrity sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ=
 
+loader-fs-cache@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/loader-fs-cache/-/loader-fs-cache-1.0.2.tgz#54cedf6b727e1779fd8f01205f05f6e88706f086"
+  integrity sha512-70IzT/0/L+M20jUlEqZhZyArTU6VKLRTYRDAYN26g4jfzpJqjipLL3/hgYpySqI9PwsVRHHFja0LfEmsx9X2Cw==
+  dependencies:
+    find-cache-dir "^0.1.1"
+    mkdirp "0.5.1"
+
 loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
@@ -5989,6 +6026,11 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-hash@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
+  integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
+
 object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
@@ -6495,6 +6537,13 @@ pkg-conf@^3.1.0:
   dependencies:
     find-up "^3.0.0"
     load-json-file "^5.2.0"
+
+pkg-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
+  integrity sha1-ektQio1bstYp1EcFb/TpyTFM89Q=
+  dependencies:
+    find-up "^1.0.0"
 
 pkg-dir@^2.0.0:
   version "2.0.0"
@@ -7883,6 +7932,14 @@ schema-utils@^2.0.0:
   dependencies:
     ajv "^6.1.0"
     ajv-keywords "^3.1.0"
+
+schema-utils@^2.2.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.4.1.tgz#e89ade5d056dc8bcaca377574bb4a9c4e1b8be56"
+  integrity sha512-RqYLpkPZX5Oc3fw/kHHHyP56fg5Y+XBpIpV8nCg0znIALfq3OH+Ea9Hfeac9BAMwG5IICltiZ0vxFvJQONfA5w==
+  dependencies:
+    ajv "^6.10.2"
+    ajv-keywords "^3.4.1"
 
 scss-tokenizer@^0.2.3:
   version "0.2.3"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds eslint to webpack, which will catch js errors in accordance with web-ui and airbnb coding standards. Currently, all js will not be checked, as this would cause too many errors and would take a while to fix all eslint errors. If a new file is added, however, this file will be linted. One can delete a file from the `.eslintignore` and it will be linted and show errors in the CL. 

This is implemented in corpsite. 

A job that fails due to linting: https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/19917153

### Additional Notes
<!-- Anything else we should know when reviewing?-->
