### PR TITLE
Update debug tracer mode instructions for .NET APM.

### DIFF
--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -171,7 +171,7 @@ Logs files are saved in the following directories:
 | Platform | Path                                                          |
 |----------|---------------------------------------------------------------|
 | Linux    | `/var/log/datadog/`                        |
-| Windows  | `C:\ProgramData\Datadog .NET Tracer\logs\` |
+| Windows  | `%ProgramData%\Datadog .NET Tracer\logs\` |
 
 
 {{% /tab %}}

--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -166,7 +166,7 @@ Tracer.Instance = tracer;
 
 The environment variable `DD_TRACE_DEBUG` can also be set to `true`.
 
-Logs (Profiler and Tracer) are saved in the following directories:
+Logs files are saved in the following directories:
 
 | Platform | Path                                                          |
 |----------|---------------------------------------------------------------|

--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -166,14 +166,7 @@ Tracer.Instance = tracer;
 
 The environment variable `DD_TRACE_DEBUG` can also be set to `true`.
 
-Location of the profiler log:
-
-| Platform | Path                                                          |
-|----------|---------------------------------------------------------------|
-| Linux    | `/var/log/datadog/dotnet-profiler.log`                        |
-| Windows  | `C:\ProgramData\Datadog .NET Tracer\logs\dotnet-profiler.log` |
-
-Location of additional logs when debug is enabled:
+Logs (Profiler and Tracer) are saved in the following directories:
 
 | Platform | Path                                                          |
 |----------|---------------------------------------------------------------|

--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -164,12 +164,21 @@ var tracer = Tracer.Create(isDebugEnabled: true);
 Tracer.Instance = tracer;
 ```
 
+The environment variable `DD_TRACE_DEBUG` can also be set to `true`.
+
 Location of the profiler log:
 
 | Platform | Path                                                          |
 |----------|---------------------------------------------------------------|
 | Linux    | `/var/log/datadog/dotnet-profiler.log`                        |
 | Windows  | `C:\ProgramData\Datadog .NET Tracer\logs\dotnet-profiler.log` |
+
+Location of additional logs when debug is enabled:
+
+| Platform | Path                                                          |
+|----------|---------------------------------------------------------------|
+| Linux    | `/var/log/datadog/`                        |
+| Windows  | `C:\ProgramData\Datadog .NET Tracer\logs\` |
 
 
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
As of .NET APM 1.8.0 (See PR: https://github.com/DataDog/dd-trace-dotnet/pull/512), there are additional logs that get added. This documentation update clarifies this folder path and also the environment variable that can be used to set **Debug** mode.

### Motivation
To assist in troubleshooting .NET APM cases.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/wantsui/update-debug-tracer-mode-instructions-dotnet/tracing/troubleshooting/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

N/A
