### PR TITLE
Fixing yaml dump for translation

### DIFF
--- a/content/en/api/logs_pipelines/_index.md
+++ b/content/en/api/logs_pipelines/_index.md
@@ -1,4 +1,4 @@
 ---
-title: Logs Pipelines
-external_redirect: /api/
+title: "Logs Pipelines"
+external_redirect: "/api/"
 ---

--- a/content/en/getting_started/integrations/_index.md
+++ b/content/en/getting_started/integrations/_index.md
@@ -2,7 +2,7 @@
 title: Introduction to Integrations
 kind: documentation
 aliases:
-- /getting_started/integrations
+- "/getting_started/integrations"
 further_reading:
 - link: "https://learn.datadoghq.com/"
   tag: "Learning Center"
@@ -11,18 +11,18 @@ further_reading:
   tag: "Integrations"
   text: "Datadog's full list of integrations"
 ---
-- [Setting up an integration](#setting-up-an-integration)
-  - [API and Application keys](#api-and-application-keys)
-  - [Installation](#installation)
-  - [Configuring Agent integrations](#configuring-agent-integrations)
-  - [Tagging](#tagging)
-  - [Validation](#validation)
-- [Installing multiple integrations](#installing-multiple-integrations)
-- [Security practices](#security-practices)
-- [What's next?](#what-s-next)
-- [Troubleshooting](#troubleshooting)
-- [Key terms](#key-terms)
-- [Further Reading](#further-reading)
+* [Setting up an integration](#setting-up-an-integration)
+  * [API and Application keys](#api-and-application-keys)
+  * [Installation](#installation)
+  * [Configuring Agent integrations](#configuring-agent-integrations)
+  * [Tagging](#tagging)
+  * [Validation](#validation)
+* [Installing multiple integrations](#installing-multiple-integrations)
+* [Security practices](#security-practices)
+* [What's next?](#whats-next)
+* [Troubleshooting](#troubleshooting)
+* [Key terms](#key-terms)
+* [Further Reading](#further-reading)
 
 This is a guide for using integrations, if you are looking for information about building a new integration, see the [Create a new integration][1] page.
 

--- a/content/en/videos/apmsetup-rails.md
+++ b/content/en/videos/apmsetup-rails.md
@@ -1,5 +1,5 @@
 ---
-title: APM - Setup for a Rails app
+title: "APM - Setup for a Rails app"
 kind: video
 language: en
 wistiaid: ps2vn2rask

--- a/local/bin/py/update_pre_build.py
+++ b/local/bin/py/update_pre_build.py
@@ -1045,7 +1045,7 @@ class PreBuild:
                     del item[0]["type"]
                 item[0]["dependencies"] = dependencies
                 fm = yaml.dump(
-                    item[0], default_flow_style=False
+                    item[0], width=150, default_style='"', default_flow_style=False
                 ).rstrip()
             else:
                 fm = {"kind": "integration"}


### PR DESCRIPTION
### What does this PR do?
This PR fixes the yaml for frontmatters in order to fix some translation job issue.

### Motivation
The following type of errors pops out in the translation CI job:

```
info: Failed content_integrations_azure_vm_scale_set_md Malformed yaml frontmatter, incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line at line 8, column 48:
     ... Surveillez des métriques by-set : octets entrant/sortant, opérat ... 
```

----


New shape of Integrations frontmatters: 
```
---
"categories":
- "cloud"
- "azure"
- "log collection"
"ddtype": "crawler"
"dependencies": []
"description": "Track by-set metrics: bytes in and out, disk operations, CPU usage, and more."
"doc_link": "https://docs.datadoghq.com/integrations/azure_vm_scale_set/"
"git_integration_title": "azure_vm_scale_set"
"has_logo": !!bool "true"
"integration_title": "Microsoft Azure Virtual Machine Scale Set"
"is_public": !!bool "true"
"kind": "integration"
"manifest_version": "1.0"
"name": "azure_vm_scale_set"
"public_title": "Datadog-Microsoft Azure Virtual Machine Scale Set Integration"
"short_description": "Track by-set metrics: bytes in and out, disk operations, CPU usage, and more."
"version": "1.0"
---
```

### Preview link

* https://docs-staging.datadoghq.com/gus/translation-fixes/integrations/