### PR TITLE
Fix tracer injection Go docs

### DIFF
--- a/content/en/tracing/manual_instrumentation/go.md
+++ b/content/en/tracing/manual_instrumentation/go.md
@@ -62,7 +62,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
     req, err := http.NewRequest("GET", "http://example.com", nil)
     req = req.WithContext(ctx)
     // Inject the span Context in the Request headers
-    err = tracer.Inject(span.Context(), tracer.HTTPHeadersCarrier(r.Header))
+    err = tracer.Inject(span.Context(), tracer.HTTPHeadersCarrier(req.Header))
     if err != nil {
         // Handle or log injection error
     }


### PR DESCRIPTION
### What does this PR do?
Fix tracer injection 
### Motivation
The code on documentation don't work correctly because the tracer injection is on wrong request.

### Preview Link

https://docs-staging.datadoghq.com/willianvalerio/fix-go-docs/tracing/manual_instrumentation/go/

### Additional Notes
Before corection:
![Captura de Tela 2020-03-20 às 11 17 35](https://user-images.githubusercontent.com/7062667/77172286-7ba3db80-6a9c-11ea-87ef-d71a51f47fe8.png)

After correction:
![Captura de Tela 2020-03-20 às 11 17 44](https://user-images.githubusercontent.com/7062667/77172308-82cae980-6a9c-11ea-8633-1c8d2b8af913.png)

