### PR TITLE
Add application key header to authentication curl example

### DIFF
--- a/content/en/api/authentication/code_snippets/api-auth.sh
+++ b/content/en/api/authentication/code_snippets/api-auth.sh
@@ -1,4 +1,3 @@
-
-
-curl "https://api.datadoghq.com/api/v1/validate" -H "DD-API-KEY: <YOUR_API_KEY>"
-
+curl "https://api.datadoghq.com/api/v1/validate" \
+    -H "DD-API-KEY: <YOUR_API_KEY>" \
+    -H "DD-APPLICATION-KEY: <YOUR_APPLICATION_KEY>"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds the `DD-APPLICATION-KEY` header to the Authentication example.

### Motivation
A previous PR updated the example to use `DD-API-KEY` but did not add `DD-APPLICATION-KEY` and that is required for most API calls.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/chris.linstid/authentication-key-headers/api/?lang=bash#authentication

### Additional Notes
<!-- Anything else we should know when reviewing?-->
