### PR TITLE
Adding id to avoid conflict for Synthetics troubleshooting section 

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1096,6 +1096,7 @@ main:
   - name: "Troubleshooting"
     url: "synthetics/troubleshooting/"
     parent: "synthetics"
+    identifier: "synthetics_troubleshooting"
     weight: 7
 
 ####################################


### PR DESCRIPTION
### What does this PR do?
Fixes main nav for the synthetics troubleshooting section.

### Motivation
It's broken.

### Preview link
https://docs-staging.datadoghq.com/gus/troubleshooting-synthetics/