### PR TITLE
Add missing link

### DIFF
--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -237,3 +237,4 @@ When logs are sent through HTTPS, use the same [set of proxy settings][10] as th
 [8]: /developers/metrics/custom_metrics
 [9]: /tagging
 [10]: /agent/proxy
+[11]: https://docs.datadoghq.com/agent/basic_agent_usage/?tab=agentv6v7#agent-overhead


### PR DESCRIPTION


### What does this PR do?
add a link to the agent overhead

### Motivation
the link was missing

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/compression-missing-link/agent/basic_agent_usage/?tab=agentv6v7#agent-overhead

### Additional Notes
<!-- Anything else we should know when reviewing?-->
