### PR TITLE
removes inaccurate note about JSON and the reserved message attribute

### DIFF
--- a/content/en/logs/processing/_index.md
+++ b/content/en/logs/processing/_index.md
@@ -96,8 +96,6 @@ The recognized date formats are: <a href="https://www.iso.org/iso-8601-date-and-
 
 By default, Datadog ingests the message value as the body of the log entry. That value is then highlighted and displayed in the [logstream][13], where it is indexed for [full text search][14].
 
-**Note**: If you send a log formatted as JSON with a `message` attribute which contains a JSON object, this JSON object is interpreted as a *string* and *NOT* expanded. Use a [Log Grok processor][4] to parse this JSON object or a [Log remapper processor][15] to remap this JSON object to a non-reserved attribute.
-
 ### *status* attribute
 
 Each log entry may specify a status level which is made available for faceted search within Datadog. However, if a JSON formatted log file includes one of the following attributes, Datadog interprets its value as the log's official status:
@@ -107,7 +105,7 @@ Each log entry may specify a status level which is made available for faceted se
 * `level`
 * `syslog.severity`
 
-If you would like to remap a status existing in the `status` attribute, you can do so with the [log status remapper][16].
+If you would like to remap a status existing in the `status` attribute, you can do so with the [log status remapper][15].
 
 ### *host* attribute
 
@@ -119,7 +117,7 @@ Using the Datadog Agent or the RFC5424 format automatically sets the host value 
 
 ### *source* attribute
 
-If a JSON formatted log file includes the `ddsource` attribute, Datadog interprets its value as the log's source. To use the same source names Datadog uses, see the [Integration Pipeline Reference][17].
+If a JSON formatted log file includes the `ddsource` attribute, Datadog interprets its value as the log's source. To use the same source names Datadog uses, see the [Integration Pipeline Reference][16].
 
 ### *service* attribute
 
@@ -130,7 +128,7 @@ Using the Datadog Agent or the RFC5424 format automatically sets the service val
 
 ### *trace_id* attribute
 
-By default, [Datadog tracers can automatically inject trace and span IDs in the logs][18]. However, if a JSON formatted log includes the following attributes, Datadog interprets its value as the log's `trace_id`:
+By default, [Datadog tracers can automatically inject trace and span IDs in the logs][17]. However, if a JSON formatted log includes the following attributes, Datadog interprets its value as the log's `trace_id`:
 
 * `dd.trace_id`
 * `contextMap.dd.trace_id`
@@ -163,7 +161,6 @@ To change the default values for each of the reserved attributes, go to the [Con
 [12]: /logs/processing/processors/#log-date-remapper
 [13]: /logs/explorer/?tab=logstream#visualization
 [14]: /logs/explorer/search
-[15]: /logs/processing/processors/?tab=ui#remapper
-[16]: /logs/processing/processors/#log-status-remapper
-[17]: /logs/faq/integration-pipeline-reference
-[18]: /tracing/connect_logs_and_traces/?tab=java
+[15]: /logs/processing/processors/#log-status-remapper
+[16]: /logs/faq/integration-pipeline-reference
+[17]: /tracing/connect_logs_and_traces/?tab=java


### PR DESCRIPTION
### What does this PR do?

Removes a **Note** about how a JSON payload is handled by the reserved message attribute of a log.

### Motivation

The note does not match current behavior. 

### Preview link


https://docs-staging.datadoghq.com/tj/remove_note_about_reserved_message_attribute_json/logs/processing/#message-attribute

### Additional Notes
<!-- Anything else we should know when reviewing?-->
