### PR TITLE
Removing counter wording

### DIFF
--- a/content/en/developers/dogstatsd/datagram_shell.md
+++ b/content/en/developers/dogstatsd/datagram_shell.md
@@ -31,11 +31,11 @@ This section specifies the raw datagram format for metrics, events, and service 
 
 Here are some example datagrams:
 
-* `page.views:1|c` : Increment the `page.views` counter.
+* `page.views:1|c` : Increment the `page.views` COUNT metric.
 * `fuel.level:0.5|g`: Record the fuel tank is half-empty.
 * `song.length:240|h|@0.5`: Sample the `song.length` histogram half of the time.
 * `users.uniques:1234|s`: Track unique visitors to the site.
-* `users.online:1|c|#country:china`: Increment the active users counter and tag by country of origin.
+* `users.online:1|c|#country:china`: Increment the active users COUNT metric and tag by country of origin.
 * `users.online:1|c|@0.5|#country:china`: Track active China users and use a sample rate.
 
 [1]: /developers/metrics/#naming-metrics

--- a/content/en/developers/metrics/agent_metrics_submission.md
+++ b/content/en/developers/metrics/agent_metrics_submission.md
@@ -15,13 +15,14 @@ Functions are used to submit metrics with a [custom Agent check][1]. Different f
 
 ### `monotonic_count()`
 
-This function is used to track a raw counter that always increases. The Datadog Agent calculates the delta between each submission. Samples that have a lower value than the previous sample are ignored. Lower values usually indicate the underlying raw counter has been reset. The function can be called multiple times during a check's execution.
+This function is used to track a raw COUNT metric that always increases. The Datadog Agent calculates the delta between each submission. Samples that have a lower value than the previous sample are ignored. Lower values usually indicate the underlying raw COUNT metric has been reset. The function can be called multiple times during a check's execution.
 
 For example, submitting samples 2, 3, 6, 7 sends a value of 5 (7-2) during the first check execution. Submitting the samples 10, 11 on the same `monotonic_count` sends a value of 4 (11-7) during the second check execution.
 
-**Note**: Metrics submitted with this function are stored with a `COUNT` metric type in Datadog. Each value in the stored timeseries is a delta of the counter's value between samples (not time-normalized).
+**Note**: Metrics submitted with this function are stored with a `COUNT` metric type in Datadog. Each value in the stored timeseries is a delta of the metric's value between samples (not time-normalized).
 
 Function template:
+
 ```python
 self.monotonic_count(name,value, tags=None, hostname=None, device_name=None)
 ```
@@ -38,9 +39,10 @@ self.monotonic_count(name,value, tags=None, hostname=None, device_name=None)
 
 This function submits the number of events that occurred during the check interval. It can be called multiple times during a check's execution, each sample being added to the value that is sent.
 
-**Note**: Metrics submitted with this function are stored with a `COUNT` metric type in Datadog. Each value in the stored timeseries is a delta of the counter's value between samples (not time-normalized).
+**Note**: Metrics submitted with this function are stored with a `COUNT` metric type in Datadog. Each value in the stored timeseries is a delta of the metric's value between samples (not time-normalized).
 
 Function template:
+
 ```python
 self.count(name, value, tags=None, hostname=None, device_name=None)
 ```
@@ -63,6 +65,7 @@ This function submits the value of a metric at a given timestamp. If called mult
 **Note**: Metrics submitted with this function are stored with a `GAUGE` metric type in Datadog.
 
 Function template:
+
 ```python
 self.gauge(name=, value, tags=None, hostname=None, device_name=None)
 ```
@@ -80,11 +83,12 @@ self.gauge(name=, value, tags=None, hostname=None, device_name=None)
 
 ### `rate()`
 
-This function submits the sampled raw value of your counter. The Datadog Agent calculates the delta of that counter value between two submission, and divides it by the submission interval to get the rate. This function should only be called once during a check, otherwise it throws away any value that is less than a previously submitted value.
+This function submits the sampled raw value of your RATE metric. The Datadog Agent calculates the delta of that metric's value between two submission, and divides it by the submission interval to get the rate. This function should only be called once during a check, otherwise it throws away any value that is less than a previously submitted value.
 
-**Note**: Metrics submitted with this function are stored as a `GAUGE` metric type in Datadog. Each value in the stored timeseries is a time-normalized delta of the counter's value between samples.
+**Note**: Metrics submitted with this function are stored as a `GAUGE` metric type in Datadog. Each value in the stored timeseries is a time-normalized delta of the metric's value between samples.
 
 Function template:
+
 ```python
 self.rate(name, value, tags=None, hostname=None, device_name=None)
 ```
@@ -108,6 +112,7 @@ This function submits the sample of a histogram metric that occurred during the 
 **Note**: All metric aggregation produced are stored as a `GAUGE` metric type in Datadog, except the `<METRIC_NAME>.count` that is stored as a `RATE` metric type in Datadog.
 
 Function template:
+
 ```python
 self.histogram(name, value, tags=None, hostname=None, device_name=None)
 ```
@@ -194,7 +199,7 @@ Follow the steps below to create a [custom Agent check][2] that sends all metric
 4. [Restart the Agent][4].
 5. Validate your custom check is running correctly with the [Agent's status subcommand][5]. Look for `metrics_example` under the Checks section:
 
-    ```
+    ```text
     =========
     Collector
     =========

--- a/content/en/developers/metrics/dogstatsd_metrics_submission.md
+++ b/content/en/developers/metrics/dogstatsd_metrics_submission.md
@@ -34,11 +34,11 @@ After [installing DogStatsD][1], the functions below are available for submittin
 
 ### COUNT
 
-| Method                                                        | Description                                               | Storage type                                                                                                                                            |
-|---------------------------------------------------------------|-----------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `increment(<METRIC_NAME>, <SAMPLE_RATE>, <TAGS>)`             | Used to increment a COUNT metric.                         | Stored as a `RATE` type in Datadog. Each value in the stored timeseries is a time-normalized delta of the counter's value over the StatsD flush period. |
-| `decrement(<METRIC_NAME>, <SAMPLE_RATE>, <TAGS>)`             | Used to decrement a COUNT metric.                         | Stored as a `RATE` type in Datadog. Each value in the stored timeseries is a time-normalized delta of the counter's value over the StatsD flush period. |
-| `count(<METRIC_NAME>, <METRIC_VALUE>, <SAMPLE_RATE>, <TAGS>)` | Use to increment a COUNT metric from an arbitrary `Value` | Stored as a `RATE` type in Datadog. Each value in the stored timeseries is a time-normalized delta of the counter's value over the StatsD flush period. |
+| Method                                                        | Description                                               | Storage type                                                                                                                                           |
+|---------------------------------------------------------------|-----------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `increment(<METRIC_NAME>, <SAMPLE_RATE>, <TAGS>)`             | Used to increment a COUNT metric.                         | Stored as a `RATE` type in Datadog. Each value in the stored timeseries is a time-normalized delta of the metric's value over the StatsD flush period. |
+| `decrement(<METRIC_NAME>, <SAMPLE_RATE>, <TAGS>)`             | Used to decrement a COUNT metric.                         | Stored as a `RATE` type in Datadog. Each value in the stored timeseries is a time-normalized delta of the metric's value over the StatsD flush period. |
+| `count(<METRIC_NAME>, <METRIC_VALUE>, <SAMPLE_RATE>, <TAGS>)` | Use to increment a COUNT metric from an arbitrary `Value` | Stored as a `RATE` type in Datadog. Each value in the stored timeseries is a time-normalized delta of the metric's value over the StatsD flush period. |
 
 **Note**: `COUNT` type metrics can show a decimal value within Datadog since they are normalized over the flush interval to report per-second units.
 
@@ -815,8 +815,8 @@ DogStatsD treats `TIMER` as a `HISTOGRAM` metric. Whether you use the `TIMER` or
 
 ### DISTRIBUTION
 
-| Method                                                | Datadog Storage type                                                                                          |
-|-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
+| Method                                                | Datadog Storage type                                                                                         |
+|-------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
 | `distribution(<METRIC_NAME>, <METRIC_VALUE>, <TAGS>)` | Stored as a `DISTRIBUTION` type in Datadog. See the dedicated [Distribution documentation][9] to learn more. |
 
 #### Code examples
@@ -989,7 +989,7 @@ Before sending a metric to Datadog, DogStatsD uses the `<SAMPLE_RATE>` to correc
 | `COUNT`     | Values received are multiplied by (`1/<SAMPLE_RATE>`). It's reasonable to assume that for one datapoint received, `1/<SAMPLE_RATE>` were actually sampled with the same value. |
 | `GAUGE`     | No correction. The value received is kept as is.                                                                                                                               |
 | `SET`       | No correction. The value received is kept as is.                                                                                                                               |
-| `HISTOGRAM` | The `histogram.count` statistic is a counter metric, and receives the correction outlined above. Other statistics are gauge metrics and aren't "corrected".                    |
+| `HISTOGRAM` | The `histogram.count` statistic is a COUNT metric, and receives the correction outlined above. Other statistics are gauge metrics and aren't "corrected".                      |
 
 #### Code examples
 


### PR DESCRIPTION
### What does this PR do?
Removes counter wording and replaces it with the `COUNT metric` wording

### Motivation

Avoiding confusion

### Preview link
