### PR TITLE
Add distribution metrics info in agent status command

### DIFF
--- a/content/en/agent/guide/agent-status-page.md
+++ b/content/en/agent/guide/agent-status-page.md
@@ -228,17 +228,21 @@ This section displays information on the Agent's aggregator, for example:
   Series Flushed: 273
   Service Check: 20
   Service Checks Flushed: 20
+  Sketches Flushed: 8
+  Checks Histogram Bucket Metric Sample: 24
 ```
 
 Terms and descriptions:
 
-| Term                    | Description                                                                              |
-|-------------------------|------------------------------------------------------------------------------------------|
-| Checks Metric Sample    | The total number of metrics sent from the checks to the aggregator.                      |
-| Dogstatsd Metric Sample | The total number of metrics sent from the DogStatsD server to the aggregator.            |
-| Event                   | The total number of events sent to the aggregator.                                       |
-| Service Check           | The total number of service checks sent to the aggregator.                               |
-| Flush                   | The number of times aggregated metrics were flushed to the forwarder to send to Datadog. |
+| Term                                         | Description                                                                                           |
+|----------------------------------------------|-------------------------------------------------------------------------------------------------------|
+| Checks Metric Sample                         | The total number of metrics sent from the checks to the aggregator.                                   |
+| Dogstatsd Metric Sample                      | The total number of metrics sent from the DogStatsD server to the aggregator.                         |
+| Event                                        | The total number of events sent to the aggregator.                                                    |
+| Service Check                                | The total number of service checks sent to the aggregator.                                            |
+| Flush                                        | The number of times aggregated metrics were flushed to the forwarder to send to Datadog.              |
+| Sketches Flushed                             | The number of times aggregated distribution metrics were flushed to the forwarder to send to Datadog. |
+| Checks Histogram Bucket Metric Sample        | The number of histogram bucket metrics sent from the checks to the aggregator.                        |
 
 ## DogStatsD
 


### PR DESCRIPTION
### What does this PR do?

Document `Sketches Flushed` and `Checks Histogram Bucket Metric Sample` in the `agent status` command output

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
PR needs to be merged once Agent 7.17/6.17 is released
