### PR TITLE
use Agent Version 6.13.0 in docs instead of latest 

### DIFF
--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -28,7 +28,7 @@ Starting with **Agent v6.11.0**, the core and APM/trace components of the Window
 #### GUI
 
 1. Download the [Datadog Agent installer][5].
-2. Run the installer (as **Administrator**) by opening `datadog-agent-6-latest.amd64.msi`.
+2. Run the installer (as **Administrator**) by opening `ddagent-cli-6.13.0.msi`.
 3. Follow the prompts, accept the license agreement, and enter your [Datadog API key][6].
 4. When the install finishes, you are given the option to launch the Datadog Agent Manager.
 
@@ -41,12 +41,12 @@ Optionally, install the Agent with the command line to add custom settings.
 
 Command prompt:
 ```cmd
-start /wait msiexec /qn /i datadog-agent-6-latest.amd64.msi APIKEY="<YOUR_DATADOG_API_KEY>"
+start /wait msiexec /qn /i ddagent-cli-6.13.0.msi APIKEY="<YOUR_DATADOG_API_KEY>"
 ```
 
 Powershell:
 ```powershell
-Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-6-latest.amd64.msi APIKEY="<YOUR_DATADOG_API_KEY>"'
+Start-Process -Wait msiexec -ArgumentList '/qn /i ddagent-cli-6.13.0.msi APIKEY="<YOUR_DATADOG_API_KEY>"'
 ```
 
 Each configuration item is added as a property to the command line. The following configuration command line options are available when installing the Agent on Windows:
@@ -363,7 +363,7 @@ After configuration is complete, [restart the Agent][14].
 [2]: /agent/basic_agent_usage/#supported-os-versions
 [3]: /agent/faq/windows-agent-ddagent-user
 [4]: /agent/faq/windows-agent-ddagent-user/#installation-in-a-domain-environment
-[5]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-6-latest.amd64.msi
+[5]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-6.13.0.msi
 [6]: https://app.datadoghq.com/account/settings#api
 [7]: /agent/proxy
 [8]: /agent/guide/datadog-agent-manager-windows

--- a/content/fr/agent/basic_agent_usage/windows.md
+++ b/content/fr/agent/basic_agent_usage/windows.md
@@ -27,7 +27,7 @@ Si vous n'avez pas encore installé l'Agent Datadog, consultez les informations 
 #### Interface graphique
 
 1. Téléchargez [le fichier d'installation de l'Agent Datadog][5].
-2. Exécutez le fichier d'installation (en tant qu'**administrateur**) en ouvrant `datadog-agent-6-latest.amd64.msi`.
+2. Exécutez le fichier d'installation (en tant qu'**administrateur**) en ouvrant `ddagent-cli-6.13.0.msi`.
 3. Suivez les instructions à l'écran, acceptez l'accord de licence et entrez votre [clé d'API Datadog][6].
 4. Une fois l'installation terminée, vous avez la possibilité de lancer Datadog Agent Manager.
 
@@ -40,12 +40,12 @@ Vous pouvez également installer l'Agent avec une ligne de commande pour ajouter
 
 Invite de commande :
 ```cmd
-start /wait msiexec /qn /i datadog-agent-6-latest.amd64.msi APIKEY="<VOTRE_CLÉ_API_DATADOG>"
+start /wait msiexec /qn /i ddagent-cli-6.13.0.msi APIKEY="<VOTRE_CLÉ_API_DATADOG>"
 ```
 
 Powershell :
 ```powershell
-Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-6-latest.amd64.msi APIKEY="<VOTRE_CLÉ_API_DATADOG>"'
+Start-Process -Wait msiexec -ArgumentList '/qn /i ddagent-cli-6.13.0.msi APIKEY="<VOTRE_CLÉ_API_DATADOG>"'
 ```
 
 Chaque élément de configuration est ajouté en tant que propriété dans la ligne de commande. Les options de configuration en ligne de commande suivantes sont disponibles à l'installation de l'Agent sur Windows :
@@ -362,7 +362,7 @@ Une fois la configuration effectuée, [redémarrez l'Agent][14].
 [2]: /fr/agent/basic_agent_usage/#supported-os-versions
 [3]: /fr/agent/faq/windows-agent-ddagent-user
 [4]: /fr/agent/faq/windows-agent-ddagent-user/#installation-in-a-domain-environment
-[5]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-6-latest.amd64.msi
+[5]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-6.13.0.msi
 [6]: https://app.datadoghq.com/account/settings#api
 [7]: /fr/agent/proxy
 [8]: /fr/agent/guide/datadog-agent-manager-windows


### PR DESCRIPTION
### What does this PR do?
Updates the agent install documentation to point to version 6.13.0 on windows instead of latest. This is to lessen the number of people that install 6.14.0 or 6.14.1 (latest) while we fix the issue behind incident-2598

### Motivation
We don't want people to install Agent 6.14.1 on windows until we can release a 6.14.2 and/or 6.15.0 and mark that version as the latest version.

### Preview link
https://docs-staging.datadoghq.com/dave/windows/agent/basic_agent_usage/windows/?tab=agentv6

I also changed the french version of this page

### Additional Notes
A similar change was made to the agent install page in dogweb https://github.com/DataDog/dogweb/pull/41003