### PR TITLE
Clarify SLO Overall Uptime Calculation

### DIFF
--- a/content/en/monitors/service_level_objectives/_index.md
+++ b/content/en/monitors/service_level_objectives/_index.md
@@ -68,18 +68,18 @@ When you create or edit an SLO, you can add tags for filtering on the [list SLOs
 
 {{< img src="monitors/service_level_objectives/overall_uptime_calculation.png" alt="overall uptime calculation"  >}}
 
-The overall uptime result calculated for a time `T_x` can be expressed using boolean logic as the logical conjunction (the `AND` conjunction) of all of the monitor states at time `T_x`.
+The overall uptime can be considered as a percentage of the time where **all** of the monitor states are in the `OK` state. It is not the average of the aggregated monitors. 
 
-If at time `T_x` the state of all monitors `[m0, ..., m_n]` are all in `OK` state, then the overall uptime for time `T_x` will be the `OK` state. However, if any number of monitors at time `T_x` have state `ALERT`, then the overall uptime for time `T_x` will be the `ALERT` state.
+Consider the following example for 3 monitors:
 
-Consider the following example:
+| Monitor            | t1 | t2 | t3    | t4 | t5    | t6 | t7 | t8 | t9    | t10 | Uptime |
+|--------------------|----|----|-------|----|-------|----|----|----|-------|-----|--------|
+| monitor 1          | OK | OK | OK    | OK | ALERT | OK | OK | OK | OK    | OK  | 90%    | 
+| monitor 2          | OK | OK | OK    | OK | OK    | OK | OK | OK | ALERT | OK  | 90%    |
+| monitor 3          | OK | OK | ALERT | OK | ALERT | OK | OK | OK | OK    | OK  | 80%    |
+| **Overall Uptime** | OK | OK | ALERT | OK | ALERT | OK | OK | OK | ALERT | OK  | 70%    |
 
-| Monitor            | t0 | t1 | t2    | t3 | t4    | t5 | t6 | t7 | t8 | t9 | t10   |
-|--------------------|----|----|-------|----|-------|----|----|----|----|----|-------|
-| m0                 | OK | OK | OK    | OK | ALERT | OK | OK | OK | OK | OK | ALERT |
-| m1                 | OK | OK | OK    | OK | OK    | OK | OK | OK | OK | OK | ALERT |
-| m2                 | OK | OK | ALERT | OK | ALERT | OK | OK | OK | OK | OK | ALERT |
-| **Overall Uptime** | OK | OK | ALERT | OK | ALERT | OK | OK | OK | OK | OK | ALERT |
+This can result in the overall uptime being lower than the average of the individual uptimes.
 
 ## View your SLOs
 

--- a/content/en/monitors/service_level_objectives/_index.md
+++ b/content/en/monitors/service_level_objectives/_index.md
@@ -68,7 +68,7 @@ When you create or edit an SLO, you can add tags for filtering on the [list SLOs
 
 {{< img src="monitors/service_level_objectives/overall_uptime_calculation.png" alt="overall uptime calculation"  >}}
 
-The overall uptime can be considered as a percentage of the time where **all** of the monitors are in the `OK` state. It is not the average of the aggregated monitors. 
+The overall uptime can be considered as a percentage of the time where **all** monitors are in the `OK` state. It is not the average of the aggregated monitors. 
 
 Consider the following example for 3 monitors:
 

--- a/content/en/monitors/service_level_objectives/_index.md
+++ b/content/en/monitors/service_level_objectives/_index.md
@@ -68,15 +68,15 @@ When you create or edit an SLO, you can add tags for filtering on the [list SLOs
 
 {{< img src="monitors/service_level_objectives/overall_uptime_calculation.png" alt="overall uptime calculation"  >}}
 
-The overall uptime can be considered as a percentage of the time where **all** of the monitor states are in the `OK` state. It is not the average of the aggregated monitors. 
+The overall uptime can be considered as a percentage of the time where **all** of the monitors are in the `OK` state. It is not the average of the aggregated monitors. 
 
 Consider the following example for 3 monitors:
 
 | Monitor            | t1 | t2 | t3    | t4 | t5    | t6 | t7 | t8 | t9    | t10 | Uptime |
 |--------------------|----|----|-------|----|-------|----|----|----|-------|-----|--------|
-| monitor 1          | OK | OK | OK    | OK | ALERT | OK | OK | OK | OK    | OK  | 90%    | 
-| monitor 2          | OK | OK | OK    | OK | OK    | OK | OK | OK | ALERT | OK  | 90%    |
-| monitor 3          | OK | OK | ALERT | OK | ALERT | OK | OK | OK | OK    | OK  | 80%    |
+| Monitor 1          | OK | OK | OK    | OK | ALERT | OK | OK | OK | OK    | OK  | 90%    | 
+| Monitor 2          | OK | OK | OK    | OK | OK    | OK | OK | OK | ALERT | OK  | 90%    |
+| Monitor 3          | OK | OK | ALERT | OK | ALERT | OK | OK | OK | OK    | OK  | 80%    |
 | **Overall Uptime** | OK | OK | ALERT | OK | ALERT | OK | OK | OK | ALERT | OK  | 70%    |
 
 This can result in the overall uptime being lower than the average of the individual uptimes.


### PR DESCRIPTION
This is to clarify the overall calculation with example percentages and simplify the wording by removing the boolean / mathematical variables.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Simplify the wording surrounding the overall uptime calculation. As well as provide example percentages to show how the math happens.

### Motivation
<!-- What inspired you to submit this pull request?-->
From a few customer facing tickets surrounding this

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 
Replace the branch name and add the complete path: -->

https://docs-staging.datadoghq.com/jack.davenport/slo_overall_uptime/monitors/service_level_objectives/#overall-uptime-calculation

### Additional Notes
Old Page:
https://docs.datadoghq.com/monitors/service_level_objectives/#overall-uptime-calculation