### PR TITLE
Adjust agent log level documentation

### DIFF
--- a/content/en/agent/troubleshooting/debug_mode.md
+++ b/content/en/agent/troubleshooting/debug_mode.md
@@ -110,13 +110,15 @@ The following Agent log levels are available for `log_level` or `DD_LOG_LEVEL`:
 
 | Option     | Critical logs | Error logs | Warn logs | Info logs | Debug logs | Trace logs |
 |------------|---------------|------------|-----------|-----------|------------|------------|
-| `OFF`      |               |            |           |           |            |            |
-| `CRITICAL` | {{< X >}}     |            |           |           |            |            |
-| `ERROR`    | {{< X >}}     | {{< X >}}  |           |           |            |            |
-| `WARN`     | {{< X >}}     | {{< X >}}  | {{< X >}} |           |            |            |
-| `INFO`     | {{< X >}}     | {{< X >}}  | {{< X >}} | {{< X >}} |            |            |
-| `DEBUG`    | {{< X >}}     | {{< X >}}  | {{< X >}} | {{< X >}} | {{< X >}}  |            |
-| `TRACE`    | {{< X >}}     | {{< X >}}  | {{< X >}} | {{< X >}} | {{< X >}}  | {{< X >}}  |
+| `'OFF'`      |               |            |           |           |            |            |
+| `'CRITICAL'` | {{< X >}}     |            |           |           |            |            |
+| `'ERROR'`    | {{< X >}}     | {{< X >}}  |           |           |            |            |
+| `'WARN'`     | {{< X >}}     | {{< X >}}  | {{< X >}} |           |            |            |
+| `'INFO'`     | {{< X >}}     | {{< X >}}  | {{< X >}} | {{< X >}} |            |            |
+| `'DEBUG'`    | {{< X >}}     | {{< X >}}  | {{< X >}} | {{< X >}} | {{< X >}}  |            |
+| `'TRACE'`    | {{< X >}}     | {{< X >}}  | {{< X >}} | {{< X >}} | {{< X >}}  | {{< X >}}  |
+
+**Note**: When setting the log level to `'OFF'` in the configuration file quotes are mandatory to prevent the value for being improperly parsed. Quotes are optional for other log levels.
 
 ## Further Reading
 


### PR DESCRIPTION
When setting the log level to off in the configuration file it shall be
quoted to prevent it from being parsed as a boolean (as per yaml 1.1
specification).

### What does this PR do?
Adjust agent log level documentation to say that the `'off'` log level shall be quoted when used.

### Motivation
If the agent is configured with log_level: off, it won't even start, and if using log_level: 'off' it works as expected.

### Preview link
https://docs-staging.datadoghq.com/prognant/improve-agent-log-level-documentation/agent/troubleshooting/debug_mode/?tab=agentv6v7

### Additional Notes
Upcoming PR in datadog-agent ./pkg/config/config_template.yaml to add the same informations.
