### PR TITLE
fixing the markdown link

### DIFF
--- a/content/en/api/events/events_post.md
+++ b/content/en/api/events/events_post.md
@@ -40,5 +40,5 @@ This endpoint allows you to post events to the stream. Tag them, set priority an
     A list of device names to post the event with.
 
 [1]: https://github.com/DataDog/dogapi-rb
-[2]: /developers/events/email.md#markdown
+[2]: content/en/developers/events/email.md#markdown
 [3]: /integrations/faq/list-of-api-source-attribute-value

--- a/content/en/api/events/events_post.md
+++ b/content/en/api/events/events_post.md
@@ -40,5 +40,5 @@ This endpoint allows you to post events to the stream. Tag them, set priority an
     A list of device names to post the event with.
 
 [1]: https://github.com/DataDog/dogapi-rb
-[2]: content/en/developers/events/email.md#markdown
+[2]: /content/en/developers/events/email.md#markdown
 [3]: /integrations/faq/list-of-api-source-attribute-value

--- a/content/en/api/events/events_post.md
+++ b/content/en/api/events/events_post.md
@@ -40,5 +40,5 @@ This endpoint allows you to post events to the stream. Tag them, set priority an
     A list of device names to post the event with.
 
 [1]: https://github.com/DataDog/dogapi-rb
-[2]: /content/en/developers/events/email.md#markdown
+[2]: /developers/events/email#markdown
 [3]: /integrations/faq/list-of-api-source-attribute-value

--- a/content/en/api/events/events_post.md
+++ b/content/en/api/events/events_post.md
@@ -40,5 +40,5 @@ This endpoint allows you to post events to the stream. Tag them, set priority an
     A list of device names to post the event with.
 
 [1]: https://github.com/DataDog/dogapi-rb
-[2]: /graphing/event_stream/#markdown-events
+[2]: /developers/events/email.md#markdown
 [3]: /integrations/faq/list-of-api-source-attribute-value


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
The markdown link on the event api page `https://github.com/DataDog/documentation/blob/master/graphing/event_stream/#markdown-events` is broken 

update the link to `https://github.com/DataDog/documentation/blob/master/content/en/developers/events/email.md#markdown`

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/mei_jin/event_api_markdown/api/?lang=python#post-an-event

### Additional Notes
<!-- Anything else we should know when reviewing?-->
