### PR TITLE
[MONA-574] Fix SLO History curl command.

### DIFF
--- a/content/en/api/service_level_objectives/code_snippets/api-slo-history.sh
+++ b/content/en/api/service_level_objectives/code_snippets/api-slo-history.sh
@@ -12,4 +12,4 @@ from_ts=<from epoch timestamp>
 curl -X GET \
 -H "DD-API-KEY: ${api_key}" \
 -H "DD-APPLICATION-KEY: ${app_key}" \
-"https://api.datadoghq.com/api/v1/slo/${slo_id}?from_ts=${from_ts}&to_ts={$to_ts}"
+"https://api.datadoghq.com/api/v1/slo/${slo_id}/history?from_ts=${from_ts}&to_ts={$to_ts}"


### PR DESCRIPTION
### What does this PR do?
Updates the curl command to use `v1/slo/{slo_id}/history?`.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/armcburney/fix_slo_history_curl_command/api

### Additional Notes
@DataDog/monitor-app 
