### PR TITLE
Add note about Docker enhancement

### DIFF
--- a/content/en/logs/guide/docker-logs-collection-troubleshooting-guide.md
+++ b/content/en/logs/guide/docker-logs-collection-troubleshooting-guide.md
@@ -88,7 +88,7 @@ This status means that the Logs Agent is running but it hasn't started collectin
 
 ### Docker Daemon started after the Host Agent
 
-If the Docker Daemon starts while the host Agent is already running, restart the Agent to retrigger container collection. This troubleshooting tip only applies to Agent versions prior to 7.17.
+For Agent version prior to 7.17, if the Docker Daemon starts while the host Agent is already running, restart the Agent to retrigger container collection. 
 
 ### You didn't mount the docker socket when you started the Container Agent
 

--- a/content/en/logs/guide/docker-logs-collection-troubleshooting-guide.md
+++ b/content/en/logs/guide/docker-logs-collection-troubleshooting-guide.md
@@ -88,7 +88,7 @@ This status means that the Logs Agent is running but it hasn't started collectin
 
 ### Docker Daemon started after the Host Agent
 
-If the Docker Daemon starts while the host Agent is already running, restart the Agent to retrigger container collection.
+If the Docker Daemon starts while the host Agent is already running, restart the Agent to retrigger container collection. This troubleshooting tip only applies to Agent versions prior to 7.17.
 
 ### You didn't mount the docker socket when you started the Container Agent
 


### PR DESCRIPTION
### What does this PR do?
Adds a note about a feature enhancement that makes the troubleshooting step "Docker Daemon started after the Host Agent" unnecessary.

### Motivation
The bug that this step is referring to will be fixed with this PR: https://github.com/DataDog/datadog-agent/pull/4536 for Agent 7.17+

### Preview link
https://docs-staging.datadoghq.com/michael.sha/docker-retry-update/logs/guide/docker-logs-collection-troubleshooting-guide/#docker-daemon-started-after-the-host-agent

### Additional Notes
<!-- Anything else we should know when reviewing?-->
