### PR TITLE
[API][Snapshot] Escape `{*}` in query params

### DIFF
--- a/content/en/api/graphs/code_snippets/api-graph-snapshot.sh
+++ b/content/en/api/graphs/code_snippets/api-graph-snapshot.sh
@@ -12,4 +12,4 @@ curl -X GET \
 -H "Content-type: application/json" \
 -H "DD-API-KEY: ${api_key}" \
 -H "DD-APPLICATION-KEY: ${app_key}" \
-"https://api.datadoghq.com/api/v1/graph/snapshot?metric_query=system.load.1{*}&start=${currenttime2}&end=${currenttime}"
+"https://api.datadoghq.com/api/v1/graph/snapshot?metric_query=system.load.1\{*\}&start=${currenttime2}&end=${currenttime}"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Escape the curly brackets from the url since it's used in double quotes.

### Motivation
<!-- What inspired you to submit this pull request?-->
Without the escape, the API is returning: `{"errors": ["The value provided for parameter 'metric_query' is invalid"]}`

### Preview link
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/api/?lang=bash#graph-snapshot

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/edznux-dd-patch-1/api/?lang=bash#graph-snapshot

### Additional Notes
<!-- Anything else we should know when reviewing?-->

The `date` utils from gnu doesn't recognise the flag `-v -1d`. I had to use `date --date="1 day ago" +%s` to make it work. I'm not sure on what should be done there.
