### PR TITLE
add logger.version in logs naming convention

### DIFF
--- a/content/en/logs/processing/attributes_naming_convention.md
+++ b/content/en/logs/processing/attributes_naming_convention.md
@@ -177,6 +177,7 @@ These attributes are related to the data used when a log or an error is generate
 | `logger.name`        | `string` | The name of the logger.                                          |
 | `logger.thread_name` | `string` | The name of the current thread when the log is fired.            |
 | `logger.method_name` | `string` | The class method name.                                           |
+| `logger.version`     | `string` | The version of the logger.                                       |
 | `error.kind`         | `string` | The error type or kind (or code is some cases).                  |
 | `error.message`      | `string` | A concise, human-readable, one-line message explaining the event |
 | `error.stack`        | `string` | The stack trace or the complementary information about the error |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add logger.version in naming convention

### Motivation
For mobile logging, the sdk will have a version and because of long adoption of mobile apps, multiple versions will be in place at any point in time

### Preview link
https://docs-staging.datadoghq.com/hkaczmarek/logs_logger_version/logs/processing/attributes_naming_convention
