### PR TITLE
APM K8S: Make Helm the default setup process

### DIFF
--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -20,13 +20,51 @@ further_reading:
   text: "Autodiscovery with the Agent"
 ---
 
-Run the Datadog Agent in your Kubernetes cluster directly in order to start collecting your cluster and applications metrics, traces, and logs. You can deploy it with a [DaemonSet](?tab=daemonset) or a [Helm chart](?tab=helm)
+Run the Datadog Agent in your Kubernetes cluster directly in order to start collecting your cluster and applications metrics, traces, and logs. You can deploy it with a [Helm chart](?tab=helm) or a [DaemonSet](?tab=daemonset).
 
 **Note**: Agent version 6.0 and above only support versions of Kubernetes higher than 1.7.6. For prior versions of Kubernetes, consult the [Legacy Kubernetes versions section][1].
 
 ## Installation
 
 {{< tabs >}}
+{{% tab "Helm" %}}
+
+To install the chart with the release name `<RELEASE_NAME>`:
+
+1. [Install Helm][1].
+2. Download the [Datadog `value.yaml` configuration file][2].
+3. Optional - Edit the `value.yaml` file and enable the Agent features you want to use.
+3. Retrieve your Datadog API key from your [Agent installation instructions][3] and run:
+
+- **Helm v3+**
+
+    ```bash
+    helm install <RELEASE_NAME> -f datadog-values-config.yaml  --set datadog.apiKey=<DATADOG_API_KEY> stable/datadog
+    ```
+
+- **Helm v1/v2**
+
+    ```bash
+    helm install -f datadog-values-config.yaml --name <RELEASE_NAME> --set datadog.apiKey=<DATADOG_API_KEY> stable/datadog
+    ```
+
+This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally deploys the [kube-state-metrics chart][4] and uses it as an additional source of metrics about the cluster. A few minutes after installation, Datadog begins to report hosts and metrics.
+
+**Note**: For a full list of the Datadog chart's configurable parameters and their default values, refer to the [Datadog Helm repository README][5].
+
+### Upgrading from chart v1.x
+
+The Datadog chart has been refactored in v2.0 to regroup the `values.yaml` parameters in a more logical way.
+
+If your current chart version deployed is earlier than `v2.0.0`, follow the [migration guide][6] to map your previous settings with the new fields.
+
+[1]: https://v3.helm.sh/docs/intro/install/
+[2]: https://github.com/helm/charts/blob/master/stable/datadog/values.yaml
+[3]: https://app.datadoghq.com/account/settings#api
+[4]: https://github.com/helm/charts/tree/master/stable/kube-state-metrics
+[5]: https://github.com/helm/charts/tree/master/stable/datadog
+[6]: https://github.com/helm/charts/blob/master/stable/datadog/docs/Migration_1.x_to_2.x.md
+{{% /tab %}}
 {{% tab "DaemonSet" %}}
 
 Take advantage of DaemonSets to deploy the Datadog Agent on all your nodes (or on specific nodes by [using nodeSelectors][1]).
@@ -105,46 +143,6 @@ To install the Datadog Agent on your Kubernetes cluster:
 [11]: /infrastructure/process/?tab=kubernetes#installation
 [12]: https://github.com/kubernetes/kube-state-metrics/tree/master/examples/standard
 [13]: /agent/kubernetes/data_collected/#kube-state-metrics
-{{% /tab %}}
-{{% tab "Helm" %}}
-
-To install the chart with the release name `<RELEASE_NAME>`:
-
-1. [Install Helm][1].
-2. Download the [Datadog `value.yaml` configuration file][2].
-3. Optional - Edit the `value.yaml` file and enable the Agent features you want to use.
-3. Retrieve your Datadog API key from your [Agent installation instructions][3] and run:
-
-- **Helm v1/v2**
-
-    ```bash
-    helm install -f datadog-values-config.yaml --name <RELEASE_NAME> --set datadog.apiKey=<DATADOG_API_KEY> stable/datadog
-    ```
-
-- **Helm v3+**
-
-    ```bash
-    helm install <RELEASE_NAME> -f datadog-values-config.yaml  --set datadog.apiKey=<DATADOG_API_KEY> stable/datadog
-    ```
-
-This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally deploys the [kube-state-metrics chart][4] and uses it as an additional source of metrics about the cluster. A few minutes after installation, Datadog begins to report hosts and metrics.
-
-**Note**: For a full list of the Datadog chart's configurable parameters and their default values, refer to the [Datadog Helm repository README][5].
-
-### Upgrading from chart v1.x
-
-The Datadog chart has been refactored in v2.0 to regroup the `values.yaml` parameters in a more logical way.
-
-If your current chart version deployed is earlier than `v2.0.0`, follow the [migration guide][6] to map your previous settings with the new fields.
-
-
-
-[1]: https://v3.helm.sh/docs/intro/install/
-[2]: https://github.com/helm/charts/blob/master/stable/datadog/values.yaml
-[3]: https://app.datadoghq.com/account/settings#api
-[4]: https://github.com/helm/charts/tree/master/stable/kube-state-metrics
-[5]: https://github.com/helm/charts/tree/master/stable/datadog
-[6]: https://github.com/helm/charts/blob/master/stable/datadog/docs/Migration_1.x_to_2.x.md
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/agent/kubernetes/apm.md
+++ b/content/en/agent/kubernetes/apm.md
@@ -33,14 +33,7 @@ To enable trace collection with your Agent, follow the instructions below:
         ## @param enabled - boolean - optional - default: false
         ## Enable this to enable APM and tracing, on port 8126
         #
-        #
         enabled: true
-
-        ## @param port - integer - optional - default: 8126
-        ## Override the trace Agent DogStatsD port.
-        ## Note: Make sure your client is sending to the same UDP port.
-        #
-        port: 8126
     ```
 
 - Then upgrade your Datadog Helm chart.

--- a/content/en/agent/kubernetes/apm.md
+++ b/content/en/agent/kubernetes/apm.md
@@ -17,7 +17,35 @@ To enable trace collection with your Agent, follow the instructions below:
 
 1. **Configure the Datadog Agent to accept traces**:
 
-    {{< tabs >}}
+{{< tabs >}}
+{{% tab "Helm" %}}
+
+**Note**: If you want to deploy the Datadog Agent as a deployment instead of a DaemonSet, configuration of APM via Helm is not supported.
+
+- Update your [datadog-values.yaml][2] file with the following APM configuration:
+
+    ```yaml
+    datadog:
+      ## @param apm - object - required
+      ## Enable apm agent and provide custom configs
+      #
+      apm:
+        ## @param enabled - boolean - optional - default: false
+        ## Enable this to enable APM and tracing, on port 8126
+        #
+        #
+        enabled: true
+
+        ## @param port - integer - optional - default: 8126
+        ## Override the trace Agent DogStatsD port.
+        ## Note: Make sure your client is sending to the same UDP port.
+        #
+        port: 8126
+    ```
+
+- Then upgrade your Datadog Helm chart.
+
+{{% /tab %}}
 {{% tab "Daemonset" %}}
 
 To enable APM trace collection in Kubernetes:
@@ -47,34 +75,6 @@ To enable APM trace collection in Kubernetes:
               protocol: TCP
      # (...)
     ```
-
-{{% /tab %}}
-{{% tab "Helm" %}}
-
-**Note**: If you want to deploy the Datadog Agent as a deployment instead of a DaemonSet, configuration of APM via Helm is not supported.
-
-- Update your [datadog-values.yaml][2] file with the following APM configuration:
-
-    ```yaml
-    datadog:
-      ## @param apm - object - required
-      ## Enable apm agent and provide custom configs
-      #
-      apm:
-        ## @param enabled - boolean - optional - default: false
-        ## Enable this to enable APM and tracing, on port 8126
-        #
-        #
-        enabled: true
-
-        ## @param port - integer - optional - default: 8126
-        ## Override the trace Agent DogStatsD port.
-        ## Note: Make sure your client is sending to the same UDP port.
-        #
-        port: 8126
-    ```
-
-- Then upgrade your Datadog Helm chart.
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/developers/dogstatsd/datagram_shell.md
+++ b/content/en/developers/dogstatsd/datagram_shell.md
@@ -205,7 +205,7 @@ PS C:\> .\send-statsd.ps1 "_sc|Redis connection|2|#env:dev|m:Redis connection ti
 {{% /tab %}}
 {{< /tabs >}}
 
-To send metrics, events, or service checks on containerized environments, refer to the [DogStatsD on Kubernetes][4] documentation, in conjunction with the instructions for configuring APM on Kubernetes using [DaemonSets][5] or [Helm][6], depending on your installation. The [Docker APM][7] documentation may also be helpful.
+To send metrics, events, or service checks on containerized environments, refer to the [DogStatsD on Kubernetes][4] documentation, in conjunction with the instructions for [configuring APM on Kubernetes][5], depending on your installation. The [Docker APM][6] documentation may also be helpful.
 
 ## Further Reading
 
@@ -216,5 +216,4 @@ To send metrics, events, or service checks on containerized environments, refer 
 [3]: /developers/dogstatsd
 [4]: /developers/dogstatsd/
 [5]: /agent/kubernetes/apm
-[6]: /agent/kubernetes/
-[7]: /agent/docker/apm
+[6]: /agent/docker/apm


### PR DESCRIPTION
### What does this PR do?
This PR rearranges existing documentation to display the [Helm](https://helm.sh/) installation process first, in contrast with manual Daemonset installation for example.

### Motivation

We are currently working on streamlining APM onboarding for Kubernetes clients and we've reached a point where our Helm chart provides a better experience for our users.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/marco/k8s-apm-recommend-helm/agent/kubernetes/#installation
https://docs-staging.datadoghq.com/marco/k8s-apm-recommend-helm/agent/kubernetes/apm/#setup
https://docs-staging.datadoghq.com/marco/k8s-apm-recommend-helm/developers/dogstatsd/datagram_shell/#python-3

### Additional Notes
<!-- Anything else we should know when reviewing?-->
