### PR TITLE
[DOCS-704] Adding PUT/POST disclaimer

### DIFF
--- a/content/en/api/integrations_pagerduty/code_snippets/pagerduty_add_services.rb
+++ b/content/en/api/integrations_pagerduty/code_snippets/pagerduty_add_services.rb
@@ -20,4 +20,7 @@ config= {
 
 dog = Dogapi::Client.new(api_key, app_key)
 
+# Warning: this function makes a PUT call to Datadog API
+# It updates your integration configuration by REPLACING
+# your current configuration with the new one.
 dog.update_integration('pagerduty', config)

--- a/content/en/api/integrations_pagerduty/pagerduty_add_services.md
+++ b/content/en/api/integrations_pagerduty/pagerduty_add_services.md
@@ -9,6 +9,11 @@ external_redirect: /api/#add-new-services-and-schedules
 
 Add new services and schedules to your Datadog-PagerDuty integration.
 
+**Note**:
+
+* Using the `POST` method updates your integration configuration by **adding** your new configuration to the existing one in your Datadog organization.
+* Using the `PUT` method updates your integration configuration by **replacing** your current configuration with the new one sent to your Datadog organization.
+
 **ARGUMENTS**:
 
 * **`services`** :

--- a/content/en/api/integrations_pagerduty/pagerduty_add_services_code.md
+++ b/content/en/api/integrations_pagerduty/pagerduty_add_services_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#add-new-services-and-schedules
 
 **SIGNATURE**:
 
-`POST /v1/integration/pagerduty`
+`PUT /v1/integration/pagerduty`
 
 **EXAMPLE REQUEST**:
 

--- a/content/en/api/integrations_pagerduty/pagerduty_create.md
+++ b/content/en/api/integrations_pagerduty/pagerduty_create.md
@@ -9,7 +9,10 @@ external_redirect: /api/#create-a-pagerduty-integration
 
 Create a new Datadog-PagerDuty integration.
 
-**Note**: All arguments are required when creating (`PUT`) a new PagerDuty configuration.
+**Note**:
+
+* Using the `POST` method updates your integration configuration by **adding** your new configuration to the existing one in your Datadog organization.
+* Using the `PUT` method updates your integration configuration by **replacing** your current configuration with the new one sent to your Datadog organization. All arguments are required when creating (`PUT`) a new PagerDuty configuration.
 
 **ARGUMENTS**:
 

--- a/content/en/api/integrations_slack/code_snippets/slack_add_channels.rb
+++ b/content/en/api/integrations_slack/code_snippets/slack_add_channels.rb
@@ -21,4 +21,7 @@ config= {
 
 dog = Dogapi::Client.new(api_key, app_key)
 
+# Warning: this function makes a PUT call to Datadog API
+# It updates your integration configuration by REPLACING
+# your current configuration with the new one.
 dog.update_integration('slack', config)

--- a/content/en/api/integrations_slack/slack_add_channels.md
+++ b/content/en/api/integrations_slack/slack_add_channels.md
@@ -9,6 +9,11 @@ external_redirect: /api/#add-channels-to-slack-integration
 
 Add channels to your Datadog-Slack integration.
 
+**Note**:
+
+* Using the `POST` method updates your integration configuration by **adding** your new configuration to the existing one in your Datadog organization.
+* Using the `PUT` method updates your integration configuration by **replacing** your current configuration with the new one sent to your Datadog organization.
+
 **ARGUMENTS**:
 
 * **`channels`** [*required*]:

--- a/content/en/api/integrations_slack/slack_add_channels_code.md
+++ b/content/en/api/integrations_slack/slack_add_channels_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#add-channels-to-slack-integration
 
 **SIGNATURE**:
 
-`POST /v1/integration/slack`
+`PUT /v1/integration/slack`
 
 **EXAMPLE REQUEST**:
 

--- a/content/en/api/integrations_slack/slack_create.md
+++ b/content/en/api/integrations_slack/slack_create.md
@@ -12,7 +12,7 @@ Create a Datadog-Slack integration. Once created, add a channel to it with the [
 **Note**:
 
 * Using the `POST` method updates your integration configuration by **adding** your new configuration to the existing one in your Datadog organization.
-* Using the `PUT` method updates your integration configuration by **replacing** your current configuration with the new one sent to your Datadog organization.
+* Using the `PUT` method updates your integration configuration by **replacing** your current configuration with the new one sent to your Datadog organization. All arguments are required when creating (`PUT`) a new Slack configuration.
 
 **ARGUMENTS**:
 

--- a/content/en/api/integrations_webhook/code_snippets/webhooks_add_webhook.rb
+++ b/content/en/api/integrations_webhook/code_snippets/webhooks_add_webhook.rb
@@ -15,4 +15,7 @@ config= {
 
 dog = Dogapi::Client.new(api_key, app_key)
 
+# Warning: this function makes a PUT call to Datadog API
+# It updates your integration configuration by REPLACING
+# your current configuration with the new one.
 dog.update_integration('webhooks', config)

--- a/content/en/api/integrations_webhook/webhooks_add_webhook.md
+++ b/content/en/api/integrations_webhook/webhooks_add_webhook.md
@@ -9,6 +9,11 @@ external_redirect: /api/#update-a-webhooks-integration
 
 Add a specific Webhook to a Datadog Webhooks integration.
 
+**Note**:
+
+* Using the `POST` method updates your integration configuration by **adding** your new configuration to the existing one in your Datadog organization.
+* Using the `PUT` method updates your integration configuration by **replacing** your current configuration with the new one sent to your Datadog organization.
+
 **ARGUMENTS**:
 
 * **`hooks`** [*required*]:

--- a/content/en/api/integrations_webhook/webhooks_add_webhook_code.md
+++ b/content/en/api/integrations_webhook/webhooks_add_webhook_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#update-a-webhooks-integration
 
 **SIGNATURE**:
 
-`POST /v1/integration/webhooks`
+`PUT /v1/integration/webhooks`
 
 **EXAMPLE REQUEST**:
 

--- a/content/en/api/integrations_webhook/webhooks_create.md
+++ b/content/en/api/integrations_webhook/webhooks_create.md
@@ -12,6 +12,7 @@ Create a Datadog-Webhooks integration.
 **Note**:
 
 * Using the `POST` method updates your integration configuration by **adding** your new configuration to the existing one in your Datadog organization.
+* Using the `PUT` method updates your integration configuration by **replacing** your current configuration with the new one sent to your Datadog organization. All arguments are required when creating (`PUT`) a new Webhook configuration.
 
 **ARGUMENTS**:
 


### PR DESCRIPTION
### What does this PR do?

* Adds a disclaimer for the create integration endpoints to better document the POST/PUT behaviour. 
* Adds a disclaimer for the ruby function `update_integration` that makes a PUT request.

### Motivation
Reduce confusion

### Preview link

* https://docs-staging.datadoghq.com/gus/api-update/api/?lang=ruby#add-channels-to-slack-integration
* https://docs-staging.datadoghq.com/gus/api-update/api/?lang=ruby#update-a-webhooks-integration
* https://docs-staging.datadoghq.com/gus/api-update/api/?lang=ruby#add-new-services-and-schedules