### PR TITLE
Clarify what rights the Windows executable needs

### DIFF
--- a/content/en/agent/guide/secrets-management.md
+++ b/content/en/agent/guide/secrets-management.md
@@ -114,7 +114,7 @@ On Linux, the executable set as `secret_backend_command` must:
 On Windows, the executable set as `secret_backend_command` must:
 
 * Have read/exec for `ddagentuser` (the user used to run the Agent).
-* Have no rights for any user or group except for the `Administrators` group, the built-in Local System account, or the agent user context (`ddagentuser` by default)
+* Have no rights for any user or group except for the `Administrators` group, the built-in Local System account, or the Agent user context (`ddagentuser` by default)
 * Be a valid Win32 application so the Agent can execute it.
 
 {{% /tab %}}

--- a/content/en/agent/guide/secrets-management.md
+++ b/content/en/agent/guide/secrets-management.md
@@ -114,7 +114,7 @@ On Linux, the executable set as `secret_backend_command` must:
 On Windows, the executable set as `secret_backend_command` must:
 
 * Have read/exec for `ddagentuser` (the user used to run the Agent).
-* Have no rights for any user or group except `Administrator` or `LocalSystem`.
+* Have no rights for any user or group except for the `Administrators` group, the built-in Local System account, or the agent user context (`ddagentuser` by default)
 * Be a valid Win32 application so the Agent can execute it.
 
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Clarifies that the secrets executable in Windows needs to have no rights for any user or group other than:

* the `Administrators` group
* the Local System user
* the agent user (`ddagentuser`)

### Motivation
<!-- What inspired you to submit this pull request?-->

The [docs in their current state](https://docs.datadoghq.com/agent/guide/secrets-management/?tab=windows#agent-security-requirements) may imply that the `Administrator` user is allowed to have rights on the executable. If the executable has rights on it from the `Administrator` user, an error is logged stating that the executable is invalid. This change explicitly calls out the `Administrators` group to avoid confusion between the user and the group.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
