### PR TITLE
Add DD_AGENT_VERSION option to our EBS sample config

### DIFF
--- a/static/config/99datadog.config
+++ b/static/config/99datadog.config
@@ -3,7 +3,9 @@ option_settings:
     - namespace:  aws:elasticbeanstalk:application:environment
       option_name:  DD_API_KEY
       value:  "<YOUR_DD_API_KEY>"
-
+    - namespace:  aws:elasticbeanstalk:application:environment
+      option_name:  DD_AGENT_VERSION
+      value:  "" # For example, "6.15.1". Leave empty to install the latest version. Only Agent 6 is supported.
 files:
     "/configure_datadog_yaml.sh":
         mode: "000700"
@@ -87,7 +89,7 @@ container_commands:
         command: "cp /datadog/hooks/99start_datadog.sh /opt/elasticbeanstalk/hooks/configdeploy/post/"
     90install_datadog:
         test: '[ -f /datadog/datadog.repo ]'
-        command: "cp /datadog/datadog.repo /etc/yum.repos.d/datadog.repo; yum -y makecache; yum -y install datadog-agent"
+        command: 'cp /datadog/datadog.repo /etc/yum.repos.d/datadog.repo; yum -y makecache; DD_AGENT_VERSION="$(/opt/elasticbeanstalk/bin/get-config environment -k DD_AGENT_VERSION)"; yum -y install datadog-agent${DD_AGENT_VERSION:+-$DD_AGENT_VERSION-1}'
     91setup_datadog:
         test: '[ -x /configure_datadog_yaml.sh ]'
         command: "/configure_datadog_yaml.sh"


### PR DESCRIPTION
## What does this PR do?
Allow users to pin a specific version of the Agent
## Testing done
Deployed on EBS for with and without specifying DD_AGENT_VERSION.
## Additional notes
Was previously merged and reverted because of a typo in the command: https://github.com/DataDog/documentation/pull/5945