### PR TITLE
[Doc]adding capability IPC_LOCK to Kubernetes ds

### DIFF
--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -179,6 +179,7 @@ spec:
                               - SYS_RESOURCE
                               - SYS_PTRACE
                               - NET_ADMIN
+                              - IPC_LOCK
                   command:
                       - /opt/datadog-agent/embedded/bin/system-probe
                   env:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
adding capability IPC_LOCK to sample Kubernetes ds as it's included in our helm chart

### Motivation
https://datadoghq.atlassian.net/browse/NET-324  

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/mei_jin/npm_k8s_installation/network_performance_monitoring/installation/?tab=kubernetes 

### Additional Notes
<!-- Anything else we should know when reviewing?-->
