### PR TITLE
Removing the beta banner for log indexes as Terraform is released

### DIFF
--- a/content/en/api/logs_indexes/logs_indexes.md
+++ b/content/en/api/logs_indexes/logs_indexes.md
@@ -7,10 +7,6 @@ external_redirect: /api/#logs-indexes
 
 ## Logs Indexes
 
-<div class="alert alert-warning">
-This endpoint is in public beta and not supported in Datadog's client libraries. If you have any feedback, <a href="/help">contact Datadog support</a>.
-</div>
-
 The `Index` object describes the configuration of a log index. It has the following attributes:
 
 * **`name`** (Read Only):


### PR DESCRIPTION
### What does this PR do?
Terraform support has been provided so we can remove the beta banner.

### Motivation
It's no longer a beta

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ils/log-api-index-beta-removal/api/?lang=python#logs-indexes

### Additional Notes
<!-- Anything else we should know when reviewing?-->
