### PR TITLE
revise port and image in Redis Autodiscovery template

### DIFF
--- a/content/en/agent/autodiscovery/integrations.md
+++ b/content/en/agent/autodiscovery/integrations.md
@@ -294,9 +294,9 @@ metadata:
 spec:
   containers:
     - name: redis
-      image: httpd
+      image: redis:latest
       ports:
-        - containerPort: 80
+        - containerPort: 6379
 ```
 
 **Note**: The `"%%env_<ENV_VAR>%%"` template variable logic is used to avoid storing the password in plain text, hence the `REDIS_PASSWORD` environment variable must be passed to the Agent. See the [Autodiscovery template variable documentation][1].


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Revises the port and image in the Redis Autodiscovery template

### Motivation
<!-- What inspired you to submit this pull request?-->
Noticed it while editing a blog post.

### Preview link
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/echang26-patch-1/agent/autodiscovery/integrations/?tab=kubernetes#datadog-redis-integration

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
