### PR TITLE
[Logs] Reserved attribute: default facets + minor wording fix

### DIFF
--- a/content/en/logs/explorer/_index.md
+++ b/content/en/logs/explorer/_index.md
@@ -171,7 +171,11 @@ Find out more in the [Log Patterns section][1]
 
 After being processed with the help of pipelines and processors, your logs attributes can be indexed as facets or measures in order to be accessible for your [context](#context) creation and [Log Analytics][3].
 
-Note: To leverage the most out of your Log explorer view, make sure your logs attributes follow [Datadog attribute naming convention][4].
+**Note**: 
+
+* To leverage the most out of your Log explorer view, make sure your logs attributes follow [Datadog attribute naming convention][4].
+
+* Facets on [Reserved Attributes][5] are available by default.
 
 {{< tabs >}}
 {{% tab "Facets" %}}
@@ -223,3 +227,4 @@ Each measure has its own unit that is then used for display in the Log Explorer 
 [2]: /logs/explorer/saved_views
 [3]: /logs/explorer/analytics
 [4]: /logs/processing/attributes_naming_convention
+[5]: /logs/processing/#reserved-attributes

--- a/content/en/logs/processing/_index.md
+++ b/content/en/logs/processing/_index.md
@@ -69,7 +69,7 @@ If you want to learn more about pure parsing possibilities of the Datadog applic
 
 ## Reserved attributes
 
-If your logs are formatted as JSON, be aware that some attributes are reserved for use by Datadog:
+If your logs are formatted as JSON, be aware that some attributes are reserved for use by Datadog and are faceted by default:
 
 ### *date* attribute
 
@@ -96,7 +96,7 @@ The recognized date formats are: <a href="https://www.iso.org/iso-8601-date-and-
 
 By default, Datadog ingests the message value as the body of the log entry. That value is then highlighted and displayed in the [logstream][13], where it is indexed for [full text search][14].
 
-**Note**: If you send a log formated as JSON with a `message` attribute which contain a JSON object, this JSON object is interpreted as a *string* and *NOT* expended. Use a [Log Grok processor][4] to parse this JSON object or a [Log remapper processor][15] to remap this JSON object to a non-reserved attribute.
+**Note**: If you send a log formatted as JSON with a `message` attribute which contains a JSON object, this JSON object is interpreted as a *string* and *NOT* expanded. Use a [Log Grok processor][4] to parse this JSON object or a [Log remapper processor][15] to remap this JSON object to a non-reserved attribute.
 
 ### *status* attribute
 


### PR DESCRIPTION
### What does this PR do?
Adds the info of default facets on reserved attributes + minor wording fix

### Motivation
Users may wonder whether or not to add facets for reserved attributes in log pipeline.
It is not needed, as they are defined by default.

### Preview link
https://docs-staging.datadoghq.com/gusai/logs/res-attr/logs/processing/#reserved-attributes
https://docs-staging.datadoghq.com/gusai/logs/res-attr/logs/explorer/#setup