### PR TITLE
Traces Search Page Edits

### DIFF
--- a/content/en/tracing/app_analytics/search.md
+++ b/content/en/tracing/app_analytics/search.md
@@ -129,7 +129,7 @@ The Trace Stream is the list of traces that match the selected context. A contex
 
 ### Traces vs Analyzed Spans
 
-Choose to display a sampled trace associated with your Analyzed Spans in the trace steam with the toggle in the upper right corner of the trace stream:
+In the Trace Stream, select **View in App Analytics** to view Traces and Analyzed Spans. Choose to display a sampled trace associated with your Analyzed Spans by clicking the **Traces** button in the upper right corner:
 
 {{< img src="tracing/app_analytics/search/trace_analysed_span.png" style="width:40%;" alt="trace_analysed_span"  >}}
 

--- a/content/en/tracing/app_analytics/search.md
+++ b/content/en/tracing/app_analytics/search.md
@@ -145,7 +145,7 @@ Click on any trace to see more details about it:
 
 ### Columns
 
-To add more Trace details to the list, click the **Columns** button and select any Facets you want to see:
+To add more Trace details to the list, click the **Options** button and select any Facets you want to see:
 
 {{< img src="tracing/app_analytics/search/trace_list_with_column.png" alt="Trace list with columns"  style="width:80%;">}}
 
@@ -166,7 +166,7 @@ Choose to display one, three, or ten lines from your traces. 3 and 10 lines disp
 
 ## Facets
 
-A Facet displays all the distinct values of an attribute or a tag as well as provides some basic analytics such as the amount of traces represented. This is also a switch to easily filter your data.
+A Facet displays all the distinct values of an attribute or a tag as well as provides some basic analytics such as the amount of traces represented. This is also a switch to filter your data.
 
 Facets allow you to pivot or filter your datasets based on a given attribute. Examples Facets may include users, services, etc...
 
@@ -182,7 +182,7 @@ Once this is done, the value of this attribute is stored **for all new traces** 
 
 ### Facet Panel
 
-Use Facets to easily filters on your Traces. The search bar and url automatically reflect your selections.
+Use Facets to filter on your Traces. The search bar and url automatically reflect your selections.
 
 {{< img src="tracing/app_analytics/search/facet_panel.png" alt="Facet panel"  style="width:30%;">}}
 


### PR DESCRIPTION
### What does this PR do?
- Notes that traces and analyzed spans are now viewable in app analytics
- Removes `easily` throughout doc
- Changes `column` to `options`

### Motivation
Docs channel request

### Preview link
https://docs-staging.datadoghq.com/sarina/traces-search/tracing/app_analytics/search