### PR TITLE
update ruby send traces example and fix syntax

### DIFF
--- a/content/en/api/tracing/code_snippets/send_trace.rb
+++ b/content/en/api/tracing/code_snippets/send_trace.rb
@@ -6,13 +6,16 @@ TRACE_ID = rand(1..1000000)
 SPAN_ID = rand(1..1000000)
 
 # Start a timer.
-START = Time.now.to_i
+START_TIME = Time.now
 
 # Do things...
 sleep 2
 
-# Stop the timer.
-DURATION = ((Time.now.to_f - START)* 1000000).to_i
+END_TIME = Time.now
+
+START = (START_TIME.to_f * 1e9).to_i
+DURATION = ((END_TIME - START_TIME) * 1e9).to_i
+
 
 # Send the traces.
 port = 8126

--- a/content/en/api/tracing/code_snippets/send_trace.rb
+++ b/content/en/api/tracing/code_snippets/send_trace.rb
@@ -1,11 +1,12 @@
 require 'net/http'
+require 'json'
 
 # Create IDs.
 TRACE_ID = rand(1..1000000)
 SPAN_ID = rand(1..1000000)
 
 # Start a timer.
-START = Time.now.to_f
+START = Time.now.to_i
 
 # Do things...
 sleep 2
@@ -16,9 +17,9 @@ DURATION = ((Time.now.to_f - START)* 1000000).to_i
 # Send the traces.
 port = 8126
 host = "127.0.0.1"
-path = "/v0.3/traces"
+path = "/v0.4/traces"
 
-req = Net::HTTP::Put.new(path, initheader = { 'Content-Type' => 'application/json'})
+req = Net::HTTP::Put.new(path, initheader = { 'Content-Type' => 'application/json', 'X-Datadog-Trace-Count' => '1'})
 
 req.body = [[{ \
 			"trace_id": TRACE_ID, \
@@ -29,6 +30,6 @@ req.body = [[{ \
 			"type": "web", \
 			"start": START, \
 			"duration": DURATION \
-		}]]
+		}]].to_json
 
 response = Net::HTTP.new(host, port).start {|http| http.request(req) }

--- a/content/en/api/tracing/code_snippets/send_trace.rb
+++ b/content/en/api/tracing/code_snippets/send_trace.rb
@@ -16,7 +16,6 @@ END_TIME = Time.now
 START = (START_TIME.to_f * 1e9).to_i
 DURATION = ((END_TIME - START_TIME) * 1e9).to_i
 
-
 # Send the traces.
 port = 8126
 host = "127.0.0.1"


### PR DESCRIPTION
### What does this PR do?
update the snippet to set the x datadog trace count header
upgrade the API version to use
send start time as integer instead of floating point
convert request body to json

### Motivation
current example is broken and throws an error because it is not sending json, and also the formatting of the body is incorrect (start time of span has to be an integer not a floating point)
API v0.4 is new standard
Missing x datadog trace count header leads to some warning in the logs of the trace agent

### Preview link
https://docs-staging.datadoghq.com/ericmustin/update_ruby_send_traces_example/api/?lang=ruby#send-traces

### Additional Notes
Updated as followup from changes suggested by @cecile75  here https://github.com/DataDog/documentation/pull/6458
