### PR TITLE
nodejs.md - change package.js to package.json

### DIFF
--- a/content/en/logs/log_collection/nodejs.md
+++ b/content/en/logs/log_collection/nodejs.md
@@ -31,7 +31,7 @@ Winston is available through [NPM][2], to get started, you want to add the depen
 npm install --save winston
 ```
 
-`package.js` is updated with the corresponding dependencies:
+`package.json` is updated with the corresponding dependencies:
 
 ```js
 {


### PR DESCRIPTION
### What does this PR do?

Fixes a grammar mistake. Changes "package.js" to "package.json."

https://www.geeksforgeeks.org/node-js-package-json/

### Motivation
Saw the error.

### Preview link

Preview Link: https://docs-staging.datadoghq.com/dan.chiniara/en_nodejs_log_collection_package.json_fix/logs/log_collection/nodejs/?tab=winston30#overview

Screenshot: https://a.cl.ly/NQuvKyZk
