### PR TITLE
Using variables in JS steps

### DIFF
--- a/content/en/synthetics/browser_tests/actions.md
+++ b/content/en/synthetics/browser_tests/actions.md
@@ -143,6 +143,12 @@ To use your variables in one of your assertions, hit *Use Variable* and select t
 
 {{< img src="synthetics/browser_tests/use_variable_in_assertion.png" alt="Use variable in assertion"  style="width:40%;">}}
 
+Alternatively, you can record a step inputting `{{ <YOUR_VARIABLE> }}` in the desired field. 
+
+### Use variables in JavaScript steps
+
+If you need to use variables in JavaScript steps (assertion or variable), use `vars.<YOUR_VARIABLE>`.
+
 ## Wait
 
 By default, Datadog waits for a page to be fully loaded before performing an action or a next step—with a timeout after 60 seconds. In some cases, however, you may wish to set a custom waiting time. For instance, if you know that a page or a page element is taking more than 60 seconds to load, you can leverage the wait step in order to extend that default timeout. If you choose to use this functionality, the value for your wait step must not exceed 300 seconds.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR adds details about how to use browser test variables in JS steps.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/margot.lepizzera/synthetics_js_var/synthetics/browser_tests/actions#use-variables-in-javascript-steps
### Additional Notes
<!-- Anything else we should know when reviewing?-->
