### PR TITLE
update wording on a date that is now past

### DIFF
--- a/content/en/infrastructure/serverless/azure_app_services.md
+++ b/content/en/infrastructure/serverless/azure_app_services.md
@@ -36,7 +36,7 @@ The Datadog .NET APM extension supports the following .NET runtimes in both x64 
 - .NET Framework 4.7 (AAS does not support more recent versions)
 - .NET Core 2.1
 - .NET Core 2.2 (Microsoft support ended 2019-12-23)
-- .NET Core 3.0 (Microsoft supports will end 2020-03-03)
+- .NET Core 3.0 (Microsoft support ended 2020-03-03)
 - .NET Core 3.1
 
 ## Installation


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update the phrase "support will end on 2020-03-03" to "support ended on 2020-03-03" because that date is now past.

### Motivation
<!-- What inspired you to submit this pull request?-->
Support ended five weeks ago.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/lucaspimentel/azure_app_services/infrastructure/serverless/azure_app_services/


### Additional Notes
<!-- Anything else we should know when reviewing?-->
none
