### PR TITLE
Private locations available on API tests only

### DIFF
--- a/content/en/synthetics/private_locations.md
+++ b/content/en/synthetics/private_locations.md
@@ -16,7 +16,7 @@ further_reading:
 ---
 
 <div class="alert alert-warning">
-This feature is in beta. To enable Synthetics private locations for your account, use the corresponding sign-up form <a href="https://app.datadoghq.com/privatelocations/2019signup">for the Datadog US site</a> or <a href="https://app.datadoghq.eu/privatelocations/2019signup">for the Datadog EU site.</a>
+This feature is in beta and available for API Tests only. To enable Synthetics private locations for your account, use the corresponding sign-up form <a href="https://app.datadoghq.com/privatelocations/2019signup">for the Datadog US site</a> or <a href="https://app.datadoghq.eu/privatelocations/2019signup">for the Datadog EU site.</a>
 </div>
 
 ## Overview


### PR DESCRIPTION
### What does this PR do?

This PR clarifies that private locations are available only for API tests for now.

### Motivation

Recent ZD ticket

### Preview link
https://docs-staging.datadoghq.com/margot.lepizzera/privatelocation_availability/synthetics/private_locations