### PR TITLE
Update the type of the servicemap widget

### DIFF
--- a/content/en/dashboards/widgets/service_map.md
+++ b/content/en/dashboards/widgets/service_map.md
@@ -39,7 +39,7 @@ The dedicated [widget JSON schema definition][4] for the service map widget is:
 SERVICEMAP_SCHEMA = {
         "type": "object",
         "properties": {
-            "type": {"enum": [WIDGET_TYPE]},
+            "type": {"enum": ["servicemap"]},
             "filters": {"type": "array", "items": {"type": "string"}, "minItems": 1},
             "service": {"type": "string"},
             "title": WidgetSchema.TITLE


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates the JSON schema for the servicemap widget to include the widget type instead of the placeholder

### Motivation
The other widgets directly state which type they are in the schema, noticed this seemed to be a placeholder while looking at widgets. 

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nick/servicemap_type/dashboards/widgets/service_map/
