### PR TITLE
add canonical

### DIFF
--- a/layouts/_default/404-baseof.html
+++ b/layouts/_default/404-baseof.html
@@ -14,6 +14,7 @@
   <title>{{ .Title }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {{ if .Params.external_redirect }} {{ partial "meta-http-equiv.html" . }} {{ end }}
+  {{- partial "canonical.html" . -}}
   {{- partial "noindex.html" . -}}
   {{- partial "hreflang.html" . -}}
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/layouts/_default/api-baseof.html
+++ b/layouts/_default/api-baseof.html
@@ -14,6 +14,7 @@
   <title>{{ .Title }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {{ if .Params.external_redirect }} {{ partial "meta-http-equiv.html" . }} {{ end }}
+  {{- partial "canonical.html" . -}}
   {{- partial "noindex.html" . -}}
   {{- partial "hreflang.html" . -}}
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,6 +16,7 @@
   </title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {{ if .Params.external_redirect }} {{ partial "meta-http-equiv.html" . }} {{ end }}
+  {{- partial "canonical.html" . -}}
   {{- partial "noindex.html" . -}}
   {{- partial "hreflang.html" . -}}
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -14,6 +14,7 @@
         </title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         {{ if .Params.external_redirect }} {{ partial "meta-http-equiv.html" . }} {{ end }}
+        {{- partial "canonical.html" . -}}
         {{- partial "noindex.html" . -}}
         {{- partial "hreflang.html" . -}}
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/layouts/partials/canonical.html
+++ b/layouts/partials/canonical.html
@@ -1,0 +1,10 @@
+{{ $dot := . }}
+{{ if isset $dot.Params "placeholder" }}
+    {{ range .Translations }}
+      {{ if eq .Lang "en" }}
+        <link rel="canonical" href="{{ .Permalink }}">
+      {{ end }}
+    {{ end }}
+{{ else }}
+    <link rel="canonical" href="{{ $dot.Permalink }}">
+{{ end }}


### PR DESCRIPTION
### What does this PR do?

- Adds the canonical tag to pages.
- if the page is a placeholder e.g English text on a localized page, we reference the English as canon

### Motivation

Discovered we weren't setting the canonical link

### Preview link

Check the source code of pages contains `<link rel="canonical"`
https://docs-staging.datadoghq.com/david.jones/canonical/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
