### PR TITLE
update Node APM docs with new features from dd-trace-js 0.19.0

### DIFF
--- a/content/en/tracing/setup/nodejs.md
+++ b/content/en/tracing/setup/nodejs.md
@@ -175,6 +175,12 @@ For details about how to how to toggle and configure plugins, check out the [API
 | [kafka-node][41]   |          | Coming Soon     |                                                        |
 | [rhea][42]         | `>=1`    | Fully supported |                                                        |
 
+#### SDK Compatibility
+
+| Module             | Versions   | Support Type    | Notes                                                  |
+| ------------------ | ---------- | --------------- | ------------------------------------------------------ |
+| [aws-sdk][52]      | `>=2.1.35` | Fully supported | CloudWatch, DynamoDB, Kinesis, Redshift, S3, SNS, SQS, and generic requests. |
+
 #### Promise Library Compatibility
 
 | Module           | Versions  | Support Type    |
@@ -249,3 +255,4 @@ For details about how to how to toggle and configure plugins, check out the [API
 [49]: https://github.com/articulate/paperplane/blob/master/docs/API.md#logger
 [50]: http://getpino.io
 [51]: https://github.com/winstonjs/winston
+[52]: https://github.com/aws/aws-sdk-js


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Add `aws-sdk` to the list of supported integrations for Node APM.

### Motivation
<!-- What inspired you to submit this pull request?-->

Update Node APM docs with new features from dd-trace-js 0.19.0.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/rochdev/dd-trace-0.19.0/tracing/setup/nodejs/#sdk-compatibility

### Additional Notes
<!-- Anything else we should know when reviewing?-->
