### PR TITLE
Fix typo in SLO docs

### DIFF
--- a/content/en/api/service_level_objectives/service_level_objectives_edit.md
+++ b/content/en/api/service_level_objectives/service_level_objectives_edit.md
@@ -22,7 +22,7 @@ external_redirect: /api/#edit-a-slo
         The timeframe to apply to the target value. Valid options are `7d`, `30d`, `90d`.
     * **`target`** [*required*]:
         The target value to associate with the SLI that defines the SLO.
-    * **`target_displauy`** [*optional*, *default* = **dynamic, based on query**]:
+    * **`target_display`** [*optional*, *default* = **dynamic, based on query**]:
         The target display value that includes the requires level of precision.
     * **`warning`** [*optional*, *default* = **none**]:
         A warning target value to indicate when the SLI is close to breaching the `target`.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fixes typo

### Motivation
<!-- What inspired you to submit this pull request?-->
I'm implementing some SLO stuff and saw the typo.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
