### PR TITLE
reverse changes that causes the fr search page to no longer work

### DIFF
--- a/src/scripts/datadog-docs.js
+++ b/src/scripts/datadog-docs.js
@@ -68,7 +68,7 @@ $(document).ready(function () {
     // algolia
     $('.ds-hint').css('background', 'transparent');
 
-    if (document.documentElement.dataset.relpermalink === '/search/') {
+    if (window.location.href.indexOf('/search/')) {
 
         const client = algoliasearch("EOIG7V0A2O", 'c7ec32b3838892b10610af30d06a4e42');
         const results = new RegExp('[\?&]' + "s" + '=([^&#]*)').exec(window.location.href);


### PR DESCRIPTION
### What does this PR do?

The search results page on fr site wasn't showing results. Specifically a link like this had no results

[https://docs.datadoghq.com/fr/search/?s=agent](https://docs.datadoghq.com/fr/search/?s=agent)

[This change appears to be the cause](https://github.com/DataDog/documentation/commit/ba8d53b45e7c196517df385bc6ec387215c3705c#diff-afeb0dc36a4f1ac0ca64ac72639553afR66), when viewing in firefox the `document.documentElement.dataset.relpermalink` variable contains `/fr/search/` which doesn't match the comparison causing it to skip the logic here.

This PR reverts to the previous working version.

### Motivation
https://trello.com/c/xaVckeKQ/4209-french-search-result-page-is-broken

### Preview link
https://docs-staging.datadoghq.com/david.jones/fix-fr-searchresults/fr/search/?s=agent
https://docs-staging.datadoghq.com/david.jones/fix-fr-searchresults/search/?s=agent

### Additional Notes

