### PR TITLE
[rum] Fix broken hash link

### DIFF
--- a/content/en/real_user_monitoring/installation/advanced_configuration.md
+++ b/content/en/real_user_monitoring/installation/advanced_configuration.md
@@ -169,4 +169,4 @@ window.DD_RUM && DD_RUM.addUserAction("Cart Payed", {
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/browser-sdk
-[2]: /logs/processing/attributes_naming_convention/#user-related-attributes]
+[2]: /logs/processing/attributes_naming_convention/#user-related-attributes


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Just removes an errant `]` from a link that was breaking the hash linkage

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
