### PR TITLE
Change python profiling references from profile to profiling

### DIFF
--- a/content/en/tracing/profiling/_index.md
+++ b/content/en/tracing/profiling/_index.md
@@ -87,7 +87,7 @@ The Datadog Profiler requires Python 2.7+. Memory profiling only works on Python
 4. To automatically profile your code, import `ddtrace.profile.auto`. After import, the profiler starts:
 
     ```python
-    import ddtrace.profile.auto
+    import ddtrace.profiling.auto
     ```
 
 5. After a minute or two, visualize your profiles on the [Datadog APM > Profiling page][2].
@@ -97,7 +97,7 @@ The Datadog Profiler requires Python 2.7+. Memory profiling only works on Python
 - If you want to control which part of your code should be profiled, use the `ddtrace.profile.profiler.Profiler` object:
 
     ```python
-    from ddtrace.profile.profiler import Profiler
+    from ddtrace.profiling import Profiler
 
     prof = Profiler()
     prof.start()


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

As a result of this PR https://github.com/DataDog/dd-trace-py/pull/1289, which was rolled out in **dd-trace-py** **0.36.0**, the examples for profiling should be updated in the docs.

### Motivation
<!-- What inspired you to submit this pull request?-->

To maintain consistency with these [API docs](http://pypi.datadoghq.com/trace/docs/basic_usage.html#profiler).

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/wantsui/profiling-doc-setup-update/content/en/tracing/profiling/_index.md

### Additional Notes
<!-- Anything else we should know when reviewing?-->
