### PR TITLE
Inject span context on correctly request header

### DIFF
--- a/content/en/tracing/manual_instrumentation/go.md
+++ b/content/en/tracing/manual_instrumentation/go.md
@@ -62,7 +62,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
     req, err := http.NewRequest("GET", "http://example.com", nil)
     req = req.WithContext(ctx)
     // Inject the span Context in the Request headers
-    err = tracer.Inject(span.Context(), tracer.HTTPHeadersCarrier(r.Header))
+    err = tracer.Inject(span.Context(), tracer.HTTPHeadersCarrier(req.Header))
     if err != nil {
         // Handle or log injection error
     }


### PR DESCRIPTION
### What does this PR do?
Fix Go manual instrumentation documentation 
### Motivation
The code don't work correctly, the injection is on wrong request.header