### PR TITLE
Fix typo in filter.query description

### DIFF
--- a/content/en/api/logs_indexes/update_an_index.md
+++ b/content/en/api/logs_indexes/update_an_index.md
@@ -18,7 +18,7 @@ This endpoint updates an `Index` identified by its name. It returns the `Index` 
 **Note**: Using the `PUT` method updates your index's configuration by **replacing** your current configuration with the new one sent to your Datadog organization.
 
 * **`filter.query`**  [*required*]:
-    Only logs matching the filter criteria will be considered for this index. The search query followis the [Log search syntax][1]
+    Only logs matching the filter criteria will be considered for this index. The search query follows the [Log search syntax][1]
 * **`exclusion_filters`** An array of `ExclusionFilter` objects (see hereafter). The logs are tested against the query of each `ExclusionFilter`, following the order of the array. Only the first matching active `ExclusionFilter` matters, others (if any) are ignored. The `ExclusionFilter` object describes the configuration of an [exclusion filter][2]. It has the following attributes:
 
   * **`name`** [*required*]:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Fix typo in filter.query description