### PR TITLE
[Doc]: Add supported content encoding for compression

### DIFF
--- a/content/en/api/logs/send_logs_datadog.md
+++ b/content/en/api/logs/send_logs_datadog.md
@@ -16,4 +16,5 @@ external_redirect: /api/#send-logs-over-http
 | Query parameters | Query parameters available are the reserved log attribute. `?ddtags=<TAGS>&ddsource=<SOURCE>&service=<SERVICE>&hostname=<HOSTNAME>` |
 | Method           | `POST`                                                                                                                |
 | Content Type     | Available content type are: `text/plain`, `application/json`, `application/logplex-1`                                 |
+| Content Encoding | *[optional]* For compressed content the available content encoding are: `gzip` and `deflate`
 **Note**: If an API key is passed in both the headers and the path only the one in the headers is taken into account.

--- a/content/en/api/logs/send_logs_datadog.md
+++ b/content/en/api/logs/send_logs_datadog.md
@@ -16,5 +16,6 @@ external_redirect: /api/#send-logs-over-http
 | Query parameters | Query parameters available are the reserved log attribute. `?ddtags=<TAGS>&ddsource=<SOURCE>&service=<SERVICE>&hostname=<HOSTNAME>` |
 | Method           | `POST`                                                                                                                |
 | Content Type     | Available content type are: `text/plain`, `application/json`, `application/logplex-1`                                 |
-| Content Encoding | *[optional]* For compressed content the available content encoding are: `gzip` and `deflate`
+| Content Encoding | *[optional]* For compressed content the available content encoding are: `gzip` and `deflate`. |
+
 **Note**: If an API key is passed in both the headers and the path only the one in the headers is taken into account.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
List content encoding headers supported for compressed content

### Motivation
Update the doc

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/gaetan.deputier/send-logs-content-encoding/api/?lang=python#send-logs-over-http

### Additional Notes
<!-- Anything else we should know when reviewing?-->
