### PR TITLE
📝[LA-87][Dash] Update docs for LogStream Widget properties

### DIFF
--- a/content/en/dashboards/widgets/log_stream.md
+++ b/content/en/dashboards/widgets/log_stream.md
@@ -60,7 +60,7 @@ LOG_STREAM_SCHEMA = {
         "title_align": {"enum": ["center", "left", "right"]},
         "time": TIME_SCHEMA
     },
-    "required": ["type", "logset"],
+    "required": ["type"],
     "additionalProperties": false
 }
 ```
@@ -68,7 +68,7 @@ LOG_STREAM_SCHEMA = {
 | Parameter     | Type   | Required | Description                                                                                                                |
 |---------------|--------|----------|----------------------------------------------------------------------------------------------------------------------------|
 | `type`        | string | yes      | Type of the widget, for the log stream widget use `log_stream`                                                             |
-| `logset`      | string | yes      | Which logset to use for the stream                                                                                         |
+| `logset`      | string | no       | Which logset to use for the stream                                                                                         |
 | `query`       | string | no       | Query to filter the log stream with                                                                                        |
 | `columns`     | array  | no       | Which columns to display on the widget                                                                                     |
 | `title`       | string | no       | Title of the widget                                                                                                        |

--- a/content/en/dashboards/widgets/log_stream.md
+++ b/content/en/dashboards/widgets/log_stream.md
@@ -53,6 +53,7 @@ LOG_STREAM_SCHEMA = {
     "properties": {
         "type": {"enum": ["log_stream"]},
         "logset": {"type": "string"},
+        "indexes": {"type": "array", "items": {"type": "string"}},
         "query": {"type": "string"},
         "columns": {"type": "array", "items": {"type": "string"}},
         "title": {"type": "string"},
@@ -68,7 +69,8 @@ LOG_STREAM_SCHEMA = {
 | Parameter     | Type   | Required | Description                                                                                                                |
 |---------------|--------|----------|----------------------------------------------------------------------------------------------------------------------------|
 | `type`        | string | yes      | Type of the widget, for the log stream widget use `log_stream`                                                             |
-| `logset`      | string | no       | The id of the index to query in the stream                                                                                 |
+| `indexes`     | string | no       | An array of index names to query in the stream.                                                                            |
+| `logset`      | string | no       | Deprecated: Use 'indexes' instead. The ID of the index to query in the stream.                                             |
 | `query`       | string | no       | Query to filter the log stream with                                                                                        |
 | `columns`     | array  | no       | Which columns to display on the widget                                                                                     |
 | `title`       | string | no       | Title of the widget                                                                                                        |

--- a/content/en/dashboards/widgets/log_stream.md
+++ b/content/en/dashboards/widgets/log_stream.md
@@ -68,7 +68,7 @@ LOG_STREAM_SCHEMA = {
 | Parameter     | Type   | Required | Description                                                                                                                |
 |---------------|--------|----------|----------------------------------------------------------------------------------------------------------------------------|
 | `type`        | string | yes      | Type of the widget, for the log stream widget use `log_stream`                                                             |
-| `logset`      | string | no       | Which logset to use for the stream                                                                                         |
+| `logset`      | string | no       | The id of the index to query in the stream                                                                                 |
 | `query`       | string | no       | Query to filter the log stream with                                                                                        |
 | `columns`     | array  | no       | Which columns to display on the widget                                                                                     |
 | `title`       | string | no       | Title of the widget                                                                                                        |


### PR DESCRIPTION
### What does this PR do?
<!-- Test -->
Updates the list of properties for the LogStream widget in dashboards to reflect that latest updates in the code:

1. `logset` is now deprecated in favor of:
1. `indexes` is now the preferred way to specify which index(es) to query
1. Neither `logset` nor `indexes` is required -- the dashboards code will now load a "default" index if none is specified.

### Motivation
https://datadoghq.atlassian.net/browse/LA-87

### Preview link
https://docs-staging.datadoghq.com/riko/log_stream/graphing/widgets/log_stream/#api

### Additional Notes
Note that multi-index queries do not work yet, so for now we'll always just use the first index in the `indexes` array. 
Support for multi-index is coming very soon, so we may want to wait to merge this until they are fully supported.