### PR TITLE
update auth-api.py for EU

### DIFF
--- a/content/en/api/authentication/code_snippets/api-auth.py
+++ b/content/en/api/authentication/code_snippets/api-auth.py
@@ -1,6 +1,7 @@
 from datadog import initialize, api
 
 options = {'api_key': '<YOUR_API_KEY>',
-           'app_key': '<YOUR_APP_KEY>'}
+           'app_key': '<YOUR_APP_KEY>',
+           'api_host': 'https://api.datadoghq.eu` #optional}
 
 initialize(**options)

--- a/content/en/api/authentication/code_snippets/api-auth.py
+++ b/content/en/api/authentication/code_snippets/api-auth.py
@@ -2,6 +2,6 @@ from datadog import initialize, api
 
 options = {'api_key': '<YOUR_API_KEY>',
            'app_key': '<YOUR_APP_KEY>',
-           'api_host': 'https://api.datadoghq.eu` #optional}
+           'api_host': 'https://api.datadoghq.com`}
 
 initialize(**options)


### PR DESCRIPTION
Related to https://github.com/DataDog/documentation/pull/5846 updating to include `api_host` code example for EU customers

### What does this PR do?
Updates the code example to align with https://github.com/DataDog/documentation/pull/5846
### Motivation
Based on customer feedback - providing a clear example of how to specify EU endpoint for Python

