### PR TITLE
Updates java log collection link to eusite log intake endpoints

### DIFF
--- a/content/en/logs/log_collection/java.md
+++ b/content/en/logs/log_collection/java.md
@@ -543,5 +543,5 @@ To generate this final JSON document:
 [2]: /logs/processing/parsing
 [3]: https://github.com/logstash/logstash-logback-encoder
 [4]: https://github.com/logstash/logstash-logback-encoder#prefixsuffix
-[5]: /logs/?tab=euregion#datadog-logs-endpoints
+[5]: /log_collection/?tab=eusite#datadog-logs-endpoints
 [6]: /logs/processing/parsing/#key-value

--- a/content/en/logs/log_collection/java.md
+++ b/content/en/logs/log_collection/java.md
@@ -543,5 +543,5 @@ To generate this final JSON document:
 [2]: /logs/processing/parsing
 [3]: https://github.com/logstash/logstash-logback-encoder
 [4]: https://github.com/logstash/logstash-logback-encoder#prefixsuffix
-[5]: /log_collection/?tab=eusite#datadog-logs-endpoints
+[5]: /logs/log_collection/?tab=eusite#datadog-logs-endpoints
 [6]: /logs/processing/parsing/#key-value


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Updates a link from the java log collection documentation to the eusite log intake endpoints

### Motivation

User reached out on Public Slack that the link was outdated. 

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/tj/update_java_log_collection_link_to_eu_endpoints/logs/log_collection/java/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
