### PR TITLE
[Agent] Update custom check imports

### DIFF
--- a/content/en/developers/write_agent_check.md
+++ b/content/en/developers/write_agent_check.md
@@ -40,11 +40,11 @@ The check itself inherits from `AgentCheck` and sends a gauge of `1` for `hello.
 {{< code-block lang="python" filename="hello.py" >}}
 # the following try/except block will make the custom check compatible with any Agent version
 try:
-    # first, try to import the base class from old versions of the Agent...
-    from checks import AgentCheck
+    # first, try to import the base class from new versions of the Agent...
+    from datadog_checks.base.checks import AgentCheck
 except ImportError:
-    # ...if the above failed, the check is running in Agent version 6 or later
-    from datadog_checks.checks import AgentCheck
+    # ...if the above failed, the check is running in Agent version < 6.6.0
+    from checks import AgentCheck
 
 # content of the special variable __version__ will be shown in the Agent status page
 __version__ = "1.0.0"

--- a/content/en/developers/write_agent_check.md
+++ b/content/en/developers/write_agent_check.md
@@ -41,7 +41,7 @@ The check itself inherits from `AgentCheck` and sends a gauge of `1` for `hello.
 # the following try/except block will make the custom check compatible with any Agent version
 try:
     # first, try to import the base class from new versions of the Agent...
-    from datadog_checks.base.checks import AgentCheck
+    from datadog_checks.base import AgentCheck
 except ImportError:
     # ...if the above failed, the check is running in Agent version < 6.6.0
     from checks import AgentCheck

--- a/content/fr/developers/write_agent_check.md
+++ b/content/fr/developers/write_agent_check.md
@@ -39,11 +39,11 @@ Le check hérite des valeurs de `AgentCheck` et envoie un gauge de valeur `1` po
 {{< code-block lang="python" filename="hello.py" >}}
 # le bloc try/except suivant rend le check custom compatible avec toutes les versions de l'Agent
 try:
-    # Premier essai d'importation de la classe de base à partir des anciennes versions de l'Agent…
-    from checks import AgentCheck
+    # Premier essai d'importation de la classe de base à partir des nouvelles versions de l'Agent…
+    from datadog_checks.base.checks import AgentCheck
 except ImportError:
-    # …si la commande ci-dessus a échoué, le check s'exécute dans l'Agent version 6 ou ultérieure
-    from datadog_checks.checks import AgentCheck
+    # …si la commande ci-dessus a échoué, le check s'exécute dans une version de l'Agent inférieure à 6.6.0
+    from checks import AgentCheck
 
 # Le contenu de la variable spéciale __version__ sera indiqué dans la page de statut de l'Agent
 __version__ = "1.0.0"

--- a/content/fr/developers/write_agent_check.md
+++ b/content/fr/developers/write_agent_check.md
@@ -40,7 +40,7 @@ Le check hérite des valeurs de `AgentCheck` et envoie un gauge de valeur `1` po
 # le bloc try/except suivant rend le check custom compatible avec toutes les versions de l'Agent
 try:
     # Premier essai d'importation de la classe de base à partir des nouvelles versions de l'Agent…
-    from datadog_checks.base.checks import AgentCheck
+    from datadog_checks.base import AgentCheck
 except ImportError:
     # …si la commande ci-dessus a échoué, le check s'exécute dans une version de l'Agent inférieure à 6.6.0
     from checks import AgentCheck

--- a/content/fr/developers/write_agent_check.md
+++ b/content/fr/developers/write_agent_check.md
@@ -39,11 +39,11 @@ Le check hérite des valeurs de `AgentCheck` et envoie un gauge de valeur `1` po
 {{< code-block lang="python" filename="hello.py" >}}
 # le bloc try/except suivant rend le check custom compatible avec toutes les versions de l'Agent
 try:
-    # Premier essai d'importation de la classe de base à partir des nouvelles versions de l'Agent…
-    from datadog_checks.base import AgentCheck
-except ImportError:
-    # …si la commande ci-dessus a échoué, le check s'exécute dans une version de l'Agent inférieure à 6.6.0
+    # Premier essai d'importation de la classe de base à partir des anciennes versions de l'Agent…
     from checks import AgentCheck
+except ImportError:
+    # …si la commande ci-dessus a échoué, le check s'exécute dans l'Agent version 6 ou ultérieure
+    from datadog_checks.checks import AgentCheck
 
 # Le contenu de la variable spéciale __version__ sera indiqué dans la page de statut de l'Agent
 __version__ = "1.0.0"


### PR DESCRIPTION

### What does this PR do?

Updates the custom check guide section on how to import the `AgentCheck` class: by default, the newer import path is used instead of the old one.

Moreover, the new import path, `datadog_checks.base` (introduced in 6.6.0), replaces the import path introduced in 6.0.0, `datadog_checks.checks`.

### Motivation

More up-to-date custom check writing instructions.

### Preview link

[Writing a custom Agent check, en](https://docs-staging.datadoghq.com/kylian.serrania/custom-check-import/developers/write_agent_check/?tab=agentv6)

### Additional Notes

The Japanese and French pages have not been modified.
