### PR TITLE
alexfren/update logs explorer search

### DIFF
--- a/content/en/logs/explorer/search.md
+++ b/content/en/logs/explorer/search.md
@@ -74,7 +74,7 @@ Examples:
 
 | Search query                                                         | Description                                                                                                                                                         |
 |----------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `@http.url_details.path:"/api/v1/test"`                              | Searches all logs containing `/api/v1/test` in the attribute `http.url_details.path`.                                                                               |
+| `@http.url_details.path:"/api/v1/test"`                              | Searches all logs matching `/api/v1/test` in the attribute `http.url_details.path`.                                                                               |
 | `@http.url:\/api\/v1\/*`                                             | Searches all logs containing a value in `http.url` attribute that start with `/api/v1/`                                                                             |
 | `@http.status_code:[200 TO 299] @http.url_details.path:\/api\/v1\/*` | Searches all logs containing a `http.status_code` value between 200 and 299, and containing a value in `http.url_details.path` attribute that start with `/api/v1/` |
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Current (@http.url_details.path:"/api/v1/test" - Searches all logs containing /api/v1/test in the attribute http.url_details.path.)

This seems to only search logs that match exactly /api/v1/test (the word containing is not accurate). In order for me to match this CONTAINING the path, the facet must be: @http.url_details.path:\/api\/v1\/test*, so changing the language from containing to matching

### Motivation
Customer Reached out via support ticket highlighting issue

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alexandrafren/logs_explorer_docs_update/logs/explorer/search

### Additional Notes
<!-- Anything else we should know when reviewing?-->
