### PR TITLE
Add .NET  global tags configuration option

### DIFF
--- a/content/en/tracing/advanced/adding_metadata_to_spans.md
+++ b/content/en/tracing/advanced/adding_metadata_to_spans.md
@@ -335,9 +335,17 @@ const tracer = require('dd-trace').init({
 {{% /tab %}}
 {{% tab ".NET" %}}
 
-Coming Soon. Reach out to [the Datadog support team][1] to learn more.
+Use the environment variable `DD_TRACE_GLOBAL_TAGS` to add [tags][1] to all the generated [spans][2]. See the [.NET configuration][3]
+section for details on how environment variables are set.
 
-[1]: /help
+```ini
+DD_TRACE_GLOBAL_TAGS=key1:value1,key2:value2
+```
+
+[1]: /tracing/visualization/#span-tags
+[2]: /tracing/visualization/#spans
+[3]: /tracing/setup/dotnet/#configuration
+
 {{% /tab %}}
 {{% tab "PHP" %}}
 

--- a/content/en/tracing/advanced/adding_metadata_to_spans.md
+++ b/content/en/tracing/advanced/adding_metadata_to_spans.md
@@ -335,8 +335,10 @@ const tracer = require('dd-trace').init({
 {{% /tab %}}
 {{% tab ".NET" %}}
 
-Use the environment variable `DD_TRACE_GLOBAL_TAGS` to add [tags][1] to all the generated [spans][2]. See the [.NET configuration][3]
-section for details on how environment variables are set.
+Add [tags][1] to all the generated [spans][2] by configuring the tracer. There are a few ways to set the configuration, as shown in the
+[.NET configuration][3] section.
+
+This example sets the environment variable:
 
 ```ini
 DD_TRACE_GLOBAL_TAGS=key1:value1,key2:value2

--- a/content/en/tracing/setup/dotnet.md
+++ b/content/en/tracing/setup/dotnet.md
@@ -445,6 +445,7 @@ Setting Name          | Property Name          | Description                    
 `DD_ENV`              | `Environment`          | If specified, adds the `env` tag with the specified value to all generated spans. See [Agent configuration][8] for more details about the `env` tag.                                                              |
 `DD_SERVICE_NAME`     | `ServiceName`          | If specified, sets the default service name. Otherwise, the .NET Tracer tries to determine service name automatically from application name (e.g. IIS application name, process entry assembly, or process name). |
 `DD_LOGS_INJECTION`   | `LogsInjectionEnabled` | Enables or disables automatic injection of correlation identifiers into application logs.                                                                                                                         |
+`DD_TRACE_GLOBAL_FLAGS` | `GlobalTags` | If specified, adds all of the specified tags to all generated spans.  |
 
 The following table lists configuration variables that are available only when using automatic instrumentation.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Replaces the `Coming soon` notice for `Add tags globally to all spans` section of the `Add Span Tags` page.

### Motivation
Global tags support will be available in the .NET Tracer version 1.9.0.

### Preview link
<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.  -->

[.NET Global Tags](https://docs-staging.datadoghq.com/bob.uva/dotnet-global-tags/tracing/advanced/adding_metadata_to_spans/?tab=net#adding-tags-to-a-span)

