### PR TITLE
Adding the is_public param for integrations

### DIFF
--- a/layouts/partials/noindex.html
+++ b/layouts/partials/noindex.html
@@ -1,3 +1,3 @@
-{{ if (or (eq .Params.beta true) (eq .Params.private true) (eq .Params.placeholder true) (eq .Site.Params.environment "preview") (eq .Params.noindex true) (in (slice "ja") (.Language.Lang | default "en") )) }}
+{{ if (or (eq .Params.beta true) (eq .Params.private true) (eq .Params.is_public false) (eq .Params.placeholder true) (eq .Site.Params.environment "preview") (eq .Params.noindex true) (in (slice "ja") (.Language.Lang | default "en") )) }}
 <meta name="robots" content="noindex, nofollow">
 {{ end }}


### PR DESCRIPTION
### What does this PR do?

Adds the `is_public` param to the no_index partial. If an integration has `is_public:false` it shouldn't be indexed publicly 

### Motivation
The airflow integration is currently indexed by google.