### PR TITLE
Ubuntu 14.04 is not supported for PHP 5.5

### DIFF
--- a/content/en/tracing/setup/php.md
+++ b/content/en/tracing/setup/php.md
@@ -45,7 +45,7 @@ Once downloaded, install the package with one of the commands below.
 # using RPM package (RHEL/Centos 6+, Fedora 20+)
 $ rpm -ivh datadog-php-tracer.rpm
 
-# using DEB package (Debian Jessie+ , Ubuntu 14.04+)
+# using DEB package (Debian Jessie+ , Ubuntu 14.04+ on supported PHP versions)
 $ dpkg -i datadog-php-tracer.deb
 
 # using APK package (Alpine)


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>
https://docs-staging.datadoghq.com/priyanshi-gupta-patch-1/tracing/setup/php/#install-the-extension
### Additional Notes
<!-- Anything else we should know when reviewing?-->
