### PR TITLE
Scrolling on top only if there is no hash

### DIFF
--- a/src/scripts/datadog-docs.js
+++ b/src/scripts/datadog-docs.js
@@ -376,8 +376,8 @@ $(document).ready(function () {
                             pagebtns[i].classList[current_page === page ? 'add' : 'remove']('active');
                         }
 
-                        // scroll to top
-                        if (!$('.api').length) {
+                        // scroll to top only if there is no hash
+                        if (!window.location.hash) {
                             $("html, body").scrollTop(0);
                         }
                     }


### PR DESCRIPTION
### What does this PR do?

Makes the doc scroll on top only if there is no hash in the URL

### Motivation

Fix glitchy behaviour where if the connection was too slow.. the page was jumping on top anyway

### Preview link

https://docs-staging.datadoghq.com/gus/scroll-fix-2/integrations/amazon_web_services/?tab=allpermissions#collecting-logs-from-s3-buckets