### PR TITLE
[MA-554] Document the new `Monitor.can_delete` endpoint.

### DIFF
--- a/content/en/api/monitors/code_snippets/api-monitor-can-delete.py
+++ b/content/en/api/monitors/code_snippets/api-monitor-can-delete.py
@@ -1,0 +1,11 @@
+from datadog import initialize, api
+
+options = {
+    'api_key': '<YOUR_API_KEY>',
+    'app_key': '<YOUR_APP_KEY>'
+}
+
+initialize(**options)
+
+# Check if you can delete the given monitors.
+api.Monitor.can_delete(monitor_ids=[2081, 2082])

--- a/content/en/api/monitors/code_snippets/api-monitor-can-delete.py
+++ b/content/en/api/monitors/code_snippets/api-monitor-can-delete.py
@@ -8,4 +8,4 @@ options = {
 initialize(**options)
 
 # Check if you can delete the given monitors.
-api.Monitor.can_delete(monitor_ids=[2081, 2082])
+api.Monitor.can_delete(monitor_ids=[56838, 771060, 1000376])

--- a/content/en/api/monitors/code_snippets/api-monitor-can-delete.rb
+++ b/content/en/api/monitors/code_snippets/api-monitor-can-delete.rb
@@ -1,0 +1,10 @@
+require 'rubygems'
+require 'dogapi'
+
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
+
+dog = Dogapi::Client.new(api_key, app_key)
+
+# Check if you can delete the given monitors.
+dog.can_delete_monitors([2081, 2082])

--- a/content/en/api/monitors/code_snippets/api-monitor-can-delete.rb
+++ b/content/en/api/monitors/code_snippets/api-monitor-can-delete.rb
@@ -7,4 +7,4 @@ app_key = '<YOUR_APP_KEY>'
 dog = Dogapi::Client.new(api_key, app_key)
 
 # Check if you can delete the given monitors.
-dog.can_delete_monitors([2081, 2082])
+dog.can_delete_monitors([56838, 771060, 1000376])

--- a/content/en/api/monitors/code_snippets/api-monitor-can-delete.sh
+++ b/content/en/api/monitors/code_snippets/api-monitor-can-delete.sh
@@ -7,4 +7,4 @@ app_key=<YOUR_APP_KEY>
 monitor_id=<YOUR_MONITOR_ID>
 
 # Check if you can delete the monitors
-curl -X GET "https://api.datadoghq.com/api/v1/monitor/can_delete?api_key=${api_key}&application_key=${app_key}&monitor_ids=2081,2082"
+curl -X GET "https://api.datadoghq.com/api/v1/monitor/can_delete?api_key=${api_key}&application_key=${app_key}&monitor_ids=56838,771060,1000376"

--- a/content/en/api/monitors/code_snippets/api-monitor-can-delete.sh
+++ b/content/en/api/monitors/code_snippets/api-monitor-can-delete.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Replace the API and APP keys below
+# with the ones for your account
+
+api_key=<YOUR_API_KEY>
+app_key=<YOUR_APP_KEY>
+monitor_id=<YOUR_MONITOR_ID>
+
+# Check if you can delete the monitors
+curl -X GET "https://api.datadoghq.com/api/v1/monitor/can_delete?api_key=${api_key}&application_key=${app_key}&monitor_ids=2081,2082"

--- a/content/en/api/monitors/code_snippets/result.api-monitor-can-delete.sh
+++ b/content/en/api/monitors/code_snippets/result.api-monitor-can-delete.sh
@@ -1,0 +1,11 @@
+{
+    "data": {"ok": [1000376]},
+    "errors": {
+        "771060": [
+            "monitor 771060 is referenced in slos: 5bb564f7fcab59afbdc486a5cbebbec3, fd09b8be2879530191de98faa674c397, e3b3896f13f754b4b4f71ccf4c903ad2, a08c015e7060564ca31d89fb0298bacd, ee7c9f30f54b552f8c7287940d22987e, cf435f8454ba567491ad76214f6246cf, 21952a2b4e6e524981603c8b7bc78fff, 0745d5a4764a56b2859f07ec236647b5"
+        ],
+        "56838": [
+            "monitor 56838 is referenced in slos: fb0b4534553653db8b955874f4c70813"
+        ],
+    },
+}

--- a/content/en/api/monitors/monitor_can_delete.md
+++ b/content/en/api/monitors/monitor_can_delete.md
@@ -1,0 +1,13 @@
+---
+title: Check if a monitor can be deleted
+type: apicontent
+order: 26.14
+external_redirect: /api/#check-if-a-monitor-can-be-deleted
+---
+
+## Check if a monitor can be deleted
+
+**ARGUMENTS**:
+
+* **`monitor_ids`**
+    The comma-separated list of monitor ids to check if they can be deleted.

--- a/content/en/api/monitors/monitor_can_delete.md
+++ b/content/en/api/monitors/monitor_can_delete.md
@@ -1,7 +1,7 @@
 ---
 title: Check if a monitor can be deleted
 type: apicontent
-order: 26.14
+order: 26.04
 external_redirect: /api/#check-if-a-monitor-can-be-deleted
 ---
 

--- a/content/en/api/monitors/monitor_can_delete_code.md
+++ b/content/en/api/monitors/monitor_can_delete_code.md
@@ -1,7 +1,7 @@
 ---
 title: Check if a monitor can be deleted
 type: apicode
-order: 26.14
+order: 26.04
 external_redirect: /api/#check-if-a-monitor-can-be-deleted
 ---
 

--- a/content/en/api/monitors/monitor_can_delete_code.md
+++ b/content/en/api/monitors/monitor_can_delete_code.md
@@ -1,0 +1,18 @@
+---
+title: Check if a monitor can be deleted
+type: apicode
+order: 26.14
+external_redirect: /api/#check-if-a-monitor-can-be-deleted
+---
+
+**SIGNATURE**:
+
+`GET /v1/monitor/can_delete`
+
+**EXAMPLE REQUEST**:
+
+{{< code-snippets basename="api-monitor-can-delete" >}}
+
+**EXAMPLE RESPONSE**:
+
+{{< code-snippets basename="result.api-monitor-can-delete" >}}

--- a/content/en/api/monitors/monitors_delete.md
+++ b/content/en/api/monitors/monitors_delete.md
@@ -1,7 +1,7 @@
 ---
 title: Delete a monitor
 type: apicontent
-order: 26.04
+order: 26.05
 external_redirect: /api/#delete-a-monitor
 ---
 

--- a/content/en/api/monitors/monitors_delete_code.md
+++ b/content/en/api/monitors/monitors_delete_code.md
@@ -1,7 +1,7 @@
 ---
 title: Delete a monitor
 type: apicode
-order: 26.04
+order: 26.05
 external_redirect: /api/#delete-a-monitor
 ---
 

--- a/content/en/api/monitors/monitors_group_search.md
+++ b/content/en/api/monitors/monitors_group_search.md
@@ -1,7 +1,7 @@
 ---
 title: Monitors group search
 type: apicontent
-order: 26.13
+order: 26.14
 external_redirect: /api/#monitors-group-search
 ---
 

--- a/content/en/api/monitors/monitors_group_search_code.md
+++ b/content/en/api/monitors/monitors_group_search_code.md
@@ -1,7 +1,7 @@
 ---
 title: Monitors Group Search
 type: apicode
-order: 26.13
+order: 26.14
 external_redirect: /api/#monitors-group-search
 ---
 

--- a/content/en/api/monitors/monitors_mute.md
+++ b/content/en/api/monitors/monitors_mute.md
@@ -1,7 +1,7 @@
 ---
 title: Mute a monitor
 type: apicontent
-order: 26.09
+order: 26.10
 external_redirect: /api/#mute-a-monitor
 ---
 

--- a/content/en/api/monitors/monitors_mute_code.md
+++ b/content/en/api/monitors/monitors_mute_code.md
@@ -1,7 +1,7 @@
 ---
 title: Mute a monitor
 type: apicode
-order: 26.09
+order: 26.10
 external_redirect: /api/#mute-a-monitor
 ---
 

--- a/content/en/api/monitors/monitors_muteall.md
+++ b/content/en/api/monitors/monitors_muteall.md
@@ -1,7 +1,7 @@
 ---
 title: Mute all monitors
 type: apicontent
-order: 26.07
+order: 26.08
 external_redirect: /api/#mute-all-monitors
 ---
 

--- a/content/en/api/monitors/monitors_muteall_code.md
+++ b/content/en/api/monitors/monitors_muteall_code.md
@@ -1,7 +1,7 @@
 ---
 title: Mute all monitors
 type: apicode
-order: 26.07
+order: 26.08
 external_redirect: /api/#mute-all-monitors
 ---
 

--- a/content/en/api/monitors/monitors_resolve.md
+++ b/content/en/api/monitors/monitors_resolve.md
@@ -1,7 +1,7 @@
 ---
 title: Resolve monitor
 type: apicontent
-order: 26.06
+order: 26.07
 external_redirect: /api/#resolve-monitor
 ---
 

--- a/content/en/api/monitors/monitors_resolve_code.md
+++ b/content/en/api/monitors/monitors_resolve_code.md
@@ -1,7 +1,7 @@
 ---
 title: Resolve monitor
 type: apicode
-order: 26.06
+order: 26.07
 external_redirect: /api/#resolve-monitor
 ---
 

--- a/content/en/api/monitors/monitors_search.md
+++ b/content/en/api/monitors/monitors_search.md
@@ -1,7 +1,7 @@
 ---
 title: Monitors search
 type: apicontent
-order: 26.12
+order: 26.13
 external_redirect: /api/#monitors-search
 ---
 

--- a/content/en/api/monitors/monitors_search_code.md
+++ b/content/en/api/monitors/monitors_search_code.md
@@ -1,7 +1,7 @@
 ---
 title: Monitors Search
 type: apicode
-order: 26.12
+order: 26.13
 external_redirect: /api/#monitors-search
 ---
 

--- a/content/en/api/monitors/monitors_showall.md
+++ b/content/en/api/monitors/monitors_showall.md
@@ -1,7 +1,7 @@
 ---
 title: Get all monitor details
 type: apicontent
-order: 26.05
+order: 26.06
 external_redirect: /api/#get-all-monitor-details
 ---
 

--- a/content/en/api/monitors/monitors_showall_code.md
+++ b/content/en/api/monitors/monitors_showall_code.md
@@ -1,7 +1,7 @@
 ---
 title: Get all monitor details
 type: apicode
-order: 26.05
+order: 26.06
 external_redirect: /api/#get-all-monitor-details
 ---
 

--- a/content/en/api/monitors/monitors_unmute.md
+++ b/content/en/api/monitors/monitors_unmute.md
@@ -1,7 +1,7 @@
 ---
 title: Unmute a monitor
 type: apicontent
-order: 26.10
+order: 26.11
 external_redirect: /api/#unmute-a-monitor
 ---
 

--- a/content/en/api/monitors/monitors_unmute_code.md
+++ b/content/en/api/monitors/monitors_unmute_code.md
@@ -1,7 +1,7 @@
 ---
 title: Unmute a monitor
 type: apicode
-order: 26.10
+order: 26.11
 external_redirect: /api/#unmute-a-monitor
 ---
 

--- a/content/en/api/monitors/monitors_unmuteall.md
+++ b/content/en/api/monitors/monitors_unmuteall.md
@@ -1,7 +1,7 @@
 ---
 title: Unmute all monitors
 type: apicontent
-order: 26.08
+order: 26.09
 external_redirect: /api/#unmute-all-monitors
 ---
 

--- a/content/en/api/monitors/monitors_unmuteall_code.md
+++ b/content/en/api/monitors/monitors_unmuteall_code.md
@@ -1,7 +1,7 @@
 ---
 title: Unmute all monitors
 type: apicode
-order: 26.08
+order: 26.09
 external_redirect: /api/#unmute-all-monitors
 ---
 

--- a/content/en/api/monitors/monitors_validate.md
+++ b/content/en/api/monitors/monitors_validate.md
@@ -1,7 +1,7 @@
 ---
 title: Validate a monitor
 type: apicontent
-order: 26.11
+order: 26.12
 external_redirect: /api/#validate-a-monitor
 ---
 ## Validate a monitor

--- a/content/en/api/monitors/monitors_validate_code.md
+++ b/content/en/api/monitors/monitors_validate_code.md
@@ -1,7 +1,7 @@
 ---
 title: Validate a monitor
 type: apicode
-order: 26.11
+order: 26.12
 external_redirect: /api/#validate-a-monitor
 ---
 


### PR DESCRIPTION
### What does this PR do?
Adds documentation and code examples for the new `Monitor.can_delete` endpoint.

### Motivation
The documentation does not exist.

### Preview link

https://docs-staging.datadoghq.com/armcburney/can_delete_endpoint/api/?lang=bash#check-if-a-monitor-can-be-deleted

### Additional Notes
- datadogpy: https://github.com/DataDog/datadogpy/pull/474
- dogapi-rb: https://github.com/DataDog/dogapi-rb/pull/195
