### PR TITLE
fix(profiling): the Python extra has been renamed

### DIFF
--- a/content/en/tracing/profiling/_index.md
+++ b/content/en/tracing/profiling/_index.md
@@ -74,7 +74,7 @@ The Datadog Profiler requires Python 2.7+. Memory profiling only works on Python
     pip install ddtrace[profiling]
     ```
 
-     **Note**: Profiling is available in the `ddtrace` library for versions 0.35+.
+     **Note**: Profiling is available in the `ddtrace` library for versions 0.36+.
 
 2. Add a valid [Datadog API key][1] in your environment variable: `DD_PROFILING_API_KEY`.
 

--- a/content/en/tracing/profiling/_index.md
+++ b/content/en/tracing/profiling/_index.md
@@ -71,7 +71,7 @@ The Datadog Profiler requires Python 2.7+. Memory profiling only works on Python
 1. Install `ddtrace` with the `profile` flavor, which contains both tracing and profiling:
 
     ```shell
-    pip install ddtrace[profile]
+    pip install ddtrace[profiling]
     ```
 
      **Note**: Profiling is available in the `ddtrace` library for versions 0.35+.


### PR DESCRIPTION
Starting with 0.36, this is the extra name to be used.