### PR TITLE
Update GCP log instruction for HIPAA users

### DIFF
--- a/content/en/security/logs.md
+++ b/content/en/security/logs.md
@@ -33,7 +33,7 @@ Prior to executing a BAA, customers transmitting ePHI to the Datadog Log Managem
 
 * The Datadog Agent must be configured to submit logs to `tcp-encrypted-intake.logs.datadoghq.com`
 * The Datadog [log collection AWS Lambda function][5] must be configured to submit logs to `lambda-tcp-encrypted-intake.logs.datadoghq.com` by setting the `DD_URL` environment variable as well as setting `DD_USE_TCP` to `true`
-* The [GCP push forwarder][] must be configured to submit logs to `gcp-encrypted-intake.logs.datadoghq.com`
+* The [GCP push forwarder][7] must be configured to submit logs to `gcp-encrypted-intake.logs.datadoghq.com`
 * Other log sources besides the Datadog Agent must be configured to submit logs to `http-encrypted-intake.logs.datadoghq.com`
 
 The following sample configuration can be used with the Datadog Agent to submit logs to a HIPAA-ready endpoint directly (i.e. without a proxy):

--- a/content/en/security/logs.md
+++ b/content/en/security/logs.md
@@ -32,7 +32,8 @@ Datadog will sign a Business Associate Agreement (BAA) with customers that trans
 Prior to executing a BAA, customers transmitting ePHI to the Datadog Log Management Service must implement the following configurations:
 
 * The Datadog Agent must be configured to submit logs to `tcp-encrypted-intake.logs.datadoghq.com`
-* The Datadog [log collection AWS Lambda function][5] must be configured to submit logs to `lambda-tcp-encrypted-intake.logs.datadoghq.com` by setting the `DD_URL` environment variable as well as setting `DD_USE_TCP` to `true`.
+* The Datadog [log collection AWS Lambda function][5] must be configured to submit logs to `lambda-tcp-encrypted-intake.logs.datadoghq.com` by setting the `DD_URL` environment variable as well as setting `DD_USE_TCP` to `true`
+* The [GCP push forwarder][] must be configured to submit logs to `gcp-encrypted-intake.logs.datadoghq.com`
 * Other log sources besides the Datadog Agent must be configured to submit logs to `http-encrypted-intake.logs.datadoghq.com`
 
 The following sample configuration can be used with the Datadog Agent to submit logs to a HIPAA-ready endpoint directly (i.e. without a proxy):
@@ -66,3 +67,4 @@ If you have any questions about how the Log Management Service satisfies the app
 [4]: /agent/logs/advanced_log_collection/#scrub-sensitive-data-from-your-logs
 [5]: /integrations/amazon_lambda/#log-collection
 [6]: /logs/explorer/#share-views
+[7]: https://docs.datadoghq.com/integrations/google_cloud_platform/?tab=datadogussite#log-collection


### PR DESCRIPTION
### What does this PR do?
Update the endpoint to submit GCP log for HIPAA customers

### Motivation
We needed a specific endpoint for GCP logs

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/gcp-hipaa-log-instructions/security/logs/#configuration-requirements-for-hipaa-enabled-customers

### Additional Notes
<!-- Anything else we should know when reviewing?-->
