### PR TITLE
Link from monitor to collaboration integrations

### DIFF
--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -85,7 +85,7 @@ Notify your team through connected integrations by using the format `@<INTEGRATI
 | [Slack][7]     | `@slack`     | [Examples][8]  |
 | [Webhooks][9]  | `@webhook`   | [Examples][10] |
 
-[List of integrations that can be used to notify your team][14]. 
+See the [list of integrations][14] that can be used to notify your team. 
 
 ### Modifications
 

--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -85,6 +85,8 @@ Notify your team through connected integrations by using the format `@<INTEGRATI
 | [Slack][7]     | `@slack`     | [Examples][8]  |
 | [Webhooks][9]  | `@webhook`   | [Examples][10] |
 
+[List of integrations that can be used to notify your team][14]. 
+
 ### Modifications
 
 An [event][11] is created anytime a monitor is created, modified, silenced, or deleted. Set the `Notify` option to notify team members and chat services of these events.
@@ -388,3 +390,4 @@ If `host.name` matches `<HOST_NAME>`, the template outputs:
 [11]: /events
 [12]: /monitors/guide/template-variable-evaluation
 [13]: /monitors/faq/what-are-recovery-thresholds
+[14]: https://docs.datadoghq.com/integrations/#cat-collaboration


### PR DESCRIPTION
### What does this PR do?
Add a link to the integration page filtered by "collaboration" in the monitors say what's happening page.

### Motivation
There was 4 examples while much more is supported.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/monitors-notifications/monitors/notifications/?tab=is_alert#integrations

### Additional Notes
<!-- Anything else we should know when reviewing?-->
