### PR TITLE
[rum] add rum monitor in api

### DIFF
--- a/content/en/api/monitors/monitors_create.md
+++ b/content/en/api/monitors/monitors_create.md
@@ -30,6 +30,7 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
 | network      | `service check`                  |
 | outlier      | `query alert`                    |
 | process      | `service check`                  |
+| rum          | `rum alert`                      |
 | watchdog     | `event alert`                    |
 
 *   **`query`** [*required*]:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add `rum alert` to monitors API

### Motivation
<!-- What inspired you to submit this pull request?-->
Exhaustiveness

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hdelaby/rum-monitor/api/?lang=bash#create-a-monitor

### Additional Notes
<!-- Anything else we should know when reviewing?-->
