### PR TITLE
Roles API page, add section for uuids

### DIFF
--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -539,7 +539,9 @@ curl -X POST \
          }'
 ```
 
-Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1]. See the [Permission UUID section](#permission-uuids) to see what roles UUIDs are available for the `<ROLE_UUID>` placeholder.
+Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1]. `USER_UUID` can also be found through the `https://app.datadoghq.com/api/v2/current_user` endpoint under `id` for data type `users`. 
+
+See the [Permission UUID section](#permission-uuids) to see what roles UUIDs are available for the `<ROLE_UUID>` placeholder.
 
 [1]: https://app.datadoghq.com/account/settings#api
 {{% /tab %}}
@@ -617,7 +619,9 @@ curl -X DELETE \
          }'
 ```
 
-Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1].  See the [Permission UUID section](#permission-uuids) to see what role UUIDs are available for the `<ROLE_UUID>` placeholder.
+Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1]. `USER_UUID` can also be found through the `https://app.datadoghq.com/api/v2/current_user` endpoint under `id` for data type `users`. 
+
+See the [Permission UUID section](#permission-uuids) to see what roles UUIDs are available for the `<ROLE_UUID>` placeholder.
 
 [1]: https://app.datadoghq.com/account/settings#api
 {{% /tab %}}

--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -539,7 +539,7 @@ curl -X POST \
          }'
 ```
 
-Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1]. `USER_UUID` can also by found by heading to [https://app.datadoghq.com/api/v2/current_user] and looking under data type `users` for `id`.
+Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1]. `USER_UUID` can also be found through the https://app.datadoghq.com/api/v2/current_user endpoint and under data type, `users`, for `id`.
 
 See the [Permission UUID section](#permission-uuids) to see what roles UUIDs are available for the `<ROLE_UUID>` placeholder.
 
@@ -619,7 +619,7 @@ curl -X DELETE \
          }'
 ```
 
-Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1]. `USER_UUID` can also by found by heading to [https://app.datadoghq.com/api/v2/current_user] and looking under data type `users` for `id`.
+Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1]. `USER_UUID` can also be found through the https://app.datadoghq.com/api/v2/current_user endpoint and under data type, `users`, for `id`.
 
 See the [Permission UUID section](#permission-uuids) to see what roles UUIDs are available for the `<ROLE_UUID>` placeholder.
 

--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -539,7 +539,7 @@ curl -X POST \
          }'
 ```
 
-Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1]. `USER_UUID` can also by heading to [https://app.datadoghq.com/api/v2/current_user] and looking under data type `users` for `id`.
+Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1]. `USER_UUID` can also by found by heading to [https://app.datadoghq.com/api/v2/current_user] and looking under data type `users` for `id`.
 
 See the [Permission UUID section](#permission-uuids) to see what roles UUIDs are available for the `<ROLE_UUID>` placeholder.
 
@@ -619,7 +619,7 @@ curl -X DELETE \
          }'
 ```
 
-Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1]. `USER_UUID` can also by heading to [https://app.datadoghq.com/api/v2/current_user] and looking under data type `users` for `id`.
+Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1]. `USER_UUID` can also by found by heading to [https://app.datadoghq.com/api/v2/current_user] and looking under data type `users` for `id`.
 
 See the [Permission UUID section](#permission-uuids) to see what roles UUIDs are available for the `<ROLE_UUID>` placeholder.
 

--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -539,7 +539,7 @@ curl -X POST \
          }'
 ```
 
-Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1]. `USER_UUID` can also be found through the https://app.datadoghq.com/api/v2/current_user endpoint and under data type, `users`, for `id`.
+Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1]. `USER_UUID` can also be found through the https://app.datadoghq.com/api/v2/current_user endpoint, specifically `id` under data type, `users`.
 
 See the [Permission UUID section](#permission-uuids) to see what roles UUIDs are available for the `<ROLE_UUID>` placeholder.
 
@@ -619,7 +619,7 @@ curl -X DELETE \
          }'
 ```
 
-Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1]. `USER_UUID` can also be found through the https://app.datadoghq.com/api/v2/current_user endpoint and under data type, `users`, for `id`.
+Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1]. `USER_UUID` can also be found through the https://app.datadoghq.com/api/v2/current_user endpoint, specifically `id` under data type, `users`.
 
 See the [Permission UUID section](#permission-uuids) to see what roles UUIDs are available for the `<ROLE_UUID>` placeholder.
 

--- a/content/en/account_management/rbac/role_api.md
+++ b/content/en/account_management/rbac/role_api.md
@@ -539,7 +539,7 @@ curl -X POST \
          }'
 ```
 
-Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1]. `USER_UUID` can also be found through the `https://app.datadoghq.com/api/v2/current_user` endpoint under `id` for data type `users`. 
+Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1]. `USER_UUID` can also by heading to [https://app.datadoghq.com/api/v2/current_user] and looking under data type `users` for `id`.
 
 See the [Permission UUID section](#permission-uuids) to see what roles UUIDs are available for the `<ROLE_UUID>` placeholder.
 
@@ -619,7 +619,7 @@ curl -X DELETE \
          }'
 ```
 
-Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1]. `USER_UUID` can also be found through the `https://app.datadoghq.com/api/v2/current_user` endpoint under `id` for data type `users`. 
+Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1]. `USER_UUID` can also by heading to [https://app.datadoghq.com/api/v2/current_user] and looking under data type `users` for `id`.
 
 See the [Permission UUID section](#permission-uuids) to see what roles UUIDs are available for the `<ROLE_UUID>` placeholder.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add a section on how to get user UUID for customers.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/raymond-you/role_api_add_uuid/account_management/rbac/role_api/?tab=datadogussite#add-user-to-role

### Additional Notes
<!-- Anything else we should know when reviewing?-->
