### PR TITLE
Rename uptime property to sli_value in SLO history API response

### DIFF
--- a/content/en/api/service_level_objectives/code_snippets/result.api-slo-history.py
+++ b/content/en/api/service_level_objectives/code_snippets/result.api-slo-history.py
@@ -11,7 +11,7 @@
       }
     },
     "overall": {
-      "uptime": 99.04629516601562,
+      "sli_value": 99.04629516601562,
       "span_precision": 2.0,
       "name": "We're not meeting our 1m SLAs for foo",
       "precision": {
@@ -132,7 +132,7 @@
     "from_ts": 1568737541,
     "groups": [
       {
-        "uptime": 99.68518829345703,
+        "sli_value": 99.68518829345703,
         "preview": false,
         "group": "foo:pig",
         "history": [
@@ -159,7 +159,7 @@
         ]
       },
       {
-        "uptime": 99.69444274902344,
+        "sli_value": 99.69444274902344,
         "preview": false,
         "group": "foo:sheep",
         "history": [
@@ -186,7 +186,7 @@
         ]
       },
       {
-        "uptime": 99.7615737915039,
+        "sli_value": 99.7615737915039,
         "preview": true,
         "group": "foo:cow",
         "history": [
@@ -237,7 +237,7 @@
         ]
       },
       {
-        "uptime": 99.84027862548828,
+        "sli_value": 99.84027862548828,
         "preview": true,
         "group": "foo:donkey",
         "history": [
@@ -280,7 +280,7 @@
         ]
       },
       {
-        "uptime": 99.84490966796875,
+        "sli_value": 99.84490966796875,
         "preview": false,
         "group": "foo:cat",
         "history": [
@@ -299,7 +299,7 @@
         ]
       },
       {
-        "uptime": 99.84954071044922,
+        "sli_value": 99.84954071044922,
         "preview": true,
         "group": "foo:dog",
         "history": [
@@ -326,7 +326,7 @@
         ]
       },
       {
-        "uptime": 99.90509033203125,
+        "sli_value": 99.90509033203125,
         "preview": true,
         "group": "foo:horse",
         "history": [
@@ -361,7 +361,7 @@
         ]
       },
       {
-        "uptime": 100.0,
+        "sli_value": 100.0,
         "preview": false,
         "group": "foo:duck",
         "history": [
@@ -372,7 +372,7 @@
         ]
       },
       {
-        "uptime": 100.0,
+        "sli_value": 100.0,
         "preview": false,
         "group": "foo:chicken",
         "history": [
@@ -467,7 +467,7 @@
       }
     },
     "overall": {
-      "uptime": 100,
+      "sli_value": 100,
       "span_precision": 0,
       "precision": {
         "7d": 0,

--- a/content/en/api/service_level_objectives/code_snippets/result.api-slo-history.rb
+++ b/content/en/api/service_level_objectives/code_snippets/result.api-slo-history.rb
@@ -11,7 +11,7 @@
       }
     },
     "overall": {
-      "uptime": 99.04629516601562,
+      "sli_value": 99.04629516601562,
       "span_precision": 2.0,
       "name": "We're not meeting our 1m SLAs for foo",
       "precision": {
@@ -132,7 +132,7 @@
     "from_ts": 1_568_737_541,
     "groups": [
       {
-        "uptime": 99.68518829345703,
+        "sli_value": 99.68518829345703,
         "preview": false,
         "group": 'foo:pig',
         "history": [
@@ -159,7 +159,7 @@
         ]
       },
       {
-        "uptime": 99.69444274902344,
+        "sli_value": 99.69444274902344,
         "preview": false,
         "group": 'foo:sheep',
         "history": [
@@ -186,7 +186,7 @@
         ]
       },
       {
-        "uptime": 99.7615737915039,
+        "sli_value": 99.7615737915039,
         "preview": true,
         "group": 'foo:cow',
         "history": [
@@ -237,7 +237,7 @@
         ]
       },
       {
-        "uptime": 99.84027862548828,
+        "sli_value": 99.84027862548828,
         "preview": true,
         "group": 'foo:donkey',
         "history": [
@@ -280,7 +280,7 @@
         ]
       },
       {
-        "uptime": 99.84490966796875,
+        "sli_value": 99.84490966796875,
         "preview": false,
         "group": 'foo:cat',
         "history": [
@@ -299,7 +299,7 @@
         ]
       },
       {
-        "uptime": 99.84954071044922,
+        "sli_value": 99.84954071044922,
         "preview": true,
         "group": 'foo:dog',
         "history": [
@@ -326,7 +326,7 @@
         ]
       },
       {
-        "uptime": 99.90509033203125,
+        "sli_value": 99.90509033203125,
         "preview": true,
         "group": 'foo:horse',
         "history": [
@@ -361,7 +361,7 @@
         ]
       },
       {
-        "uptime": 100.0,
+        "sli_value": 100.0,
         "preview": false,
         "group": 'foo:duck',
         "history": [
@@ -372,7 +372,7 @@
         ]
       },
       {
-        "uptime": 100.0,
+        "sli_value": 100.0,
         "preview": false,
         "group": 'foo:chicken',
         "history": [
@@ -467,7 +467,7 @@
       }
     },
     "overall": {
-      "uptime": 100,
+      "sli_value": 100,
       "span_precision": 0,
       "precision": {
         "7d": 0,

--- a/content/en/api/service_level_objectives/code_snippets/result.api-slo-history.sh
+++ b/content/en/api/service_level_objectives/code_snippets/result.api-slo-history.sh
@@ -11,7 +11,7 @@
       }
     },
     "overall": {
-      "uptime": 99.04629516601562,
+      "sli_value": 99.04629516601562,
       "span_precision": 2.0,
       "name": "We're not meeting our 1m SLAs for foo",
       "precision": {
@@ -132,7 +132,7 @@
     "from_ts": 1568737541,
     "groups": [
       {
-        "uptime": 99.68518829345703,
+        "sli_value": 99.68518829345703,
         "preview": false,
         "group": "foo:pig",
         "history": [
@@ -159,7 +159,7 @@
         ]
       },
       {
-        "uptime": 99.69444274902344,
+        "sli_value": 99.69444274902344,
         "preview": false,
         "group": "foo:sheep",
         "history": [
@@ -186,7 +186,7 @@
         ]
       },
       {
-        "uptime": 99.7615737915039,
+        "sli_value": 99.7615737915039,
         "preview": true,
         "group": "foo:cow",
         "history": [
@@ -237,7 +237,7 @@
         ]
       },
       {
-        "uptime": 99.84027862548828,
+        "sli_value": 99.84027862548828,
         "preview": true,
         "group": "foo:donkey",
         "history": [
@@ -280,7 +280,7 @@
         ]
       },
       {
-        "uptime": 99.84490966796875,
+        "sli_value": 99.84490966796875,
         "preview": false,
         "group": "foo:cat",
         "history": [
@@ -299,7 +299,7 @@
         ]
       },
       {
-        "uptime": 99.84954071044922,
+        "sli_value": 99.84954071044922,
         "preview": true,
         "group": "foo:dog",
         "history": [
@@ -326,7 +326,7 @@
         ]
       },
       {
-        "uptime": 99.90509033203125,
+        "sli_value": 99.90509033203125,
         "preview": true,
         "group": "foo:horse",
         "history": [
@@ -361,7 +361,7 @@
         ]
       },
       {
-        "uptime": 100.0,
+        "sli_value": 100.0,
         "preview": false,
         "group": "foo:duck",
         "history": [
@@ -372,7 +372,7 @@
         ]
       },
       {
-        "uptime": 100.0,
+        "sli_value": 100.0,
         "preview": false,
         "group": "foo:chicken",
         "history": [
@@ -467,7 +467,7 @@
       }
     },
     "overall": {
-      "uptime": 100,
+      "sli_value": 100,
       "span_precision": 0,
       "precision": {
         "7d": 0,


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This API is still in beta, but to avoid inconveniencing users, the `uptime` property will remain (as a duplicate of `sli_value`) for existing API users to give them time to migrate. We shouldn't advertise it going forward though.

### Motivation
<!-- What inspired you to submit this pull request?-->

We have renamed this property because not all SLIs track uptime. 

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/chrism/slo-history/api/?lang=bash#get-an-slo-s-history

### Additional Notes
<!-- Anything else we should know when reviewing?-->
