### PR TITLE
Removing references to increment/decrement

### DIFF
--- a/content/en/developers/metrics/agent_metrics_submission.md
+++ b/content/en/developers/metrics/agent_metrics_submission.md
@@ -191,9 +191,8 @@ Follow the steps below to create a [custom Agent check][2] that sends all metric
             )
     ```
 
-1. [Restart the Agent][4].
-
-2. Validate your custom check is running correctly with the [Agent's status subcommand][5]. Look for `metrics_example` under the Checks section:
+4. [Restart the Agent][4].
+5. Validate your custom check is running correctly with the [Agent's status subcommand][5]. Look for `metrics_example` under the Checks section:
 
     ```
     =========
@@ -216,7 +215,7 @@ Follow the steps below to create a [custom Agent check][2] that sends all metric
 
         (...)
     ```
-3. Verify your metrics are reporting to Datadog on your [Metric Summary page][6]:
+6. Verify your metrics are reporting to Datadog on your [Metric Summary page][6]:
 
 {{< img src="developers/metrics/agent_metrics_submission/metrics_metrics_summary.png" alt="Metrics in metric summary" responsive="true" style="width:80%;">}}
 

--- a/content/en/developers/metrics/agent_metrics_submission.md
+++ b/content/en/developers/metrics/agent_metrics_submission.md
@@ -53,31 +53,6 @@ self.count(name, value, tags=None, hostname=None, device_name=None)
 | `hostname`    | String          | No       | current host  | A hostname to associate with this metric.                                           |
 | `device_name` | String          | No       | -             | Deprecated. Adds a tag in the form `device:<DEVICE_NAME>` to the tags list instead. |
 
-### `increment() / decrement()`
-
-These **deprecated** functions are used to modify a count of events identified by a metric key string by `1` at each call. It can be called multiple times during a check's execution, and is handled by the aggregator `Counter` class. If you want to increment/decrement by more than one, use the `count()` function.
-
-**Note**: Metrics submitted with these functions are stored with a `RATE` type in Datadog. Each value in the stored timeseries is a delta of the counter's value between samples (time-normalized by the aggregation interval which defaults to `10 seconds` for Agent checks. The value is generally the raw count value).
-
-Datadog recommends using the `count()` function even if you wish to increment/decrement by `1`. Indeed, if later down the road you wish to increment/decrement your metric by more than one, then you will have to use a different metric name since the metric type stored within Datadog is different (`RATE` for the `increment()`/`decrement()` functions vs `COUNT` for the `count()`).
-
-Function templates:
-```python
-self.increment(name, value=1, tags=None, hostname=None, device_name=None)
-```
-
-```python
-self.decrement(name, value=1, tags=None, hostname=None, device_name=None)
-```
-
-| Parameter     | Type            | Required | Default Value | Description                                                                         |
-|---------------|-----------------|----------|---------------|-------------------------------------------------------------------------------------|
-| `name`        | String          | Yes      | -             | The name of the metric.                                                             |
-| `value`       | Float           | No       | `1`           | The increment/decrement value for the metric.                                       |
-| `tags`        | List of strings | No       | -             | A list of tags to associate with this metric.                                       |
-| `hostname`    | String          | No       | current host  | A hostname to associate with this metric.                                           |
-| `device_name` | String          | No       | -             | Deprecated. Adds a tag in the form `device:<DEVICE_NAME>` to the tags list instead. |
-
 {{% /tab %}}
 {{% tab "Gauge" %}}
 
@@ -176,12 +151,14 @@ Follow the steps below to create a [custom Agent check][2] that sends all metric
                 2,
                 tags="metric_submission_type:count",
             )
-            self.decrement(
+            self.count(
                 "example_metric.decrement",
+                -1,
                 tags="metric_submission_type:count",
             )
-            self.increment(
+            self.count(
                 "example_metric.increment",
+                1,
                 tags="metric_submission_type:count",
             )
             self.rate(
@@ -214,9 +191,9 @@ Follow the steps below to create a [custom Agent check][2] that sends all metric
             )
     ```
 
-4. [Restart the Agent][4].
+1. [Restart the Agent][4].
 
-5. Validate your custom check is running correctly with the [Agent's status subcommand][5]. Look for `metrics_example` under the Checks section:
+2. Validate your custom check is running correctly with the [Agent's status subcommand][5]. Look for `metrics_example` under the Checks section:
 
     ```
     =========
@@ -239,7 +216,7 @@ Follow the steps below to create a [custom Agent check][2] that sends all metric
 
         (...)
     ```
-6. Verify your metrics are reporting to Datadog on your [Metric Summary page][6]:
+3. Verify your metrics are reporting to Datadog on your [Metric Summary page][6]:
 
 {{< img src="developers/metrics/agent_metrics_submission/metrics_metrics_summary.png" alt="Metrics in metric summary" responsive="true" style="width:80%;">}}
 

--- a/content/en/developers/metrics/metric_type_modifiers.md
+++ b/content/en/developers/metrics/metric_type_modifiers.md
@@ -35,8 +35,6 @@ The two main in-application modifiers are `as_count()` and `as_rate()`.
 | `as_count()` | Sets the operations necessary to display the given metric in `COUNT` form, giving you the absolute variation of a metric value over [a rollup interval][2]. Note that since it depends on the rollup interval, [graphing a longer time interval changes your graph shape][3]. |
 | `as_rate()`  | Sets the operations necessary to display the given metric in `RATE` form, giving you the absolute variation of a metric value per second.                                                                                                                                     |
 
-**Note**: Metrics submitted from Agent based integrations do not have an interval associated to them, so the `as_count()` and `as_rate()` modifiers have no effect upon an Agent integration metric with the `RATE` in-app type.
-
 Depending on the metric type you applied them to, the behavior differs:
 
 {{< tabs >}}

--- a/content/en/developers/metrics/metrics_type.md
+++ b/content/en/developers/metrics/metrics_type.md
@@ -276,8 +276,6 @@ Each source has its own limitations, and metric submission types do not always m
 | [DogStatsD][10]   | `dog.set(...)`                       | SET             | GAUGE               |
 | [DogStatsD][11]   | `dog.histogram(...)`                 | HISTOGRAM       | GAUGE, RATE         |
 | [Agent check][12] | `self.count(...)`                    | COUNT           | COUNT               |
-| [Agent check][13] | `self.increment(...)`                | COUNT           | RATE                |
-| [Agent check][13] | `self.decrement(...)`                | COUNT           | RATE                |
 | [Agent check][14] | `self.monotonic_count(...)`          | COUNT           | COUNT               |
 | [Agent check][15] | `self.gauge(...)`                    | GAUGE           | GAUGE               |
 | [Agent check][16] | `self.histogram(...)`                | HISTOGRAM       | GAUGE, RATE         |


### PR DESCRIPTION
### What does this PR do?
Removes references to `self.increment()` and `self.decrement()` since they are deprecated and lead to user confusion

Alternative is to use `self.count()`

### Motivation
Support feedback.

### Preview

https://docs-staging.datadoghq.com/gus/increment-decrement/developers/metrics/agent_metrics_submission/?tab=count