### PR TITLE
Update agent and cluster agent setup docs

### DIFF
--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -70,7 +70,7 @@ Setting the value without a secret results in the token being readable in the `P
 
 3. Refer to this secret with the environment variable `DD_CLUSTER_AGENT_AUTH_TOKEN` in the manifests of the Cluster Agent. See [Step 3 - Create the Cluster Agent and its service](#step-3-create-the-cluster-agent-and-its-service)) and [Step 2 - Enable the Datadog Cluster Agent](#step-2-enable-the-datadog-agent).
 
-[1]: 
+[1]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/dca-secret.yaml
 {{% /tab %}}
 {{% tab "Environment Variable" %}}
 
@@ -111,7 +111,7 @@ Setting the value without a secret results in the token being readable in the `P
 
 1. Download the following manifests:
 
-  * [`datadog-cluster-agent_service.yaml`: The Cluster Agent Service manifest.][3]
+  * [`datadog-cluster-agent_service.yaml`: The Cluster Agent Service manifest][3]
   * [`cluster-agent.yaml`: Cluster Agent manifest][4]
 
 2. In the `cluster-agent.yaml` manifest, replace `<YOUR_API_KEY>` with [your Datadog API key][5]:

--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -66,7 +66,7 @@ Setting the value without a secret results in the token being readable in the `P
     kubectl create secret generic datadog-auth-token --from-literal=token=<ThirtyX2XcharactersXlongXtoken>
     ```
 
-    Alternatively, you can specify the token in the `dca-secret.yaml` file located in the [`manifest/cluster-agent` directory][1].
+    Alternatively, you can specify the token in the `dca-secret.yaml` file located in the [manifest/cluster-agent directory][1].
 
 3. Refer to this secret with the environment variable `DD_CLUSTER_AGENT_AUTH_TOKEN` in the manifests of the Cluster Agent. See [Step 3 - Create the Cluster Agent and its service](#step-3-create-the-cluster-agent-and-its-service)) and [Step 2 - Enable the Datadog Cluster Agent](#step-2-enable-the-datadog-agent).
 
@@ -147,7 +147,7 @@ NAME                    TYPE           CLUSTER-IP       EXTERNAL-IP        PORT(
 datadog-cluster-agent   ClusterIP      10.100.202.234   none               5005/TCP         1d
 ```
 
-**Note**: If you already have the Datadog Agent running, you may need to [apply the `rbac-agent.yaml` manifest](#step-1-set-configure-rbac-permissions-for-node-based-agents) before the Cluster Agent can start running.
+**Note**: If you already have the Datadog Agent running, you may need to apply the [rbac-agent.yaml manifest](#step-1-set-configure-rbac-permissions-for-node-based-agents) before the Cluster Agent can start running.
 
 ## Configure the Datadog Agent
 
@@ -156,13 +156,13 @@ After having set up the Datadog Cluster Agent, configure your Datadog Agent to c
 ### Setup
 #### Step 1 - Set Configure RBAC permissions for node-based Agents
 
-1. Dowload the the [`rbac-agent.yaml`][6] manifest. Note that when using the Cluster Agent, your node Agents are not able to interact with the Kubernetes API server—only the Cluster Agent is able to do so.
+1. Download the the [rbac-agent.yaml manifest][6]. **Note**: When using the Cluster Agent, your node Agents are not able to interact with the Kubernetes API server—only the Cluster Agent is able to do so.
 
 2. Run: `kubectl apply -f rbac-agent.yaml`
 
 #### Step 2 - Enable the Datadog Agent
 
-1. Dowload the [`agent.yaml` manifest][7].
+1. Download the [agent.yaml manifest][7].
 
 2. In the `agent.yaml` manifest, replace `<YOUR_API_KEY>` with [your Datadog API key][5]:
 

--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -31,7 +31,7 @@ The Datadog Cluster Agent needs a proper RBAC to be up and running:
 
 1. Review the manifests in the [Datadog Cluster Agent RBAC folder][1]. Note that when using the Cluster Agent, your node Agents are not able to interact with the Kubernetes API server—only the Cluster Agent is able to do so.
 
-2. To configure Cluster Agent RBAC permissions, apply the following manifests:
+2. To configure Cluster Agent RBAC permissions, apply the following manifests. (You may have done this already when setting up the [node Agent daemonset][1].)
 
   ```
   kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/rbac/clusterrole.yaml"
@@ -70,7 +70,7 @@ Setting the value without a secret results in the token being readable in the `P
 
 3. Refer to this secret with the environment variable `DD_CLUSTER_AGENT_AUTH_TOKEN` in the manifests of the Cluster Agent. See [Step 3 - Create the Cluster Agent and its service](#step-3-create-the-cluster-agent-and-its-service)) and [Step 2 - Enable the Datadog Cluster Agent](#step-2-enable-the-datadog-agent).
 
-[1]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/dca-secret.yaml
+[1]: 
 {{% /tab %}}
 {{% tab "Environment Variable" %}}
 
@@ -147,6 +147,8 @@ NAME                    TYPE           CLUSTER-IP       EXTERNAL-IP        PORT(
 datadog-cluster-agent   ClusterIP      10.100.202.234   none               5005/TCP         1d
 ```
 
+**Note**: If you already have the Datadog Agent running, you may need to [apply the `rbac-agent.yaml` manifest][5] before the Cluster Agent can start running.
+
 ## Configure the Datadog Agent
 
 After having set up the Datadog Cluster Agent, configure your Datadog Agent to communicate with the Datadog Cluster Agent.
@@ -154,13 +156,13 @@ After having set up the Datadog Cluster Agent, configure your Datadog Agent to c
 ### Setup
 #### Step 1 - Set Configure RBAC permissions for node-based Agents
 
-1. Dowload the the [`rbac-agent.yaml`][5] manifest. Note that when using the Cluster Agent, your node Agents are not able to interact with the Kubernetes API server—only the Cluster Agent is able to do so.
+1. Dowload the the [`rbac-agent.yaml`][6] manifest. Note that when using the Cluster Agent, your node Agents are not able to interact with the Kubernetes API server—only the Cluster Agent is able to do so.
 
 2. Run: `kubectl apply -f rbac-agent.yaml`
 
 #### Step 2 - Enable the Datadog Agent
 
-1. Dowload the [`agent.yaml` manifest][6].
+1. Dowload the [`agent.yaml` manifest][7].
 
 2. In the `agent.yaml` manifest, replace `<DD_API_KEY>` with [your Datadog API key][4]:
 
@@ -198,9 +200,10 @@ Kubernetes events are beginning to flow into your Datadog account, and relevant 
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/manifests/cluster-agent/rbac
+[1]: agent/kubernetes/daemonset_setup/?tab=k8sfile#configure-rbac-permissions
 [2]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/datadog-cluster-agent_service.yaml
 [3]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/cluster-agent.yaml
 [4]: https://app.datadoghq.com/account/settings#api
-[5]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/rbac/rbac-agent.yaml
-[6]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/agent.yaml
+[5]: /agent/cluster_agent/setup/?tab=secret#step-1-set-configure-rbac-permissions-for-node-based-agents
+[6]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/rbac/rbac-agent.yaml
+[7]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/agent.yaml

--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -31,7 +31,7 @@ The Datadog Cluster Agent needs a proper RBAC to be up and running:
 
 1. Review the manifests in the [Datadog Cluster Agent RBAC folder][1]. Note that when using the Cluster Agent, your node Agents are not able to interact with the Kubernetes API server—only the Cluster Agent is able to do so.
 
-2. To configure Cluster Agent RBAC permissions, apply the following manifests. (You may have done this already when setting up the [node Agent daemonset][1].)
+2. To configure Cluster Agent RBAC permissions, apply the following manifests. (You may have done this already when setting up the [node Agent daemonset][2].)
 
   ```
   kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/rbac/clusterrole.yaml"
@@ -111,10 +111,10 @@ Setting the value without a secret results in the token being readable in the `P
 
 1. Download the following manifests:
 
-  * [`datadog-cluster-agent_service.yaml`: The Cluster Agent Service manifest.][2]
-  * [`cluster-agent.yaml`: Cluster Agent manifest][3]
+  * [`datadog-cluster-agent_service.yaml`: The Cluster Agent Service manifest.][3]
+  * [`cluster-agent.yaml`: Cluster Agent manifest][4]
 
-2. In the `cluster-agent.yaml` manifest, replace `<DD_API_KEY>` with [your Datadog API key][4]:
+2. In the `cluster-agent.yaml` manifest, replace `<YOUR_API_KEY>` with [your Datadog API key][5]:
 
 3. In the `cluster-agent.yaml` manifest, set the token from [Step 2 - Secure Cluster-Agent-to-Agent Communication](#step-2-secure-cluster-agent-to-agent-communication). The format depends on how you set up your secret; instructions can be found in the manifest directly.
 
@@ -147,7 +147,7 @@ NAME                    TYPE           CLUSTER-IP       EXTERNAL-IP        PORT(
 datadog-cluster-agent   ClusterIP      10.100.202.234   none               5005/TCP         1d
 ```
 
-**Note**: If you already have the Datadog Agent running, you may need to [apply the `rbac-agent.yaml` manifest][5] before the Cluster Agent can start running.
+**Note**: If you already have the Datadog Agent running, you may need to [apply the `rbac-agent.yaml` manifest](#step-1-set-configure-rbac-permissions-for-node-based-agents) before the Cluster Agent can start running.
 
 ## Configure the Datadog Agent
 
@@ -164,7 +164,7 @@ After having set up the Datadog Cluster Agent, configure your Datadog Agent to c
 
 1. Dowload the [`agent.yaml` manifest][7].
 
-2. In the `agent.yaml` manifest, replace `<DD_API_KEY>` with [your Datadog API key][4]:
+2. In the `agent.yaml` manifest, replace `<YOUR_API_KEY>` with [your Datadog API key][5]:
 
 3. In the `agent.yaml` manifest, replace `<DD_SITE>` with the Datadog site you are using, i.e. `datadoghq.com` or `datadoghq.eu`. This value defaults to `datadoghq.com`.
 
@@ -200,10 +200,10 @@ Kubernetes events are beginning to flow into your Datadog account, and relevant 
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: agent/kubernetes/daemonset_setup/?tab=k8sfile#configure-rbac-permissions
-[2]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/datadog-cluster-agent_service.yaml
-[3]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/cluster-agent.yaml
-[4]: https://app.datadoghq.com/account/settings#api
-[5]: /agent/cluster_agent/setup/?tab=secret#step-1-set-configure-rbac-permissions-for-node-based-agents
+[1]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/manifests/cluster-agent/rbac
+[2]: agent/kubernetes/daemonset_setup/?tab=k8sfile#configure-rbac-permissions
+[3]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/datadog-cluster-agent_service.yaml
+[4]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/cluster-agent.yaml
+[5]: https://app.datadoghq.com/account/settings#api
 [6]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/rbac/rbac-agent.yaml
 [7]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/agent.yaml

--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -201,7 +201,7 @@ Kubernetes events are beginning to flow into your Datadog account, and relevant 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/manifests/cluster-agent/rbac
-[2]: agent/kubernetes/daemonset_setup/?tab=k8sfile#configure-rbac-permissions
+[2]: /agent/kubernetes/daemonset_setup/?tab=k8sfile#configure-rbac-permissions
 [3]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/datadog-cluster-agent_service.yaml
 [4]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/cluster-agent.yaml
 [5]: https://app.datadoghq.com/account/settings#api

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -33,15 +33,15 @@ kubectl create -f "https://raw.githubusercontent.com/DataDog/datadog-agent/maste
 ```
 
 ## Create manifest
-Create the following `datadog-agent.yaml` manifest.
+Create the following `datadog-agent.yaml` manifest. (This manifest assumes you are using Docker; if you are using Containerd, see [this example][3].)
 
-Remember to encode your API key using `base64`:
+Remember to encode your API key using `base64` if you are using RBAC:
 
 ```
-echo -n <DD_API_KEY> | base64
+echo -n <YOUR_API_KEY> | base64
 ```
 
-**Note**: If you are using KMS or have high DogStatsD usage, you may need a higher memory limit.
+**Note**: You may need a higher memory limit for Kube State Metrics or high DogStatsD usage.
 
 ```yaml
 # datadog-agent.yaml
@@ -56,7 +56,7 @@ echo -n <DD_API_KEY> | base64
 #     app: "datadog"
 # type: Opaque
 # data:
-#   api-key: "<YOUR_BASE64_ENCODED_DATADOG_API_KEY>"
+#   api-key: "<YOUR_BASE64_ENCODED_API_KEY>"
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -91,7 +91,8 @@ spec:
             protocol: TCP
         env:
           - name: DD_API_KEY
-            ## Kubernetes Secrets - uncomment this section to supply API Key with secrets
+            value: "<YOUR_API_KEY>"
+            ## Kubernetes Secrets - use this section instead of `value` to supply the API Key with secrets
             # valueFrom:
             #   secretKeyRef:
             #     name: datadog-secret
@@ -163,14 +164,14 @@ spec:
           name: cgroups
 ```
 
-Replace `<YOUR_API_KEY>` with [your Datadog API key][3] or use [Kubernetes secrets][4] to set your API key as an [environment variable][5]. If you opt to use Kubernetes secrets, refer to Datadog's [instructions for setting an API key with Kubernetes secrets][6]. Consult the [Docker integration][7] to discover all of the configuration options.
+Replace `<YOUR_API_KEY>` with [your Datadog API key][4] or use [Kubernetes secrets][5] to set your API key as an [environment variable][6]. If you opt to use Kubernetes secrets, refer to Datadog's [instructions for setting an API key with Kubernetes secrets][7]. Consult the [Docker integration][8] to discover all of the configuration options.
 
 Deploy the DaemonSet with the command:
 ```
 kubectl create -f datadog-agent.yaml
 ```
 
-**Note**:  This manifest enables Autodiscovery's auto configuration feature. To learn how to configure Autodiscovery, see the [dedicated Autodiscovery documentation][8].
+**Note**:  This manifest enables Autodiscovery's auto configuration feature. To learn how to configure Autodiscovery, see the [dedicated Autodiscovery documentation][9].
 
 ### Verification
 
@@ -195,14 +196,14 @@ Starting with version 6.11.0, the Datadog Agent can auto-detect the Kubernetes c
 
 On Google GKE and Azure AKS, the cluster name is retrieved from the cloud provider API. For AWS EKS, the cluster name is retrieved from EC2 instance tags.
 
-**Note**: On AWS, it is required to add the `ec2:DescribeInstances` [permission][9] to your Datadog IAM policy so that the Agent can query the EC2 instance tags.
+**Note**: On AWS, it is required to add the `ec2:DescribeInstances` [permission][10] to your Datadog IAM policy so that the Agent can query the EC2 instance tags.
 
 
 ## Enable capabilities
 
 ### Log Collection
 
-To enable [Log collection][10] with your DaemonSet:
+To enable [Log collection][11] with your DaemonSet:
 
 1. Set the `DD_LOGS_ENABLED` and `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL` variable to true in your *env* section:
 
@@ -307,7 +308,7 @@ The Datadog Agent follows the below logic to know where logs should be picked up
 
 **Note**: If you do want to collect logs from `/var/log/pods` even if the Docker socket is mounted, set the environment variable `DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE` (or `logs_config.k8s_container_use_file` in `datadog.yaml`) to `true` in order to force the Agent to go for the file collection mode.
 
-Finally, use [Autodiscovery with Pod Annotations][11] to enhance log collection for your containers.
+Finally, use [Autodiscovery with Pod Annotations][12] to enhance log collection for your containers.
 
 #### Short lived containers
 
@@ -382,11 +383,11 @@ tracer.configure(
 )
 ```
 
-Refer to the [language-specific APM instrumentation docs][12] for more examples.
+Refer to the [language-specific APM instrumentation docs][13] for more examples.
 
 ### Process Collection
 
-See [Process collection for Kubernetes][13].
+See [Process collection for Kubernetes][14].
 
 ### DogStatsD
 
@@ -401,7 +402,7 @@ To send custom metrics via DogStatsD, set the `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` v
 (...)
 ```
 
-Learn more about this in the [Kubernetes DogStatsD documentation][14]
+Learn more about this in the [Kubernetes DogStatsD documentation][15]
 
 To send custom metrics via DogStatsD from your application pods, uncomment the `# hostPort: 8125` line in your `datadog-agent.yaml` manifest. This exposes the DogStatsD port on each of your Kubernetes nodes.
 
@@ -415,15 +416,16 @@ The workaround in this case is to add `hostNetwork: true` in your Agent pod spec
 
 [1]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 [2]: https://hub.docker.com/r/datadog/agent
-[3]: https://app.datadoghq.com/account/settings#api
-[4]: https://kubernetes.io/docs/concepts/configuration/secret
-[5]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information
-[6]: /agent/faq/kubernetes-secrets
-[7]: /agent/docker/#environment-variables
-[8]: /agent/autodiscovery/?tab=agent#how-to-set-it-up
-[9]: /integrations/amazon_ec2/#configuration
-[10]: /logs
-[11]: /agent/autodiscovery/integrations/?tab=kubernetes
-[12]: /tracing/setup
-[13]: /graphing/infrastructure/process/?tab=kubernetes#installation
-[14]: /agent/kubernetes/dogstatsd
+[3]: /integrations/containerd/#installation-on-containers
+[4]: https://app.datadoghq.com/account/settings#api
+[5]: https://kubernetes.io/docs/concepts/configuration/secret
+[6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information
+[7]: /agent/faq/kubernetes-secrets
+[8]: /agent/docker/#environment-variables
+[9]: /agent/autodiscovery/?tab=agent#how-to-set-it-up
+[10]: /integrations/amazon_ec2/#configuration
+[11]: /logs
+[12]: /agent/autodiscovery/integrations/?tab=kubernetes
+[13]: /tracing/setup
+[14]: /graphing/infrastructure/process/?tab=kubernetes#installation
+[15]: /agent/kubernetes/dogstatsd

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -35,7 +35,7 @@ kubectl create -f "https://raw.githubusercontent.com/DataDog/datadog-agent/maste
 ## Create manifest
 Create the following `datadog-agent.yaml` manifest. (This manifest assumes you are using Docker; if you are using Containerd, see [this example][3].)
 
-Remember to encode your API key using `base64` if you are using `secret`s:
+Remember to encode your API key using `base64` if you are using secrets:
 
 ```
 echo -n <YOUR_API_KEY> | base64

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -35,13 +35,13 @@ kubectl create -f "https://raw.githubusercontent.com/DataDog/datadog-agent/maste
 ## Create manifest
 Create the following `datadog-agent.yaml` manifest. (This manifest assumes you are using Docker; if you are using Containerd, see [this example][3].)
 
-Remember to encode your API key using `base64` if you are using RBAC:
+Remember to encode your API key using `base64` if you are using `secret`s:
 
 ```
 echo -n <YOUR_API_KEY> | base64
 ```
 
-**Note**: You may need a higher memory limit for Kube State Metrics or high DogStatsD usage.
+**Note**: You may need a higher memory limit if you are using `kube-state-metrics` or have high DogStatsD usage.
 
 ```yaml
 # datadog-agent.yaml
@@ -92,7 +92,7 @@ spec:
         env:
           - name: DD_API_KEY
             value: "<YOUR_API_KEY>"
-            ## Kubernetes Secrets - use this section instead of `value` to supply the API Key with secrets
+            ## Kubernetes secrets - use this section instead of `value` to supply the API Key with secrets
             # valueFrom:
             #   secretKeyRef:
             #     name: datadog-secret


### PR DESCRIPTION
### What does this PR do?
- Add missing API key `value` for agent daemonset manifest
- Fix references to `DD_API_KEY` -> `YOUR_API_KEY`
- Clarify agent ds manifest assumes Docker usage
- Clarify encoded API key only needed under RBAC
- Clarify cluster agent setup verification step may be slightly different if node agent is setup first

### Motivation
Confusions and errors noticed while following the docs during setup

### Preview link

https://docs-staging.datadoghq.com/celene/agent_docs/agent/kubernetes/daemonset_setup/
https://docs-staging.datadoghq.com/celene/agent_docs/agent/cluster_agent/setup

### Additional Notes
