### PR TITLE
Correct syntax error in bash examples

### DIFF
--- a/content/en/logs/guide/collect-multiple-logs-with-pagination.md
+++ b/content/en/logs/guide/collect-multiple-logs-with-pagination.md
@@ -28,15 +28,16 @@ Start by creating a query to retrieve your logs for a given context, for example
 
 ```bash
 curl -X POST \
-  'https://api.datadoghq.com/api/v1/logs-queries/list?api_key=<DATADOG_API_KEY>&application_key=<DATADOG_APPLICATION_KEY>' \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "limit":50,
-    "query": "*",
-    "sort": "desc",
-    "time": {
-        "from": "2019-08-07T00:00:00Z",
-        "to": "2019-08-06T00:00:00Z"
+'https://api.datadoghq.com/api/v1/logs-queries/list?api_key=<DATADOG_API_KEY>&application_key=<DATADOG_APPLICATION_KEY>' \
+-H 'content-type: application/json' \
+-d '{
+        "limit": 50,
+        "query": "*",
+        "sort": "desc",
+        "time": {
+            "from": "2019-08-07T00:00:00Z",
+            "to": "2019-08-06T00:00:00Z"
+        }
     }'
 ```
 
@@ -59,16 +60,17 @@ To retrieve the next page of logs, re-send your query, but this time with the `s
 
 ```bash
 curl -X POST \
-  'https://api.datadoghq.com/api/v1/logs-queries/list?api_key=<DATADOG_API_KEY>&application_key=<DATADOG_APPLICATION_KEY>' \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "limit": 1000,
-    "query": "*",
-    "startAt": "AAAAAAAAAAAAAAAABBBBBBBBBBBBBBCCCCCCCCCCDDDDDDDDDD",
-    "sort": "desc",
-    "time": {
-        "from": "2019-08-07T00:00:00Z",
-        "to": "2019-08-06T00:00:00Z"
+'https://api.datadoghq.com/api/v1/logs-queries/list?api_key=<DATADOG_API_KEY>&application_key=<DATADOG_APPLICATION_KEY>' \
+-H 'Content-Type: application/json' \
+-d '{
+        "limit": 1000,
+        "query": "*",
+        "startAt": "AAAAAAAAAAAAAAAABBBBBBBBBBBBBBCCCCCCCCCCDDDDDDDDDD",
+        "sort": "desc",
+        "time": {
+            "from": "2019-08-07T00:00:00Z",
+            "to": "2019-08-06T00:00:00Z"
+        }
     }'
 ```
 


### PR DESCRIPTION
### What does this PR do?
Corrects a syntax error in the two examples in our pagination doc.

### Motivation
The current example generates an error if you try to run it because it's missing the last `}` needed to close the query block. This change fixes the error and also cleans up the indentation a bit.

### Preview link

https://docs-staging.datadoghq.com/michael.sha/correct-pagination/logs/guide/collect-multiple-logs-with-pagination/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
