### PR TITLE
Add example for the monitor validation endpoint using the Python client.

### DIFF
--- a/content/en/api/downtimes/code_snippets/result.api-monitor-get-downtimes.py
+++ b/content/en/api/downtimes/code_snippets/result.api-monitor-get-downtimes.py
@@ -1,5 +1,3 @@
-
-
 [
     {
         'active': False,

--- a/content/en/api/monitors/code_snippets/api-monitor-validate.py
+++ b/content/en/api/monitors/code_snippets/api-monitor-validate.py
@@ -13,7 +13,7 @@ monitor_options = {"thresholds": {"critical": 90.0}}
 
 # Validate a monitor's definition
 api.Monitor.validate(
-  type=monitor_type,
-  query=query,
-  options=monitor_options,
+    type=monitor_type,
+    query=query,
+    options=monitor_options,
 )

--- a/content/en/api/monitors/code_snippets/api-monitor-validate.py
+++ b/content/en/api/monitors/code_snippets/api-monitor-validate.py
@@ -1,2 +1,19 @@
-# This is not yet supported by the Python Client for Datadog API
-# Consult the curl example
+from datadog import initialize, api
+
+options = {
+    "api_key": "<YOUR_API_KEY>",
+    "app_key": "<YOUR_APP_KEY>"
+}
+
+initialize(**options)
+
+monitor_type = "metric alert"
+query = "avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 200"
+monitor_options = {"thresholds": {"critical": 90.0}}
+
+# Validate a monitor's definition
+api.Monitor.validate(
+  type=monitor_type,
+  query=query,
+  options=monitor_options,
+)

--- a/content/en/api/monitors/code_snippets/result.api-monitor-validate.py
+++ b/content/en/api/monitors/code_snippets/result.api-monitor-validate.py
@@ -1,1 +1,1 @@
-{}
+{"errors": ["Alert threshold (90.0) does not match that used in the query (200.0)."]}

--- a/content/en/api/monitors/monitors_validate.md
+++ b/content/en/api/monitors/monitors_validate.md
@@ -6,9 +6,6 @@ external_redirect: /api/#validate-a-monitor
 ---
 ## Validate a monitor
 
-<mark>This endpoint is not supported in Datadog's client libraries. To request this functionality, contact [Datadog Support][1].</mark>
+Validates a monitor definition (see [Create a monitor][1] for details on constructing a monitor definition).
 
-Validates a monitor definition (see [Create a monitor][2] for details on constructing a monitor definition).
-
-[1]: /help
-[2]: /api/#create-a-monitor
+[1]: /api/#create-a-monitor


### PR DESCRIPTION
### What does this PR do?
Adds an example for the monitor validation endpoint using the Python client.

### Motivation
We recently implemented the ability to validate a monitor's definition using the Python client.

### Preview link
https://docs-staging.datadoghq.com/armcburney/add_alerting_api_examples/api

### Additional Notes
The client library PR needs to be merged first and released with the updated version: https://github.com/DataDog/datadogpy/pull/487
