### PR TITLE
fix rds faq redirects

### DIFF
--- a/content/fr/integrations/amazon_rds.md
+++ b/content/fr/integrations/amazon_rds.md
@@ -1,8 +1,8 @@
 ---
 aliases:
-  - /integrations/awsrds/
-  - /integrations/rds/
-  - /integrations/faq/how-can-i-monitor-the-health-status-of-my-rds-instances/
+  - /fr/integrations/awsrds/
+  - /fr/integrations/rds/
+  - /fr/integrations/faq/how-can-i-monitor-the-health-status-of-my-rds-instances/
 categories:
   - cloud
   - data store
@@ -78,7 +78,7 @@ Activez la surveillance améliorée de votre instance RDS. Vous pouvez activer c
 10. Collez l'identifiant de la clé créée dans le paramètre `KMSKeyId` de la section précédente et effectuez le déploiement.
 11. Une fois l'application déployée, ouvrez la fonction Lambda créée (cliquez sur la fonction dans « Resource »).
  {{< img src="integrations/awsrds/click-function.png" alt="Fonction Lambda ouverte" responsive="true">}}
-12. Faites défiler vers le bas jusqu'à la section `Environment variables`. Remplacez `<VOTRE_CLÉ_API>` par votre [clé d'API Datadog][17] au format `{"api_key":"<VOTRE_CLÉ_API>"}` :
+12. Faites défiler vers le bas jusqu'à la section `Environment variables`. Remplacez `<VOTRE_CLÉ_API>` par votre [clé d'API Datadog][2] au format `{"api_key":"<VOTRE_CLÉ_API>"}` :
 {{< img src="integrations/awsrds/env-variables.png" alt="Variables d'environnement" responsive="true">}}
 13. Ouvrez la section `Encryption configuration` et sélectionnez `Enable helpers for encryption in transit`.
 14. Dans `KMS key to encrypt in transit`, sélectionnez la même clé que celle qui figure sous `KMS key to encrypt at rest`.
@@ -116,9 +116,9 @@ Vous pouvez l'ignorer. Le bouton de test ne fonctionne pas avec cette configurat
 
 #### Intégration RDS standard ou améliorée
 
-1. Dans le [carré d'intégration AWS][2], assurez-vous que l'option `RDS` est cochée dans la section concernant la collecte des métriques.
+1. Dans le [carré d'intégration AWS][3], assurez-vous que l'option `RDS` est cochée dans la section concernant la collecte des métriques.
 
-2. Ajoutez les autorisations suivantes à votre [stratégie IAM Datadog][3] afin de recueillir des métriques Amazon RDS. Pour en savoir plus sur les stratégies RDS, consultez [la documentation du site Web d'AWS][4].
+2. Ajoutez les autorisations suivantes à votre [stratégie IAM Datadog][4] afin de recueillir des métriques Amazon RDS. Pour en savoir plus sur les stratégies RDS, consultez [la documentation du site Web d'AWS][5].
 
 | Autorisation AWS            | Description                          |
 |---------------------------|--------------------------------------|
@@ -126,7 +126,7 @@ Vous pouvez l'ignorer. Le bouton de test ne fonctionne pas avec cette configurat
 | `rds:ListTagsForResource` | Ajoute des tags personnalisés sur les instances RDS.    |
 | `rds:DescribeEvents`      | Ajoute des événements associés aux bases de données RDS. |
 
-3. Installez l'[intégration Datadog/AWS RDS][5].
+3. Installez l'[intégration Datadog/AWS RDS][6].
 
 #### Intégration de base de données native
 Configurez un Agent et connectez-vous à votre instance RDS en modifiant le fichier YAML approprié dans votre répertoire conf.d, puis redémarrez votre Agent : 
@@ -193,32 +193,32 @@ Checks
 
 ### Utilisation
 
-Après quelques minutes, les métriques RDS et les [métriques de MySQL, Aurora, MariaDB, SQL Server ou PostgreSQL][6] peuvent être consultées dans Datadog depuis le Metrics Explorer, les [graphiques][7] et les [alertes][8].
+Après quelques minutes, les métriques RDS et les [métriques de MySQL, Aurora, MariaDB, SQL Server ou PostgreSQL][7] peuvent être consultées dans Datadog depuis le Metrics Explorer, les [graphiques][8] et les [alertes][9].
 Voici un exemple de dashboard Aurora affichant un certain nombre de métriques issues des intégrations MySQL et RDS. Les métriques des deux intégrations sur l'instance `quicktestrds` sont unifiées à l'aide du tag `dbinstanceidentifier`.
 {{< img src="integrations/awsrds/aurora-rds-dash.png" alt="dashboard rds aurora" responsive="true" popup="true">}}
 
 Voici le dashboard par défaut pour MySQL sur Amazon RDS :
 {{< img src="integrations/awsrds/rds-mysql.png" alt="dashboard par défaut RDS MySQL" responsive="true" popup="true">}}
 
-Pour savoir comment surveiller les métriques de performance MySQL d'Amazon RDS, consultez [notre série d'articles à ce sujet][9]. Vous y trouverez des informations supplémentaires sur les principales métriques de performance ainsi que des conseils pour les recueillir et pour utiliser Datadog afin de surveiller MySQL sur Amazon RDS.
+Pour savoir comment surveiller les métriques de performance MySQL d'Amazon RDS, consultez [notre série d'articles à ce sujet][10]. Vous y trouverez des informations supplémentaires sur les principales métriques de performance ainsi que des conseils pour les recueillir et pour utiliser Datadog afin de surveiller MySQL sur Amazon RDS.
 
 ### Collecte de logs
 #### Activer la journalisation RDS
 
-Vous pouvez transmettre des logs MySQL, MariaDB et Postgres à Amazon CloudWatch. Suivez les instructions figurant [ici][10] pour commencer à envoyer vos logs RDS à CloudWatch.
+Vous pouvez transmettre des logs MySQL, MariaDB et Postgres à Amazon CloudWatch. Suivez les instructions figurant [ici][11] pour commencer à envoyer vos logs RDS à CloudWatch.
 
 #### Envoyer des logs à Datadog
 
-1. Si vous ne l'avez pas déjà fait, configurez [la fonction Lambda de collecte de logs AWS avec Datadog][11].
+1. Si vous ne l'avez pas déjà fait, configurez [la fonction Lambda de collecte de logs AWS avec Datadog][12].
 2. Une fois la fonction lambda installée, ajoutez manuellement un déclencheur dans la console AWS sur le groupe de logs CloudWatch qui contient vos logs RDS :
 {{< img src="integrations/amazon_cloudwatch/cloudwatch_log_collection_1.png" alt="groupes de logs cloudwatch" responsive="true" popup="true" style="width:70%;">}}
    Sélectionnez le groupe de logs CloudWatch correspondant, ajoutez un nom de filtre (vous pouvez toutefois laisser le filtre vide) et ajoutez le déclencheur :
 {{< img src="integrations/amazon_cloudwatch/cloudwatch_log_collection_2.png" alt="Déclencheur cloudwatch" responsive="true" popup="true" style="width:70%;">}}
 
-Accédez ensuite à la [section Log de Datadog][12] pour commencer à explorer vos logs !
+Accédez ensuite à la [section Log de Datadog][13] pour commencer à explorer vos logs !
 
 ## Données collectées
-Outre les [métriques recueillies depuis les moteurs de base de données][13], vous recevez également les métriques RDS suivantes :
+Outre les [métriques recueillies depuis les moteurs de base de données][14], vous recevez également les métriques RDS suivantes :
 
 ### Métriques
 {{< get-metrics-from-git "amazon_rds" >}}
@@ -233,7 +233,7 @@ L'intégration AWS RDS comprend des événements liés aux instances de base de
 
 ### Checks de service
 **aws.rds.read_replica_status**
-Surveille le statut du [réplica en lecture][16]. Ce check renvoie l'un des statuts suivants :
+Surveille le statut du [réplica en lecture][15]. Ce check renvoie l'un des statuts suivants :
 
 * OK - En cours de réplication ou de connexion
 * CRITICAL - Erreur ou terminé
@@ -241,29 +241,28 @@ Surveille le statut du [réplica en lecture][16]. Ce check renvoie l'un des stat
 * UNKNOWN - Autre
 
 ## Dépannage
-Besoin d'aide ? Contactez [l'assistance Datadog][15].
+Besoin d'aide ? Contactez [l'assistance Datadog][16].
 
 ## Pour aller plus loin
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://docs.datadoghq.com/fr/integrations/amazon_web_services
-[2]: https://app.datadoghq.com/account/settings#integrations/amazon_web_services
-[3]: https://docs.datadoghq.com/fr/integrations/amazon_web_services/#installation
-[4]: https://docs.aws.amazon.com/IAM/latest/UserGuide/list_rds.html
-[5]: https://app.datadoghq.com/account/settings#integrations/amazon_rds
-[6]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Monitoring.html
-[7]: https://docs.datadoghq.com/fr/graphing
-[8]: https://docs.datadoghq.com/fr/monitors
-[9]: https://www.datadoghq.com/blog/monitoring-rds-mysql-performance-metrics
-[10]: https://aws.amazon.com/blogs/database/monitor-amazon-rds-for-mysql-and-mariadb-logs-with-amazon-cloudwatch
-[11]: https://docs.datadoghq.com/fr/integrations/amazon_web_services/#create-a-new-lambda-function
-[12]: https://app.datadoghq.com/logs
-[13]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Monitoring.html
-[14]: https://github.com/DataDog/dogweb/blob/prod/integration/amazon_rds/amazon_rds_metadata.csv
-[15]: https://docs.datadoghq.com/fr/help
-[16]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html#USER_ReadRepl.Monitoring
-[17]: https://app.datadoghq.com/account/settings#api
 
 
 {{< get-dependencies >}}
+[1]: https://docs.datadoghq.com/fr/integrations/amazon_web_services
+[2]: https://app.datadoghq.com/account/settings#api
+[3]: https://app.datadoghq.com/account/settings#integrations/amazon_web_services
+[4]: https://docs.datadoghq.com/fr/integrations/amazon_web_services/#installation
+[5]: https://docs.aws.amazon.com/IAM/latest/UserGuide/list_rds.html
+[6]: https://app.datadoghq.com/account/settings#integrations/amazon_rds
+[7]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Monitoring.html
+[8]: https://docs.datadoghq.com/fr/graphing
+[9]: https://docs.datadoghq.com/fr/monitors
+[10]: https://www.datadoghq.com/blog/monitoring-rds-mysql-performance-metrics
+[11]: https://aws.amazon.com/blogs/database/monitor-amazon-rds-for-mysql-and-mariadb-logs-with-amazon-cloudwatch
+[12]: https://docs.datadoghq.com/fr/integrations/amazon_web_services/#create-a-new-lambda-function
+[13]: https://app.datadoghq.com/logs
+[14]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Monitoring.html
+[15]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html#USER_ReadRepl.Monitoring
+[16]: https://docs.datadoghq.com/fr/help


### PR DESCRIPTION
Fix the aliases on amazon rds `fr` pages, see the `content/ja/integrations/amazon_rds.md` as example. Without the leading `fr` hugo generates an index with a meta refresh from the top level english page.

There's also no `content/en/integrations/amazon_rds.md`??