### PR TITLE
Fix api-metrics-query code snippet

### DIFF
--- a/content/en/api/metrics/code_snippets/api-metrics-query.sh
+++ b/content/en/api/metrics/code_snippets/api-metrics-query.sh
@@ -1,12 +1,9 @@
 api_key=<YOUR_API_KEY>
 app_key=<YOUR_APP_KEY>
 to_time=$(date +%s)
-from_time=$(date -v -1d +%s)
+from_time=$(date --date='1 day ago' +%s)
 
 curl -X GET \
--H "DD-API-KEY: ${api_key}" \
--H "DD-APPLICATION-KEY: ${app_key}" \
--d "from=${from_time}" \
--d "to=${to_time}" \
--d "query=system.cpu.idle{*}by{host}" \
-"https://api.datadoghq.com/api/v1/query"
+    -H "DD-API-KEY: ${api_key}" \
+    -H "DD-APPLICATION-KEY: ${app_key}" \
+    "https://api.datadoghq.com/api/v1/query?&query=avg:system.cpu.user\{*\}by\{host\}&from=${from_time}&to=${to_time}"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

- Same as https://github.com/DataDog/documentation/pull/5828 but for `api-metrics-query.sh`.

#### Before

<a href="https://cl.ly/492fb0bf3093" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/0u2E452F2g1I3m440w3Y/Screen%20Recording%202019-11-05%20at%2011.27%20AM.gif" style="display: block;height: auto;width: 100%;"/></a>

#### After

<a href="https://cl.ly/8bda2e0ad6d7" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/2i223Y1O3a0f2S043e13/Screen%20Recording%202019-11-05%20at%2011.43%20AM.gif" style="display: block;height: auto;width: 100%;"/></a>


### Motivation

- https://datadog.zendesk.com/agent/tickets/273864

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

- Waiting on this.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nico.suarez-canton/update_api-metrics-query_sh/api/?lang=bash#query-timeseries-points

### Additional Notes

- Note that `{}` need to be escaped as `\{\}`
