### PR TITLE
state value we expect for multiple params

### DIFF
--- a/content/en/agent/autodiscovery/clusterchecks.md
+++ b/content/en/agent/autodiscovery/clusterchecks.md
@@ -56,7 +56,7 @@ Refer to [the dedicated Cluster Checks Autodiscovery guide][5] for more configur
 
 Enable the `clusterchecks` configuration provider on the Datadog **Host** Agent. This can be done in two ways:
 
-- By setting the `DD_EXTRA_CONFIG_PROVIDERS` environment variable:
+- By setting the `DD_EXTRA_CONFIG_PROVIDERS` environment variable. This takes a space separated string if you have multiple values:
 
 ```
 DD_EXTRA_CONFIG_PROVIDERS="clusterchecks"

--- a/content/en/agent/autodiscovery/endpointschecks.md
+++ b/content/en/agent/autodiscovery/endpointschecks.md
@@ -75,7 +75,7 @@ This feature requires a running [Cluster Agent with the Cluster Checks feature e
 
 Enable the `endpointschecks` configuration providers on the Datadog **Node** Agent. This can be done in two ways:
 
-- By setting the `DD_EXTRA_CONFIG_PROVIDERS` environment variable:
+- By setting the `DD_EXTRA_CONFIG_PROVIDERS` environment variable. This takes a space separated string if you have multiple values:
 
 ```
 DD_EXTRA_CONFIG_PROVIDERS="endpointschecks"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Explicitly mention to users that want to add `endpointschecks` && `clusterchecks` via the `DD_EXTRA_CONFIG_PROVIDERS` env var to pass a single string with each parameter separated by spaces.

### Motivation
<!-- What inspired you to submit this pull request?-->
Customer request

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
* https://docs-staging.datadoghq.com/dylan/config-providers/agent/autodiscovery/endpointschecks/
* https://docs-staging.datadoghq.com/dylan/config-providers/agent/autodiscovery/clusterchecks/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
