### PR TITLE
Fixing HPA service format

### DIFF
--- a/content/en/agent/cluster_agent/external_metrics.md
+++ b/content/en/agent/cluster_agent/external_metrics.md
@@ -48,7 +48,7 @@ Once the Datadog Cluster Agent is up and running:
 
 1. Create the `datadog-custom-metrics-server` service, exposing the port `443` with the following `custom-metric-server.yaml` manifest:
 
-    ```yaml
+    ```
     kind: Service
     apiVersion: v1
     metadata:

--- a/content/en/agent/cluster_agent/external_metrics.md
+++ b/content/en/agent/cluster_agent/external_metrics.md
@@ -48,18 +48,18 @@ Once the Datadog Cluster Agent is up and running:
 
 1. Create the `datadog-custom-metrics-server` service, exposing the port `443` with the following `custom-metric-server.yaml` manifest:
 
-    ```
-    kind: Service
-    apiVersion: v1
-    metadata:
-      name: datadog-custom-metrics-server
-    spec:
-      selector:
-        app: datadog-cluster-agent
-      ports:
-      - protocol: TCP
-        port: 443
-        targetPort: 443
+    ```yaml
+      kind: Service
+      apiVersion: v1
+      metadata:
+        name: datadog-custom-metrics-server
+      spec:
+        selector:
+          app: datadog-cluster-agent
+        ports:
+        - protocol: TCP
+          port: 443
+          targetPort: 443
     ```
 
     Apply this change by running `kubectl apply -f custom-metric-server.yaml`


### PR DESCRIPTION
### What does this PR do?
Apparently the yaml code snippet does not work when indented:https://docs.datadoghq.com/agent/cluster_agent/external_metrics/#register-the-external-metrics-provider
I removed the yaml keyword to make it work and see the snippet correctly.

### Motivation
It was not rendered well in the docs.