### PR TITLE
Fixing makefile to include ja content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,10 +46,12 @@ clean-integrations:  ## Remove built integrations files.
 	@if [ -d data/integrations ]; then \
 		find ./data/integrations -type f -maxdepth 1 \
 	    -a -not -name '*.fr.yaml' \
+		-a -not -name '*.ja.yaml' \
 	    -exec rm -rf {} \; ;fi
 	@if [ -d data/service_checks ]; then \
 		find ./data/service_checks -type f -maxdepth 1 \
 	    -a -not -name '*.fr.json' \
+		-a -not -name '*.ja.json' \
 	    -exec rm -rf {} \; ;fi
 	@find ./content/en/integrations -type f -maxdepth 1 \
 		-a -not -name '_index.md' \
@@ -78,7 +80,6 @@ clean-integrations:  ## Remove built integrations files.
 		-a -not -name 'system.md' \
 		-a -not -name 'tcprtt.md' \
 		-a -not -name 'uwsgi.md' \
-		-a -not -name '*.fr.md' \
 		-exec rm -rf {} \;
 
 clean-auto-doc: ##Remove all doc automatically created

--- a/Makefile
+++ b/Makefile
@@ -46,12 +46,12 @@ clean-integrations:  ## Remove built integrations files.
 	@if [ -d data/integrations ]; then \
 		find ./data/integrations -type f -maxdepth 1 \
 	    -a -not -name '*.fr.yaml' \
-		-a -not -name '*.ja.yaml' \
+	    -a -not -name '*.ja.yaml' \
 	    -exec rm -rf {} \; ;fi
 	@if [ -d data/service_checks ]; then \
 		find ./data/service_checks -type f -maxdepth 1 \
 	    -a -not -name '*.fr.json' \
-		-a -not -name '*.ja.json' \
+	    -a -not -name '*.ja.json' \
 	    -exec rm -rf {} \; ;fi
 	@find ./content/en/integrations -type f -maxdepth 1 \
 		-a -not -name '_index.md' \


### PR DESCRIPTION
### What does this PR do?

Now that even more ja content is being included in the doc, it seems that the makefile was removing them when doing `make clean`. This PR fixes it.

### Motivation
Prepare JA GA
