### PR TITLE
fixing broken formatting in the API reference

### DIFF
--- a/content/en/api/monitors/monitors_create.md
+++ b/content/en/api/monitors/monitors_create.md
@@ -130,35 +130,39 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
         *   False: `[Triggered] Monitor Title`
 
     ##### Anomaly Options
+    
     _These options only apply to anomaly monitors and are ignored for other monitor types._
 
-    -   **`threshold_windows`** a dictionary containing `recovery_window` and `trigger_window`.
-        * `recovery_window` describes how long an anomalous metric must be normal before the alert recovers
-        * `trigger_window` describes how long a metric must be anomalous before an alert triggers
+    - **`threshold_windows`** a dictionary containing `recovery_window` and `trigger_window`.
+        
+        - `recovery_window` describes how long an anomalous metric must be normal before the alert recovers
+        - `trigger_window` describes how long a metric must be anomalous before an alert triggers
 
-            Example: `{'threshold_windows': {'recovery_window': 'last_15m', 'trigger_window': 'last_15m'}}`
+        Example: `{'threshold_windows': {'recovery_window': 'last_15m', 'trigger_window': 'last_15m'}}`
 
     ##### Metric Alert Options
+    
     _These options only apply to metric alerts._
 
-    -   **`thresholds`** a dictionary of thresholds by threshold type. There are two threshold types for metric alerts: *critical* and *warning*. *Critical* is defined in the query, but can also be specified in this option. *Warning* threshold can only be specified using the thresholds option.
-    If you want to use [recovery thresholds][6] for your monitor, use the attributes `critical_recovery` and `warning_recovery`.
+   - **`thresholds`** a dictionary of thresholds by threshold type. There are two threshold types for metric alerts: *critical* and *warning*. *Critical* is defined in the query, but can also be specified in this option. *Warning* threshold can only be specified using the thresholds option. If you want to use [recovery thresholds][6] for your monitor, use the attributes `critical_recovery` and `warning_recovery`.
 
-            Example: `{'critical': 90, 'warning': 80,  'critical_recovery': 70, 'warning_recovery': 50}`
+    Example: `{'critical': 90, 'warning': 80,  'critical_recovery': 70, 'warning_recovery': 50}`
 
-    -   **`evaluation_delay`** Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min), the timeframe is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55. This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
+   - **`evaluation_delay`** Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min), the timeframe is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55. This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
 
     ##### Service Check Options
+    
     _These options only apply to service checks and are ignored for other monitor types._
 
-    -   **`thresholds`** a dictionary of thresholds by status. Because service checks can have multiple thresholds, we don't define them directly in the query.
+   - **`thresholds`** a dictionary of thresholds by status. Because service checks can have multiple thresholds, we don't define them directly in the query.
 
-            Example: `{'ok': 1, 'critical': 1, 'warning': 1}`
+    Example: `{'ok': 1, 'critical': 1, 'warning': 1}`
 
     ##### Errors and Validation
-    If an invalid monitor option is included in the request, the response will be:
+    
+    - If an invalid monitor option is included in the request, the response will be:
 
-            Error: 400 - ["Invalid monitor option:<invalid option>"]
+    `Error: 400 - ["Invalid monitor option:<invalid option>"]`
 
 
 [1]: /monitors/monitor_types/#import


### PR DESCRIPTION
### What does this PR do?
Fixes broken md - there's some odd spacing and missing code backticks that's making it format oddly

### Motivation
It is broken

### Preview link

https://docs-staging.datadoghq.com/kaylyn/api-formatting/api/?lang=python#create-a-monitor

#### Before

![image](https://user-images.githubusercontent.com/28788585/68428031-8c485a80-0168-11ea-8dfa-a3ab5063c2bf.png)

#### After

![image](https://user-images.githubusercontent.com/28788585/68428003-805c9880-0168-11ea-9940-3bf27150feb4.png)

