### PR TITLE
Update java profiling apikey docs

### DIFF
--- a/content/en/tracing/profiling/_index.md
+++ b/content/en/tracing/profiling/_index.md
@@ -55,7 +55,7 @@ The Datadog Profiler requires [Java Flight Recorder][1]. The Datadog Profiling l
 | ----------------------------- | ------------------------- | ------------------------------------------------- |
 | `-Ddd.profiling.enabled`      | DD_PROFILING_ENABLED      | Set to `true` to enable profiling.                |
 | `-Ddd.profiling.api-key-file` | DD_PROFILING_API_KEY_FILE | File that should contain the API key as a string. |
-| `-Ddd.profiling.api-key`      | DD_PROFILING_API_KEY      | Datadog API key.                                  |
+|                               | DD_PROFILING_API_KEY      | Datadog API key.                                  |
 
 
 [1]: https://docs.oracle.com/javacomponents/jmc-5-4/jfr-runtime-guide/about.htm


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
The use of `-Ddd.profiling.api-key` as a system property for setting the api key in java has been removed due to security implications of passing plaintext api-key as a system property, which would cause it potentially to be picked up in the profiling data. By removing the system property option , only the env var can be used, which is correct.

This can further be verified via code comments

https://github.com/DataDog/dd-trace-java/blob/060c05671e3100f0b2497a9bc2b3d2f560634a00/dd-trace-api/src/main/java/datadog/trace/api/Config.java#L432

@mar-kolya or @hugokash per our convo could one of you confirm this change so the docs team has the necessary approvals from eng?

### Motivation
Blocking users during setup from using profiling, creating unnecessary support requests

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ericmustin/profiling-java-apikey-docs/tracing/profiling/?tab=java#setup

### Additional Notes
<!-- Anything else we should know when reviewing?-->
