### PR TITLE
New issue template: Edit this page.

### DIFF
--- a/.github/ISSUE_TEMPLATE/edit_this_page.md
+++ b/.github/ISSUE_TEMPLATE/edit_this_page.md
@@ -1,9 +1,9 @@
 ---
 name: Edit this page
-about: Many thanks for your feedback but the page you are trying to edit is not available publicly. Please fill out the information below and Datadog Documentation team will take care of updating the corresponding documentation page.
+about: Thanks for your feedback, but the page you are trying to edit is not available publicly. Fill out the information below, and Datadog's Documentation team will take care of updating the corresponding documentation page.
 
 ---
 
 **Documentation page to update**:
 
-**Describtion of the update to make**:
+**Description of the update**:

--- a/.github/ISSUE_TEMPLATE/edit_this_page.md
+++ b/.github/ISSUE_TEMPLATE/edit_this_page.md
@@ -1,0 +1,9 @@
+---
+name: Edit this page
+about: Many thanks for your feedback but the page you are trying to edit is not available publicly. Please fill out the information below and Datadog Documentation team will take care of updating the corresponding documentation page.
+
+---
+
+**Documentation page to update**:
+
+**Describtion of the update to make**:

--- a/.github/ISSUE_TEMPLATE/edit_this_page.md
+++ b/.github/ISSUE_TEMPLATE/edit_this_page.md
@@ -4,6 +4,6 @@ about: Thanks for your feedback, but the page you are trying to edit is not avai
 
 ---
 
-**Documentation page to update**:
+**Documentation page URL to update**:
 
 **Description of the update**:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: "Suggest an idea for the Datadog documentation. To request a product feature, please file a ticket to Datadog support team directly: https://docs.datadoghq.com/help/".
+about: "Suggest an idea for the Datadog documentation. To request a product feature, please file a ticket to Datadog's support team directly: https://docs.datadoghq.com/help/".
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for the Datadog documentation. To request a product feature, please [file a ticket to Datadog support team directly](https://docs.datadoghq.com/help/).
+about: "Suggest an idea for the Datadog documentation. To request a product feature, please file a ticket to Datadog support team directly: https://docs.datadoghq.com/help/".
 
 ---
 


### PR DESCRIPTION
### What does this PR do?

Creates a new issue template to take into account the case where a documentation page doesn't have a public source file. 

### Motivation

https://github.com/DataDog/documentation/pull/6384/