### PR TITLE
finish the span in the client

### DIFF
--- a/content/en/tracing/manual_instrumentation/go.md
+++ b/content/en/tracing/manual_instrumentation/go.md
@@ -57,6 +57,8 @@ import (
 
 func handler(w http.ResponseWriter, r *http.Request) {
     span, ctx := tracer.StartSpanFromContext(r.Context(), "post.process")
+    defer span.Finish()
+    
     req, err := http.NewRequest("GET", "http://example.com", nil)
     req = req.WithContext(ctx)
     // Inject the span Context in the Request headers


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
makes the doc work

### Motivation
i spent many hours trying to figure out why my spans weren't showing up in datadog

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
