### PR TITLE
[DOCS-820] Source param is a string not an array

### DIFF
--- a/content/en/logs/log_collection/ruby.md
+++ b/content/en/logs/log_collection/ruby.md
@@ -76,7 +76,7 @@ This section describe the minimum setup required in order to forward your Rails 
 
     # This is useful if you want to log query parameters
     config.lograge.custom_options = lambda do |event|
-        { :ddsource => ["ruby"],
+        { :ddsource => 'ruby',
           :params => event.payload[:params].reject { |k| %w(controller action).include? k }
         }
     end


### PR DESCRIPTION
Fixing Ruby code example as the ddsource param expect a string not an array of strings