### PR TITLE
Fix URLs for User Invitations v2 APIs

### DIFF
--- a/content/en/api/users/code_snippets/api-user-invitation.sh
+++ b/content/en/api/users/code_snippets/api-user-invitation.sh
@@ -5,7 +5,7 @@
 api_key="<DATADOG_API_KEY>"
 app_key="<DATADOG_APPLICATION_KEY>"
 
-curl --request POST 'https://api.datadoghq.com/v2/user_invitations' \
+curl --request POST 'https://api.datadoghq.com/api/v2/user_invitations' \
 --header "DD-API-KEY: ${api_key}" \
 --header "DD-APPLICATION-KEY: ${app_key}"
 --header 'Content-Type: application/json' \

--- a/content/en/api/users/get_invitation_email_code.md
+++ b/content/en/api/users/get_invitation_email_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#get-a-user-invitation
 
 **SIGNATURE**:
 
-`GET /v2/user_invitations/<USER_INVITATION_UUID>`
+`GET /api/v2/user_invitations/<USER_INVITATION_UUID>`
 
 **EXAMPLE REQUEST**:
 

--- a/content/en/api/users/send_invitation_email_code.md
+++ b/content/en/api/users/send_invitation_email_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#send-invitation-email-to-a-user
 
 **SIGNATURE**:
 
-`POST /v2/user_invitations`
+`POST /api/v2/user_invitations`
 
 **EXAMPLE REQUEST**:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes the URL used for v2 of the user invitations API. The prefix should be `/api/v2/user_invitations`.

### Motivation
Customer reported getting a 404 for the documented URLs.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/chris.linstid/fix-user-invitiations-v2-api-path

### Additional Notes
<!-- Anything else we should know when reviewing?-->
