### PR TITLE
adding _ as option for italic wording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,7 @@ Use text formatting to clarify and enhance content.
 |-------------------|-------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
 | `` `backquote` `` | Used every time there is code related content in some text                                                              | Use the `foo` parameter                               |
 | `**Bold**`        | Subjectively pointing the reader to something that he shouldn't miss.                                                   | **This is important**, not that.                      |
-| `*Italic*`        | Literally translated words, default values, functions, settings, and page names.                                        | Go the the *setting* page in your Datadog application |
+| `*Italic*` or `_Italic_`        | Literally translated words, default values, functions, settings, and page names.                                        | Go the the *setting* page in your Datadog application |
 | `[Link][3]`       | Links must be specified using the reference format (i.e. in the footnote) in order to aid [the translation process][5]. | Text with [a link][1]                                 |
 
 


### PR DESCRIPTION
### What does this PR do?

Adds `_` to define italic in the doc.

### Motivation

It's now a thing.. and both logic are going to co-exists, but moving forward only this format should be left.