### PR TITLE
Fix logs link

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1041,7 +1041,7 @@ main:
     weight: 8
 
   - name: "Correlate Logs with Metrics"
-    url: "graphing/dashboards/timeboard/#correlation-between-logs-and-metrics"
+    url: "graphing/dashboards/timeboard/#graph-menu"
     parent: "log_management"
     identifier: "logs_metrics_correlation"
     weight: 9

--- a/content/en/logs/_index.md
+++ b/content/en/logs/_index.md
@@ -38,7 +38,7 @@ Datadog's log management removes these limitations by decoupling log ingestion f
 {{< /whatsnext >}}
 {{< whatsnext desc="Finally, leverage the pillars of observability with metrics and traces:">}}
   {{< nextlink href="/tracing/advanced/connect_logs_and_traces/?tab=java">}}<u>Connect Logs and Traces</u>: See the exact trace correlated with the observed log.{{< /nextlink >}}
-  {{< nextlink href="/graphing/dashboards/timeboard/#correlation-between-logs-and-metrics">}}<u>Correlate Logs and Metrics</u>: See the exact metric correlated with the observed log.{{< /nextlink >}}
+  {{< nextlink href="/graphing/dashboards/timeboard/#graph-menu">}}<u>Correlate Logs and Metrics</u>: See the exact metric correlated with the observed log.{{< /nextlink >}}
 {{< /whatsnext >}}
 
 ## Further Reading


### PR DESCRIPTION
### What does this PR do?
Fix logs link due to updated timeboards page

### Motivation
Trello request

### Preview link
https://docs-staging.datadoghq.com/ruth/log-link/logs/

### Additional Notes
Apparently, this doesn't fix anything because `whatsnext` partials don't support anchor links. Created a separate card for this issue.
