### PR TITLE
Add configuration step to enable system-probe on boot

### DIFF
--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -73,6 +73,7 @@ To enable network performance monitoring with the Datadog Agent, use the followi
 
 6. Start the system-probe: `sudo service datadog-agent-sysprobe start`
 7. [Restart the Agent][2]: `sudo service datadog-agent restart`
+8. Enable the system-probe to start on boot: `sudo service enable datadog-agent-sysprobe`
 
 [1]: https://docs.datadoghq.com/graphing/infrastructure/process/?tab=linuxwindows#installation
 [2]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#restart-the-agent

--- a/content/fr/network_performance_monitoring/installation.md
+++ b/content/fr/network_performance_monitoring/installation.md
@@ -70,6 +70,7 @@ Pour activer la surveillance des performances réseau avec l'Agent Datadog, util
 
 5. Démarrez le system-probe : `sudo service datadog-agent-sysprobe start`
 6. [[Redémarrez l'Agent][1].]: `sudo service datadog-agent restart`
+7. Activez la sonde-système pour démarrer au démarrage: `sudo service enable datadog-agent-sysprobe`
 
 [1]: https://docs.datadoghq.com/fr/agent/guide/agent-commands/?tab=agentv6#restart-the-agent
 {{% /tab %}}


### PR DESCRIPTION
### What does this PR do?
Adds an agent configuration step to enable the sysprobe service on boot.

### Motivation
The installation steps do not make reference to enabling the sysprobe service to start on boot. A customer explicitly referenced this as their instances were no longer reporting NPM data after patching/reboots.

### Preview link
https://docs-staging.datadoghq.com/thematthewgreen/npm-enable-sysprobe-on-boot>

### Additional Notes
Google translate provided the French verbiage.
