### PR TITLE
Docker Integrations Autodiscovery link

### DIFF
--- a/content/en/agent/kubernetes/integrations.md
+++ b/content/en/agent/kubernetes/integrations.md
@@ -478,7 +478,7 @@ etcdctl set /datadog/check_configs/httpd/instances '[[{"apache_status_url": "htt
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /agent/kubernetes/integrations
+[1]: /agent/docker/integrations
 [2]: /getting_started/integrations/#configuring-agent-integrations
 [3]: /integrations/#cat-autodiscovery
 [4]: /integrations/ceph


### PR DESCRIPTION
### What does this PR do?
Corrects the Docker Integrations Autodiscovery documentation link (currently forwards to Kubernetes)

### Motivation
Docs channel request