### PR TITLE
Update DD_DOGSTATSD_TAG_CARDINALITY behavior

### DIFF
--- a/content/en/developers/dogstatsd/_index.md
+++ b/content/en/developers/dogstatsd/_index.md
@@ -159,15 +159,16 @@ env:
               fieldPath: metadata.uid
 ```
 
-To set [tag cardinality][5] for the metrics collected using origin detection, use the environment variable `DD_DOGSTATSD_TAG_CARDINALITY`.
+To set [tag cardinality][5] for the metrics collected using origin detection, set the environment variable `DD_DOGSTATSD_TAG_CARDINALITY` to either `low` or `orchestrator`. The default is `low`.
 
-There are two environment variables that set tag cardinality: `DD_CHECKS_TAG_CARDINALITY` and `DD_DOGSTATSD_TAG_CARDINALITY`—as DogStatsD is priced differently, its tag cardinality setting is separated in order to provide the opportunity for finer configuration. Otherwise, these variables function the same way: they can have values `low`, `orchestrator`, or `high`. They both default to `low`.
+**Note:** `pod_name` tags are not added to avoid creating too many [custom metrics][6]. 
 
 [1]: /developers/dogstatsd/unix_socket/
 [2]: https://github.com/containernetworking/cni
 [3]: https://kubernetes.io/docs/setup/independent/troubleshooting-kubeadm/#hostport-services-do-not-work
 [4]: /developers/dogstatsd/unix_socket/#using-origin-detection-for-container-tagging
 [5]: /tagging/assigning_tags/#environment-variables
+[6]: /developers/metrics/custom_metrics
 {{% /tab %}}
 {{% tab "Helm" %}}
 

--- a/content/en/developers/dogstatsd/_index.md
+++ b/content/en/developers/dogstatsd/_index.md
@@ -161,7 +161,7 @@ env:
 
 To set [tag cardinality][5] for the metrics collected using origin detection, set the environment variable `DD_DOGSTATSD_TAG_CARDINALITY` to either `low` (default) or `orchestrator`.
 
-**Note:** `pod_name` tags are not added to avoid creating too many [custom metrics][6]. 
+**Note:** For UDP, `pod_name` tags are not added by default to avoid creating too many [custom metrics][6]. 
 
 [1]: /developers/dogstatsd/unix_socket/
 [2]: https://github.com/containernetworking/cni

--- a/content/en/developers/dogstatsd/_index.md
+++ b/content/en/developers/dogstatsd/_index.md
@@ -159,7 +159,7 @@ env:
               fieldPath: metadata.uid
 ```
 
-To set [tag cardinality][5] for the metrics collected using origin detection, set the environment variable `DD_DOGSTATSD_TAG_CARDINALITY` to either `low` or `orchestrator`. The default is `low`.
+To set [tag cardinality][5] for the metrics collected using origin detection, set the environment variable `DD_DOGSTATSD_TAG_CARDINALITY` to either `low` (default) or `orchestrator`.
 
 **Note:** `pod_name` tags are not added to avoid creating too many [custom metrics][6]. 
 

--- a/content/en/developers/dogstatsd/unix_socket.md
+++ b/content/en/developers/dogstatsd/unix_socket.md
@@ -133,7 +133,7 @@ volumes:
 
 Origin detection allows DogStatsD to detect where the container metrics come from, and tag metrics automatically. When this mode is enabled, all metrics received via UDS are tagged by the same container tags as Autodiscovery metrics.
 
-To configure [tag cardinality][13] for the metrics collected using origin detection, set the environment variable `DD_DOGSTATSD_TAG_CARDINALITY` to `low`, `orchestrator`, or `high`. The default is `low`.
+To configure [tag cardinality][13] for the metrics collected using origin detection, set the environment variable `DD_DOGSTATSD_TAG_CARDINALITY` to `low` (default), `orchestrator`, or `high`.
 
 **Note:** `container_id`, `container_name`, and `pod_name` tags are not added automatically to avoid creating too many [custom metrics][11].
 

--- a/content/en/developers/dogstatsd/unix_socket.md
+++ b/content/en/developers/dogstatsd/unix_socket.md
@@ -133,7 +133,9 @@ volumes:
 
 Origin detection allows DogStatsD to detect where the container metrics come from, and tag metrics automatically. When this mode is enabled, all metrics received via UDS are tagged by the same container tags as Autodiscovery metrics.
 
-**Note:** `container_id`, `container_name`, and `pod_name` tags are not added automatically to avoid creating too many [custom metrics][11]. The [tag cardinality][13] for the metrics collected using origin detection can be modified with `DD_DOGSTATSD_TAG_CARDINALITY`.
+To configure [tag cardinality][13] for the metrics collected using origin detection, set the environment variable `DD_DOGSTATSD_TAG_CARDINALITY` to either `low`, `orchestrator`, or `high`. The default is `low`.
+
+**Note:** `container_id`, `container_name`, and `pod_name` tags are not added automatically to avoid creating too many [custom metrics][11].
 
 To use origin detection:
 

--- a/content/en/developers/dogstatsd/unix_socket.md
+++ b/content/en/developers/dogstatsd/unix_socket.md
@@ -133,7 +133,7 @@ volumes:
 
 Origin detection allows DogStatsD to detect where the container metrics come from, and tag metrics automatically. When this mode is enabled, all metrics received via UDS are tagged by the same container tags as Autodiscovery metrics.
 
-**Note:** `container_id`, `container_name`, and `pod_name` tags are not added to avoid creating too many [custom metrics][11].
+**Note:** `container_id`, `container_name`, and `pod_name` tags are not added automatically to avoid creating too many [custom metrics][11]. The [tag cardinality][13] for the metrics collected using origin detection can be modified with `DD_DOGSTATSD_TAG_CARDINALITY`.
 
 To use origin detection:
 
@@ -171,3 +171,4 @@ When running inside a container, DogStatsd needs to run in the host's PID namesp
 [10]: https://github.com/DataDog/datadog-agent/wiki/Unix-Domain-Sockets-support
 [11]: /developers/metrics/custom_metrics
 [12]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_definition_pidmode
+[13]: /tagging/assigning_tags/?tab=agentv6v7#environment-variables

--- a/content/en/developers/dogstatsd/unix_socket.md
+++ b/content/en/developers/dogstatsd/unix_socket.md
@@ -173,4 +173,4 @@ When running inside a container, DogStatsd needs to run in the host's PID namesp
 [10]: https://github.com/DataDog/datadog-agent/wiki/Unix-Domain-Sockets-support
 [11]: /developers/metrics/custom_metrics
 [12]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_definition_pidmode
-[13]: /tagging/assigning_tags/?tab=agentv6v7#environment-variables
+[13]: /tagging/assigning_tags/#environment-variables

--- a/content/en/developers/dogstatsd/unix_socket.md
+++ b/content/en/developers/dogstatsd/unix_socket.md
@@ -135,7 +135,7 @@ Origin detection allows DogStatsD to detect where the container metrics come fro
 
 To configure [tag cardinality][13] for the metrics collected using origin detection, set the environment variable `DD_DOGSTATSD_TAG_CARDINALITY` to `low` (default), `orchestrator`, or `high`.
 
-**Note:** `container_id`, `container_name`, and `pod_name` tags are not added automatically to avoid creating too many [custom metrics][11].
+**Note:** `container_id`, `container_name`, and `pod_name` tags are not added by default to avoid creating too many [custom metrics][11].
 
 To use origin detection:
 

--- a/content/en/developers/dogstatsd/unix_socket.md
+++ b/content/en/developers/dogstatsd/unix_socket.md
@@ -133,7 +133,7 @@ volumes:
 
 Origin detection allows DogStatsD to detect where the container metrics come from, and tag metrics automatically. When this mode is enabled, all metrics received via UDS are tagged by the same container tags as Autodiscovery metrics.
 
-To configure [tag cardinality][13] for the metrics collected using origin detection, set the environment variable `DD_DOGSTATSD_TAG_CARDINALITY` to either `low`, `orchestrator`, or `high`. The default is `low`.
+To configure [tag cardinality][13] for the metrics collected using origin detection, set the environment variable `DD_DOGSTATSD_TAG_CARDINALITY` to `low`, `orchestrator`, or `high`. The default is `low`.
 
 **Note:** `container_id`, `container_name`, and `pod_name` tags are not added automatically to avoid creating too many [custom metrics][11].
 


### PR DESCRIPTION
### What does this PR do?
Add notes about changing tag cardinality in UDS and UDP DSD with `DD_DOGSTATSD_TAG_CARDINALITY`

### Motivation
Clarification based on support escalation

### Preview link
Kubernetes UDP: https://docs-staging.datadoghq.com/caroline.kim/add-tag-cardinality-option/developers/dogstatsd/?tab=kubernetes#origin-detection-over-udp
UDS: https://docs-staging.datadoghq.com/caroline.kim/add-tag-cardinality-option/developers/dogstatsd/unix_socket/?tab=docker#using-origin-detection-for-container-tagging

### Additional Notes
