### PR TITLE
Adding command to build doc faster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,8 +114,8 @@ source-helpers: hugpython  ## source the helper functions used in build, test, d
 	@find ${LOCALBIN}/*  -type f -exec cp {} ${EXEDIR} \;
 	@cp -r local/githooks/* .git/hooks
 
-start: clean source-helpers ## Build the documentation with all external content
-	@echo "Building the documentation without ALL external content"
+start: clean source-helpers ## Build the documentation with all external content.
+	@echo "Building the documentation without ALL external content."
 	@if [ ${PY3} != "false" ]; then \
 		source ${VIRENV}/bin/activate;  \
 		FETCH_INTEGRATIONS=${FETCH_INTEGRATIONS} \
@@ -131,8 +131,8 @@ start: clean source-helpers ## Build the documentation with all external content
 		RUN_SERVER=${RUN_SERVER} \
 		run-site.sh; fi
 
-start-no-pre-build: clean source-helpers ## Build the documentation without automatically pulled content
-	@echo "Building the documentation without any pulled content"
+start-no-pre-build: clean source-helpers ## Build the documentation without automatically pulled content.
+	@echo "Building the documentation without any pulled content."
 	@if [ ${PY3} != "false" ]; then \
 		source ${VIRENV}/bin/activate;  \
 		RUN_SERVER=${RUN_SERVER} \

--- a/Makefile
+++ b/Makefile
@@ -21,13 +21,13 @@ include $(CONFIG_FILE)
 help:
 	@perl -nle'print $& if m{^[a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
 
-clean: stop  ## clean all make installs.
+clean: stop  ## Clean all make installs.
 	@echo "cleaning up..."
 	make clean-build
 	make clean-integrations
 	make clean-auto-doc
 
-clean-all: stop  ## clean everything.
+clean-all: stop  ## Clean everything.
 	make clean-build
 	make clean-exe
 	make clean-integrations
@@ -35,13 +35,13 @@ clean-all: stop  ## clean everything.
 	make clean-node
 	make clean-virt
 
-clean-build:  ## remove build artifacts.
+clean-build:  ## Remove build artifacts.
 	@if [ -d public ]; then rm -r public; fi
 
-clean-exe:  ## remove execs.
+clean-exe:  ## Remove execs.
 	@rm -rf ${EXE_LIST}
 
-clean-integrations:  ## remove built integrations files.
+clean-integrations:  ## Remove built integrations files.
 	@rm -rf ./integrations_data/
 	@if [ -d data/integrations ]; then \
 		find ./data/integrations -type f -maxdepth 1 \
@@ -83,7 +83,7 @@ clean-integrations:  ## remove built integrations files.
 	    -a -not -name '*.fr.md' \
 	    -exec rm -rf {} \;
 
-clean-auto-doc: ##remove all doc automatically created
+clean-auto-doc: ##Remove all doc automatically created
 	@if [ -d content/en/developers/integrations ]; then \
 	find ./content/en/developers/integrations -type f -maxdepth 1 -exec rm -rf {} \; ;fi
 	@if [ content/en/agent/basic_agent_usage/heroku.md ]; then \
@@ -95,21 +95,21 @@ clean-auto-doc: ##remove all doc automatically created
 	@if [ content/en/logs/log_collection/android.md ]; then \
 	rm -f content/en/logs/log_collection/android.md ;fi
 
-clean-node:  ## remove node_modules.
+clean-node:  ## Remove node_modules.
 	@if [ -d node_modules ]; then rm -r node_modules; fi
 
-clean-virt:  ## remove python virtual env.
+clean-virt:  ## Remove python virtual env.
 	@if [ -d ${VIRENV} ]; then rm -rf $(VIRENV); fi
 
-hugpython: hugpython/bin/activate  ## build virtualenv used for tests.
+hugpython: hugpython/bin/activate  ## Build virtualenv used for tests.
 
-hugpython/bin/activate: local/etc/requirements3.txt  ## start python virtual environment.
+hugpython/bin/activate: local/etc/requirements3.txt  ## Start python virtual environment.
 	@if [ ${PY3} != "false" ]; then \
 		test -x ${VIRENV}/bin/pip || ${PY3} -m venv --clear ${VIRENV}; \
 		$(VIRENV)/bin/pip install -r local/etc/requirements3.txt; \
 	else printf "\e[93mPython 3 is required to fetch integrations and run tests.\033[0m Try https://github.com/pyenv/pyenv.\n"; fi
 
-source-helpers: hugpython  ## source the helper functions used in build, test, deploy.
+source-helpers: hugpython  ## Source the helper functions used in build, test, deploy.
 	@mkdir -p ${EXEDIR}
 	@find ${LOCALBIN}/*  -type f -exec cp {} ${EXEDIR} \;
 	@cp -r local/githooks/* .git/hooks
@@ -134,7 +134,7 @@ start-no-pre-build: clean source-helpers ## Build the documentation without auto
 		run-site-no-pre-build.sh; \
 	else @echo "\033[31m\033[1mPython 3 must be available to Build the documentation.\033[0m" ; fi
 
-stop:  ## stop wepack watch/hugo server.
+stop:  ## Stop wepack watch/hugo server.
 	@echo "stopping previous..."
 	@pkill -x webpack || true
 	@pkill -x hugo server --renderToDisk || true

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ start: clean source-helpers ## Build the documentation with all external content
 		source ${VIRENV}/bin/activate;  \
 		GITHUB_TOKEN=${GITHUB_TOKEN} \
 		RUN_SERVER=${RUN_SERVER} \
+		CREATE_I18N_PLACEHOLDERS=${CREATE_I18N_PLACEHOLDERS} \
 		CONFIGURATION_FILE=${CONFIGURATION_FILE} \
 		LOCAL=${LOCAL}\
 		run-site.sh; \

--- a/Makefile
+++ b/Makefile
@@ -115,31 +115,23 @@ source-helpers: hugpython  ## source the helper functions used in build, test, d
 	@cp -r local/githooks/* .git/hooks
 
 start: clean source-helpers ## Build the documentation with all external content.
-	@echo "Building the documentation without ALL external content."
+	@echo "\033[35m\033[1m\nBuilding the documentation with ALL external content:\033[0m"
 	@if [ ${PY3} != "false" ]; then \
 		source ${VIRENV}/bin/activate;  \
-		FETCH_INTEGRATIONS=${FETCH_INTEGRATIONS} \
 		GITHUB_TOKEN=${GITHUB_TOKEN} \
 		RUN_SERVER=${RUN_SERVER} \
-		CREATE_I18N_PLACEHOLDERS=${CREATE_I18N_PLACEHOLDERS} \
 		CONFIGURATION_FILE=${CONFIGURATION_FILE} \
 		LOCAL=${LOCAL}\
 		run-site.sh; \
-	else \
-		FETCH_INTEGRATIONS="false" \
-		CREATE_I18N_PLACEHOLDERS="false" \
-		RUN_SERVER=${RUN_SERVER} \
-		run-site.sh; fi
+	else @echo "\033[31m\033[1mPython 3 must be available to Build the documentation.\033[0m" ; fi
 
 start-no-pre-build: clean source-helpers ## Build the documentation without automatically pulled content.
-	@echo "Building the documentation without any pulled content."
+	@echo "\033[35m\033[1m\nBuilding the documentation with NO external content:\033[0m"
 	@if [ ${PY3} != "false" ]; then \
 		source ${VIRENV}/bin/activate;  \
 		RUN_SERVER=${RUN_SERVER} \
 		run-site-no-pre-build.sh; \
-	else \
-		RUN_SERVER=${RUN_SERVER} \
-		run-site.sh; fi
+	else @echo "\033[31m\033[1mPython 3 must be available to Build the documentation.\033[0m" ; fi
 
 stop:  ## stop wepack watch/hugo server.
 	@echo "stopping previous..."

--- a/Makefile
+++ b/Makefile
@@ -114,8 +114,8 @@ source-helpers: hugpython  ## source the helper functions used in build, test, d
 	@find ${LOCALBIN}/*  -type f -exec cp {} ${EXEDIR} \;
 	@cp -r local/githooks/* .git/hooks
 
-start: clean source-helpers ## start the webpack/hugo server.
-	@echo "starting up..."
+start: clean source-helpers ## Build the documentation with all external content
+	@echo "Building the documentation without ALL external content"
 	@if [ ${PY3} != "false" ]; then \
 		source ${VIRENV}/bin/activate;  \
 		FETCH_INTEGRATIONS=${FETCH_INTEGRATIONS} \
@@ -128,6 +128,16 @@ start: clean source-helpers ## start the webpack/hugo server.
 	else \
 		FETCH_INTEGRATIONS="false" \
 		CREATE_I18N_PLACEHOLDERS="false" \
+		RUN_SERVER=${RUN_SERVER} \
+		run-site.sh; fi
+
+start-no-pre-build: clean source-helpers ## Build the documentation without automatically pulled content
+	@echo "Building the documentation without any pulled content"
+	@if [ ${PY3} != "false" ]; then \
+		source ${VIRENV}/bin/activate;  \
+		RUN_SERVER=${RUN_SERVER} \
+		run-site-no-pre-build.sh; \
+	else \
 		RUN_SERVER=${RUN_SERVER} \
 		run-site.sh; fi
 

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -2,6 +2,7 @@
 # Create a new file called Makefile.config using this file as a template for your local config
 
 GITHUB_TOKEN := ${github_personal_token}
+CREATE_I18N_PLACEHOLDERS:= false
 RUN_SERVER := true
 RUN_WEBPACK := true
 CONFIGURATION_FILE := "./local/bin/py/build/configurations/pull_config_preview.yaml"

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -1,8 +1,6 @@
 # Makefile.config
 # Create a new file called Makefile.config using this file as a template for your local config
 
-CREATE_I18N_PLACEHOLDERS := false
-FETCH_INTEGRATIONS := true
 GITHUB_TOKEN := ${github_personal_token}
 RUN_SERVER := true
 RUN_WEBPACK := true

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Inside `documentation/` folder, create a `Makefile.config` file from the [Makefi
 
 If you are a Datadog employee, add your [Github personal token][6]
 
-To run the site execute:
+To run the documentation site locally, execute:
 
 | Command                   | Description                                                                                                                                                                                                                             |
 |---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -38,18 +38,18 @@ To use the Makefile, create a Makefile.config. See the instructions at the top o
 After you have a config file you can run `make help` to see options:
 
 ```text
-clean-all                 clean everything.
-clean-build               remove build artifacts.
-clean-exe                 remove execs.
-clean-integrations        remove built integrations files.
-clean-node                remove node_modules.
-clean-virt                remove python virtual env.
-clean                     clean all make installs.
-hugpython                 build virtualenv used for tests.
-source-helpers            source the helper functions used in build, test, deploy.
+clean-all                 Clean everything.
+clean-build               Remove build artifacts.
+clean-exe                 Remove execs.
+clean-integrations        Remove built integrations files.
+clean-node                Remove node_modules.
+clean-virt                Remove python virtual env.
+clean                     Clean all make installs.
+hugpython                 Build virtualenv used for tests.
+source-helpers            Source the helper functions used in build, test, deploy.
 start-no-pre-build        Build the documentation without automatically pulled content.
 start                     Build the documentation with all external content.
-stop                      stop wepack watch/hugo server.
+stop                      Stop wepack watch/hugo server.
 ```
 
 ## Working on Docs

--- a/README.md
+++ b/README.md
@@ -3,15 +3,16 @@
 Built with [hugo][1], a static website generation tool.
 
 ## Setup
+
 ### Installation
 
 1. [Install npm][2]
 
 2. [Install Python3][3] (you can also use [pyenv][4])
 
-3. Install yarn: ```npm install -g yarn```
+3. Install yarn: `npm install -g yarn`
 
-4. Download the documentation repo ```git clone https://github.com/DataDog/documentation.git```
+4. Download the documentation repo `git clone https://github.com/DataDog/documentation.git`
 
 ### Run the server
 
@@ -19,11 +20,14 @@ Inside `documentation/` folder, create a `Makefile.config` file from the [Makefi
 
 If you are a Datadog employee, add your [Github personal token][6]
 
-To run the site and perform administrative tasks (compile metrics, create i18n placeholders, etc), just execute:
+To run the site execute:
 
-`make start`
+| Command                   | Description                                                                                                                                                                                                                             |
+|---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `make start-no-pre-build` | Build the lightweight version of the documentation with no extra content                                                                                                                                                                |
+| `make start`              | Build the full documentation with all extra content (integrations, extra pulled files, localised content...). Only useful if you have a Github personal token setup in your `Makefile.config` or the extra content is available localy. |
 
-Documentation is available at `http://localhost:1313`
+**Documentation is then available at `http://localhost:1313`**
 
 To learn more about how the documentation is build refer to the [Documentation Build Wiki][7].
 
@@ -33,7 +37,8 @@ To use the Makefile, create a Makefile.config. See the instructions at the top o
 
 After you have a config file you can run `make help` to see options:
 
-```
+```text
+clean-all                 clean everything.
 clean-build               remove build artifacts.
 clean-exe                 remove execs.
 clean-integrations        remove built integrations files.
@@ -42,8 +47,9 @@ clean-virt                remove python virtual env.
 clean                     clean all make installs.
 hugpython                 build virtualenv used for tests.
 source-helpers            source the helper functions used in build, test, deploy.
-start                     start the gulp/hugo server.
-stop                      stop the gulp/hugo server.
+start-no-pre-build        Build the documentation without automatically pulled content.
+start                     Build the documentation with all external content.
+stop                      stop wepack watch/hugo server.
 ```
 
 ## Working on Docs
@@ -65,13 +71,11 @@ stop                      stop the gulp/hugo server.
 
 This site uses [Goldmark][9] for markdown which is compliant with [CommonMark 0.29][10].
 
-If you include ANY Markdown in a file, give it an .md extension.
+If you include ANY Markdown in a file, give it an `.md` extension.
 
 Make sure all files are lowercase. Macs are case insensitive when creating links to images and pages, but the server is not so tests may be fine locally but the site will fail in production.
 
 ## Releasing
-
-If you receive an error regarding `There was a problem getting GitHub Metrics`, please see the [Github personal access token][6].
 
 Within 5 minutes of merging to master, it deploys automatically.
 

--- a/local/bin/py/build/content_manager.py
+++ b/local/bin/py/build/content_manager.py
@@ -71,7 +71,7 @@ def local_or_upstream(github_token, extract_dir, list_of_contents):
                 repo_name,
                 content["globs"],
             )
-        elif github_token != "False":
+        elif github_token != "false":
             print(
                 "\x1b[32mINFO\x1b[0m: No local version of {} found, downloading content from upstream version".format(
                     content["repo_name"]
@@ -96,7 +96,7 @@ def local_or_upstream(github_token, extract_dir, list_of_contents):
             )
         elif getenv("LOCAL") == 'True':
             print(
-                "\x1b[33mWARNING\x1b[0m: Local mode detected: No local version of {} found, no GITHUB_TOKEN available. Documentation is now in degraded mode".format(content["repo_name"]))
+                "\x1b[33mWARNING\x1b[0m: No local version of {} found, no GITHUB_TOKEN available. Documentation is now in degraded mode".format(content["repo_name"]))
             content["action"] = "Not Available"
         else:
             print(
@@ -151,7 +151,7 @@ def prepare_content(configuration, github_token, extract_dir):
     except:
         if getenv("LOCAL") == 'True':
             print(
-                "\x1b[33mWARNING\x1b[0m: Local mode detected: Downloading files failed, documentation is now in degraded mode.")
+                "\x1b[33mWARNING\x1b[0m: Downloading files failed, documentation is now in degraded mode.")
         else:
             print(
                 "\x1b[31mERROR\x1b[0m: Downloading files failed, stoping build.")

--- a/local/bin/py/build/update_pre_build.py
+++ b/local/bin/py/build/update_pre_build.py
@@ -83,7 +83,7 @@ class Build:
         except:
             if getenv("LOCAL") == 'True':
                 print(
-                    "\x1b[33mWARNING\x1b[0m: Local mode detected: Integration merge failed, documentation is now in degraded mode.")
+                    "\x1b[33mWARNING\x1b[0m:Integration merge failed, documentation is now in degraded mode.")
             else:
                 print(
                     "\x1b[31mERROR\x1b[0m: Integration merge failed, stoping build.")

--- a/local/bin/py/build/update_pre_build.py
+++ b/local/bin/py/build/update_pre_build.py
@@ -83,7 +83,7 @@ class Build:
         except:
             if getenv("LOCAL") == 'True':
                 print(
-                    "\x1b[33mWARNING\x1b[0m:Integration merge failed, documentation is now in degraded mode.")
+                    "\x1b[33mWARNING\x1b[0m: Integration merge failed, documentation is now in degraded mode.")
             else:
                 print(
                     "\x1b[31mERROR\x1b[0m: Integration merge failed, stoping build.")

--- a/local/bin/sh/run-site-no-pre-build.sh
+++ b/local/bin/sh/run-site-no-pre-build.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+
+RUN_SERVER=${RUN_SERVER:=false}
+RUN_WEBPACK=${RUN_WEBPACK:=true}
+RENDER_SITE_TO_DISK=${RENDER_SITE_TO_DISK:=false}
+
+if [ ${RUN_SERVER} == true ]; then
+
+  # Building the documentation
+	if [ ${RUN_WEBPACK} == true ]; then
+		echo "checking that node modules are installed and up-to-date"
+    npm --global install yarn && \
+    npm cache clean --force && yarn install --frozen-lockfile
+    echo "starting webpack and hugo build"
+	yarn run start
+
+    sleep 5
+	fi
+
+else
+	exit 0
+fi

--- a/local/bin/sh/run-site-no-pre-build.sh
+++ b/local/bin/sh/run-site-no-pre-build.sh
@@ -1,18 +1,17 @@
-#!/usr/bin/env sh
+#!/bin/bash
 
 RUN_SERVER=${RUN_SERVER:=false}
 RUN_WEBPACK=${RUN_WEBPACK:=true}
 RENDER_SITE_TO_DISK=${RENDER_SITE_TO_DISK:=false}
 
-if [ ${RUN_SERVER} == true ]; then
-
+if [ ${RUN_SERVER} = true ]; then
   # Building the documentation
-	if [ ${RUN_WEBPACK} == true ]; then
-		echo "checking that node modules are installed and up-to-date"
+  if [ ${RUN_WEBPACK} = true ]; then
+    printf "checking that node modules are installed and up-to-date"
     npm --global install yarn && \
     npm cache clean --force && yarn install --frozen-lockfile
-    echo "starting webpack and hugo build"
-	yarn run start
+    printf "starting webpack and hugo build"
+	  yarn run start
 
     sleep 5
 	fi

--- a/local/bin/sh/run-site.sh
+++ b/local/bin/sh/run-site.sh
@@ -11,12 +11,13 @@ if [ ${RUN_SERVER} = true ]; then
 	# integrations
 	if [ ${GITHUB_TOKEN} != false ]; then
 		args="${args} --token ${GITHUB_TOKEN}"
-    update_pre_build.py "${args}"
 	else
 		printf "\033[31m\033[1mNo GITHUB TOKEN was found. Skipping any data sync that relies on pulling from web.\033[0m\n"
 		printf "\033[33m\033[1mAdd all source repositories in the same parent folder as the documentation/ folder to build the full doc locally.\nOr use the 'make start-no-pre-build' command to build the doc without any external content.\033[0m\n"
-		update_pre_build.py
+    args="${args} --token 'false'"
 	fi
+
+  update_pre_build.py "${args}"
 
   # placeholders
 	if [ ${CREATE_I18N_PLACEHOLDERS} == true ]; then

--- a/local/bin/sh/run-site.sh
+++ b/local/bin/sh/run-site.sh
@@ -11,27 +11,25 @@ if [ ${RUN_SERVER} = true ]; then
 	# integrations
 	if [ ${GITHUB_TOKEN} != false ]; then
 		args="${args} --token ${GITHUB_TOKEN}"
+    update_pre_build.py "${args}"
 	else
-		printf "No GITHUB TOKEN was found. skipping any data sync that relies on pulling from web.\n"
-		printf "Add all source repositories in the same parent folder as the documentation/ folder to build the full doc locally.\n"
+		printf "\033[31m\033[1mNo GITHUB TOKEN was found. Skipping any data sync that relies on pulling from web.\033[0m\n"
+		printf "\033[33m\033[1mAdd all source repositories in the same parent folder as the documentation/ folder to build the full doc locally.\nOr use the 'make start-no-pre-build' command to build the doc without any external content.\033[0m\n"
 		update_pre_build.py
-	fi
-	if [[ ${args} != "" ]]; then
-		update_pre_build.py "${args}"
 	fi
 
   # placeholders
 	if [ ${CREATE_I18N_PLACEHOLDERS} == true ]; then
-		echo "creating i18n placeholder pages."
+		echo "Creating i18n placeholder pages."
 		placehold_translations.py -c "config/_default/languages.yaml"
 	fi
 
 	# webpack
 	if [ ${RUN_WEBPACK} = true ]; then
-		echo "checking that node modules are installed and up-to-date"
+		echo "Checking that node modules are installed and up-to-date."
     npm --global install yarn && \
     npm cache clean --force && yarn install --frozen-lockfile
-    echo "starting webpack and hugo build"
+    echo "Starting webpack and hugo build."
 	yarn run start
 
     sleep 5

--- a/local/bin/sh/run-site.sh
+++ b/local/bin/sh/run-site.sh
@@ -1,37 +1,30 @@
-#!/usr/bin/env sh
+#!/bin/bash
 
 RUN_SERVER=${RUN_SERVER:=false}
-FETCH_INTEGRATIONS=${FETCH_INTEGRATIONS:=false}
 GITHUB_TOKEN=${GITHUB_TOKEN:="False"}
 RUN_WEBPACK=${RUN_WEBPACK:=true}
-CREATE_I18N_PLACEHOLDERS=${CREATE_I18N_PLACEHOLDERS:=false}
 RENDER_SITE_TO_DISK=${RENDER_SITE_TO_DISK:=false}
 LOCAL=${LOCAL:=False}
 
-if [ ${RUN_SERVER} == true ]; then
+if [ ${RUN_SERVER} = true ]; then
 	# integrations
-	if [ ${FETCH_INTEGRATIONS} == true ]; then
-		args=""
-		if [ ${GITHUB_TOKEN} != "False" ]; then
-			args="${args} --token ${GITHUB_TOKEN}"
-		else
-			echo "No GITHUB TOKEN was found. skipping any data sync that relies on pulling from web.\n"
-			echo "Add all source repositories in the same parent folder as the documentation/ folder to build the full doc locally.\n"
-			update_pre_build.py
-		fi
-		if [[ ${args} != "" ]]; then
-			update_pre_build.py ${args}
-		fi
+	if [ ${GITHUB_TOKEN} != "False" ]; then
+		args="${args} --token ${GITHUB_TOKEN}"
+	else
+		printf "No GITHUB TOKEN was found. skipping any data sync that relies on pulling from web.\n"
+		printf "Add all source repositories in the same parent folder as the documentation/ folder to build the full doc locally.\n"
+		update_pre_build.py
+	fi
+	if [[ ${args} != "" ]]; then
+		update_pre_build.py "${args}"
 	fi
 
 	# placeholders
-	if [ ${CREATE_I18N_PLACEHOLDERS} == true ]; then
-		echo "creating i18n placeholder pages."
-		placehold_translations.py -c "config/_default/languages.yaml"
-	fi
+	echo "creating i18n placeholder pages."
+  placehold_translations.py -c "config/_default/languages.yaml"
 
 	# webpack
-	if [ ${RUN_WEBPACK} == true ]; then
+	if [ ${RUN_WEBPACK} = true ]; then
 		echo "checking that node modules are installed and up-to-date"
     npm --global install yarn && \
     npm cache clean --force && yarn install --frozen-lockfile

--- a/local/bin/sh/run-site.sh
+++ b/local/bin/sh/run-site.sh
@@ -4,6 +4,7 @@ RUN_SERVER=${RUN_SERVER:=false}
 GITHUB_TOKEN=${GITHUB_TOKEN:="False"}
 RUN_WEBPACK=${RUN_WEBPACK:=true}
 RENDER_SITE_TO_DISK=${RENDER_SITE_TO_DISK:=false}
+CREATE_I18N_PLACEHOLDERS=${CREATE_I18N_PLACEHOLDERS:=false}
 LOCAL=${LOCAL:=False}
 
 if [ ${RUN_SERVER} = true ]; then
@@ -19,9 +20,11 @@ if [ ${RUN_SERVER} = true ]; then
 		update_pre_build.py "${args}"
 	fi
 
-	# placeholders
-	echo "creating i18n placeholder pages."
-  placehold_translations.py -c "config/_default/languages.yaml"
+  # placeholders
+	if [ ${CREATE_I18N_PLACEHOLDERS} == true ]; then
+		echo "creating i18n placeholder pages."
+		placehold_translations.py -c "config/_default/languages.yaml"
+	fi
 
 	# webpack
 	if [ ${RUN_WEBPACK} = true ]; then

--- a/local/bin/sh/run-site.sh
+++ b/local/bin/sh/run-site.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 RUN_SERVER=${RUN_SERVER:=false}
-GITHUB_TOKEN=${GITHUB_TOKEN:="False"}
+GITHUB_TOKEN=${GITHUB_TOKEN:=false}
 RUN_WEBPACK=${RUN_WEBPACK:=true}
 RENDER_SITE_TO_DISK=${RENDER_SITE_TO_DISK:=false}
 CREATE_I18N_PLACEHOLDERS=${CREATE_I18N_PLACEHOLDERS:=false}
@@ -9,7 +9,7 @@ LOCAL=${LOCAL:=False}
 
 if [ ${RUN_SERVER} = true ]; then
 	# integrations
-	if [ ${GITHUB_TOKEN} != "False" ]; then
+	if [ ${GITHUB_TOKEN} != false ]; then
 		args="${args} --token ${GITHUB_TOKEN}"
 	else
 		printf "No GITHUB TOKEN was found. skipping any data sync that relies on pulling from web.\n"


### PR DESCRIPTION
### What does this PR do?
Creates a new Makefile command:

`make start-no-pre-build` 

that builds the documentation without any extra content.

This allow to decrease build time from **~90s** to **~40s** when the pulled content is available locally.. it should decrease build time even more if content is not available locally.

Other changes:

* Updates Main Readme.md
* Changes default value for Github Token from `False` to `false`
* If Python 3 is missing => documentation doesn't build 
* Lint bash files

### Motivation

Allowing faster build when not working on pulled content.

### Preview link

* http://docs-staging.datadoghq.com/gus/build-faster