### PR TITLE
[Synthetics] Remove --init param to start PL docker

### DIFF
--- a/content/en/getting_started/synthetics/private_location.md
+++ b/content/en/getting_started/synthetics/private_location.md
@@ -41,7 +41,7 @@ Once you create a private location, the process of configuring a [Synthetics API
 6. Launch your worker as a standalone container using the Docker run command provided and the previously created configuration file:
 
     ```shell
-    docker run --init --rm -v $PWD/worker-config-<LOCATION_ID>.json:/etc/datadog/synthetics-check-runner.json datadog/synthetics-private-location-worker
+    docker run --rm -v $PWD/worker-config-<LOCATION_ID>.json:/etc/datadog/synthetics-check-runner.json datadog/synthetics-private-location-worker
     ```
 
 7. If your private location reports correctly to Datadog, you will see the corresponding health status displayed if the private location polled your endpoint less than five seconds before loading the settings or create test pages:

--- a/content/en/synthetics/private_locations.md
+++ b/content/en/synthetics/private_locations.md
@@ -51,7 +51,7 @@ Once you created a private location, configuring a Synthetics API test from a pr
 Launch your worker as a standalone container using the Docker run command provided and the previously created configuration file:
 
 ```shell
-docker run --init --rm -v $PWD/worker-config-<LOCATION_ID>.json:/etc/datadog/synthetics-check-runner.json datadog/synthetics-private-location-worker
+docker run --rm -v $PWD/worker-config-<LOCATION_ID>.json:/etc/datadog/synthetics-check-runner.json datadog/synthetics-private-location-worker
 ```
 
     {{% /tab %}}

--- a/content/fr/synthetics/private_locations.md
+++ b/content/fr/synthetics/private_locations.md
@@ -50,7 +50,7 @@ Une fois votre emplacement privé créé, pour configurer un test API Synthetics
 Lancez votre worker en tant que conteneur autonome à l'aide de la commande d'exécution Docker fournie et du fichier de configuration précédemment créé :
 
 ```shell
-docker run --init --rm -v $PWD/worker-config-<ID_EMPLACEMENT>.json:/etc/datadog/synthetics-check-runner.json datadog/synthetics-private-location-worker
+docker run --rm -v $PWD/worker-config-<ID_EMPLACEMENT>.json:/etc/datadog/synthetics-check-runner.json datadog/synthetics-private-location-worker
 ```
 
     {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update documentation to launch synthetics Private locations with the new version

### Motivation
Code change implies new usage

### Preview link
* https://docs-staging.datadoghq.com/denis.rampnoux/synthetics/SP-421-remove-docker-init-param/fr/synthetics/private_locations?tab=docker
* + us page
* https://docs-staging.datadoghq.com/denis.rampnoux/synthetics/SP-421-remove-docker-init-param/fr/getting_started/synthetics/private_location

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/denis.rampnoux/synthetics/SP-421-remove-docker-init-param/

### Additional Notes

N/A
