### PR TITLE
Fixing lint issues within the Tagging section

### DIFF
--- a/content/en/tagging/_index.md
+++ b/content/en/tagging/_index.md
@@ -57,16 +57,17 @@ Below are Datadog's tagging restrictions, requirements, and suggestions:
 3. Tags are converted to lowercase. Therefore, `CamelCase` tags are not recommended. Authentication (crawler) based integrations convert camel case tags to underscores, for example `TestTag` --> `test_tag`.
 4. A tag can be in the format `value` or `<KEY>:<VALUE>`. For optimal functionality, **we recommend constructing tags in the `<KEY>:<VALUE>` format.** Commonly used tag keys are `env`, `instance`, and `name`. The key always precedes the first colon of the global tag definition, for example:
 
-| Tag                | Key           | Value          |
-|--------------------|---------------|----------------|
-| `env:staging:east` | `env`         | `staging:east` |
-| `env_staging:east` | `env_staging` | `east`         |
+    | Tag                | Key           | Value          |
+    |--------------------|---------------|----------------|
+    | `env:staging:east` | `env`         | `staging:east` |
+    | `env_staging:east` | `env_staging` | `east`         |
 
-5.  **Reserved tag keys** `host`, `device`, `source`, and `service` cannot be used in the standard way.
+5. **Reserved tag keys** `host`, `device`, `source`, and `service` cannot be used in the standard way.
 
 6. Tags shouldn't originate from unbounded sources, such as EPOCH timestamps, user IDs, or request IDs. Doing so may infinitely [increase the number of metrics][2] for your organization and impact your billing.
 
 ## Assigning Tags
+
 Tags may be assigned using any (or all) of the following methods. Refer to the dedicated [Assigning Tags documentation][3] to learn more:
 
 | Method                       | Assign tags                                                                                  |

--- a/content/en/tagging/assigning_tags.md
+++ b/content/en/tagging/assigning_tags.md
@@ -63,13 +63,13 @@ Tags for the [integrations][5] installed with the Agent are configured with YAML
 
 In YAML files, use a list of strings under the `tags` key to assign a list of tags. In YAML, lists are defined with two different yet functionally equivalent forms:
 
-```text
+```yaml
 tags: ["<KEY_1>:<VALUE_1>", "<KEY_2>:<VALUE_2>", "<KEY_3>:<VALUE_3>"]
 ```
 
 or
 
-```text
+```yaml
 tags:
     - "<KEY_1>:<VALUE_1>"
     - "<KEY_2>:<VALUE_2>"

--- a/content/en/tagging/using_tags.md
+++ b/content/en/tagging/using_tags.md
@@ -285,17 +285,17 @@ Additionally, tags are used to filter a logs [Pipeline][14]. In the example belo
 
 Tags can be used in various ways with the [API][15]. See the list below for links to those sections:
 
-- [Schedule monitor downtime][16]
-- [Query the event stream][17]
-- [Search hosts][18]
-- [Integrations][19] for [AWS][20] and [Google Cloud][21]
-- [Querying timeseries points][22]
-- [Get all monitor details][23]
-- [Mute a monitor][24]
-- [Monitors search][25]
-- [Monitors group search][26]
-- [Create a Screenboard][27]
-- [Create a Timeboard][28]
+* [Schedule monitor downtime][16]
+* [Query the event stream][17]
+* [Search hosts][18]
+* [Integrations][19] for [AWS][20] and [Google Cloud][21]
+* [Querying timeseries points][22]
+* [Get all monitor details][23]
+* [Mute a monitor][24]
+* [Monitors search][25]
+* [Monitors group search][26]
+* [Create a Screenboard][27]
+* [Create a Timeboard][28]
 
 ## Further Reading
 


### PR DESCRIPTION
### What does this PR do?

* Fixes the list layout that was broken with the table not being indented.
* Fixes lint issues in the markdown files.

### Preview

* https://docs-staging.datadoghq.com/gus/tagging-lint-issues/tagging/#defining-tags