### PR TITLE
Revert "add documentation for configuring docker labels for tag autodiscovery"

### DIFF
--- a/content/en/agent/autodiscovery/tag.md
+++ b/content/en/agent/autodiscovery/tag.md
@@ -44,13 +44,6 @@ annotations:
   ad.datadoghq.com/<CONTAINER_IDENTIFIER>.tags: '{"<TAG_KEY>": "<TAG_VALUE>","<TAG_KEY_1>": "<TAG_VALUE_1>"}'
 ```
 
-Starting with Agent v7.17+, the Agent can Autodiscover tags from Docker labels. This process allows the Agent to associate custom tags to all data emitted by a container, without [modifying the Agent `datadog.yaml` file][1].
-
-```yaml
-com.datadoghq.ad.tags: '["<TAG_KEY>:TAG_VALUE", "<TAG_KEY_1>:<TAG_VALUE_1>"]'
-```
-
-
 ### Extract Node Labels as Tags
 
 Starting with Agent v6.0+, the Agent can collect labels for a given node and use them as tags to attach to all metrics emitted by all pods on this node:
@@ -275,4 +268,3 @@ DD_DOCKER_ENV_AS_TAGS='{"ENVIRONMENT":"env"}'
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
-[1]: /agent/autodiscovery/tag/?tab=agent#extract-labels-as-tags


### PR DESCRIPTION
Reverts DataDog/documentation#6265

Reverting this docs change because the feature was put on hold.