### PR TITLE
now live tail is available for hipaa compliant customers

### DIFF
--- a/content/en/security/logs.md
+++ b/content/en/security/logs.md
@@ -50,7 +50,8 @@ With the Docker Agent, pass in ```DD_LOGS_CONFIG_LOGS_DD_URL=tcp-encrypted-intak
 Additionally, certain features are not available at the moment to customers who have signed Datadog's BAA, notably:
 
 * Users cannot request support via chat
-* The logs Live Tail, Rehydrate from Archives, and Generate Metrics features are disabled
+* Rehydration from Log Archives is disabled
+* Generation of Metrics from logs is disabled
 * Notifications from Log Monitors cannot include log samples
 * Log Monitors cannot be configured with a `group-by` clause
 * You cannot [share][6] logs (nor traces) from the explorer through web integrations.

--- a/content/en/security/logs.md
+++ b/content/en/security/logs.md
@@ -51,7 +51,7 @@ Additionally, certain features are not available at the moment to customers who 
 
 * Users cannot request support via chat
 * Rehydration from Log Archives is disabled
-* Generation of Metrics from logs is disabled
+* Generation of metrics from logs is disabled
 * Notifications from Log Monitors cannot include log samples
 * Log Monitors cannot be configured with a `group-by` clause
 * You cannot [share][6] logs (nor traces) from the explorer through web integrations.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
removes "live tail" from the list of disabled features for hipaa compliant customers

### Motivation
<!-- What inspired you to submit this pull request?-->
we added hipaa support for Live Tail!

### Preview link
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/estib/hipaa-logs-livetail-enabled/security/logs/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Thanks!