### PR TITLE
java tracer - dd.trace.debug

### DIFF
--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -40,7 +40,7 @@ Debug mode is disabled by default. To enable it, follow the corresponding langua
 {{< tabs >}}
 {{% tab "Java" %}}
 
-To enable debug mode for the Datadog Java Tracer, set the flag `-Ddd.trace.debug=true` when starting the JVM or add  `DD_TRACE_DEBUG=true` as environment variable.
+To enable debug mode for the Datadog Java Tracer, set the flag `-Ddd.trace.debug=true` when starting the JVM or add `DD_TRACE_DEBUG=true` as environment variable.
 
 **Note**: Datadog Java Tracer implements SL4J SimpleLogger. As such, [all of its settings can be applied][1] like logging to a dedicated log file: `-Ddatadog.slf4j.simpleLogger.logFile=<NEW_LOG_FILE_PATH>`
 

--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -40,7 +40,7 @@ Debug mode is disabled by default. To enable it, follow the corresponding langua
 {{< tabs >}}
 {{% tab "Java" %}}
 
-To enable debug mode for the Datadog Java Tracer, set the flag `-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug` when starting the JVM.
+To enable debug mode for the Datadog Java Tracer, set the flag `-Ddd.trace.debug=true` when starting the JVM or add  `DD_TRACE_DEBUG=true` as environment variable.
 
 **Note**: Datadog Java Tracer implements SL4J SimpleLogger. As such, [all of its settings can be applied][1] like logging to a dedicated log file: `-Ddatadog.slf4j.simpleLogger.logFile=<NEW_LOG_FILE_PATH>`
 


### PR DESCRIPTION
### What does this PR do?
change the configuration variable to set the java tracer in debug mode

### Motivation
https://github.com/DataDog/dd-trace-java/releases
"Tracer debug logging can now be enabled using the following settings: #1033 (Thanks @cecile75)
System Property: -Ddd.trace.debug=true
Environment Variable: DD_TRACE_DEBUG=true"

### Preview link

https://docs-staging.datadoghq.com/c%C3%A9cile/logleveljavatracer/tracing/troubleshooting/?tab=java

### Additional Notes
the old configuration key has not be deprecated
