### PR TITLE
[dogstatsd] Fix syntax of java example of event submission

### DIFF
--- a/content/en/developers/events/dogstatsd.md
+++ b/content/en/developers/events/dogstatsd.md
@@ -114,7 +114,7 @@ public class DogStatsdClient {
           .withAlertType(Event.AlertType.ERROR)
           .build();
 
-        Statsd.event(event)
+        Statsd.recordEvent(event);
     }
 }
 {{< /code-block >}}


### PR DESCRIPTION
### What does this PR do?

Fixes syntax of java example of event submission, see related source code: https://github.com/DataDog/java-dogstatsd-client/blob/f78bf2895103c6fb6d4b25a84879b8df290d3114/src/main/java/com/timgroup/statsd/StatsDClient.java#L490-L504
 
Reported by @gzussa 