### PR TITLE
Fix incorrect environment variable

### DIFF
--- a/content/en/tracing/setup/java.md
+++ b/content/en/tracing/setup/java.md
@@ -253,7 +253,7 @@ supported:
 Injection styles can be configured using:
 
 * System Property: `-Ddd.propagation.style.inject=Datadog,B3`
-* Environment Variable: `DD_PROPAGATION_STYLE_INJECTION=Datadog,B3`
+* Environment Variable: `DD_PROPAGATION_STYLE_INJECT=Datadog,B3`
 
 The value of the property or environment variable is a comma (or
 space) separated list of header styles that are enabled for


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update an environment variable to be correct

### Motivation
A github [issue](https://github.com/DataDog/dd-trace-java/issues/1121) was raised by a user

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/landerson/java-inject-variable/tracing/setup/java

