### PR TITLE
Fix documented tag format in agent config files

### DIFF
--- a/content/en/tagging/assigning_tags.md
+++ b/content/en/tagging/assigning_tags.md
@@ -58,22 +58,22 @@ Tags for the [integrations][5] installed with the Agent are configured with YAML
 
 #### YAML formats
 
-In YAML files, use a tag dictionary to assign a list of tags. Tag dictionaries have two different yet functionally equivalent forms:
+In YAML files, use a list of strings under the `tags` key to assign a list of tags. In YAML, lists are defined with two different yet functionally equivalent forms:
 
 ```
-tags: <KEY_1>:<VALUE_1>, <KEY_2>:<VALUE_2>, <KEY_3>:<VALUE_3>
+tags: ["<KEY_1>:<VALUE_1>", "<KEY_2>:<VALUE_2>", "<KEY_3>:<VALUE_3>"]
 ```
 
 or
 
 ```
 tags:
-    - <KEY_1>:<VALUE_1>
-    - <KEY_2>:<VALUE_2>
-    - <KEY_3>:<VALUE_3>
+    - "<KEY_1>:<VALUE_1>"
+    - "<KEY_2>:<VALUE_2>"
+    - "<KEY_3>:<VALUE_3>"
 ```
 
-It is recommended to assign tags as `<KEY>:<VALUE>` pairs, but simple tags are also accepted. See [defining tags][1] for more details.
+It is recommended to assign tags as `<KEY>:<VALUE>` pairs, but tags only consisting of keys (`<KEY>`) are also accepted. See [defining tags][1] for more details.
 
 ## Environment Variables
 


### PR DESCRIPTION
### What does this PR do?

Fixes documented tag format in agent config files.

The format `tags: <KEY1>:<VALUE1>, <KEY2>:<VALUE2>` never worked in YAML files, it only works in the Agent v5's `datadog.conf`. The other changes are cosmetic or there to reduce the chances of users making mistakes when defining tags.