### PR TITLE
Mount the directory containing the docker socket instead of the socket itself

### DIFF
--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -297,7 +297,7 @@ Mount the docker socket into the Datadog Agent:
   (...)
 ```
 
-**Note**: Mounting only the `docker.sock` socket instead of the whole directory containing it prevents the agent from recovering after a docker daemon restart.
+**Note**: Mounting only the `docker.sock` socket instead of the whole directory containing it prevents the Agent from recovering after a Docker daemon restart.
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/logs/faq/how-to-set-up-only-logs.md
+++ b/content/en/logs/faq/how-to-set-up-only-logs.md
@@ -116,6 +116,10 @@ spec:
           ## Set DD_SITE to "datadoghq.eu" to send your Agent data to the Datadog EU site
           - {name: DD_SITE, value: "datadoghq.com"}
 
+          ## Path to docker socket
+          - {name: DD_CRI_SOCKET_PATH, value: /host/var/run/docker.sock}
+          - {name: DOCKER_HOST, value: unix:///host/var/run/docker.sock}
+
           ## Set DD_DOGSTATSD_NON_LOCAL_TRAFFIC to true to allow StatsD collection.
           - {name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC, value: "false" }
           - {name: KUBERNETES, value: "true"}
@@ -153,7 +157,7 @@ spec:
             memory: "256Mi"
             cpu: "200m"
         volumeMounts:
-          - {name: dockersocket, mountPath: /var/run/docker.sock}
+          - {name: dockersocketdir, mountPath: /host/var/run}
           - {name: procdir, mountPath: /host/proc, readOnly: true}
           - {name: cgroups, mountPath: /host/sys/fs/cgroup, readOnly: true}
           - {name: s6-run, mountPath: /var/run/s6}
@@ -173,7 +177,7 @@ spec:
           successThreshold: 1
           failureThreshold: 3
       volumes:
-        - {name: dockersocket, hostPath: {path: /var/run/docker.sock}}
+        - {name: dockersocketdir, hostPath: {path: /var/run}}
         - {name: procdir, hostPath: {path: /proc}}
         - {name: cgroups, hostPath: {path: /sys/fs/cgroup}}
         - {name: s6-run, emptyDir: {}}

--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -140,6 +140,10 @@ spec:
                         valueFrom:
                             fieldRef:
                                 fieldPath: status.hostIP
+                      - name: DD_CRI_SOCKET_PATH
+                        value: /host/var/run/docker.sock
+                      - name: DOCKER_HOST,
+                        value: unix:///host/var/run/docker.sock
                   resources:
                       requests:
                           memory: 256Mi
@@ -148,8 +152,8 @@ spec:
                           memory: 256Mi
                           cpu: 200m
                   volumeMounts:
-                      - name: dockersocket
-                        mountPath: /var/run/docker.sock
+                      - name: dockersocketdir
+                        mountPath: /host/var/run
                       - name: procdir
                         mountPath: /host/proc
                         readOnly: true
@@ -205,9 +209,9 @@ spec:
                       - name: s6-run
                         mountPath: /var/run/s6
             volumes:
-                - name: dockersocket
+                - name: dockersocketdir
                   hostPath:
-                      path: /var/run/docker.sock
+                      path: /var/run
                 - name: procdir
                   hostPath:
                       path: /proc

--- a/content/fr/network_performance_monitoring/installation.md
+++ b/content/fr/network_performance_monitoring/installation.md
@@ -120,6 +120,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
+          - {name: DD_CRI_SOCKET_PATH, value: /host/var/run/docker.sock}
+          - {name: DOCKER_HOST, value: unix:///host/var/run/docker.sock}
         resources:
           requests:
             memory: "256Mi"
@@ -128,7 +130,7 @@ spec:
             memory: "256Mi"
             cpu: "200m"
         volumeMounts:
-          - {name: dockersocket, mountPath: /var/run/docker.sock}
+          - {name: dockersocketdir, mountPath: /host/var/run}
           - {name: procdir, mountPath: /host/proc, readOnly: true}
           - {name: cgroups, mountPath: /host/sys/fs/cgroup, readOnly: true}
           - {name: debugfs, mountPath: /sys/kernel/debug}
@@ -166,7 +168,7 @@ spec:
           - {name: debugfs, mountPath: /sys/kernel/debug}
           - {name: s6-run, mountPath: /var/run/s6}
       volumes:
-        - {name: dockersocket, hostPath: {path: /var/run/docker.sock}}
+        - {name: dockersocketdir, hostPath: {path: /var/run}}
         - {name: procdir, hostPath: {path: /proc}}
         - {name: cgroups, hostPath: {path: /sys/fs/cgroup}}
         - {name: s6-run, emptyDir: {}}


### PR DESCRIPTION
This is to handle the cases where the docker daemon is restarted.
In this case, the docker daemon will recreate its docker socket.
On k8s context, the containers will not be restarted.
And, if the agent container bind-mounted directly the socket, the container would still have access to the old socket instead of the one of the new docker daemon.
As a consequence, with a bind-mount of the socket directly, a docker restart disconnects the agent from docker forever; until the agent POD is destroyed and recreated.

On the other hand, if we bind-mount the directory containing the socket, when the daemon recreates a new socket following a restart, it will be visible from the agent container. The agent will be disconnected from the old socket, and it will reconnect on the new one.

On non-k8s context link ECS or bare docker, docker is configured by default to restart its containers when the daemon is restarted so that there isn’t the issue described above.