### PR TITLE
replace google hangout with zoom for office hours

### DIFF
--- a/content/en/developers/office_hours.md
+++ b/content/en/developers/office_hours.md
@@ -7,7 +7,7 @@ Datadog runs twice monthly code reviews and office hours to assist community mem
 
 ### Where
 
-Office hours will be held in #integrations in the [Datadog Community Slack][1] ([get an invitation][2]), in conjunction with a [Google Hangout][3].
+Office hours will be held in #integrations in the [Datadog Community Slack][1] ([get an invitation][2]), in conjunction with a [Zoom videoconference][3].
 
 ### When
 

--- a/content/fr/developers/office_hours.md
+++ b/content/fr/developers/office_hours.md
@@ -6,7 +6,7 @@ Toutes les deux semaines, Datadog procède à des revues de code et assure des h
 
 ### Lieu
 
-Les heures de permanence sont assurées sur la chaîne #integrations du [Slack dédié à la communauté de Datadog][1] ([demander une invitation][2]), ainsi que sur [Google Hangouts][3].
+Les heures de permanence sont assurées sur la chaîne #integrations du [Slack dédié à la communauté de Datadog][1] ([demander une invitation][2]), ainsi que sur une [vidéoconférence Zoom][3].
 
 ### Date
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Replaces the reference to Google Hangouts with Zoom videoconference (as we no longer use Hangouts).

### Motivation
Accuracy.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/phrawzty/office_hours_wording/developers/office_hours

### Additional Notes

The Japanese page probably needs to be updated but `¯\_(ツ)_/¯`
