### PR TITLE
remove pa11y errors due to wistia iframe

### DIFF
--- a/local/bin/js/pa11y.js
+++ b/local/bin/js/pa11y.js
@@ -43,7 +43,7 @@ const excludeUrls = [
 
 // some results will contain errors from third parties, or should be excluded from pa11y output.
 // If you find an error from a 3rd party, exclude it by adding the string in this array from the issue.context result
-const filterBadResults = ['bid.g.doubleclick.net', '_hj'];
+const filterBadResults = ['bid.g.doubleclick.net', '_hj', 'https://fast.wistia.com/embed/iframe_shim?domain=com'];
 
 const options = {
   pa11yConfig,


### PR DESCRIPTION
### What does this PR do?
removes pa11y error relating to wistia videos. When a page with a wista video first loads, an iframe is loaded with the video src, then wistia dynamically loads a video tag with the video src. Pa11y picks up the iframe, however, and since a `title` attribute is not present, throws an a11y error. We can remove this error from the output errors, since the iframe will not be available from the user's perspective.
