### PR TITLE
Specifying port 443 should allow outbound traffic

### DIFF
--- a/content/en/synthetics/private_locations.md
+++ b/content/en/synthetics/private_locations.md
@@ -62,7 +62,7 @@ Once you created a private location, configuring a Synthetics API test from a pr
     * For the Datadog US site: `curl https://api.datadoghq.com`.
     * For the Datadog EU site:   `curl https://api.datadoghq.eu`.
     
-**Note**: Since test configurations are pulled and test results are pushed via HTTPS, you need to make sure to allow outbound traffic on port 443.
+**Note**: You must allow outbound traffic on port `443` because test configurations are pulled and test results are pushed via HTTPS.
 
 5. If your private location reports correctly to Datadog you should see the corresponding health status displayed if the private location polled your endpoint less than 5 seconds before loading the settings or create test pages:
 

--- a/content/en/synthetics/private_locations.md
+++ b/content/en/synthetics/private_locations.md
@@ -61,6 +61,8 @@ Once you created a private location, configuring a Synthetics API test from a pr
 
     * For the Datadog US site: `curl https://api.datadoghq.com`.
     * For the Datadog EU site:   `curl https://api.datadoghq.eu`.
+    
+**Note**: Since test configurations are pulled and test results are pushed via HTTPS, you need to make sure to allow outbound traffic on port 443.
 
 5. If your private location reports correctly to Datadog you should see the corresponding health status displayed if the private location polled your endpoint less than 5 seconds before loading the settings or create test pages:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

This PR adds a note to inform users they should make sure to allow outbound traffic on port 443 to get their private locations working.

### Motivation

https://trello.com/c/vONM01b6/1276-capital-one-feedback-investigation

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
