### PR TITLE
Java Tracing: Add new version of netty to version range

### DIFF
--- a/content/en/tracing/setup/java.md
+++ b/content/en/tracing/setup/java.md
@@ -85,7 +85,7 @@ Beta integrations are disabled by default but can be enabled individually.
 | Java Servlet Compatible | 2.3+, 3.0+ | Fully Supported | `servlet`, `servlet-2`, `servlet-3`            |
 | Jax-RS Annotations      | JSR311-API | Fully Supported | `jax-rs`, `jaxrs`, `jax-rs-annotations`        |
 | Jetty (non-Servlet)     | 8+         | [Beta][8]       | `jetty`, `jetty-8`                             |
-| Netty HTTP Server       | 4.0+       | Fully Supported | `netty`, `netty-4.0`, `netty-4.1`              |
+| Netty HTTP Server       | 3.8+       | Fully Supported | `netty`, `netty-3.8`, `netty-4.0`, `netty-4.1` |
 | Play                    | 2.4-2.7    | Fully Supported | `play`                                         |
 | Ratpack                 | 1.4+       | Fully Supported | `ratpack`                                      |
 | Spark Java              | 2.3+       | [Beta][8]       | `sparkjava` (requires `jetty`)                 |

--- a/content/fr/tracing/setup/java.md
+++ b/content/fr/tracing/setup/java.md
@@ -84,7 +84,7 @@ Les intégrations bêta sont désactivées par défaut, mais peuvent être activ
 | Servlet Java compatible | 2.3+, 3.0+ | Prise en charge complète | `servlet`, `servlet-2`, `servlet-3`            |
 | Annotations Jax-RS      | JSR311-API | Prise en charge complète | `jax-rs`, `jaxrs`, `jax-rs-annotations`        |
 | Jetty (hors servlet)     | 8+         | [Bêta][8]       | `jetty`, `jetty-8`                             |
-| Netty HTTP Server       | 4.0+       | Prise en charge complète | `netty`, `netty-4.0`, `netty-4.1`              |
+| Netty HTTP Server       | 3.8+       | Prise en charge complète | `netty`, `netty-3.8`, `netty-4.0`, `netty-4.1` |
 | Play                    | 2.4-2.7    | Prise en charge complète | `play`                                         |
 | Ratpack                 | 1.4+       | Prise en charge complète | `ratpack`                                      |
 | Spark Java              | 2.3+       | [Bêta][8]       | `sparkjava` (nécessite `jetty`)                 |

--- a/content/ja/tracing/setup/java.md
+++ b/content/ja/tracing/setup/java.md
@@ -84,7 +84,7 @@ Datadog は、Oracle JDK と OpenJDK の両方の Java JRE 1.7 以上を公式�
 | Java Servlet 互換 | 2.3+、3.0+ | 完全対応 | `servlet`、`servlet-2`、`servlet-3`            |
 | Jax-RS アノテーション      | JSR311-API | 完全対応 | `jax-rs`、`jaxrs`、`jax-rs-annotations`        |
 | Jetty (非 Servlet)     | 8+         | [ベータ][8]       | `jetty`、`jetty-8`                             |
-| Netty HTTP サーバー       | 4.0+       | 完全対応 | `netty`、`netty-4.0`、`netty-4.1`              |
+| Netty HTTP サーバー       | 3.8+       | 完全対応 | `netty`、`netty-3.8`、`netty-4.0`、`netty-4.1` |
 | Play                    | 2.4-2.7    | 完全対応 | `play`                                         |
 | Ratpack                 | 1.4+       | 完全対応 | `ratpack`                                      |
 | Spark Java              | 2.3+       | [ベータ][8]       | `sparkjava` (要 `jetty`)                 |


### PR DESCRIPTION
### What does this PR do?
Adds a supported version of netty to the Java tracer docs

### Motivation
We've added a supported version of netty

### Preview link
https://docs-staging.datadoghq.com/brian.devinssuresh/java-update-netty-version-range/tracing/setup/java/
