### PR TITLE
Update wording and links

### DIFF
--- a/content/en/tracing/livetail.md
+++ b/content/en/tracing/livetail.md
@@ -2,27 +2,42 @@
 title: Live Tail
 kind: documentation
 description: "See all your trace spans in real time."
+further_reading:
+- link: "tracing/setup/"
+  tag: "Documentation"
+  text: "Learn how to setup APM tracing with your application"
+- link: "tracing/visualization/services_list/"
+  tag: "Documentation"
+  text: "Discover the list of services reporting to Datadog"
+- link: "tracing/visualization/service"
+  tag: "Documentation"
+  text: "Learn more about services in Datadog"
+- link: "tracing/visualization/resource"
+  tag: "Documentation"
+  text: "Dive into your resource performance and traces"
+- link: "tracing/visualization/trace"
+  tag: "Documentation"
+  text: "Understand how to read a Datadog Trace"
+- link: "tracing/app_analytics/analytics"
+  tag: "Documentation"
+  text: "Analytics on your APM data at infinite cardinality"
 ---
-
 
 {{< img src="tracing/live_tail/livetail_view.gif" alt="Live tail" >}}
 
 ## Overview
-The APM [Live Tail][1] gives users the ability to see all trace spans in near real-time from anywhere in the Datadog UI. It displays spans as soon as they get out of the Datadog agent section and before they are indexed by Datadog and it has these features:
-- All trace spans ingested by Datadog are displayed because It’s a part of tracing without Limits*
-- It displays spans that have been processed.
-- The span stream can be paused.
-- You can write search parameters to refine the streaming view.
-- View the distributed trace in real-time.
-4. Add or remove columns from span tags for a customized view 
+
+The APM [Live Tail][1] gives you the ability to see all trace spans in near real-time from anywhere in the Datadog UI. It displays spans as soon as they get out of the Datadog Agent section and before they are indexed by Datadog. All trace spans ingested by Datadog are displayed (tracing without Limits\*) after being processed. With the APM Live tail page you can:
+
+- Write search parameters to refine the stream of traces.
+- View distributed trace in real-time.
+- Add or remove columns from span tags for a customized view.
 
 This feature allows you, for instance, to check if a process has correctly started, or if a new deployment went smoothly. Or view outage related information in real-time
 
 ## Live Tail view
 
-Choose the `Live Tail` option in the time range selector to switch to the Live Tail view.
-The number of received spans per second is displayed at the top left, as well as the sampling rate. Since a stream of thousands of spans per second is not human readable, high throughput span streams are sampled for visual clarity.
-Use the Live Tail search bar filtering features to filter the spans stream and the Pause/Play button at the top right of the screen to pause or resume the stream.
+Choose the `Live Tail` option in the time range selector to switch to the Live Tail view. The number of received spans per second is displayed at the top left, as well as the sampling rate. Since a stream of thousands of spans per second is not human readable, high throughput span streams are sampled for visual clarity. Use the Live Tail search bar filtering features to filter the spans stream and the Pause/Play button at the top right of the screen to pause or resume the stream.
 
 **Note**: Selecting any span pauses the stream and displays more details about the selected span in the trace side panel.
 
@@ -31,9 +46,9 @@ Use the Live Tail search bar filtering features to filter the spans stream and t
 Customize the Live Tail column view to better highlight the relevant information in your traces. Click on the column dropdown at the top right of the column header to activate one of the options below:
 {{< img src="tracing/live_tail/column_livetail.png" alt="Live tail" >}}
 
-1. Move column to the right or left
-2. Insert column to the right or left from span tags
-3. Remove or replace column column
+1. Move column to the right or left.
+2. Insert column to the right or left from span tags.
+3. Remove or replace column column.
 
 ## Filtering the trace Stream
 
@@ -45,7 +60,12 @@ A valid query in the search bar displays traces that match your search criteria.
 
 Any query that works in other views works in the Live Tail view, but you can only filter on attributes that are defined as facets.
 For example, to filter on the a customer_id attribute, there are two options:
- - Click on the attribute and add it to the search using the query `@customer_id:1123`.
+
+- Click on the attribute and add it to the search using the query `@customer_id:1123`.
 - Filter on all spans with a duration above 150ms using the query: `@duration:>150ms`.
 
-[1]: /apm/livetail
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://app.datadoghq.com/apm/livetail

--- a/content/en/tracing/livetail.md
+++ b/content/en/tracing/livetail.md
@@ -45,7 +45,7 @@ Choose the `Live Tail` option in the time range selector to switch to the Live T
 
 Customize the Live Tail column view to better highlight the relevant information in your traces. Click on the column dropdown at the top right of the column header to activate one of the options below:
 
-{{< img src="tracing/live_tail/column_livetail.png" alt="Live tail" >}}
+{{< img src="tracing/live_tail/column_livetail.png" alt="Live tail" style="width:20%;">}}
 
 1. Move column to the right or left.
 2. Insert column to the right or left from span tags.

--- a/content/en/tracing/livetail.md
+++ b/content/en/tracing/livetail.md
@@ -44,6 +44,7 @@ Choose the `Live Tail` option in the time range selector to switch to the Live T
 ## Column Options
 
 Customize the Live Tail column view to better highlight the relevant information in your traces. Click on the column dropdown at the top right of the column header to activate one of the options below:
+
 {{< img src="tracing/live_tail/column_livetail.png" alt="Live tail" >}}
 
 1. Move column to the right or left.
@@ -58,8 +59,7 @@ A valid query in the search bar displays traces that match your search criteria.
 
 {{< img src="tracing/live_tail/search_livetail.png" alt="Live tail" >}}
 
-Any query that works in other views works in the Live Tail view, but you can only filter on attributes that are defined as facets.
-For example, to filter on the a customer_id attribute, there are two options:
+Any query that works in other views works in the Live Tail view, but you can only filter on attributes that are defined as facets. For example, to filter on the a customer_id attribute, there are two options:
 
 - Click on the attribute and add it to the search using the query `@customer_id:1123`.
 - Filter on all spans with a duration above 150ms using the query: `@duration:>150ms`.


### PR DESCRIPTION
### What does this PR do?

Updates wording and links from the APM live tail page introduced by: https://github.com/DataDog/documentation/pull/7022

It also add a further reading section

### Motivation
Link is broken, wording and layout were a bit off.

### Preview link

* https://docs-staging.datadoghq.com/gus/link-fix-44/tracing/livetail/