### PR TITLE
Update custom log collection with HTTPS example

### DIFF
--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -75,6 +75,38 @@ Select your Cloud provider below to see how to automatically collect your logs a
 Any custom process or [logging library][18] able to forward logs through **TCP** or **HTTP** can be used in conjunction with Datadog Logs. Choose below which Datadog site you want to forward logs to:
 
 {{< tabs >}}
+{{% tab "HTTP US Site" %}}
+
+The public endpoint is `http-intake.logs.datadoghq.com`, the API Key must be added either in the path or as a header, for instance:
+
+```
+curl -X POST https://http-intake.logs.datadoghq.com/v1/input \
+     -H "Content-Type: text/plain" \
+     -H "DD-API-KEY: <API_KEY>" \
+     -d 'hello world'
+```
+
+For more example with JSON formats, multiple logs per requests and the use of query parameters, refer to the [Datadog Log HTTP API documentation][1].
+
+[1]: https://docs.datadoghq.com/api/?lang=bash#send-logs-over-http
+{{% /tab %}}
+
+{{< tabs >}}
+{{% tab "HTTP EU Site" %}}
+
+The public endpoint is `http-intake.logs.datadoghq.eu`, the API Key must be added either in the path or as a header, for instance:
+
+```
+curl -X POST https://http-intake.logs.datadoghq.eu/v1/input \
+     -H "Content-Type: text/plain" \
+     -H "DD-API-KEY: <API_KEY>" \
+     -d 'hello world'
+```
+
+For more example with JSON formats, multiple logs per requests and the use of query parameters, refer to the [Datadog Log HTTP API documentation][1].
+
+[1]: https://docs.datadoghq.com/api/?lang=bash#send-logs-over-http
+{{% /tab %}}
 {{% tab "TCP US Site" %}}
 
 The secure TCP endpoint is `intake.logs.datadoghq.com:10516` (or port `10514` for insecure connections).
@@ -144,12 +176,6 @@ telnet tcp-intake.logs.datadoghq.eu 1883
 
 [1]: https://app.datadoghq.com/account/settings#api
 [2]: https://app.datadoghq.com/logs/livetail
-{{% /tab %}}
-{{% tab "HTTP" %}}
-
-To send logs over HTTPs for the **EU** or **US** site, refer to the [Datadog Log HTTP API documentation][1].
-
-[1]: https://docs.datadoghq.com/api/?lang=python#send-logs-over-http
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -77,7 +77,7 @@ Any custom process or [logging library][18] able to forward logs through **TCP**
 {{< tabs >}}
 {{% tab "HTTP US Site" %}}
 
-The public endpoint is `http-intake.logs.datadoghq.com`, the API Key must be added either in the path or as a header, for instance:
+The public endpoint is `http-intake.logs.datadoghq.com`. The API key must be added either in the path or as a header, for instance:
 
 ```
 curl -X POST https://http-intake.logs.datadoghq.com/v1/input \
@@ -86,13 +86,13 @@ curl -X POST https://http-intake.logs.datadoghq.com/v1/input \
      -d 'hello world'
 ```
 
-For more example with JSON formats, multiple logs per requests and the use of query parameters, refer to the [Datadog Log HTTP API documentation][1].
+For more examples with JSON formats, multiple logs per request, or the use of query parameters, refer to the [Datadog Log HTTP API documentation][1].
 
 [1]: https://docs.datadoghq.com/api/?lang=bash#send-logs-over-http
 {{% /tab %}}
 {{% tab "HTTP EU Site" %}}
 
-The public endpoint is `http-intake.logs.datadoghq.eu`, the API Key must be added either in the path or as a header, for instance:
+The public endpoint is `http-intake.logs.datadoghq.eu`. The API key must be added either in the path or as a header, for instance:
 
 ```
 curl -X POST https://http-intake.logs.datadoghq.eu/v1/input \
@@ -101,7 +101,7 @@ curl -X POST https://http-intake.logs.datadoghq.eu/v1/input \
      -d 'hello world'
 ```
 
-For more example with JSON formats, multiple logs per requests and the use of query parameters, refer to the [Datadog Log HTTP API documentation][1].
+For more examples with JSON formats, multiple logs per request, or the use of query parameters, refer to the [Datadog Log HTTP API documentation][1].
 
 [1]: https://docs.datadoghq.com/api/?lang=bash#send-logs-over-http
 {{% /tab %}}

--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -90,8 +90,6 @@ For more example with JSON formats, multiple logs per requests and the use of qu
 
 [1]: https://docs.datadoghq.com/api/?lang=bash#send-logs-over-http
 {{% /tab %}}
-
-{{< tabs >}}
 {{% tab "HTTP EU Site" %}}
 
 The public endpoint is `http-intake.logs.datadoghq.eu`, the API Key must be added either in the path or as a header, for instance:


### PR DESCRIPTION
### What does this PR do?
Put HTTPS forwarding example first and add details before linking to the documentation

### Motivation
HTTP is now the new recommendation.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/custom-log-https/logs/log_collection/?tab=tcpussite#custom-log-forwarder

### Additional Notes
<!-- Anything else we should know when reviewing?-->
