### PR TITLE
[api] [slo] Fix search examples, faceted search not available yet.

### DIFF
--- a/content/en/api/service_level_objectives/code_snippets/api-slo-search.py
+++ b/content/en/api/service_level_objectives/code_snippets/api-slo-search.py
@@ -13,5 +13,5 @@ slo_ids = ["<YOUR_SLO_ID>", "<YOUR_SLO_ID>"]
 api.ServiceLevelObjective.get_all(ids=slo_ids, offset=0)
 
 # search with a query
-query = "tags:app:frontend"
+query = "my team"
 api.ServiceLevelObjective.get_all(query=query, offset=0)

--- a/content/en/api/service_level_objectives/code_snippets/api-slo-search.rb
+++ b/content/en/api/service_level_objectives/code_snippets/api-slo-search.rb
@@ -10,5 +10,5 @@ slo_ids = ['<YOUR_SLO_ID>']
 dog.search_service_level_objective(slo_ids: slo_ids, offset: 0)
 
 # Search with a query
-query = 'tags:app:frontend'
+query = 'my team'
 dog.search_service_level_objective(query: query, offset: 0)

--- a/content/en/api/service_level_objectives/code_snippets/api-slo-search.sh
+++ b/content/en/api/service_level_objectives/code_snippets/api-slo-search.sh
@@ -5,7 +5,7 @@
 api_key="<DATADOG_API_KEY>"
 app_key="<DATADOG_APPLICATION_KEY>"
 
-query=<SLO_LIST_QUERY>
+query="my team"
 offset=<OFFSET>
 limit=<LIMIT>
 

--- a/content/en/api/service_level_objectives/service_level_objectives_search.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_search.md
@@ -17,9 +17,7 @@ Search and filter your service level objectives.
 
 * **`query`** [*optional*]:
 
-    After entering a search query in your [List Service Level Objectives page][1], use the query parameter value in the URL of the page as value for this parameter. For more information on building a query, see [Searching SLOs][2].
-
-    The query can contain any number of space-separated monitor attributes, for instance `query="type:metric foo"`.
+    The query is a simple search of the SLO name, for instance `query="my team"`.
 
 * **`offset`** [*optional*, *default* = **0**]:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fix SLO search examples and documentation - full facted search is not available yet, only simple search on SLO name.

### Motivation
<!-- What inspired you to submit this pull request?-->
🐛 

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/pb/fix-slo-search/api/?lang=bash#search-slos

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Looks like these docs were based on similar endpoints for monitors, dashboards.
