### PR TITLE
Agent metrics collection fixing tags setup

### DIFF
--- a/content/en/developers/metrics/agent_metrics_submission.md
+++ b/content/en/developers/metrics/agent_metrics_submission.md
@@ -149,32 +149,32 @@ Follow the steps below to create a [custom Agent check][2] that sends all metric
             self.count(
                 "example_metric.count",
                 2,
-                tags="metric_submission_type:count",
+                tags=["env:dev","metric_submission_type:count"],
             )
             self.count(
                 "example_metric.decrement",
                 -1,
-                tags="metric_submission_type:count",
+                tags=["env:dev","metric_submission_type:count"],
             )
             self.count(
                 "example_metric.increment",
                 1,
-                tags="metric_submission_type:count",
+                tags=["env:dev","metric_submission_type:count"],
             )
             self.rate(
                 "example_metric.rate",
                 1,
-                tags="metric_submission_type:rate",
+                tags=["env:dev","metric_submission_type:rate"],
             )
             self.gauge(
                 "example_metric.gauge",
                 random.randint(0, 10),
-                tags="metric_submission_type:gauge",
+                tags=["env:dev","metric_submission_type:gauge"],
             )
             self.monotonic_count(
                 "example_metric.monotonic_count",
                 2,
-                tags="metric_submission_type:monotonic_count",
+                tags=["env:dev","metric_submission_type:monotonic_count"],
             )
 
             # Calling the functions below twice simulates
@@ -182,12 +182,12 @@ Follow the steps below to create a [custom Agent check][2] that sends all metric
             self.histogram(
                 "example_metric.histogram",
                 random.randint(0, 10),
-                tags="metric_submission_type:histogram",
+                tags=["env:dev","metric_submission_type:histogram"],
             )
             self.histogram(
                 "example_metric.histogram",
                 random.randint(0, 10),
-                tags="metric_submission_type:histogram",
+                tags=["env:dev","metric_submission_type:histogram"],
             )
     {{< /code-block >}}
 


### PR DESCRIPTION
### What does this PR do?
Tags parameter should only take an array instead of a string.

### Motivation
it messes up with the tags displayed.