### PR TITLE
Update Agent SUSE 11 support + small typo fixes

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -133,19 +133,21 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 {{< tabs >}}
 {{% tab "Agent v6 & v7" %}}
 
-| OS                                | Supported versions                                |
-|-----------------------------------|---------------------------------------------------|
-| [Amazon][1]                       | Amazon Linux 2                                    |
-| [Debian x86_64][2]                | Debian 7 (wheezy)+ and SysVinit in Agent 6.6.0+)  |
-| [Ubuntu x86_64][3]                | Ubuntu 14.04+                                     |
-| [RedHat/CentOS x86_64][4]         | RedHat/CentOS 6+                                  |
-| [Docker][5]                       | Version 1.12+                                     |
-| [Kubernetes][6]                   | Version 1.3+                                      |
-| [SUSE Enterprise Linux x86_64][7] | SUSE 11 SP4+ (not SysVinit)                       |
-| [Fedora x86_64][8]                | Fedora 26+                                        |
-| [macOS][9]                        | macOS 10.12+                                      |
-| [Windows server 64-bit][10]       | Windows Server 2008r2+ and Server Core (not Nano) |
-| [Windows 64-bit][10]              | Windows 7+                                        |
+| OS                                              | Supported versions                                     |
+|-------------------------------------------------|--------------------------------------------------------|
+| [Amazon][1]                                     | Amazon Linux 2                                         |
+| [Debian x86_64][2] with systemd                 | Debian 7 (wheezy)+                                     |
+| [Debian x86_64][2] with SysVinit                | Debian 7 (wheezy)+ in Agent 6.6.0+                     |
+| [Ubuntu x86_64][3]                              | Ubuntu 14.04+                                          |
+| [RedHat/CentOS x86_64][4]                       | RedHat/CentOS 6+                                       |
+| [Docker][5]                                     | Version 1.12+                                          |
+| [Kubernetes][6]                                 | Version 1.3+                                           |
+| [SUSE Enterprise Linux x86_64][7] with systemd  | SUSE 11 SP4+                                           |
+| [SUSE Enterprise Linux x86_64][7] with SysVinit | SUSE 11 SP4 in Agent 7.16.0+                           |
+| [Fedora x86_64][8]                              | Fedora 26+                                             |
+| [macOS][9]                                      | macOS 10.12+                                           |
+| [Windows server 64-bit][10]                     | Windows Server 2008r2+ and Server Core (not Nano)      |
+| [Windows 64-bit][10]                            | Windows 7+                                             |
 
 **Note**: [Source][11] install may work on operating systems not listed here and is supported on a best effort basis.
 
@@ -174,7 +176,7 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 | [SUSE Enterprise Linux x86_64][7] | SUSE 11 SP4+           |
 | [Fedora x86_64][8]                | Fedora 26+             |
 | [MacOS][9]                        | macOS 10.10+           |
-| [Windows server 64-bit][10]       | Windows server 2008r2+ |
+| [Windows server 64-bit][10]       | Windows Server 2008r2+ |
 | [Windows 64-bit][10]              | Windows 7+             |
 
 **Note**: [Source][11] install may work on operating systems not listed here and is supported on a best effort basis.

--- a/content/en/agent/basic_agent_usage/suse.md
+++ b/content/en/agent/basic_agent_usage/suse.md
@@ -20,7 +20,7 @@ further_reading:
 
 This page outlines the basic features of the Datadog Agent for SUSE. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
-**Note**: SUSE 11 SP4 and above (we do not support SysVinit) are supported.
+**Note**: SUSE 11 SP4 and above are supported.
 
 ## Commands
 


### PR DESCRIPTION
### What does this PR do?

Adds mention of SUSE 11 SysVinit support.

### Motivation

Starting with Agent 6.16.0/7.16.0, we now support SysVInit for SUSE 11.

### Preview link

[Basic Agent usage page](https://docs-staging.datadoghq.com/kylian.serrania/update-suse-support/agent/basic_agent_usage/?tab=agentv6v7)
[SUSE basic Agent usage page](https://docs-staging.datadoghq.com/kylian.serrania/update-suse-support/agent/basic_agent_usage/suse/?tab=agentv6v7)

