### PR TITLE
Log Rehydration constraints update

### DIFF
--- a/content/en/logs/archives/rehydrating.md
+++ b/content/en/logs/archives/rehydrating.md
@@ -20,7 +20,7 @@ With historical views, teams rehydrate archived log events precisely by timefram
 
 1. **Select the archive** from which you wish to rehydrate log events. Only archives that are [configured to use role delegation](#permissions) are available for rehydrating.
 
-2. **Choose the time period** for which you wish to rehydrate log events. The time period must be older than 24 hours.
+2. **Choose the time period** for which you wish to rehydrate log events.
 
 3. **Input the query**. The query syntax is the same as that of the [log explorer search][4], but is limited to log attributes, [reserved attributes][5], and free text search on the message.
 


### PR DESCRIPTION
### What does this PR do?
Remove the instruction about timeframe limitation for log rehydration.

### Motivation
This limit was removed in the product so the documentation should be updated as well.

### Preview link


<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/rehydration/logs/archives/rehydrating/?tab=awss3#overview

### Additional Notes
<!-- Anything else we should know when reviewing?-->
