### PR TITLE
Adding EU site info

### DIFF
--- a/content/en/tracing/guide/trace_sampling_and_storage.md
+++ b/content/en/tracing/guide/trace_sampling_and_storage.md
@@ -109,6 +109,7 @@ public class MyClass {
     }
 }
 ```
+
 Manually drop a trace:
 
 ```java
@@ -128,7 +129,6 @@ public class MyClass {
     }
 }
 ```
-
 
 {{% /tab %}}
 {{% tab "Python" %}}
@@ -174,6 +174,7 @@ Datadog.tracer.trace(name, options) do |span|
   # method impl follows
 end
 ```
+
 Manually drop a trace:
 
 ```ruby
@@ -183,6 +184,7 @@ Datadog.tracer.trace(name, options) do |span|
   # method impl follows
 end
 ```
+
 {{% /tab %}}
 {{% tab "Go" %}}
 
@@ -250,6 +252,7 @@ span.setTag(tags.MANUAL_KEEP)
 //method impl follows
 
 ```
+
 Manually drop a trace:
 
 ```js
@@ -281,6 +284,7 @@ using(var scope = Tracer.Instance.StartActive(operationName))
     //method impl follows
 }
 ```
+
 Manually drop a trace:
 
 ```cs
@@ -345,6 +349,7 @@ auto span = tracer->StartSpan("operation_name");
 span->SetTag(datadog::tags::manual_keep, {});
 //method impl follows
 ```
+
 Manually drop a trace:
 
 ```cpp
@@ -365,17 +370,15 @@ another_span->SetTag(datadog::tags::manual_drop, {});
 
 Note that trace priority should be manually controlled only before any context propagation. If this happens after the propagation of a context, the system can’t ensure that the entire trace is kept across services. Manually controlled trace priority is set at tracing client location, the trace can still be dropped by Agent or server location based on the [sampling rules](#sampling-rules).
 
-
 ## Trace Storage
 
-Individual traces are stored for 15 days. This means that all **sampled** traces are retained for a period of 15 days and at the end of the 15th day, the entire set of expired traces is deleted. In addition, once a trace has been viewed by opening a full page, it continues to be available by using its trace ID in the URL: `https://app.datadoghq.com/apm/trace/<TRACE_ID>`. This is true even if it "expires" from the UI. This behavior is independent of the UI retention time buckets.
+Individual traces are stored for 15 days. This means that all **sampled** traces are retained for a period of 15 days and at the end of the 15th day, the entire set of expired traces is deleted. In addition, once a trace has been viewed by opening a full page, it continues to be available by using its trace ID in the URL: `https://app.datadoghq.com/apm/trace/<TRACE_ID>` (`https://app.datadoghq.eu/apm/trace/<TRACE_ID>` for Datadog EU site). This is true even if it "expires" from the UI. This behavior is independent of the UI retention time buckets.
 
 {{< img src="tracing/guide/trace_sampling_and_storage/trace_id.png" alt="Trace ID" responsive="true" >}}
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
-
 
 [1]: /tracing/visualization/#trace
 [2]: /tracing/faq/how-to-configure-an-apdex-for-your-traces-with-datadog-apm


### PR DESCRIPTION
### What does this PR do?

Adds DD EU site info after: https://github.com/DataDog/documentation/pull/6284/