### PR TITLE
update supported libraries for dd-trace-js

### DIFF
--- a/content/en/tracing/setup/nodejs.md
+++ b/content/en/tracing/setup/nodejs.md
@@ -143,6 +143,7 @@ For details about how to how to toggle and configure plugins, check out the [API
 | Module      | Support Type    |
 |-------------|-----------------|
 | [dns][21]   | Fully supported |
+| [fs][51]    | Fully supported |
 | [http][22]  | Fully supported |
 | [https][23] | Fully supported |
 | [net][24]   | Fully supported |
@@ -172,7 +173,7 @@ For details about how to how to toggle and configure plugins, check out the [API
 | [amqplib][38]      | `>=0.5`  | Fully supported | Supports AMQP 0.9 brokers (i.e. RabbitMQ, Apache Qpid) |
 | [generic-pool][39] | `>=2`    | Fully supported |                                                        |
 | [kafka-node][40]   |          | Coming Soon     |                                                        |
-| [rhea][41]         |          | Coming Soon     |                                                        |
+| [rhea][41]         | `>=1`    | Fully supported |                                                        |
 
 #### Promise Library Compatibility
 
@@ -247,3 +248,4 @@ For details about how to how to toggle and configure plugins, check out the [API
 [48]: https://github.com/articulate/paperplane/blob/master/docs/API.md#logger
 [49]: http://getpino.io
 [50]: https://github.com/winstonjs/winston
+[51]: https://nodejs.org/api/fs.html


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Update supported libraries for dd-trace-js.

### Motivation
<!-- What inspired you to submit this pull request?-->

We have released 0.17.0 which supported new modules out of the box.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->

https://docs-staging.datadoghq.com/rochdev/dd-trace-js-0.17.0/tracing/setup/nodejs/#compatibility

### Additional Notes
<!-- Anything else we should know when reviewing?-->
