### PR TITLE
Removing Beta Flag from Distribution Docs

### DIFF
--- a/content/en/developers/metrics/types.md
+++ b/content/en/developers/metrics/types.md
@@ -175,10 +175,6 @@ Discover how to submit histogram metrics:
 {{% /tab %}}
 {{% tab "DISTRIBUTION" %}}
 
-<div class="alert alert-warning">
-This feature is in beta. <a href="https://docs.datadoghq.com/help/">Contact Datadog support</a> to enable distribution metrics for your account.
-</div>
-
 **A `DISTRIBUTION` is a metric submission type that allows you to aggregate values sent from multiple hosts during a flush interval to measure statistical distributions across your entire infrastructure.** `DISTRIBUTION` metrics are designed to instrument logical objects, like services, independently from the underlying hosts.
 
 Unlike the `HISTOGRAM` metric type, which aggregates on the Agent side during the flush interval, a `DISTRIBUTION` metric sends all the raw data during a flush interval to Datadog, and aggregations occur server-side. Because the underlying data structure represents raw, unaggregated data, distributions provide two major features:

--- a/content/en/graphing/metrics/distributions.md
+++ b/content/en/graphing/metrics/distributions.md
@@ -9,9 +9,6 @@ further_reading:
     tag: "Documentation"
     text: "Using Distributions in DogStatsD"
 ---
-<div class="alert alert-warning">
-This feature is in beta. <a href="https://docs.datadoghq.com/help/">Contact Datadog support</a> to enable distribution metrics for your account.
-</div>
 
 ## Overview
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes the header flags that say distributions are in beta. They are now generally available

