### PR TITLE
Fix NPM example manifest

### DIFF
--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -94,6 +94,9 @@ metadata:
     name: datadog-agent
     namespace: default
 spec:
+    selector:
+        matchLabels:
+            app: datadog-agent
     template:
         metadata:
             labels:
@@ -135,7 +138,7 @@ spec:
                                 fieldPath: status.hostIP
                       - name: DD_CRI_SOCKET_PATH
                         value: /host/var/run/docker.sock
-                      - name: DOCKER_HOST,
+                      - name: DOCKER_HOST
                         value: unix:///host/var/run/docker.sock
                   resources:
                       requests:


### PR DESCRIPTION
1.  Fix invalid syntax where env var `DOCKER_HOST` had a trailing comma

2.  Add `selector` block as it's a required field.  Without it, here's the error:

```
error: error validating "../../datadog-network-agent.yaml": error validating data: ValidationError(DaemonSet.spec): missing required field "selector" in io.k8s.api.apps.v1.DaemonSetSpec; if you choose to ignore these errors, turn validation off with --validate=false
```

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update NPM example manifest 

### Motivation
Prospect that tried to explicitly apply this manifest encountered errors and reported them to me.  Confirmed the updates made here resolved the errors he encountered.    

### Impacted page
https://docs.datadoghq.com/network_performance_monitoring/installation/?tab=kubernetes#setup

