### PR TITLE
Adding details on whitelisting special purpose ips

### DIFF
--- a/content/en/synthetics/private_locations.md
+++ b/content/en/synthetics/private_locations.md
@@ -108,6 +108,10 @@ By default, the Datadog workers use `8.8.8.8` to perform DNS resolution. If it f
 
 If you are testing an internal URL and need to use an internal DNS server you can set the `dnsServer` option to a specific DNS IP address. Alternatively leverage the `dnsUseHost` parameter to have your worker use your local DNS config from the `etc/resolv.conf` file.
 
+### Special-purpose IPv4 whitelisting 
+
+If you are using private locations to monitor internal endpoints, some of your servers might be using [special-purpose IPv4][2]. These IPs are blacklisted by default, so if your private location needs to run a test on one of them, you first need to whitelist it using the `whitelistedRange` parameter.
+
 ## Security
 
 The private location workers only pull data from Datadog servers. Datadog does not push data to the workers.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

This PR adds details on how to whitelist special purpose IPs on private locations.

### Motivation

https://datadog.zendesk.com/agent/tickets/288610

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/margot.lepizzera/privatelocations_ipwhitelisting/synthetics/private_locations#special-purpose-ipv4-whitelisting
### Additional Notes
<!-- Anything else we should know when reviewing?-->
