### PR TITLE
Update api-slo-create.py sample code

### DIFF
--- a/content/en/api/service_level_objectives/code_snippets/api-slo-create.py
+++ b/content/en/api/service_level_objectives/code_snippets/api-slo-create.py
@@ -17,8 +17,10 @@ api.ServiceLevelObjective.create(
     type="metric",
     name="Custom Metric SLO",
     description="SLO tracking custom service SLO",
-    numerator="sum:my.custom.metric{type:good}.as_count()",
-    denominator="sum:my.custom.metric{*}.as_count()",
+    query={
+        "numerator": "sum:my.custom.metric{type:good}.as_count()",
+        "denominator": "sum:my.custom.metric{*}.as_count()"
+    },
     tags=tags,
     thresholds=thresholds
 )


### PR DESCRIPTION
### What does this PR do?
Update api-slo-create.py sample code to a working one; currently returns error 502 Bad Gateway

### Motivation
Customer issue

### Preview link
https://docs-staging.datadoghq.com/ian.bucad/update_slo_py_sample/api/?lang=python#create-a-service-level-objective

### Additional Notes

- The ruby one `api-slo-create.rb` works for dogapi version 1.37.0 but removed from 1.37.1 due to a bug; so does not really work with the latest. Should we remove?
