### PR TITLE
Note for java path section in JMX troubleshooting doc

### DIFF
--- a/content/en/integrations/faq/troubleshooting-jmx-integrations.md
+++ b/content/en/integrations/faq/troubleshooting-jmx-integrations.md
@@ -151,6 +151,8 @@ The Agent does not come with a bundled JVM, but uses the one installed on your s
 
 Alternatively, you can specify the JVM path in the integration's configuration file with the `java_bin_path` parameter.
 
+**Note**: Only one valid Java path needs to be specified for JMXFetch.
+
 ### JVM metrics
 
 Datadog's Java APM library is capable of collecting JVM metrics without the JMX integration. See [Runtime Metrics][3], for more details.


### PR DESCRIPTION
### What does this PR do?
Adds a small note about java_bin_path to the java path section for JMX doc

### Motivation
Trello request

### Preview link
https://docs-staging.datadoghq.com/sarina/jmx-note/integrations/faq/troubleshooting-jmx-integrations/?tab=agentv6v7#java-path