### PR TITLE
remove beta message for GCS archives and specify that rehydration is …

### DIFF
--- a/content/en/logs/archives/_index.md
+++ b/content/en/logs/archives/_index.md
@@ -93,10 +93,6 @@ To add server side encryption to your S3 log archives, go to the **Properties** 
 
 {{% tab "Google Cloud Storage" %}}
 
-<div class="alert alert-warning">
-    GCS Archives are in private beta. Request early access by contacting <a href="/help">Datadog Support</a>. GCS Archives do not yet support rehydration.
-</div>
-
 1. Go to your [GCP account][1] and [create a GCS bucket][2] to send your archives to. Under "Choose how to control access to objects", select "Set object-level and bucket-level permissions."
 
 2. Set up the [GCP integration][3] for the project that holds your GCS storage bucket, if you haven’t already. This involves [creating a GCS Service Account that Datadog can use][4] to integrate with.

--- a/content/en/logs/archives/rehydrating.md
+++ b/content/en/logs/archives/rehydrating.md
@@ -7,7 +7,7 @@ aliases:
 ---
 
 <div class="alert alert-warning">
-	Log Archive Rehydrating is in public beta. Request early access by contacting <a href="/help">Datadog Support</a>. Rehydrating is currently only supported for AWS S3 Archives, and for users of the Datadog US site. <a href="https://forms.gle/X4jhi13Rd2pFSuSHA">Send feedback for this feature</a>.
+	Log Archive Rehydrating is in public beta. Request early access by contacting <a href="/help">Datadog Support</a>. Rehydrating is currently only supported for users of the Datadog US site. <a href="https://forms.gle/X4jhi13Rd2pFSuSHA">Send feedback for this feature</a>.
 </div>
 
 ## Overview


### PR DESCRIPTION
…supported

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes the beta message for GCS archives, and remove words that say GCS rehydration isn't supported. 

### Motivation
<!-- What inspired you to submit this pull request?-->
GCS archives are GA! and rehydration is supported now too!

### Preview link
<!-- Impacted pages preview links-->
- https://docs-staging.datadoghq.com/estib/gcs-log-archives-ga/logs/archives/?tab=googlecloudstorage
- https://docs-staging.datadoghq.com/estib/gcs-log-archives-ga/logs/archives/rehydrating/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Thanks!
