### PR TITLE
Removes outdated instructions for istio

### DIFF
--- a/content/en/tracing/setup/istio.md
+++ b/content/en/tracing/setup/istio.md
@@ -26,59 +26,6 @@ Datadog APM is available for Istio v1.1.3+ on Kubernetes clusters.
 2. [Make sure APM is enabled for your Agent][2].
 3. Uncomment the `hostPort` setting so that Istio sidecars can connect to the Agent and submit traces.
 
-**Note**: The Agent pods fails to start up if Istio's automatic sidecar injection is enabled on the namespace that Datadog Agent runs in. To avoid this:
-
-- [Disable Sidecar Injection for the Datadog Agent](#disable-sidecar-injection-for-the-datadog-agent)
-- [Create a Headless Service for the Datadog Agent](#create-a-headless-service-for-the-datadog-agent)
-
-#### Disable Sidecar Injection for the Datadog Agent
-
-Add the `sidecar.istio.io/inject: "false"` annotation to the `datadog-agent` daemonset:
-
-```yaml
-...
-spec:
-  ...
-  template:
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
-    ...
-
-```
-
-This can also be done with the `kubectl patch` command.
-
-```shell
-kubectl patch daemonset datadog-agent -p '{"spec":{"template":{"metadata":{"annotations":{"sidecar.istio.io/inject":"false"}}}}}'
-```
-
-#### Create a Headless Service for the Datadog Agent
-
-Create a headless service for the Datadog Agent using the YAML configuration specified below.
-
-```yaml
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog-agent
-  name: datadog-agent
-spec:
-  clusterIP: None
-  ports:
-  - name: dogstatsdport
-    port: 8125
-    protocol: UDP
-    targetPort: 8125
-  - name: traceport
-    port: 8126
-    protocol: TCP
-    targetPort: 8126
-  selector:
-    app: datadog-agent
-```
-
 ### Istio Configuration and Installation
 
 To enable Datadog APM, a [custom Istio installation][3] is required to add two extra options before Istio is installed. These options are passed at the final `helm template` or `helm install` step:

--- a/content/fr/tracing/setup/istio.md
+++ b/content/fr/tracing/setup/istio.md
@@ -25,33 +25,6 @@ L'APM Datadog est disponible pour Istio 1.1.3 et ultérieur sur les clusters Kub
 2. [Veillez à ce que l'APM soit activé pour votre Agent][2].
 3. Supprimez la mise en commentaire du paramètre `hostPort` pour que les sidecars Istio puissent se connecter à l'Agent et envoyer des traces.
 
-**Remarque** : les pods de l'Agent ne sont pas en mesure de démarrer si l'injection automatique de sidecar d'Istio est activée sur l'espace de nommage sur lequel l'Agent Datadog est exécuté. Pour éviter cela :
-
-- [Désactivez l'injection de sidecar pour l'Agent Datadog.](#disable-sidecar-injection-for-the-datadog-agent)
-- [Créez un service headless pour l'Agent Datadog.](#create-a-headless-service-for-the-datadog-agent)
-
-#### Désactiver l'injection de sidecar pour l'Agent Datadog
-
-Ajoutez l'annotation `sidecar.istio.io/inject: "false"` au daemonset `datadog-agent` :
-
-```yaml
-...
-spec:
-  ...
-  template:
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
-    ...
-
-```
-
-Vous pouvez également utiliser la commande `kubectl patch`.
-
-```shell
-kubectl patch daemonset datadog-agent -p '{"spec":{"template":{"metadata":{"annotations":{"sidecar.istio.io/inject":"false"}}}}}'
-```
-
 #### Créer un service headless pour l'Agent Datadog
 
 Créez un service headless pour l'Agent Datadog avec la configuration YAML spécifiée ci-dessous.


### PR DESCRIPTION
### What does this PR do?
Removes outdated parts of the setup instructions for istio.
These were applicable at the time, but now can cause errors when users apply them.

### Motivation
Problems reported to support, resolved by undoing those steps.

### Preview link
https://docs-staging.datadoghq.com/cgilmour/istio-doc-update/tracing/setup/istio/

### Additional Notes
Removed from FR translation also
