### PR TITLE
[dashboards] Fix Get Items of a Dashboard List examples

### DIFF
--- a/content/en/api/dashboard_lists/code_snippets/result.api-dashboard-list-get-items.py
+++ b/content/en/api/dashboard_lists/code_snippets/result.api-dashboard-list-get-items.py
@@ -42,7 +42,7 @@
                 'handle': 'test1@datadoghq.com',
                 'name': 'Author Name'
             },
-            'url': '/dash/qts-q2k-yq6/trace-api',
+            'url': '/dashboard/qts-q2k-yq6/trace-api',
             'title': 'Trace API',
             'modified': '2018-03-16T13:39:39.517133+00:00',
             'created': '2015-10-21T13:22:48.633391+00:00',
@@ -59,7 +59,7 @@
                 'handle': 'test2@datadoghq.com',
                 'name': 'Other Author Name'
             },
-            'url': '/screen/rys-xwq-geh/agent-stats',
+            'url': '/dashboard/rys-xwq-geh/agent-stats',
             'title': 'Agent Stats',
             'modified': '2018-03-16T12:54:25.968134+00:00',
             'created': '2014-06-18T18:19:00.974763+00:00',

--- a/content/en/api/dashboard_lists/code_snippets/result.api-dashboard-list-get-items.rb
+++ b/content/en/api/dashboard_lists/code_snippets/result.api-dashboard-list-get-items.rb
@@ -48,7 +48,7 @@
                     "handle" => "test1@datadoghq.com",
                     "name" => "Author Name"
                 },
-                "url" => "/dash/qts-q2k-yq6/trace-api",
+                "url" => "/dashboard/qts-q2k-yq6/trace-api",
                 "created" => "2015-10-21T13:22:48.633391+00:00",
                 "modified" => "2018-03-16T13:39:39.517133+00:00",
                 "is_read_only" => false,
@@ -65,7 +65,7 @@
                     "handle" => "test2@datadoghq.com",
                     "name" => "Other Author Name"
                 },
-                "url" => "/screen/rys-xwq-geh/agent-stats",
+                "url" => "/dashboard/rys-xwq-geh/agent-stats",
                 "created" => "2014-06-18T18:19:00.974763+00:00",
                 "modified" => "2018-03-16T12:54:25.968134+00:00",
                 "is_read_only" => false,

--- a/content/en/api/dashboard_lists/code_snippets/result.api-dashboard-list-get-items.sh
+++ b/content/en/api/dashboard_lists/code_snippets/result.api-dashboard-list-get-items.sh
@@ -42,7 +42,7 @@
                 "handle": "test1@datadoghq.com",
                 "name": "Author Name"
             },
-            "url": "/dash/qts-q2k-yq6/trace-api",
+            "url": "/dashboard/qts-q2k-yq6/trace-api",
             "title": "Trace API",
             "modified": "2018-03-16T13:39:39.517133+00:00",
             "created": "2015-10-21T13:22:48.633391+00:00",
@@ -59,7 +59,7 @@
                 "handle": "test2@datadoghq.com",
                 "name": "Other Author Name"
             },
-            "url": "/screen/rys-xwq-geh/agent-stats",
+            "url": "/dashboard/rys-xwq-geh/agent-stats",
             "title": "Agent Stats",
             "modified": "2018-03-16T12:54:25.968134+00:00",
             "created": "2014-06-18T18:19:00.974763+00:00",


### PR DESCRIPTION
### What does this PR do?
Fixes examples for GET Items of Dashboard List endpoint (replacing `/screen` and `/dash` to `/dashboard` for custom_timeboards and custom_screenboards

### Motivation
Two examples are wrong because the `url` field is not the good one.

### Preview link
https://docs-staging.datadoghq.com/julia/get-items-dashboard-list-v2-examples-fix/api/?lang=python#get-items-of-a-dashboard-list


### Additional Notes
<!-- Anything else we should know when reviewing?-->
