### PR TITLE
Add links to legacy endpoints docs

### DIFF
--- a/content/en/api/screenboards/screenboards.md
+++ b/content/en/api/screenboards/screenboards.md
@@ -7,5 +7,5 @@ external_redirect: /api/#screenboards
 ## Screenboards
 
 <div class="alert alert-danger">
-    This endpoint is outdated. Use the <a href="https://docs.datadoghq.com/api/#dashboards">new Dashboard endpoint</a> instead.
+    This endpoint is outdated. Use the <a href="https://docs.datadoghq.com/api/#dashboards">new Dashboard endpoint</a> instead. Documentation for old endpoints is available <a href="https://docs.datadoghq.com/graphing/faq/screenboard-api-doc"> here</a>.
 </div>

--- a/content/en/api/screenboards/screenboards.md
+++ b/content/en/api/screenboards/screenboards.md
@@ -7,5 +7,5 @@ external_redirect: /api/#screenboards
 ## Screenboards
 
 <div class="alert alert-danger">
-    This endpoint is outdated. Use the <a href="https://docs.datadoghq.com/api/#dashboards">new Dashboard endpoint</a> instead. Documentation for old endpoints is available <a href="https://docs.datadoghq.com/graphing/faq/screenboard-api-doc"> here</a>.
+    This endpoint is outdated. Use the <a href="https://docs.datadoghq.com/api/#dashboards">new Dashboard endpoint</a> instead. Documentation for old endpoints is available in the <a href="https://docs.datadoghq.com/graphing/faq/screenboard-api-doc">Screenboard API documentation</a>.
 </div>

--- a/content/en/api/timeboards/timeboards.md
+++ b/content/en/api/timeboards/timeboards.md
@@ -7,5 +7,5 @@ external_redirect: /api/#timeboards
 ## Timeboards
 
 <div class="alert alert-danger">
-    This endpoint is outdated. Use the <a href="https://docs.datadoghq.com/api/#dashboards">new Dashboard endpoint</a> instead.
+    This endpoint is outdated. Use the <a href="https://docs.datadoghq.com/api/#dashboards">new Dashboard endpoint</a> instead. Documentation for old endpoints is available <a href="https://docs.datadoghq.com/graphing/faq/timeboard-api-doc"> here</a>.
 </div>

--- a/content/en/api/timeboards/timeboards.md
+++ b/content/en/api/timeboards/timeboards.md
@@ -7,5 +7,5 @@ external_redirect: /api/#timeboards
 ## Timeboards
 
 <div class="alert alert-danger">
-    This endpoint is outdated. Use the <a href="https://docs.datadoghq.com/api/#dashboards">new Dashboard endpoint</a> instead. Documentation for old endpoints is available <a href="https://docs.datadoghq.com/graphing/faq/timeboard-api-doc"> here</a>.
+    This endpoint is outdated. Use the <a href="https://docs.datadoghq.com/api/#dashboards">new Dashboard endpoint</a> instead. Documentation for old endpoints is available in the <a href="https://docs.datadoghq.com/graphing/faq/screenboard-api-doc">Screenboard API documentation</a>.
 </div>


### PR DESCRIPTION

### What does this PR do?
Adds a link to the legacy timeboards and screenboards API docs from the main API docs page.

Before:
![image](https://user-images.githubusercontent.com/1262407/67411969-76457200-f58c-11e9-9dc0-e31a652894dd.png)

![image](https://user-images.githubusercontent.com/1262407/67411992-80677080-f58c-11e9-817e-eb1fda56a14a.png)

After:
![image](https://user-images.githubusercontent.com/1262407/67412030-8d845f80-f58c-11e9-924b-01abefb02f84.png)

![image](https://user-images.githubusercontent.com/1262407/67412062-970dc780-f58c-11e9-9937-ccc9ca11ee6e.png)

### Motivation
This seems to be confusing for other engineers and might give the impressions that these two endpoints are deprecated and not supported anymore. https://dd.slack.com/archives/CHU8KNZ6X/p1571780552167000


### Preview link
https://docs-staging.datadoghq.com/rami/link_legacy_apis/api/?lang=python#screenboards

and

https://docs-staging.datadoghq.com/rami/link_legacy_apis/api/?lang=python#timeboards

### Additional Notes
<!-- Anything else we should know when reviewing?-->
