### PR TITLE
Add NPM to retention page

### DIFF
--- a/content/en/developers/faq/data-collection-resolution-retention.md
+++ b/content/en/developers/faq/data-collection-resolution-retention.md
@@ -26,7 +26,7 @@ Find below a summary of Datadog data collection, resolution, and retention:
 | AWS                          | API crawler                                                           | 10 min ([default][2]) | 1 min              | 15 months                                                                                                                                                    | Cloud            |
 | Azure                        | API crawler                                                           | 5 min ([default][2])  | 1 min              | 15 months                                                                                                                                                    | Cloud            |
 | Google Cloud                 | API crawler                                                           | 5 min ([default][2])  | 1 min              | 15 months                                                                                                                                                    | Cloud            |
-
+| Network Performance Monitoring                 | System Probe                                                           | 5 minutes ([default][2])  | 1 min              | 7 days                                                                                                                                                    | Infrastructure            |
 
 [1]: /tracing/guide/trace_sampling_and_storage
 [2]: /integrations/faq/cloud-metric-delay/#faster-metrics


### PR DESCRIPTION
### What does this PR do?
This PR adds network retention and data collection info to the appropriate FAQ docs page.

### Motivation
The information is important to NPM customers.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/yael/npm_retention/developers/faq/data-collection-resolution-retention

### Additional Notes
<!-- Anything else we should know when reviewing?-->
