### PR TITLE
[DOCS-786] Fixing PHP connect logs and traces

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/_index.md
+++ b/content/en/tracing/connect_logs_and_traces/_index.md
@@ -8,7 +8,7 @@ aliases:
 
 {{< img src="tracing/connect_logs_and_traces/trace_id_injection.png" alt="Logs in Traces"  style="width:100%;">}}
 
-The correlation between Datadog APM and Datadog Log Management is improved by automatically adding a `trace_id` and `span_id` in your logs with the Tracing Libraries. This can then be used in the platform to show you the exact logs correlated to the observed [trace][1].
+The correlation between Datadog APM and Datadog Log Management is improved by automatically adding a `dd.trace_id` and `dd.span_id` attributes in your logs with the Tracing Libraries. This can then be used in the platform to show you the exact logs correlated to the observed [trace][1].
 
 Before correlating traces with logs, ensure your logs are either sent as JSON, or [parsed by the proper language level log processor][2].
 

--- a/content/en/tracing/connect_logs_and_traces/_index.md
+++ b/content/en/tracing/connect_logs_and_traces/_index.md
@@ -8,7 +8,7 @@ aliases:
 
 {{< img src="tracing/connect_logs_and_traces/trace_id_injection.png" alt="Logs in Traces"  style="width:100%;">}}
 
-The correlation between Datadog APM and Datadog Log Management is improved by automatically adding a `dd.trace_id` and `dd.span_id` attributes in your logs with the Tracing Libraries. This can then be used in the platform to show you the exact logs correlated to the observed [trace][1].
+The correlation between Datadog APM and Datadog Log Management is improved by automatically adding `dd.trace_id` and `dd.span_id` attributes in your logs with the Tracing Libraries. This can then be used in the platform to show you the exact logs correlated to the observed [trace][1].
 
 Before correlating traces with logs, ensure your logs are either sent as JSON, or [parsed by the proper language level log processor][2].
 

--- a/content/en/tracing/connect_logs_and_traces/php.md
+++ b/content/en/tracing/connect_logs_and_traces/php.md
@@ -19,14 +19,14 @@ further_reading:
 
 ## Automatic Trace ID injection
 
-Given the many different ways to implement logging in PHP with some completely circumventing PHP's built-in error-logging API, the Datadog PHP tracing library cannot reliably inject trace and span ID's into logs automatically.
+Given the many different ways to implement logging in PHP<span class="x x-first x-last">,</span> with some completely circumventing PHP's built-in error-logging API, the Datadog PHP tracing library cannot reliably inject trace and span <span class="x x-first x-last">IDs</span> into logs automatically.
 See the section below to learn how to connect your PHP Logs and traces manually.
 
 ## Manual Trace ID injection
 
 To connect your logs and traces together, your logs must contain the `dd.trace_id` and `dd.span_id` attributes that respectively contain your trace ID and your span ID.
 
-If you are not using a [Datadog Log Integration][1] to parse your logs, a custom log parsing rules need to ensure that `dd.trace_id` and `dd.span_id` are being parsed as strings and remapped thanks to the [Trace Remapper][2]. More information can be found in the [Why can't I see my correlated logs in the Trace ID panel?][3] FAQ.
+If you are not using a [Datadog Log Integration][1] to parse your logs, custom log parsing rules need to ensure that `dd.trace_id` and `dd.span_id` are being parsed as strings and remapped thanks to the [Trace Remapper][2]. More information can be found in the [Why can't I see my correlated logs in the Trace ID panel?][3] FAQ.
 
 For instance, you would append those two attributes to your logs with:
 

--- a/content/en/tracing/connect_logs_and_traces/php.md
+++ b/content/en/tracing/connect_logs_and_traces/php.md
@@ -19,7 +19,8 @@ further_reading:
 
 ## Automatic Trace ID injection
 
-PHP’s logging design prevents Datadog PHP tracing library to inject trace and span IDs into your logs automatically. See the section below to learn how to connect your PHP Logs and traces manually.
+Given the many different ways to implement logging in PHP with some completely circumventing PHP's built-in error-logging API, the Datadog PHP tracing library cannot reliably inject trace and span ID's into logs automatically.
+See the section below to learn how to connect your PHP Logs and traces manually.
 
 ## Manual Trace ID injection
 

--- a/content/en/tracing/connect_logs_and_traces/php.md
+++ b/content/en/tracing/connect_logs_and_traces/php.md
@@ -19,15 +19,15 @@ further_reading:
 
 ## Automatic Trace ID injection
 
-PHP’s logging design prevents Datadog tracing library to inject trace and span IDs into your logs automatically. See the section below to learn how to connect your PHP Logs and traces manually.
+PHP’s logging design prevents Datadog PHP tracing library to inject trace and span IDs into your logs automatically. See the section below to learn how to connect your PHP Logs and traces manually.
 
 ## Manual Trace ID injection
 
-To connect your logs and traces together, your logs must have the `dd.trace_id` and `dd.span_id` attributes that respectively contain your trace ID and your span ID.
+To connect your logs and traces together, your logs must contain the `dd.trace_id` and `dd.span_id` attributes that respectively contain your trace ID and your span ID.
 
-If you are not using a [Datadog Log Integration][1] to parse your logs, a custom log parsing rules need to ensure that `dd.trace_id` and `dd.span_id` are being parsed as strings and remapped thanks to the [Trace Remapper][2]. More information can be found in the [ Why can't I see my correlated logs in the Trace ID panel?][3] FAQ.
+If you are not using a [Datadog Log Integration][1] to parse your logs, a custom log parsing rules need to ensure that `dd.trace_id` and `dd.span_id` are being parsed as strings and remapped thanks to the [Trace Remapper][2]. More information can be found in the [Why can't I see my correlated logs in the Trace ID panel?][3] FAQ.
 
-For instance, you would append those two attributes with:
+For instance, you would append those two attributes to your logs with:
 
 ```php
   <?php
@@ -65,6 +65,6 @@ If the logger implements the [**monolog/monolog** library][4], use `Logger::push
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /logs/log_collection/php
-[2]: /logs/processing/processors/?tab=ui#trace-remapper
+[2]: /logs/processing/processors/#trace-remapper
 [3]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/?tab=custom
 [4]: https://github.com/Seldaek/monolog

--- a/content/en/tracing/connect_logs_and_traces/php.md
+++ b/content/en/tracing/connect_logs_and_traces/php.md
@@ -19,6 +19,16 @@ further_reading:
 
 ## Automatic Trace ID injection
 
+PHP’s logging design prevents Datadog tracing library to inject trace and span IDs into your logs automatically. See the section below to learn how to connect your PHP Logs and traces manually.
+
+## Manual Trace ID injection
+
+To connect your logs and traces together, your logs must have the `dd.trace_id` and `dd.span_id` attributes that respectively contain your trace ID and your span ID.
+
+If you are not using a [Datadog Log Integration][1] to parse your logs, a custom log parsing rules need to ensure that `dd.trace_id` and `dd.span_id` are being parsed as strings and remapped thanks to the [Trace Remapper][2]. More information can be found in the [ Why can't I see my correlated logs in the Trace ID panel?][3] FAQ.
+
+For instance, you would append those two attributes with:
+
 ```php
   <?php
   $span = \DDTrace\GlobalTracer::get()->getActiveSpan();
@@ -31,7 +41,7 @@ further_reading:
 ?>
 ```
 
-If the logger implements the [**monolog/monolog** library][1], use `Logger::pushProcessor()` to automatically append the identifiers to all the log messages:
+If the logger implements the [**monolog/monolog** library][4], use `Logger::pushProcessor()` to automatically append the identifiers to all log messages:
 
 ```php
 <?php
@@ -50,17 +60,11 @@ If the logger implements the [**monolog/monolog** library][1], use `Logger::push
 ?>
 ```
 
-**Note**: If you are not using a [Datadog Log Integration][2] to parse your logs, custom log parsing rules need to ensure that `dd.trace_id` and `dd.span_id` are being parsed as strings. More information can be found in the [FAQ on this topic][3].
-
-## Manual Trace ID injection
-
-Coming Soon. Reach out to [the Datadog support team][4] to learn more.
-
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/Seldaek/monolog
-[2]: /logs/log_collection/php
+[1]: /logs/log_collection/php
+[2]: /logs/processing/processors/?tab=ui#trace-remapper
 [3]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/?tab=custom
-[4]: /help
+[4]: https://github.com/Seldaek/monolog


### PR DESCRIPTION
### What does this PR do?
Fixes PHP connect logs and traces documentation as automated correlation is impossible.

This PR updates the wording in order to reflect that + fixes the attribute name in the section homepage.

### Motivation
Support feedback

### Preview link

* https://docs-staging.datadoghq.com/gus/apm-php-trace-injection/tracing/connect_logs_and_traces/php