### PR TITLE
Adding alias

### DIFF
--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -5,6 +5,7 @@ aliases:
   - /guides/basic_agent_usage/docker/
   - /agent/docker
   - /agent/basic_agent_usage/docker/
+  - /integrations/docker_daemon/
 further_reading:
 - link: "/integrations/java/?tab=docker#configuration"
   tag: "Documentation"


### PR DESCRIPTION
### What does this PR do?

Setup an alias between the docker integration documentation and the main agent docker page.

### Motivation
https://github.com/DataDog/integrations-core/pull/5988/
