### PR TITLE
Add #is_match var supports multiple args

### DIFF
--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -205,6 +205,14 @@ For example, if you want to notify your DB team if a triggering host has the `ro
 {{/is_match}}
 ```
 
+It is also possible to match multiple strings in a single expression. 
+
+```text 
+{{#is_match "env.name" "prod" "dev" "staging"}}
+  This will match if `prod`, `dev`, or `staging` appear in the env: tag variable.
+{{/is_match}}
+```
+
 ##### {{is_exact_match}}
 
 The `{{is_exact_match}}` conditional looks for the exact string in the tag variable, rather than using substring matching. The variable uses the following format:

--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -209,7 +209,7 @@ It is also possible to match multiple strings in a single expression.
 
 ```text 
 {{#is_match "env.name" "prod" "dev" "staging"}}
-  This will match if `prod`, `dev`, or `staging` appear in the env: tag variable.
+  This will match if `prod`, `dev`, or `staging` appear in the "env" tag variable.
 {{/is_match}}
 ```
 


### PR DESCRIPTION
The #is_match variable supports multiple string arguments, added an example

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
The is_match variable supports multiple arguments. This PR documents the feature. 

### Motivation
Customer request 

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

