### PR TITLE
Adding PHP timer doc

### DIFF
--- a/content/en/developers/metrics/dogstatsd_metrics_submission.md
+++ b/content/en/developers/metrics/dogstatsd_metrics_submission.md
@@ -55,7 +55,7 @@ Run the following Python code to submit a DogStatsD `COUNT` metric to Datadog:
 from datadog import initialize, statsd
 import time
 
-options = {ÿ
+options = {
     'statsd_host':'127.0.0.1',
     'statsd_port':8125
 }
@@ -101,12 +101,12 @@ import (
 	"github.com/DataDog/datadog-go/statsd"
 )
 
-func main() {ÿ
+func main() {
 	statsd, err := statsd.New("127.0.0.1:8125")
-	if err != nil {ÿ
+	if err != nil {
 		log.Fatal(err)
 	}
-	for {ÿ
+	for {
 
 		statsd.Incr("example_metric.increment", []string{"environment:dev"}, 1)
 		statsd.Decr("example_metric.decrement", []string{"environment:dev"}, 1)
@@ -126,12 +126,12 @@ import com.timgroup.statsd.NonBlockingStatsDClient;
 import com.timgroup.statsd.StatsDClient;
 import java.util.Random;
 
-public class DogStatsdClient {ÿ
+public class DogStatsdClient {
 
-    public static void main(String[] args) throws Exception {ÿ
+    public static void main(String[] args) throws Exception {
 
         StatsDClient Statsd = new NonBlockingStatsDClient("statsd", "localhost", 8125);
-        for (int i = 0; i < 10; i++) {ÿ
+        for (int i = 0; i < 10; i++) {
             Statsd.incrementCounter("example_metric.increment", ["environment:dev"]);
             Statsd.decrementCounter("example_metric.decrement", ["environment:dev"]);
             Statsd.count("example_metric.count", 2, ["environment:dev"]);
@@ -151,11 +151,11 @@ using StatsdClient;
 using System;
 
 public class DogStatsdClient
-{ÿ
+{
     public static void Main()
-    {ÿ
+    {
         var dogstatsdConfig = new StatsdConfig
-        {ÿ
+        {
             StatsdServerName = "127.0.0.1",
             StatsdPort = 8125,
         };
@@ -165,7 +165,7 @@ public class DogStatsdClient
         var random = new Random(0);
 
         for (int i = 0; i < 10; i++)
-        {ÿ
+        {
             DogStatsd.Increment("example_metric.increment", tags: new[] {"environment:dev"});
             DogStatsd.Decrement("example_metric.decrement", tags: new[] {"environment:dev"});
             DogStatsd.Counter("example_metric.count", 2, tags: new[] {"environment:dev"});
@@ -193,7 +193,7 @@ $statsd = new DogStatsd(
      )
   );
 
-while (TRUE) {ÿ
+while (TRUE) {
     $statsd->increment('example_metric.increment', array('environment'=>'dev'));
     $statsd->decrement('example_metric.decrement', array('environment'=>'dev'));
     sleep(10);
@@ -230,7 +230,7 @@ Run the following Python code to submit a DogStatsD `GAUGE` metric to Datadog:
 from datadog import initialize, statsd
 import time
 
-options = {ÿ
+options = {
     'statsd_host':'127.0.0.1',
     'statsd_port':8125
 }
@@ -279,13 +279,13 @@ import (
 	"github.com/DataDog/datadog-go/statsd"
 )
 
-func main() {ÿ
+func main() {
 	statsd, err := statsd.New("127.0.0.1:8125")
-	if err != nil {ÿ
+	if err != nil {
 		log.Fatal(err)
 	}
 	var i float64
-	for {ÿ
+	for {
 		i += 1
 		statsd.Gauge("example_metric.gauge", i, []string{"environment:dev"}, 1)
 		time.Sleep(10 * time.Second)
@@ -303,12 +303,12 @@ import com.timgroup.statsd.NonBlockingStatsDClient;
 import com.timgroup.statsd.StatsDClient;
 import java.util.Random;
 
-public class DogStatsdClient {ÿ
+public class DogStatsdClient {
 
-    public static void main(String[] args) throws Exception {ÿ
+    public static void main(String[] args) throws Exception {
 
         StatsDClient Statsd = new NonBlockingStatsDClient("statsd", "localhost", 8125);
-        for (int i = 0; i < 10; i++) {ÿ
+        for (int i = 0; i < 10; i++) {
             Statsd.recordGaugeValue("example_metric.gauge", i, ["environment:dev"]);
             Thread.sleep(10000);
         }
@@ -326,11 +326,11 @@ using StatsdClient;
 using System;
 
 public class DogStatsdClient
-{ÿ
+{
     public static void Main()
-    {ÿ
+    {
         var dogstatsdConfig = new StatsdConfig
-        {ÿ
+        {
             StatsdServerName = "127.0.0.1",
             StatsdPort = 8125,
         };
@@ -340,7 +340,7 @@ public class DogStatsdClient
         var random = new Random(0);
 
         for (int i = 0; i < 10; i++)
-        {ÿ
+        {
             DogStatsd.Gauge("example_metric.gauge", i, tags: new[] {"environment:dev"});
             System.Threading.Thread.Sleep(100000);
         }
@@ -367,7 +367,7 @@ $statsd = new DogStatsd(
   );
 
 $i = 0;
-while (TRUE) {ÿ
+while (TRUE) {
     $i++;
     $statsd->gauge('example_metric.gauge', $i, array('environment'=>'dev'));
     sleep(10);
@@ -401,7 +401,7 @@ from datadog import initialize, statsd
 import time
 import random
 
-options = {ÿ
+options = {
     'statsd_host':'127.0.0.1',
     'statsd_port':8125
 }
@@ -449,13 +449,13 @@ import (
 	"github.com/DataDog/datadog-go/statsd"
 )
 
-func main() {ÿ
+func main() {
 	statsd, err := statsd.New("127.0.0.1:8125")
-	if err != nil {ÿ
+	if err != nil {
 		log.Fatal(err)
 	}
 	var i float64
-	for {ÿ
+	for {
 		i += 1
 		statsd.Set("example_metric.set", strconv.Itoa(i), []string{"environment:dev"}, 1)
 		time.Sleep(rand.Intn(10) * time.Second)
@@ -473,11 +473,11 @@ using StatsdClient;
 using System;
 
 public class DogStatsdClient
-{ÿ
+{
     public static void Main()
-    {ÿ
+    {
         var dogstatsdConfig = new StatsdConfig
-        {ÿ
+        {
             StatsdServerName = "127.0.0.1",
             StatsdPort = 8125,
         };
@@ -487,7 +487,7 @@ public class DogStatsdClient
         var random = new Random(0);
 
         for (int i = 0; i < 10; i++)
-        {ÿ
+        {
             DogStatsd.Set("example_metric.set", i, tags: new[] {"environment:dev"});
             System.Threading.Thread.Sleep(random.Next(100000));
         }
@@ -515,7 +515,7 @@ $statsd = new DogStatsd(
 
 $i = 0;
 
-while (TRUE) {ÿ
+while (TRUE) {
     $i++;
     $statsd->set('example_metric.set', i, array('environment'=>'dev'));
     sleep(rand(0, 10));
@@ -554,7 +554,7 @@ from datadog import initialize, statsd
 import time
 import random
 
-options = {ÿ
+options = {
     'statsd_host':'127.0.0.1',
     'statsd_port':8125
 }
@@ -598,13 +598,13 @@ import (
 	"github.com/DataDog/datadog-go/statsd"
 )
 
-func main() {ÿ
+func main() {
 	statsd, err := statsd.New("127.0.0.1:8125")
-	if err != nil {ÿ
+	if err != nil {
 		log.Fatal(err)
 	}
 
-	for {ÿ
+	for {
 		statsd.Histogram("example_metric.histogram", rand.Intn(20), []string{"environment:dev"}, 1)
 		time.Sleep(2 * time.Second)
 	}
@@ -621,12 +621,12 @@ import com.timgroup.statsd.NonBlockingStatsDClient;
 import com.timgroup.statsd.StatsDClient;
 import java.util.Random;
 
-public class DogStatsdClient {ÿ
+public class DogStatsdClient {
 
-    public static void main(String[] args) throws Exception {ÿ
+    public static void main(String[] args) throws Exception {
 
         StatsDClient Statsd = new NonBlockingStatsDClient("statsd", "localhost", 8125);
-        for (int i = 0; i < 10; i++) {ÿ
+        for (int i = 0; i < 10; i++) {
             Statsd.recordHistogramValue("example_metric.histogram", new Random().nextInt(20), ["environment:dev"]);
             Thread.sleep(2000);
         }
@@ -644,11 +644,11 @@ using StatsdClient;
 using System;
 
 public class DogStatsdClient
-{ÿ
+{
     public static void Main()
-    {ÿ
+    {
         var dogstatsdConfig = new StatsdConfig
-        {ÿ
+        {
             StatsdServerName = "127.0.0.1",
             StatsdPort = 8125,
         };
@@ -658,7 +658,7 @@ public class DogStatsdClient
         var random = new Random(0);
 
         for (int i = 0; i < 10; i++)
-        {ÿ
+        {
             DogStatsd.Histogram("example_metric.histogram", random.Next(20), tags: new[] {"environment:dev"});
             System.Threading.Thread.Sleep(2000);
         }
@@ -684,7 +684,7 @@ $statsd = new DogStatsd(
      )
   );
 
-while (TRUE) {ÿ
+while (TRUE) {
     $statsd->histogram('example_metric.histogram', rand(0, 20), array('environment'=>'dev'));
     sleep(2);
 }
@@ -733,7 +733,7 @@ from datadog import initialize, statsd
 import time
 import random
 
-options = {ÿ
+options = {
     'statsd_host':'127.0.0.1',
     'statsd_port':8125
 }
@@ -785,11 +785,11 @@ $statsd = new DogStatsd(
      )
   );
 
-function runfunction() {ÿ
+function runfunction() {
     sleep(rand(0, 20));
 }
 
-while (TRUE) {ÿ
+while (TRUE) {
   $start_time = microtime(TRUE);
   runfunction();
   $statsd->microtiming('example_metric.timer', microtime(TRUE) - $start_time);
@@ -835,7 +835,7 @@ from datadog import initialize, statsd
 import time
 import random
 
-options = {ÿ
+options = {
     'statsd_host':'127.0.0.1',
     'statsd_port':8125
 }
@@ -879,13 +879,13 @@ import (
 	"github.com/DataDog/datadog-go/statsd"
 )
 
-func main() {ÿ
+func main() {
 	statsd, err := statsd.New("127.0.0.1:8125")
-	if err != nil {ÿ
+	if err != nil {
 		log.Fatal(err)
 	}
 
-	for {ÿ
+	for {
 		statsd.Distribution("example_metric.distribution", float64(rand.Intn(20)), []string{"environment:dev"}, 1)
 		time.Sleep(2 * time.Second)
 	}
@@ -902,12 +902,12 @@ import com.timgroup.statsd.NonBlockingStatsDClient;
 import com.timgroup.statsd.StatsDClient;
 import java.util.Random;
 
-public class DogStatsdClient {ÿ
+public class DogStatsdClient {
 
-    public static void main(String[] args) throws Exception {ÿ
+    public static void main(String[] args) throws Exception {
 
         StatsDClient Statsd = new NonBlockingStatsDClient("statsd", "localhost", 8125);
-        for (int i = 0; i < 10; i++) {ÿ
+        for (int i = 0; i < 10; i++) {
             Statsd.recordDistributionValue("example_metric.distribution", new Random().nextInt(20), ["environment:dev"]);
             Thread.sleep(2000);
         }
@@ -925,11 +925,11 @@ using StatsdClient;
 using System;
 
 public class DogStatsdClient
-{ÿ
+{
     public static void Main()
-    {ÿ
+    {
         var dogstatsdConfig = new StatsdConfig
-        {ÿ
+        {
             StatsdServerName = "127.0.0.1",
             StatsdPort = 8125,
         };
@@ -939,7 +939,7 @@ public class DogStatsdClient
         var random = new Random(0);
 
         for (int i = 0; i < 10; i++)
-        {ÿ
+        {
             DogStatsd.Distribution("example_metric.distribution", random.Next(20), tags: new[] {"environment:dev"});
             System.Threading.Thread.Sleep(2000);
         }
@@ -965,7 +965,7 @@ $statsd = new DogStatsd(
      )
   );
 
-while (TRUE) {ÿ
+while (TRUE) {
     $statsd->distribution('example_metric.distribution', rand(0, 20), array('environment'=>'dev'));
     sleep(2);
 }

--- a/content/en/developers/metrics/dogstatsd_metrics_submission.md
+++ b/content/en/developers/metrics/dogstatsd_metrics_submission.md
@@ -26,7 +26,7 @@ While StatsD accepts only metrics, DogStatsD accepts all three of the major Data
 After [installing DogStatsD][1], the functions below are available for submitting your metrics to Datadog depending on their metric type. The functions have the following shared parameters:
 
 | Parameter        | Type            | Required | Description                                                                                                                                                                                    |
-| ---------------- | --------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|------------------|-----------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `<METRIC_NAME>`  | String          | Yes      | Name of the metric to submit.                                                                                                                                                                  |
 | `<METRIC_VALUE>` | Double          | Yes      | Value associated with your metric.                                                                                                                                                             |
 | `<SAMPLE_RATE>`  | Double          | No       | The sample rate to apply to the metric. Takes a value between `0` (everything is sampled, so nothing is sent) and `1` (no sample). See the [Sample Rate section](#sample-rates) to learn more. |
@@ -35,7 +35,7 @@ After [installing DogStatsD][1], the functions below are available for submittin
 ### COUNT
 
 | Method                                                        | Description                                               | Storage type                                                                                                                                            |
-| ------------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|---------------------------------------------------------------|-----------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `increment(<METRIC_NAME>, <SAMPLE_RATE>, <TAGS>)`             | Used to increment a COUNT metric.                         | Stored as a `RATE` type in Datadog. Each value in the stored timeseries is a time-normalized delta of the counter's value over the StatsD flush period. |
 | `decrement(<METRIC_NAME>, <SAMPLE_RATE>, <TAGS>)`             | Used to decrement a COUNT metric.                         | Stored as a `RATE` type in Datadog. Each value in the stored timeseries is a time-normalized delta of the counter's value over the StatsD flush period. |
 | `count(<METRIC_NAME>, <METRIC_VALUE>, <SAMPLE_RATE>, <TAGS>)` | Use to increment a COUNT metric from an arbitrary `Value` | Stored as a `RATE` type in Datadog. Each value in the stored timeseries is a time-normalized delta of the counter's value over the StatsD flush period. |
@@ -55,7 +55,7 @@ Run the following Python code to submit a DogStatsD `COUNT` metric to Datadog:
 from datadog import initialize, statsd
 import time
 
-options = {
+options = {ÿ
     'statsd_host':'127.0.0.1',
     'statsd_port':8125
 }
@@ -101,12 +101,12 @@ import (
 	"github.com/DataDog/datadog-go/statsd"
 )
 
-func main() {
+func main() {ÿ
 	statsd, err := statsd.New("127.0.0.1:8125")
-	if err != nil {
+	if err != nil {ÿ
 		log.Fatal(err)
 	}
-	for {
+	for {ÿ
 
 		statsd.Incr("example_metric.increment", []string{"environment:dev"}, 1)
 		statsd.Decr("example_metric.decrement", []string{"environment:dev"}, 1)
@@ -126,12 +126,12 @@ import com.timgroup.statsd.NonBlockingStatsDClient;
 import com.timgroup.statsd.StatsDClient;
 import java.util.Random;
 
-public class DogStatsdClient {
+public class DogStatsdClient {ÿ
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws Exception {ÿ
 
         StatsDClient Statsd = new NonBlockingStatsDClient("statsd", "localhost", 8125);
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 10; i++) {ÿ
             Statsd.incrementCounter("example_metric.increment", ["environment:dev"]);
             Statsd.decrementCounter("example_metric.decrement", ["environment:dev"]);
             Statsd.count("example_metric.count", 2, ["environment:dev"]);
@@ -151,11 +151,11 @@ using StatsdClient;
 using System;
 
 public class DogStatsdClient
-{
+{ÿ
     public static void Main()
-    {
+    {ÿ
         var dogstatsdConfig = new StatsdConfig
-        {
+        {ÿ
             StatsdServerName = "127.0.0.1",
             StatsdPort = 8125,
         };
@@ -165,7 +165,7 @@ public class DogStatsdClient
         var random = new Random(0);
 
         for (int i = 0; i < 10; i++)
-        {
+        {ÿ
             DogStatsd.Increment("example_metric.increment", tags: new[] {"environment:dev"});
             DogStatsd.Decrement("example_metric.decrement", tags: new[] {"environment:dev"});
             DogStatsd.Counter("example_metric.count", 2, tags: new[] {"environment:dev"});
@@ -193,7 +193,7 @@ $statsd = new DogStatsd(
      )
   );
 
-while (TRUE) {
+while (TRUE) {ÿ
     $statsd->increment('example_metric.increment', array('environment'=>'dev'));
     $statsd->decrement('example_metric.decrement', array('environment'=>'dev'));
     sleep(10);
@@ -214,7 +214,7 @@ Since the value is submitted as a `COUNT` it's stored as `RATE` in Datadog. To g
 ### GAUGE
 
 | Method                                                        | Datadog Storage type                                                                                                                                      |
-| ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|---------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `gauge(<METRIC_NAME>, <METRIC_VALUE>, <SAMPLE_RATE>, <TAGS>)` | Stored as a `GAUGE` type in Datadog. Each value in the stored timeseries is the last gauge value submitted for the metric during the StatsD flush period. |
 
 #### Code examples
@@ -230,7 +230,7 @@ Run the following Python code to submit a DogStatsD `GAUGE` metric to Datadog:
 from datadog import initialize, statsd
 import time
 
-options = {
+options = {ÿ
     'statsd_host':'127.0.0.1',
     'statsd_port':8125
 }
@@ -279,13 +279,13 @@ import (
 	"github.com/DataDog/datadog-go/statsd"
 )
 
-func main() {
+func main() {ÿ
 	statsd, err := statsd.New("127.0.0.1:8125")
-	if err != nil {
+	if err != nil {ÿ
 		log.Fatal(err)
 	}
 	var i float64
-	for {
+	for {ÿ
 		i += 1
 		statsd.Gauge("example_metric.gauge", i, []string{"environment:dev"}, 1)
 		time.Sleep(10 * time.Second)
@@ -303,12 +303,12 @@ import com.timgroup.statsd.NonBlockingStatsDClient;
 import com.timgroup.statsd.StatsDClient;
 import java.util.Random;
 
-public class DogStatsdClient {
+public class DogStatsdClient {ÿ
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws Exception {ÿ
 
         StatsDClient Statsd = new NonBlockingStatsDClient("statsd", "localhost", 8125);
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 10; i++) {ÿ
             Statsd.recordGaugeValue("example_metric.gauge", i, ["environment:dev"]);
             Thread.sleep(10000);
         }
@@ -326,11 +326,11 @@ using StatsdClient;
 using System;
 
 public class DogStatsdClient
-{
+{ÿ
     public static void Main()
-    {
+    {ÿ
         var dogstatsdConfig = new StatsdConfig
-        {
+        {ÿ
             StatsdServerName = "127.0.0.1",
             StatsdPort = 8125,
         };
@@ -340,7 +340,7 @@ public class DogStatsdClient
         var random = new Random(0);
 
         for (int i = 0; i < 10; i++)
-        {
+        {ÿ
             DogStatsd.Gauge("example_metric.gauge", i, tags: new[] {"environment:dev"});
             System.Threading.Thread.Sleep(100000);
         }
@@ -367,7 +367,7 @@ $statsd = new DogStatsd(
   );
 
 $i = 0;
-while (TRUE) {
+while (TRUE) {ÿ
     $i++;
     $statsd->gauge('example_metric.gauge', $i, array('environment'=>'dev'));
     sleep(10);
@@ -384,7 +384,7 @@ After running the code above, your metric data is available to graph in Datadog:
 ### SET
 
 | Method                                                      | Datadog Storage type                                                                                                                                           |
-| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `set(<METRIC_NAME>, <METRIC_VALUE>, <SAMPLE_RATE>, <TAGS>)` | Stored as a `GAUGE` type in Datadog. Each value in the stored timeseries is the count of unique values submitted to StatsD for a metric over the flush period. |
 
 #### Code examples
@@ -401,7 +401,7 @@ from datadog import initialize, statsd
 import time
 import random
 
-options = {
+options = {ÿ
     'statsd_host':'127.0.0.1',
     'statsd_port':8125
 }
@@ -449,13 +449,13 @@ import (
 	"github.com/DataDog/datadog-go/statsd"
 )
 
-func main() {
+func main() {ÿ
 	statsd, err := statsd.New("127.0.0.1:8125")
-	if err != nil {
+	if err != nil {ÿ
 		log.Fatal(err)
 	}
 	var i float64
-	for {
+	for {ÿ
 		i += 1
 		statsd.Set("example_metric.set", strconv.Itoa(i), []string{"environment:dev"}, 1)
 		time.Sleep(rand.Intn(10) * time.Second)
@@ -473,11 +473,11 @@ using StatsdClient;
 using System;
 
 public class DogStatsdClient
-{
+{ÿ
     public static void Main()
-    {
+    {ÿ
         var dogstatsdConfig = new StatsdConfig
-        {
+        {ÿ
             StatsdServerName = "127.0.0.1",
             StatsdPort = 8125,
         };
@@ -487,7 +487,7 @@ public class DogStatsdClient
         var random = new Random(0);
 
         for (int i = 0; i < 10; i++)
-        {
+        {ÿ
             DogStatsd.Set("example_metric.set", i, tags: new[] {"environment:dev"});
             System.Threading.Thread.Sleep(random.Next(100000));
         }
@@ -515,7 +515,7 @@ $statsd = new DogStatsd(
 
 $i = 0;
 
-while (TRUE) {
+while (TRUE) {ÿ
     $i++;
     $statsd->set('example_metric.set', i, array('environment'=>'dev'));
     sleep(rand(0, 10));
@@ -532,7 +532,7 @@ After running the code above, your metrics data is available to graph in Datadog
 ### HISTOGRAM
 
 | Method                                                            | Datadog Storage type                                                                                                                                              |
-| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `histogram(<METRIC_NAME>, <METRIC_VALUE>, <SAMPLE_RATE>, <TAGS>)` | Since multiple metrics are submitted, metric types stored (`GAUGE`, `RATE`) depend of the metric. See the [HISTOGRAM metric type][7] documentation to learn more. |
 
 #### Configuration
@@ -554,7 +554,7 @@ from datadog import initialize, statsd
 import time
 import random
 
-options = {
+options = {ÿ
     'statsd_host':'127.0.0.1',
     'statsd_port':8125
 }
@@ -598,13 +598,13 @@ import (
 	"github.com/DataDog/datadog-go/statsd"
 )
 
-func main() {
+func main() {ÿ
 	statsd, err := statsd.New("127.0.0.1:8125")
-	if err != nil {
+	if err != nil {ÿ
 		log.Fatal(err)
 	}
 
-	for {
+	for {ÿ
 		statsd.Histogram("example_metric.histogram", rand.Intn(20), []string{"environment:dev"}, 1)
 		time.Sleep(2 * time.Second)
 	}
@@ -621,12 +621,12 @@ import com.timgroup.statsd.NonBlockingStatsDClient;
 import com.timgroup.statsd.StatsDClient;
 import java.util.Random;
 
-public class DogStatsdClient {
+public class DogStatsdClient {ÿ
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws Exception {ÿ
 
         StatsDClient Statsd = new NonBlockingStatsDClient("statsd", "localhost", 8125);
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 10; i++) {ÿ
             Statsd.recordHistogramValue("example_metric.histogram", new Random().nextInt(20), ["environment:dev"]);
             Thread.sleep(2000);
         }
@@ -644,11 +644,11 @@ using StatsdClient;
 using System;
 
 public class DogStatsdClient
-{
+{ÿ
     public static void Main()
-    {
+    {ÿ
         var dogstatsdConfig = new StatsdConfig
-        {
+        {ÿ
             StatsdServerName = "127.0.0.1",
             StatsdPort = 8125,
         };
@@ -658,7 +658,7 @@ public class DogStatsdClient
         var random = new Random(0);
 
         for (int i = 0; i < 10; i++)
-        {
+        {ÿ
             DogStatsd.Histogram("example_metric.histogram", random.Next(20), tags: new[] {"environment:dev"});
             System.Threading.Thread.Sleep(2000);
         }
@@ -684,7 +684,7 @@ $statsd = new DogStatsd(
      )
   );
 
-while (TRUE) {
+while (TRUE) {ÿ
     $statsd->histogram('example_metric.histogram', rand(0, 20), array('environment'=>'dev'));
     sleep(2);
 }
@@ -696,7 +696,7 @@ while (TRUE) {
 The above instrumentation produces the following metrics:
 
 | Metric                                  | Description                             |
-| --------------------------------------- | --------------------------------------- |
+|-----------------------------------------|-----------------------------------------|
 | `example_metric.histogram.count`        | Number of times this metric was sampled |
 | `example_metric.histogram.avg`          | Average time of the sampled values      |
 | `example_metric.histogram.median`       | Median sampled value                    |
@@ -712,7 +712,7 @@ After running the code above, your metrics data is available to graph in Datadog
 `TIMER` metric type in DogStatsD is an implementation of `HISTOGRAM` metric type (not to be confused with timers in the standard StatsD). It measure timing data only: for example, the amount of time a section of code takes to execute.
 
 | Method                                                        | Datadog Storage type                                                                                                                                              |
-| ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|---------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `timed(<METRIC_NAME>, <METRIC_VALUE>, <SAMPLE_RATE>, <TAGS>)` | Since multiple metrics are submitted, metric types stored (`GAUGE`, `RATE`) depend of the metric. See the [HISTOGRAM metric type][7] documentation to learn more. |
 
 ##### Configuration
@@ -733,7 +733,7 @@ from datadog import initialize, statsd
 import time
 import random
 
-options = {
+options = {ÿ
     'statsd_host':'127.0.0.1',
     'statsd_port':8125
 }
@@ -770,12 +770,39 @@ while(1):
 {{< /code-block >}}
 
 {{% /tab %}}
+{{% tab "PHP" %}}
+
+{{< code-block lang="php" filename="timer.php" >}}
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+
+use DataDog\DogStatsd;
+
+$statsd = new DogStatsd(
+    array('host' => '127.0.0.1',
+          'port' => 8125,
+     )
+  );
+
+function runfunction() {ÿ
+    sleep(rand(0, 20));
+}
+
+while (TRUE) {ÿ
+  $start_time = microtime(TRUE);
+  runfunction();
+  $statsd->microtiming('example_metric.timer', microtime(TRUE) - $start_time);
+}
+{{< /code-block >}}
+
+{{% /tab %}}
 {{< /tabs >}}
 
 As DogStatsD receives the timer metric data, it calculates the statistical distribution of render times and sends the following metrics to Datadog:
 
 | Metric                              | Description                             |
-| ----------------------------------- | --------------------------------------- |
+|-------------------------------------|-----------------------------------------|
 | `example_metric.timer.count`        | Number of times this metric was sampled |
 | `example_metric.timer.avg`          | Average time of the sampled values      |
 | `example_metric.timer.median`       | Median sampled value                    |
@@ -791,7 +818,7 @@ DogStatsD treats `TIMER` as a `HISTOGRAM` metric. Whether you use the `TIMER` or
 Distribution metrics are in BETA. [Contact Datadog support][9] to enable the feature for your account.
 
 | Method                                                | Datadog Storage type                                                                                          |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+|-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
 | `distribution(<METRIC_NAME>, <METRIC_VALUE>, <TAGS>)` | Stored as a `DISTRIBUTION` type in Datadog. See the dedicated [Distribution documentation][10] to learn more. |
 
 #### Code examples
@@ -808,7 +835,7 @@ from datadog import initialize, statsd
 import time
 import random
 
-options = {
+options = {ÿ
     'statsd_host':'127.0.0.1',
     'statsd_port':8125
 }
@@ -852,13 +879,13 @@ import (
 	"github.com/DataDog/datadog-go/statsd"
 )
 
-func main() {
+func main() {ÿ
 	statsd, err := statsd.New("127.0.0.1:8125")
-	if err != nil {
+	if err != nil {ÿ
 		log.Fatal(err)
 	}
 
-	for {
+	for {ÿ
 		statsd.Distribution("example_metric.distribution", float64(rand.Intn(20)), []string{"environment:dev"}, 1)
 		time.Sleep(2 * time.Second)
 	}
@@ -875,12 +902,12 @@ import com.timgroup.statsd.NonBlockingStatsDClient;
 import com.timgroup.statsd.StatsDClient;
 import java.util.Random;
 
-public class DogStatsdClient {
+public class DogStatsdClient {ÿ
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws Exception {ÿ
 
         StatsDClient Statsd = new NonBlockingStatsDClient("statsd", "localhost", 8125);
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 10; i++) {ÿ
             Statsd.recordDistributionValue("example_metric.distribution", new Random().nextInt(20), ["environment:dev"]);
             Thread.sleep(2000);
         }
@@ -898,11 +925,11 @@ using StatsdClient;
 using System;
 
 public class DogStatsdClient
-{
+{ÿ
     public static void Main()
-    {
+    {ÿ
         var dogstatsdConfig = new StatsdConfig
-        {
+        {ÿ
             StatsdServerName = "127.0.0.1",
             StatsdPort = 8125,
         };
@@ -912,7 +939,7 @@ public class DogStatsdClient
         var random = new Random(0);
 
         for (int i = 0; i < 10; i++)
-        {
+        {ÿ
             DogStatsd.Distribution("example_metric.distribution", random.Next(20), tags: new[] {"environment:dev"});
             System.Threading.Thread.Sleep(2000);
         }
@@ -938,7 +965,7 @@ $statsd = new DogStatsd(
      )
   );
 
-while (TRUE) {
+while (TRUE) {ÿ
     $statsd->distribution('example_metric.distribution', rand(0, 20), array('environment'=>'dev'));
     sleep(2);
 }
@@ -960,7 +987,7 @@ A sample rate of `1` sends metrics 100% of the time, while a sample rate of `0` 
 Before sending a metric to Datadog, DogStatsD uses the `<SAMPLE_RATE>` to correct the metric value depending on the metric type (to estimate the value without sampling):
 
 | Metric Type | Sample rate correction                                                                                                                                                         |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `COUNT`     | Values received are multiplied by (`1/<SAMPLE_RATE>`). It's reasonable to assume that for one datapoint received, `1/<SAMPLE_RATE>` were actually sampled with the same value. |
 | `GAUGE`     | No correction. The value received is kept as is.                                                                                                                               |
 | `SET`       | No correction. The value received is kept as is.                                                                                                                               |


### PR DESCRIPTION
### What does this PR do?
Adds TIMER metric type doc code example for PHP.

### Motivation
Review on: https://github.com/DataDog/php-datadogstatsd/pull/93

### Preview link
https://docs-staging.datadoghq.com/gus/php-timer/developers/metrics/dogstatsd_metrics_submission/?tab=php#configuration-1