### PR TITLE
Update Agent downgrade page

### DIFF
--- a/content/en/agent/faq/agent-downgrade-minor.md
+++ b/content/en/agent/faq/agent-downgrade-minor.md
@@ -1,20 +1,24 @@
 ---
-title: Downgrade the Agent v6 to a prior minor version
+title: Downgrade the Agent to a prior minor version
 kind: faq
 aliases:
 - /agent/faq/downgrade-datadog-agent
 ---
 
-For DEB or RPM packages of the Datadog Agent, find below instructions to downgrade the Datadog Agent to version `6.X.Y`.
+For DEB or RPM packages of the Datadog Agent, find below instructions to downgrade the Datadog Agent to a prior minor version.
+
+To downgrade the Datadog Agent to a prior major version, follow the instructions on the [dedicated page][1].
 
 **Note**: These instructions only work for Datadog Agent version 6.x and above.
+
+**Note**: These instructions for configuration management tools only work with the latest major version of these tools. If using a prior version, refer to the documentation for this version on the tools' repositories: [Chef cookbook][2], [Puppet module][3], [Ansible role][4].
 
 ## Debian/Ubuntu
 
 ### CLI
 
 ```
-sudo apt-get update && sudo apt-get install --allow-downgrades datadog-agent=1:6.X.Y-1
+sudo apt-get update && sudo apt-get install --allow-downgrades datadog-agent=1:X.Y.Z-1
 ```
 
 **Note**: If the option `--allow-downgrades` doesn't exist for your apt version, you can use `--force-yes` instead.
@@ -24,32 +28,30 @@ sudo apt-get update && sudo apt-get install --allow-downgrades datadog-agent=1:6
 {{< tabs >}}
 {{% tab "Chef Cookbook" %}}
 
-Set the following attributes on your nodes:
-
 ```rb
-node["datadog"]["agent6_version"] = "1:6.X.Y-1"
-node["datadog"]["agent6_package_action"] = "install"
+node["datadog"]["agent_version"] = "1:X.Y.Z-1"
+node["datadog"]["agent_package_action"] = "install"
 node["datadog"]["agent_allow_downgrade"] = true
 ```
 
 {{% /tab %}}
-{{% tab "Puppet" %}}
+{{% tab "Puppet Module" %}}
 
 ```
 class { 'datadog_agent':
       ...
-      agent_version => “1:6.X.Y-1”,
+      agent_version => “1:X.Y.Z-1”,
 }
 ```
 
 {{% /tab %}}
-{{% tab "Ansible" %}}
+{{% tab "Ansible Role" %}}
 
 Add the following attributes in your playbook:
 
 ```yaml
-datadog_agent_version: "1:6.X.Y-1"
-datadog_agent_allow_downgrade: true
+datadog_agent_version: "1:X.Y.Z-1"
+datadog_agent_allow_downgrade: yes
 ```
 
 {{% /tab %}}
@@ -60,7 +62,7 @@ datadog_agent_allow_downgrade: true
 ### CLI
 
 ```
-sudo yum clean expire-cache metadata && sudo yum downgrade datadog-agent-6.X.Y-1
+sudo yum clean expire-cache metadata && sudo yum downgrade datadog-agent-X.Y.Z-1
 ```
 
 ### Configuration management tools
@@ -71,29 +73,29 @@ sudo yum clean expire-cache metadata && sudo yum downgrade datadog-agent-6.X.Y-1
 Set the following attributes on your nodes:
 
 ```rb
-node["datadog"]["agent6_version"] = "6.X.Y-1"
-node["datadog"]["agent6_package_action"] = "install"
+node["datadog"]["agent_version"] = "X.Y.Z-1"
+node["datadog"]["agent_package_action"] = "install"
 node["datadog"]["agent_allow_downgrade"] = true
 ```
 
 {{% /tab %}}
-{{% tab "Puppet" %}}
+{{% tab "Puppet Module" %}}
 
 ```
 class { 'datadog_agent':
       ...
-      agent_version => “6.X.Y-1”,
+      agent_version => “X.Y.Z-1”,
 }
 ```
 
 {{% /tab %}}
-{{% tab "Ansible" %}}
+{{% tab "Ansible Role" %}}
 
 Add the following attributes in your playbook (on CentOS, this only works with Ansible 2.4+):
 
 ```yaml
-datadog_agent_version: "6.X.Y-1"
-datadog_agent_allow_downgrade: true
+datadog_agent_version: "X.Y.Z-1"
+datadog_agent_allow_downgrade: yes
 ```
 
 {{% /tab %}}
@@ -104,7 +106,7 @@ datadog_agent_allow_downgrade: true
 ### CLI
 
 ```
-sudo zypper --no-gpg-check refresh datadog && sudo zypper install --oldpackage datadog-agent-1:6.X.Y-1
+sudo zypper --no-gpg-check refresh datadog && sudo zypper install --oldpackage datadog-agent-1:X.Y.Z-1
 ```
 
 ### Configuration management tools
@@ -112,22 +114,33 @@ sudo zypper --no-gpg-check refresh datadog && sudo zypper install --oldpackage d
 {{< tabs >}}
 {{% tab "Chef Cookbook" %}}
 
-Datadog's cookbook doesn’t support SUSE.
+Set the following attributes on your nodes:
+
+```rb
+node["datadog"]["agent_version"] = "1:X.Y.Z-1"
+node["datadog"]["agent_package_action"] = "install"
+node["datadog"]["agent_allow_downgrade"] = true
+```
 
 {{% /tab %}}
-{{% tab "Puppet" %}}
+{{% tab "Puppet Module" %}}
 
 Datadog's module doesn’t support SUSE.
 
 {{% /tab %}}
-{{% tab "Ansible" %}}
+{{% tab "Ansible Role" %}}
 
 Add the following attributes in your playbook:
 
 ```yaml
-datadog_agent_version: "1:6.X.Y-1"
-datadog_agent_allow_downgrade: true
+datadog_agent_version: "1:X.Y.Z-1"
+datadog_agent_allow_downgrade: yes
 ```
 
 {{% /tab %}}
 {{< /tabs >}}
+
+[1]: /agent/faq/agent-downgrade-major
+[2]: https://github.com/DataDog/chef-datadog/tree/3.x
+[3]: https://github.com/DataDog/puppet-datadog-agent/tree/2.x
+[4]: https://github.com/DataDog/ansible-datadog/tree/3.x

--- a/content/en/agent/faq/agent-downgrade-minor.md
+++ b/content/en/agent/faq/agent-downgrade-minor.md
@@ -11,7 +11,7 @@ To downgrade the Datadog Agent to a prior major version, follow the instructions
 
 **Note**: These instructions only work for Datadog Agent version 6.x and above.
 
-**Note**: These instructions for configuration management tools only work with the latest major version of these tools. If using a prior version, refer to the documentation for this version on the tools' repositories: [Chef cookbook][2], [Puppet module][3], [Ansible role][4].
+**Note**: These instructions for configuration management tools only work with the latest major version of these tools: v4.x for the Chef cookbook, v3.x for the Puppet module and v4.x for the Ansible role. If using a prior version, refer to the documentation for this version on the tools' repositories: [Chef cookbook v3.x][2], [Puppet module v2.x][3], [Ansible role v3.x][4].
 
 ## Debian/Ubuntu
 
@@ -26,7 +26,7 @@ sudo apt-get update && sudo apt-get install --allow-downgrades datadog-agent=1:X
 ### Configuration management tools
 
 {{< tabs >}}
-{{% tab "Chef Cookbook" %}}
+{{% tab "Chef" %}}
 
 ```rb
 node["datadog"]["agent_version"] = "1:X.Y.Z-1"
@@ -35,7 +35,7 @@ node["datadog"]["agent_allow_downgrade"] = true
 ```
 
 {{% /tab %}}
-{{% tab "Puppet Module" %}}
+{{% tab "Puppet" %}}
 
 ```
 class { 'datadog_agent':
@@ -45,7 +45,7 @@ class { 'datadog_agent':
 ```
 
 {{% /tab %}}
-{{% tab "Ansible Role" %}}
+{{% tab "Ansible" %}}
 
 Add the following attributes in your playbook:
 
@@ -68,7 +68,7 @@ sudo yum clean expire-cache metadata && sudo yum downgrade datadog-agent-X.Y.Z-1
 ### Configuration management tools
 
 {{< tabs >}}
-{{% tab "Chef Cookbook" %}}
+{{% tab "Chef" %}}
 
 Set the following attributes on your nodes:
 
@@ -79,7 +79,7 @@ node["datadog"]["agent_allow_downgrade"] = true
 ```
 
 {{% /tab %}}
-{{% tab "Puppet Module" %}}
+{{% tab "Puppet" %}}
 
 ```
 class { 'datadog_agent':
@@ -89,7 +89,7 @@ class { 'datadog_agent':
 ```
 
 {{% /tab %}}
-{{% tab "Ansible Role" %}}
+{{% tab "Ansible" %}}
 
 Add the following attributes in your playbook (on CentOS, this only works with Ansible 2.4+):
 
@@ -112,7 +112,7 @@ sudo zypper --no-gpg-check refresh datadog && sudo zypper install --oldpackage d
 ### Configuration management tools
 
 {{< tabs >}}
-{{% tab "Chef Cookbook" %}}
+{{% tab "Chef" %}}
 
 Set the following attributes on your nodes:
 
@@ -123,12 +123,12 @@ node["datadog"]["agent_allow_downgrade"] = true
 ```
 
 {{% /tab %}}
-{{% tab "Puppet Module" %}}
+{{% tab "Puppet" %}}
 
 Datadog's module doesn’t support SUSE.
 
 {{% /tab %}}
-{{% tab "Ansible Role" %}}
+{{% tab "Ansible" %}}
 
 Add the following attributes in your playbook:
 

--- a/content/en/agent/faq/agent-downgrade-minor.md
+++ b/content/en/agent/faq/agent-downgrade-minor.md
@@ -1,17 +1,19 @@
 ---
-title: Downgrade the Agent to a prior minor version
+title: Downgrade the Agent to a Prior Minor Version
 kind: faq
 aliases:
 - /agent/faq/downgrade-datadog-agent
 ---
 
-For DEB or RPM packages of the Datadog Agent, find below instructions to downgrade the Datadog Agent to a prior minor version.
+For DEB or RPM packages of the Datadog Agent, find the instructions below to downgrade the Datadog Agent to a prior minor version.
 
 To downgrade the Datadog Agent to a prior major version, follow the instructions on the [dedicated page][1].
 
-**Note**: These instructions only work for Datadog Agent version 6.x and above.
+**Notes**:
 
-**Note**: These instructions for configuration management tools only work with the latest major version of these tools: v4.x for the Chef cookbook, v3.x for the Puppet module and v4.x for the Ansible role. If using a prior version, refer to the documentation for this version on the tools' repositories: [Chef cookbook v3.x][2], [Puppet module v2.x][3], [Ansible role v3.x][4].
+* These instructions only work for Datadog Agent version 6.x and above.
+* The instructions below for configuration management tools only work with the latest major version of these tools: v4.x for the Chef cookbook, v3.x for the Puppet module, and v4.x for the Ansible role. If you are using a prior version, refer to the documentation for that version on the tools' repositories: [Chef cookbook v3.x][2], [Puppet module v2.x][3], or [Ansible role v3.x][4].
+
 
 ## Debian/Ubuntu
 


### PR DESCRIPTION
### What does this PR do?

Changes the Agent minor version downgrade page to not be version-specific, and to use the latest version of the configuration management tools.
Adds SUSE Chef support mention (since we do support it now) on this page.
Changes the Ansible instructions for the `datadog_agent_allow_downgrade` to use the same value as the README on the tool's repository.

### Motivation

Up-to-date documentation.

### Preview link

[Agent minor version downgrade](https://docs-staging.datadoghq.com/kylian.serrania/fix-agent-downgrade-page/agent/faq/agent-downgrade-minor/?tab=chefcookbook)

