### PR TITLE
Update doc for CBDefense

### DIFF
--- a/content/en/integrations/carbon_black.md
+++ b/content/en/integrations/carbon_black.md
@@ -25,10 +25,7 @@ Use the Datadog-Carbon Black integration in order to forward your Carbon Black D
 
 ### Installation
 
-First, install and setup the [Carbon Black Defense log shipper][1]. The shipper is available for:
-
-- [RPM based Linux distributions][2]
-- [Docker][3]
+First, install and setup the [Carbon Black Defense log shipper][1]
 
 ### Configuration
 
@@ -95,7 +92,5 @@ You can find your Carbon Black Defense server URL within your Carbon Black dashb
 Need help? Contact [Datadog support][5].
 
 [1]: https://github.com/carbonblack/cb-defense-syslog-tls
-[2]: https://github.com/carbonblack/cb-defense-syslog-tls#installation
-[3]: https://github.com/carbonblack/cb-defense-syslog-tls#installation-via-docker
 [4]: https://app.datadoghq.com/account/settings#api
 [5]: /help

--- a/content/en/integrations/carbon_black.md
+++ b/content/en/integrations/carbon_black.md
@@ -25,7 +25,7 @@ Use the Datadog-Carbon Black integration in order to forward your Carbon Black D
 
 ### Installation
 
-First, install and setup the [Carbon Black Defense log shipper][1]
+First, install and setup the [Carbon Black Defense log shipper][1].
 
 ### Configuration
 


### PR DESCRIPTION
Update the documentation to match updates to CBDefense syslog shipper

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update the documentation to match updates to CBDefense syslog shipper

### Motivation
CBDefense syslog shipper has changed

### Preview link


<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
