### PR TITLE
TCP RTT Check only shipped with Agent in v5.

### DIFF
--- a/content/en/integrations/tcprtt.md
+++ b/content/en/integrations/tcprtt.md
@@ -15,7 +15,7 @@ dependencies: ["https://github.com/DataDog/documentation/blob/master/content/en/
 
 The TCP RTT check reports on roundtrip times between the host the Agent is running on and any host it is communicating with. This check is passive and will only report RTT times for packets being sent and received from outside the check. The check itself will not send any packets.
 
-This check is only shipped in the 64-bit DEB and RPM Datadog Agent packages.
+This check is only shipped in the 64-bit DEB and RPM Datadog Agent v5 packages.
 
 ## Setup
 


### PR DESCRIPTION
### What does this PR do?
State that the TCP RTT Check is only shipped with Agent in v5.

### Motivation
to match https://github.com/DataDog/integrations-core/tree/master/go-metro#overview 
based on comments in https://trello.com/c/IO5u7aVL/1009-go-metro-for-agent-6

### Preview link
https://docs.datadoghq.com/integrations/tcprtt/

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes

