### PR TITLE
[DOCS-768] Adding docker daemon metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Hugo
 public/
-data/integrations/
 data/service_checks/
 integrations_data
 
@@ -23,6 +22,8 @@ package-lock.json
 
 # Ignoring all integrations file
 content/en/integrations/*.md
+data/integrations/
+!data/integrations/docker_daemon.yaml
 !content/en/integrations/_index.md
 !content/en/integrations/cloudability.md
 !content/en/integrations/cloudcheckr.md

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ clean-integrations:  ## Remove built integrations files.
 		find ./data/integrations -type f -maxdepth 1 \
 	    -a -not -name '*.fr.yaml' \
 	    -a -not -name '*.ja.yaml' \
+		-a -not -name 'docker_daemon.yaml' \
 	    -exec rm -rf {} \; ;fi
 	@if [ -d data/service_checks ]; then \
 		find ./data/service_checks -type f -maxdepth 1 \

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -222,6 +222,11 @@ main:
     parent: "agent_docker"
     identifier: "agent_docker_prometheus"
     weight: 204
+  - name: "Data Collected"
+    url: "agent/docker/data_collected/"
+    parent: "agent_docker"
+    identifier: "agent_docker_data_collected"
+    weight: 205
 
   ## AGENT - Kubernetes
 

--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -276,7 +276,7 @@ The same can be done for the `/checks.d` folder. Any Python files in the `/check
 [20]: /agent/autodiscovery/management/?tab=containerizedagent
 [21]: /integrations/system/#metrics
 [22]: /integrations/disk/#metrics
-[23]: /integrations/docker_daemon/#metrics
+[23]: /agent/docker/data_collected/#metrics
 [24]: /integrations/network/#metrics
 [25]: /integrations/ntp/#metrics
 [26]: /agent/autodiscovery/integrations

--- a/content/en/agent/docker/data_collected.md
+++ b/content/en/agent/docker/data_collected.md
@@ -1,0 +1,37 @@
+---
+title: Docker Data Collected
+kind: documentation
+---
+
+## Metrics
+
+Metrics collected by the Agent when deployed in a Docker container:
+
+{{< get-metrics-from-git "docker_daemon" >}}
+
+## Events
+
+The Docker Agent produces the following events:
+
+- Delete Image
+- Die
+- Error
+- Fail
+- Kill
+- Out of memory (oom)
+- Pause
+- Restart container
+- Restart Daemon
+- Update
+
+## Service Checks
+
+- **docker.service_up**:
+    Returns `CRITICAL` if the Agent is unable to collect the list of containers from the Docker daemon, otherwise returns `OK`.
+
+- **docker.container_health**:
+    This Service Check is only available for Agent v5. It returns `CRITICAL` if a container is unhealthy, `UNKNOWN` if the health is unknown, and `OK` otherwise.
+
+- **docker.exit**:
+    Returns `CRITICAL` if a container exited with a non-zero exit code, otherwise returns `OK`.
+

--- a/content/en/getting_started/agent/_index.md
+++ b/content/en/getting_started/agent/_index.md
@@ -151,7 +151,7 @@ For help troubleshooting the Agent:
 [14]: /integrations/agent_metrics
 [15]: /integrations/system/#metrics
 [16]: /integrations/disk/#metrics
-[17]: /integrations/docker_daemon/#metrics
+[17]: /agent/docker/data_collected/#metrics
 [18]: /integrations/network/#metrics
 [19]: /integrations/ntp/#metrics
 [20]: /getting_started/integrations

--- a/data/integrations/docker_daemon.yaml
+++ b/data/integrations/docker_daemon.yaml
@@ -1,0 +1,1087 @@
+docker_daemon:
+- description: The percent of time the CPU is executing system calls on behalf of
+    processes of this container, unnormalized
+  integration: docker
+  interval: ''
+  metric_name: docker.cpu.system
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: cpu system
+  unit_name: percent
+- description: 95th percentile of docker.cpu.system
+  integration: docker
+  interval: ''
+  metric_name: docker.cpu.system.95percentile
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: cpu system 95%
+  unit_name: percent
+- description: Average value of docker.cpu.system
+  integration: docker
+  interval: ''
+  metric_name: docker.cpu.system.avg
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: cpu system avg
+  unit_name: percent
+- description: The rate that the value of docker.cpu.system was sampled
+  integration: docker
+  interval: ''
+  metric_name: docker.cpu.system.count
+  metric_type: rate
+  orientation: '0'
+  per_unit_name: second
+  short_name: cpu system count
+  unit_name: sample
+- description: Max value of docker.cpu.system
+  integration: docker
+  interval: ''
+  metric_name: docker.cpu.system.max
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: cpu system max
+  unit_name: percent
+- description: Median value of docker.cpu.system
+  integration: docker
+  interval: ''
+  metric_name: docker.cpu.system.median
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: cpu system median
+  unit_name: percent
+- description: The percent of time the CPU is under direct control of processes of
+    this container, unnormalized
+  integration: docker
+  interval: ''
+  metric_name: docker.cpu.user
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: cpu user
+  unit_name: percent
+- description: 95th percentile of docker.cpu.user
+  integration: docker
+  interval: ''
+  metric_name: docker.cpu.user.95percentile
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: cpu user 95%
+  unit_name: percent
+- description: Average value of docker.cpu.user
+  integration: docker
+  interval: ''
+  metric_name: docker.cpu.user.avg
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: cpu user avg
+  unit_name: percent
+- description: The rate that the value of docker.cpu.user was sampled
+  integration: docker
+  interval: ''
+  metric_name: docker.cpu.user.count
+  metric_type: rate
+  orientation: '0'
+  per_unit_name: second
+  short_name: cpu user count
+  unit_name: sample
+- description: Max value of docker.cpu.user
+  integration: docker
+  interval: ''
+  metric_name: docker.cpu.user.max
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: cpu user max
+  unit_name: percent
+- description: Median value of docker.cpu.user
+  integration: docker
+  interval: ''
+  metric_name: docker.cpu.user.median
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: cpu user median
+  unit_name: percent
+- description: The percent of CPU time obtained by this container
+  integration: docker
+  interval: ''
+  metric_name: docker.cpu.usage
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: docker.cpu.usage
+  unit_name: percent
+- description: Number of times the cgroup has been throttled
+  integration: docker
+  interval: ''
+  metric_name: docker.cpu.throttled
+  metric_type: gauge
+  orientation: '-1'
+  per_unit_name: ''
+  short_name: cpu throttled
+  unit_name: ''
+- description: Shares of CPU usage allocated to the container
+  integration: docker
+  interval: ''
+  metric_name: docker.cpu.shares
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: cpu shares
+  unit_name: ''
+- description: The amount of kernel memory that belongs to the container's processes.
+  integration: docker
+  interval: ''
+  metric_name: docker.kmem.usage
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: kmem usage
+  unit_name: byte
+- description: The amount of memory that is being used to cache data from disk (e.g.
+    memory contents that can be associated precisely with a block on a block device)
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.cache
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem cache
+  unit_name: byte
+- description: 95th percentile value of docker.mem.cache
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.cache.95percentile
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem cache 95%
+  unit_name: byte
+- description: Average value of docker.mem.cache
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.cache.avg
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem cache avg
+  unit_name: byte
+- description: The rate that the value of docker.mem.cache was sampled
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.cache.count
+  metric_type: rate
+  orientation: '0'
+  per_unit_name: second
+  short_name: mem cache count
+  unit_name: sample
+- description: Max value of docker.mem.cache
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.cache.max
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem cache max
+  unit_name: byte
+- description: Median value of docker.mem.cache
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.cache.median
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem cache median
+  unit_name: byte
+- description: The amount of non-cache memory that belongs to the container's processes.
+    Used for stacks, heaps, etc.
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.rss
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem rss
+  unit_name: byte
+- description: 95th percentile value of docker.mem.rss
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.rss.95percentile
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem rss 95%
+  unit_name: byte
+- description: Average value of docker.mem.rss
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.rss.avg
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem rss avg
+  unit_name: byte
+- description: The rate that the value of docker.mem.rss was sampled
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.rss.count
+  metric_type: rate
+  orientation: '0'
+  per_unit_name: second
+  short_name: mem rss count
+  unit_name: sample
+- description: Max value of docker.mem.rss
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.rss.max
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem rss max
+  unit_name: byte
+- description: Median value of docker.mem.rss
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.rss.median
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem rss median
+  unit_name: byte
+- description: The amount of swap currently used by the container
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.swap
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem swap
+  unit_name: byte
+- description: 95th percentile value of docker.mem.swap
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.swap.95percentile
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem swap 95%
+  unit_name: byte
+- description: Average value of docker.mem.swap
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.swap.avg
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem swap avg
+  unit_name: byte
+- description: The rate that the value of docker.mem.swap was sampled
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.swap.count
+  metric_type: rate
+  orientation: '0'
+  per_unit_name: second
+  short_name: mem swap count
+  unit_name: sample
+- description: Max value of docker.mem.swap
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.swap.max
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem swap max
+  unit_name: byte
+- description: Median value of docker.mem.swap
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.swap.median
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem swap median
+  unit_name: byte
+- description: The number of open file descriptors
+  integration: docker
+  interval: ''
+  metric_name: docker.container.open_fds
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: open_fds
+  unit_name: file
+- description: Total size of all the files in the container which have been created
+    or changed by processes running in the container
+  integration: docker
+  interval: ''
+  metric_name: docker.container.size_rw
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: changed files size
+  unit_name: byte
+- description: 95th percentile of docker.container.size_rw
+  integration: docker
+  interval: ''
+  metric_name: docker.container.size_rw.95percentile
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: changed files size 95%
+  unit_name: byte
+- description: Average value of docker.container.size_rw
+  integration: docker
+  interval: ''
+  metric_name: docker.container.size_rw.avg
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: changed files size avg
+  unit_name: byte
+- description: The rate that the value of docker.container.size_rw was sampled
+  integration: docker
+  interval: ''
+  metric_name: docker.container.size_rw.count
+  metric_type: rate
+  orientation: '0'
+  per_unit_name: second
+  short_name: changed files size count
+  unit_name: sample
+- description: Max value of docker.container.size_rw
+  integration: docker
+  interval: ''
+  metric_name: docker.container.size_rw.max
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: changed files size max
+  unit_name: byte
+- description: Median value of docker.container.size_rw
+  integration: docker
+  interval: ''
+  metric_name: docker.container.size_rw.median
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: changed files size median
+  unit_name: byte
+- description: Total size of all the files in the container
+  integration: docker
+  interval: ''
+  metric_name: docker.container.size_rootfs
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: filesystem size
+  unit_name: byte
+- description: 95th percentile of docker.container.size_rootfs
+  integration: docker
+  interval: ''
+  metric_name: docker.container.size_rootfs.95percentile
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: filesystem size 95%
+  unit_name: byte
+- description: Average value of docker.container.size_rootfs
+  integration: docker
+  interval: ''
+  metric_name: docker.container.size_rootfs.avg
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: filesystem size avg
+  unit_name: byte
+- description: The rate that the value of docker.container.size_rw was sampled
+  integration: docker
+  interval: ''
+  metric_name: docker.container.size_rootfs.count
+  metric_type: rate
+  orientation: '0'
+  per_unit_name: second
+  short_name: filesystem size count
+  unit_name: sample
+- description: Max value of docker.container.size_rootfs
+  integration: docker
+  interval: ''
+  metric_name: docker.container.size_rootfs.max
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: filesystem size max
+  unit_name: byte
+- description: Median value of docker.container.size_rootfs
+  integration: docker
+  interval: ''
+  metric_name: docker.container.size_rootfs.median
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: filesystem size median
+  unit_name: byte
+- description: The number of containers running on this host tagged by image
+  integration: docker
+  interval: ''
+  metric_name: docker.containers.running
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: containers running
+  unit_name: ''
+- description: The number of containers stopped on this host tagged by image
+  integration: docker
+  interval: ''
+  metric_name: docker.containers.stopped
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: containers stopped
+  unit_name: ''
+- description: The total number of containers running on this host
+  integration: docker
+  interval: ''
+  metric_name: docker.containers.running.total
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: total containers running
+  unit_name: ''
+- description: The total number of containers stopped on this host
+  integration: docker
+  interval: ''
+  metric_name: docker.containers.stopped.total
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: total containers stopped
+  unit_name: ''
+- description: The number of top-level images
+  integration: docker
+  interval: ''
+  metric_name: docker.images.available
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: images avail
+  unit_name: ''
+- description: The number of intermediate images, which are intermediate layers that
+    make up other images
+  integration: docker
+  interval: ''
+  metric_name: docker.images.intermediate
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: images intermediate
+  unit_name: ''
+- description: The memory limit for the container, if set
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.limit
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem limit
+  unit_name: byte
+- description: 95th percentile of docker.mem.limit. Ordinarily this value will not
+    change
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.limit.95percentile
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem limit 95%
+  unit_name: byte
+- description: Average value of docker.mem.limit. Ordinarily this value will not change
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.limit.avg
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem limit avg
+  unit_name: byte
+- description: The rate that the value of docker.mem.limit was sampled
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.limit.count
+  metric_type: rate
+  orientation: '0'
+  per_unit_name: second
+  short_name: mem limit count
+  unit_name: sample
+- description: Max value of docker.mem.limit. Ordinarily this value will not change
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.limit.max
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem limit max
+  unit_name: byte
+- description: Median value of docker.mem.limit. Ordinarily this value will not change
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.limit.median
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem limit median
+  unit_name: byte
+- description: The swap + memory limit for the container, if set
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.sw_limit
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem + sw limit
+  unit_name: byte
+- description: 95th percentile of docker.mem.sw_limit. Ordinarily this value will
+    not change
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.sw_limit.95percentile
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem + sw limit 95%
+  unit_name: byte
+- description: Average value of docker.mem.sw_limit. Ordinarily this value will not
+    change
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.sw_limit.avg
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem + sw limit avg
+  unit_name: byte
+- description: The rate that the value of docker.mem.sw_limit was sampled
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.sw_limit.count
+  metric_type: rate
+  orientation: '0'
+  per_unit_name: second
+  short_name: mem + sw limit count
+  unit_name: sample
+- description: Max value of docker.mem.sw_limit. Ordinarily this value will not change
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.sw_limit.max
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem + sw limit max
+  unit_name: byte
+- description: Median value of docker.mem.sw_limit. Ordinarily this value will not
+    change
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.sw_limit.median
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem + sw limit median
+  unit_name: byte
+- description: The memory reservation limit for the container, if set
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.soft_limit
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem soft limit
+  unit_name: byte
+- description: 95th percentile of docker.mem.soft_limit. Ordinarily this value will
+    not change
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.soft_limit.95percentile
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: soft limit 95%
+  unit_name: byte
+- description: Average value of docker.mem.soft_limit. Ordinarily this value will
+    not change
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.soft_limit.avg
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: soft limit avg
+  unit_name: byte
+- description: The rate that the value of docker.mem.soft_limit was sampled
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.soft_limit.count
+  metric_type: rate
+  orientation: '0'
+  per_unit_name: second
+  short_name: soft limit count
+  unit_name: sample
+- description: Max value of docker.mem.soft_limit. Ordinarily this value will not
+    change
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.soft_limit.max
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: soft limit max
+  unit_name: byte
+- description: Median value of docker.mem.soft_limit. Ordinarily this value will not
+    change
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.soft_limit.median
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: soft limit median
+  unit_name: byte
+- description: The fraction of used memory to available memory, IF THE LIMIT IS SET
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.in_use
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem in use
+  unit_name: fraction
+- description: 95th percentile of docker.mem.in_use
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.in_use.95percentile
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem in use 95%
+  unit_name: fraction
+- description: Average value of docker.mem.in_use
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.in_use.avg
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem in use avg
+  unit_name: fraction
+- description: The rate that the value of docker.mem.in_use was sampled
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.in_use.count
+  metric_type: rate
+  orientation: '0'
+  per_unit_name: second
+  short_name: mem in use count
+  unit_name: sample
+- description: Max value of docker.container.mem.in_use
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.in_use.max
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem in use max
+  unit_name: fraction
+- description: Median value of docker.container.mem.in_use
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.in_use.median
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem in use median
+  unit_name: fraction
+- description: The fraction of used swap + memory to available swap + memory, if the
+    limit is set
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.sw_in_use
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem + sw in use
+  unit_name: fraction
+- description: 95th percentile of docker.mem.sw<em>in</em>use
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.sw_in_use.95percentile
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem + sw in use 95%
+  unit_name: fraction
+- description: Average value of docker.mem.sw<em>in</em>use
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.sw_in_use.avg
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem + sw in use avg
+  unit_name: fraction
+- description: The rate that the value of docker.mem.sw<em>in</em>use was sampled
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.sw_in_use.count
+  metric_type: rate
+  orientation: '0'
+  per_unit_name: second
+  short_name: mem + sw in use count
+  unit_name: sample
+- description: Max value of docker.container.mem.sw<em>in</em>use
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.sw_in_use.max
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem + sw in use max
+  unit_name: fraction
+- description: Median value of docker.container.mem.sw<em>in</em>use
+  integration: docker
+  interval: ''
+  metric_name: docker.mem.sw_in_use.median
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: mem + sw in use median
+  unit_name: fraction
+- description: Bytes read per second from disk by the processes of the container
+  integration: docker
+  interval: ''
+  metric_name: docker.io.read_bytes
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: second
+  short_name: io read
+  unit_name: byte
+- description: 95th percentile of docker.io.read_bytes
+  integration: docker
+  interval: ''
+  metric_name: docker.io.read_bytes.95percentile
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: second
+  short_name: io read 95%
+  unit_name: byte
+- description: Average value of docker.io.read_bytes
+  integration: docker
+  interval: ''
+  metric_name: docker.io.read_bytes.avg
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: second
+  short_name: io read avg
+  unit_name: byte
+- description: The rate that the value of docker.io.read_bytes was sampled
+  integration: docker
+  interval: ''
+  metric_name: docker.io.read_bytes.count
+  metric_type: rate
+  orientation: '0'
+  per_unit_name: second
+  short_name: io read count
+  unit_name: sample
+- description: Max value of docker.container.io.read_bytes
+  integration: docker
+  interval: ''
+  metric_name: docker.io.read_bytes.max
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: second
+  short_name: io read max
+  unit_name: byte
+- description: Median value of docker.container.io.read_bytes
+  integration: docker
+  interval: ''
+  metric_name: docker.io.read_bytes.median
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: second
+  short_name: io read median
+  unit_name: byte
+- description: Bytes written per second to disk by the processes of the container
+  integration: docker
+  interval: ''
+  metric_name: docker.io.write_bytes
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: second
+  short_name: io write
+  unit_name: byte
+- description: 95th percentile of docker.io.write_bytes
+  integration: docker
+  interval: ''
+  metric_name: docker.io.write_bytes.95percentile
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: second
+  short_name: io write 95%
+  unit_name: byte
+- description: Average value of docker.io.write_bytes
+  integration: docker
+  interval: ''
+  metric_name: docker.io.write_bytes.avg
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: second
+  short_name: io write avg
+  unit_name: byte
+- description: The rate that the value of docker.io.write_bytes was sampled
+  integration: docker
+  interval: ''
+  metric_name: docker.io.write_bytes.count
+  metric_type: rate
+  orientation: '0'
+  per_unit_name: second
+  short_name: io write count
+  unit_name: sample
+- description: Max value of docker.container.io.write_bytes
+  integration: docker
+  interval: ''
+  metric_name: docker.io.write_bytes.max
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: second
+  short_name: io write max
+  unit_name: byte
+- description: Median value of docker.container.io.write_bytes
+  integration: docker
+  interval: ''
+  metric_name: docker.io.write_bytes.median
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: second
+  short_name: io write median
+  unit_name: byte
+- description: Size of all layers of the image on disk
+  integration: docker
+  interval: ''
+  metric_name: docker.image.virtual_size
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: image v size
+  unit_name: byte
+- description: Size of all layers of the image on disk
+  integration: docker
+  interval: ''
+  metric_name: docker.image.size
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: image size
+  unit_name: byte
+- description: Bytes received per second from the network
+  integration: docker
+  interval: ''
+  metric_name: docker.net.bytes_rcvd
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: second
+  short_name: net received
+  unit_name: byte
+- description: 95th percentile of docker.net.bytes_rcvd
+  integration: docker
+  interval: ''
+  metric_name: docker.net.bytes_rcvd.95percentile
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: second
+  short_name: net received 95%
+  unit_name: byte
+- description: Average value of docker.net.bytes_rcvd
+  integration: docker
+  interval: ''
+  metric_name: docker.net.bytes_rcvd.avg
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: second
+  short_name: net received avg
+  unit_name: byte
+- description: The rate that the value of docker.net.bytes_rcvd was sampled
+  integration: docker
+  interval: ''
+  metric_name: docker.net.bytes_rcvd.count
+  metric_type: rate
+  orientation: '0'
+  per_unit_name: second
+  short_name: net received count
+  unit_name: sample
+- description: Max value of docker.container.net.bytes_rcvd
+  integration: docker
+  interval: ''
+  metric_name: docker.net.bytes_rcvd.max
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: second
+  short_name: net received max
+  unit_name: byte
+- description: Median value of docker.container.net.bytes_rcvd
+  integration: docker
+  interval: ''
+  metric_name: docker.net.bytes_rcvd.median
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: second
+  short_name: net received median
+  unit_name: byte
+- description: Bytes sent per second to the network
+  integration: docker
+  interval: ''
+  metric_name: docker.net.bytes_sent
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: second
+  short_name: net sent
+  unit_name: byte
+- description: 95th percentile of docker.net.bytes<em>sent</em>bytes
+  integration: docker
+  interval: ''
+  metric_name: docker.net.bytes_sent_bytes.95percentile
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: second
+  short_name: net sent 95%
+  unit_name: byte
+- description: Average value of docker.net.bytes<em>sent</em>bytes
+  integration: docker
+  interval: ''
+  metric_name: docker.net.bytes_sent_bytes.avg
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: second
+  short_name: net sent avg
+  unit_name: byte
+- description: The rate that the value of docker.net.bytes<em>sent</em>bytes was sampled
+  integration: docker
+  interval: ''
+  metric_name: docker.net.bytes_sent_bytes.count
+  metric_type: rate
+  orientation: '0'
+  per_unit_name: second
+  short_name: net sent count
+  unit_name: sample
+- description: Max value of docker.container.net.bytes<em>sent</em>bytes
+  integration: docker
+  interval: ''
+  metric_name: docker.net.bytes_sent_bytes.max
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: second
+  short_name: net sent max
+  unit_name: byte
+- description: Median value of docker.container.net.bytes<em>sent</em>bytes
+  integration: docker
+  interval: ''
+  metric_name: docker.net.bytes_sent_bytes.median
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: second
+  short_name: net sent median
+  unit_name: byte
+- description: Storage pool disk space used
+  integration: docker
+  interval: ''
+  metric_name: docker.data.used
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: used disk space
+  unit_name: byte
+- description: Storage pool disk space free
+  integration: docker
+  interval: ''
+  metric_name: docker.data.free
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: free disk space
+  unit_name: byte
+- description: Storage pool disk space total
+  integration: docker
+  interval: ''
+  metric_name: docker.data.total
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: total disk space
+  unit_name: byte
+- description: The percent of storage pool used
+  integration: docker
+  interval: ''
+  metric_name: docker.data.percent
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: percent of used disk space
+  unit_name: percent
+- description: Storage pool metadata space used
+  integration: docker
+  interval: ''
+  metric_name: docker.metadata.used
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: metadata space used
+  unit_name: byte
+- description: Storage pool metadata space free
+  integration: docker
+  interval: ''
+  metric_name: docker.metadata.free
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: metadata space free
+  unit_name: byte
+- description: Storage pool metadata space total
+  integration: docker
+  interval: ''
+  metric_name: docker.metadata.total
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: metadata space total
+  unit_name: byte
+- description: The percent of storage pool metadata used
+  integration: docker
+  interval: ''
+  metric_name: docker.metadata.percent
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: percent of metadata space total
+  unit_name: percent
+- description: Current thread count for the container
+  integration: docker
+  interval: ''
+  metric_name: docker.thread.count
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: thread.count
+  unit_name: thread
+- description: Thread count limit for the container, if set
+  integration: docker
+  interval: ''
+  metric_name: docker.thread.limit
+  metric_type: gauge
+  orientation: '0'
+  per_unit_name: ''
+  short_name: thread.limit
+  unit_name: thread


### PR DESCRIPTION
### What does this PR do?

Adds back docker daemon metrics removed by: https://github.com/DataDog/integrations-core/pull/5988/

### Motivation
Get the list of docker metrics collected.

### Preview link

* https://docs-staging.datadoghq.com/gus/docker_daemon_metrics/agent/docker/?tab=standard#data-collected
* [Docker Data collected](https://docs-staging.datadoghq.com/gus/docker_daemon_metrics/agent/docker/data_collected/)