### PR TITLE
Update APM > Connect Logs and Traces > .NET documentation

### DIFF
--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -24,20 +24,20 @@ further_reading:
   text: "Log Collection Troubleshooting Guide"
 ---
 
-To send your C# logs to Datadog, we recommend logging to a file and then tailing that file with your Datadog Agent. Here are setup examples for the `log4Net`, `serilog` and `Nlog` logging libraries
+To send your C# logs to Datadog, we recommend logging to a file and then tailing that file with your Datadog Agent. Here are setup examples for the `log4net`, `Serilog` and `NLog` logging libraries
 
 We strongly encourage setting up your logging library to produce your logs in JSON format to avoid the need for [custom parsing rules][1].
 
 ## Configure your logger
 
 {{< tabs >}}
-{{% tab "SeriLog" %}}
+{{% tab "Serilog" %}}
 
 Like many other libraries for .NET, Serilog provides diagnostic logging into files, console, and elsewhere. It is easy to set up, has a clean API, and is portable between recent .NET platforms.
 
 Unlike other logging libraries, Serilog is built with powerful structured event data in mind.
 
-Install Serilog via NuGet. Run the following command in the Package Manager Consol:
+Install Serilog via NuGet. Run the following command in the Package Manager Console:
 
 ```text
 PM> Install-Package Serilog.Sinks.File
@@ -269,7 +269,7 @@ That's it! Now, all your logs are going to be in proper JSON automatically under
 
 It is possible to stream logs from your application to Datadog or to the Datadog Agent directly. This is not the recommended setup as handling connection issues should not be done directly in your application, but it might not be possible to log to a file when your application is running on a machine that cannot be accessed.
 {{< tabs >}}
-{{% tab "SeriLog" %}}
+{{% tab "Serilog" %}}
 
 Install the Datadog [Serilog sink][1], which sends events and logs to Datadog. By default the sink forwards logs through HTTPS on port 443.
 Run the following command in the Package Manager Console:

--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -24,7 +24,7 @@ further_reading:
   text: "Log Collection Troubleshooting Guide"
 ---
 
-To send your C# logs to Datadog, we recommend logging to a file and then tailing that file with your Datadog Agent. Here are setup examples for the `log4net`, `Serilog` and `NLog` logging libraries
+To send your C# logs to Datadog, we recommend logging to a file and then tailing that file with your Datadog Agent. Here are setup examples for the `Serilog`, `NLog`, and `log4net` logging libraries
 
 We strongly encourage setting up your logging library to produce your logs in JSON format to avoid the need for [custom parsing rules][1].
 

--- a/content/en/tracing/connect_logs_and_traces/_index.md
+++ b/content/en/tracing/connect_logs_and_traces/_index.md
@@ -123,7 +123,7 @@ This enables automatic trace ID injection for `bunyan`, `paperplane`, `pino`, an
 
 Enable injection in the .NET Tracer’s [configuration][1] by setting `DD_LOGS_INJECTION=true` through environment variables or the configuration files.
 
-The .NET Tracer uses the [LibLog][2] library to automatically inject trace IDs into your application logs if you are using [Serilog][3], [NLog][4] (version 2.0.0.2000+), or [log4net][5]. Automatic injection will only display in the appliation logs after enabling `LogContext` enrichment in your `Serilog` logger or `Mapped Diagnostics Context` in your `NLog` or `log4net` logger (see examples below). **Note**: Automatic injection only works for logs formatted as JSON.
+The .NET Tracer uses the [LibLog][2] library to automatically inject trace IDs into your application logs if you are using [Serilog][3], [NLog][4] (version 2.0.0.2000+), or [log4net][5]. Automatic injection will only display in the application logs after enabling `LogContext` enrichment in your `Serilog` logger or `Mapped Diagnostics Context` in your `NLog` or `log4net` logger (see examples below). **Note**: Automatic injection only works for logs formatted as JSON.
 
 **Automatic Trace ID Injection for Serilog**
 ```csharp

--- a/content/en/tracing/connect_logs_and_traces/_index.md
+++ b/content/en/tracing/connect_logs_and_traces/_index.md
@@ -123,7 +123,7 @@ This enables automatic trace ID injection for `bunyan`, `paperplane`, `pino`, an
 
 Enable injection in the .NET Tracer’s [configuration][1] by setting `DD_LOGS_INJECTION=true` through environment variables or the configuration files.
 
-The .NET Tracer uses the [LibLog][2] library to automatically inject trace IDs into your application logs if you are using [Serilog][3], [NLog][4] (version 2.0.0.2000+), or [Log4Net][5]. Automatic injection will only display in your logs after configuring your logger to emit MDC attributes (see examples below). **Note**: Automatic injection only works for logs formatted as JSON.
+The .NET Tracer uses the [LibLog][2] library to automatically inject trace IDs into your application logs if you are using [Serilog][3], [NLog][4] (version 2.0.0.2000+), or [Log4Net][5]. Automatic injection will only display in your logs after configuring your logger to emit MappedDiagnosticsContext attributes (see examples below). **Note**: Automatic injection only works for logs formatted as JSON.
 
 **Automatic Trace ID Injection for Serilog**
 ```csharp

--- a/content/en/tracing/connect_logs_and_traces/_index.md
+++ b/content/en/tracing/connect_logs_and_traces/_index.md
@@ -123,7 +123,7 @@ This enables automatic trace ID injection for `bunyan`, `paperplane`, `pino`, an
 
 Enable injection in the .NET Tracer’s [configuration][1] by setting `DD_LOGS_INJECTION=true` through environment variables or the configuration files.
 
-The .NET Tracer uses the [LibLog][2] library to automatically inject trace IDs into your application logs if you are using [Serilog][3], [NLog][4] (version 2.0.0.2000+), or [log4net][5]. Automatic injection will only display in the application logs after enabling `LogContext` enrichment in your `Serilog` logger or `Mapped Diagnostics Context` in your `NLog` or `log4net` logger (see examples below). **Note**: Automatic injection only works for logs formatted as JSON.
+The .NET Tracer uses the [LibLog][2] library to automatically inject trace IDs into your application logs if you are using [Serilog][3], [NLog][4] (version 2.0.0.2000+), or [log4net][5]. Automatic injection only displays in the application logs after enabling `LogContext` enrichment in your `Serilog` logger or `Mapped Diagnostics Context` in your `NLog` or `log4net` logger (see examples below). **Note**: Automatic injection only works for logs formatted as JSON.
 
 **Automatic Trace ID Injection for Serilog**
 ```csharp
@@ -477,7 +477,7 @@ Coming Soon. Reach out to [the Datadog support team][1] to learn more.
 If you prefer to manually correlate your [traces][1] with your logs, leverage the Datadog API to retrieve correlation identifiers:
 
 * Use `CorrelationIdentifier.TraceId` and `CorrelationIdentifier.SpanId` API methods to inject identifiers at the beginning and end of each [span][2] to log (see examples below).
-* Configure MDC to use the injected Keys:
+* Configure MDC to use the injected keys:
   * `dd.trace_id` Active Trace ID during the log statement (or `0` if no trace)
   * `dd.span_id` Active Span ID during the log statement (or `0` if no trace)
 * `Serilog` example:
@@ -530,7 +530,7 @@ finally
 }
 ```
 
-**Note**: If you are not using a [Datadog Log Integration][3] to parse your logs, custom log parsing rules need to ensure that `trace_id` and `span_id` are being parsed as a string. More information can be found in the [FAQ on this topic][4].
+**Note**: If you are not using a [Datadog Log Integration][3] to parse your logs, custom log parsing rules need to ensure that `trace_id` and `span_id` are parsed as strings. More information can be found in the [FAQ on this topic][4].
 [1]: /tracing/visualization/#trace
 [2]: /tracing/visualization/#spans
 [3]: /logs/log_collection/csharp/#configure-your-logger

--- a/content/en/tracing/connect_logs_and_traces/_index.md
+++ b/content/en/tracing/connect_logs_and_traces/_index.md
@@ -121,9 +121,9 @@ This enables automatic trace ID injection for `bunyan`, `paperplane`, `pino`, an
 {{% /tab %}}
 {{% tab ".NET" %}}
 
-Enable injection in the .NET Tracer’s [configuration][5] by setting `DD_LOGS_INJECTION=true` through environment variables or the configuration files.
+Enable injection in the .NET Tracer’s [configuration][1] by setting `DD_LOGS_INJECTION=true` through environment variables or the configuration files.
 
-The .NET Tracer uses the [LibLog][1] library to automatically inject trace IDs into your application logs if you are using [NLog][2], [Log4Net][3], or [Serilog][4]. Automatic injection will only display in your logs after configuring your logger to emit MDC attributes (see examples below). **Note**: Automatic injection only works for logs formatted as JSON.
+The .NET Tracer uses the [LibLog][2] library to automatically inject trace IDs into your application logs if you are using [Serilog][3], [NLog][4], or [Log4Net][5]. Automatic injection will only display in your logs after configuring your logger to emit MDC attributes (see examples below). **Note**: Automatic injection only works for logs formatted as JSON.
 
 **Automatic Trace ID Injection for Serilog**
 ```csharp
@@ -172,12 +172,11 @@ var log = new LoggerConfiguration()
   </layout>
 ```
 
-
-[1]: https://github.com/damianh/LibLog
-[2]: http://nlog-project.org
-[3]: https://logging.apache.org/log4net
-[4]: http://serilog.net
-[5]: /tracing/setup/dotnet/#configuration
+[1]: /tracing/setup/dotnet/#configuration
+[2]: https://github.com/damianh/LibLog
+[3]: http://serilog.net
+[4]: http://nlog-project.org
+[5]: https://logging.apache.org/log4net
 {{% /tab %}}
 {{% tab "PHP" %}}
 

--- a/content/en/tracing/connect_logs_and_traces/_index.md
+++ b/content/en/tracing/connect_logs_and_traces/_index.md
@@ -128,14 +128,14 @@ The .NET Tracer uses the [LibLog][2] library to automatically inject trace IDs i
 **Automatic Trace ID Injection for Serilog**
 ```csharp
 var log = new LoggerConfiguration()
-    .Enrich.FromLogContext() // Add Enrich.FromLogContext to emit the MDC properties in the log output
+    .Enrich.FromLogContext() // Add Enrich.FromLogContext to emit MDC properties
     .WriteTo.File(new JsonFormatter(), "log.json")
     .CreateLogger();
 ```
 
 **Automatic Trace ID Injection for NLog 4.5**
 ```xml
-  <!-- Add includeMdc="true" to emit the MDC properties in the log output -->
+  <!-- Add includeMdc="true" to emit MDC properties -->
   <layout xsi:type="JsonLayout" includeMdc="true">
     <attribute name="date" layout="${longdate}" />
     <attribute name="level" layout="${level:upperCase=true}"/>
@@ -146,7 +146,7 @@ var log = new LoggerConfiguration()
 
 **Automatic Trace ID Injection for NLog 4.6+**
 ```xml
-  <!-- Add includeMdlc="true" to emit the MDC properties in the log output -->
+  <!-- Add includeMdlc="true" to emit MDC properties -->
   <layout xsi:type="JsonLayout" includeMdlc="true">
     <attribute name="date" layout="${longdate}" />
     <attribute name="level" layout="${level:upperCase=true}"/>
@@ -167,7 +167,7 @@ var log = new LoggerConfiguration()
     <member value="message:messageobject" />
     <!--add raw message-->
 
-    <!-- Add value='properties' to emit the MDC properties in the log output -->
+    <!-- Add value='properties' to emit MDC properties -->
     <member value='properties'/>
   </layout>
 ```

--- a/content/en/tracing/connect_logs_and_traces/_index.md
+++ b/content/en/tracing/connect_logs_and_traces/_index.md
@@ -123,7 +123,7 @@ This enables automatic trace ID injection for `bunyan`, `paperplane`, `pino`, an
 
 Enable injection in the .NET Tracer’s [configuration][5] by setting `DD_LOGS_INJECTION=true` through environment variables or the configuration files.
 
-The .NET Tracer uses the [LibLog][1] library to automatically inject trace IDs into your application logs if you are using [NLog][2], [Log4Net][3], or [Serilog][4]. Follow the steps below for your logging library to emit the MDC attributes injected by the .NET Tracer. **Note**: Automatic injection only works for logs formatted as JSON.
+The .NET Tracer uses the [LibLog][1] library to automatically inject trace IDs into your application logs if you are using [NLog][2], [Log4Net][3], or [Serilog][4]. Automatic injection will only display in your logs after configuring your logger to emit MDC attributes (see examples below). **Note**: Automatic injection only works for logs formatted as JSON.
 
 **Automatic Trace ID Injection for Serilog**
 ```csharp
@@ -475,23 +475,66 @@ Coming Soon. Reach out to [the Datadog support team][1] to learn more.
 {{% /tab %}}
 {{% tab ".NET" %}}
 
-To manually inject trace identifiers into your logs, access the necessary values through the `CorrelationIdentifier` static class. If your logging library supports structured logging, such as JSON messages, add the `dd.trace_id` and `dd.span_id` properties with their respective values.
+If you prefer to manually correlate your [traces][1] with your logs, leverage the Datadog API to retrieve correlation identifiers:
 
-Otherwise, add the strings `dd.trace_id=<TRACE_ID>` and `dd.span_id=<SPAN_ID>` to your log message. For example:
+* Use `CorrelationIdentifier.TraceId` and `CorrelationIdentifier.SpanId` API methods to inject identifiers at the beginning and end of each [span][2] to log (see examples below).
+* Configure MDC to use the injected Keys:
+  * `dd.trace_id` Active Trace ID during the log statement (or `0` if no trace)
+  * `dd.span_id` Active Span ID during the log statement (or `0` if no trace)
+* `Serilog` example:
 
 ```csharp
 using Datadog.Trace;
+using Serilog.Context;
 
-var traceId = CorrelationIdentifier.TraceId;
-var spanId = CorrelationIdentifier.SpanId;
-
-var message = $"My log message. [dd.trace_id={traceId} dd.span_id={spanId}]";
+// there must be spans started and active before this block.
+using (LogContext.PushProperty("dd.trace_id", CorrelationIdentifier.TraceId.ToString()))
+using (LogContext.PushProperty("dd.span_id", CorrelationIdentifier.SpanId.ToString()))
+{
+    // Log something
+}
 ```
 
-**Note**: If you are not using a [Datadog Log Integration][1] to parse your logs, custom log parsing rules need to ensure that `trace_id` and `span_id` are being parsed as a string. More information can be found in the [FAQ on this topic][2].
+* `NLog` example:
 
-[1]: /logs/log_collection/csharp/#configure-your-logger
-[2]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel
+```csharp
+using Datadog.Trace;
+using NLog;
+
+// there must be spans started and active before this block.
+using (MappedDiagnosticsLogicalContext.SetScoped("dd.trace_id", CorrelationIdentifier.TraceId.ToString()))
+using (MappedDiagnosticsLogicalContext.SetScoped("dd.span_id", CorrelationIdentifier.SpanId.ToString()))
+{
+    // Log something
+}
+```
+
+* `log4net` example:
+
+```csharp
+using Datadog.Trace;
+using log4net;
+
+// there must be spans started and active before this block.
+try
+{
+    LogicalThreadContext.Properties["dd.trace_id"] = CorrelationIdentifier.TraceId.ToString();
+    LogicalThreadContext.Properties["dd.span_id"] = CorrelationIdentifier.SpanId.ToString();
+
+    // Log something
+}
+finally
+{
+    LogicalThreadContext.Properties.Remove("dd.trace_id");
+    LogicalThreadContext.Properties.Remove("dd.span_id");
+}
+```
+
+**Note**: If you are not using a [Datadog Log Integration][3] to parse your logs, custom log parsing rules need to ensure that `trace_id` and `span_id` are being parsed as a string. More information can be found in the [FAQ on this topic][4].
+[1]: /tracing/visualization/#trace
+[2]: /tracing/visualization/#spans
+[3]: /logs/log_collection/csharp/#configure-your-logger
+[4]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel
 {{% /tab %}}
 {{% tab "PHP" %}}
 

--- a/content/en/tracing/connect_logs_and_traces/_index.md
+++ b/content/en/tracing/connect_logs_and_traces/_index.md
@@ -123,7 +123,7 @@ This enables automatic trace ID injection for `bunyan`, `paperplane`, `pino`, an
 
 Enable injection in the .NET Tracer’s [configuration][1] by setting `DD_LOGS_INJECTION=true` through environment variables or the configuration files.
 
-The .NET Tracer uses the [LibLog][2] library to automatically inject trace IDs into your application logs if you are using [Serilog][3], [NLog][4] (version 2.0.0.2000+), or [log4net][5]. Automatic injection will only display in your logs after enabling `LogContext` enrichment in your `Serilog` logger or Mapped Diagnostics Context in your `NLog` or `log4net` logger (see examples below). **Note**: Automatic injection only works for logs formatted as JSON.
+The .NET Tracer uses the [LibLog][2] library to automatically inject trace IDs into your application logs if you are using [Serilog][3], [NLog][4] (version 2.0.0.2000+), or [log4net][5]. Automatic injection will only display in the appliation logs after enabling `LogContext` enrichment in your `Serilog` logger or `Mapped Diagnostics Context` in your `NLog` or `log4net` logger (see examples below). **Note**: Automatic injection only works for logs formatted as JSON.
 
 **Automatic Trace ID Injection for Serilog**
 ```csharp
@@ -521,6 +521,7 @@ try
     LogicalThreadContext.Properties["dd.span_id"] = CorrelationIdentifier.SpanId.ToString();
 
     // Log something
+
 }
 finally
 {

--- a/content/en/tracing/connect_logs_and_traces/_index.md
+++ b/content/en/tracing/connect_logs_and_traces/_index.md
@@ -123,7 +123,7 @@ This enables automatic trace ID injection for `bunyan`, `paperplane`, `pino`, an
 
 Enable injection in the .NET Tracer’s [configuration][1] by setting `DD_LOGS_INJECTION=true` through environment variables or the configuration files.
 
-The .NET Tracer uses the [LibLog][2] library to automatically inject trace IDs into your application logs if you are using [Serilog][3], [NLog][4], or [Log4Net][5]. Automatic injection will only display in your logs after configuring your logger to emit MDC attributes (see examples below). **Note**: Automatic injection only works for logs formatted as JSON.
+The .NET Tracer uses the [LibLog][2] library to automatically inject trace IDs into your application logs if you are using [Serilog][3], [NLog][4] (version 2.0.0.2000+), or [Log4Net][5]. Automatic injection will only display in your logs after configuring your logger to emit MDC attributes (see examples below). **Note**: Automatic injection only works for logs formatted as JSON.
 
 **Automatic Trace ID Injection for Serilog**
 ```csharp

--- a/content/en/tracing/connect_logs_and_traces/_index.md
+++ b/content/en/tracing/connect_logs_and_traces/_index.md
@@ -123,7 +123,7 @@ This enables automatic trace ID injection for `bunyan`, `paperplane`, `pino`, an
 
 Enable injection in the .NET Tracer’s [configuration][1] by setting `DD_LOGS_INJECTION=true` through environment variables or the configuration files.
 
-The .NET Tracer uses the [LibLog][2] library to automatically inject trace IDs into your application logs if you are using [Serilog][3], [NLog][4] (version 2.0.0.2000+), or [log4net][5]. Automatic injection will only display in your logs after enabling Enrichment in your `Serilog` logger or Mapped Diagnostics Context in your `NLog` or `log4net` logger (see examples below). **Note**: Automatic injection only works for logs formatted as JSON.
+The .NET Tracer uses the [LibLog][2] library to automatically inject trace IDs into your application logs if you are using [Serilog][3], [NLog][4] (version 2.0.0.2000+), or [log4net][5]. Automatic injection will only display in your logs after enabling `LogContext` enrichment in your `Serilog` logger or Mapped Diagnostics Context in your `NLog` or `log4net` logger (see examples below). **Note**: Automatic injection only works for logs formatted as JSON.
 
 **Automatic Trace ID Injection for Serilog**
 ```csharp

--- a/content/en/tracing/connect_logs_and_traces/_index.md
+++ b/content/en/tracing/connect_logs_and_traces/_index.md
@@ -123,7 +123,7 @@ This enables automatic trace ID injection for `bunyan`, `paperplane`, `pino`, an
 
 Enable injection in the .NET Tracer’s [configuration][1] by setting `DD_LOGS_INJECTION=true` through environment variables or the configuration files.
 
-The .NET Tracer uses the [LibLog][2] library to automatically inject trace IDs into your application logs if you are using [Serilog][3], [NLog][4] (version 2.0.0.2000+), or [Log4Net][5]. Automatic injection will only display in your logs after configuring your logger to emit MappedDiagnosticsContext attributes (see examples below). **Note**: Automatic injection only works for logs formatted as JSON.
+The .NET Tracer uses the [LibLog][2] library to automatically inject trace IDs into your application logs if you are using [Serilog][3], [NLog][4] (version 2.0.0.2000+), or [log4net][5]. Automatic injection will only display in your logs after enabling Enrichment in your `Serilog` logger or Mapped Diagnostics Context in your `NLog` or `log4net` logger (see examples below). **Note**: Automatic injection only works for logs formatted as JSON.
 
 **Automatic Trace ID Injection for Serilog**
 ```csharp

--- a/content/fr/logs/log_collection/csharp.md
+++ b/content/fr/logs/log_collection/csharp.md
@@ -23,14 +23,14 @@ further_reading:
     tag: FAQ
     text: Dépannage pour la collecte de logs
 ---
-Pour envoyer vos logs C# à Datadog, nous vous recommandons d'activer la journalisation au sein d'un fichier et de le suivre avec l'Agent Datadog. Voici des exemples de configuration pour les bibliothèques de journalisation `log4Net`, `serilog` et `Nlog`.
+Pour envoyer vos logs C# à Datadog, nous vous recommandons d'activer la journalisation au sein d'un fichier et de le suivre avec l'Agent Datadog. Voici des exemples de configuration pour les bibliothèques de journalisation `log4net`, `Serilog` et `NLog`.
 
 Nous vous encourageons fortement à configurer votre bibliothèque de journalisation afin de générer vos logs au format JSON et d'éviter de créer des [règles de parsing personnalisées][1].
 
 ## Configurer votre logger
 
 {{< tabs >}}
-{{% tab "SeriLog" %}}
+{{% tab "Serilog" %}}
 
 Comme bien d'autres bibliothèques pour .NET, Serilog vous permet d'effectuer une journalisation de diagnostic dans des fichiers, une console ou d'autres éléments. Ce processus de journalisation est facilement configurable, dispose d'une API épurée et peut être utilisé sur les plateformes .NET récentes.
 
@@ -275,7 +275,7 @@ Et voilà ! Désormais, tous vos logs seront automatiquement au format JSON com
 
 Il est possible de transmettre des logs depuis votre application vers Datadog ou directement vers l'Agent Datadog. Il ne s'agit pas de la configuration recommandée, car la gestion des problèmes de connexion ne doit pas se faire directement dans votre application, mais il peut arriver qu'il soit impossible d'enregistrer un log dans un fichier lorsque votre application est utilisée sur une machine hors d'accès.
 {{< tabs >}}
-{{% tab "SeriLog" %}}
+{{% tab "Serilog" %}}
 
 Installez le [récepteur Serilog][1] de Datadog, qui envoie les événements et les logs à Datadog. Par défaut, le récepteur transfère les logs via HTTPS sur le port 443.
 Exécutez la commande suivante dans la console de gestion de paquet :


### PR DESCRIPTION
### What does this PR do?
The PR updates the documentation for setting up .NET APM Logs Injection, specifically adding missing information regarding the additional logger configuration changes required to get the correlation working in the backend. To a smaller extent this PR standardizes the order of the logging libraries in the documentation and fixes small typos.

### Motivation
We have a number of customer issues regarding .NET APM Logs Injection setup and this aims to resolve those issues.

### Preview link
https://docs-staging.datadoghq.com/zach.montoya/logs-injection-update/tracing/connect_logs_and_traces/?tab=net

### Additional Notes
N/A
