### PR TITLE
[DOCS-571] Adding missing DCA doc

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -285,11 +285,21 @@ main:
     identifier: "cluster_agent_commands"
     parent: "agent_cluster"
     weight: 404
+  - name: "Cluster metadata provider"
+    url: "agent/cluster_agent/metadata_provider/"
+    identifier: "cluster_agent_metadata_provider"
+    parent: "agent_cluster"
+    weight: 405
+  - name: "Build"
+    url: "agent/cluster_agent/build/"
+    identifier: "cluster_agent_build"
+    parent: "agent_cluster"
+    weight: 406
   - name: "Troubleshooting"
     url: "agent/cluster_agent/troubleshooting/"
     identifier: "cluster_agent_troubleshooting"
     parent: "agent_cluster"
-    weight: 405
+    weight: 407
 
   ## AGENT - Autodiscovery
 

--- a/content/en/agent/cluster_agent/build.md
+++ b/content/en/agent/cluster_agent/build.md
@@ -1,0 +1,11 @@
+---
+title: Build the Datadog Cluster Agent
+kind: documentation
+---
+
+The Datadog Cluster Agent is designed to be used in a containerized ecosystem. To build it:
+
+1. Clone the [DataDog/datadog-agent github repository][1]
+2. In the `datadog-agent/` folder downloaded, Create the binary by running `inv -e cluster-agent.build`. This adds a binary in `./bin/datadog-cluster-agent/`
+3. Then from the same folder, run `inv -e cluster-agent.image-build`.
+[1]: https://github.com/DataDog/datadog-agent/

--- a/content/en/agent/cluster_agent/build.md
+++ b/content/en/agent/cluster_agent/build.md
@@ -5,8 +5,8 @@ kind: documentation
 
 The Datadog Cluster Agent is designed to be used in a containerized ecosystem. To build it:
 
-1. Clone the [DataDog/datadog-agent github repository][1]
-2. In the `datadog-agent/` folder downloaded, Create the binary by running `inv -e cluster-agent.build`. This adds a binary in `./bin/datadog-cluster-agent/`
+1. Clone the [DataDog/datadog-agent Github repository][1]
+2. In the `datadog-agent/` folder downloaded, create the binary by running `inv -e cluster-agent.build`. This adds a binary in `./bin/datadog-cluster-agent/`
 3. Then from the same folder, run `inv -e cluster-agent.image-build`.
 
 [1]: https://github.com/DataDog/datadog-agent/

--- a/content/en/agent/cluster_agent/build.md
+++ b/content/en/agent/cluster_agent/build.md
@@ -8,4 +8,5 @@ The Datadog Cluster Agent is designed to be used in a containerized ecosystem. T
 1. Clone the [DataDog/datadog-agent github repository][1]
 2. In the `datadog-agent/` folder downloaded, Create the binary by running `inv -e cluster-agent.build`. This adds a binary in `./bin/datadog-cluster-agent/`
 3. Then from the same folder, run `inv -e cluster-agent.image-build`.
+
 [1]: https://github.com/DataDog/datadog-agent/

--- a/content/en/agent/cluster_agent/metadata_provider.md
+++ b/content/en/agent/cluster_agent/metadata_provider.md
@@ -23,10 +23,10 @@ To enable the cluster metadata provider feature:
 
 1. Ensure the Node Agents and the Datadog Cluster Agent [can properly communicate][1].
 2. Create a [Cluster Agent service][2] in front of the Datadog Cluster Agent.
-3. [Ensure an auth_token is properly shared between the agents][1].
+3. [Ensure an auth_token is properly shared between the Agents][1].
 4. [Confirm the RBAC rules are properly set][1].
 5. In the Node Agent, set the environment variable `DD_CLUSTER_AGENT_ENABLED` to `true`.
-6. *Optional* - The env var `DD_KUBERNETES_METADATA_TAG_UPDATE_FREQ` can be set to specify how often the Node Agents hit the Datadog Cluster Agent.
+6. *Optional* - The environment variable `DD_KUBERNETES_METADATA_TAG_UPDATE_FREQ` can be set to specify how often the Node Agents hit the Datadog Cluster Agent.
 7. *Optional* - Disable the Kubernetes metadata tag collection with `DD_KUBERNETES_COLLECT_METADATA_TAGS=false`.
 
 ## Further Reading

--- a/content/en/agent/cluster_agent/metadata_provider.md
+++ b/content/en/agent/cluster_agent/metadata_provider.md
@@ -31,5 +31,7 @@ To enable the cluster metadata provider feature:
 
 ## Further Reading
 
-{{< partial name="whats-next/whats-next.html" >}}[1]: /agent/cluster_agent/troubleshooting
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /agent/cluster_agent/troubleshooting
 [2]: /agent/cluster_agent/setup/#step-3-create-the-cluster-agent-and-its-service

--- a/content/en/agent/cluster_agent/metadata_provider.md
+++ b/content/en/agent/cluster_agent/metadata_provider.md
@@ -1,0 +1,35 @@
+---
+title: Cluster metadata provider
+kind: documentation
+further_reading:
+- link: "https://www.datadoghq.com/blog/datadog-cluster-agent/"
+  tag: "Blog"
+  text: "Introducing the Datadog Cluster Agent"
+- link: "https://www.datadoghq.com/blog/autoscale-kubernetes-datadog/"
+  tag: "Blog"
+  text: "Autoscale your Kubernetes workloads with any Datadog metric"
+- link: "/agent/autodiscovery/clusterchecks"
+  tag: "Documentation"
+  text: "Running Cluster Checks with Autodiscovery"
+- link: "agent/kubernetes/daemonset_setup"
+  tag: "Documentation"
+  text: "Kubernetes DaemonSet Setup"
+- link: "/agent/cluster_agent/troubleshooting"
+  tag: "Documentation"
+  text: "Troubleshooting the Datadog Cluster Agent"
+---
+
+To enable the cluster metadata provider feature:
+
+1. Ensure the Node Agents and the Datadog Cluster Agent [can properly communicate][1].
+2. Create a [Cluster Agent service][2] in front of the Datadog Cluster Agent.
+3. [Ensure an auth_token is properly shared between the agents][1].
+4. [Confirm the RBAC rules are properly set][1].
+5. In the Node Agent, set the environment variable `DD_CLUSTER_AGENT_ENABLED` to `true`.
+6. *Optional* - The env var `DD_KUBERNETES_METADATA_TAG_UPDATE_FREQ` can be set to specify how often the Node Agents hit the Datadog Cluster Agent.
+7. *Optional* - Disable the Kubernetes metadata tag collection with `DD_KUBERNETES_COLLECT_METADATA_TAGS=false`.
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}[1]: /agent/cluster_agent/troubleshooting
+[2]: /agent/cluster_agent/setup/#step-3-create-the-cluster-agent-and-its-service

--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -69,7 +69,7 @@ Setting the value without a secret results in the token being readable in the `P
     kubectl create secret generic datadog-auth-token --from-literal=token=<ThirtyX2XcharactersXlongXtoken>
     ```
 
-    Alternatively, modify the value of the secret in `the dca-secret.yaml` file located in the [manifest/cluster-agent directory][1] then create it with:
+    Alternatively, modify the value of the secret in the `dca-secret.yaml` file located in the [manifest/cluster-agent directory][1] or create it with:
 
     `kubectl create -f Dockerfiles/manifests/cluster-agent/dca-secret.yaml`
 

--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -69,7 +69,9 @@ Setting the value without a secret results in the token being readable in the `P
     kubectl create secret generic datadog-auth-token --from-literal=token=<ThirtyX2XcharactersXlongXtoken>
     ```
 
-    Alternatively, you can specify the token in the `dca-secret.yaml` file located in the [manifest/cluster-agent directory][1].
+    Alternatively, modify the value of the secret in `the dca-secret.yaml` file located in the [manifest/cluster-agent directory][1] then create it with:
+
+    `kubectl create -f Dockerfiles/manifests/cluster-agent/dca-secret.yaml`
 
 3. Refer to this secret with the environment variable `DD_CLUSTER_AGENT_AUTH_TOKEN` in the manifests of the Cluster Agent. See [Step 3 - Create the Cluster Agent and its service](#step-3-create-the-cluster-agent-and-its-service)) and [Step 2 - Enable the Datadog Cluster Agent](#step-2-enable-the-datadog-agent).
 


### PR DESCRIPTION
### What does this PR do?

Adds the missing documentation from:

https://github.com/DataDog/datadog-agent/pull/4807
into the documentation.

### Motivation

Remove duplication of DCA documentation

### Preview link

* https://docs-staging.datadoghq.com/gus/dca-update/agent/cluster_agent/metadata_provider/
* https://docs-staging.datadoghq.com/gus/dca-update/agent/cluster_agent/build/