### PR TITLE
Fix code snippets that cause error.

### DIFF
--- a/content/en/api/usage/code_snippets/api-billing-usage-fargate.sh
+++ b/content/en/api/usage/code_snippets/api-billing-usage-fargate.sh
@@ -7,6 +7,4 @@ end_hr=$(date +%Y-%m-%dT%H)
 curl -X GET \
 -H "DD-API-KEY: ${api_key}" \
 -H "DD-APPLICATION-KEY: ${app_key}" \
--d "start_hr=${start_hr}" \
--d "end_hr=${end_hr}" \
-"https://api.datadoghq.com/api/v1/usage/fargate"
+"https://api.datadoghq.com/api/v1/usage/fargate?&start_hr=${start_hr}&end_hr=${end_hr}"

--- a/content/en/api/usage/code_snippets/api-billing-usage-hosts.sh
+++ b/content/en/api/usage/code_snippets/api-billing-usage-hosts.sh
@@ -7,6 +7,4 @@ end_hr=$(date +%Y-%m-%dT%H)
 curl -X GET \
 -H "DD-API-KEY: ${api_key}" \
 -H "DD-APPLICATION-KEY: ${app_key}" \
--d "start_hr=${start_hr}" \
--d "end_hr=${end_hr}" \
-"https://api.datadoghq.com/api/v1/usage/hosts"
+"https://api.datadoghq.com/api/v1/usage/hosts?&start_hr=${start_hr}&end_hr=${end_hr}"

--- a/content/en/api/usage/code_snippets/api-billing-usage-logs.sh
+++ b/content/en/api/usage/code_snippets/api-billing-usage-logs.sh
@@ -7,6 +7,4 @@ end_hr=$(date +%Y-%m-%dT%H)
 curl -X GET \
 -H "DD-API-KEY: ${api_key}" \
 -H "DD-APPLICATION-KEY: ${app_key}" \
--d "start_hr=${start_hr}" \
--d "end_hr=${end_hr}" \
-"https://api.datadoghq.com/api/v1/usage/logs"
+"https://api.datadoghq.com/api/v1/usage/logs?&start_hr=${start_hr}&end_hr=${end_hr}"

--- a/content/en/api/usage/code_snippets/api-billing-usage-synthetics.sh
+++ b/content/en/api/usage/code_snippets/api-billing-usage-synthetics.sh
@@ -7,6 +7,4 @@ end_hr=$(date +%Y-%m-%dT%H)
 curl -X GET \
 -H "DD-API-KEY: ${api_key}" \
 -H "DD-APPLICATION-KEY: ${app_key}" \
--d "start_hr=${start_hr}" \
--d "end_hr=${end_hr}" \
-"https://api.datadoghq.com/api/v1/usage/synthetics"
+"https://api.datadoghq.com/api/v1/usage/synthetics?&start_hr=${start_hr}&end_hr=${end_hr}"

--- a/content/en/api/usage/code_snippets/api-billing-usage-timeseries.sh
+++ b/content/en/api/usage/code_snippets/api-billing-usage-timeseries.sh
@@ -7,6 +7,4 @@ end_hr=$(date +%Y-%m-%dT%H)
 curl -X GET \
 -H "DD-API-KEY: ${api_key}" \
 -H "DD-APPLICATION-KEY: ${app_key}" \
--d "start_hr=${start_hr}" \
--d "end_hr=${end_hr}" \
-"https://api.datadoghq.com/api/v1/usage/timeseries"
+"https://api.datadoghq.com/api/v1/usage/timeseries?&start_hr=${start_hr}&end_hr=${end_hr}"

--- a/content/en/api/usage/code_snippets/api-billing-usage-top-avg-metrics.sh
+++ b/content/en/api/usage/code_snippets/api-billing-usage-top-avg-metrics.sh
@@ -6,6 +6,4 @@ month=$(date +%Y-%m)
 curl -X GET \
 -H "DD-API-KEY: ${api_key}" \
 -H "DD-APPLICATION-KEY: ${app_key}" \
--d "month=${month}" \
--d "names=aws.ec2.spot_history,system.processes.number" \
-"https://api.datadoghq.com/api/v1/usage/top_avg_metrics"
+"https://api.datadoghq.com/api/v1/usage/top_avg_metrics?&month=${month}&names=aws.ec2.spot_history,system.processes.number"

--- a/content/en/api/usage/code_snippets/api-billing-usage-trace-search.sh
+++ b/content/en/api/usage/code_snippets/api-billing-usage-trace-search.sh
@@ -7,6 +7,4 @@ end_hr=$(date +%Y-%m-%dT%H)
 curl -X GET \
 -H "DD-API-KEY: ${api_key}" \
 -H "DD-APPLICATION-KEY: ${app_key}" \
--d "start_hr=${start_hr}" \
--d "end_hr=${end_hr}" \
-"https://api.datadoghq.com/api/v1/usage/traces"
+"https://api.datadoghq.com/api/v1/usage/traces?&start_hr=${start_hr}&end_hr=${end_hr}"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
These code snippets are wrong as it will alway return something similar to: {"errors": ["The parameter 'start_hr' is required"]}.

The reason for this is that curl GET cannot be used with the -d/--data option unless we're dealing with a POST request. In the latter case, the request body (--data) does not get passed in which explains the error aforementioned.

Discussed further in this card: https://trello.com/c/DEJde56A

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/api/?lang=bash#usage-metering

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
