### PR TITLE
Reorganisation of the Agent Log collection page

### DIFF
--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -29,7 +29,7 @@ Collecting logs is **disabled** by default in the Datadog Agent.
 {{< tabs >}}
 {{% tab "(Recommended) HTTP compressed" %}}
 
-To send compressed logs over HTTPS with the Datadog Agent 6.14+, enable log collection in the Agent's [main configuration file][2] (`datadog.yaml`):
+To send compressed logs over HTTPS with the Datadog Agent v6.14+, enable log collection in the Agent's [main configuration file][2] (`datadog.yaml`):
 
 ```yaml
 logs_enabled: true
@@ -38,7 +38,7 @@ logs_config:
   use_compression: true
 ```
 
-Use the following parameters to configure this with environment variable:
+To send logs with environment variables, configure the following:
 
 * `DD_LOGS_ENABLED`
 * `DD_LOGS_CONFIG_USE_HTTP`
@@ -51,7 +51,7 @@ For more details about the compression perfomances and batching size, refer to t
 {{% /tab %}}
 {{% tab "HTTP uncompressed" %}}
 
-To send logs over HTTPS with the Datadog Agent 6.14+, enable log collection in the Agent's [main configuration file][2] (`datadog.yaml`):
+To send logs over HTTPS with the Datadog Agent v6.14+, enable log collection in the Agent's [main configuration file][2] (`datadog.yaml`):
 
 ```yaml
 logs_enabled: true
@@ -80,7 +80,7 @@ By default, the Datadog Agent sends its logs to Datadog over TLS-encrypted TCP. 
 {{% /tab %}}
 {{< /tabs >}}
 
-The Agent is ready to forward logs to Datadog. To start collecting logs, you should now tell the Agent where to collect those from.
+After activating log collection, the Agent is ready to forward logs to Datadog. Next, configure the Agent on where to collect logs from.
 
 ## Enabling log collection from integrations
 
@@ -90,7 +90,7 @@ To collect logs for a given integration, uncomment the logs section in that inte
 Consult the <a href="/integrations/#cat-log-collection">list of supported integrations</a>  that include out of the box log configurations.
 </div>
 
-Check the specific setup instructions for [Kubernetes][3] or [Docker][4] environment if you are using a containerised infrastructure.
+See the setup instructions for [Kubernetes][3] or [Docker][4] if you are using a containerized infrastructure.
 
 If an integration does not support logs by default, use the custom log collection.
 
@@ -232,7 +232,7 @@ The Agent sends HTTPS batches with the following limits:
 * Maximum size for a single log: 256kB
 * Maximum array size if sending multiple logs in an array: 200 entries logs.
 
-### Log Compression
+### Log compression
 
 The `compression_level` parameter (or `DD_LOGS_CONFIG_COMPRESSION_LEVEL`) accepts values from `0` (no compression) to `9` (maximum compression but higher resource usage). The default value is `6`.
 
@@ -250,7 +250,7 @@ logs_config:
 ```
 
 Or use the `DD_LOGS_CONFIG_BATCH_WAIT` environment variable.
-The value is in seconds and must be an integer between `1` and `10`.
+The unit is seconds and must be an integer between `1` and `10`.
 
 ### HTTPS Proxy configuration
 

--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -22,7 +22,51 @@ further_reading:
 
 Log collection requires the Datadog Agent v6.0+. Older versions of the Agent do not include the `log collection` interface. If you are not using the Agent already, follow the [Agent installation instructions][1].
 
-Collecting logs is **disabled** by default in the Datadog Agent. Enable log collection in the Agent's [main configuration file][2] (`datadog.yaml`):
+## Activate log collection
+
+Collecting logs is **disabled** by default in the Datadog Agent.
+
+{{< tabs >}}
+{{% tab "(Recommended) HTTP compressed" %}}
+
+To send compressed logs over HTTPS with the Datadog Agent 6.14+, enable log collection in the Agent's [main configuration file][2] (`datadog.yaml`):
+
+```yaml
+logs_enabled: true
+logs_config:
+  use_http: true
+  use_compression: true
+```
+
+Use the following parameters to configure this with environment variable:
+
+* `DD_LOGS_ENABLED`
+* `DD_LOGS_CONFIG_USE_HTTP`
+* `DD_LOGS_CONFIG_USE_COMPRESSION`
+
+For more details about the compression perfomances and batching size, refer to the [HTTPS section][#send-logs-over-https].
+
+[2]: /agent/guide/agent-configuration-files
+{{% /tab %}}
+{{% tab "HTTP uncompressed" %}}
+
+To send logs over HTTPS with the Datadog Agent 6.14+, enable log collection in the Agent's [main configuration file][2] (`datadog.yaml`):
+
+```yaml
+logs_enabled: true
+logs_config:
+  use_http: true
+```
+
+Use `DD_LOGS_CONFIG_USE_HTTP` to configure this through environment variable.
+
+For more details about the compression perfomances and batching size, refer to the [HTTPS section][#send-logs-over-https].
+
+[2]: /agent/guide/agent-configuration-files
+{{% /tab %}}
+{{% tab "(Default) TCP" %}}
+
+Enable log collection in the Agent's [main configuration file][2] (`datadog.yaml`):
 
 ```yaml
 logs_enabled: true
@@ -30,9 +74,11 @@ logs_enabled: true
 
 By default, the Datadog Agent sends its logs to Datadog over TLS-encrypted TCP. This requires outbound communication over port `10516`.
 
-[See below to send logs over HTTPS](#send-logs-over-https).
+[2]: /agent/guide/agent-configuration-files
+{{% /tab %}}
+{{< /tabs >}}
 
-**Note**: If you're using Kubernetes, make sure to [enable log collection in your DaemonSet setup][3]. If you're using Docker, [enable log collection for the containerized Agent][4].
+As it has been enabled, the agent is now ready to forward logs to Datadog. To start collecting logs, you should now tell the Agent where to collect those from.
 
 ## Enabling log collection from integrations
 
@@ -41,6 +87,8 @@ To collect logs for a given integration, uncomment the logs section in that inte
 <div class="alert alert-warning">
 Consult the <a href="/integrations/#cat-log-collection">list of supported integrations</a>  that include out of the box log configurations.
 </div>
+
+Check the specific setup instructions for [Kubernetes][3] or [Docker][4] environment if you are unsing a containerised infrastructure.
 
 If an integration does not support logs by default, use the custom log collection.
 
@@ -164,52 +212,33 @@ List of all available parameters for log collection:
 | `exclude_units`  | No       | If `type` is **journald**, list of the specific journald units to exclude.                                                                                                                                                                                                                                                                              |
 | `sourcecategory` | No       | A multiple value attribute used to refine the source attribute, for example: `source:mongodb, sourcecategory:db_slow_logs`.                                                                                                                                                                                                                             |
 | `tags`           | No       | A list of tags added to each log collected ([learn more about tagging][9]).                                                                                                                                                                                                                                                                             |
-
 ## Send logs over HTTPS
 
-To send logs over HTTPS with the Datadog Agent 6.14+, add the following in the Agent's [main configuration file][4] (`datadog.yaml`):
-
-{{< tabs >}}
-{{% tab "Compression enabled" %}}
+**Compressed HTTPS forwarding is the recommended configuration** 
 
 ```yaml
+logs_enabled: true
 logs_config:
   use_http: true
   use_compression: true
   compression_level: 6
 ```
 
-Or set the `DD_LOGS_CONFIG_USE_HTTP` and `DD_LOGS_CONFIG_USE_COMPRESSION` environment variables to `true`.
-The `compression_level` parameter (or `DD_LOGS_CONFIG_COMPRESSION_LEVEL` environment variable) accepts values from 0 (no compression) to 9 (maximum compression but higher resource usage). The default value is 6.
-See the [Datadog Agent overhead section][1] for more information about Agent resource usage when compression is enabled.
-
-Then restart the Agent to send logs through HTTPS to `agent-http-intake.logs.datadoghq.com` (US site) or `agent-http-intake.logs.datadoghq.eu` (EU site) on port `443`.
-
-
-[1]: /agent/basic_agent_usage/#agent-overhead
-{{% /tab %}}
-{{% tab "Compression Disabled" %}}
-
-```yaml
-logs_config:
-  use_http: true
-```
-
-Or set the `DD_LOGS_CONFIG_USE_HTTP` environment variable to `true`.
-Then restart the Agent to send logs through HTTPS to `agent-http-intake.logs.datadoghq.com` (US site) or `agent-http-intake.logs.datadoghq.eu` (EU site) on port 443.
-
-{{% /tab %}}
-{{< /tabs >}}
-
-The Agent sends batches that have the following limits:
+The Agent sends HTTPS batches with the following limits:
 
 * Maximum content size per payload: 1MB
 * Maximum size for a single log: 256kB
 * Maximum array size if sending multiple logs in an array: 200 entries logs.
 
-The Agent waits up to 5 seconds to fill each batch (either in content size or number of logs). Therefore, in the worst case scenario (when very few logs are generated) switching to HTTPS might add a 5-second latency compared to TCP, which sends all logs in real time.
+### Log Compression
 
-**Configure the batch wait time**
+The `compression_level` parameter (or `DD_LOGS_CONFIG_COMPRESSION_LEVEL`) accepts values from `0` (no compression) to `9` (maximum compression but higher resource usage). The default value is `6`.
+
+See the [Datadog Agent overhead section][11] for more information about Agent resource usage when compression is enabled.
+
+### Configure the batch wait time
+
+The Agent waits up to 5 seconds to fill each batch (either in content size or number of logs). Therefore, in the worst case scenario (when very few logs are generated) switching to HTTPS might add a 5-second latency compared to TCP, which sends all logs in real time.
 
 To change the maximum time the Datadog Agent waits to fill each batch, add the following in the Agent's [main configuration file][4] (`datadog.yaml`):
 
@@ -221,9 +250,10 @@ logs_config:
 Or use the `DD_LOGS_CONFIG_BATCH_WAIT` environment variable.
 The value is in seconds and must be an integer between 1 and 10.
 
-**HTTPS Proxy configuration**
+### HTTPS Proxy configuration
 
 When logs are sent through HTTPS, use the same [set of proxy settings][10] as the other data types to send logs through a web proxy.
+
 
 ## Further Reading
 
@@ -239,3 +269,4 @@ When logs are sent through HTTPS, use the same [set of proxy settings][10] as th
 [8]: /developers/metrics/custom_metrics
 [9]: /tagging
 [10]: /agent/proxy
+[11]: /agent/basic_agent_usage/#agent-overhead

--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -44,8 +44,9 @@ Use the following parameters to configure this with environment variable:
 * `DD_LOGS_CONFIG_USE_HTTP`
 * `DD_LOGS_CONFIG_USE_COMPRESSION`
 
-For more details about the compression perfomances and batching size, refer to the [HTTPS section][#send-logs-over-https].
+For more details about the compression perfomances and batching size, refer to the [HTTPS section][1].
 
+[1]: /agent/logs/?tab=tailexistingfiles#send-logs-over-https
 [2]: /agent/guide/agent-configuration-files
 {{% /tab %}}
 {{% tab "HTTP uncompressed" %}}
@@ -60,8 +61,9 @@ logs_config:
 
 Use `DD_LOGS_CONFIG_USE_HTTP` to configure this through environment variable.
 
-For more details about the compression perfomances and batching size, refer to the [HTTPS section][#send-logs-over-https].
+For more details about the compression perfomances and batching size, refer to the [HTTPS section][1].
 
+[1]: /agent/logs/?tab=tailexistingfiles#send-logs-over-https
 [2]: /agent/guide/agent-configuration-files
 {{% /tab %}}
 {{% tab "(Default) TCP" %}}
@@ -78,7 +80,7 @@ By default, the Datadog Agent sends its logs to Datadog over TLS-encrypted TCP. 
 {{% /tab %}}
 {{< /tabs >}}
 
-As it has been enabled, the agent is now ready to forward logs to Datadog. To start collecting logs, you should now tell the Agent where to collect those from.
+The Agent is ready to forward logs to Datadog. To start collecting logs, you should now tell the Agent where to collect those from.
 
 ## Enabling log collection from integrations
 
@@ -88,7 +90,7 @@ To collect logs for a given integration, uncomment the logs section in that inte
 Consult the <a href="/integrations/#cat-log-collection">list of supported integrations</a>  that include out of the box log configurations.
 </div>
 
-Check the specific setup instructions for [Kubernetes][3] or [Docker][4] environment if you are unsing a containerised infrastructure.
+Check the specific setup instructions for [Kubernetes][3] or [Docker][4] environment if you are using a containerised infrastructure.
 
 If an integration does not support logs by default, use the custom log collection.
 
@@ -214,7 +216,7 @@ List of all available parameters for log collection:
 | `tags`           | No       | A list of tags added to each log collected ([learn more about tagging][9]).                                                                                                                                                                                                                                                                             |
 ## Send logs over HTTPS
 
-**Compressed HTTPS forwarding is the recommended configuration** 
+**Compressed HTTPS log forwarding is the recommended configuration** 
 
 ```yaml
 logs_enabled: true
@@ -248,7 +250,7 @@ logs_config:
 ```
 
 Or use the `DD_LOGS_CONFIG_BATCH_WAIT` environment variable.
-The value is in seconds and must be an integer between 1 and 10.
+The value is in seconds and must be an integer between `1` and `10`.
 
 ### HTTPS Proxy configuration
 

--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -166,7 +166,7 @@ Endpoints that can be used to send logs to Datadog:
 | Endpoints for SSL encrypted connections | Port    | Description                                                                                                                                                                 |
 |-----------------------------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `agent-intake.logs.datadoghq.com`       | `10516` | Used by the Agent to send logs in protobuf format over an SSL-encrypted TCP connection.                                                                                     |
-| `agent-http-intake.logs.datadoghq.com`  | `443`   | Used by the Agent to send logs in protobuf format over HTTPS. See the [How to send logs over HTTP documentation][1].                                                        |
+| `agent-http-intake.logs.datadoghq.com`  | `443`   | Used by the Agent to send logs in JSON format over HTTPS. See the [How to send logs over HTTP documentation][1].                                                        |
 | `http-intake.logs.datadoghq.com`        | `443`   | Used by custom forwarder to send logs in JSON or plain text format over HTTPS. See the [How to send logs over HTTP documentation][1].                                       |
 | `intake.logs.datadoghq.com`             | `10516` | Used by custom forwarders to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection.                                                                 |
 | `lambda-intake.logs.datadoghq.com`      | `10516` | Used by Lambda functions to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection.                                                                  |
@@ -184,7 +184,7 @@ Endpoints that can be used to send logs to Datadog:
 | Endpoints for SSL encrypted connections | Port  | Description                                                                                                                                                                 |
 |-----------------------------------------|-------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `agent-intake.logs.datadoghq.eu`        | `443` | Used by the Agent to send logs in protobuf format over an SSL-encrypted TCP connection.                                                                                     |
-| `agent-http-intake.logs.datadoghq.eu`   | `443` | Used by the Agent to send logs in protobuf format over HTTPS. See the [How to send logs over HTTP documentation][1].                                                        |
+| `agent-http-intake.logs.datadoghq.eu`   | `443` | Used by the Agent to send logs in JSON format over HTTPS. See the [How to send logs over HTTP documentation][1].                                                        |
 | `http-intake.logs.datadoghq.eu`         | `443` | Used by custom forwarder to send logs in JSON or plain text format over HTTPS. See the [How to send logs over HTTP documentation][1].                                       |
 | `tcp-intake.logs.datadoghq.eu`          | `443` | Used by custom forwarders to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection.                                                                 |
 | `lambda-intake.logs.datadoghq.eu`       | `443` | Used by Lambda functions to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection.                                                                  |
@@ -198,8 +198,6 @@ Endpoints that can be used to send logs to Datadog:
 [1]: /agent/logs/?tab=tailexistingfiles#send-logs-over-https
 {{% /tab %}}
 {{< /tabs >}}
-
-To send logs over HTTPs, refer to the [Datadog Log HTTP API documentation][23].
 
 ## Reserved attributes
 


### PR DESCRIPTION
### What does this PR do?
Reorganise the Agent Log collection page

### Motivation
The goal was to push for HTTPS and highlight it much more

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/agent-log-collection/agent/logs/?tab=compressionenabled#send-logs-over-https


https://docs-staging.datadoghq.com/nils/agent-log-collection/logs/log_collection/?tab=tcpussite#datadog-logs-endpoints

### Additional Notes
