### PR TITLE
Infrastructure landing page

### DIFF
--- a/content/en/infrastructure/_index.md
+++ b/content/en/infrastructure/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Infrastructure
 kind: documentation
+disable_toc: true
 aliases:
   - /graphing/infrastructure/
 ---


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Disable the toc on the infrastructure landing page

### Motivation
Other simple landing pages have this disabled

### Preview link
https://docs-staging.datadoghq.com/ruth/infra-disable-toc/infrastructure

### Additional Notes
N/A
