### PR TITLE
Removed query example that did not work

### DIFF
--- a/content/en/graphing/event_stream/_index.md
+++ b/content/en/graphing/event_stream/_index.md
@@ -30,7 +30,6 @@ Use tag search to find all events with the same key tag with the following query
 | Filter               | Description                                                                    |
 | ----                 | ---                                                                            |
 | `tags:<KEY>:<VALUE>` | Shows events with the `<KEY>:<VALUE>` tag.                                     |
-| `tags:<VALUE>`       | Shows all events with the `<VALUE>` attached, whatever the `<KEY>`.            |
 | `<KEY>:*`            | Shows all events with the `<KEY>` attached.                                    |
 | `<KEY>`:`<REGEX>`    | Shows all events with `<KEY>:<VALUE>` tag where `<VALUE>` matches the `<REGEX>`|
 | `tags:<KEY>`         | Doesn't return anything.                                                       |
@@ -67,14 +66,9 @@ Combine prefixes to construct more complex searches. For example, if you wanted 
 * `@test@example.com` Sends an email to `test@example.com`.
 * If you have Slack, Webhooks, Pagerduty, or VictorOps, use:
     * `@slack-<SLACK_ACCOUNT>-<CHANNEL_NAME>` – posts the event or graph to that channel.
-    * `@webhook` – Alerts or triggers whatever is attached to that webhook. Check out [our blogpost on Webhooks][7]!
+    * `@webhook` – Alerts or triggers whatever is attached to that webhook. Check out [our blogpost on Webhooks][2]!
     * `@pagerduty` – Sends an alert to Pagerduty. You can also use `@pagerduty-acknowledge` and `@pagerduty-resolve`.
 
 
 [1]: https://app.datadoghq.com/event/stream
-[2]: /integrations
-[3]: /agent/agent_checks
-[4]: /api/#events
-[5]: https://app.datadoghq.com
-[6]: http://daringfireball.net/projects/markdown/syntax#lin
-[7]: https://www.datadoghq.com/blog/send-alerts-sms-customizable-webhooks-twilio
+[2]: https://www.datadoghq.com/blog/send-alerts-sms-customizable-webhooks-twilio


### PR DESCRIPTION
### What does this PR do?
Removes an event query example for tags that does not function as described

### Motivation
Customer reached out about the example not working for them

### Preview link
https://docs-staging.datadoghq.com/storms/update_event_query/graphing/event_stream/_index.md 
