### PR TITLE
[MA-902] clarify no_data_timeframe requirements/recommendations

### DIFF
--- a/content/en/api/monitors/monitors_create.md
+++ b/content/en/api/monitors/monitors_create.md
@@ -71,7 +71,7 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
 
     *  **`event`**, the event query string:
     *   **`string_query`** free text query to match against event title and text.
-    *   **`sources`** event sources (comma-separated). 
+    *   **`sources`** event sources (comma-separated).
     *   **`status`** event statuses (comma-separated). Valid options: error, warn, and info.
     *   **`priority`** event priorities (comma-separated). Valid options: low, normal, all.
     *   **`host`** event reporting host (comma-separated).
@@ -114,7 +114,7 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
 
     *   **`notify_no_data`** a Boolean indicating whether this monitor notifies when data stops reporting. Default: **false**
 
-    *   **`no_data_timeframe`** the number of minutes before a monitor notifies when data stops reporting. This parameter is mandatory when `notify_no_data​` is set to `true`. It must be at least 2x the monitor timeframe for metric alerts or 2 minutes for service checks. Default: **2x timeframe for metric alerts, 2 minutes for service checks**
+    *   **`no_data_timeframe`** The number of minutes before a monitor will notify when data stops reporting.  We recommend at least 2x the monitor timeframe for metric alerts or 2 minutes for service checks.  **If omitted, we fall back to the evaluation timeframe for metric alerts, and 24 hours for service checks.**
 
     *   **`timeout_h`** the number of hours of the monitor not reporting data before it automatically resolves from a triggered state. Default: **None**.
 

--- a/content/en/api/monitors/monitors_create.md
+++ b/content/en/api/monitors/monitors_create.md
@@ -114,7 +114,7 @@ If you manage and deploy monitors programmatically, it's easier to define the mo
 
     *   **`notify_no_data`** a Boolean indicating whether this monitor notifies when data stops reporting. Default: **false**
 
-    *   **`no_data_timeframe`** The number of minutes before a monitor will notify when data stops reporting.  We recommend at least 2x the monitor timeframe for metric alerts or 2 minutes for service checks.  **If omitted, we fall back to the evaluation timeframe for metric alerts, and 24 hours for service checks.**
+    *   **`no_data_timeframe`** The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the monitor timeframe for metric alerts or 2 minutes for service checks.  **If omitted, the evaluation timeframe is used for metric alerts, and 24 hours is used for service checks.**
 
     *   **`timeout_h`** the number of hours of the monitor not reporting data before it automatically resolves from a triggered state. Default: **None**.
 


### PR DESCRIPTION
### What does this PR do?
Corrects/clarifies requirements and recommendations for no_data_timeframe monitor setting (recently documented our main docs and forgot to update here)

### Motivation
Recent discovery & support cases

### Preview link
https://docs-staging.datadoghq.com/bcon/no-data-timeframe-clarification-part-deux/api/#create-a-monitor
