### PR TITLE
update helm deployment for v2 chart

### DIFF
--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -427,7 +427,7 @@ The workaround in this case is to add `hostNetwork: true` in your Agent pod spec
 [8]: /agent/docker/#environment-variables
 [9]: /agent/autodiscovery/?tab=agent#how-to-set-it-up
 [10]: /integrations/amazon_ec2/#configuration
-[11]: https://github.com/helm/charts/blob/2d905afa38f59b73e1043252022dfc934aff588d/stable/datadog/values.yaml#L72
+[11]: https://github.com/helm/charts/blob/a744ff8c90730d6d36698412150875fa96882b9d/stable/datadog/values.yaml#L58
 [12]: /logs
 [13]: /agent/autodiscovery/integrations/?tab=kubernetes
 [14]: /tracing/setup

--- a/content/en/agent/kubernetes/helm.md
+++ b/content/en/agent/kubernetes/helm.md
@@ -241,9 +241,10 @@ datadog:
 
 ## Upgrading from chart v1.x
 
-The datadog chart has been refactored to regroup the values.yaml parameters in a more logical way. Please follow the migration guide to update your values.yaml file.
+The Datadog chart has been refactored in v2.0 to regroup the `values.yaml` parameters in a more logical way. 
 
-If the current chart version deployed is earlier than `v2.0.0`, migrating from 1.x to 2.x requires updating the values.yaml file to map your previous settings with the new fields. The mapping can be found in the [migration guide][11]
+If your current chart version deployed is earlier than `v2.0.0`, follow the [migration guide][11] to map your previous settings with the new fields. 
+
 
 ## Uninstalling the Datadog Helm Chart
 

--- a/content/en/agent/kubernetes/helm.md
+++ b/content/en/agent/kubernetes/helm.md
@@ -161,7 +161,8 @@ To gather custom metrics with [DogStatsD][8], update your [datadog-values.yaml][
 ```text
 datadog:
   (...)
-  nonLocalTraffic: true
+  dogstatsd:
+    nonLocalTraffic: true
 ```
 
 ### Enable APM and Distributed Tracing
@@ -173,14 +174,8 @@ Update your [datadog-values.yaml][7] file with the following APM configuration:
 ```text
 datadog:
   (...)
-  apmEnabled: true
-  nonLocalTraffic: true
-
-(...)
-
-daemonset:
-  (...)
-  useHostPort: true
+  apm:
+   enabled: true
 ```
 
 Update the `env` section of your application's manifest with the following:
@@ -216,7 +211,8 @@ Update your [datadog-values.yaml][7] file with the following process collection 
 ```text
 datadog:
   (...)
-  processAgentEnabled: true
+  processAgent:
+   enabled: true
 ```
 
 ### Enabling integrations with Helm
@@ -243,6 +239,12 @@ datadog:
           port: "%%port_0%%"
 ```
 
+## Upgrading from chart v1.x
+
+The datadog chart has been refactored to regroup the values.yaml parameters in a more logical way. Please follow the migration guide to update your values.yaml file.
+
+If the current chart version deployed is earlier than `v2.0.0`, migrating from 1.x to 2.x requires updating the values.yaml file to map your previous settings with the new fields. The mapping can be found in the [migration guide][11]
+
 ## Uninstalling the Datadog Helm Chart
 
 To uninstall or delete a deployment called `<RELEASE_NAME>`:
@@ -263,3 +265,4 @@ This command removes all Kubernetes components associated with the chart and del
 [8]: /developers/metrics/dogstatsd_metrics_submission
 [9]: /tracing/setup
 [10]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/entrypoint/89-copy-customfiles.sh
+[11]: https://github.com/helm/charts/blob/master/stable/datadog/docs/Migration_1.x_to_2.x.md

--- a/content/en/agent/kubernetes/helm.md
+++ b/content/en/agent/kubernetes/helm.md
@@ -150,8 +150,9 @@ Update your [datadog-values.yaml][7] file with the following log collection conf
 ```text
 datadog:
   (...)
- logsEnabled: true
- logsConfigContainerCollectAll: true
+ logs:
+  enabled: true
+  containerCollectAll: true
 ```
 
 ### Enable Custom Metrics Collection


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Update agent deployment using `helm` according to the new chart version (v2.0.0)
 
### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/clamoriniere/helmchartv2/agent/kubernetes/helm/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
