### PR TITLE
Fixing placeholder

### DIFF
--- a/content/en/agent/autodiscovery/clusterchecks.md
+++ b/content/en/agent/autodiscovery/clusterchecks.md
@@ -106,7 +106,7 @@ The `cluster_check` field informs the Cluster Agent to delegate this check to on
 You can annotate services with the following syntax, similar to the syntax for [annotating Kubernetes Pods][9]:
 
 ```yaml
-  ad.datadoghq.com/service.check_names: '[<CHECK_NAME>]'
+  ad.datadoghq.com/service.check_names: '[<INTEGRATION_NAME>]'
   ad.datadoghq.com/service.init_configs: '[<INIT_CONFIG>]'
   ad.datadoghq.com/service.instances: '[<INSTANCE_CONFIG>]'
 ```

--- a/content/en/agent/autodiscovery/endpointschecks.md
+++ b/content/en/agent/autodiscovery/endpointschecks.md
@@ -118,7 +118,7 @@ DD_EXTRA_CONFIG_PROVIDERS="endpointschecks clusterchecks"
 Similar to [annotating Kubernetes Pods][6], Services can be annotated with the following syntax:
 
 ```yaml
-  ad.datadoghq.com/endpoints.check_names: '[<CHECK_NAME>]'
+  ad.datadoghq.com/endpoints.check_names: '[<INTEGRATION_NAME>]'
   ad.datadoghq.com/endpoints.init_configs: '[<INIT_CONFIG>]'
   ad.datadoghq.com/endpoints.instances: '[<INSTANCE_CONFIG>]'
 ```

--- a/content/en/agent/autodiscovery/integrations.md
+++ b/content/en/agent/autodiscovery/integrations.md
@@ -76,12 +76,12 @@ kind: Pod
 metadata:
   name: '<POD_NAME>'
   annotations:
-    ad.datadoghq.com/<CONTAINER_IDENTIFIER_1>.check_names: '[<CHECK_NAME_1>]'
+    ad.datadoghq.com/<CONTAINER_IDENTIFIER_1>.check_names: '[<INTEGRATION_NAME_1>]'
     ad.datadoghq.com/<CONTAINER_IDENTIFIER_1>.init_configs: '[<INIT_CONFIG_1>]'
     ad.datadoghq.com/<CONTAINER_IDENTIFIER_1>.instances: '[<INSTANCE_CONFIG_1>]'
     ad.datadoghq.com/<CONTAINER_IDENTIFIER_1>.logs: '[<LOG_CONFIG_1>]'
     # (...)
-    ad.datadoghq.com/<CONTAINER_IDENTIFIER_2>.check_names: '[<CHECK_NAME_2>]'
+    ad.datadoghq.com/<CONTAINER_IDENTIFIER_2>.check_names: '[<INTEGRATION_NAME_2>]'
     ad.datadoghq.com/<CONTAINER_IDENTIFIER_2>.init_configs: '[<INIT_CONFIG_2>]'
     ad.datadoghq.com/<CONTAINER_IDENTIFIER_2>.instances: '[<INSTANCE_CONFIG_2>]'
     ad.datadoghq.com/<CONTAINER_IDENTIFIER_2>.logs: '[<LOG_CONFIG_2>]'

--- a/content/en/agent/autodiscovery/integrations.md
+++ b/content/en/agent/autodiscovery/integrations.md
@@ -56,7 +56,7 @@ kind: Pod
 metadata:
   name: '<POD_NAME>'
   annotations:
-    ad.datadoghq.com/<CONTAINER_IDENTIFIER>.check_names: '[<CHECK_NAME>]'
+    ad.datadoghq.com/<CONTAINER_IDENTIFIER>.check_names: '[<INTEGRATION_NAME>]'
     ad.datadoghq.com/<CONTAINER_IDENTIFIER>.init_configs: '[<INIT_CONFIG>]'
     ad.datadoghq.com/<CONTAINER_IDENTIFIER>.instances: '[<INSTANCE_CONFIG>]'
     ad.datadoghq.com/<CONTAINER_IDENTIFIER>.logs: '[<LOG_CONFIG>]'
@@ -103,7 +103,7 @@ Integrations templates can be stored as Docker labels. With Autodiscovery, the A
 **Dockerfile**:
 
 ```yaml
-LABEL "com.datadoghq.ad.check_names"='[<CHECK_NAME>]'
+LABEL "com.datadoghq.ad.check_names"='[<INTEGRATION_NAME>]'
 LABEL "com.datadoghq.ad.init_configs"='[<INIT_CONFIG>]'
 LABEL "com.datadoghq.ad.instances"='[<INSTANCE_CONFIG>]'
 LABEL "com.datadoghq.ad.logs"='[<LOGS_CONFIG>]'
@@ -113,7 +113,7 @@ LABEL "com.datadoghq.ad.logs"='[<LOGS_CONFIG>]'
 
 ```yaml
 labels:
-  com.datadoghq.ad.check_names: '[<CHECK_NAME>]'
+  com.datadoghq.ad.check_names: '[<INTEGRATION_NAME>]'
   com.datadoghq.ad.init_configs: '[<INIT_CONFIG>]'
   com.datadoghq.ad.instances: '[<INSTANCE_CONFIG>]'
   com.datadoghq.ad.logs: '[<LOGS_CONFIG>]'
@@ -122,7 +122,7 @@ labels:
 **docker run command**:
 
 ```shell
--l com.datadoghq.ad.check_names='[<CHECK_NAME>]' -l com.datadoghq.ad.init_configs='[<INIT_CONFIG>]' -l com.datadoghq.ad.instances='[<INSTANCE_CONFIG>]' -l com.datadoghq.ad.logs='[<LOGS_CONFIG>]'
+-l com.datadoghq.ad.check_names='[<INTEGRATION_NAME>]' -l com.datadoghq.ad.init_configs='[<INIT_CONFIG>]' -l com.datadoghq.ad.instances='[<INSTANCE_CONFIG>]' -l com.datadoghq.ad.logs='[<LOGS_CONFIG>]'
 ```
 
 **Docker Swarm**:
@@ -136,7 +136,7 @@ services:
   project:
     image: '<IMAGE_NAME>'
     labels:
-      com.datadoghq.ad.check_names: '[<CHECK_NAME>]'
+      com.datadoghq.ad.check_names: '[<INTEGRATION_NAME>]'
       com.datadoghq.ad.init_configs: '[<INIT_CONFIG>]'
       com.datadoghq.ad.instances: '[<INSTANCE_CONFIG>]'
       com.datadoghq.ad.logs: '[<LOGS_CONFIG>]'


### PR DESCRIPTION
### What does this PR do?
Fixes the `<CHECK_NAME>` with `<INTEGRATION_NAME>` in the autodiscovery section to be consistent with the doc: https://docs.datadoghq.com/agent/autodiscovery/integrations/

### Motivation
https://github.com/DataDog/documentation/pull/6290