### PR TITLE
Remove link to Okta documentation

### DIFF
--- a/content/en/account_management/saml/okta.md
+++ b/content/en/account_management/saml/okta.md
@@ -14,8 +14,6 @@ further_reading:
 
 It's recommended that you set up Datadog as an Okta application manually, as opposed to using a 'pre-configured' configuration.
 
-[Consult the dedicated Okta documentation, to know how to Configure SAML 2.0 for Datadog][1]
-
 ## General Details
 
 * **Single Sign On URL**: https://app.datadoghq.com/account/saml/assertion
@@ -58,7 +56,6 @@ In the event that you need to upload an `IDP.XML` file to Datadog before being a
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: http://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-for-DataDog.html
 [2]: https://app.datadoghq.com/saml/saml_setup
 [3]: /account_management/saml
 [4]: https://support.okta.com/help/s/article/How-do-we-download-the-IDP-XML-metadata-file-from-a-SAML-Template-App


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes the link to the Okta documentation.

### Motivation
We don't want customers to use the Okta documentation because it's for setting up the pre-configured Datadog application in Okta. We want users to always setup a new application manually in Okta for Datadog, because the pre-configured application does not work for orgs with custom subdomains. Many support tickets were generated around this, and in many of those users referenced the fact that our doc linked to the Okta doc.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jodiely%2Fupdate_okta_saml_doc/account_management/saml/okta/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
