### PR TITLE
Agent log level

### DIFF
--- a/content/en/agent/troubleshooting/debug_mode.md
+++ b/content/en/agent/troubleshooting/debug_mode.md
@@ -108,16 +108,15 @@ Or the container can be restarted.
 
 The following Agent log levels are available for `log_level` or `DD_LOG_LEVEL`:
 
-| Option  | Fatal logs | Error logs | Warn logs | Info logs | Debug logs | Trace logs | All logs  |
-|---------|------------|------------|-----------|-----------|------------|------------|-----------|
-| `OFF`   |            |            |           |           |            |            |           |
-| `FATAL` | {{< X >}}  |            |           |           |            |            |           |
-| `ERROR` | {{< X >}}  | {{< X >}}  |           |           |            |            |           |
-| `WARN`  | {{< X >}}  | {{< X >}}  | {{< X >}} |           |            |            |           |
-| `INFO`  | {{< X >}}  | {{< X >}}  | {{< X >}} | {{< X >}} |            |            |           |
-| `DEBUG` | {{< X >}}  | {{< X >}}  | {{< X >}} | {{< X >}} | {{< X >}}  |            |           |
-| `TRACE` | {{< X >}}  | {{< X >}}  | {{< X >}} | {{< X >}} | {{< X >}}  | {{< X >}}  |           |
-| `ALL`   | {{< X >}}  | {{< X >}}  | {{< X >}} | {{< X >}} | {{< X >}}  | {{< X >}}  | {{< X >}} |
+| Option  | Critical logs | Error logs | Warn logs | Info logs | Debug logs | Trace logs |
+|---------|---------------|------------|-----------|-----------|------------|------------|
+| `OFF`   |               |            |           |           |            |            |
+| `CRIT`  | {{< X >}}     |            |           |           |            |            |
+| `ERROR` | {{< X >}}     | {{< X >}}  |           |           |            |            |
+| `WARN`  | {{< X >}}     | {{< X >}}  | {{< X >}} |           |            |            |
+| `INFO`  | {{< X >}}     | {{< X >}}  | {{< X >}} | {{< X >}} |            |            |
+| `DEBUG` | {{< X >}}     | {{< X >}}  | {{< X >}} | {{< X >}} | {{< X >}}  |            |
+| `TRACE` | {{< X >}}     | {{< X >}}  | {{< X >}} | {{< X >}} | {{< X >}}  | {{< X >}}  |
 
 ## Further Reading
 


### PR DESCRIPTION
### What does this PR do?
Update Agent log levels for [changes](https://github.com/DataDog/integrations-core/blob/230236537acb9fc9ebeca427a01959b7bed22ac5/datadog_checks_base/datadog_checks/base/log.py#L69):
- Remove `ALL`
- Rename `FATAL` to `CRIT`

### Motivation
Trello request

### Preview link
https://docs-staging.datadoghq.com/ruth/agent-logs/agent/troubleshooting/debug_mode/?tab=agentv6#agent-log-level

### Additional Notes
N/A
