### PR TITLE
add that logs are uploaded to log archives every 15 minutes

### DIFF
--- a/content/en/logs/archives/_index.md
+++ b/content/en/logs/archives/_index.md
@@ -109,7 +109,7 @@ To add server side encryption to your S3 log archives, go to the **Properties** 
 
 Once your archive settings are successfully configured in your Datadog account, your processing pipelines begin to enrich all the logs that Datadog ingests. These logs are subsequently forwarded to your archive.
 
-However, after creating or updating your archive configurations, it can take several minutes before the next archive upload is attempted, so **you should check back on your storage bucket in 15 minutes** to make sure the archives are successfully being uploaded from your Datadog account. Logs are uploaded to the archive every 15 minutes.   
+However, after creating or updating your archive configurations, it can take several minutes before the next archive upload is attempted. Logs are uploaded to the archive every 15 minutes, so **you should check back on your storage bucket in 15 minutes** maximum to make sure the archives are successfully being uploaded from your Datadog account. 
 
 ## Format of the Archives
 

--- a/content/en/logs/archives/_index.md
+++ b/content/en/logs/archives/_index.md
@@ -109,7 +109,7 @@ To add server side encryption to your S3 log archives, go to the **Properties** 
 
 Once your archive settings are successfully configured in your Datadog account, your processing pipelines begin to enrich all the logs that Datadog ingests. These logs are subsequently forwarded to your archive.
 
-However, after creating or updating your archive configurations, it can take several minutes before the next archive upload is attempted, so **you should check back on your storage bucket in 15 minutes** to make sure the archives are successfully being uploaded from your Datadog account.
+However, after creating or updating your archive configurations, it can take several minutes before the next archive upload is attempted, so **you should check back on your storage bucket in 15 minutes** to make sure the archives are successfully being uploaded from your Datadog account. Logs are uploaded to the archive every 15 minutes.   
 
 ## Format of the Archives
 


### PR DESCRIPTION

### What does this PR do?
This PR adds that logs are uploaded to S3 archives every 15 minutes. 

### Motivation

Customer request 

### Preview link

https://docs-staging.datadoghq.com/laura.hampton/add-log-archive-upload-interval/logs/archives/?tab=awss3#server-side-encryption-sse

