### PR TITLE
dan.chiniara/add case-sensitive for ALL in SQLServer

### DIFF
--- a/content/en/integrations/guide/collect-sql-server-custom-metrics.md
+++ b/content/en/integrations/guide/collect-sql-server-custom-metrics.md
@@ -52,7 +52,7 @@ custom_metrics:
   object_name: SQLServer:Plan Cache
 ```
 
-To collect all instances of a counter with multiple instances use the special value `ALL` for the `instance_name` parameter which **requires** a value for the `tag_by` parameter. This example gets metrics tagged as `db:mydb1`, `db:mydb2`:
+To collect all instances of a counter with multiple instances use the special, case-sensitive value `ALL` for the `instance_name` parameter which **requires** a value for the `tag_by` parameter. This example gets metrics tagged as `db:mydb1`, `db:mydb2`:
 
 ```yaml
 - name: sqlserver.db.commit_table_entries


### PR DESCRIPTION
### What does this PR do?

adds case-sensitive for `ALL`

### Motivation

https://datadog.zendesk.com/agent/tickets/307562

Looking at the check for SQLServer, it appears that the parameter is case-sensitive: https://github.com/DataDog/integrations-core/blob/master/sqlserver/datadog_checks/sqlserver/sqlserver.py#L34. 

### Preview Page

https://docs-staging.datadoghq.com/dan.chiniara/add_case-sensitive_for_sqlserver-guide/integrations/guide/collect-sql-server-custom-metrics/#collecting-metrics-from-dmv