### PR TITLE
Document the `with_downtimes` parameter for the `GET /v1/monitor/<MONITOR_ID>` endpoint.

### DIFF
--- a/content/en/api/monitors/monitors_get.md
+++ b/content/en/api/monitors/monitors_get.md
@@ -11,3 +11,5 @@ external_redirect: /api/#get-a-monitor-s-details
 
 * **`group_states`** [*optional*, *default*=**None**]:
     If this argument is set, the returned data includes additional information (if available) regarding the specified group states, including the last notification timestamp, last resolution timestamp and details about the last time the monitor was triggered. The argument should include a string list indicating what, if any, group states to include. Choose one or more from **all**, **alert**, **warn**, or **no data**. Example: 'alert,warn'"
+* **`with_downtimes`** [*optional*, *default* = **false**]:
+    If this argument is set to `true`, then the returned data includes all current downtimes for the monitor.


### PR DESCRIPTION
### What does this PR do?
Documents the `with_downtimes` parameter for the `GET /v1/monitor/<MONITOR_ID>` endpoint.

### Motivation
The parameter was undocumented.

### Preview link
https://docs-staging.datadoghq.com/armcburney/document_with_downtimes_parameter/api/?lang=python#get-a-monitor-s-details

### Additional Notes
N/A
