### PR TITLE
Adding site checking step for Agent troubleshooting

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -368,6 +368,10 @@ main:
     url: "agent/troubleshooting/integrations/"
     parent: "agent_troubleshooting"
     weight: 906
+  - name: "Site Issues"
+    url: "agent/troubleshooting/site/"
+    parent: "agent_troubleshooting"
+    weight: 907
 
   ## AGENT - Guides
   - name: "Guides"

--- a/content/en/agent/troubleshooting/_index.md
+++ b/content/en/agent/troubleshooting/_index.md
@@ -6,19 +6,22 @@ aliases:
     - /agent/faq/common-windows-agent-installation-error-1721
 further_reading:
 - link: "/agent/troubleshooting/debug_mode"
-  tag: "Agent Troubleshooting"
+  tag: "Documentation"
   text: "Agent Debug Mode"
 - link: "/agent/troubleshooting/send_a_flare"
-  tag: "Agent Troubleshooting"
+  tag: "Documentation"
   text: "Send an Agent Flare"
 - link: "/agent/troubleshooting/permissions"
-  tag: "Agent Troubleshooting"
+  tag: "Documentation"
   text: "Agent Permission Issues"
+- link: "/agent/troubleshooting/site"
+  tag: "Documentation"
+  text: "Check Agent Site"
 - link: "/agent/troubleshooting/ntp"
-  tag: "Agent Troubleshooting"
+  tag: "Documentation"
   text: "Agent NTP issues"
 - link: "/agent/troubleshooting/agent_check_status"
-  tag: "Agent Troubleshooting"
+  tag: "Documentation"
   text: "Get the Status of an Agent Check"
 ---
 
@@ -29,12 +32,13 @@ If you think you might be experiencing issues, follow this checklist first:
 * Is your host connected to the internet or able to access it through a proxy?
 * If using a proxy: is your [Agent configured for this proxy][3]?
 * Is the Datadog API key set up in your `datadog.yaml` configuration file [the API key corresponding to your Datadog platform][4]?
+* Is the site configured in your `datadog.yaml` configuration file [matching the one from your organization][5]?
 * Is there only one Datadog Agent running on your host?
 * Did you restart the Datadog Agent after editing a yaml configuration file?
 
-If the answer to all questions above is `yes`, then [run the status command][5] for more details about your Agent and its integrations status. You can also check the [Agent logs][6] directly and enable debug mode to [get more logging from the Agent][7].
+If the answer to all questions above is `yes`, then [run the status command][6] for more details about your Agent and its integrations status. You can also check the [Agent logs][7] directly and enable debug mode to [get more logging from the Agent][8].
 
-If you're still unsure about the issue, you may reach out to the [Datadog support team][8] with [a flare][9] from your Agent.
+If you're still unsure about the issue, you may reach out to the [Datadog support team][9] with [a flare][10] from your Agent.
 
 ## Further Reading
 
@@ -44,8 +48,9 @@ If you're still unsure about the issue, you may reach out to the [Datadog suppor
 [2]: https://app.datadoghq.com/metric/explorer
 [3]: /agent/proxy
 [4]: https://app.datadoghq.com/account/settings#api
-[5]: /agent/guide/agent-commands/#agent-status-and-information
-[6]: /agent/guide/agent-log-files
-[7]: /agent/troubleshooting/debug_mode
-[8]: /help
-[9]: /agent/troubleshooting/send_a_flare
+[5]: /agent/troubleshooting/site
+[6]: /agent/guide/agent-commands/#agent-status-and-information
+[7]: /agent/guide/agent-log-files
+[8]: /agent/troubleshooting/debug_mode
+[9]: /help
+[10]: /agent/troubleshooting/send_a_flare

--- a/content/en/agent/troubleshooting/site.md
+++ b/content/en/agent/troubleshooting/site.md
@@ -1,0 +1,37 @@
+---
+title: Agent Site issues
+kind: documentation
+disable_toc: true
+---
+
+By default the Agent sends its data to Datadog US site: `app.datadoghq.com`. If your organization is on another site, you must update the `site` parameter in your [Agent main configuraiton file][1] accordingly or set the `DD_SITE` environment variable:
+
+{{< tabs >}}
+{{% tab "US Site" %}}
+
+Set the `DD_SITE` variable to `datadoghq.com`or update the parameter `site` parameter in your `datadog.yaml`
+
+```yaml
+## @param site - string - optional - default: datadoghq.com
+## The site of the Datadog intake to send Agent data to.
+## Set to 'datadoghq.eu' to send data to the EU site.
+#
+site: datadoghq.com
+```
+
+{{% /tab %}}
+{{% tab "EU Site" %}}
+
+Set the `DD_SITE` variable to `datadoghq.eu`or update the parameter `site` parameter in your `datadog.yaml`:
+
+```yaml
+## @param site - string - optional - default: datadoghq.com
+## The site of the Datadog intake to send Agent data to.
+## Set to 'datadoghq.eu' to send data to the EU site.
+#
+site: datadoghq.eu
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file


### PR DESCRIPTION
### What does this PR do?

Support team gave us the feedback that site setup issues can happen. In order to quickly rule out this option, it's now added in the Agent troubleshooting checklist.


### Preview link
