### PR TITLE
[agent] Add details on uninstall methods

### DIFF
--- a/content/en/agent/faq/how-do-i-uninstall-the-agent.md
+++ b/content/en/agent/faq/how-do-i-uninstall-the-agent.md
@@ -15,15 +15,42 @@ Choose your platform to see dedicated instructions to uninstall the Agent:
 {{% tab "Agent v6" %}}
 
 ```
-sudo apt-get --purge remove datadog-agent -y
+sudo apt-get remove --purge datadog-agent -y
+```
+
+This command removes the Agent, but does not remove:
+
+- the `datadog.yaml` configuration file,
+- user-created files in the `/etc/datadog-agent` configuration folder,
+- user-created files in the `/opt/datadog-agent` folder,
+- the `dd-agent` user.
+
+If you also want to remove these elements, use this command instead:
+
+```
+sudo apt-get remove --purge datadog-agent -y
 ```
 
 {{% /tab %}}
 {{% tab "Agent v5" %}}
 
 ```
+sudo apt-get remove datadog-agent -y
+```
+
+This command removes the Agent, but does not remove:
+
+- the `datadog.yaml` configuration file,
+- user-created files in the `/etc/dd-agent` configuration folder,
+- user-created files in the `/opt/datadog-agent` folder,
+- the `dd-agent` user.
+
+If you also want to remove these elements, use this command instead:
+
+```
 sudo apt-get --purge remove datadog-agent -y
 ```
+
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -37,12 +64,60 @@ sudo apt-get --purge remove datadog-agent -y
 sudo yum remove datadog-agent
 ```
 
+This command removes the Agent, but does not remove:
+
+- the `datadog.yaml` configuration file,
+- user-created files in the `/etc/datadog-agent` configuration folder,
+- user-created files in the `/opt/datadog-agent` folder,
+- the `dd-agent` user.
+
 {{% /tab %}}
 {{% tab "Agent v5" %}}
 
 ```
 sudo yum remove datadog-agent
 ```
+
+This command removes the Agent, but does not remove:
+
+- the `datadog.yaml` configuration file,
+- user-created files in the `/etc/dd-agent` configuration folder,
+- user-created files in the `/opt/datadog-agent` folder,
+- the `dd-agent` user.
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### openSUSE/SLES
+
+{{< tabs >}}
+{{% tab "Agent v6" %}}
+
+```
+sudo zypper remove datadog-agent
+```
+
+This command removes the Agent, but does not remove:
+
+- the `datadog.yaml` configuration file,
+- user-created files in the `/etc/datadog-agent` configuration folder,
+- user-created files in the `/opt/datadog-agent` folder,
+- the `dd-agent` user.
+
+{{% /tab %}}
+{{% tab "Agent v5" %}}
+
+```
+sudo zypper remove datadog-agent
+```
+
+This command removes the Agent, but does not remove:
+
+- the `datadog.yaml` configuration file,
+- user-created files in the `/etc/dd-agent` configuration folder,
+- user-created files in the `/opt/datadog-agent` folder,
+- the `dd-agent` user.
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -61,6 +136,8 @@ sudo rm -rf /usr/local/bin/datadog-agent
 sudo rm -rf ~/.datadog-agent/**​ #to remove broken symlinks
 ```
 Then, reboot your machine for changes to take effect.
+
+This method removes the Agent, as well as all Agent configuration files.
 
 {{% /tab %}}
 {{% tab "Agent v5" %}}
@@ -83,6 +160,8 @@ sudo launchctl unload -w /Library/LaunchDaemons/com.datadoghq.agent.plist
 sudo rm /Library/LaunchDaemons/com.datadoghq.agent.plist
 ```
 
+This method removes the Agent, as well as all Agent configuration files.
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -101,6 +180,8 @@ Alternatively, use the Powershell command below. **Note**: Some Agent versions m
 (Get-WmiObject -Class Win32_Product -Filter "Name='Datadog Agent'" -ComputerName . ).Uninstall()
 ```
 
+Both methods remove the Agent, but they do not remove the `C:\ProgramData\Datadog` configuration folder on the host.
+
 {{% /tab %}}
 {{% tab "Agent v5" %}}
 
@@ -111,6 +192,8 @@ Alternatively, use the Powershell command below. **Note**: Some Agent versions m
 ```
 (Get-WmiObject -Class Win32_Product -Filter "Name='Datadog Agent'" -ComputerName . ).Uninstall()
 ```
+
+Both methods remove the Agent, but they do not remove the `C:\ProgramData\Datadog` configuration folder on the host.
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
### What does this PR do?

Add uninstall method for SUSE.
Add details on what is / is not uninstalled with each uninstall method.

### Motivation

Clearer uninstall doc.

### Preview link
[How do I uninstall the Agent?](https://docs-staging.datadoghq.com/kylian.serrania/update-agent-uninstall-doc/agent/faq/how-do-i-uninstall-the-agent/?tab=agentv6#pagetitle)
