### PR TITLE
Update JMX included in tracer doc

### DIFF
--- a/content/en/tracing/advanced/runtime_metrics.md
+++ b/content/en/tracing/advanced/runtime_metrics.md
@@ -171,7 +171,8 @@ The following metrics are collected by default after enabling JVM metrics.
 
 Along with displaying these metrics in your APM Service Page, Datadog provides a [default JVM Runtime Dashboard][1] with the `service` and `runtime-id` tags that are applied to these metrics.
 
-Additional JMX metrics can be added using configuration files that are passed to `jmxfetch.metrics-configs`. You can also enable existing Datadog JMX integrations individually with the `dd.integration.<name>` parameter. This auto-embeds configuration from Datadog's [existing JMX configuration files][2]. See the [JMX Integration][3] for further details on configuration.
+Additional JMX metrics can be added using configuration files that are passed on using `dd.jmxfetch.config.dir` and
+`dd.jmxfetch.config`. You can also enable existing Datadog JMX integrations individually with the `dd.jmxfetch.<integration>.enabled=true` parameter. This auto-embeds configuration from Datadog's [existing JMX configuration files][2]. See the [JMX Integration][3] for further details on configuration.
 
 [1]: https://app.datadoghq.com/dash/integration/256/jvm-runtime-metrics
 [2]: https://github.com/DataDog/integrations-core/search?q=jmx_metrics&unscoped_q=jmx_metrics

--- a/content/en/tracing/advanced/runtime_metrics.md
+++ b/content/en/tracing/advanced/runtime_metrics.md
@@ -171,8 +171,7 @@ The following metrics are collected by default after enabling JVM metrics.
 
 Along with displaying these metrics in your APM Service Page, Datadog provides a [default JVM Runtime Dashboard][1] with the `service` and `runtime-id` tags that are applied to these metrics.
 
-Additional JMX metrics can be added using configuration files that are passed on using `dd.jmxfetch.config.dir` and
-`dd.jmxfetch.config`. You can also enable existing Datadog JMX integrations individually with the `dd.jmxfetch.<integration>.enabled=true` parameter. This auto-embeds configuration from Datadog's [existing JMX configuration files][2]. See the [JMX Integration][3] for further details on configuration.
+Additional JMX metrics can be added using configuration files that are passed on using `dd.jmxfetch.config.dir` and `dd.jmxfetch.config`. You can also enable existing Datadog JMX integrations individually with the `dd.jmxfetch.<integration>.enabled=true` parameter. This auto-embeds configuration from Datadog's [existing JMX configuration files][2]. See the [JMX Integration][3] for further details on configuration.
 
 [1]: https://app.datadoghq.com/dash/integration/256/jvm-runtime-metrics
 [2]: https://github.com/DataDog/integrations-core/search?q=jmx_metrics&unscoped_q=jmx_metrics

--- a/content/en/tracing/advanced/runtime_metrics.md
+++ b/content/en/tracing/advanced/runtime_metrics.md
@@ -171,7 +171,7 @@ The following metrics are collected by default after enabling JVM metrics.
 
 Along with displaying these metrics in your APM Service Page, Datadog provides a [default JVM Runtime Dashboard][1] with the `service` and `runtime-id` tags that are applied to these metrics.
 
-Additional JMX metrics can be added using configuration files that are passed on using `dd.jmxfetch.config.dir` and `dd.jmxfetch.config`. You can also enable existing Datadog JMX integrations individually with the `dd.jmxfetch.<integration>.enabled=true` parameter. This auto-embeds configuration from Datadog's [existing JMX configuration files][2]. See the [JMX Integration][3] for further details on configuration.
+Additional JMX metrics can be added using configuration files that are passed on using `dd.jmxfetch.config.dir` and `dd.jmxfetch.config`. You can also enable existing Datadog JMX integrations individually with the `dd.jmxfetch.<INTEGRATION_NAME>.enabled=true` parameter. This auto-embeds configuration from Datadog's [existing JMX configuration files][2]. See the [JMX Integration][3] for further details on configuration.
 
 [1]: https://app.datadoghq.com/dash/integration/256/jvm-runtime-metrics
 [2]: https://github.com/DataDog/integrations-core/search?q=jmx_metrics&unscoped_q=jmx_metrics


### PR DESCRIPTION
### What does this PR do?

Update how to use default JMX configuration files for some integration,  in the java tracer

### Motivation
https://github.com/DataDog/dd-trace-java/releases/tag/v0.29.0

### Preview link
https://docs-staging.datadoghq.com/cécile/UpdateJMXincludedintracerdoc/tracing/advanced/runtime_metrics/?tab=java#data-collected

### Additional Notes

