### PR TITLE
Document the monitor summary widget's sort param

### DIFF
--- a/content/en/dashboards/widgets/monitor_summary.md
+++ b/content/en/dashboards/widgets/monitor_summary.md
@@ -72,6 +72,7 @@ MANAGE_STATUS_SCHEMA = {
         "type": {"enum": ["manage_status"]},
         "query": {"type": "string"},
         "summary_type": {"enum": ["monitors", "groups", "combined"]},
+        "sort": {"type": "string"},
         "display_format": {"enum": ["counts", "countsAndList", "list"]},
         "color_preference": {"enum": ["background", "text"]},
         "hide_zero_counts": {"type": "boolean"},
@@ -90,8 +91,9 @@ MANAGE_STATUS_SCHEMA = {
 | `type`                | string  | yes      | Type of the widget, for the monitor summary widget use `manage_status`                   |
 | `query`               | string  | yes      | Query to filter the monitors with                                                        |
 | `summary_type`        | string  | no       | Which summary type should be used                                                        |
+| `sort`                | string  | no       | How to sort results, e.g. `status,asc`. Available sort field values are: `group`, `name`, `status` or `triggered`, and available order values are `asc` or `desc`. Defaults to `status,asc`.|
 | `display_format`      | string  | no       | What to display on the widget. Available values are: `counts`, `countsAndList` or `list` |
-| `color_preference`    | string  | no       | Which color to use on the widget. Available values are:`background` or `text`            |
+| `color_preference`    | string  | no       | Which color to use on the widget. Available values are: `background` or `text`           |
 | `hide_zero_counts`    | Boolean | no       | Whether to show counts of 0 or not                                                       |
 | `show_last_triggered` | Boolean | no       | Whether to show the time that has elapsed since the monitor/group triggered              |
 | `title`               | string  | no       | Title of the widget                                                                      |


### PR DESCRIPTION
### What does this PR do?

It documents the monitor summary widget's sort param.

### Motivation

There is some confusion about which monitor summary widget parameters are supported: https://github.com/terraform-providers/terraform-provider-datadog/pull/300. All three params (`count`, `start`, and `sort`) are still supported, but `count` and `start` don't currently have any use cases, so they shouldn't be documented to avoid confusion. They will be marked as deprecated in the terraform code, though we will continue to support them for now.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/chrism/monitor-summary-widget/dashboards/widgets/monitor_summary/#api

### Additional Notes
<!-- Anything else we should know when reviewing?-->
