### PR TITLE
Add links to new Docker troubleshooting guide

### DIFF
--- a/content/en/logs/guide/_index.md
+++ b/content/en/logs/guide/_index.md
@@ -9,6 +9,7 @@ disable_toc: true
     {{< nextlink href="logs/guide/collect-heroku-logs" >}}Collect Heroku Logs{{< /nextlink >}}
     {{< nextlink href="logs/guide/integration-pipeline-reference" >}}Integration Pipeline Reference{{< /nextlink >}}
     {{< nextlink href="logs/guide/log-collection-troubleshooting-guide" >}}Log Collection Troubleshooting Guide{{< /nextlink >}}
+    {{< nextlink href="logs/guide/docker-logs-collection-troubleshooting-guide" >}}Docker Log Collection Troubleshooting Guide{{< /nextlink >}}
     {{< nextlink href="logs/guide/log-parsing-best-practice" >}}Log Parsing Best Practices{{< /nextlink >}}
     {{< nextlink href="logs/guide/setting-file-permissions-for-rotating-logs" >}}Setting File Permissions for Rotating Logs (Linux){{< /nextlink >}}
     {{< nextlink href="logs/guide/collect-multiple-logs-with-pagination" >}}Collect multiple logs with the Log List API and pagination.{{< /nextlink >}}

--- a/content/en/logs/guide/docker-logs-collection-troubleshooting-guide.md
+++ b/content/en/logs/guide/docker-logs-collection-troubleshooting-guide.md
@@ -9,31 +9,31 @@ There are a number of common issues that can get in the way when sending new con
 
 1. To see if the logging Agent is experiencing any issues, run the following command:
 
-```
-docker exec -it <CONTAINER_NAME> agent status
-```
+    ```
+    docker exec -it <CONTAINER_NAME> agent status
+    ```
 
 2. If everything is running smoothly, you should see something like the following status:
 
-```
-==========
-Logs Agent
-==========
-    LogsProcessed: 42
-    LogsSent: 42
+    ```
+    ==========
+    Logs Agent
+    ==========
+        LogsProcessed: 42
+        LogsSent: 42
 
-  container_collect_all
-  ---------------------
-    Type: docker
-    Status: OK
-    Inputs: 497f0cc8b673397ed31222c0f94128c27a480cb3b2022e71d42a8299039006fb
-```
+      container_collect_all
+      ---------------------
+        Type: docker
+        Status: OK
+        Inputs: 497f0cc8b673397ed31222c0f94128c27a480cb3b2022e71d42a8299039006fb
+    ```
 
 3. If the Logs Agent Status doesn't look like the above, refer to the troubleshooting tips in the following sections.
 
 4. If you see a status like the above example and you still aren't receiving logs, refer to the section [If the Logs Agent Status shows no errors](#if-the-logs-agent-status-shows-no-errors)
 
-## The Logs Agent shows "not running" in its status 
+## The Logs Agent shows "not running" in its status
 If you see the following message when you run the Agent Status command:
 
 ```
@@ -44,7 +44,7 @@ Logs Agent
   Logs Agent is not running
 ```
 
-This means that you did not enable logging in the Agent. 
+This means that you did not enable logging in the Agent.
 
 To enable logging for the Container Agent, set the following environment variable: `DD_LOGS_ENABLED=true`.
 
@@ -59,17 +59,17 @@ Logs Agent
     LogsSent: 0
 ```
 
-This status means that logs are enabled but you haven't specified which containers the Agent should collect from. 
+This status means that logs are enabled but you haven't specified which containers the Agent should collect from.
 
 1. To check what environment variables you've set, run the command `docker inspect <agent-container>`.
 
-2. To configure the Agent to collect from other containers, set the `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL` environment variable to `true`. 
+2. To configure the Agent to collect from other containers, set the `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL` environment variable to `true`.
 
 ## The Logs Agent shows "Status: Pending"
 
 If the Logs Agent Status shows `Status: Pending`:
 
-``` 
+```
 ==========
 Logs Agent
 ==========
@@ -105,6 +105,7 @@ If you're using the Host Agent, the user `dd-agent` needs to be added to the Doc
 
 ```
 2019-10-11 09:17:56 UTC | CORE | INFO | (pkg/autodiscovery/autoconfig.go:360 in initListenerCandidates) | docker listener cannot start, will retry: temporary failure in dockerutil, will retry later: could not determine docker server API version: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get http://%2Fvar%2Frun%2Fdocker.sock/version: dial unix /var/run/docker.sock: connect: permission denied
+
 2019-10-11 09:17:56 UTC | CORE | ERROR | (pkg/autodiscovery/config_poller.go:123 in collect) | Unable to collect configurations from provider docker: temporary failure in dockerutil, will retry later: could not determine docker server API version: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get http://%2Fvar%2Frun%2Fdocker.sock/version: dial unix /var/run/docker.sock: connect: permission denied
 ```
 
@@ -113,8 +114,8 @@ If you're using the Host Agent, the user `dd-agent` needs to be added to the Doc
 ## If the Logs Agent Status shows no errors
 If the Logs Agent Status looks like the example in [Check the Agent status](#check-the-agent-status) but your logs still aren't reaching the Datadog platform, there could be a problem with one of the following:
 
-* the required port (10516) for sending logs to Datadog is being blocked 
-* your container is using a different logging driver than the Agent expects
+* The required port (10516) for sending logs to Datadog is being blocked.
+* Your container is using a different logging driver than the Agent expects.
 
 ### Outbound traffic on port 10516 is blocked
 
@@ -138,21 +139,21 @@ Docker's default is the json-file logging driver so the Container Agent tries to
 
 1. If you're unsure of which logging driver your containers are using, use `docker inspect <container-name>` to see what logging driver you have set. The following block appears in the Docker Inspect when the container is using the JSON logging driver:
 
-```
-"LogConfig": {
-    "Type": "json-file",
-    "Config": {}
-},
-```
+    ```
+    "LogConfig": {
+        "Type": "json-file",
+        "Config": {}
+    },
+    ```
 
 2. If the container is set to the journald logging driver the following block appears in the Docker Inspect:
 
-```
-"LogConfig": {
-    "Type": "journald",
-    "Config": {}
-},
-```
+    ```
+    "LogConfig": {
+        "Type": "journald",
+        "Config": {}
+    },
+    ```
 
 3. To collect logs from the journald logging driver, set up the journald integration [following this documentation][2].
 

--- a/content/en/logs/guide/log-collection-troubleshooting-guide.md
+++ b/content/en/logs/guide/log-collection-troubleshooting-guide.md
@@ -122,41 +122,7 @@ sudo cat /var/log/datadog/agent.log | grep ERROR
 
 ## Docker environment
 
-### Log collection is not enabled
-
-1. Make sure the Datadog Agent has access to the Docker socket
-2. Check if the Agent user is in the Docker group: `usermod -a -G docker dd-agent`
-3. Check if log collection has been enabled `DD_LOGS_ENABLED=true` in the configuration
-
-### Configuration issues
-
-At least one valid log configuration must be set to start log collection. There are several options to configure log collection; ensure that at least one of them is activated:
-
-1. `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true`, which collects logs from all containers (see [here how to exclude a subset][9])
-
-2. Autodiscovery via [container labels][10]. In this case, ensure that `datadog.yaml` has Docker listener and config provider:
-
-```
-listeners:
-  - name: docker
-config_providers:
-  - name: docker
-    polling: true
-```
-
-3. Autodiscovery in Kubernetes via [pod annotations][11]. In this case, ensure that `datadog.yaml` has the kubelet listener and config provider:
-
-```
-listeners:
-  - name: kubelet
-config_providers:
-  - name: kubelet
-    polling: true
-```
-
-### Journald
-
-When using Journald in a containerized environment, make sure to follow the instructions in the [journald integration][7] as there is a specific file used to mount to the Agent.
+See the [Docker Log Collection Troubleshooting Guide][16]
 
 ## Serverless environment
 
@@ -199,3 +165,4 @@ Check if logs appear in the [Datadog Live Tail][14]. If they appear in the Live 
 [13]: https://app.datadoghq.com/account/settings#api
 [14]: https://app.datadoghq.com/logs/livetail
 [15]: /logs/indexes/#exclusion-filters
+[16]: /logs/guide/docker-logs-collection-troubleshooting-guide


### PR DESCRIPTION
### What does this PR do?
Removes duplicated content from the Log Collection Troubleshooting Guide and replaces it with a link to the new Docker-specific guide to troubleshooting. 

### Motivation
This is to make it easier for users to find the new doc and also to reduce redundancy since the current Docker section of the Log Collection Troubleshooting Guide is included in the new doc and also expanded upon.

### Preview link

https://docs-staging.datadoghq.com/michael.sha/link-to-docker-doc/logs/guide/log-collection-troubleshooting-guide/

https://docs-staging.datadoghq.com/michael.sha/link-to-docker-doc/logs/guide/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
