### PR TITLE
update metric name for the log usage dashboard

### DIFF
--- a/static/resources/json/estimated_log_usage_dashboard_configuration.json
+++ b/static/resources/json/estimated_log_usage_dashboard_configuration.json
@@ -117,7 +117,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:datadog.estimated_usage.logs.ingested_events{datadog_is_excluded:true,$service,$index}.as_count()/sum:logs.estimated.ingested_events.count{$service,$index}.as_count()*100",
+                        "q": "sum:datadog.estimated_usage.logs.ingested_events{datadog_is_excluded:true,$service,$index}.as_count()/sum:datadog.estimated_usage.logs.ingested_events.count{$service,$index}.as_count()*100",
                         "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
@@ -171,7 +171,7 @@
                 "type": "query_value",
                 "requests": [
                     {
-                        "q": "sum:datadog.estimated_usage.logs.ingested_events{datadog_is_excluded:true,$service,$index} by {service}.as_count()/sum:logs.estimated.ingested_events.count{$service,$index} by {service}.as_count()*100",
+                        "q": "sum:datadog.estimated_usage.logs.ingested_events{datadog_is_excluded:true,$service,$index} by {service}.as_count()/sum:datadog.estimated_usage.logs.ingested_events{$service,$index} by {service}.as_count()*100",
                         "aggregator": "sum"
                     }
                 ],
@@ -385,7 +385,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:datadog.estimated_usage.logs.ingested_events{datadog_is_excluded:true,$service,$index} by {service}.as_count()/sum:logs.estimated.ingested_events.count{$service,$index} by {service}.as_count()*100",
+                        "q": "sum:datadog.estimated_usage.logs.ingested_events{datadog_is_excluded:true,$service,$index} by {service}.as_count()/sum:datadog.estimated_usage.logs.ingested_events{$service,$index} by {service}.as_count()*100",
                         "display_type": "line",
                         "style": {
                             "palette": "dog_classic",

--- a/static/resources/json/estimated_log_usage_dashboard_configuration.json
+++ b/static/resources/json/estimated_log_usage_dashboard_configuration.json
@@ -117,7 +117,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:datadog.estimated_usage.logs.ingested_events{datadog_is_excluded:true,$service,$index}.as_count()/sum:datadog.estimated_usage.logs.ingested_events.count{$service,$index}.as_count()*100",
+                        "q": "sum:datadog.estimated_usage.logs.ingested_events{datadog_is_excluded:true,$service,$index}.as_count()/sum:datadog.estimated_usage.logs.ingested_events{$service,$index}.as_count()*100",
                         "display_type": "line",
                         "style": {
                             "palette": "dog_classic",


### PR DESCRIPTION
### What does this PR do?
Dashboard was still using some old metric names in the % calculation.

### Motivation
Making sure the dashboard is usable as is.

### Preview link


<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/log-usage-metric-update/logs/guide/logs-monitors-on-volumes/#estimated-usage-dashboard

### Additional Notes
<!-- Anything else we should know when reviewing?-->
