### PR TITLE
Update the keyvalue examples to refer to logfmt

### DIFF
--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -159,14 +159,14 @@ server on server %{notSpace:server.name} in %{notSpace:server.env}
 
 Some examples demonstrating how to use parsers:
 
-* [Key value](#key-value)
+* [Key value or logfmt](#key-value-or-logfmt)
 * [Parsing dates](#parsing-dates)
 * [Conditional patterns](#conditional-pattern)
 * [Optional attribute](#optional-attribute)
 * [Nested JSON](#nested-json)
 * [Regex](#regex)
 
-### Key value
+### Key value or logfmt
 
 This is the key-value core filter: `keyvalue([separatorStr[, characterWhiteList[, quotingStr]]])` where:
 
@@ -179,7 +179,7 @@ This is the key-value core filter: `keyvalue([separatorStr[, characterWhiteList[
 * Empty values (`key=`) or `null` values (`key=null`) are not displayed in the output JSON.
 * If you define a *keyvalue* filter on a `data` object, and this filter is not matched, then an empty JSON `{}` is returned (e.g. input: `key:=valueStr`, parsing rule: `rule_test %{data::keyvalue("=")}`, output: `{}`).
 
-Use filters such as **keyvalue** to more-easily map strings to attributes:
+Use filters such as **keyvalue** to more-easily map strings to attributes for keyvalue or logfmt formats:
 
 Log:
 


### PR DESCRIPTION
### What does this PR do?
Another name for keyvalue in the log management industry is logfmt and it was not mentioned in the documentation.

### Motivation
Searching on logfmt was not returning anything for Datadog

### Preview link
https://docs-staging.datadoghq.com/nils/keyvalue-logfmt/logs/processing/parsing/?tab=matcher#key-value-or-logfmt

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
