### PR TITLE
Update API Reference - Usage metering section

### DIFF
--- a/content/en/api/usage/usage.md
+++ b/content/en/api/usage/usage.md
@@ -7,7 +7,7 @@ external_redirect: /api/#usage-metering
 
 ## Usage metering
 
-This API is available to all Pro and Enterprise customers. Python and Ruby clients are not yet supported. Usage is only accessible for parent-level organizations.
+This API is available to all Pro and Enterprise customers. Python and Ruby clients are not yet supported. Usage is only accessible for [parent-level organizations][1].
 
 The usage metering end-point allows you to:
 
@@ -20,3 +20,5 @@ The usage metering end-point allows you to:
 * Get Hourly Usage For Fargate Tasks
 
 Usage data is delayed by up to 72 hours from when it was incurred. It is retained for the past 15 months.
+
+[1]: /account_management/multi_organization/

--- a/content/en/api/usage/usage.md
+++ b/content/en/api/usage/usage.md
@@ -7,7 +7,7 @@ external_redirect: /api/#usage-metering
 
 ## Usage metering
 
-This API is available to all customers. Python and Ruby clients are not yet supported.
+This API is available to all Pro and Enterprise customers. Python and Ruby clients are not yet supported. Usage is only accessible for parent-level organizations.
 
 The usage metering end-point allows you to:
 


### PR DESCRIPTION
### What does this PR do?
Tweaks the verbiage for the Usage metering page under API reference.

### Motivation
Multiple tickets have come through with confusion regarding access to the usage API endpoint.

Specified access to the usage metering API endpoint is only possible for:
- Paying accounts
- Parent-level organizations

### Preview link
https://docs-staging.datadoghq.com/emily.hayman/api/api/?lang=bash#usage-metering