### PR TITLE
Addings details on feature variables from tests

### DIFF
--- a/content/en/synthetics/settings/_index.md
+++ b/content/en/synthetics/settings/_index.md
@@ -49,7 +49,7 @@ Choose the type of variable you want to create:
 This feature is in private beta, <a href="/help">contact Datadog support</a> to turn on this feature for your account.
 </div>
 
-You can create variables using parsed response headers and body from your existing HTTP tests. Variables are updated at the frequency of the test it is parsing from. 
+You can create variables from your existing HTTP tests by parsing its response headers or body. Variables are updated with the same frequency as the test it's coming from:
 
 1. Enter a **Variable Name**. Your variable name can only use uppercase letters, numbers, and underscores.
 2. Pick the test you want to extract your variable from.

--- a/content/en/synthetics/settings/_index.md
+++ b/content/en/synthetics/settings/_index.md
@@ -49,6 +49,8 @@ Choose the type of variable you want to create:
 This feature is in private beta, <a href="/help">contact Datadog support</a> to turn on this feature for your account.
 </div>
 
+You can create variables using parsed response headers and body from your existing HTTP tests. Variables are updated at the frequency of the test it is parsing from. 
+
 1. Enter a **Variable Name**. Your variable name can only use uppercase letters, numbers, and underscores.
 2. Pick the test you want to extract your variable from.
 3. Decide whether to make your variable secure. Securing your variable means that only a subset of chosen users in your organization will be able to access them.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR adds details about one of the new Synthetics features: the ability to create variables from HTTP test responses.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/margot.lepizzera/variables_from_tests/synthetics/settings/?tab=createfromhttptest#global-variables
### Additional Notes
<!-- Anything else we should know when reviewing?-->
