### PR TITLE
Doc update for Browser Log Collection in Javascript

### DIFF
--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -44,7 +44,7 @@ import { datadogLogs } from '@datadog/browser-logs';
 datadogLogs.init({
   clientToken: '<DATADOG_CLIENT_TOKEN>',
   datacenter: 'us',
-  isCollectingError: true,
+  forwardErrorsToLogs: true,
   sampleRate: 100
 });
 ```
@@ -58,7 +58,7 @@ import { datadogLogs } from '@datadog/browser-logs';
 datadogLogs.init({
   clientToken: '<DATADOG_CLIENT_TOKEN>',
   datacenter: 'eu',
-  isCollectingError: true,
+  forwardErrorsToLogs: true,
   sampleRate: 100
 });
 ```
@@ -81,7 +81,7 @@ In order to not miss any logs or errors, you should load and configure the libra
     <script>
       window.DD_LOGS && DD_LOGS.init({
         clientToken: '<CLIENT_TOKEN>',
-        isCollectingError: true,
+        forwardErrorsToLogs: true,
         sampleRate: 100
       });
     </script>
@@ -100,7 +100,7 @@ In order to not miss any logs or errors, you should load and configure the libra
     <script>
       window.DD_LOGS && DD_LOGS.init({
         clientToken: '<CLIENT_TOKEN>',
-        isCollectingError: true,
+        forwardErrorsToLogs: true,
         sampleRate: 100
       });
     </script>


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
This PR updates the following documentation page: https://docs.datadoghq.com/logs/log_collection/javascript/?tab=us#npm-setup

The motivation is that the parameter "isCollectingError" has been deprecated for quite a while, and it was replaced with the parameter "forwardErrorsToLogs"

### Preview link
<!-- Impacted pages preview links-->
Current doc page: https://docs.datadoghq.com/logs/log_collection/javascript/?tab=us

Impacted doc page on staging: https://docs-staging.datadoghq.com/przemek.zientala/browser_log_collection_iscollectingerror_doc_update/logs/log_collection/javascript/?tab=us

### Additional Notes
N/A