### PR TITLE
Fix docker socket mount paths

### DIFF
--- a/static/resources/yaml/datadog-agent-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-all-features.yaml
@@ -132,7 +132,7 @@ spec:
             ## Metric collection ##
             #######################
             - name: dockersocketdir
-              mountPath: /host/var/run
+              mountPath: /var/run
             - name: procdir
               mountPath: /host/proc
               readOnly: true

--- a/static/resources/yaml/datadog-agent-apm.yaml
+++ b/static/resources/yaml/datadog-agent-apm.yaml
@@ -99,7 +99,7 @@ spec:
             ## Metric collection ##
             #######################
             - name: dockersocketdir
-              mountPath: /host/var/run
+              mountPath: /var/run
             - name: procdir
               mountPath: /host/proc
               readOnly: true

--- a/static/resources/yaml/datadog-agent-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-logs-apm.yaml
@@ -111,7 +111,7 @@ spec:
             ## Metric collection ##
             #######################
             - name: dockersocketdir
-              mountPath: /host/var/run
+              mountPath: /var/run
             - name: procdir
               mountPath: /host/proc
               readOnly: true

--- a/static/resources/yaml/datadog-agent-logs.yaml
+++ b/static/resources/yaml/datadog-agent-logs.yaml
@@ -94,7 +94,7 @@ spec:
             ## Metric collection ##
             #######################
             - name: dockersocketdir
-              mountPath: /host/var/run
+              mountPath: /var/run
             - name: procdir
               mountPath: /host/proc
               readOnly: true


### PR DESCRIPTION

### What does this PR do?
Fix the Docker socket mount path for the static manifests for Kubernetes

### Motivation
Using those manifests, the docker check won't work correctly


