### PR TITLE
update JS sample code to use required JSON format

### DIFF
--- a/content/en/tracing/advanced/connect_logs_and_traces.md
+++ b/content/en/tracing/advanced/connect_logs_and_traces.md
@@ -433,7 +433,7 @@ class Logger {
       tracer.inject(span.context(), formats.LOG, record)
     }
 
-    console.log(record)
+    console.log(JSON.stringify(record))
   }
 }
 


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fixes the JavaScript sample code on the docs page for linking logs to traces to log in the format the Datadog Agent requires.
### Motivation
<!-- What inspired you to submit this pull request?-->
Gini helped me diagnose a bug in my manual linking of logs to traces, that ultimately stemmed from me following this code. The docs do specify JSON format before the sample code, but the code itself logs the object itself (which does not link the trace).

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
N/A - working off a fork 

### Additional Notes
<!-- Anything else we should know when reviewing?-->
