### PR TITLE
fix weird sentence

### DIFF
--- a/content/en/tracing/guide/metrics_namespace.md
+++ b/content/en/tracing/guide/metrics_namespace.md
@@ -23,7 +23,7 @@ aliases:
 ---
 
 ## Overview
-The [trace metrics][1] namespace is `trace.<name>.<metrics>{<tags>}` where
+The [trace metrics][1] namespace is `trace.<name>.<metrics>{<tags>}`.
 
 Tracing application metrics are collected after [enabling trace collection][2] and [instrumenting your application][3]. These metrics are available for dashboards and monitors.
 


### PR DESCRIPTION
this sentence had "where" at it at the end for no reason




so it's gone now