### PR TITLE
remove `DD_CLUSTER_NAME` mention

### DIFF
--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -187,9 +187,7 @@ NAME            DESIRED   CURRENT   READY     UP-TO-DATE   AVAILABLE   NODE SELE
 datadog-agent   2         2         2         2            2           <none>          16h
 ```
 
-### Kubernetes cluster name auto detection
-
-Since version 6.5.0 of the Datadog Agent, the Agent configuration contains a cluster name attribute to be used in Kubernetes clusters, so that host aliases are unique. This attribute can be set using the `DD_CLUSTER_NAME` environment variable.
+### Kubernetes Cluster Name Auto Detection
 
 Starting with version 6.11.0, the Datadog Agent can auto-detect the Kubernetes cluster name on Google GKE, Azure AKS, and AWS EKS. This feature facilitates the identification of nodes across Kubernetes clusters by adding an alias which contains the cluster name as a suffix on the node name.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes the section mentioning `DD_CLUSTER_NAME` under "cluster name auto detection" as this is not relevant to how the agent collects the `cluster-name` tag. Cluster name tags will either be auto-detected via a cloud provider's available metadata API or can be set manually via `DD_TAGS`. 

`DD_CLUSTER_NAME` should only be used either to append a unique string to host aliases to prevent hostname overlap from different clusters (host aliasing issues), or to add the [unique tag to clusterchecks](https://github.com/DataDog/documentation/blob/06f1cce7dd7521c33a5ddf7f450016bb788b7b70/content/en/agent/autodiscovery/clusterchecks.md#cluster-agent-setup) as cluster checks cannot resolve to a host.

### Motivation
Customer requests. This causes some confusion as it makes it seem as though the environment variable adds a tag.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/dylan-cluster-name/kubernetes/daemonset_setup/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
