### PR TITLE
adding a tab for the new dd-operator beta

### DIFF
--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -148,7 +148,7 @@ To install the Datadog Agent on your Kubernetes cluster:
 [13]: /agent/kubernetes/data_collected/#kube-state-metrics
 {{% /tab %}}
 {{% tab "Operator" %}}
-[The Datadog Operator][2] is in public beta. The Datadog Operator is a way to deploy the Datadog Agent on Kubernetes and OpenShift. It reports deployment status, health, and errors in its Custom Resource status, and it limits the risk of misconfiguration thanks to higher-level configuration options. To get started, install the operator from the [OperatorHub.io Datadog Operator page][3] or the [Red Hat Products Catalog][4] and check out the [Getting Started page][1] in the [Datadog Operator repo][2].
+[The Datadog Operator][2] is in public beta. The Datadog Operator is a way to deploy the Datadog Agent on Kubernetes and OpenShift. It reports deployment status, health, and errors in its Custom Resource status, and it limits the risk of misconfiguration thanks to higher-level configuration options. To get started, check out the [Getting Started page][1] in the [Datadog Operator repo][2] and install the operator from the [OperatorHub.io Datadog Operator page][3] or the [Red Hat Products Catalog][4].
 
 [1]: https://github.com/DataDog/datadog-operator/blob/master/docs/getting_started.md
 [2]: https://github.com/DataDog/datadog-operator

--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -147,6 +147,12 @@ To install the Datadog Agent on your Kubernetes cluster:
 [12]: https://github.com/kubernetes/kube-state-metrics/tree/master/examples/standard
 [13]: /agent/kubernetes/data_collected/#kube-state-metrics
 {{% /tab %}}
+{{% tab "Operator" %}}
+[The Datadog Operator][2] is in public beta. The Datadog Operator is a way to deploy the Datadog Agent on Kubernetes and it reports deployment status, health, and errors in its Custom Resource status, and it limits the risk of misconfiguration thanks to higher-level configuration options. To get started, see [Getting Started][1] in the [Datadog Agent Kubernetes Operator repo][2].
+
+[1]: https://github.com/DataDog/datadog-operator/blob/master/docs/getting_started.md
+[2]: https://github.com/DataDog/datadog-operator
+{{% /tab %}}
 {{< /tabs >}}
 
 ## Integrations

--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -148,10 +148,12 @@ To install the Datadog Agent on your Kubernetes cluster:
 [13]: /agent/kubernetes/data_collected/#kube-state-metrics
 {{% /tab %}}
 {{% tab "Operator" %}}
-[The Datadog Operator][2] is in public beta. The Datadog Operator is a way to deploy the Datadog Agent on Kubernetes and it reports deployment status, health, and errors in its Custom Resource status, and it limits the risk of misconfiguration thanks to higher-level configuration options. To get started, see [Getting Started][1] in the [Datadog Agent Kubernetes Operator repo][2].
+[The Datadog Operator][2] is in public beta. The Datadog Operator is a way to deploy the Datadog Agent on Kubernetes and OpenShift. It reports deployment status, health, and errors in its Custom Resource status, and it limits the risk of misconfiguration thanks to higher-level configuration options. To get started, install the operator from the [OperatorHub.io Datadog Operator page][3] or the [Red Hat Products Catalog][4] and check out the [Getting Started page][1] in the [Datadog Operator repo][2].
 
 [1]: https://github.com/DataDog/datadog-operator/blob/master/docs/getting_started.md
 [2]: https://github.com/DataDog/datadog-operator
+[3]: https://operatorhub.io/operator/datadog-operator
+[4]: https://access.redhat.com/containers/#/registry.connect.redhat.com/datadog/operator
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
# What does this PR do?
Adds in info and links to the the beta Datadog Agent Kubernetes Operator repo.

### Motivation
We're in beta!

### Preview link
https://docs-staging.datadoghq.com/kaylyn/dd-operator/agent/kubernetes/?tab=helm
