### PR TITLE
[RBAC] Remove dupe uuids from examples of roles

### DIFF
--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -71,7 +71,7 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 	    {ÿ
             "type": "roles",
             "id": "$ROLE_UUID",
-                "attributes": {ÿ
+            "attributes": {ÿ
                 "created_at": "2000-02-29T16:50:43.607749+00:00",
                 "user_count": 2122,
                 "modified_at": "2000-02-29T16:50:43.607749+00:00",

--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -61,30 +61,30 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 {{% tab "Response" %}}
 
 {{< code-block lang="json" filename="response.json" disable_copy="true" >}}
-{ÿ
-    "meta": {ÿ
-        "page": {ÿ
+{?
+    "meta": {?
+        "page": {?
             "total_count": 7
         }
     },
     "data": [
-	    {ÿ
+	    {?
             "type": "roles",
             "id": "$ROLE_UUID",
-                "attributes": {ÿ
+                "attributes": {?
                 "created_at": "2000-02-29T16:50:43.607749+00:00",
                 "user_count": 2122,
                 "modified_at": "2000-02-29T16:50:43.607749+00:00",
                 "name": "$ROLE_NAME"
             },
-            "relationships": {ÿ
-                "permissions": {ÿ
+            "relationships": {?
+                "permissions": {?
                     "data": [
-                        {ÿ
+                        {?
                             "type": "permissions",
                             "id": "$PERMISSION_UUID"
                         },
-                        {ÿ
+                        {?
                             "type": "permissions",
                             "id": "$PERMISSION_UUID"
                         }
@@ -483,7 +483,7 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
             "name": "logs_metrics_read",
             "created": "2000-02-29T14:26:26.983187+00:00",
             "group_name": "Logs",
-            "display_type": "other",
+            "display_type": "other"
         }
     }]
 }

--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -61,31 +61,30 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 {{% tab "Response" %}}
 
 {{< code-block lang="json" filename="response.json" disable_copy="true" >}}
-{
-    "meta": {
-        "page": {
+{ÿ
+    "meta": {ÿ
+        "page": {ÿ
             "total_count": 7
         }
     },
     "data": [
-	    {
+	    {ÿ
             "type": "roles",
             "id": "$ROLE_UUID",
-                "attributes": {
+                "attributes": {ÿ
                 "created_at": "2000-02-29T16:50:43.607749+00:00",
                 "user_count": 2122,
                 "modified_at": "2000-02-29T16:50:43.607749+00:00",
-                "uuid": "$ROLE_UUID",
                 "name": "$ROLE_NAME"
             },
-            "relationships": {
-                "permissions": {
+            "relationships": {ÿ
+                "permissions": {ÿ
                     "data": [
-                        {
+                        {ÿ
                             "type": "permissions",
                             "id": "$PERMISSION_UUID"
                         },
-                        {
+                        {ÿ
                             "type": "permissions",
                             "id": "$PERMISSION_UUID"
                         }
@@ -132,7 +131,6 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
                 "created_at": "2000-02-29T16:50:43.607749+00:00",
                 "user_count": 2122,
                 "modified_at": "2000-02-29T16:50:43.607749+00:00",
-                "uuid": "$ROLE_UUID",
                 "name": "$ROLE_NAME"
             },
             "relationships": {
@@ -198,7 +196,6 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
                 "created_at": "2000-02-29T16:50:43.607749+00:00",
                 "user_count": 0,
                 "modified_at": "2000-02-29T16:50:43.607749+00:00",
-                "uuid": "$ROLE_UUID",
                 "name": "$ROLE_NAME"
             },
             "relationships": {
@@ -256,7 +253,6 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
                 "created_at": "2000-02-29T16:50:43.607749+00:00",
                 "user_count": 0,
                 "modified_at": "2000-02-29T16:50:43.607749+00:00",
-                "uuid": "$ROLE_UUID",
                 "name": "$ROLE_NAME"
             },
             "relationships": {
@@ -339,8 +335,7 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
             "name": "logs_metrics_write",
             "created": "2000-02-29T14:26:26.983187+00:00",
             "group_name": "Logs",
-            "display_type": "other",
-            "uuid": "$PERMISSION_UUID"
+            "display_type": "other"
         }
     }]
 }
@@ -384,8 +379,7 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
             "name": "logs_metrics_write",
             "created": "2000-02-29T14:26:26.983187+00:00",
             "group_name": "Logs",
-            "display_type": "other",
-            "uuid": "<PERMISSION_UUID>"
+            "display_type": "other"
         }
     }]
 }
@@ -437,8 +431,7 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
             "name": "logs_metrics_write",
             "created": "2000-02-29T14:26:26.983187+00:00",
             "group_name": "Logs",
-            "display_type": "other",
-            "uuid": "<PERMISSION_UUID>"
+            "display_type": "other"
         }
     }]
 }
@@ -491,7 +484,6 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
             "created": "2000-02-29T14:26:26.983187+00:00",
             "group_name": "Logs",
             "display_type": "other",
-            "uuid": "$DIFFERENT_PERMISSION_UUID"
         }
     }]
 }

--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -60,31 +60,31 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 {{% /tab %}}
 {{% tab "Response" %}}
 
-{{< code-block lang="json" filename="response.json" disable_copy="true" >}}
-{ÿ
-    "meta": {ÿ
-        "page": {ÿ
+```json
+{
+    "meta": {
+        "page": {
             "total_count": 7
         }
     },
     "data": [
-	    {ÿ
+	    {
             "type": "roles",
             "id": "$ROLE_UUID",
-            "attributes": {ÿ
+            "attributes": {
                 "created_at": "2000-02-29T16:50:43.607749+00:00",
                 "user_count": 2122,
                 "modified_at": "2000-02-29T16:50:43.607749+00:00",
                 "name": "$ROLE_NAME"
             },
-            "relationships": {ÿ
-                "permissions": {ÿ
+            "relationships": {
+                "permissions": {
                     "data": [
-                        {ÿ
+                        {
                             "type": "permissions",
                             "id": "$PERMISSION_UUID"
                         },
-                        {ÿ
+                        {
                             "type": "permissions",
                             "id": "$PERMISSION_UUID"
                         }
@@ -94,7 +94,7 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
         }
     ]
 }
-{{< /code-block >}}
+```
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -61,30 +61,30 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 {{% tab "Response" %}}
 
 {{< code-block lang="json" filename="response.json" disable_copy="true" >}}
-{?
-    "meta": {?
-        "page": {?
+{ÿ
+    "meta": {ÿ
+        "page": {ÿ
             "total_count": 7
         }
     },
     "data": [
-	    {?
+	    {ÿ
             "type": "roles",
             "id": "$ROLE_UUID",
-                "attributes": {?
+                "attributes": {ÿ
                 "created_at": "2000-02-29T16:50:43.607749+00:00",
                 "user_count": 2122,
                 "modified_at": "2000-02-29T16:50:43.607749+00:00",
                 "name": "$ROLE_NAME"
             },
-            "relationships": {?
-                "permissions": {?
+            "relationships": {ÿ
+                "permissions": {ÿ
                     "data": [
-                        {?
+                        {ÿ
                             "type": "permissions",
                             "id": "$PERMISSION_UUID"
                         },
-                        {?
+                        {ÿ
                             "type": "permissions",
                             "id": "$PERMISSION_UUID"
                         }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Examples of roles responses had duplicate UUID fields in them. This is being changed in code and also being removed in documentation.


### Motivation
Correct examples 

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
