### PR TITLE
Making android tracing doc accessible with link only

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -881,11 +881,11 @@ main:
     parent: "tracing_setup"
     identifier: "tracing_setup_cpp"
     weight: 209
-  - name: "Android"
-    url: "tracing/setup/android/"
-    parent: "tracing_setup"
-    identifier: "tracing_setup_android"
-    weight: 210
+# - name: "Android"
+#   url: "tracing/setup/android/"
+#   parent: "tracing_setup"
+#   identifier: "tracing_setup_android"
+#   weight: 210
   - name: "Envoy"
     url: "tracing/setup/envoy/"
     parent: "tracing_setup"

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -155,6 +155,7 @@
         front_matters:
           title: Android Trace Collection
           kind: documentation
+          beta: true
           description: "Collect traces from your Android applications."
           dependencies: ["https://github.com/DataDog/dd-sdk-android/blob/dd-tracing/docs/trace_collection.md"]
           further_reading:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -155,6 +155,7 @@
         front_matters:
           title: Android Trace Collection
           kind: documentation
+          beta: true
           description: "Collect traces from your Android applications."
           dependencies: ["https://github.com/DataDog/dd-sdk-android/blob/dd-tracing/docs/trace_collection.md"]
           further_reading:


### PR DESCRIPTION
### What does this PR do?

Making android tracing doc only accessible with the direct URL

### Motivation
PM request