### PR TITLE
[DOCS-386] removing old links to api source attribute faq

### DIFF
--- a/content/en/api/events/events_post.md
+++ b/content/en/api/events/events_post.md
@@ -34,12 +34,11 @@ This endpoint allows you to post events to the stream. Tag them, set priority an
 * **`source_type_name`** [*optional*, *default*=**None**]:
     The type of event being posted.
     Options: **nagios**, **hudson**, **jenkins**, **my_apps**, **chef**, **puppet**, **git**, **bitbucket**...
-    [Complete list of source attribute values][3]
 * **`related_event_id`** [*optional*, *default*=**None**]:
     ID of the parent event. Must be sent as an integer (i.e. no quotes).
 * **`device_name`** [*optional*, *default*=**None**]:
     A list of device names to post the event with.
 
+
 [1]: https://github.com/DataDog/dogapi-rb
 [2]: /developers/events/email#markdown
-[3]: /integrations/faq/list-of-api-source-attribute-value

--- a/content/en/api/monitors/monitors_create.md
+++ b/content/en/api/monitors/monitors_create.md
@@ -70,7 +70,7 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
 
     *  **`event`**, the event query string:
     *   **`string_query`** free text query to match against event title and text.
-    *   **`sources`** event sources (comma-separated). [Complete list of source attribute values][4]
+    *   **`sources`** event sources (comma-separated). 
     *   **`status`** event statuses (comma-separated). Valid options: error, warn, and info.
     *   **`priority`** event priorities (comma-separated). Valid options: low, normal, all.
     *   **`host`** event reporting host (comma-separated).
@@ -83,7 +83,7 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
 
     `processes(search).over(tags).rollup('count').last(timeframe) operator #`
 
-    *   **`search`** free text search string for querying processes. Matching processes match results on the [Live Processes][5] page
+    *   **`search`** free text search string for querying processes. Matching processes match results on the [Live Processes][4] page
     *   **`tags`** one or more tags (comma-separated)
     *   **`timeframe`** the timeframe to roll up the counts. Examples: 60s, 4h. Supported timeframes: s, m, h and d
     *   **`operator`** <, <=, >, >=, ==, or !=
@@ -146,7 +146,7 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
 
     _These options only apply to metric alerts._
 
-   - **`thresholds`** a dictionary of thresholds by threshold type. There are two threshold types for metric alerts: *critical* and *warning*. *Critical* is defined in the query, but can also be specified in this option. *Warning* threshold can only be specified using the thresholds option. If you want to use [recovery thresholds][6] for your monitor, use the attributes `critical_recovery` and `warning_recovery`.
+   - **`thresholds`** a dictionary of thresholds by threshold type. There are two threshold types for metric alerts: *critical* and *warning*. *Critical* is defined in the query, but can also be specified in this option. *Warning* threshold can only be specified using the thresholds option. If you want to use [recovery thresholds][5] for your monitor, use the attributes `critical_recovery` and `warning_recovery`.
 
     Example: `{'critical': 90, 'warning': 80,  'critical_recovery': 70, 'warning_recovery': 50}`
 
@@ -169,6 +169,5 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
 [1]: /monitors/monitor_types/#import
 [2]: /monitors/monitor_types
 [3]: /monitors/monitor_types/#define-the-conditions
-[4]: /integrations/faq/list-of-api-source-attribute-value
-[5]: /infrastructure/process
-[6]: /monitors/faq/what-are-recovery-thresholds
+[4]: /infrastructure/process
+[5]: /monitors/faq/what-are-recovery-thresholds

--- a/content/en/api/tags/tags.md
+++ b/content/en/api/tags/tags.md
@@ -10,9 +10,8 @@ external_redirect: /api/#tags
 The tag endpoint allows you to tag hosts with keywords meaningful to you - like `role:database`.
 All metrics sent from a host have its tags applied. When fetching and applying tags to a particular host, refer to hosts by name (yourhost.example.com).
 
-The component of your infrastructure responsible for a tag is identified by a source. Valid sources are: nagios, hudson, jenkins, users, feed, chef, puppet, git, bitbucket, fabric, capistrano... [Complete list of source attribute values][1]
+The component of your infrastructure responsible for a tag is identified by a source. Valid sources are: nagios, hudson, jenkins, users, feed, chef, puppet, git, bitbucket, fabric, capistrano... 
 
-[Read more about tags on the dedicated documentation page][2].
+[Read more about tags on the dedicated documentation page][1].
 
-[1]: /integrations/faq/list-of-api-source-attribute-value
-[2]: /tagging
+[1]: /tagging

--- a/content/en/api/tags/tags_add.md
+++ b/content/en/api/tags/tags_add.md
@@ -15,6 +15,5 @@ This endpoint allows you to add new tags to a host, optionally specifying where 
     A list of tags to apply to the host
 * **`source`** [*optional*, *default*=**users**]:
     The source of the tags (e.g. chef, puppet).
-    [Complete list of source attribute values][1]
 
-[1]: /integrations/faq/list-of-api-source-attribute-value
+

--- a/content/en/api/tags/tags_update.md
+++ b/content/en/api/tags/tags_update.md
@@ -15,6 +15,4 @@ This endpoint allows you to update/replace all tags in an integration source wit
     A list of tags
 * **`source`** [*optional*, *default*=**users**]:
     The source of the tags (e.g. chef, puppet).
-    [Complete list of source attribute values][1]
 
-[1]: /integrations/faq/list-of-api-source-attribute-value

--- a/content/en/developers/events/agent.md
+++ b/content/en/developers/events/agent.md
@@ -38,16 +38,16 @@ The following keys and data types are available in the event dictionary:
 | `msg_text`         | String          | Yes      | The text body of the event                                    |
 | `aggregation_key`  | String          | No       | A key to use for aggregating events                           |
 | `alert_type`       | String          | No       | `error`, `warning`, `success`, or `info` (defaults to `info`) |
-| `source_type_name` | String          | No       | The [source type][1] name                                     |
+| `source_type_name` | String          | No       | The source type name                                     |
 | `host`             | String          | No       | The host name                                                 |
 | `tags`             | List of strings | No       | A list of tags associated with this event.                    |
 | `priority`         | String          | No       | Specifies the priority of the event (`normal` or `low`).      |
 
 ### Example
 
-This is an example of using a custom Agent check to send one event periodically. See [Writing a Custom Agent Check][2] for more details.
+This is an example of using a custom Agent check to send one event periodically. See [Writing a Custom Agent Check][1] for more details.
 
-1. Create a new directory `event_example.d/` in the `conf.d/` folder at the root of your [Agent's configuration directory][3].
+1. Create a new directory `event_example.d/` in the `conf.d/` folder at the root of your [Agent's configuration directory][2].
 
 2. In the `event_example.d/` folder, create a configuration file named `event_example.yaml` with the following content:
 
@@ -76,8 +76,8 @@ This is an example of using a custom Agent check to send one event periodically.
             )
     {{< /code-block >}}
 
-5. [Restart the Agent][4].
-6. For validation, run the [Agent's status command][5] and look for `event_example` under the Checks section:
+5. [Restart the Agent][3].
+6. For validation, run the [Agent's status command][4] and look for `event_example` under the Checks section:
 
     ```
     =========
@@ -101,7 +101,7 @@ This is an example of using a custom Agent check to send one event periodically.
         (...)
     ```
 
-7. Finally, go to your [Datadog Event stream][6] to see your events:
+7. Finally, go to your [Datadog Event stream][5] to see your events:
 
 {{< img src="developers/events/agent_check/event_stream_example.png" alt="Event stream example"  style="width:80%;">}}
 
@@ -109,9 +109,9 @@ This is an example of using a custom Agent check to send one event periodically.
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /integrations/faq/list-of-api-source-attribute-value
-[2]: /developers/write_agent_check
-[3]: /agent/guide/agent-configuration-files/#agent-configuration-directory
-[4]: /agent/guide/agent-commands/#restart-the-agent
-[5]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-information
-[6]: https://app.datadoghq.com/event/stream
+
+[1]: /developers/write_agent_check
+[2]: /agent/guide/agent-configuration-files/#agent-configuration-directory
+[3]: /agent/guide/agent-commands/#restart-the-agent
+[4]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-information
+[5]: https://app.datadoghq.com/event/stream

--- a/content/en/developers/events/dogstatsd.md
+++ b/content/en/developers/events/dogstatsd.md
@@ -32,7 +32,7 @@ event(<TITLE>, <TEXT>, <TIMESTAMP>, <HOSTNAME>, <AGGREGATION_KEY>, <PRIORITY>, <
 | `<HOSTNAME>`         | String          | No       | The name of the host                                                                       |
 | `<AGGREGATION_KEY>`  | String          | No       | A key to use for aggregating events                                                        |
 | `<PRIORITY>`         | String          | No       | Specifies the priority of the event (`normal` or `low`).                                   |
-| `<SOURCE_TYPE_NAME>` | String          | No       | The [source type][3] name                                                                  |
+| `<SOURCE_TYPE_NAME>` | String          | No       | The source type name                                                                  |
 | `<ALERT_TYPE>`       | String          | No       | `error`, `warning`, `success`, or `info` (defaults to `info`)                              |
 | `<TAGS>`             | List of strings | No       | A list of tags associated with this event.                                                 |
 
@@ -201,6 +201,6 @@ $statsd->event('An error occurred.',
 
 {{< partial name="whats-next/whats-next.html" >}}
 
+
 [1]: /developers/dogstatsd
 [2]: /events
-[3]: /integrations/faq/list-of-api-source-attribute-value


### PR DESCRIPTION
removes a bunch of old links to a page that doesn't really exist anymore