### PR TITLE
fix get aws get logs service signature

### DIFF
--- a/content/en/api/integrations_aws/aws_get_available_log_services_code.md
+++ b/content/en/api/integrations_aws/aws_get_available_log_services_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#get-list-of-aws-log-ready-services
 
 **SIGNATURE**:
 
-`GET /aws/logs/services`
+`GET /v1/integration/aws/logs/services`
 
 **EXAMPLE REQUEST**:
 


### PR DESCRIPTION
it didn't match the format of all the other endpoints that included the `/v1/integration` part
