### PR TITLE
Update the uninstall instruction for Windows Agent.

### DIFF
--- a/content/en/agent/faq/how-do-i-uninstall-the-agent.md
+++ b/content/en/agent/faq/how-do-i-uninstall-the-agent.md
@@ -166,8 +166,6 @@ This method removes the Agent, as well as all Agent configuration files.
 
 ### Windows
 
-It's important to uninstall the Agent with the **original account** used to install the Agent, otherwise it may not be cleanly removed.
-
 {{< tabs >}}
 {{% tab "Agent v6 & v7" %}}
 
@@ -183,6 +181,8 @@ Both methods remove the Agent, but they do not remove the `C:\ProgramData\Datado
 
 {{% /tab %}}
 {{% tab "Agent v5" %}}
+
+**Note**: For versions of the agent less than 5.12.0 on Windows, It's important to uninstall the Agent with the **original account** used to install the Agent, otherwise it may not be cleanly removed.
 
 Uninstall the Agent using Add/Remove Programs.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Update the uninstall instruction for Windows Agent as below:

- Add detailed information about agent version.
- Move it to "Agent v5" tab.


### Motivation
<!-- What inspired you to submit this pull request?-->

This internal documentation shows that the "**For versions of the agent less than 5.12.0 on Windows**, you must use the same user that installed the agent to uninstall it."

https://github.com/DataDog/se-docs/wiki/Uninstalling-Old-Agent-Versions-on-Windows

However, the public documentation doesn't mention about the agent version for now.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/KosukeKamiya/fix-uninstall-instruction-for-windows/agent/faq/how-do-i-uninstall-the-agent/?tab=agentv5#windows

### Additional Notes
<!-- Anything else we should know when reviewing?-->
