### PR TITLE
removed deprecated section re adding evaluation delay

### DIFF
--- a/content/en/monitors/guide/monitor-arithmetic-and-sparse-metrics.md
+++ b/content/en/monitors/guide/monitor-arithmetic-and-sparse-metrics.md
@@ -18,7 +18,7 @@ Consider the following metric values:
 - `A = (10, 10, 10)`
 - `B = (0, 1, -)`
 
-For the formula `a/b`, the monitor would evaluate:  
+For the formula `a/b`, the monitor would evaluate:
 
 ```
 10/0 + 10/1 + 10/NaN = 10
@@ -116,23 +116,6 @@ With `.fill(last,900)`, the new result is:
 | :------------------ | :-------------------------------------------- | :----- |
 | `classic_eval_path` | **(1)/1 + 1/1 + 0/1 + 0/1 + 1/1 + 1/1 + 1/1** | 5      |
 
-### Short evaluation windows
-
-It is possible to have timing issues in monitors with division over short evaluation windows. If your monitor query requires division over an evaluation window of 1 minute, the numerator and denominator represent time buckets on the order of a few seconds. If metrics for the numerator and denominator aren't both available at query time, you could get unwanted evaluation values.
-
-```
-| Timestamp             | sum:my_num{*}       | sum:my_denom{*}     |
-| :-------------------- | :------------------ | :------------------ |
-| ...                   | ...                 | ...                 |
-| 2019-03-29 13:30:50   | 900                 | 1000                |
-| 2019-03-29 13:30:52   | 900                 | 1000                |
-| 2019-03-29 13:30:54   | 900                 | 1000                |
-| 2019-03-29 13:30:56   | 120 (inc)           | 850 (inc)           |
-```
-
-In the case of a query like `min(last_1m):sum:my_num{*}/sum:my_denom{*}`, the minimum value could be skewed and could trigger your monitor unintentionally.
-
-Therefore, adding a short evaluation delay of 30-60 seconds to adjust for timing issues should be considered for queries with divison over short evaluation windows. Alternatively, changing to a 5 minute evaluation window can help.
 
 [Reach out to the Datadog support team][1] if you have any questions regarding this logic.
 


### PR DESCRIPTION
### What does this PR do?
Remove a section of monitor docs regarding adding short evaluation delays.  

### Motivation
The evaluation team has changed the default evaluation delay behavior and this recommendation should no longer apply or be necessary.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/bcon/remove-short-eval-window-recs/monitors/guide/monitor-arithmetic-and-sparse-metrics

### Additional Notes
