### PR TITLE
[metric,monitor,usage] Avoid passing params in GET body.

### DIFF
--- a/content/en/api/metrics/code_snippets/api-metrics-list.sh
+++ b/content/en/api/metrics/code_snippets/api-metrics-list.sh
@@ -6,6 +6,4 @@ from_time=$((date +%s - 86400))
 curl -X GET \
 -H "DD-API-KEY: ${api_key}" \
 -H "DD-APPLICATION-KEY: ${app_key}" \
--d "from=${from_time}" \
--d "host=<HOSTNAME>" \
-"https://api.datadoghq.com/api/v1/metrics"
+"https://api.datadoghq.com/api/v1/metrics?from=${from_time}&host=<HOSTNAME>"

--- a/content/en/api/metrics/code_snippets/api-metrics-search.sh
+++ b/content/en/api/metrics/code_snippets/api-metrics-search.sh
@@ -4,6 +4,4 @@ app_key="<DATADOG_APPLICATION_KEY>"
 curl -X GET \
 -H "DD-API-KEY: ${api_key}" \
 -H "DD-APPLICATION-KEY: ${app_key}" \
--d "api_key=${api_key}" \
--d "application_key=${app_key}" \
 "https://api.datadoghq.com/api/v1/search?q=metrics:aws"

--- a/content/en/api/monitors/code_snippets/api-monitor-show.sh
+++ b/content/en/api/monitors/code_snippets/api-monitor-show.sh
@@ -10,5 +10,4 @@ monitor_id=<YOUR_MONITOR_ID>
 curl -X GET \
 -H "DD-API-KEY: ${api_key}" \
 -H "DD-APPLICATION-KEY: ${app_key}" \
--d "group_states=all" \
-"https://api.datadoghq.com/api/v1/monitor/${monitor_id}"
+"https://api.datadoghq.com/api/v1/monitor/${monitor_id}?group_states=all"

--- a/content/en/api/usage/code_snippets/api-billing-usage-summary.sh
+++ b/content/en/api/usage/code_snippets/api-billing-usage-summary.sh
@@ -8,7 +8,4 @@ include_org_details=true
 curl -X GET \
 -H "DD-API-KEY: ${api_key}" \
 -H "DD-APPLICATION-KEY: ${app_key}" \
--d "start_month=${start_month}" \
--d "end_month=${end_month}" \
--d "include_org_details=${include_org_details}" \
-"https://api.datadoghq.com/api/v1/usage/summary"
+"https://api.datadoghq.com/api/v1/usage/summary?start_month=${start_month}&end_month=${end_month}&include_org_details=${include_org_details}"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Although not clearly disallowed in the HTTP spec, it is unusual to pass params in a GET body and server behavior is not consistent. It appears that GCP (for e.g. DD in EU) blocks these requests at the edge as invalid. This moves the params to the query which is consistent and supported in all environemnts.

### Motivation
<!-- What inspired you to submit this pull request?-->

Users trying to run the "get monitor details" example and receiving:
```
<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 400 (Bad Request)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>400.</b> <ins>That’s an error.</ins>
  <p>Your client has issued a malformed or illegal request.  <ins>That’s all we know.</ins>
```

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
