### PR TITLE
Log monitor notification - pagerduty

### DIFF
--- a/content/en/monitors/monitor_types/log.md
+++ b/content/en/monitors/monitor_types/log.md
@@ -68,7 +68,7 @@ By default, when a logs monitor is triggered, samples or values are added to the
 | Log count        | Grouped: The top 10 breaching values and their corresponding counts.<br>Ungrouped: Up to 10 log samples. |
 | Facet or measure | The top 10 facet or measure values.                                                                      |
 
-These are available for notifications sent to Slack, Jira, webhooks, Microsoft Teams, and email. **Note**: Samples are not displayed for recovery notifications.
+These are available for notifications sent to Slack, Jira, webhooks, Microsoft Teams, Pagerduty, and email. **Note**: Samples are not displayed for recovery notifications.
 
 To disable log samples, uncheck the box at the bottom of the **Say what's happening** section. The text next to the box is based on your monitor's grouping (as stated above).
 


### PR DESCRIPTION

### What does this PR do?
Add pagerduty to the list of supported output

### Motivation
This was recently added

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/log-monitor-notification-pagerduty/monitors/monitor_types/log/#log-samples

### Additional Notes
<!-- Anything else we should know when reviewing?-->
