### PR TITLE
[APM] PHP tracer support for PHP 7.4

### DIFF
--- a/content/en/tracing/setup/php.md
+++ b/content/en/tracing/setup/php.md
@@ -95,6 +95,7 @@ PHP APM supports the following PHP versions:
 
 | Version | Support type    |
 |:--------|:----------------|
+| 7.4.x   | Fully Supported |
 | 7.3.x   | Fully Supported |
 | 7.2.x   | Fully Supported |
 | 7.1.x   | Fully Supported |


### PR DESCRIPTION
### What does this PR do?

Adds PHP 7.4 support for the PHP tracer (released in v0.38.0).

### Preview link

https://docs-staging.datadoghq.com/sammyk/php-7.4/tracing/setup/php/#compatibility
