### PR TITLE
[api] [monitors] Add option for force delete.

### DIFF
--- a/content/en/api/monitors/code_snippets/api-monitor-delete.py
+++ b/content/en/api/monitors/code_snippets/api-monitor-delete.py
@@ -9,3 +9,6 @@ initialize(**options)
 
 # Delete a monitor
 api.Monitor.delete(2081)
+
+# Force delete a monitor to override warnings
+api.Monitor.delete(2081, force=True)

--- a/content/en/api/monitors/code_snippets/api-monitor-delete.sh
+++ b/content/en/api/monitors/code_snippets/api-monitor-delete.sh
@@ -8,3 +8,6 @@ monitor_id=<YOUR_MONITOR_ID>
 
 # Delete a monitor
 curl -X DELETE "https://api.datadoghq.com/api/v1/monitor/${monitor_id}?api_key=${api_key}&application_key=${app_key}"
+
+# Force delete a monitor
+curl -X DELETE "https://api.datadoghq.com/api/v1/monitor/${monitor_id}?force=true&api_key=${api_key}&application_key=${app_key}"

--- a/content/en/api/monitors/monitors_delete.md
+++ b/content/en/api/monitors/monitors_delete.md
@@ -9,4 +9,8 @@ external_redirect: /api/#delete-a-monitor
 
 **ARGUMENTS**:
 
-This endpoint takes no JSON arguments.
+If a monitor is used elsewhere, this endpoint returns an error because the monitor is referenced.
+
+* **`force`** [*optional*, *default*=**False**]:
+
+    Boolean: Force delete the monitor. The monitor is deleted even if it's referenced by other resources (e.g. SLO, composite monitor).


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds documentation and examples of using monitor delete with force, these options were added to clients and released:
* https://github.com/DataDog/datadogpy/pull/513
* https://github.com/DataDog/dogapi-rb/pull/213

### Motivation
<!-- What inspired you to submit this pull request?-->
MA-17

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/pb/mon-del-force/api

### Additional Notes
<!-- Anything else we should know when reviewing?-->
