### PR TITLE
Enforcing wording of Datadog app and api key placeholder

### DIFF
--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -42,7 +42,7 @@ DOCKER_CONTENT_TRUST=1 \
 docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /proc/:/host/proc/:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-              -e DD_API_KEY=<DATADOG_API_KEY> \
+              -e DD_API_KEY="<DATADOG_API_KEY>" \
               datadog/agent:latest
 ```
 
@@ -54,7 +54,7 @@ DOCKER_CONTENT_TRUST=1 \
 docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro \
                               -v /proc/:/host/proc/:ro \
                               -v /cgroup/:/host/sys/fs/cgroup:ro \
-                              -e DD_API_KEY=<DATADOG_API_KEY> \
+                              -e DD_API_KEY="<DATADOG_API_KEY>" \
                               datadog/agent:latest
 ```
 

--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -42,7 +42,7 @@ DOCKER_CONTENT_TRUST=1 \
 docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /proc/:/host/proc/:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-              -e DD_API_KEY=<YOUR_DATADOG_API_KEY> \
+              -e DD_API_KEY=<DATADOG_API_KEY> \
               datadog/agent:latest
 ```
 
@@ -54,7 +54,7 @@ DOCKER_CONTENT_TRUST=1 \
 docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro \
                               -v /proc/:/host/proc/:ro \
                               -v /cgroup/:/host/sys/fs/cgroup:ro \
-                              -e DD_API_KEY=<YOUR_DATADOG_API_KEY> \
+                              -e DD_API_KEY=<DATADOG_API_KEY> \
                               datadog/agent:latest
 ```
 

--- a/content/en/agent/docker/apm.md
+++ b/content/en/agent/docker/apm.md
@@ -32,7 +32,7 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /proc/:/host/proc/:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
               -p 127.0.0.1:8126:8126/tcp \
-              -e DD_API_KEY=<DATADOG_API_KEY> \
+              -e DD_API_KEY="<DATADOG_API_KEY>" \
               -e DD_APM_ENABLED=true \
               datadog/agent:latest
 ```
@@ -82,7 +82,7 @@ docker run -d --name datadog-agent \
               -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /proc/:/host/proc/:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-              -e DD_API_KEY=<DATADOG_API_KEY> \
+              -e DD_API_KEY="<DATADOG_API_KEY>" \
               -e DD_APM_ENABLED=true \
               -e DD_APM_NON_LOCAL_TRAFFIC=true \
               datadog/agent:latest

--- a/content/en/agent/docker/apm.md
+++ b/content/en/agent/docker/apm.md
@@ -32,7 +32,7 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /proc/:/host/proc/:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
               -p 127.0.0.1:8126:8126/tcp \
-              -e DD_API_KEY=<YOUR_API_KEY> \
+              -e DD_API_KEY=<DATADOG_API_KEY> \
               -e DD_APM_ENABLED=true \
               datadog/agent:latest
 ```
@@ -82,7 +82,7 @@ docker run -d --name datadog-agent \
               -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /proc/:/host/proc/:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-              -e DD_API_KEY=<YOUR_API_KEY> \
+              -e DD_API_KEY=<DATADOG_API_KEY> \
               -e DD_APM_ENABLED=true \
               -e DD_APM_NON_LOCAL_TRAFFIC=true \
               datadog/agent:latest

--- a/content/en/agent/docker/log.md
+++ b/content/en/agent/docker/log.md
@@ -44,7 +44,7 @@ To run a [Docker container][1] that embeds the Datadog Agent to monitor your hos
 
 ```shell
 docker run -d --name datadog-agent \
-           -e DD_API_KEY=<YOUR_API_KEY> \
+           -e DD_API_KEY=<DATADOG_API_KEY> \
            -e DD_LOGS_ENABLED=true \
            -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
            -e DD_AC_EXCLUDE="name:datadog-agent" \

--- a/content/en/agent/docker/log.md
+++ b/content/en/agent/docker/log.md
@@ -44,7 +44,7 @@ To run a [Docker container][1] that embeds the Datadog Agent to monitor your hos
 
 ```shell
 docker run -d --name datadog-agent \
-           -e DD_API_KEY=<DATADOG_API_KEY> \
+           -e DD_API_KEY="<DATADOG_API_KEY>" \
            -e DD_LOGS_ENABLED=true \
            -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
            -e DD_AC_EXCLUDE="name:datadog-agent" \

--- a/content/en/agent/guide/agent-5-kubernetes-basic-agent-usage.md
+++ b/content/en/agent/guide/agent-5-kubernetes-basic-agent-usage.md
@@ -60,7 +60,7 @@ spec:
             protocol: UDP
         env:
           - name: API_KEY
-            value: "YOUR_API_KEY"
+            value: "DATADOG_API_KEY"
           - name: KUBERNETES
             value: "yes"
         volumeMounts:
@@ -84,7 +84,7 @@ spec:
           name: cgroups
 ```
 
-Replace `YOUR_API_KEY` with [your api key][6] or use [Kubernetes secrets][7] to set your API key [as an environment variable][8].
+Replace `DATADOG_API_KEY` with [your api key][6] or use [Kubernetes secrets][7] to set your API key [as an environment variable][8].
 
 * Deploy the DaemonSet with the command:
   ```shell

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -41,7 +41,7 @@ Create the following `datadog-agent.yaml` manifest. (This manifest assumes you a
 Remember to encode your API key using `base64` if you are using secrets:
 
 ```shell
-echo -n <YOUR_API_KEY> | base64
+echo -n <DATADOG_API_KEY> | base64
 ```
 
 **Note**: You may need a higher memory limit if you are using `kube-state-metrics` or have high DogStatsD usage.
@@ -100,7 +100,7 @@ spec:
           ## Set the Datadog API Key related to your Organization
           ## If you use the Kubernetes Secret use the following env variable:
           ## - {name: DD_API_KEY, valueFrom: { secretKeyRef: { name: datadog-secret, key: api-key }}}
-          - {name: DD_API_KEY, value: "<YOUR_API_KEY>"}
+          - {name: DD_API_KEY, value: "<DATADOG_API_KEY>"}
 
           ## Set DD_SITE to "datadoghq.eu" to send your Agent data to the Datadog EU site
           - {name: DD_SITE, value: "datadoghq.com"}
@@ -161,7 +161,7 @@ spec:
         - {name: logcontainerpath, hostPath: {path: /var/lib/docker/containers}}
 ```
 
-Replace `<YOUR_API_KEY>` with [your Datadog API key][4] or use [Kubernetes secrets][5] to set your API key as an [environment variable][6]. If you opt to use Kubernetes secrets, refer to Datadog's [instructions for setting an API key with Kubernetes secrets][7]. Consult the [Docker integration][8] to discover all of the configuration options.
+Replace `<DATADOG_API_KEY>` with [your Datadog API key][4] or use [Kubernetes secrets][5] to set your API key as an [environment variable][6]. If you opt to use Kubernetes secrets, refer to Datadog's [instructions for setting an API key with Kubernetes secrets][7]. Consult the [Docker integration][8] to discover all of the configuration options.
 
 Deploy the DaemonSet with the command:
 

--- a/content/en/api/key_management/code_snippets/create_app_key.sh
+++ b/content/en/api/key_management/code_snippets/create_app_key.sh
@@ -8,6 +8,6 @@ curl -X POST \
 -H "DD-API-KEY: ${api_key}" \
 -H "DD-APPLICATION-KEY: ${app_key}" \
 -d '{
-	      "name": "<APP_KEY_NAME>"
+	      "name": "<DATADOG_APPLICATION_KEY_NAME>"
     }' \
 "https://app.datadoghq.com/api/v1/application_key"

--- a/content/en/api/key_management/get_app_key_code.md
+++ b/content/en/api/key_management/get_app_key_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#get-an-application-key
 
 **SIGNATURE**:
 
-`GET /v1/application_key/<APP_KEY>`
+`GET /v1/application_key/<DATADOG_APPLICATION_KEY>`
 
 **EXAMPLE REQUEST**:
 

--- a/content/en/dashboards/faq/embeddable-graphs-with-template-variables.md
+++ b/content/en/dashboards/faq/embeddable-graphs-with-template-variables.md
@@ -17,8 +17,8 @@ import json
 
 # Initialize request parameters with Datadog API/APP key
 options = {
-    'api_key': '<DD_API_KEY>',
-    'app_key': '<DD_APP_KEY>'
+    'api_key': '<DATADOG_API_KEY>',
+    'app_key': '<DATADOG_APPLICATION_KEY>'
 }
 
 initialize(**options)

--- a/content/en/dashboards/guide/dashboard-lists-api-v1-doc.md
+++ b/content/en/dashboards/guide/dashboard-lists-api-v1-doc.md
@@ -34,8 +34,8 @@ This endpoint is outdated. Use the <a href="https://docs.datadoghq.com/api#get-i
 from datadog import initialize, api
 
 options = {
-    'api_key': '<YOUR_API_KEY>',
-    'app_key': '<YOUR_APP_KEY>'
+    'api_key': '<DATADOG_API_KEY>',
+    'app_key': '<DATADOG_APPLICATION_KEY>'
 }
 
 initialize(**options)
@@ -51,8 +51,8 @@ api.DashboardList.get_items(4741)
 require 'rubygems'
 require 'dogapi'
 
-api_key = '<YOUR_API_KEY>'
-app_key = '<YOUR_APP_KEY>'
+api_key = '<DATADOG_API_KEY>'
+app_key = '<DATADOG_APPLICATION_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 
@@ -63,8 +63,8 @@ result = dog.get_items_of_dashboard_list(4741)
 {{% tab "Curl" %}}
 
 ```sh
-api_key=<YOUR_API_KEY>
-app_key=<YOUR_APP_KEY>
+api_key=<DATADOG_API_KEY>
+app_key=<DATADOG_APPLICATION_KEY>
 
 list_id=4741
 
@@ -411,8 +411,8 @@ This endpoint is outdated. Use the <a href="https://docs.datadoghq.com/api#add-i
 from datadog import initialize, api
 
 options = {
-    'api_key': '<YOUR_API_KEY>',
-    'app_key': '<YOUR_APP_KEY>'
+    'api_key': '<DATADOG_API_KEY>',
+    'app_key': '<DATADOG_APPLICATION_KEY>'
 }
 
 initialize(**options)
@@ -452,8 +452,8 @@ api.DashboardList.add_items(list_id, dashboards=dashboards)
 require 'rubygems'
 require 'dogapi'
 
-api_key = '<YOUR_API_KEY>'
-app_key = '<YOUR_APP_KEY>'
+api_key = '<DATADOG_API_KEY>'
+app_key = '<DATADOG_APPLICATION_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 
@@ -488,8 +488,8 @@ result = dog.add_items_of_dashboard_list(list_id, dashboards)
 {{% tab "Curl" %}}
 
 ```sh
-api_key=<YOUR_API_KEY>
-app_key=<YOUR_APP_KEY>
+api_key=<DATADOG_API_KEY>
+app_key=<DATADOG_APPLICATION_KEY>
 
 list_id=4741
 
@@ -662,8 +662,8 @@ This endpoint is outdated. Use the <a href="https://docs.datadoghq.com/api#updat
 from datadog import initialize, api
 
 options = {
-    'api_key': '<YOUR_API_KEY>',
-    'app_key': '<YOUR_APP_KEY>'
+    'api_key': '<DATADOG_API_KEY>',
+    'app_key': '<DATADOG_APPLICATION_KEY>'
 }
 
 initialize(**options)
@@ -703,8 +703,8 @@ api.DashboardList.update_items(list_id, dashboards=dashboards)
 require 'rubygems'
 require 'dogapi'
 
-api_key = '<YOUR_API_KEY>'
-app_key = '<YOUR_APP_KEY>'
+api_key = '<DATADOG_API_KEY>'
+app_key = '<DATADOG_APPLICATION_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 
@@ -741,8 +741,8 @@ result = dog.update_items_of_dashboard_list(list_id, dashboards)
 
 ```sh
 
-api_key=<YOUR_API_KEY>
-app_key=<YOUR_APP_KEY>
+api_key=<DATADOG_API_KEY>
+app_key=<DATADOG_APPLICATION_KEY>
 
 list_id=4741
 
@@ -915,8 +915,8 @@ This endpoint is outdated. Use the <a href="https://docs.datadoghq.com/api#delet
 from datadog import initialize, api
 
 options = {
-    'api_key': '<YOUR_API_KEY>',
-    'app_key': '<YOUR_APP_KEY>'
+    'api_key': '<DATADOG_API_KEY>',
+    'app_key': '<DATADOG_APPLICATION_KEY>'
 }
 
 initialize(**options)
@@ -956,8 +956,8 @@ api.DashboardList.delete_items(list_id, dashboards=dashboards)
 require 'rubygems'
 require 'dogapi'
 
-api_key = '<YOUR_API_KEY>'
-app_key = '<YOUR_APP_KEY>'
+api_key = '<DATADOG_API_KEY>'
+app_key = '<DATADOG_APPLICATION_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 
@@ -994,8 +994,8 @@ result = dog.delete_items_from_dashboard_list(list_id, dashboards)
 
 ```sh
 
-api_key=<YOUR_API_KEY>
-app_key=<YOUR_APP_KEY>
+api_key=<DATADOG_API_KEY>
+app_key=<DATADOG_APPLICATION_KEY>
 
 list_id=4741
 

--- a/content/en/dashboards/guide/screenboard-api-doc.md
+++ b/content/en/dashboards/guide/screenboard-api-doc.md
@@ -40,8 +40,8 @@ The Screenboard endpoint allows you to programmatically create, update, delete, 
 from datadog import initialize, api
 
 options = {
-    'api_key': '<YOUR_API_KEY>',
-    'app_key': '<YOUR_APP_KEY>'
+    'api_key': '<DATADOG_API_KEY>',
+    'app_key': '<DATADOG_APPLICATION_KEY>'
 }
 
 initialize(**options)
@@ -78,8 +78,8 @@ api.Screenboard.create(board_title=board_title,
 require 'rubygems'
 require 'dogapi'
 
-api_key='<YOUR_API_KEY>'
-app_key='<YOUR_APP_KEY>'
+api_key='<DATADOG_API_KEY>'
+app_key='<DATADOG_APPLICATION_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 
@@ -106,8 +106,8 @@ result = dog.create_screenboard(board)
 {{% tab "Bash" %}}
 
 ```bash
-api_key=<YOUR_API_KEY>
-app_key=<YOUR_APP_KEY>
+api_key=<DATADOG_API_KEY>
+app_key=<DATADOG_APPLICATION_KEY>
 
 curl -X POST -H "Content-type: application/json" \
 -d '{
@@ -163,8 +163,8 @@ curl -X POST -H "Content-type: application/json" \
 from datadog import initialize, api
 
 options = {
-    'api_key': '<YOUR_API_KEY>',
-    'app_key': '<YOUR_APP_KEY>'
+    'api_key': '<DATADOG_API_KEY>',
+    'app_key': '<DATADOG_APPLICATION_KEY>'
 }
 
 initialize(**options)
@@ -202,8 +202,8 @@ api.Screenboard.update(board_id,
 require 'rubygems'
 require 'dogapi'
 
-api_key = '<YOUR_API_KEY>'
-app_key = '<YOUR_APP_KEY>'
+api_key = '<DATADOG_API_KEY>'
+app_key = '<DATADOG_APPLICATION_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 
@@ -229,8 +229,8 @@ result = dog.update_screenboard(board_id, board)
 {{% tab "Bash" %}}
 
 ```bash
-api_key=<YOUR_API_KEY>
-app_key=<YOUR_APP_KEY>
+api_key=<DATADOG_API_KEY>
+app_key=<DATADOG_APPLICATION_KEY>
 
 curl -X PUT -H "Content-type: application/json" \
 -d '{
@@ -277,8 +277,8 @@ Delete an existing [Screenboard][1].
 from datadog import initialize, api
 
 options = {
-    'api_key': '<YOUR_API_KEY>',
-    'app_key': '<YOUR_APP_KEY>'
+    'api_key': '<DATADOG_API_KEY>',
+    'app_key': '<DATADOG_APPLICATION_KEY>'
 }
 
 initialize(**options)
@@ -294,8 +294,8 @@ api.Screenboard.delete(811)
 require 'rubygems'
 require 'dogapi'
 
-api_key = '<YOUR_API_KEY>'
-app_key = '<YOUR_APP_KEY>'
+api_key = '<DATADOG_API_KEY>'
+app_key = '<DATADOG_APPLICATION_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 
@@ -307,8 +307,8 @@ result = dog.delete_screenboard(board_id)
 {{% tab "Bash" %}}
 
 ```bash
-api_key=<YOUR_API_KEY>
-app_key=<YOUR_APP_KEY>
+api_key=<DATADOG_API_KEY>
+app_key=<DATADOG_APPLICATION_KEY>
 board_id=2471
 
 # Create a screenboard to delete
@@ -358,8 +358,8 @@ Fetch an existing Screenboard's definition.
 from datadog import initialize, api
 
 options = {
-    'api_key': '<YOUR_API_KEY>',
-    'app_key': '<YOUR_APP_KEY>'
+    'api_key': '<DATADOG_API_KEY>',
+    'app_key': '<DATADOG_APPLICATION_KEY>'
 }
 
 initialize(**options)
@@ -374,8 +374,8 @@ api.Screenboard.get(811)
 require 'rubygems'
 require 'dogapi'
 
-api_key = '<YOUR_API_KEY>'
-app_key = '<YOUR_APP_KEY>'
+api_key = '<DATADOG_API_KEY>'
+app_key = '<DATADOG_APPLICATION_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 
@@ -387,8 +387,8 @@ result = dog.get_screenboard(board_id)
 {{% tab "Bash" %}}
 
 ```bash
-api_key=<YOUR_API_KEY>
-app_key=<YOUR_APP_KEY>
+api_key=<DATADOG_API_KEY>
+app_key=<DATADOG_APPLICATION_KEY>
 board_id=6334
 
 # Create a screenboard to get
@@ -438,8 +438,8 @@ Fetch all of your [Screenboards][1]' definitions.
 from datadog import initialize, api
 
 options = {
-    'api_key': '<YOUR_API_KEY>',
-    'app_key': '<YOUR_APP_KEY>'
+    'api_key': '<DATADOG_API_KEY>',
+    'app_key': '<DATADOG_APPLICATION_KEY>'
 }
 
 initialize(**options)
@@ -455,8 +455,8 @@ api.Screenboard.get_all()
 require 'rubygems'
 require 'dogapi'
 
-api_key = '<YOUR_API_KEY>'
-app_key = '<YOUR_APP_KEY>'
+api_key = '<DATADOG_API_KEY>'
+app_key = '<DATADOG_APPLICATION_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 
@@ -467,8 +467,8 @@ result = dog.get_all_screenboards()
 {{% tab "Bash" %}}
 
 ```bash
-api_key=<YOUR_API_KEY>
-app_key=<YOUR_APP_KEY>
+api_key=<DATADOG_API_KEY>
+app_key=<DATADOG_APPLICATION_KEY>
 
 curl -X GET "https://api.datadoghq.com/api/v1/screen?api_key=${api_key}&application_key=${app_key}"
 ```

--- a/content/en/dashboards/guide/timeboard-api-doc.md
+++ b/content/en/dashboards/guide/timeboard-api-doc.md
@@ -54,8 +54,8 @@ The Timeboard endpoint allows you to programmatically create, update delete and 
 from datadog import initialize, api
 
 options = {
-    'api_key': '<YOUR_API_KEY>',
-    'app_key': '<YOUR_APP_KEY>'
+    'api_key': '<DATADOG_API_KEY>',
+    'app_key': '<DATADOG_APPLICATION_KEY>'
 }
 
 initialize(**options)
@@ -95,8 +95,8 @@ api.Timeboard.create(title=title,
 require 'rubygems'
 require 'dogapi'
 
-api_key = '<YOUR_API_KEY>'
-app_key = '<YOUR_APP_KEY>'
+api_key = '<DATADOG_API_KEY>'
+app_key = '<DATADOG_APPLICATION_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 
@@ -126,8 +126,8 @@ dog.create_dashboard(title, description, graphs, template_variables)
 {{% tab "Bash" %}}
 
 ```bash
-api_key=<YOUR_API_KEY>
-app_key=<YOUR_APP_KEY>
+api_key=<DATADOG_API_KEY>
+app_key=<DATADOG_APPLICATION_KEY>
 
 curl  -X POST -H "Content-type: application/json" \
 -d '{
@@ -195,8 +195,8 @@ curl  -X POST -H "Content-type: application/json" \
 ```python
 from datadog import initialize, api
 
-options = {'api_key': '<YOUR_API_KEY>',
-           'app_key': '<YOUR_APP_KEY>'}
+options = {'api_key': '<DATADOG_API_KEY>',
+           'app_key': '<DATADOG_APPLICATION_KEY>'}
 
 initialize(**options)
 
@@ -228,8 +228,8 @@ api.Timeboard.update(
 require 'rubygems'
 require 'dogapi'
 
-api_key = '<YOUR_API_KEY>'
-app_key = '<YOUR_APP_KEY>'
+api_key = '<DATADOG_API_KEY>'
+app_key = '<DATADOG_APPLICATION_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 
@@ -259,8 +259,8 @@ dog.update_dashboard(dash_id, title, description, graphs, template_variables)
 {{% tab "Bash" %}}
 
 ```bash
-api_key=<YOUR_API_KEY>
-app_key=<YOUR_APP_KEY>
+api_key=<DATADOG_API_KEY>
+app_key=<DATADOG_APPLICATION_KEY>
 dash_id=2532
 
 # Create a dashboard to get. Use jq (http://stedolan.github.io/jq/download/) to get the dash id.
@@ -334,8 +334,8 @@ Delete an existing [timeboard][1].
 from datadog import initialize, api
 
 options = {
-    'api_key': '<YOUR_API_KEY>',
-    'app_key': '<YOUR_APP_KEY>'
+    'api_key': '<DATADOG_API_KEY>',
+    'app_key': '<DATADOG_APPLICATION_KEY>'
 }
 
 initialize(**options)
@@ -374,8 +374,8 @@ api.Timeboard.delete(newboard['dash']['id'])
 require 'rubygems'
 require 'dogapi'
 
-api_key = '<YOUR_API_KEY>'
-app_key = '<YOUR_APP_KEY>'
+api_key = '<DATADOG_API_KEY>'
+app_key = '<DATADOG_APPLICATION_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 
@@ -387,8 +387,8 @@ dog.delete_dashboard(dash_id)
 {{% tab "Bash" %}}
 
 ```bash
-api_key=<YOUR_API_KEY>
-app_key=<YOUR_APP_KEY>
+api_key=<DATADOG_API_KEY>
+app_key=<DATADOG_APPLICATION_KEY>
 dash_id=2471
 
 # Create a dashboard to delete. Use jq (http://stedolan.github.io/jq/download/) to get the dash id.
@@ -441,8 +441,8 @@ Fetch an existing dashboard's definition.
 from datadog import initialize, api
 
 options = {
-    'api_key': '<YOUR_API_KEY>',
-    'app_key': '<YOUR_APP_KEY>'
+    'api_key': '<DATADOG_API_KEY>',
+    'app_key': '<DATADOG_APPLICATION_KEY>'
 }
 
 initialize(**options)
@@ -457,8 +457,8 @@ api.Timeboard.get(4953)
 require 'rubygems'
 require 'dogapi'
 
-api_key = '<YOUR_API_KEY>'
-app_key = '<YOUR_APP_KEY>'
+api_key = '<DATADOG_API_KEY>'
+app_key = '<DATADOG_APPLICATION_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 
@@ -470,8 +470,8 @@ dog.get_dashboard(dash_id)
 {{% tab "Bash" %}}
 
 ```bash
-api_key=<YOUR_API_KEY>
-app_key=<YOUR_APP_KEY>
+api_key=<DATADOG_API_KEY>
+app_key=<DATADOG_APPLICATION_KEY>
 dash_id=2473
 
 # Create a dashboard to get. Use jq (http://stedolan.github.io/jq/download/) to get the dash id.
@@ -524,8 +524,8 @@ Fetch all of your [timeboard][1]' definitions.
 from datadog import initialize, api
 
 options = {
-    'api_key': '<YOUR_API_KEY>',
-    'app_key': '<YOUR_APP_KEY>'
+    'api_key': '<DATADOG_API_KEY>',
+    'app_key': '<DATADOG_APPLICATION_KEY>'
 }
 
 initialize(**options)
@@ -540,8 +540,8 @@ print api.Timeboard.get_all()
 require 'rubygems'
 require 'dogapi'
 
-api_key = '<YOUR_API_KEY>'
-app_key = '<YOUR_APP_KEY>'
+api_key = '<DATADOG_API_KEY>'
+app_key = '<DATADOG_APPLICATION_KEY>'
 
 dog = Dogapi::Client.new(api_key, app_key)
 
@@ -552,8 +552,8 @@ dog.get_dashboards
 {{% tab "Bash" %}}
 
 ```bash
-api_key=<YOUR_API_KEY>
-app_key=<YOUR_APP_KEY>
+api_key=<DATADOG_API_KEY>
+app_key=<DATADOG_APPLICATION_KEY>
 
 curl "https://api.datadoghq.com/api/v1/dash?api_key=${api_key}&application_key=${app_key}"
 ```

--- a/content/en/developers/guide/calling-on-datadog-s-api-with-the-webhooks-integration.md
+++ b/content/en/developers/guide/calling-on-datadog-s-api-with-the-webhooks-integration.md
@@ -16,7 +16,7 @@ Each webhook must be set up with a name (to be referenced in monitors) and a URL
 * The **name field**: whatever you like, as long as it is unique among all the other webhook name fields.
 
 * The **url field**: the URL used when pinging the API. It looks like this:
-`https://api.datadoghq.com/api/v1/<API_ENDPOINT>?api_key=<YOUR_API_KEY>`
+`https://api.datadoghq.com/api/v1/<API_ENDPOINT>?api_key=<DATADOG_API_KEY>`
 
 * The **custom payload field**: contains the JSON with all the options you want to include in the API call. The type of API call determines the appropriate options. You can sometimes use the monitor's `$symbol` content to fill in parts of the option values.
 

--- a/content/en/developers/guide/dogshell-quickly-use-datadog-s-api-from-terminal-shell.md
+++ b/content/en/developers/guide/dogshell-quickly-use-datadog-s-api-from-terminal-shell.md
@@ -49,7 +49,7 @@ In the event that you would rather just write the `.dogrc` file yourself (perhap
 
 ```text
 [Connection]
-apikey = <YOUR_API_KEY>
+apikey = <DATADOG_API_KEY>
 appkey = <YOUR_APPLICATION_KEY>
 ```
 

--- a/content/en/developers/guide/query-the-infrastructure-list-via-the-api.md
+++ b/content/en/developers/guide/query-the-infrastructure-list-via-the-api.md
@@ -7,7 +7,7 @@ aliases:
 
 More advanced Datadog users may sometimes want to use [the API][1] to query general data about their infrastructure—the kind of data that you can find in your [infrastructure list][2] or the [host map][3]. You can do this via an API GET request on the `reports/v2/overview` endpoint.
 
-## Overview 
+## Overview
 
 This endpoint takes the following required parameters:
 
@@ -34,7 +34,7 @@ If, for example, you want to query general data from all your hosts that include
 import requests
 s = requests.session()
 s.params = {
-  'api_key': 'YOUR_API_KEY',
+  'api_key': 'DATADOG_API_KEY',
   'application_key': 'YOUR_APPLICATION_KEY',
   'tags': 'env:prod,role:elasticsearch'
 }
@@ -51,7 +51,7 @@ import requests
 def iterate_all_hosts():
   s = requests.session()
   s.params = {
-    'api_key': '<YOUR_API_KEY>',
+    'api_key': '<DATADOG_API_KEY>',
     'application_key': '<YOUR_APPLICATION_KEY>',
     'start': 0
   }

--- a/content/en/developers/metrics/powershell_metrics_submission.md
+++ b/content/en/developers/metrics/powershell_metrics_submission.md
@@ -36,8 +36,8 @@ function postMetric($metric,$tags) {
 }
 
 # Datadog account, API information and optional parameters
-$app_key = "<YOUR_APP_KEY_HERE>" #provide your valid app key
-$api_key = "<YOUR_API_KEY_HERE>" #provide your valid api key
+$app_key = "<DATADOG_APPLICATION_KEY>" #provide your valid app key
+$api_key = "<DATADOG_API_KEY>" #provide your valid api key
 $url_base = "https://app.datadoghq.com/"
 $url_signature = "api/v1/series"
 $url = $url_base + $url_signature + "?api_key=$api_key" + "&" + "application_key=$app_key"
@@ -96,8 +96,8 @@ $http_request.responseText
 1. Replace the API/app key with yours:
 
     ```powershell
-    $api_key = "<YOUR_API_KEY>"
-    $app_key = "<YOUR_APP_KEY>"
+    $api_key = "<DATADOG_API_KEY>"
+    $app_key = "<DATADOG_APPLICATION_KEY>"
     ```
 
 2. Set up your parameters according to [the description in the host API][3]:
@@ -121,8 +121,8 @@ $http_request.responseText
 1. Replace the API/app key with yours:
 
     ```powershell
-    $api_key = "<YOUR_API_KEY>"
-    $app_key = "<YOUR_APP_KEY>"
+    $api_key = "<DATADOG_API_KEY>"
+    $app_key = "<DATADOG_APPLICATION_KEY>"
     ```
 
 2. Set up parameters according to [description in the metrics API][4]:

--- a/content/en/getting_started/logs/_index.md
+++ b/content/en/getting_started/logs/_index.md
@@ -100,14 +100,14 @@ To install the Datadog Agent within your Vagrant host, use the [one line install
 {{% tab "US Site" %}}
 
 ```text
-DD_API_KEY=<YOUR_DD_API_KEY>  bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
+DD_API_KEY=<DATADOG_API_KEY>  bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
 ```
 
 {{% /tab %}}
 {{% tab "EU Site" %}}
 
 ```text
-DD_API_KEY=<YOUR_DD_API_KEY> DD_SITE="datadoghq.eu" bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
+DD_API_KEY=<DATADOG_API_KEY> DD_SITE="datadoghq.eu" bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
 ```
 
 {{% /tab %}}

--- a/content/en/getting_started/tracing/_index.md
+++ b/content/en/getting_started/tracing/_index.md
@@ -36,7 +36,7 @@ vagrant ssh
 To install the Datadog Agent on a host, use the [one line install command][5] updated with your [Datadog API key][6]:
 
 ```shell
-DD_API_KEY=<YOUR_DD_API_KEY> bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
+DD_API_KEY=<DATADOG_API_KEY> bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
 ```
 
 ### Validation

--- a/content/en/integrations/faq/how-to-make-trello-card-using-webhooks.md
+++ b/content/en/integrations/faq/how-to-make-trello-card-using-webhooks.md
@@ -44,7 +44,7 @@ Enable Custom Payload and fill in a json object that looks like:
 {
   "name": "$USER : $EVENT_TITLE",
   "desc": "$EVENT_MSG",
-  "key": "{APP_KEY}",
+  "key": "{DATADOG_APPLICATION_KEY}",
   "token": "{TOKEN_KEY}",
   "pos": "bottom",
   "idList": "{ID_LIST_VALUE}"

--- a/content/en/integrations/pivotal_platform.md
+++ b/content/en/integrations/pivotal_platform.md
@@ -108,7 +108,7 @@ If you are a [meta-buildpack][10] user, Datadog's buildpack can be used as a dec
 
 ```shell
 # set the environment variable
-cf set-env <YOUR_APP> DD_API_KEY <DD_API_KEY>
+cf set-env <YOUR_APP> DD_API_KEY <DATADOG_API_KEY>
 # restage the application to make it pick up the new environment variable and use the buildpack
 cf restage <YOUR_APP>
 ```
@@ -222,7 +222,7 @@ addons:
     dd:
       use_dogstatsd: true
       dogstatsd_port: 18125       # Many CF deployments have a StatsD already on port 8125
-      api_key: <DD_API_KEY>
+      api_key: <DATADOG_API_KEY>
       tags: ["<KEY:VALUE>"]       # any tags you wish
       generate_processes: true    # to enable the process check
 ```

--- a/content/en/logs/faq/how-to-set-up-only-logs.md
+++ b/content/en/logs/faq/how-to-set-up-only-logs.md
@@ -37,7 +37,7 @@ If you are using the container Agent, set the environment variable `DD_ENABLE_PA
 
 ```shell
 docker run -d --name datadog-agent \
-           -e DD_API_KEY="<YOUR_API_KEY>" \
+           -e DD_API_KEY="<DATADOG_API_KEY>" \
            -e DD_LOGS_ENABLED=true \
            -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
            -e DD_AC_EXCLUDE="name:datadog-agent" \
@@ -111,7 +111,7 @@ spec:
           ## Set the Datadog API Key related to your Organization
           ## If you use the Kubernetes Secret use the following env variable:
           ## {name: DD_API_KEY, valueFrom:{ secretKeyRef:{ name: datadog-secret, key: api-key }}
-          - {name: DD_API_KEY, value: "<YOUR_API_KEY>"}
+          - {name: DD_API_KEY, value: "<DATADOG_API_KEY>"}
 
           ## Set DD_SITE to "datadoghq.eu" to send your Agent data to the Datadog EU site
           - {name: DD_SITE, value: "datadoghq.com"}

--- a/content/en/monitors/faq/how-can-i-export-alert-history.md
+++ b/content/en/monitors/faq/how-can-i-export-alert-history.md
@@ -13,8 +13,8 @@ You can also fetch this CSV using curl:
 {{% tab "US" %}}
 
 ```shell
-api_key=<API_KEY>
-app_key = <APP_KEY>
+api_key=<DATADOG_API_KEY>
+app_key = <DATADOG_APPLICATION_KEY>
 
 curl -G \
     "https://app.datadoghq.com/report/hourly_data/monitor" \
@@ -33,8 +33,8 @@ org_id,hour,source_type_name,alert_type,priority,event_object,host_name,device_n
 {{% tab "EU" %}}
 
 ```shell
-api_key=<API_KEY>
-app_key = <APP_KEY>
+api_key=<DATADOG_API_KEY>
+app_key = <DATADOG_APPLICATION_KEY>
 
 curl -G \
     "https://app.datadoghq.eu/report/hourly_data/monitor" \

--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -107,7 +107,7 @@ spec:
           - {containerPort: 8125, name: dogstatsdport, protocol: UDP}
           - {containerPort: 8126, name: traceport, protocol: TCP}
         env:
-          - {name: DD_API_KEY, value: <YOUR_API_KEY>}
+          - {name: DD_API_KEY, value: <DATADOG_API_KEY>}
           - {name: KUBERNETES, value: "true"}
           - {name: DD_HEALTH_PORT, value: "5555"}
           - {name: DD_PROCESS_AGENT_ENABLED, value: "true"}

--- a/content/en/tagging/assigning_tags.md
+++ b/content/en/tagging/assigning_tags.md
@@ -129,7 +129,7 @@ services:
       - '/proc:/host/proc:ro'
       - '/sys/fs/cgroup/:/host/sys/fs/cgroup:ro'
     environment:
-      - DD_API_KEY=abcdefghijklmnop
+      - DD_API_KEY= "<DATADOG_API_KEY>"
       - DD_DOCKER_LABELS_AS_TAGS={"my.custom.label.project":"projecttag","my.custom.label.version":"versiontag"}
       - DD_TAGS="key1:value1 key2:value2 key3:value3"
     image: 'datadog/agent:latest'


### PR DESCRIPTION
### What does this PR do?
Enforces more placeholder wording to use `<DATADOG_API_KEY>` and `<DATADOG_APPLICATION_KEY>` when possible.

### Motivation

Translators feedback