### PR TITLE
[DOCS-553] DogStatsD mapper

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1358,6 +1358,10 @@ main:
     url: "developers/dogstatsd/data_aggregation/"
     parent: "dev_tools_dogstatsd"
     weight: 104
+  - name: "DogStatsD Mapper"
+    url: "developers/dogstatsd/dogstatsd_mapper/"
+    parent: "dev_tools_dogstatsd"
+    weight: 105
 
   ## DEVELOPERS - Metrics
 

--- a/content/en/developers/dogstatsd/dogstatsd_mapper.md
+++ b/content/en/developers/dogstatsd/dogstatsd_mapper.md
@@ -118,7 +118,7 @@ dogstatsd_mapper_profiles:
                 tag_key_2: '$2'
 ```
 
-It would send the metric `custom_metric.process.prod.value_1.live` to Datadog with the tags `tag_key_2:value_2`.
+It would send the metric `custom_metric.process.prod.value_1.live` to Datadog with the tag `tag_key_2:value_2`.
 
 ## Further Reading
 

--- a/content/en/developers/dogstatsd/dogstatsd_mapper.md
+++ b/content/en/developers/dogstatsd/dogstatsd_mapper.md
@@ -30,7 +30,7 @@ To create a mapping rule:
 
 ## Mapping rule configuration
 
-A mapping rule block have the following layout:
+A mapping rule block has the following layout:
 
 ```yaml
 dogstatsd_mapper_profiles:

--- a/content/en/developers/dogstatsd/dogstatsd_mapper.md
+++ b/content/en/developers/dogstatsd/dogstatsd_mapper.md
@@ -16,12 +16,12 @@ further_reading:
 
 With Agent v7.17+, the DogStatsD Mapper feature allows you to convert parts of a metric name submitted to DogStatsD to tags using mapping rules with wildcard and regex patterns. For example it allows you to transform the metric:
 
-- `airflow.job.duration.<JOB_TYPE>.<JOB_NAME>`
+-   `airflow.job.duration.<JOB_TYPE>.<JOB_NAME>`
 
 into the metric `airflow.job.duration` with two associated tags:
 
-- `job_type:<JOB_TYPE>`
-- `job_name:<JOB_NAME>`.
+-   `job_type:<JOB_TYPE>`
+-   `job_name:<JOB_NAME>`.
 
 To create a mapping rule:
 
@@ -46,19 +46,19 @@ dogstatsd_mapper_profiles:
 
 With the following placeholders:
 
-| Placeholder             |  Definition                                                                                                                               |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-|  `<PROFILE_NAME>`       | A name to give to your mapping rule profile.                                                                                              |
-| `<PROFILE_PREFIX>`      | The metric name prefix associated to this profile.                                                                                        |
-| `<METRIC_TO_MATCH>`     | The metric name to extract groups from with the [Wildcard](#wildcard-match-pattern) or [Regex](#regex-match-pattern) match logic.         |
-| `<MATCH_TYPE>`          | The type of match to apply to the `<METRIC_TO_MATCH>`. Either [`wildcard`](#wildcard-match-pattern) or [`regex`](#regex-match-pattern)    |
-| `<MAPPED_METRIC_NAME>`  | The new metric name to send to Datadog with the tags defined in the same group.                                                           |
-| `<TAG_KEY>`             | The Tag key to associate to the tags collected.                                                                                           |
-| `<TAG_VALUE_TO_EXPAND>` | The tags collected from the `<MATCH_TYPE>` to inline.                                                                                     |
+| Placeholder             |  Definition                                                                                                                               | Required                |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+|  `<PROFILE_NAME>`       | A name to give to your mapping rule profile.                                                                                              | yes                     |
+| `<PROFILE_PREFIX>`      | The metric name prefix associated to this profile.                                                                                        | yes                     |
+| `<METRIC_TO_MATCH>`     | The metric name to extract groups from with the [Wildcard](#wildcard-match-pattern) or [Regex](#regex-match-pattern) match logic.         | yes                     |
+| `<MATCH_TYPE>`          | The type of match to apply to the `<METRIC_TO_MATCH>`. Either [`wildcard`](#wildcard-match-pattern) or [`regex`](#regex-match-pattern)    | no, default: `wildcard` |
+| `<MAPPED_METRIC_NAME>`  | The new metric name to send to Datadog with the tags defined in the same group.                                                           | yes                     |
+| `<TAG_KEY>`             | The Tag key to associate to the tags collected.                                                                                           | no                      |
+| `<TAG_VALUE_TO_EXPAND>` | The tags collected from the `<MATCH_TYPE>` to inline.                                                                                     | no                      |
 
 ## Wildcard Match Pattern
 
-The wildcard match pattern matches dot-separated metric names using `*` as wildcard. The metric name must be only composed of alphanumeric, `.`, and `_`  characters for this pattern to work.
+The wildcard match pattern matches dot-separated metric names using `*` as wildcard. The metric name must be only composed of alphanumeric, `.`, and `_` characters for this pattern to work.
 Groups extracted can then be expanded with the `$n` format e.g. `$1`, `$2`, `$3`... or the `${n}` format e.g. `${1}`, `${2}`, `${3}`, ...
 
 For instance, if you have the metric `custom_metric.value_1.value_2` with the following mapping group configuration:

--- a/content/en/developers/dogstatsd/dogstatsd_mapper.md
+++ b/content/en/developers/dogstatsd/dogstatsd_mapper.md
@@ -58,15 +58,14 @@ With the following placeholders:
 
 ## Wildcard Match Pattern
 
-The wildcard match pattern matches dot-separated metric names using `*` as wildcard. The metric name must be only composed of alphanumeric, `.`, and `_` characters for this pattern to work.
-Groups extracted can then be expanded with the `$n` format e.g. `$1`, `$2`, `$3`... or the `${n}` format e.g. `${1}`, `${2}`, `${3}`, ...
+The wildcard match pattern matches dot-separated metric names using `*` as wildcard. The metric name must be only composed of alphanumeric, `.`, and `_` characters for this pattern to work. Groups extracted can then be expanded with the `$n` format e.g. `$1`, `$2`, `$3`... or the `${n}` format e.g. `${1}`, `${2}`, `${3}`, ...
 
 For instance, if you have the metric `custom_metric.process.value_1.value_2` with the following mapping group configuration:
 
 ```yaml
 dogstatsd_mapper_profiles:
     - name: my_custom_metric_profile
-      prefix: custom_metric
+      prefix: custom_metric.
       mappings:
           - match: 'custom_metric.process.*.*'
             match_type: wildcard
@@ -82,45 +81,44 @@ It would send the metric `custom_metric.process` to Datadog with the tags `tag_k
 
 ## Regex Match Pattern
 
-The regex match pattern matches metric names using regex patterns. Compared to the wildcard match pattern, it allows to define captured groups that contain `.`.
-Groups extracted can then be expanded with the `$n` format e.g. `$1`, `$2`, `$3`... or the `${n}` format e.g. `${1}`, `${2}`, `${3}`, ...
+The regex match pattern matches metric names using regex patterns. Compared to the wildcard match pattern, it allows to define captured groups that contain `.`. Groups extracted can then be expanded with the `$n` format e.g. `$1`, `$2`, `$3`... or the `${n}` format e.g. `${1}`, `${2}`, `${3}`, ...
 
-For instance, if you have the metric `custom_metric.value_1.value.with.dots._2` with the following mapping group configuration:
+For instance, if you have the metric `custom_metric.process.value_1.value.with.dots._2` with the following mapping group configuration:
 
 ```yaml
 dogstatsd_mapper_profiles:
     - name: my_custom_metric_profile
-      prefix: custom_metric
+      prefix: custom_metric.
       mappings:
-          - match: 'custom_metric\.([\w_]+)\.(.+)'
+          - match: 'custom_metric\.process\.([\w_]+)\.(.+)'
             match_type: regex
-            name: custom_metric
+            name: custom_metric.process
             tags:
                 tag_key_1: '$1'
                 tag_key_2: '$2'
 ```
 
-It would send the metric `custom_metric` to Datadog with the tags `tag_key_1:value_1` and `tag_key_2:value.with.dots._2`.
+It would send the metric `custom_metric.process` to Datadog with the tags `tag_key_1:value_1` and `tag_key_2:value.with.dots._2`.
 
 **Note**: If the incoming metric have already at least one tag, no mapping is applied.
 
 ## Expand group in metric name
 
-For the `regex` and `wildcard` match type, group collected can be expanded as tags value with an associated tag key as see above, but can also be used in the metric `name` parameter. For instance, if you have the metric `custom_metric.value_1.value_2` with the following mapping group configuration:
+For the `regex` and `wildcard` match type, group collected can be expanded as tags value with an associated tag key as see above, but can also be used in the metric `name` parameter. For instance, if you have the metric `custom_metric.process.value_1.value_2` with the following mapping group configuration:
 
 ```yaml
 dogstatsd_mapper_profiles:
     - name: my_custom_metric_profile
-      prefix: custom_metric
+      prefix: custom_metric.
       mappings:
-          - match: 'custom_metric.*'
+          - match: 'custom_metric.process.*.*'
             match_type: wildcard
-            name: 'custom_metric.prod.$1.live'
+            name: 'custom_metric.process.prod.$1.live'
             tags:
                 tag_key_2: '$2'
 ```
 
-It would send the metric `custom_metric.prod.value_1.live` to Datadog with the tags `tag_key_2:value_2`.
+It would send the metric `custom_metric.process.prod.value_1.live` to Datadog with the tags `tag_key_2:value_2`.
 
 ## Further Reading
 

--- a/content/en/developers/dogstatsd/dogstatsd_mapper.md
+++ b/content/en/developers/dogstatsd/dogstatsd_mapper.md
@@ -58,7 +58,7 @@ With the following placeholders:
 
 ## Wildcard Match Pattern
 
-The wildcard match pattern matches dot-separated metric names using `*` as wildcard. The metric name must follow the [metrics naming convention][2] for the pattern to work.
+The wildcard match pattern matches dot-separated metric names using `*` as wildcard. The metric name must be only composed of alphanumeric, `.`, and `_`  characters for this pattern to work.
 Groups extracted can then be expanded with the `$n` format e.g. `$1`, `$2`, `$3`... or the `${n}` format e.g. `${1}`, `${2}`, `${3}`, ...
 
 For instance, if you have the metric `custom_metric.value_1.value_2` with the following mapping group configuration:
@@ -78,7 +78,7 @@ dogstatsd_mapper_profiles:
 
 It would send the metric `custom_metric` to Datadog with the tags `tag_key_1:value_1` and `tag_key_2:value_2`.
 
-**Note**: If the incoming metric have already a tag key that matches one defined in the mapping group, no mapping is applied.
+**Note**: If the incoming metric have already at least one tag, no mapping is applied.
 
 ## Regex Match Pattern
 
@@ -102,9 +102,11 @@ dogstatsd_mapper_profiles:
 
 It would send the metric `custom_metric` to Datadog with the tags `tag_key_1:value_1` and `tag_key_2:value.with.dots._2`.
 
-## Catched group in metric name
+**Note**: If the incoming metric have already at least one tag, no mapping is applied.
 
-For the `regex` and `wildcard` match type, catched group can be expanded as tags value with an associated tag key as see above, but can also be used in the metric `name` parameter. For instance, if you have the metric `custom_metric.value_1.value_2` with the following mapping group configuration:
+## Expand group in metric name
+
+For the `regex` and `wildcard` match type, group collected can be expanded as tags value with an associated tag key as see above, but can also be used in the metric `name` parameter. For instance, if you have the metric `custom_metric.value_1.value_2` with the following mapping group configuration:
 
 ```yaml
 dogstatsd_mapper_profiles:
@@ -125,4 +127,3 @@ It would send the metric `custom_metric.prod.value_1.live` to Datadog with the t
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
-[2]: /developers/metrics/#naming-custom-metrics

--- a/content/en/developers/dogstatsd/dogstatsd_mapper.md
+++ b/content/en/developers/dogstatsd/dogstatsd_mapper.md
@@ -61,22 +61,22 @@ With the following placeholders:
 The wildcard match pattern matches dot-separated metric names using `*` as wildcard. The metric name must be only composed of alphanumeric, `.`, and `_` characters for this pattern to work.
 Groups extracted can then be expanded with the `$n` format e.g. `$1`, `$2`, `$3`... or the `${n}` format e.g. `${1}`, `${2}`, `${3}`, ...
 
-For instance, if you have the metric `custom_metric.value_1.value_2` with the following mapping group configuration:
+For instance, if you have the metric `custom_metric.process.value_1.value_2` with the following mapping group configuration:
 
 ```yaml
 dogstatsd_mapper_profiles:
     - name: my_custom_metric_profile
       prefix: custom_metric
       mappings:
-          - match: 'custom_metric.*'
+          - match: 'custom_metric.process.*.*'
             match_type: wildcard
-            name: custom_metric
+            name: custom_metric.process
             tags:
                 tag_key_1: '$1'
                 tag_key_2: '$2'
 ```
 
-It would send the metric `custom_metric` to Datadog with the tags `tag_key_1:value_1` and `tag_key_2:value_2`.
+It would send the metric `custom_metric.process` to Datadog with the tags `tag_key_1:value_1` and `tag_key_2:value_2`.
 
 **Note**: If the incoming metric have already at least one tag, no mapping is applied.
 

--- a/content/en/developers/dogstatsd/dogstatsd_mapper.md
+++ b/content/en/developers/dogstatsd/dogstatsd_mapper.md
@@ -14,14 +14,21 @@ further_reading:
       text: 'DogStatsD source code'
 ---
 
-With Agent v7.17+, the DogStatsD Mapper feature allows you to convert parts of a metric name submitted to DogStatsD to tags using mapping rules with wildcard and regex patterns.
+With Agent v7.17+, the DogStatsD Mapper feature allows you to convert parts of a metric name submitted to DogStatsD to tags using mapping rules with wildcard and regex patterns. For example it allows you to transform the metric:
 
-For example it allows you to transform the metric `airflow.job.duration.<JOB_TYPE>.<JOB_NAME>` into `airflow.job.duration` with two associated tags: `job_type:<JOB_TYPE>` and `job_name:<JOB_NAME>`. To create a mapping rule:
+- `airflow.job.duration.<JOB_TYPE>.<JOB_NAME>`
+
+into the metric `airflow.job.duration` with two associated tags:
+
+- `job_type:<JOB_TYPE>`
+- `job_name:<JOB_NAME>`.
+
+To create a mapping rule:
 
 1. [Open your `datadog.yaml` file][1].
-2. Add a [mapping rule configuration block](#mapping-rule) under the `dogstatsd_mapper_profiles` parameter.
+2. Add a [mapping rule configuration block](#mapping-rule-configuration) under the `dogstatsd_mapper_profiles` parameter.
 
-## Mapping rule
+## Mapping rule configuration
 
 A mapping rule block have the following layout:
 
@@ -43,7 +50,7 @@ With the following placeholders:
 | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 |  `<PROFILE_NAME>`       | A name to give to your mapping rule profile.                                                                                              |
 | `<PROFILE_PREFIX>`      | The metric name prefix associated to this profile.                                                                                        |
-| `<METRIC_TO_MATCH>`     | The metric name to match. [Wildcard](#wildcard-match-pattern) or [Regex](#regex-match-pattern) are supported.                             |
+| `<METRIC_TO_MATCH>`     | The metric name to extract groups from with the [Wildcard](#wildcard-match-pattern) or [Regex](#regex-match-pattern) match logic.         |
 | `<MATCH_TYPE>`          | The type of match to apply to the `<METRIC_TO_MATCH>`. Either [`wildcard`](#wildcard-match-pattern) or [`regex`](#regex-match-pattern)    |
 | `<MAPPED_METRIC_NAME>`  | The new metric name to send to Datadog with the tags defined in the same group.                                                           |
 | `<TAG_KEY>`             | The Tag key to associate to the tags collected.                                                                                           |
@@ -58,15 +65,15 @@ For instance, if you have the metric `custom_metric.value_1.value_2` with the fo
 
 ```yaml
 dogstatsd_mapper_profiles:
-  - name: my_custom_metric_profile
-    prefix: custom_metric
-    mappings:
-      - match: 'custom_metric.*'
-        match_type: wildcard
-        name: custom_metric
-        tags:
-          tag_key_1: '$1'
-          tag_key_2: '$2'
+    - name: my_custom_metric_profile
+      prefix: custom_metric
+      mappings:
+          - match: 'custom_metric.*'
+            match_type: wildcard
+            name: custom_metric
+            tags:
+                tag_key_1: '$1'
+                tag_key_2: '$2'
 ```
 
 It would send the metric `custom_metric` to Datadog with the tags `tag_key_1:value_1` and `tag_key_2:value_2`.

--- a/content/en/developers/dogstatsd/dogstatsd_mapper.md
+++ b/content/en/developers/dogstatsd/dogstatsd_mapper.md
@@ -14,7 +14,9 @@ further_reading:
       text: 'DogStatsD source code'
 ---
 
-With Agent v7.17+, the DogStatsD Mapper feature allows you to convert parts of a metric name submitted to DogStatsD to tags using mapping rules with wildcard and regex patterns. For example it allows you to transform the metric `airflow.job.duration.<JOB_TYPE>.<JOB_NAME>` into `airflow.job.duration` with two associated tags: `job_type:<JOB_TYPE>` and `job_name:<JOB_NAME>`. To create a mapping rule:
+With Agent v7.17+, the DogStatsD Mapper feature allows you to convert parts of a metric name submitted to DogStatsD to tags using mapping rules with wildcard and regex patterns.
+
+For example it allows you to transform the metric `airflow.job.duration.<JOB_TYPE>.<JOB_NAME>` into `airflow.job.duration` with two associated tags: `job_type:<JOB_TYPE>` and `job_name:<JOB_NAME>`. To create a mapping rule:
 
 1. [Open your `datadog.yaml` file][1].
 2. Add a [mapping rule configuration block](#mapping-rule) under the `dogstatsd_mapper_profiles` parameter.
@@ -50,6 +52,7 @@ With the following placeholders:
 ## Wildcard Match Pattern
 
 The wildcard match pattern matches dot-separated metric names using `*` as wildcard. The metric name must follow the [metrics naming convention][2] for the pattern to work.
+Groups extracted can then be expanded with the `$n` format e.g. `$1`, `$2`, `$3`... or the `${n}` format e.g. `${1}`, `${2}`, `${3}`, ...
 
 For instance, if you have the metric `custom_metric.value_1.value_2` with the following mapping group configuration:
 
@@ -73,6 +76,7 @@ It would send the metric `custom_metric` to Datadog with the tags `tag_key_1:val
 ## Regex Match Pattern
 
 The regex match pattern matches metric names using regex patterns. Compared to the wildcard match pattern, it allows to define captured groups that contain `.`.
+Groups extracted can then be expanded with the `$n` format e.g. `$1`, `$2`, `$3`... or the `${n}` format e.g. `${1}`, `${2}`, `${3}`, ...
 
 For instance, if you have the metric `custom_metric.value_1.value.with.dots._2` with the following mapping group configuration:
 
@@ -81,7 +85,7 @@ dogstatsd_mapper_profiles:
     - name: my_custom_metric_profile
       prefix: custom_metric
       mappings:
-          - match: 'custom_metric.(\w+)\.(.+)'
+          - match: 'custom_metric\.([\w_]+)\.(.+)'
             match_type: regex
             name: custom_metric
             tags:
@@ -93,7 +97,7 @@ It would send the metric `custom_metric` to Datadog with the tags `tag_key_1:val
 
 ## Catched group in metric name
 
-For the `regex` and `wildcard` match_type, catched group can be passed as tags value with the associated tag key as see above, but can also be used in the `name` parameter. For instance, if you have the metric `custom_metric.value_1.value_2` with the following mapping group configuration:
+For the `regex` and `wildcard` match type, catched group can be expanded as tags value with an associated tag key as see above, but can also be used in the metric `name` parameter. For instance, if you have the metric `custom_metric.value_1.value_2` with the following mapping group configuration:
 
 ```yaml
 dogstatsd_mapper_profiles:
@@ -112,5 +116,6 @@ It would send the metric `custom_metric.prod.value_1.live` to Datadog with the t
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
 [1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 [2]: /developers/metrics/#naming-custom-metrics


### PR DESCRIPTION
### What does this PR do?

Adds DogStatsD mapper documentation.

### Motivation

It has been released with Agent 7.17+

### Preview link

* https://docs-staging.datadoghq.com/gus/dogstatsd-mapper/developers/dogstatsd/dogstatsd_mapper/