### PR TITLE
Adding doc for EU region

### DIFF
--- a/content/en/api/authentication/authentication.md
+++ b/content/en/api/authentication/authentication.md
@@ -4,8 +4,12 @@ type: apicontent
 order: 2
 external_redirect: /api/#authentication
 ---
+
 ## Authentication
+
 All requests to Datadog's API must be authenticated. Requests that write data require *reporting access* and require an `API key`. Requests that read data require *full access* and also require an `application key`.
+
+**Note**: All Datadog API Clients are configured by default to consume Datadog US site APIs. If you are on the Datadog EU site, Set the environment variable `DATADOG_HOST` to `https://api.datadoghq.eu` or overide this value directly when creating your Client.
 
 [Manage your account's API and application keys][1].
 

--- a/content/en/api/authentication/code_snippets/api-auth.py
+++ b/content/en/api/authentication/code_snippets/api-auth.py
@@ -1,6 +1,7 @@
 from datadog import initialize, api
 
 options = {'api_key': '<YOUR_API_KEY>',
-           'app_key': '<YOUR_APP_KEY>'}
+           'app_key': '<YOUR_APP_KEY>',
+           'api_host': 'https: // api.datadoghq.com'}
 
 initialize(**options)

--- a/content/en/api/authentication/code_snippets/api-auth.py
+++ b/content/en/api/authentication/code_snippets/api-auth.py
@@ -2,6 +2,6 @@ from datadog import initialize, api
 
 options = {'api_key': '<YOUR_API_KEY>',
            'app_key': '<YOUR_APP_KEY>',
-           'api_host': 'https: // api.datadoghq.com'}
+           'api_host': 'https://api.datadoghq.com'}
 
 initialize(**options)

--- a/content/en/api/authentication/code_snippets/api-auth.rb
+++ b/content/en/api/authentication/code_snippets/api-auth.rb
@@ -1,4 +1,4 @@
 require 'rubygems'
 require 'dogapi'
 
-dog = Dogapi::Client.new('<YOUR_API_KEY>', '<YOUR_APP_KEY>')
+dog = Dogapi::Client.new(:api_key => '<YOUR_API_KEY>', :application_key => '<YOUR_APP_KEY>', :endpoint => 'https://api.datadoghq.com')


### PR DESCRIPTION
### What does this PR do?

Based on customer feedback - providing a clear example of how to specify EU endpoint for Python and Ruby API client.

### Motivation

* https://github.com/DataDog/documentation/pull/5847
* https://github.com/DataDog/documentation/pull/5846

### Preview link

https://docs-staging.datadoghq.com/gus/api-client-eu/api/?lang=python#authentication