### PR TITLE
Changed hostmap default color from red to orange

### DIFF
--- a/content/en/graphing/infrastructure/hostmap.md
+++ b/content/en/graphing/infrastructure/hostmap.md
@@ -62,7 +62,7 @@ Click the name of an integration for a condensed dashboard of metrics for that i
 
 ### Shapes and colors
 
-By default the color of each host is set to represent the percentage of CPU usage on that host, where the color ranges from green (0% utilized) to red (100% utilized). You can select different metrics from the `Color by` selector.  
+By default the color of each host is set to represent the percentage of CPU usage on that host, where the color ranges from green (0% utilized) to orange (100% utilized). You can select different metrics from the `Color by` selector.  
 
 Host Maps can also communicate an additional, optional metric with the size of the hexagon: use the `Size by` selector. 
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Changes default hostmap color for 100% utilization from red to orange.

### Motivation
Trello card request.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/sarina/hostmap-orange/graphing/infrastructure/hostmap

### Additional Notes