### PR TITLE
[rum] add window.DD_RUM check

### DIFF
--- a/content/en/real_user_monitoring/_index.md
+++ b/content/en/real_user_monitoring/_index.md
@@ -45,7 +45,7 @@ Paste the generated code snippet into the head tag (in front of any other script
   type="text/javascript">
 </script>
 <script>
-  window.DD_RUM.init({
+  window.DD_RUM && window.DD_RUM.init({
     clientToken: '<CLIENT_TOKEN>',
     applicationId: '<APPLICATION_ID>',
   });
@@ -61,7 +61,7 @@ Paste the generated code snippet into the head tag (in front of any other script
   type="text/javascript">
 </script>
 <script>
-  window.DD_RUM.init({
+  window.DD_RUM && window.DD_RUM.init({
     clientToken: '<CLIENT_TOKEN>',
     applicationId: '<APPLICATION_ID>',
   });
@@ -70,6 +70,8 @@ Paste the generated code snippet into the head tag (in front of any other script
 
 {{% /tab %}}
 {{< /tabs >}}
+
+**Note**: The `window.DD_RUM` check is used to prevent issues if a loading failure occurs with the library.
 
 ### Client Tokens
 

--- a/content/fr/real_user_monitoring/_index.md
+++ b/content/fr/real_user_monitoring/_index.md
@@ -44,7 +44,7 @@ Collez l'extrait de code généré dans le tag d'en-tête (avant tous les autres
   type="text/javascript">
 </script>
 <script>
-  window.DD_RUM.init({
+  window.DD_RUM && window.DD_RUM.init({
     clientToken: '<TOKEN_CLIENT>',
     applicationId: '<ID_APPLICATION>',
   });
@@ -60,7 +60,7 @@ Collez l'extrait de code généré dans le tag d'en-tête (avant tous les autres
   type="text/javascript">
 </script>
 <script>
-  window.DD_RUM.init({
+  window.DD_RUM && window.DD_RUM.init({
     clientToken: '<TOKEN_CLIENT>',
     applicationId: '<ID_APPLICATION>',
   });
@@ -69,6 +69,8 @@ Collez l'extrait de code généré dans le tag d'en-tête (avant tous les autres
 
 {{% /tab %}}
 {{< /tabs >}}
+
+**Remarque**: La vérification `window.DD_LOGS` sert à éviter les problèmes liés au chargement du script.
 
 ### Tokens client
 

--- a/content/fr/real_user_monitoring/_index.md
+++ b/content/fr/real_user_monitoring/_index.md
@@ -70,7 +70,7 @@ Collez l'extrait de code généré dans le tag d'en-tête (avant tous les autres
 {{% /tab %}}
 {{< /tabs >}}
 
-**Remarque**: La vérification `window.DD_LOGS` sert à éviter les problèmes liés au chargement du script.
+**Remarque**: le check `window.DD_LOGS` est utilisé pour éviter tout problème si le chargement de la bibliothèque échoue.
 
 ### Tokens client
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Just like for [logs browser collection](https://docs.datadoghq.com/logs/log_collection/javascript/?tab=us#configure-the-javascript-logger), we add that `window.DD_RUM` so that nothing breaks on the user website if the loading of the script is blocked by `AdBlock` for instance.

### Motivation
<!-- What inspired you to submit this pull request?-->
Not break websites

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hdelaby/add-rum-load-check/real_user_monitoring

### Additional Notes
<!-- Anything else we should know when reviewing?-->
