### PR TITLE
[slo] Fix `can_delete` shell example.

### DIFF
--- a/content/en/api/service_level_objectives/code_snippets/api-slo-can-delete.sh
+++ b/content/en/api/service_level_objectives/code_snippets/api-slo-can-delete.sh
@@ -10,4 +10,4 @@ slo_id=<YOUR_SLO_ID>
 curl -X GET \
 -H "DD-API-KEY: ${api_key}" \
 -H "DD-APPLICATION-KEY: ${app_key}" \
-"https://api.datadoghq.com/api/v1/slo/can_delete"
+"https://api.datadoghq.com/api/v1/slo/can_delete?ids=${slo_id}"


### PR DESCRIPTION
### What does this PR do?
Fixes the `api/v1/slo/can_delete` shell example to include a required `ids` parameter.

### Preview link
https://docs-staging.datadoghq.com/armcburney/fix_can_delete_bash_docs/api/?lang=bash#check-if-a-service-level-objective-can-be-deleted

### Additional Notes
@DataDog/monitor-app 