### PR TITLE
[NPM] Manifest specifies latest version of Agent

### DIFF
--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -99,7 +99,7 @@ spec:
     spec:
       serviceAccountName: datadog-agent
       containers:
-      - image: datadog/agent:6.12.0
+      - image: datadog/agent:latest
         imagePullPolicy: Always
         name: datadog-agent
         ports:
@@ -140,7 +140,7 @@ spec:
           successThreshold: 1
           failureThreshold: 3
       - name: system-probe
-        image: datadog/agent:6.12.0
+        image: datadog/agent:latest
         imagePullPolicy: Always
         securityContext:
           capabilities:


### PR DESCRIPTION

### What does this PR do?
updates manifest to show latest version of agent

### Motivation
h/t @burnsie7 

### Preview link

https://docs-staging.datadoghq.com/cswatt/npm-k8s/network_performance_monitoring/installation/?tab=kubernetes

### Additional Notes
<!-- Anything else we should know when reviewing?-->
