### PR TITLE
Change .NET Tracer minimum ASP.NET WebApi version from 5.2 to 5.1

### DIFF
--- a/content/en/tracing/setup/dotnet.md
+++ b/content/en/tracing/setup/dotnet.md
@@ -289,7 +289,7 @@ The .NET Tracer can instrument the following libraries automatically:
 | Framework or library           | NuGet package name                       | Package versions | Integration Name     |
 |--------------------------------|------------------------------------------|------------------|----------------------|
 | ASP.NET MVC                    | `Microsoft.AspNet.Mvc`                   | 4.0+             | `AspNetMvc`          |
-| ASP.NET Web API 2              | `Microsoft.AspNet.WebApi.Core`           | 5.2+             | `AspNetWebApi2`      |
+| ASP.NET Web API 2              | `Microsoft.AspNet.WebApi.Core`           | 5.1+             | `AspNetWebApi2`      |
 | ASP.NET Core MVC               | `Microsoft.AspNetCore.Mvc.Core`          | 2.0+             | `AspNetCoreMvc2`     |
 | ASP.NET Web Forms              | built-in                                 |                  | `AspNet`             |
 | WCF                            | built-in                                 |                  | `Wcf`                |


### PR DESCRIPTION
### What does this PR do?
Changes the minimum supported version of ASP.NET Web API for the .NET Tracer.

### Motivation
Added support for Web API 5.1 in .NET Tracer

### Preview link
https://docs-staging.datadoghq.com/bob/min-webapi-version/tracing/setup/dotnet?tab=netframeworkonwindows#integrations

