### PR TITLE
[MA-902]clarify no data timeframe recommendation

### DIFF
--- a/content/en/monitors/monitor_types/metric.md
+++ b/content/en/monitors/monitor_types/metric.md
@@ -169,7 +169,9 @@ This setting allows you to change when the alerting engine considers a monitor a
 
 `Do not notify` if data is missing or `Notify` if data is missing for more than `N` minutes.
 
-Notifications for missing data are useful if you expect a metric to always be reporting data under normal circumstances. For example, if a host with the Agent must be up continuously, you can expect the metric `system.cpu.idle` to always report data. For this case, you should enable notifications for missing data. **Note**: We recommend you set the missing data window to at least two times the evaluation period.
+Notifications for missing data are useful if you expect a metric to always be reporting data under normal circumstances. For example, if a host with the Agent must be up continuously, you can expect the metric `system.cpu.idle` to always report data. For this case, you should enable notifications for missing data. 
+
+**Note**: It is recommended that you set the missing data window to at least two times the evaluation period.
 
 Alternatively, if you are monitoring a metric over an auto-scaling group of hosts that stop and start automatically, notifying for no data would produce a lot of notifications. For this case, you should not enable notifications for missing data.
 

--- a/content/en/monitors/monitor_types/metric.md
+++ b/content/en/monitors/monitor_types/metric.md
@@ -169,7 +169,7 @@ This setting allows you to change when the alerting engine considers a monitor a
 
 `Do not notify` if data is missing or `Notify` if data is missing for more than `N` minutes.
 
-Notifications for missing data are useful if you expect a metric to always be reporting data under normal circumstances. For example, if a host with the Agent must be up continuously, you can expect the metric `system.cpu.idle` to always report data. For this case, you should enable notifications for missing data. **Note**: The missing data window must be at least two times the evaluation period to work.
+Notifications for missing data are useful if you expect a metric to always be reporting data under normal circumstances. For example, if a host with the Agent must be up continuously, you can expect the metric `system.cpu.idle` to always report data. For this case, you should enable notifications for missing data. **Note**: We recommend you set the missing data window to at least two times the evaluation period.
 
 Alternatively, if you are monitoring a metric over an auto-scaling group of hosts that stop and start automatically, notifying for no data would produce a lot of notifications. For this case, you should not enable notifications for missing data.
 


### PR DESCRIPTION
### What does this PR do?
Just a semantic update.  This is a recommendation, not a requirement.  Customers have settings that don't meet this criteria that work, so this language is sometimes confusing.  

### Motivation
Support Cases

### Preview link
https://docs-staging.datadoghq.com/bcon/no-data-timeframe-clarification/monitors/monitor_types/metric
