### PR TITLE
added doc for force flag

### DIFF
--- a/content/en/api/service_level_objectives/service_level_objectives_delete.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_delete.md
@@ -9,8 +9,10 @@ external_redirect: /api/#delete-a-service-level-objective
 
 Permanently delete a SLO.
 
+If an SLO is used in a dashboard, the DELETE /v1/slo/ endpoint will return a 409 conflict error because the SLO is referenced in a dashboard.
+
 **ARGUMENTS**:
 
 * **`force`** [*optional*]:
 
-    Boolean: Force delete SLO.  Required if SLO exists in a dashboard.  Default `false`
+    Boolean: Force delete the SLO. The SLO will be deleted regardless of if it's referenced in a dashboard. Defaultfalse.

--- a/content/en/api/service_level_objectives/service_level_objectives_delete.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_delete.md
@@ -11,4 +11,6 @@ Permanently delete a SLO.
 
 **ARGUMENTS**:
 
-This endpoint takes no JSON arguments.
+* **`force`** [*optional*]:
+
+    Boolean: Force delete SLO.  Required if SLO exists in a dashboard.  Default `false`

--- a/content/en/api/service_level_objectives/service_level_objectives_delete.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_delete.md
@@ -9,10 +9,10 @@ external_redirect: /api/#delete-a-service-level-objective
 
 Permanently delete a SLO.
 
-If an SLO is used in a dashboard, the DELETE /v1/slo/ endpoint will return a 409 conflict error because the SLO is referenced in a dashboard.
+If an SLO is used in a dashboard, the DELETE /v1/slo/ endpoint returns a 409 conflict error because the SLO is referenced in a dashboard.
 
 **ARGUMENTS**:
 
-* **`force`** [*optional*]:
+* **`force`** [*optional*, *default*=**False**]:
 
-    Boolean: Force delete the SLO. The SLO will be deleted regardless of if it's referenced in a dashboard. Defaultfalse.
+    Boolean: Force delete the SLO. The SLO is deleted even if it's referenced in a dashboard.


### PR DESCRIPTION
### What does this PR do?
Added doc for force flag so user can delete an SLO if it exists in a dashboard

### Motivation
Support ticket

### Preview link
Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/bcon/slo-force-delete-api/api/?lang=bash#service-level-objectives

### Additional Notes

