### PR TITLE
emphasize that log archives are compressed before being uploaded

### DIFF
--- a/content/en/logs/archives/s3.md
+++ b/content/en/logs/archives/s3.md
@@ -116,7 +116,7 @@ However, after creating or updating your archive configurations, it can take sev
 
 ## Format of the S3 Archives
 
-The log archives that Datadog forwards to your S3 bucket are in zipped (gzip) JSON format. Under whatever prefix you indicate (or `/` if there is none), the archives are stored in a directory structure that indicates on what date and at what time the archive files were generated, like so:
+The log archives that Datadog forwards to your S3 bucket are in compressed JSON format (`.json.gz`). Under whatever prefix you indicate (or `/` if there is none), the archives are stored in a directory structure that indicates on what date and at what time the archive files were generated, like so:
 
 `/my/s3/prefix/dt=20180515/hour=14/archive_143201.1234.7dq1a9mnSya3bFotoErfxl.json.gz`
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
small change to clarify that archives are compressed. 

### Motivation
<!-- What inspired you to submit this pull request?-->
some customers have apparently been a bit confused

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/estib/archives-are-compressed/logs/archives/s3/?tab=ussite

### Additional Notes
<!-- Anything else we should know when reviewing?-->
thanks!