### PR TITLE
Documented new header to pass API key in logs HTTP API

### DIFF
--- a/content/en/api/logs/code_snippets/send_logs_datadog.sh
+++ b/content/en/api/logs/code_snippets/send_logs_datadog.sh
@@ -1,4 +1,17 @@
 ## Simple Raw Message
+## API key passed in headers
+
+curl -X POST https://http-intake.logs.datadoghq.com/v1/input \
+     -H "Content-Type: text/plain" \
+     -H "DD-API-KEY: <API_KEY>" \
+     -d 'hello world'
+
+## API key passed in path
+
+curl -X POST https://http-intake.logs.datadoghq.com/v1/input/<API_KEY> \
+     -H "Content-Type: text/plain" \
+     -d 'hello world'
+
 ## Log attributes can be passed as query parameters
 
 curl -X POST https://http-intake.logs.datadoghq.com/v1/input/<API_KEY>?ddtags=env:prod,user:my-user \

--- a/content/en/api/logs/send_logs_datadog.md
+++ b/content/en/api/logs/send_logs_datadog.md
@@ -11,7 +11,8 @@ external_redirect: /api/#send-logs-over-http
 | ------           | ---------                                                                                                             |
 | Protocol         | http: 80<br>https: 443                                                                                                |
 | Host             | For Datadog US: `http-intake.logs.datadoghq.com` <br> For Datadog EU: `http-intake.logs.datadoghq.eu`                 |
-| Path             | `/v1/input/<DATADOG_API_KEY>`                                                                                         |
+| Path             | For API key passed in headers: `/v1/input`<br> For API key passed in path: `/v1/input/<DATADOG_API_KEY>`              |
+| Headers          | Header to pass the API key: `DD-API-KEY`                                                                              |
 | Query parameters | Query parameters available are the reserved log attribute. `?ddtags=<TAGS>&ddsource=<SOURCE>&service=<SERVICE>&hostname=<HOSTNAME>` |
 | Method           | `POST`                                                                                                                |
 | Content Type     | Available content type are: `text/plain`, `application/json`, `application/logplex-1`                                 |

--- a/content/en/api/logs/send_logs_datadog.md
+++ b/content/en/api/logs/send_logs_datadog.md
@@ -16,3 +16,4 @@ external_redirect: /api/#send-logs-over-http
 | Query parameters | Query parameters available are the reserved log attribute. `?ddtags=<TAGS>&ddsource=<SOURCE>&service=<SERVICE>&hostname=<HOSTNAME>` |
 | Method           | `POST`                                                                                                                |
 | Content Type     | Available content type are: `text/plain`, `application/json`, `application/logplex-1`                                 |
+**Note**: The API key can be passed in both the headers and the path but the one that will be used in that case is the one passed in the headers.

--- a/content/en/api/logs/send_logs_datadog.md
+++ b/content/en/api/logs/send_logs_datadog.md
@@ -16,4 +16,4 @@ external_redirect: /api/#send-logs-over-http
 | Query parameters | Query parameters available are the reserved log attribute. `?ddtags=<TAGS>&ddsource=<SOURCE>&service=<SERVICE>&hostname=<HOSTNAME>` |
 | Method           | `POST`                                                                                                                |
 | Content Type     | Available content type are: `text/plain`, `application/json`, `application/logplex-1`                                 |
-**Note**: The API key can be passed in both the headers and the path but the one that will be used in that case is the one passed in the headers.
+**Note**: If an API key is passed in both the headers and the path only the one in the headers is taken into account.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
* Added headers section in API documentation for logs http endpoint to document new header to pass the API key
* Updated path section ton include new path without the API key
* Changed bash examples to present the two ways to pass the API key

### Motivation
<!-- What inspired you to submit this pull request?-->
Documented new header `DD-API-KEY` to pass API key in logs HTTP API

### Preview link
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/api/?lang=bash#send-logs-over-http

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ajacquemot/logs_http_api_api_key_headers/api/?lang=bash#send-logs-over-http

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Do we want to deprecate passing the API key in the path ? cc @NBParis 