### PR TITLE
removing API argument that is not available

### DIFF
--- a/content/en/api/service_level_objectives/service_level_objectives_create.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_create.md
@@ -46,9 +46,6 @@ For more information, see [Monitor SLOs][1].
 * **`monitor_ids`** [*required*, *default* = **empty list**]:
     Specify up to 20 monitor IDs directly for a monitor-based SLO. You can optionally on-create-dynamically select
     monitor IDs using the following option instead:
-* **`monitor_search`** [*optional*]:
-    Optional way to specify monitor IDs on create is to use a monitor search. On first create or edit, it will dynamically
-    search for the provided parameters and select up to the first 50 monitors matching the query.
 * **`groups`** [*optional*, *default* = **empty list**]:
     **Note: Only valid on single monitor SLOs** Specify the selected groups as a sub query of the selected monitor.
 

--- a/content/en/api/service_level_objectives/service_level_objectives_edit.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_edit.md
@@ -35,9 +35,6 @@ For more information, see [Monitor SLOs][1].
 * **`monitor_ids`** [*required*, *default* = **empty list**]:
     Specify up to 20 monitor IDs directly for a monitor-based SLO. You can optionally on-create-dynamically select
     monitor IDs using the following option instead:
-* **`monitor_search`** [*optional*]:
-    Optional way to specify monitor IDs on create is to use a monitor search. On first create or edit, it will dynamically
-    search for the provided parameters and select up to the first 50 monitors matching the query.
 * **`groups`** [*optional*, *default* = **empty list**]:
     **Note: Only valid on single monitor SLOs** Specify the selected groups as a sub query of the selected monitor.
 

--- a/content/en/api/service_level_objectives/service_level_objectives_edit.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_edit.md
@@ -32,6 +32,7 @@ external_redirect: /api/#edit-a-service-level-objective
 ## Monitor Based SLO
 
 For more information, see [Monitor SLOs][1].
+
 * **`monitor_ids`** [*required*, *default* = **empty list**]:
     Specify up to 20 monitor IDs directly for a monitor-based SLO. You can optionally on-create-dynamically select
     monitor IDs using the following option instead:


### PR DESCRIPTION
### What does this PR do?
Removes an argument that is not yet available from the API docs for SLO create and edit calls.

### Motivation
PM Requested

### Preview link
https://docs-staging.datadoghq.com/storms/remove_monitor_search_arg_from_api/api/?lang=python#create-a-service-level-objective