### PR TITLE
APM > .NET > Update HttpMessageHandler integration

### DIFF
--- a/content/en/tracing/setup/dotnet-core.md
+++ b/content/en/tracing/setup/dotnet-core.md
@@ -201,17 +201,17 @@ CMD ["dotnet", "example.dll"]
 
 The .NET Tracer can instrument the following libraries automatically:
 
-| Framework or library           | NuGet package                                                           | Integration Name     |
-|--------------------------------|-------------------------------------------------------------------------|----------------------|
-| ASP.NET Core                   | `Microsoft.AspNetCore`</br>`Microsoft.AspNetCore.App`</br>2.0+ and 3.0+ | `AspNetCore`         |
-| ADO.NET                        | `System.Data.Common`</br>`System.Data.SqlClient` 4.0+                   | `AdoNet`             |
-| HttpClient / HttpClientHandler | `System.Net.Http` 4.0+                                                  | `HttpMessageHandler` |
-| WebClient / WebRequest         | `System.Net.Requests` 4.0+                                              | `WebRequest`         |
-| Redis (StackExchange client)   | `StackExchange.Redis` 1.0.187+                                          | `StackExchangeRedis` |
-| Redis (ServiceStack client)    | `ServiceStack.Redis` 4.0.48+                                            | `ServiceStackRedis`  |
-| Elasticsearch                  | `Elasticsearch.Net` 5.3.0+                                              | `ElasticsearchNet`   |
-| MongoDB                        | `MongoDB.Driver.Core` 2.1.0+                                            | `MongoDb`            |
-| PostgreSQL                     | `Npgsql` 4.0+                                                           | `AdoNet`             |
+| Framework or library            | NuGet package                                                           | Integration Name     |
+|---------------------------------|-------------------------------------------------------------------------|----------------------|
+| ASP.NET Core                    | `Microsoft.AspNetCore`</br>`Microsoft.AspNetCore.App`</br>2.0+ and 3.0+ | `AspNetCore`         |
+| ADO.NET                         | `System.Data.Common`</br>`System.Data.SqlClient` 4.0+                   | `AdoNet`             |
+| HttpClient / HttpMessageHandler | `System.Net.Http` 4.0+                                                  | `HttpMessageHandler` |
+| WebClient / WebRequest          | `System.Net.Requests` 4.0+                                              | `WebRequest`         |
+| Redis (StackExchange client)    | `StackExchange.Redis` 1.0.187+                                          | `StackExchangeRedis` |
+| Redis (ServiceStack client)     | `ServiceStack.Redis` 4.0.48+                                            | `ServiceStackRedis`  |
+| Elasticsearch                   | `Elasticsearch.Net` 5.3.0+                                              | `ElasticsearchNet`   |
+| MongoDB                         | `MongoDB.Driver.Core` 2.1.0+                                            | `MongoDb`            |
+| PostgreSQL                      | `Npgsql` 4.0+                                                           | `AdoNet`             |
 
 **Note:** The ADO.NET integration instruments calls made through the `DbCommand` abstract class or the `IDbCommand` interface, regardless of the underlying implementation. It also instruments direct calls to `SqlCommand`.
 

--- a/content/en/tracing/setup/dotnet-framework.md
+++ b/content/en/tracing/setup/dotnet-framework.md
@@ -87,20 +87,20 @@ To set environment variables for a Windows Service, use the multi-string key `HK
 
 The .NET Tracer can instrument the following libraries automatically:
 
-| Framework or library           | NuGet package                  | Integration Name     |
-| ------------------------------ | ------------------------------ | -------------------- |
-| ASP.NET (including Web Forms)  | built-in                       | `AspNet`             |
-| ASP.NET MVC                    | `Microsoft.AspNet.Mvc` 4.0+    | `AspNetMvc`          |
-| ASP.NET Web API 2              | `Microsoft.AspNet.WebApi` 5.1+ | `AspNetWebApi2`      |
-| WCF (server)                   | built-in                       | `Wcf`                |
-| ADO.NET                        | built-in                       | `AdoNet`             |
-| HttpClient / HttpClientHandler | built-in                       | `HttpMessageHandler` |
-| WebClient / WebRequest         | built-in                       | `WebRequest`         |
-| Redis (StackExchange client)   | `StackExchange.Redis` 1.0.187+ | `StackExchangeRedis` |
-| Redis (ServiceStack client)    | `ServiceStack.Redis` 4.0.48+   | `ServiceStackRedis`  |
-| Elasticsearch                  | `Elasticsearch.Net` 5.3.0+     | `ElasticsearchNet`   |
-| MongoDB                        | `MongoDB.Driver.Core` 2.1.0+   | `MongoDb`            |
-| PostgreSQL                     | `Npgsql` 4.0+                  | `AdoNet`             |
+| Framework or library            | NuGet package                  | Integration Name     |
+| ------------------------------- | ------------------------------ | -------------------- |
+| ASP.NET (including Web Forms)   | built-in                       | `AspNet`             |
+| ASP.NET MVC                     | `Microsoft.AspNet.Mvc` 4.0+    | `AspNetMvc`          |
+| ASP.NET Web API 2               | `Microsoft.AspNet.WebApi` 5.1+ | `AspNetWebApi2`      |
+| WCF (server)                    | built-in                       | `Wcf`                |
+| ADO.NET                         | built-in                       | `AdoNet`             |
+| HttpClient / HttpMessageHandler | built-in                       | `HttpMessageHandler` |
+| WebClient / WebRequest          | built-in                       | `WebRequest`         |
+| Redis (StackExchange client)    | `StackExchange.Redis` 1.0.187+ | `StackExchangeRedis` |
+| Redis (ServiceStack client)     | `ServiceStack.Redis` 4.0.48+   | `ServiceStackRedis`  |
+| Elasticsearch                   | `Elasticsearch.Net` 5.3.0+     | `ElasticsearchNet`   |
+| MongoDB                         | `MongoDB.Driver.Core` 2.1.0+   | `MongoDb`            |
+| PostgreSQL                      | `Npgsql` 4.0+                  | `AdoNet`             |
 
 **Update:** Starting with .NET Tracer version `1.12.0`, the ASP.NET integration is enabled automatically. The NuGet packages `Datadog.Trace.AspNet` or `Datadog.Trace.ClrProfiler.Managed` are no longer required. Remove them from your application when you update the .NET Tracer.
 


### PR DESCRIPTION
### What does this PR do?
Updates the .NET integrations table to clarify that HttpMessageHandler's in general are instrumented, not just HttpClientHandler

### Motivation
Update to .NET Tracer

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/zach.montoya/csharp-update-httpmessagehandler-integration/tracing/setup/dotnet-core/?tab=windows#integrations

### Additional Notes
N/A
