### PR TITLE
Replace crit loglevel by critical

### DIFF
--- a/content/en/agent/troubleshooting/debug_mode.md
+++ b/content/en/agent/troubleshooting/debug_mode.md
@@ -108,15 +108,15 @@ Or the container can be restarted.
 
 The following Agent log levels are available for `log_level` or `DD_LOG_LEVEL`:
 
-| Option  | Critical logs | Error logs | Warn logs | Info logs | Debug logs | Trace logs |
-|---------|---------------|------------|-----------|-----------|------------|------------|
-| `OFF`   |               |            |           |           |            |            |
-| `CRIT`  | {{< X >}}     |            |           |           |            |            |
-| `ERROR` | {{< X >}}     | {{< X >}}  |           |           |            |            |
-| `WARN`  | {{< X >}}     | {{< X >}}  | {{< X >}} |           |            |            |
-| `INFO`  | {{< X >}}     | {{< X >}}  | {{< X >}} | {{< X >}} |            |            |
-| `DEBUG` | {{< X >}}     | {{< X >}}  | {{< X >}} | {{< X >}} | {{< X >}}  |            |
-| `TRACE` | {{< X >}}     | {{< X >}}  | {{< X >}} | {{< X >}} | {{< X >}}  | {{< X >}}  |
+| Option     | Critical logs | Error logs | Warn logs | Info logs | Debug logs | Trace logs |
+|------------|---------------|------------|-----------|-----------|------------|------------|
+| `OFF`      |               |            |           |           |            |            |
+| `CRITICAL` | {{< X >}}     |            |           |           |            |            |
+| `ERROR`    | {{< X >}}     | {{< X >}}  |           |           |            |            |
+| `WARN`     | {{< X >}}     | {{< X >}}  | {{< X >}} |           |            |            |
+| `INFO`     | {{< X >}}     | {{< X >}}  | {{< X >}} | {{< X >}} |            |            |
+| `DEBUG`    | {{< X >}}     | {{< X >}}  | {{< X >}} | {{< X >}} | {{< X >}}  |            |
+| `TRACE`    | {{< X >}}     | {{< X >}}  | {{< X >}} | {{< X >}} | {{< X >}}  | {{< X >}}  |
 
 ## Further Reading
 


### PR DESCRIPTION
We are using seelog thus crit is not supported. As per
https://github.com/cihub/seelog/blob/master/common_loglevel.go#L42-L50
it shall be critical.


### What does this PR do?
Replace `crit` by `critical` in the log level documentation table.

### Motivation
Using the `crit` log level make the agent not able to start. Whereas
using `critical` works as expected.

### Preview link
https://docs-staging.datadoghq.com/prognant/fix-agent-log-level/agent/troubleshooting/debug_mode/?tab=agentv6v7#agent-log-level

### Additional Notes
N/A