### PR TITLE
Tweaks about secure global variables

### DIFF
--- a/content/en/synthetics/settings/_index.md
+++ b/content/en/synthetics/settings/_index.md
@@ -24,6 +24,8 @@ On the [Synthetics settings page][1], you can adjust the following settings:
 - [Default settings](#default-settings)
     - [Default Locations](#default-locations)
     - [APM integration for Browser Tests](#apm-integration-for-browser-tests)
+    
+Only [Admin and Standard users][3] can access Synthetics `Settings` page.
 
 ## Global Variables
 
@@ -35,7 +37,7 @@ Choose the type of variable you want to create:
 
 1. Enter a **Variable Name**. Your variable name can only use uppercase letters, numbers, and underscores.
 2. Enter the given **Value**.
-3. Decide whether to make your variable secure. Securing your variable means that only a subset of chosen users in your organization will be able to access them.
+3. Decide whether to make your variable secure. Securing your variable will obfuscate its value for all users on your test results.
 4. Optional: select **Tags** to associate to your variable.
 5. Optional: enter a **Description** for your variable.
 
@@ -53,7 +55,7 @@ You can create variables from your existing HTTP tests by parsing its response h
 
 1. Enter a **Variable Name**. Your variable name can only use uppercase letters, numbers, and underscores.
 2. Pick the test you want to extract your variable from.
-3. Decide whether to make your variable secure. Securing your variable means that only a subset of chosen users in your organization will be able to access them.
+3. Decide whether to make your variable secure. Securing your variable will obfuscate its value for all users on your test results.
 4. Optional: select **Tags** to associate to your variable.
 5. Optional: enter a **Description** for your variable.
 6. Decide whether to extract your variable from the response headers, or from the response body.
@@ -86,5 +88,6 @@ If the endpoint is being traced and whitelisted, your browser test results are t
 {{< partial name="whats-next/whats-next.html" >}}
 [1]: https://app.datadoghq.com/synthetics/settings
 [2]: /synthetics/private_locations
-[3]: /synthetics/api_tests#use-global-variables
-[4]: /synthetics/browser_tests#use-global-variables
+[3]: /account_management/users/default_roles/
+[4]: /synthetics/api_tests#use-global-variables
+[5]: /synthetics/browser_tests#use-global-variables

--- a/content/en/synthetics/settings/_index.md
+++ b/content/en/synthetics/settings/_index.md
@@ -19,12 +19,12 @@ further_reading:
 
 On the [Synthetics settings page][1], you can adjust the following settings:
 
-- [Global Variables](#global-variables)
-- [Private Locations][2]
-- [Default settings](#default-settings)
-    - [Default Locations](#default-locations)
-    - [APM integration for Browser Tests](#apm-integration-for-browser-tests)
-    
+* [Global Variables](#global-variables)
+* [Private Locations][2]
+* [Default settings](#default-settings)
+  * [Default Locations](#default-locations)
+  * [APM integration for Browser Tests](#apm-integration-for-browser-tests)
+
 Only [Admin and Standard users][3] can access Synthetics `Settings` page.
 
 ## Global Variables
@@ -86,8 +86,8 @@ If the endpoint is being traced and whitelisted, your browser test results are t
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
 [1]: https://app.datadoghq.com/synthetics/settings
 [2]: /synthetics/private_locations
 [3]: /account_management/users/default_roles/
 [4]: /synthetics/api_tests#use-global-variables
-[5]: /synthetics/browser_tests#use-global-variables

--- a/content/en/synthetics/settings/_index.md
+++ b/content/en/synthetics/settings/_index.md
@@ -55,7 +55,7 @@ You can create variables from your existing HTTP tests by parsing its response h
 
 1. Enter a **Variable Name**. Your variable name can only use uppercase letters, numbers, and underscores.
 2. Pick the test you want to extract your variable from.
-3. Decide whether to make your variable secure. Securing your variable will obfuscate its value for all users on your test results.
+3. Decide whether to make your variable secure. Securing your variable obfuscates its value for all users on your test results.
 4. Optional: select **Tags** to associate to your variable.
 5. Optional: enter a **Description** for your variable.
 6. Decide whether to extract your variable from the response headers, or from the response body.

--- a/content/en/synthetics/settings/_index.md
+++ b/content/en/synthetics/settings/_index.md
@@ -37,7 +37,7 @@ Choose the type of variable you want to create:
 
 1. Enter a **Variable Name**. Your variable name can only use uppercase letters, numbers, and underscores.
 2. Enter the given **Value**.
-3. Decide whether to make your variable secure. Securing your variable will obfuscate its value for all users on your test results.
+3. Decide whether to make your variable secure. Securing your variable obfuscates its value for all users on your test results.
 4. Optional: select **Tags** to associate to your variable.
 5. Optional: enter a **Description** for your variable.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR adds details about the secure global variables feature and specify that the settings page can only be accessed by standard & admin users.

### Motivation
Discussion on public Slack

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
