### PR TITLE
layout logic for disabled toc

### DIFF
--- a/content/en/getting_started/_index.md
+++ b/content/en/getting_started/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Getting started
 kind: documentation
+disable_toc: true
 aliases:
   - /overview
   - /getting_started/faq/

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -246,5 +246,8 @@
   },
   "table_of_contents_heading": {
     "other": "On this Page"
+  },
+  "edit": {
+    "other": "Edit"
   }
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -243,5 +243,8 @@
   },
   "groups_return_to_": {
     "other": "Back to"
+  },
+  "table_of_contents_heading": {
+    "other": "On this Page"
   }
 }

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -47,7 +47,7 @@
       <div class="d-none d-lg-flex col-12 col-sm-3 side">
         {{ partial "sidenav/sidenav.html" . }}
       </div>
-      <div class="mainContent-wrapper col-12 col-lg-7 main">
+      <div class="mainContent-wrapper col-12 {{ if eq .Params.disable_toc true}} col-lg-9 {{ else }} col-lg-7 {{end}} main">
         <div class="{{ if and (eq $.Section "integrations") (eq $.Kind "page") }}integrations-single{{ end }}"
           id="mainContent">
           {{ block "main" . }}{{ end }}

--- a/layouts/partials/page-edit-body.html
+++ b/layouts/partials/page-edit-body.html
@@ -2,5 +2,5 @@
 {{ $ctx := .ctx }}
 {{ $type := .type }}
 {{ if eq $type "edit"}}
-<div class="pb-2 js-toc-edit-btn toc-edit-btn"><a href="{{.link}}" class="text-primary text-uppercase font-semibold font-18">{{ partial "img.html" (dict "root" $ctx "src" "icons/icon-pencil.svg" "class" "static" "alt" "edit" "width" "25") }} Edit</a></div>
+<div class="pb-2 js-toc-edit-btn toc-edit-btn"><a href="{{.link}}" class="text-primary text-uppercase font-semibold font-18">{{ partial "img.html" (dict "root" $ctx "src" "icons/icon-pencil.svg" "class" "static" "alt" "edit" "width" "25") }} {{ i18n "edit"}}</a></div>
 {{ end }}

--- a/layouts/partials/table-of-contents/table-of-contents.html
+++ b/layouts/partials/table-of-contents/table-of-contents.html
@@ -7,7 +7,7 @@
     <div class="sticky toc">
         <div class="js-toc {{ if .Params.disable_toc }} d-none {{ else }} {{ end }}">
             {{ partial "page-edit.html" (dict "ctx" $ctx "type" "edit") }}
-            <p class="text-uppercase text-gray-darkish font-semibold mb-2 toc-title js-toc-title {{ if .Params.disable_toc }} d-none {{ else }} {{ end }}">On this page</p>
+            <p class="text-uppercase text-gray-darkish font-semibold mb-2 toc-title js-toc-title {{ if .Params.disable_toc }} d-none {{ else }} {{ end }}">{{ i18n "table_of_contents_heading"}}</p>
         {{ .TableOfContents }}
         </div>
         

--- a/layouts/partials/table-of-contents/table-of-contents.html
+++ b/layouts/partials/table-of-contents/table-of-contents.html
@@ -8,7 +8,8 @@
         <div class="js-toc {{ if .Params.disable_toc }} d-none {{ else }} {{ end }}">
             {{ partial "page-edit.html" (dict "ctx" $ctx "type" "edit") }}
             <p class="text-uppercase text-gray-darkish font-semibold mb-2 toc-title js-toc-title {{ if .Params.disable_toc }} d-none {{ else }} {{ end }}">{{ i18n "table_of_contents_heading"}}</p>
-        {{ .TableOfContents }}
+            {{ if ne .Params.disable_toc true }}{{ .TableOfContents }}{{ end }}
+            
         </div>
         
     </div>

--- a/layouts/shortcodes/integrations.html
+++ b/layouts/shortcodes/integrations.html
@@ -84,7 +84,7 @@
         {{/* if  $src */}}
         {{ if and $indx (fileExists (print "static/" $src)) }}
             {{ if $formatname }}
-            <div id="mixid_{{$i}}" class="col-6 col-sm-4 col-md-3 col-lg-4 col-xl-3 mix text-center {{ range $i, $e := $v.Params.categories }} cat-{{ replace $e "/" "" | urlize }} {{ end }}" data-id="{{ $i }}" data-ref="item">
+            <div id="mixid_{{$i}}" class="col-6 col-sm-4 col-md-3 col-lg-3 col-xl-2-4 mix text-center {{ range $i, $e := $v.Params.categories }} cat-{{ replace $e "/" "" | urlize }} {{ end }}" data-id="{{ $i }}" data-ref="item">
                 <div id="{{ $v.Params.name | default ($urlname | lower) }}" class="card">
                     <a class="card-img" href="{{ (print "integrations/" ($urlname | lower)) | absLangURL }}">
                         {{ $.Scratch.Set "url" ""}}

--- a/src/scripts/datadog-docs.js
+++ b/src/scripts/datadog-docs.js
@@ -783,6 +783,9 @@ function loadPage(newUrl) {
                 return;
             }
     
+            const mainContentWrapper = document.querySelector('.mainContent-wrapper');
+            const newmainContentWrapper = httpRequest.responseXML.querySelector(".mainContent-wrapper");
+
             const newContent = httpRequest.responseXML.getElementById("mainContent");
             const newTOC = httpRequest.responseXML.querySelector(".js-toc-container");
 
@@ -839,6 +842,11 @@ function loadPage(newUrl) {
             if (mainContent.parentElement) {
                 mainContent.parentElement.replaceChild(newContent, mainContent);
                 mainContent = newContent;
+
+                // update mainContent-wrapper classes
+                mainContentWrapper.className = `${newmainContentWrapper.classList}`
+
+
             } else {
                 window.location.href = newUrl;
             }


### PR DESCRIPTION
### What does this PR do?
1. When TOC is disabled with Front matter: `disable_toc: true`, the mainContent layout will be 9 columns as opposed to the 7 columns when the TOC is visible. 
2. Adds i18n support for TOC heading.

### Motivation
https://trello.com/c/IycJHnm7/4350-docs-layout-updates-phase-2

### Preview link
https://docs-staging.datadoghq.com/zach/layout-updates/
