### PR TITLE
add process collection to steps in NPM install

### DIFF
--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -45,7 +45,7 @@ To enable network performance monitoring, configure it in your [Agent's main con
 
 To enable network performance monitoring with the Datadog Agent, use the following configurations:
 
-1. [Enable live process collection](https://docs.datadoghq.com/graphing/infrastructure/process/?tab=linuxwindows#installation) if you have not done so already. 
+1. If you haven't already, enable [live process collection][1] first. 
 
 2. Copy the system-probe example configuration:
     ```

--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -72,7 +72,7 @@ To enable network performance monitoring with the Datadog Agent, use the followi
     ```
 
 6. Start the system-probe: `sudo service datadog-agent-sysprobe start`
-7. [Restart the Agent][1]: `sudo service datadog-agent restart`
+7. [Restart the Agent][2]: `sudo service datadog-agent restart`
 
 [1]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#restart-the-agent
 {{% /tab %}}

--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -45,14 +45,16 @@ To enable network performance monitoring, configure it in your [Agent's main con
 
 To enable network performance monitoring with the Datadog Agent, use the following configurations:
 
-1. Copy the system-probe example configuration:
+1. [Enable live process collection](https://docs.datadoghq.com/graphing/infrastructure/process/?tab=linuxwindows#installation) if you have not done so already. 
+
+2. Copy the system-probe example configuration:
     ```
     sudo -u dd-agent cp /etc/datadog-agent/system-probe.yaml.example /etc/datadog-agent/system-probe.yaml
     ```
 
-2. Modify the system-probe configuration file to set the enable flag to `true`.<br>
+3. Modify the system-probe configuration file to set the enable flag to `true`.<br>
 
-3. Optionally uncomment the `system_probe_config` parameter to add a custom object:
+4. Optionally uncomment the `system_probe_config` parameter to add a custom object:
     ```
     ## @param system_probe_config - custom object - optional
     ## (...)
@@ -60,7 +62,7 @@ To enable network performance monitoring with the Datadog Agent, use the followi
     system_probe_config:
     ```
 
-4. Enter specific configurations for your System Probe data collection:
+5. Enter specific configurations for your System Probe data collection:
     ```
     system_probe_config:
         ## @param enabled - boolean - optional - default: false
@@ -69,8 +71,8 @@ To enable network performance monitoring with the Datadog Agent, use the followi
         enabled: true
     ```
 
-5. Start the system-probe: `sudo service datadog-agent-sysprobe start`
-6. [Restart the Agent][1]: `sudo service datadog-agent restart`
+6. Start the system-probe: `sudo service datadog-agent-sysprobe start`
+7. [Restart the Agent][1]: `sudo service datadog-agent restart`
 
 [1]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#restart-the-agent
 {{% /tab %}}

--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -74,7 +74,8 @@ To enable network performance monitoring with the Datadog Agent, use the followi
 6. Start the system-probe: `sudo service datadog-agent-sysprobe start`
 7. [Restart the Agent][2]: `sudo service datadog-agent restart`
 
-[1]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#restart-the-agent
+[1]: https://docs.datadoghq.com/graphing/infrastructure/process/?tab=linuxwindows#installation
+[2]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#restart-the-agent
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
[Internal KB article](https://docs.datadoghq.com/graphing/infrastructure/process/?tab=linuxwindows#installation) mentions that process agent needs to be configured before NPM will work. Adding this to eliminate confusion. `DD_PROCESS_AGENT_ENABLED=true` is already mentioned in the Kubernetes and Docker install instructions. 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
