### PR TITLE
shortening metrics entry in api

### DIFF
--- a/content/en/api/metrics/metrics.md
+++ b/content/en/api/metrics/metrics.md
@@ -7,17 +7,11 @@ external_redirect: /api/#metrics
 
 ## Metrics
 
-The metrics end-point allows you to:
+The metrics endpoint allows you to:
 
 * Post metrics data so it can be graphed on Datadog's dashboards
 * Query metrics from any time period
 
-As occurs within the Datadog UI, a graph can only contain a set number of points and as the timeframe over which a metric is viewed increases, aggregation between points occurs to stay below that set number.
+Note that a graph can only contain a set number of points, and as the timeframe over which a metric is viewed increases, aggregation between points occurs to stay below that set number.
 
-Thus, if you are querying for larger timeframes of data, the points returned is more aggregated. The max granularity within Datadog is one point per second, so if you had submitted points at that interval and requested a very small interval from the query API (in this case, probably less than 100 seconds), you could end up getting all of those points back. Otherwise, Datadog algorithm tries to return about 150 points per any given time window, so you'll see coarser and coarser granularity as the amount of time requested increases. We do this time aggregation via averages.
-
-We store metric points at the 1 second resolution, but we'd prefer if you only
-submitted points every 15 seconds. Any metrics with fractions of a second timestamps gets rounded to the nearest second, and if any points have the same timestamp, the latest point overwrites the previous ones.
-
-We have a soft limit of 100 timeseries per host, where a timeseries is
-defined as a unique combination of metric name and tag.
+Datadog has a soft limit of 100 timeseries per host, where a timeseries is defined as a unique combination of metric name and tag.

--- a/content/en/metrics/introduction.md
+++ b/content/en/metrics/introduction.md
@@ -33,6 +33,8 @@ A sequence of data points is stored as a time series:
 [  7.06,  22:12:00 ]
 ```
 
+Datadog stores metric points at a 1 second resolution. However, it is recommended that you only submit points every 15 seconds. Any metrics with fractions of a second timestamps are rounded to the nearest second. If any points have the same timestamp, the latest point overwrites the previous ones.
+
 ### Query
 
 A query extracts a stored time series and reports the data points over a defined span of time. This is a graphed time series over 15 minutes:
@@ -46,6 +48,8 @@ When the selected time span is small, all data points are displayed. However, as
 Datadog uses time aggregation to solve the display problem. Data points are placed into buckets of time with preset start and end points. For example, when examining four hours, data points are combined into five-minute buckets. Combining data points in this way is referred to as a **rollup**:
 
 {{< img src="graphing/metrics/introduction/time-aggregation.png" alt="Time Aggregation" >}}
+
+Datadog tries to return about 150 points for any given time window. Granularity becomes coarser as the amount of time requested increases. Time aggregation is done through averages.
 
 ### Combining time series
 


### PR DESCRIPTION
### What does this PR do?
takes some of the info from https://docs.datadoghq.com/api/?lang=bash#metrics and puts it into https://docs.datadoghq.com/metrics/introduction/ because that entry is really long and it makes it look like the lack of sample code is a mistake

### Motivation
aesthetic pleasure

### Preview link

https://docs-staging.datadoghq.com/cswatt/metrics-api-fix>/api/?lang=bash#metrics
https://docs-staging.datadoghq.com/cswatt/metrics-api-fix>/metrics/introduction

