### PR TITLE
Pulling datadog operator doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ integrations_data
 content/en/developers/integrations/*.md
 content/en/developers/amazon_cloudformation.md
 
+# Developers/ Operators
+content/en/developers/datadog_operator/*
 # Agent section
 content/en/agent/basic_agent_usage/heroku.md
 

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,8 @@ clean-auto-doc: ##Remove all doc automatically created
 	rm -f content/en/logs/log_collection/android.md ;fi
 	@if [ content/en/tracing/setup/android.md ]; then \
 	rm -f content/en/tracing/setup/android.md ;fi
+	@if [ -d content/en/developers/datadog_operator ]; then \
+	find ./content/en/developers/datadog_operator -type f -maxdepth 1 -exec rm -rf {} \; ;fi
 
 clean-node:  ## Remove node_modules.
 	@if [ -d node_modules ]; then rm -r node_modules; fi

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1476,6 +1476,34 @@ main:
     identifier: "dev_tools_service_check_api"
     weight: 403
 
+ ##  DEVELOPERS - Datadog Operator
+
+  - name: "Kubernetes Operator"
+    url: "developers/datadog_operator/"
+    parent: "dev_tools"
+    identifier: "dev_tools_operator"
+    weight: 5
+  - name: "Getting Started"
+    url: "/developers/datadog_operator/getting_started"
+    parent: "dev_tools_operator"
+    identifier: "dev_tools_operator_gs"
+    weight: 501
+  - name: "Custom Check"
+    url: "/developers/datadog_operator/custom_check"
+    parent: "dev_tools_operator"
+    identifier: "dev_tools_operator_custom_check"
+    weight: 502
+  - name: "Cluster Agent"
+    url: "/developers/datadog_operator/cluster_agent_setup"
+    parent: "dev_tools_operator"
+    identifier: "dev_tools_operator_dca"
+    weight: 503
+  - name: "Data Collected"
+    url: "/developers/datadog_operator/data_collected"
+    parent: "dev_tools_operator"
+    identifier: "dev_tools_operator_data_collected"
+    weight: 504
+
   - name: "Libraries"
     url: "developers/libraries/"
     parent: "dev_tools"

--- a/local/bin/py/build/actions/pull_and_push_file.py
+++ b/local/bin/py/build/actions/pull_and_push_file.py
@@ -4,6 +4,7 @@ import re
 import yaml
 
 from os.path import basename
+from os import makedirs
 
 
 def pull_and_push_file(content, content_dir):
@@ -14,6 +15,9 @@ def pull_and_push_file(content, content_dir):
     :param content: object with a file_name, a file_path, and options to apply
     :param content_dir: The directory where content should be put
     """
+
+    makedirs("{}{}".format(content_dir,content["options"]["dest_path"][1:]), exist_ok=True)
+
     with open("".join(content["globs"]), mode="r+") as f:
         file_content = f.read()
         # If options include front params, then the H1 title of the source file is striped
@@ -24,6 +28,23 @@ def pull_and_push_file(content, content_dir):
                           default_flow_style=False) + "---\n"
             file_content = re.sub(
                 r'^(#{1}).*', front_matters, file_content, count=1)
+
+        if "link_relative" in content["options"]:
+            # Replacing links that point to the Github folder by link that point to the doc.
+            new_link = (content["options"]["dest_path"] + "\\2" + "/")
+
+            regex_github_link = re.compile(
+                r"(https:\/\/github\.com\/{}\/{}\/blob\/{}\/{})(\S+)\.md".format(
+                    content["org_name"],
+                    content["repo_name"],
+                    content["branch"],
+                    content["options"][
+                        "path_to_remove"
+                    ],
+                )
+            )
+            file_content = re.sub(regex_github_link,new_link,file_content,count=0)
+
     with open(
         "{}{}{}".format(
             content_dir,

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -164,3 +164,74 @@
             - link: "tracing/visualization/"
               tag: "Documentation"
               text: "Explore your services, resources and traces"
+
+  - repo_name: datadog-operator
+    contents:
+
+    - action: pull-and-push-file
+      branch: gus/doc-refactoring
+      globs:
+      - 'README.md'
+      options:
+        dest_path: '/developers/datadog_operator/'
+        file_name: '_index.md'
+        link_relative: true
+        path_to_remove: 'docs/'
+        front_matters:
+          title: Datadog Operator
+          kind: documentation
+          description: "Deploy the Datadog Agent on Kubernetes."
+          dependencies: ["https://github.com/DataDog/datadog-operator/blob/master/README.md"]
+
+    - action: pull-and-push-file
+      branch: gus/doc-refactoring
+      globs:
+      - 'docs/getting_started.md'
+      options:
+        dest_path: '/developers/datadog_operator/'
+        file_name: 'getting_started.md'
+        front_matters:
+          title: Getting started with the Datadog Operator
+          kind: documentation
+          description: "Deploy the Datadog Agent with the Datadog operator."
+          dependencies: ["https://github.com/DataDog/datadog-operator/blob/master/docs/getting_started.md"]
+
+    - action: pull-and-push-file
+      branch: gus/doc-refactoring
+      globs:
+      - 'docs/custom_check.md'
+      options:
+        dest_path: '/developers/datadog_operator/'
+        file_name: 'custom_check.md'
+        front_matters:
+          title: Custom Check
+          kind: documentation
+          description: "Deploy Custom Check with the Datadog Operator."
+          dependencies: ["https://github.com/DataDog/datadog-operator/blob/master/docs/custom_check.md"]
+
+    - action: pull-and-push-file
+      branch: gus/doc-refactoring
+      globs:
+      - 'docs/cluster_agent_setup.md'
+      options:
+        dest_path: '/developers/datadog_operator/'
+        file_name: 'cluster_agent_setup.md'
+        front_matters:
+          title: Cluster Agent setup with Operator
+          kind: documentation
+          description: "Deploy the Datadog Cluster Agent with the Datadog Operator."
+          dependencies: ["https://github.com/DataDog/datadog-operator/blob/master/docs/cluster_agent_setup.md"]
+
+    - action: pull-and-push-file
+      branch: gus/doc-refactoring
+      globs:
+      - 'docs/data_collected.md'
+      options:
+        dest_path: '/developers/datadog_operator/'
+        file_name: 'data_collected.md'
+        front_matters:
+          title: Data collected by the Operator
+          kind: documentation
+          disable_toc: true
+          description: "Metrics and events collected by the Datadog Operator."
+          dependencies: ["https://github.com/DataDog/datadog-operator/blob/master/docs/data_collected.md"]


### PR DESCRIPTION
### What does this PR do?

Prepare pulling operator doc from: https://github.com/DataDog/datadog-operator/pull/32

As it's beta only, it will live in the developers section until it's GA and the Agent documentation gets improved to support this.

### Preview link

*  https://docs-staging.datadoghq.com/gus/operator-doc/developers/datadog_operator/ 