### PR TITLE
[en] dan.chiniara/ change curl path for get_pipeline.sh to include pipelines

### DIFF
--- a/content/en/api/logs_pipelines/code_snippets/get_pipeline.sh
+++ b/content/en/api/logs_pipelines/code_snippets/get_pipeline.sh
@@ -7,4 +7,4 @@ pipeline_id=<PIPELINE_ID>
 curl -X GET \
 -H "DD-API-KEY: ${api_key}" \
 -H "DD-APPLICATION-KEY: ${app_key}" \
-"https://api.datadoghq.com/api/v1/logs/config/${pipeline_id}"
+"https://api.datadoghq.com/api/v1/logs/config/pipelines/${pipeline_id}"


### PR DESCRIPTION
### What does this PR do?
changes the curl command for the [API Reference](https://docs.datadoghq.com/api/?lang=bash#get-a-pipeline)

**Original Line:**
`"https://api.datadoghq.com/api/v1/logs/config/${pipeline_id}"`
 
**Updated Line:**
`"https://api.datadoghq.com/api/v1/logs/config/pipelines/${pipeline_id}"`

### Motivation
https://datadog.zendesk.com/agent/tickets/305412

### Preview link

**Original API Referene Link:**
https://docs.datadoghq.com/api/?lang=bash#get-a-pipeline

**Updated API Referene Link:**
https://docs-staging.datadoghq.com/dan.chiniara/en.get-pipelines_add-pipelines-1/api/?lang=bash#get-a-pipeline