### PR TITLE
make the header logo go to ja site when on ja site

### DIFF
--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -40,7 +40,13 @@
                 </ul>
             </div>
             <div class="col-1 text-center">
-                <a href="https://www.datadoghq.com/" id="logo">
+                {{ $allowedLangs := (slice "ja") }}
+                {{ .Scratch.Set "logoURL" "https://www.datadoghq.com/" }}
+                {{ if in $allowedLangs .Site.Language.Lang }}
+                  {{ .Scratch.Set "logoURL" (print "https://www.datadoghq.com/" .Site.Language.Lang "/") }}
+                {{ end }}
+                {{ $logoURL := .Scratch.Get "logoURL" }}
+                <a href="{{ $logoURL }}" id="logo">
                     {{ partial "img.html" (dict "root" . "src" "dd_logo_n_70x75.png" "class" "logo-img" "alt" "DataDog" "height" "75" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=70&h=75" "disable_lazy" "true") }}
                     {{ partial "img.html" (dict "root" . "src" "dd-logo-n-200.png" "class" "logo-text" "alt" "DataDog" "height" "14" "img_param" "?ch=Width,DPR&fit=max&auto=format&h=14" "disable_lazy" "true") }}
                 </a>


### PR DESCRIPTION
### What does this PR do?

Updates the header logo url which normally goes to `www.datadoghq.com` to go to the language version you are on if its in the allowed list.

e.g 
`docs.datadoghq.com` ---> `www.datadoghq.com`
`docs.datadoghq.com/ja/` ---> `www.datadoghq.com/ja/`
`docs.datadoghq.com/fr/` ---> `www.datadoghq.com/`   (no french version on main site yet)

### Motivation
https://trello.com/c/eQ9i2r4l/4266-japan-corp-site-datadog-logo-link-to-jp-home-page

### Preview link
https://docs-staging.datadoghq.com/david.jones/ja-logo-link/

### Additional Notes

