### PR TITLE
[PROD] include cluster agent token piece

### DIFF
--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -121,6 +121,21 @@ spec:
           - {name: DD_CRI_SOCKET_PATH, value: /host/var/run/docker.sock}
           - {name: DOCKER_HOST, value: unix:///host/var/run/docker.sock}
 
+          ## For secure communication with the cluster agent (required to use the cluster agent)
+          # - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+          #
+          ## If using a simple env var uncomment this section
+          #
+          #   value: <THIRTY_2_CHARACTERS_LONG_TOKEN>
+          #
+          ## If using a secret uncomment this section
+          #
+          #   valueFrom:
+          #     secretKeyRef:
+          #       name: datadog-auth-token
+          #       key: token
+
+
         ## Note these are the minimum suggested values for requests and limits.
         ## The amount of resources required by the Agent varies depending on:
         ## * The number of checks

--- a/content/en/agent/kubernetes/daemonset_setup.md
+++ b/content/en/agent/kubernetes/daemonset_setup.md
@@ -121,7 +121,7 @@ spec:
           - {name: DD_CRI_SOCKET_PATH, value: /host/var/run/docker.sock}
           - {name: DOCKER_HOST, value: unix:///host/var/run/docker.sock}
 
-          ## For secure communication with the cluster agent (required to use the cluster agent)
+          ## For secure communication with the Cluster Agent (required to use the Cluster Agent)
           # - name: DD_CLUSTER_AGENT_AUTH_TOKEN
           #
           ## If using a simple env var uncomment this section


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
The cluster agent is very commonly deployed in Kubernetes environments and requires an auth token to communicate with the node agent. This is mentioned in [these docs](https://docs.datadoghq.com/agent/cluster_agent/setup/?tab=secret#configure-the-datadog-agent), but it will make for a much easier install if the environment is already there and just needs to be commented out (we already do this for a lot of add-ons like APM). 


### Motivation

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
