### PR TITLE
Fixing frontmatters for the jenkins documentation

### DIFF
--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -14,8 +14,18 @@
         dest_path: '/integrations/'
         file_name: 'jenkins.md'
         front_matters:
-          title: Datadog-Jenkins Integration
-          kind: documentation
+          public_title: Datadog-Jenkins Integration
+          kind: integration
+          name: jenkins
+          is_public: true
+          integration_title: Jenkins
+          has_logo: true
+          git_integration_title: jenkins
+          description: "Automatically forward your Jenkins metrics, events, and service checks to Datadog."
+          short_description: "Automatically forward your Jenkins metrics, events, and service checks to Datadog."
+          categories:
+            - "configuration & deployment"
+          doc_link: https://docs.datadoghq.com/integrations/jenkins/
 
 - org_name: DataDog
 

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -22,6 +22,7 @@
           has_logo: true
           git_integration_title: jenkins
           description: "Automatically forward your Jenkins metrics, events, and service checks to Datadog."
+          short_description: "Automatically forward your Jenkins metrics, events, and service checks to Datadog."
           categories:
             - "configuration & deployment"
           doc_link: https://docs.datadoghq.com/integrations/jenkins/

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -14,8 +14,17 @@
         dest_path: '/integrations/'
         file_name: 'jenkins.md'
         front_matters:
-          title: Datadog-Jenkins Integration
-          kind: documentation
+          public_title: Datadog-Jenkins Integration
+          kind: integration
+          name: jenkins
+          is_public: true
+          integration_title: Jenkins
+          has_logo: true
+          git_integration_title: jenkins
+          description: "Automatically forward your Jenkins metrics, events, and service checks to Datadog."
+          categories:
+            - "configuration & deployment"
+          doc_link: https://docs.datadoghq.com/integrations/jenkins/
 
 - org_name: DataDog
 


### PR DESCRIPTION
### What does this PR do?

Adds missing frontmatters for the jenkins documentation in order to make it searchable and available in the /integrations page.

http://docs-staging.datadoghq.com/gus/jenkins-fix/integrations