### PR TITLE
render html that exists in the markdown files for hugo 0.60

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -18,3 +18,8 @@ defaultContentLanguageInSubdir: false
 
 # set this as a default otherwise we get "Error: found overlapping content dirs"
 contentDir: "content/en"
+
+markup:
+  goldmark:
+    renderer:
+      unsafe: true


### PR DESCRIPTION
### What does this PR do?

A newer version of hugo doesn't render the html inside of markdown causing the search results page to no longer have the div that javascript relied on to populate content.

### Motivation
Bug fixing

### Preview link
https://docs-staging.datadoghq.com/david.jones/render-html-in-md/search/?s=docker

### Additional Notes
<!-- Anything else we should know when reviewing?-->
