### PR TITLE
Adding security monitoring section to the search results

### DIFF
--- a/local/etc/algolia/docs_datadoghq.json
+++ b/local/etc/algolia/docs_datadoghq.json
@@ -113,6 +113,7 @@
           "logs",
           "monitors",
           "security",
+          "security_monitoring",
           "synthetics",
           "real_user_monitoring",
           "network_performance_monitoring",

--- a/local/etc/algolia/docs_datadoghq_preview.json
+++ b/local/etc/algolia/docs_datadoghq_preview.json
@@ -113,6 +113,7 @@
           "logs",
           "monitors",
           "security",
+          "security_monitoring",
           "synthetics",
           "real_user_monitoring",
           "network_performance_monitoring",


### PR DESCRIPTION
### What does this PR do?

Adding security monitoring section to the search results following: https://github.com/DataDog/documentation/pull/6092