### PR TITLE
Fix eks-fargate documentation

### DIFF
--- a/content/en/integrations/amazon_eks_fargate.md
+++ b/content/en/integrations/amazon_eks_fargate.md
@@ -348,14 +348,14 @@ spec:
 
 ## Events Collection
 
-To collect events from your AWS EKS Fargate pods, run a Datadog Cluster Agent over an AWS EKS EC2 pod within your Kubernetes cluster:
+To collect events from your AWS EKS Fargate API server, run a Datadog Cluster Agent over an AWS EKS EC2 pod within your Kubernetes cluster:
 
 1. [Setup the Datadog Cluster Agent][10].
 2. [Enable Event collection for your Cluster Agent][11].
 
 Optionally, deploy cluster check runners in addition to setting up the Datadog Cluster Agent to enable cluster checks.
 
-**Note**: You can also collect events if you run the DCA in a pod in Fargate.
+**Note**: You can also collect events if you run the Datadog Cluster Agent in a pod in Fargate.
 
 ## Troubleshooting
 


### PR DESCRIPTION
### What does this PR do?
Fixes the eks-fargate integration docs

### Motivation
- The Cluster Agent collects events from the API server, not EKS Fargate pods
- Use `Datadog Cluster Agent` instead of `DCA`

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
