### PR TITLE
update docs to version 6.14.2 of the Windows Datadog Agent

### DIFF
--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -28,7 +28,7 @@ Starting with **Agent v6.11.0**, the core and APM/trace components of the Window
 #### GUI
 
 1. Download the [Datadog Agent installer][5].
-2. Run the installer (as **Administrator**) by opening `ddagent-cli-6.13.0.msi`.
+2. Run the installer (as **Administrator**) by opening `ddagent-cli-6.14.2.msi`.
 3. Follow the prompts, accept the license agreement, and enter your [Datadog API key][6].
 4. When the install finishes, you are given the option to launch the Datadog Agent Manager.
 
@@ -41,12 +41,12 @@ Optionally, install the Agent with the command line to add custom settings.
 
 Command prompt:
 ```cmd
-start /wait msiexec /qn /i ddagent-cli-6.13.0.msi APIKEY="<YOUR_DATADOG_API_KEY>"
+start /wait msiexec /qn /i ddagent-cli-6.14.2.msi APIKEY="<YOUR_DATADOG_API_KEY>"
 ```
 
 Powershell:
 ```powershell
-Start-Process -Wait msiexec -ArgumentList '/qn /i ddagent-cli-6.13.0.msi APIKEY="<YOUR_DATADOG_API_KEY>"'
+Start-Process -Wait msiexec -ArgumentList '/qn /i ddagent-cli-6.14.2.msi APIKEY="<YOUR_DATADOG_API_KEY>"'
 ```
 
 Each configuration item is added as a property to the command line. The following configuration command line options are available when installing the Agent on Windows:
@@ -363,7 +363,7 @@ After configuration is complete, [restart the Agent][14].
 [2]: /agent/basic_agent_usage/#supported-os-versions
 [3]: /agent/faq/windows-agent-ddagent-user
 [4]: /agent/faq/windows-agent-ddagent-user/#installation-in-a-domain-environment
-[5]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-6.13.0.msi
+[5]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-6.14.2.msi
 [6]: https://app.datadoghq.com/account/settings#api
 [7]: /agent/proxy
 [8]: /agent/guide/datadog-agent-manager-windows

--- a/content/en/agent/guide/upgrade-to-agent-v6.md
+++ b/content/en/agent/guide/upgrade-to-agent-v6.md
@@ -451,4 +451,4 @@ With:
 [7]: https://www.datadoghq.com/blog/monitor-prometheus-metrics
 [8]: /logs
 [9]: https://github.com/DataDog/datadog-agent/releases
-[10]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-6-latest.amd64.msi
+[10]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-6.14.2.msi

--- a/content/fr/agent/basic_agent_usage/windows.md
+++ b/content/fr/agent/basic_agent_usage/windows.md
@@ -27,7 +27,7 @@ Si vous n'avez pas encore installé l'Agent Datadog, consultez les informations 
 #### Interface graphique
 
 1. Téléchargez [le fichier d'installation de l'Agent Datadog][5].
-2. Exécutez le fichier d'installation (en tant qu'**administrateur**) en ouvrant `ddagent-cli-6.13.0.msi`.
+2. Exécutez le fichier d'installation (en tant qu'**administrateur**) en ouvrant `ddagent-cli-6.14.2.msi`.
 3. Suivez les instructions à l'écran, acceptez l'accord de licence et entrez votre [clé d'API Datadog][6].
 4. Une fois l'installation terminée, vous avez la possibilité de lancer Datadog Agent Manager.
 
@@ -40,12 +40,12 @@ Vous pouvez également installer l'Agent avec une ligne de commande pour ajouter
 
 Invite de commande :
 ```cmd
-start /wait msiexec /qn /i ddagent-cli-6.13.0.msi APIKEY="<VOTRE_CLÉ_API_DATADOG>"
+start /wait msiexec /qn /i ddagent-cli-6.14.2.msi APIKEY="<VOTRE_CLÉ_API_DATADOG>"
 ```
 
 Powershell :
 ```powershell
-Start-Process -Wait msiexec -ArgumentList '/qn /i ddagent-cli-6.13.0.msi APIKEY="<VOTRE_CLÉ_API_DATADOG>"'
+Start-Process -Wait msiexec -ArgumentList '/qn /i ddagent-cli-6.14.2.msi APIKEY="<VOTRE_CLÉ_API_DATADOG>"'
 ```
 
 Chaque élément de configuration est ajouté en tant que propriété dans la ligne de commande. Les options de configuration en ligne de commande suivantes sont disponibles à l'installation de l'Agent sur Windows :
@@ -362,7 +362,7 @@ Une fois la configuration effectuée, [redémarrez l'Agent][14].
 [2]: /fr/agent/basic_agent_usage/#supported-os-versions
 [3]: /fr/agent/faq/windows-agent-ddagent-user
 [4]: /fr/agent/faq/windows-agent-ddagent-user/#installation-in-a-domain-environment
-[5]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-6.13.0.msi
+[5]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-6.14.2.msi
 [6]: https://app.datadoghq.com/account/settings#api
 [7]: /fr/agent/proxy
 [8]: /fr/agent/guide/datadog-agent-manager-windows

--- a/content/fr/agent/guide/upgrade-to-agent-v6.md
+++ b/content/fr/agent/guide/upgrade-to-agent-v6.md
@@ -450,4 +450,4 @@ Où :
 [7]: https://www.datadoghq.com/blog/monitor-prometheus-metrics
 [8]: /fr/logs
 [9]: https://github.com/DataDog/datadog-agent/releases
-[10]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-6-latest.amd64.msi
+[10]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-6.14.2.msi


### PR DESCRIPTION
update docs to version 6.14.2 of the Windows Datadog Agent instead of latest, and instead of 6.13. Response to incident-2958

### What does this PR do?
Updates the documentation so people will download Windows Agent 6.14.2 instead of latest (and instead of 6.13.0, as a previous PR did (#5768)

### Motivation
Response to incident-2958

### Preview link
<!-- Impacted pages preview links-->

https://docs-staging.datadoghq.com/dave/windows_agent/agent/basic_agent_usage/windows/?tab=agentv6
https://docs-staging.datadoghq.com/dave/windows_agent/agent/guide/upgrade-to-agent-v6/#windows

Also changed the French version of those pages

### Additional Notes
<!-- Anything else we should know when reviewing?-->
