### PR TITLE
Adding FAQ article about cloning Synthetics tests

### DIFF
--- a/content/en/synthetics/faq/_index.md
+++ b/content/en/synthetics/faq/_index.md
@@ -7,4 +7,5 @@ disable_toc: true
 
 {{< whatsnext desc="List of Frequently Asked Questions:">}}
     {{< nextlink href="/synthetics/faq/uptime-check-internal-website" >}}Create an API Tests for private website{{< /nextlink >}}
+    {{< nextlink href="/synthetics/faq/clone-test" >}}Clone your Synthetics tests{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/synthetics/faq/clone-test.md
+++ b/content/en/synthetics/faq/clone-test.md
@@ -1,0 +1,21 @@
+---
+title: Clone your Synthetics tests
+kind: faq
+further_reading:
+- link: "synthetics/"
+  tag: "Documentation"
+  text: "Manage your checks"
+- link: "synthetics/"
+  tag: "Documentation"
+  text: "Manage your checks"
+---
+
+You can clone your Synthetics tests using our API: 
+
+1. Retrieve your test configuration using the [Get a test][1] endpoint.
+2. Perform modifications if needed (URL, tags, etc.).
+3. Send your new test configuration using the [Create a test][2] endpoint. 
+For browser tests, add the `from_test_id` parameter at the end of the endpoint and set its value to the id of the test being cloned. This will allow steps cloning. The endpoint should be `https://api.datadoghq.com/api/v1/synthetics/tests?from_test_id=<SYNTHETICS_TEST_PUBLIC_ID>`.
+
+[1]: /api/?lang=bash#get-a-test 
+[2]: /api/?lang=bash#create-a-test

--- a/content/en/synthetics/faq/clone-test.md
+++ b/content/en/synthetics/faq/clone-test.md
@@ -14,7 +14,7 @@ You can clone your Synthetics tests using our API:
 
 1. Retrieve your test configuration using the [Get a test][1] endpoint.
 2. Perform modifications if needed (URL, tags, etc.).
-3. Send your new test configuration using the [Create a test][2] endpoint. 
+3. Send your new test configuration using the [Create a test][2] endpoint.    
 For browser tests, add the `from_test_id` parameter at the end of the endpoint and set its value to the id of the test being cloned. This will allow steps cloning. The endpoint should be `https://api.datadoghq.com/api/v1/synthetics/tests?from_test_id=<SYNTHETICS_TEST_PUBLIC_ID>`.
 
 [1]: /api/?lang=bash#get-a-test 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR adds a FAQ article about cloning Synthetics tests

### Motivation
Customer request while we work on export browser tests as JSON
Specifically useful for browser tests since steps are not retrieved when calling API

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/margot.lepizzera/clone_synthetics_test/synthetics/faq/
https://docs-staging.datadoghq.com/margot.lepizzera/clone_synthetics_test/synthetics/faq/clone-test/
### Additional Notes
<!-- Anything else we should know when reviewing?-->
