### PR TITLE
Banner to specify variables from tests are in beta

### DIFF
--- a/content/en/synthetics/api_tests/_index.md
+++ b/content/en/synthetics/api_tests/_index.md
@@ -159,9 +159,9 @@ A test is considered `FAILED` if it does not satisfy its assertions or if the re
 
 If a test fails, the uptime directly considers the endpoint as `down`. It is not re-tested until the next test run.
 
-### Use variables
+### Use global variables
 
-You can use the [variables defined in the `Settings`][3] in the URL, Advanced Options, and in the assertions of your API tests. To display your list of variables, type `{{` in your desired field.
+You can use the [global variables defined in the `Settings`][3] in the URL, Advanced Options, and in the assertions of your API tests. To display your list of variables, type `{{` in your desired field.
 
 {{< img src="synthetics/api_tests/usingvariablesapi.mp4" alt="Using Variables in API tests" video="true" responsive="true" width="80%" >}}
 
@@ -197,7 +197,7 @@ Response time is the sum of these network timings.
 
 [1]: /api/?lang=bash#get-available-locations
 [2]: /synthetics/api_tests/errors#ssl-errors
-[3]: /synthetics/settings#variables
+[3]: /synthetics/settings#global-variables
 [4]: /integrations/#cat-notification
 [5]: /monitors/notifications/#notification
 [6]: http://daringfireball.net/projects/markdown/syntax

--- a/content/en/synthetics/browser_tests.md
+++ b/content/en/synthetics/browser_tests.md
@@ -118,7 +118,7 @@ After selecting the Hover action, click on the element you want to choose to cre
 To create a variable, first give it a name then define its value from:
 
 * **An Element**: Create a variable out of a `span`, `div`, etc. content by extracting the text of this element.
-* **A Variable**: Store and use global variables through [Synthetics Settings][11]).
+* **A Global Variable**: Store and use global variables through [Synthetics Settings][11]).
 * **An Email**: Generate a random Synthetics email address that can be used in your test steps to assert if an email was correctly sent or to perform actions over the sent email content (e.g. click a confirmation link).
 * **A Pattern**:
 

--- a/content/en/synthetics/browser_tests.md
+++ b/content/en/synthetics/browser_tests.md
@@ -42,9 +42,9 @@ Define the configuration of your browser test.
 5. **Locations**: The Datadog managed locations to run the test from. Many AWS locations from around the world are available. The full list is retrievable through the [Datadog API][2]. You can also set up a [Private Location][3] to run a Synthetics Browser test on a private URL not accessible from the public internet.
 6. **How often should Datadog run the test?** Intervals are available between every 15 minutes to once per week. [Contact support][4] to enable additional frequencies for your test.
 
-### Use variables
+### Use global variables
 
-You can use the [variables defined in the `Settings`][5] in the URL, as well as in the Advanced Options of your browser tests. To display your list of variables, type `{{` in your desired field.
+You can use the [global variables defined in the `Settings`][5] in the URL, as well as in the Advanced Options of your browser tests. To display your list of variables, type `{{` in your desired field.
 
 {{< img src="synthetics/browser_tests/using_variables_browser.mp4" alt="Using Variables in Browser Tests" video="true" responsive="true" width="80%" >}}
 
@@ -190,7 +190,7 @@ Common failure reasons include:
 [2]: /api/?lang=bash#get-available-locations
 [3]: /synthetics/private_locations
 [4]: /help
-[5]: /synthetics/settings#variables
+[5]: /synthetics/settings#global-variables
 [6]: http://daringfireball.net/projects/markdown/syntax
 [7]: /integrations/#cat-notification
 [8]: https://www.google.com/chrome

--- a/content/en/synthetics/settings/_index.md
+++ b/content/en/synthetics/settings/_index.md
@@ -45,19 +45,23 @@ Choose the type of variable you want to create:
 
 {{% tab "Create From HTTP Test" %}} 
 
+<div class="alert alert-warning">
+This feature is in private beta, reach out to [support][1] to turn on this feature for your account. 
+</div>
+
 1. Enter a **Variable Name**. Your variable name can only use uppercase letters, numbers, and underscores.
 2. Pick the test you want to extract your variable from.
 3. Decide whether to make your variable secure. Securing your variable means that only a subset of chosen users in your organization will be able to access them.
 4. Optional: select **Tags** to associate to your variable.
 5. Optional: enter a **Description** for your variable.
 6. Decide whether to extract your variable from the response headers, or from the response body.
-    * Extract the value from **response header**: use the full response header for your variable, or parse it with a [regex][1].
-    * Extract the value from **response body**: parse the response body of the request with a JSON path, with a [regex][1], or use the full response body.
+    * Extract the value from **response header**: use the full response header for your variable, or parse it with a [regex][2].
+    * Extract the value from **response body**: parse the response body of the request with a JSON path, with a [regex][2], or use the full response body.
 
 {{< img src="synthetics/settings/variable_fromhttp.png" alt="Credential" responsive="true" style="width:80%;">}}
 
-
-[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+[1]: /help
+[2]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
 {{% /tab %}} 
 
 {{< /tabs >}}

--- a/content/en/synthetics/settings/_index.md
+++ b/content/en/synthetics/settings/_index.md
@@ -27,11 +27,11 @@ On the [Synthetics settings page][1], you can adjust the following settings:
 
 ## Global Variables
 
-Variables are global and can be used by multiple [API tests][3] and [browser tests][4]. To create a new global variable, go to the **Global Variables** tab of your **Settings** page, and click **New Global Variable** in the upper right corner of your page.  
+Variables are global and can be used by multiple [API tests][3] and [browser tests][4]. To create a new global variable, go to the **Global Variables** tab of your **Settings** page, and click **New Global Variable** in the upper right corner of your page.
 Choose the type of variable you want to create:
 
-{{< tabs >}} 
-{{% tab "Specify Value" %}} 
+{{< tabs >}}
+{{% tab "Specify Value" %}}
 
 1. Enter a **Variable Name**. Your variable name can only use uppercase letters, numbers, and underscores.
 2. Enter the given **Value**.
@@ -41,12 +41,12 @@ Choose the type of variable you want to create:
 
 {{< img src="synthetics/settings/variable_specifyvalue.png" alt="Global Variable Specify Value" responsive="true" style="width:80%;">}}
 
-{{% /tab %}} 
+{{% /tab %}}
 
-{{% tab "Create From HTTP Test" %}} 
+{{% tab "Create From HTTP Test" %}}
 
 <div class="alert alert-warning">
-This feature is in private beta, reach out to support to turn on this feature for your account. 
+This feature is in private beta, <a href="/help">contact Datadog support</a> to turn on this feature for your account.
 </div>
 
 1. Enter a **Variable Name**. Your variable name can only use uppercase letters, numbers, and underscores.
@@ -61,7 +61,7 @@ This feature is in private beta, reach out to support to turn on this feature fo
 {{< img src="synthetics/settings/variable_fromhttp.png" alt="Credential" responsive="true" style="width:80%;">}}
 
 [1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
-{{% /tab %}} 
+{{% /tab %}}
 
 {{< /tabs >}}
 
@@ -73,7 +73,7 @@ Choose the default locations for your browser and API tests details. Options inc
 
 ### APM integration for Browser Tests
 
-Whitelist URLs to add APM integration headers to that URL. Datadog's APM integration headers allow Datadog to link browser tests with APM. Define which endpoints should be sent the APM headers by adding a URL into this section. 
+Whitelist URLs to add APM integration headers to that URL. Datadog's APM integration headers allow Datadog to link browser tests with APM. Define which endpoints should be sent the APM headers by adding a URL into this section.
 
 Use `*` to whitelist wider domain names. For example, adding `https://*.datadoghq.com/*` whitelists everything on `https://datadoghq.com/`.
 

--- a/content/en/synthetics/settings/_index.md
+++ b/content/en/synthetics/settings/_index.md
@@ -19,15 +19,15 @@ further_reading:
 
 On the [Synthetics settings page][1], you can adjust the following settings:
 
-- [Variables](#variables)
+- [Global Variables](#global-variables)
 - [Private Locations][2]
 - [Default settings](#default-settings)
     - [Default Locations](#default-locations)
     - [APM integration for Browser Tests](#apm-integration-for-browser-tests)
 
-## Variables
+## Global Variables
 
-Variables are global and can be used by multiple [API tests][3] and [browser tests][4]. To create a new global variable, go to the **Variables** tab of your **Settings** page, and click **New Variable** in the upper right corner of your page.  
+Variables are global and can be used by multiple [API tests][3] and [browser tests][4]. To create a new global variable, go to the **Global Variables** tab of your **Settings** page, and click **New Global Variable** in the upper right corner of your page.  
 Choose the type of variable you want to create:
 
 {{< tabs >}} 
@@ -46,7 +46,7 @@ Choose the type of variable you want to create:
 {{% tab "Create From HTTP Test" %}} 
 
 <div class="alert alert-warning">
-This feature is in private beta, reach out to [support][1] to turn on this feature for your account. 
+This feature is in private beta, reach out to support to turn on this feature for your account. 
 </div>
 
 1. Enter a **Variable Name**. Your variable name can only use uppercase letters, numbers, and underscores.
@@ -55,13 +55,12 @@ This feature is in private beta, reach out to [support][1] to turn on this featu
 4. Optional: select **Tags** to associate to your variable.
 5. Optional: enter a **Description** for your variable.
 6. Decide whether to extract your variable from the response headers, or from the response body.
-    * Extract the value from **response header**: use the full response header for your variable, or parse it with a [regex][2].
-    * Extract the value from **response body**: parse the response body of the request with a JSON path, with a [regex][2], or use the full response body.
+    * Extract the value from **response header**: use the full response header for your variable, or parse it with a [regex][1].
+    * Extract the value from **response body**: parse the response body of the request with a JSON path, with a [regex][1], or use the full response body.
 
 {{< img src="synthetics/settings/variable_fromhttp.png" alt="Credential" responsive="true" style="width:80%;">}}
 
-[1]: /help
-[2]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
 {{% /tab %}} 
 
 {{< /tabs >}}
@@ -85,5 +84,5 @@ If the endpoint is being traced and whitelisted, your browser test results are t
 {{< partial name="whats-next/whats-next.html" >}}
 [1]: https://app.datadoghq.com/synthetics/settings
 [2]: /synthetics/private_locations
-[3]: /synthetics/api_tests#use-variables
-[4]: /synthetics/browser_tests#use-variables
+[3]: /synthetics/api_tests#use-global-variables
+[4]: /synthetics/browser_tests#use-global-variables


### PR DESCRIPTION
### What does this PR do?
This PR adds a banner to specify the create variables from tests feature is in beta & changes the wording from "variables" to "global variables"

### Motivation
PM request

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/margot.lepizzera/variablesfromtests/synthetics/settings/?tab=createfromhttptest

### Additional Notes
<!-- Anything else we should know when reviewing?-->
