### PR TITLE
Changed js extension to ts for TypeScript

### DIFF
--- a/content/en/tracing/setup/nodejs.md
+++ b/content/en/tracing/setup/nodejs.md
@@ -57,11 +57,11 @@ const tracer = require('dd-trace').init();
 
 ##### TypeScript
 
-```js
-// server.js
+```typescript
+// server.ts
 import './tracer'; // must come before importing any instrumented module.
 
-// tracer.js
+// tracer.ts
 import tracer from 'dd-trace';
 tracer.init(); // initialized in a different file to avoid hoisting.
 export default tracer;


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Changed `.js` extension to `.ts` for TypeScript.
This conforms to the TypeScript standard file extension.
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->
Saw an improvement, made an improvement 💪
