### PR TITLE
content/en/tracing/setup: make sure Go code is correctly formatted

### DIFF
--- a/content/en/tracing/setup/go.md
+++ b/content/en/tracing/setup/go.md
@@ -108,32 +108,31 @@ The tracer is configured with options parameters when the `Start` function is ca
 package main
 
 import (
-    "net/http"
-    "strings"
-    "log"
-    httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
-    "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"log"
+	"net/http"
+	"strings"
+
+	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 func sayHello(w http.ResponseWriter, r *http.Request) {
-  message := r.URL.Path
-  message = strings.TrimPrefix(message, "/")
-  message = "Hello " + message
-  w.Write([]byte(message))
+	msg := "Hello " + strings.TrimPrefix(r.URL.Path, "/")
+	w.Write([]byte(msg))
 }
 
 func main() {
-    // start the tracer with zero or more options
-    tracer.Start(tracer.WithServiceName("test-go"))
-    defer tracer.Stop()
+	// start the tracer with zero or more options
+	tracer.Start(tracer.WithServiceName("test-go"))
+	defer tracer.Stop()
 
-    mux := httptrace.NewServeMux() // init the http tracer
-    mux.HandleFunc("/", sayHello) // use the tracer to handle the urls
+	mux := httptrace.NewServeMux() // init the http tracer
+	mux.HandleFunc("/", sayHello)  // use the tracer to handle the urls
 
-    err := http.ListenAndServe(":9090", mux) // set listen port
-    if err != nil {
-        log.Fatal("ListenAndServe: ", err)
-    }
+	err := http.ListenAndServe(":9090", mux) // set listen port
+	if err != nil {
+		log.Fatal("ListenAndServe: ", err)
+	}
 }
 ```
 


### PR DESCRIPTION
We should always make sure that all Go code we post is formatted using
the standard [`gofmt`](https://golang.org/cmd/gofmt/). From a Go developers perspective, it's unprofessional for it not to be. It will negatively impact our image.

It's obvious from looking at the page that this looks wrong:

<img width="1329" alt="Screenshot 2019-12-10 at 10 12 20" src="https://user-images.githubusercontent.com/6686356/70507809-d345b900-1b35-11ea-9662-8b455a75c606.png">
