### PR TITLE
fix the banner link to have the ref otherwise we never reach the english

### DIFF
--- a/layouts/partials/translate_status_banner/translate_status_banner.html
+++ b/layouts/partials/translate_status_banner/translate_status_banner.html
@@ -13,7 +13,7 @@
   {{ if (and $outdated (not .Params.placeholder)) }}
     {{ $text := .Site.Params.translate_status_banner | default "" }}
     <div class="translate_status_banner text-left">
-      <a href="{{ range where $dot.Page.Translations "Lang" "en"}}{{ .Permalink }}{{ end }}">
+      <a href="{{ range where $dot.Page.Translations "Lang" "en"}}{{ .Permalink }}{{ end }}?lang_pref=en">
         <div class='alert alert-info'>{{ $text }}</div>
       </a>
     </div>


### PR DESCRIPTION
### What does this PR do?

Updates the translate banner to include the lang pref so we don't get sent straight back to our preference when we are specifically redirecting a user to english.

### Motivation

https://trello.com/c/Gnm9F7dt/4408-ja-banner-that-goes-to-en-on-docs-redirects-back-to-ja-site-if-you-have-the-cookie-set

### Preview link

I couldn't find a link currently on the ja site that had the banner but i tested locally and the changes work as expected
https://docs-staging.datadoghq.com/david.jones/fix-banner-link/ja/

### Additional Notes

