### PR TITLE
fix logs/guide sidenav

### DIFF
--- a/src/scripts/datadog-docs.js
+++ b/src/scripts/datadog-docs.js
@@ -787,6 +787,11 @@ function getPathElement(){
         maPath = document.querySelector('header [data-path*="graphing/guide"]');
     }
 
+    if (path.includes('logs/guide')) {
+        aPath = document.querySelector('.side [data-path*="logs/guide"]');
+        maPath = document.querySelector('header [data-path*="logs/guide"]');
+    }
+
     if (path.includes('security/logs')) {
         aPath = document.querySelectorAll('.side [data-path*="security/logs"]')[1];
         maPath = document.querySelectorAll('header [data-path*="security/logs"]')[1];


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
fix sidenav to show active subnav link for `logs/guide/**`

### Motivation
https://trello.com/c/9Mms7scL/3971-logs-guides-dont-expand-side-bar

### Preview link
https://docs-staging.datadoghq.com/zach/fix-sidenav/logs/guide/log-parsing-best-practice/

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 



### Additional Notes
<!-- Anything else we should know when reviewing?-->
