### PR TITLE
Update snmp.md

### DIFF
--- a/content/en/integrations/faq/snmp.md
+++ b/content/en/integrations/faq/snmp.md
@@ -224,6 +224,7 @@ init_config:
   profiles:
     my-profile:
       definition:
+        metrics:
         - MIB: IP-MIB
           table: ipSystemStatsTable
           symbols:
@@ -231,7 +232,7 @@ init_config:
           metric_tags:
             - tag: ipversion
           index: 1
-      sysobjectid: '1.3.6.1.4.1.8072.3.2.10'
+        sysobjectid: '1.3.6.1.4.1.8072.3.2.10'
 ```
 
 Then either reference it explicitly by name, or use sysObjectID detection:


### PR DESCRIPTION
The sysobjectid attribute needs to be inside the profiles.my_profile.definition section.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
It updates a mistake in the documentation for updating the SNMP integration's yaml file.

### Motivation
I wasted at least 1 hour trying to get the new SNMP check's auto discovery feature working.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
