### PR TITLE
Making link relative

### DIFF
--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -237,4 +237,4 @@ When logs are sent through HTTPS, use the same [set of proxy settings][10] as th
 [8]: /developers/metrics/custom_metrics
 [9]: /tagging
 [10]: /agent/proxy
-[11]: https://docs.datadoghq.com/agent/basic_agent_usage/?tab=agentv6v7#agent-overhead
+[11]: /agent/basic_agent_usage/#agent-overhead


### PR DESCRIPTION
Links pointing to the doc itself should be relative in order to support localisation.

This follow this PR: https://github.com/DataDog/documentation/pull/6699/files

And is a complement of this PR: https://github.com/DataDog/documentation/pull/6640