### PR TITLE
Variables from tests: JSONPath not supported yet

### DIFF
--- a/content/en/synthetics/settings/_index.md
+++ b/content/en/synthetics/settings/_index.md
@@ -59,7 +59,7 @@ You can create variables from your existing HTTP tests by parsing its response h
 5. Optional: enter a **Description** for your variable.
 6. Decide whether to extract your variable from the response headers, or from the response body.
     * Extract the value from **response header**: use the full response header for your variable, or parse it with a [regex][1].
-    * Extract the value from **response body**: parse the response body of the request with a JSON path, with a [regex][1], or use the full response body.
+    * Extract the value from **response body**: parse the response body of the request with a [regex][1], or use the full response body.
 
 {{< img src="synthetics/settings/variable_fromhttp.png" alt="Credential"  style="width:80%;">}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR removes the reference to jsonpath as we do not support that just yet.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/margot.lepizzera/synthetics_vft_jsonpath/synthetics/settings/?tab=createfromhttptest#global-variables
### Additional Notes
<!-- Anything else we should know when reviewing?-->
