### PR TITLE
David.jones/ja nav

### DIFF
--- a/data/partials/footer.ja.yaml
+++ b/data/partials/footer.ja.yaml
@@ -2,66 +2,66 @@ footer_blurb_heading: Can't find something?
 footer_blurb_desc: Our friendly, knowledgeable solutions engineers are here to help!
 col1:
   - name: product
-    link: 'https://www.datadoghq.com/product/'
+    link: 'https://www.datadoghq.com/ja/product/'
     title: 機能
   - name: integrations
-    link: 'https://www.datadoghq.com/product/integrations/'
+    link: 'https://www.datadoghq.com/ja/product/integrations/'
     title: インテグレーション
   - name: apm
-    link: 'https://www.datadoghq.com/apm/'
+    link: 'https://www.datadoghq.com/ja/apm/'
     title: APM
   - name: logs
-    link: 'https://www.datadoghq.com/log-management/'
+    link: 'https://www.datadoghq.com/ja/log-management/'
     title: ログ管理
   - name: dashboards
-    link: 'https://www.datadoghq.com/dashboarding/'
+    link: 'https://www.datadoghq.com/ja/dashboarding/'
     title: 'ダッシュボード  '
   - name: synthetics
-    link: 'https://www.datadoghq.com/synthetics/'
+    link: 'https://www.datadoghq.com/ja/synthetics/'
     title: Synthetics
   - name: alerts
-    link: 'https://www.datadoghq.com/alerts/'
+    link: 'https://www.datadoghq.com/ja/alerts/'
     title: アラート
 col2:
   - name: pricing
-    link: 'https://www.datadoghq.com/pricing/'
+    link: 'https://www.datadoghq.com/ja/pricing/'
     title: 料金
   - name: documentation
     link: 'https://docs.datadoghq.com/'
     title: Documentation
   - name: support
-    link: 'https://www.datadoghq.com/support/'
+    link: 'https://www.datadoghq.com/ja/support/'
     title: サポート
   - name: resources
-    link: 'https://www.datadoghq.com/resources/'
+    link: 'https://www.datadoghq.com/ja/resources/'
     title: リソース
   - name: security
-    link: 'https://www.datadoghq.com/security/'
+    link: 'https://www.datadoghq.com/ja/security/'
     title: セキュリティ
   - name: api
     link: api/
     title: API
 col3:
   - name: contact
-    link: 'https://www.datadoghq.com/about/contact/'
+    link: 'https://www.datadoghq.com/ja/about/contact/'
     title: お問い合わせ
   - name: partners
-    link: 'https://www.datadoghq.com/partner-with-datadog/'
+    link: 'https://www.datadoghq.com/ja/partner-with-datadog/'
     title: パートナー
   - name: press
-    link: 'https://www.datadoghq.com/about/press/'
+    link: 'https://www.datadoghq.com/ja/about/press/'
     title: プレス
   - name: ourteam
-    link: 'https://www.datadoghq.com/about/team/'
+    link: 'https://www.datadoghq.com/ja/about/team/'
     title: チーム
   - name: careers
-    link: 'https://www.datadoghq.com/careers/'
+    link: 'https://www.datadoghq.com/ja/careers/'
     title: 採用情報
   - name: legal
-    link: 'https://www.datadoghq.com/legal/'
+    link: 'https://www.datadoghq.com/ja/legal/'
     title: 各種規約
   - name: analyst
-    link: 'https://www.datadoghq.com/about/analyst/'
+    link: 'https://www.datadoghq.com/ja/about/analyst/'
     title: アナリストレポート
 col4:
   - name: blog

--- a/data/partials/header.ja.yaml
+++ b/data/partials/header.ja.yaml
@@ -35,7 +35,7 @@ left:
     title: 料金
   - name: solutions
     link: '#'
-    title: お客様事例
+    title: ソリューション
     children:
       - name: solutions_financial
         link: 'https://www.datadoghq.com/solutions/financial-services/'
@@ -57,10 +57,10 @@ left:
         title: ゲーム業界
       - name: solutions_cloudmigration
         link: "https://www.datadoghq.com/solutions/cloud-migration/"
-        title: "Cloud Migration"
+        title: "クラウド移行"
       - name: solutions_monitoringconsolidation
         link: "https://www.datadoghq.com/solutions/monitoring-consolidation/"
-        title: "Monitoring Consolidation"
+        title: "統合監視"
       - name: solutions_devops
         link: "https://www.datadoghq.com/solutions/devops/"
         title: "DevOps"
@@ -80,14 +80,20 @@ right:
         link: 'https://www.datadoghq.com/about/press/'
         title: プレス
       - name: about_team
-        link: 'https://www.datadoghq.com/about/team/'
-        title: チーム
+        link: 'https://www.datadoghq.com/about/leadership/'
+        title: 経営陣
       - name: about_careers
         link: 'https://www.datadoghq.com/careers/'
         title: 採用情報
       - name: about_analyst
         link: 'https://www.datadoghq.com/about/analyst/'
         title: アナリストレポート
+      - name: about_investor
+        link: 'https://investors.datadoghq.com/'
+        title: Investor Relations
+      - name: about_timeline
+        link: 'https://www.datadoghq.com/about/timeline/'
+        title: 沿革
   - name: blog
     link: 'https://www.datadoghq.com/blog/'
     title: ブログ
@@ -98,12 +104,12 @@ right:
       - name: blog_engineering
         link: 'https://www.datadoghq.com/blog/engineering/'
         title: エンジニアリング
-      - name: blog_community
-        link: 'https://www.datadoghq.com/blog/community/'
-        title: コミュニティ
       - name: blog_pupculture
         link: 'https://www.datadoghq.com/blog/pup-culture/'
         title: 企業文化
+      - name: blog_community
+        link: 'https://www.datadoghq.com/blog/community/'
+        title: コミュニティ
   - name: docs
     link: ''
     title: ドキュメント

--- a/data/partials/header.ja.yaml
+++ b/data/partials/header.ja.yaml
@@ -1,114 +1,114 @@
 left:
   - name: product
-    link: 'https://www.datadoghq.com/product/'
+    link: 'https://www.datadoghq.com/ja/product/'
     title: 製品
     children:
       - name: product_features
-        link: 'https://www.datadoghq.com/product/'
+        link: 'https://www.datadoghq.com/ja/product/'
         title: 機能
       - name: product_integrations
-        link: 'https://www.datadoghq.com/product/integrations/'
+        link: 'https://www.datadoghq.com/ja/product/integrations/'
         title: インテグレーション
       - name: product_apm
-        link: 'https://www.datadoghq.com/apm/'
+        link: 'https://www.datadoghq.com/ja/apm/'
         title: APM
       - name: product_logs
-        link: 'https://www.datadoghq.com/log-management/'
+        link: 'https://www.datadoghq.com/ja/log-management/'
         title: ログ管理
       - name: product_dashboards
-        link: 'https://www.datadoghq.com/dashboarding/'
+        link: 'https://www.datadoghq.com/ja/dashboarding/'
         title: ダッシュボード
       - name: product_synthetics
-        link: 'https://www.datadoghq.com/synthetics/'
+        link: 'https://www.datadoghq.com/ja/synthetics/'
         title: Synthetics
       - name: product_alerts
-        link: 'https://www.datadoghq.com/alerts/'
+        link: 'https://www.datadoghq.com/ja/alerts/'
         title: アラート
       - name: product_api
         link: api
         title: API
   - name: customers
-    link: 'https://www.datadoghq.com/customers/'
+    link: 'https://www.datadoghq.com/ja/customers/'
     title: お客様
   - name: pricing
-    link: 'https://www.datadoghq.com/pricing/'
+    link: 'https://www.datadoghq.com/ja/pricing/'
     title: 料金
   - name: solutions
     link: '#'
     title: ソリューション
     children:
       - name: solutions_financial
-        link: 'https://www.datadoghq.com/solutions/financial-services/'
+        link: 'https://www.datadoghq.com/ja/solutions/financial-services/'
         title: 金融サービス
       - name: solutions_manufacturing
-        link: 'https://www.datadoghq.com/solutions/manufacturing-logistics/'
+        link: 'https://www.datadoghq.com/ja/solutions/manufacturing-logistics/'
         title: 製造 / 物流
       - name: solutions_healthcare
-        link: 'https://www.datadoghq.com/solutions/healthcare/'
+        link: 'https://www.datadoghq.com/ja/solutions/healthcare/'
         title: 医療 / ライフサイエンス
       - name: solutions_retail
-        link: 'https://www.datadoghq.com/solutions/retail-ecommerce/'
+        link: 'https://www.datadoghq.com/ja/solutions/retail-ecommerce/'
         title: 小売業 / eコマース
       - name: solutions_media
-        link: 'https://www.datadoghq.com/solutions/media-entertainment/'
+        link: 'https://www.datadoghq.com/ja/solutions/media-entertainment/'
         title: メディア / エンターテインメント
       - name: solutions_gaming
-        link: 'https://www.datadoghq.com/solutions/gaming/'
+        link: 'https://www.datadoghq.com/ja/solutions/gaming/'
         title: ゲーム業界
       - name: solutions_cloudmigration
-        link: "https://www.datadoghq.com/solutions/cloud-migration/"
+        link: "https://www.datadoghq.com/ja/solutions/cloud-migration/"
         title: "クラウド移行"
       - name: solutions_monitoringconsolidation
-        link: "https://www.datadoghq.com/solutions/monitoring-consolidation/"
+        link: "https://www.datadoghq.com/ja/solutions/monitoring-consolidation/"
         title: "統合監視"
       - name: solutions_devops
-        link: "https://www.datadoghq.com/solutions/devops/"
+        link: "https://www.datadoghq.com/ja/solutions/devops/"
         title: "DevOps"
         
 right:
   - name: about
-    link: 'https://www.datadoghq.com/about/'
+    link: 'https://www.datadoghq.com/ja/about/'
     title: 会社情報
     children:
       - name: about_contact
-        link: 'https://www.datadoghq.com/about/contact/'
+        link: 'https://www.datadoghq.com/ja/about/contact/'
         title: お問い合わせ
       - name: about_partners
-        link: 'https://www.datadoghq.com/partner-with-datadog/'
+        link: 'https://www.datadoghq.com/ja/partner-with-datadog/'
         title: パートナー
       - name: about_press
-        link: 'https://www.datadoghq.com/about/press/'
+        link: 'https://www.datadoghq.com/ja/about/press/'
         title: プレス
       - name: about_team
-        link: 'https://www.datadoghq.com/about/leadership/'
+        link: 'https://www.datadoghq.com/ja/about/leadership/'
         title: 経営陣
       - name: about_careers
-        link: 'https://www.datadoghq.com/careers/'
+        link: 'https://www.datadoghq.com/ja/careers/'
         title: 採用情報
       - name: about_analyst
-        link: 'https://www.datadoghq.com/about/analyst/'
+        link: 'https://www.datadoghq.com/ja/about/analyst/'
         title: アナリストレポート
       - name: about_investor
         link: 'https://investors.datadoghq.com/'
         title: Investor Relations
       - name: about_timeline
-        link: 'https://www.datadoghq.com/about/timeline/'
+        link: 'https://www.datadoghq.com/ja/about/timeline/'
         title: 沿革
   - name: blog
-    link: 'https://www.datadoghq.com/blog/'
+    link: 'https://www.datadoghq.com/ja/blog/'
     title: ブログ
     children:
       - name: blog_themonitor
-        link: 'https://www.datadoghq.com/blog/'
+        link: 'https://www.datadoghq.com/ja/blog/'
         title: モニター
       - name: blog_engineering
-        link: 'https://www.datadoghq.com/blog/engineering/'
+        link: 'https://www.datadoghq.com/ja/blog/engineering/'
         title: エンジニアリング
       - name: blog_pupculture
-        link: 'https://www.datadoghq.com/blog/pup-culture/'
+        link: 'https://www.datadoghq.com/ja/blog/pup-culture/'
         title: 企業文化
       - name: blog_community
-        link: 'https://www.datadoghq.com/blog/community/'
+        link: 'https://www.datadoghq.com/ja/blog/community/'
         title: コミュニティ
   - name: docs
     link: ''

--- a/data/partials/header.yaml
+++ b/data/partials/header.yaml
@@ -104,12 +104,12 @@ right:
           - name: blog_engineering
             link: "https://www.datadoghq.com/blog/engineering/"
             title: "Engineering"
-          - name: blog_community
-            link: "https://www.datadoghq.com/blog/community/"
-            title: "Community"
           - name: blog_pupculture
             link: "https://www.datadoghq.com/blog/pup-culture/"
             title: "Pup Culture"
+          - name: blog_community
+            link: "https://www.datadoghq.com/blog/community/"
+            title: "Community"
   - name: docs
     link: ""
     title: "Docs"


### PR DESCRIPTION
### What does this PR do?
This PR

- updates the ja header nav to point back to the ja corpsite
- updates the ja footer nav to point back to the ja corpsite
- updates the english menu to match corpsite

### Motivation
To match and direct between corp and docs when on ja

### Preview link
https://docs-staging.datadoghq.com/david.jones/ja-nav/ja/

### Additional Notes


