### PR TITLE
siobhan.mahoney/synthetics api code snippet fix

### DIFF
--- a/content/en/api/synthetics/code_snippets/post_test.py
+++ b/content/en/api/synthetics/code_snippets/post_test.py
@@ -13,13 +13,12 @@ name = "test"
 api_test_type = "api"
 api_config = {
   "assertions": [
-            {"operator": "is", "type": "statusCode", "target": 403},
-            {"operator": "is", "property": "content-type",
-                "type": "header", "target": "text/html"},
-            {"operator": "lessThan", "type": "responseTime", "target": 2000}
-         ],
+    {"operator": "is", "type": "statusCode", "target": 403},
+    {"operator": "is", "property": "content-type", "type": "header", "target": "text/html"},
+    {"operator": "lessThan", "type": "responseTime", "target": 2000}
+  ],
   "request": {"method": "GET", "url": "https://datadoghq.com", "timeout": 30, "headers": {"header1": "value1", "header2": "value2"}}
-           }
+}
 message = "test"
 api_test_options = {"tick_every": 60, "min_failure_duration": 0,
     "min_location_failed": 1, "follow_redirects": True}
@@ -34,13 +33,15 @@ api.Synthetics.create_test(name=name, type=api_test_type, config=api_config, opt
 
 name = "test"
 browser_test_type = "browser"
-request = {"method": "GET", "url": "https://example.com/"}
+browser_config = {
+  "request": {"method": "GET", "url": "https://example.com/"},
+  "assertions": []
+}
 message = "test"
 browser_test_options = {"device_ids": ["laptop_large"], "tick_every": 3600, "min_failure_duration": 0,
     "min_location_failed": 1, "monitor_options": {"renotify_interval": 30}, "retry": {"count": 2, "interval": 30}}
-assertions = []
-location = ["aws:ca-central-1", "aws:us-east-2"]
+locations = ["aws:ca-central-1", "aws:us-east-2"]
 tags = []
 
-api.Synthetics.create_test(name=name, type=browser_test_type, request=request, options=browser_test_options,
-                           message=message, assertions=assertions, location=location, tags=tags)
+api.Synthetics.create_test(name=name, type=browser_test_type, config=browser_config, options=browser_test_options,
+                           message=message, locations=locations, tags=tags)

--- a/content/en/api/synthetics/code_snippets/post_test.py
+++ b/content/en/api/synthetics/code_snippets/post_test.py
@@ -11,22 +11,24 @@ initialize(**options)
 
 name = "test"
 api_test_type = "api"
-request = {"method": "GET", "url": "https://datadoghq.com", "timeout": 30, "headers": {"header1": "value1", "header2": "value2"}
-message = "test"
-api_test_options = {"tick_every": 60, "min_failure_duration": 0,
-    "min_location_failed": 1, "follow_redirects": true}
-assertions = [
+api_config = {
+  "assertions": [
             {"operator": "is", "type": "statusCode", "target": 403},
             {"operator": "is", "property": "content-type",
                 "type": "header", "target": "text/html"},
             {"operator": "lessThan", "type": "responseTime", "target": 2000}
-         ]
-location = ["aws:us-east-2", "aws:eu-central-1", "aws:ca-central-1",
+         ],
+  "request": {"method": "GET", "url": "https://datadoghq.com", "timeout": 30, "headers": {"header1": "value1", "header2": "value2"}}
+           }
+message = "test"
+api_test_options = {"tick_every": 60, "min_failure_duration": 0,
+    "min_location_failed": 1, "follow_redirects": True}
+locations = ["aws:us-east-2", "aws:eu-central-1", "aws:ca-central-1",
     "aws:eu-west-2", "aws:ap-northeast-1", "aws:us-west-2", "aws:ap-southeast-2"]
 tags = ["foo:bar"]
 
-api.Synthetics.create_test(name=name, type=api_test_type, request=request, options=api_test_options,
-                           message=message, assertions=assertions, location=location, tags=tags)
+api.Synthetics.create_test(name=name, type=api_test_type, config=api_config, options=api_test_options,
+                           message=message, locations=locations, tags=tags)
 
 # To create a browser test
 

--- a/content/en/api/synthetics/code_snippets/put_test.py
+++ b/content/en/api/synthetics/code_snippets/put_test.py
@@ -13,20 +13,21 @@ test_id='<SYNTHETICS_TEST_PUBLIC_ID>'
 
 name = "test"
 api_test_type = "api"
-request = {"method": "GET", "url": "https://datadoghq.com", "timeout": 30, "headers": {"header1": "value1", "header2": "value2"}
+api_config = {
+  "assertions": [
+            {"operator": "is", "type": "statusCode", "target": 403},
+            {"operator": "is", "property": "content-type", "type": "header", "target": "text/html"},
+            {"operator": "lessThan", "type": "responseTime", "target": 2000}
+         ], 
+  "request": {"method": "GET", "url": "https://datadoghq.com", "timeout": 30, "headers": {"header1": "value1", "header2": "value2"}}
+}
 message = "test-edited"
 api_test_options = {"tick_every": 60, "min_failure_duration": 0,
-    "min_location_failed": 1, "follow_redirects": true}
-assertions = [
-            {"operator": "is", "type": "statusCode", "target": 403},
-            {"operator": "is", "property": "content-type",
-                "type": "header", "target": "text/html"},
-            {"operator": "lessThan", "type": "responseTime", "target": 2000}
-         ]
-location = ["aws:us-east-2", "aws:eu-central-1", "aws:ca-central-1",
+    "min_location_failed": 1, "follow_redirects": True}
+locations = ["aws:us-east-2", "aws:eu-central-1", "aws:ca-central-1",
     "aws:eu-west-2", "aws:ap-northeast-1", "aws:us-west-2", "aws:ap-southeast-2"]
 tags = ["foo:bar"]
 
 
-api.Synthetics.edit_test(id=test_id,name=name, type=api_test_type, request=request, options=api_test_options,
-                           message=message, assertions=assertions, location=location, tags=tags)
+api.Synthetics.edit_test(id=test_id, name=name, type=api_test_type, config=api_config, options=api_test_options,
+                           message=message, locations=locations, tags=tags)


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes Python snippets for the following Synthetics API endpoints:

- `Create a Test`
- `Edit a Test` 

### Motivation
Aligning example snippets to match schema expected at endpoints

### Preview link

- https://docs-staging.datadoghq.com/siobhan.mahoney/synthetics-api-code-snippet-fix/api/?lang=python#create-a-test
- https://docs-staging.datadoghq.com/siobhan.mahoney/synthetics-api-code-snippet-fix/api/?lang=python#edit-a-test

### Additional Notes
<!-- Anything else we should know when reviewing?-->
