### PR TITLE
Remove invalid characters

### DIFF
--- a/content/en/real_user_monitoring/data_collected/_index.md
+++ b/content/en/real_user_monitoring/data_collected/_index.md
@@ -32,7 +32,7 @@ These five event categories have attributes attached by default:
 
 | Attribute name   | Type   | Description                 |
 |------------------|--------|-----------------------------|
-| `application_id` | string | The Datadog application ID. |
+| `application_id` | string | The Datadog application ID. |
 | `session_id`     | string | The session ID.             |
 
 ### View Attribute
@@ -53,7 +53,7 @@ The following contexts—following the [Datadog Standard Attributes][1] logic—
 
 | Attribute name                           | Type   | Description                                     |
 |------------------------------------------|--------|-------------------------------------------------|
-| `http.useragent_details.os.family`       | string | The OS family reported by the User-Agent.       |
+| `http.useragent_details.os.family`       | string | The OS family reported by the User-Agent.       |
 | `http.useragent_details.browser.family`  | string | The browser Family reported by the User-Agent.  |
 | `http.useragent_details.device.family`   | string | The device family reported by the User-Agent.   |
 | `http.useragent_details.device.category` | string | The device category reported by the User-Agent. |


### PR DESCRIPTION
Cleanup to remove couple of  (box) characters

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Two  (box) characters were in there. This is just to clean those up.

### Motivation
<!-- What inspired you to submit this pull request?-->
Cleanup

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jack.davenport/rum_data_collected_cleanup/real_user_monitoring/data_collected/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Current Link:
https://docs.datadoghq.com/real_user_monitoring/data_collected/