### PR TITLE
update to include instructions for EU endpoint

### DIFF
--- a/content/en/api/authentication/authentication.md
+++ b/content/en/api/authentication/authentication.md
@@ -7,7 +7,7 @@ external_redirect: /api/#authentication
 ## Authentication
 All requests to Datadog's API must be authenticated. Requests that write data require *reporting access* and require an `API key`. Requests that read data require *full access* and also require an `application key`.
 
-By default, the Datadog API authenticates against the Datadog US site. If you are on the Datadog EU site, make sure to add `api_host` to  your options parameters. 
+**Note**: All Datadog API Clients are configured by default to consume Datadog US site APIs. If you are on the Datadog EU site, make sure to configure `api_host` to `https://api.datadoghq.eu` in the options parameters. 
 
 [Manage your account's API and application keys][1].
 

--- a/content/en/api/authentication/authentication.md
+++ b/content/en/api/authentication/authentication.md
@@ -7,6 +7,8 @@ external_redirect: /api/#authentication
 ## Authentication
 All requests to Datadog's API must be authenticated. Requests that write data require *reporting access* and require an `API key`. Requests that read data require *full access* and also require an `application key`.
 
+By default, the Datadog API authenticates against the Datadog US site. If you are on the Datadog EU site, make sure to add `api_host` to  your options parameters. 
+
 [Manage your account's API and application keys][1].
 
 [1]: https://app.datadoghq.com/account/settings#api


### PR DESCRIPTION
added paragraph to make clear how EU hosted customers can configure the `api_host`

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a paragraph to make it obvious for EU hosted customers how to configure the EU endpoints

### Motivation
Having worked with multiple EU customers, I get asked this a lot. More advanced Python users may figure this out themselves but I think it's worth making it clear. No harm in over communicating! 


