### PR TITLE
Update reserved attribute links in FAQ

### DIFF
--- a/content/en/logs/faq/why-do-my-logs-show-up-with-an-info-status-even-for-warnings-or-errors.md
+++ b/content/en/logs/faq/why-do-my-logs-show-up-with-an-info-status-even-for-warnings-or-errors.md
@@ -68,5 +68,5 @@ There are specific status formats that must be adhered to for the remapping to w
 
 [1]: /logs/processing/parsing/?tab=matcher
 [2]: /logs/processing/processors/#log-status-remapper
-[3]: /logs/#reserved-attributes
-[4]: /logs/#edit-reserved-attributes
+[3]: /logs/processing/#reserved-attributes
+[4]: /logs/processing/#edit-reserved-attributes


### PR DESCRIPTION
### What does this PR do?
Changes the reserved attribute doc links to the proper endpoint `/logs/processing/#reserved-attributes` and `/logs/processing/#edit-reserved-attributes`. 

[Link 3](https://docs.datadoghq.com/logs/processing/#reserved-attributes)
[Link 4](https://docs.datadoghq.com/logs/processing/#edit-reserved-attributes)

[Affected page/link](https://docs.datadoghq.com/logs/faq/why-do-my-logs-show-up-with-an-info-status-even-for-warnings-or-errors/#json-logs)

### Motivation
Client reached out about the links being dead. I was able to confirm that is indeed the case and being that it's a simple fix, I decided to do it.
