### PR TITLE
add a note about upgrading the agent on a domain controller

### DIFF
--- a/content/en/agent/faq/windows-agent-ddagent-user.md
+++ b/content/en/agent/faq/windows-agent-ddagent-user.md
@@ -36,6 +36,12 @@ For installs on a domain controller, the `<USERNAME>` and `<PASSWORD>` supplied 
 
 **Note**: These options are honored even in a non-domain environment, if the user wishes to supply a username/password to use rather than have the installer generate one.
 
+**Note**: When upgrading the Datadog Agent on a Domain Controller (or on any host where the user has supplied a username for the Agent), you need to supply the DDAGENTUSER_NAME (but not the DDAGENTUSER_PASSWORD):
+
+```shell
+  Msiexec /i ddagent.msi DDAGENTUSER_NAME=<DOMAIN>\<USERNAME>
+```
+
 ### Installation with Chef
 
 If you use Chef and the official `datadog` cookbook to deploy the Agent on Windows hosts, **use version 2.18.0 or above** of the cookbook to ensure that the Agent’s configuration files have the correct permissions

--- a/content/en/agent/faq/windows-agent-ddagent-user.md
+++ b/content/en/agent/faq/windows-agent-ddagent-user.md
@@ -36,10 +36,10 @@ For installs on a domain controller, the `<USERNAME>` and `<PASSWORD>` supplied 
 
 **Note**: These options are honored even in a non-domain environment, if the user wishes to supply a username/password to use rather than have the installer generate one.
 
-**Note**: When upgrading the Datadog Agent on a Domain Controller (or on any host where the user has supplied a username for the Agent), you need to supply the DDAGENTUSER_NAME (but not the DDAGENTUSER_PASSWORD):
+**Note**: When upgrading the Datadog Agent on a domain controller or host where the user has supplied a username for the Agent, you need to supply the `<DDAGENTUSER_NAME>` but not the `<DDAGENTUSER_PASSWORD>`:
 
 ```shell
-  Msiexec /i ddagent.msi DDAGENTUSER_NAME=<DOMAIN>\<USERNAME>
+  Msiexec /i ddagent.msi <DDAGENTUSER_NAME>=<DOMAIN>\<USERNAME>
 ```
 
 ### Installation with Chef


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
A small update for users who will upgrade the Datadog Agent on Domain controller. The process is a bit different than the initial install, and it's different than installing the Agent on a regular host (a host that's not a domain controller).

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
https://docs-staging.datadoghq.com/dave/win_dc/agent/faq/windows-agent-ddagent-user/#installation-in-a-domain-environment

### Additional Notes
<!-- Anything else we should know when reviewing?-->
