### PR TITLE
Updating link to point at Agent instructions

### DIFF
--- a/content/en/getting_started/tracing/distributed-tracing.md
+++ b/content/en/getting_started/tracing/distributed-tracing.md
@@ -184,7 +184,7 @@ The Datadog APM allows you to trace all interactions of a request with the diffe
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /tracing
-[2]: /tracing/setup
+[2]: /tracing/send_traces
 [3]: https://app.datadoghq.com/apm/home
 [4]: /tracing/visualization/services_list
 [5]: /tracing/visualization/service

--- a/content/en/tracing/app_analytics/agent_trace_search.md
+++ b/content/en/tracing/app_analytics/agent_trace_search.md
@@ -62,7 +62,7 @@ For example, if you have a Python service named `python-api`, and it's running F
 [1]: https://app.datadoghq.com/apm/services
 [2]: /tracing/app_analytics/#automatic-configuration
 [3]: /tracing/app_analytics/#custom-instrumentation
-[4]: /tracing/setup
+[4]: /tracing/send_traces
 [5]: https://app.datadoghq.com/apm/docs/trace-search
 [6]: /tracing/visualization/#services
 [7]: /tracing/visualization/#resources

--- a/content/en/tracing/setup/cpp.md
+++ b/content/en/tracing/setup/cpp.md
@@ -184,7 +184,7 @@ Configure your application level tracers to submit traces to a custom Agent host
 
 [1]: /tracing/setup/envoy
 [2]: /tracing/setup/nginx
-[3]: /tracing/setup
+[3]: /tracing/send_traces
 [4]: https://github.com/opentracing/opentracing-cpp
 [5]: https://github.com/opentracing/opentracing-cpp/#cc98
 [6]: /help

--- a/content/en/tracing/setup/dotnet.md
+++ b/content/en/tracing/setup/dotnet.md
@@ -278,10 +278,10 @@ ENV DD_DOTNET_TRACER_HOME=/opt/datadog
 
 The .NET Tracer supports automatic instrumentation on the following runtimes:
 
-| Runtime                | Versions | OS              |
-| ---------------------- | -------- | --------------- |
-| .NET Framework         | 4.5+     | Windows         |
-| .NET Core <sup>1</sup> | 2.0+     | Windows, Linux  |
+| Runtime                | Versions | OS             |
+|------------------------|----------|----------------|
+| .NET Framework         | 4.5+     | Windows        |
+| .NET Core <sup>1</sup> | 2.0+     | Windows, Linux |
 
 <sup>1</sup> There is an issue in .NET Core versions 2.1.0, 2.1.1, and 2.1.2 that can prevent profilers from working correctly. This issue is fixed in .NET Core 2.1.3. See [this GitHub issue][2] for more details.
 
@@ -291,20 +291,20 @@ Don’t see your desired frameworks? Datadog is continually adding additional su
 
 The .NET Tracer can instrument the following libraries automatically:
 
-| Framework or library            | NuGet package name                       | Package versions     | Integration Name     |
-| ------------------------------- | ---------------------------------------- | -------------------- | -------------------- |
-| ASP.NET MVC                     | `Microsoft.AspNet.Mvc`                   | 5.1.0+ and 4.0.40804 | `AspNetMvc`          |
-| ASP.NET Web API 2               | `Microsoft.AspNet.WebApi.Core`           | 5.2+                 | `AspNetWebApi2`      |
-| ASP.NET Core MVC                | `Microsoft.AspNetCore.Mvc.Core`          | 2.0+                 | `AspNetCoreMvc2`     |
-| ASP.NET Web Forms <sup>1</sup>  | built-in                                 |                      | `AspNet`             |
-| WCF                             | built-in                                 |                      | `Wcf`                |
-| ADO.NET <sup>2</sup>            | built-in                                 |                      | `AdoNet`             |
-| WebClient / WebRequest          | built-in                                 |                      | `WebRequest`         |
-| HttpClient / HttpClientHandler  | built-in or `System.Net.Http`            | 4.0+                 | `HttpMessageHandler` |
-| Redis (StackExchange client)    | `StackExchange.Redis`                    | 1.0.187+             | `StackExchangeRedis` |
-| Redis (ServiceStack client)     | `ServiceStack.Redis`                     | 4.0.48+              | `ServiceStackRedis`  |
-| Elasticsearch                   | `NEST` / `Elasticsearch.Net`             | 5.3.0+               | `ElasticsearchNet`   |
-| MongoDB                         | `MongoDB.Driver` / `MongoDB.Driver.Core` | 2.1.0+               | `MongoDb`            |
+| Framework or library           | NuGet package name                       | Package versions     | Integration Name     |
+|--------------------------------|------------------------------------------|----------------------|----------------------|
+| ASP.NET MVC                    | `Microsoft.AspNet.Mvc`                   | 5.1.0+ and 4.0.40804 | `AspNetMvc`          |
+| ASP.NET Web API 2              | `Microsoft.AspNet.WebApi.Core`           | 5.2+                 | `AspNetWebApi2`      |
+| ASP.NET Core MVC               | `Microsoft.AspNetCore.Mvc.Core`          | 2.0+                 | `AspNetCoreMvc2`     |
+| ASP.NET Web Forms <sup>1</sup> | built-in                                 |                      | `AspNet`             |
+| WCF                            | built-in                                 |                      | `Wcf`                |
+| ADO.NET <sup>2</sup>           | built-in                                 |                      | `AdoNet`             |
+| WebClient / WebRequest         | built-in                                 |                      | `WebRequest`         |
+| HttpClient / HttpClientHandler | built-in or `System.Net.Http`            | 4.0+                 | `HttpMessageHandler` |
+| Redis (StackExchange client)   | `StackExchange.Redis`                    | 1.0.187+             | `StackExchangeRedis` |
+| Redis (ServiceStack client)    | `ServiceStack.Redis`                     | 4.0.48+              | `ServiceStackRedis`  |
+| Elasticsearch                  | `NEST` / `Elasticsearch.Net`             | 5.3.0+               | `ElasticsearchNet`   |
+| MongoDB                        | `MongoDB.Driver` / `MongoDB.Driver.Core` | 2.1.0+               | `MongoDb`            |
 
 Notes:
 
@@ -325,7 +325,7 @@ For more details on manual instrumentation and custom tagging, see [Manual instr
 Manual instrumentation is supported on .NET Framework 4.5+ on Windows and on any platform that implements .NET Standard 2.0 or above:
 
 | Runtime        | Versions | OS                    |
-| -------------- | -------- | --------------------- |
+|----------------|----------|-----------------------|
 | .NET Framework | 4.5+     | Windows               |
 | .NET Core      | 2.0+     | Windows, Linux, macOS |
 | Mono           | 5.4+     | Windows, Linux, macOS |
@@ -437,39 +437,39 @@ The following tables list the supported configuration variables. In each table, 
 
 The first table below lists configuration variables that are available for both automatic and manual instrumentation.
 
-Setting Name          | Property Name          | Description                                                                                                                                                                                                       |
---------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-`DD_TRACE_AGENT_URL`  | `AgentUri`             | Sets the URL endpoint where traces are sent. Overrides `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` if set. Default value is `http://<DD_AGENT_HOST>:<DD_TRACE_AGENT_PORT>`.                                         |
-`DD_AGENT_HOST`       | N/A                    | Sets the host where traces are sent (the host running the Agent). Can be a hostname or an IP address. Ignored if `DD_TRACE_AGENT_URL` is set. Default is value `localhost`.                                       |
-`DD_TRACE_AGENT_PORT` | N/A                    | Sets the port where traces are sent (the port where the Agent is listening for connections). Ignored if `DD_TRACE_AGENT_URL` is set. Default value is `8126`.                                                     |
-`DD_ENV`              | `Environment`          | If specified, adds the `env` tag with the specified value to all generated spans. See [Agent configuration][8] for more details about the `env` tag.                                                              |
-`DD_SERVICE_NAME`     | `ServiceName`          | If specified, sets the default service name. Otherwise, the .NET Tracer tries to determine service name automatically from application name (e.g. IIS application name, process entry assembly, or process name). |
-`DD_LOGS_INJECTION`   | `LogsInjectionEnabled` | Enables or disables automatic injection of correlation identifiers into application logs.                                                                                                                         |
-`DD_TRACE_GLOBAL_FLAGS` | `GlobalTags` | If specified, adds all of the specified tags to all generated spans.  |
+| Setting Name            | Property Name          | Description                                                                                                                                                                                                       |
+|-------------------------|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DD_TRACE_AGENT_URL`    | `AgentUri`             | Sets the URL endpoint where traces are sent. Overrides `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` if set. Default value is `http://<DD_AGENT_HOST>:<DD_TRACE_AGENT_PORT>`.                                         |
+| `DD_AGENT_HOST`         | N/A                    | Sets the host where traces are sent (the host running the Agent). Can be a hostname or an IP address. Ignored if `DD_TRACE_AGENT_URL` is set. Default is value `localhost`.                                       |
+| `DD_TRACE_AGENT_PORT`   | N/A                    | Sets the port where traces are sent (the port where the Agent is listening for connections). Ignored if `DD_TRACE_AGENT_URL` is set. Default value is `8126`.                                                     |
+| `DD_ENV`                | `Environment`          | If specified, adds the `env` tag with the specified value to all generated spans. See [Agent configuration][8] for more details about the `env` tag.                                                              |
+| `DD_SERVICE_NAME`       | `ServiceName`          | If specified, sets the default service name. Otherwise, the .NET Tracer tries to determine service name automatically from application name (e.g. IIS application name, process entry assembly, or process name). |
+| `DD_LOGS_INJECTION`     | `LogsInjectionEnabled` | Enables or disables automatic injection of correlation identifiers into application logs.                                                                                                                         |
+| `DD_TRACE_GLOBAL_FLAGS` | `GlobalTags`           | If specified, adds all of the specified tags to all generated spans.                                                                                                                                              |
 
 The following table lists configuration variables that are available only when using automatic instrumentation.
 
-Setting Name                 | Property Name              | Description                                                                                                                                                                                                                                                                                  |
------------------------------| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-`DD_TRACE_ENABLED`           | `TraceEnabled`             | Enables or disables all automatic instrumentation. Setting the environment variable to `false` completely disables the CLR profiler. For other configuration methods, the CLR profiler is still loaded, but traces will not be generated. Valid values are: `true` (default) or `false`.     |
-`DD_TRACE_DEBUG`             | N/A                        | Enables or disables the CLR profiler's debug mode. Valid values are: `true` or `false` (default).                                                                                                                                                                                            |
-`DD_TRACE_LOG_PATH`          | N/A                        | Sets the path for the CLR profiler's log file.<br/><br/>Windows default: `%ProgramData%\Datadog .NET Tracer\logs\dotnet-profiler.log`<br/><br/>Linux default: `/var/log/datadog/dotnet-profiler.log`                                                                                         |
-`DD_DISABLED_INTEGRATIONS`   | `DisabledIntegrationNames` | Sets a list of integrations to disable. All other integrations remain enabled. If not set, all integrations are enabled. Supports multiple values separated with semicolons. Valid values are the integration names listed in the [Integrations][9] section above.                           |
-`DD_TRACE_ANALYTICS_ENABLED` | `AnalyticsEnabled`         | Shorthand that enables default App Analytics settings for web framework integrations. Valid values are: `true` or `false` (default).                                                                                                                                            |
+| Setting Name                 | Property Name              | Description                                                                                                                                                                                                                                                                              |
+|------------------------------|----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DD_TRACE_ENABLED`           | `TraceEnabled`             | Enables or disables all automatic instrumentation. Setting the environment variable to `false` completely disables the CLR profiler. For other configuration methods, the CLR profiler is still loaded, but traces will not be generated. Valid values are: `true` (default) or `false`. |
+| `DD_TRACE_DEBUG`             | N/A                        | Enables or disables the CLR profiler's debug mode. Valid values are: `true` or `false` (default).                                                                                                                                                                                        |
+| `DD_TRACE_LOG_PATH`          | N/A                        | Sets the path for the CLR profiler's log file.<br/><br/>Windows default: `%ProgramData%\Datadog .NET Tracer\logs\dotnet-profiler.log`<br/><br/>Linux default: `/var/log/datadog/dotnet-profiler.log`                                                                                     |
+| `DD_DISABLED_INTEGRATIONS`   | `DisabledIntegrationNames` | Sets a list of integrations to disable. All other integrations remain enabled. If not set, all integrations are enabled. Supports multiple values separated with semicolons. Valid values are the integration names listed in the [Integrations][9] section above.                       |
+| `DD_TRACE_ANALYTICS_ENABLED` | `AnalyticsEnabled`         | Shorthand that enables default App Analytics settings for web framework integrations. Valid values are: `true` or `false` (default).                                                                                                                                                     |
 
 The following table lists configuration variables that are available only when using automatic instrumentation and can be set for each integration. The first column, _Setting Name_, indicates the variable name used when using environment variables or configuration files. The second column, _Propery Name_, indicates the name of the equivalent propery on the `IntegrationSettings` class when changing settings in the code. Access these properties through the `TracerSettings.Integrations[string integrationName]` indexer. Integration names are listed in the [Integrations][9] section above.
 
-Setting Name                             | Property Name              | Description                                                                                                                        |
----------------------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-`DD_<INTEGRATION>_ENABLED`               | `Enabled`                  | Enables or disables a specific integration. Valid values are: `true` (default) or `false`.                                         |
-`DD_<INTEGRATION>_ANALYTICS_ENABLED`     | `AnalyticsEnabled`         | Enables or disable App Analytics for a specific integration. Valid values are: `true` or `false` (default).           |
-`DD_<INTEGRATION>_ANALYTICS_SAMPLE_RATE` | `AnalyticsSampleRate`      | Sets the App Analytics sampling rate for a specific integration. A floating number between `0.0` and `1.0` (default). |
+| Setting Name                             | Property Name         | Description                                                                                                           |
+|------------------------------------------|-----------------------|-----------------------------------------------------------------------------------------------------------------------|
+| `DD_<INTEGRATION>_ENABLED`               | `Enabled`             | Enables or disables a specific integration. Valid values are: `true` (default) or `false`.                            |
+| `DD_<INTEGRATION>_ANALYTICS_ENABLED`     | `AnalyticsEnabled`    | Enables or disable App Analytics for a specific integration. Valid values are: `true` or `false` (default).           |
+| `DD_<INTEGRATION>_ANALYTICS_SAMPLE_RATE` | `AnalyticsSampleRate` | Sets the App Analytics sampling rate for a specific integration. A floating number between `0.0` and `1.0` (default). |
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /agent/apm
+[1]: /tracing/send_traces
 [2]: https://github.com/dotnet/coreclr/issues/18448
 [3]: /help
 [4]: https://www.nuget.org/packages/Datadog.Trace.ClrProfiler.Managed

--- a/content/en/tracing/setup/go.md
+++ b/content/en/tracing/setup/go.md
@@ -57,42 +57,42 @@ To begin tracing your Go applications, your environment must first meet the foll
 
 Integrate the Go tracer with the following list of web frameworks using one of the following helper packages.
 
-| Framework        | Support Type    | GoDoc Datadog Documentation                                              |
-|------------------|-----------------|--------------------------------------------------------------------------|
-| [Gin][8]         | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/gin-gonic/gin][9]               |
+| Framework         | Support Type    | GoDoc Datadog Documentation                                              |
+|-------------------|-----------------|--------------------------------------------------------------------------|
+| [Gin][8]          | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/gin-gonic/gin][9]               |
 | [Gorilla Mux][10] | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/gorilla/mux][11]                |
-| [gRPC][12]       | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc][13]     |
-| [gRPC v1.2][14]  | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc.v12][15] |
+| [gRPC][12]        | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc][13]     |
+| [gRPC v1.2][14]   | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc.v12][15] |
 
 #### Library Compatibility
 
 The Go tracer includes support for the following data stores and libraries.
 
-| Library                 | Support Type        | Examples and Documentation                                                        |
-|-------------------------|---------------------|-----------------------------------------------------------------------------------|
-| [AWS SDK][16]           | Fully Supported     | [gopkg.in/DataDog/dd-trace-go.v1/contrib/aws/aws-sdk-go/aws][17]                  |
-| [Elasticsearch][18]     | Fully Supported     | [gopkg.in/DataDog/dd-trace-go.v1/contrib/olivere/elastic][19]                     |
-| [Cassandra][20]         | Fully Supported     | [gopkg.in/DataDog/dd-trace-go.v1/contrib/gocql/gocql][21]                         |
-| [GraphQL][22]           | Fully Supported     | [gopkg.in/DataDog/dd-trace-go.v1/contrib/graph-gophers/graphql-go][23]            |
-| [HTTP][24]              | Fully Supported     | [gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http][25]                            |
-| [HTTP router][26]       | Fully Supported     | [gopkg.in/DataDog/dd-trace-go.v1/contrib/julienschmidt/httprouter][27]            |
-| [Redis (go-redis)][28]  | Fully Supported     | [gopkg.in/DataDog/dd-trace-go.v1/contrib/go-redis/redis][29]                      |
-| [Redis (redigo)][30]    | Fully Supported     | [gopkg.in/DataDog/dd-trace-go.v1/contrib/garyburd/redigo][31]                     |
-| [SQL][32]               | Fully Supported     | [gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql][33]                        |
-| [SQLx][34]              | Fully Supported     | [gopkg.in/DataDog/dd-trace-go.v1/contrib/jmoiron/sqlx][35]                        |
-| [MongoDB][36]           | Fully Supported     | [gopkg.in/DataDog/dd-trace-go.v1/contrib/go.mongodb.org/mongo-driver/mongo][38]   |
-| [BuntDB][39]            | Fully Supported     | [gopkg.in/DataDog/dd-trace-go.v1/contrib/tidwall/buntdb][40]                      |
-| [LevelDB][41]           | Fully Supported     | [gopkg.in/DataDog/dd-trace-go.v1/contrib/syndtr/goleveldb/leveldb][42]            |
-| [miekg/dns][43]         | Fully Supported     | [gopkg.in/DataDog/dd-trace-go.v1/contrib/miekg/dns][44]                           |
-| [Kafka (confluent)][45] | Fully Supported     | [gopkg.in/DataDog/dd-trace-go.v1/contrib/confluentinc/confluent-kafka-go][46]     |
-| [Kafka (sarama)][47]    | Fully Supported     | [gopkg.in/DataDog/dd-trace-go.v1/contrib/Shopify/sarama][48]                      |
-| [Google API][49]        | Fully Supported     | [gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/api][50]               |
-| [go-restful][51]        | Fully Supported     | [gopkg.in/DataDog/dd-trace-go.v1/contrib/emicklei/go-restful][52]                 |
-| [Twirp][53]        | Fully Supported     | [gopkg.in/DataDog/dd-trace-go.v1/contrib/twitchtv/twirp][54]                 |
-| [Vault][55]        | Fully Supported     | [gopkg.in/DataDog/dd-trace-go.v1/contrib/hashicorp/vault][56]                 |
+| Library                 | Support Type    | Examples and Documentation                                                      |
+|-------------------------|-----------------|---------------------------------------------------------------------------------|
+| [AWS SDK][16]           | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/aws/aws-sdk-go/aws][17]                |
+| [Elasticsearch][18]     | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/olivere/elastic][19]                   |
+| [Cassandra][20]         | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/gocql/gocql][21]                       |
+| [GraphQL][22]           | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/graph-gophers/graphql-go][23]          |
+| [HTTP][24]              | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http][25]                          |
+| [HTTP router][26]       | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/julienschmidt/httprouter][27]          |
+| [Redis (go-redis)][28]  | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/go-redis/redis][29]                    |
+| [Redis (redigo)][30]    | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/garyburd/redigo][31]                   |
+| [SQL][32]               | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql][33]                      |
+| [SQLx][34]              | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/jmoiron/sqlx][35]                      |
+| [MongoDB][36]           | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/go.mongodb.org/mongo-driver/mongo][37] |
+| [BuntDB][38]            | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/tidwall/buntdb][39]                    |
+| [LevelDB][40]           | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/syndtr/goleveldb/leveldb][41]          |
+| [miekg/dns][42]         | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/miekg/dns][43]                         |
+| [Kafka (confluent)][44] | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/confluentinc/confluent-kafka-go][45]   |
+| [Kafka (sarama)][46]    | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/Shopify/sarama][47]                    |
+| [Google API][48]        | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/api][49]             |
+| [go-restful][50]        | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/emicklei/go-restful][51]               |
+| [Twirp][52]             | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/twitchtv/twirp][53]                    |
+| [Vault][54]             | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/hashicorp/vault][55]                   |
 
 
-**Note**: The [integrations documentation][57] provides a detailed overview of the supported packages and their APIs, along with usage examples.
+**Note**: The [integrations documentation][56] provides a detailed overview of the supported packages and their APIs, along with usage examples.
 
 Packages must be imported, i.e.:
 
@@ -137,7 +137,7 @@ func main() {
 }
 ```
 
-For more tracer settings, see available options in the [configuration documentation][58].
+For more tracer settings, see available options in the [configuration documentation][57].
 
 ## Change Agent Hostname
 
@@ -174,7 +174,7 @@ func main() {
 [2]: /tracing/visualization
 [3]: https://github.com/DataDog/dd-trace-go/tree/v1#contributing
 [4]: https://github.com/DataDog/dd-trace-go/tree/v1/MIGRATING.md
-[5]: /tracing/setup
+[5]: /tracing/send_traces
 [6]: /tracing/setup/docker
 [7]: /agent/kubernetes/daemonset_setup/#trace-collection
 [8]: https://gin-gonic.com
@@ -206,25 +206,24 @@ func main() {
 [34]: https://github.com/jmoiron/sqlx
 [35]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/jmoiron/sqlx
 [36]: https://github.com/mongodb/mongo-go-driver
-[37]: https://github.com/mongodb/mongo-go-driver/releases/tag/v0.2.0
-[38]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/go.mongodb.org/mongo-driver/mongo
-[39]: https://github.com/tidwall/buntdb
-[40]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/tidwall/buntdb
-[41]: https://github.com/syndtr/goleveldb
-[42]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/syndtr/goleveldb/leveldb
-[43]: https://github.com/miekg/dns
-[44]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/miekg/dns
-[45]: https://github.com/confluentinc/confluent-kafka-go
-[46]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/confluentinc/confluent-kafka-go
-[47]: https://github.com/Shopify/sarama
-[48]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/Shopify/sarama
-[49]: https://github.com/googleapis/google-api-go-client
-[50]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/api
-[51]: https://github.com/emicklei/go-restful
-[52]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/emicklei/go-restful
-[53]: https://github.com/twitchtv/twirp
-[54]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/twitchtv/twirp
-[55]: https://github.com/hashicorp/vault
-[56]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/hashicorp/vault
-[57]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib
-[58]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#StartOption
+[37]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/go.mongodb.org/mongo-driver/mongo
+[38]: https://github.com/tidwall/buntdb
+[39]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/tidwall/buntdb
+[40]: https://github.com/syndtr/goleveldb
+[41]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/syndtr/goleveldb/leveldb
+[42]: https://github.com/miekg/dns
+[43]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/miekg/dns
+[44]: https://github.com/confluentinc/confluent-kafka-go
+[45]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/confluentinc/confluent-kafka-go
+[46]: https://github.com/Shopify/sarama
+[47]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/Shopify/sarama
+[48]: https://github.com/googleapis/google-api-go-client
+[49]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/api
+[50]: https://github.com/emicklei/go-restful
+[51]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/emicklei/go-restful
+[52]: https://github.com/twitchtv/twirp
+[53]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/twitchtv/twirp
+[54]: https://github.com/hashicorp/vault
+[55]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/hashicorp/vault
+[56]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib
+[57]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#StartOption

--- a/content/en/tracing/setup/nodejs.md
+++ b/content/en/tracing/setup/nodejs.md
@@ -126,46 +126,46 @@ For details about how to how to toggle and configure plugins, check out the [API
 | Module                 | Versions | Support Type    | Notes                                            |
 |------------------------|----------|-----------------|--------------------------------------------------|
 | [cassandra-driver][24] | `>=3`    | Fully Supported |                                                  |
-| [couchbase][49]        | `^2.4.2` | Fully Supported |                                                  |
-| [elasticsearch][25]    | `>=10`   | Fully Supported | Supports `@elastic/elasticsearch` versions `>=5` |
-| [ioredis][26]          | `>=2`    | Fully Supported |                                                  |
-| [knex][27]             | `>=0.8`  | Fully Supported | This integration is only for context propagation |
-| [memcached][28]        | `>=2.2`  | Fully Supported |                                                  |
-| [mongodb-core][29]     | `>=2`    | Fully Supported | Supports Mongoose                                |
-| [mysql][30]            | `>=2`    | Fully Supported |                                                  |
-| [mysql2][31]           | `>=1`    | Fully Supported |                                                  |
-| [pg][32]               | `>=4`    | Fully Supported | Supports `pg-native` when used with `pg`         |
-| [redis][33]            | `>=0.12` | Fully Supported |                                                  |
-| [tedious][34]          | `>=1`    | Fully Supported | SQL Server driver for `mssql` and `sequelize`    |
+| [couchbase][25]        | `^2.4.2` | Fully Supported |                                                  |
+| [elasticsearch][26]    | `>=10`   | Fully Supported | Supports `@elastic/elasticsearch` versions `>=5` |
+| [ioredis][27]          | `>=2`    | Fully Supported |                                                  |
+| [knex][28]             | `>=0.8`  | Fully Supported | This integration is only for context propagation |
+| [memcached][29]        | `>=2.2`  | Fully Supported |                                                  |
+| [mongodb-core][30]     | `>=2`    | Fully Supported | Supports Mongoose                                |
+| [mysql][31]            | `>=2`    | Fully Supported |                                                  |
+| [mysql2][32]           | `>=1`    | Fully Supported |                                                  |
+| [pg][33]               | `>=4`    | Fully Supported | Supports `pg-native` when used with `pg`         |
+| [redis][34]            | `>=0.12` | Fully Supported |                                                  |
+| [tedious][35]          | `>=1`    | Fully Supported | SQL Server driver for `mssql` and `sequelize`    |
 
 #### Worker Compatibility
 
 | Module             | Versions | Support Type    | Notes                                                  |
 |--------------------|----------|-----------------|--------------------------------------------------------|
-| [amqp10][35]       | `>=3`    | Fully Supported | Supports AMQP 1.0 brokers (i.e. ActiveMQ, Apache Qpid) |
-| [amqplib][36]      | `>=0.5`  | Fully Supported | Supports AMQP 0.9 brokers (i.e. RabbitMQ, Apache Qpid) |
-| [generic-pool][37] | `>=2`    | Fully Supported |                                                        |
-| [kafka-node][38]   |          | Coming Soon     |                                                        |
-| [rhea][39]         |          | Coming Soon     |                                                        |
+| [amqp10][36]       | `>=3`    | Fully Supported | Supports AMQP 1.0 brokers (i.e. ActiveMQ, Apache Qpid) |
+| [amqplib][37]      | `>=0.5`  | Fully Supported | Supports AMQP 0.9 brokers (i.e. RabbitMQ, Apache Qpid) |
+| [generic-pool][38] | `>=2`    | Fully Supported |                                                        |
+| [kafka-node][39]   |          | Coming Soon     |                                                        |
+| [rhea][40]         |          | Coming Soon     |                                                        |
 
 #### Promise Library Compatibility
 
 | Module           | Versions  | Support Type    |
 |------------------|-----------|-----------------|
-| [bluebird][40]   | `>=2`     | Fully Supported |
-| [promise][41]    | `>=7`     | Fully Supported |
-| [promise-js][42] | `>=0.0.3` | Fully Supported |
-| [q][43]          | `>=1`     | Fully Supported |
-| [when][44]       | `>=3`     | Fully Supported |
+| [bluebird][41]   | `>=2`     | Fully Supported |
+| [promise][42]    | `>=7`     | Fully Supported |
+| [promise-js][43] | `>=0.0.3` | Fully Supported |
+| [q][44]          | `>=1`     | Fully Supported |
+| [when][45]       | `>=3`     | Fully Supported |
 
 #### Logger Compatibility
 
 | Module           | Versions  | Support Type    |
 |------------------|-----------|-----------------|
-| [bunyan][45]     | `>=1`     | Fully Supported |
-| [paperplane][46] | `>=2.3.2` | Fully Supported |
-| [pino][47]       | `>=2`     | Fully Supported |
-| [winston][48]    | `>=1`     | Fully Supported |
+| [bunyan][46]     | `>=1`     | Fully Supported |
+| [paperplane][47] | `>=2.3.2` | Fully Supported |
+| [pino][48]       | `>=2`     | Fully Supported |
+| [winston][49]    | `>=1`     | Fully Supported |
 
 ## Further Reading
 
@@ -174,7 +174,7 @@ For details about how to how to toggle and configure plugins, check out the [API
 [1]: /tracing/visualization
 [2]: https://datadog.github.io/dd-trace-js
 [3]: https://github.com/DataDog/dd-trace-js/blob/master/README.md#development
-[4]: /tracing/setup
+[4]: /tracing/send_traces
 [5]: /tracing/setup/docker
 [6]: /agent/kubernetes/daemonset_setup/#trace-collection
 [7]: https://datadog.github.io/dd-trace-js/#tracer-settings
@@ -195,28 +195,28 @@ For details about how to how to toggle and configure plugins, check out the [API
 [22]: https://nodejs.org/api/https.html
 [23]: https://nodejs.org/api/net.html
 [24]: https://github.com/datastax/nodejs-driver
-[25]: https://github.com/elastic/elasticsearch-js
-[26]: https://github.com/luin/ioredis
-[27]: https://knexjs.org
-[28]: https://github.com/3rd-Eden/memcached
-[29]: http://mongodb.github.io/node-mongodb-native/core
-[30]: https://github.com/mysqljs/mysql
-[31]: https://github.com/sidorares/node-mysql2
-[32]: https://node-postgres.com
-[33]: https://github.com/NodeRedis/node_redis
-[34]: http://tediousjs.github.io/tedious
-[35]: https://github.com/noodlefrenzy/node-amqp10
-[36]: https://github.com/squaremo/amqp.node
-[37]: https://github.com/coopernurse/node-pool
-[38]: https://github.com/SOHU-Co/kafka-node
-[39]: https://github.com/amqp/rhea
-[40]: https://github.com/petkaantonov/bluebird
-[41]: https://github.com/then/promise
-[42]: https://github.com/kevincennis/promise
-[43]: https://github.com/kriskowal/q
-[44]: https://github.com/cujojs/when
-[45]: https://github.com/trentm/node-bunyan
-[46]: https://github.com/articulate/paperplane/blob/master/docs/API.md#logger
-[47]: http://getpino.io
-[48]: https://github.com/winstonjs/winston
-[49]: https://github.com/couchbase/couchnode
+[25]: https://github.com/couchbase/couchnode
+[26]: https://github.com/elastic/elasticsearch-js
+[27]: https://github.com/luin/ioredis
+[28]: https://knexjs.org
+[29]: https://github.com/3rd-Eden/memcached
+[30]: http://mongodb.github.io/node-mongodb-native/core
+[31]: https://github.com/mysqljs/mysql
+[32]: https://github.com/sidorares/node-mysql2
+[33]: https://node-postgres.com
+[34]: https://github.com/NodeRedis/node_redis
+[35]: http://tediousjs.github.io/tedious
+[36]: https://github.com/noodlefrenzy/node-amqp10
+[37]: https://github.com/squaremo/amqp.node
+[38]: https://github.com/coopernurse/node-pool
+[39]: https://github.com/SOHU-Co/kafka-node
+[40]: https://github.com/amqp/rhea
+[41]: https://github.com/petkaantonov/bluebird
+[42]: https://github.com/then/promise
+[43]: https://github.com/kevincennis/promise
+[44]: https://github.com/kriskowal/q
+[45]: https://github.com/cujojs/when
+[46]: https://github.com/trentm/node-bunyan
+[47]: https://github.com/articulate/paperplane/blob/master/docs/API.md#logger
+[48]: http://getpino.io
+[49]: https://github.com/winstonjs/winston

--- a/content/en/tracing/setup/php.md
+++ b/content/en/tracing/setup/php.md
@@ -88,7 +88,7 @@ See [tracer configuration][12] for more information on how to set these variable
 PHP APM supports the following PHP versions:
 
 | Version | Support type    |
-| :------ | :-------------- |
+|:--------|:----------------|
 | 7.3.x   | Fully Supported |
 | 7.2.x   | Fully Supported |
 | 7.1.x   | Fully Supported |
@@ -99,7 +99,7 @@ PHP APM supports the following PHP versions:
 PHP APM supports the following SAPI's:
 
 | SAPI           | Support type    |
-| :------------- | :-------------- |
+|:---------------|:----------------|
 | apache2handler | Fully Supported |
 | cli            | Fully Supported |
 | fpm            | Fully Supported |
@@ -111,7 +111,7 @@ PHP APM supports the following SAPI's:
 If the web framework that you use is not listed below, you can still see traces for your web requests in the UI. However, some metadata and spans that are very specific to that particular web framework may not display.
 
 | Module         | Versions      | Support Type    |
-| :------------- | :------------ | :-------------- |
+|:---------------|:--------------|:----------------|
 | CakePHP        | 2.x           | Fully Supported |
 | CodeIgniter    | 2.x           | PHP 7           |
 | Laravel        | 4.2, 5.x      | Fully Supported |
@@ -135,7 +135,7 @@ Don’t see your desired frameworks? Datadog is continually adding additional su
 Tracing from the CLI SAPI is disabled by default. To enable tracing of PHP CLI scripts, set `DD_TRACE_CLI_ENABLED=true`.
 
 | Module          | Versions | Support Type    |
-| :-------------- | :------- | :-------------- |
+|:----------------|:---------|:----------------|
 | CakePHP Console | 2.x      | Fully Supported |
 | Laravel Artisan | 5.x      | Fully Supported |
 | Symfony Console |          | _Coming Soon_   |
@@ -145,7 +145,7 @@ Don’t see your desired CLI library? Datadog is continually adding additional s
 #### Datastore Compatibility
 
 | Module                           | Versions                   | Support Type    |
-| :------------------------------- | :------------------------- | :-------------- |
+|:---------------------------------|:---------------------------|:----------------|
 | Amazon RDS (using PDO or MySQLi) | *(Any Supported PHP)*      | Fully Supported |
 | Elasticsearch                    | 1.x                        | Fully Supported |
 | Eloquent                         | Laravel supported versions | Fully Supported |
@@ -167,7 +167,7 @@ Don’t see your desired datastores? Datadog is continually adding additional su
 #### Library Compatibility
 
 | Module     | Versions              | Support Type    |
-| :--------- | :-------------------- | :-------------- |
+|:-----------|:----------------------|:----------------|
 | Curl       | *(Any Supported PHP)* | Fully Supported |
 | Guzzle     | 5.x                   | Fully Supported |
 | Guzzle     | 6.x                   | Fully Supported |
@@ -209,7 +209,7 @@ DD_TRACE_DEBUG=true php -S localhost:8888
 ### Environment Variable Configuration
 
 | Env variable                              | Default     | Note                                                                                                              |
-| ----------------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------- |
+|-------------------------------------------|-------------|-------------------------------------------------------------------------------------------------------------------|
 | `DD_AGENT_HOST`                           | `localhost` | The Agent host name                                                                                               |
 | `DD_AUTOFINISH_SPANS`                     | `false`     | Whether spans are automatically finished when the tracer is flushed                                               |
 | `DD_DISTRIBUTED_TRACING`                  | `true`      | Whether to enable distributed tracing                                                                             |
@@ -243,14 +243,14 @@ This functionality is in public beta. For assistance, contact <a href="/help">Da
 When `DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED=true`, the URL is used to form the trace resource name in the format `<HTTP_REQUEST_METHOD> <NORMALIZED_URL>`, with the query string removed from the URL. This allows better visibility in any custom framework that is not automatically instrumented by normalizing the URLs and grouping together generic endpoints under one resource.
 
 | HTTP Request                       | Resource Name |
-| :--------------------------------- | :------------ |
+|:-----------------------------------|:--------------|
 | **GET** request to `/foo?a=1&b=2`  | `GET /foo`    |
 | **POST** request to `/bar?foo=bar` | `POST /bar`   |
 
 Numeric IDs, UUIDs (with and without dashes), and 32-to-512-bit hexadecimal hashes are automatically replaced with a `?` character.
 
 | URL (GET request)                              | Resource Name      |
-| :--------------------------------------------- | :----------------- |
+|:-----------------------------------------------|:-------------------|
 | `/user/123/show`                               | `GET /user/?/show` |
 | `/widget/b7a992e0-3300-4030-8617-84553b11c993` | `GET /widget/?`    |
 | `/api/v2/b7a992e033004030861784553b11c993/123` | `GET /api/v2/?/?`  |
@@ -265,7 +265,7 @@ Rules are applied in the same order as they appear in `DD_TRACE_RESOURCE_URI_MAP
 The `*` wildcard is replaced with `?`.
 
 | Mapping Rule | URL (GET request)  | Resource Name    |
-| :----------- | :----------------- | :--------------- |
+|:-------------|:-------------------|:-----------------|
 | `/foo/*`     | `/foo/bar`         | `GET /foo/?`     |
 | `/foo/*/bar` | `/foo/baz/faz/bar` | `GET /foo/?/bar` |
 | `/foo-*-bar` | `/foo-secret-bar`  | `GET /foo-?-bar` |
@@ -273,7 +273,7 @@ The `*` wildcard is replaced with `?`.
 The `$*` wildcard matches without replacement.
 
 | Mapping Rule        | URL (GET request)           | Resource Name              |
-| :------------------ | :-------------------------- | :------------------------- |
+|:--------------------|:----------------------------|:---------------------------|
 | `/state/$*/show`    | `/state/kentucky/show`      | `GET /state/kentucky/show` |
 | `/widget/*/type/$*` | `/widget/foo-id/type/green` | `GET /widget/?/type/green` |
 
@@ -287,7 +287,7 @@ To upgrade the PHP tracer, [download the latest release][7] and follow the same 
 
 [1]: /tracing/visualization
 [2]: https://github.com/DataDog/dd-trace-php/blob/master/CONTRIBUTING.md
-[3]: /agent/?tab=agentv6
+[3]: /tracing/send_traces
 [4]: /tracing/setup/docker
 [5]: /agent/kubernetes/daemonset_setup/#trace-collection
 [6]: /tracing/send_traces

--- a/content/en/tracing/setup/python.md
+++ b/content/en/tracing/setup/python.md
@@ -74,13 +74,13 @@ The `ddtrace` library includes support for a number of web frameworks, including
 
 | Framework                | Supported Version | PyPi Datadog Documentation                                         |
 |--------------------------|-------------------|--------------------------------------------------------------------|
-| [aiohttp][5]            | >= 1.2            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#aiohttp |
+| [aiohttp][5]             | >= 1.2            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#aiohttp |
 | [Bottle][6]              | >= 0.11           | http://pypi.datadoghq.com/trace/docs/web_integrations.html#bottle  |
 | [Django][7]              | >= 1.8            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#django  |
 | [djangorestframework][7] | >= 3.4            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#django  |
 | [Falcon][8]              | >= 1.0            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#falcon  |
 | [Flask][9]               | >= 0.10           | http://pypi.datadoghq.com/trace/docs/web_integrations.html#flask   |
-| [Molten][10]              | >= 0.7.0          | http://pypi.datadoghq.com/trace/docs/web_integrations.html#molten  |
+| [Molten][10]             | >= 0.7.0          | http://pypi.datadoghq.com/trace/docs/web_integrations.html#molten  |
 | [Pylons][11]             | >= 0.9.6          | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pylons  |
 | [Pyramid][12]            | >= 1.7            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pyramid |
 | [Tornado][13]            | >= 4.0            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#tornado |
@@ -133,7 +133,7 @@ The `ddtrace` library includes support for the following libraries:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/setup
+[1]: /tracing/send_traces
 [2]: /tracing/setup/docker
 [3]: /agent/kubernetes/daemonset_setup/#trace-collection
 [4]: http://pypi.datadoghq.com/trace/docs

--- a/content/en/tracing/visualization/services_list.md
+++ b/content/en/tracing/visualization/services_list.md
@@ -71,7 +71,7 @@ Choose what to display in your services list:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/setup
+[1]: /tracing/send_traces
 [2]: /tracing/visualization/#services
 [3]: https://app.datadoghq.com/apm/services
 [4]: /tracing/visualization/service


### PR DESCRIPTION
### What does this PR do?

Updates Tracing links to point to the Agent installation instructions instead of redundant language instrumentation selection.

### Motivation
Customer feedback.

### Note

Lots of changes because of linting.. but the only things that changed are links that are now pointing to `/tracing/send_traces/`