### PR TITLE
[DOCS-809] note on case-sensitivity

### DIFF
--- a/content/en/agent/docker/tag.md
+++ b/content/en/agent/docker/tag.md
@@ -36,6 +36,8 @@ For example, you could set up:
 DD_DOCKER_LABELS_AS_TAGS='{"com.docker.compose.service":"service_name"}'
 ```
 
+**Note**: `<LABEL_NAME>` is not case-sensitive. For example, if you have labels named `foo` and `FOO`, and you set `DD_DOCKER_LABELS_AS_TAGS='{"foo": "bar"}'`, both `foo` and `FOO` will be mapped to `bar`.
+
 {{% /tab %}}
 {{% tab "Agent" %}}
 

--- a/content/en/agent/docker/tag.md
+++ b/content/en/agent/docker/tag.md
@@ -36,7 +36,7 @@ For example, you could set up:
 DD_DOCKER_LABELS_AS_TAGS='{"com.docker.compose.service":"service_name"}'
 ```
 
-**Note**: `<LABEL_NAME>` is not case-sensitive. For example, if you have labels named `foo` and `FOO`, and you set `DD_DOCKER_LABELS_AS_TAGS='{"foo": "bar"}'`, both `foo` and `FOO` will be mapped to `bar`.
+**Note**: `<LABEL_NAME>` is not case-sensitive. For example, if you have labels named `foo` and `FOO`, and you set `DD_DOCKER_LABELS_AS_TAGS='{"foo": "bar"}'`, both `foo` and `FOO` are mapped to `bar`.
 
 {{% /tab %}}
 {{% tab "Agent" %}}


### PR DESCRIPTION

### What does this PR do?
adds a note that DD_DOCKER_LABELS_AS_TAGS is not case-sensitive

### Motivation
support request

### Preview link

https://docs-staging.datadoghq.com/cswatt/docker-label-detail/agent/docker/tag/?tab=containerizedagent#extract-labels-as-tags
