### PR TITLE
Update public Roles API Page

### DIFF
--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -40,7 +40,7 @@ Page number of roles to return for a given page.
 Number of roles to return for a given page.
 * **`sort`** [*optional*, *default*=**name**]:
 Sort roles depending on the given field. Sort order is **ascending** by default. Sort order is **descending** if the field is prefixed by a negative sign (Eg: *sort=-name*).
-    Options: **name**, **modified_at**
+  * Options: **name**, **modified_at**
 * **`filter`**[*optional*, *default*=**None**]:
 Filter all roles by the given string.
 
@@ -686,7 +686,7 @@ Page number of users to return for a given page.
 Number of users to return for a given page.
 * **`sort`** [*optional*, *default*=**name**]:
 Sort users depending on the given field. Sort order is **ascending** by default. Sort order is **descending** if the field is prefixed by a negative sign (Eg: *sort=-name*).
-    Options: **name**, **modified_at**
+  * Options: **name**, **modified_at**
 * **`filter`**[*optional*, *default*=**None**]:
 Filter all users by the given string.
 

--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -40,7 +40,7 @@ Page number of roles to return for a given page.
 Number of roles to return for a given page.
 * **`sort`** [*optional*, *default*=**name**]:
 Sort roles depending on the given field. Sort order is **ascending** by default. Sort order is **descending** if the field is prefixed by a negative sign (Eg: *sort=-name*).
-  * Options: **name**, **modified_at**
+  * Options: **name**, **uuid**
 * **`filter`**[*optional*, *default*=**None**]:
 Filter all roles by the given string.
 
@@ -686,7 +686,7 @@ Page number of users to return for a given page.
 Number of users to return for a given page.
 * **`sort`** [*optional*, *default*=**name**]:
 Sort users depending on the given field. Sort order is **ascending** by default. Sort order is **descending** if the field is prefixed by a negative sign (Eg: *sort=-name*).
-  * Options: **name**, **modified_at**
+  * Options: **name**, **email**, **status**
 * **`filter`**[*optional*, *default*=**None**]:
 Filter all users by the given string.
 

--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -126,29 +126,29 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 ```json
 {
 	"data": {
-            "type": "roles",
-            "id": "$ROLE_UUID",
-            "attributes": {
-                "name": "$ROLE_NAME",
-                "created_at": "2000-02-29T16:50:43.607749+00:00",
-                "modified_at": "2000-02-29T16:50:43.607749+00:00",
-                "user_count": 2122
-            },
-            "relationships": {
-                "permissions": {
-                    "data": [
-                        {
-                            "type": "permissions",
-                            "id": "$PERMISSION_UUID"
-                        },
-                        {
-                            "type": "permissions",
-                            "id": "$PERMISSION_UUID"
-                        }
-                    ]
-                }
+        "type": "roles",
+        "id": "$ROLE_UUID",
+        "attributes": {
+            "name": "$ROLE_NAME",
+            "created_at": "2000-02-29T16:50:43.607749+00:00",
+            "modified_at": "2000-02-29T16:50:43.607749+00:00",
+            "user_count": 2122
+        },
+        "relationships": {
+            "permissions": {
+                "data": [
+                    {
+                        "type": "permissions",
+                        "id": "$PERMISSION_UUID"
+                    },
+                    {
+                        "type": "permissions",
+                        "id": "$PERMISSION_UUID"
+                    }
+                ]
             }
         }
+    }
 }
 ```
 
@@ -191,19 +191,19 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 ```json
 {
 	"data": {
-            "type": "roles",
-            "id": "$ROLE_UUID",
-            "attributes": {
-                "name": "$ROLE_NAME",
-                "created_at": "2000-02-29T16:50:43.607749+00:00",
-                "modified_at": "2000-02-29T16:50:43.607749+00:00"
-            },
-            "relationships": {
-                "permissions": {
-                    "data": []
-                }
+        "type": "roles",
+        "id": "$ROLE_UUID",
+        "attributes": {
+            "name": "$ROLE_NAME",
+            "created_at": "2000-02-29T16:50:43.607749+00:00",
+            "modified_at": "2000-02-29T16:50:43.607749+00:00"
+        },
+        "relationships": {
+            "permissions": {
+                "data": []
             }
         }
+    }
 }
 
 ```
@@ -247,19 +247,19 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 ```json
 {
 	"data": {
-            "type": "roles",
-            "id": "$ROLE_UUID",
-            "attributes": {
-                "name": "$ROLE_NAME",
-                "created_at": "2000-02-29T16:50:43.607749+00:00",
-                "modified_at": "2000-02-29T16:50:43.607749+00:00"
-            },
-            "relationships": {
-                "permissions": {
-                    "data": []
-                }
+        "type": "roles",
+        "id": "$ROLE_UUID",
+        "attributes": {
+            "name": "$ROLE_NAME",
+            "created_at": "2000-02-29T16:50:43.607749+00:00",
+            "modified_at": "2000-02-29T16:50:43.607749+00:00"
+        },
+        "relationships": {
+            "permissions": {
+                "data": []
             }
         }
+    }
 }
 
 ```
@@ -541,38 +541,40 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
             "total_count": 1
         }
     },
-	"data": [{
-        "type": "users",
-        "id": "$USER_UUID",
-        "attributes": {
-            "name": "Example user",
-            "handle": "user@example.org",
-            "created_at": "2000-02-29T14:26:26.983187+00:00",
-            "email": "user@example.org",
-            "icon": "https://secure.gravatar.com/avatar/abc123abc123",
-            "title": null,
-            "verified": true,
-            "disabled": false,
-            "allowed_login_methods": [],
-            "status": "Active"
-        },
-        "relationships": {
-            "roles": {
-                "data": [
-                    {
-                        "type": "roles",
-                        "id": "$ROLE_UUID"
-                    }
-                ]
+	"data": [
+        {
+            "type": "users",
+            "id": "$USER_UUID",
+            "attributes": {
+                "name": "Example user",
+                "handle": "user@example.org",
+                "created_at": "2000-02-29T14:26:26.983187+00:00",
+                "email": "user@example.org",
+                "icon": "https://secure.gravatar.com/avatar/abc123abc123",
+                "title": null,
+                "verified": true,
+                "disabled": false,
+                "allowed_login_methods": [],
+                "status": "Active"
             },
-            "org": {
-                "data": {
-                    "type": "orgs",
-                    "id": "$ORG_UUID"
+            "relationships": {
+                "roles": {
+                    "data": [
+                        {
+                            "type": "roles",
+                            "id": "$ROLE_UUID"
+                        }
+                    ]
+                },
+                "org": {
+                    "data": {
+                        "type": "orgs",
+                        "id": "$ORG_UUID"
+                    }
                 }
             }
         }
-    }]
+    ]
 }
 ```
 
@@ -617,38 +619,40 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
             "total_count": 1
         }
     },
-	"data": [{
-        "type": "users",
-        "id": "$USER_UUID",
-        "attributes": {
-            "name": "Example user",
-            "handle": "user@example.org",
-            "created_at": "2000-02-29T14:26:26.983187+00:00",
-            "email": "user@example.org",
-            "icon": "https://secure.gravatar.com/avatar/abc123abc123",
-            "title": null,
-            "verified": true,
-            "disabled": false,
-            "allowed_login_methods": [],
-            "status": "Active"
-        },
-        "relationships": {
-            "roles": {
-                "data": [
-                    {
-                        "type": "roles",
-                        "id": "$ROLE_UUID"
-                    }
-                ]
+	"data": [
+        {
+            "type": "users",
+            "id": "$USER_UUID",
+            "attributes": {
+                "name": "Example user",
+                "handle": "user@example.org",
+                "created_at": "2000-02-29T14:26:26.983187+00:00",
+                "email": "user@example.org",
+                "icon": "https://secure.gravatar.com/avatar/abc123abc123",
+                "title": null,
+                "verified": true,
+                "disabled": false,
+                "allowed_login_methods": [],
+                "status": "Active"
             },
-            "org": {
-                "data": {
-                    "type": "orgs",
-                    "id": "$ORG_UUID"
+            "relationships": {
+                "roles": {
+                    "data": [
+                        {
+                            "type": "roles",
+                            "id": "$ROLE_UUID"
+                        }
+                    ]
+                },
+                "org": {
+                    "data": {
+                        "type": "orgs",
+                        "id": "$ORG_UUID"
+                    }
                 }
             }
         }
-    }]
+    ]
 }
 ```
 

--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -42,7 +42,7 @@ Number of roles to return for a given page.
 Sort roles depending on the given field. Sort order is **ascending** by default. Sort order is **descending** if the field is prefixed by a negative sign (Eg: *sort=-name*).
     Options: **name**, **modified_at**
 * **`filter`**[*optional*, *default*=**None**]:
-    Filter all roles by the given string.
+Filter all roles by the given string.
 
 
 {{< tabs >}}
@@ -677,6 +677,18 @@ Get all users of a role
 | Method   | Endpoint path                  | Required payload |
 |----------|--------------------------------|------------------|
 | `GET`    | `/v2/roles/<ROLE_UUID>/users`  | No Payload       |
+
+##### ARGUMENTS
+
+* **`page[size]`** [*optional*, *default*=**0**]:
+Page number of users to return for a given page.
+* **`page[count]`** [*optional*, *default*=**10**]:
+Number of users to return for a given page.
+* **`sort`** [*optional*, *default*=**name**]:
+Sort users depending on the given field. Sort order is **ascending** by default. Sort order is **descending** if the field is prefixed by a negative sign (Eg: *sort=-name*).
+    Options: **name**, **modified_at**
+* **`filter`**[*optional*, *default*=**None**]:
+Filter all users by the given string.
 
 {{< tabs >}}
 {{% tab "Example" %}}

--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -29,8 +29,8 @@ All the API endpoints below can have two different host endpoints:
 Returns all roles, including their names and UUIDs.
 
 | Method | Endpoint path | Required payload |
-|--------|--------------|------------------|
-| `GET`  | `/v2/roles`  | No Payload       |
+|--------|--------------|-------------------|
+| `GET`  | `/v2/roles`  | No Payload        |
 
 ##### ARGUMENTS
 
@@ -105,8 +105,8 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 Returns a specific role, including its name and UUID.
 
 | Method | Endpoint path            | Required payload |
-|--------|-------------------------|------------------|
-| `GET`  | `/v2/roles/<ROLE_UUID>` | No Payload       |
+|--------|-------------------------|-------------------|
+| `GET`  | `/v2/roles/<ROLE_UUID>` | No Payload        |
 
 {{< tabs >}}
 {{% tab "Example" %}}
@@ -161,8 +161,8 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 Creates a new role. Returns role name and UUID.
 
 | Method | Endpoint path | Required payload                           |
-|--------|--------------|--------------------------------------------|
-| `POST` | `/v2/roles`  | **type="roles"**<br>**attributes["name"]** |
+|--------|---------------|--------------------------------------------|
+| `POST` | `/v2/roles`   | **type="roles"**<br>**attributes["name"]** |
 
 {{< tabs >}}
 {{% tab "Example" %}}
@@ -200,7 +200,12 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
         },
         "relationships": {
             "permissions": {
-                "data": []
+                "data": [
+                    {
+                        "type": "permissions",
+                        "id": "$PERMISSION_UUID"
+                    },
+                ]
             }
         }
     }
@@ -215,9 +220,9 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 
 Updates an existing role's name. Returns role name and UUID.
 
-| Method  | Endpoint path            | Required payload                           |
-|---------|-------------------------|--------------------------------------------|
-| `PATCH` | `/v2/roles/<ROLE_UUID>` | **type="roles"**<br>**attributes["name"]** |
+| Method  | Endpoint path            | Required payload                                                |
+|---------|--------------------------|-----------------------------------------------------------------|
+| `PATCH` | `/v2/roles/<ROLE_UUID>`  | **type="roles"**<br>**id="ROLE_UUID"**<br>**attributes["name"]**|
 
 {{< tabs >}}
 {{% tab "Example" %}}
@@ -231,6 +236,7 @@ curl -X PATCH \
          -d '{
              "data": {
                  "type": "roles",
+                 "id": <ROLE_UUID>,
                  "attributes": {
                      "name": <ROLE_NAME>
                 }
@@ -256,7 +262,12 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
         },
         "relationships": {
             "permissions": {
-                "data": []
+                "data": [
+                    {
+                        "type": "permissions",
+                        "id": "$PERMISSION_UUID"
+                    },
+                ]
             }
         }
     }
@@ -272,8 +283,8 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 Deletes a role.
 
 | Method   | Endpoint path            | Required payload |
-|----------|-------------------------|------------------|
-| `DELETE` | `/v2/roles/<ROLE_UUID>` | No Payload       |
+|----------|-------------------------|-------------------|
+| `DELETE` | `/v2/roles/<ROLE_UUID>` | No Payload        |
 
 {{< tabs >}}
 {{% tab "Example" %}}
@@ -351,8 +362,8 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 Returns a list of all permissions for a single role.
 
 | Method | Endpoint path                        | Required payload |
-|--------|-------------------------------------|------------------|
-| `GET`  | `/v2/roles/<ROLE_UUID>/permissions` | No Payload       |
+|--------|--------------------------------------|------------------|
+| `GET`  | `/v2/roles/<ROLE_UUID>/permissions`  | No Payload       |
 
 {{< tabs >}}
 {{% tab "Example" %}}
@@ -398,8 +409,8 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 Adds a permission to a role.
 
 | Method | Endpoint path                        | Required payload                                                  |
-|--------|-------------------------------------|-------------------------------------------------------------------|
-| `POST` | `/v2/roles/<ROLE_UUID>/permissions` | **data["type"]="permissions"**<br>**data["id"]=$PERMISSION_UUID** |
+|--------|--------------------------------------|-------------------------------------------------------------------|
+| `POST` | `/v2/roles/<ROLE_UUID>/permissions`  | **data["type"]="permissions"**<br>**data["id"]=$PERMISSION_UUID** |
 
 {{< tabs >}}
 {{% tab "Example" %}}
@@ -453,8 +464,8 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 Removes a permission from a role.
 
 | Method   | Endpoint path                        | Required payload                                                  |
-|----------|-------------------------------------|-------------------------------------------------------------------|
-| `DELETE` | `/v2/roles/<ROLE_UUID>/permissions` | **data["type"]="permissions"**<br>**data["id"]=$PERMISSION_UUID** |
+|----------|--------------------------------------|-------------------------------------------------------------------|
+| `DELETE` | `/v2/roles/<ROLE_UUID>/permissions`  | **data["type"]="permissions"**<br>**data["id"]=$PERMISSION_UUID** |
 
 {{< tabs >}}
 {{% tab "Example" %}}
@@ -508,8 +519,8 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 Adds a user to a role.
 
 | Method | Endpoint path                  | Required payload                                        |
-|--------|-------------------------------|---------------------------------------------------------|
-| `POST` | `/v2/roles/<ROLE_UUID>/users` | **data["type"]="users"**<br>**data["id"]=$USER_UUID** |
+|--------|--------------------------------|---------------------------------------------------------|
+| `POST` | `/v2/roles/<ROLE_UUID>/users`  | **data["type"]="users"**<br>**data["id"]=$USER_UUID** |
 
 {{< tabs >}}
 {{% tab "Example" %}}
@@ -586,8 +597,8 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 Removes a user from a role.
 
 | Method   | Endpoint path                  | Required payload                                        |
-|----------|-------------------------------|---------------------------------------------------------|
-| `DELETE` | `/v2/roles/<ROLE_UUID>/users` | **data["type"]="users"**<br>**data["id"]=$USER_UUID** |
+|----------|--------------------------------|---------------------------------------------------------|
+| `DELETE` | `/v2/roles/<ROLE_UUID>/users`  | **data["type"]="users"**<br>**data["id"]=$USER_UUID** |
 
 {{< tabs >}}
 {{% tab "Example" %}}

--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -839,9 +839,9 @@ Certain permissions can be granted within a limited scope. This can be done manu
 
 | Permission Name                | Scope Name | Format                                   | Description                                                     |
 |--------------------------------|------------|------------------------------------------|-----------------------------------------------------------------|
-| `logs_read_index_data`         | indexes    | list of index names (string)             | Grant read on only certain log indexes.                         |
-| `logs_write_exclusion_filters` | indexes    | list of index names (string)             | Grant update on the exclusion filters for only certain indexes. |
-| `logs_write_processors`        | pipelines  | list of processing pipeline ids (string) | Grant update on only the processors of certain pipelines.       |
+| `logs_read_index_data`         | indexes    | list of index names (string)             | Grant read on only certain log indexes                          |
+| `logs_write_exclusion_filters` | indexes    | list of index names (string)             | Grant update on the exclusion filters for only certain indexes  |
+| `logs_write_processors`        | pipelines  | list of processing pipeline ids (string) | Grant update on only the processors of certain pipelines        |
 
 For example, to grant read access only on two indexes named `main` and `support` to a role named `support`, your API call  looks like this:
 

--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -670,6 +670,102 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 {{% /tab %}}
 {{< /tabs >}}
 
+### Get users of role
+
+Get all users of a role
+
+| Method   | Endpoint path                  | Required payload |
+|----------|--------------------------------|------------------|
+| `GET`    | `/v2/roles/<ROLE_UUID>/users`  | No Payload       |
+
+{{< tabs >}}
+{{% tab "Example" %}}
+
+```sh
+curl -X GET "https://app.datadoghq.com/api/v2/roles/<ROLE_UUID>/users" \
+     -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
+     -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>"
+```
+
+Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1].  See the [Permission UUID section](#permission-uuids) to see what role UUIDs are available for the `<ROLE_UUID>` placeholder.
+
+[1]: https://app.datadoghq.com/account/settings#api
+{{% /tab %}}
+{{% tab "Response" %}}
+
+```json
+{
+    "included": [
+        {
+            "type": "roles",
+            "id": "$ROLE_UUID",
+            "attributes": {
+                "name": "$ROLE_NAME",
+                "created_at": "2000-02-29T16:50:43.607749+00:00",
+                "modified_at": "2000-02-29T16:50:43.607749+00:00"
+            },
+            "relationships": {
+                "permissions": {
+                    "data": [
+                        {
+                            "type": "permissions",
+                            "id": "$PERMISSION_UUID"
+                        },
+                        {
+                            "type": "permissions",
+                            "id": "$PERMISSION_UUID"
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "meta": {
+        "page": {
+            "total_filtered_count": 1,
+            "total_count": 1
+        }
+    },
+	"data": [
+        {
+            "type": "users",
+            "id": "$USER_UUID",
+            "attributes": {
+                "name": "Example user",
+                "handle": "user@example.org",
+                "created_at": "2000-02-29T14:26:26.983187+00:00",
+                "email": "user@example.org",
+                "icon": "https://secure.gravatar.com/avatar/abc123abc123",
+                "title": null,
+                "verified": true,
+                "disabled": false,
+                "allowed_login_methods": [],
+                "status": "Active"
+            },
+            "relationships": {
+                "roles": {
+                    "data": [
+                        {
+                            "type": "roles",
+                            "id": "$ROLE_UUID"
+                        }
+                    ]
+                },
+                "org": {
+                    "data": {
+                        "type": "orgs",
+                        "id": "$ORG_UUID"
+                    }
+                }
+            }
+        }
+    ]
+}
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ## Permission UUIDs
 
 In order to grant or remove a global permission to/from a role, use the UUID for both the role and the permission.

--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -64,6 +64,7 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 {
     "meta": {
         "page": {
+            "total_filtered_count": 7,
             "total_count": 7
         }
     },
@@ -72,10 +73,10 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
             "type": "roles",
             "id": "$ROLE_UUID",
             "attributes": {
+                "name": "$ROLE_NAME",
                 "created_at": "2000-02-29T16:50:43.607749+00:00",
-                "user_count": 2122,
                 "modified_at": "2000-02-29T16:50:43.607749+00:00",
-                "name": "$ROLE_NAME"
+                "user_count": 2122
             },
             "relationships": {
                 "permissions": {
@@ -127,11 +128,11 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 	"data": {
             "type": "roles",
             "id": "$ROLE_UUID",
-                "attributes": {
+            "attributes": {
+                "name": "$ROLE_NAME",
                 "created_at": "2000-02-29T16:50:43.607749+00:00",
-                "user_count": 2122,
                 "modified_at": "2000-02-29T16:50:43.607749+00:00",
-                "name": "$ROLE_NAME"
+                "user_count": 2122
             },
             "relationships": {
                 "permissions": {
@@ -192,11 +193,10 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 	"data": {
             "type": "roles",
             "id": "$ROLE_UUID",
-                "attributes": {
+            "attributes": {
+                "name": "$ROLE_NAME",
                 "created_at": "2000-02-29T16:50:43.607749+00:00",
-                "user_count": 0,
-                "modified_at": "2000-02-29T16:50:43.607749+00:00",
-                "name": "$ROLE_NAME"
+                "modified_at": "2000-02-29T16:50:43.607749+00:00"
             },
             "relationships": {
                 "permissions": {
@@ -249,11 +249,10 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 	"data": {
             "type": "roles",
             "id": "$ROLE_UUID",
-                "attributes": {
+            "attributes": {
+                "name": "$ROLE_NAME",
                 "created_at": "2000-02-29T16:50:43.607749+00:00",
-                "user_count": 0,
-                "modified_at": "2000-02-29T16:50:43.607749+00:00",
-                "name": "$ROLE_NAME"
+                "modified_at": "2000-02-29T16:50:43.607749+00:00"
             },
             "relationships": {
                 "permissions": {
@@ -326,19 +325,21 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 
 ```json
 {
-	"data": [{
-        "type": "permissions",
-        "id": "$PERMISSION_UUID",
-        "attributes": {
-            "display_name": "Logs metrics write",
-            "description": "Update a custom metric",
-            "name": "logs_metrics_write",
-            "created": "2000-02-29T14:26:26.983187+00:00",
-            "restricted": false,
-            "group_name": "Logs",
-            "display_type": "other"
+	"data": [
+        {
+            "type": "permissions",
+            "id": "$PERMISSION_UUID",
+            "attributes": {
+                "name": "logs_metrics_write",
+                "display_name": "Logs metrics write",
+                "description": "Update a custom metric",
+                "created": "2000-02-29T14:26:26.983187+00:00",
+                "group_name": "Logs",
+                "display_type": "other",
+                "restricted": false
+            }
         }
-    }]
+    ]
 }
 ```
 
@@ -371,19 +372,21 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 
 ```json
 {
-	"data": [{
-        "type": "permissions",
-        "id": "$PERMISSION_UUID",
-        "attributes": {
-            "display_name": "Logs metrics write",
-            "description": "Update a custom metric",
-            "name": "logs_metrics_write",
-            "created": "2000-02-29T14:26:26.983187+00:00",
-            "restricted": false,
-            "group_name": "Logs",
-            "display_type": "other"
+	"data": [
+        {
+            "type": "permissions",
+            "id": "$PERMISSION_UUID",
+            "attributes": {
+                "name": "logs_metrics_write",
+                "display_name": "Logs metrics write",
+                "description": "Update a custom metric",
+                "created": "2000-02-29T14:26:26.983187+00:00",
+                "group_name": "Logs",
+                "display_type": "other",
+                "restricted": false
+            }
         }
-    }]
+    ]
 }
 ```
 
@@ -424,19 +427,21 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 
 ```json
 {
-	"data": [{
-        "type": "permissions",
-        "id": "$PERMISSION_UUID",
-        "attributes": {
-            "display_name": "Logs metrics write",
-            "description": "Update a custom metric",
-            "name": "logs_metrics_write",
-            "created": "2000-02-29T14:26:26.983187+00:00",
-            "restricted": false,
-            "group_name": "Logs",
-            "display_type": "other"
+	"data": [
+        {
+            "type": "permissions",
+            "id": "$PERMISSION_UUID",
+            "attributes": {
+                "name": "logs_metrics_write",
+                "display_name": "Logs metrics write",
+                "description": "Update a custom metric",
+                "created": "2000-02-29T14:26:26.983187+00:00",
+                "group_name": "Logs",
+                "display_type": "other",
+                "restricted": false
+            }
         }
-    }]
+    ]
 }
 ```
 
@@ -477,19 +482,21 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 
 ```json
 {
-	"data": [{
-        "type": "permissions",
-        "id": "$DIFFERENT_PERMISSION_UUID",
-        "attributes": {
-            "display_name": "Logs metrics read",
-            "description": "Update a read metric",
-            "name": "logs_metrics_read",
-            "created": "2000-02-29T14:26:26.983187+00:00",
-            "restricted": false,
-            "group_name": "Logs",
-            "display_type": "other"
+	"data": [
+        {
+            "type": "permissions",
+            "id": "$DIFFERENT_PERMISSION_UUID",
+            "attributes": {
+                "name": "logs_metrics_write",
+                "display_name": "Logs metrics write",
+                "description": "Update a custom metric",
+                "created": "2000-02-29T14:26:26.983187+00:00",
+                "group_name": "Logs",
+                "display_type": "other",
+                "restricted": false
+            }
         }
-    }]
+    ]
 }
 ```
 
@@ -502,7 +509,7 @@ Adds a user to a role.
 
 | Method | Endpoint path                  | Required payload                                        |
 |--------|-------------------------------|---------------------------------------------------------|
-| `POST` | `/v2/roles/<ROLE_UUID>/users` | **data["type"]="users"**<br>**data["id"]=$USER_HANDLE** |
+| `POST` | `/v2/roles/<ROLE_UUID>/users` | **data["type"]="users"**<br>**data["id"]=$USER_UUID** |
 
 {{< tabs >}}
 {{% tab "Example" %}}
@@ -516,7 +523,7 @@ curl -X POST \
          -d '{
              "data": {
                  "type": "users",
-                 "id": "user@example.org"
+                 "id": <USER_UUID>
              }
          }'
 ```
@@ -529,18 +536,41 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 
 ```json
 {
+    "meta": {
+        "page": {
+            "total_count": 1
+        }
+    },
 	"data": [{
         "type": "users",
-        "id": "user@example.org",
+        "id": "$USER_UUID",
         "attributes": {
-            "handle": "user@example.org",
             "name": "Example user",
-            "title": null,
+            "handle": "user@example.org",
             "created_at": "2000-02-29T14:26:26.983187+00:00",
-            "org_id": 99,
-            "disabled": false,
+            "email": "user@example.org",
+            "icon": "https://secure.gravatar.com/avatar/abc123abc123",
+            "title": null,
             "verified": true,
-            "email": "user@example.org"
+            "disabled": false,
+            "allowed_login_methods": [],
+            "status": "Active"
+        },
+        "relationships": {
+            "roles": {
+                "data": [
+                    {
+                        "type": "roles",
+                        "id": "$ROLE_UUID"
+                    }
+                ]
+            },
+            "org": {
+                "data": {
+                    "type": "orgs",
+                    "id": "$ORG_UUID"
+                }
+            }
         }
     }]
 }
@@ -555,7 +585,7 @@ Removes a user from a role.
 
 | Method   | Endpoint path                  | Required payload                                        |
 |----------|-------------------------------|---------------------------------------------------------|
-| `DELETE` | `/v2/roles/<ROLE_UUID>/users` | **data["type"]="users"**<br>**data["id"]=$USER_HANDLE** |
+| `DELETE` | `/v2/roles/<ROLE_UUID>/users` | **data["type"]="users"**<br>**data["id"]=$USER_UUID** |
 
 {{< tabs >}}
 {{% tab "Example" %}}
@@ -569,7 +599,7 @@ curl -X DELETE \
          -d '{
              "data": {
                  "type": "users",
-                 "id": "user@example.org"
+                 "id": <USER_UUID>
              }
          }'
 ```
@@ -582,18 +612,41 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 
 ```json
 {
+    "meta": {
+        "page": {
+            "total_count": 1
+        }
+    },
 	"data": [{
         "type": "users",
-        "id": "user2@example.org",
+        "id": "$USER_UUID",
         "attributes": {
-            "handle": "user2@example.org",
-            "name": "Example user 2",
-            "title": null,
+            "name": "Example user",
+            "handle": "user@example.org",
             "created_at": "2000-02-29T14:26:26.983187+00:00",
-            "org_id": 99,
-            "disabled": false,
+            "email": "user@example.org",
+            "icon": "https://secure.gravatar.com/avatar/abc123abc123",
+            "title": null,
             "verified": true,
-            "email": "user2@example.org"
+            "disabled": false,
+            "allowed_login_methods": [],
+            "status": "Active"
+        },
+        "relationships": {
+            "roles": {
+                "data": [
+                    {
+                        "type": "roles",
+                        "id": "$ROLE_UUID"
+                    }
+                ]
+            },
+            "org": {
+                "data": {
+                    "type": "orgs",
+                    "id": "$ORG_UUID"
+                }
+            }
         }
     }]
 }

--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -669,37 +669,47 @@ The UUIDs for the permissions are as follows:
 
 {{< tabs >}}
 {{% tab "Datadog US site" %}}
-| name                         | UUID                                 | description                                  |
-|------------------------------|--------------------------------------|----------------------------------------------|
-| admin                        | 984a2bd4-d3b4-11e8-a1ff-a7f660d43029 | Read and write permission to all of datadog  |
-| standard                     | 984d2f00-d3b4-11e8-a200-bb47109e9987 | Read and write permission to most of datadog |
-| read_only                    | 984fe6fa-d3b4-11e8-a201-47a7999cc331 | Read permission to most of datadog           |
-| logs_read_index_data         | 5e605652-dd12-11e8-9e53-375565b8970e | Read a subset of all log indexes             |
-| logs_modify_indexes          | 62cc036c-dd12-11e8-9e54-db9995643092 | Update the definition of log indexes         |
-| logs_live_tail               | 6f66600e-dd12-11e8-9e55-7f30fbb45e73 | Access the live tail feature                 |
-| logs_generate_metrics        | 979df720-aed7-11e9-99c6-a7eb8373165a | Access the Generate Metrics feature          |
-| logs_write_exclusion_filters | 7d7c98ac-dd12-11e8-9e56-93700598622d | Update a subset of the exclusion filters     |
-| logs_write_pipelines         | 811ac4ca-dd12-11e8-9e57-676a7f0beef9 | Update a subset of the log pipelines         |
-| logs_write_processors        | 84aa3ae4-dd12-11e8-9e58-a373a514ccd0 | Update the log processors in an index        |
-| logs_write_archives          | 87b00304-dd12-11e8-9e59-cbeb5f71f72f | Update the external archives configuration   |
-| logs_public_config_api       | 1a92ede2-6cb2-11e9-99c6-2b3a4a0cdf0a | Access the Logs Public Config API (r/w)      |
+| name                         | UUID                                 | description                                    |
+|------------------------------|--------------------------------------|------------------------------------------------|
+| admin                        | 984a2bd4-d3b4-11e8-a1ff-a7f660d43029 | Read and write permission to all of datadog    |
+| standard                     | 984d2f00-d3b4-11e8-a200-bb47109e9987 | Read and write permission to most of datadog   |
+| logs_read_index_data         | 5e605652-dd12-11e8-9e53-375565b8970e | Read a subset of all log indexes               |
+| logs_modify_indexes          | 62cc036c-dd12-11e8-9e54-db9995643092 | Update the definition of log indexes           |
+| logs_live_tail               | 6f66600e-dd12-11e8-9e55-7f30fbb45e73 | Access the live tail feature                   |
+| logs_write_exclusion_filters | 7d7c98ac-dd12-11e8-9e56-93700598622d | Update a subset of the exclusion filters       |
+| logs_write_pipelines         | 811ac4ca-dd12-11e8-9e57-676a7f0beef9 | Update a subset of the log pipelines           |
+| logs_write_processors        | 84aa3ae4-dd12-11e8-9e58-a373a514ccd0 | Update the log processors in an index          |
+| logs_write_archives          | 87b00304-dd12-11e8-9e59-cbeb5f71f72f | Update the external archives configuration     |
+| logs_public_config_api       | 1a92ede2-6cb2-11e9-99c6-2b3a4a0cdf0a | Access the Logs Public Config API (r/w)        |
+| logs_generate_metrics        | 979df720-aed7-11e9-99c6-a7eb8373165a | Access the Generate Metrics feature            |
+| dashboards_read              | d90f6830-d3d8-11e9-a77a-b3404e5e9ee2 | Ability to view dashboards                     |
+| dashboards_write             | d90f6831-d3d8-11e9-a77a-4fd230ddbc6a | Ability to create and change dashboards        |
+| dashboards_public_share      | d90f6832-d3d8-11e9-a77a-bf8a2607f864 | Ability to share dashboards externally         |
+| monitors_read                | 4441648c-d8b1-11e9-a77a-1b899a04b304 | Ability to view monitors                       |
+| monitors_write               | 48ef71ea-d8b1-11e9-a77a-93f408470ad0 | Ability to change, mute, and delete  monitors  |
+| monitors_downtime            | 4d87d5f8-d8b1-11e9-a77a-eb9c8350d04f | Ability to set downtimes for your monitors     |
 
 {{% /tab %}}
 {{% tab "Datadog EU site" %}}
-| name                         | UUID                                 | description                                  |
-|------------------------------|--------------------------------------|----------------------------------------------|
-| admin                        | f1624684-d87d-11e8-acac-efb4dbffab1c | Read and write permission to all of datadog  |
-| standard                     | f1666372-d87d-11e8-acac-6be484ba794a | Read and write permission to most of datadog |
-| read_only                    | f1682b6c-d87d-11e8-acac-9f3040c65f48 | Read permission to most of datadog           |
-| logs_read_index_data         | 4fbb1652-dd15-11e8-9308-77be61fbb2c7 | Read a subset of all log indexes             |
-| logs_modify_indexes          | 4fbd1e66-dd15-11e8-9308-53cb90e4ef1c | Update the definition of log indexes         |
-| logs_live_tail               | 4fbeec96-dd15-11e8-9308-d3aac44f93e5 | Access the live tail feature                 |
-| logs_generate_metrics        | 06f715e2-aed9-11e9-aac6-eb5723c0dffc | Access the Generate Metrics feature          |
-| logs_write_exclusion_filters | 4fc2807c-dd15-11e8-9308-d3bfffb7f039 | Update a subset of the exclusion filters     |
-| logs_write_pipelines         | 4fc43656-dd15-11e8-9308-f3e2bb5e31b4 | Update a subset of the log pipelines         |
-| logs_write_processors        | 505f4538-dd15-11e8-9308-47a4732f715f | Update the log processors in an index        |
-| logs_write_archives          | 505fd138-dd15-11e8-9308-afd2db62791e | Update the external archives configuration   |
-| logs_public_config_api       | bd837a80-6cb2-11e9-8fc4-339b4b012214 | Access the Logs Public Config API (r/w)      |
+| name                         | UUID                                 | description                                    |
+|------------------------------|--------------------------------------|------------------------------------------------|
+| admin                        | f1624684-d87d-11e8-acac-efb4dbffab1c | Read and write permission to all of datadog    |
+| standard                     | f1666372-d87d-11e8-acac-6be484ba794a | Read and write permission to most of datadog   |
+| logs_read_index_data         | 4fbb1652-dd15-11e8-9308-77be61fbb2c7 | Read a subset of all log indexes               |
+| logs_modify_indexes          | 4fbd1e66-dd15-11e8-9308-53cb90e4ef1c | Update the definition of log indexes           |
+| logs_live_tail               | 4fbeec96-dd15-11e8-9308-d3aac44f93e5 | Access the live tail feature                   |
+| logs_write_exclusion_filters | 4fc2807c-dd15-11e8-9308-d3bfffb7f039 | Update a subset of the exclusion filters       |
+| logs_write_pipelines         | 4fc43656-dd15-11e8-9308-f3e2bb5e31b4 | Update a subset of the log pipelines           |
+| logs_write_processors        | 505f4538-dd15-11e8-9308-47a4732f715f | Update the log processors in an index          |
+| logs_write_archives          | 505fd138-dd15-11e8-9308-afd2db62791e | Update the external archives configuration     |
+| logs_public_config_api       | bd837a80-6cb2-11e9-8fc4-339b4b012214 | Access the Logs Public Config API (r/w)        |
+| logs_generate_metrics        | 06f715e2-aed9-11e9-aac6-eb5723c0dffc | Access the Generate Metrics feature            |
+| dashboards_read              | 2147a4f0-d3d9-11e9-a614-83d5d3c791ee | Ability to view dashboards                     |
+| dashboards_write             | 2149e512-d3d9-11e9-a614-bb8f0dcf0205 | Ability to create and change dashboards        |
+| dashboards_public_share      | 214c10b2-d3d9-11e9-a614-3759c7ad528f | Ability to share dashboards externally         |
+| monitors_read                | c898551e-d8b2-11e9-a336-e3a79c23bd8d | Ability to view monitors                       |
+| monitors_write               | cdc3e3d2-d8b2-11e9-943b-e70db6c573b8 | Ability to change, mute, and delete  monitors  |
+| monitors_downtime            | d3159858-d8b2-11e9-a336-e363d6ef331b | Ability to set downtimes for your monitors     |
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Changes include:
- Fix `assign user to role` and `unassign user to role` endpoints as they should use `user_uuid` rather than `handle` in the data body
- Updated all permissions to be up-to-date for both US Prod and EU Prod
- Updated the responses as some of the attributes are no longer returned due to API changes recently
- Add missing `users of a specific role` endpoint that should be included in this page
- Cleaned up the formatting for JSON responses and other nit cleanups
- Reordered response attributes based on the actual order they are returned

### Motivation
The Roles API page is pretty outdated.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/raymond-you/role_api/account_management/rbac/role_api/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
