### PR TITLE
Sabiur.rahman/aws integration excluded regions api

### DIFF
--- a/content/en/api/integrations_aws/aws_create.md
+++ b/content/en/api/integrations_aws/aws_create.md
@@ -48,6 +48,10 @@ Create a Datadog-Amazon Web Services integration.
 
     An object (in the form `{"namespace1":true/false, "namespace2":true/false}`) that enables or disables metric collection for specific AWS namespaces for this AWS account only. A list of namespaces can be found at the `/v1/integration/aws/available_namespace_rules` endpoint.
 
+* **`excluded_regions`** [*optional*, *default*=**None**]:
+
+    Array of AWS regions that will be excluded from metrics collection. 
+
 [1]: /integrations/amazon_web_services/#configuration
 [2]: /integrations/amazon_web_services/#installation
 [3]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html

--- a/content/en/api/integrations_aws/aws_create.md
+++ b/content/en/api/integrations_aws/aws_create.md
@@ -50,7 +50,7 @@ Create a Datadog-Amazon Web Services integration.
 
 * **`excluded_regions`** [*optional*, *default*=**None**]:
 
-    Array of AWS regions that will be excluded from metrics collection. 
+    An array of AWS regions to exclude from metrics collection. 
 
 [1]: /integrations/amazon_web_services/#configuration
 [2]: /integrations/amazon_web_services/#installation

--- a/content/en/api/integrations_aws/aws_update.md
+++ b/content/en/api/integrations_aws/aws_update.md
@@ -114,6 +114,10 @@ Update a Datadog-Amazon Web Services integration.
 
     An object (in the form `{"namespace1":true/false, "namespace2":true/false}`) that enables or disables metric collection for specific AWS namespaces for this AWS account only. A list of namespaces can be found at the `/v1/integration/aws/available_namespace_rules` endpoint.
 
+* **`excluded_regions`** [*optional*, *default*=**None**]:
+
+    Array of AWS regions that will be excluded from metrics collection. 
+
 [1]: /integrations/amazon_web_services/#configuration
 [2]: /integrations/amazon_web_services/#installation
 [3]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html

--- a/content/en/api/integrations_aws/aws_update.md
+++ b/content/en/api/integrations_aws/aws_update.md
@@ -116,7 +116,7 @@ Update a Datadog-Amazon Web Services integration.
 
 * **`excluded_regions`** [*optional*, *default*=**None**]:
 
-    Array of AWS regions that will be excluded from metrics collection. 
+    An array of AWS regions to exclude from metrics collection. 
 
 [1]: /integrations/amazon_web_services/#configuration
 [2]: /integrations/amazon_web_services/#installation

--- a/content/en/api/integrations_aws/code_snippets/aws_create.py
+++ b/content/en/api/integrations_aws/code_snippets/aws_create.py
@@ -12,5 +12,6 @@ api.AwsIntegration.create(
     host_tags=["tag:example"],
     filter_tags=["filter:example"],
     role_name="<AWS_ROLE_NAME>",
-    account_specific_namespace_rules={'namespace1': True/False, 'namespace2': True/False}
+    account_specific_namespace_rules={'namespace1': True/False, 'namespace2': True/False},
+    excluded_regions=["us-east-1", "us-west-1"]
 )

--- a/content/en/api/integrations_aws/code_snippets/aws_create.rb
+++ b/content/en/api/integrations_aws/code_snippets/aws_create.rb
@@ -11,7 +11,8 @@ config = {
   "filter_tags": ["<KEY>:<VALUE>"],
   "host_tags": ["<KEY>:<VALUE>"],
   "role_name": "DatadogAWSIntegrationRole",
-  "account_specific_namespace_rules": {"auto_scaling": false, "opsworks": false}
+  "account_specific_namespace_rules": {"auto_scaling": false, "opsworks": false},
+  "excluded_regions": ["us-east-1", "us-west-1"]
 }
 
 dog.aws_integration_create(config)

--- a/content/en/api/integrations_aws/code_snippets/aws_create.sh
+++ b/content/en/api/integrations_aws/code_snippets/aws_create.sh
@@ -16,6 +16,7 @@ curl -X POST \
         "account_specific_namespace_rules": {
         	"auto_scaling": false,
         	"opsworks": false
-        }
+        },
+        "excluded_regions": ["us-east-1", "us-west-1"]
     }'\
 "https://api.datadoghq.com/api/v1/integration/aws"

--- a/content/en/api/integrations_aws/code_snippets/aws_update.py
+++ b/content/en/api/integrations_aws/code_snippets/aws_update.py
@@ -15,5 +15,6 @@ api.AwsIntegration.update(
     new_role_name="<NEW_AWS_ROLE_NAME>",
     host_tags=["hosttag:example"],
     filter_tags=["filter:example"],
-    account_specific_namespace_rules = {"namespace1":True/False, "namespace2":True/False}
+    account_specific_namespace_rules = {"namespace1":True/False, "namespace2":True/False},
+    excluded_regions=["us-east-1", "us-west-1"]
 )

--- a/content/en/api/integrations_aws/code_snippets/aws_update.rb
+++ b/content/en/api/integrations_aws/code_snippets/aws_update.rb
@@ -15,7 +15,8 @@ new_config = {
   "account_id": '<NEW_AWS_ACCOUNT_ID>',
   "host_tags": ["<KEY>:<VALUE>"],
   "filter_tags": ["<KEY>:<VALUE>"],
-  "role_name": '<NEW_AWS_ROLE_NAME>'
+  "role_name": '<NEW_AWS_ROLE_NAME>',
+  "excluded_regions": ["us-east-1", "us-west-1"]
 }
 
 dog = Dogapi::Client.new(api_key, app_key)

--- a/content/en/api/integrations_aws/code_snippets/aws_update.sh
+++ b/content/en/api/integrations_aws/code_snippets/aws_update.sh
@@ -19,6 +19,7 @@ curl -X PUT \
         "account_specific_namespace_rules": {
             "auto_scaling": false,
             "opsworks": false
-        }
+        },
+        "excluded_regions": ["us-east-1", "us-west-1"]
     }' \
 "https://api.datadoghq.com/api/v1/integration/aws?account_id=<YOUR_AWS_ACCOUNT_ID>&role_name=<ROLE_NAME>"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates the `POST/PUT /v1/integration/aws` endpoints to include new field for `excluded_regions`. 

### Motivation
<!-- What inspired you to submit this pull request?-->
API Updates

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/sabiur.rahman/aws-integration-excluded-regions-api/api

### Additional Notes
<!-- Anything else we should know when reviewing?-->
