### PR TITLE
Removing trailing underscores from tag values.

### DIFF
--- a/content/en/developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags.md
+++ b/content/en/developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags.md
@@ -30,7 +30,7 @@ Metrics reported by the Agent are in a pseudo-hierarchical dotted format (e.g. `
 
 * Tags must start with a letter.
 * May contain alphanumerics, underscores, minuses, colons, periods, and slashes. Other characters are converted to underscores.
-* Any trailing underscore will get removed, whether if it originated from a convereted charachter or if it was in the original tag value.
+* Any trailing underscore will get removed, whether if it originated from a converted character or if it was in the original tag value.
 * Tags can be up to 200 characters long and support Unicode.
 * Tags are converted to lowercase.
 * For optimal functionality, it is recommended to use the `key:value` syntax.

--- a/content/en/developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags.md
+++ b/content/en/developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags.md
@@ -30,6 +30,7 @@ Metrics reported by the Agent are in a pseudo-hierarchical dotted format (e.g. `
 
 * Tags must start with a letter.
 * May contain alphanumerics, underscores, minuses, colons, periods, and slashes. Other characters are converted to underscores.
+* Any trailing underscore will get removed, whether if it originated from a convereted charachter or if it was in the original tag value.
 * Tags can be up to 200 characters long and support Unicode.
 * Tags are converted to lowercase.
 * For optimal functionality, it is recommended to use the `key:value` syntax.


### PR DESCRIPTION
Updating per this code snippet:
https://github.com/DataDog/dogweb/blob/prod/dd/utils/context/tag.py#L81-L90
And following a ticket we received from a client: https://datadog.zendesk.com/agent/tickets/303051

This was also discussed on 2015 ad expected behavior, on this Trello ticket: https://trello.com/c/yXQz0bwl/632-trailing-underscores-in-tags

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Edit to https://docs.datadoghq.com/developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags/#pagetitle article

### Motivation
Asked by a client on this ticket: https://datadog.zendesk.com/agent/tickets/303051

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://github.com/DataDog/documentation/pull/6589/files

