### PR TITLE
[DOCS-601] rbac enabled by default on new k8s versions

### DIFF
--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -22,7 +22,7 @@ Take advantage of DaemonSets to deploy the Datadog Agent on all your nodes (or o
 
 ## Configure RBAC permissions
 
-If your Kubernetes has role-based access control (RBAC) enabled, configure RBAC permissions for your Datadog Agent service account.
+If your Kubernetes has role-based access control (RBAC) enabled, configure RBAC permissions for your Datadog Agent service account. From Kubernetes 1.6 onwards, RBAC is enabled by default.
 
 Create the appropriate ClusterRole, ServiceAccount, and ClusterRoleBinding:
 


### PR DESCRIPTION
rbac is enabled by default on new k8s versions so the language reflects this

https://docs-staging.datadoghq.com/rbac-default/agent/kubernetes/daemonset_setup
