### PR TITLE
Add documentation about B3 header use with go.

### DIFF
--- a/content/en/tracing/setup/go.md
+++ b/content/en/tracing/setup/go.md
@@ -145,10 +145,7 @@ Datadog APM tracer supports [B3 headers extraction][58] and injection for distri
 
 Distributed headers injection and extraction is controlled by
 configuring injection/extraction styles. Currently two styles are
-supported:
-
-* Datadog: `Datadog`
-* B3: `B3`
+supported: `Datadog` and `B3`.
 
 Injection styles can be configured using the environment variable
 `DD_PROPAGATION_STYLE_INJECT=Datadog,B3`
@@ -160,8 +157,8 @@ The values of these environment variables are comma separated lists of
 header styles that are enabled for injection or extraction. By default only
 Datadog extraction style is enabled.
 
-If multiple extraction styles are enabled extraction attempt is done
-on the order those styles are configured and first successful
+If multiple extraction styles are enabled, extraction attempts are made
+in the order that those styles are specified and the first successful
 extracted value is used.
 
 ## Change Agent Hostname

--- a/content/en/tracing/setup/go.md
+++ b/content/en/tracing/setup/go.md
@@ -139,6 +139,35 @@ func main() {
 
 For more tracer settings, see available options in the [configuration documentation][57].
 
+### B3 Headers Extraction and Injection
+
+Datadog APM tracer supports [B3 headers extraction][58] and injection for distributed tracing.
+
+Distributed headers injection and extraction is controlled by
+configuring injection/extraction styles. Currently two styles are
+supported:
+
+* Datadog: `Datadog`
+* B3: `B3`
+
+Injection styles can be configured using the environment Variable
+`DD_PROPAGATION_STYLE_INJECTION=Datadog,B3`
+
+The value of the property or environment variable is a comma separated list of
+header styles that are enabled for injection. By default only Datadog injection
+style is enabled.
+
+Extraction styles can be configured using the environment Variable
+`DD_PROPAGATION_STYLE_EXTRACT=Datadog,B3`
+
+The value of the property or environment variable is a comma separated list of
+header styles that are enabled for extraction. By default onlyDatadog extraction
+style is enabled.
+
+If multiple extraction styles are enabled extraction attempt is done
+on the order those styles are configured and first successful
+extracted value is used.
+
 ## Change Agent Hostname
 
 Configure your application level tracers to submit traces to a custom Agent hostname:
@@ -227,3 +256,4 @@ func main() {
 [55]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/hashicorp/vault
 [56]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib
 [57]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#StartOption
+[58]: https://github.com/openzipkin/b3-propagation

--- a/content/en/tracing/setup/go.md
+++ b/content/en/tracing/setup/go.md
@@ -150,19 +150,15 @@ supported:
 * Datadog: `Datadog`
 * B3: `B3`
 
-Injection styles can be configured using the environment Variable
-`DD_PROPAGATION_STYLE_INJECTION=Datadog,B3`
+Injection styles can be configured using the environment variable
+`DD_PROPAGATION_STYLE_INJECT=Datadog,B3`
 
-The value of the property or environment variable is a comma separated list of
-header styles that are enabled for injection. By default only Datadog injection
-style is enabled.
-
-Extraction styles can be configured using the environment Variable
+Extraction styles can be configured using the environment variable
 `DD_PROPAGATION_STYLE_EXTRACT=Datadog,B3`
 
-The value of the property or environment variable is a comma separated list of
-header styles that are enabled for extraction. By default onlyDatadog extraction
-style is enabled.
+The values of these environment variables are comma separated lists of
+header styles that are enabled for injection or extraction. By default only
+Datadog extraction style is enabled.
 
 If multiple extraction styles are enabled extraction attempt is done
 on the order those styles are configured and first successful

--- a/content/en/tracing/setup/go.md
+++ b/content/en/tracing/setup/go.md
@@ -141,7 +141,7 @@ For more tracer settings, see available options in the [configuration documentat
 
 ### B3 Headers Extraction and Injection
 
-Datadog APM tracer supports [B3 headers extraction][58] and injection for distributed tracing.
+The Datadog APM tracer supports [B3 headers extraction][58] and injection for distributed tracing.
 
 Distributed headers injection and extraction is controlled by
 configuring injection/extraction styles. Currently two styles are
@@ -155,10 +155,10 @@ Extraction styles can be configured using the environment variable
 
 The values of these environment variables are comma separated lists of
 header styles that are enabled for injection or extraction. By default only
-Datadog extraction style is enabled.
+the `Datadog` extraction style is enabled.
 
 If multiple extraction styles are enabled, extraction attempts are made
-in the order that those styles are specified and the first successful
+in the order that those styles are specified and the first successfully
 extracted value is used.
 
 ## Change Agent Hostname

--- a/content/en/tracing/setup/go.md
+++ b/content/en/tracing/setup/go.md
@@ -144,13 +144,13 @@ For more tracer settings, see available options in the [configuration documentat
 The Datadog APM tracer supports [B3 headers extraction][58] and injection for distributed tracing.
 
 Distributed headers injection and extraction is controlled by
-configuring injection/extraction styles. Currently two styles are
+configuring injection/extraction styles. Two styles are
 supported: `Datadog` and `B3`.
 
-Injection styles can be configured using the environment variable
+Configure injection styles using the environment variable
 `DD_PROPAGATION_STYLE_INJECT=Datadog,B3`
 
-Extraction styles can be configured using the environment variable
+Configure extraction styles using the environment variable
 `DD_PROPAGATION_STYLE_EXTRACT=Datadog,B3`
 
 The values of these environment variables are comma separated lists of
@@ -158,7 +158,7 @@ header styles that are enabled for injection or extraction. By default only
 the `Datadog` extraction style is enabled.
 
 If multiple extraction styles are enabled, extraction attempts are made
-in the order that those styles are specified and the first successfully
+in the order that those styles are specified. The first successfully
 extracted value is used.
 
 ## Change Agent Hostname


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR adds documentation describing the use of the B3 headers with Go.

### Motivation
This is part of an effort to document B3 header use for all languages that implement it.

### Preview link
https://docs-staging.datadoghq.com/knusbaum/go-b3-headers/tracing/setup/go

This documentation is lifted nearly word-for-word from [the Java section](https://docs.datadoghq.com/tracing/setup/java/#b3-headers-extraction-and-injection), but I've verified that everything here is correct for the go tracer.