### PR TITLE
[DOCS-745] Adding body limitation for synthetics test

### DIFF
--- a/content/en/synthetics/api_tests/_index.md
+++ b/content/en/synthetics/api_tests/_index.md
@@ -41,7 +41,7 @@ Define the request you want to be executed by Datadog:
 2. Choose the **Method** and **URL** to query. Available methods are: `GET`, `POST`, `PATCH`, `PUT`, `HEAD`, `DELETE`, and `OPTIONS`.
     * Advanced Options (optional): Use custom request headers, authentication credentials, body content, or cookies.
         * Follow redirects: Toggle to have the monitored endpoint follow up to ten redirects.
-        * Allow insecure certificates: Toggle to have your HTTP test go on with connection even if there is an error when validating the certificate. 
+        * Allow insecure certificates: Toggle to have your HTTP test go on with connection even if there is an error when validating the certificate.
         * Headers: Defined headers override the default browser headers. For example, set the User Agent in the header to [identify Datadog scripts][1].
         * Authentication: HTTP basic authentication with username and password
         * Body: Request body and body type (`text/plain`, `application/json`, `text/xml`, `text/html`, or `None`)
@@ -115,6 +115,9 @@ When running an API test, you must define at least one assertion that should be 
 | Response time | `lessThan`                                                                      | _Integer (ms)_             |
 | Headers       | `contains`, `does not contain`, `is`, `is not` <br> `matches`, `does not match` | _String_ <br> _[Regex][1]_ |
 | Body          | `contains`, `does not contain`, `is`, `is not` <br> `matches`, `does not match` | _String_ <br> _[Regex][1]_ |
+
+
+**Note**: The body content retrieved is limited to a maximum size of 50 kilobyte, bigger body gets truncated at 50 kilobyte.
 
 If you click on **Test URL**, then the basic assertions are automatically filled:
 

--- a/content/en/synthetics/api_tests/_index.md
+++ b/content/en/synthetics/api_tests/_index.md
@@ -44,7 +44,7 @@ Define the request you want to be executed by Datadog:
         * Allow insecure certificates: Toggle to have your HTTP test go on with connection even if there is an error when validating the certificate.
         * Headers: Defined headers override the default browser headers. For example, set the User Agent in the header to [identify Datadog scripts][1].
         * Authentication: HTTP basic authentication with username and password
-        * Body: Request body and body type (`text/plain`, `application/json`, `text/xml`, `text/html`, or `None`). **Note**: The request body is limited to a maximum size of 50 kilobyte.
+        * Body: Request body and body type (`text/plain`, `application/json`, `text/xml`, `text/html`, or `None`). **Note**: The request body is limited to a maximum size of 50 kilobytes.
         * Cookies: Defined cookies are added to the default browser cookies. Set multiple cookies using the format `<COOKIE_NAME1>=<COOKIE_VALUE1>; <COOKIE_NAME2>=<COOKIE_VALUE2>`.
 
 3. **Name**: The name of your API test.

--- a/content/en/synthetics/api_tests/_index.md
+++ b/content/en/synthetics/api_tests/_index.md
@@ -44,7 +44,7 @@ Define the request you want to be executed by Datadog:
         * Allow insecure certificates: Toggle to have your HTTP test go on with connection even if there is an error when validating the certificate.
         * Headers: Defined headers override the default browser headers. For example, set the User Agent in the header to [identify Datadog scripts][1].
         * Authentication: HTTP basic authentication with username and password
-        * Body: Request body and body type (`text/plain`, `application/json`, `text/xml`, `text/html`, or `None`)
+        * Body: Request body and body type (`text/plain`, `application/json`, `text/xml`, `text/html`, or `None`). **Note**: The request body is limited to a maximum size of 50 kilobyte.
         * Cookies: Defined cookies are added to the default browser cookies. Set multiple cookies using the format `<COOKIE_NAME1>=<COOKIE_VALUE1>; <COOKIE_NAME2>=<COOKIE_VALUE2>`.
 
 3. **Name**: The name of your API test.
@@ -115,9 +115,6 @@ When running an API test, you must define at least one assertion that should be 
 | Response time | `lessThan`                                                                      | _Integer (ms)_             |
 | Headers       | `contains`, `does not contain`, `is`, `is not` <br> `matches`, `does not match` | _String_ <br> _[Regex][1]_ |
 | Body          | `contains`, `does not contain`, `is`, `is not` <br> `matches`, `does not match` | _String_ <br> _[Regex][1]_ |
-
-
-**Note**: The body content retrieved is limited to a maximum size of 50 kilobyte, bigger body gets truncated at 50 kilobyte.
 
 If you click on **Test URL**, then the basic assertions are automatically filled:
 


### PR DESCRIPTION
### What does this PR do?
Body retrieved is limited to 50K

### Motivation
Support feedback

### Preview link

* https://docs-staging.datadoghq.com/gus/synthetics/synthetics/api_tests/?tab=httptest#assertions