### PR TITLE
Add compression instruction for the Datadog Agent

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -274,6 +274,46 @@ Enabling JMX Checks forces the Agent to use more memory depending on the number 
 {{% /tab %}}
 {{< /tabs >}}
 
+**Log Collection** 
+
+The below results are obtained from the collection of *110KB of logs per seconds* from a file with the [HTTP forwarder][8] enabled. It shows the evolution of resource usage for the different compression level available.
+
+{{< tabs >}}
+{{% tab "HTTP compression level 6" %}}
+
+* Agent Test version: 6.15.0
+* CPU: ~ 1.5% of the CPU used on average
+* Memory: ~ 95MB of RAM used.
+* Network bandwidth: ~ 14 KB/s ▲
+* Disk:
+  * Linux 350MB to 400MB depending on the distribution
+  * Windows: 260MB
+
+{{% /tab %}}
+{{% tab "HTTP compression level 1" %}}
+
+* Agent Test version: 6.15.0
+* CPU: ~ 1% of the CPU used on average
+* Memory: ~ 95MB of RAM used.
+* Network bandwidth: ~ 20 KB/s ▲
+* Disk:
+  * Linux 350MB to 400MB depending on the distribution
+  * Windows: 260MB
+
+{{% /tab %}}
+{{% tab "HTTP Uncompressed" %}}
+
+* Agent Test version: 6.15.0
+* CPU: ~ 0.7% of the CPU used on average
+* Memory: ~ 90MB of RAM used (RSS memory)
+* Network bandwidth: ~ 200 KB/s ▲
+* Disk:
+  * Linux 350MB to 400MB depending on the distribution
+  * Windows: 260MB
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ## Configuration management tools
 
 Manage the Datadog Agent and [Integrations][1] using configuration management tools:
@@ -348,3 +388,4 @@ To send your Agent data to the [Datadog EU site][5], edit your [Agent main confi
 [5]: https://app.datadoghq.eu
 [6]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
 [7]: /agent/guide/agent-log-files
+[8]: https://docs.datadoghq.com/agent/logs/?tab=tailexistingfiles#send-logs-over-https

--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -276,7 +276,7 @@ Enabling JMX Checks forces the Agent to use more memory depending on the number 
 
 **Log Collection** 
 
-The below results are obtained from the collection of *110KB of logs per seconds* from a file with the [HTTP forwarder][8] enabled. It shows the evolution of resource usage for the different compression level available.
+The results below are obtained from a collection of *110KB of logs per seconds* from a file with the [HTTP forwarder][8] enabled. It shows the evolution of resource usage for the different compression levels available.
 
 {{< tabs >}}
 {{% tab "HTTP compression level 6" %}}

--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -388,4 +388,4 @@ To send your Agent data to the [Datadog EU site][5], edit your [Agent main confi
 [5]: https://app.datadoghq.eu
 [6]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
 [7]: /agent/guide/agent-log-files
-[8]: https://docs.datadoghq.com/agent/logs/?tab=tailexistingfiles#send-logs-over-https
+[8]: /agent/logs/?tab=tailexistingfiles#send-logs-over-https

--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -183,8 +183,8 @@ logs_config:
 ```
 
 Or set the `DD_LOGS_CONFIG_USE_HTTP` and `DD_LOGS_CONFIG_USE_COMPRESSION` environment variables to `true`.
-The `compression_level` parameter (or `DD_LOGS_CONFIG_COMPRESSION_LEVEL` environment variable) accept value from 0 (no compression) to 9 (maximum compression but higher resource usage). The default value is 6.
-See the [Datadog Agent overhead section][10] for more information about the agent usage when compression is enabled.
+The `compression_level` parameter (or `DD_LOGS_CONFIG_COMPRESSION_LEVEL` environment variable) accepts values from 0 (no compression) to 9 (maximum compression but higher resource usage). The default value is 6.
+See the [Datadog Agent overhead section][10] for more information about Agent resource usage when compression is enabled.
 
 Then restart the Agent to sends logs through HTTPS to `agent-http-intake.logs.datadoghq.com` (US site) or `agent-http-intake.logs.datadoghq.eu` (EU site) on port 443.
 

--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -172,6 +172,24 @@ List of all available parameters for log collection:
 
 To send logs over HTTPS with the Datadog Agent 6.14+, add the following in the Agent's [main configuration file][4] (`datadog.yaml`):
 
+{{< tabs >}}
+{{% tab "Compression enabled" %}}
+
+```
+logs_config:
+  use_http: true
+  use_compression: true
+  compression_level: 6
+```
+
+Or set the `DD_LOGS_CONFIG_USE_HTTP` and `DD_LOGS_CONFIG_USE_COMPRESSION` environment variables to `true`.
+The `compression_level` parameter (or `DD_LOGS_CONFIG_COMPRESSION_LEVEL` environment variable) accept value from 0 (no compression) to 9 (maximum compression but higher resource usage). The default value is 6.
+
+Then restart the Agent to sends logs through HTTPS to `agent-http-intake.logs.datadoghq.com` (US site) or `agent-http-intake.logs.datadoghq.eu` (EU site) on port 443.
+
+{{% /tab %}}
+{{% tab "Compression Disabled" %}}
+
 ```
 logs_config:
   use_http: true
@@ -179,6 +197,9 @@ logs_config:
 
 Or set the `DD_LOGS_CONFIG_USE_HTTP` environment variable to `true`.
 Then restart the Agent to sends logs through HTTPS to `agent-http-intake.logs.datadoghq.com` (US site) or `agent-http-intake.logs.datadoghq.eu` (EU site) on port 443.
+
+{{% /tab %}}
+{{< /tabs >}}
 
 The Agent sends batches that have the following limits:
 

--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -184,6 +184,7 @@ logs_config:
 
 Or set the `DD_LOGS_CONFIG_USE_HTTP` and `DD_LOGS_CONFIG_USE_COMPRESSION` environment variables to `true`.
 The `compression_level` parameter (or `DD_LOGS_CONFIG_COMPRESSION_LEVEL` environment variable) accept value from 0 (no compression) to 9 (maximum compression but higher resource usage). The default value is 6.
+See the [Datadog Agent overhead section][10] for more information about the agent usage when compression is enabled.
 
 Then restart the Agent to sends logs through HTTPS to `agent-http-intake.logs.datadoghq.com` (US site) or `agent-http-intake.logs.datadoghq.eu` (EU site) on port 443.
 
@@ -240,3 +241,4 @@ When logs are sent through HTTPS, use the same [set of proxy settings][10] as th
 [8]: /developers/metrics/custom_metrics
 [9]: /tagging
 [10]: /agent/proxy
+[11]: https://docs.datadoghq.com/agent/basic_agent_usage/?tab=agentv6#agent-overhead

--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -186,7 +186,7 @@ Or set the `DD_LOGS_CONFIG_USE_HTTP` and `DD_LOGS_CONFIG_USE_COMPRESSION` enviro
 The `compression_level` parameter (or `DD_LOGS_CONFIG_COMPRESSION_LEVEL` environment variable) accepts values from 0 (no compression) to 9 (maximum compression but higher resource usage). The default value is 6.
 See the [Datadog Agent overhead section][10] for more information about Agent resource usage when compression is enabled.
 
-Then restart the Agent to sends logs through HTTPS to `agent-http-intake.logs.datadoghq.com` (US site) or `agent-http-intake.logs.datadoghq.eu` (EU site) on port 443.
+Then restart the Agent to sends logs through HTTPS to `agent-http-intake.logs.datadoghq.com` (US site) or `agent-http-intake.logs.datadoghq.eu` (EU site) on port `443`.
 
 {{% /tab %}}
 {{% tab "Compression Disabled" %}}

--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -241,4 +241,4 @@ When logs are sent through HTTPS, use the same [set of proxy settings][10] as th
 [8]: /developers/metrics/custom_metrics
 [9]: /tagging
 [10]: /agent/proxy
-[11]: https://docs.datadoghq.com/agent/basic_agent_usage/?tab=agentv6#agent-overhead
+[11]: /agent/basic_agent_usage/?tab=agentv6#agent-overhead


### PR DESCRIPTION
### What does this PR do?
Add compression instructions for the Datadog agent through HTTPS

### Motivation
Delivered in agent 6.16

### Preview link

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/compression-http-agent/agent/logs/?tab=tailexistingfiles#send-logs-over-https

https://docs-staging.datadoghq.com/nils/compression-http-agent/agent/basic_agent_usage/?tab=agentv6#agent-overhead

### Additional Notes
<!-- Anything else we should know when reviewing?-->
