### PR TITLE
Truncate too large logs in HTTP API

### DIFF
--- a/content/en/api/logs/logs.md
+++ b/content/en/api/logs/logs.md
@@ -15,6 +15,11 @@ Send your logs to your Datadog platform over HTTP. Limits per HTTP request are:
 * Maximum size for a single log: 256kB
 * Maximum array size if sending multiple logs in an array: 500 entries
 
+All logs exceeding 256KB are accepted and truncated by the platform:
+
+* For a single log request, the API truncates the log at 256KB and returns a 2xx.
+* For a multi-logs request, the API processes all the logs, truncates the larger logs at 256KB, and returns a 2xx.
+
 **Note**: If you are in the Datadog EU site (`app.datadoghq.eu`), the HTTP log endpoint is: `http-intake.logs.datadoghq.eu`.
 
 [1]: /help

--- a/content/en/api/logs/logs.md
+++ b/content/en/api/logs/logs.md
@@ -18,7 +18,7 @@ Send your logs to your Datadog platform over HTTP. Limits per HTTP request are:
 All logs exceeding 256KB are accepted and truncated by the platform:
 
 * For a single log request, the API truncates the log at 256KB and returns a 2xx.
-* For a multi-logs request, the API processes all the logs, truncates the larger logs at 256KB, and returns a 2xx.
+* For a multi-logs request, the API processes all logs, truncates only logs larger than 256KB, and returns a 2xx.
 
 **Note**: If you are in the Datadog EU site (`app.datadoghq.eu`), the HTTP log endpoint is: `http-intake.logs.datadoghq.eu`.
 

--- a/content/en/api/logs/logs.md
+++ b/content/en/api/logs/logs.md
@@ -15,7 +15,7 @@ Send your logs to your Datadog platform over HTTP. Limits per HTTP request are:
 * Maximum size for a single log: 256kB
 * Maximum array size if sending multiple logs in an array: 500 entries
 
-All logs exceeding 256KB are accepted and truncated by the platform:
+Any log exceeding 256KB is accepted and truncated by Datadog:
 
 * For a single log request, the API truncates the log at 256KB and returns a 2xx.
 * For a multi-logs request, the API processes all logs, truncates only logs larger than 256KB, and returns a 2xx.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Documented the behaviour of the HTTP API regarding too large messages. In the past, we used to reject the whole request, now we accept the request and truncate every single message which is too large.

### Motivation
<!-- What inspired you to submit this pull request?-->
Make sure customers understand the impact of the limits we have.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ajacquemot/logs_http_large_log_trunc

### Additional Notes
<!-- Anything else we should know when reviewing?-->
