### PR TITLE
http.version added to standard attributes

### DIFF
--- a/content/en/logs/processing/attributes_naming_convention.md
+++ b/content/en/logs/processing/attributes_naming_convention.md
@@ -144,6 +144,7 @@ Typical integrations relying on these attributes include [Apache][1], Rails, [AW
 | `http.referer`     | `string` | HTTP header field that identifies the address of the webpage that linked to the resource being requested.|
 | `http.request_id`  | `string` | The ID of the HTTP request.                                                                       |
 | `http.useragent`   | `string` | The User-Agent as it is sent (raw format). [See below for more details](#user-agent-attributes). |
+| `http.version`     | `string` | The version of HTTP used for the request. |
 
 #### URL details attributes
 


### PR DESCRIPTION
### What does this PR do?
Adds `http.version` to the list of standard attributes.

### Motivation
The HTTP version is always remapped to `http.version` in the pipelines. This means it's a so-called standard attribute. This information was missing from the public documentation.

### Preview link
https://docs-staging.datadoghq.com/gusai/http-vers-stdAttr/logs/processing/attributes_naming_convention/#http-requests
