### PR TITLE
Update the number of log entries per HTTP batch

### DIFF
--- a/content/en/api/logs/logs.md
+++ b/content/en/api/logs/logs.md
@@ -13,7 +13,7 @@ Send your logs to your Datadog platform over HTTP. Limits per HTTP request are:
 
 * Maximum content size per payload: 5MB
 * Maximum size for a single log: 256kB
-* Maximum array size if sending multiple logs in an array: 200 entries
+* Maximum array size if sending multiple logs in an array: 500 entries
 
 **Note**: If you are in the Datadog EU site (`app.datadoghq.eu`), the HTTP log endpoint is: `http-intake.logs.datadoghq.eu`.
 


### PR DESCRIPTION
### What does this PR do?
Update the maximum number of entries per batch

### Motivation
The API was modified to support batch up to 500 entries.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/log-batch-number-update/api/?lang=python#logs

### Additional Notes
<!-- Anything else we should know when reviewing?-->
