### PR TITLE
Fix mistranslation

### DIFF
--- a/config/_default/params.ja.yaml
+++ b/config/_default/params.ja.yaml
@@ -2,7 +2,7 @@ site_name: Datadogでインフラストラクチャーとアプリケーショ�
 meta_image: datadog_logo_share_tt.png
 meta_title: Datadogを始めてみましょう
 meta_description: Datadogが大規模なクラウドのモニタリングサービスをリードします。
-disclaimer: このページは英語では対応しておりません。随時翻訳に取り組んでいます。翻訳に関してご質問やご意見ございましたら、お気軽にご連絡ください。
+disclaimer: このページは日本語には対応しておりません。随時翻訳に取り組んでいます。翻訳に関してご質問やご意見ございましたら、お気軽にご連絡ください。
 announcement_banner:
   desktop_message: ネットワーク パフォーマンス モニタリングの正式提供を開始しました！
   mobile_message: ネットワーク パフォーマンス モニタリング提供開始!


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Fix mistranslation.

### Motivation

When user is in Japanese environment, "このページは英語では対応しておりません" is shown in the documentations that is not translated to Japanese.

However, the meaning for this language is "English is not available in this page". It is opposite meaning.

### Preview link

https://docs-staging.datadoghq.com/kosukekamiya/fix_translation/ja/getting_started/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Nothing.