### PR TITLE
Add doumentation for journald/container_mode option

### DIFF
--- a/content/en/integrations/journald.md
+++ b/content/en/integrations/journald.md
@@ -54,6 +54,8 @@ logs:
     container_mode: true
 ```
 
+**Note**: `container_mode` is set to `true`, to automatically set the `source` attribute of your logs to the corresponding short image name of the container instead of simply `docker`.
+
 Finally, [restart the agent][2].
 
 #### Advanced features
@@ -92,16 +94,6 @@ Tags are critical for finding information in highly dynamic containerized enviro
 This works automatically when the Agent is running from the host. If you are using the containerized version of the Datadog Agent, mount your journal path and the following file:
 
 - `/etc/machine-id`: this ensures that the Agent can query the journal that is stored on the host.
-
-Finally, [restart the agent][2].
-
-It's recommended to always activate the `container_mode` option, it will allow the agent to automatically set source/origin of your logs to the short image name instead of simply `docker` when logs are coming from a container.
-
-```
-logs:
-  - type: journald
-    container_mode: true
-```
 
 ## Troubleshooting
 

--- a/content/en/integrations/journald.md
+++ b/content/en/integrations/journald.md
@@ -54,7 +54,7 @@ logs:
     container_mode: true
 ```
 
-**Note**: `container_mode` is set to `true`, to automatically set the `source` attribute of your logs to the corresponding short image name of the container instead of simply `docker`.
+**Note**: With Agent 7.17+ if `container_mode` is set to `true`, the `source` attribute of your logs is automatically set to the corresponding short image name of the container instead of simply `docker`.
 
 Finally, [restart the agent][2].
 

--- a/content/en/integrations/journald.md
+++ b/content/en/integrations/journald.md
@@ -51,6 +51,7 @@ Then add this configuration block to your `journald.d/conf.yaml` file to start c
 ```
 logs:
   - type: journald
+    container_mode: true
 ```
 
 Finally, [restart the agent][2].
@@ -93,6 +94,14 @@ This works automatically when the Agent is running from the host. If you are usi
 - `/etc/machine-id`: this ensures that the Agent can query the journal that is stored on the host.
 
 Finally, [restart the agent][2].
+
+It's recommended to always activate the `container_mode` option, it will allow the agent to automatically set source/origin of your logs to the short image name instead of simply `docker` when logs are coming from a container.
+
+```
+logs:
+  - type: journald
+    container_mode: true
+```
 
 ## Troubleshooting
 


### PR DESCRIPTION
### What does this PR do?
Add documentation for journald container_mode.

### Motivation
https://github.com/DataDog/datadog-agent/pull/4550

### Preview link

[](https://docs-staging.datadoghq.com/vboulineau/journald/integrations/journald)

### Additional Notes
