### PR TITLE
Adding how to set an error with opentracing and java

### DIFF
--- a/content/en/tracing/advanced/opentracing.md
+++ b/content/en/tracing/advanced/opentracing.md
@@ -175,7 +175,6 @@ try (Scope scope = tracer.buildSpan("ServiceHandlerSpan").startActive(false)) {
 }
 ```
 
-
 #### Create a distributed trace using manual instrumentation with OpenTracing
 
 ```java
@@ -239,11 +238,41 @@ public class MyHttpRequestExtractAdapter implements TextMap {
   }
 }
 ```
+
 Notice the above examples only use the OpenTracing classes. Check the [OpenTracing API][1] for more details and information.
+
+#### Set errors
+
+To customize an error associated to one of your span, you must import the `io.opentracing.Span`, `io.opentracing.tag.Tags`, and `io.opentracing.util.GlobalTracer` library in the method where the error occurs:
+
+```java
+import io.opentracing.Span;
+import io.opentracing.tag.Tags;
+import io.opentracing.util.GlobalTracer;
+```
+
+Then you need to set the error to `true` and add *at least* the `error.msg`, `error.type`, and `error.stack` tag to your span.
+
+```java
+    final Span span = GlobalTracer.get().activeSpan();
+    if (span != null) {
+      Tags.ERROR.set(span, true);
+      span.setTag("error.msg", "<ERROR_MESSAGE>");
+      span.setTag("error.type", "<EXCEPTION_NAME>");
+      span.setTag("error.stack", "<ERROR_STACK>");
+    }
+```
+
+**Note**: Any relevant error metadata explained in [the Trace View docs][4] can also be added.
+If the current span isn't the root span, mark it as an error by using the `dd-trace-api` library to grab the root span with `MutableSpan` and use `setError(true)` (See [source code][5]).
+
+
 
 [1]: https://github.com/opentracing/opentracing-java
 [2]: /tracing/visualization/#trace
 [3]: /tracing/setup/java/#configuration
+[4]: /tracing/visualization/trace/?tab=spantags#more-information
+[5]: https://github.com/DataDog/dd-trace-java/blob/master/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java#L51
 {{% /tab %}}
 {{% tab "Python" %}}
 

--- a/content/en/tracing/advanced/opentracing.md
+++ b/content/en/tracing/advanced/opentracing.md
@@ -266,8 +266,6 @@ Then you need to set the error to `true` and add *at least* the `error.msg`, `er
 **Note**: Any relevant error metadata explained in [the Trace View docs][4] can also be added.
 If the current span isn't the root span, mark it as an error by using the `dd-trace-api` library to grab the root span with `MutableSpan` and use `setError(true)` (See [source code][5]).
 
-
-
 [1]: https://github.com/opentracing/opentracing-java
 [2]: /tracing/visualization/#trace
 [3]: /tracing/setup/java/#configuration

--- a/content/en/tracing/advanced/opentracing.md
+++ b/content/en/tracing/advanced/opentracing.md
@@ -243,7 +243,7 @@ Notice the above examples only use the OpenTracing classes. Check the [OpenTraci
 
 #### Set errors
 
-To customize an error associated to one of your span, you must import the `io.opentracing.Span`, `io.opentracing.tag.Tags`, and `io.opentracing.util.GlobalTracer` library in the method where the error occurs:
+To customize an error associated to one of your spans, import the `io.opentracing.Span`, `io.opentracing.tag.Tags`, and `io.opentracing.util.GlobalTracer` libraries into the method where the error occurs:
 
 ```java
 import io.opentracing.Span;
@@ -251,7 +251,7 @@ import io.opentracing.tag.Tags;
 import io.opentracing.util.GlobalTracer;
 ```
 
-Then you need to set the error to `true` and add *at least* the `error.msg`, `error.type`, and `error.stack` tag to your span.
+Then, set the error to `true` and add *at least* the `error.msg`, `error.type`, and `error.stack` tags to your span.
 
 ```java
     final Span span = GlobalTracer.get().activeSpan();
@@ -261,8 +261,8 @@ Then you need to set the error to `true` and add *at least* the `error.msg`, `er
     }
 ```
 
-**Note**: Any relevant error metadata explained in [the Trace View docs][4] can also be added.
-If the current span isn't the root span, mark it as an error by using the `dd-trace-api` library to grab the root span with `MutableSpan` and use `setError(true)` (See [source code][5]).
+**Note**: Any relevant error metadata explained in the [Trace View docs][4] can also be added.
+If the current span isn't the root span, mark it as an error by using the `dd-trace-api` library to grab the root span with `MutableSpan`, then use `setError(true)`. See the [source code][5] for more details.
 
 [1]: https://github.com/opentracing/opentracing-java
 [2]: /tracing/visualization/#trace

--- a/content/en/tracing/advanced/opentracing.md
+++ b/content/en/tracing/advanced/opentracing.md
@@ -257,9 +257,7 @@ Then you need to set the error to `true` and add *at least* the `error.msg`, `er
     final Span span = GlobalTracer.get().activeSpan();
     if (span != null) {
       Tags.ERROR.set(span, true);
-      span.setTag("error.msg", "<ERROR_MESSAGE>");
-      span.setTag("error.type", "<EXCEPTION_NAME>");
-      span.setTag("error.stack", "<ERROR_STACK>");
+      span.log(Collections.singletonMap(Fields.ERROR_OBJECT, ex));
     }
 ```
 


### PR DESCRIPTION
### What does this PR do?

Adds info on how to set a span as error with opentracing in java

### Motivation

Support feedback

### Preview link

* https://docs-staging.datadoghq.com/gus/errors-opentracing-faq/tracing/advanced/opentracing/?tab=java#set-errors