### PR TITLE
[API curl examples] Change all curl examples to have api and app keys in headers

### DIFF
--- a/content/en/api/authentication/code_snippets/api-auth.sh
+++ b/content/en/api/authentication/code_snippets/api-auth.sh
@@ -1,4 +1,4 @@
 
 
-curl "https://api.datadoghq.com/api/v1/validate?api_key=<YOUR_API_KEY>"
+curl "https://api.datadoghq.com/api/v1/validate" -H "DD-API-KEY: <YOUR_API_KEY>"
 

--- a/content/en/api/comments/code_snippets/api-comment-create.sh
+++ b/content/en/api/comments/code_snippets/api-comment-create.sh
@@ -1,8 +1,11 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl  -X POST -H "Content-type: application/json" \
+curl  -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
         "message" : "There is a problem with the database."
 }' \
-"https://api.datadoghq.com/api/v1/comments?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/comments"

--- a/content/en/api/comments/code_snippets/api-comment-edit.sh
+++ b/content/en/api/comments/code_snippets/api-comment-edit.sh
@@ -3,10 +3,13 @@ app_key=<YOUR_APP_KEY>
 comment_id=<COMMENT_ID>
 
 # Create a comment to edit. Use jq (http://stedolan.github.io/jq/download/) to get the comment id.
-comment_id=$(curl -X POST -H "Content-type: application/json" -d '{"message" : "This comment was submitted and will be edited by the api."}' "https://api.datadoghq.com/api/v1/comments?api_key=${api_key}&application_key=${app_key}" | jq -r '.comment.resource|ltrimstr("/api/v1/comments/")')
+comment_id=$(curl -X POST -H "Content-type: application/json" -H "DD-API-KEY: ${api_key}" -H "DD-APPLICATION-KEY: ${app_key}" -d '{"message" : "This comment was submitted and will be edited by the api."}' "https://api.datadoghq.com/api/v1/comments}" | jq -r '.comment.resource|ltrimstr("/api/v1/comments/")')
 
-curl -X PUT -H "Content-type: application/json" \
+curl -X PUT \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
         "message" : "Actually, I am changing my mind."
 }' \
-"https://api.datadoghq.com/api/v1/comments/${comment_id}?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/comments/${comment_id}"

--- a/content/en/api/dashboard_lists/code_snippets/api-dashboard-list-add-items.sh
+++ b/content/en/api/dashboard_lists/code_snippets/api-dashboard-list-add-items.sh
@@ -3,7 +3,10 @@ app_key=<YOUR_APP_KEY>
 
 list_id=4741
 
-curl -X POST -H "Content-type: application/json" \
+curl -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
         "dashboards": [
             {
@@ -28,4 +31,4 @@ curl -X POST -H "Content-type: application/json" \
             }
         ]
 }' \
-"https://api.datadoghq.com/api/v2/dashboard/lists/manual/${list_id}/dashboards?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v2/dashboard/lists/manual/${list_id}/dashboards"

--- a/content/en/api/dashboard_lists/code_snippets/api-dashboard-list-create.sh
+++ b/content/en/api/dashboard_lists/code_snippets/api-dashboard-list-create.sh
@@ -1,8 +1,11 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -X POST -H "Content-type: application/json" \
+curl -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
         "name": "My Dashboard List"
 }' \
-"https://api.datadoghq.com/api/v1/dashboard/lists/manual?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/dashboard/lists/manual"

--- a/content/en/api/dashboard_lists/code_snippets/api-dashboard-list-delete-items.sh
+++ b/content/en/api/dashboard_lists/code_snippets/api-dashboard-list-delete-items.sh
@@ -3,7 +3,10 @@ app_key=<YOUR_APP_KEY>
 
 list_id=4741
 
-curl -X DELETE -H "Content-type: application/json" \
+curl -X DELETE \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
         "dashboards": [
             {
@@ -28,4 +31,4 @@ curl -X DELETE -H "Content-type: application/json" \
             }
         ]
 }' \
-"https://api.datadoghq.com/api/v2/dashboard/lists/manual/${list_id}/dashboards?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v2/dashboard/lists/manual/${list_id}/dashboards"

--- a/content/en/api/dashboard_lists/code_snippets/api-dashboard-list-delete.sh
+++ b/content/en/api/dashboard_lists/code_snippets/api-dashboard-list-delete.sh
@@ -4,4 +4,6 @@ app_key=<YOUR_APP_KEY>
 list_id=4741
 
 curl -X DELETE \
-"https://api.datadoghq.com/api/v1/dashboard/lists/manual/${list_id}?api_key=${api_key}&application_key=${app_key}"
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/dashboard/lists/manual/${list_id}"

--- a/content/en/api/dashboard_lists/code_snippets/api-dashboard-list-get-all.sh
+++ b/content/en/api/dashboard_lists/code_snippets/api-dashboard-list-get-all.sh
@@ -2,4 +2,6 @@ api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
 curl -X GET \
-"https://api.datadoghq.com/api/v1/dashboard/lists/manual?api_key=${api_key}&application_key=${app_key}"
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/dashboard/lists/manual"

--- a/content/en/api/dashboard_lists/code_snippets/api-dashboard-list-get-items.sh
+++ b/content/en/api/dashboard_lists/code_snippets/api-dashboard-list-get-items.sh
@@ -4,4 +4,6 @@ app_key=<YOUR_APP_KEY>
 list_id=4741
 
 curl -X GET \
-"https://api.datadoghq.com/api/v2/dashboard/lists/manual/${list_id}/dashboards?api_key=${api_key}&application_key=${app_key}"
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v2/dashboard/lists/manual/${list_id}/dashboards"

--- a/content/en/api/dashboard_lists/code_snippets/api-dashboard-list-get.sh
+++ b/content/en/api/dashboard_lists/code_snippets/api-dashboard-list-get.sh
@@ -4,4 +4,6 @@ app_key=<YOUR_APP_KEY>
 list_id=4741
 
 curl -X GET \
-"https://api.datadoghq.com/api/v1/dashboard/lists/manual/${list_id}?api_key=${api_key}&application_key=${app_key}"
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/dashboard/lists/manual/${list_id}"

--- a/content/en/api/dashboard_lists/code_snippets/api-dashboard-list-update-items.sh
+++ b/content/en/api/dashboard_lists/code_snippets/api-dashboard-list-update-items.sh
@@ -3,7 +3,10 @@ app_key=<YOUR_APP_KEY>
 
 list_id=4741
 
-curl -X PUT -H "Content-type: application/json" \
+curl -X PUT \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
         "dashboards": [
             {
@@ -28,4 +31,4 @@ curl -X PUT -H "Content-type: application/json" \
             }
         ]
 }' \
-"https://api.datadoghq.com/api/v2/dashboard/lists/manual/${list_id}/dashboards?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v2/dashboard/lists/manual/${list_id}/dashboards"

--- a/content/en/api/dashboard_lists/code_snippets/api-dashboard-list-update.sh
+++ b/content/en/api/dashboard_lists/code_snippets/api-dashboard-list-update.sh
@@ -3,9 +3,12 @@ app_key=<YOUR_APP_KEY>
 
 list_id=4741
 
-curl -X PUT -H "Content-type: application/json" \
+curl -X PUT \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
         "name": "My Updated Dashboard List"
 }' \
-"https://api.datadoghq.com/api/v1/dashboard/lists/manual/${list_id}?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/dashboard/lists/manual/${list_id}"
 

--- a/content/en/api/dashboards/code_snippets/api-dashboard-create.sh
+++ b/content/en/api/dashboards/code_snippets/api-dashboard-create.sh
@@ -1,7 +1,10 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl  -X POST -H "Content-type: application/json" \
+curl  -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
       "title" : "Average Memory Free Shell",
       "widgets" : [{
@@ -23,4 +26,4 @@ curl  -X POST -H "Content-type: application/json" \
           "default": "my-host"
       }]
 }' \
-"https://api.datadoghq.com/api/v1/dashboard?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/dashboard"

--- a/content/en/api/dashboards/code_snippets/api-dashboard-delete.sh
+++ b/content/en/api/dashboards/code_snippets/api-dashboard-delete.sh
@@ -2,4 +2,7 @@ api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 dashboard_id="<DASHBOARD_ID>"
 
-curl -X DELETE "https://api.datadoghq.com/api/v1/dashboard/${dashboard_id}?api_key=${api_key}&application_key=${app_key}"
+curl -X DELETE \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/dashboard/${dashboard_id}"

--- a/content/en/api/dashboards/code_snippets/api-dashboard-get.sh
+++ b/content/en/api/dashboards/code_snippets/api-dashboard-get.sh
@@ -2,4 +2,7 @@ api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 dashboard_id="<DASHBOARD_ID>"
 
-curl "https://api.datadoghq.com/api/v1/dashboard/${dashboard_id}?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/dashboard/${dashboard_id}"

--- a/content/en/api/dashboards/code_snippets/api-dashboard-get_all.sh
+++ b/content/en/api/dashboards/code_snippets/api-dashboard-get_all.sh
@@ -1,4 +1,7 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl "https://api.datadoghq.com/api/v1/dashboard?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/dashboard"

--- a/content/en/api/dashboards/code_snippets/api-dashboard-update.sh
+++ b/content/en/api/dashboards/code_snippets/api-dashboard-update.sh
@@ -2,7 +2,10 @@ api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 dashboard_id="<DASHBOARD_ID>"
 
-curl  -X PUT -H "Content-type: application/json" \
+curl  -X PUT \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
       "title" : "Sum of Memory Free",
       "widgets" : [{
@@ -24,4 +27,4 @@ curl  -X PUT -H "Content-type: application/json" \
           "default": "my-host"
       }]
 }' \
-"https://api.datadoghq.com/api/v1/dashboard/${dashboard_id}?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/dashboard/${dashboard_id}"

--- a/content/en/api/downtimes/code_snippets/api-monitor-cancel-downtime-by-scope.sh
+++ b/content/en/api/downtimes/code_snippets/api-monitor-cancel-downtime-by-scope.sh
@@ -3,8 +3,12 @@
 api_key="<YOUR_API_KEY>"
 app_key="<YOUR_APP_KEY>"
 
-curl -X POST -H "Content-type: application/json" -H "Accept: application/json" \
+curl -X POST \
+-H "Content-type: application/json" \
+-H "Accept: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d "{
       \"scope\": \"host:i-123\"
 }" \
-   "https://api.datadoghq.com/api/v1/downtime/cancel/by_scope?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/downtime/cancel/by_scope"

--- a/content/en/api/downtimes/code_snippets/api-monitor-cancel-downtime.sh
+++ b/content/en/api/downtimes/code_snippets/api-monitor-cancel-downtime.sh
@@ -4,11 +4,18 @@ downtime_id=1656
 
 # Create a downtime to delete
 currenttime=$(date +%s)
-downtime_id=$(curl -X POST -H "Content-type: application/json" \
--d "{
+downtime_id=$(curl -X POST \
+    -H "Content-type: application/json" \
+    -H "DD-API-KEY: ${api_key}" \
+    -H "DD-APPLICATION-KEY: ${app_key}" \
+    -d "{
       \"scope\": \"env:prod\",
       \"start\": \"${currenttime}\"
-  }" \
-    "https://api.datadoghq.com/api/v1/downtime?api_key=${api_key}&application_key=${app_key}" | jq '.id')
+    }" \
+    "https://api.datadoghq.com/api/v1/downtime" | jq '.id')
 
-curl -X DELETE -H "Content-type: application/json" "https://api.datadoghq.com/api/v1/downtime/${downtime_id}?api_key=${api_key}&application_key=${app_key}"
+curl -X DELETE \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/downtime/${downtime_id}"

--- a/content/en/api/downtimes/code_snippets/api-monitor-get-downtime.sh
+++ b/content/en/api/downtimes/code_snippets/api-monitor-get-downtime.sh
@@ -3,4 +3,7 @@ app_key=<YOUR_APP_KEY>
 
 downtime_id=2473
 
-curl "https://api.datadoghq.com/api/v1/downtime/${downtime_id}?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/downtime/${downtime_id}"

--- a/content/en/api/downtimes/code_snippets/api-monitor-get-downtimes.sh
+++ b/content/en/api/downtimes/code_snippets/api-monitor-get-downtimes.sh
@@ -1,7 +1,8 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -G "https://api.datadoghq.com/api/v1/downtime" \
-     -d "api_key=${api_key}" \
-     -d "application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/downtime"
 

--- a/content/en/api/downtimes/code_snippets/api-monitor-schedule-downtime.sh
+++ b/content/en/api/downtimes/code_snippets/api-monitor-schedule-downtime.sh
@@ -5,7 +5,10 @@ start=$(date +%s)
 end=$(date -v+3H +%s)
 end_recurrence=$(date -v+21d +%s)
 
-curl -X POST -H "Content-type: application/json" \
+curl -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
       "scope": "env:prod",
       "start": '"${start}"',
@@ -17,4 +20,4 @@ curl -X POST -H "Content-type: application/json" \
         "until_date": '"${end_recurrence}"'
       }
 }' \
-    "https://api.datadoghq.com/api/v1/downtime?api_key=${api_key}&application_key=${app_key}"
+    "https://api.datadoghq.com/api/v1/downtime"

--- a/content/en/api/downtimes/code_snippets/api-monitor-update-downtime.sh
+++ b/content/en/api/downtimes/code_snippets/api-monitor-update-downtime.sh
@@ -4,16 +4,22 @@ downtime_id=4336
 
 # Create a downtime to update
 currenttime=$(date +%s)
-downtime_id=$(curl -X POST -H "Content-type: application/json" \
--d "{
+downtime_id=$(curl -X POST \
+    -H "Content-type: application/json" \
+    -H "DD-API-KEY: ${api_key}" \
+    -H "DD-APPLICATION-KEY: ${app_key}" \
+    -d "{
       \"scope\": \"env:prod\",
       \"start\": \"${currenttime}\"
-  }" \
-    "https://api.datadoghq.com/api/v1/downtime?api_key=${api_key}&application_key=${app_key}" | jq '.id')
+    }" \
+    "https://api.datadoghq.com/api/v1/downtime}" | jq '.id')
 
-curl -X PUT -H "Content-type: application/json" \
+curl -X PUT \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
       "scope": "env:staging",
       "message": "Doing some testing on staging"
 }' \
-    "https://api.datadoghq.com/api/v1/downtime/${downtime_id}?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/downtime/${downtime_id}"

--- a/content/en/api/embeds/code_snippets/api-embeds-create.sh
+++ b/content/en/api/embeds/code_snippets/api-embeds-create.sh
@@ -1,10 +1,12 @@
 api_key="<YOUR_API_KEY>"
 app_key="<YOUR_APP_KEY>"
 
-curl -POST \
-    -d 'graph_json={"requests":[{"q":"avg:system.load.1{*}"}],"viz":"timeseries","events":[]}' \
-    -d "timeframe=1_hour" \
-    -d "size=medium" \
-    -d "legend=yes" \
-    "https://api.datadoghq.com/api/v1/graph/embed?api_key=${api_key}&application_key=${app_key}"
+curl -X POST \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d 'graph_json={"requests":[{"q":"avg:system.load.1{*}"}],"viz":"timeseries","events":[]}' \
+-d "timeframe=1_hour" \
+-d "size=medium" \
+-d "legend=yes" \
+"https://api.datadoghq.com/api/v1/graph/embed"
 

--- a/content/en/api/embeds/code_snippets/api-embeds-enable.sh
+++ b/content/en/api/embeds/code_snippets/api-embeds-enable.sh
@@ -2,5 +2,8 @@ api_key="<YOUR_API_KEY>"
 app_key="<YOUR_APP_KEY>"
 embed_id="5f585b01c81b12ecdf5f40df0382738d0919170639985d3df5e2fc4232865b0c"
 
-curl -X GET "https://api.datadoghq.com/api/v1/graph/embed/${embed_id}/enable?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/graph/embed/${embed_id}/enable"
 

--- a/content/en/api/embeds/code_snippets/api-embeds-get-all.sh
+++ b/content/en/api/embeds/code_snippets/api-embeds-get-all.sh
@@ -1,5 +1,8 @@
 api_key="<YOUR_API_KEY>"
 app_key="<YOUR_APP_KEY>"
 
-curl -X GET "https://api.datadoghq.com/api/v1/graph/embed?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/graph/embed"
 

--- a/content/en/api/embeds/code_snippets/api-embeds-get.sh
+++ b/content/en/api/embeds/code_snippets/api-embeds-get.sh
@@ -3,5 +3,8 @@ app_key="<YOUR_APP_KEY>"
 
 embed_id="5f585b01c81b12ecdf5f40df0382738d0919170639985d3df5e2fc4232865b0c"
 
-curl -X GET "https://api.datadoghq.com/api/v1/graph/embed/${embed_id}?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/graph/embed/${embed_id}"
 

--- a/content/en/api/embeds/code_snippets/api-embeds-revoke.sh
+++ b/content/en/api/embeds/code_snippets/api-embeds-revoke.sh
@@ -3,5 +3,8 @@ app_key="<YOUR_APP_KEY>"
 
 embed_id="5f585b01c81b12ecdf5f40df0382738d0919170639985d3df5e2fc4232865b0c"
 
-curl -X GET "https://api.datadoghq.com/api/v1/graph/embed/${embed_id}/revoke?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/graph/embed/${embed_id}/revoke"
 

--- a/content/en/api/events/code_snippets/api-events-get.sh
+++ b/content/en/api/events/code_snippets/api-events-get.sh
@@ -6,4 +6,7 @@ event_id=1377281704830403917
 event_id=$(curl  -X POST -H "Content-type: application/json" -d "{\"title\": \"Did you hear the news today?\"}" "https://api.datadoghq.com/api/v1/events?api_key=<YOUR_API_KEY>" | jq -r '.event.url|ltrimstr("https://app.datadoghq.com/event/event?id=")')
 sleep 5
 
-curl "https://api.datadoghq.com/api/v1/events/${event_id}?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/events/${event_id}"

--- a/content/en/api/events/code_snippets/api-events-stream.sh
+++ b/content/en/api/events/code_snippets/api-events-stream.sh
@@ -2,12 +2,13 @@
 currenttime=$(date +%s)
 currenttime2=$(date --date='1 day ago' +%s)
 
-curl -G -H "Content-type: application/json" \
-    -d "start=${currenttime2}" \
-    -d "end=${currenttime}" \
-    -d "sources=My Apps" \
-    -d "tags=-env:dev,application:web" \
-    -d "unaggregated=true"\
-    -d "api_key=<YOUR_API_KEY>" \
-    -d "application_key=<YOUR_APP_KEY>" \
-    "https://api.datadoghq.com/api/v1/events"
+curl -X GET \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d "start=${currenttime2}" \
+-d "end=${currenttime}" \
+-d "sources=My Apps" \
+-d "tags=-env:dev,application:web" \
+-d "unaggregated=true"\
+"https://api.datadoghq.com/api/v1/events"

--- a/content/en/api/graphs/code_snippets/api-graph-snapshot.sh
+++ b/content/en/api/graphs/code_snippets/api-graph-snapshot.sh
@@ -2,11 +2,12 @@
 currenttime=$(date +%s)
 currenttime2=$(date -v -1d +%s)
 
-curl -G -H "Content-type: application/json" \
-    -d "metric_query=system.load.1{*}" \
-    -d "start=${currenttime2}" \
-    -d "end=${currenttime}" \
-    -d "api_key=<YOUR_API_KEY>" \
-    -d "application_key=<YOUR_APP_KEY>" \
-    "https://api.datadoghq.com/api/v1/graph/snapshot"
+curl -X GET \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d "metric_query=system.load.1{*}" \
+-d "start=${currenttime2}" \
+-d "end=${currenttime}" \
+"https://api.datadoghq.com/api/v1/graph/snapshot"
 

--- a/content/en/api/hosts/code_snippets/api-host-mute.sh
+++ b/content/en/api/hosts/code_snippets/api-host-mute.sh
@@ -1,8 +1,12 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -X POST -H "Content-type: application/json" \
+curl -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
       "message": "Muting this host for a test!"
-}' "https://api.datadoghq.com/api/v1/host/test.host/mute?api_key=${api_key}&application_key=${app_key}"
+}' \
+"https://api.datadoghq.com/api/v1/host/test.host/mute"
 

--- a/content/en/api/hosts/code_snippets/api-host-unmute.sh
+++ b/content/en/api/hosts/code_snippets/api-host-unmute.sh
@@ -1,5 +1,9 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -X POST -H "Content-type: application/json" "https://api.datadoghq.com/api/v1/host/test.host/unmute?api_key=${api_key}&application_key=${app_key}"
+curl -X POST \
+-H "Content-type: application/json"
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/host/test.host/unmute"
 

--- a/content/en/api/hosts/code_snippets/api-hosts-search.sh
+++ b/content/en/api/hosts/code_snippets/api-hosts-search.sh
@@ -1,6 +1,7 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -G "https://api.datadoghq.com/api/v1/hosts" \
-     -d "api_key=${api_key}" \
-     -d "application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/hosts"

--- a/content/en/api/hosts/code_snippets/api-hosts-totals.sh
+++ b/content/en/api/hosts/code_snippets/api-hosts-totals.sh
@@ -1,6 +1,7 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -G "https://api.datadoghq.com/api/v1/hosts/totals" \
-     -d "api_key=${api_key}" \
-     -d "application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/hosts/totals"

--- a/content/en/api/integrations_aws/code_snippets/aws_add_log_arn_code.sh
+++ b/content/en/api/integrations_aws/code_snippets/aws_add_log_arn_code.sh
@@ -5,9 +5,12 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -X POST -H "Content-type: application/json" \
+curl -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
         "account_id": "<AWS_ACCOUNT_ID>",
         "lambda_arn": "arn:aws:lambda:us-east-1:123456789012:function:PushLogs"
     }'\
-"https://api.datadoghq.com/api/v1/integration/aws/logs?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/integration/aws/logs"

--- a/content/en/api/integrations_aws/code_snippets/aws_create.sh
+++ b/content/en/api/integrations_aws/code_snippets/aws_create.sh
@@ -6,7 +6,10 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 # Create an AWS Account in Datadog
-curl -X POST -H "Content-type: application/json" \
+curl -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
         "account_id": "<AWS_ACCOUNT_ID>",
         "filter_tags": ["<KEY>:<VALUE>"],
@@ -17,4 +20,4 @@ curl -X POST -H "Content-type: application/json" \
         	"opsworks": false
         }
     }'\
-"https://api.datadoghq.com/api/v1/integration/aws?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/integration/aws"

--- a/content/en/api/integrations_aws/code_snippets/aws_delete.sh
+++ b/content/en/api/integrations_aws/code_snippets/aws_delete.sh
@@ -6,9 +6,12 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 # Delete an AWS Account in Datadog
-curl -X DELETE -H "Content-type: application/json" \
+curl -X DELETE \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
         "account_id": "<AWS_ACCOUNT_ID>",
         "role_name": "DatadogAWSIntegrationRole"
 }' \
-"https://api.datadoghq.com/api/v1/integration/aws?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/integration/aws"

--- a/content/en/api/integrations_aws/code_snippets/aws_delete_log_collection.sh
+++ b/content/en/api/integrations_aws/code_snippets/aws_delete_log_collection.sh
@@ -5,9 +5,12 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -X DELETE -H "Content-type: application/json" \
+curl -X DELETE \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
         "account_id": "<AWS_ACCOUNT_ID>",
         "lambda_arn": "arn:aws:lambda:us-east-1:123456789012:function:PushLogs"
     }'\
-"https://api.datadoghq.com/api/v1/integration/aws/logs?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/integration/aws/logs"

--- a/content/en/api/integrations_aws/code_snippets/aws_enable_service_log_collection.sh
+++ b/content/en/api/integrations_aws/code_snippets/aws_enable_service_log_collection.sh
@@ -5,9 +5,12 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -X POST -H "Content-type: application/json" \
+curl -X POST \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-H "Content-type: application/json" \
 -d '{
         "account_id": "<AWS_ACCOUNT_ID>",
         "services": ["elb","s3"]
     }'\
-"https://api.datadoghq.com/api/v1/integration/aws/logs/services?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/integration/aws/logs/services"

--- a/content/en/api/integrations_aws/code_snippets/aws_generate_new_external_id.sh
+++ b/content/en/api/integrations_aws/code_snippets/aws_generate_new_external_id.sh
@@ -5,11 +5,13 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -X PUT -H "Content-type: application/json"
+curl -X PUT \
+-H "Content-type: application/json"
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d
   '{
-    "account_id": "<YOUR_AWS_ACCOUNT_ID>",
-    "role_name": "DatadogAWSIntegrationRole"
-    }'
-
-"https://dd.datadoghq.com/api/v1/integration/aws/generate_new_external_id?${api_key}&application_key=${app_key}"
+        "account_id": "<YOUR_AWS_ACCOUNT_ID>",
+        "role_name": "DatadogAWSIntegrationRole"
+    }' \
+"https://dd.datadoghq.com/api/v1/integration/aws/generate_new_external_id"

--- a/content/en/api/integrations_aws/code_snippets/aws_get_available_log_services.sh
+++ b/content/en/api/integrations_aws/code_snippets/aws_get_available_log_services.sh
@@ -5,4 +5,7 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -X GET "https://api.datadoghq.com/api/v1/integration/aws/logs/services?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/integration/aws/logs/services"

--- a/content/en/api/integrations_aws/code_snippets/aws_list.sh
+++ b/content/en/api/integrations_aws/code_snippets/aws_list.sh
@@ -6,4 +6,7 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 # List AWS Accounts (role-based only) in Datadog
-curl -X GET "https://api.datadoghq.com/api/v1/integration/aws?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/integration/aws"

--- a/content/en/api/integrations_aws/code_snippets/aws_namespace.sh
+++ b/content/en/api/integrations_aws/code_snippets/aws_namespace.sh
@@ -6,4 +6,7 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 # List available namespace rules
-curl -X GET "https://api.datadoghq.com/api/v1/integration/aws/available_namespace_rules?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/integration/aws/available_namespace_rules"

--- a/content/en/api/integrations_aws/code_snippets/aws_update.sh
+++ b/content/en/api/integrations_aws/code_snippets/aws_update.sh
@@ -8,17 +8,19 @@ app_key=<DD_APP_KEY>
 # Update an AWS Account in Datadog
 
 curl -X PUT \
-  "https://api.datadoghq.com/api/v1/integration/aws?api_key=${api_key}&application_key=${app_key}&account_id=<YOUR_AWS_ACCOUNT_ID>&role_name=<ROLE_NAME>" \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "filter_tags": [
-        "<TAG_KEY>:<TAG_VALUE>"
-    ],
-    "host_tags": [
-        "<TAG_KEY>:<TAG_VALUE>"
-    ],
-    "account_specific_namespace_rules": {
-        "auto_scaling": false,
-        "opsworks": false
-    }
-}'
+-H 'Content-Type: application/json' \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d '{
+        "filter_tags": [
+            "<TAG_KEY>:<TAG_VALUE>"
+        ],
+        "host_tags": [
+            "<TAG_KEY>:<TAG_VALUE>"
+        ],
+        "account_specific_namespace_rules": {
+            "auto_scaling": false,
+            "opsworks": false
+        }
+    }' \
+"https://api.datadoghq.com/api/v1/integration/aws?account_id=<YOUR_AWS_ACCOUNT_ID>&role_name=<ROLE_NAME>"

--- a/content/en/api/integrations_azure/code_snippets/azure_create.sh
+++ b/content/en/api/integrations_azure/code_snippets/azure_create.sh
@@ -6,11 +6,14 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 # Create an Azure account in Datadog
-curl -X POST -H "Content-type: application/json" \
+curl -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
         "tenant_name": "<AZURE_TENANT_NAME>",
         "client_id": "<AZURE_CLIENT_ID>",
         "client_secret": "<AZURE_CLIENT_SECRET>",
         "host_filters": "<KEY_1>:<VALUE_1>,<KEY_2>:<VALUE_2>"
     }' \
-"https://api.datadoghq.com/api/v1/integration/azure?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/integration/azure"

--- a/content/en/api/integrations_azure/code_snippets/azure_delete.sh
+++ b/content/en/api/integrations_azure/code_snippets/azure_delete.sh
@@ -5,9 +5,12 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -X DELETE -H "Content-type: application/json" \
+curl -X DELETE \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
         "tenant_name": "<AZURE_TENANT_NAME>",
         "client_id": "<AZURE_CLIENT_ID>"
     }' \
-"https://api.datadoghq.com/api/v1/integration/azure?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/integration/azure"

--- a/content/en/api/integrations_azure/code_snippets/azure_host_filters.sh
+++ b/content/en/api/integrations_azure/code_snippets/azure_host_filters.sh
@@ -5,11 +5,14 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -X POST -H "Content-type: application/json" \
+curl -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
         "tenant_name": "<AZURE_TENANT_NAME>",
         "client_id": "<AZURE_CLIENT_ID>",
         "client_secret": "<AZURE_CLIENT_SECRET>",
         "host_filters": "<KEY_1>:<VALUE_1>,<KEY_2>:<VALUE_2>"
     }' \
-"https://api.datadoghq.com/api/v1/integration/azure/host_filters?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/integration/azure/host_filters"

--- a/content/en/api/integrations_azure/code_snippets/azure_list.sh
+++ b/content/en/api/integrations_azure/code_snippets/azure_list.sh
@@ -5,4 +5,7 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -X GET "https://api.datadoghq.com/api/v1/integration/azure?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/integration/azure"

--- a/content/en/api/integrations_gcp/code_snippets/gcp_automute.sh
+++ b/content/en/api/integrations_gcp/code_snippets/gcp_automute.sh
@@ -5,10 +5,13 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -X PUT -H "Content-type: application/json" \
+curl -X PUT \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
         "project_id": "<GCP_PROJECT_ID>",
         "client_email": "<CLIENT_EMAIL>",
         "automute": <AUTOMUTE>
     }' \
-"https://api.datadoghq.com/api/v1/integration/gcp?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/integration/gcp"

--- a/content/en/api/integrations_gcp/code_snippets/gcp_create.sh
+++ b/content/en/api/integrations_gcp/code_snippets/gcp_create.sh
@@ -5,7 +5,10 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -X POST -H "Content-type: application/json" \
+curl -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
         "type": "service_account",
         "project_id": "<GCP_PROJECT_ID>",
@@ -19,4 +22,4 @@ curl -X POST -H "Content-type: application/json" \
         "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/<CLIENT_EMAIL>",
         "host_filters": "<KEY_1>:<VALUE_1>,<KEY_2>:<VALUE_2>"
     }' \
-"https://api.datadoghq.com/api/v1/integration/gcp?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/integration/gcp"

--- a/content/en/api/integrations_gcp/code_snippets/gcp_delete.sh
+++ b/content/en/api/integrations_gcp/code_snippets/gcp_delete.sh
@@ -5,9 +5,12 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -X DELETE -H "Content-type: application/json" \
+curl -X DELETE \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
         "project_id": "<GCP_PROJECT_ID>",
         "client_email": "<CLIENT_EMAIL>"
     }' \
-"https://api.datadoghq.com/api/v1/integration/gcp?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/integration/gcp"

--- a/content/en/api/integrations_gcp/code_snippets/gcp_list.sh
+++ b/content/en/api/integrations_gcp/code_snippets/gcp_list.sh
@@ -5,4 +5,7 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -X GET "https://api.datadoghq.com/api/v1/integration/gcp?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/integration/gcp"

--- a/content/en/api/integrations_pagerduty/code_snippets/pagerduty_add_services.sh
+++ b/content/en/api/integrations_pagerduty/code_snippets/pagerduty_add_services.sh
@@ -5,7 +5,10 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -v -X POST -H "Content-type: application/json" \
+curl -v -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
       "services": [
         {
@@ -19,4 +22,4 @@ curl -v -X POST -H "Content-type: application/json" \
       ],
       "schedules": ["<SCHEDULE_1>", "<SCHEDULE_2>"],
   }' \
-"https://api.datadoghq.com/api/v1/integration/pagerduty?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/integration/pagerduty"

--- a/content/en/api/integrations_pagerduty/code_snippets/pagerduty_create.sh
+++ b/content/en/api/integrations_pagerduty/code_snippets/pagerduty_create.sh
@@ -5,7 +5,10 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -v -X PUT -H "Content-type: application/json" \
+curl -v -X PUT \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
       "services": [
         {
@@ -21,4 +24,4 @@ curl -v -X PUT -H "Content-type: application/json" \
       "schedules": ["<SCHEDULE_1>", "<SCHEDULE_2>"],
       "api_token": "<PAGERDUTY_TOKEN>"
   }' \
-"https://api.datadoghq.com/api/v1/integration/pagerduty?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/integration/pagerduty"

--- a/content/en/api/integrations_pagerduty/code_snippets/pagerduty_delete.sh
+++ b/content/en/api/integrations_pagerduty/code_snippets/pagerduty_delete.sh
@@ -6,4 +6,6 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 curl -v -X DELETE \
-"https://api.datadoghq.com/api/v1/integration/pagerduty?api_key=${api_key}&application_key=${app_key}"
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/integration/pagerduty"

--- a/content/en/api/integrations_pagerduty/code_snippets/pagerduty_get.sh
+++ b/content/en/api/integrations_pagerduty/code_snippets/pagerduty_get.sh
@@ -6,4 +6,6 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 curl -v -X GET \
-"https://api.datadoghq.com/api/v1/integration/pagerduty?api_key=${api_key}&application_key=${app_key}"
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/integration/pagerduty"

--- a/content/en/api/integrations_slack/code_snippets/slack_add_channels.sh
+++ b/content/en/api/integrations_slack/code_snippets/slack_add_channels.sh
@@ -5,7 +5,10 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -X POST -H "Content-type: application/json" \
+curl -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
     "channels": [
         {
@@ -20,4 +23,4 @@ curl -X POST -H "Content-type: application/json" \
         }
     ]
 }' \
-"https://api.datadoghq.com/api/v1/integration/slack?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/integration/slack"

--- a/content/en/api/integrations_slack/code_snippets/slack_create.sh
+++ b/content/en/api/integrations_slack/code_snippets/slack_create.sh
@@ -5,7 +5,10 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -v -X POST -H "Content-type: application/json" \
+curl -v -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
     "service_hooks": [
       {
@@ -18,4 +21,4 @@ curl -v -X POST -H "Content-type: application/json" \
       }
     ]
   }' \
-"https://api.datadoghq.com/api/v1/integration/slack?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/integration/slack"

--- a/content/en/api/integrations_slack/code_snippets/slack_delete.sh
+++ b/content/en/api/integrations_slack/code_snippets/slack_delete.sh
@@ -5,4 +5,7 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -v -X DELETE "https://api.datadoghq.com/api/v1/integration/slack?api_key=${api_key}&application_key=${app_key}"
+curl -v -X DELETE \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/integration/slack"

--- a/content/en/api/integrations_slack/code_snippets/slack_get.sh
+++ b/content/en/api/integrations_slack/code_snippets/slack_get.sh
@@ -5,4 +5,7 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -v -X GET "https://api.datadoghq.com/api/v1/integration/slack?api_key=${api_key}&application_key=${app_key}"
+curl -v -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/integration/slack"

--- a/content/en/api/integrations_webhook/code_snippets/webhooks_add_webhook.sh
+++ b/content/en/api/integrations_webhook/code_snippets/webhooks_add_webhook.sh
@@ -5,7 +5,10 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -v -X POST -H "Content-type: application/json" \
+curl -v -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
     "hooks": [
       {
@@ -14,4 +17,4 @@ curl -v -X POST -H "Content-type: application/json" \
       }
     ]
 }' \
-"https://api.datadoghq.com/api/v1/integration/webhooks?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/integration/webhooks"

--- a/content/en/api/integrations_webhook/code_snippets/webhooks_create.sh
+++ b/content/en/api/integrations_webhook/code_snippets/webhooks_create.sh
@@ -5,7 +5,10 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -v -X POST -H "Content-type: application/json" \
+curl -v -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
     "hooks": [
       {
@@ -14,4 +17,4 @@ curl -v -X POST -H "Content-type: application/json" \
       }
     ]
 }' \
-"https://api.datadoghq.com/api/v1/integration/webhooks?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/integration/webhooks"

--- a/content/en/api/integrations_webhook/code_snippets/webhooks_delete.sh
+++ b/content/en/api/integrations_webhook/code_snippets/webhooks_delete.sh
@@ -5,4 +5,7 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -v -X DELETE "https://api.datadoghq.com/api/v1/integration/webhooks?api_key=${api_key}&application_key=${app_key}"
+curl -v -X DELETE \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/integration/webhooks"

--- a/content/en/api/integrations_webhook/code_snippets/webhooks_get.sh
+++ b/content/en/api/integrations_webhook/code_snippets/webhooks_get.sh
@@ -5,4 +5,7 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -v -X GET "https://api.datadoghq.com/api/v1/integration/webhooks?api_key=${api_key}&application_key=${app_key}"
+curl -v -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/integration/webhooks"

--- a/content/en/api/key_management/code_snippets/create_api_key.sh
+++ b/content/en/api/key_management/code_snippets/create_api_key.sh
@@ -6,8 +6,10 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 curl -X POST \
-  "https://app.datadoghq.com/api/v1/api_key?api_key=${api_key}&application_key=${app_key}" \
-  -H 'Content-Type: application/json' \
-  -d '{
-	"name": "<API_KEY_NAME>"
-}'
+-H 'Content-Type: application/json' \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d '{
+	      "name": "<API_KEY_NAME>"
+    }' \
+"https://app.datadoghq.com/api/v1/api_key"

--- a/content/en/api/key_management/code_snippets/create_app_key.sh
+++ b/content/en/api/key_management/code_snippets/create_app_key.sh
@@ -6,8 +6,10 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 curl -X POST \
-  "https://app.datadoghq.com/api/v1/application_key?api_key=${api_key}&application_key=${app_key}" \
-  -H 'Content-Type: application/json' \
-  -d '{
-	"name": "<APP_KEY_NAME>"
-}'
+-H 'Content-Type: application/json' \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d '{
+	      "name": "<APP_KEY_NAME>"
+    }' \
+"https://app.datadoghq.com/api/v1/application_key"

--- a/content/en/api/key_management/code_snippets/delete_api_key.sh
+++ b/content/en/api/key_management/code_snippets/delete_api_key.sh
@@ -6,5 +6,7 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 curl -X DELETE \
-  "https://app.datadoghq.com/api/v1/api_key/<API_KEY_TO_DELETE>?api_key=${api_key}&application_key=${app_key}" \
-  -H 'Content-Type: application/json'
+-H 'Content-Type: application/json'
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://app.datadoghq.com/api/v1/api_key/<API_KEY_TO_DELETE>"

--- a/content/en/api/key_management/code_snippets/delete_app_key.sh
+++ b/content/en/api/key_management/code_snippets/delete_app_key.sh
@@ -6,5 +6,7 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 curl -X DELETE \
-  "https://app.datadoghq.com/api/v1/application_key/<APP_KEY_TO_DELETE>?api_key=${api_key}&application_key=${app_key}" \
-  -H 'Content-Type: application/json'
+-H 'Content-Type: application/json'
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://app.datadoghq.com/api/v1/application_key/<APP_KEY_TO_DELETE>"

--- a/content/en/api/key_management/code_snippets/edit_api_key.sh
+++ b/content/en/api/key_management/code_snippets/edit_api_key.sh
@@ -6,8 +6,10 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 curl -X PUT \
-  "https://app.datadoghq.com/api/v1/api_key/<API_KEY_TO_EDIT>?api_key=${api_key}&application_key=${app_key}" \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "name":"<NEW_API_KEY_NAME>"
-}'
+-H 'Content-Type: application/json' \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d '{
+        "name":"<NEW_API_KEY_NAME>"
+    }' \
+"https://app.datadoghq.com/api/v1/api_key/<API_KEY_TO_EDIT>"

--- a/content/en/api/key_management/code_snippets/edit_app_key.sh
+++ b/content/en/api/key_management/code_snippets/edit_app_key.sh
@@ -6,8 +6,10 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 curl -X PUT \
-  "https://app.datadoghq.com/api/v1/application_key/<APP_KEY_TO_EDIT>?api_key=${api_key}&application_key=${app_key}" \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "name":"<NEW_APP_KEY_NAME>"
-}'
+-H 'Content-Type: application/json' \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d '{
+        "name":"<NEW_APP_KEY_NAME>"
+    }' \
+"https://app.datadoghq.com/api/v1/application_key/<APP_KEY_TO_EDIT>"

--- a/content/en/api/key_management/code_snippets/get_all_api_key.sh
+++ b/content/en/api/key_management/code_snippets/get_all_api_key.sh
@@ -6,5 +6,7 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 curl -X GET \
-  "https://app.datadoghq.com/api/v1/api_key?api_key=${api_key}&application_key=${app_key}" \
-  -H 'Content-Type: application/json'
+-H 'Content-Type: application/json' \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://app.datadoghq.com/api/v1/api_key"

--- a/content/en/api/key_management/code_snippets/get_all_app_key.sh
+++ b/content/en/api/key_management/code_snippets/get_all_app_key.sh
@@ -6,5 +6,7 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 curl -X GET \
-  "https://app.datadoghq.com/api/v1/application_key?api_key=${api_key}&application_key=${app_key}" \
-  -H 'Content-Type: application/json'
+-H 'Content-Type: application/json' \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://app.datadoghq.com/api/v1/application_key"

--- a/content/en/api/key_management/code_snippets/get_api_key.sh
+++ b/content/en/api/key_management/code_snippets/get_api_key.sh
@@ -6,5 +6,7 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 curl -X GET \
-  "https://app.datadoghq.com/api/v1/api_key/<API_KEY_TO_GET>?api_key=${api_key}&application_key=${app_key}" \
-  -H 'Content-Type: application/json'
+-H 'Content-Type: application/json' \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://app.datadoghq.com/api/v1/api_key/<API_KEY_TO_GET>"

--- a/content/en/api/key_management/code_snippets/get_app_key.sh
+++ b/content/en/api/key_management/code_snippets/get_app_key.sh
@@ -6,5 +6,7 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 curl -X GET \
-  "https://app.datadoghq.com/api/v1/application_key/<APP_KEY_TO_GET>?api_key=${api_key}&application_key=${app_key}" \
-  -H 'Content-Type: application/json'
+-H 'Content-Type: application/json' \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://app.datadoghq.com/api/v1/application_key/<APP_KEY_TO_GET>"

--- a/content/en/api/logs/code_snippets/list_logs.sh
+++ b/content/en/api/logs/code_snippets/list_logs.sh
@@ -6,6 +6,16 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 curl -X POST \
-  "https://api.datadoghq.com/api/v1/logs-queries/list?api_key=${api_key}&application_key=${app_key}" \
-  -H 'content-type: application/json' \
-  -d '{"query": "service:nginx -@http.method:POST","time": {"from": "now - 1h", "to": "now"}, "sort": "desc", "limit": 50}'
+-H 'content-type: application/json' \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d '{ 
+        "query": "service:nginx -@http.method:POST",
+        "time": {
+            "from": "now - 1h",
+            "to": "now"
+        },
+        "sort": "desc",
+        "limit": 50
+    }' \
+"https://api.datadoghq.com/api/v1/logs-queries/list"

--- a/content/en/api/logs_indexes/code_snippets/get_all_indexes.sh
+++ b/content/en/api/logs_indexes/code_snippets/get_all_indexes.sh
@@ -6,5 +6,7 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 curl -X GET \
-  "https://api.datadoghq.com/api/v1/logs/config/indexes?api_key=${api_key}&application_key=${app_key}" \
-  -H 'content-type: application/json'
+-H 'content-type: application/json' \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/logs/config/indexes"

--- a/content/en/api/logs_indexes/code_snippets/get_an_index.sh
+++ b/content/en/api/logs_indexes/code_snippets/get_an_index.sh
@@ -6,5 +6,7 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 curl -X GET \
-  "https://api.datadoghq.com/api/v1/logs/config/indexes/<INDEX_NAME>?api_key=${api_key}&application_key=${app_key}" \
-  -H 'content-type: application/json'
+-H 'content-type: application/json' \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/logs/config/indexes/<INDEX_NAME>"

--- a/content/en/api/logs_indexes/code_snippets/get_indexes_order.sh
+++ b/content/en/api/logs_indexes/code_snippets/get_indexes_order.sh
@@ -6,5 +6,7 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 curl -X GET \
-  "https://api.datadoghq.com/api/v1/logs/config/index-order?api_key=${api_key}&application_key=${app_key}" \
-  -H 'content-type: application/json'
+-H 'content-type: application/json' \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/logs/config/index-order"

--- a/content/en/api/logs_indexes/code_snippets/update_an_index.sh
+++ b/content/en/api/logs_indexes/code_snippets/update_an_index.sh
@@ -6,9 +6,10 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 curl -X PUT \
-  "https://api.datadoghq.com/api/v1/logs/config/indexes/<INDEX_NAME>?api_key=${api_key}&application_key=${app_key}" \
-  -H 'content-type: application/json' \
-  -d '{
+-H 'content-type: application/json' \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d '{
     "filter": {
         "query": "<NEW_INDEX_FILTER_QUERY>"
     },
@@ -30,4 +31,5 @@ curl -X PUT \
         }
       }
     ]
-}'
+}' \
+"https://api.datadoghq.com/api/v1/logs/config/indexes/<INDEX_NAME>"

--- a/content/en/api/logs_indexes/code_snippets/update_indexes_order.sh
+++ b/content/en/api/logs_indexes/code_snippets/update_indexes_order.sh
@@ -6,11 +6,13 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 curl -X PUT \
-  "https://api.datadoghq.com/api/v1/logs/config/index-order?api_key=${api_key}&application_key=${app_key}" \
-  -H 'content-type: application/json' \
-  -d '{
+-H 'content-type: application/json' \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d '{
 	"index_names": [
     "<INDEX_NAME_2>",
 		"<INDEX_NAME_1>"
 	]
-}'
+}' \
+"https://api.datadoghq.com/api/v1/logs/config/index-order"

--- a/content/en/api/logs_pipelines/code_snippets/create_pipeline.sh
+++ b/content/en/api/logs_pipelines/code_snippets/create_pipeline.sh
@@ -6,9 +6,10 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
 curl -X POST \
-  "https://api.datadoghq.com/api/v1/logs/config/pipelines?api_key=${api_key}&application_key=${app_key}" \
-  -H 'Content-Type: application/json' \
-  -d '{
+-H 'Content-Type: application/json' \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d '{
     "name": "<PIPELINE_NAME>",
     "is_enabled": true,
     "filter": {
@@ -24,4 +25,5 @@ curl -X POST \
             "type": "date-remapper"
         }
     ]
-}'
+}' \
+"https://api.datadoghq.com/api/v1/logs/config/pipelines"

--- a/content/en/api/logs_pipelines/code_snippets/delete_pipeline.sh
+++ b/content/en/api/logs_pipelines/code_snippets/delete_pipeline.sh
@@ -6,4 +6,7 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 pipeline_id=<PIPELINE_ID>
 
-curl -X DELETE "https://api.datadoghq.com/api/v1/logs/config/pipelines/${pipeline_id}?api_key=${api_key}&application_key=${app_key}"
+curl -X DELETE \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/logs/config/pipelines/${pipeline_id}"

--- a/content/en/api/logs_pipelines/code_snippets/get_all_pipelines.sh
+++ b/content/en/api/logs_pipelines/code_snippets/get_all_pipelines.sh
@@ -5,4 +5,7 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -X GET "https://api.datadoghq.com/api/v1/logs/config/pipelines?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/logs/config/pipelines"

--- a/content/en/api/logs_pipelines/code_snippets/get_pipeline.sh
+++ b/content/en/api/logs_pipelines/code_snippets/get_pipeline.sh
@@ -6,4 +6,7 @@ api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 pipeline_id=<PIPELINE_ID>
 
-curl -X GET "https://api.datadoghq.com/api/v1/logs/config/${pipeline_id}?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/logs/config/${pipeline_id}"

--- a/content/en/api/logs_pipelines/code_snippets/get_pipelines_order.sh
+++ b/content/en/api/logs_pipelines/code_snippets/get_pipelines_order.sh
@@ -5,4 +5,7 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -X GET "https://api.datadoghq.com/api/v1/logs/config/pipeline-order?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/logs/config/pipeline-order"

--- a/content/en/api/logs_pipelines/code_snippets/update_pipeline.sh
+++ b/content/en/api/logs_pipelines/code_snippets/update_pipeline.sh
@@ -7,9 +7,10 @@ app_key=<DD_APP_KEY>
 pipeline_id=<PIPELINE_ID>
 
 curl -X PUT \
-  "https://api.datadoghq.com/api/v1/logs/config/pipelines/${pipeline_id}?api_key=${api_key}&application_key=${app_key}" \
-  -H 'Content-Type: application/json' \
-  -d '{
+-H 'Content-Type: application/json' \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d '{
     "name": "<NEW_PIPELINE_NAME>",
     "is_enabled": true,
     "filter": {
@@ -25,4 +26,5 @@ curl -X PUT \
             "type": "date-remapper"
         }
     ]
-}'
+}' \
+"https://api.datadoghq.com/api/v1/logs/config/pipelines/${pipeline_id}"

--- a/content/en/api/logs_pipelines/code_snippets/update_pipeline_order.sh
+++ b/content/en/api/logs_pipelines/code_snippets/update_pipeline_order.sh
@@ -5,12 +5,15 @@
 api_key=<DD_API_KEY>
 app_key=<DD_APP_KEY>
 
-curl -X PUT "https://api.datadoghq.com/api/v1/logs/config/pipeline-order?api_key=${api_key}&application_key=${app_key}" \
-  -H 'Content-Type: application/json' \
-  -d '{
+curl -X PUT \
+-H 'Content-Type: application/json' \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d '{
     "pipeline_ids": [
         "<PIPELINE_1_ID>",
         "<PIPELINE_2_ID>",
         "<PIPELINE_3_ID>"
     ]
-}'
+}' \
+"https://api.datadoghq.com/api/v1/logs/config/pipeline-order"

--- a/content/en/api/metrics/code_snippets/api-metric-metadata-get.sh
+++ b/content/en/api/metrics/code_snippets/api-metric-metadata-get.sh
@@ -4,5 +4,8 @@ app_key=<YOUR_APP_KEY>
 
 metric_name="system.net.bytes_sent"
 
-curl "https://api.datadoghq.com/api/v1/metrics/${metric_name}?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/metrics/${metric_name}"
 

--- a/content/en/api/metrics/code_snippets/api-metric-metadata-update.sh
+++ b/content/en/api/metrics/code_snippets/api-metric-metadata-update.sh
@@ -3,7 +3,10 @@ app_key=<YOUR_APP_KEY>
 
 metric_name="system.net.bytes_sent"
 
-curl -X PUT -H "Content-type: application/json" \
+curl -X PUT \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
       "type": "gauge",
       "description": "my custom description",
@@ -11,5 +14,5 @@ curl -X PUT -H "Content-type: application/json" \
       "unit": "byte",
       "per_unit": "second"
 }' \
-    "https://api.datadoghq.com/api/v1/metrics/${metric_name}?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/metrics/${metric_name}"
 

--- a/content/en/api/metrics/code_snippets/api-metrics-list.sh
+++ b/content/en/api/metrics/code_snippets/api-metrics-list.sh
@@ -3,9 +3,9 @@ app_key=<YOUR_APP_KEY>
 
 from_time=$(date -v -1d +%s)
 
-curl -G \
-    "https://api.datadoghq.com/api/v1/metrics" \
-    -d "api_key=${api_key}" \
-    -d "application_key=${app_key}" \
-    -d "from=${from_time}" \
-    -d "host=<HOSTNAME>"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d "from=${from_time}" \
+-d "host=<HOSTNAME>" \
+"https://api.datadoghq.com/api/v1/metrics"

--- a/content/en/api/metrics/code_snippets/api-metrics-query.sh
+++ b/content/en/api/metrics/code_snippets/api-metrics-query.sh
@@ -3,10 +3,10 @@ app_key=<YOUR_APP_KEY>
 to_time=$(date +%s)
 from_time=$(date -v -1d +%s)
 
-curl -G \
-    "https://api.datadoghq.com/api/v1/query" \
-    -d "api_key=${api_key}" \
-    -d "application_key=${app_key}" \
-    -d "from=${from_time}" \
-    -d "to=${to_time}" \
-    -d "query=system.cpu.idle{*}by{host}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d "from=${from_time}" \
+-d "to=${to_time}" \
+-d "query=system.cpu.idle{*}by{host}" \
+"https://api.datadoghq.com/api/v1/query"

--- a/content/en/api/metrics/code_snippets/api-metrics-search.sh
+++ b/content/en/api/metrics/code_snippets/api-metrics-search.sh
@@ -1,8 +1,11 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -G "https://api.datadoghq.com/api/v1/search" \
-    -d "api_key=${api_key}" \
-    -d "application_key=${app_key}" \
-    -d "q=metrics:test"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d "api_key=${api_key}" \
+-d "application_key=${app_key}" \
+-d "q=metrics:test" \
+"https://api.datadoghq.com/api/v1/search"
 

--- a/content/en/api/monitors/code_snippets/api-monitor-bulk-resolve.sh
+++ b/content/en/api/monitors/code_snippets/api-monitor-bulk-resolve.sh
@@ -5,11 +5,14 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -X POST -H "Content-type: application/json" \
+curl -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
 "resolve": [
           {"<YOUR_MONITOR_ID>": "<YOUR_FIRST_GROUP>"},
           {"<YOUR_MONITOR_ID>": "<YOUR_SECOND_GROUP>"}
       ]
 }' \
-    "https://app.datadoghq.com/monitor/bulk_resolve?api_key=${api_key}&application_key=${app_key}"
+"https://app.datadoghq.com/monitor/bulk_resolve"

--- a/content/en/api/monitors/code_snippets/api-monitor-create.sh
+++ b/content/en/api/monitors/code_snippets/api-monitor-create.sh
@@ -5,7 +5,10 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -X POST -H "Content-type: application/json" \
+curl -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
       "type": "metric alert",
       "query": "avg(last_5m):sum:system.net.bytes_rcvd{host:host0} > 100",
@@ -17,4 +20,4 @@ curl -X POST -H "Content-type: application/json" \
       	"no_data_timeframe": 20
       }
 }' \
-    "https://api.datadoghq.com/api/v1/monitor?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/monitor"

--- a/content/en/api/monitors/code_snippets/api-monitor-edit.sh
+++ b/content/en/api/monitors/code_snippets/api-monitor-edit.sh
@@ -7,10 +7,13 @@ app_key=<YOUR_APP_KEY>
 monitor_id=<YOUR_MONITOR_ID>
 
 # Edit a monitor
-curl -X PUT -H "Content-type: application/json" \
+curl -X PUT \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
       "query": "avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 100",
       "name": "Bytes received on host0",
       "message": "We may need to add web hosts if this is consistently high."
 }' \
-    "https://api.datadoghq.com/api/v1/monitor/${monitor_id}?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/monitor/${monitor_id}"

--- a/content/en/api/monitors/code_snippets/api-monitor-group-search.sh
+++ b/content/en/api/monitors/code_snippets/api-monitor-group-search.sh
@@ -11,4 +11,6 @@ per_page=<PER_PAGE>
 sort=<SORT>
 
 curl -X GET \
-    "https://api.datadoghq.com/api/v1/monitor/groups/search?api_key=${api_key}&application_key=${app_key}&query=${query}&page=${page}&per_page=${per_page}&sort=${sort}"
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/monitor/groups/search?query=${query}&page=${page}&per_page=${per_page}&sort=${sort}"

--- a/content/en/api/monitors/code_snippets/api-monitor-mute-all.sh
+++ b/content/en/api/monitors/code_snippets/api-monitor-mute-all.sh
@@ -5,4 +5,8 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -X POST -H "Content-type: application/json" "https://api.datadoghq.com/api/v1/monitor/mute_all?api_key=${api_key}&application_key=${app_key}"
+curl -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/monitor/mute_all"

--- a/content/en/api/monitors/code_snippets/api-monitor-mute.sh
+++ b/content/en/api/monitors/code_snippets/api-monitor-mute.sh
@@ -7,4 +7,8 @@ app_key=<YOUR_APP_KEY>
 monitor_id=<YOUR_MONITOR_ID>
 
 # Mute a monitor
-curl -X POST -H "Content-type: application/json" "https://api.datadoghq.com/api/v1/monitor/${monitor_id}/mute?api_key=${api_key}&application_key=${app_key}"
+curl -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/monitor/${monitor_id}/mute"

--- a/content/en/api/monitors/code_snippets/api-monitor-search.sh
+++ b/content/en/api/monitors/code_snippets/api-monitor-search.sh
@@ -11,4 +11,6 @@ per_page=<PER_PAGE>
 sort=<SORT>
 
 curl -X GET \
-    "https://api.datadoghq.com/api/v1/monitor/search?api_key=${api_key}&application_key=${app_key}&query=${query}&page=${page}&per_page=${per_page}&sort=${sort}"
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/monitor/search?query=${query}&page=${page}&per_page=${per_page}&sort=${sort}"

--- a/content/en/api/monitors/code_snippets/api-monitor-show-all.sh
+++ b/content/en/api/monitors/code_snippets/api-monitor-show-all.sh
@@ -5,6 +5,7 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -G "https://api.datadoghq.com/api/v1/monitor" \
-     -d "api_key=${api_key}" \
-     -d "application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/monitor"

--- a/content/en/api/monitors/code_snippets/api-monitor-show.sh
+++ b/content/en/api/monitors/code_snippets/api-monitor-show.sh
@@ -7,7 +7,8 @@ app_key=<YOUR_APP_KEY>
 monitor_id=<YOUR_MONITOR_ID>
 
 # Show a monitor
-curl -G "https://api.datadoghq.com/api/v1/monitor/${monitor_id}" \
-     -d "api_key=${api_key}" \
-     -d "application_key=${app_key}" \
-     -d "group_states=all"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d "group_states=all" \
+"https://api.datadoghq.com/api/v1/monitor/${monitor_id}"

--- a/content/en/api/monitors/code_snippets/api-monitor-unmute-all.sh
+++ b/content/en/api/monitors/code_snippets/api-monitor-unmute-all.sh
@@ -5,4 +5,8 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -X POST -H "Content-type: application/json" "https://api.datadoghq.com/api/v1/monitor/unmute_all?api_key=${api_key}&application_key=${app_key}"
+curl -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/monitor/unmute_all"

--- a/content/en/api/monitors/code_snippets/api-monitor-unmute.sh
+++ b/content/en/api/monitors/code_snippets/api-monitor-unmute.sh
@@ -7,4 +7,7 @@ app_key=<YOUR_APP_KEY>
 monitor_id=<YOUR_MONITOR_ID>
 
 # Unmute a monitor
-curl -X POST "https://api.datadoghq.com/api/v1/monitor/${monitor_id}/unmute?api_key=${api_key}&application_key=${app_key}"
+curl -X POST \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/monitor/${monitor_id}/unmute"

--- a/content/en/api/monitors/code_snippets/api-monitor-validate.sh
+++ b/content/en/api/monitors/code_snippets/api-monitor-validate.sh
@@ -5,7 +5,10 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -X POST -H "Content-type: application/json" \
+curl -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
       "type": "metric alert",
       "query": "THIS QUERY IS INVALID",
@@ -17,4 +20,4 @@ curl -X POST -H "Content-type: application/json" \
       	"no_data_timeframe": 20
       }
 }' \
-    "https://api.datadoghq.com/api/v1/monitor/validate?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/monitor/validate"

--- a/content/en/api/org/code_snippets/api-idp-upload.sh
+++ b/content/en/api/org/code_snippets/api-idp-upload.sh
@@ -3,13 +3,19 @@ app_key=<YOUR_APP_KEY>
 public_id=<DD_APP_PUBLIC_ID>
 
 # Upload IdP file using multipart/form-data
-curl -X POST -H "Content-Type: multipart/form-data" \
-    -F "idp_file=@metadata.xml" \
-    "https://api.datadoghq.com/api/v1/org/${public_id}/idp_metadata?api_key=${api_key}&application_key=${app_key}"
+curl -X POST \
+-H "Content-Type: multipart/form-data" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-F "idp_file=@metadata.xml" \
+"https://api.datadoghq.com/api/v1/org/${public_id}/idp_metadata"
 
 # OR
 
 # Upload IdP file using application/xml
-curl -X POST -H "Content-Type: application/xml" \
-    --data-binary "@metadata.xml" \
-    "https://api.datadoghq.com/api/v1/org/${public_id}/idp_metadata?api_key=${api_key}&application_key=${app_key}"
+curl -X POST \
+-H "Content-Type: application/xml" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+--data-binary "@metadata.xml" \
+"https://api.datadoghq.com/api/v1/org/${public_id}/idp_metadata"

--- a/content/en/api/org/code_snippets/api-org-create.sh
+++ b/content/en/api/org/code_snippets/api-org-create.sh
@@ -1,10 +1,13 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -X POST -H "Content-type: application/json" \
-    -d '{
+curl -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d '{
         "name" :"My Org",
         "subscription" :{"type":"pro"},
         "billing" :{"type":"parent_billing"}
 }' \
-    "https://api.datadoghq.com/api/v1/org?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/org"

--- a/content/en/api/org/code_snippets/api-org-get.sh
+++ b/content/en/api/org/code_snippets/api-org-get.sh
@@ -1,4 +1,7 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -X GET "https://api.datadoghq.com/api/v1/org?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/org"

--- a/content/en/api/org/code_snippets/api-org-update.sh
+++ b/content/en/api/org/code_snippets/api-org-update.sh
@@ -2,8 +2,11 @@ api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 public_id=axd2s
 
-curl -X PUT -H "Content-type: application/json" \
-    -d '{
+curl -X PUT \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d '{
         "settings": {
             "saml": {
                 "enabled": true
@@ -23,4 +26,4 @@ curl -X PUT -H "Content-type: application/json" \
             }
         }
 }' \
-    "https://api.datadoghq.com/api/v1/org/${public_id}?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/org/${public_id}"

--- a/content/en/api/service_level_objectives/code_snippets/api-slo-bulk-delete.sh
+++ b/content/en/api/service_level_objectives/code_snippets/api-slo-bulk-delete.sh
@@ -6,6 +6,9 @@ api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
 # Bulk Delete SLOs
-curl -X POST -H "Content-Type: application/json" \
+curl -X POST \
+-H "Content-Type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
  -d '{"12341234123412341234123412341234": ["7d"], "43210000432100004321000043210000": ["30d"]}}' \
- "https://api.datadoghq.com/api/v1/slo/bulk_delete?api_key=${api_key}&application_key=${app_key}"
+ "https://api.datadoghq.com/api/v1/slo/bulk_delete"

--- a/content/en/api/service_level_objectives/code_snippets/api-slo-can-delete.sh
+++ b/content/en/api/service_level_objectives/code_snippets/api-slo-can-delete.sh
@@ -7,4 +7,7 @@ app_key=<YOUR_APP_KEY>
 slo_id=<YOUR_SLO_ID>
 
 # Check if it is safe to delete a SLO
-curl -X GET "https://api.datadoghq.com/api/v1/slo/can_delete?api_key=${api_key}&application_key=${app_key}&ids=${slo_id}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/slo/can_delete"

--- a/content/en/api/service_level_objectives/code_snippets/api-slo-create.sh
+++ b/content/en/api/service_level_objectives/code_snippets/api-slo-create.sh
@@ -6,6 +6,8 @@ api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
 curl -X POST -H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
       "type": "monitor",
       "name": "Critical Foo Host Uptime",
@@ -16,4 +18,4 @@ curl -X POST -H "Content-type: application/json" \
         {"timeframe": "30d", "target": 95, "warning": 98}
       ]
 }' \
-    "https://api.datadoghq.com/api/v1/slo?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/slo"

--- a/content/en/api/service_level_objectives/code_snippets/api-slo-delete-many.sh
+++ b/content/en/api/service_level_objectives/code_snippets/api-slo-delete-many.sh
@@ -7,5 +7,9 @@ app_key=<YOUR_APP_KEY>
 slo_ids=<YOUR_SLO_IDS_CSV>
 
 # Delete a SLO
-curl -X DELETE -H "Content-Type: applicaton/json" -d '[${slo_ids}]' \
-  "https://api.datadoghq.com/api/v1/slo/?api_key=${api_key}&application_key=${app_key}"
+curl -X DELETE \
+-H "Content-Type: applicaton/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d '[${slo_ids}]' \
+"https://api.datadoghq.com/api/v1/slo/"

--- a/content/en/api/service_level_objectives/code_snippets/api-slo-delete.sh
+++ b/content/en/api/service_level_objectives/code_snippets/api-slo-delete.sh
@@ -7,4 +7,7 @@ app_key=<YOUR_APP_KEY>
 slo_id=<YOUR_SLO_ID>
 
 # Delete a SLO
-curl -X DELETE "https://api.datadoghq.com/api/v1/slo/${slo_id}?api_key=${api_key}&application_key=${app_key}"
+curl -X DELETE \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/slo/${slo_id}"

--- a/content/en/api/service_level_objectives/code_snippets/api-slo-edit.sh
+++ b/content/en/api/service_level_objectives/code_snippets/api-slo-edit.sh
@@ -7,9 +7,12 @@ app_key=<YOUR_APP_KEY>
 slo_id=<YOUR_SLO_ID>
 
 # Edit a SLO
-curl -X PUT -H "Content-type: application/json" \
+curl -X PUT \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
       "name": "Host0 uptime",
       "description": "We may need to replace this host if it is constantly down."
 }' \
-    "https://api.datadoghq.com/api/v1/slo/${slo_id}?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/slo/${slo_id}"

--- a/content/en/api/service_level_objectives/code_snippets/api-slo-get.sh
+++ b/content/en/api/service_level_objectives/code_snippets/api-slo-get.sh
@@ -7,4 +7,7 @@ app_key=<YOUR_APP_KEY>
 slo_id=<YOUR_SLO_ID>
 
 # Get a SLO
-curl -X GET "https://api.datadoghq.com/api/v1/slo/${slo_id}?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/slo/${slo_id}"

--- a/content/en/api/service_level_objectives/code_snippets/api-slo-history.sh
+++ b/content/en/api/service_level_objectives/code_snippets/api-slo-history.sh
@@ -9,4 +9,7 @@ to_ts=<to epoch timestamp>
 from_ts=<from epoch timestamp>
 
 # Get SLO history
-curl -X GET "https://api.datadoghq.com/api/v1/slo/${slo_id}?api_key=${api_key}&application_key=${app_key}&from_ts=${from_ts}&to_ts={$to_ts}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/slo/${slo_id}?from_ts=${from_ts}&to_ts={$to_ts}"

--- a/content/en/api/service_level_objectives/code_snippets/api-slo-search.sh
+++ b/content/en/api/service_level_objectives/code_snippets/api-slo-search.sh
@@ -10,4 +10,6 @@ offset=<OFFSET>
 limit=<LIMIT>
 
 curl -X GET \
-    "https://api.datadoghq.com/api/v1/slo?api_key=${api_key}&application_key=${app_key}&query=${query}&offset=${page}&limit=${per_page}"
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/slo?query=${query}&offset=${page}&limit=${per_page}"

--- a/content/en/api/synthetics/code_snippets/get_browsers.sh
+++ b/content/en/api/synthetics/code_snippets/get_browsers.sh
@@ -1,4 +1,7 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl "https://api.datadoghq.com/api/v1/synthetics/browser/devices?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/synthetics/browser/devices"

--- a/content/en/api/synthetics/code_snippets/get_locations.sh
+++ b/content/en/api/synthetics/code_snippets/get_locations.sh
@@ -1,4 +1,7 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl "https://api.datadoghq.com/api/v1/synthetics/locations?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/synthetics/locations"

--- a/content/en/api/synthetics/code_snippets/get_result.sh
+++ b/content/en/api/synthetics/code_snippets/get_result.sh
@@ -3,4 +3,7 @@ app_key=<YOUR_APP_KEY>
 public_id=<SYNTHETICS_TEST_PUBLIC_ID>
 result_id=<TEST_RESULT_ID>
 
-curl "https://api.datadoghq.com/api/v1/synthetics/tests/${public_id}/results/${result_id}?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/synthetics/tests/${public_id}/results/${result_id}"

--- a/content/en/api/synthetics/code_snippets/get_results.sh
+++ b/content/en/api/synthetics/code_snippets/get_results.sh
@@ -2,4 +2,7 @@ api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 public_id=<SYNTHETICS_TEST_PUBLIC_ID>
 
-curl "https://api.datadoghq.com/api/v1/synthetics/tests/${public_id}/results?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/synthetics/tests/${public_id}/results"

--- a/content/en/api/synthetics/code_snippets/get_test.sh
+++ b/content/en/api/synthetics/code_snippets/get_test.sh
@@ -2,4 +2,7 @@ api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 public_id=<SYNTHETICS_TEST_PUBLIC_ID>
 
-curl "https://api.datadoghq.com/api/v1/synthetics/tests/${public_id}?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/synthetics/tests/${public_id}"

--- a/content/en/api/synthetics/code_snippets/get_tests.sh
+++ b/content/en/api/synthetics/code_snippets/get_tests.sh
@@ -1,4 +1,7 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl "https://api.datadoghq.com/api/v1/synthetics/tests?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/synthetics/tests"

--- a/content/en/api/synthetics/code_snippets/post_delete.sh
+++ b/content/en/api/synthetics/code_snippets/post_delete.sh
@@ -3,11 +3,14 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -X POST -H "Content-type: application/json" \
+curl -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
    "public_ids":[
       "aaa-bbb-ccc",
       "bbb-ccc-ddd"
    ]
 }' \
-"https://api.datadoghq.com/api/v1/synthetics/tests/delete?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/synthetics/tests/delete"

--- a/content/en/api/synthetics/code_snippets/post_test.sh
+++ b/content/en/api/synthetics/code_snippets/post_test.sh
@@ -4,9 +4,10 @@ api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
 curl -X POST \
-  "https://api.datadoghq.com/api/v1/synthetics/tests?api_key=${api_key}&application_key=${app_key}" \
-  -H 'Content-Type: application/json' \
-  -d '{
+-H 'Content-Type: application/json' \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d '{
    "config":{
       "assertions":[
          {
@@ -58,14 +59,18 @@ curl -X POST \
       "foo:bar"
    ],
    "type":"api"
-}'
+}' \
+"https://api.datadoghq.com/api/v1/synthetics/tests"
 
 ### To create a browser test
 
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl  -X POST -H "Content-type: application/json" \
+curl  -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
    "locations":[
       "aws:ca-central-1",
@@ -95,4 +100,4 @@ curl  -X POST -H "Content-type: application/json" \
    ],
    "type":"browser"
 }' \
-"https://api.datadoghq.com/api/v1/synthetics/tests?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/synthetics/tests"

--- a/content/en/api/synthetics/code_snippets/put_status.sh
+++ b/content/en/api/synthetics/code_snippets/put_status.sh
@@ -4,6 +4,9 @@ api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 public_id=<SYNTHETICS_TEST_PUBLIC_ID>
 
-curl -X PUT -H "Content-type: application/json" \
+curl -X PUT \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{"new_status":"paused"}' \
-"https://api.datadoghq.com/api/v1/synthetics/tests/${public_id}/status?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/synthetics/tests/${public_id}/status"

--- a/content/en/api/synthetics/code_snippets/put_test.sh
+++ b/content/en/api/synthetics/code_snippets/put_test.sh
@@ -4,7 +4,10 @@ api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 public_id=<SYNTHETICS_TEST_PUBLIC_ID>
 
-curl -X PUT -H "Content-type: application/json" \
+curl -X PUT \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
    "config":{
       "assertions":[
@@ -58,4 +61,4 @@ curl -X PUT -H "Content-type: application/json" \
    ],
    "type":"api"
 }' \
-"https://api.datadoghq.com/api/v1/synthetics/tests/${public_id}?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/synthetics/tests/${public_id}"

--- a/content/en/api/tags/code_snippets/api-tags-add.sh
+++ b/content/en/api/tags/code_snippets/api-tags-add.sh
@@ -5,13 +5,19 @@ host=YourHostName
 source=YourSource
 
 # Find a host to add a tag to
-host_name=$(curl -G "https://api.datadoghq.com/api/v1/search" \
+host_name=$(curl -X GET \
+    -H "DD-API-KEY: ${api_key}" \
+    -H "DD-APPLICATION-KEY: ${app_key}" \
     -d "api_key=${api_key}" \
     -d "application_key=${app_key}" \
-    -d "q=hosts:$host" | cut -d'"' -f6)
+    -d "q=hosts:$host" | cut -d'"' -f6 \
+    "https://api.datadoghq.com/api/v1/search")
 
-curl  -X POST -H "Content-type: application/json" \
+curl  -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d "{
       \"tags\" : [\"environment:production\", \"role:webserver\"]
 }" \
-"https://api.datadoghq.com/api/v1/tags/hosts/${host_name}?api_key=${api_key}&application_key=${app_key}&source=${source}"
+"https://api.datadoghq.com/api/v1/tags/hosts/${host_name}?source=${source}"

--- a/content/en/api/tags/code_snippets/api-tags-get-host.sh
+++ b/content/en/api/tags/code_snippets/api-tags-get-host.sh
@@ -5,9 +5,15 @@ app_key=<YOUR_APP_KEY>
 host=$1
 
 # Find a host to add a tag to
-host_name=$(curl -G "https://api.datadoghq.com/api/v1/search" \
-    -d "api_key=${api_key}" \
-    -d "application_key=${app_key}" \
-	-d "q=hosts:$host" | cut -d'"' -f6)
+host_name=$(curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d "api_key=${api_key}" \
+-d "application_key=${app_key}" \
+-d "q=hosts:$host" | cut -d'"' -f6 \
+"https://api.datadoghq.com/api/v1/search")
 
-curl "https://api.datadoghq.com/api/v1/tags/hosts/${host_name}?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/tags/hosts/${host_name}"

--- a/content/en/api/tags/code_snippets/api-tags-get.sh
+++ b/content/en/api/tags/code_snippets/api-tags-get.sh
@@ -1,5 +1,8 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl "https://api.datadoghq.com/api/v1/tags/hosts?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/tags/hosts"
 

--- a/content/en/api/tags/code_snippets/api-tags-remove.sh
+++ b/content/en/api/tags/code_snippets/api-tags-remove.sh
@@ -2,14 +2,23 @@ api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
 # Find a host to remove a tag from
-host_name=$(curl -G "https://api.datadoghq.com/api/v1/search" \
+host_name=$(curl -X GET \
+    -H "DD-API-KEY: ${api_key}" \
+    -H "DD-APPLICATION-KEY: ${app_key}" \
     -d "api_key=${api_key}" \
     -d "application_key=${app_key}" \
-    -d "q=hosts:" | jq -r '.results.hosts[0]')
+    -d "q=hosts:" | jq -r '.results.hosts[0]' \
+    "https://api.datadoghq.com/api/v1/search")
 
 # Add tags to the host
-curl  -X POST -H "Content-type: application/json" \
+curl  -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d "{\"tags\" : [\"environment:production\", \"role:webserver\"]}" \
-"https://api.datadoghq.com/api/v1/tags/hosts/${host_name}?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/tags/hosts/${host_name}"
 
-curl -X DELETE "https://api.datadoghq.com/api/v1/tags/hosts/${host_name}?api_key=${api_key}&application_key=${app_key}"
+curl -X DELETE \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/tags/hosts/${host_name}"

--- a/content/en/api/tags/code_snippets/api-tags-update.sh
+++ b/content/en/api/tags/code_snippets/api-tags-update.sh
@@ -2,8 +2,11 @@ api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 host_name=test.host
 
-curl -X PUT -H "Content-type: application/json" \
+curl -X PUT \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
       "tags" : ["environment:production", "role:webserver"]
 }' \
-"https://api.datadoghq.com/api/v1/tags/hosts/${host_name}?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/tags/hosts/${host_name}"

--- a/content/en/api/usage/code_snippets/api-billing-usage-fargate.sh
+++ b/content/en/api/usage/code_snippets/api-billing-usage-fargate.sh
@@ -4,9 +4,9 @@ app_key=<YOUR_APP_KEY>
 start_hr=$(date -v -10d +%Y-%m-%dT%H)
 end_hr=$(date +%Y-%m-%dT%H)
 
-curl -G \
-    "https://api.datadoghq.com/api/v1/usage/fargate" \
-    -d "api_key=${api_key}" \
-    -d "application_key=${app_key}" \
-    -d "start_hr=${start_hr}" \
-    -d "end_hr=${end_hr}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d "start_hr=${start_hr}" \
+-d "end_hr=${end_hr}" \
+"https://api.datadoghq.com/api/v1/usage/fargate"

--- a/content/en/api/usage/code_snippets/api-billing-usage-hosts.sh
+++ b/content/en/api/usage/code_snippets/api-billing-usage-hosts.sh
@@ -4,9 +4,9 @@ app_key=<YOUR_APP_KEY>
 start_hr=$(date -v -10d +%Y-%m-%dT%H)
 end_hr=$(date +%Y-%m-%dT%H)
 
-curl -G \
-    "https://api.datadoghq.com/api/v1/usage/hosts" \
-    -d "api_key=${api_key}" \
-    -d "application_key=${app_key}" \
-    -d "start_hr=${start_hr}" \
-    -d "end_hr=${end_hr}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d "start_hr=${start_hr}" \
+-d "end_hr=${end_hr}" \
+"https://api.datadoghq.com/api/v1/usage/hosts"

--- a/content/en/api/usage/code_snippets/api-billing-usage-logs.sh
+++ b/content/en/api/usage/code_snippets/api-billing-usage-logs.sh
@@ -4,9 +4,9 @@ app_key=<YOUR_APP_KEY>
 start_hr=$(date -v -10d +%Y-%m-%dT%H)
 end_hr=$(date +%Y-%m-%dT%H)
 
-curl -G \
-    "https://api.datadoghq.com/api/v1/usage/logs" \
-    -d "api_key=${api_key}" \
-    -d "application_key=${app_key}" \
-    -d "start_hr=${start_hr}" \
-    -d "end_hr=${end_hr}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d "start_hr=${start_hr}" \
+-d "end_hr=${end_hr}" \
+"https://api.datadoghq.com/api/v1/usage/logs"

--- a/content/en/api/usage/code_snippets/api-billing-usage-summary.sh
+++ b/content/en/api/usage/code_snippets/api-billing-usage-summary.sh
@@ -5,10 +5,10 @@ start_month=$(date -v -60d +%Y-%m)
 end_month=$(date +%Y-%m)
 include_org_details=true
 
-curl -G \
-    "https://api.datadoghq.com/api/v1/usage/summary" \
-    -d "api_key=${api_key}" \
-    -d "application_key=${app_key}" \
-    -d "start_month=${start_month}" \
-    -d "end_month=${end_month}" \
-    -d "include_org_details=${include_org_details}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d "start_month=${start_month}" \
+-d "end_month=${end_month}" \
+-d "include_org_details=${include_org_details}" \
+"https://api.datadoghq.com/api/v1/usage/summary"

--- a/content/en/api/usage/code_snippets/api-billing-usage-synthetics.sh
+++ b/content/en/api/usage/code_snippets/api-billing-usage-synthetics.sh
@@ -4,9 +4,9 @@ app_key=<YOUR_APP_KEY>
 start_hr=$(date -v -10d +%Y-%m-%dT%H)
 end_hr=$(date +%Y-%m-%dT%H)
 
-curl -G \
-    "https://api.datadoghq.com/api/v1/usage/synthetics" \
-    -d "api_key=${api_key}" \
-    -d "application_key=${app_key}" \
-    -d "start_hr=${start_hr}" \
-    -d "end_hr=${end_hr}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d "start_hr=${start_hr}" \
+-d "end_hr=${end_hr}" \
+"https://api.datadoghq.com/api/v1/usage/synthetics"

--- a/content/en/api/usage/code_snippets/api-billing-usage-timeseries.sh
+++ b/content/en/api/usage/code_snippets/api-billing-usage-timeseries.sh
@@ -4,9 +4,9 @@ app_key=<YOUR_APP_KEY>
 start_hr=$(date -v -10d +%Y-%m-%dT%H)
 end_hr=$(date +%Y-%m-%dT%H)
 
-curl -G \
-    "https://api.datadoghq.com/api/v1/usage/timeseries" \
-    -d "api_key=${api_key}" \
-    -d "application_key=${app_key}" \
-    -d "start_hr=${start_hr}" \
-    -d "end_hr=${end_hr}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d "start_hr=${start_hr}" \
+-d "end_hr=${end_hr}" \
+"https://api.datadoghq.com/api/v1/usage/timeseries"

--- a/content/en/api/usage/code_snippets/api-billing-usage-top-avg-metrics.sh
+++ b/content/en/api/usage/code_snippets/api-billing-usage-top-avg-metrics.sh
@@ -3,9 +3,9 @@ app_key=<YOUR_APP_KEY>
 
 month=$(date +%Y-%m)
 
-curl -G \
-    "https://api.datadoghq.com/api/v1/usage/top_avg_metrics" \
-    -d "api_key=${api_key}" \
-    -d "application_key=${app_key}" \
-    -d "month=${month}" \
-    -d "names=aws.ec2.spot_history,system.processes.number"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d "month=${month}" \
+-d "names=aws.ec2.spot_history,system.processes.number" \
+"https://api.datadoghq.com/api/v1/usage/top_avg_metrics"

--- a/content/en/api/usage/code_snippets/api-billing-usage-trace-search.sh
+++ b/content/en/api/usage/code_snippets/api-billing-usage-trace-search.sh
@@ -4,9 +4,9 @@ app_key=<YOUR_APP_KEY>
 start_hr=$(date -v -10d +%Y-%m-%dT%H)
 end_hr=$(date +%Y-%m-%dT%H)
 
-curl -G \
-    "https://api.datadoghq.com/api/v1/usage/traces" \
-    -d "api_key=${api_key}" \
-    -d "application_key=${app_key}" \
-    -d "start_hr=${start_hr}" \
-    -d "end_hr=${end_hr}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d "start_hr=${start_hr}" \
+-d "end_hr=${end_hr}" \
+"https://api.datadoghq.com/api/v1/usage/traces"

--- a/content/en/api/users/code_snippets/api-user-create.sh
+++ b/content/en/api/users/code_snippets/api-user-create.sh
@@ -1,7 +1,10 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -X POST -H "Content-type: application/json" \
-    -d '{"handle":"test@datadoghq.com","name":"test user", "access_role":"st"}' \
-    "https://api.datadoghq.com/api/v1/user?api_key=${api_key}&application_key=${app_key}"
+curl -X POST \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d '{"handle":"test@datadoghq.com","name":"test user", "access_role":"st"}' \
+"https://api.datadoghq.com/api/v1/user"
 

--- a/content/en/api/users/code_snippets/api-user-disable.sh
+++ b/content/en/api/users/code_snippets/api-user-disable.sh
@@ -2,5 +2,8 @@ api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 user_id=test@datadoghq.com
 
-curl -X DELETE "https://api.datadoghq.com/api/v1/user/${user_id}?api_key=${api_key}&application_key=${app_key}"
+curl -X DELETE \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/user/${user_id}"
 

--- a/content/en/api/users/code_snippets/api-user-get-all.sh
+++ b/content/en/api/users/code_snippets/api-user-get-all.sh
@@ -1,5 +1,8 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 
-curl -X GET "https://api.datadoghq.com/api/v1/user?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/user"
 

--- a/content/en/api/users/code_snippets/api-user-get.sh
+++ b/content/en/api/users/code_snippets/api-user-get.sh
@@ -2,5 +2,8 @@ api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 user_id=test@datadoghq.com
 
-curl -X GET "https://api.datadoghq.com/api/v1/user/${user_id}?api_key=${api_key}&application_key=${app_key}"
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/user/${user_id}"
 

--- a/content/en/api/users/code_snippets/api-user-update.sh
+++ b/content/en/api/users/code_snippets/api-user-update.sh
@@ -2,7 +2,10 @@ api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 user_id=test@datadoghq.com
 
-curl -X PUT -H "Content-type: application/json" \
-    -d '{"email":"test+1@datadoghq.com","name":"alt user", "access_role":"ro"}' \
-    "https://api.datadoghq.com/api/v1/user/${user_id}?api_key=${api_key}&application_key=${app_key}"
+curl -X PUT \
+-H "Content-type: application/json" \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+-d '{"email":"test+1@datadoghq.com","name":"alt user", "access_role":"ro"}' \
+"https://api.datadoghq.com/api/v1/user/${user_id}"
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR changes all curl examples to show the correct new way of submitting API and APP keys. The correct way is in headers.

This PR also reformats all curl examples to a unified common format for customer ease

### Motivation
Update in the way datadog backend works

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
