### PR TITLE
Update example get_all_api_keys key name

### DIFF
--- a/content/en/api/key_management/code_snippets/result.get_all_api_key.sh
+++ b/content/en/api/key_management/code_snippets/result.get_all_api_key.sh
@@ -8,7 +8,7 @@
         },
         {
             "created_by": "jane@example.com",
-            "name": "<APP_KEY_NAME_2>",
+            "name": "<API_KEY_NAME_2>",
             "key": "2111111111111111aaaaaaaaaaaaaaaa",
             "created": "2019-04-05 09:19:53"
         }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Small one char change to update the name of the second key returned in the bash `get_all_api_keys` endpoint. 

### Motivation
Just to be clearer that this endpoint only returns api key objects

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
