### PR TITLE
homepage tile alignment fix

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -93,7 +93,7 @@
                             
                             {{ range $i, $navtile := $section.navtiles }} 
                                 <div class="col-12 col-md-6 col-lg-4 col-xl-3 nav-tile d-flex mb-2 mb-md-3">
-                                        <a class="d-flex flex-column justify-content-center align-items-center w-100 small font-semibold" href="{{ $navtile.link | absLangURL }}">
+                                        <a class="d-flex flex-column align-items-center w-100 small font-semibold" href="{{ $navtile.link | absLangURL }}">
                                                 {{ partial "svg" (dict "context" $dot "src" $navtile.icon "color" "#632CA6" )}}
                                                 {{ $navtile.title }}<span class="font-regular text-center smaller">{{ $navtile.desc }}</span></a>
                                         </a>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
adjust alignment for main tiles on homepage.

### Motivation
https://trello.com/c/xw0evdqq/4183-enhancement-of-type-alignment-in-topic-tiles

### Preview link
http://docs-staging.datadoghq.com/zach/homepage-tweaks


### Additional Notes
<!-- Anything else we should know when reviewing?-->
