### PR TITLE
Adding conditional variables and renotify option

### DIFF
--- a/content/en/synthetics/api_tests/_index.md
+++ b/content/en/synthetics/api_tests/_index.md
@@ -172,15 +172,14 @@ A notification is sent according to the set of alerting conditions. To configure
 1. Select users and/or [services][4] to send the notifications to. Note that you can use [`@-notification`][5] in the **message** field, similarly to monitors.
 2. Enter a **message** for the API test. This field allows standard [Markdown formatting][6] and supports the below [conditional variables][7]:
 
-   | Conditional Variable       | Description                                                         |
-   |----------------------------|---------------------------------------------------------------------|
-   | `{{#is_alert}}`            | Show when monitor alerts                                            |
-   | `{{^is_alert}}`            | Show unless monitor alerts                                          |
-   | `{{#is_recovery}}`         | Show when monitor recovers from either WARNING, ALERT, or NO DATA   |
-   | `{{^is_recovery}}`         | Show unless monitor recovers from either WARNING, ALERT, or NO DATA |
+    | Conditional Variable       | Description                                                         |
+    |----------------------------|---------------------------------------------------------------------|
+    | `{{#is_alert}}`            | Show when monitor alerts                                            |
+    | `{{^is_alert}}`            | Show unless monitor alerts                                          |
+    | `{{#is_recovery}}`         | Show when monitor recovers from either ALERT   |
+    | `{{^is_recovery}}`         | Show unless monitor recovers from either ALERT |
 
-   Notification messages include the **message** defined in this section and information about which assertion failed and why.
-
+    Notification messages include the **message** defined in this section and information about which assertion failed and why.
 3. Specify a renotification frequency. If you don't want to be renotified in case your test keeps failing, leave the option to `Never renotify if the monitor has not been resolved`.
 4. Click **Save** to save your API test.
 

--- a/content/en/synthetics/api_tests/_index.md
+++ b/content/en/synthetics/api_tests/_index.md
@@ -181,7 +181,7 @@ A notification is sent according to the set of alerting conditions. To configure
 
     Notification messages include the **message** defined in this section and information about which assertion failed and why.
 3. Specify a renotification frequency. If you don't want to be renotified in case your test keeps failing, leave the option to `Never renotify if the monitor has not been resolved`.
-4. Click **Save** to save your API test.
+4. Click **Save**.
 
 Notifications example:
 

--- a/content/en/synthetics/api_tests/_index.md
+++ b/content/en/synthetics/api_tests/_index.md
@@ -180,7 +180,7 @@ A notification is sent according to the set of alerting conditions. To configure
     | `{{^is_recovery}}`         | Show unless monitor recovers from either ALERT |
 
     Notification messages include the **message** defined in this section and information about which assertion failed and why.
-3. Specify a renotification frequency. If you don't want to be renotified in case your test keeps failing, leave the option to `Never renotify if the monitor has not been resolved`.
+3. Specify a renotification frequency. To prevent renotification on failing tests, leave the option as `Never renotify if the monitor has not been resolved`.
 4. Click **Save**.
 
 Notifications example:

--- a/content/en/synthetics/api_tests/_index.md
+++ b/content/en/synthetics/api_tests/_index.md
@@ -169,9 +169,20 @@ You can use the [global variables defined in the `Settings`][3] in the URL, Adva
 
 A notification is sent according to the set of alerting conditions. To configure notifications:
 
-1. Select users and/or [services][4] to send the notifications to. Note that you can use the [`@-notification` feature][5] in the **message** field.
-2. Enter a **message** for the API test. This field allows standard [Markdown formatting][6]. Notification messages include the **message** defined in this section and information about which assertion failed and why.
-3. Click **Save** to save your API test.
+1. Select users and/or [services][4] to send the notifications to. Note that you can use [`@-notification`][5] in the **message** field, similarly to monitors.
+2. Enter a **message** for the API test. This field allows standard [Markdown formatting][6] and supports the below [conditional variables][7]:
+
+   | Conditional Variable       | Description                                                         |
+   |----------------------------|---------------------------------------------------------------------|
+   | `{{#is_alert}}`            | Show when monitor alerts                                            |
+   | `{{^is_alert}}`            | Show unless monitor alerts                                          |
+   | `{{#is_recovery}}`         | Show when monitor recovers from either WARNING, ALERT, or NO DATA   |
+   | `{{^is_recovery}}`         | Show unless monitor recovers from either WARNING, ALERT, or NO DATA |
+
+   Notification messages include the **message** defined in this section and information about which assertion failed and why.
+
+3. Specify a renotification frequency. If you don't want to be renotified in case your test keeps failing, leave the option to `Never renotify if the monitor has not been resolved`.
+4. Click **Save** to save your API test.
 
 Notifications example:
 
@@ -201,3 +212,4 @@ Response time is the sum of these network timings.
 [4]: /integrations/#cat-notification
 [5]: /monitors/notifications/#notification
 [6]: http://daringfireball.net/projects/markdown/syntax
+[7]: /monitors/notifications/?tab=is_recoveryis_alert_recovery#conditional-variables

--- a/content/en/synthetics/api_tests/_index.md
+++ b/content/en/synthetics/api_tests/_index.md
@@ -169,7 +169,7 @@ You can use the [global variables defined in the `Settings`][3] in the URL, Adva
 
 A notification is sent according to the set of alerting conditions. To configure notifications:
 
-1. Select users and/or [services][4] to send the notifications to. Note that you can use [`@-notification`][5] in the **message** field, similarly to monitors.
+1. Select users and/or [services][4] to receive notifications. **Note**: [`@-notifications`][5] are available in the **message** field, similar to monitors.
 2. Enter a **message** for the API test. This field allows standard [Markdown formatting][6] and supports the below [conditional variables][7]:
 
     | Conditional Variable       | Description                                                         |

--- a/content/en/synthetics/api_tests/_index.md
+++ b/content/en/synthetics/api_tests/_index.md
@@ -170,7 +170,7 @@ You can use the [global variables defined in the `Settings`][3] in the URL, Adva
 A notification is sent according to the set of alerting conditions. To configure notifications:
 
 1. Select users and/or [services][4] to receive notifications. **Note**: [`@-notifications`][5] are available in the **message** field, similar to monitors.
-2. Enter a **message** for the API test. This field allows standard [Markdown formatting][6] and supports the below [conditional variables][7]:
+2. Enter a **message** for the API test. This field allows standard [Markdown formatting][6] and supports the following [conditional variables][7]:
 
     | Conditional Variable       | Description                                                         |
     |----------------------------|---------------------------------------------------------------------|

--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -59,7 +59,7 @@ An alert is triggered if any assertion fails for `<INSERT_NUMBER>` minutes from 
 
 A notification is sent according to the set of alerting conditions. To configure your notifications:
 
-1. Enter a **message** for the browser test. This field allows standard [Markdown formatting][6] and supports the below [conditional variables][7]:
+1. Enter a **message** for the browser test. This field allows standard [Markdown formatting][6] and supports the following [conditional variables][7]:
 
     | Conditional Variable       | Description                                                         |
     |----------------------------|---------------------------------------------------------------------|

--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -57,12 +57,23 @@ An alert is triggered if any assertion fails for `<INSERT_NUMBER>` minutes from 
 
 ### Notifications
 
-To configure your notifications:
+A notification is sent according to the set of alerting conditions. To configure your notifications:
 
-1. Enter a **message** for the browser test. This field allows standard [Markdown formatting][6]. Notification messages include the **message** defined in this section and information about which assertion failed and why.
+1. Enter a **message** for the browser test. This field allows standard [Markdown formatting][6] and supports the below [conditional variables][7]:
+
+    | Conditional Variable       | Description                                                         |
+    |----------------------------|---------------------------------------------------------------------|
+    | `{{#is_alert}}`            | Show when monitor alerts                                            |
+    | `{{^is_alert}}`            | Show unless monitor alerts                                          |
+    | `{{#is_recovery}}`         | Show when monitor recovers from either ALERT   |
+    | `{{^is_recovery}}`         | Show unless monitor recovers from either ALERT |
+
+    Notification messages include the **message** defined in this section and information about the failing locations.
+
 2. Choose your [services][7] and/or team members to notify.
-3. Click **Save Details and Record Test** to save your browser test.
-4. Start to record your test.
+3. Specify a renotification frequency. If you don't want to be renotified in case your test keeps failing, leave the option to `Never renotify if the monitor has not been resolved`.
+4. Click **Save Details and Record Test** to save your browser test.
+5. Start to record your test.
 
 ## Record test
 

--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -55,7 +55,7 @@ You can use the [global variables defined in the `Settings`][5] in the URL, as w
 
 An alert is triggered if any assertion fails for `<INSERT_NUMBER>` minutes from any `<INSERT_NUMBER>` of `<NUMBER_OF_CHOSEN>` locations.
 
-### Notifications
+### Notify your team
 
 A notification is sent according to the set of alerting conditions. To configure your notifications:
 

--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -73,7 +73,7 @@ A notification is sent according to the set of alerting conditions. To configure
 2. Choose your [services][7] and/or team members to notify.
 3. Specify a renotification frequency. If you don't want to be renotified in case your test keeps failing, leave the option to `Never renotify if the monitor has not been resolved`.
 4. Click **Save Details and Record Test**.
-5. Start to record your test.
+5. Record your test.
 
 ## Record test
 

--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -71,7 +71,7 @@ A notification is sent according to the set of alerting conditions. To configure
     Notification messages include the **message** defined in this section and information about the failing locations.
 
 2. Choose your [services][7] and/or team members to notify.
-3. Specify a renotification frequency. If you don't want to be renotified in case your test keeps failing, leave the option to `Never renotify if the monitor has not been resolved`.
+3. Specify a renotification frequency. To prevent renotification on failing tests, leave the option as `Never renotify if the monitor has not been resolved`.
 4. Click **Save Details and Record Test**.
 5. Record your test.
 

--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -72,7 +72,7 @@ A notification is sent according to the set of alerting conditions. To configure
 
 2. Choose your [services][7] and/or team members to notify.
 3. Specify a renotification frequency. If you don't want to be renotified in case your test keeps failing, leave the option to `Never renotify if the monitor has not been resolved`.
-4. Click **Save Details and Record Test** to save your browser test.
+4. Click **Save Details and Record Test**.
 5. Start to record your test.
 
 ## Record test


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR adds details on conditional variables and renotify option on Synthetics tests

### Motivation
<!-- What inspired you to submit this pull request?-->
Freshly released features

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
API tests: https://docs-staging.datadoghq.com/margot.lepizzera/synthetics_tests_notifs/synthetics/api_tests/?tab=httptest#notify-your-team
Browser tests: https://docs-staging.datadoghq.com/margot.lepizzera/synthetics_tests_notifs/synthetics/browser_tests/#notifications

### Additional Notes
<!-- Anything else we should know when reviewing?-->
