### PR TITLE
Adding statement to cover native memory consumption

### DIFF
--- a/content/en/tracing/setup/java.md
+++ b/content/en/tracing/setup/java.md
@@ -317,6 +317,7 @@ Java APM has minimal impact on the overhead of an application:
 
 * No collections maintained by Java APM grow unbounded in memory
 * Reporting traces does not block the application thread
+* Java APM loads additional classes for trace collection and library instrumentation
 * Java APM typically adds no more than a 3% increase in CPU usage
 * Java APM typically adds no more than a 3% increase in JVM heap usage
 


### PR DESCRIPTION
### What does this PR do?
Adds a small statement to our overhead section to cover the fact that we load additional classes (which in most JVMs will consume native memory).

### Motivation
Recent issues where customers were surprised by increased native memory when enabled the DataDog java tracer.

### Preview link
https://docs-staging.datadoghq.com/dougqh/overhead-update/tracing/setup/java

### Additional Notes
None
