### PR TITLE
fix issue with node-sass

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:zach_fix-node-sass
   tags:
     - "runner:main"
     - "size:large"

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "html-loader": "^0.5.5",
     "imports-loader": "^0.8.0",
     "mini-css-extract-plugin": "^0.8.0",
-    "node-sass": "^4.13.0",
+    "node-sass": "4.13.0",
     "npm-run-all": "^4.1.5",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "postcss-import": "^12.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6002,7 +6002,7 @@ node-releases@^1.1.42:
   dependencies:
     semver "^6.3.0"
 
-node-sass@^4.13.0:
+node-sass@4.13.0:
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.0.tgz#b647288babdd6a1cb726de4545516b31f90da066"
   integrity sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==


### PR DESCRIPTION
### What does this PR do?
seems running the corp-ci image now gives an error due to an updated `node-sass` package. Locking the version to `4.13.0` fixes this. https://gitlab.ddbuild.io/DataDog/corp-ci/-/jobs/24385167

### Preview link
http://docs-staging.datadoghq.com/zach/update-node-sass
