### PR TITLE
Table fix

### DIFF
--- a/content/en/tracing/guide/agent-5-tracing-setup.md
+++ b/content/en/tracing/guide/agent-5-tracing-setup.md
@@ -53,8 +53,6 @@ The Datadog Agent uses the configuration file for both infrastructure monitoring
 
 Additionally, some configuration options may be set as environment variables. Note that options set as environment variables overrides the settings defined in the configuration file.
 
-{{% table  %}}
-
 | File setting            | Environment variable       | Description                                                                                                                                                      |
 |-------------------------|----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `apm_enabled`           | `DD_APM_ENABLED`           | The Datadog Agent accepts trace metrics when the value is set to `true`. The default value is `true`.                                                            |
@@ -63,8 +61,6 @@ Additionally, some configuration options may be set as environment variables. No
 | `receiver_port`         | `DD_RECEIVER_PORT`         | The port that the Datadog Agent's trace receiver should listen on. The default value is `8126`.                                                                  |
 | `connection_limit`      | `DD_CONNECTION_LIMIT`      | The number of unique client connections to allow during one 30 second lease period. The default value is `2000`.                                                 |
 | `resource`              | `DD_IGNORE_RESOURCE`       | A blacklist of regular expressions to filter out traces by their resource name.                                                                                  |
-
-{{% /table %}}
 
 For more information about the Datadog Agent, see the [dedicated doc page][9] or refer to the [`datadog.conf.example` file][10].
 

--- a/content/en/tracing/setup/java.md
+++ b/content/en/tracing/setup/java.md
@@ -371,7 +371,7 @@ To report a trace to Datadog the following happens:
 * In a separate reporting thread, the trace queue is flushed and traces are encoded via msgpack then sent to the Datadog Agent via http
 * Queue flushing happens on a schedule of once per second
 
-To see the actual code, documentation, and usage examples for any of the libraries and frameworks that Datadog supports, check the full list of auto- instrumented components for Java applications in the [Integrations](#integrations) section.
+To see the actual code, documentation, and usage examples for any of the libraries and frameworks that Datadog supports, check the full list of auto-instrumented components for Java applications in the [Integrations](#integrations) section.
 
 ### Trace Annotation
 

--- a/content/en/tracing/setup/java.md
+++ b/content/en/tracing/setup/java.md
@@ -149,16 +149,16 @@ Don't see your desired networking framework? Datadog is continually adding addit
 
 `dd-java-agent` is also compatible with common JDBC drivers including:
 
-*  Apache Derby
-*  Firebird SQL
-*  H2 Database Engine
-*  HSQLDB
-*  IBM DB2
-*  MariaDB
-*  MSSQL (Microsoft SQL Server)
-*  MySQL
-*  Oracle
-*  Postgres SQL
+* Apache Derby
+* Firebird SQL
+* H2 Database Engine
+* HSQLDB
+* IBM DB2
+* MariaDB
+* MSSQL (Microsoft SQL Server)
+* MySQL
+* Oracle
+* Postgres SQL
 
 **Datastore tracing provides:** timing request to response, query info (e.g. a sanitized query string), and error and stacktrace capturing.
 
@@ -191,8 +191,6 @@ To improve visibility into applications using unsupported frameworks, consider:
 The tracer is configured using System Properties and Environment Variables as follows:
 (See integration specific config in the [integrations](#integrations) section above.)
 
-{{% table  %}}
-
 | System Property                        | Environment Variable                   | Default                           | Description                                                                                                                                                                                                                                                            |
 |----------------------------------------|----------------------------------------|-----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `dd.trace.enabled`                     | `DD_TRACE_ENABLED`                     | `true`                            | When `false` tracing agent is disabled.                                                                                                                                                                                                                                |
@@ -207,7 +205,7 @@ The tracer is configured using System Properties and Environment Variables as fo
 | `dd.trace.span.tags`                   | `DD_TRACE_SPAN_TAGS`                   | `null`                            | (Example: `key1:value1,key2:value2`) A list of default tags to be added to every span. Tags of the same name added directly to a span overwrite the defaults provided here.                                                                                            |
 | `dd.trace.jmx.tags`                    | `DD_TRACE_JMX_TAGS`                    | `null`                            | (Example: `key1:value1,key2:value2`) A list of default tags to be added to every JMX metric. Tags of the same name added in JMX metrics configuration overwrite the defaults provided here.                                                                            |
 | `dd.trace.header.tags`                 | `DD_TRACE_HEADER_TAGS`                 | `null`                            | (Example: `CASE-insensitive-Header:my-tag-name,User-ID:userId`) A map of header keys to tag names.  Automatically apply header values as tags on traces.                                                                                                               |
-| `dd.trace.annotations`                 | `DD_TRACE_ANNOTATIONS`                 | ([listed here][2])                | (Example: `com.some.Trace;io.other.Trace`) A list of method annotations to treat as `@Trace`.                                                                                                                                                                          |
+| `dd.trace.annotations`                 | `DD_TRACE_ANNOTATIONS`                 | ([listed here][10])                | (Example: `com.some.Trace;io.other.Trace`) A list of method annotations to treat as `@Trace`.                                                                                                                                                                          |
 | `dd.trace.methods`                     | `DD_TRACE_METHODS`                     | `null`                            | (Example: `package.ClassName[method1,method2,...];AnonymousClass$1[call]`) List of class/interface and methods to trace.  Similar to adding `@Trace`, but without changing code.                                                                                       |
 | `dd.trace.partial.flush.min.spans`     | `DD_TRACE_PARTIAL_FLUSH_MIN_SPANS`     | `1000`                            | Set a number of partial spans to flush on. Useful to reduce memory overhead when dealing with heavy traffic or long running traces.                                                                                                                                    |
 | `dd.trace.report-hostname`             | `DD_TRACE_REPORT_HOSTNAME`             | `false`                           | When enabled, it adds the detected hostname to trace metadata                                                                                                                                                                                                          |
@@ -226,28 +224,23 @@ The tracer is configured using System Properties and Environment Variables as fo
 | `dd.jmxfetch.refresh-beans-period`     | `DD_JMXFETCH_REFRESH_BEANS_PERIOD`     | `600`                             | How often to refresh list of avalable JMX beans (in seconds).                                                                                                                                                                                                          |
 | `dd.jmxfetch.statsd.host`              | `DD_JMXFETCH_STATSD_HOST`              | same as `agent.host`              | Statsd host to send JMX metrics to.                                                                                                                                                                                                                                    |
 | `dd.jmxfetch.statsd.port`              | `DD_JMXFETCH_STATSD_PORT`              | 8125                              | Statsd port to send JMX metrics to.                                                                                                                                                                                                                                    |
-| `dd.logs.injection`                    | `DD_LOGS_INJECTION`                    | false                             | Enabled automatic MDC key injection for Datadog trace and span ids. See [Advanced Usage][3] for details                                                                                                                                                                |
-
-[1]: /agent/docker/apm
-[2]: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java#L37
-[3]: /tracing/connect_logs_and_traces/?tab=java
-{{% /table %}}
+| `dd.logs.injection`                    | `DD_LOGS_INJECTION`                    | false                             | Enabled automatic MDC key injection for Datadog trace and span ids. See [Advanced Usage][11] for details                                                                                                                                                                |
 
 **Note**:
 
 * If the same key type is set for both, the system property configuration takes priority.
 * System properties can be used as JVM parameters.
-* By default, JMX metrics from your application are sent to the Datadog Agent thanks to DogStatsD over port `8125`. Make sure that [DogStatsD is enabled for the Agent][10].
-If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to `true`][11], and that port `8125` is open on the Agent container.
-In Kubernetes, [bind the DogStatsD port to a host port][12]; in ECS, [set the appropriate flags in your task definition][13].
+* By default, JMX metrics from your application are sent to the Datadog Agent thanks to DogStatsD over port `8125`. Make sure that [DogStatsD is enabled for the Agent][12].
+If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to `true`][13], and that port `8125` is open on the Agent container.
+In Kubernetes, [bind the DogStatsD port to a host port][14]; in ECS, [set the appropriate flags in your task definition][15].
 
 ### Configuration Examples
 
 #### `dd.trace.enabled`
 
-**Example with system property and debug app mode**
+**Example with system property and debug app mode**:
 
-```
+```shell
 java -javaagent:/path/to/dd-java-agent.jar -Ddd.trace.enabled=false -Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug -jar path/to/application.jar
 ```
 
@@ -255,8 +248,9 @@ Debug app logs show that `Tracing is disabled, not installing instrumentations.`
 
 #### `dd.service.name`
 
-**Example with system property**
-```
+**Example with system property**:
+
+```shell
 java -javaagent:/path/to/dd-java-agent.jar -Ddd.service.name=web-app -jar path/to/application.jar
 ```
 
@@ -264,8 +258,9 @@ java -javaagent:/path/to/dd-java-agent.jar -Ddd.service.name=web-app -jar path/t
 
 #### `dd.service.mapping`
 
-**Example with system property**
-```
+**Example with system property**:
+
+```shell
 java -javaagent:/path/to/dd-java-agent.jar -Ddd.service.name=web-app -Ddd.service.mapping=postgresql:web-app-pg -jar path/to/application.jar
 ```
 
@@ -273,9 +268,9 @@ java -javaagent:/path/to/dd-java-agent.jar -Ddd.service.name=web-app -Ddd.servic
 
 #### `dd.trace.global.tags`
 
-**Setting a global env for spans and JMX metrics**
+**Setting a global env for spans and JMX metrics**:
 
-```
+```shell
 java -javaagent:/path/to/dd-java-agent.jar -Ddd.service.name=web-app -Ddd.trace.global.tags=env:dev -jar path/to/application.jar
 ```
 
@@ -283,9 +278,9 @@ java -javaagent:/path/to/dd-java-agent.jar -Ddd.service.name=web-app -Ddd.trace.
 
 #### `dd.trace.span.tags`
 
-**Example with adding project:test to every span**
+**Example with adding project:test to every span**:
 
-```
+```shell
 java -javaagent:/path/to/dd-java-agent.jar -Ddd.service.name=web-app -Ddd.trace.global.tags=env:dev -Ddd.trace.span.tags=project:test -jar path/to/application.jar
 ```
 
@@ -293,9 +288,9 @@ java -javaagent:/path/to/dd-java-agent.jar -Ddd.service.name=web-app -Ddd.trace.
 
 #### `dd.trace.jmx.tags`
 
-**Setting custom.type:2 on a JMX metric**
+**Setting custom.type:2 on a JMX metric**:
 
-```
+```shell
 java -javaagent:/path/to/dd-java-agent.jar -Ddd.service.name=web-app -Ddd.trace.global.tags=env:dev -Ddd.trace.span.tags=project:test -Ddd.trace.jmx.tags=custom.type:2 -jar path/to/application.jar
 ```
 
@@ -303,9 +298,9 @@ java -javaagent:/path/to/dd-java-agent.jar -Ddd.service.name=web-app -Ddd.trace.
 
 #### `dd.trace.methods`
 
-**Example with system property**
+**Example with system property**:
 
-```
+```shell
 java -javaagent:/path/to/dd-java-agent.jar -Ddd.trace.global.tags=env:dev -Ddd.service.name=web-app -Ddd.trace.methods=notes.app.NotesHelper[customMethod3] -jar path/to/application.jar
 ```
 
@@ -314,7 +309,8 @@ java -javaagent:/path/to/dd-java-agent.jar -Ddd.trace.global.tags=env:dev -Ddd.s
 #### `dd.trace.db.client.split-by-instance`
 
 Example with system property:
-```
+
+```shell
 java -javaagent:/path/to/dd-java-agent.jar -Ddd.trace.global.tags=env:dev -Ddd.service.name=web-app -Ddd.trace.db.client.split-by-instance=TRUE -jar path/to/application.jar
 ```
 
@@ -331,7 +327,8 @@ Similarly on the service map, you would now see one web app making calls to two 
 #### `dd.http.server.tag.query-string`
 
 Example with system property:
-```
+
+```shell
 java -javaagent:/path/to/dd-java-agent.jar -Ddd.service.name=web-app -Ddd.trace.global.tags=env:dev -Ddd.http.server.tag.query-string=TRUE -jar path/to/application.jar
 ```
 
@@ -339,11 +336,9 @@ java -javaagent:/path/to/dd-java-agent.jar -Ddd.service.name=web-app -Ddd.trace.
 
 ### B3 Headers Extraction and Injection
 
-Datadog APM tracer supports [B3 headers extraction][14] and injection for distributed tracing.
+Datadog APM tracer supports [B3 headers extraction][16] and injection for distributed tracing.
 
-Distributed headers injection and extraction is controlled by
-configuring injection/extraction styles. Currently two styles are
-supported:
+Distributed headers injection and extraction is controlled by configuring injection/extraction styles. Currently two styles are supported:
 
 * Datadog: `Datadog`
 * B3: `B3`
@@ -353,22 +348,16 @@ Injection styles can be configured using:
 * System Property: `-Ddd.propagation.style.inject=Datadog,B3`
 * Environment Variable: `DD_PROPAGATION_STYLE_INJECT=Datadog,B3`
 
-The value of the property or environment variable is a comma (or
-space) separated list of header styles that are enabled for
-injection. By default only Datadog injection style is enabled.
+The value of the property or environment variable is a comma (or space) separated list of header styles that are enabled for injection. By default only Datadog injection style is enabled.
 
 Extraction styles can be configured using:
 
 * System Property: `-Ddd.propagation.style.extract=Datadog,B3`
 * Environment Variable: `DD_PROPAGATION_STYLE_EXTRACT=Datadog,B3`
 
-The value of the property or environment variable is a comma (or
-space) separated list of header styles that are enabled for
-extraction. By default only Datadog extraction style is enabled.
+The value of the property or environment variable is a comma (or space) separated list of header styles that are enabled for extraction. By default only Datadog extraction style is enabled.
 
-If multiple extraction styles are enabled extraction attempt is done
-on the order those styles are configured and first successful
-extracted value is used.
+If multiple extraction styles are enabled extraction attempt is done on the order those styles are configured and first successful extracted value is used.
 
 ## Trace Reporting
 
@@ -382,9 +371,7 @@ To report a trace to Datadog the following happens:
 * In a separate reporting thread, the trace queue is flushed and traces are encoded via msgpack then sent to the Datadog Agent via http
 * Queue flushing happens on a schedule of once per second
 
-To see the actual code, documentation, and usage examples for any of the
-libraries and frameworks that Datadog supports, check the full list of auto-
-instrumented components for Java applications in the [Integrations](#integrations) section.
+To see the actual code, documentation, and usage examples for any of the libraries and frameworks that Datadog supports, check the full list of auto- instrumented components for Java applications in the [Integrations](#integrations) section.
 
 ### Trace Annotation
 
@@ -450,8 +437,10 @@ java -javaagent:<DD-JAVA-AGENT-PATH>.jar \
 [7]: http://bytebuddy.net
 [8]: /help
 [9]: https://github.com/DataDog/documentation#outside-contributors
-[10]: /developers/dogstatsd/#setup
-[11]: /agent/docker/#dogstatsd-custom-metrics
-[12]: /agent/kubernetes/dogstatsd/#bind-the-dogstatsd-port-to-a-host-port
-[13]: /integrations/amazon_ecs/?tab=python#create-an-ecs-task
-[14]: https://github.com/openzipkin/b3-propagation
+[10]: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java#L37
+[11]: /tracing/connect_logs_and_traces/?tab=java
+[12]: /developers/dogstatsd/#setup
+[13]: /agent/docker/#dogstatsd-custom-metrics
+[14]: /agent/kubernetes/dogstatsd/#bind-the-dogstatsd-port-to-a-host-port
+[15]: /integrations/amazon_ecs/?tab=python#create-an-ecs-task
+[16]: https://github.com/openzipkin/b3-propagation

--- a/layouts/shortcodes/table.html
+++ b/layouts/shortcodes/table.html
@@ -1,2 +1,2 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
-<div class="{{- if .Get "responsive" -}}table-responsive-container{{- end -}} {{- if .Get "wide" -}}table-wide{{- end -}} {{- if .Get "vertical-mobile" -}}table-vertical-mobile{{- end -}}">{{- if .Get "responsive" -}}<div class="table-scroll">{{- .Inner -}}</div>{{- else -}}{{- .Inner -}}{{- end -}}</div>
+<div class="{{- if .Get "responsive" -}}table-responsive{{- end -}} {{- if .Get "wide" -}}table-wide{{- end -}} {{- if .Get "vertical-mobile" -}}table-vertical-mobile{{- end -}}">{{- if .Get "responsive" -}}<div class="table-scroll">{{- .Inner -}}</div>{{- else -}}{{- .Inner -}}{{- end -}}</div>


### PR DESCRIPTION
### What does this PR do?

Fixes table layout and removes the responsive aspect so that the table can overflow over the ToC. The idea is to prioritise the content over the navigation when the table is "too big"

It also lint the setup/java page

### Motivation
https://github.com/DataDog/documentation/pull/6509

### Preview link

* https://docs-staging.datadoghq.com/gus/table-fix/tracing/setup/java/#configuration