### PR TITLE
[DOCS-404] moving browser tests apm page

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1171,10 +1171,14 @@ main:
     url: "synthetics/browser_tests/actions"
     parent: "synthetics_browser_tests"
     weight: 201
+  - name: "Test Results"
+    url: "synthetics/browser_tests/test_results"
+    parent: "synthetics_browser_tests"
+    weight: 202
   - name: "Advanced Options"
     url: "synthetics/browser_tests/advanced_options"
     parent: "synthetics_browser_tests"
-    weight: 202
+    weight: 203
 
   - name: "Private Locations"
     url: "synthetics/private_locations"
@@ -1189,10 +1193,6 @@ main:
     parent: "synthetics"
     identifier: "synthetics_apm"
     weight: 4
-  - name: "Browser Tests"
-    url: "synthetics/apm/browser_tests"
-    parent: "synthetics_apm"
-    weight: 401
 
   - name: "Identify Synthetics Bots"
     url: "synthetics/identify_synthetics_bots/"

--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -18,6 +18,9 @@ further_reading:
 - link: "synthetics/api_tests"
   tag: "Documentation"
   text: "Configure an API Test"
+- link: "synthetics/browser_tests/test_results"
+  tag: "Documentation"
+  text: "Browser test results"
 ---
 
 ## Overview
@@ -80,20 +83,6 @@ Hitting **Open in a pop-up** and **Shift** opens the pop up in incognito mode. T
 ## Actions
 
 After saving a browser test, you can record [Actions][10] as a series of steps, which you can then edit or build on. You can also configure actions with [advanced options][11].
-
-## Test failure and errors
-
-A test is considered `FAILED` if it does not satisfy its assertions or if the request failed for another reason. You can view specific browser test errors by clicking on the error in the step results.
-
-Common failure reasons include:
-
-| Error                                | Description                                                                                                          |
-|--------------------------------------|----------------------------------------------------------------------------------------------------------------------|
-| `Element located but it's invisible` | The element is on the page but cannot be clicked on—for instance, if another element is overlaid on top of it.       |
-| `Cannot locate element`              | The element cannot be found in the HTML.                                                                             |
-| `Select did not have option`         | The specified option is missing from the dropdown menu.                                                              |
-| `Forbidden URL`                      | The test likely encountered a protocol that is not supported. Reach out to [Datadog support][4] for further details. |
-| `General test failure`               | A general error message. [Contact support][4] for further details.                                                   |
 
 ## Further Reading
 

--- a/content/en/synthetics/browser_tests/test_results.md
+++ b/content/en/synthetics/browser_tests/test_results.md
@@ -1,22 +1,19 @@
 ---
-title: Browser Tests with APM
+title: Browser Test Results
 kind: documentation
-description: Synthetics browser tests with APM
+description: Synthetics browser test results
+aliases:
+ - "/synthetics/apm/browser_tests"
 further_reading:
 - link: "/synthetics/browser_tests/"
   tag: "Documentation"
   text: "Browser Tests"
 ---
 
+
 ## Overview
 
-Browser tests with APM connect synthetics tests with your backend traces.
-
-## Test results
-
 Test results are accessed from the **Step Results** section on your browser test's status page.
-
-<POSSIBLE_SCREENSHOT>
 
 ### Errors
 
@@ -50,8 +47,23 @@ The traces panel shows your traces associated with the browser synthetics test. 
 
 One browser step can make multiple requests to different URLs/endpoints, which results in several associated traces (dependent on tracing and whitelisting setup). Use the dropdown to choose the trace to view.
 
+## Test failure and errors
+
+A test is considered `FAILED` if it does not satisfy its assertions or if the request failed for another reason. You can view specific browser test errors by clicking on the error in the step results.
+
+Common failure reasons include:
+
+| Error                                | Description                                                                                                          |
+|--------------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| `Element located but it's invisible` | The element is on the page but cannot be clicked on—for instance, if another element is overlaid on top of it.       |
+| `Cannot locate element`              | The element cannot be found in the HTML.                                                                             |
+| `Select did not have option`         | The specified option is missing from the dropdown menu.                                                              |
+| `Forbidden URL`                      | The test likely encountered a protocol that is not supported. Reach out to [Datadog support][2] for further details. |
+| `General test failure`               | A general error message. [Contact support][2] for further details.                                                   |
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /tracing/visualization/trace
+[2]: /help


### PR DESCRIPTION


### What does this PR do?
consolidates former APM Browser Tests page and the Test Errors section of the Browser Tests page into: Browser tests --> Test Results

### Motivation
Former page didn't have much to do with APM

### Preview link

https://docs-staging.datadoghq.com/cswatt/synthetics-test-results/synthetics/browser_tests/test_results

