### PR TITLE
[DOCS-618] Build container agent

### DIFF
--- a/content/en/agent/guide/_index.md
+++ b/content/en/agent/guide/_index.md
@@ -20,6 +20,7 @@ private: true
     {{< nextlink href="agent/guide/cluster-agent-custom-metrics-server" >}}Cluster Agent and Horizontal Pod Autoscaling: Custom Metrics Server{{< /nextlink >}}
     {{< nextlink href="agent/guide/autodiscovery-with-jmx" >}}Autodiscovery with JMX{{< /nextlink >}}
     {{< nextlink href="agent/guide/private-link" >}}Forward your telemetry securely to Datadog over AWS PrivateLink{{< /nextlink >}}
+    {{< nextlink href="agent/guide/build-container-agent" >}}Build Datadog Agent image{{< /nextlink >}}
 {{< /whatsnext >}}
 <br>
 {{< whatsnext desc="Agent 5 Guides:" >}}

--- a/content/en/agent/guide/_index.md
+++ b/content/en/agent/guide/_index.md
@@ -20,7 +20,7 @@ private: true
     {{< nextlink href="agent/guide/cluster-agent-custom-metrics-server" >}}Cluster Agent and Horizontal Pod Autoscaling: Custom Metrics Server{{< /nextlink >}}
     {{< nextlink href="agent/guide/autodiscovery-with-jmx" >}}Autodiscovery with JMX{{< /nextlink >}}
     {{< nextlink href="agent/guide/private-link" >}}Forward your telemetry securely to Datadog over AWS PrivateLink{{< /nextlink >}}
-    {{< nextlink href="agent/guide/build-container-agent" >}}Build Datadog Agent image{{< /nextlink >}}
+    {{< nextlink href="agent/guide/build-container-agent" >}}Build a Datadog Agent image{{< /nextlink >}}
 {{< /whatsnext >}}
 <br>
 {{< whatsnext desc="Agent 5 Guides:" >}}

--- a/content/en/agent/guide/build-container-agent.md
+++ b/content/en/agent/guide/build-container-agent.md
@@ -3,9 +3,9 @@ title: Build Datadog Agent image
 kind: guide
 ---
 
-Follow the instructions below to build the Datadog docker Agent image for a given `<AGENT_VERSION>` Agent version (above v6.0).
+Follow the instructions below to build the Datadog Docker Agent image for a given `<AGENT_VERSION>` Agent version (above v6.0).
 
-1. Clone the Datadog agent repository:
+1. Clone the Datadog Agent repository:
 
     ```shell
     git clone https://github.com/DataDog/datadog-agent.git
@@ -17,13 +17,13 @@ Follow the instructions below to build the Datadog docker Agent image for a give
     cd datadog-agent/Dockerfile/agent/
     ```
 
-3. Switch to the Agent version branch you want to build Agent from:
+3. Switch to the Agent version branch you want to build the Agent from:
 
     ```shell
     git branch <AGENT_VERSION> && git checkout <AGENT_VERSION>
     ```
 
-4. Download the Agent debian package corresponding to the Agent version you want. Choose between the AMD and ARM architecture:
+4. Download the Agent Debian package that corresponds to the Agent version you want. Choose between the AMD and ARM architecture:
 
     {{< tabs >}}
 {{% tab "AMD" %}}
@@ -42,7 +42,7 @@ curl https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/datadog-agent_<AGENT_V
 {{% /tab %}}
 {{< /tabs >}}
 
-    **Note**: The full list of debian package available can be found [on this APT listing][1]
+    **Note**: The full list of Debian packages available can be found [on this APT listing][1].
 
 5. Build the Agent image by running:
 
@@ -60,8 +60,8 @@ curl https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/datadog-agent_<AGENT_V
 
     | Argument          | Definition                                                                  | Default |
     | ----------------- | --------------------------------------------------------------------------- | ------- |
-    | PYTHON_VERSION    | The python runtime version for your Agent check.                            | `-`     |
+    | PYTHON_VERSION    | The Python runtime version for your Agent check.                            | `-`     |
     | WITH_JMX          | If set to `true`, the Agent container contains the JMX fetch logic.         | `false` |
-    | DD_AGENT_ARTIFACT | Path to the Agent debian artifact package to use if not in the same folder. | `-`     |
+    | DD_AGENT_ARTIFACT | Path to the Agent Debian artifact package to use if not in the same folder. | `-`     |
 
 [1]: http://apt.datadoghq.com/pool/d/da/

--- a/content/en/agent/guide/build-container-agent.md
+++ b/content/en/agent/guide/build-container-agent.md
@@ -1,10 +1,6 @@
 ---
 title: Build Datadog Agent image
 kind: guide
-further_reading:
-    - link: 'agent/versions/upgrade_to_agent_v7'
-      tag: 'Documentation'
-      text: 'Upgrade to Agent v7'
 ---
 
 Follow the instructions below to build the Datadog docker Agent image for a given `<AGENT_VERSION>` Agent version (above v6.0).
@@ -60,12 +56,12 @@ curl https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/datadog-agent_<AGENT_V
     docker build --build-arg PYTHON_VERSION=3 --pull --tag documentation-example .
     ```
 
-Available `<BUILD_ARGS>` are:
+     Available `<BUILD_ARGS>` are:
 
-| Argument          | Definition                                                                  | Default |
-| ----------------- | --------------------------------------------------------------------------- | ------- |
-| PYTHON_VERSION    | The python runtime version for your Agent check.                            | `-`     |
-| WITH_JMX          | If set to `true`, the Agent container contains the JMX fetch logic.         | `false` |
-| DD_AGENT_ARTIFACT | Path to the Agent debian artifact package to use if not in the same folder. | `-`     |
+    | Argument          | Definition                                                                  | Default |
+    | ----------------- | --------------------------------------------------------------------------- | ------- |
+    | PYTHON_VERSION    | The python runtime version for your Agent check.                            | `-`     |
+    | WITH_JMX          | If set to `true`, the Agent container contains the JMX fetch logic.         | `false` |
+    | DD_AGENT_ARTIFACT | Path to the Agent debian artifact package to use if not in the same folder. | `-`     |
 
 [1]: http://apt.datadoghq.com/pool/d/da/

--- a/content/en/agent/guide/build-container-agent.md
+++ b/content/en/agent/guide/build-container-agent.md
@@ -1,0 +1,70 @@
+---
+title: Build Datadog Agent image
+kind: guide
+further_reading:
+    - link: 'agent/versions/upgrade_to_agent_v7'
+      tag: 'Documentation'
+      text: 'Upgrade to Agent v7'
+---
+
+Follow the instructions below to build the Datadog docker Agent image for a given `<AGENT_VERSION>` Agent version (above v6.0).
+
+1. Clone the Datadog agent repository:
+
+    ```shell
+    git clone https://github.com/DataDog/datadog-agent.git
+    ```
+
+2. Go into the `datadog-agent/Dockerfile/agent/` folder:
+
+    ```shell
+    cd datadog-agent/Dockerfile/agent/
+    ```
+
+3. Switch to the Agent version branch you want to build Agent from:
+
+    ```shell
+    git branch <AGENT_VERSION> && git checkout <AGENT_VERSION>
+    ```
+
+4. Download the Agent debian package corresponding to the Agent version you want. Choose between the AMD and ARM architecture:
+
+    {{< tabs >}}
+{{% tab "AMD" %}}
+
+```shell
+curl https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/datadog-agent_<AGENT_VERSION>-1_amd64.deb -o datadog-agent_<AGENT_VERSION>-1_amd64.deb
+```
+
+{{% /tab %}}
+{{% tab "ARM" %}}
+
+```shell
+curl https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/datadog-agent_<AGENT_VERSION>-1_arm64.deb -o datadog-agent_<AGENT_VERSION>-1_arm64.deb
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+    **Note**: The full list of debian package available can be found [on this APT listing][1]
+
+5. Build the Agent image by running:
+
+    ```shell
+    docker build --build-arg <BUILD_ARGS> --pull --tag <IMAGE_TAG> .
+    ```
+
+    For instance to build the Agent version 7.17.0 with the Python 3 runtime you would run:
+
+    ```shell
+    docker build --build-arg PYTHON_VERSION=3 --pull --tag documentation-example .
+    ```
+
+Available `<BUILD_ARGS>` are:
+
+| Argument          | Definition                                                                  | Default |
+| ----------------- | --------------------------------------------------------------------------- | ------- |
+| PYTHON_VERSION    | The python runtime version for your Agent check.                            | `-`     |
+| WITH_JMX          | If set to `true`, the Agent container contains the JMX fetch logic.         | `false` |
+| DD_AGENT_ARTIFACT | Path to the Agent debian artifact package to use if not in the same folder. | `-`     |
+[1]: http://apt.datadoghq.com/pool/d/da/

--- a/content/en/agent/guide/build-container-agent.md
+++ b/content/en/agent/guide/build-container-agent.md
@@ -67,4 +67,5 @@ Available `<BUILD_ARGS>` are:
 | PYTHON_VERSION    | The python runtime version for your Agent check.                            | `-`     |
 | WITH_JMX          | If set to `true`, the Agent container contains the JMX fetch logic.         | `false` |
 | DD_AGENT_ARTIFACT | Path to the Agent debian artifact package to use if not in the same folder. | `-`     |
+
 [1]: http://apt.datadoghq.com/pool/d/da/


### PR DESCRIPTION
### What does this PR do?

Adds guide to build the Agent container for a given Agent version, for a given Architecture.

### Motivation
It was missing

### Preview link

* https://docs-staging.datadoghq.com/gus/build-container-agent/agent/guide/build-container-agent/