### PR TITLE
[WEB-77] fingerprint content images

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -27,3 +27,6 @@ markup:
   defaultMarkdownHandler: blackfriday
   highlight:
     guessSyntax: true
+
+# so we can access images as resources
+assetDir: "static"

--- a/layouts/partials/img-resource.html
+++ b/layouts/partials/img-resource.html
@@ -1,1 +1,1 @@
-{{- $dot := .context -}}{{- with resources.Get .src  -}}{{- $perm := ( . | resources.Fingerprint).RelPermalink -}}{{- print (strings.TrimRight "/" $dot.Site.Params.img_url) $perm -}}{{- end -}}
+{{- $dot := .context -}}{{- with resources.Get .src  -}}{{- $perm := ( . | resources.Fingerprint "md5").RelPermalink -}}{{- print (strings.TrimRight "/" $dot.Site.Params.img_url) $perm -}}{{- end -}}

--- a/layouts/partials/img-resource.html
+++ b/layouts/partials/img-resource.html
@@ -1,0 +1,1 @@
+{{- $dot := .context -}}{{- with resources.Get .src  -}}{{- $perm := ( . | resources.Fingerprint).RelPermalink -}}{{- print (strings.TrimRight "/" $dot.Site.Params.img_url) $perm -}}{{- end -}}

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -14,6 +14,8 @@
 {{- $src := (.Get "src") -}}
 {{- $img := (print .Site.Params.img_url "images/" $src) -}}
 
+{{- $img_resource := partial "img-resource.html" (dict "context" . "src" (print "images/" $src)) -}}
+
 {{- $image_type_arr := split (.Get "src") "." -}}
 {{- $image_ext := index $image_type_arr 1 -}}
 {{- if $wide -}}
@@ -54,24 +56,24 @@
     </video>
 {{- else -}}
     {{- if (and (eq $isPopup "true") (ne $image_ext "gif")) -}}
-      <a href="{{ print $img $pop_param | relURL }}" class="pop" data-toggle="modal" data-target="#popupImageModal">
+      <a href="{{ print $img_resource $pop_param | relURL }}" class="pop" data-toggle="modal" data-target="#popupImageModal">
     {{- else if .Get "href" -}}
       <a href="{{- with .Get "href" -}}{{- . -}}{{- end -}}"
          {{- if .Get "target" -}}target="{{- with .Get "target" -}}{{- . -}}{{- end -}}"{{- end -}} >
     {{- end -}}
     {{- if $wide -}}
-      {{ $e := (print $img "?auto=format" | relURL | safeURL) }}
+      {{ $e := (print $img_resource "?auto=format" safeURL) }}
       {{- if eq $image_ext "gif" -}}
-        <img class="img-fluid" src="{{ (print $img "?fm=gif" | relURL | safeURL) }}" {{ if .Get "style" }} style="{{ with .Get "style" }}{{ . | safeCSS }}{{end}}" {{ end }} {{ if .Get "alt" }} alt="{{ with .Get "alt"}}{{ . }}{{ end }}" {{ end }} />
+        <img class="img-fluid" src="{{ (print $img_resource "?fm=gif" | safeURL) }}" {{ if .Get "style" }} style="{{ with .Get "style" }}{{ . | safeCSS }}{{end}}" {{ end }} {{ if .Get "alt" }} alt="{{ with .Get "alt"}}{{ . }}{{ end }}" {{ end }} />
       {{- else -}}
         <picture {{ if .Get "style" }} style="{{- with .Get "style" -}}{{- . | safeCSS -}}{{- end -}}" {{ end }}>
           <img class="lazyload img-fluid" srcset="{{ $e }}" {{ if .Get "style" }} style="{{ with .Get "style" }}{{ . | safeCSS }}{{end}}" {{ end }} {{ if .Get "alt" }} alt="{{ with .Get "alt"}}{{ . }}{{ end }}" {{ end }} />
         </picture>
       {{- end -}}
     {{- else -}}
-        {{ $e := (print $img "?auto=format" | relURL | safeURL) }}
+        {{ $e := (print $img_resource "?auto=format" | safeURL) }}
         {{- if eq $image_ext "gif" -}}
-            <img class="img-fluid" src="{{ (print $img "?fm=gif" | relURL | safeURL) }}" {{ if .Get "style" }} style="{{- with .Get "style" -}}{{ . | safeCSS }}{{- end -}}" {{ end }} {{ if .Get "alt" }} alt="{{- with .Get "alt" -}}{{.}}{{- end -}}" {{ end }} />
+            <img class="img-fluid" src="{{ (print $img_resource "?fm=gif" | safeURL) }}" {{ if .Get "style" }} style="{{- with .Get "style" -}}{{ . | safeCSS }}{{- end -}}" {{ end }} {{ if .Get "alt" }} alt="{{- with .Get "alt" -}}{{.}}{{- end -}}" {{ end }} />
         {{- else -}}
           <picture class="" {{ if .Get "style" }} style="{{- with .Get "style" -}}{{- . | safeCSS -}}{{- end -}}" {{ end }} >
           <img class="lazyload img-fluid" srcset="{{ $e }}" {{ if .Get "style" }} style="{{ with .Get "style" }}{{ . | safeCSS }}{{ end }}" {{ end }} {{ if .Get "alt" }} alt="{{- with .Get "alt" -}}{{.}}{{- end -}}" {{ end }} />


### PR DESCRIPTION
### What does this PR do?

**Problem:**
If we replace an existing image on the documentation (e.g same filename but different content) the image change isn't visible on the site due to caching at imgix.

From Imgix documentation:
> To absolutely ensure compliance for an updated image, it is best to give the image a new path by renaming the file. Purging an image is only recommended when absolutely necessary. 

Sometimes we manually purge the problem images or recommend the contributor to create a new image filename, however this isn't always ideal for contributors and also leaves unused assets or additional reliance on our team to purge that might not be necessary.

**Solution:**
Prior to the migration from gulp to webpack we were fingerprinting images with an outdated gulp script. This PR attempts to bring back fingerprinting of images so that content changes will cause a new fingerprint and no cache on the image.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-77

### Preview link

See that images in the content now appear with the hash in the filename e.g `dashboard_list2.da62e33eca39488c13a20c385a0d3654.png`

https://docs-staging.datadoghq.com/david.jones/fingerprint/

### Additional Notes

