### PR TITLE
Install Agent 7 in our EBS sample config

### DIFF
--- a/static/config/99datadog.config
+++ b/static/config/99datadog.config
@@ -5,7 +5,7 @@ option_settings:
       value:  "<YOUR_DD_API_KEY>"
     - namespace:  aws:elasticbeanstalk:application:environment
       option_name:  DD_AGENT_VERSION
-      value:  "" # For example, "6.15.1". Leave empty to install the latest version. Only Agent 6 is supported.
+      value:  "" # For example, "7.16.0". Leave empty to install the latest version. Only Agent 7 is supported.
 files:
     "/configure_datadog_yaml.sh":
         mode: "000700"
@@ -25,11 +25,10 @@ files:
         content: |
             [datadog]
             name = Datadog, Inc.
-            baseurl = https://yum.datadoghq.com/stable/6/x86_64/
+            baseurl = https://yum.datadoghq.com/stable/7/x86_64/
             enabled=1
             gpgcheck=1
-            gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-                   https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+            gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
 
     "/datadog/hooks/99start_datadog.sh":
         mode: "000755"


### PR DESCRIPTION
### What does this PR do?
Install Agent 7 in our EBS sample config and stop trusting our old RPM signing key. Agent 7 packages are always signed with the new key.

### Motivation
Agent 7 release.

### Additional Notes
To be merged after Agent 7 goes GA.
