### PR TITLE
fix spacing, a11y color contrast issues

### DIFF
--- a/layouts/partials/whats-next/whats-next.html
+++ b/layouts/partials/whats-next/whats-next.html
@@ -1,7 +1,7 @@
 {{ $dot := . }}
 <div class="whatsnext">
     <p>{{ i18n "additional_sentence" }}:</p>
-    <ul class="list-group">
+    <div class="list-group">
         {{ range $dot.Page.Params.further_reading }}
             {{ if eq (substr .link 0 4) "http"}}
                 {{ $.Scratch.Set "link" .link}}
@@ -22,11 +22,12 @@
                 {{ end }}
             {{ end }}
             {{ $link := $.Scratch.Get "link" }}
-            <a class="list-group-item list-group-item-white d-flex justify-content-between align-items-center" href="{{ $link }}">
-                <span><span class="text">{{ .text }}</span>{{ if .tag }}<span class="badge badge-white">{{ .tag | upper }}</span>{{ end }}</span>
-                {{ partial "img.html" (dict "root" $dot "src" "icons/list-group-whats-next-arrow-1.png" "class" "img-fluid static" "alt" "more") }}
-                {{ partial "img.html" (dict "root" $dot "src" "icons/list-group-whats-next-arrow-2.png" "class" "img-fluid hover" "alt" "more") }}
-            </a>
+                    <a class="list-group-item list-group-item-action list-group-item-white  d-flex justify-content-between align-items-center" href="{{ $link }}">
+                            <span><span class="text">{{ .text }}</span>{{ if .tag }}<span class="badge badge-white">{{ .tag | upper }}</span>{{ end }}</span>
+                            {{ partial "img.html" (dict "root" $dot "src" "icons/list-group-whats-next-arrow-1.png" "class" "img-fluid static" "alt" "more") }}
+                            {{ partial "img.html" (dict "root" $dot "src" "icons/list-group-whats-next-arrow-2.png" "class" "img-fluid hover" "alt" "more") }}
+                        </a>
+            
         {{ end }}
-    </ul>
+    </div>
 </div>

--- a/src/styles/components/_header.scss
+++ b/src/styles/components/_header.scss
@@ -60,7 +60,7 @@ body > header {
     }
     .nav-item {
       .nav-link {
-        color: #777;
+        color: #555;
         text-transform: uppercase;
         font-size: 18px;
         font-weight: 600;

--- a/src/styles/components/_whats-next.scss
+++ b/src/styles/components/_whats-next.scss
@@ -33,7 +33,7 @@ $ddpurple:    #632CA6;
       right: 51px;
       top: 17px;
       font-size: 14px;
-      color: #D6D6D6;
+      color: #555;
       border-color: transparent;
       letter-spacing: 0.04em;
       -webkit-font-smoothing: antialiased;

--- a/src/styles/pages/_global.scss
+++ b/src/styles/pages/_global.scss
@@ -300,6 +300,9 @@ h5{
     -webkit-font-smoothing: subpixel-antialiased;
     -moz-osx-font-smoothing: auto;
   }
+  p + ul, div + ul {
+    margin-bottom: 1rem;
+  }
 }
 
 /* codetabs inside content */


### PR DESCRIPTION
### What does this PR do?
1. Fix spacing below a `ul` element to be consistent
2. Change main nav text color to match corpsites.
3. Change `Further Reading` section html element and color to fix a11y issues regarding colo contrast. Can see issues by running lighthouse a11y on say: https://docs.datadoghq.com/synthetics/private_locations/

### Motivation
https://trello.com/c/crxwBzQV/4061-fix-documentation-css-to-have-an-empty-line-below-the-last-item-of-a-bullet-list

### Preview link
https://docs-staging.datadoghq.com/zach/list-spacing-fix/synthetics/private_locations/#create-a-new-private-location
