### PR TITLE
Make curl the default tab

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -7,12 +7,12 @@ imgix:
   png: "?fm=png&auto=format&lossless=1"
   gif: ""
 code_languages:
+  - display_name: Curl
+    key: bash
   - display_name: Python
     key: python
   - display_name: Ruby
     key: ruby
-  - display_name: Curl
-    key: bash
 
 header_scripts:
   - datadog_monitoring: false

--- a/src/scripts/components/codenav.js
+++ b/src/scripts/components/codenav.js
@@ -1,16 +1,16 @@
 $(document).ready(function () {
-    // determine from the url the language if we can
-    var sPageURL = decodeURIComponent(window.location.search.substring(1));
-    var sURLVariables = sPageURL.split('&');
-    var lang = sURLVariables.filter(function(item) {
-       return item.split('=')[0] === 'lang';
-    }).map(function(item) {
-        return item.split('=')[1];
-    }).toString();
+  // determine from the url the language if we can
+  var sPageURL = decodeURIComponent(window.location.search.substring(1));
+  var sURLVariables = sPageURL.split('&');
+  var lang = sURLVariables.filter(function (item) {
+    return item.split('=')[0] === 'lang';
+  }).map(function (item) {
+    return item.split('=')[1];
+  }).toString();
 
-    // set a default
-    if(lang === '') lang = 'python';
+  // set a default
+  if (lang === '') lang = 'bash';
 
-    // click the language nav we want
-    $('.codenav [data-lang="'+lang+'"]').click();
+  // click the language nav we want
+  $('.codenav [data-lang="' + lang + '"]').click();
 });


### PR DESCRIPTION
### What does this PR do?
Makes curl the default tab open in the API page

### Motivation
Avoid deceptive user experience with lack of support of certain endpoint with the py or rb lib

### Preview link

* https://docs-staging.datadoghq.com/gus/api-default-curl/api/