### PR TITLE
adding a note to make it clear that exclusions do not impact rehydrat…

### DIFF
--- a/content/en/logs/archives/rehydrating.md
+++ b/content/en/logs/archives/rehydrating.md
@@ -16,6 +16,8 @@ With historical views, teams rehydrate archived log events precisely by timefram
 
 {{< img src="logs/archives/log_archives_rehydrate_historical.png" alt="Historical Views"  style="width:75%;">}}
 
+Index exclusion filters do not apply to historical views, so there is no need to modify exclusion filters when you rehydrate from archives. 
+
 ### Add new historical views
 
 1. **Select the archive** from which you wish to rehydrate log events. Only archives that are [configured to use role delegation](#permissions) are available for rehydrating.


### PR DESCRIPTION
…ions

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
adds a note to explicitly state that exclusion filters do not apply to rehydrations.

### Motivation
<!-- What inspired you to submit this pull request?-->
we've had a few tickets where customers assumed that exclusion filters would filter out what log events were going to be rehydrated

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/estib/rehydrations-skip-exclusion-filters/logs/archives/rehydrating/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
this can be merged when the docs team is happy with it. 
