### PR TITLE
[authn_mappings api] update documentation for recent changes [DO NOT MERGE UNTIL 03/31]

### DIFF
--- a/content/en/account_management/authn_mapping/_index.md
+++ b/content/en/account_management/authn_mapping/_index.md
@@ -110,12 +110,14 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
                     "name": "Developer Role"
                 },
                 "relationships": {
-                    "data": [
-                        {
-                            "id": "123e4567-e89b-12d3-a456-426655441000",
-                            "type": "permissions"
-                        }
-                    ]
+                    "permissions": {
+                        "data": [
+                            {
+                                "id": "123e4567-e89b-12d3-a456-426655441000",
+                                "type": "permissions"
+                            }
+                        ]
+                    }
                 }
             }
         },
@@ -206,12 +208,14 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
             "name": "Developer Role"
           },
           "relationships": {
-            "data": [
-              {
-                "id": "123e4567-e89b-12d3-a456-426655440000",
-                "type": "permissions"
-              }
-            ]
+            "permissions": {
+                "data": [
+                  {
+                    "id": "123e4567-e89b-12d3-a456-426655440000",
+                    "type": "permissions"
+                  }
+                ]
+            }
           }
         }
       },
@@ -305,12 +309,14 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
                     "name": "Developer Role"
                 },
                 "relationships": {
-                    "data": [
-                        {
-                            "id": "123e4567-e89b-12d3-a456-426655440000",
-                            "type": "permissions"
-                        }
-                    ]
+                    "permissions": {
+                        "data": [
+                            {
+                                "id": "123e4567-e89b-12d3-a456-426655440000",
+                                "type": "permissions"
+                            }
+                        ]
+                    }
                 }
             }
         },
@@ -500,7 +506,7 @@ Check whether Authn Mappings are enabled or disabled.
 
 ```sh
 curl -X GET \
-         "https://api.datadoghq.com/api/v1/org_perferences" \
+         "https://api.datadoghq.com/api/v1/org_preferences" \
          -H "Content-Type: application/json" \
          -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
          -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
@@ -517,7 +523,7 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
   "data": {
     "attributes": {
         "preference_data": "saml_authn_mapping_roles",
-        "preference_type: true
+        "preference_type": true
     },
     "type": "org_preferences",
     "id": 1,
@@ -538,7 +544,7 @@ Enables/disables the enforcement of all AuthN Mappings.
 
 | Method   | Endpoint path               | Required payload |
 |----------|-----------------------------|------------------|
-| `POST`   | `/v1/org_preferrences`      | JSON             |
+| `POST`   | `/v1/org_preferences`       | JSON             |
 
 ##### ARGUMENTS
 
@@ -552,13 +558,13 @@ Enables/disables the enforcement of all AuthN Mappings.
 
 ```sh
 curl -X POST \
-    "https://api.datadoghq.com/api/v1/org_perferences" \
+    "https://api.datadoghq.com/api/v1/org_preferences" \
     -H "Content-Type: application/json" \
     -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
     -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
     -d '{
         "data": {
-            "type": "org_peferences",
+            "type": "org_preferences",
             "attributes": {
                 "preference_type": "saml_authn_mapping_roles",
                 "preference_data": true
@@ -579,7 +585,7 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
   "data": {
     "attributes": {
         "preference_type": "saml_authn_mapping_roles",
-        "preference_data: true
+        "preference_data": true
     },
     "type": "org_preferences",
     "id": 1,

--- a/content/en/account_management/authn_mapping/_index.md
+++ b/content/en/account_management/authn_mapping/_index.md
@@ -352,7 +352,7 @@ Updates the AuthN Mapping `role`, `saml_assertion_attribute_id`, or both from a 
   Replace `{authn_mapping_id}` with the ID of the AuthN Mapping you want to update. This is required in both the path of the request and the body of the request.
 * **`role["data"]["id"]`** [*optional*, *default*=none]:
  The `ID` of the Role to map to. The Roles API can be used to create and manage Datadog roles, what global permissions they grant, and which users belong to them. 
- **Note**: This attribute should be presented as part of a `role` relationship block in requests. See the example below for more details. When you create a Role, it is assigned a ID. For more information about finding the `ID` for the role you want to map to, see the [Role API documentation][1].
+ **Note**: This attribute should be presented as part of a `role` relationship block in requests. See the example below for more details. When you create a Role, it is assigned an ID. For more information about finding the `ID` for the role you want to map to, see the [Role API documentation][1].
 * **`attributes["attribute_key"]`** [*optional*, *default*=none]:
  The `attribute_key` is the key portion of a key/value pair that represents an attribute sent from your Identity Provider. You can define these for your own use case. For example, `attribute_key` could be `member-of` and the `attribute_value` could be `Development`.
 * **`attributes["attribute_value"]`** [*optional*, *default*=none]:
@@ -551,7 +551,7 @@ Enables/disables the enforcement of all AuthN Mappings.
 * **`{preference_type}`** [*required*, no default]:
   Preference to update, required to be "saml_authn_mapping_roles"
 * **`{preference_data}`** [*required*, no default]:
-  Data to update preference with, must be true or false. true to enable all mappings, false to disable
+  Data to update preference with, must be true or false: true to enable all mappings, false to disable
 
 {{< tabs >}}
 {{% tab "Example" %}}

--- a/content/en/account_management/authn_mapping/_index.md
+++ b/content/en/account_management/authn_mapping/_index.md
@@ -35,9 +35,9 @@ Create a new AuthN Mapping from a JSON body. Returns the newly created AuthN Map
 
 ##### ARGUMENTS
 
-* **`roles.uuid`** [*required*, no default]:
+* **`role.uuid`** [*required*, no default]:
  The `UUID` of the Role to map to. The Roles API can be used to create and manage Datadog roles, what global permissions they grant, and which users belong to them. 
- **Note**: This attribute should be presented as part of a `roles` relationship block in requests. See the example below for more details. When you create a Role, it is assigned a UUID. For more information about finding the `UUID` for the role you want to map to, see the [Role API documentation][1].
+ **Note**: This attribute should be presented as part of a `role` relationship block in requests. See the example below for more details. When you create a Role, it is assigned a UUID. For more information about finding the `UUID` for the role you want to map to, see the [Role API documentation][1].
 * **`attribute_key`** [*required*, no default]:
  The `attribute_key` is the key portion of a key/value pair that represents an attribute sent from your Identity Provider. You can define these for your own use case. For example, `attribute_key` could be `member-of` and the `attribute_value` could be `Development`.
 * **`attribute_value`** [*required*, no default]:
@@ -60,7 +60,7 @@ curl -X POST \
                     "attribute_value": "Development"
                 }
                 "relationships": {
-                    "roles": {
+                    "role": {
                         "data": {
                             "id": "123e4567-e89b-12d3-a456-426655445555",
                             "type": "roles"
@@ -89,13 +89,13 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
     "type": "authn_mappings",
     "id": "123e4567-e89b-12d3-a456-426655440000",
     "relationships": {
-      "saml_assertion_attributes": {
+      "saml_assertion_attribute": {
         "data": {
           "id": 0,
           "type": "saml_assertion_attributes"
         }
       },
-      "roles": {
+      "role": {
         "data": {
           "id": "123e4567-e89b-12d3-a456-426655440000",
           "type": "roles"
@@ -152,7 +152,7 @@ Returns a list of AuthN Mappings
 ##### ARGUMENTS
 
 * **`sort`** [*optional*, *default*=**created\_at**]:
-  Sort attribute and direction—defaults to ascending order, `-<attribute>` sorts in descending order. Can also sort on relationship attributes `roles.name`, `saml_assertion_attributes.attribute_key`, `saml_assertion_attributes.attribute_value`.
+  Sort attribute and direction—defaults to ascending order, `-<attribute>` sorts in descending order. Can also sort on relationship attributes `role.name`, `saml_assertion_attribute.attribute_key`, `saml_assertion_attribute.attribute_value`.
 * **`page[number]`** [*optional*, *default*=**0**, *minimum*=**0**]:
   The page of results to return.
 * **`page[size]`** [*optional*, *default*=**10**]:
@@ -182,10 +182,10 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
       "type": "authn_mapping",
       "id": "123e4567-e89b-12d3-a456-426655440000",
       "relationships": {
-        "saml_assertion_attributes": {
+        "saml_assertion_attribute": {
           "data": {"id": 0, "type": "saml_assertion_attributes"}
         },
-        "roles": {
+        "role": {
           "data": {
             "id": "123e4567-e89b-12d3-a456-426655440000",
             "type": "roles"
@@ -283,10 +283,10 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
     "type": "authn_mappings",
     "id": "123e4567-e89b-12d3-a456-426655440000",
     "relationships": {
-      "saml_assertion_attributes": {
+      "saml_assertion_attribute": {
         "data": {"id": 0, "type": "saml_assertion_attributes"}
       },
-      "roles": {
+      "role": {
         "data": {"id": "123e4567-e89b-12d3-a456-426655440000", "type": "roles"}
       }
     }
@@ -344,9 +344,9 @@ Updates the AuthN Mapping `role`, `saml_assertion_attribute_id`, or both from a 
   Replace `{UUID}` with the UUID of the AuthN Mapping you want to update.
 * **`id`** [*required*, no default]:
   The UUID of the AuthN Mapping being updated. This property must match the `{UUID}` path parameter in the request.
-* **`roles.uuid`** [*optional*, *default*=none]:
+* **`role.uuid`** [*optional*, *default*=none]:
  The `UUID` of the Role to map to. The Roles API can be used to create and manage Datadog roles, what global permissions they grant, and which users belong to them. 
- **Note**: This attribute should be presented as part of a `roles` relationship block in requests. See the example below for more details. When you create a Role, it is assigned a UUID. For more information about finding the `UUID` for the role you want to map to, see the [Role API documentation][1].
+ **Note**: This attribute should be presented as part of a `role` relationship block in requests. See the example below for more details. When you create a Role, it is assigned a UUID. For more information about finding the `UUID` for the role you want to map to, see the [Role API documentation][1].
 * **`attribute_key`** [*optional*, *default*=none]:
  The `attribute_key` is the key portion of a key/value pair that represents an attribute sent from your Identity Provider. You can define these for your own use case. For example, `attribute_key` could be `member-of` and the `attribute_value` could be `Development`.
 * **`attribute_value`** [*optional*, *default*=none]:
@@ -370,7 +370,7 @@ curl -X PATCH \
                       "attribute_value": "Developer"
                  }
                  "relationships": {
-                    "roles": {
+                    "role": {
                     "data": {"id": "123e4567-e89b-12d3-a456-426655440000", "type": "roles"}
                     }
                 }
@@ -395,10 +395,10 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
     "type": "authn_mappings",
     "id": "123e4567-e89b-12d3-a456-426655440000",
     "relationships": {
-      "saml_assertion_attributes": {
+      "saml_assertion_attribute": {
         "data": {"id": 0, "type": "saml_assertion_attributes"}
       },
-      "roles": {
+      "role": {
         "data": {"id": "123e4567-e89b-12d3-a456-426655440000", "type": "roles"}
       }
     }
@@ -530,7 +530,7 @@ Enables/disables all AuthN Mappings.
 ##### ARGUMENTS
 
 * **`{preference_type}`** [*required*, no default]:
-  Org preference to update, required to be "saml_authn_mapping_roles"
+  Preference to update, required to be "saml_authn_mapping_roles"
 * **`{preference_data}`** [*required*, no default]:
   Data to update preference with, must be true or false. true to enable all mappings, false to disable
 

--- a/content/en/account_management/authn_mapping/_index.md
+++ b/content/en/account_management/authn_mapping/_index.md
@@ -478,6 +478,105 @@ HTTP/2 204
 {{% /tab %}}
 {{< /tabs >}}
 
+### Get Authn Mapping Enablement
+
+Check whether Authn Mappings are enabled or disabled.
+
+| Method   | Endpoint path               | Required payload |
+|----------|-----------------------------|------------------|
+| `GET`    | `/v1/org_preferrences`      | None             |
+
+{{< tabs >}}
+{{% tab "Example" %}}
+
+```sh
+curl -X GET \
+         "https://api.datadoghq.com/api/v1/org_perferences" \
+         -H "Content-Type: application/json" \
+         -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
+         -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
+```
+
+Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1].
+
+[1]: https://api.datadoghq.com/account/settings#api
+{{% /tab %}}
+{{% tab "Response" %}}
+
+{{< code-block lang="json" filename="response.json" disable_copy="true" >}}
+{
+  "data": {
+    "attributes": {
+        "preference_data": "saml_authn_mapping_roles",
+        "preference_type: true
+    },
+    "type": "org_preferences",
+    "id": 1,
+  },
+}
+{{< /code-block >}}
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### Enable/Disable All Mappings
+
+Enables/disables all AuthN Mappings.
+
+| Method   | Endpoint path               | Required payload |
+|----------|-----------------------------|------------------|
+| `POST`   | `/v1/org_preferrences`      | JSON             |
+
+##### ARGUMENTS
+
+* **`{preference_type}`** [*required*, no default]:
+  Org preference to update, required to be "saml_authn_mapping_roles"
+* **`{preference_data}`** [*required*, no default]:
+  Data to update preference with, must be true or false. true to enable all mappings, false to disable
+
+{{< tabs >}}
+{{% tab "Example" %}}
+
+```sh
+curl -X POST \
+         "https://api.datadoghq.com/api/v1/org_perferences" \
+         -H "Content-Type: application/json" \
+         -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
+         -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
+         -d '{
+             "data": {
+                 "type": "org_peferences",
+                 "attributes": {
+                    "preference_type": "saml_authn_mapping_roles",
+                    "preference_data": true
+                j}
+             }
+         }'
+`
+```
+
+Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1].
+
+[1]: https://api.datadoghq.com/account/settings#api
+{{% /tab %}}
+{{% tab "Response" %}}
+
+{{< code-block lang="json" filename="response.json" disable_copy="true" >}}
+{
+  "data": {
+    "attributes": {
+        "preference_data": "saml_authn_mapping_roles",
+        "preference_type: true
+    },
+    "type": "org_preferences",
+    "id": 1,
+  },
+}
+{{< /code-block >}}
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/account_management/authn_mapping/_index.md
+++ b/content/en/account_management/authn_mapping/_index.md
@@ -10,10 +10,6 @@ further_reading:
   text: "RBAC for Log Management"
 ---
 
-<div class="alert alert-warning">
-The Federated Authentication to Role Mapping API is currently in closed beta. Functionality and performance may not be ideal, and we reserve the right to change the functionality at any time without warning. Ask your customer success manager or <a href="/help">Datadog Support</a> to enable this feature.
-</div>
-
 If you are using Federated Authentication mechanisms, this API allows you to automatically map groups of users to roles in Datadog using attributes sent from your Identity Provider.
 
 **Note**: If you are a SAML user, and you have been using the existing beta Federated Mapping mechanism (`roles_v2_saml`), Datadog strongly recommends that you transition to using this API.
@@ -35,12 +31,12 @@ Create a new AuthN Mapping from a JSON body. Returns the newly created AuthN Map
 
 ##### ARGUMENTS
 
-* **`role.uuid`** [*required*, no default]:
- The `UUID` of the Role to map to. The Roles API can be used to create and manage Datadog roles, what global permissions they grant, and which users belong to them. 
- **Note**: This attribute should be presented as part of a `role` relationship block in requests. See the example below for more details. When you create a Role, it is assigned a UUID. For more information about finding the `UUID` for the role you want to map to, see the [Role API documentation][1].
-* **`attribute_key`** [*required*, no default]:
+* **`role["data"]["id"]`** [*required*, no default]:
+ The `ID` of the Role to map to. The Roles API can be used to create and manage Datadog roles, what global permissions they grant, and which users belong to them. 
+ **Note**: This attribute should be presented as part of a `role` relationship block in requests. See the example below for more details. When you create a Role, it is assigned an ID. For more information about finding the `ID` for the role you want to map to, see the [Role API documentation][1].
+* **`attributes["attribute_key"]`** [*required*, no default]:
  The `attribute_key` is the key portion of a key/value pair that represents an attribute sent from your Identity Provider. You can define these for your own use case. For example, `attribute_key` could be `member-of` and the `attribute_value` could be `Development`.
-* **`attribute_value`** [*required*, no default]:
+* **`attributes["attribute_value"]`** [*required*, no default]:
  The `attribute_value` is the value portion of a key/value pair that represents an attribute sent from your Identity Provider. You can define these for your own use case. For example, `attribute_key` could be `member-of` and the `attribute_value` could be `Development`.
 
 {{< tabs >}}
@@ -48,17 +44,17 @@ Create a new AuthN Mapping from a JSON body. Returns the newly created AuthN Map
 
 ```sh
 curl -X POST \
-         "https://api.datadoghq.com/api/v2/authn_mappings" \
-         -H "Content-Type: application/json" \
-         -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
-         -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
-         -d '{
-             "data": {
-                 "type": "authn_mappings",
-                 "attributes": {
+    "https://api.datadoghq.com/api/v2/authn_mappings" \
+    -H "Content-Type: application/json" \
+    -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
+    -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
+    -d '{
+            "data": {
+                "type": "authn_mappings",
+                "attributes": {
                     "attribute_key": "member-of",
                     "attribute_value": "Development"
-                }
+                },
                 "relationships": {
                     "role": {
                         "data": {
@@ -67,8 +63,8 @@ curl -X POST \
                         }
                     }
                 }
-             }
-         }'
+            }
+        }'
 ```
 
 Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1].
@@ -79,62 +75,62 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 
 {{< code-block lang="json" filename="response.json" disable_copy="true" >}}
 {
-  "data": {
-    "attributes": {
-      "created_at": "2019-11-04 17:41:29.015504",
-      "modified_at": "2019-11-04 17:41:29.015504",
-      "role_uuid": "00000000-0000-0000-0000-000000000000",
-      "saml_assertion_attribute_id": 0
-    },
-    "type": "authn_mappings",
-    "id": "123e4567-e89b-12d3-a456-426655440000",
-    "relationships": {
-      "saml_assertion_attribute": {
-        "data": {
-          "id": 0,
-          "type": "saml_assertion_attributes"
-        }
-      },
-      "role": {
-        "data": {
-          "id": "123e4567-e89b-12d3-a456-426655440000",
-          "type": "roles"
-        }
-      }
-    }
-  },
-  "included": [
-    {
-      "data": {
-        "id": "123e4567-e89b-12d3-a456-426655440000",
-        "type": "roles",
+    "data": {
         "attributes": {
-          "created_at": "2019-11-04 17:41:29.015504",
-          "modified_at": "2019-11-06 17:41:29.015504",
-          "name": "Developer Role"
+            "created_at": "2019-11-04 17:41:29.015504",
+            "modified_at": "2019-11-04 17:41:29.015504",
+            "role_uuid": "00000000-0000-0000-0000-000000000000",
+            "saml_assertion_attribute_id": 0
         },
+        "type": "authn_mappings",
+        "id": "123e4567-e89b-12d3-a456-426655440000",
         "relationships": {
-          "data": [
-            {
-              "id": "123e4567-e89b-12d3-a456-426655441000",
-              "type": "permissions"
+            "saml_assertion_attribute": {
+                "data": {
+                    "id": 0,
+                    "type": "saml_assertion_attributes"
+                }
+            },
+            "role": {
+                "data": {
+                    "id": "123e4567-e89b-12d3-a456-426655440000",
+                    "type": "roles"
+                }
             }
-          ]
         }
-      }
     },
-    {
-      "data": {
-        "id": 6,
-        "type": "saml_assertion_attributes",
-        "attributes": {
-          "id": 6,
-          "attribute_key": "member-of",
-          "attribute_value": "Development"
+    "included": [
+        {
+            "data": {
+                "id": "123e4567-e89b-12d3-a456-426655440000",
+                "type": "roles",
+                "attributes": {
+                    "created_at": "2019-11-04 17:41:29.015504",
+                    "modified_at": "2019-11-06 17:41:29.015504",
+                    "name": "Developer Role"
+                },
+                "relationships": {
+                    "data": [
+                        {
+                            "id": "123e4567-e89b-12d3-a456-426655441000",
+                            "type": "permissions"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "data": {
+                "id": 6,
+                "type": "saml_assertion_attributes",
+                "attributes": {
+                    "id": 6,
+                    "attribute_key": "member-of",
+                    "attribute_value": "Development"
+                }
+            }
         }
-      }
-    }
-  ]
+    ]
 }
 {{< /code-block >}}
 
@@ -177,66 +173,66 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 
 ```json
 {
-  "data": [
-    {
-      "type": "authn_mapping",
-      "id": "123e4567-e89b-12d3-a456-426655440000",
-      "relationships": {
-        "saml_assertion_attribute": {
-          "data": {"id": 0, "type": "saml_assertion_attributes"}
+    "data": [
+      {
+        "type": "authn_mapping",
+        "id": "123e4567-e89b-12d3-a456-426655440000",
+        "relationships": {
+          "saml_assertion_attribute": {
+            "data": {"id": 0, "type": "saml_assertion_attributes"}
+          },
+          "role": {
+            "data": {
+              "id": "123e4567-e89b-12d3-a456-426655440000",
+              "type": "roles"
+            }
+          }
         },
-        "role": {
-          "data": {
-            "id": "123e4567-e89b-12d3-a456-426655440000",
-            "type": "roles"
+        "attributes": {
+          "created_at": "2019-11-04 17:41:29.015504",
+          "modified_at": "2019-11-04 17:41:29.015504",
+          "saml_assertion_attribute_id": 0
+        }
+      }
+    ],
+    "included": [
+      {
+        "data": {
+          "id": "123e4567-e89b-12d3-a456-426655440000",
+          "type": "roles",
+          "attributes": {
+            "created_at": "2019-11-04 17:41:29.015504",
+            "modified_at": "2019-11-06 17:41:29.015504",
+            "name": "Developer Role"
+          },
+          "relationships": {
+            "data": [
+              {
+                "id": "123e4567-e89b-12d3-a456-426655440000",
+                "type": "permissions"
+              }
+            ]
           }
         }
       },
-      "attributes": {
-        "created_at": "2019-11-04 17:41:29.015504",
-        "modified_at": "2019-11-04 17:41:29.015504",
-        "saml_assertion_attribute_id": 0
-      }
-    }
-  ],
-  "included": [
-    {
-      "data": {
-        "id": "123e4567-e89b-12d3-a456-426655440000",
-        "type": "roles",
-        "attributes": {
-          "created_at": "2019-11-04 17:41:29.015504",
-          "modified_at": "2019-11-06 17:41:29.015504",
-          "name": "Developer Role"
-        },
-        "relationships": {
-          "data": [
-            {
-              "id": "123e4567-e89b-12d3-a456-426655440000",
-              "type": "permissions"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "data": {
-        "id": 6,
-        "type": "saml_assertion_attributes",
-        "attributes": {
+      {
+        "data": {
           "id": 6,
-          "attribute_key": "member-of",
-          "attribute_value": "Developer"
+          "type": "saml_assertion_attributes",
+          "attributes": {
+            "id": 6,
+            "attribute_key": "member-of",
+            "attribute_value": "Developer"
+          }
         }
       }
+    ],
+    "meta": {
+      "page": {
+        "total_count": 1, 
+        "total_filtered_count": 1, 
+      }
     }
-  ],
-  "meta": {
-    "page": {
-      "total_count": 1, 
-      "total_filtered_count": 1, 
-    }
-  }
 }
 ```
 
@@ -249,18 +245,18 @@ Returns a specific AuthN Mapping by UUID.
 
 | Method | Endpoint path            | Required payload |
 |--------|--------------------------|------------------|
-| `GET`  | `/authn_mappings/{UUID}` | URL parameter    |
+| `GET`  | `/authn_mappings/{authn_mapping_id}` | URL parameter    |
 
 ##### ARGUMENTS
 
-* **`{UUID}`** [*required*, no default]:
-  Replace `{UUID}` with the UUID of the AuthN Mapping you want to view.
+* **`{authn_mapping_id}`** [*required*, no default]:
+  Replace `{authn_mapping_id}` with the ID of the AuthN Mapping you want to view.
 
 {{< tabs >}}
 {{% tab "Example" %}}
 
 ```sh
-curl -X GET "https://api.datadoghq.com/api/v2/authn_mappings/{UUID}" \
+curl -X GET "https://api.datadoghq.com/api/v2/authn_mappings/{authn_mapping_id}" \
      -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
      -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>"
 ```
@@ -273,57 +269,63 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 
 ```json
 {
-  "data": {
-    "attributes": {
-      "created_at": "2019-11-04 17:41:29.015504",
-      "modified_at": "2019-11-04 17:41:29.015504",
-      "uuid": "123e4567-e89b-12d3-a456-426655440000",
-      "saml_assertion_attribute_id": 0
-    },
-    "type": "authn_mappings",
-    "id": "123e4567-e89b-12d3-a456-426655440000",
-    "relationships": {
-      "saml_assertion_attribute": {
-        "data": {"id": 0, "type": "saml_assertion_attributes"}
-      },
-      "role": {
-        "data": {"id": "123e4567-e89b-12d3-a456-426655440000", "type": "roles"}
-      }
-    }
-  },
-  "included": [
-    {
-      "data": {
-        "id": "123e4567-e89b-12d3-a456-426655440000",
-        "type": "roles",
+    "data": {
         "attributes": {
-          "created_at": "2019-11-04 17:41:29.015504",
-          "modified_at": "2019-11-06 17:41:29.015504",
-          "uuid": "123e4567-e89b-12d3-a456-426655440000",
-          "name": "Developer Role"
+            "created_at": "2019-11-04 17:41:29.015504",
+            "modified_at": "2019-11-04 17:41:29.015504",
+            "uuid": "123e4567-e89b-12d3-a456-426655440000",
+            "saml_assertion_attribute_id": 0
         },
+        "type": "authn_mappings",
+        "id": "123e4567-e89b-12d3-a456-426655440000",
         "relationships": {
-          "data": [
-            {
-              "id": "123e4567-e89b-12d3-a456-426655440000",
-              "type": "permissions"
+            "saml_assertion_attribute": {
+                "data": {
+                    "id": 0,
+                    "type": "saml_assertion_attributes"
+                }
+            },
+            "role": {
+                "data": {
+                    "id": "123e4567-e89b-12d3-a456-426655440000",
+                    "type": "roles"
+                }
             }
-          ]
         }
-      }
     },
-    {
-      "data": {
-        "id": 6,
-        "type": "saml_assertion_attributes",
-        "attributes": {
-          "id": 6,
-          "attribute_key": "member-of",
-          "attribute_value": "Developer"
+    "included": [
+        {
+            "data": {
+                "id": "123e4567-e89b-12d3-a456-426655440000",
+                "type": "roles",
+                "attributes": {
+                    "created_at": "2019-11-04 17:41:29.015504",
+                    "modified_at": "2019-11-06 17:41:29.015504",
+                    "uuid": "123e4567-e89b-12d3-a456-426655440000",
+                    "name": "Developer Role"
+                },
+                "relationships": {
+                    "data": [
+                        {
+                            "id": "123e4567-e89b-12d3-a456-426655440000",
+                            "type": "permissions"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "data": {
+                "id": 6,
+                "type": "saml_assertion_attributes",
+                "attributes": {
+                    "id": 6,
+                    "attribute_key": "member-of",
+                    "attribute_value": "Developer"
+                }
+            }
         }
-      }
-    }
-  ]
+    ]
 }
 ```
 
@@ -334,22 +336,20 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 
 Updates the AuthN Mapping `role`, `saml_assertion_attribute_id`, or both from a JSON body. Returns the updated AuthN Mapping.
 
-| Method  | Endpoint path               | Required payload    |
-|---------|-----------------------------|---------------------|
-| `PATCH` | `/v2/authn_mappings/{UUID}` | URL parameter, JSON |
+| Method  | Endpoint path                           | Required payload    |
+|---------|-----------------------------------------|---------------------|
+| `PATCH` | `/v2/authn_mappings/{authn_mapping_id}` | URL parameter, JSON |
 
 ##### ARGUMENTS
 
-* **`{UUID}`** [*required*, no default]:
-  Replace `{UUID}` with the UUID of the AuthN Mapping you want to update.
-* **`id`** [*required*, no default]:
-  The UUID of the AuthN Mapping being updated. This property must match the `{UUID}` path parameter in the request.
-* **`role.uuid`** [*optional*, *default*=none]:
- The `UUID` of the Role to map to. The Roles API can be used to create and manage Datadog roles, what global permissions they grant, and which users belong to them. 
- **Note**: This attribute should be presented as part of a `role` relationship block in requests. See the example below for more details. When you create a Role, it is assigned a UUID. For more information about finding the `UUID` for the role you want to map to, see the [Role API documentation][1].
-* **`attribute_key`** [*optional*, *default*=none]:
+* **`{authn_mapping_id}`** [*required*, no default]:
+  Replace `{authn_mapping_id}` with the ID of the AuthN Mapping you want to update. This is required in both the path of the request and the body of the request.
+* **`role["data"]["id"]`** [*optional*, *default*=none]:
+ The `ID` of the Role to map to. The Roles API can be used to create and manage Datadog roles, what global permissions they grant, and which users belong to them. 
+ **Note**: This attribute should be presented as part of a `role` relationship block in requests. See the example below for more details. When you create a Role, it is assigned a ID. For more information about finding the `ID` for the role you want to map to, see the [Role API documentation][1].
+* **`attributes["attribute_key"]`** [*optional*, *default*=none]:
  The `attribute_key` is the key portion of a key/value pair that represents an attribute sent from your Identity Provider. You can define these for your own use case. For example, `attribute_key` could be `member-of` and the `attribute_value` could be `Development`.
-* **`attribute_value`** [*optional*, *default*=none]:
+* **`attributes["attribute_value"]`** [*optional*, *default*=none]:
  The `attribute_value` is the value portion of a key/value pair that represents an attribute sent from your Identity Provider. You can define these for your own use case. For example, `attribute_key` could be `member-of` and the `attribute_value` could be `Development`.
 
 {{< tabs >}}
@@ -357,21 +357,24 @@ Updates the AuthN Mapping `role`, `saml_assertion_attribute_id`, or both from a 
 
 ```sh
 curl -X PATCH \
-         "https://api.datadoghq.com/api/v2/authn_mappings/{UUID}" \
-         -H "Content-Type: application/json" \
-         -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
-         -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
-         -d '{
-             "data": {
-                 "type": "authn_mappings",
-                 "id": "{UUID}",
-                 "attributes": {
-                      "attribute_key": "member-of",
-                      "attribute_value": "Developer"
-                 }
-                 "relationships": {
-                    "role": {
-                    "data": {"id": "123e4567-e89b-12d3-a456-426655440000", "type": "roles"}
+    "https://api.datadoghq.com/api/v2/authn_mappings/{UUID}" \
+    -H "Content-Type: application/json" \
+    -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
+    -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
+    -d '{
+            "data": {
+                "type": "authn_mappings",
+                "id": "{authn_mapping_id}",
+                "attributes": {
+                    "attribute_key": "member-of",
+                    "attribute_value": "Developer"
+                }
+                "relationships": {
+                "role": {
+                    "data": {
+                            "id": "123e4567-e89b-12d3-a456-426655440000", 
+                            "type": "roles"
+                        }
                     }
                 }
             }
@@ -386,56 +389,62 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 
 ```json
 {
-  "data": {
-    "attributes": {
-      "created_at": "2019-11-04 17:41:29.015504",
-      "modified_at": "2019-11-04 17:41:29.015504",
-      "saml_assertion_attribute_id": 0
-    },
-    "type": "authn_mappings",
-    "id": "123e4567-e89b-12d3-a456-426655440000",
-    "relationships": {
-      "saml_assertion_attribute": {
-        "data": {"id": 0, "type": "saml_assertion_attributes"}
-      },
-      "role": {
-        "data": {"id": "123e4567-e89b-12d3-a456-426655440000", "type": "roles"}
-      }
-    }
-  },
-  "included": [
-    {
-      "data": {
-        "id": "123e4567-e89b-12d3-a456-426655440000",
-        "type": "roles",
+    "data": {
         "attributes": {
-          "created_at": "2019-11-04 17:41:29.015504",
-          "modified_at": "2019-11-06 17:41:29.015504",
-          "uuid": "123e4567-e89b-12d3-a456-426655440000",
-          "name": "Developer Role"
+            "created_at": "2019-11-04 17:41:29.015504",
+            "modified_at": "2019-11-04 17:41:29.015504",
+            "saml_assertion_attribute_id": 0
         },
+        "type": "authn_mappings",
+        "id": "123e4567-e89b-12d3-a456-426655440000",
         "relationships": {
-          "data": [
-            {
-              "id": "123e4567-e89b-12d3-a456-426655440000",
-              "type": "permissions"
+            "saml_assertion_attribute": {
+                "data": {
+                    "id": 0,
+                    "type": "saml_assertion_attributes"
+                }
+            },
+            "role": {
+                "data": {
+                    "id": "123e4567-e89b-12d3-a456-426655440000",
+                    "type": "roles"
+                }
             }
-          ]
         }
-      }
     },
-    {
-      "data": {
-        "id": 6,
-        "type": "saml_assertion_attributes",
-        "attributes": {
-          "id": 6,
-          "attribute_key": "member-of",
-          "attribute_value": "Developer"
+    "included": [
+        {
+            "data": {
+                "id": "123e4567-e89b-12d3-a456-426655440000",
+                "type": "roles",
+                "attributes": {
+                    "created_at": "2019-11-04 17:41:29.015504",
+                    "modified_at": "2019-11-06 17:41:29.015504",
+                    "uuid": "123e4567-e89b-12d3-a456-426655440000",
+                    "name": "Developer Role"
+                },
+                "relationships": {
+                    "data": [
+                        {
+                            "id": "123e4567-e89b-12d3-a456-426655440000",
+                            "type": "permissions"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "data": {
+                "id": 6,
+                "type": "saml_assertion_attributes",
+                "attributes": {
+                    "id": 6,
+                    "attribute_key": "member-of",
+                    "attribute_value": "Developer"
+                }
+            }
         }
-      }
-    }
-  ]
+    ]
 }
 ```
 
@@ -446,14 +455,14 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 
 Deletes a specific AuthN Mapping.
 
-| Method   | Endpoint path               | Required payload |
-|----------|-----------------------------|------------------|
-| `DELETE` | `/v2/authn_mappings/{UUID}` | URL parameter    |
+| Method   | Endpoint path                           | Required payload |
+|----------|-----------------------------------------|------------------|
+| `DELETE` | `/v2/authn_mappings/{authn_mapping_id}` | URL parameter    |
 
 ##### ARGUMENTS
 
-* **`{UUID}`** [*required*, no default]:
-  Replace `{UUID}` with the UUID of the AuthN Mapping you want to delete.
+* **`{authn_mapping_id}`** [*required*, no default]:
+  Replace `{authn_mapping_id}` with the ID of the AuthN Mapping you want to delete.
 
 {{< tabs >}}
 {{% tab "Example" %}}
@@ -482,9 +491,9 @@ HTTP/2 204
 
 Check whether Authn Mappings are enabled or disabled.
 
-| Method   | Endpoint path               | Required payload |
-|----------|-----------------------------|------------------|
-| `GET`    | `/v1/org_preferrences`      | None             |
+| Method   | Endpoint path              | Required payload |
+|----------|----------------------------|------------------|
+| `GET`    | `/v1/org_preferences`      | None             |
 
 {{< tabs >}}
 {{% tab "Example" %}}
@@ -521,7 +530,11 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 
 ### Enable/Disable All Mappings
 
-Enables/disables all AuthN Mappings.
+<div class="alert alert-warning">
+When enabled all users logging in with SAML will be stripped of any roles they have currently and reassigned roles based on the values in their SAML Assertion. It's important that you confirm you are receiving the expected SAML Assertions in your login before enabling the Mapping enforcement.
+</div>
+
+Enables/disables the enforcement of all AuthN Mappings. 
 
 | Method   | Endpoint path               | Required payload |
 |----------|-----------------------------|------------------|
@@ -539,19 +552,19 @@ Enables/disables all AuthN Mappings.
 
 ```sh
 curl -X POST \
-         "https://api.datadoghq.com/api/v1/org_perferences" \
-         -H "Content-Type: application/json" \
-         -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
-         -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
-         -d '{
-             "data": {
-                 "type": "org_peferences",
-                 "attributes": {
-                    "preference_type": "saml_authn_mapping_roles",
-                    "preference_data": true
-                j}
-             }
-         }'
+    "https://api.datadoghq.com/api/v1/org_perferences" \
+    -H "Content-Type: application/json" \
+    -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
+    -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
+    -d '{
+        "data": {
+            "type": "org_peferences",
+            "attributes": {
+                "preference_type": "saml_authn_mapping_roles",
+                "preference_data": true
+            }
+        }
+    }'
 `
 ```
 

--- a/content/en/account_management/authn_mapping/_index.md
+++ b/content/en/account_management/authn_mapping/_index.md
@@ -36,8 +36,8 @@ Create a new AuthN Mapping from a JSON body. Returns the newly created AuthN Map
 ##### ARGUMENTS
 
 * **`roles.uuid`** [*required*, no default]:
-The `UUID` of the Role to map to. The Roles API can be used to create and manage Datadog roles, what global permissions they grant, and which users belong to them. Note that this attribute should be presented as part of a `roles` relationship block in requests. See the example below for more details. When you create a Role, it is assigned a UUID. For more information about finding the `UUID` for the role you want to map to, see the [Role API documentation][1].
-
+ The `UUID` of the Role to map to. The Roles API can be used to create and manage Datadog roles, what global permissions they grant, and which users belong to them. 
+ **Note**: This attribute should be presented as part of a `roles` relationship block in requests. See the example below for more details. When you create a Role, it is assigned a UUID. For more information about finding the `UUID` for the role you want to map to, see the [Role API documentation][1].
 * **`attribute_key`** [*required*, no default]:
  The `attribute_key` is the key portion of a key/value pair that represents an attribute sent from your Identity Provider. You can define these for your own use case. For example, `attribute_key` could be `member-of` and the `attribute_value` could be `Development`.
 * **`attribute_value`** [*required*, no default]:
@@ -345,7 +345,8 @@ Updates the AuthN Mapping `role`, `saml_assertion_attribute_id`, or both from a 
 * **`id`** [*required*, no default]:
   The UUID of the AuthN Mapping being updated. This property must match the `{UUID}` path parameter in the request.
 * **`roles.uuid`** [*optional*, *default*=none]:
-  The `UUID` of the Role to map to. The Roles API can be used to create and manage Datadog roles, what global permissions they grant, and which users belong to them. Note that this attribute should be presented as part of a `roles` relationship block in requests. See the example below for more details. When you create a Role, it is assigned a UUID. For more information about finding the `UUID` for the role you want to map to, see the [Role API documentation][1].
+ The `UUID` of the Role to map to. The Roles API can be used to create and manage Datadog roles, what global permissions they grant, and which users belong to them. 
+ **Note**: This attribute should be presented as part of a `roles` relationship block in requests. See the example below for more details. When you create a Role, it is assigned a UUID. For more information about finding the `UUID` for the role you want to map to, see the [Role API documentation][1].
 * **`attribute_key`** [*optional*, *default*=none]:
  The `attribute_key` is the key portion of a key/value pair that represents an attribute sent from your Identity Provider. You can define these for your own use case. For example, `attribute_key` could be `member-of` and the `attribute_value` could be `Development`.
 * **`attribute_value`** [*optional*, *default*=none]:

--- a/content/en/account_management/authn_mapping/_index.md
+++ b/content/en/account_management/authn_mapping/_index.md
@@ -235,8 +235,6 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
     "page": {
       "total_count": 1, 
       "total_filtered_count": 1, 
-      "page_number": 0, 
-      "page_size": 0
     }
   }
 }

--- a/content/en/account_management/authn_mapping/_index.md
+++ b/content/en/account_management/authn_mapping/_index.md
@@ -152,7 +152,7 @@ Returns a list of AuthN Mappings
 ##### ARGUMENTS
 
 * **`sort`** [*optional*, *default*=**created\_at**]:
-  Sort attribute and direction—defaults to ascending order, `-` sorts in descending order.
+  Sort attribute and direction—defaults to ascending order, `-<attribute>` sorts in descending order. Can also sort on relationship attributes `roles.name`, `saml_assertion_attributes.attribute_key`, `saml_assertion_attributes.attribute_value`.
 * **`page[number]`** [*optional*, *default*=**0**, *minimum*=**0**]:
   The page of results to return.
 * **`page[size]`** [*optional*, *default*=**10**]:
@@ -231,7 +231,14 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
       }
     }
   ],
-  "meta": {"page": {"total_count": 1, "total_filtered_count": 1, "page_number": 0, "page_size": 0}}
+  "meta": {
+    "page": {
+      "total_count": 1, 
+      "total_filtered_count": 1, 
+      "page_number": 0, 
+      "page_size": 0
+    }
+  }
 }
 ```
 

--- a/content/en/account_management/authn_mapping/_index.md
+++ b/content/en/account_management/authn_mapping/_index.md
@@ -565,8 +565,8 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
 {
   "data": {
     "attributes": {
-        "preference_data": "saml_authn_mapping_roles",
-        "preference_type: true
+        "preference_type": "saml_authn_mapping_roles",
+        "preference_data: true
     },
     "type": "org_preferences",
     "id": 1,

--- a/content/en/account_management/authn_mapping/_index.md
+++ b/content/en/account_management/authn_mapping/_index.md
@@ -35,11 +35,12 @@ Create a new AuthN Mapping from a JSON body. Returns the newly created AuthN Map
 
 ##### ARGUMENTS
 
-* **`role_uuid`** [*required*, *default*=none]:
-  The `UUID` of the Role to map to. The Roles API can be used to create and manage Datadog roles, what global permissions they grant, and which users belong to them. When you create a Role, it is assigned a UUID. For more information about finding the `role_uuid` for the role you want to map to, see the [Role API documentation][1].
-* **`attribute_key`** [*required*, *default*=none]:
+* **`roles.uuid`** [*required*, no default]:
+The `UUID` of the Role to map to. The Roles API can be used to create and manage Datadog roles, what global permissions they grant, and which users belong to them. Note that this attribute should be presented as part of a `roles` relationship block in requests. See the example below for more details. When you create a Role, it is assigned a UUID. For more information about finding the `UUID` for the role you want to map to, see the [Role API documentation][1].
+
+* **`attribute_key`** [*required*, no default]:
  The `attribute_key` is the key portion of a key/value pair that represents an attribute sent from your Identity Provider. You can define these for your own use case. For example, `attribute_key` could be `member-of` and the `attribute_value` could be `Development`.
-* **`attribute_value`** [*required*, *default*=none]:
+* **`attribute_value`** [*required*, no default]:
  The `attribute_value` is the value portion of a key/value pair that represents an attribute sent from your Identity Provider. You can define these for your own use case. For example, `attribute_key` could be `member-of` and the `attribute_value` could be `Development`.
 
 {{< tabs >}}
@@ -55,9 +56,16 @@ curl -X POST \
              "data": {
                  "type": "authn_mappings",
                  "attributes": {
-                      "role_uuid": "123e4567-e89b-12d3-a456-426655445555",
-                      "attribute_key": "member-of",
-                      "attribute_value": "Development"
+                    "attribute_key": "member-of",
+                    "attribute_value": "Development"
+                }
+                "relationships": {
+                    "roles": {
+                        "data": {
+                            "id": "123e4567-e89b-12d3-a456-426655445555",
+                            "type": "roles"
+                        }
+                    }
                 }
              }
          }'
@@ -74,6 +82,7 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
   "data": {
     "attributes": {
       "created_at": "2019-11-04 17:41:29.015504",
+      "modified_at": "2019-11-04 17:41:29.015504",
       "role_uuid": "00000000-0000-0000-0000-000000000000",
       "saml_assertion_attribute_id": 0
     },
@@ -142,13 +151,13 @@ Returns a list of AuthN Mappings
 
 ##### ARGUMENTS
 
-* **`sort`** [*optional*, *default*=**+**]:
+* **`sort`** [*optional*, *default*=**created\_at**]:
   Sort attribute and direction—defaults to ascending order, `-` sorts in descending order.
 * **`page[number]`** [*optional*, *default*=**0**, *minimum*=**0**]:
   The page of results to return.
 * **`page[size]`** [*optional*, *default*=**10**]:
   The number of results to return on each page.
-* **`filter`** [*optional*, no default]:
+* **`filter`** [*optional*, default=none]:
   Filter by tags as strings. For example, `Billing Users`.
 
 {{< tabs >}}
@@ -185,7 +194,7 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
       },
       "attributes": {
         "created_at": "2019-11-04 17:41:29.015504",
-        "role_uuid": "123e4567-e89b-12d3-a456-426655445555",
+        "modified_at": "2019-11-04 17:41:29.015504",
         "saml_assertion_attribute_id": 0
       }
     }
@@ -222,7 +231,7 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
       }
     }
   ],
-  "meta": {"page": {"total": 0, "page_number": 0, "page_size": 0}}
+  "meta": {"page": {"total_count": 1, "total_filtered_count": 1, "page_number": 0, "page_size": 0}}
 }
 ```
 
@@ -262,8 +271,8 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
   "data": {
     "attributes": {
       "created_at": "2019-11-04 17:41:29.015504",
+      "modified_at": "2019-11-04 17:41:29.015504",
       "uuid": "123e4567-e89b-12d3-a456-426655440000",
-      "role_uuid": "123e4567-e89b-12d3-a456-426655445555",
       "saml_assertion_attribute_id": 0
     },
     "type": "authn_mappings",
@@ -328,13 +337,13 @@ Updates the AuthN Mapping `role`, `saml_assertion_attribute_id`, or both from a 
 
 * **`{UUID}`** [*required*, no default]:
   Replace `{UUID}` with the UUID of the AuthN Mapping you want to update.
-* **`id`** [*required*, *default*=none]:
+* **`id`** [*required*, no default]:
   The UUID of the AuthN Mapping being updated. This property must match the `{UUID}` path parameter in the request.
-* **`role_uuid`** [*required*, *default*=none]:
-  The Roles API can be used to create and manage Datadog roles, what global permissions they grant, and which users belong to them. When you create a Role, it is assigned a UUID. For more information about finding the `role_uuid` for the role you are updating, see the [Role API documentation][1].
-* **`attribute_key`** [*required*, *default*=none]:
+* **`roles.uuid`** [*optional*, *default*=none]:
+  The `UUID` of the Role to map to. The Roles API can be used to create and manage Datadog roles, what global permissions they grant, and which users belong to them. Note that this attribute should be presented as part of a `roles` relationship block in requests. See the example below for more details. When you create a Role, it is assigned a UUID. For more information about finding the `UUID` for the role you want to map to, see the [Role API documentation][1].
+* **`attribute_key`** [*optional*, *default*=none]:
  The `attribute_key` is the key portion of a key/value pair that represents an attribute sent from your Identity Provider. You can define these for your own use case. For example, `attribute_key` could be `member-of` and the `attribute_value` could be `Development`.
-* **`attribute_value`** [*required*, *default*=none]:
+* **`attribute_value`** [*optional*, *default*=none]:
  The `attribute_value` is the value portion of a key/value pair that represents an attribute sent from your Identity Provider. You can define these for your own use case. For example, `attribute_key` could be `member-of` and the `attribute_value` could be `Development`.
 
 {{< tabs >}}
@@ -351,12 +360,16 @@ curl -X PATCH \
                  "type": "authn_mappings",
                  "id": "{UUID}",
                  "attributes": {
-                      "role_uuid": "123e4567-e89b-12d3-a456-426655445555",
                       "attribute_key": "member-of",
                       "attribute_value": "Developer"
+                 }
+                 "relationships": {
+                    "roles": {
+                    "data": {"id": "123e4567-e89b-12d3-a456-426655440000", "type": "roles"}
+                    }
                 }
-             }
-         }'
+            }
+        }'
 ```
 
 Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1].
@@ -370,7 +383,7 @@ Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeh
   "data": {
     "attributes": {
       "created_at": "2019-11-04 17:41:29.015504",
-      "role_uuid": "123e4567-e89b-12d3-a456-426655445555",
+      "modified_at": "2019-11-04 17:41:29.015504",
       "saml_assertion_attribute_id": 0
     },
     "type": "authn_mappings",


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR updates the authn_mapping API documentation to match recent changes. The changes are listed as follows:

```
renaming meta page total → total_count

addition of total_filtered_count

additional sort methods: roles.name, saml_assertion_attributes.attribute_key, saml_assertion_attributes.attribute_value

removal of role_uuid from responses

removal of role_uuid from requests

receiving role uuid from relationship field in requests for POST and pATCH
```

This PR also does some minor corrections (modified_at, and optional fields
, and no default when applicable).
### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nathan/authn-mapping-doc-updates/account_management/authn_mapping/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
