### PR TITLE
adding in serverless billing to main billing page

### DIFF
--- a/content/en/account_management/billing/_index.md
+++ b/content/en/account_management/billing/_index.md
@@ -43,6 +43,7 @@ You can set specific email addresses to receive invoices on the [Plan][7] page u
     {{< nextlink href="account_management/billing/containers/" >}}Containers{{< /nextlink >}}
     {{< nextlink href="account_management/billing/log_management/" >}}Log management{{< /nextlink >}}
     {{< nextlink href="account_management/billing/apm_distributed_tracing/" >}}APM & Distributed Tracing{{< /nextlink >}}
+    {{< nextlink href="account_management/billing/serverless/" >}}Serverless{{< /nextlink >}}
     {{< nextlink href="account_management/billing/aws/" >}}AWS integration{{< /nextlink >}}
     {{< nextlink href="account_management/billing/azure/" >}}Azure integration{{< /nextlink >}}
     {{< nextlink href="account_management/billing/google_cloud/" >}}Google Cloud integration{{< /nextlink >}}


### PR DESCRIPTION
### What does this PR do?
Adds serverless billing page as a reference to main page

### Motivation
We missed adding it when we created the page

### Preview link
https://docs-staging.datadoghq.com/kaylyn/serverless/account_management/billing/#further-reading