### PR TITLE
AuthN Mapping Cleanup

### DIFF
--- a/content/en/account_management/authen_mapping/_index.md
+++ b/content/en/account_management/authen_mapping/_index.md
@@ -136,7 +136,7 @@ Returns a list of AuthN Mappings
 
 | Method | Endpoint path        | Required payload          |
 |--------|----------------------|---------------------------|
-| `GET`  | `/v2/authn_mappings` | optional query parameters |
+| `GET`  | `/v2/authn_mappings` | Optional query parameters |
 
 ##### ARGUMENTS
 

--- a/content/en/account_management/authen_mapping/_index.md
+++ b/content/en/account_management/authen_mapping/_index.md
@@ -53,7 +53,6 @@ curl -X POST \
          -d '{
              "data": {
                  "type": "authn_mappings",
-                 "id": "123e4567-e89b-12d3-a456-426655440000",
                  "attributes": {
                       "role_uuid": "123e4567-e89b-12d3-a456-426655445555",
                       "attribute_key": "string",
@@ -146,7 +145,7 @@ Returns a list of AuthN Mappings
 * **`sort`** [*optional*, *default*=**+**]:
   Sort attribute and direction—defaults to ascending order, `-` sorts in descending order.
 * **`page[number]`** [*optional*, *default*=**0**, *minimum*=**0**]:
-  The page of results to return. 
+  The page of results to return.
 * **`page[size]`** [*optional*, *default*=**10**]:
   The number of results to return on each page.
 * **`filter`** [*optional*, no default]:

--- a/content/en/account_management/authen_mapping/_index.md
+++ b/content/en/account_management/authen_mapping/_index.md
@@ -12,7 +12,7 @@ further_reading:
 The Federated Authentication to Role Mapping API is currently in closed beta. Functionality and performance may not be ideal, and we reserve the right to change the functionality at any time without warning. Ask your customer success manager or <a href="/help">Datadog Support</a> to enable this feature.
 </div>
 
-If you are using Federated Authentication mechanisms, this API allows you to automatically map groups of users to roles in Datadog.
+If you are using Federated Authentication mechanisms, this API allows you to automatically map groups of users to roles in Datadog using attributes sent from your Identity Provider.
 
 **Note**: If you are a SAML user, and you have been using the existing beta Federated Mapping mechanism (`roles_v2_saml`), Datadog strongly recommends that you transition to using this API.
 
@@ -25,7 +25,6 @@ All the API endpoints below can have two different host endpoints:
 
 ### Create a new Authentication mapping
 
-
 Create a new AuthN Mapping from a JSON body. Returns the newly created AuthN Mapping.
 
 | Method | Endpoint path | Required payload |
@@ -35,18 +34,18 @@ Create a new AuthN Mapping from a JSON body. Returns the newly created AuthN Map
 ##### ARGUMENTS
 
 * **`role_uuid`** [*required*, *default*=none]:
-  The Roles API can be used to create and manage Datadog roles, what global permissions they grant, and which users belong to them. When you create a Role, it is assigned a UUID. For more information about finding the `role_uuid` for the role you are updating, see the [Role API documentation][1].
+  The `UUID` of the Role to map to. The Roles API can be used to create and manage Datadog roles, what global permissions they grant, and which users belong to them. When you create a Role, it is assigned a UUID. For more information about finding the `role_uuid` for the role you want to map to, see the [Role API documentation][1].
 * **`attribute_key`** [*required*, *default*=none]:
- The `attribute_key` and the `attribute_value` are key/value pairs defined in their SAML assertions from their Identity Providers. You can define these for your own use case. For example, `attribute_key` could be `member-of` and the `attribute_value` could be `Development`.
+ The `attribute_key` is the key portion of a key/value pair that represents an attribute sent from your Identity Provider. You can define these for your own use case. For example, `attribute_key` could be `member-of` and the `attribute_value` could be `Development`.
 * **`attribute_value`** [*required*, *default*=none]:
-  The `attribute_key` and the `attribute_value` are key/value pairs defined in their SAML assertions from their Identity Providers. You can define these for your own use case. For example, `attribute_key` could be `member-of` and the `attribute_value` could be `Development`.
+ The `attribute_value` is the value portion of a key/value pair that represents an attribute sent from your Identity Provider. You can define these for your own use case. For example, `attribute_key` could be `member-of` and the `attribute_value` could be `Development`.
 
 {{< tabs >}}
 {{% tab "Example" %}}
 
 ```sh
 curl -X POST \
-         "https://app.datadoghq.com/api/v2/authn_mappings/{UUID}" \
+         "https://api.datadoghq.com/api/v2/authn_mappings" \
          -H "Content-Type: application/json" \
          -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
          -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
@@ -55,8 +54,8 @@ curl -X POST \
                  "type": "authn_mappings",
                  "attributes": {
                       "role_uuid": "123e4567-e89b-12d3-a456-426655445555",
-                      "attribute_key": "string",
-                      "attribute_value": "string"
+                      "attribute_key": "member-of",
+                      "attribute_value": "Development"
                 }
              }
          }'
@@ -64,7 +63,7 @@ curl -X POST \
 
 Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1].
 
-[1]: https://app.datadoghq.com/account/settings#api
+[1]: https://api.datadoghq.com/account/settings#api
 {{% /tab %}}
 {{% tab "Response" %}}
 
@@ -73,12 +72,11 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
   "data": {
     "attributes": {
       "created_at": "2019-11-04 17:41:29.015504",
-      "created_by": "string",
       "role_uuid": "00000000-0000-0000-0000-000000000000",
       "saml_assertion_attribute_id": 0
     },
     "type": "authn_mappings",
-    "id": "string",
+    "id": "123e4567-e89b-12d3-a456-426655440000",
     "relationships": {
       "saml_assertion_attributes": {
         "data": {
@@ -97,12 +95,12 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
   "included": [
     {
       "data": {
-        "id": "string",
+        "id": "123e4567-e89b-12d3-a456-426655440000",
         "type": "roles",
         "attributes": {
           "created_at": "2019-11-04 17:41:29.015504",
           "modified_at": "2019-11-06 17:41:29.015504",
-          "name": "string"
+          "name": "Developer Role"
         },
         "relationships": {
           "data": [
@@ -120,8 +118,8 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
         "type": "saml_assertion_attributes",
         "attributes": {
           "id": 6,
-          "attribute_key": "string",
-          "attribute_value": "string"
+          "attribute_key": "member-of",
+          "attribute_value": "Development"
         }
       }
     }
@@ -136,9 +134,9 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 
 Returns a list of AuthN Mappings
 
-| Method | Endpoint path            | Required payload |
-|--------|-------------------------|------------------|
-| `GET`  | `/v2/authn_mappings` | optional queries       |
+| Method | Endpoint path        | Required payload          |
+|--------|----------------------|---------------------------|
+| `GET`  | `/v2/authn_mappings` | optional query parameters |
 
 ##### ARGUMENTS
 
@@ -155,14 +153,14 @@ Returns a list of AuthN Mappings
 {{% tab "Example" %}}
 
 ```sh
-curl -X GET "https://app.datadoghq.com/api/v2/authn_mappings" \
+curl -X GET "https://api.datadoghq.com/api/v2/authn_mappings" \
      -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
      -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>"
 ```
 
 Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1].
 
-[1]: https://app.datadoghq.com/account/settings#api
+[1]: https://api.datadoghq.com/account/settings#api
 {{% /tab %}}
 {{% tab "Response" %}}
 
@@ -188,7 +186,6 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
       },
       "attributes": {
         "created_at": "2019-11-04 17:41:29.015504",
-        "created_by": "string",
         "role_uuid": "123e4567-e89b-12d3-a456-426655445555",
         "saml_assertion_attribute_id": 0
       }
@@ -202,7 +199,7 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
         "attributes": {
           "created_at": "2019-11-04 17:41:29.015504",
           "modified_at": "2019-11-06 17:41:29.015504",
-          "name": "string"
+          "name": "Developer Role"
         },
         "relationships": {
           "data": [
@@ -220,8 +217,8 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
         "type": "saml_assertion_attributes",
         "attributes": {
           "id": 6,
-          "attribute_key": "string",
-          "attribute_value": "string"
+          "attribute_key": "member-of",
+          "attribute_value": "Developer"
         }
       }
     }
@@ -256,14 +253,14 @@ Returns a specific AuthN Mapping by UUID.
 {{% tab "Example" %}}
 
 ```sh
-curl -X GET "https://app.datadoghq.com/api/v2/authn_mappings/{UUID}" \
+curl -X GET "https://api.datadoghq.com/api/v2/authn_mappings/{UUID}" \
      -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
      -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>"
 ```
 
 Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1].
 
-[1]: https://app.datadoghq.com/account/settings#api
+[1]: https://api.datadoghq.com/account/settings#api
 {{% /tab %}}
 {{% tab "Response" %}}
 
@@ -272,7 +269,6 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
   "data": {
     "attributes": {
       "created_at": "2019-11-04 17:41:29.015504",
-      "created_by": "string",
       "uuid": "123e4567-e89b-12d3-a456-426655440000",
       "role_uuid": "123e4567-e89b-12d3-a456-426655445555",
       "saml_assertion_attribute_id": 0
@@ -303,7 +299,7 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
           "created_at": "2019-11-04 17:41:29.015504",
           "modified_at": "2019-11-06 17:41:29.015504",
           "uuid": "123e4567-e89b-12d3-a456-426655440000",
-          "name": "string"
+          "name": "Developer Role"
         },
         "relationships": {
           "data": [
@@ -321,8 +317,8 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
         "type": "saml_assertion_attributes",
         "attributes": {
           "id": 6,
-          "attribute_key": "string",
-          "attribute_value": "string"
+          "attribute_key": "member-of",
+          "attribute_value": "Developer"
         }
       }
     }
@@ -338,38 +334,40 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 Updates the AuthN Mapping `role`, `saml_assertion_attribute_id`, or both from a JSON body. Returns the updated AuthN Mapping.
 
 
-| Method | Endpoint path | Required payload |
-|--------|--------------|------------------|
-| `PATCH`  | `/v2/authn_mappings/{ID}`  | JSON       |
+| Method  | Endpoint path               | Required payload    |
+|---------|-----------------------------|---------------------|
+| `PATCH` | `/v2/authn_mappings/{UUID}` | URL parameter, JSON |
 
 ##### ARGUMENTS
 
+* **`{UUID}`** [*required*, no default]:
+  Replace `{UUID}` with the UUID of the AuthN Mapping you want to update.
 * **`id`** [*required*, *default*=none]:
-  The UUID of the `authinmap` being updated. For more information about finding your UUID, see the [Role API documentation][1].
+  The UUID of the AuthN Mapping being updated. This property must match the `{UUID}` path parameter in the request.
 * **`role_uuid`** [*required*, *default*=none]:
   The Roles API can be used to create and manage Datadog roles, what global permissions they grant, and which users belong to them. When you create a Role, it is assigned a UUID. For more information about finding the `role_uuid` for the role you are updating, see the [Role API documentation][1].
 * **`attribute_key`** [*required*, *default*=none]:
- The `attribute_key` and the `attribute_value` are key/value pairs defined in their SAML assertions from their Identity Providers. You can define these for your own use case. For example, `attribute_key` could be `member-of` and the `attribute_value` could be `Development`.
+ The `attribute_key` is the key portion of a key/value pair that represents an attribute sent from your Identity Provider. You can define these for your own use case. For example, `attribute_key` could be `member-of` and the `attribute_value` could be `Development`.
 * **`attribute_value`** [*required*, *default*=none]:
-  The `attribute_key` and the `attribute_value` are key/value pairs defined in their SAML assertions from their Identity Providers. You can define these for your own use case. For example, `attribute_key` could be `member-of` and the `attribute_value` could be `Development`.
+ The `attribute_value` is the value portion of a key/value pair that represents an attribute sent from your Identity Provider. You can define these for your own use case. For example, `attribute_key` could be `member-of` and the `attribute_value` could be `Development`.
 
 {{< tabs >}}
 {{% tab "Example" %}}
 
 ```sh
 curl -X PATCH \
-         "https://app.datadoghq.com/api/v2/authn_mappings/{UUID}" \
+         "https://api.datadoghq.com/api/v2/authn_mappings/{UUID}" \
          -H "Content-Type: application/json" \
          -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
          -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
          -d '{
              "data": {
                  "type": "authn_mappings",
-                 "id": "123e4567-e89b-12d3-a456-426655440000",
+                 "id": "{UUID}",
                  "attributes": {
                       "role_uuid": "123e4567-e89b-12d3-a456-426655445555",
-                      "attribute_key": "string",
-                      "attribute_value": "string"
+                      "attribute_key": "member-of",
+                      "attribute_value": "Developer"
                 }
              }
          }'
@@ -377,7 +375,7 @@ curl -X PATCH \
 
 Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1].
 
-[1]: https://app.datadoghq.com/account/settings#api
+[1]: https://api.datadoghq.com/account/settings#api
 {{% /tab %}}
 {{% tab "Response" %}}
 
@@ -386,7 +384,6 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
   "data": {
     "attributes": {
       "created_at": "2019-11-04 17:41:29.015504",
-      "created_by": "string",
       "role_uuid": "123e4567-e89b-12d3-a456-426655445555",
       "saml_assertion_attribute_id": 0
     },
@@ -416,7 +413,7 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
           "created_at": "2019-11-04 17:41:29.015504",
           "modified_at": "2019-11-06 17:41:29.015504",
           "uuid": "123e4567-e89b-12d3-a456-426655440000",
-          "name": "string"
+          "name": "Developer Role"
         },
         "relationships": {
           "data": [
@@ -434,8 +431,8 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
         "type": "saml_assertion_attributes",
         "attributes": {
           "id": 6,
-          "attribute_key": "string",
-          "attribute_value": "string"
+          "attribute_key": "member-of",
+          "attribute_value": "Developer"
         }
       }
     }
@@ -451,9 +448,9 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 
 Deletes a specific AuthN Mapping.
 
-| Method   | Endpoint path            | Required payload |
-|----------|-------------------------|------------------|
-| `DELETE` | `/v2/authn_mappings/{UUID}` | URL parameter |
+| Method   | Endpoint path               | Required payload |
+|----------|-----------------------------|------------------|
+| `DELETE` | `/v2/authn_mappings/{UUID}` | URL parameter    |
 
 ##### ARGUMENTS
 
@@ -464,7 +461,7 @@ Deletes a specific AuthN Mapping.
 {{% tab "Example" %}}
 
 ```sh
-curl -X DELETE "https://app.datadoghq.com/api/v2/authn_mappings/{UUID}" \
+curl -X DELETE "https://api.datadoghq.com/api/v2/authn_mappings/{UUID}" \
          -H "Content-Type: application/json" \
          -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
          -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>"
@@ -472,7 +469,7 @@ curl -X DELETE "https://app.datadoghq.com/api/v2/authn_mappings/{UUID}" \
 
 Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1].
 
-[1]: https://app.datadoghq.com/account/settings#api
+[1]: https://api.datadoghq.com/account/settings#api
 {{% /tab %}}
 {{% tab "Response" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Cleans up documentation for the Federated Authentication Mapping feature.

- Corrects paths and properties included/required in the JSON body
- Clarifies where some of the properties or parameters come from.
- Improves some of the example values so they are closer to what you would use in real life.
- Corrects the Datadog hostname in request examples.
- Loosens the language around attributes since they may come from IdPs other than SAML like OAuth or SCIM in the future.

### Motivation
Some customers are starting to kick the tires on this beta feature so we want to help them have a better experience.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/chris.linstid/authn-mapping-cleanup/account_management/authen_mapping/?tab=example

### Additional Notes
<!-- Anything else we should know when reviewing?-->
