### PR TITLE
[DOCS-805] Npm k8s instructions refactoring

### DIFF
--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -113,9 +113,10 @@ To install the Datadog Agent on your Kubernetes cluster:
     - [Manifest with Logs, APM, and metrics collection enabled][4].
     - [Manifest with Logs and metrics collection enabled][5].
     - [Manifest with APM and metrics collection enabled][6].
-    - [Vanilla Manifest with just metrics collection enabled][7].
+    - [Manifest with Network Performance Monitoring enabled][7]
+    - [Vanilla Manifest with just metrics collection enabled][8].
 
-     To enable trace collection completely, [extra steps are required on your application pod configuration][8]. Refer also to the [logs][9], [APM][10], and [processes][11] documentation pages to learn how to enable each feature individually.
+     To enable trace collection completely, [extra steps are required on your application pod configuration][9]. Refer also to the [logs][10], [APM][11], [processes][12], and [Network Performance Monitoring][13] documentation pages to learn how to enable each feature individually.
 
      **Note**: Those manifests are set for the `default` namespace by default. If you are in a custom namespace, update the `metadata.namespace` parameter before applying them.
 
@@ -140,7 +141,7 @@ To install the Datadog Agent on your Kubernetes cluster:
     datadog-agent   2         2         2         2            2           <none>          10s
     ```
 
-7. Optional - **Setup Kubernetes State metrics**: Download the [Kube-State manifests folder][12] and apply them to your Kubernetes cluster to automatically collects [kube-state metrics][13]:
+7. Optional - **Setup Kubernetes State metrics**: Download the [Kube-State manifests folder][14] and apply them to your Kubernetes cluster to automatically collects [kube-state metrics][15]:
 
     ```shell
     kubectl apply -f <NAME_OF_THE_KUBE_STATE_MANIFESTS_FOLDER>
@@ -153,20 +154,22 @@ To install the Datadog Agent on your Kubernetes cluster:
 [4]: /resources/yaml/datadog-agent-logs-apm.yaml
 [5]: /resources/yaml/datadog-agent-logs.yaml
 [6]: /resources/yaml/datadog-agent-apm.yaml
-[7]: /resources/yaml/datadog-agent-vanilla.yaml
-[8]: /agent/kubernetes/apm/#setup
-[9]: /agent/kubernetes/log
-[10]: /agent/kubernetes/apm
-[11]: /infrastructure/process/?tab=kubernetes#installation
-[12]: https://github.com/kubernetes/kube-state-metrics/tree/master/examples/standard
-[13]: /agent/kubernetes/data_collected/#kube-state-metrics
+[7]: /resources/yaml/datadog-agent-npm.yaml
+[8]: /resources/yaml/datadog-agent-vanilla.yaml
+[9]: /agent/kubernetes/apm/#setup
+[10]: /agent/kubernetes/log
+[11]: /agent/kubernetes/apm
+[12]: /infrastructure/process/?tab=kubernetes#installation
+[13]: /network_performance_monitoring/installation
+[14]: https://github.com/kubernetes/kube-state-metrics/tree/master/examples/standard
+[15]: /agent/kubernetes/data_collected/#kube-state-metrics
 {{% /tab %}}
 {{% tab "Operator" %}}
 
-[The Datadog Operator][2] is in public beta. The Datadog Operator is a way to deploy the Datadog Agent on Kubernetes and OpenShift. It reports deployment status, health, and errors in its Custom Resource status, and it limits the risk of misconfiguration thanks to higher-level configuration options. To get started, check out the [Getting Started page][1] in the [Datadog Operator repo][2] or install the operator from the [OperatorHub.io Datadog Operator page][3].
+[The Datadog Operator][1] is in public beta. The Datadog Operator is a way to deploy the Datadog Agent on Kubernetes and OpenShift. It reports deployment status, health, and errors in its Custom Resource status, and it limits the risk of misconfiguration thanks to higher-level configuration options. To get started, check out the [Getting Started page][2] in the [Datadog Operator repo][1] or install the operator from the [OperatorHub.io Datadog Operator page][3].
 
-[1]: https://github.com/DataDog/datadog-operator
-[2]: https://github.com/DataDog/datadog-operator/blob/master/docs/getting_started.md
+[1]: https://github.com/DataDog/datadog-operator/blob/master/docs/getting_started.md
+[2]: https://github.com/DataDog/datadog-operator
 [3]: https://operatorhub.io/operator/datadog-operator
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -114,7 +114,7 @@ To install the Datadog Agent on your Kubernetes cluster:
     - [Manifest with Logs and metrics collection enabled][5].
     - [Manifest with APM and metrics collection enabled][6].
     - [Manifest with Network Performance Monitoring enabled][7]
-    - [Vanilla Manifest with just metrics collection enabled][8].
+    - [Vanilla manifest with just metrics collection enabled][8].
 
      To enable trace collection completely, [extra steps are required on your application pod configuration][9]. Refer also to the [logs][10], [APM][11], [processes][12], and [Network Performance Monitoring][13] documentation pages to learn how to enable each feature individually.
 

--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -96,7 +96,7 @@ To enable network performance monitoring with Kubernetes from scratch:
     kubectl apply -f datadog-agent.yaml
     ```
 
-If you already have the [Agent running with a Manifest][3]:
+If you already have the [Agent running with a manifest][3]:
 
 1. Add the annotation `container.apparmor.security.beta.kubernetes.io/system-probe: unconfined` on the `datadog-agent` template:
 

--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -65,7 +65,7 @@ To enable network performance monitoring with the Datadog Agent, use the followi
 4. If you are running an Agent older than v6.18 or 7.18, manually start the system-probe and enable it to start on boot (since v6.18 and v7.18 the system-probe starts automatically when the Agent is started):
 
     ```shell
-    sudo systemctl start datadog-agent-sysprobe 
+    sudo systemctl start datadog-agent-sysprobe
     sudo systemctl enable datadog-agent-sysprobe
     ```
 
@@ -85,147 +85,19 @@ To enable network performance monitoring with the Datadog Agent, use the followi
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 
-To enable network performance monitoring with Kubernetes, use the following configuration:
+To enable network performance monitoring with Kubernetes:
 
-```yaml
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-    name: datadog-agent
-    namespace: default
-spec:
-    selector:
-        matchLabels:
-            app: datadog-agent
-    template:
-        metadata:
-            labels:
-                app: datadog-agent
-            name: datadog-agent
-            annotations:
-                container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
-        spec:
-            serviceAccountName: datadog-agent
-            containers:
-                - image: 'datadog/agent:latest'
-                  imagePullPolicy: Always
-                  name: datadog-agent
-                  ports:
-                      - containerPort: 8125
-                        name: dogstatsdport
-                        protocol: UDP
-                      - containerPort: 8126
-                        name: traceport
-                        protocol: TCP
-                  env:
-                      - name: DD_API_KEY
-                        value: '<DATADOG_API_KEY>'
-                      - name: KUBERNETES
-                        value: 'true'
-                      - name: DD_HEALTH_PORT
-                        value: '5555'
-                      - name: DD_PROCESS_AGENT_ENABLED
-                        value: 'true'
-                      - name: DD_SYSTEM_PROBE_ENABLED
-                        value: 'true'
-                      - name: DD_SYSTEM_PROBE_EXTERNAL
-                        value: 'true'
-                      - name: DD_SYSPROBE_SOCKET
-                        value: /var/run/s6/sysprobe.sock
-                      - name: DD_KUBERNETES_KUBELET_HOST
-                        valueFrom:
-                            fieldRef:
-                                fieldPath: status.hostIP
-                      - name: DD_CRI_SOCKET_PATH
-                        value: /host/var/run/docker.sock
-                      - name: DOCKER_HOST
-                        value: unix:///host/var/run/docker.sock
-                  resources:
-                      requests:
-                          memory: 256Mi
-                          cpu: 200m
-                      limits:
-                          memory: 256Mi
-                          cpu: 200m
-                  volumeMounts:
-                      - name: dockersocketdir
-                        mountPath: /host/var/run
-                      - name: procdir
-                        mountPath: /host/proc
-                        readOnly: true
-                      - name: cgroups
-                        mountPath: /host/sys/fs/cgroup
-                        readOnly: true
-                      - name: debugfs
-                        mountPath: /sys/kernel/debug
-                      - name: s6-run
-                        mountPath: /var/run/s6
-                  livenessProbe:
-                      httpGet:
-                          path: /health
-                          port: 5555
-                      initialDelaySeconds: 15
-                      periodSeconds: 15
-                      timeoutSeconds: 5
-                      successThreshold: 1
-                      failureThreshold: 3
-                - name: system-probe
-                  image: 'datadog/agent:latest'
-                  imagePullPolicy: Always
-                  securityContext:
-                      capabilities:
-                          add:
-                              - SYS_ADMIN
-                              - SYS_RESOURCE
-                              - SYS_PTRACE
-                              - NET_ADMIN
-                              - IPC_LOCK
-                  command:
-                      - /opt/datadog-agent/embedded/bin/system-probe
-                  env:
-                      - name: DD_SYSTEM_PROBE_ENABLED
-                        value: 'true'
-                      - name: DD_SYSPROBE_SOCKET
-                        value: /var/run/s6/sysprobe.sock
-                  resources:
-                      requests:
-                          memory: 150Mi
-                          cpu: 200m
-                      limits:
-                          memory: 150Mi
-                          cpu: 200m
-                  volumeMounts:
-                      - name: procdir
-                        mountPath: /host/proc
-                        readOnly: true
-                      - name: cgroups
-                        mountPath: /host/sys/fs/cgroup
-                        readOnly: true
-                      - name: debugfs
-                        mountPath: /sys/kernel/debug
-                      - name: s6-run
-                        mountPath: /var/run/s6
-            volumes:
-                - name: dockersocketdir
-                  hostPath:
-                      path: /var/run
-                - name: procdir
-                  hostPath:
-                      path: /proc
-                - name: cgroups
-                  hostPath:
-                      path: /sys/fs/cgroup
-                - name: s6-run
-                  emptyDir: {}
-                - name: debugfs
-                  hostPath:
-                      path: /sys/kernel/debug
-```
+1. Download the [datadog-agent.yaml manifest][1] template.
+2. Replace `<DATADOG_API_KEY>` with your [Datadog API key][2].
+3. Optional - **Set your Datadog site**. If you are using the Datadog EU site, set the `DD_SITE` environment variable to `datadoghq.eu` in the `datadog-agent.yaml` manifest.
+4. **Deploy the DaemonSet** with the command:
 
-Replace `<DATADOG_API_KEY>` with your [Datadog API key][1].
+    ```shell
+    kubectl apply -f datadog-agent.yaml
+    ```
 
-
-[1]: https://app.datadoghq.com/account/settings#api
+[1]: /resources/yaml/datadog-agent-npm.yaml
+[2]: https://app.datadoghq.com/account/settings#api
 {{% /tab %}}
 {{% tab "Docker" %}}
 

--- a/static/resources/yaml/datadog-agent-npm.yaml
+++ b/static/resources/yaml/datadog-agent-npm.yaml
@@ -1,0 +1,134 @@
+# datadog-agent.yaml
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+    name: datadog-agent
+    namespace: default
+spec:
+    selector:
+        matchLabels:
+            app: datadog-agent
+    template:
+        metadata:
+            labels:
+                app: datadog-agent
+            name: datadog-agent
+            annotations:
+                container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
+        spec:
+            serviceAccountName: datadog-agent
+            containers:
+                - image: 'datadog/agent:latest'
+                  imagePullPolicy: Always
+                  name: datadog-agent
+                  ports:
+                      - containerPort: 8125
+                        name: dogstatsdport
+                        protocol: UDP
+                      - containerPort: 8126
+                        name: traceport
+                        protocol: TCP
+                  env:
+                      - name: DD_API_KEY
+                        value: '<DATADOG_API_KEY>'
+                      - name: KUBERNETES
+                        value: 'true'
+                      - name: DD_HEALTH_PORT
+                        value: '5555'
+                      - name: DD_PROCESS_AGENT_ENABLED
+                        value: 'true'
+                      - name: DD_SYSTEM_PROBE_ENABLED
+                        value: 'true'
+                      - name: DD_SYSTEM_PROBE_EXTERNAL
+                        value: 'true'
+                      - name: DD_SYSPROBE_SOCKET
+                        value: /var/run/s6/sysprobe.sock
+                      - name: DD_KUBERNETES_KUBELET_HOST
+                        valueFrom:
+                            fieldRef:
+                                fieldPath: status.hostIP
+                      - name: DD_CRI_SOCKET_PATH
+                        value: /host/var/run/docker.sock
+                      - name: DOCKER_HOST
+                        value: unix:///host/var/run/docker.sock
+                  resources:
+                      requests:
+                          memory: 256Mi
+                          cpu: 200m
+                      limits:
+                          memory: 256Mi
+                          cpu: 200m
+                  volumeMounts:
+                      - name: dockersocketdir
+                        mountPath: /host/var/run
+                      - name: procdir
+                        mountPath: /host/proc
+                        readOnly: true
+                      - name: cgroups
+                        mountPath: /host/sys/fs/cgroup
+                        readOnly: true
+                      - name: debugfs
+                        mountPath: /sys/kernel/debug
+                      - name: s6-run
+                        mountPath: /var/run/s6
+                  livenessProbe:
+                      httpGet:
+                          path: /health
+                          port: 5555
+                      initialDelaySeconds: 15
+                      periodSeconds: 15
+                      timeoutSeconds: 5
+                      successThreshold: 1
+                      failureThreshold: 3
+                - name: system-probe
+                  image: 'datadog/agent:latest'
+                  imagePullPolicy: Always
+                  securityContext:
+                      capabilities:
+                          add:
+                              - SYS_ADMIN
+                              - SYS_RESOURCE
+                              - SYS_PTRACE
+                              - NET_ADMIN
+                              - IPC_LOCK
+                  command:
+                      - /opt/datadog-agent/embedded/bin/system-probe
+                  env:
+                      - name: DD_SYSTEM_PROBE_ENABLED
+                        value: 'true'
+                      - name: DD_SYSPROBE_SOCKET
+                        value: /var/run/s6/sysprobe.sock
+                  resources:
+                      requests:
+                          memory: 150Mi
+                          cpu: 200m
+                      limits:
+                          memory: 150Mi
+                          cpu: 200m
+                  volumeMounts:
+                      - name: procdir
+                        mountPath: /host/proc
+                        readOnly: true
+                      - name: cgroups
+                        mountPath: /host/sys/fs/cgroup
+                        readOnly: true
+                      - name: debugfs
+                        mountPath: /sys/kernel/debug
+                      - name: s6-run
+                        mountPath: /var/run/s6
+            volumes:
+                - name: dockersocketdir
+                  hostPath:
+                      path: /var/run
+                - name: procdir
+                  hostPath:
+                      path: /proc
+                - name: cgroups
+                  hostPath:
+                      path: /sys/fs/cgroup
+                - name: s6-run
+                  emptyDir: {}
+                - name: debugfs
+                  hostPath:
+                      path: /sys/kernel/debug

--- a/static/resources/yaml/datadog-agent-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-vanilla.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: datadog-agent
+  namespace: default
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
### What does this PR do?

* Moves K8s setup instructions to a resource file
* Link manifest for NPM from the main K8s page
* Update the npm/installation instructions to show installation from scratch and diff if the Agent is already installed.

### Motivation

More consistency for all Agent "products" doc

### Preview link

* https://docs-staging.datadoghq.com/gus/NPM-k8s-instructions/network_performance_monitoring/installation?tab=kubernetes#setup