### PR TITLE
hosts search API response update

### DIFF
--- a/content/en/api/hosts/code_snippets/result.api-hosts-search.sh
+++ b/content/en/api/hosts/code_snippets/result.api-hosts-search.sh
@@ -4,7 +4,7 @@
     {
       "name": "i-deadbeef",
       "up": true,
-      'is_muted': True,
+      'is_muted': true,
       'mute_timeout': 1560010000,
       "last_reported_time": 1560000000,
       "apps": [

--- a/content/en/api/hosts/code_snippets/result.api-hosts-search.sh
+++ b/content/en/api/hosts/code_snippets/result.api-hosts-search.sh
@@ -4,7 +4,8 @@
     {
       "name": "i-deadbeef",
       "up": true,
-      "is_muted": false,
+      'is_muted': True,
+      'mute_timeout': 1560010000,
       "last_reported_time": 1560000000,
       "apps": [
         "agent"


### PR DESCRIPTION
### What does this PR do?
Adds `'mute_timeout'` to the hosts search API response and updates `'is_muted'` to reflect the new field.

### Motivation
updated functionality 

### Preview link

https://docs-staging.datadoghq.com/kaylyn/hosts-api/api/?lang=python#search-hosts
