### PR TITLE
Updated Interpolation page

### DIFF
--- a/content/en/dashboards/faq/interpolation-the-fill-modifier-explained.md
+++ b/content/en/dashboards/faq/interpolation-the-fill-modifier-explained.md
@@ -44,7 +44,6 @@ Interpolation is not needed when you graph one metric submitted from one source,
 
 Interpolation is not performed for multi-part queries, for example: `avg:system.cpu.user{env:prod},avg:system.cpu.user{env:dev}`
 
-The type of interpolation described in this article is also not performed for arithmetic. When evaluating queries, Datadog's backend rolls data up into intervals (one for each point in a timeseries graph, see [this article][1] for more details). If a query involves arithmetic, and one of these intervals is missing data for part of a query, the query system substitutes 0 for that interval. This behavior cannot be controlled with the fill modifier.
 
 ## How to control interpolation?
 


### PR DESCRIPTION
Removed bit about "Arithmetic doesn't use interpolation properly" - that was fixed some time ago. Checked with the Metrics Query Lead, Wendell Smith, on this one, he confirmed. Thanks!

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes an erroneous paragraph about old interpolation behavior with arithmetic.


### Preview link

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/bradleyjay-interpolation-doc-update/content/en/dashboards/faq/interpolation-the-fill-modifier-explained.md

### Additional Notes
Checked with the Query Team lead on this one, he confirmed.
