### PR TITLE
[DOCS-664] Adding doc around receiver_socket and DD_TRACE_AGENT_URL logic

### DIFF
--- a/content/en/agent/docker/apm.md
+++ b/content/en/agent/docker/apm.md
@@ -2,28 +2,28 @@
 title: Tracing Docker Applications
 kind: Documentation
 aliases:
-  - /tracing/docker/
-  - /tracing/setup/docker/
-  - /agent/apm/docker
+    - /tracing/docker/
+    - /tracing/setup/docker/
+    - /agent/apm/docker
 further_reading:
-  - link: "https://github.com/DataDog/datadog-agent/tree/master/pkg/trace"
-    tag: "Github"
-    text: Source code
-  - link: "/integrations/amazon_ecs/#trace-collection"
-    tag: "Documentation"
-    text: "Trace your ECS applications"
-  - link: "tracing/visualization/"
-    tag: "Documentation"
-    text: "Explore your services, resources and traces"
+    - link: 'https://github.com/DataDog/datadog-agent/tree/master/pkg/trace'
+      tag: 'Github'
+      text: Source code
+    - link: '/integrations/amazon_ecs/#trace-collection'
+      tag: 'Documentation'
+      text: 'Trace your ECS applications'
+    - link: 'tracing/visualization/'
+      tag: 'Documentation'
+      text: 'Explore your services, resources and traces'
 ---
 
 Enable the Trace Agent in the `datadog/agent` container by passing `DD_APM_ENABLED=true` as an environment variable.
 
 ## Tracing from the host
 
-Tracing is available on port `8126/tcp` from *your host only* by adding the option `-p 127.0.0.1:8126:8126/tcp` to the `docker run` command.
+Tracing is available on port `8126/tcp` from _your host only_ by adding the option `-p 127.0.0.1:8126:8126/tcp` to the `docker run` command.
 
-To make it available from *any host*, use `-p 8126:8126/tcp` instead.
+To make it available from _any host_, use `-p 8126:8126/tcp` instead.
 
 For example, the following command allows the Agent to receive traces from your host only:
 
@@ -42,12 +42,13 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
 List of all environment variables available for tracing within the Docker Agent:
 
 | Environment variable       | Description                                                                                                                                                                                                                                                                                                                 |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `DD_API_KEY`               | [Datadog API Key][1]                                                                                                                                                                                                                                                                                                        |
 | `DD_PROXY_HTTPS`           | Set up the URL for the proxy to use.                                                                                                                                                                                                                                                                                        |
 | `DD_APM_REPLACE_TAGS`      | [Scrub sensitive data from your span’s tags][2].                                                                                                                                                                                                                                                                            |
 | `DD_HOSTNAME`              | Manually set the hostname to use for metrics if autodection fails, or when running the Datadog Cluster Agent.                                                                                                                                                                                                               |
 | `DD_DOGSTATSD_PORT`        | Set the DogStatsD port.                                                                                                                                                                                                                                                                                                     |
+| `DD_APM_RECEIVER_SOCKET`   |  Collect your traces through a Unix Domain Sockets and takes priority over hostname and port configuration if set. Off by default, when set it must point to a valid sock file.                                                                                                                                             |
 | `DD_BIND_HOST`             | Set the StatsD & receiver hostname.                                                                                                                                                                                                                                                                                         |
 | `DD_LOG_LEVEL`             | Set the logging level. (`trace`/`debug`/`info`/`warn`/`error`/`critical`/`off`)                                                                                                                                                                                                                                             |
 | `DD_APM_ENABLED`           | When set to `true`, the Datadog Agent accepts trace metrics.                                                                                                                                                                                                                                                                |

--- a/content/en/tracing/setup/dotnet-framework.md
+++ b/content/en/tracing/setup/dotnet-framework.md
@@ -119,10 +119,10 @@ Manual instrumentation is supported on .NET Framework 4.5 and above on Windows a
 
 There are multiple ways to configure the .NET Tracer:
 
--   in .NET code
--   setting environment variables
--   editing the application's `app.config`/`web.config` file (.NET Framework only)
--   creating a `datadog.json` file
+- in .NET code
+- setting environment variables
+- editing the application's `app.config`/`web.config` file (.NET Framework only)
+- creating a `datadog.json` file
 
 {{< tabs >}}
 {{% tab "Code" %}}

--- a/content/en/tracing/setup/dotnet-framework.md
+++ b/content/en/tracing/setup/dotnet-framework.md
@@ -2,27 +2,27 @@
 title: Tracing .NET Framework Applications
 kind: documentation
 aliases:
-  - /tracing/dotnet
-  - /tracing/languages/dotnet
-  - /tracing/setup/dotnet
-  - /agent/apm/dotnet/
-  - /tracing/dotnet-framework
-  - /tracing/languages/dotnet-framework
-  - /tracing/setup/dotnet-framework
-  - /agent/apm/dotnet-framework/
+    - /tracing/dotnet
+    - /tracing/languages/dotnet
+    - /tracing/setup/dotnet
+    - /agent/apm/dotnet/
+    - /tracing/dotnet-framework
+    - /tracing/languages/dotnet-framework
+    - /tracing/setup/dotnet-framework
+    - /agent/apm/dotnet-framework/
 further_reading:
-  - link: "https://github.com/DataDog/dd-trace-dotnet"
-    tag: "GitHub"
-    text: "Source code"
-  - link: "https://www.datadoghq.com/blog/net-monitoring-apm/"
-    tag: "Blog"
-    text: ".NET monitoring with Datadog APM and distributed tracing"
-  - link: "tracing/visualization/"
-    tag: "Documentation"
-    text: "Explore your services, resources and traces"
-  - link: "tracing/"
-    tag: "Advanced Usage"
-    text: "Advanced Usage"
+    - link: 'https://github.com/DataDog/dd-trace-dotnet'
+      tag: 'GitHub'
+      text: 'Source code'
+    - link: 'https://www.datadoghq.com/blog/net-monitoring-apm/'
+      tag: 'Blog'
+      text: '.NET monitoring with Datadog APM and distributed tracing'
+    - link: 'tracing/visualization/'
+      tag: 'Documentation'
+      text: 'Explore your services, resources and traces'
+    - link: 'tracing/'
+      tag: 'Advanced Usage'
+      text: 'Advanced Usage'
 ---
 
 ## Getting Started
@@ -63,10 +63,10 @@ If your application runs in IIS, skip the rest of this section.
 
 For Windows applications **not** running in IIS, set these two environment variables before starting your application to enable automatic instrumentation:
 
-Name                   | Value
------------------------|------
-`COR_ENABLE_PROFILING` | `1`
-`COR_PROFILER`         | `{846F5F1C-F9AE-4B07-969E-05C26BC060D8}`
+| Name                   | Value                                    |
+| ---------------------- | ---------------------------------------- |
+| `COR_ENABLE_PROFILING` | `1`                                      |
+| `COR_PROFILER`         | `{846F5F1C-F9AE-4B07-969E-05C26BC060D8}` |
 
 For example, to set the environment variables from a batch file before starting your application:
 
@@ -88,8 +88,8 @@ To set environment variables for a Windows Service, use the multi-string key `HK
 The .NET Tracer can instrument the following libraries automatically:
 
 | Framework or library           | NuGet package                  | Integration Name     |
-|--------------------------------|--------------------------------|----------------------|
-| ASP.NET (including  Web Forms) | built-in                       | `AspNet`             |
+| ------------------------------ | ------------------------------ | -------------------- |
+| ASP.NET (including Web Forms)  | built-in                       | `AspNet`             |
 | ASP.NET MVC                    | `Microsoft.AspNet.Mvc` 4.0+    | `AspNetMvc`          |
 | ASP.NET Web API 2              | `Microsoft.AspNet.WebApi` 5.1+ | `AspNetWebApi2`      |
 | WCF (server)                   | built-in                       | `Wcf`                |
@@ -98,7 +98,7 @@ The .NET Tracer can instrument the following libraries automatically:
 | WebClient / WebRequest         | built-in                       | `WebRequest`         |
 | Redis (StackExchange client)   | `StackExchange.Redis` 1.0.187+ | `StackExchangeRedis` |
 | Redis (ServiceStack client)    | `ServiceStack.Redis` 4.0.48+   | `ServiceStackRedis`  |
-| Elasticsearch                  | `Elasticsearch.Net`  5.3.0+    | `ElasticsearchNet`   |
+| Elasticsearch                  | `Elasticsearch.Net` 5.3.0+     | `ElasticsearchNet`   |
 | MongoDB                        | `MongoDB.Driver.Core` 2.1.0+   | `MongoDb`            |
 
 **Update:** Starting with .NET Tracer version `1.12.0`, the ASP.NET integration is enabled automatically. The NuGet packages `Datadog.Trace.AspNet` or `Datadog.Trace.ClrProfiler.Managed` are no longer required. Remove them from your application when you update the .NET Tracer.
@@ -119,10 +119,10 @@ Manual instrumentation is supported on .NET Framework 4.5 and above on Windows a
 
 There are multiple ways to configure the .NET Tracer:
 
-* in .NET code
-* setting environment variables
-* editing the application's `app.config`/`web.config` file (.NET Framework only)
-* creating a `datadog.json` file
+-   in .NET code
+-   setting environment variables
+-   editing the application's `app.config`/`web.config` file (.NET Framework only)
+-   creating a `datadog.json` file
 
 {{< tabs >}}
 {{% tab "Code" %}}
@@ -195,9 +195,9 @@ To configure the Tracer using a JSON file, create `datadog.json` in the instrume
 
 ```json
 {
-  "DD_TRACE_AGENT_URL": "http://localhost:8126",
-  "DD_SERVICE_NAME": "MyService",
-  "DD_ADONET_ENABLED": "false"
+    "DD_TRACE_AGENT_URL": "http://localhost:8126",
+    "DD_SERVICE_NAME": "MyService",
+    "DD_ADONET_ENABLED": "false"
 }
 ```
 
@@ -212,7 +212,7 @@ The following tables list the supported configuration variables. Use the first n
 The first table below lists configuration variables that are available for both automatic and manual instrumentation.
 
 | Setting Name                                        | Description                                                                                                                                                                                                       |
-|-----------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `DD_TRACE_AGENT_URL`<br/><br/>`AgentUri`            | Sets the URL endpoint where traces are sent. Overrides `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` if set. Default value is `http://<DD_AGENT_HOST>:<DD_TRACE_AGENT_PORT>`.                                         |
 | `DD_AGENT_HOST`                                     | Sets the host where traces are sent (the host running the Agent). Can be a hostname or an IP address. Ignored if `DD_TRACE_AGENT_URL` is set. Default is value `localhost`.                                       |
 | `DD_TRACE_AGENT_PORT`                               | Sets the port where traces are sent (the port where the Agent is listening for connections). Ignored if `DD_TRACE_AGENT_URL` is set. Default value is `8126`.                                                     |
@@ -224,7 +224,7 @@ The first table below lists configuration variables that are available for both 
 The following table lists configuration variables that are available only when using automatic instrumentation.
 
 | Setting Name                                                   | Description                                                                                                                                                                                                                                                                              |
-|----------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `DD_TRACE_ENABLED`<br/><br/>`TraceEnabled`                     | Enables or disables all automatic instrumentation. Setting the environment variable to `false` completely disables the CLR profiler. For other configuration methods, the CLR profiler is still loaded, but traces will not be generated. Valid values are: `true` (default) or `false`. |
 | `DD_TRACE_DEBUG`                                               | Enables or disables debug logs in the Tracer. Valid values are: `true` or `false` (default). Setting this as an environment variable also enabled debug logs in the CLR Profiler.                                                                                                        |
 | `DD_TRACE_LOG_PATH`                                            | Sets the path for the CLR profiler's log file.<br/><br/>Default: `%ProgramData%\Datadog .NET Tracer\logs\dotnet-profiler.log`                                                                                                                                                            |
@@ -234,7 +234,7 @@ The following table lists configuration variables that are available only when u
 The following table lists configuration variables that are available only when using automatic instrumentation and can be set for each integration. Use the first name (e.g. `DD_<INTEGRATION>_ENABLED`) when setting environment variables or configuration files. The second name (e.g. `Enabled`), indicates the name the `IntegrationSettings` propery to use when changing settings in the code. Access these properties through the `TracerSettings.Integrations[]` indexer. Integration names are listed in the [Integrations](#integrations) section above.
 
 | Setting Name                                                            | Description                                                                                                           |
-|-------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
 | `DD_<INTEGRATION>_ENABLED`<br/><br/>`Enabled`                           | Enables or disables a specific integration. Valid values are: `true` (default) or `false`.                            |
 | `DD_<INTEGRATION>_ANALYTICS_ENABLED`<br/><br/>`AnalyticsEnabled`        | Enables or disable App Analytics for a specific integration. Valid values are: `true` or `false` (default).           |
 | `DD_<INTEGRATION>_ANALYTICS_SAMPLE_RATE`<br/><br/>`AnalyticsSampleRate` | Sets the App Analytics sampling rate for a specific integration. A floating number between `0.0` and `1.0` (default). |

--- a/content/en/tracing/setup/nodejs.md
+++ b/content/en/tracing/setup/nodejs.md
@@ -2,24 +2,24 @@
 title: Tracing Node.js Applications
 kind: documentation
 aliases:
-- /tracing/nodejs/
-- /tracing/languages/nodejs/
-- /tracing/languages/javascript/
-- /tracing/setup/javascript/
-- /agent/apm/nodejs/
+    - /tracing/nodejs/
+    - /tracing/languages/nodejs/
+    - /tracing/languages/javascript/
+    - /tracing/setup/javascript/
+    - /agent/apm/nodejs/
 further_reading:
-- link: "https://github.com/DataDog/dd-trace-js"
-  tag: "GitHub"
-  text: "Source code"
-- link: "https://datadog.github.io/dd-trace-js"
-  tag: "Documentation"
-  text: "API documentation"
-- link: "tracing/visualization/"
-  tag: "Use the APM UI"
-  text: "Explore your services, resources and traces"
-- link: "tracing/"
-  tag: "Advanced Usage"
-  text: "Advanced Usage"
+    - link: 'https://github.com/DataDog/dd-trace-js'
+      tag: 'GitHub'
+      text: 'Source code'
+    - link: 'https://datadog.github.io/dd-trace-js'
+      tag: 'Documentation'
+      text: 'API documentation'
+    - link: 'tracing/visualization/'
+      tag: 'Use the APM UI'
+      text: 'Explore your services, resources and traces'
+    - link: 'tracing/'
+      tag: 'Advanced Usage'
+      text: 'Advanced Usage'
 ---
 
 ## Installation And Getting Started
@@ -52,17 +52,17 @@ Finally, import and initialize the tracer:
 
 ```js
 // This line must come before importing any instrumented module.
-const tracer = require('dd-trace').init()
+const tracer = require('dd-trace').init();
 ```
 
 ##### TypeScript
 
 ```js
 // server.js
-import "./tracer"; // must come before importing any instrumented module.
+import './tracer'; // must come before importing any instrumented module.
 
 // tracer.js
-import tracer from "dd-trace";
+import tracer from 'dd-trace';
 tracer.init(); // initialized in a different file to avoid hoisting.
 export default tracer;
 ```
@@ -73,26 +73,26 @@ See the [tracer settings][7] for the list of initialization options.
 
 Tracer settings can be configured as a parameter to the `init()` method or as environment variables.
 
-| Config         | Environment Variable         | Default     | Description                                                                                                                                                                              |
-|----------------|------------------------------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| enabled        | `DD_TRACE_ENABLED`           | `true`      | Whether to enable the tracer.                                                                                                                                                            |
-| debug          | `DD_TRACE_DEBUG`             | `false`     | Enable debug logging in the tracer.                                                                                                                                                      |
-| service        | `DD_SERVICE_NAME`            | `null`      | The service name to be used for this program.                                                                                                                                            |
-| url            | `DD_TRACE_AGENT_URL`         | `null`      | The URL of the Trace Agent that the tracer submits to. Takes priority over hostname and port, if set.                                                                                    |
-| hostname       | `DD_TRACE_AGENT_HOSTNAME`    | `localhost` | The address of the Agent that the tracer submits to.                                                                                                                                     |
-| port           | `DD_TRACE_AGENT_PORT`        | `8126`      | The port of the Trace Agent that the tracer submits to.                                                                                                                                  |
-| dogstatsd.port | `DD_DOGSTATSD_PORT`          | `8125`      | The port of the DogStatsD Agent that metrics are submitted to.                                                                                                                           |
-| env            | `DD_ENV`                     | `null`      | Set an application's environment e.g. `prod`, `pre-prod`, `stage`, etc.                                                                                                                  |
-| logInjection   | `DD_LOGS_INJECTION`          | `false`     | Enable automatic injection of trace IDs in logs for supported logging libraries.                                                                                                         |
-| tags           | `DD_TAGS`                    | `{}`        | Set global tags that should be applied to all spans and metrics. When passed as an environment variable, the format is `key:value, key:value`.                                           |
-| sampleRate     | -                            | `1`         | Percentage of spans to sample as a float between `0` and `1`.                                                                                                                            |
-| flushInterval  | -                            | `2000`      | Interval (in milliseconds) at which the tracer submits traces to the Agent.                                                                                                              |
-| runtimeMetrics | `DD_RUNTIME_METRICS_ENABLED` | `false`     | Whether to enable capturing runtime metrics. Port `8125` (or configured with `dogstatsd.port`) must be opened on the Agent for UDP.                                                      |
-| reportHostname | `DD_TRACE_REPORT_HOSTNAME`   | `false`     | Whether to report the system's hostname for each trace. When disabled, the hostname of the Agent is used instead.                                                                        |
-| experimental   | -                            | `{}`        | Experimental features can be enabled all at once using Boolean true or individually using key/value pairs. [Contact support][8] to learn more about the available experimental features. |
-| plugins        | -                            | `true`      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins.                                                                                     |
-| clientToken    | `DD_CLIENT_TOKEN`            | `null`      | Client token for browser tracing. Can be generated in Datadog in **Integrations** -> **APIs**.                                                                                           |
-| logLevel       | `DD_TRACE_LOG_LEVEL`         | `debug`     | A string for the minimum log level for the tracer to use when debug logging is enabled, e.g. `error`, `debug`.                                                                           |
+| Config         | Environment Variable         | Default     | Description                                                                                                                                                                                                                                                                |
+| -------------- | ---------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| enabled        | `DD_TRACE_ENABLED`           | `true`      | Whether to enable the tracer.                                                                                                                                                                                                                                              |
+| debug          | `DD_TRACE_DEBUG`             | `false`     | Enable debug logging in the tracer.                                                                                                                                                                                                                                        |
+| service        | `DD_SERVICE_NAME`            | `null`      | The service name to be used for this program.                                                                                                                                                                                                                              |
+| url            | `DD_TRACE_AGENT_URL`         | `null`      | The URL of the Trace Agent that the tracer submits to. Takes priority over hostname and port, if set. Supports Unix Domain Sockets in combination with the `apm_config.receiver_socket` in your `datadog.yaml` file, or the `DD_APM_RECEIVER_SOCKET` environment variable. |
+| hostname       | `DD_TRACE_AGENT_HOSTNAME`    | `localhost` | The address of the Agent that the tracer submits to.                                                                                                                                                                                                                       |
+| port           | `DD_TRACE_AGENT_PORT`        | `8126`      | The port of the Trace Agent that the tracer submits to.                                                                                                                                                                                                                    |
+| dogstatsd.port | `DD_DOGSTATSD_PORT`          | `8125`      | The port of the DogStatsD Agent that metrics are submitted to.                                                                                                                                                                                                             |
+| env            | `DD_ENV`                     | `null`      | Set an application's environment e.g. `prod`, `pre-prod`, `stage`, etc.                                                                                                                                                                                                    |
+| logInjection   | `DD_LOGS_INJECTION`          | `false`     | Enable automatic injection of trace IDs in logs for supported logging libraries.                                                                                                                                                                                           |
+| tags           | `DD_TAGS`                    | `{}`        | Set global tags that should be applied to all spans and metrics. When passed as an environment variable, the format is `key:value, key:value`.                                                                                                                             |
+| sampleRate     | -                            | `1`         | Percentage of spans to sample as a float between `0` and `1`.                                                                                                                                                                                                              |
+| flushInterval  | -                            | `2000`      | Interval (in milliseconds) at which the tracer submits traces to the Agent.                                                                                                                                                                                                |
+| runtimeMetrics | `DD_RUNTIME_METRICS_ENABLED` | `false`     | Whether to enable capturing runtime metrics. Port `8125` (or configured with `dogstatsd.port`) must be opened on the Agent for UDP.                                                                                                                                        |
+| reportHostname | `DD_TRACE_REPORT_HOSTNAME`   | `false`     | Whether to report the system's hostname for each trace. When disabled, the hostname of the Agent is used instead.                                                                                                                                                          |
+| experimental   | -                            | `{}`        | Experimental features can be enabled all at once using Boolean true or individually using key/value pairs. [Contact support][8] to learn more about the available experimental features.                                                                                   |
+| plugins        | -                            | `true`      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins.                                                                                                                                                                       |
+| clientToken    | `DD_CLIENT_TOKEN`            | `null`      | Client token for browser tracing. Can be generated in Datadog in **Integrations** -> **APIs**.                                                                                                                                                                             |
+| logLevel       | `DD_TRACE_LOG_LEVEL`         | `debug`     | A string for the minimum log level for the tracer to use when debug logging is enabled, e.g. `error`, `debug`.                                                                                                                                                             |
 
 ## Change Agent Hostname
 
@@ -127,7 +127,7 @@ For details about how to how to toggle and configure plugins, check out the [API
 #### Web Framework Compatibility
 
 | Module           | Versions | Support Type    | Notes                                      |
-|------------------|----------|-----------------|--------------------------------------------|
+| ---------------- | -------- | --------------- | ------------------------------------------ |
 | [connect][10]    | `>=2`    | Fully supported |                                            |
 | [express][11]    | `>=4`    | Fully supported | Supports Sails, Loopback, and [more][12]   |
 | [fastify][13]    | `>=1`    | Fully supported |                                            |
@@ -141,7 +141,7 @@ For details about how to how to toggle and configure plugins, check out the [API
 #### Native Module Compatibility
 
 | Module      | Support Type    |
-|-------------|-----------------|
+| ----------- | --------------- |
 | [dns][21]   | Fully supported |
 | [fs][22]    | Fully supported |
 | [http][23]  | Fully supported |
@@ -151,7 +151,7 @@ For details about how to how to toggle and configure plugins, check out the [API
 #### Data Store Compatibility
 
 | Module                 | Versions | Support Type    | Notes                                            |
-|------------------------|----------|-----------------|--------------------------------------------------|
+| ---------------------- | -------- | --------------- | ------------------------------------------------ |
 | [cassandra-driver][26] | `>=3`    | Fully supported |                                                  |
 | [couchbase][27]        | `^2.4.2` | Fully supported |                                                  |
 | [elasticsearch][28]    | `>=10`   | Fully supported | Supports `@elastic/elasticsearch` versions `>=5` |
@@ -168,7 +168,7 @@ For details about how to how to toggle and configure plugins, check out the [API
 #### Worker Compatibility
 
 | Module             | Versions | Support Type    | Notes                                                  |
-|--------------------|----------|-----------------|--------------------------------------------------------|
+| ------------------ | -------- | --------------- | ------------------------------------------------------ |
 | [amqp10][38]       | `>=3`    | Fully supported | Supports AMQP 1.0 brokers (i.e. ActiveMQ, Apache Qpid) |
 | [amqplib][39]      | `>=0.5`  | Fully supported | Supports AMQP 0.9 brokers (i.e. RabbitMQ, Apache Qpid) |
 | [generic-pool][40] | `>=2`    | Fully supported |                                                        |
@@ -178,7 +178,7 @@ For details about how to how to toggle and configure plugins, check out the [API
 #### Promise Library Compatibility
 
 | Module           | Versions  | Support Type    |
-|------------------|-----------|-----------------|
+| ---------------- | --------- | --------------- |
 | [bluebird][43]   | `>=2`     | Fully supported |
 | [promise][44]    | `>=7`     | Fully supported |
 | [promise-js][45] | `>=0.0.3` | Fully supported |
@@ -188,7 +188,7 @@ For details about how to how to toggle and configure plugins, check out the [API
 #### Logger Compatibility
 
 | Module           | Versions  | Support Type    |
-|------------------|-----------|-----------------|
+| ---------------- | --------- | --------------- |
 | [bunyan][48]     | `>=1`     | Fully supported |
 | [paperplane][49] | `>=2.3.2` | Fully supported |
 | [pino][50]       | `>=2`     | Fully supported |

--- a/content/en/tracing/setup/python.md
+++ b/content/en/tracing/setup/python.md
@@ -2,22 +2,22 @@
 title: Tracing Python Applications
 kind: documentation
 aliases:
-- /tracing/python/
-- /tracing/languages/python/
-- /agent/apm/python/
+    - /tracing/python/
+    - /tracing/languages/python/
+    - /agent/apm/python/
 further_reading:
-- link: "https://github.com/DataDog/dd-trace-py"
-  tag: "GitHub"
-  text: "Source code"
-- link: "http://pypi.datadoghq.com/trace/docs/"
-  tag: "Pypi"
-  text: "API Docs"
-- link: "tracing/visualization/"
-  tag: "Documentation"
-  text: "Explore your services, resources and traces"
-- link: "tracing/"
-  tag: "Advanced Usage"
-  text: "Advanced Usage"
+    - link: 'https://github.com/DataDog/dd-trace-py'
+      tag: 'GitHub'
+      text: 'Source code'
+    - link: 'http://pypi.datadoghq.com/trace/docs/'
+      tag: 'Pypi'
+      text: 'API Docs'
+    - link: 'tracing/visualization/'
+      tag: 'Documentation'
+      text: 'Explore your services, resources and traces'
+    - link: 'tracing/'
+      tag: 'Advanced Usage'
+      text: 'Advanced Usage'
 ---
 
 <div class="alert alert-info">
@@ -40,8 +40,8 @@ Then to instrument your Python application use the included `ddtrace-run` comman
 
 For example, if your application is started with `python app.py` then:
 
-```sh
-$ ddtrace-run python app.py
+```shell
+ddtrace-run python app.py
 ```
 
 For more advanced usage, configuration, and fine-grain control, see Datadog's [API documentation][4].
@@ -51,7 +51,7 @@ For more advanced usage, configuration, and fine-grain control, see Datadog's [A
 When using **ddtrace-run**, the following [environment variable options][5] can be used:
 
 | Environment Variable               | Default     | Description                                                                                                                                                                                                                                                                 |
-|------------------------------------|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ---------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `DATADOG_TRACE_ENABLED`            | `true`      | Enable web framework and library instrumentation. When `false`, your application code doesn't generate any traces.                                                                                                                                                          |
 | `DATADOG_ENV`                      | `null`      | Set an application’s environment e.g. `prod`, `pre-prod`, `staging`. Learn more about [how to setup your environment][6].                                                                                                                                                   |
 | `DATADOG_TRACE_DEBUG`              | `false`     | Enable debug logging in the tracer. Note that this is [not available with Django][7].                                                                                                                                                                                       |
@@ -59,6 +59,7 @@ When using **ddtrace-run**, the following [environment variable options][5] can 
 | `DATADOG_PATCH_MODULES`            | `none`      | Override the modules patched for this program execution. It should follow this format: `DATADOG_PATCH_MODULES=module:patch,module:patch...`.                                                                                                                                |
 | `DD_AGENT_HOST`                    | `localhost` | Override the address of the trace Agent host that the default tracer attempts to submit traces to.                                                                                                                                                                          |
 | `DATADOG_TRACE_AGENT_PORT`         | `8126`      | Override the port that the default tracer submit traces to.                                                                                                                                                                                                                 |
+| `DD_TRACE_AGENT_URL`               | `null`      | The URL of the Trace Agent that the tracer submits to. Takes priority over hostname and port, if set. Supports Unix Domain Sockets in combination with the `apm_config.receiver_socket` in your `datadog.yaml` file, or the `DD_APM_RECEIVER_SOCKET` environment variable.  |
 | `DATADOG_PRIORITY_SAMPLING`        | `true`      | Enable [Priority Sampling][8].                                                                                                                                                                                                                                              |
 | `DD_LOGS_INJECTION`                | `false`     | Enable [connecting logs and traces Injection][9].                                                                                                                                                                                                                           |
 | `DD_TRACE_ANALYTICS_ENABLED`       | `false`     | Enable App Analytics globally for [web integrations][10].                                                                                                                                                                                                                   |
@@ -89,7 +90,7 @@ Python versions `2.7` and `3.4` and onwards are supported.
 The `ddtrace` library includes support for a number of web frameworks, including:
 
 | Framework                 | Supported Version | PyPi Datadog Documentation                                         |
-|---------------------------|-------------------|--------------------------------------------------------------------|
+| ------------------------- | ----------------- | ------------------------------------------------------------------ |
 | [aiohttp][11]             | >= 1.2            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#aiohttp |
 | [Bottle][12]              | >= 0.11           | http://pypi.datadoghq.com/trace/docs/web_integrations.html#bottle  |
 | [Django][13]              | >= 1.8            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#django  |
@@ -106,7 +107,7 @@ The `ddtrace` library includes support for a number of web frameworks, including
 The `ddtrace` library includes support for the following data stores:
 
 | Datastore                          | Supported Version | PyPi Datadog Documentation                                                                    |
-|------------------------------------|-------------------|-----------------------------------------------------------------------------------------------|
+| ---------------------------------- | ----------------- | --------------------------------------------------------------------------------------------- |
 | [Cassandra][20]                    | >= 3.5            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#cassandra                           |
 | [Elasticsearch][21]                | >= 1.6            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#elasticsearch                       |
 | [Flask Cache][22]                  | >= 0.12           | http://pypi.datadoghq.com/trace/docs/db_integrations.html#flask-cache                         |
@@ -130,7 +131,7 @@ The `ddtrace` library includes support for the following data stores:
 The `ddtrace` library includes support for the following libraries:
 
 | Library           | Supported Version | PyPi Datadog Documentation                                               |
-|-------------------|-------------------|--------------------------------------------------------------------------|
+| ----------------- | ----------------- | ------------------------------------------------------------------------ |
 | [asyncio][40]     | Fully Supported   | http://pypi.datadoghq.com/trace/docs/async_integrations.html#asyncio     |
 | [gevent][41]      | >= 1.0            | http://pypi.datadoghq.com/trace/docs/async_integrations.html#gevent      |
 | [aiobotocore][42] | >= 0.2.3          | http://pypi.datadoghq.com/trace/docs/other_integrations.html#aiobotocore |


### PR DESCRIPTION
### What does this PR do?

Documents the receiver_socket and DD_TRACE_AGENT_URL logic for the Agent and the Python and NodeJS tracers

### Motivation

https://github.com/DataDog/datadog-agent/pull/4983

### Preview link

* [Docker APM doc](https://docs-staging.datadoghq.com/gus/apm-socket/agent/docker/apm/?tab=java#docker-apm-agent-environment-variables)
* [Python doc](https://docs-staging.datadoghq.com/gus/apm-socket/tracing/setup/python/#environment-variable)
* [NodeJS doc](https://docs-staging.datadoghq.com/gus/apm-socket/tracing/setup/nodejs/#configuration)