### PR TITLE
frontmatter is aliases not alias

### DIFF
--- a/content/en/developers/dogstatsd/data_aggregation.md
+++ b/content/en/developers/dogstatsd/data_aggregation.md
@@ -2,7 +2,7 @@
 title: DogStatsD Data Aggregation
 kind: documentation
 description: Learn how the DogStatsD server aggregates your data before sending it to Datadog
-alias:
+aliases:
 - /developers/faq/data-aggregation-with-dogstatsd-threadstats
 further_reading:
 - link: "developers/dogstatsd"


### PR DESCRIPTION
### What does this PR do?

The alias in place wasn't actually working because the front matter parameter is `aliases` not `alias`

### Motivation

Discovered the redirect wasn't working while investigating links

### Preview link

This url should redirect to `developers/dogstatsd/data_aggregation`
https://docs-staging.datadoghq.com/david.jones/alias-fix/developers/faq/data-aggregation-with-dogstatsd-threadstats/

### Additional Notes

