### PR TITLE
updated ja banner messaging with additional breaking point

### DIFF
--- a/config/_default/params.ja.yaml
+++ b/config/_default/params.ja.yaml
@@ -4,7 +4,7 @@ meta_title: Datadogを始めてみましょう
 meta_description: Datadogが大規模なクラウドのモニタリングサービスをリードします。
 disclaimer: このページは英語では対応しておりません。随時翻訳に取り組んでいます。翻訳に関してご質問やご意見ございましたら、お気軽にご連絡ください。
 announcement_banner:
-  desktop_message: Dash イベントで発表された新しいサーバーレス、ネットワーク、RUM などの機能をぜひご確認ください！
-  mobile_message: Dash イベントで発表された新機能！
-  link: 'https://www.datadoghq.com/blog/dash-2019-new-feature-roundup/'
+  desktop_message: "<span class='d-inline'>日本初となるDatadog Summit を11月13日水曜日に東京 明治記念館にて開催いたします。</span><span class='d-none d-lg-inline'>是非ご参加ください！</span>"
+  mobile_message: Datadog Summit Tokyo 開催！
+  link: 'https://www.datadoghq.com/summit/tokyo19/'
   exclude: []


### PR DESCRIPTION
### What does this PR do?
— updating `/ja` page banner messaging + link

### Motivation
— requested by Ilan + Hideki

### Preview link
https://docs-staging.datadoghq.com/won/201911-ja-banner-update/ja/

### Additional Notes
additional media query break was added by using `<span class="...">` with helper classes for this banner messaging — this can be removed for next banner messaging
