### PR TITLE
fix anchor links in whats next sections

### DIFF
--- a/layouts/shortcodes/nextlink.html
+++ b/layouts/shortcodes/nextlink.html
@@ -12,6 +12,17 @@
         {{ $.Scratch.Set "link" ($href | absLangURL) }}
     {{ end }}
 {{ end }}
+
+{{/*
+  If the url ends with a anchor link e.g #graphing then make sure this doesn't get stripped during the abslang
+*/}}
+{{ $fragment := (urls.Parse $href).Fragment }}
+{{ if $fragment }}
+  {{ if not (strings.HasSuffix ($.Scratch.Get "link") (print "#" $fragment)) }}
+    {{ $.Scratch.Set "link" (print ($.Scratch.Get "link") "#" $fragment) }}
+  {{ end }}
+{{ end }}
+
 {{ $link := $.Scratch.Get "link" }}
 
 {{- with .Parent -}}


### PR DESCRIPTION
### What does this PR do?
This PR attempts to fix the issue with whats next links not including the anchor fragment.

### Motivation
https://trello.com/c/8HWljktO/4237-whats-next-partial

### Preview link
Look at the link that says 
`Correlate Logs and Metrics: See the exact metric correlated with the observed log.`
also test other links without anchors still work

https://docs-staging.datadoghq.com/david.jones/whatsnext-bugfix/logs/

### Additional Notes
