### PR TITLE
Edits to network page

### DIFF
--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -36,7 +36,7 @@ The following provisioning systems are supported:
 
 * Daemonset / Helm: See the [Datadog Helm chart][1]
 * Chef: See the [Datadog Chef recipe][2]
-* Ansible
+* Ansible: See the [Datadog Ansible role][5]
 
 ## Setup
 
@@ -88,40 +88,35 @@ To enable network performance monitoring with the Datadog Agent, use the followi
 To enable network performance monitoring with Kubernetes, use the following configuration:
 
 ```yaml
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: datadog-agent
   namespace: default
 spec:
-  selector:
-    matchLabels:
-      app: datadog-agent
   template:
     metadata:
       labels:
         app: datadog-agent
       name: datadog-agent
       annotations:
-        container.apparmor.security.beta.kubernetes.io/datadog-agent: unconfined
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
     spec:
       serviceAccountName: datadog-agent
       containers:
-      - image: datadog/agent:latest
+      - image: datadog/agent:6.12.0
         imagePullPolicy: Always
         name: datadog-agent
-        securityContext:
-          capabilities:
-            add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN"]
         ports:
           - {containerPort: 8125, name: dogstatsdport, protocol: UDP}
           - {containerPort: 8126, name: traceport, protocol: TCP}
         env:
-          - {name: DD_API_KEY, value: <DATADOG_API_KEY>}
+          - {name: DD_API_KEY, value: <YOUR_API_KEY>}
           - {name: KUBERNETES, value: "true"}
           - {name: DD_HEALTH_PORT, value: "5555"}
           - {name: DD_PROCESS_AGENT_ENABLED, value: "true"}
           - {name: DD_SYSTEM_PROBE_ENABLED, value: "true"}
+          - {name: DD_SYSTEM_PROBE_EXTERNAL, value: "true"}
           - {name: DD_SYSPROBE_SOCKET, value: "/var/run/s6/sysprobe.sock"}
           - name: DD_KUBERNETES_KUBELET_HOST
             valueFrom:
@@ -149,6 +144,29 @@ spec:
           timeoutSeconds: 5
           successThreshold: 1
           failureThreshold: 3
+      - name: system-probe
+        image: datadog/agent:6.12.0
+        imagePullPolicy: Always
+        securityContext:
+          capabilities:
+            add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN"]
+        command:
+          - /opt/datadog-agent/embedded/bin/system-probe
+        env:
+          - {name: DD_SYSTEM_PROBE_ENABLED, value: "true"}
+          - {name: DD_SYSPROBE_SOCKET, value: "/var/run/s6/sysprobe.sock"}
+        resources:
+          requests:
+            memory: "150Mi"
+            cpu: "200m"
+          limits:
+            memory: "150Mi"
+            cpu: "200m"
+        volumeMounts:
+          - {name: procdir, mountPath: /host/proc, readOnly: true}
+          - {name: cgroups, mountPath: /host/sys/fs/cgroup, readOnly: true}
+          - {name: debugfs, mountPath: /sys/kernel/debug}
+          - {name: s6-run, mountPath: /var/run/s6}
       volumes:
         - {name: dockersocket, hostPath: {path: /var/run/docker.sock}}
         - {name: procdir, hostPath: {path: /proc}}
@@ -195,3 +213,4 @@ Replace `<DATADOG_API_KEY>` with your [Datadog API key][1].
 [2]: https://github.com/DataDog/chef-datadog
 [3]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
 [4]: https://www.redhat.com/en/blog/introduction-ebpf-red-hat-enterprise-linux-7
+[5]: https://github.com/DataDog/ansible-datadog/blob/master/README.md#system-probe 


### PR DESCRIPTION
### What does this PR do?
1. Update Kubernetes config to encourage customers to use two containers
2. Add Ansible role for Ansible support

### Motivation
For 1 - Customers are currently installing the system probe on one container and we want to update this behavior
For 2 - This is to provide support docs for Ansible (we already have this for Helm and Chef)

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/shlomoartzi/documentation/documentation/content/en/network_performance_monitoring/installation.md
