### PR TITLE
Update Logs HTTPS batch wait parameter

### DIFF
--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -188,6 +188,20 @@ The Agent sends batches that have the following limits:
 
 The Agent waits up to 5 seconds to fill each batch (either in content size or number of logs). Therefore, in the worst case scenario (when very few logs are generated) switching to HTTPS might add a 5-second latency compared to TCP, which sends all logs in real time.
 
+**Configure the batch wait time**
+
+To change the maximum time the Datadog Agent waits to fill each batch, add the following in the Agent's [main configuration file][4] (`datadog.yaml`):
+
+```
+logs_config:
+  batch_wait: 2
+```
+
+Or use the `DD_LOGS_CONFIG_BATCH_WAIT` environment variable. 
+The value is in seconds and must be an integer between 1 and 10.
+
+**HTTPS Proxy configuration**
+
 When logs are sent through HTTPS, use the same [set of proxy settings][10] as the other data types to send logs through a web proxy.
 
 ## Further Reading


### PR DESCRIPTION
### What does this PR do?
Add instruction to configure the batch wait to send logs in HTTPS

### Motivation
Agent release 6.15

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/log-https-batch-wait/agent/logs/?tab=tailexistingfiles#send-logs-over-https

### Additional Notes
<!-- Anything else we should know when reviewing?-->
