### PR TITLE
fix code block code fence rendering issue

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -25,3 +25,5 @@ enableGitInfo: true
 # Allow to render HTML in markdown files
 markup:
   defaultMarkdownHandler: blackfriday
+  highlight:
+    guessSyntax: true


### PR DESCRIPTION
### What does this PR do?
Fix a code block rendering issue after this merge: https://github.com/DataDog/documentation/pull/6516

Code blocks in `md` files with triple back ticks need to have a language param after to get correctly complied. There are currently many files that don't have a lang param set. Using hugo's built in config option: 

```
highlight:
    guessSyntax: true
```
solves this. https://gohugo.io/getting-started/configuration-markup

### Preview link
http://docs-staging.datadoghq.com/zach/fix-render

