### PR TITLE
[Browser log] fix setLevel/setHandler usage

### DIFF
--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -345,7 +345,7 @@ window.DD_LOGS && DD_LOGS.addContext('referrer', document.referrer);
 
 ### Filter by status
 
-Once Datadog Browser log library is initialized, you can set the minimul log level for your logger with the API:
+Once Datadog Browser log library is initialized, you can set the minimal log level for your logger with the API:
 
 `setLevel (level?: 'debug' | 'info' | 'warn' | 'error')`
 
@@ -357,7 +357,7 @@ Only logs with a status equal to or higher than the specified level are sent.
 ```javascript
 import { datadogLogs } from '@datadog/browser-logs';
 
-datadogLogs.setLevel('<LEVEL>');
+datadogLogs.logger.setLevel('<LEVEL>');
 ```
 
 {{% /tab %}}
@@ -385,14 +385,14 @@ Once Datadog Browser log library is initialized, it is possible to configure the
 ```javascript
 import { datadogLogs } from '@datadog/browser-logs';
 
-datadogLogs.setHandler('<HANDLER>');
+datadogLogs.logger.setHandler('<HANDLER>');
 ```
 
 {{% /tab %}}
 {{% tab "Bundle" %}}
 
 ```javascript
-window.DD_LOGS && DD_LOGS.setHandler('<HANDLER>');
+window.DD_LOGS && DD_LOGS.logger.setHandler('<HANDLER>');
 ```
 
 **Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the library.

--- a/content/fr/logs/log_collection/javascript.md
+++ b/content/fr/logs/log_collection/javascript.md
@@ -356,7 +356,7 @@ Seuls les logs avec un statut égal ou supérieur au niveau indiqué sont envoy�
 ```javascript
 import { datadogLogs } from '@datadog/browser-logs';
 
-datadogLogs.setLevel('<NIVEAU>');
+datadogLogs.logger.setLevel('<NIVEAU>');
 ```
 
 {{% /tab %}}
@@ -384,14 +384,14 @@ Une fois la bibliothèque lancée, il est possible de configurer le logger de fa
 ```javascript
 import { datadogLogs } from '@datadog/browser-logs';
 
-datadogLogs.setHandler('<GESTIONNAIRE>');
+datadogLogs.logger.setHandler('<GESTIONNAIRE>');
 ```
 
 {{% /tab %}}
 {{% tab "Bundle" %}}
 
 ```javascript
-window.DD_LOGS && DD_LOGS.setHandler('<GESTIONNAIRE>');
+window.DD_LOGS && DD_LOGS.logger.setHandler('<GESTIONNAIRE>');
 ```
 
 **Remarque** : le check `window.DD_LOGS` est utilisé pour éviter tout problème si le chargement de la bibliothèque échoue.

--- a/content/ja/logs/log_collection/javascript.md
+++ b/content/ja/logs/log_collection/javascript.md
@@ -356,7 +356,7 @@ Datadog ブラウザのログライブラリが初期化されると、API を�
 ```javascript
 import { datadogLogs } from '@datadog/browser-logs';
 
-datadogLogs.setLevel('<LEVEL>');
+datadogLogs.logger.setLevel('<LEVEL>');
 ```
 
 {{% /tab %}}
@@ -384,14 +384,14 @@ Datadog ブラウザのログライブラリが初期化されると、ログを
 ```javascript
 import { datadogLogs } from '@datadog/browser-logs';
 
-datadogLogs.setHandler('<HANDLER>');
+datadogLogs.logger.setHandler('<HANDLER>');
 ```
 
 {{% /tab %}}
 {{% tab "Bundle" %}}
 
 ```javascript
-window.DD_LOGS && DD_LOGS.setHandler('<HANDLER>');
+window.DD_LOGS && DD_LOGS.logger.setHandler('<HANDLER>');
 ```
 
 **注**: `window.DD_LOGS` チェックは、ライブラリで読み込みエラーが起きた際に問題を防ぐために使用されます。


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
fix setLevel/setHandler usage

### Motivation
Raised by customer https://github.com/DataDog/browser-sdk/issues/300

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/bcaudan/fix-logger/logs/log_collection/javascript/?tab=us#filter-by-status


