### PR TITLE
Fix kubernetes agent yaml

### DIFF
--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -99,7 +99,7 @@ spec:
         env:
           ## Set the Datadog API Key related to your Organization
           ## If you use the Kubernetes Secret use the following env variable:
-          ## {name: DD_API_KEY, valueFrom:{ secretKeyRef:{ name: datadog-secret, key: api-key }}
+          ## - {name: DD_API_KEY, valueFrom: { secretKeyRef: { name: datadog-secret, key: api-key }}}
           - {name: DD_API_KEY, value: "<YOUR_API_KEY>"}
 
           ## Set DD_SITE to "datadoghq.eu" to send your Agent data to the Datadog EU site


### PR DESCRIPTION
Fix kubernetes agent yaml, so uncommenting the env variable for the api key doesn't give yaml errors

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fix agent kubernetes manifest yaml

### Motivation
I was using the agent yaml in the documentation to deploy the agent to openshift and uncommenting the api_key to use a secret line gave yaml errors.

### Preview link

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ara.pulido/fix_kubernetes_agent_manifest/agent/kubernetes/daemonset_setup/?tab=k8sfile


