### PR TITLE
Update the alert value schema to change text_size to title_size

### DIFF
--- a/content/en/dashboards/widgets/alert_value.md
+++ b/content/en/dashboards/widgets/alert_value.md
@@ -58,8 +58,8 @@ ALERT_VALUE_SCHEMA = {
         "alert_id": {"type": "string"},
         "precision": {"type": "integer"},
         "unit": {"type": "string"},
-        "text_size": {"type": "string"},
         "text_align": {"enum": ["left", "center", "right"]},
+        "title_size": {"type": "string"},
         "title": {"type": "string"}
     },
     "required": ["type", "alert_id"],
@@ -73,8 +73,8 @@ ALERT_VALUE_SCHEMA = {
 | `alert_id`   | string  | yes      | ID of the alert to use in the widget                                                    |
 | `precision`  | integer | no       | Number of decimal places to show. If not defined, uses the raw value                    |
 | `unit`       | string  | no       | Unit to display with the value                                                          |
-| `text_size`  | string  | no       | Size of value in the widget                                                             |
 | `text_align` | string  | no       | How to align the value in the widget. Available values are: `left`, `center` or `right` |
+| `title_size`  | string  | no       | Size of value in the widget                                                             |
 | `title`      | string  | no       | Title of the widget                                                                     |
 
 ## Further Reading


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates the schema of the alert value widget to change `text_size` to `title_size`

### Motivation
There isn't a `text_size` option available in this widget

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nick/av_schema/dashboards/widgets/alert_value/
