### PR TITLE
Add logs back to K8S autodiscovery instructions

### DIFF
--- a/content/en/agent/autodiscovery/endpointschecks.md
+++ b/content/en/agent/autodiscovery/endpointschecks.md
@@ -125,6 +125,7 @@ Similar to [annotating Kubernetes Pods][6], Services can be annotated with the f
   ad.datadoghq.com/endpoints.check_names: '[<INTEGRATION_NAME>]'
   ad.datadoghq.com/endpoints.init_configs: '[<INIT_CONFIG>]'
   ad.datadoghq.com/endpoints.instances: '[<INSTANCE_CONFIG>]'
+  ad.datadoghq.com/endpoints.logs: '[<LOGS_CONFIG>]'
 ```
 
 The `%%host%%` [template variable][7] is supported and is replaced by the endpoints' IPs. The `kube_namespace`, `kube_service`, and `kube_endpoint_ip`  tags are automatically added to the instances.
@@ -160,6 +161,7 @@ metadata:
           "nginx_status_url": "http://%%host%%:%%port%%/nginx_status"
         }
       ]
+    ad.datadoghq.com/endpoints.logs: '[{"source":"nginx","service":"webapp"}]'
 spec:
   ports:
   - port: 80


### PR DESCRIPTION
### What does this PR do?
Add log configuration instruction in pod annotations for autodiscovery

### Motivation
Seems that the Log section was missing in the example.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/autodiscovery-K8s-Logs/agent/autodiscovery/endpointschecks/#setting-up-check-configurations-via-kubernetes-service-annotations

### Additional Notes
<!-- Anything else we should know when reviewing?-->
