### PR TITLE
Add clarification on escaping characters in pod annotations with mult…

### DIFF
--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -173,6 +173,8 @@ spec:
           image: postgres:latest
 ```
 
+**Note**: Be sure to escape regex characters in your patterns when performing multi-line aggregation with pod annotations. E.g. `\d` becomes `\\d`, `\w` becomes `\\w` etc.
+
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -173,7 +173,7 @@ spec:
           image: postgres:latest
 ```
 
-**Note**: Be sure to escape regex characters in your patterns when performing multi-line aggregation with pod annotations. E.g. `\d` becomes `\\d`, `\w` becomes `\\w` etc.
+**Note**: Escape regex characters in your patterns when performing multi-line aggregation with pod annotations. For example, `\d` becomes `\\d`, `\w` becomes `\\w`, etc.
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
…i-line aggregation

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Making a change to clarify multi-line aggregation within Kubernetes. I've run into this problem many times and the docs don't make it clear that you need to escape `\` characters when doing multi-line aggregation, even though the example demonstrates this. 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
