### PR TITLE
Log mask sequence update

### DIFF
--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -104,7 +104,7 @@ logs:
         pattern: (?:4[0-9]{12}(?:[0-9]{3})?|[25][1-7][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\d{3})\d{11})
 ```
 
-**Note**: As of Agent version 6.17, the `replace_placeholder` string can expand references to capture groups such as `$1`, `$2` and so forth. See the following example:
+**Note**: With Agent version 7.17+, the `replace_placeholder` string can expand references to capture groups such as `$1`, `$2` and so forth. See the following example:
 
 ```
 pattern: (data:) values
@@ -113,7 +113,7 @@ replace_placeholder: "$1 [masked_values]"
 Resulting string: "data: [masked_values]"
 ```
 
-If you want a string to follow the capture group with no space in between, use the format `${<group_number>}`:
+If you want a string to follow the capture group with no space in between, use the format `${<GROUP_NUMBER>}`:
 
 ```
 pattern: (Data)Dog

--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -104,6 +104,24 @@ logs:
         pattern: (?:4[0-9]{12}(?:[0-9]{3})?|[25][1-7][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\d{3})\d{11})
 ```
 
+**Note**: The `replace_placeholder` string can expand references to capture groups such as `$1`, `$2` and so forth. See the following example:
+
+```
+pattern: (data:) values
+replace_placeholder: "$1 [masked_values]"
+
+Resulting string: "data: [masked_values]"
+```
+
+If you want a string to follow the capture group with no space in between, use the format `${<group_number>}`:
+
+```
+pattern: (Data)Dog
+replace_placeholder: "${1}dog"
+
+Resulting string: "Datadog"
+```
+
 ## Multi-line aggregation
 
 If your logs are not sent in JSON and you want to aggregate several lines into a single entry, configure the Datadog Agent to detect a new log using a specific regex pattern instead of having one log per line. This is accomplished by using the `log_processing_rules` parameter in your configuration file with the **multi_line** `type` which aggregates all lines into a single entry until the given pattern is detected again.

--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -104,7 +104,7 @@ logs:
         pattern: (?:4[0-9]{12}(?:[0-9]{3})?|[25][1-7][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\d{3})\d{11})
 ```
 
-**Note**: The `replace_placeholder` string can expand references to capture groups such as `$1`, `$2` and so forth. See the following example:
+**Note**: As of Agent version 6.17, the `replace_placeholder` string can expand references to capture groups such as `$1`, `$2` and so forth. See the following example:
 
 ```
 pattern: (data:) values

--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -104,23 +104,15 @@ logs:
         pattern: (?:4[0-9]{12}(?:[0-9]{3})?|[25][1-7][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\d{3})\d{11})
 ```
 
-**Note**: With Agent version 7.17+, the `replace_placeholder` string can expand references to capture groups such as `$1`, `$2` and so forth. See the following example:
+**Note**: With Agent version 7.17+, the `replace_placeholder` string can expand references to capture groups such as `$1`, `$2` and so forth. If you want a string to follow the capture group with no space in between, use the format `${<GROUP_NUMBER>}`. For instance, to scrub user information from the log `User email: foo.bar@example.com`, the following configuration:
 
 ```
-pattern: (data:) values
-replace_placeholder: "$1 [masked_values]"
-
-Resulting string: "data: [masked_values]"
+(...)
+pattern: "(User email: )[^@]*@(.*)"
+replace_placeholder: "$1 masked_user@${2}"
 ```
 
-If you want a string to follow the capture group with no space in between, use the format `${<GROUP_NUMBER>}`:
-
-```
-pattern: (Data)Dog
-replace_placeholder: "${1}dog"
-
-Resulting string: "Datadog"
-```
+Would send the following log to Datadog: `User email: masked_user@example.com`
 
 ## Multi-line aggregation
 


### PR DESCRIPTION
### What does this PR do?
Adds a note to the mask sequence documentation to let customers know about the upcoming feature in this PR: https://github.com/DataDog/datadog-agent/pull/4563. The feature will be released for Agent version 6.17/7.17 so please don't merge until that version is released.

### Motivation
Documenting a feature enhancement for mask sequences.

### Preview link

https://docs-staging.datadoghq.com/michael.sha/mask-sequence-update/agent/logs/advanced_log_collection/