### PR TITLE
Add example for the monitor validation endpoint using the Ruby client.

### DIFF
--- a/content/en/api/monitors/code_snippets/api-monitor-validate.rb
+++ b/content/en/api/monitors/code_snippets/api-monitor-validate.rb
@@ -1,2 +1,22 @@
-# This is not yet supported by the Ruby Client for Datadog API
-# Consult the curl example
+require 'dogapi'
+
+api_key = '<YOUR_API_KEY>'
+app_key = '<YOUR_APP_KEY>'
+
+dog = Dogapi::Client.new(api_key, app_key)
+
+type = 'metric alert'
+query = 'THIS IS A BAD QUERY'
+parameters = {
+  name: 'Bytes received on host0',
+  message: 'We may need to add web hosts if this is consistently high.',
+  tags: ['app:webserver', 'frontend'],
+  options: {
+    notify_no_data: true,
+    no_data_timeframe: 20,
+    thresholds: { critical: 90.0 }
+  }
+}
+
+# Validate a monitor definition
+dog.validate_monitor(type, query, parameters)

--- a/content/en/api/monitors/code_snippets/result.api-monitor-validate.rb
+++ b/content/en/api/monitors/code_snippets/result.api-monitor-validate.rb
@@ -1,1 +1,3 @@
-["200", {}]
+['400', {
+  'errors' => ["The value provided for parameter 'query' is invalid"]
+}]


### PR DESCRIPTION
### What does this PR do?
Adds an example of monitor validation using the Ruby client.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/armcburney/add_alerting_api_examples/api/?lang=ruby#validate-a-monitor
