### PR TITLE
Estib/rehydration limits link

### DIFF
--- a/content/en/logs/archives/rehydrating.md
+++ b/content/en/logs/archives/rehydrating.md
@@ -30,7 +30,7 @@ With historical views, teams rehydrate archived log events precisely by timefram
 
 {{< img src="logs/archives/log_archives_rehydrate_reload.png" alt="Reload from Archive" responsive="true" style="width:75%;">}}
 
-<p name="limits">A historical view can contain a maximum of 300 million log events. There is no limit to how large its time range can be, but if you expect a historical view may exceed that limit, make your query filter more specific.</p>
+<p id="limits">A historical view can contain a maximum of 300 million log events. There is no limit to how large its time range can be, but if you expect a historical view may exceed that limit, make your query filter more specific.</p>
 
 ### View historical view content
 

--- a/content/en/logs/archives/rehydrating.md
+++ b/content/en/logs/archives/rehydrating.md
@@ -30,8 +30,7 @@ With historical views, teams rehydrate archived log events precisely by timefram
 
 {{< img src="logs/archives/log_archives_rehydrate_reload.png" alt="Reload from Archive" responsive="true" style="width:75%;">}}
 
-{#limits}
-A historical view can contain a maximum of 300 million log events. There is no limit to how large its time range can be, but if you expect a historical view may exceed that limit, make your query filter more specific.
+<p name="limits">A historical view can contain a maximum of 300 million log events. There is no limit to how large its time range can be, but if you expect a historical view may exceed that limit, make your query filter more specific.</p>
 
 ### View historical view content
 

--- a/content/en/logs/archives/rehydrating.md
+++ b/content/en/logs/archives/rehydrating.md
@@ -32,7 +32,7 @@ With historical views, teams rehydrate archived log events precisely by timefram
 
 #### Rehydrate by Query
 
-By creating historical views with specific queries (for example, over one or more services, url endpoints, or customer id), you can reduce the time and cost involved in rehydrating your logs. This is especially helpful when rehydrating over wider time ranges. Today you can rehydrate up to 300 million log events per historical view you create.
+By creating historical views with specific queries (for example, over one or more services, URL endpoints, or customer IDs), you can reduce the time and cost involved in rehydrating your logs. This is especially helpful when rehydrating over wider time ranges. You can rehydrate up to 300 million log events per historical view you create.
 
 ### View historical view content
 

--- a/content/en/logs/archives/rehydrating.md
+++ b/content/en/logs/archives/rehydrating.md
@@ -30,7 +30,7 @@ With historical views, teams rehydrate archived log events precisely by timefram
 
 {{< img src="logs/archives/log_archives_rehydrate_reload.png" alt="Reload from Archive" responsive="true" style="width:75%;">}}
 
-A historical view can contain a maximum of 300 million log events. There is no limit to how large its time range can be, but if you expect a historical view may exceed that limit, make your query filter more specific.
+A historical view can contain a maximum of 300 million log events. There is no limit to how large its time range can be, but if you expect a historical view may exceed that limit, make your query filter more specific. {#limits}
 
 ### View historical view content
 

--- a/content/en/logs/archives/rehydrating.md
+++ b/content/en/logs/archives/rehydrating.md
@@ -30,7 +30,9 @@ With historical views, teams rehydrate archived log events precisely by timefram
 
 {{< img src="logs/archives/log_archives_rehydrate_reload.png" alt="Reload from Archive" responsive="true" style="width:75%;">}}
 
-<p id="limits">A historical view can contain a maximum of 300 million log events. There is no limit to how large its time range can be, but if you expect a historical view may exceed that limit, make your query filter more specific.</p>
+#### Rehydrate by Query
+
+By creating historical views with specific queries (for example, over one or more services, url endpoints, or customer id), you can reduce the time and cost involved in rehydrating your logs. This is especially helpful when rehydrating over wider time ranges. Today you can rehydrate up to 300 million log events per historical view you create.
 
 ### View historical view content
 

--- a/content/en/logs/archives/rehydrating.md
+++ b/content/en/logs/archives/rehydrating.md
@@ -30,7 +30,8 @@ With historical views, teams rehydrate archived log events precisely by timefram
 
 {{< img src="logs/archives/log_archives_rehydrate_reload.png" alt="Reload from Archive" responsive="true" style="width:75%;">}}
 
-A historical view can contain a maximum of 300 million log events. There is no limit to how large its time range can be, but if you expect a historical view may exceed that limit, make your query filter more specific. {#limits}
+{#limits}
+A historical view can contain a maximum of 300 million log events. There is no limit to how large its time range can be, but if you expect a historical view may exceed that limit, make your query filter more specific.
 
 ### View historical view content
 


### PR DESCRIPTION

### What does this PR do?
adds an anchor in the rehydration page so that we can quickly link customers to the indexing count limit

### Motivation
so that we can better expose the fact that there is a limit to what count of logs can be rehydrated at once

### Preview link
https://docs-staging.datadoghq.com/estib/rehydration-limits-link/logs/archives/rehydrating/?tab=awss3#limits

### Additional Notes
thanks!
