### PR TITLE
updating the SLO API toc

### DIFF
--- a/content/en/api/service_level_objectives/service_level_objectives.md
+++ b/content/en/api/service_level_objectives/service_level_objectives.md
@@ -2,14 +2,14 @@
 title: Service Level Objectives
 type: apicontent
 order: 29
-external_redirect: /api/#servicelevelobjectives
+external_redirect: /api/#service-level-objectives
 ---
 ## Service Level Objectives
 
-[Service Level Objectives][1] (or SLOs) are a key part of the site reliability engineering toolkit. SLOs provide a 
-framework for defining clear targets around application performance, which ultimately help teams provide a consistent 
-customer experience, balance feature development with platform stability, and improve communication with internal and 
-external users. 
+[Service Level Objectives][1] (or SLOs) are a key part of the site reliability engineering toolkit. SLOs provide a
+framework for defining clear targets around application performance, which ultimately help teams provide a consistent
+customer experience, balance feature development with platform stability, and improve communication with internal and
+external users.
 
 For more information on creating SLOs, see the [Configuring Service Level Objectives info][2].
 

--- a/content/en/api/service_level_objectives/service_level_objectives_bulk_delete.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_bulk_delete.md
@@ -1,5 +1,5 @@
 ---
-title: Bulk Delete Service Level Objective Timeframes
+title: Bulk Delete SLO Timeframes
 type: apicontent
 order: 29.06
 external_redirect: /api/#bulk-delete-service-level-objectives-timeframes

--- a/content/en/api/service_level_objectives/service_level_objectives_bulk_delete.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_bulk_delete.md
@@ -5,7 +5,7 @@ order: 29.06
 external_redirect: /api/#bulk-delete-slo-timeframes
 ---
 
-## Bulk Delete Service Level Objective Timeframes
+## Bulk Delete SLO Timeframes
 
 **ARGUMENTS**:
 

--- a/content/en/api/service_level_objectives/service_level_objectives_bulk_delete.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_bulk_delete.md
@@ -2,7 +2,7 @@
 title: Bulk Delete SLO Timeframes
 type: apicontent
 order: 29.06
-external_redirect: /api/#bulk-delete-service-level-objectives-timeframes
+external_redirect: /api/#bulk-delete-slo-timeframes
 ---
 
 ## Bulk Delete Service Level Objective Timeframes

--- a/content/en/api/service_level_objectives/service_level_objectives_can_delete.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_can_delete.md
@@ -1,5 +1,5 @@
 ---
-title: Check if a service level objective can be deleted
+title: Check if a SLO can be deleted
 type: apicontent
 order: 29.03
 external_redirect: /api/#can-delete-a-service-level-objective-s

--- a/content/en/api/service_level_objectives/service_level_objectives_can_delete.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_can_delete.md
@@ -2,7 +2,7 @@
 title: Check if a SLO can be deleted
 type: apicontent
 order: 29.03
-external_redirect: /api/#can-delete-a-service-level-objective-s
+external_redirect: /api/#check-if-a-slo-can-be-deleted
 ---
 
 ## Check if a service level objective can be deleted

--- a/content/en/api/service_level_objectives/service_level_objectives_can_delete.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_can_delete.md
@@ -5,7 +5,7 @@ order: 29.03
 external_redirect: /api/#check-if-a-slo-can-be-deleted
 ---
 
-## Check if a service level objective can be deleted
+## Check if a SLO can be deleted
 
 Check if a SLO can be safely deleted.
 

--- a/content/en/api/service_level_objectives/service_level_objectives_code.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_code.md
@@ -2,5 +2,5 @@
 title: Service Level Objectives
 type: apicode
 order: 29
-external_redirect: /api/#servicelevelobjectives
+external_redirect: /api/#service-level-objectives
 ---

--- a/content/en/api/service_level_objectives/service_level_objectives_create.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_create.md
@@ -2,7 +2,7 @@
 title: Create a SLO
 type: apicontent
 order: 29.01
-external_redirect: /api/#create-a-service-level-objective
+external_redirect: /api/#create-a-slo
 ---
 
 ## Create a service level objective

--- a/content/en/api/service_level_objectives/service_level_objectives_create.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_create.md
@@ -1,5 +1,5 @@
 ---
-title: Create a service level objective
+title: Create a SLO
 type: apicontent
 order: 29.01
 external_redirect: /api/#create-a-service-level-objective

--- a/content/en/api/service_level_objectives/service_level_objectives_create.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_create.md
@@ -5,7 +5,7 @@ order: 29.01
 external_redirect: /api/#create-a-slo
 ---
 
-## Create a service level objective
+## Create a SLO
 
 Create a JSON to define your SLO.
 
@@ -14,10 +14,10 @@ Create a JSON to define your SLO.
 * **`type`** [*required*]:
     The type of the SLO, chosen from:
 
-| SLO Type     | supported value             |
-|:-------------|:---------------------------------|
-| [event][1]       | `metric`                         |
-| [monitor][2]      | `monitor`                        |
+| SLO Type     | supported value |
+|:-------------|:----------------|
+| [event][1]   | `metric`        |
+| [monitor][2] | `monitor`       |
 
 * **`name`** [*required*, *default* = **dynamic, based on query**]:
     The name of the SLO.
@@ -27,8 +27,8 @@ Create a JSON to define your SLO.
     A list of tags to associate with your SLO.
 * **`thresholds`** [*required*]:
     A list of Target thresholds, requires at least 1.
-    
-    * **`timeframe`** [*required*]: 
+
+    * **`timeframe`** [*required*]:
         The timeframe to apply to the target value. Valid options are `7d`, `30d`, `90d`.
     * **`target`** [*required*]:
         The target value to associate with the SLI that defines the SLO.
@@ -52,7 +52,7 @@ For more information, see [Monitor SLOs][1].
 * **`groups`** [*optional*, *default* = **empty list**]:
     **Note: Only valid on single monitor SLOs** Specify the selected groups as a sub query of the selected monitor.
 
-### Event Based SLOs  
+### Event Based SLOs
 
 There is one type of event based SLO, a metric query. For more information, see [Event SLOs][2].
 
@@ -60,7 +60,7 @@ There is one type of event based SLO, a metric query. For more information, see 
 
 * **`query`** [*required*]:
     The query defines the metric-based SLO query. It requires two arguments:
-    
+
     * **`numerator`** [*required*]:
         Defines the sum of the `good` events
     * **`denominator`** [*required*]:

--- a/content/en/api/service_level_objectives/service_level_objectives_delete.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_delete.md
@@ -5,7 +5,7 @@ order: 29.04
 external_redirect: /api/#delete-a-slo
 ---
 
-## Delete a Service Level Objective
+## Delete a SLO
 
 Permanently delete a SLO.
 

--- a/content/en/api/service_level_objectives/service_level_objectives_delete.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_delete.md
@@ -1,5 +1,5 @@
 ---
-title: Delete a Service Level Objective
+title: Delete a SLO
 type: apicontent
 order: 29.04
 external_redirect: /api/#delete-a-service-level-objective

--- a/content/en/api/service_level_objectives/service_level_objectives_delete.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_delete.md
@@ -2,7 +2,7 @@
 title: Delete a SLO
 type: apicontent
 order: 29.04
-external_redirect: /api/#delete-a-service-level-objective
+external_redirect: /api/#delete-a-slo
 ---
 
 ## Delete a Service Level Objective

--- a/content/en/api/service_level_objectives/service_level_objectives_delete_many.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_delete_many.md
@@ -5,7 +5,7 @@ order: 29.05
 external_redirect: /api/#delete-multiple-slos
 ---
 
-## Delete multiple Service Level Objectives
+## Delete multiple SLOs
 
 **ARGUMENTS**:
 

--- a/content/en/api/service_level_objectives/service_level_objectives_delete_many.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_delete_many.md
@@ -1,11 +1,11 @@
 ---
-title: Delete many Service Level Objectives
+title: Delete multiple SLOs
 type: apicontent
 order: 29.05
 external_redirect: /api/#delete-many-service-level-objectives
 ---
 
-## Delete many Service Level Objectives
+## Delete multiple Service Level Objectives
 
 **ARGUMENTS**:
 

--- a/content/en/api/service_level_objectives/service_level_objectives_delete_many.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_delete_many.md
@@ -2,7 +2,7 @@
 title: Delete multiple SLOs
 type: apicontent
 order: 29.05
-external_redirect: /api/#delete-many-service-level-objectives
+external_redirect: /api/#delete-multiple-slos
 ---
 
 ## Delete multiple Service Level Objectives

--- a/content/en/api/service_level_objectives/service_level_objectives_edit.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_edit.md
@@ -2,7 +2,7 @@
 title: Edit a SLO
 type: apicontent
 order: 29.03
-external_redirect: /api/#edit-a-service-level-objective
+external_redirect: /api/#edit-a-slo
 ---
 
 ## Edit A Service Level Objective

--- a/content/en/api/service_level_objectives/service_level_objectives_edit.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_edit.md
@@ -5,7 +5,7 @@ order: 29.03
 external_redirect: /api/#edit-a-slo
 ---
 
-## Edit A Service Level Objective
+## Edit a SLO
 
 **ARGUMENTS**:
 
@@ -17,8 +17,8 @@ external_redirect: /api/#edit-a-slo
     A list of tags to associate with your SLO.
 * **`thresholds`** [*optional*, *default*=**None**]:
     A list of Target thresholds, do not specify if not changing.
-    
-    * **`timeframe`** [*required*]: 
+
+    * **`timeframe`** [*required*]:
         The timeframe to apply to the target value. Valid options are `7d`, `30d`, `90d`.
     * **`target`** [*required*]:
         The target value to associate with the SLI that defines the SLO.
@@ -49,7 +49,7 @@ There is one type of event based SLO, a metric query. For more information, see 
 
 * **`query`** [*required*]:
     The query defines the event-based SLO query. It requires two arguments:
-    
+
     * **`numerator`** [*required*]:
         Defines the sum of the `good` events.
     * **`denominator`** [*required*]:

--- a/content/en/api/service_level_objectives/service_level_objectives_edit.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_edit.md
@@ -1,5 +1,5 @@
 ---
-title: Edit a Service Level Objective
+title: Edit a SLO
 type: apicontent
 order: 29.03
 external_redirect: /api/#edit-a-service-level-objective

--- a/content/en/api/service_level_objectives/service_level_objectives_get.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_get.md
@@ -2,7 +2,7 @@
 title: Get a SLO's details
 type: apicontent
 order: 29.02
-external_redirect: /api/#get-a-service-level-objective-s-details
+external_redirect: /api/#get-a-slo-s-details
 ---
 
 ## Get a service level objective's details

--- a/content/en/api/service_level_objectives/service_level_objectives_get.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_get.md
@@ -5,7 +5,7 @@ order: 29.02
 external_redirect: /api/#get-a-slo-s-details
 ---
 
-## Get a service level objective's details
+## Get a SLO's details
 
 Get a specific SLO's details
 

--- a/content/en/api/service_level_objectives/service_level_objectives_get.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_get.md
@@ -1,5 +1,5 @@
 ---
-title: Get a service level objective's details
+title: Get a SLO's details
 type: apicontent
 order: 29.02
 external_redirect: /api/#get-a-service-level-objective-s-details

--- a/content/en/api/service_level_objectives/service_level_objectives_history.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_history.md
@@ -5,7 +5,7 @@ order: 29.03
 external_redirect: /api/#get-a-slo-s-history
 ---
 
-## Get a service level objective's history
+## Get a SLO's history
 
 Get a specific SLO's history, regardless of it's SLO type.
 

--- a/content/en/api/service_level_objectives/service_level_objectives_history.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_history.md
@@ -1,5 +1,5 @@
 ---
-title: Get a service level objective's history
+title: Get a SLO's history
 type: apicontent
 order: 29.03
 external_redirect: /api/#get-a-service-level-objective-s-history

--- a/content/en/api/service_level_objectives/service_level_objectives_history.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_history.md
@@ -2,7 +2,7 @@
 title: Get a SLO's history
 type: apicontent
 order: 29.03
-external_redirect: /api/#get-a-service-level-objective-s-history
+external_redirect: /api/#get-a-slo-s-history
 ---
 
 ## Get a service level objective's history

--- a/content/en/api/service_level_objectives/service_level_objectives_search.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_search.md
@@ -5,7 +5,7 @@ order: 29.07
 external_redirect: /api/#search-slo-s
 ---
 
-## Search Service Level Objectives
+## Search SLOs
 
 Search and filter your service level objectives.
 

--- a/content/en/api/service_level_objectives/service_level_objectives_search.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_search.md
@@ -1,5 +1,5 @@
 ---
-title: Search Service Level Objectives
+title: Search SLOs
 type: apicontent
 order: 29.07
 external_redirect: /api/#search-service-level-objectives

--- a/content/en/api/service_level_objectives/service_level_objectives_search.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_search.md
@@ -2,7 +2,7 @@
 title: Search SLOs
 type: apicontent
 order: 29.07
-external_redirect: /api/#search-service-level-objectives
+external_redirect: /api/#search-slo-s
 ---
 
 ## Search Service Level Objectives


### PR DESCRIPTION
### What does this PR do?
Updates the SLO API toc to use `SLO`.

### Motivation
It was inconsistent and it often went onto two lines, which wasn't necessary. 

### Preview link

https://docs-staging.datadoghq.com/kaylyn/slo-formatting/api/?lang=python#service-level-objectives

