### PR TITLE
Change Trace Search to App Analytics in API documentation

### DIFF
--- a/content/en/api/usage/usage.md
+++ b/content/en/api/usage/usage.md
@@ -16,7 +16,7 @@ The usage metering end-point allows you to:
 * Get Hourly Usage For Logs By Index
 * Get Hourly Usage For Custom Metrics
 * Get Top Custom Metrics By Hourly Average
-* Get Hourly Usage For Trace Search
+* Get Hourly Usage For App Analytics
 * Get Hourly Usage For Synthetics API Checks
 * Get Hourly Usage For Synthetics Browser Checks
 * Get Hourly Usage For Fargate Tasks

--- a/content/en/api/usage/usage_trace_search.md
+++ b/content/en/api/usage/usage_trace_search.md
@@ -1,13 +1,13 @@
 ---
-title: Get hourly usage for Trace Search
+title: Get hourly usage for App Analytics
 type: apicontent
 order: 35.6
-external_redirect: /api/#get-hourly-usage-for-trace-search
+external_redirect: /api/#get-hourly-usage-for-app-analytics
 ---
 
-## Get hourly usage for Trace Search
+## Get hourly usage for App Analytics
 
-Get hourly usage For Trace Search.
+Get hourly usage For App Analytics.
 
 **ARGUMENTS**:
 

--- a/content/en/api/usage/usage_trace_search_code.md
+++ b/content/en/api/usage/usage_trace_search_code.md
@@ -1,5 +1,5 @@
 ---
-title: Get hourly usage for Trace Search
+title: Get hourly usage for App Analytics
 type: apicode
 order: 35.6
 external_redirect: /api/#get-hourly-usage-for-app-analytics

--- a/content/en/api/usage/usage_trace_search_code.md
+++ b/content/en/api/usage/usage_trace_search_code.md
@@ -2,7 +2,7 @@
 title: Get hourly usage for Trace Search
 type: apicode
 order: 35.6
-external_redirect: /api/#get-hourly-usage-for-trace-search
+external_redirect: /api/#get-hourly-usage-for-app-analytics
 ---
 
 **SIGNATURE**:


### PR DESCRIPTION
### What does this PR do?
Change "Trace Search" in the API documentation to "App Analytics"

### Motivation
Make API documentation consistent with pricing page (https://www.datadoghq.com/pricing/#section-apm)

### Preview link
https://docs-staging.datadoghq.com/julian-leung/trace-search-name/api/?lang=bash#get-hourly-usage-for-app-analytics

### Additional Notes
No.