### PR TITLE
Updated Agent documentation for release of the ARM Agent

### DIFF
--- a/content/en/agent/_index.md
+++ b/content/en/agent/_index.md
@@ -33,6 +33,8 @@ Agent v6 is available. <a href="/agent/faq/upgrade-to-agent-v6">Upgrade to the n
 
 The Datadog Agent is software that runs on your hosts. It collects events and metrics from hosts and sends them to Datadog, where you can analyze your monitoring and performance data. The Datadog Agent is open-source, and its source code is available on GitHub at [DataDog/datadog-agent][1].
 
+Packages are available for 64-bit x86 and Arm v8 architectures. For other architectures, use the source install.
+
 {{< partial name="platforms/platforms.html" links="platforms" >}}
 
 {{< whatsnext desc="This section includes the following topics:">}}

--- a/content/en/agent/basic_agent_usage/amazonlinux.md
+++ b/content/en/agent/basic_agent_usage/amazonlinux.md
@@ -20,6 +20,8 @@ further_reading:
 
 This page outlines the basic features of the Datadog Agent for Amazon Linux. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
+Packages are available for 64-bit x86 and Arm v8 architectures. For other architectures, use the source install.
+
 ## Commands
 
 In Agent v6, the service manager provided by the operating system is responsible for the Agent lifecycle, while other commands must be run via the Agent binary directly. In Agent v5, almost everything is done via the service manager.

--- a/content/en/agent/basic_agent_usage/deb.md
+++ b/content/en/agent/basic_agent_usage/deb.md
@@ -22,6 +22,8 @@ further_reading:
 
 This page outlines the basic features of the Datadog Agent for Debian. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
+Packages are available for 64-bit x86 and Arm v8 architectures. For other architectures, use the source install.
+
 **Note**: Debian 7 (wheezy) and above (we support SysVinit in Agent 6.6.0 above) are supported.
 
 ## Commands

--- a/content/en/agent/basic_agent_usage/ubuntu.md
+++ b/content/en/agent/basic_agent_usage/ubuntu.md
@@ -20,6 +20,8 @@ further_reading:
 
 This page outlines the basic features of the Datadog Agent for Ubuntu. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
+Packages are available for 64-bit x86 and Arm v8 architectures. For other architectures, use the source install.
+
 **Note**: Ubuntu 14.04 and above are supported.
 
 ## Commands

--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -23,6 +23,8 @@ further_reading:
 ## Overview
 The Datadog Docker Agent is the containerized version of the host [Agent][1]. The official [Docker image][2] is available on Docker Hub.
 
+Images are available for 64-bit x86 and Arm v8 architectures.
+
 ## Setup
 If you haven’t installed the Docker Agent, see below or the [in-app installation instructions][3]. See the Agent documentation for [supported versions][4].
 


### PR DESCRIPTION
### What does this PR do?
We are officially supporting builds of the Datadog Agent for hosts running ARM processors.

Updated Agent Overview to mention that packages are available for x86 and ARM CPU architectures. Also updated pages for individual platforms with x86 and ARM support.

### Motivation
Launch of official support for ARM instances.

### Preview link
[Agent Overview](https://docs-staging.datadoghq.com/jimmy.caputo/arm-agent/agent/)
[Amazon Linux](https://docs-staging.datadoghq.com/jimmy.caputo/arm-agent/agent/basic_agent_usage/amazonlinux/?tab=agentv6)
[Debian](https://docs-staging.datadoghq.com/jimmy.caputo/arm-agent/agent/basic_agent_usage/deb/?tab=agentv6)
[Ubuntu](https://docs-staging.datadoghq.com/jimmy.caputo/arm-agent/agent/basic_agent_usage/ubuntu/?tab=agentv6)
[Docker](https://docs-staging.datadoghq.com/jimmy.caputo/arm-agent/agent/docker/?tab=standard)

### Additional Notes
This is a feature we're preparing to launch in the next few weeks. This can be reviewed, but shouldn't be merged yet.
