### PR TITLE
APM > .NET > update not about change in JIT bug workaround

### DIFF
--- a/content/en/tracing/setup/dotnet-core.md
+++ b/content/en/tracing/setup/dotnet-core.md
@@ -44,7 +44,7 @@ The .NET Tracer supports automatic instrumentation on .NET Core 2.1, 3.0, and 3.
 
 **Note:** The .NET Tracer works on .NET Core 2.0, 2.2, and 3.0, but these versions reached their end of life and are no longer supported by Microsoft. See [Microsoft's support policy][9] for more details. We recommend using the latest patch version of .NET Core 2.1 or 3.1.
 
-**Note:** Older versions of .NET Core on Linux/x64 have JIT compiler bugs that can cause applications to throw exceptions when using automatic instrumentation. If your application is running on .NET Core 2.0, 2.1.0-2.1.11, or 2.2.0-2.2.5, we strongly recommend you update your .NET Core runtime. If you cannot update, you may need to set the environment variable `DD_CLR_DISABLE_OPTIMIZATIONS =true` to work around the issue. See [dotnet/runtime/issues/10506][3] and [DataDog/dd-trace-dotnet/issues/302][4] for more details.
+**Note:** Older versions of .NET Core on Linux/x64 have JIT compiler bugs that can cause applications to throw exceptions when using automatic instrumentation. If your application is running on .NET Core 2.0, 2.1.0-2.1.11, or 2.2.0-2.2.5, we strongly recommend you update your .NET Core runtime. If you cannot update, you may need to set the environment variable `DD_CLR_DISABLE_OPTIMIZATIONS=true` to work around the issue. See [dotnet/runtime/issues/10506][3] and [DataDog/dd-trace-dotnet/issues/302][4] for more details.
 
 ### Installation
 

--- a/content/en/tracing/setup/dotnet-core.md
+++ b/content/en/tracing/setup/dotnet-core.md
@@ -44,7 +44,7 @@ The .NET Tracer supports automatic instrumentation on .NET Core 2.1, 3.0, and 3.
 
 **Note:** The .NET Tracer works on .NET Core 2.0, 2.2, and 3.0, but these versions reached their end of life and are no longer supported by Microsoft. See [Microsoft's support policy][9] for more details. We recommend using the latest patch version of .NET Core 2.1 or 3.1.
 
-**Note:** Older versions of .NET Core on Linux/x64 have JIT compiler bugs that can cause applications to throw exceptions when using automatic instrumentation. If your application is running on .NET Core 2.0, 2.1.0-2.1.11, or 2.2.0-2.2.5, we strongly recommend you update your .NET Core runtime. If you cannot update, you may need to set the environment variable `DD_CLR_DISABLE_OPTIMIZATIONS=true` to work around the issue. See [dotnet/runtime/issues/10506][3] and [DataDog/dd-trace-dotnet/issues/302][4] for more details.
+**Note:** Older versions of .NET Core on Linux/x64 have JIT compiler bugs that can cause applications to throw exceptions when using automatic instrumentation. If your application is running on .NET Core 2.0, 2.1.0-2.1.11, or 2.2.0-2.2.5, we strongly recommend you update your .NET Core runtime. If you cannot update, you may need to set the environment variable `DD_CLR_DISABLE_OPTIMIZATIONS=true` to work around the issue. See [DataDog/dd-trace-dotnet/issues/302][4] for more details.
 
 ### Installation
 
@@ -352,7 +352,6 @@ The following table lists configuration variables that are available only when u
 
 [1]: /tracing/send_traces
 [2]: /tracing/setup/dotnet-framework
-[3]: https://github.com/dotnet/runtime/issues/10506
 [4]: https://github.com/DataDog/dd-trace-dotnet/issues/302#issuecomment-603269367
 [5]: /help
 [6]: https://www.nuget.org/packages/Datadog.Trace

--- a/content/en/tracing/setup/dotnet-core.md
+++ b/content/en/tracing/setup/dotnet-core.md
@@ -42,9 +42,9 @@ Automatic instrumentation captures:
 
 The .NET Tracer supports automatic instrumentation on .NET Core 2.1, 3.0, and 3.1. It also supports [.NET Framework][2].
 
-**Note:** The .NET Tracer works on .NET Core 2.0, 2.2, and 3.0, but these versions reached their end of life and are no longer supported by Microsoft. See [Microsoft's support policy][9] for more details.
+**Note:** The .NET Tracer works on .NET Core 2.0, 2.2, and 3.0, but these versions reached their end of life and are no longer supported by Microsoft. See [Microsoft's support policy][9] for more details. We recommend using the latest patch version of .NET Core 2.1 or 3.1.
 
-**Note:** Due to several issues in older versions of the .NET Core 2.1 runtime, we strongly recommend .NET Core versions 2.1.12 or higher. For .NET Core 2.2, we recommend version 2.2.6 or higher. See [dotnet/runtime/issues/10506][3] and [DataDog/dd-trace-dotnet/issues/302][4] for more details.
+**Note:** Older versions of .NET Core on Linux/x64 have JIT compiler bugs that can cause applications to throw exceptions when using automatic instrumentation. If your application is running on .NET Core 2.0, 2.1.0-2.1.11, or 2.2.0-2.2.5, we strongly recommend you update your .NET Core runtime. If you cannot update, you may need to set the environment variable `DD_CLR_DISABLE_OPTIMIZATIONS =true` to work around the issue. See [dotnet/runtime/issues/10506][3] and [DataDog/dd-trace-dotnet/issues/302][4] for more details.
 
 ### Installation
 
@@ -353,7 +353,7 @@ The following table lists configuration variables that are available only when u
 [1]: /tracing/send_traces
 [2]: /tracing/setup/dotnet-framework
 [3]: https://github.com/dotnet/runtime/issues/10506
-[4]: https://github.com/DataDog/dd-trace-dotnet/issues/302#issuecomment-511011364
+[4]: https://github.com/DataDog/dd-trace-dotnet/issues/302#issuecomment-603269367
 [5]: /help
 [6]: https://www.nuget.org/packages/Datadog.Trace
 [7]: /tracing/manual_instrumentation/dotnet


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR reflects [recent changes](/DataDog/dd-trace-dotnet/pull/473) in the default value of the `DD_CLR_DISABLE_OPTIMIZATIONS`.

### Motivation
We released [.NET Tracer 1.15.0](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v1.15.0) which changes the default value of `DD_CLR_DISABLE_OPTIMIZATIONS` on Linux.

### Preview link
https://docs-staging.datadoghq.com/lpimentel/dotnet-jit-changes/tracing/setup/dotnet-core/?tab=linux#automatic-instrumentation

### Additional Notes
Ready to merge after approval.