### PR TITLE
Changing API endpoints depending on image version

### DIFF
--- a/content/en/synthetics/private_locations.md
+++ b/content/en/synthetics/private_locations.md
@@ -54,12 +54,12 @@ Once you created a private location, configuring a Synthetics API test from a pr
 
 4. To pull test configurations and push test results, the private location worker needs access to one of the Datadog API endpoints:
 
-    * For the Datadog US site: `api.datadoghq.com/api/`.
+    * For the Datadog US site: `api.datadoghq.com/api/` for images version 0.1.5 and below. `intake.synthetics.datadoghq.com` for images version 0.1.6 and above. 
     * For the Datadog EU site: `api.datadoghq.eu/api/`.
 
-    Check if the endpoint corresponding to your Datadog Site is available from the host runing the worker:
+    Check if the endpoint corresponding to your Datadog `site` is available from the host runing the worker:
 
-    * For the Datadog US site: `curl https://api.datadoghq.com`.
+    * For the Datadog US site: `curl https://api.datadoghq.com` or `curl intake.synthetics.datadoghq.com` depending on the version of the image you are using.
     * For the Datadog EU site:   `curl https://api.datadoghq.eu`.
     
 **Note**: You must allow outbound traffic on port `443` because test configurations are pulled and test results are pushed via HTTPS.

--- a/content/en/synthetics/private_locations.md
+++ b/content/en/synthetics/private_locations.md
@@ -59,7 +59,7 @@ Once you created a private location, configuring a Synthetics API test from a pr
 
     Check if the endpoint corresponding to your Datadog `site` is available from the host runing the worker:
 
-    * For the Datadog US site: `curl https://api.datadoghq.com` or `curl intake.synthetics.datadoghq.com` depending on the version of the image you are using.
+    * For the Datadog US site: for version 0.1.6+ use `curl intake.synthetics.datadoghq.com` (`curl https://api.datadoghq.com` for versions <0.1.5) .
     * For the Datadog EU site:   `curl https://api.datadoghq.eu`.
     
 **Note**: You must allow outbound traffic on port `443` because test configurations are pulled and test results are pushed via HTTPS.

--- a/content/en/synthetics/private_locations.md
+++ b/content/en/synthetics/private_locations.md
@@ -54,7 +54,7 @@ Once you created a private location, configuring a Synthetics API test from a pr
 
 4. To pull test configurations and push test results, the private location worker needs access to one of the Datadog API endpoints:
 
-    * For the Datadog US site: `api.datadoghq.com/api/` for images version 0.1.5 and below. `intake.synthetics.datadoghq.com` for images version 0.1.6 and above. 
+    * For the Datadog US site: for version 0.1.6+ use `intake.synthetics.datadoghq.com` ( `api.datadoghq.com/api/` for versions <0.1.5).
     * For the Datadog EU site: `api.datadoghq.eu/api/`.
 
     Check if the endpoint corresponding to your Datadog `site` is available from the host runing the worker:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

This PR changes the endpoints that are being used for private locations depending on the version of the image users are leveraging.

### Motivation

Changes performed by eng team.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/margot.lepizzera/privatelocations_endpoints/synthetics/private_locations#create-a-new-private-location
### Additional Notes
<!-- Anything else we should know when reviewing?-->
