### PR TITLE
Remove reference to TCP port 443 for proxy logs instruction

### DIFF
--- a/content/en/agent/logs/proxy.md
+++ b/content/en/agent/logs/proxy.md
@@ -69,9 +69,6 @@ When the Agent is [configured to send logs through HTTPS][1], use the same [set 
 {{% /tab %}}
 {{< /tabs >}}
 
-### Port 443
-
-The parameter `use_port_443` does not affect logs sent through a proxy. You need to configure the proxy itself to forward logs to `agent-443-intake.logs.datadoghq.com:443`.
 
 ## Further Reading
 

--- a/content/en/logs/guide/log-collection-troubleshooting-guide.md
+++ b/content/en/logs/guide/log-collection-troubleshooting-guide.md
@@ -39,12 +39,14 @@ And then by sending a log like the following:
 <API_KEY> this is a test message
 ```
 
-- If opening the port 10514 or 10516 is not an option, it is possible to configure the Datadog Agent to use the port `443` (this port is only available with the Datadog Agent) by adding the following in `datadog.yaml`:
+- If opening the port 10514 or 10516 is not an option, it is possible to configure the Datadog Agent to send logs through HTTPS by adding the following in `datadog.yaml`:
 
 ```
 logs_config:
-  use_port_443: true
+  use_http: true
 ```
+
+See the [HTTPS log forwarding section][15] for more information.
 
 ## Check the status of the agent
 
@@ -196,3 +198,4 @@ Check if logs appear in the [Datadog Live Tail][13]. If they appear in the Live 
 [12]: https://app.datadoghq.com/account/settings#api
 [13]: https://app.datadoghq.com/logs/livetail
 [14]: /logs/indexes/#exclusion-filters
+[15]: https://docs.datadoghq.com/agent/logs/?tab=tailexistingfiles#send-logs-over-https


### PR DESCRIPTION
### What does this PR do?
Removes the reference to the use of port 443 

### Motivation
Now that HTTPS is supported, the suggestion to use the port 443 to send logs in TCP should not be made anymore as it was mostly for those who could not forward data to the 10516 port.
Using HTTPS in those cases should be the default.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/log-proxy-443/agent/logs/proxy?tab=tcp

### Additional Notes
<!-- Anything else we should know when reviewing?-->
