### PR TITLE
Update ruby doc ActiveSupport::Logger

### DIFF
--- a/content/en/logs/log_collection/ruby.md
+++ b/content/en/logs/log_collection/ruby.md
@@ -72,7 +72,7 @@ This section describe the minimum setup required in order to forward your Rails 
     config.colorize_logging = false
 
     # Log to a dedicated file
-    config.lograge.logger = ActiveSupport::BufferedLogger.new(File.join(Rails.root, 'log', "#{Rails.env}.log"))
+    config.lograge.logger = ActiveSupport::Logger.new(File.join(Rails.root, 'log', "#{Rails.env}.log"))
 
     # This is useful if you want to log query parameters
     config.lograge.custom_options = lambda do |event|


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update Ruby documentation
### Motivation
<!-- What inspired you to submit this pull request?-->
BufferedLogger is deprecated since rails 4.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs.datadoghq.com/logs/log_collection/ruby/

