### PR TITLE
make larger tables responsive

### DIFF
--- a/content/en/tracing/setup/java.md
+++ b/content/en/tracing/setup/java.md
@@ -191,7 +191,7 @@ To improve visibility into applications using unsupported frameworks, consider:
 The tracer is configured using System Properties and Environment Variables as follows:
 (See integration specific config in the [integrations](#integrations) section above.)
 
-{{% table  %}}
+{{% table responsive=true  %}}
 
 | System Property                        | Environment Variable                   | Default                           | Description                                                                                                                                                                                                                                                            |
 |----------------------------------------|----------------------------------------|-----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/content/en/tracing/setup/php.md
+++ b/content/en/tracing/setup/php.md
@@ -214,6 +214,8 @@ DD_TRACE_DEBUG=true php -S localhost:8888
 
 ### Environment Variable Configuration
 
+{{% table responsive=true  %}}
+
 | Env variable                              | Default     | Note                                                                                                                                           |
 |-------------------------------------------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------|
 | `DD_AGENT_HOST`                           | `localhost` | The Agent host name                                                                                                                            |
@@ -239,6 +241,8 @@ DD_TRACE_DEBUG=true php -S localhost:8888
 | `DD_TRACE_RESOURCE_URI_MAPPING`           | `null`      | CSV of URL-to-resource-name mapping rules; e.g., `/foo/*,/bar/$*/baz`; [see "Custom URL-To-Resource Mapping"](#custom-url-to-resource-mapping) |
 | `DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED`  | `false`     | Enable URL's as resource names; [see "Map Resource Names To Normalized URI"](#map-resource-names-to-normalized-uri)                            |
 | `DD_<INTEGRATION>_ANALYTICS_ENABLED`      | `false`     | Flag to enable app analytics for relevant spans in a specific integration                                                                      |
+
+{{% /table %}}
 
 #### Map Resource Names To Normalized URI
 

--- a/content/en/tracing/setup/python.md
+++ b/content/en/tracing/setup/python.md
@@ -50,6 +50,8 @@ For more advanced usage, configuration, and fine-grain control, see Datadog's [A
 
 When using **ddtrace-run**, the following [environment variable options][5] can be used:
 
+{{% table responsive=true  %}}
+
 | Environment Variable               | Default     | Description                                                                                                                                                                                                                                                                 |
 |------------------------------------|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `DATADOG_TRACE_ENABLED`            | `true`      | Enable web framework and library instrumentation. When `false`, your application code doesn't generate any traces.                                                                                                                                                          |
@@ -63,6 +65,8 @@ When using **ddtrace-run**, the following [environment variable options][5] can 
 | `DD_LOGS_INJECTION`                | `false`     | Enable [connecting logs and traces Injection][9].                                                                                                                                                                                                                           |
 | `DD_TRACE_ANALYTICS_ENABLED`       | `false`     | Enable App Analytics globally for [web integrations][10].                                                                                                                                                                                                                   |
 | `DD_INTEGRATION_ANALYTICS_ENABLED` | `false`     | Enable App Analytics for a specific integration. Example: `DD_BOTO_ANALYTICS_ENABLED=true` .                                                                                                                                                                                |
+
+{{% /table %}}
 
 ## Change Agent Hostname
 
@@ -88,6 +92,8 @@ Python versions `2.7` and `3.4` and onwards are supported.
 
 The `ddtrace` library includes support for a number of web frameworks, including:
 
+{{% table responsive=true  %}}
+
 | Framework                 | Supported Version | PyPi Datadog Documentation                                         |
 |---------------------------|-------------------|--------------------------------------------------------------------|
 | [aiohttp][11]             | >= 1.2            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#aiohttp |
@@ -101,9 +107,13 @@ The `ddtrace` library includes support for a number of web frameworks, including
 | [Pyramid][18]             | >= 1.7            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pyramid |
 | [Tornado][19]             | >= 4.0            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#tornado |
 
+{{% /table %}}
+
 #### Datastore Compatibility
 
 The `ddtrace` library includes support for the following data stores:
+
+{{% table responsive=true  %}}
 
 | Datastore                          | Supported Version | PyPi Datadog Documentation                                                                    |
 |------------------------------------|-------------------|-----------------------------------------------------------------------------------------------|
@@ -125,9 +135,13 @@ The `ddtrace` library includes support for the following data stores:
 | [SQLite3][38]                      | Fully Supported   | http://pypi.datadoghq.com/trace/docs/db_integrations.html#sqlite                              |
 | [Vertica][39]                      | >= 0.6            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#vertica                             |
 
+{{% /table %}}
+
 #### Library Compatibility
 
 The `ddtrace` library includes support for the following libraries:
+
+{{% table responsive=true  %}}
 
 | Library           | Supported Version | PyPi Datadog Documentation                                               |
 |-------------------|-------------------|--------------------------------------------------------------------------|
@@ -144,6 +158,9 @@ The `ddtrace` library includes support for the following libraries:
 | [Kombu][48]       | >= 4.0            | http://pypi.datadoghq.com/trace/docs/other_integrations.html#kombu       |
 | [Mako][49]        | >= 0.1.0          | http://pypi.datadoghq.com/trace/docs/other_integrations.html#mako        |
 | [Requests][50]    | >= 2.08           | http://pypi.datadoghq.com/trace/docs/other_integrations.html#requests    |
+
+{{% /table %}}
+
 
 ## Further Reading
 

--- a/layouts/shortcodes/table.html
+++ b/layouts/shortcodes/table.html
@@ -1,2 +1,2 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
-<div class="{{- if .Get "responsive" -}}table-responsive-container{{- end -}} {{- if .Get "wide" -}}table-wide{{- end -}} {{- if .Get "vertical-mobile" -}}table-vertical-mobile{{- end -}}">{{- if .Get "responsive" -}}<div class="table-scroll">{{- .Inner -}}</div>{{- else -}}{{- .Inner -}}{{- end -}}</div>
+<div class="{{- if .Get "responsive" -}}table-responsive{{- end -}} {{- if .Get "wide" -}}table-wide{{- end -}} {{- if .Get "vertical-mobile" -}}table-vertical-mobile{{- end -}}">{{- if .Get "responsive" -}}<div class="table-scroll">{{- .Inner -}}</div>{{- else -}}{{- .Inner -}}{{- end -}}</div>


### PR DESCRIPTION
### What does this PR do?
As a result of https://github.com/DataDog/documentation/pull/6384 and the new main content area reduced column width, some larger tables extend over the TOC. This was expected and it was preferred to have the TOC hidden under the content rather than hiding the content. 

Using the existing shortcode `{{% table responsive=true  %}}` around tables will make the larger table fit inside the column and scrollable horizontally. 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
http://docs-staging.datadoghq.com/zach/tables-responsive/tracing/setup/java/


