### PR TITLE
Update link for replace_tags documentation

### DIFF
--- a/content/en/security/tracing.md
+++ b/content/en/security/tracing.md
@@ -66,7 +66,7 @@ If a customer requires tailored instrumentation for a specific application, they
 
 [1]: /security
 [2]: /tracing/setup
-[3]: /tracing/setup/#agent-configuration
+[3]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml#L472-L490
 [4]: https://github.com/DataDog/dd-trace-java/blob/master/dd-trace-api/src/main/java/datadog/trace/api/interceptor/TraceInterceptor.java
 [5]: http://gems.datadoghq.com/trace/docs/#Processing_Pipeline
 [6]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#trace-filtering

--- a/content/en/security/tracing.md
+++ b/content/en/security/tracing.md
@@ -66,7 +66,7 @@ If a customer requires tailored instrumentation for a specific application, they
 
 [1]: /security
 [2]: /tracing/setup
-[3]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml#L472-L490
+[3]: https://github.com/DataDog/datadog-agent/blob/780caa2855a237fa731b78a1bb3ead5492f0e5c6/pkg/config/config_template.yaml#L472-L490
 [4]: https://github.com/DataDog/dd-trace-java/blob/master/dd-trace-api/src/main/java/datadog/trace/api/interceptor/TraceInterceptor.java
 [5]: http://gems.datadoghq.com/trace/docs/#Processing_Pipeline
 [6]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#trace-filtering


### PR DESCRIPTION
### What does this PR do?
Update link of replace_tags setting as it was redirecting to APM languages page.

### Motivation
Customer reported this issue as it took them a long time to find the replace_tags description.
https://datadog.zendesk.com/agent/tickets/278800

### Preview link
https://github.com/DataDog/documentation/blob/824f4d241ca58a4bb9a6ffa0f5353268dd5567b4/content/en/security/tracing.md

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/content/en/security/tracing.md
