### PR TITLE
Logs - Trace correlation page highlighted

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1038,7 +1038,7 @@ main:
     parent: "log_explorer"
     weight: 704
     
-  - name: "Correlate with Traces"
+  - name: "Connect Logs and Traces"
     url: "tracing/advanced/connect_logs_and_traces/?tab=java"
     parent: "log_management"
     identifier: "log_traces_correlation"

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1041,19 +1041,25 @@ main:
   - name: "Connect Logs and Traces"
     url: "tracing/advanced/connect_logs_and_traces/?tab=java"
     parent: "log_management"
-    identifier: "log_traces_correlation"
+    identifier: "logs_traces_correlation"
     weight: 8
+    
+  - name: "Connect Logs and Metrics"
+    url: "graphing/dashboards/timeboard/#correlation-between-logs-and-metrics"
+    parent: "log_management"
+    identifier: "logs_metrics_correlation"
+    weight: 9
 
   - name: "Guides"
     url: "logs/guide/"
     parent: "log_management"
     identifier: "log_guides"
-    weight: 9
+    weight: 10
 
   - name: "Security"
     url: "security/logs/"
     parent: "log_management"
-    weight: 10
+    weight: 11
 
 ################
 ## SYNTHETICS ##

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1037,17 +1037,23 @@ main:
     url: "logs/explorer/patterns/"
     parent: "log_explorer"
     weight: 704
+    
+  - name: "Correlate with Traces"
+    url: "tracing/advanced/connect_logs_and_traces/?tab=java"
+    parent: "log_management"
+    identifier: "log_traces_correlation"
+    weight: 8
 
   - name: "Guides"
     url: "logs/guide/"
     parent: "log_management"
     identifier: "log_guides"
-    weight: 8
+    weight: 9
 
   - name: "Security"
     url: "security/logs/"
     parent: "log_management"
-    weight: 9
+    weight: 10
 
 ################
 ## SYNTHETICS ##

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1041,10 +1041,10 @@ main:
   - name: "Connect Logs and Traces"
     url: "tracing/advanced/connect_logs_and_traces/?tab=java"
     parent: "log_management"
-    identifier: "logs_traces_correlation"
+    identifier: "logs_traces_connection"
     weight: 8
     
-  - name: "Connect Logs and Metrics"
+  - name: "Correlate Logs with Metrics"
     url: "graphing/dashboards/timeboard/#correlation-between-logs-and-metrics"
     parent: "log_management"
     identifier: "logs_metrics_correlation"

--- a/content/en/logs/_index.md
+++ b/content/en/logs/_index.md
@@ -29,14 +29,14 @@ Datadog's log management removes these limitations by decoupling log ingestion f
   {{< nextlink href="/logs/archives">}}<u>Archives</u>: Archive all enriched logs into S3 buckets.{{< /nextlink >}}
   {{< nextlink href="/logs/indexes">}}<u>Index</u>: Dynamically decide what to include or exclude from your indexes to control your costs.{{< /nextlink >}}
 {{< /whatsnext >}}
-{{< whatsnext desc="Once your logs are indexed, you can explore them in the Log Explorer:">}}
+{{< whatsnext desc="After indexing your logs, explore them in the Log Explorer:">}}
   {{< nextlink href="/logs/explorer/">}}<u>Log Explorer</u>: Discover the Log Explorer view, how to add Facets and Measures.{{< /nextlink >}}
   {{< nextlink href="/logs/explorer">}}<u>Search</u>: Search through all of your indexed logs.{{< /nextlink >}}
   {{< nextlink href="/logs/explorer/analytics">}}<u>Analytics</u>: Perform Log Analytics over your indexed logs.{{< /nextlink >}}
   {{< nextlink href="/logs/explorer/patterns">}}<u>Patterns</u>: Spot Log Patterns by clustering your indexed logs together.{{< /nextlink >}}
   {{< nextlink href="/logs/explorer/saved_views/">}}<u>Saved Views</u>: Use Saved Views to automatically configure your Log Explorer.{{< /nextlink >}}
 {{< /whatsnext >}}
-{{< whatsnext desc="Once your logs are indexed, you can leverage the pillars of observability:">}}
+{{< whatsnext desc="Finally, leverage the pillars of observability with metrics and traces:">}}
   {{< nextlink href="/tracing/advanced/connect_logs_and_traces/?tab=java">}}<u>Connect Logs and Traces</u>: See the exact trace correlated with the observed log.{{< /nextlink >}}
   {{< nextlink href="/graphing/dashboards/timeboard/#correlation-between-logs-and-metrics">}}<u>Correlate Logs and Metrics</u>: See the exact metric correlated with the observed log.{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/logs/_index.md
+++ b/content/en/logs/_index.md
@@ -26,7 +26,6 @@ Datadog's log management removes these limitations by decoupling log ingestion f
   {{< nextlink href="/logs/processing">}}<u>Processing</u>: Process and enrich all of your logs with pipelines and processors. {{< /nextlink >}}
   {{< nextlink href="/logs/live_tail">}}<u>Live Tail</u>: See your ingested logs in real time across all your environments.{{< /nextlink >}}
   {{< nextlink href="/logs/logs_to_metrics">}}<u>Generate Metrics</u>: Generate Metrics from Ingested Logs.{{< /nextlink >}}
-  {{< nextlink href="/tracing/advanced/connect_logs_and_traces/?tab=java">}}<u>Connect Logs and Traces</u>: See the exact trace correlated with the observed log.{{< /nextlink >}}
   {{< nextlink href="/logs/archives">}}<u>Archives</u>: Archive all enriched logs into S3 buckets.{{< /nextlink >}}
   {{< nextlink href="/logs/indexes">}}<u>Index</u>: Dynamically decide what to include or exclude from your indexes to control your costs.{{< /nextlink >}}
 {{< /whatsnext >}}
@@ -36,6 +35,10 @@ Datadog's log management removes these limitations by decoupling log ingestion f
   {{< nextlink href="/logs/explorer/analytics">}}<u>Analytics</u>: Perform Log Analytics over your indexed logs.{{< /nextlink >}}
   {{< nextlink href="/logs/explorer/patterns">}}<u>Patterns</u>: Spot Log Patterns by clustering your indexed logs together.{{< /nextlink >}}
   {{< nextlink href="/logs/explorer/saved_views/">}}<u>Saved Views</u>: Use Saved Views to automatically configure your Log Explorer.{{< /nextlink >}}
+{{< /whatsnext >}}
+{{< whatsnext desc="Once your logs are indexed, you can leverage the pillars of observability:">}}
+  {{< nextlink href="/tracing/advanced/connect_logs_and_traces/?tab=java">}}<u>Connect Logs and Traces</u>: See the exact trace correlated with the observed log.{{< /nextlink >}}
+  {{< nextlink href="/graphing/dashboards/timeboard/#correlation-between-logs-and-metrics">}}<u>Connect Logs and Metrics</u>: See the exact metric correlated with the observed log.{{< /nextlink >}}
 {{< /whatsnext >}}
 
 ## Further Reading

--- a/content/en/logs/_index.md
+++ b/content/en/logs/_index.md
@@ -26,7 +26,7 @@ Datadog's log management removes these limitations by decoupling log ingestion f
   {{< nextlink href="/logs/processing">}}<u>Processing</u>: Process and enrich all of your logs with pipelines and processors. {{< /nextlink >}}
   {{< nextlink href="/logs/live_tail">}}<u>Live Tail</u>: See your ingested logs in real time across all your environments.{{< /nextlink >}}
   {{< nextlink href="/logs/logs_to_metrics">}}<u>Generate Metrics</u>: Generate Metrics from Ingested Logs.{{< /nextlink >}}
-  {{< nextlink href="/tracing/advanced/connect_logs_and_traces/?tab=java">}}<u>Connect Logs and Traces</u>: See the exact trace correlated to the observed log.{{< /nextlink >}}
+  {{< nextlink href="/tracing/advanced/connect_logs_and_traces/?tab=java">}}<u>Connect Logs and Traces</u>: See the exact trace correlated with the observed log.{{< /nextlink >}}
   {{< nextlink href="/logs/archives">}}<u>Archives</u>: Archive all enriched logs into S3 buckets.{{< /nextlink >}}
   {{< nextlink href="/logs/indexes">}}<u>Index</u>: Dynamically decide what to include or exclude from your indexes to control your costs.{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/logs/_index.md
+++ b/content/en/logs/_index.md
@@ -10,9 +10,6 @@ further_reading:
 - link: "/logs/guide"
   tag: "Guide"
   text: Additional helpful articles about log collection and processing.
-- link: "tracing/advanced/connect_logs_and_traces/?tab=java"
-  tag: "Documentation"
-  text: "Connect Logs and Traces"
 - link: "https://learn.datadoghq.com"
   tag: "Learning Center"
   text: "Introduction to Logs in Datadog"
@@ -29,6 +26,7 @@ Datadog's log management removes these limitations by decoupling log ingestion f
   {{< nextlink href="/logs/processing">}}<u>Processing</u>: Process and enrich all of your logs with pipelines and processors. {{< /nextlink >}}
   {{< nextlink href="/logs/live_tail">}}<u>Live Tail</u>: See your ingested logs in real time across all your environments.{{< /nextlink >}}
   {{< nextlink href="/logs/logs_to_metrics">}}<u>Generate Metrics</u>: Generate Metrics from Ingested Logs.{{< /nextlink >}}
+  {{< nextlink href="/tracing/advanced/connect_logs_and_traces/?tab=java">}}<u>Connect Logs and Traces</u>: See the exact trace correlated to the observed log.{{< /nextlink >}}
   {{< nextlink href="/logs/archives">}}<u>Archives</u>: Archive all enriched logs into S3 buckets.{{< /nextlink >}}
   {{< nextlink href="/logs/indexes">}}<u>Index</u>: Dynamically decide what to include or exclude from your indexes to control your costs.{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/logs/_index.md
+++ b/content/en/logs/_index.md
@@ -38,7 +38,7 @@ Datadog's log management removes these limitations by decoupling log ingestion f
 {{< /whatsnext >}}
 {{< whatsnext desc="Once your logs are indexed, you can leverage the pillars of observability:">}}
   {{< nextlink href="/tracing/advanced/connect_logs_and_traces/?tab=java">}}<u>Connect Logs and Traces</u>: See the exact trace correlated with the observed log.{{< /nextlink >}}
-  {{< nextlink href="/graphing/dashboards/timeboard/#correlation-between-logs-and-metrics">}}<u>Connect Logs and Metrics</u>: See the exact metric correlated with the observed log.{{< /nextlink >}}
+  {{< nextlink href="/graphing/dashboards/timeboard/#correlation-between-logs-and-metrics">}}<u>Correlate Logs and Metrics</u>: See the exact metric correlated with the observed log.{{< /nextlink >}}
 {{< /whatsnext >}}
 
 ## Further Reading


### PR DESCRIPTION
### What does this PR do?
Add links to the "Connect Traces to Logs" page in Logs section.

### Motivation
Clients don't find the documentation page easily.

### Preview link
https://docs-staging.datadoghq.com/gusai/log-trace-correl/logs/
