### PR TITLE
[Synthetics] browser test interval options update

### DIFF
--- a/content/en/synthetics/browser_tests.md
+++ b/content/en/synthetics/browser_tests.md
@@ -40,7 +40,7 @@ Define the configuration of your browser test.
 3. **Select your tags**: The tags attached to your browser test. Use the `<KEY>:<VALUE>` format to filter on a `<VALUE>` for a given `<KEY>` on the Synthetics page.
 4. **Devices**: The devices to run your check on. Available devices are `Laptop Large`, `Tablet`, and `Mobile Small`.
 5. **Locations**: The Datadog managed locations to run the test from. Many AWS locations from around the world are available. The full list is retrievable through the [Datadog API][2]. You can also set up a [Private Location][3] to run a Synthetics Browser test on a private URL not accessible from the public internet.
-6. **How often should Datadog run the test?** Intervals are available between every 15 minutes to once per week. [Contact support][4] to enable additional frequencies for your test.
+6. **How often should Datadog run the test?** Intervals are available between every 5 minutes to once per week.
 
 ### Use global variables
 


### PR DESCRIPTION
Updating details about available check run interval options for Synthetics Browser tests

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updating details about available check run interval options for Synthetics Browser tests

### Motivation
5min interval now available for Browser tests by default

### Preview link
https://docs-staging.datadoghq.com/siobhan.mahoney/synthetics/browser/updating-available-check-interval-details/synthetics/browser_tests