### PR TITLE
Update tcprtt.md

### DIFF
--- a/content/en/integrations/tcprtt.md
+++ b/content/en/integrations/tcprtt.md
@@ -15,7 +15,7 @@ dependencies: ["https://github.com/DataDog/documentation/blob/master/content/en/
 
 The TCP RTT check reports on roundtrip times between the host the Agent is running on and any host it is communicating with. This check is passive and will only report RTT times for packets being sent and received from outside the check. The check itself will not send any packets.
 
-This check is only shipped in the 64-bit DEB and RPM Datadog Agent v5 packages.  For instructions on how to build the go-metro binary for other versions of the Agent, please see: https://github.com/DataDog/go-metro#usage
+This check is only shipped in the 64-bit DEB and RPM Datadog Agent v5 packages.  For instructions on how to build the go-metro binary for other versions of the Agent, see the [Datadog/go-metro usage](https://github.com/DataDog/go-metro#usage)
 
 ## Setup
 

--- a/content/en/integrations/tcprtt.md
+++ b/content/en/integrations/tcprtt.md
@@ -15,7 +15,7 @@ dependencies: ["https://github.com/DataDog/documentation/blob/master/content/en/
 
 The TCP RTT check reports on roundtrip times between the host the Agent is running on and any host it is communicating with. This check is passive and will only report RTT times for packets being sent and received from outside the check. The check itself will not send any packets.
 
-This check is only shipped in the 64-bit DEB and RPM Datadog Agent packages.
+This check is only shipped in the 64-bit DEB and RPM Datadog Agent v5 packages.  For instructions on how to build the go-metro binary for other versions of the Agent, please see: https://github.com/DataDog/go-metro#usage
 
 ## Setup
 


### PR DESCRIPTION
### What does this PR do?
State that the TCP RTT Check is only shipped with Agent in v5 and provide workaround for building the binary for other versions

### Motivation
to match https://github.com/DataDog/integrations-core/tree/master/go-metro#overview
based on comments in https://trello.com/c/IO5u7aVL/1009-go-metro-for-agent-6

### Preview link
https://docs.datadoghq.com/integrations/tcprtt/

### Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/LawrenceLin690-patch-1/

### Additional Notes