### PR TITLE
[DOC] Keyvalue parser + JSON empty values + typo log size limit

### DIFF
--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -55,6 +55,7 @@ After processing, the following structured log is generated:
   * Each rule can reference parsing rules defined above itself in the list.
 * You must have unique rule names within the same Grok parser.
 * The rule name must contain only: alphanumeric characters, `_`, and `.`. It must start with an alphanumeric character.
+* Properties with null or empty values are not displayed.
 
 ### Matcher and Filter
 
@@ -172,12 +173,15 @@ Some examples demonstrating how to use parsers:
 This is the key-value core filter: `keyvalue([separatorStr[, characterWhiteList[, quotingStr]]])` where:
 
 * `separatorStr`: defines the separator. Defaults to `=`.
-* `characterWhiteList`: defines additional non-escaped value chars. Defaults to `\\w.\\-_@`. Used only for non-quoted values (e.g. `key=@valueStr`).
-* `quotingStr`: defines quotes. Default behavior detects quotes (`<>`, `""`, etc.). 
+* `characterWhiteList`: defines extra non-escaped value chars in addition to the default `\\w.\\-_@`. Used only for non-quoted values (e.g. `key=@valueStr`).
+* `quotingStr`: defines quotes, replacing the default quotes detection: `<>`, `""`, `''`. 
 
-**Note**: If you define a *keyvalue* filter on a `data` object, and this filter is not matched, then an empty JSON `{}` is returned (e.g. input: `key:=valueStr`, parsing rule: `rule_test %{data::keyvalue("=")}`, output: `{}`).
+**Note**: 
 
-Use filters such as **keyvalue()** to more-easily map strings to attributes:
+* Empty values (`key=`) or `null` values (`key=null`) are not displayed in the output JSON.
+* If you define a *keyvalue* filter on a `data` object, and this filter is not matched, then an empty JSON `{}` is returned (e.g. input: `key:=valueStr`, parsing rule: `rule_test %{data::keyvalue("=")}`, output: `{}`).
+
+Use filters such as **keyvalue** to more-easily map strings to attributes:
 
 Log:
 

--- a/content/en/logs/processing/pipelines.md
+++ b/content/en/logs/processing/pipelines.md
@@ -112,7 +112,7 @@ To make sure the Log Management solution functions in an optimal way, we set the
 
 ### Limits applied to ingested log events
 
-* The size of a log event should not exceed 256K bytes.
+* The size of a log event should not exceed 25K bytes.
 * Log events can be submitted up to 6h in the past and 2h in the future.
 * A log event once converted to JSON format should contain less than 256 attributes. Each of those attribute's key should be less than 50 characters, be nested in less than 10 successive levels, and their respective value should be less than 1024 characters if promoted as a facet.
 * A log event should not have more than 100 tags and each tag should not exceed 256 characters for a maximum of 10 million unique tags per day.

--- a/content/en/logs/processing/pipelines.md
+++ b/content/en/logs/processing/pipelines.md
@@ -112,7 +112,7 @@ To make sure the Log Management solution functions in an optimal way, we set the
 
 ### Limits applied to ingested log events
 
-* The size of a log event should not exceed 25K bytes.
+* The size of a log event should not exceed 256K bytes.
 * Log events can be submitted up to 6h in the past and 2h in the future.
 * A log event once converted to JSON format should contain less than 256 attributes. Each of those attribute's key should be less than 50 characters, be nested in less than 10 successive levels, and their respective value should be less than 1024 characters if promoted as a facet.
 * A log event should not have more than 100 tags and each tag should not exceed 256 characters for a maximum of 10 million unique tags per day.


### PR DESCRIPTION
### What does this PR do?
Improves doc for KeyValue parser.
Fixes typo in max log size.

### Motivation
People asking questions on Slack on KeyValue parser cause the doc was not clear.
People asking questions on Log limits.

### Preview link
https://docs-staging.datadoghq.com/gusai/doc-upd/logs/processing/parsing/?tab=matcher#key-value
https://docs-staging.datadoghq.com/gusai/doc-upd/logs/processing/pipelines/#limits-applied-to-ingested-log-events