### PR TITLE
Adding allow insecure certificate feature

### DIFF
--- a/content/en/synthetics/api_tests/_index.md
+++ b/content/en/synthetics/api_tests/_index.md
@@ -40,7 +40,8 @@ Define the request you want to be executed by Datadog:
 1. **Choose request type**: `HTTP`
 2. Choose the **Method** and **URL** to query. Available methods are: `GET`, `POST`, `PATCH`, `PUT`, `HEAD`, `DELETE`, and `OPTIONS`.
     * Advanced Options (optional): Use custom request headers, authentication credentials, body content, or cookies.
-        * Follow Redirects: Toggle to have the monitored endpoint follow up to ten redirects.
+        * Follow redirects: Toggle to have the monitored endpoint follow up to ten redirects.
+        * Allow insecure certificates: Toggle to have your HTTP test go on with connection even if there is an error when validating the certificate. 
         * Headers: Defined headers override the default browser headers. For example, set the User Agent in the header to [identify Datadog scripts][1].
         * Authentication: HTTP basic authentication with username and password
         * Body: Request body and body type (`text/plain`, `application/json`, `text/xml`, `text/html`, or `None`)


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR adds documentation for the latest HTTP tests advanced option: allow insecure certificate.

### Motivation
PM request

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/margot.lepizzera/httptests_insecurecert/synthetics/api_tests/?tab=httptest
### Additional Notes
<!-- Anything else we should know when reviewing?-->
