### PR TITLE
use html utf8 when uploading files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:zach_fix-node-sass
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:david.jones_html-contenttype
   tags:
     - "runner:main"
     - "size:large"


### PR DESCRIPTION
### What does this PR do?

Switch to an image that uploads html files as `text/html; charset=utf-8`

### Motivation

issues with bullet points on some browsers

### Preview link
https://docs-staging.datadoghq.com/david.jones/htmlencoding/

### Additional Notes

