### PR TITLE
Fine tuning Algolia to avoid warning

### DIFF
--- a/local/etc/algolia/docs_datadoghq.json
+++ b/local/etc/algolia/docs_datadoghq.json
@@ -24,8 +24,6 @@
           "agent",
           "integrations",
           "dashboards",
-          "infrastructure",
-          "metrics",
           "monitors",
           "tracing",
           "logs",
@@ -47,8 +45,6 @@
         "section": [
           "agent",
           "dashboards",
-          "infrastructure",
-          "metrics",
           "integrations",
           "monitors",
           "tracing",

--- a/local/etc/algolia/docs_datadoghq_preview.json
+++ b/local/etc/algolia/docs_datadoghq_preview.json
@@ -24,8 +24,6 @@
           "agent",
           "integrations",
           "dashboards",
-          "infrastructure",
-          "metrics",
           "monitors",
           "tracing",
           "logs",
@@ -47,8 +45,6 @@
         "section": [
           "agent",
           "dashboards",
-          "infrastructure",
-          "metrics",
           "integrations",
           "monitors",
           "tracing",


### PR DESCRIPTION
### What does this PR do?

infrastructure and metrics section have no Guide/faq yet. In order to avoid 404 during algolia indexing, let's remove them for now form the conf.