### PR TITLE
Add information about HTTPS log forwarding

### DIFF
--- a/content/en/security/logs.md
+++ b/content/en/security/logs.md
@@ -17,7 +17,7 @@ The Log Management product supports multiple [environments and formats][2], allo
 
 ## Information Security
 
-The Datadog Agent submits logs to Datadog over a TLS-encrypted TCP connection, requiring an outbound communication over port `10516`. Datadog uses symmetric encryption at rest (AES-256) for indexed logs. Indexed logs are deleted from the Datadog platform once their retention period, as defined by the customer, expires.
+The Datadog Agent submits logs to Datadog over a TLS-encrypted TCP connection, requiring an outbound communication over port `10516`. The Datadog Agent can also be configured to send logs over secured HTTPS requests, requiring an outbound communication over port `443`. Datadog uses symmetric encryption at rest (AES-256) for indexed logs. Indexed logs are deleted from the Datadog platform once their retention period, as defined by the customer, expires.
 
 ## Logs Filtering
 


### PR DESCRIPTION
### What does this PR do?
Add reference to HTTPS in the security documentation

### Motivation
There was no reference to HTTPS

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/security-log-https/security/logs/#information-security

### Additional Notes
<!-- Anything else we should know when reviewing?-->
