### PR TITLE
[PROD] add https:// prefix to env var, add clarification about cluster agent

### DIFF
--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -90,7 +90,7 @@ To forward your metrics to Datadog using this new VPC endpoint, configure `pvtli
 
 2. [Restart your Agent][2] to send metrics to Datadog through AWS PrivateLink.
 
-**Note**: if you are using the container Agent, set the environment variable instead: `DD_DD_URL="pvtlink.agent.datadoghq.com"`
+**Note**: If you are using the container Agent, set the environment variable instead: `DD_DD_URL="https://pvtlink.agent.datadoghq.com"`. Configure this environment variable on _both_ the Cluster Agent & Node Agent if using the Cluster Agent to monitor a Kubernetes environment.
 
 
 [1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file


### PR DESCRIPTION
### What does this PR do?
Customer was receiving errors when attempting to send metrics out to `pvtlink.agent.datadoghq.com`. Problems were fixed when this was changed to `https://pvtlink.agent.datadoghq.com`. 

```datadog-agent-b8t5f datadog-agent 2020-04-02 21:02:29 UTC | CORE | ERROR | (pkg/forwarder/worker.go:157 in process) | Error while processing transaction: error while sending transaction, rescheduling it: Post pvtlink.agent.datadoghq.com/api/v1/series?api_key=*************************fcb13: unsupported protocol scheme ""
datadog-agent-b8t5f datadog-agent 2020-04-02 21:02:29 UTC | CORE | ERROR | (pkg/forwarder/worker.go:153 in process) | Too many errors for endpoint 'pvtlink.agent.datadoghq.com/api/v1/series?api_key=*************************fcb13': retrying later
datadog-agent-b8t5f datadog-agent 2020-04-02 21:02:29 UTC | CORE | ERROR | (pkg/forwarder/worker.go:153 in process) | Too many errors for endpoint 'pvtlink.agent.datadoghq.com/api/v1/check_run?api_key=*************************fcb13': retrying later
datadog-agent-b8t5f datadog-agent 2020-04-02 21:02:29 UTC | CORE | ERROR | (pkg/forwarder/worker.go:153 in process) | Too many errors for endpoint 'pvtlink.agent.datadoghq.com/api/v1/series?api_key=*************************fcb13': retrying later```

Also clears up ambiguity about the cluster agent, which is not mention in these setup docs. 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
