### PR TITLE
DOCS-631 Puppet doc pull

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ content/en/developers/amazon_cloudformation.md
 
 # Agent section
 content/en/agent/basic_agent_usage/heroku.md
+content/en/agent/basic_agent_usage/puppet.md
 
 # Tracing
 content/en/tracing/setup/ruby.md

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -106,7 +106,7 @@ build_live:
   variables:
     CONFIG: ${LIVE_CONFIG}
     URL: ${LIVE_DOMAIN}
-    UNTRACKED_EXTRAS: "data,content/en/integrations,content/en/agent/basic_agent_usage/heroku.md,content/en/developers/integrations,content/en/developers/amazon_cloudformation.md"
+    UNTRACKED_EXTRAS: "data,content/en/integrations,content/en/agent/basic_agent_usage/heroku.md,content/en/agent/basic_agent_usage/puppet.md,content/en/developers/integrations,content/en/developers/amazon_cloudformation.md"
     CONFIGURATION_FILE: "./local/bin/py/build/configurations/pull_config.yaml"
     LOCAL: "False"
   script:

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,8 @@ clean-auto-doc: ##Remove all doc automatically created
 	find ./content/en/developers/integrations -type f -maxdepth 1 -exec rm -rf {} \; ;fi
 	@if [ content/en/agent/basic_agent_usage/heroku.md ]; then \
 	rm -f content/en/agent/basic_agent_usage/heroku.md ;fi
+	@if [ content/en/agent/basic_agent_usage/puppet.md ]; then \
+	rm -f content/en/agent/basic_agent_usage/puppet.md ;fi
 	@if [ content/en/tracing/setup/ruby.md ]; then \
 	rm -f content/en/tracing/setup/ruby.md ;fi
 	@if [ content/en/developers/amazon_cloudformation.md ]; then \

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -174,30 +174,35 @@ main:
     url: "agent/basic_agent_usage/osx/"
     weight: 108
     parent: "basic_agent_usage"
+  - name: "Puppet"
+    identifier: "basic_agent_usage_puppet"
+    url: "agent/basic_agent_usage/puppet/"
+    weight: 109
+    parent: "basic_agent_usage"
   - name: "Red Hat"
     identifier: "basic_agent_usage_redhat"
     url: "agent/basic_agent_usage/redhat/"
-    weight: 109
+    weight: 110
     parent: "basic_agent_usage"
   - name: "SUSE"
     identifier: "basic_agent_usage_suse"
     url: "agent/basic_agent_usage/suse/"
-    weight: 110
+    weight: 111
     parent: "basic_agent_usage"
   - name: "Ubuntu"
     identifier: "basic_agent_usage_ubuntu"
     url: "agent/basic_agent_usage/ubuntu/"
-    weight: 111
+    weight: 112
     parent: "basic_agent_usage"
   - name: "Windows"
     identifier: "basic_agent_usage_windows"
     url: "agent/basic_agent_usage/windows/"
-    weight: 112
+    weight: 113
     parent: "basic_agent_usage"
   - name: "From Source"
     identifier: "basic_agent_usage_source"
     url: "agent/basic_agent_usage/source/"
-    weight: 113
+    weight: 114
     parent: "basic_agent_usage"
 
   ## AGENT - Docker

--- a/data/partials/platforms.yaml
+++ b/data/partials/platforms.yaml
@@ -20,6 +20,9 @@ platforms:
   - name: heroku
     link: "agent/basic_agent_usage/heroku/"
     image: "platform_heroku.png"
+  - name: puppet
+    link: "agent/basic_agent_usage/puppet/"
+    image: "platform_puppet.png"
   - name: kubernetes
     link: "agent/kubernetes/"
     image: "platform_kubernetes.png"

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -90,6 +90,21 @@
           aliases:
           - /developers/faq/how-do-i-collect-metrics-from-heroku-with-datadog
 
+  - repo_name: puppet-datadog-agent
+    contents:
+
+    - action: pull-and-push-file
+      branch: master
+      globs:
+      - README.md
+      options:
+        dest_path: '/agent/basic_agent_usage/'
+        file_name: 'puppet.md'
+        front_matters:
+          title: Puppet
+          kind: documentation
+          dependencies: ["https://github.com/DataDog/puppet-datadog-agent/blob/master/README.md"]
+
   - repo_name: dd-trace-rb
     contents:
     - action: pull-and-push-file

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -90,6 +90,21 @@
           aliases:
           - /developers/faq/how-do-i-collect-metrics-from-heroku-with-datadog
 
+  - repo_name: puppet-datadog-agent
+    contents:
+
+    - action: pull-and-push-file
+      branch: master
+      globs:
+      - README.md
+      options:
+        dest_path: '/agent/basic_agent_usage/'
+        file_name: 'puppet.md'
+        front_matters:
+          title: Puppet
+          kind: documentation
+          dependencies: ["https://github.com/DataDog/puppet-datadog-agent/blob/master/README.md"]
+
   - repo_name: dd-trace-rb
     contents:
     - action: pull-and-push-file

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -94,7 +94,7 @@
     contents:
 
     - action: pull-and-push-file
-      branch: ruth/docs-631
+      branch: master
       globs:
       - README.md
       options:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -94,7 +94,7 @@
     contents:
 
     - action: pull-and-push-file
-      branch: master
+      branch: ruth/docs-631
       globs:
       - README.md
       options:


### PR DESCRIPTION
### What does this PR do?
Add puppet repo to docs pull

### Motivation
OKR

### Preview link
https://docs-staging.datadoghq.com/ruth/docs-631/agent/basic_agent_usage/puppet

### Additional Notes
Merge is dependent on: https://github.com/DataDog/puppet-datadog-agent/pull/617
