### PR TITLE
Adding details on user locator behavior

### DIFF
--- a/content/en/synthetics/browser_tests.md
+++ b/content/en/synthetics/browser_tests.md
@@ -87,7 +87,8 @@ The default timeout for each step is approximately 60 seconds. You can override 
 | `Test the content of the URL of the active page`          | Takes the URL of the last page that was interacted with, then asserts whether a specific value (`string`, `number`, `regex`) is present within it.                                     |
 | `Test that an email was received`                         | Asserts that an email was sent and whether specific values (`string`, `number`, `regex`) are present within the email subject or body. This assertion leverages  [email variables][9]. |
 
-Advanced options for assertions allow you to specify an X-path or a CSS class or ID that you want to use to perform the element selection for any HTML element. For example, `div`, `h1`, or `.hero-body`. Once you define an element, hit **Test**, and it will highlight the element in the recording on the right.
+Advanced options for assertions allow you to specify an X-path or a CSS class or ID that you want to use to perform the element selection for any HTML element. For example, `div`, `h1`, or `.hero-body`. Once you define an element, hit **Test**, and it will highlight the element in the recording on the right.  
+If the defined user locator fails, by default the test will be considered as failed. You can decide to fallback on the regular Browser tests algorithm by unticking the `If user specified locator fails, fail test` box.
 
 ### Navigation
 

--- a/content/en/synthetics/browser_tests.md
+++ b/content/en/synthetics/browser_tests.md
@@ -87,7 +87,7 @@ The default timeout for each step is approximately 60 seconds. You can override 
 | `Test the content of the URL of the active page`          | Takes the URL of the last page that was interacted with, then asserts whether a specific value (`string`, `number`, `regex`) is present within it.                                     |
 | `Test that an email was received`                         | Asserts that an email was sent and whether specific values (`string`, `number`, `regex`) are present within the email subject or body. This assertion leverages  [email variables][9]. |
 
-Advanced options for assertions allow you to specify an X-path or a CSS class or ID that you want to use to perform the element selection for any HTML element. For example, `div`, `h1`, or `.hero-body`. Once you define an element, hit **Test**, and it will highlight the element in the recording on the right.  
+Advanced options for assertions allow you to specify an X-path or a CSS class or ID that you want to use to perform the element selection for any HTML element. For example, `div`, `h1`, or `.hero-body`. Once you define an element, hit **Test** to highlight the element in the recording on the right.  
 If the defined user locator fails, by default the test is considered as failed. You can decide to fallback on the regular Browser tests algorithm by unticking the `If user specified locator fails, fail test` box.
 
 ### Navigation

--- a/content/en/synthetics/browser_tests.md
+++ b/content/en/synthetics/browser_tests.md
@@ -88,7 +88,7 @@ The default timeout for each step is approximately 60 seconds. You can override 
 | `Test that an email was received`                         | Asserts that an email was sent and whether specific values (`string`, `number`, `regex`) are present within the email subject or body. This assertion leverages  [email variables][9]. |
 
 Advanced options for assertions allow you to specify an X-path or a CSS class or ID that you want to use to perform the element selection for any HTML element. For example, `div`, `h1`, or `.hero-body`. Once you define an element, hit **Test**, and it will highlight the element in the recording on the right.  
-If the defined user locator fails, by default the test will be considered as failed. You can decide to fallback on the regular Browser tests algorithm by unticking the `If user specified locator fails, fail test` box.
+If the defined user locator fails, by default the test is considered as failed. You can decide to fallback on the regular Browser tests algorithm by unticking the `If user specified locator fails, fail test` box.
 
 ### Navigation
 

--- a/content/en/synthetics/browser_tests.md
+++ b/content/en/synthetics/browser_tests.md
@@ -87,8 +87,7 @@ The default timeout for each step is approximately 60 seconds. You can override 
 | `Test the content of the URL of the active page`          | Takes the URL of the last page that was interacted with, then asserts whether a specific value (`string`, `number`, `regex`) is present within it.                                     |
 | `Test that an email was received`                         | Asserts that an email was sent and whether specific values (`string`, `number`, `regex`) are present within the email subject or body. This assertion leverages  [email variables][9]. |
 
-Advanced options for assertions allow you to specify an X-path or a CSS class or ID that you want to use to perform the element selection for any HTML element. For example, `div`, `h1`, or `.hero-body`. Once you define an element, hit **Test** to highlight the element in the recording on the right.  
-If the defined user locator fails, by default the test is considered as failed. You can decide to fallback on the regular Browser tests algorithm by unticking the `If user specified locator fails, fail test` box.
+*Advanced options* section for assertions allows you to specify a custom locator: an X-path or a CSS class/ID that you want to use to perform the element selection for any HTML element. For example, `div`, `h1`, or `.hero-body`. Once you have defined an element, hit **Test** to highlight the element in the recording on the right. If the defined locator fails, by default the test is considered as failed. You can decide to fallback on the regular Browser tests algorithm by unticking the `If user specified locator fails, fail test` box.
 
 ### Navigation
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR adds details to the user locator behavior by specifying what the `If user specified locator fails, fail test` box is about.

### Motivation
https://trello.com/c/W0YvcN9q/1765-synthetics-browser-tests-document-the-if-user-specified-locator-fails-fail-test-box-in-the-advanced-options-user-locator

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/margot.lepizzera/userlocator/synthetics/browser_tests/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
