### PR TITLE
Update minimum Ansible version for system probe

### DIFF
--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -34,7 +34,7 @@ The following provisioning systems are supported:
 
 * Daemonset / Helm 1.38.11+: See the [Datadog Helm chart][3]
 * Chef 12.7+: See the [Datadog Chef recipe][4]
-* Ansible 4.0.1+: See the [Datadog Ansible role][5]
+* Ansible 2.6+: See the [Datadog Ansible role][5]
 
 ## Setup
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Change Ansible minimum version from 4.0.1 (which is the minimum Playbook version) to 2.6+, which is accurate. 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
