### PR TITLE
APM > .NET > Improved logging on Linux

### DIFF
--- a/content/en/tracing/setup/dotnet-core.md
+++ b/content/en/tracing/setup/dotnet-core.md
@@ -75,7 +75,7 @@ To use automatic instrumentation on Linux, follow these three steps:
 
 2. Create the required environment variables. See [Required Environment Variables](#required-environment-variables) below for details.
 
-3. run the `/opt/datadog/createLogPath.sh` script, which creates a directory for the log files and set appropriate directory permissions. The log file default path is `/var/log/datadog/dotnet`.
+3. Run the `/opt/datadog/createLogPath.sh` script, which creates a directory for the log files and sets appropriate directory permissions. The default directory for log files is `/var/log/datadog/dotnet`.
 
 **Update:** Starting with .NET Tracer version `1.8.0`, the `Datadog.Trace.ClrProfiler.Managed` NuGet package is no longer required for automatic instrumentation in .NET Core and is deprecated. Remove it from your application when you update the .NET Tracer and add the new environment variable, `DD_DOTNET_TRACER_HOME`. See [Required Environment Variables](#required-environment-variables) below for details.
 

--- a/content/en/tracing/setup/dotnet-core.md
+++ b/content/en/tracing/setup/dotnet-core.md
@@ -71,7 +71,7 @@ net start w3svc
 
 To use automatic instrumentation on Linux, follow these three steps:
 
-1. install the .NET Tracer in the environment where your application is running using one of the packages available from the `dd-trace-dotnet` [releases page][1].
+1. Install the .NET Tracer in the environment where your application is running using one of the packages available from the `dd-trace-dotnet` [releases page][1].
 
 2. create the required environment variables. See [Required Environment Variables](#required-environment-variables) below for details.
 

--- a/content/en/tracing/setup/dotnet-core.md
+++ b/content/en/tracing/setup/dotnet-core.md
@@ -73,7 +73,7 @@ To use automatic instrumentation on Linux, follow these three steps:
 
 1. Install the .NET Tracer in the environment where your application is running using one of the packages available from the `dd-trace-dotnet` [releases page][1].
 
-2. create the required environment variables. See [Required Environment Variables](#required-environment-variables) below for details.
+2. Create the required environment variables. See [Required Environment Variables](#required-environment-variables) below for details.
 
 3. run the `/opt/datadog/createLogPath.sh` script, which creates a directory for the log files and set appropriate directory permissions. The log file default path is `/var/log/datadog/dotnet`.
 

--- a/content/en/tracing/setup/dotnet-core.md
+++ b/content/en/tracing/setup/dotnet-core.md
@@ -69,11 +69,13 @@ net start w3svc
 
 {{% tab "Linux" %}}
 
-To use automatic instrumentation on Linux, install the .NET Tracer in the environment where your application is running using one of the packages available from the `dd-trace-dotnet` [releases page][1].
+To use automatic instrumentation on Linux, follow these three steps:
 
-In addition to installing the .NET Tracer package, several environment variables are required to enabled automatic instrumentation in your application. See [Required Environment Variables](#required-environment-variables) below for details.
+1. install the .NET Tracer in the environment where your application is running using one of the packages available from the `dd-trace-dotnet` [releases page][1].
 
-To generate Tracer log files for troubleshooting, you must create the logs directory. The default path is `/var/log/datadog/`.
+2. create the required environment variables. See [Required Environment Variables](#required-environment-variables) below for details.
+
+3. run the `/opt/datadog/createLogPath.sh` script, which creates a directory for the log files and set appropriate directory permissions. The log file default path is `/var/log/datadog/dotnet`.
 
 **Update:** Starting with .NET Tracer version `1.8.0`, the `Datadog.Trace.ClrProfiler.Managed` NuGet package is no longer required for automatic instrumentation in .NET Core and is deprecated. Remove it from your application when you update the .NET Tracer and add the new environment variable, `DD_DOTNET_TRACER_HOME`. See [Required Environment Variables](#required-environment-variables) below for details.
 
@@ -329,7 +331,7 @@ The following table lists configuration variables that are available only when u
 |----------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `DD_TRACE_ENABLED`<br/><br/>`TraceEnabled`                     | Enables or disables all automatic instrumentation. Setting the environment variable to `false` completely disables the CLR profiler. For other configuration methods, the CLR profiler is still loaded, but traces will not be generated. Valid values are: `true` (default) or `false`. |
 | `DD_TRACE_DEBUG`                                               | Enables or disables debug logs in the Tracer. Valid values are: `true` or `false` (default). Setting this as an environment variable also enabled debug logs in the CLR Profiler.                                                                                                        |
-| `DD_TRACE_LOG_PATH`                                            | Sets the path for the CLR profiler's log file.<br/><br/>Windows default: `%ProgramData%\Datadog .NET Tracer\logs\dotnet-profiler.log`<br/><br/>Linux default: `/var/log/datadog/dotnet-profiler.log`                                                                                                                         |
+| `DD_TRACE_LOG_PATH`                                            | Sets the path for the CLR profiler's log file.<br/><br/>Windows default: `%ProgramData%\Datadog .NET Tracer\logs\dotnet-profiler.log`<br/><br/>Linux default: `/var/log/datadog/dotnet/dotnet-profiler.log`                                                                                                                         |
 | `DD_DISABLED_INTEGRATIONS`<br/><br/>`DisabledIntegrationNames` | Sets a list of integrations to disable. All other integrations remain enabled. If not set, all integrations are enabled. Supports multiple values separated with semicolons. Valid values are the integration names listed in the [Integrations](#integrations) section above.           |
 | `DD_TRACE_ANALYTICS_ENABLED`<br/><br/>`AnalyticsEnabled`       | Shorthand that enables default App Analytics settings for web framework integrations. Valid values are: `true` or `false` (default).                                                                                                                                                     |
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Gives instruction for running a bash script that creates a tracer log directory and assigns permissions to it. The PR also simplifies the installation of automatic instrumentation for the .NET Tracer in Linux by numbering the three steps needed.

### Motivation
Support usually does not get tracer log files because the user does not know to set up the log directory and provide permissions in Linux.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/bob/dotnet-tracer-linux-logging/tracing/setup/dotnet-core/

(edited by @lucaspimentel: add pull path to preview link)
