### PR TITLE
Add notes to using template variables

### DIFF
--- a/content/en/agent/autodiscovery/template_variables.md
+++ b/content/en/agent/autodiscovery/template_variables.md
@@ -26,6 +26,11 @@ Use the following template variables when configuring Autodiscovery in order to 
 | `"%%hostname%%"`            | Retrieves the `hostname` value from the container configuration. Only use it if the `"%%host%%"` variable cannot fetch a reliable IP (example: [ECS awsvpc mode][1]).                                       |
 | `"%%env_<ENV_VAR>%%"`       | Uses the contents of the `$<ENV_VAR>` environment variable **as seen by the Agent process**.                                                                                                                |
 
+**Note**:
+
+* Template variables need to be in quotations.
+* Replace `<NETWORK NAME>`, `<NAME>`, etc. with the actual name; angle brackets are not necessary.
+
 **Fall back**:
 
 * For the `"%%host%%"` template variable: in case the Agent is not able to find it, this template variable falls back to the `bridge` network IP.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Add a Note section to highlight something that seems to be not obvious when using template variables.

### Motivation
<!-- What inspired you to submit this pull request?-->

https://datadog.zendesk.com/agent/tickets/302797

> The angle brackets in your docs are not literal, so they DO NOT need to be added for the parser. > You should probably make a note of that in your docs. Further, this does not work:
> 
> - host: common-rds.%%env_AWS_ENVIRONMENT%%.opploans.com . <=== NOT AN ERROR
> port: 5432
> username: %%env_DATADOG_DB_USERNAME%% . <=== ERROR
> 
> It blows up on the username line because the percents start with the first character of the data. > You must surround that with double quotes or you will get the error I got above. Note that the > > host: line works because the percents are in the center of the string. If you do not specify this, > > please update your docs, as this is confusing and not intuitive. You can close this.

### Preview link
<!-- Impacted pages preview links-->

https://docs.datadoghq.com/agent/autodiscovery/template_variables/

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes

I can't seem to make any of these work:

https://docs-staging.datadoghq.com/mecsantos-patch-302797/agent/autodiscovery/template_variables/

https://docs-staging.datadoghq.com/mecsantos-patch-302797/https://docs.datadoghq.com/agent/autodiscovery/template_variables/

https://docs-staging.datadoghq.com/mecsantos-patch-302797/docs.datadoghq.com/agent/autodiscovery/template_variables/
