### PR TITLE
fixed Basic Agent Usage typo

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -26,7 +26,7 @@ further_reading:
 
 Agent v6 is a complete rewrite in Go of the Agent v5. V6 offers better performances, smaller footprint, and more features. It is the default Datadog Agent (v5 is no longer in active development).
 
-Agent v6 is a composed of a main process responsible for collecting infrastructure metrics, logs, and receiving [DogStatsD metrics][1]. The main components to this process are:
+Agent v6 is composed of a main process responsible for collecting infrastructure metrics, logs, and receiving [DogStatsD metrics][1]. The main components to this process are:
 
 * The Collector is in charge of running checks and collecting metrics.
 * The Forwarder sends payloads to Datadog.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fix typo on https://docs.datadoghq.com/agent/basic_agent_usage/?tab=agentv6
Instead of "Agent v6 is a composed of", changed to "Agent v6 is composed of".

### Motivation
I'm learning more about the architecture and design of the agent, and noticed the typo during my research reading.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/tina.wu/typo-in-basic-agent-usage/agent/basic_agent_usage/?tab=agentv6
### Additional Notes
<!-- Anything else we should know when reviewing?-->
