### PR TITLE
Updating "manfest" typo to "manifest"

### DIFF
--- a/content/en/agent/cluster_agent/troubleshooting.md
+++ b/content/en/agent/cluster_agent/troubleshooting.md
@@ -224,7 +224,7 @@ If the metric's flag `Valid` is set to `false`, the metric is not considered in 
 
 ### Describing the HPA manifest
 
-If you see the following mesage when describing the HPA manifest:
+If you see the following message when describing the HPA manifest:
 
 ```text
 Conditions:

--- a/content/en/agent/cluster_agent/troubleshooting.md
+++ b/content/en/agent/cluster_agent/troubleshooting.md
@@ -222,7 +222,7 @@ The flare command generates a zip file containing the `custom-metrics-provider.l
 
 If the metric's flag `Valid` is set to `false`, the metric is not considered in the HPA pipeline.
 
-### Describing the HPA manfest
+### Describing the HPA manifest
 
 If you see the following mesage when describing the HPA manifest:
 


### PR DESCRIPTION
### What does this PR do?
This PR updates the "manfest" typo to "manifest" instead.

### Motivation
I saw the typo and decided to make the PR:
https://a.cl.ly/qGuo9o5z

### Preview link
https://docs.datadoghq.com/agent/cluster_agent/troubleshooting/#describing-the-hpa-manfest

Replace the branch name and add the complete path: -->

https://docs-staging.datadoghq.com/link04-patch-1/agent/cluster_agent/troubleshooting/#describing-the-hpa-manfest

### Additional Notes
This typo is also present in the link used to redirect to this section of the documentation which means that maybe the Id for this section/title/link needs to be updated as well.
https://a.cl.ly/qGuo9o5z
