### PR TITLE
rename "Conditional patern" in"Alternating patern"

### DIFF
--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -300,7 +300,7 @@ The date matcher transforms your timestamp in the EPOCH format (unit of measure 
 
 ### Alternating pattern
 
-If you have logs with two possible formats which differ in only one attribute, set a single rule using Alternating with `(<REGEX_1>|<REGEX_2>)`. It's equivalent to a boolean OR.
+If you have logs with two possible formats which differ in only one attribute, set a single rule using alternating with `(<REGEX_1>|<REGEX_2>)`. It's equivalent to a boolean OR.
 
 **Log**:
 

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -298,9 +298,9 @@ The date matcher transforms your timestamp in the EPOCH format (unit of measure 
 
 **Note**: Parsing a date **doesn't** set its value as the log official date. For this use the [Log Date Remapper][2] in a subsequent Processor.
 
-### Conditional pattern
+### Alternating pattern
 
-If you have logs with two possible formats which differ in only one attribute, set a single rule using conditionals with `(<REGEX_1>|<REGEX_2>)`.
+If you have logs with two possible formats which differ in only one attribute, set a single rule using Alternating with `(<REGEX_1>|<REGEX_2>)`. It's equivalent to a boolean OR.
 
 **Log**:
 

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -300,7 +300,7 @@ The date matcher transforms your timestamp in the EPOCH format (unit of measure 
 
 ### Alternating pattern
 
-If you have logs with two possible formats which differ in only one attribute, set a single rule using alternating with `(<REGEX_1>|<REGEX_2>)`. It's equivalent to a boolean OR.
+If you have logs with two possible formats which differ in only one attribute, set a single rule using alternating with `(<REGEX_1>|<REGEX_2>)`. This rule is equivalent to a Boolean OR.
 
 **Log**:
 

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -168,7 +168,7 @@ Some examples demonstrating how to use parsers:
 
 * [Key value or logfmt](#key-value-or-logfmt)
 * [Parsing dates](#parsing-dates)
-* [Conditional patterns](#conditional-pattern)
+* [Alternating patterns](#alternating-pattern)
 * [Optional attribute](#optional-attribute)
 * [Nested JSON](#nested-json)
 * [Regex](#regex)


### PR DESCRIPTION
### What does this PR do?
rename "Conditional patern" in "Alternating patern"

### Motivation
I had a hard time finding that part of the doc. 
Usually, Conditional patern refer to IF statement not to OR

### Preview link

https://docs-staging.datadoghq.com/pvr/logs-rename-conditionnal-patern/logs/processing/parsing

### Additional Notes
<!-- Anything else we should know when reviewing?-->
