### PR TITLE
Added note for trace_id and span_id requirements

### DIFF
--- a/content/en/api/tracing/send_trace.md
+++ b/content/en/api/tracing/send_trace.md
@@ -24,7 +24,7 @@ and each span is a dictionary with a `trace_id`, `span_id`, `resource`..
 
 [Learn more about the APM & Distributed Tracing terminology][4]
 
-**Note**: Each span within a trace should use the same `trace_id`. However, `trace_id` and `span_id` require different values. To avoid unexpected value returns, use different values or a unique scheme.
+**Note**: Each span within a trace should use the same `trace_id`. However, `trace_id` and `span_id` must have different values.
 
 **ARGUMENTS**:
 

--- a/content/en/api/tracing/send_trace.md
+++ b/content/en/api/tracing/send_trace.md
@@ -24,7 +24,7 @@ and each span is a dictionary with a `trace_id`, `span_id`, `resource`..
 
 [Learn more about the APM & Distributed Tracing terminology][4]
 
-**Note**: Each span within a trace should use the same trace_id.
+**Note**: Each span within a trace should use the same `trace_id`. However, `trace_id` and `span_id` require different values. To avoid unexpected value returns, use different values or a unique scheme.
 
 **ARGUMENTS**:
 


### PR DESCRIPTION
### What does this PR do?
Adds note about the requirement of different values for `trace_id` and `span_id`.

### Motivation
Trello card request.

### Preview link
https://docs-staging.datadoghq.com/sarina/span-values/api/tracing/send_trace