### PR TITLE
Replace broken link Kube-State manifests folder

### DIFF
--- a/content/en/agent/kubernetes/host_setup.md
+++ b/content/en/agent/kubernetes/host_setup.md
@@ -63,7 +63,7 @@ Use [Autodiscovery with Pod Annotations][8] to configure log collection to add m
 ## Further Reading
 To get a better idea of how (or why) to integrate your Kubernetes service, see the related series of [Datadog blog posts][6].
 
-[1]: https://github.com/kubernetes/kube-state-metrics/tree/master/kubernetes
+[1]: https://github.com/kubernetes/kube-state-metrics/tree/master/examples/standard
 [2]: /agent
 [3]: /agent/autodiscovery
 [4]: https://app.datadoghq.com/account/settings#agent/kubernetes


### PR DESCRIPTION
The old link doesn't exist any more on the master repo, the Kubernetes folder only shows when picking a release, the network policy now exists under https://github.com/kubernetes/kube-state-metrics/tree/master/examples/standard in the master branch.

### What does this PR do?
Change the link behind: Kube-State manifests folder
From: https://github.com/kubernetes/kube-state-metrics/tree/master/kubernetes
To https://github.com/kubernetes/kube-state-metrics/tree/master/examples/standard

### Motivation
While working on a ticket with SNCF, we realized that the link was broken.

### Preview link
https://docs.datadoghq.com/agent/kubernetes/host_setup/#pagetitle

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/Hadhemi/update-Kubernetes-host-setup-page-broken-link/agent/kubernetes/host_setup/

### Additional Notes
This change was approved upon discussion with Simone Guerrier : https://share.getcloudapp.com/jkuym76Q 