### PR TITLE
put try-excepts in the prebuild script

### DIFF
--- a/local/bin/py/update_pre_build.py
+++ b/local/bin/py/update_pre_build.py
@@ -536,21 +536,43 @@ class PreBuild:
         for content in self.list_of_contents:
             # print("Processing content: {}".format(content))
             if content["action"] == "integrations":
-                self.process_integrations(content)
+                try:
+                    self.process_integrations(content)
+                except:
+                    print("Unsuccessful processing of {}".format(
+                            content
+                        )
+                    )
 
             elif content["action"] == "source":
-
-                self.process_source_attribute(content)
+                try:
+                    self.process_source_attribute(content)
+                except:
+                    print("Unsuccessful processing of {}".format(
+                            content
+                        )
+                    )
 
             elif (
                 content["action"] == "pull-and-push-folder"
             ):
-
-                self.pull_and_push_folder(content)
+                try:
+                    self.pull_and_push_folder(content)
+                except:
+                    print("Unsuccessful processing of {}".format(
+                            content
+                        )
+                    )
 
             elif content["action"] == "pull-and-push-file":
 
-                self.pull_and_push_file(content)
+                try:
+                    self.pull_and_push_file(content)
+                except:
+                    print("Unsuccessful processing of {}".format(
+                            content
+                        )
+                    )
 
             else:
                 print(

--- a/local/bin/py/update_pre_build.py
+++ b/local/bin/py/update_pre_build.py
@@ -539,7 +539,7 @@ class PreBuild:
                 try:
                     self.process_integrations(content)
                 except:
-                    print("Unsuccessful processing of {}".format(
+                    print("\x1b[31mERROR\x1b[0m: Unsuccessful processing of {}".format(
                             content
                         )
                     )
@@ -548,7 +548,7 @@ class PreBuild:
                 try:
                     self.process_source_attribute(content)
                 except:
-                    print("Unsuccessful processing of {}".format(
+                    print("\x1b[31mERROR\x1b[0m: Unsuccessful processing of {}".format(
                             content
                         )
                     )
@@ -559,7 +559,7 @@ class PreBuild:
                 try:
                     self.pull_and_push_folder(content)
                 except:
-                    print("Unsuccessful processing of {}".format(
+                    print("\x1b[31mERROR\x1b[0m: Unsuccessful processing of {}".format(
                             content
                         )
                     )
@@ -569,7 +569,7 @@ class PreBuild:
                 try:
                     self.pull_and_push_file(content)
                 except:
-                    print("Unsuccessful processing of {}".format(
+                    print("\x1b[31mERROR\x1b[0m: Unsuccessful processing of {}".format(
                             content
                         )
                     )


### PR DESCRIPTION


### What does this PR do?
adds try-excepts to the prebuild `process_filnames()` function so that it doesn't crash and burn every time an error occurs. logs stuff in the console tho.

### Motivation
the for-loop was breaking for dumb reasons

i don't know how to test this