### PR TITLE
Update to live processes search docs

### DIFF
--- a/content/en/infrastructure/process.md
+++ b/content/en/infrastructure/process.md
@@ -143,7 +143,7 @@ process_config:
 
 ### Search Syntax
 
-Processes and containers are, by their nature, extremely high cardinality objects. Fuzzy string search helps you view relevant information. Below is Datadog's demo environment, filtered with the string `postgres /9.`.
+Processes and containers are, by their nature, extremely high cardinality objects. Fuzzy string search helps you view relevant information. Enter a string of two or more characters to see results. Below is Datadog's demo environment, filtered with the string `postgres /9.`.
 
 **Note**: `/9.` has matched in the command path, and `postgres` matches the command itself.
 


### PR DESCRIPTION
### What does this PR do? 
The string-based filter bar of the processes app requires at least 2 characters to be inputted to see results, due to an implementational detail. Inputting one character only will show no results, and in this case we want to let customers know that the search is not broken, but rather requires another character to be entered. This info will also be surfaced in an error message in-app, with a link to these docs.

### Motivation
Confusing behavior in the live processes search bar. 

### Preview link
Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/yael/processes_edit/content/en/infrastructure/process.md

### Additional Notes
<!-- Anything else we should know when reviewing?-->
