### PR TITLE
Removing private beta flag as it's public beta now

### DIFF
--- a/content/en/dashboards/correlations/_index.md
+++ b/content/en/dashboards/correlations/_index.md
@@ -3,7 +3,6 @@ title: Metric Correlations
 kind: documentation
 aliases:
     - /graphing/correlations/
-beta: true
 further_reading:
 - link: "/dashboards"
   tag: "Documentation"

--- a/content/en/dashboards/widgets/table.md
+++ b/content/en/dashboards/widgets/table.md
@@ -1,7 +1,6 @@
 ---
 title: Table Widget
 kind: documentation
-beta: true
 aliases:
     - /graphing/widgets/table/
 further_reading:

--- a/content/en/logs/logs_to_metrics.md
+++ b/content/en/logs/logs_to_metrics.md
@@ -1,7 +1,6 @@
 ---
 title: Generate Metrics from Ingested Logs
 kind: documentation
-beta: false
 aliases:
  - /logs/processing/logs_to_metrics/
 description: "Generate Metrics from Ingested Logs."


### PR DESCRIPTION
### What does this PR do?
Removes private beta flag on those pages to make them available to search.