### PR TITLE
Add docs for "show_legend" property of certain graph types

### DIFF
--- a/content/en/graphing/widgets/distribution.md
+++ b/content/en/graphing/widgets/distribution.md
@@ -76,6 +76,7 @@ DISTIBUTION_SCHEMA = {
 | `type`     | string          | yes      | Type of widget, for the distribution widget use `distribution`.                                                                                                 |
 | `requests` | array of objects | yes      | Array of one `request` object to display in the widget. See the dedicated [Request JSON schema documentation][3] to learn how to build the `REQUEST_SCHEMA`. |
 | `title`    | string          | no       | Title of your widget.                                                                                                                                        |
+| `show_legend` | boolean | no | (screenboard only) Show the legend for this widget |
 
 
 Additional properties allowed the `request` object:

--- a/content/en/graphing/widgets/distribution.md
+++ b/content/en/graphing/widgets/distribution.md
@@ -64,7 +64,8 @@ DISTIBUTION_SCHEMA = {
             "minItems": 1,
             "maxItems": 1
         },
-        "title": {"type": "string"}
+        "title":   {"type": "string"},
+        "show_legend": {"type": "boolean"}
     },
     "required": ["type", "requests"],
     "additionalProperties": false

--- a/content/en/graphing/widgets/heat_map.md
+++ b/content/en/graphing/widgets/heat_map.md
@@ -94,6 +94,7 @@ HEATMAP_SCHEMA = {
 | `yaxis`    | object          | no       | Y-axis control options. See the dedicated [Y-axis JSON schema documentation][5] to learn how to build the `<AXIS_SCHEMA>`.                                   |
 | `events`   | object          | no       | Event overlay control options. See the dedicated [Events JSON schema documentation][6] to learn how to build the `<EVENTS_SCHEMA>`                           |
 | `title`    | string          | no       | Title of your widget.                                                                                                                                        |
+| `show_legend` | boolean | no | (screenboard only) Show the legend for this widget |
 
 
 Additional properties allowed in the `requests` object:

--- a/content/en/graphing/widgets/heat_map.md
+++ b/content/en/graphing/widgets/heat_map.md
@@ -80,7 +80,8 @@ HEATMAP_SCHEMA = {
         },
         "yaxis":  AXIS_SCHEMA,
         "events": EVENTS_SCHEMA,
-        "title": {"type": "string"}
+        "title":   {"type": "string"},
+        "show_legend": {"type": "boolean"}
     },
     "required": ["type", "requests"],
     "additionalProperties": false

--- a/content/en/graphing/widgets/timeseries.md
+++ b/content/en/graphing/widgets/timeseries.md
@@ -118,7 +118,8 @@ TIMESERIES_SCHEMA = {
         "yaxis":   AXIS_SCHEMA,
         "events":  EVENTS_SCHEMA,
         "markers": MARKERS_SCHEMA,
-        "title":   {"type": "string"}
+        "title":   {"type": "string"},
+        "show_legend": {"type": "boolean"}
     },
     "required": ["type", "requests"],
     "additionalProperties": false

--- a/content/en/graphing/widgets/timeseries.md
+++ b/content/en/graphing/widgets/timeseries.md
@@ -133,6 +133,7 @@ TIMESERIES_SCHEMA = {
 | `events`   | object           | no       | Event overlay control options. See the dedicated [Events JSON schema documentation][13] to learn how to build the `EVENTS_SCHEMA`                        |
 | `markers`  | object           | no       | Markers overlay control options. See the dedicated [Markers JSON schema documentation][14] to learn how to build the `MARKERS_SCHEMA`                    |
 | `title`    | string           | no       | Title of your widget.                                                                                                                                    |
+| `show_legend` | boolean | no | (screenboard only) Show the legend for this widget |
 
 Additional properties allowed in each `request` object:
 


### PR DESCRIPTION
This PR adds docs for the `show_legend` property of timeseries, heatmap, and distribution graphs (the property is effective on screenboards only)