### PR TITLE
Fix api-events-stream code snippet

### DIFF
--- a/content/en/api/events/code_snippets/api-events-stream.sh
+++ b/content/en/api/events/code_snippets/api-events-stream.sh
@@ -3,12 +3,7 @@ currenttime=$(date +%s)
 currenttime2=$(date --date='1 day ago' +%s)
 
 curl -X GET \
--H "Content-type: application/json" \
--H "DD-API-KEY: ${api_key}" \
--H "DD-APPLICATION-KEY: ${app_key}" \
--d "start=${currenttime2}" \
--d "end=${currenttime}" \
--d "sources=My Apps" \
--d "tags=-env:dev,application:web" \
--d "unaggregated=true"\
-"https://api.datadoghq.com/api/v1/events"
+    -H "Content-type: application/json" \
+    -H "DD-API-KEY: $api_key" \
+    -H "DD-APPLICATION-KEY: $app_key" \
+    "https://api.datadoghq.com/api/v1/events?&start=${currenttime2}&end=${currenttime}&tags=check_type:api&sources=alert&unaggregated=true"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

- The code snippet `api-events-stream.sh` is wrong as it will alway return: `{"errors": ["The parameter 'start' is required"]}`.
- The reason for this is that `curl GET` cannot be used with the `-d/--data` option unless we're dealing with a POST request. In the latter case, the request body (`--data`) does not get passed in which explains the error aforementioned.

#### Before: 
<a href="https://cl.ly/b68dbf6d4b2d" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/3q2T2h2o3V2S3z050b11/Screen%20Recording%202019-11-04%20at%2007.25%20PM.gif" style="display: block;height: auto;width: 100%;"/></a>

#### After: 

<a href="https://cl.ly/9d414d27e4d5" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/0K153d0Y1I2i3n2q2X2L/Screen%20Recording%202019-11-04%20at%2007.21%20PM.gif" style="display: block;height: auto;width: 100%;"/></a>

### Motivation
- This ticket in which the customer could not work it out: https://datadog.zendesk.com/agent/tickets/273513.
- We had some internal discussion on the matter as well: https://dd.slack.com/archives/CJ2LV4ELF/p1572885499073300.

### Preview link

- https://docs-staging.datadoghq.com/nico.suarez-canton/update_api-events-stream_sh/api/?lang=bash#query-the-event-stream
