### PR TITLE
Add DD_AGENT_VERSION option to our EBS sample config

### DIFF
--- a/static/config/99datadog.config
+++ b/static/config/99datadog.config
@@ -3,7 +3,9 @@ option_settings:
     - namespace:  aws:elasticbeanstalk:application:environment
       option_name:  DD_API_KEY
       value:  "<YOUR_DD_API_KEY>"
-
+    - namespace:  aws:elasticbeanstalk:application:environment
+      option_name:  DD_AGENT_VERSION
+      value:  "" # Eg: 6.15.0, leave empty to install latest
 files:
     "/configure_datadog_yaml.sh":
         mode: "000700"
@@ -87,7 +89,7 @@ container_commands:
         command: "cp /datadog/hooks/99start_datadog.sh /opt/elasticbeanstalk/hooks/configdeploy/post/"
     90install_datadog:
         test: '[ -f /datadog/datadog.repo ]'
-        command: "cp /datadog/datadog.repo /etc/yum.repos.d/datadog.repo; yum -y makecache; yum -y install datadog-agent"
+        command: "cp /datadog/datadog.repo /etc/yum.repos.d/datadog.repo; yum -y makecache; DD_AGENT_VERSION="$(/opt/elasticbeanstalk/bin/get-config environment -k DD_AGENT_VERSION)"; yum -y install datadog-agent${DD_AGENT_VERSION:+-$DD_AGENT_VERSION-1}"
     91setup_datadog:
         test: '[ -x /configure_datadog_yaml.sh ]'
         command: "/configure_datadog_yaml.sh"

--- a/static/config/99datadog.config
+++ b/static/config/99datadog.config
@@ -5,7 +5,7 @@ option_settings:
       value:  "<YOUR_DD_API_KEY>"
     - namespace:  aws:elasticbeanstalk:application:environment
       option_name:  DD_AGENT_VERSION
-      value:  "" # Eg: 6.15.0, leave empty to install latest
+      value:  "" # Eg: "6.15.0", leave empty to install latest
 files:
     "/configure_datadog_yaml.sh":
         mode: "000700"

--- a/static/config/99datadog.config
+++ b/static/config/99datadog.config
@@ -5,7 +5,7 @@ option_settings:
       value:  "<YOUR_DD_API_KEY>"
     - namespace:  aws:elasticbeanstalk:application:environment
       option_name:  DD_AGENT_VERSION
-      value:  "" # Eg: "6.15.0", leave empty to install latest
+      value:  "" # For example, "6.15.0", leave empty to install the latest version.
 files:
     "/configure_datadog_yaml.sh":
         mode: "000700"


### PR DESCRIPTION
### What does this PR do?
Allow users to pin a specific version of the Agent.
