### PR TITLE
[APM] Update .NET Setup instructions

### DIFF
--- a/content/en/tracing/setup/dotnet.md
+++ b/content/en/tracing/setup/dotnet.md
@@ -101,10 +101,14 @@ curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v<TRACER_VE
 | sudo tar xzf - -C /opt/datadog
 ```
 
-For Alpine Linux you also need to install `libc6-compat`
+For Alpine Linux, you also need to install the following packages:
 
 ```bash
+# All Alpine versions
 apk add libc6-compat
+
+# Alpine versions 3.9 and higher
+apk add gcompat
 ```
 
 - Native library: deployed into `/opt/datadog/` by default, or manually if using the `tar` package.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR updates the .NET Setup instructions to clarify that certain Alpine Linux versions require an additional package to be installed on the machine for the .NET APM to work.

### Motivation
Customer feedback that tracing wasn't working.

### Preview link
[Tracing .NET Applications](https://docs-staging.datadoghq.com/zach.montoya/dotnet-tracer-alpine-setup/tracing/setup/dotnet/?tab=netcoreonlinux#installation)

### Additional Notes
None.
