### PR TITLE
Updating docs for getting the hostname from an agent check

### DIFF
--- a/content/en/dashboards/faq/how-do-i-add-hostname-to-event-titles-and-messages-submitted-by-my-custom-agent-checks.md
+++ b/content/en/dashboards/faq/how-do-i-add-hostname-to-event-titles-and-messages-submitted-by-my-custom-agent-checks.md
@@ -5,19 +5,18 @@ aliases:
     - /graphing/faq/how-do-i-add-hostname-to-event-titles-and-messages-submitted-by-my-custom-agent-checks
 ---
 
-When you submit events to your Datadog account from a [custom Agent check][1], they get a host tag associated with them by default. But it can sometimes be useful to include the hostname as part of the event title or content. This can be achieved if, in your custom Agent check's code, you import `get_hostname` from `util`, and then feed `self.agentConfig` as an argument to `get_hostname`, as in this example:
+When you submit events to your Datadog account from a [custom Agent check][1], they get a host tag associated with them by default. But it can sometimes be useful to include the hostname as part of the event title or content. This can be achieved by importing `get_hostname` from `datadog_agent` in your custom Agent check's code, as in this example:
 
 ```python
 
 import time
 from datadog_checks.base import AgentCheck
-from utils import get_hostname
+from datadog_agent import get_hostname
 
-hostname = get_hostname(self.agentConfig)
 
 class TestCheck(AgentCheck):
     def check(self, instance):
-        hostname = get_hostname(self.agentConfig)
+        hostname = get_hostname()
         self.event({
             'timestamp': int(time.time()),
             'event_type': 'test',
@@ -30,6 +29,6 @@ class TestCheck(AgentCheck):
 Such an Agent check would create the following event in your event stream:
 {{< img src="dashboards/faq/event_example.png" alt="event_example"  >}}
 
-In this example, the host tag would have been applied even without referencing `get_hostname(self.agentConfig)`, but that reference added the hostname to the event title and content.
+In this example, the host tag would have been applied even without referencing `get_hostname()`, but that reference added the hostname to the event title and content.
 
 [1]: /agent/agent_checks


### PR DESCRIPTION
The doc page is misleading, it advises customer to use the `datadogpy` library (which is not shipped with the agent).
The correct way to get the hostname from a check is to call the `get_hostname` method from the `datadog_agent` library.


https://docs-staging.datadoghq.com/florian/fix_get_hostname_docs

