### PR TITLE
Updating new APM header specific to browser tests

### DIFF
--- a/content/en/synthetics/apm/_index.md
+++ b/content/en/synthetics/apm/_index.md
@@ -55,7 +55,7 @@ Datadog uses the distributed tracing protocol and sets up the following HTTP hea
 
 * `x-datadog-trace-id`, generated from the Synthetics backend. Allows Datadog to link the trace with the test result.
 * `x-datadog-parent-id: 0`
-* `x-datadog-origin: synthetics`, to make sure the generated traces don't affect your APM quotas. See below.
+* `x-datadog-origin: synthetics`, to make sure the generated traces don't affect your APM quotas. See below. For browser tests, the header is `x-datadog-origin: synthetics-browser`.
 * `x-datadog-sampling-priority: 1`, [to make sure that the Agent keeps the trace][10].
 
 ### How are APM quotas affected?

--- a/content/en/synthetics/apm/_index.md
+++ b/content/en/synthetics/apm/_index.md
@@ -56,7 +56,7 @@ Datadog uses the distributed tracing protocol and sets up the following HTTP hea
 | Header                                 | Description                                                                                                             |
 |----------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
 | `x-datadog-trace-id`                   | Generated from the Synthetics backend. Allows Datadog to link the trace with the test result.                           |
-| `x-datadog-parent-id: 0`               |                                                                                                                         |
+| `x-datadog-parent-id: 0`               | To have Synthetics be the root span of the generated trace.                                                                                                                        |
 | `x-datadog-origin: synthetics`         | To make sure the generated traces from your API tests [don't affect your APM quotas](#how-are-apm-quotas-affected).     |
 | `x-datadog-origin: synthetics-browser` | To make sure the generated traces from your Browser tests [don't affect your APM quotas](#how-are-apm-quotas-affected). |
 | `x-datadog-sampling-priority: 1`       | [To make sure that the Agent keeps the trace][10].                                                                      |

--- a/content/en/synthetics/apm/_index.md
+++ b/content/en/synthetics/apm/_index.md
@@ -53,10 +53,13 @@ The following Datadog tracing libraries are supported:
 
 Datadog uses the distributed tracing protocol and sets up the following HTTP headers:
 
-* `x-datadog-trace-id`, generated from the Synthetics backend. Allows Datadog to link the trace with the test result.
-* `x-datadog-parent-id: 0`
-* `x-datadog-origin: synthetics`, to make sure the generated traces don't affect your APM quotas. See below. For browser tests, the header is `x-datadog-origin: synthetics-browser`.
-* `x-datadog-sampling-priority: 1`, [to make sure that the Agent keeps the trace][10].
+| Header                                 | Description                                                                                                             |
+|----------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| `x-datadog-trace-id`                   | Generated from the Synthetics backend. Allows Datadog to link the trace with the test result.                           |
+| `x-datadog-parent-id: 0`               |                                                                                                                         |
+| `x-datadog-origin: synthetics`         | To make sure the generated traces from your API tests [don't affect your APM quotas](#how-are-apm-quotas-affected).     |
+| `x-datadog-origin: synthetics-browser` | To make sure the generated traces from your Browser tests [don't affect your APM quotas](#how-are-apm-quotas-affected). |
+| `x-datadog-sampling-priority: 1`       | [To make sure that the Agent keeps the trace][10].                                                                      |
 
 ### How are APM quotas affected?
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR adds info about the `x-datadog-origin` header for browser tests

### Motivation
Changes on eng side

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/margot.lepizzera/browsertest_apm_header/synthetics/apm/#how-are-traces-linked-to-tests

### Additional Notes
<!-- Anything else we should know when reviewing?-->
