### PR TITLE
Removing hard coded agent v6 tab

### DIFF
--- a/content/en/agent/autodiscovery/_index.md
+++ b/content/en/agent/autodiscovery/_index.md
@@ -68,7 +68,7 @@ config_providers:
     polling: true
 ```
 
-[1]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
+[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}
 {{% tab "Containerized Agent" %}}
 
@@ -95,7 +95,7 @@ config_providers:
     polling: true
 ```
 
-[1]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
+[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}
 {{% tab "Containerized Agent" %}}
 

--- a/content/en/agent/autodiscovery/management.md
+++ b/content/en/agent/autodiscovery/management.md
@@ -37,7 +37,7 @@ To remove a given Docker container with the name `<NAME>` from Autodiscovery, ad
 ac_exclude: [name:<NAME>]
 ```
 
-[1]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
+[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}
 {{% tab "Containerized Agent" %}}
 
@@ -93,7 +93,7 @@ To include a given Docker container with the name `<NAME>` from Autodiscovery, a
 ac_include: [name:<NAME>]
 ```
 
-[1]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
+[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}
 {{% tab "Containerized Agent" %}}
 
@@ -130,4 +130,4 @@ To disable this behavior and include pause containers in the Autodiscovery perim
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
-[1]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
+[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file

--- a/content/en/agent/autodiscovery/tag.md
+++ b/content/en/agent/autodiscovery/tag.md
@@ -65,7 +65,7 @@ kubernetes_node_labels_as_tags:
   app: kube_app
 ```
 
-[1]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
+[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}
 {{% tab "Containerized Agent" %}}
 
@@ -114,7 +114,7 @@ kubernetes_pod_labels_as_tags:
 
 **Note**: Using this method may [increase the number of metrics][2] for your organization and impact your billing.
 
-[1]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
+[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 [2]: /developers/metrics/custom_metrics/#how-is-a-custom-metric-defined
 {{% /tab %}}
 {{% tab "Containerized Agent" %}}
@@ -164,7 +164,7 @@ kubernetes_pod_annotations_as_tags:
   app: kube_app
 ```
 
-[1]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
+[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}
 {{% tab "Containerized Agent" %}}
 
@@ -206,7 +206,7 @@ docker_labels_as_tags:
   com.docker.compose.service: service_name
 ```
 
-[1]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
+[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}
 {{% tab "Containerized Agent" %}}
 
@@ -246,7 +246,7 @@ docker_env_as_tags:
   ENVIRONMENT: env
 ```
 
-[1]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
+[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}
 {{% tab "Containerized Agent" %}}
 

--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -66,8 +66,8 @@ In v6, DogStatsD is a Golang implementation of [Etsy's StatsD][5] metric aggrega
 
 [1]: /developers/metrics/dogstatsd_metrics_submission/#metrics
 [2]: /tracing/guide/terminology
-[3]: /agent/guide/network/?tab=agentv6#open-ports
-[4]: /developers/write_agent_check/?tab=agentv6
+[3]: /agent/guide/network/#open-ports
+[4]: /developers/write_agent_check/
 [5]: https://github.com/etsy/statsd
 [6]: /developers/metrics/dogstatsd_metrics_submission
 {{% /tab %}}
@@ -187,7 +187,7 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 
 **Note**: [Source][11] install may work on operating systems not listed here and is supported on a best effort basis.
 
-[1]: /agent/basic_agent_usage/amazonlinux/?tab=agentv6
+[1]: /agent/basic_agent_usage/amazonlinux/
 [2]: /agent/basic_agent_usage/deb
 [3]: /agent/basic_agent_usage/ubuntu
 [4]: /agent/basic_agent_usage/redhat
@@ -346,5 +346,5 @@ To send your Agent data to the [Datadog EU site][5], edit your [Agent main confi
 [3]: /agent/guide/integration-management
 [4]: /agent/guide/agent-configuration-files
 [5]: https://app.datadoghq.eu
-[6]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
+[6]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 [7]: /agent/guide/agent-log-files

--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -66,23 +66,23 @@ The Agent's [main configuration file][6] is `datadog.yaml`. For the Docker Agent
 
 ##### Global options
 
-| Env Variable  | Description                                                                                                                                                 |
-|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DD_API_KEY`  | Your Datadog API key (**required**)                                                                                                                         |
-| `DD_HOSTNAME` | Hostname to use for metrics (if autodetection fails)                                                                                                        |
-| `DD_TAGS`     | Host tags separated by spaces. For example: `simple-tag-0 tag-key-1:tag-value-1`                                                                            |
-| `DD_SITE`     | Destination site for your metrics, traces, and logs. Valid options are `datadoghq.com` for the Datadog US site, and `datadoghq.eu` for the Datadog EU site. |
-| `DD_DD_URL`   | Optional setting to override the URL for metric submission. |
+| Env Variable       | Description                                                                                                                                                                                                                                                                                                                                      |
+|--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DD_API_KEY`       | Your Datadog API key (**required**)                                                                                                                                                                                                                                                                                                              |
+| `DD_HOSTNAME`      | Hostname to use for metrics (if autodetection fails)                                                                                                                                                                                                                                                                                             |
+| `DD_TAGS`          | Host tags separated by spaces. For example: `simple-tag-0 tag-key-1:tag-value-1`                                                                                                                                                                                                                                                                 |
+| `DD_SITE`          | Destination site for your metrics, traces, and logs. Valid options are `datadoghq.com` for the Datadog US site, and `datadoghq.eu` for the Datadog EU site.                                                                                                                                                                                      |
+| `DD_DD_URL`        | Optional setting to override the URL for metric submission.                                                                                                                                                                                                                                                                                      |
 | `DD_CHECK_RUNNERS` | The Agent runs all checks concurrently by default (default value = `4` runners). To run the checks sequentially, set the value to `1`. If you need to run a high number of checks (or slow checks) the `collector-queue` component might fall behind and fail the healthcheck. You can increase the number of runners to run checks in parallel. |
 
-##### Proxy Settings 
+##### Proxy Settings
 
 Starting with Agent v6.4.0 (and v6.5.0 for the Trace Agent), you can override the Agent proxy settings with the following environment variables:
 
-| Env Variable | Description |
+| Env Variable        | Description                                                       |
 |---------------------|-------------------------------------------------------------------|
-| `DD_PROXY_HTTP` | An HTTP URL to use as a proxy for `http` requests. |
-| `DD_PROXY_HTTPS` | An HTTPS URL to use as a proxy for `https` requests. |
+| `DD_PROXY_HTTP`     | An HTTP URL to use as a proxy for `http` requests.                |
+| `DD_PROXY_HTTPS`    | An HTTPS URL to use as a proxy for `https` requests.              |
 | `DD_PROXY_NO_PROXY` | A space-separated list of URLs for which no proxy should be used. |
 
 For more information about proxy settings, see the [Agent v6 Proxy documentation][7].
@@ -91,24 +91,24 @@ For more information about proxy settings, see the [Agent v6 Proxy documentation
 
 Optional collection Agents are disabled by default for security or performance reasons. Use these environment variables to enable them:
 
-| Env Variable               | Description                                                                                                                                                |
-|----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DD_APM_ENABLED`           | Enable [trace collection][8] with the Trace Agent.                                                                                                        |
-| `DD_LOGS_ENABLED`          | Enable [log collection][9] with the Logs Agent.                                                                                                            |
-| `DD_PROCESS_AGENT_ENABLED` | Enable [live process collection][10] with the Process Agent. The [live container view][11] is already enabled by default if the Docker socket is available. If set to `false`, the [live process collection][10] and the [live container view][11] are disabled.|
+| Env Variable               | Description                                                                                                                                                                                                                                                      |
+|----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DD_APM_ENABLED`           | Enable [trace collection][8] with the Trace Agent.                                                                                                                                                                                                               |
+| `DD_LOGS_ENABLED`          | Enable [log collection][9] with the Logs Agent.                                                                                                                                                                                                                  |
+| `DD_PROCESS_AGENT_ENABLED` | Enable [live process collection][10] with the Process Agent. The [live container view][11] is already enabled by default if the Docker socket is available. If set to `false`, the [live process collection][10] and the [live container view][11] are disabled. |
 
 ##### DogStatsD (custom metrics)
 
 Send custom metrics with [the StatsD protocol][12]:
 
-| Env Variable                     | Description                                                                                       |
-|----------------------------------|---------------------------------------------------------------------------------------------------|
-| `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` | Listen to DogStatsD packets from other containers (required to send custom metrics).              |
-| `DD_HISTOGRAM_PERCENTILES`       | The histogram percentiles to compute (separated by spaces). The default is "0.95".                |
-| `DD_HISTOGRAM_AGGREGATES`        | The histogram aggregates to compute (separated by spaces). The default is "max median avg count". |
-| `DD_DOGSTATSD_SOCKET`            | Path to the unix socket to listen to. Must be in a `rw` mounted volume.                           |
-| `DD_DOGSTATSD_ORIGIN_DETECTION`  | Enable container detection and tagging for unix socket metrics.                                   |
-| `DD_DOGSTATSD_TAGS`  | Additional tags to append to all metrics, events, and service checks received by this DogStatsD server, for example: `["env:golden", "group:retrievers"]`. |
+| Env Variable                     | Description                                                                                                                                                |
+|----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` | Listen to DogStatsD packets from other containers (required to send custom metrics).                                                                       |
+| `DD_HISTOGRAM_PERCENTILES`       | The histogram percentiles to compute (separated by spaces). The default is "0.95".                                                                         |
+| `DD_HISTOGRAM_AGGREGATES`        | The histogram aggregates to compute (separated by spaces). The default is "max median avg count".                                                          |
+| `DD_DOGSTATSD_SOCKET`            | Path to the unix socket to listen to. Must be in a `rw` mounted volume.                                                                                    |
+| `DD_DOGSTATSD_ORIGIN_DETECTION`  | Enable container detection and tagging for unix socket metrics.                                                                                            |
+| `DD_DOGSTATSD_TAGS`              | Additional tags to append to all metrics, events, and service checks received by this DogStatsD server, for example: `["env:golden", "group:retrievers"]`. |
 
 Learn more about [DogStatsD over Unix Domain Sockets][13].
 
@@ -255,7 +255,7 @@ The same can be done for the `/checks.d` folder. Any Python files in the `/check
 [15]: https://github.com/DataDog/datadog-agent/blob/master/pkg/tagger/collectors/kubelet_extract.go
 [16]: https://github.com/DataDog/datadog-agent/blob/master/pkg/tagger/collectors/ecs_extract.go
 [17]: /agent/autodiscovery/tag/?tab=containerizedagent
-[18]: /agent/guide/secrets-management/?tab=linux#pagetitle
+[18]: /agent/guide/secrets-management/?tab=linux
 [19]: /agent/autodiscovery/management/?tab=containerizedagent
 [20]: /integrations/system/#metrics
 [21]: /integrations/disk/#metrics

--- a/content/en/agent/docker/log.md
+++ b/content/en/agent/docker/log.md
@@ -93,7 +93,7 @@ logs_config:
 
 [1]: /agent/basic_agent_usage
 [2]: /agent/logs/#custom-log-collection
-[3]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
+[3]: /agent/guide/agent-commands/#restart-the-agent
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/agent/faq/agent-v6-changes.md
+++ b/content/en/agent/faq/agent-v6-changes.md
@@ -89,9 +89,9 @@ The following Agent configuration options were changed or removed in Agent v6. C
 | `use_curl_http_client`       |                                                                                                                       |
 | `collect_security_groups`    | Obsolete, feature is available with the [AWS integration][6].                                                         |
 
-[1]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
+[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 [2]: /agent/guide/upgrade-to-agent-v6
-[3]: /agent/proxy/?tab=agentv6
+[3]: /agent/proxy/
 [4]: /integrations/disk
 [5]: /logs
 [6]: /integrations/amazon_web_services
@@ -165,7 +165,7 @@ The precedence order of Agent v6 proxy options is different from previous versio
 
 There are differences in hostname resolution between Agent v5 and Agent v6. For details, see the [dedicated documentation][1].
 
-[1]: /agent/faq/how-datadog-agent-determines-the-hostname/?tab=agentv6#agent-versions
+[1]: /agent/faq/how-datadog-agent-determines-the-hostname/#agent-versions
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -409,7 +409,7 @@ Troubleshooting command syntax has changed. These commands are available for v6.
 `sudo datadog-agent jmx list collected --checks tomcat`
 
 [1]: https://github.com/jiaqi/jmxterm
-[2]: /integrations/faq/troubleshooting-jmx-integrations/?tab=agentv62#agent-troubleshooting
+[2]: /integrations/faq/troubleshooting-jmx-integrations/2#agent-troubleshooting
 {{% /tab %}}
 {{% tab "System" %}}
 
@@ -564,8 +564,8 @@ Similarly, you may have added a PIP package to meet a requirement for a custom c
 [2]: https://github.com/DataDog/dd-agent/wiki/Using-custom-emitters
 [3]: /agent/guide/dogstream
 [4]: /integrations/go-metro
-[5]: /agent/guide/agent-log-files/?tab=agentv6
-[6]: /agent/guide/agent-commands/?tab=agentv6
+[5]: /agent/guide/agent-log-files/
+[6]: /agent/guide/agent-commands/
 [7]: https://docs.datadoghq.com/agent/autodiscovery
 [8]: https://github.com/DataDog/integrations-core/tree/master/datadog_checks_base
 [9]: https://github.com/DataDog/datadog-agent/tree/master/docs/dev/checks

--- a/content/en/agent/faq/heroku-troubleshooting.md
+++ b/content/en/agent/faq/heroku-troubleshooting.md
@@ -11,7 +11,7 @@ For example, to display the status of your Datadog Agent and enabled integration
 agent-wrapper status
 ```
 
-Next, verify the Datadog Agent is listening by sending a custom metric: 
+Next, verify the Datadog Agent is listening by sending a custom metric:
 
 ```shell
 # From your project directory:
@@ -45,4 +45,4 @@ Generate a flare by running the [`agent-wrapper` command][1]:
 agent-wrapper flare
 ```
 
-[1]: /agent/guide/agent-commands/?tab=agentv6#agent-status-and-information
+[1]: /agent/guide/agent-commands/#agent-status-and-information

--- a/content/en/agent/guide/agent-commands.md
+++ b/content/en/agent/guide/agent-commands.md
@@ -200,7 +200,7 @@ A properly configured integration is displayed under **Running Checks** with no 
 ```
 
 
-[1]: /agent/basic_agent_usage/?tab=agentv6#gui
+[1]: /agent/basic_agent_usage/#gui
 [2]: /agent/basic_agent_usage/windows/#status-and-information
 {{% /tab %}}
 {{% tab "Agent v5" %}}

--- a/content/en/agent/guide/autodiscovery-with-jmx.md
+++ b/content/en/agent/guide/autodiscovery-with-jmx.md
@@ -62,7 +62,7 @@ The Datadog-Kafka integration example below leverages JMX to collect metrics and
 
 4. [Enable Autodiscovery for your Agent][4].
 
-[1]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-configuration-directory
+[1]: /agent/guide/agent-configuration-files/#agent-configuration-directory
 [2]: /agent/autodiscovery/template_variables
 [3]: https://docs.datadoghq.com/agent/autodiscovery/ad_identifiers/#short-image-container-identifiers
 [4]: /agent/autodiscovery/?tab=agent#docker-autodiscovery
@@ -127,7 +127,7 @@ The Datadog-Kafka integration example below leverages JMX to collect metrics and
 
     Then use this new custom image as the regular containerized Agent.
 
-[1]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-configuration-directory
+[1]: /agent/guide/agent-configuration-files/#agent-configuration-directory
 [2]: /integrations/activemq
 [3]: https://github.com/DataDog/integrations-core/blob/master/activemq/datadog_checks/activemq/data/metrics.yaml
 [4]: https://github.com/DataDog/integrations-core/blob/master/activemq/datadog_checks/activemq/data/conf.yaml.example

--- a/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
+++ b/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
@@ -53,7 +53,7 @@ To install the `<INTEGRATION_NAME>` check on your host:
 [1]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [2]: https://app.datadoghq.com/account/settings#agent
 [3]: /getting_started/integrations
-[4]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
+[4]: /agent/guide/agent-commands/#restart-the-agent
 {{% /tab %}}
 {{% tab "Docker" %}}
 
@@ -92,9 +92,9 @@ To install the `<INTEGRATION_NAME>` check on your host:
 
 [1]: https://app.datadoghq.com/account/settings#agent
 [2]: https://github.com/DataDog/integrations-extras
-[3]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6#agent-configuration-directory
+[3]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [4]: /getting_started/integrations
-[5]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
+[5]: /agent/guide/agent-commands/#restart-the-agent
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/agent/guide/environment-variables.md
+++ b/content/en/agent/guide/environment-variables.md
@@ -11,7 +11,7 @@ further_reading:
   - link: "/logs/log_collection/#container-log-collection"
     tag: "Documentation"
     text: "Container log collection"
-  - link: "/agent/proxy/?tab=agentv6#environment-variables"
+  - link: "/agent/proxy/#environment-variables"
     tag: "Documentation"
     text: "Proxy environment variables"
 ---
@@ -24,7 +24,7 @@ For Agent v5, reference the <a href="https://github.com/DataDog/docker-dd-agent#
 
 For Agent v6, most of the configuration options in the [Agent's main configuration file][1] (`datadog.yaml`) can be set through environment variables.
 
-## General use 
+## General use
 
 In general, use the following rules:
 
@@ -69,6 +69,6 @@ In general, use the following rules:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
-[2]: /agent/proxy/?tab=agentv6#environment-variables
+[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
+[2]: /agent/proxy/#environment-variables
 [3]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config.go

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -105,7 +105,7 @@ Open the following ports in order to benefit from all the Agent functionalities:
 [2]: /logs
 [3]: /agent/basic_agent_usage/kubernetes
 [4]: /integrations/go_expvar
-[5]: /agent/basic_agent_usage/?tab=agentv6#gui
+[5]: /agent/basic_agent_usage/#gui
 [6]: /tracing
 {{% /tab %}}
 {{% tab "Agent v5 & v4" %}}

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -286,8 +286,8 @@ Use the built-in `next` function instead of calling the `next` method. For insta
 
 
 [1]: https://app.datadoghq.com/compatibility_check
-[2]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
-[3]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
+[2]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
+[3]: /agent/guide/agent-commands/#restart-the-agent
 [4]: /developers/integrations/new_check_howto/#building
 [5]: https://datadog-checks-base.readthedocs.io/en/latest/datadog_checks_dev.cli.html
 [6]: https://docs.python.org/3.1/library/2to3.html

--- a/content/en/agent/guide/secrets-management.md
+++ b/content/en/agent/guide/secrets-management.md
@@ -393,7 +393,7 @@ exit code:
 
 The first thing the Agent does on startup is to load `datadog.yaml` and decrypt any secrets in it. This is done before setting up the logging. This means that on platforms like Windows, errors occurring when loading `datadog.yaml` aren't written in the logs, but on `stderr`. This can occur when the executable given to the Agent for secrets returns an error.
 
-If you have secrets in `datadog.yaml` and the Agent refuses to start: 
+If you have secrets in `datadog.yaml` and the Agent refuses to start:
 
 * Try to start the Agent manually to be able to see `stderr`.
 * Remove the secrets from `datadog.yaml` and test with secrets in a check configuration file first.
@@ -403,5 +403,5 @@ If you have secrets in `datadog.yaml` and the Agent refuses to start:
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /agent/autodiscovery
-[2]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
+[2]: /agent/guide/agent-commands/#restart-the-agent
 [3]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/secrets_scripts/secrets_tester.ps1

--- a/content/en/agent/guide/upgrade-to-agent-v6.md
+++ b/content/en/agent/guide/upgrade-to-agent-v6.md
@@ -442,7 +442,7 @@ With:
 
 **Note**: `datadog.conf` is automatically upgraded to `datadog.yaml` on upgrade.
 
-[1]: /agent/?tab=agentv6#agent-architecture
+[1]: /agent/#agent-architecture
 [2]: /agent/guide/agent-commands
 [3]: /developers/dogstatsd/unix_socket
 [4]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md

--- a/content/en/agent/kubernetes/host_setup.md
+++ b/content/en/agent/kubernetes/host_setup.md
@@ -67,6 +67,6 @@ To get a better idea of how (or why) to integrate your Kubernetes service, see t
 [2]: /agent
 [3]: /agent/autodiscovery
 [4]: https://app.datadoghq.com/account/settings#agent/kubernetes
-[5]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#start-stop-and-restart-the-agent
+[5]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [6]: https://docs.datadoghq.com/agent/autodiscovery/integrations/?tab=kubernetes
 [7]: https://www.datadoghq.com/blog/monitoring-kubernetes-era

--- a/content/en/agent/troubleshooting/debug_mode.md
+++ b/content/en/agent/troubleshooting/debug_mode.md
@@ -29,9 +29,9 @@ To enable the Agent full debug mode:
 
 4. Wait a few minutes to generate some logs. See [Agent Log Files][3] for OS specific details.
 
-[1]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
-[2]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
-[3]: /agent/guide/agent-log-files/?tab=agentv6
+[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
+[2]: /agent/guide/agent-commands/#restart-the-agent
+[3]: /agent/guide/agent-log-files/
 {{% /tab %}}
 {{% tab "Agent v5" %}}
 

--- a/content/en/agent/troubleshooting/permissions.md
+++ b/content/en/agent/troubleshooting/permissions.md
@@ -113,8 +113,8 @@ If you are running Agent v6 less than v6.3, try updating the Agent and using the
 
 
 [1]: https://github.com/DataDog/datadog-agent
-[2]: /agent/guide/agent-commands/?tab=agentv6#stop-the-agent
-[3]: /agent/guide/agent-commands/?tab=agentv6#start-the-agent
+[2]: /agent/guide/agent-commands/#stop-the-agent
+[3]: /agent/guide/agent-commands/#start-the-agent
 {{% /tab %}}
 {{% tab "Agent v5" %}}
 
@@ -153,6 +153,6 @@ See the following GitHub issues for more information and other potential methods
 [2]: /agent/guide/agent-log-files
 [3]: /agent/faq/error-restarting-agent-already-listening-on-a-configured-port
 [4]: /agent/faq/network
-[5]: /agent/guide/agent-commands/?tab=agentv6#start-the-agent
+[5]: /agent/guide/agent-commands/#start-the-agent
 [6]: /help
 [7]: /integrations/process

--- a/content/en/agent/troubleshooting/send_a_flare.md
+++ b/content/en/agent/troubleshooting/send_a_flare.md
@@ -18,7 +18,7 @@ If you are running Agent 5.3+, you can send necessary troubleshooting informatio
 **Confirm the upload of the archive to immediately send it to Datadog support**.
 Datadog Agent is completely open source, which allows you to [verify the code's behavior][1]. If needed, the flare can be reviewed prior to sending since the flare prompts a confirmation before uploading it.
 
-In the commands below, replace `<CASE_ID>` with your Datadog support case ID if you have one, then enter the email address associated with it. 
+In the commands below, replace `<CASE_ID>` with your Datadog support case ID if you have one, then enter the email address associated with it.
 If you don't have a case ID, just enter your email address used to login in Datadog to create a new support case.
 
 
@@ -42,7 +42,7 @@ If you don't have a case ID, just enter your email address used to login in Data
 | Heroku       | Consult the dedicated [Heroku documentation][3]         |
 
 
-[1]: /agent/basic_agent_usage/?tab=agentv6#gui
+[1]: /agent/basic_agent_usage/#gui
 [2]: /agent/basic_agent_usage/windows/#agent-v6
 [3]: https://docs.datadoghq.com/agent/faq/heroku-troubleshooting/#send-a-flare
 {{% /tab %}}

--- a/content/en/developers/events/agent.md
+++ b/content/en/developers/events/agent.md
@@ -115,5 +115,5 @@ This is an example of using a custom Agent check to send one event periodically.
 [2]: /developers/write_agent_check
 [3]: /agent/guide/agent-configuration-files/#agent-configuration-directory
 [4]: /agent/guide/agent-commands/#restart-the-agent
-[5]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#agent-information
+[5]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-information
 [6]: https://app.datadoghq.com/event/stream

--- a/content/en/developers/metrics/agent_metrics_submission.md
+++ b/content/en/developers/metrics/agent_metrics_submission.md
@@ -3,7 +3,7 @@ title: "Metric Submission: Custom Agent Check"
 kind: documentation
 disable_toc: true
 further_reading:
-- link: "developers/write_agent_check/?tab=agentv6"
+- link: "developers/write_agent_check/"
   tag: "Documentation"
   text: "Write an Agent Custom Check"
 ---
@@ -227,5 +227,5 @@ Follow the steps below to create a [custom Agent check][2] that sends all metric
 [2]: /developers/metrics/types
 [3]: /agent/guide/agent-configuration-files/#agent-configuration-directory
 [4]: /agent/guide/agent-commands/#restart-the-agent
-[5]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#agent-information
+[5]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-information
 [6]: https://app.datadoghq.com/metric/summary

--- a/content/en/developers/service_checks/agent_service_checks_submission.md
+++ b/content/en/developers/service_checks/agent_service_checks_submission.md
@@ -3,7 +3,7 @@ title: "Service Check Submission: Agent Check"
 kind: documentation
 disable_toc: true
 further_reading:
-- link: "developers/write_agent_check/?tab=agentv6"
+- link: "developers/write_agent_check/"
   tag: "Documentation"
   text: "Write an Agent Custom Check"
 ---
@@ -85,5 +85,5 @@ Here is an example of a dummy Agent check sending only one service check periodi
 [1]: /developers/write_agent_check
 [2]: /agent/guide/agent-configuration-files/#agent-configuration-directory
 [3]: /agent/guide/agent-commands/#restart-the-agent
-[4]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#agent-information
+[4]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-information
 [5]: https://app.datadoghq.com/check/summary

--- a/content/en/getting_started/integrations/_index.md
+++ b/content/en/getting_started/integrations/_index.md
@@ -153,7 +153,7 @@ If you continue to have problems, reach out to [our awesome Support team][35].
 [7]: /api
 [8]: /integrations/node
 [9]: /integrations/python
-[10]: /developers/write_agent_check/?tab=agentv6
+[10]: /developers/write_agent_check/
 [11]: https://github.com/DataDog/integrations-core
 [12]: https://github.com/DataDog/integrations-extras
 [13]: /developers/integrations/new_check_howto/#developer-toolkit
@@ -165,11 +165,11 @@ If you continue to have problems, reach out to [our awesome Support team][35].
 [19]: https://app.datadoghq.com/account/settings#agent
 [20]: https://app.datadoghq.com/account/settings#agent/docker
 [21]: https://app.datadoghq.com/account/settings#agent/kubernetes
-[22]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
+[22]: /agent/guide/agent-commands/#restart-the-agent
 [23]: /developers/integrations/new_check_howto/#param-specification
 [24]: https://github.com/DataDog/integrations-core/blob/master/apache/datadog_checks/apache/data/conf.yaml.example
 [25]: /tagging
-[26]: /agent/guide/agent-commands/?tab=agentv6#agent-status-and-information
+[26]: /agent/guide/agent-commands/#agent-status-and-information
 [27]: /security
 [28]: /graphing/metrics/explorer
 [29]: /graphing
@@ -177,9 +177,9 @@ If you continue to have problems, reach out to [our awesome Support team][35].
 [31]: /logs
 [32]: /tracing
 [33]: /synthetics
-[34]: /agent/troubleshooting/?tab=agentv6
+[34]: /agent/troubleshooting/
 [35]: /help
-[36]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-configuration-directory
+[36]: /agent/guide/agent-configuration-files/#agent-configuration-directory
 [37]: https://app.datadoghq.com/event/stream
 [38]: https://github.com/DataDog/integrations-core/blob/master/http_check/datadog_checks/http_check/data/conf.yaml.example#L13
 [39]: /developers/metrics

--- a/content/en/getting_started/integrations/prometheus.md
+++ b/content/en/getting_started/integrations/prometheus.md
@@ -56,7 +56,7 @@ instances:
       - '<PROMETHEUS_METRIC_TO_FETCH>: <DATADOG_NEW_METRIC_NAME>'
 ```
 
-[1]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6#agent-configuration-directory
+[1]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [2]: /agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [3]: https://github.com/DataDog/integrations-core/blob/master/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
 [4]: https://github.com/DataDog/integrations-core/blob/master/prometheus/datadog_checks/prometheus/data/conf.yaml.example

--- a/content/en/getting_started/logs/_index.md
+++ b/content/en/getting_started/logs/_index.md
@@ -219,7 +219,7 @@ This produces the following result in the [Log Explorer Page][2]:
 [5]: https://app.datadoghq.com/account/settings#api
 [6]: https://app.datadoghq.com/account/settings#agent/ubuntu
 [7]: https://app.datadoghq.com/account/settings#api
-[8]: /agent/guide/agent-commands/?tab=agentv6#agent-information
+[8]: /agent/guide/agent-commands/#agent-information
 [9]: https://app.datadoghq.com/infrastructure
-[10]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
-[11]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-configuration-directory
+[10]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
+[11]: /agent/guide/agent-configuration-files/#agent-configuration-directory

--- a/content/en/getting_started/tracing/_index.md
+++ b/content/en/getting_started/tracing/_index.md
@@ -149,9 +149,9 @@ After a few minutes, your trace displays in Datadog under the `flask` service. C
 [4]: https://www.vagrantup.com/intro/getting-started/index.html
 [5]: https://app.datadoghq.com/account/settings#agent/ubuntu
 [6]: https://app.datadoghq.com/account/settings#api
-[7]: /agent/guide/agent-commands/?tab=agentv6#agent-information
+[7]: /agent/guide/agent-commands/#agent-information
 [8]: https://app.datadoghq.com/infrastructure
-[9]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
-[10]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
+[9]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
+[10]: /agent/guide/agent-commands/#restart-the-agent
 [11]: https://app.datadoghq.com/apm/services
 [12]: https://app.datadoghq.com/apm/traces

--- a/content/en/graphing/guide/uptime-percentage-widget.md
+++ b/content/en/graphing/guide/uptime-percentage-widget.md
@@ -119,7 +119,7 @@ This example can be extended to additional use cases:
 [2]: /graphing/widgets/query_value
 [3]: https://app.datadoghq.com/account/settings#agent
 [4]: /agent/guide/agent-configuration-files
-[5]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
+[5]: /agent/guide/agent-commands/#restart-the-agent
 [6]: https://github.com/DataDog/integrations-core/blob/master/http_check/datadog_checks/http_check/data/conf.yaml.example
 [7]: https://app.datadoghq.com/metric/explorer
 [8]: /monitors/monitor_types/metric

--- a/content/en/graphing/infrastructure/livecontainers.md
+++ b/content/en/graphing/infrastructure/livecontainers.md
@@ -46,7 +46,7 @@ config_providers:
 
 
 [1]: /agent/docker/log/?tab=hostinstallation
-[2]: /agent/guide/agent-configuration-files/?tab=agentv6
+[2]: /agent/guide/agent-configuration-files/
 {{% /tab %}}
 
 {{% tab "Docker" %}}

--- a/content/en/graphing/infrastructure/process.md
+++ b/content/en/graphing/infrastructure/process.md
@@ -46,8 +46,8 @@ Additionally, some configuration options may be set as environment variables.
 After configuration is complete, [restart the Agent][2].
 
 
-[1]: /agent/guide/agent-configuration-files/?tab=agentv6
-[2]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
+[1]: /agent/guide/agent-configuration-files/
+[2]: /agent/guide/agent-commands/#restart-the-agent
 {{% /tab %}}
 {{% tab "Docker" %}}
 

--- a/content/en/integrations/adobe_experience_manager.md
+++ b/content/en/integrations/adobe_experience_manager.md
@@ -65,6 +65,6 @@ Need help? Contact [Datadog support][4].
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/account/settings#agent
-[2]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-configuration-directory
+[2]: /agent/guide/agent-configuration-files/#agent-configuration-directory
 [3]: /agent/guide/agent-commands/#restart-the-agent
 [4]: /help

--- a/content/en/integrations/faq/how-do-i-pull-my-ec2-tags-without-using-the-aws-integration.md
+++ b/content/en/integrations/faq/how-do-i-pull-my-ec2-tags-without-using-the-aws-integration.md
@@ -16,7 +16,7 @@ To pull custom AWS tags for an EC2 instance through the Datadog Agent without us
 
 
 [1]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
-[2]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
+[2]: /agent/guide/agent-commands/#restart-the-agent
 {{% /tab %}}
 {{% tab "Agent v5" %}}
 

--- a/content/en/integrations/faq/jboss-eap-7-datadog-monitoring-via-jmx.md
+++ b/content/en/integrations/faq/jboss-eap-7-datadog-monitoring-via-jmx.md
@@ -46,9 +46,9 @@ For `<socket-binding-group name="full-ha-sockets" default-interface="public">`, 
 
 
 Add an application user for the Application Realm:
- 
+
 ```
-JBoss_EAP_INSTALL_DIR/bin/add_user.sh 
+JBoss_EAP_INSTALL_DIR/bin/add_user.sh
 ```
 
 **Note**: Be sure to add to the Application Realm.
@@ -76,7 +76,7 @@ Edit `/etc/datadog-agent/conf.d/jmx.d/conf.yaml` file to activate the jmx integr
 
 ```
 init_config:
- 
+
   custom_jar_paths:
     - JBoss_EAP_INSTALL_LOCATION/bin/client/jboss-cli-client.jar
 
@@ -102,7 +102,7 @@ Finally, run the [Datadog Agent status command][3] to ensure Datadog can connect
 ========
 JMXFetch
 ========
- Initialized checks 
+ Initialized checks
 08/10/2018 4
  ==================
  jmx
@@ -117,5 +117,5 @@ JMXFetch
 ```
 
 [1]: https://app.datadoghq.com/account/settings#agent/centos
-[2]: /agent/guide/agent-commands/?tab=agentv6#start-stop-and-restart-the-agent
-[3]: /agent/guide/agent-commands/?tab=agentv6#agent-status-and-information
+[2]: /agent/guide/agent-commands/#start-stop-and-restart-the-agent
+[3]: /agent/guide/agent-commands/#agent-status-and-information

--- a/content/en/integrations/faq/postgres-custom-metric-collection-explained.md
+++ b/content/en/integrations/faq/postgres-custom-metric-collection-explained.md
@@ -92,7 +92,7 @@ Additionally, the [Agent's logs][6] may provide useful information.
 
 [1]: /agent/guide/agent-configuration-files/#agent-configuration-directory
 [2]: https://github.com/DataDog/integrations-core/blob/master/postgres/datadog_checks/postgres/data/conf.yaml.example
-[3]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
+[3]: /agent/guide/agent-commands/#restart-the-agent
 [4]: /graphing/metrics/explorer
 [5]: /agent/guide/agent-commands/#agent-status-and-information
 [6]: /agent/guide/agent-log-files

--- a/content/en/integrations/guide/mongo-custom-query-collection.md
+++ b/content/en/integrations/guide/mongo-custom-query-collection.md
@@ -149,7 +149,7 @@ To verify the result, search for the metrics using the [Metrics Explorer][5]:
 [1]: /agent/guide/agent-configuration-files/#agent-configuration-directory
 [2]: https://github.com/DataDog/integrations-core/blob/master/mongo/datadog_checks/mongo/data/conf.yaml.example
 [3]: https://docs.mongodb.com/manual/reference/command
-[4]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
+[4]: /agent/guide/agent-commands/#restart-the-agent
 [5]: /graphing/metrics/explorer
 [6]: /agent/guide/agent-commands/#agent-status-and-information
 [7]: /agent/guide/agent-log-files

--- a/content/en/integrations/marklogic.md
+++ b/content/en/integrations/marklogic.md
@@ -53,5 +53,5 @@ The Marklogic integration is included in the [Datadog Agent][1] package, so you 
 [Run the Agent's `status` subcommand][3] and look for `marklogic` under the Checks section.
 
 [1]: https://app.datadoghq.com/account/settings#agent
-[2]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
-[3]: /agent/guide/agent-commands/?tab=agentv6#agent-status-and-information
+[2]: /agent/guide/agent-commands/#restart-the-agent
+[3]: /agent/guide/agent-commands/#agent-status-and-information

--- a/content/en/integrations/sidekiq.md
+++ b/content/en/integrations/sidekiq.md
@@ -55,5 +55,5 @@ The Sidekiq integration is included in the [Datadog Agent][1] package, so you do
 
 [1]: https://app.datadoghq.com/account/settings#agent
 [2]: https://github.com/mperham/sidekiq/wiki/Logging#log-file
-[3]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
-[4]: /agent/guide/agent-commands/?tab=agentv6#agent-status-and-information
+[3]: /agent/guide/agent-commands/#restart-the-agent
+[4]: /agent/guide/agent-commands/#agent-status-and-information

--- a/content/en/integrations/sinatra.md
+++ b/content/en/integrations/sinatra.md
@@ -93,5 +93,5 @@ This logger uses the common Apache Access format and generates logs in the follo
 [4]: http://rack.github.io
 [5]: https://www.rubydoc.info/github/rack/rack/Rack/CommonLogger
 [6]: http://recipes.sinatrarb.com/p/middleware/rack_commonlogger
-[7]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-configuration-directory
-[8]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
+[7]: /agent/guide/agent-configuration-files/#agent-configuration-directory
+[8]: /agent/guide/agent-commands/#restart-the-agent

--- a/content/en/integrations/stunnel.md
+++ b/content/en/integrations/stunnel.md
@@ -59,5 +59,5 @@ Create a `stunnel.d/conf.yaml` file in the `conf.d/` folder at the root of your 
 
 [1]: https://app.datadoghq.com/account/settings#agent
 [2]: /agent/guide/agent-configuration-files/#agent-configuration-directory
-[3]: /agent/guide/agent-commands/?tab=agentv6#start-stop-restart-the-agent
+[3]: /agent/guide/agent-commands/#start-stop-restart-the-agent
 [4]: /agent/guide/agent-commands/#agent-status-and-information

--- a/content/en/integrations/system.md
+++ b/content/en/integrations/system.md
@@ -127,7 +127,7 @@ The System Swap check does not include any service checks.
 [2]: /integrations/disk
 [3]: /integrations/process
 [4]: /agent/guide/agent-commands/#agent-status-and-information
-[5]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-configuration-directory
+[5]: /agent/guide/agent-configuration-files/#agent-configuration-directory
 [6]: https://github.com/DataDog/integrations-core/blob/master/system_core/datadog_checks/system_core/data/conf.yaml.example
 [7]: /agent/guide/agent-commands/#start-stop-restart-the-agent
 [8]: https://github.com/DataDog/integrations-core/blob/master/system_swap/datadog_checks/system_swap/data/conf.yaml.example

--- a/content/en/logs/faq/how-to-set-up-only-logs.md
+++ b/content/en/logs/faq/how-to-set-up-only-logs.md
@@ -6,14 +6,14 @@ beta: true
 ---
 
 <div class="alert alert-danger">
-To setup Log collection without metrics, you have to disable some payloads. This results in the potential loss of metadata and tags on the logs you are collecting. Datadog does not recommend this. For more information about the impact of this configuration, contact <a href="/help/">Datadog Support</a>. 
+To setup Log collection without metrics, you have to disable some payloads. This results in the potential loss of metadata and tags on the logs you are collecting. Datadog does not recommend this. For more information about the impact of this configuration, contact <a href="/help/">Datadog Support</a>.
 </div>
 
 To disable payloads, you must be running Agent v6.4+. This disables metric data submission, so that hosts stop showing up in Datadog. Follow these steps:
 
 1. Open the [datadog.yaml configuration file][1].
-2. Add the enable_payloads attribute with the following settings: 
-    
+2. Add the enable_payloads attribute with the following settings:
+
     ```
     enable_payloads:
  		series: false
@@ -38,6 +38,6 @@ DD_ENABLE_PAYLOADS_SKETCHES
 
 
 
-[1]: /agent/guide/agent-configuration-files/?tab=agentv6
+[1]: /agent/guide/agent-configuration-files/
 [2]: /logs/log_collection
 [3]: /agent/guide/agent-commands/#restart-the-agent

--- a/content/en/logs/faq/why-do-my-logs-show-up-with-an-info-status-even-for-warnings-or-errors.md
+++ b/content/en/logs/faq/why-do-my-logs-show-up-with-an-info-status-even-for-warnings-or-errors.md
@@ -3,7 +3,7 @@ title: Why do my logs show up with an Info status even for Warnings or Errors?
 kind: faq
 disable_toc: true
 further_reading:
-- link: "logs/faq/how-to-remap-custom-severity-values-to-the-official-log-status/#pagetitle"
+- link: "logs/faq/how-to-remap-custom-severity-values-to-the-official-log-status/"
   tag: "FAQ"
   text: "Learn how to remap custom severity values to the official log status"
 - link: "logs/processing"

--- a/content/en/logs/guide/log-collection-troubleshooting-guide.md
+++ b/content/en/logs/guide/log-collection-troubleshooting-guide.md
@@ -186,10 +186,10 @@ Check if logs appear in the [Datadog Live Tail][13]. If they appear in the Live 
 
 [1]: /logs
 [2]: /help
-[3]: /agent/guide/agent-commands/?tab=agentv6#restart-the-agent
-[4]: /agent/guide/agent-commands/?tab=agentv6#agent-status-and-information
+[3]: /agent/guide/agent-commands/#restart-the-agent
+[4]: /agent/guide/agent-commands/#agent-status-and-information
 [5]: https://en.wikipedia.org/wiki/Chmod
-[6]: https://docs.datadoghq.com/integrations/journald/#pagetitle
+[6]: https://docs.datadoghq.com/integrations/journald/
 [7]: https://codebeautify.org/yaml-validator
 [8]: /agent/docker/log/?tab=containerinstallation#filter-containers
 [9]: /agent/autodiscovery/integrations/?tab=dockerlabel#configuration

--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -76,7 +76,7 @@ To enable network performance monitoring with the Datadog Agent, use the followi
 8. Enable the system-probe to start on boot: `sudo service enable datadog-agent-sysprobe`
 
 [1]: https://docs.datadoghq.com/graphing/infrastructure/process/?tab=linuxwindows#installation
-[2]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#restart-the-agent
+[2]: https://docs.datadoghq.com/agent/guide/agent-commands/#restart-the-agent
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 
@@ -209,4 +209,4 @@ Replace `<DATADOG_API_KEY>` with your [Datadog API key][1].
 [3]: https://github.com/helm/charts/blob/master/stable/datadog/README.md#enabling-system-probe-collection
 [4]: https://github.com/DataDog/chef-datadog
 [5]: https://github.com/DataDog/ansible-datadog/blob/master/README.md#system-probe
-[6]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
+[6]: /agent/guide/agent-configuration-files/#agent-main-configuration-file

--- a/content/en/tracing/advanced/setting_primary_tags_to_scope.md
+++ b/content/en/tracing/advanced/setting_primary_tags_to_scope.md
@@ -75,6 +75,6 @@ Primary tags appear at the top of APM pages. Use these selectors to slice the da
 
 [1]: /tracing/visualization/#trace
 [2]: /tagging
-[3]: /agent/guide/agent-configuration-files/?tab=agentv6
+[3]: /agent/guide/agent-configuration-files/
 [4]: /tagging/assigning_tags/#traces
 [5]: https://app.datadoghq.com/apm/settings

--- a/content/en/tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel.md
+++ b/content/en/tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel.md
@@ -67,7 +67,7 @@ Here is an example with the Java integration pipeline:
 
 Now it is possible that the log format is not covered by the integration pipeline. In this case, clone the pipeline and [follow our parsing troubleshooting guide][1] to make sure it fits your format.
 
-[1]: /logs/faq/how-to-investigate-a-log-parsing-issue/#pagetitle
+[1]: /logs/faq/how-to-investigate-a-log-parsing-issue/
 {{% /tab %}}
 {{% tab "Custom" %}}
 
@@ -92,6 +92,6 @@ Once the IDs are properly injected and remapped into your logs, you can make a d
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /tracing/visualization/#trace
-[2]: /logs/faq/why-do-my-logs-not-have-the-expected-timestamp/#pagetitle
+[2]: /logs/faq/why-do-my-logs-not-have-the-expected-timestamp/
 [3]: /tracing/visualization/#services
 [4]: /tracing/advanced/connect_logs_and_traces

--- a/content/en/tracing/guide/alert_anomalies_p99_database.md
+++ b/content/en/tracing/guide/alert_anomalies_p99_database.md
@@ -79,7 +79,7 @@ Datadog allows you to set monitors to keep track of the health of your services 
 {{< partial name="whats-next/whats-next.html" >}}
 
 
-[1]: https://docs.datadoghq.com/monitors/monitor_types/anomaly/#pagetitle
+[1]: https://docs.datadoghq.com/monitors/monitor_types/anomaly/
 [2]: https://app.datadoghq.com/monitors#/create
 [3]: https://app.datadoghq.com/monitors#create/apm
 [4]: /tracing/visualization/#resources

--- a/content/en/tracing/send_traces/_index.md
+++ b/content/en/tracing/send_traces/_index.md
@@ -83,7 +83,7 @@ Next, [Instrument your application][14]. For the full overview of all of the ste
 
 [1]: /tracing/visualization/#trace
 [2]: /tracing
-[3]: /agent/guide/agent-configuration-files/?tab=agentv6#agent-main-configuration-file
+[3]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 [4]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
 [5]: /tracing/send_traces/agent-apm-metrics
 [6]: /agent

--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -208,7 +208,7 @@ make install
 
 [1]: /help
 [2]: /tracing/setup/#agent-configuration
-[3]: /agent/troubleshooting/?tab=agentv6#get-more-logging-from-the-agent
+[3]: /agent/troubleshooting/#get-more-logging-from-the-agent
 [4]: /agent/guide/agent-log-files
 [5]: /tracing/visualization/#trace
 [6]: /help


### PR DESCRIPTION
### What does this PR do?
To prepare the release of Agent v7 we remove the hardcoded tab link since we want all links to default to the latest Agent version.