### PR TITLE
WEB-12 Use Imgix for Docs Images.

### DIFF
--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -10,7 +10,7 @@
 {{- $video :=  .Get "video" -}}
 {{- $local_ref := (.Get "src") -}}
 {{- $hash_ref := $local_ref -}}
-{{- $.Scratch.Add "_img" (print "images/" $hash_ref) -}}
+{{- $.Scratch.Add "_img" (print .Site.Params.img_url "images/" $hash_ref) -}}
 {{- $img := $.Scratch.Get "_img" -}}
 {{- $image_type_arr := split (.Get "src") "." -}}
 {{- $image_ext := index $image_type_arr 1 -}}

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -1,3 +1,6 @@
+{{ if  not (.Get "src") }}
+    {{ errorf "Img shortcode error: Missing value for param 'src': %s" .Position }}
+{{ end }}
 {{- if eq (.Get "popup") "false" -}}
   {{- $.Scratch.Set "popup" "false" -}}
 {{- else -}}
@@ -8,10 +11,9 @@
 {{- $img_height := .Get "height" -}}
 {{- $wide :=  .Get "wide" -}}
 {{- $video :=  .Get "video" -}}
-{{- $local_ref := (.Get "src") -}}
-{{- $hash_ref := $local_ref -}}
-{{- $.Scratch.Add "_img" (print .Site.Params.img_url "images/" $hash_ref) -}}
-{{- $img := $.Scratch.Get "_img" -}}
+{{- $src := (.Get "src") -}}
+{{- $img := (print .Site.Params.img_url "images/" $src) -}}
+
 {{- $image_type_arr := split (.Get "src") "." -}}
 {{- $image_ext := index $image_type_arr 1 -}}
 {{- if $wide -}}
@@ -44,7 +46,7 @@
            playsinline
            autoplay
            loop >
-      <source src="{{ print $img | relURL }}"
+      <source src="{{ (print "/images/" $src) | relURL }}"
               type="video/mp4"
               media="(min-width: 0px)" >
       <div class="play"></div>


### PR DESCRIPTION
### What does this PR do?
Uses `imgix` image urls. Currently some images are not being served from the imgix urls, but rather an images folder under the docs.datadoghq.com domain. These should be using the imgix domain. 

For example, view some images html on this page: https://docs.datadoghq.com/getting_started/logs/?tab=ussite, their urls are `https://docs.datadoghq.com/images/getting_started/logs/plain_text_log.png?auto=format`

they should be at 
`https://datadog-docs.imgix.net/images/getting_started/logs/plain_text_log.png?auto=format`

### Motivation
https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-12

### Preview link
https://docs-staging.datadoghq.com/zach/use-imgix/
For staging, images are at the staging imgix url:
`https://datadog-docs-staging.imgix.net/images/getting_started/logs/plain_text_log.png?auto=format`

