### PR TITLE
Add docs to system-probe k8s config instructions

### DIFF
--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -113,6 +113,9 @@ spec:
           - {name: DD_HEALTH_PORT, value: "5555"}
           - {name: DD_PROCESS_AGENT_ENABLED, value: "true"}
           - {name: DD_SYSTEM_PROBE_ENABLED, value: "true"}
+          # Setting DD_SYSTEM_PROBE_EXTERNAL to true runs the system probe agent
+          # in a dedicated container (the recommended configuration) instead of the 
+          # Datadog agent container
           - {name: DD_SYSTEM_PROBE_EXTERNAL, value: "true"}
           - {name: DD_SYSPROBE_SOCKET, value: "/var/run/s6/sysprobe.sock"}
           - name: DD_KUBERNETES_KUBELET_HOST


### PR DESCRIPTION
### What does this PR do?
Add docs: "Setting DD_SYSTEM_PROBE_EXTERNAL to true runs the system probe agent in a dedicated container (the recommended configuration) instead of the Datadog agent container" to Kubernetes installation instructions in response to customer confusion.

### Motivation
<!-- What inspired you to submit this pull request?-->
Customer confusion: https://github.com/DataDog/documentation/issues/6391 

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/DataDog/documentation/content/en/network_performance_monitoring/installation.md

### Additional Notes
<!-- Anything else we should know when reviewing?-->
