### PR TITLE
Add .NET tracer logs examples to the tracer debug docs

### DIFF
--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -391,6 +391,30 @@ YYYY/MM/DD 16:06:35 Datadog Tracer <version> DEBUG: Sending payload: size: <size
 </p>
 </details>
 
+<details><summary>Tracer logs showing spans were generated</summary>
+<p>
+
+```shell
+{ MachineName: ".", ProcessName: "dotnet", PID: <process id>, AppDomainName: "test-webapi" }
+YYYY-MM-DD HH:MM:SS.<integer> +00:00 [DBG] Span started: [s_id: <span id>, p_id: <parent span id>, t_id: <trace id>]
+{ MachineName: ".", ProcessName: "dotnet", PID: <process id>, AppDomainName: "test-webapi" }
+YYYY-MM-DD HH:MM:SS.<integer> +00:00 [DBG] Span closed: [s_id: <span id>, p_id: <parent span id>, t_id: <trace id>] for (Service: test-webapi, Resource: custom, Operation: custom.function, Tags: [<span tags>])
+```
+
+</p>
+</details>
+
+<details><summary>Tracer logs showing traces couldn't be sent to the Datadog Agent</summary>
+<p>
+
+```shell
+YYYY-MM-DD HH:MM:SS.<integer> +00:00 [ERR] An error occurred while sending traces to the agent at System.Net.Http.HttpRequestException: Connection refused ---> System.Net.Sockets.SocketException: Connection refused
+   at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken)
+   --- End of inner exception stack trace ---
+```
+
+</p>
+</details>
 
 {{% /tab %}}
 {{% tab "PHP" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Add tracer logs examples to the tracer debug docs.

### Motivation
<!-- What inspired you to submit this pull request?-->

.NET APM generates two sets of logs in debug mode (profiler and tracer logs). This PR adds examples for .NET's tracer logs, which provides information about traces that were generated.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/wantsui/add-dotnet-tracer-logs-example/tracing/troubleshooting


### Additional Notes
<!-- Anything else we should know when reviewing?-->
