### PR TITLE
Key Value delimiter

### DIFF
--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -184,13 +184,13 @@ This is the key-value core filter: `keyvalue([separatorStr[, characterWhiteList[
 
 Use filters such as **keyvalue** to more-easily map strings to attributes for keyvalue or logfmt formats:
 
-Log:
+**Log:**
 
 ```text
 user=john connect_date=11/08/2017 id=123 action=click
 ```
 
-Rule
+**Rule:**
 
 ```text
 rule %{data::keyvalue}
@@ -205,13 +205,13 @@ If you add an **extract** attribute `my_attribute` in your rule pattern you will
 
 If `=` is not the default separator between your key and values, add a parameter in your parsing rule with a separator.
 
-Log:
+**Log:**
 
 ```text
 user: john connect_date: 11/08/2017 id: 123 action: click
 ```
 
-Rule
+**Rule:**
 
 ```text
 rule %{data::keyvalue(": ")}
@@ -221,13 +221,13 @@ rule %{data::keyvalue(": ")}
 
 If logs contain special characters in an attribute value, such as `/` in a url for instance, add it to the whitelist in the parsing rule:
 
-Log:
+**Log:**
 
 ```text
 url=https://app.datadoghq.com/event/stream user=john
 ```
 
-Rule:
+**Rule:**
 
 ```text
 rule %{data::keyvalue("=","/:")}
@@ -248,19 +248,19 @@ Other examples:
 **Multiple QuotingString example**: When multiple quotingstring are defined, the default behavior is replaced with a defined quoting character.
 The key-value always matches inputs without any quoting characters, regardless of what is specified in `quotingStr`. When quoting characters are used, the `characterWhiteList` is ignored as everything between the quoting characters is extracted.
 
-Log:
+**Log:**
 
   ```text
   key1:=valueStr key2:=</valueStr2> key3:="valueStr3"
   ```
 
-Rule:
+**Rule:**
 
   ```text
   rule %{data::keyvalue(":=","","<>")}
   ```
 
-Result:
+**Result:**
 
   ```json
   {

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -272,7 +272,7 @@ Result:
 
 _example_:
 
-Log:
+**Log:**
 
   ```text
   key1=value1|key2=value2|key3=value3

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -268,7 +268,7 @@ Result:
     "key2": "/valueStr2"
   }
   ```
-**Custom delimiter example**: If all the key values pairs are concatenated with no standard delimiter to split them, a custom delimiter can specified. Defining `""` as `quotingStr` will keep the default configuration for quoting.
+**Custom delimiter example**: Define a custom delimiter if all the key values pairs are concatenated with no standard delimiter to split them. Note that defining `""` as `quotingStr` keeps the default configuration for quoting.
 
 _example_:
 

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -284,7 +284,7 @@ Rule:
   rule %{data::keyvalue("=","","","|")}
   ```
 
-Result:
+**Result:**
 
   ```json
   {

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -180,7 +180,7 @@ This is the key-value core filter: `keyvalue([separatorStr[, characterWhiteList[
 * `separatorStr`: defines the separator between key and values. Defaults to `=`.
 * `characterWhiteList`: defines extra non-escaped value chars in addition to the default `\\w.\\-_@`. Used only for non-quoted values (e.g. `key=@valueStr`).
 * `quotingStr`: defines quotes, replacing the default quotes detection: `<>`, `""`, `''`. 
-* `delimiter`: defines the separator between the different key values pairs (e.g.`|`is the delimiter in `key1=value1|key2=value2`). Default to ` `, `,` and `;`.
+* `delimiter`: defines the separator between the different key values pairs (e.g.`|`is the delimiter in `key1=value1|key2=value2`). Default to ` ` (normal space), `,` and `;`.
 
 Use filters such as **keyvalue** to more-easily map strings to attributes for keyvalue or logfmt formats:
 

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -271,10 +271,11 @@ Result:
 **Custom delimiter example**: If all the key values pairs are concatenated with no standard delimiter to split them, a custom delimiter can specified. Defining `""` as `quotingStr` will keep the default configuration for quoting.
 
 _example_:
+
 Log:
 
   ```text
-  key1=value1|key2=value2|key3=value3"
+  key1=value1|key2=value2|key3=value3
   ```
 
 Rule:

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -180,7 +180,7 @@ This is the key-value core filter: `keyvalue([separatorStr[, characterWhiteList[
 * `separatorStr`: defines the separator between key and values. Defaults to `=`.
 * `characterWhiteList`: defines extra non-escaped value chars in addition to the default `\\w.\\-_@`. Used only for non-quoted values (e.g. `key=@valueStr`).
 * `quotingStr`: defines quotes, replacing the default quotes detection: `<>`, `""`, `''`. 
-* `delimiter`: defines the separator between the different key values pairs (e.g.`|`is the delimiter in `key1=value1|key2=value2`). Default to ` `,`,`,`;`,`\`,`[` and `]`.
+* `delimiter`: defines the separator between the different key values pairs (e.g.`|`is the delimiter in `key1=value1|key2=value2`). Default to ` `, `,` and `;`.
 
 Use filters such as **keyvalue** to more-easily map strings to attributes for keyvalue or logfmt formats:
 

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -237,13 +237,17 @@ rule %{data::keyvalue("=","/:")}
 
 Other examples:
 
-| **Raw string**  | **Parsing rule**                    | **Result**           |
-|:----------------|:------------------------------------|:---------------------|
-| key=valueStr    | `%{data::keyvalue}`                 | {"key": "valueStr}   |
-| key=\<valueStr> | `%{data::keyvalue}`                 | {"key": "valueStr"}  |
-| key:valueStr    | `%{data::keyvalue(":")}`            | {"key": "valueStr"}  |
-| key:"/valueStr" | `%{data::keyvalue(":", "/")}`       | {"key": "/valueStr"} |
-| key:={valueStr} | `%{data::keyvalue(":=", "", "{}")}` | {"key": "valueStr"}  |
+| **Raw string**               | **Parsing rule**                       | **Result**                            |
+|:-----------------------------|:---------------------------------------|:--------------------------------------|
+| key=valueStr                 | `%{data::keyvalue}`                    | {"key": "valueStr}                    |
+| key=\<valueStr>              | `%{data::keyvalue}`                    | {"key": "valueStr"}                   |
+| "key"="valueStr"             | `%{data::keyvalue}`                    | {"key": "valueStr"}                   |
+| key:valueStr                 | `%{data::keyvalue(":")}`               | {"key": "valueStr"}                   |
+| key:"/valueStr"              | `%{data::keyvalue(":", "/")}`          | {"key": "/valueStr"}                  |
+| /key:/valueStr               | `%{data::keyvalue(":", "/")}`          | {"/key": "/valueStr"}                 |
+| key:={valueStr}              | `%{data::keyvalue(":=", "", "{}")}`    | {"key": "valueStr"}                   |
+| key1=value1\|key2=value2     | `%{data::keyvalue("=", "", "", "\|")}` | {"key1": "value1", "key2": "value2"}  |
+| key1="value1"\|key2="value2" | `%{data::keyvalue("=", "", "", "\|")}` | {"key1": "value1", "key2": "value2"}  |
 
 **Multiple QuotingString example**: When multiple quotingstring are defined, the default behavior is replaced with a defined quoting character.
 The key-value always matches inputs without any quoting characters, regardless of what is specified in `quotingStr`. When quoting characters are used, the `characterWhiteList` is ignored as everything between the quoting characters is extracted.
@@ -265,33 +269,12 @@ The key-value always matches inputs without any quoting characters, regardless o
   ```json
   {"key1": "valueStr", "key2": "/valueStr2"}
   ```
-**Custom delimiter example**: Define a custom delimiter if all the key values pairs are concatenated with no standard delimiter to split them. Note that defining `""` as `quotingStr` keeps the default configuration for quoting.
-
-_example_:
-
-**Log:**
-
-  ```text
-  key1=value1|key2=value2|key3=value3
-  ```
-
-**Rule:**
-
-  ```text
-  rule %{data::keyvalue("=","","","|")}
-  ```
-
-**Result:**
-
-  ```json
-  {"key1": "value1", "key2": "value2", "key3": "value3"}
-  ```
-
 
 **Note**:
 
 * Empty values (`key=`) or `null` values (`key=null`) are not displayed in the output JSON.
 * If you define a *keyvalue* filter on a `data` object, and this filter is not matched, then an empty JSON `{}` is returned (e.g. input: `key:=valueStr`, parsing rule: `rule_test %{data::keyvalue("=")}`, output: `{}`).
+* Defining `""` as `quotingStr` keeps the default configuration for quoting.
 
 ### Parsing dates
 

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -263,10 +263,7 @@ The key-value always matches inputs without any quoting characters, regardless o
 **Result:**
 
   ```json
-  {
-    "key1": "valueStr",
-    "key2": "/valueStr2"
-  }
+  {"key1": "valueStr", "key2": "/valueStr2"}
   ```
 **Custom delimiter example**: Define a custom delimiter if all the key values pairs are concatenated with no standard delimiter to split them. Note that defining `""` as `quotingStr` keeps the default configuration for quoting.
 
@@ -287,11 +284,7 @@ _example_:
 **Result:**
 
   ```json
-  {
-    "key1": "value1",
-    "key2": "value2",
-    "key3": "value3"
-  }
+  {"key1": "value1", "key2": "value2", "key3": "value3"}
   ```
 
 

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -278,7 +278,7 @@ Log:
   key1=value1|key2=value2|key3=value3
   ```
 
-Rule:
+**Rule:**
 
   ```text
   rule %{data::keyvalue("=","","","|")}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
 Document how to configure a delimiter in the keyvalue grok parser

### Motivation
https://datadoghq.atlassian.net/browse/LI-287

### Preview link

https://docs-staging.datadoghq.com/pvr/log-keyvalue-delimiter/logs/processing/parsing/?tab=matcher#key-value-or-logfmt

### Additional Notes
<!-- Anything else we should know when reviewing?-->
