### PR TITLE
[DOCS-617] cluster checks refactor

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -280,26 +280,34 @@ main:
     parent: "agent_cluster"
     identifier: "cluster_agent_external_metrics"
     weight: 403
+  - name: "Cluster Checks"
+    url: "agent/cluster_agent/clusterchecks/"
+    parent: "agent_cluster"
+    weight: 404
+  - name: "Endpoints Checks"
+    url: "agent/cluster_agent/endpointschecks/"
+    parent: "agent_cluster"
+    weight: 405
   - name: "Commands & Options"
     url: "agent/cluster_agent/commands/"
     identifier: "cluster_agent_commands"
     parent: "agent_cluster"
-    weight: 404
+    weight: 406
   - name: "Cluster metadata provider"
     url: "agent/cluster_agent/metadata_provider/"
     identifier: "cluster_agent_metadata_provider"
     parent: "agent_cluster"
-    weight: 405
+    weight: 407
   - name: "Build"
     url: "agent/cluster_agent/build/"
     identifier: "cluster_agent_build"
     parent: "agent_cluster"
-    weight: 406
+    weight: 408
   - name: "Troubleshooting"
     url: "agent/cluster_agent/troubleshooting/"
     identifier: "cluster_agent_troubleshooting"
     parent: "agent_cluster"
-    weight: 407
+    weight: 409
 
   ## AGENT - Autodiscovery
 
@@ -336,14 +344,6 @@ main:
     url: "agent/autodiscovery/management/"
     parent: "agent_autodiscovery"
     weight: 506
-  - name: "Cluster Checks"
-    url: "agent/autodiscovery/clusterchecks/"
-    parent: "agent_autodiscovery"
-    weight: 507
-  - name: "Endpoints Checks"
-    url: "agent/autodiscovery/endpointschecks/"
-    parent: "agent_autodiscovery"
-    weight: 508
   - name: "Troubleshooting"
     url: "agent/autodiscovery/troubleshooting/"
     parent: "agent_autodiscovery"

--- a/content/en/agent/autodiscovery/_index.md
+++ b/content/en/agent/autodiscovery/_index.md
@@ -37,9 +37,7 @@ To solve this issue, you can use Datadog’s Autodiscovery feature to automatica
     {{< nextlink href="/agent/autodiscovery/template_variables" >}}<u>Template Variables</u>: Template variables enable you to dynamically assign your container's values.{{< /nextlink >}}
     {{< nextlink href="/agent/autodiscovery/tag" >}}<u>Tag Extraction</u>: Datadog can create and assign tags to all metrics, traces, and logs emitted by a Pod, based on its labels or annotations.{{< /nextlink >}}
     {{< nextlink href="/agent/autodiscovery/management" >}}<u>Discovery Management</u>: Datadog Autodiscovers all containers available by default. To restrict its discovery perimeter and limit data collection to a subset of containers only, include or exclude them through a dedicated configuration.{{< /nextlink >}}
-    {{< nextlink href="/agent/autodiscovery/clusterchecks" >}}<u>Cluster Checks</u>: The Cluster Check feature provides the ability to Autodiscover and perform checks on load-balanced cluster services like Kubernetes.{{< /nextlink >}}
-    {{< nextlink href="/agent/autodiscovery/endpointschecks" >}}<u>Endpoints Checks</u>: Endpoints Checks extend Cluster Checks to monitor any endpoint behind cluster services.{{< /nextlink >}}
-    {{< nextlink href="/agent/autodiscovery/troubleshooting" >}}<u>Troubleshooting</u>: Solve common Autodiscovery issues.{{< /nextlink >}}
+    
 {{< /whatsnext >}}
 
 ## Further Reading

--- a/content/en/agent/cluster_agent/_index.md
+++ b/content/en/agent/cluster_agent/_index.md
@@ -43,6 +43,9 @@ Using the Datadog Cluster Agent allows you to:
     {{< nextlink href="/agent/cluster_agent/commands" >}}<u>Commands</u>:List of all commands and options available for the Cluster Agent.{{< /nextlink >}}
     {{< nextlink href="/agent/cluster_agent/event_collection" >}}<u>Event Collection</u>: Use the Cluster Agent to collect all events from your Kubernetes Cluster.{{< /nextlink >}}
     {{< nextlink href="/agent/cluster_agent/external_metrics" >}}<u>External Metrics</u>: Leverage the Cluster Agent Custom metrics server to auto-scale your applications thanks to all your Datadog Metrics.{{< /nextlink >}}
+    {{< nextlink href="/agent/autodiscovery/clusterchecks" >}}<u>Cluster Checks</u>: The Cluster Check feature provides the ability to Autodiscover and perform checks on load-balanced cluster services like Kubernetes.{{< /nextlink >}}
+    {{< nextlink href="/agent/autodiscovery/endpointschecks" >}}<u>Endpoints Checks</u>: Endpoints Checks extend Cluster Checks to monitor any endpoint behind cluster services.{{< /nextlink >}}
+    {{< nextlink href="/agent/autodiscovery/troubleshooting" >}}<u>Troubleshooting</u>: Solve common Autodiscovery issues.{{< /nextlink >}}
     {{< nextlink href="/agent/cluster_agent/troubleshooting" >}}<u>Troubleshooting</u>: Find troubleshooting information for the Datadog Cluster Agent.{{< /nextlink >}}
 {{< /whatsnext >}}
 

--- a/content/en/agent/cluster_agent/clusterchecks.md
+++ b/content/en/agent/cluster_agent/clusterchecks.md
@@ -17,42 +17,44 @@ further_reading:
 
 ## How it Works
 
-The Datadog Agent is able to auto-discover containers and create Check configurations via [the Autodiscovery mechanism][1]. The Cluster Checks feature extends this mechanism to monitor non-containerized workloads, including:
+The Datadog Agent can Autodiscover containers and create check configurations with [the Autodiscovery mechanism][1]. 
 
-- out-of-cluster datastores and endpoints (eg. RDS or CloudSQL)
-- load-balanced cluster services (eg. Kubernetes services)
+Cluster checks extend this mechanism to monitor noncontainerized workloads, including:
 
-To ensure that only one instance of each Check runs, [the Cluster Agent][2] holds the configurations and dynamically dispatches them to node-based Agents. The Agents connect to the Cluster Agent every 10 seconds and retrieve the configurations to run. If an Agent stops reporting, the Cluster Agent removes it from the active pool and dispatches the configurations to other Agents. This ensures one (and only one) instance always runs even as nodes are added and removed from the cluster.
+- Out-of-cluster datastores and endpoints (for example, RDS or CloudSQL).
+- Load-balanced cluster services (for example, Kubernetes services).
 
-Metrics, Events and Service Checks collected by Cluster Checks will be submitted without a hostname, as it is not relevant. A `cluster_name` tag is added, to allow you to scope and slice your data.
+To ensure that only one instance of each check runs, [the Cluster Agent][2] holds the configurations and dynamically dispatches them to node-based Agents. The Agents connect to the Cluster Agent every 10 seconds and retrieve the configurations to run. If an Agent stops reporting, the Cluster Agent removes it from the active pool and dispatches the configurations to other Agents. This ensures one (and only one) instance always runs even as nodes are added and removed from the cluster.
 
-This feature is currently supported on Kubernetes for versions 6.9.0+ of the Agent, and versions 1.2.0+ of the Cluster Agent.
+Metrics, events, and service checks collected by cluster checks are submitted without a hostname, as it is not relevant. A `cluster_name` tag is added, to allow you to scope and slice your data.
 
-## How to set it up
+This feature is supported on Kubernetes for versions 6.9.0+ of the Agent, and versions 1.2.0+ of the Cluster Agent.
 
-### Cluster Agent setup
+## Set up cluster checks
+
+### Cluster Agent
 
 This feature requires a running [Cluster Agent][3].
 
 Then enable the cluster check feature:
 
-Starting with version 1.2.0, the Datadog Cluster Agent extends the Autodiscovery mechanism for non-containerized cluster resources. To enable this, make the following changes to the Cluster Agent deployment:
+Starting with version 1.2.0, the Datadog Cluster Agent extends the Autodiscovery mechanism for noncontainerized cluster resources. To enable this, make the following changes to the Cluster Agent deployment:
 
 1. Set `DD_CLUSTER_CHECKS_ENABLED` to `true`.
 2. Pass your cluster name as `DD_CLUSTER_NAME`. To help you scope your metrics, Datadog injects your cluster name as a `cluster_name` instance tag to all configurations.
 3. The recommended leader election lease duration is 15 seconds. Set it with the `DD_LEADER_LEASE_DURATION` environment variable.
 4. If the service name is different from the default `datadog-cluster-agent`, ensure the `DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME` environment variable reflects the service name.
 
-The following two configuration sources are currently supported. [They are described in the Autodiscovery documentation][4]:
+The following two configuration sources are supported. [They are described in the Autodiscovery documentation][4]:
 
 * You can mount YAML files from a ConfigMap in the `/conf.d` folder. They are automatically imported by the image's entrypoint.
-* Kubernetes Service annotations require setting both the `DD_EXTRA_CONFIG_PROVIDERS` and `DD_EXTRA_LISTENERS` environment variables to `kube_services`.
+* Kubernetes Service Annotations require setting both the `DD_EXTRA_CONFIG_PROVIDERS` and `DD_EXTRA_LISTENERS` environment variables to `kube_services`.
 
 Note that hostnames are not linked to cluster checks metrics, which limits the use of host tags and the `DD_TAGS` environment variable. To add tags to cluster checks metrics, use the `DD_CLUSTER_CHECKS_EXTRA_TAGS` environment variable.
 
 Refer to [the dedicated Cluster Checks Autodiscovery guide][5] for more configuration and troubleshooting details on this feature.
 
-### Agent setup
+### Agent
 
 Enable the `clusterchecks` configuration provider on the Datadog **Host** Agent. This can be done in two ways:
 
@@ -83,7 +85,7 @@ Running [custom Agent checks][7] as cluster checks is supported, as long as all 
 
 ### Static configurations in files
 
-When the IP of a given resource is constant (eg. external service endpoint, public URL...), a static configuration can be passed to the Cluster Agent as yaml files. The file name convention and syntax are the same as the static configurations on the node-based Agent, with the addition of the `cluster_check: true` line.
+When the IP of a given resource is constant (eg. external service endpoint, public URL, etc.), a static configuration can be passed to the Cluster Agent as YAML files. The file name convention and syntax are the same as the static configurations on the node-based Agent, with the addition of the `cluster_check: true` line.
 
 #### Example: MySQL check on a CloudSQL database
 
@@ -113,7 +115,7 @@ You can annotate services with the following syntax, similar to the syntax for [
 
 The `%%host%%` [template variable][10] is supported and is replaced by the service's IP. The `kube_namespace` and `kube_service` tags are automatically added to the instance.
 
-#### Example: HTTP check on an nginx-backed service
+#### Example: HTTP check on an NGINX-backed service
 
 The following Service definition exposes the Pods from the `my-nginx` deployment and runs an [HTTP check][11] to measure the latency of the load balanced service:
 
@@ -147,7 +149,7 @@ In addition, each pod should be monitored with the [NGINX check][12], as it enab
 
 ## Troubleshooting
 
-Due to the distributed nature of Cluster Checks, troubleshooting them is a bit more involved. The following sections explain the dispatching process and the associated troubleshooting commands.
+Due to the distributed nature of cluster checks, troubleshooting them is a bit more involved. The following sections explain the dispatching process and the associated troubleshooting commands.
 
 ### Kubernetes: find the leader Cluster Agent
 

--- a/content/en/agent/cluster_agent/clusterchecks.md
+++ b/content/en/agent/cluster_agent/clusterchecks.md
@@ -2,7 +2,7 @@
 title: Running Cluster Checks with Autodiscovery
 kind: documentation
 aliases:
-  - "agent/autodiscovery/clusterchecks"
+  - "/agent/autodiscovery/clusterchecks"
 further_reading:
 - link: "/agent/autodiscovery"
   tag: "Documentation"

--- a/content/en/agent/cluster_agent/clusterchecks.md
+++ b/content/en/agent/cluster_agent/clusterchecks.md
@@ -1,6 +1,8 @@
 ---
 title: Running Cluster Checks with Autodiscovery
 kind: documentation
+aliases:
+  - "agent/autodiscovery/clusterchecks"
 further_reading:
 - link: "/agent/autodiscovery"
   tag: "Documentation"

--- a/content/en/agent/cluster_agent/endpointschecks.md
+++ b/content/en/agent/cluster_agent/endpointschecks.md
@@ -17,17 +17,19 @@ further_reading:
 
 ## How it Works
 
-The [Cluster Check][1] feature provides the ability to autodiscover and perform checks on load-balanced cluster services (eg. Kubernetes services). The Endpoints Checks feature extends this mechanism to monitor any endpoint behind cluster services.
+The [Cluster Check][1] feature provides the ability to Autodiscover and perform checks on load-balanced cluster services (eg. Kubernetes services). 
+
+Endpoint checks extend this mechanism to monitor any endpoint behind cluster services.
 
 The [Cluster Agent][2] holds the configurations and exposes them to node-based Agents so they can consume and convert them into Endpoints Checks.
 
-Endpoints Checks are scheduled by Agents that run on the same node as the pod(s) that back the endpoint(s) of the monitored service.
+Endpoints checks are scheduled by Agents that run on the same node as the pod(s) that back the endpoint(s) of the monitored service.
 
-The Agents connect to the Cluster Agent every 10 seconds and retrieve the check configurations to run. Metrics coming from Endpoints Checks will be submitted with service, pod, and host tags.
+The Agents connect to the Cluster Agent every 10 seconds and retrieve the check configurations to run. Metrics coming from endpoints checks are submitted with service, pod, and host tags.
 
-This feature is currently supported on Kubernetes for versions 6.12.0+ of the Agent, and versions 1.3.0+ of the Cluster Agent.
+This feature is supported on Kubernetes for versions 6.12.0+ of the Agent, and versions 1.3.0+ of the Cluster Agent.
 
-Starting with version 1.4.0, the Cluster Agent converts every Endpoints Check of a non-pod-backed endpoint into a regular Cluster Check. Enable the [Cluster Check][1] feature alongside Endpoints Checks to take advantage of this functionality.
+Starting with version 1.4.0, the Cluster Agent converts every endpoints check of a non-pod-backed endpoint into a regular cluster check. Enable the [cluster check][1] feature alongside Endpoints Checks to take advantage of this functionality.
 
 #### Example: three NGINX pods exposed by the `nginx` service
 
@@ -69,9 +71,9 @@ nginx-758655469f-lk9p6   1/1     Running   0          20h
       ...
 ```
 
-By design, Endpoints Checks are scheduled by Agents that run on the same node as the pods that back the endpoints of the `nginx` service, so only Agents running on the nodes `gke-cluster-default-pool-4658d5d4-k2sn` and `gke-cluster-default-pool-4658d5d4-p39c` will schedule the checks on the `nginx` pods.
+By design, endpoints checks are scheduled by Agents that run on the same node as the pods that back the endpoints of the `nginx` service, so only Agents running on the nodes `gke-cluster-default-pool-4658d5d4-k2sn` and `gke-cluster-default-pool-4658d5d4-p39c` will schedule the checks on the `nginx` pods.
 
-This works like that to leverage [autodiscovery][3], and attach pod and container tags to the metrics coming from these pods.
+This works like that to leverage [Autodiscovery][3], and attach pod and container tags to the metrics coming from these pods.
 
 ## How to set it up
 

--- a/content/en/agent/cluster_agent/endpointschecks.md
+++ b/content/en/agent/cluster_agent/endpointschecks.md
@@ -2,7 +2,7 @@
 title: Running Endpoints Checks with Autodiscovery
 kind: documentation
 aliases:
-  - "agent/autodiscovery/endpointchecks"
+  - "/agent/autodiscovery/endpointchecks"
 further_reading:
 - link: "/agent/autodiscovery"
   tag: "Documentation"

--- a/content/en/agent/cluster_agent/endpointschecks.md
+++ b/content/en/agent/cluster_agent/endpointschecks.md
@@ -1,6 +1,8 @@
 ---
 title: Running Endpoints Checks with Autodiscovery
 kind: documentation
+aliases:
+  - "agent/autodiscovery/endpointchecks"
 further_reading:
 - link: "/agent/autodiscovery"
   tag: "Documentation"

--- a/content/en/agent/cluster_agent/endpointschecks.md
+++ b/content/en/agent/cluster_agent/endpointschecks.md
@@ -17,11 +17,11 @@ further_reading:
 
 ## How it Works
 
-The [Cluster Check][1] feature provides the ability to Autodiscover and perform checks on load-balanced cluster services (eg. Kubernetes services). 
+The [cluster check][1] feature provides the ability to Autodiscover and perform checks on load-balanced cluster services (eg. Kubernetes services). 
 
 Endpoint checks extend this mechanism to monitor any endpoint behind cluster services.
 
-The [Cluster Agent][2] holds the configurations and exposes them to node-based Agents so they can consume and convert them into Endpoints Checks.
+The [Cluster Agent][2] holds the configurations and exposes them to node-based Agents so they can consume and convert them into endpoints checks.
 
 Endpoints checks are scheduled by Agents that run on the same node as the pod(s) that back the endpoint(s) of the monitored service.
 
@@ -29,7 +29,7 @@ The Agents connect to the Cluster Agent every 10 seconds and retrieve the check 
 
 This feature is supported on Kubernetes for versions 6.12.0+ of the Agent, and versions 1.3.0+ of the Cluster Agent.
 
-Starting with version 1.4.0, the Cluster Agent converts every endpoints check of a non-pod-backed endpoint into a regular cluster check. Enable the [cluster check][1] feature alongside Endpoints Checks to take advantage of this functionality.
+Starting with version 1.4.0, the Cluster Agent converts every endpoints check of a non-pod-backed endpoint into a regular cluster check. Enable the [cluster check][1] feature alongside endpoints checks to take advantage of this functionality.
 
 #### Example: three NGINX pods exposed by the `nginx` service
 
@@ -86,7 +86,7 @@ DD_EXTRA_CONFIG_PROVIDERS="kube_endpoints"
 DD_EXTRA_LISTENERS="kube_endpoints"
 ```
 
-**Note**: If the monitored endpoints are not backed by pods, you must [enable Cluster Checks][4]. This can be done by adding the `kube_services` configuration provider and listener:
+**Note**: If the monitored endpoints are not backed by pods, you must [enable cluster checks][4]. This can be done by adding the `kube_services` configuration provider and listener:
 
 ```shell
 DD_EXTRA_CONFIG_PROVIDERS="kube_endpoints kube_services"
@@ -113,7 +113,7 @@ config_providers:
     polling: true
 ```
 
-**Note**: If the monitored endpoints are not backed by pods, you must [enable Cluster Checks][1]. This can be done by adding the `clusterchecks` configuration provider:
+**Note**: If the monitored endpoints are not backed by pods, you must [enable cluster checks][1]. This can be done by adding the `clusterchecks` configuration provider:
 
 ```shell
 DD_EXTRA_CONFIG_PROVIDERS="endpointschecks clusterchecks"
@@ -123,7 +123,7 @@ DD_EXTRA_CONFIG_PROVIDERS="endpointschecks clusterchecks"
 
 ## Setting up Check Configurations via Kubernetes Service Annotations
 
-Similar to [annotating Kubernetes Pods][6], Services can be annotated with the following syntax:
+Similar to [annotating Kubernetes Pods][6], services can be annotated with the following syntax:
 
 ```yaml
   ad.datadoghq.com/endpoints.check_names: '[<INTEGRATION_NAME>]'
@@ -174,9 +174,9 @@ spec:
 
 ## Troubleshooting
 
-Troubleshooting Endpoints Checks is similar to [troubleshooting Cluster Checks][10]—the only difference is on the node-based Agents, where scheduled Endpoints Checks appear alongside the Cluster Check.
+Troubleshooting endpoints checks is similar to [troubleshooting cluster checks][10]—the only difference is on the node-based Agents, where scheduled endpoints checks appear alongside the cluster check.
 
-**Note**: Endpoints Checks are scheduled by Agents that run on the same node as the pod(s) that back the endpoint(s) of the service. If an endpoint is not backed by a pod, the Cluster Agent converts the check into a Cluster Check. This Cluster Check can be run by any node Agent.
+**Note**: Endpoints checks are scheduled by Agents that run on the same node as the pod(s) that back the endpoint(s) of the service. If an endpoint is not backed by a pod, the Cluster Agent converts the check into a cluster check. This cluster check can be run by any node Agent.
 
 ### Autodiscovery in the node-based Agent
 


### PR DESCRIPTION
move cluster checks and endpoint checks pages out of Autodiscovery section and into Cluster Agent section


https://docs-staging.datadoghq.com/cswatt/cluster-checks-clarity/agent/cluster_agent/clusterchecks

https://docs-staging.datadoghq.com/cswatt/cluster-checks-clarity/agent/cluster_agent/endpointschecks


