### PR TITLE
APM > .NET > Add Npgsql integration

### DIFF
--- a/content/en/tracing/setup/dotnet-core.md
+++ b/content/en/tracing/setup/dotnet-core.md
@@ -211,6 +211,7 @@ The .NET Tracer can instrument the following libraries automatically:
 | Redis (ServiceStack client)    | `ServiceStack.Redis` 4.0.48+                                            | `ServiceStackRedis`  |
 | Elasticsearch                  | `Elasticsearch.Net` 5.3.0+                                              | `ElasticsearchNet`   |
 | MongoDB                        | `MongoDB.Driver.Core` 2.1.0+                                            | `MongoDb`            |
+| PostgreSQL                     | `Npgsql` 4.0+                                                           | `Postgres`           |
 
 **Note:** The ADO.NET integration instruments calls made through the `DbCommand` abstract class or the `IDbCommand` interface, regardless of the underlying implementation. It also instruments direct calls to `SqlCommand`.
 

--- a/content/en/tracing/setup/dotnet-core.md
+++ b/content/en/tracing/setup/dotnet-core.md
@@ -211,7 +211,7 @@ The .NET Tracer can instrument the following libraries automatically:
 | Redis (ServiceStack client)    | `ServiceStack.Redis` 4.0.48+                                            | `ServiceStackRedis`  |
 | Elasticsearch                  | `Elasticsearch.Net` 5.3.0+                                              | `ElasticsearchNet`   |
 | MongoDB                        | `MongoDB.Driver.Core` 2.1.0+                                            | `MongoDb`            |
-| PostgreSQL                     | `Npgsql` 4.0+                                                           | `Postgres`           |
+| PostgreSQL                     | `Npgsql` 4.0+                                                           | `AdoNet`             |
 
 **Note:** The ADO.NET integration instruments calls made through the `DbCommand` abstract class or the `IDbCommand` interface, regardless of the underlying implementation. It also instruments direct calls to `SqlCommand`.
 

--- a/content/en/tracing/setup/dotnet-framework.md
+++ b/content/en/tracing/setup/dotnet-framework.md
@@ -100,7 +100,7 @@ The .NET Tracer can instrument the following libraries automatically:
 | Redis (ServiceStack client)    | `ServiceStack.Redis` 4.0.48+   | `ServiceStackRedis`  |
 | Elasticsearch                  | `Elasticsearch.Net` 5.3.0+     | `ElasticsearchNet`   |
 | MongoDB                        | `MongoDB.Driver.Core` 2.1.0+   | `MongoDb`            |
-| PostgreSQL                     | `Npgsql` 4.0+                  | `Postgres`           |
+| PostgreSQL                     | `Npgsql` 4.0+                  | `AdoNet`             |
 
 **Update:** Starting with .NET Tracer version `1.12.0`, the ASP.NET integration is enabled automatically. The NuGet packages `Datadog.Trace.AspNet` or `Datadog.Trace.ClrProfiler.Managed` are no longer required. Remove them from your application when you update the .NET Tracer.
 

--- a/content/en/tracing/setup/dotnet-framework.md
+++ b/content/en/tracing/setup/dotnet-framework.md
@@ -100,6 +100,7 @@ The .NET Tracer can instrument the following libraries automatically:
 | Redis (ServiceStack client)    | `ServiceStack.Redis` 4.0.48+   | `ServiceStackRedis`  |
 | Elasticsearch                  | `Elasticsearch.Net` 5.3.0+     | `ElasticsearchNet`   |
 | MongoDB                        | `MongoDB.Driver.Core` 2.1.0+   | `MongoDb`            |
+| PostgreSQL                     | `Npgsql` 4.0+                  | `Postgres`           |
 
 **Update:** Starting with .NET Tracer version `1.12.0`, the ASP.NET integration is enabled automatically. The NuGet packages `Datadog.Trace.AspNet` or `Datadog.Trace.ClrProfiler.Managed` are no longer required. Remove them from your application when you update the .NET Tracer.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds PostGreSQL integration to the lists of integrations for .NET Framework and .NET Core for the .NET Tracer.

### Motivation
Integration added in the .NET Tracer [1.14.0 release](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v1.14.0).

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/bob/npqsql-dotnet-tracer/tracing/setup/dotnet-framework#integrations

https://docs-staging.datadoghq.com/bob/npqsql-dotnet-tracer/tracing/setup/dotnet-core#integrations

(edit by @lucaspimentel: preview links)