### PR TITLE
add identifiers to exclude api url links from async load

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1190,7 +1190,7 @@ main:
     identifier: "dev_tools_metrics_powershell"
     weight: 204
   - name: "Submission - API "
-    url: "https://docs.datadoghq.com/api/#post-timeseries-points"
+    url: "api/#post-timeseries-points"
     parent: "dev_tools_metrics"
     identifier: "dev_tools_metrics_api"
     weight: 205
@@ -1234,7 +1234,7 @@ main:
     identifier: "dev_tools_events_mail"
     weight: 303
   - name: "API"
-    url: "https://docs.datadoghq.com/api/#post-an-event"
+    url: "api/#post-an-event"
     parent: "dev_tools_events"
     identifier: "dev_tools_events_api"
     weight: 304

--- a/layouts/partials/sidenav/nav-new.html
+++ b/layouts/partials/sidenav/nav-new.html
@@ -2,7 +2,7 @@
 {{ $ctx := . }}
 {{ $menu := .Site.Menus.main }}
 {{/* Menu identifiers to apply class to */}}
-{{ $excludeAsyc := (slice "api" "integrations_top_level" "tracing api" "watchdog_top_level" "glossary_top_level" "video_top_level" "help_top_level" "other_integrations") }}
+{{ $excludeAsyc := (slice "api" "dev_tools_metrics_api" "dev_tools_events_api" "integrations_top_level" "tracing api" "watchdog_top_level" "glossary_top_level" "video_top_level" "help_top_level" "other_integrations") }}
 
 {{ $path := (printf "%s/" $.Site.Params.branch) }}
 
@@ -19,6 +19,7 @@
     {{ $currentPage := . }}
     {{ range .Site.Menus.main }}
         {{ if .HasChildren }}
+            
             <li class="nav-top-level {{ if (not (in $excludeAsyc .Identifier)) }} js-load {{- end -}}
             {{ if $currentPage.HasMenuCurrent "main" . }}active{{ end }}">
                 <a href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print .URL) | relLangURL)) "/" }}">
@@ -26,6 +27,7 @@
                 </a>
                 <ul class="list-unstyled sub-menu">
                     {{ range .Children }}
+                   
                         <li class="{{ if (not (in $excludeAsyc .Identifier )) }} js-load {{- end -}} {{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }}">
                             <a href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print .URL) | relLangURL)) "/" }}">
                                 {{ if .Pre }}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}{{ end }} <span>{{ .Name }}</span>

--- a/layouts/partials/sidenav/nav-new.html
+++ b/layouts/partials/sidenav/nav-new.html
@@ -19,7 +19,6 @@
     {{ $currentPage := . }}
     {{ range .Site.Menus.main }}
         {{ if .HasChildren }}
-            
             <li class="nav-top-level {{ if (not (in $excludeAsyc .Identifier)) }} js-load {{- end -}}
             {{ if $currentPage.HasMenuCurrent "main" . }}active{{ end }}">
                 <a href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print .URL) | relLangURL)) "/" }}">
@@ -27,7 +26,6 @@
                 </a>
                 <ul class="list-unstyled sub-menu">
                     {{ range .Children }}
-                   
                         <li class="{{ if (not (in $excludeAsyc .Identifier )) }} js-load {{- end -}} {{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }}">
                             <a href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print .URL) | relLangURL)) "/" }}">
                                 {{ if .Pre }}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}{{ end }} <span>{{ .Name }}</span>


### PR DESCRIPTION
### What does this PR do?
removes async loading from two api links in side nav

### Motivation
https://trello.com/c/9MfC70UG/4069-docs-sidebar-links-to-api-guides-conflict-with-api-page

### Preview link
https://docs-staging.datadoghq.com/zach/api-link-fix/developers/metrics/
click `Submission - API` should link to proper `api` page anchor
