### PR TITLE
[rbac] roles api: change scope example to use v2 api

### DIFF
--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -852,8 +852,7 @@ curl -X POST \
         -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
         -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
         -d '{
-                "data":
-                {
+                "data": {
                     "type": "permissions",
                     "id": <PERMISSION_UUID>,
                     "scope": {
@@ -875,8 +874,7 @@ curl -X POST \
         -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
         -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
         -d '{
-                "data":
-                {
+                "data": {
                     "type": "permissions",
                     "id": <PERMISSION_UUID>,
                     "scope": {

--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -847,32 +847,46 @@ For example, to grant read access only on two indexes named `main` and `support`
 
 ```sh
 curl -X POST \
-  "https://app.datadoghq.com/api/v1/roles/${ROLEUUID}/permissions/${PERMISSION}?api_key=${API_KEY}&application_key=${APP_KEY}" \
-  -H "Content-type: application/json" \
-  -d '{
-      	"scope": {
-      		"indexes": [
-      			"main",
-      			"support"
-      		]
-      	}
-      }'
+        https://app.datadoghq.com/api/v2/roles/<ROLE_UUID>/permissions \
+        -H "Content-Type: application/json" \
+        -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
+        -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
+        -d '{
+                "data":
+                {
+                    "type": "permissions",
+                    "id": <PERMISSION_UUID>,
+                    "scope": {
+                        "indexes": [
+                            "main",
+                            "support"
+                        ]
+                    }
+                }
+            }'
 ```
 
 To grant write access to only two processing pipelines whose IDs are `abcd-1234` and `bcde-2345` respectively, your API call  looks like this:
 
 ```sh
 curl -X POST \
-    "https://app.datadoghq.com/api/v1/roles/${ROLEUUID}/permissions/${PERMISSION}?api_key=${API_KEY}&application_key=${APP_KEY}"
-    -H "Content-type: application/json" \
-    -d '{
-          "scope": {
-            "pipelines": [
-        		  "abcd-1234",
-        		  "bcde-2345"
-        	 ]
-         }
-       }'
+        https://app.datadoghq.com/api/v2/roles/<ROLE_UUID>/permissions \
+        -H "Content-Type: application/json" \
+        -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
+        -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
+        -d '{
+                "data":
+                {
+                    "type": "permissions",
+                    "id": <PERMISSION_UUID>,
+                    "scope": {
+                        "pipelines": [
+                            "abcd-1234",
+                            "bcde-2345"
+                        ]
+                    }
+                }
+            }'
 ```
 
 ## Further Reading


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Change scope example at the bottom to use the v2 api format.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/raymond-you/roles-api-to-v2/account_management/rbac/role_api/?tab=example#granting-permissions-within-limited-scopes

### Additional Notes
<!-- Anything else we should know when reviewing?-->
