### PR TITLE
Morgan.lupton/tiller version caveat

### DIFF
--- a/content/en/agent/kubernetes/helm.md
+++ b/content/en/agent/kubernetes/helm.md
@@ -47,6 +47,9 @@ For other platforms and methods of installing Helm, refer to the [Helm documenta
 
 ### Installing the Helm server (Tiller)
 
+**Note**: This is not required for versions of Helm greater than 3.0.0. Skip to [Installing the Datadog Helm chart][11] if this applies to you. 
+
+
 If your Kubernetes environment does not use RBAC, the following command installs Tiller in your cluster:
 
 ```bash
@@ -247,3 +250,4 @@ This command removes all Kubernetes components associated with the chart and del
 [8]: /developers/metrics/dogstatsd_metrics_submission
 [9]: /tracing/setup
 [10]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/entrypoint/89-copy-customfiles.sh
+[11]: https://docs.datadoghq.com/agent/kubernetes/helm/?tab=macoshomebrew#installing-the-datadog-helm-chart

--- a/content/en/agent/kubernetes/helm.md
+++ b/content/en/agent/kubernetes/helm.md
@@ -47,7 +47,7 @@ For other platforms and methods of installing Helm, refer to the [Helm documenta
 
 ### Installing the Helm server (Tiller)
 
-**Note**: This is not required for versions of Helm greater than 3.0.0. Skip to [Installing the Datadog Helm chart][11] if this applies to you. 
+**Note**: This is not required for versions of Helm greater than 3.0.0. Skip to [Installing the Datadog Helm chart][#installing-the-datadog-helm-chart] if this applies to you. 
 
 
 If your Kubernetes environment does not use RBAC, the following command installs Tiller in your cluster:
@@ -264,4 +264,3 @@ This command removes all Kubernetes components associated with the chart and del
 [8]: /developers/metrics/dogstatsd_metrics_submission
 [9]: /tracing/setup
 [10]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/entrypoint/89-copy-customfiles.sh
-[11]: https://docs.datadoghq.com/agent/kubernetes/helm/?tab=macoshomebrew#installing-the-datadog-helm-chart

--- a/content/en/agent/kubernetes/helm.md
+++ b/content/en/agent/kubernetes/helm.md
@@ -110,9 +110,23 @@ tiller-deploy-f54b67464-jl5gm 1/1 Running 0 3h16m
 
 To install the chart with the release name `<RELEASE_NAME>`, retrieve your Datadog API key from your [Agent installation instructions][4] and run:
 
+{{< tabs >}}
+{{% tab "Helm v1/v2" %}} 
+
 ```bash
 helm install --name <RELEASE_NAME> --set datadog.apiKey=<DATADOG_API_KEY> stable/datadog
 ```
+
+{{% /tab %}}
+
+{{% tab "Helm v3+" %}}
+
+```bash
+helm install <RELEASE_NAME> --set datadog.apiKey=<DATADOG_API_KEY> stable/datadog
+```
+
+{{% /tab %}}
+{{< /tabs >}}
 
 This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally deploys the [kube-state-metrics chart][5] and uses it as an additional source of metrics about the cluster. A few minutes after installation, Datadog begins to report hosts and metrics.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Helm v3 has been out since November, with some major changes that have been made. See link to more details on this release here: https://helm.sh/blog/helm-3-released/

1. Tiller no longer exists and is no longer a required step to deploy the datadog agent. 
2. The `--name` option for Helm no longer exists. 

This docs change reflects both of these changes. 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
