### PR TITLE
Fix syntax when we use dd.trace.global.tags

### DIFF
--- a/content/en/tracing/guide/adding_metadata_to_spans.md
+++ b/content/en/tracing/guide/adding_metadata_to_spans.md
@@ -252,7 +252,7 @@ Add [tags][1] to all [spans][2] by configuring the tracer with the system proper
 
 ```bash
 java -javaagent:<DD-JAVA-AGENT-PATH>.jar \
-     -Ddd.trace.global.tags='env:dev,<TAG_KEY>:<TAG_VALUE>' \
+     -Ddd.trace.global.tags=env:dev,<TAG_KEY>:<TAG_VALUE> \
      -jar <YOUR_APPLICATION_PATH>.jar
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fix syntax when we use dd.trace.global.tags
Remove the single quotes

### Motivation
https://trello.com/c/iOzwiNwU/3067-reference-manual-of-ddtraceglobaltags-is-wrong
https://github.com/DataDog/dd-trace-java/issues/1222

### Preview link
https://docs-staging.datadoghq.com/c%C3%A9cile/JavaFixAddingtagsgloballytoallspans/tracing/guide/adding_metadata_to_spans/?tab=java

### Additional Notes

