### PR TITLE
🐛[Synthetics] Fix links for using global variables

### DIFF
--- a/content/en/synthetics/settings/_index.md
+++ b/content/en/synthetics/settings/_index.md
@@ -89,5 +89,5 @@ If the endpoint is being traced and whitelisted, your browser test results are t
 [1]: https://app.datadoghq.com/synthetics/settings
 [2]: /synthetics/private_locations
 [3]: /account_management/users/default_roles/
-[4]: /synthetics/api_tests#use-global-variables
+[4]: /synthetics/api_tests/#use-global-variables
 [5]: /synthetics/browser_tests/#use-global-variables

--- a/content/en/synthetics/settings/_index.md
+++ b/content/en/synthetics/settings/_index.md
@@ -28,7 +28,7 @@ Only [Admin and Standard users][3] can access Synthetics `Settings` page.
 
 ## Global Variables
 
-Variables are global and can be used by multiple [API tests][3] and [browser tests][4]. To create a new global variable, go to the **Global Variables** tab of your **Settings** page, and click **New Global Variable** in the upper right corner of your page.
+Variables are global and can be used by multiple [API tests][4] and [browser tests][5]. To create a new global variable, go to the **Global Variables** tab of your **Settings** page, and click **New Global Variable** in the upper right corner of your page.
 Choose the type of variable you want to create:
 
 {{< tabs >}}
@@ -90,3 +90,4 @@ If the endpoint is being traced and whitelisted, your browser test results are t
 [2]: /synthetics/private_locations
 [3]: /account_management/users/default_roles/
 [4]: /synthetics/api_tests#use-global-variables
+[5]: /synthetics/browser_tests/#use-global-variables


### PR DESCRIPTION
### What does this PR do?
Fixes these links:
![image](https://user-images.githubusercontent.com/793700/73657621-edfa6100-4692-11ea-8119-0a4e9f3f4ab7.png)


### Motivation
I was using the docs to understand how to use the product. Noticed they were wrong.

### Preview link
https://docs.datadoghq.com/synthetics/settings/?tab=specifyvalue#global-variables

