### PR TITLE
Cécile/x datadog trace count

### DIFF
--- a/content/en/api/tracing/code_snippets/send_trace.py
+++ b/content/en/api/tracing/code_snippets/send_trace.py
@@ -18,7 +18,7 @@ time.sleep(2)
 DURATION= int(time.time() * 1000000000) - START
 
 # Send the traces.
-headers = {"Content-Type": "application/json"}
+headers = {"Content-Type": "application/json", "X-Datadog-Trace-Count": "1"} 
 
 data = [[{
                 "trace_id": TRACE_ID,
@@ -31,4 +31,4 @@ data = [[{
                 "duration": DURATION
         }]]
 
-requests.put("http://localhost:8126/v0.3/traces", data=json.dumps(data), headers=headers)
+requests.put("http://localhost:8126/v0.4/traces", data=json.dumps(data), headers=headers)

--- a/content/en/api/tracing/code_snippets/send_trace.sh
+++ b/content/en/api/tracing/code_snippets/send_trace.sh
@@ -16,7 +16,7 @@ sleep 2
 DURATION=$(($(date +%s%N) - $START))
 
 # Send the traces.
-curl -X PUT -H "Content-type: application/json" \
+curl -X PUT -H "Content-type: application/json" -H "X-Datadog-Trace-Count: 1" \
   -d "[[{
     \"trace_id\": $TRACE_ID,
     \"span_id\": $SPAN_ID,
@@ -27,4 +27,4 @@ curl -X PUT -H "Content-type: application/json" \
     \"start\": $START,
     \"duration\": $DURATION
 }]]" \
-  http://localhost:8126/v0.3/traces
+  http://localhost:8126/v0.4/traces


### PR DESCRIPTION

### What does this PR do?
update the snippet to set the x datadog trace count header
upgrade the API version to use

### Motivation
API v0.4 exists since more than a year
Missing x datadog trace count header leads to some warning in the logs of the trace agent

### Preview link
https://docs-staging.datadoghq.com/c%C3%A9cile/X-Datadog-Trace-Count/api/?lang=python#send-traces

https://docs-staging.datadoghq.com/c%C3%A9cile/X-Datadog-Trace-Count/api/?lang=bash#send-traces

### Additional Notes
Ruby example should be changed as well
