### PR TITLE
system-probe: Update install instruction for 7.18

### DIFF
--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -62,7 +62,7 @@ To enable network performance monitoring with the Datadog Agent, use the followi
         enabled: true
     ```
 
-4. If you are running an Agent older than v6.18/7.18, manually start the system-probe and enable it to start on boot (since v6.18/v7.18, system-probe will start automatically when the Agent is started by systemd):
+4. If you are running an Agent older than v6.18/7.18, manually start the system-probe and enable it to start on boot (since v6.18/v7.18, system-probe will start automatically when the Agent is started):
 
     ```shell
     sudo systemctl start datadog-agent-sysprobe 

--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -62,7 +62,7 @@ To enable network performance monitoring with the Datadog Agent, use the followi
         enabled: true
     ```
 
-4. If you are running an Agent older than v6.18/7.18, manually start the system-probe and enable it to start on boot (since v6.18/v7.18, system-probe will start automatically when the Agent is started):
+4. If you are running an Agent older than v6.18 or 7.18, manually start the system-probe and enable it to start on boot (since v6.18 and v7.18 the system-probe starts automatically when the Agent is started):
 
     ```shell
     sudo systemctl start datadog-agent-sysprobe 

--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -62,29 +62,22 @@ To enable network performance monitoring with the Datadog Agent, use the followi
         enabled: true
     ```
 
-4. Start the system-probe:
+4. If you are running an Agent older than v6.18/7.18, manually start the system-probe and enable it to start on boot (since v6.18/v7.18, system-probe will start automatically when the Agent is started by systemd):
 
     ```shell
-    sudo service datadog-agent-sysprobe start
+    sudo systemctl start datadog-agent-sysprobe 
+    sudo systemctl enable datadog-agent-sysprobe
     ```
 
-    **Note**: If the `service` command is not available on your system, run the following command instead: `sudo systemctl start datadog-agent-sysprobe`
+    **Note**: If the `systemctl` command is not available on your system, start it with following command instead: `sudo service datadog-agent-sysprobe start` and then set it up to start on boot before `datadog-agent` starts.
 
 5. [Restart the Agent][2]
 
     ```shell
-    sudo service datadog-agent restart
+    sudo systemctl restart datadog-agent
     ```
 
-    **Note**: If the `service` command is not available on your system, run the following command instead: `sudo systemctl restart datadog-agent`
-
-6. Enable the system-probe to start on boot:
-
-    ```shell
-    sudo service enable datadog-agent-sysprobe
-    ```
-
-    **Note**: If the `service` command is not available on your system, run the following command instead: `sudo systemctl enable datadog-agent-sysprobe`
+    **Note**: If the `systemctl` command is not available on your system, run the following command instead: `sudo service datadog-agent restart`
 
 
 [1]: /infrastructure/process/?tab=linuxwindows#installation


### PR DESCRIPTION
### DO NOT MERGE until Agent 6.18/7.18 is released.

### What does this PR do?
- Mention that the `start` and `enable` steps are only needed for Agents < 6.18/7.18.
- Change the default instructions to use `sytemctl` and move the alternative instructions using `service` to the note text. Not only `systemctl` (systemd) is more common in modern distros, but also I think that the instructions using `service` were wrong since I don't think that `service enable` exists.
- When on older Agent versions, mention that system-probe needs to be started on boot before the main Agent, but leave up to the user to figure out how to do that on non-systemd systems (since I think that the `service enable` instructions we were giving were wrong).

### Motivation
Since Agent 6.18/7.18 there is no need to start and enable system-probe separately.

### Preview

https://docs-staging.datadoghq.com/albertvaka/system-probe-7.18/network_performance_monitoring/installation?tab=agent#setup