### PR TITLE
Documented that too large messages are accepted and dropped for HTTP API

### DIFF
--- a/content/en/api/logs/logs.md
+++ b/content/en/api/logs/logs.md
@@ -15,7 +15,10 @@ Send your logs to your Datadog platform over HTTP. Limits per HTTP request are:
 * Maximum size for a single log: 256kB
 * Maximum array size if sending multiple logs in an array: 500 entries
 
-All logs exceeding 256kB are accepted and dropped by the platform.
+All logs exceeding 256kB are accepted and dropped by the platform:
+
+* for a single-log request the API drops the log and returns a 2xx
+* for a multi-logs request the API processes all the logs smaller or equal to 256kB, drop the others and returns a 2xx
 
 **Note**: If you are in the Datadog EU site (`app.datadoghq.eu`), the HTTP log endpoint is: `http-intake.logs.datadoghq.eu`.
 

--- a/content/en/api/logs/logs.md
+++ b/content/en/api/logs/logs.md
@@ -15,7 +15,7 @@ Send your logs to your Datadog platform over HTTP. Limits per HTTP request are:
 * Maximum size for a single log: 256kB
 * Maximum array size if sending multiple logs in an array: 500 entries
 
-All logs exceeding 256KB are accepted and dropped by the platform.
+All logs exceeding 256kB are accepted and dropped by the platform.
 
 **Note**: If you are in the Datadog EU site (`app.datadoghq.eu`), the HTTP log endpoint is: `http-intake.logs.datadoghq.eu`.
 

--- a/content/en/api/logs/logs.md
+++ b/content/en/api/logs/logs.md
@@ -15,6 +15,8 @@ Send your logs to your Datadog platform over HTTP. Limits per HTTP request are:
 * Maximum size for a single log: 256kB
 * Maximum array size if sending multiple logs in an array: 500 entries
 
+All logs exceeding 256kB will be accepted and dropped by the platform.
+
 **Note**: If you are in the Datadog EU site (`app.datadoghq.eu`), the HTTP log endpoint is: `http-intake.logs.datadoghq.eu`.
 
 [1]: /help

--- a/content/en/api/logs/logs.md
+++ b/content/en/api/logs/logs.md
@@ -15,10 +15,10 @@ Send your logs to your Datadog platform over HTTP. Limits per HTTP request are:
 * Maximum size for a single log: 256kB
 * Maximum array size if sending multiple logs in an array: 500 entries
 
-All logs exceeding 256kB are accepted and dropped by the platform:
+All logs exceeding 256KB are accepted and dropped by the platform:
 
-* for a single-log request the API drops the log and returns a 2xx
-* for a multi-logs request the API processes all the logs smaller or equal to 256kB, drop the others and returns a 2xx
+* For a single log request, the API drops the log and returns a 2xx.
+* For a multi-logs request, the API processes all the logs less than or equal to 256KB, drops the larger logs, and returns a 2xx.
 
 **Note**: If you are in the Datadog EU site (`app.datadoghq.eu`), the HTTP log endpoint is: `http-intake.logs.datadoghq.eu`.
 

--- a/content/en/api/logs/logs.md
+++ b/content/en/api/logs/logs.md
@@ -15,7 +15,7 @@ Send your logs to your Datadog platform over HTTP. Limits per HTTP request are:
 * Maximum size for a single log: 256kB
 * Maximum array size if sending multiple logs in an array: 500 entries
 
-All logs exceeding 256kB will be accepted and dropped by the platform.
+All logs exceeding 256KB are accepted and dropped by the platform.
 
 **Note**: If you are in the Datadog EU site (`app.datadoghq.eu`), the HTTP log endpoint is: `http-intake.logs.datadoghq.eu`.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Documented that too large messages are accepted and dropped by the logs HTTP API

### Motivation
Make sure customers are aware of the behaviour of the HTTP API

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

https://docs-staging.datadoghq.com/ajacquemot/logs_http_api_drop_too_large_message

### Additional Notes
<!-- Anything else we should know when reviewing?-->
