### PR TITLE
Update markdown usage since hugo 0.61

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ stop                      stop the gulp/hugo server.
 
 ### A note about markdown
 
-This site uses Blackfriday for markdown. To learn about the syntax, [see this site][9].
+This site uses Goldmark for markdown which is compliant with [CommonMark 0.29](https://spec.commonmark.org/0.29/)
 
 If you include ANY Markdown in a file, give it an .md extension.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ stop                      stop the gulp/hugo server.
 
 ### A note about markdown
 
-This site uses Goldmark for markdown which is compliant with [CommonMark 0.29][9]
+This site uses [Goldmark][9] for markdown which is compliant with [CommonMark 0.29][10].
 
 If you include ANY Markdown in a file, give it an .md extension.
 
@@ -77,7 +77,7 @@ Within 5 minutes of merging to master, it deploys automatically.
 
 ## How to add a new integration
 
-[See the dedicated doc page][10]
+[See the dedicated doc page][11]
 
 [1]: https://gohugo.io
 [2]: https://nodejs.org/en/download/package-manager
@@ -87,5 +87,6 @@ Within 5 minutes of merging to master, it deploys automatically.
 [6]: https://github.com/DataDog/documentation/wiki/Github-personal-token
 [7]: https://github.com/DataDog/documentation/wiki/Documentation-Build
 [8]: https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md
-[9]: https://spec.commonmark.org/0.29/
-[10]: https://docs.datadoghq.com/developers/integrations
+[9]: https://github.com/yuin/goldmark
+[10]: https://spec.commonmark.org/0.29/
+[11]: https://docs.datadoghq.com/developers/integrations

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ stop                      stop the gulp/hugo server.
 
 ### A note about markdown
 
-This site uses Goldmark for markdown which is compliant with [CommonMark 0.29](https://spec.commonmark.org/0.29/)
+This site uses Goldmark for markdown which is compliant with [CommonMark 0.29][9]
 
 If you include ANY Markdown in a file, give it an .md extension.
 
@@ -71,13 +71,13 @@ Make sure all files are lowercase. Macs are case insensitive when creating links
 
 ## Releasing
 
-If you receive an error regarding `There was a problem getting GitHub Metrics`, please see the [Github personal access token][10].
+If you receive an error regarding `There was a problem getting GitHub Metrics`, please see the [Github personal access token][6].
 
 Within 5 minutes of merging to master, it deploys automatically.
 
 ## How to add a new integration
 
-[See the dedicated doc page][11]
+[See the dedicated doc page][10]
 
 [1]: https://gohugo.io
 [2]: https://nodejs.org/en/download/package-manager
@@ -87,6 +87,5 @@ Within 5 minutes of merging to master, it deploys automatically.
 [6]: https://github.com/DataDog/documentation/wiki/Github-personal-token
 [7]: https://github.com/DataDog/documentation/wiki/Documentation-Build
 [8]: https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md
-[9]: https://github.com/russross/blackfriday
-[10]: https://github.com/DataDog/documentation/wiki/Github-personal-token
-[11]: https://docs.datadoghq.com/developers/integrations
+[9]: https://spec.commonmark.org/0.29/
+[10]: https://docs.datadoghq.com/developers/integrations


### PR DESCRIPTION
### What does this PR do?
Updates the main Readme to better reflect the new markdown rendering.