### PR TITLE
[DOCS-810] Adding link to log collection doc + disclaimer on reserved attribute

### DIFF
--- a/content/en/api/logs/send_logs_datadog.md
+++ b/content/en/api/logs/send_logs_datadog.md
@@ -21,5 +21,6 @@ external_redirect: /api/#send-logs-over-http
 See the [log collection documentation][1] to learn more about the different ways to collect logs from your application. If you are logging pure JSON objects, they are parsed automatically by Datadog Log management.
 
 **Note**: When logging pure JSON objects, Datadog has a set of [reserved attributes][2] with a specific behavior.
+
 [1]: /logs/log_collection/
 [2]: /logs/log_collection/#reserved-attributes

--- a/content/en/api/logs/send_logs_datadog.md
+++ b/content/en/api/logs/send_logs_datadog.md
@@ -12,13 +12,13 @@ external_redirect: /api/#send-logs-over-http
 | Protocol         | http: 80<br>https: 443                                                                                                                                |
 | Host             | For Datadog US: `http-intake.logs.datadoghq.com` <br> For Datadog EU: `http-intake.logs.datadoghq.eu`                                                 |
 | Path             | For API key passed in headers: `/v1/input`<br> For API key passed in path: `/v1/input/<DATADOG_API_KEY>`                                              |
-| Headers          | Header to pass the API key: `DD-API-KEY`. If an API key is passed in both the headers and the path only the one in the headers is taken into account. |
+| Headers          | The header to pass in the API key: `DD-API-KEY`. If an API key is passed in both the headers and the path, only the one in the headers is taken into account. |
 | Query parameters | Query parameters available are the reserved log attribute. `?ddtags=<TAGS>&ddsource=<SOURCE>&service=<SERVICE>&hostname=<HOSTNAME>`                   |
 | Method           | `POST`                                                                                                                                                |
 | Content Type     | Available content type are: `text/plain`, `application/json`, `application/logplex-1`                                                                 |
 | Content Encoding | _[optional]_ For compressed content the available content encoding are: `gzip` and `deflate`.                                                         |
 
-See the [log collection documentation][1] to learn more about the different ways to collect logs from your application. If you are logging pure JSON objects, they are parsed automatically by Datadog Log management.
+See the [log collection documentation][1] to learn more about the different ways to collect logs from your application. If you are logging pure JSON objects, they are parsed automatically by Datadog log management.
 
 **Note**: When logging pure JSON objects, Datadog has a set of [reserved attributes][2] with a specific behavior.
 

--- a/content/en/api/logs/send_logs_datadog.md
+++ b/content/en/api/logs/send_logs_datadog.md
@@ -7,15 +7,19 @@ external_redirect: /api/#send-logs-over-http
 
 ## Send Logs over HTTP
 
-| Item             | Description                                                                                                           |
-| ------           | ---------                                                                                                             |
-| Protocol         | http: 80<br>https: 443                                                                                                |
-| Host             | For Datadog US: `http-intake.logs.datadoghq.com` <br> For Datadog EU: `http-intake.logs.datadoghq.eu`                 |
-| Path             | For API key passed in headers: `/v1/input`<br> For API key passed in path: `/v1/input/<DATADOG_API_KEY>`              |
-| Headers          | Header to pass the API key: `DD-API-KEY`                                                                              |
-| Query parameters | Query parameters available are the reserved log attribute. `?ddtags=<TAGS>&ddsource=<SOURCE>&service=<SERVICE>&hostname=<HOSTNAME>` |
-| Method           | `POST`                                                                                                                |
-| Content Type     | Available content type are: `text/plain`, `application/json`, `application/logplex-1`                                 |
-| Content Encoding | *[optional]* For compressed content the available content encoding are: `gzip` and `deflate`. |
+| Item             | Description                                                                                                                                           |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Protocol         | http: 80<br>https: 443                                                                                                                                |
+| Host             | For Datadog US: `http-intake.logs.datadoghq.com` <br> For Datadog EU: `http-intake.logs.datadoghq.eu`                                                 |
+| Path             | For API key passed in headers: `/v1/input`<br> For API key passed in path: `/v1/input/<DATADOG_API_KEY>`                                              |
+| Headers          | Header to pass the API key: `DD-API-KEY`. If an API key is passed in both the headers and the path only the one in the headers is taken into account. |
+| Query parameters | Query parameters available are the reserved log attribute. `?ddtags=<TAGS>&ddsource=<SOURCE>&service=<SERVICE>&hostname=<HOSTNAME>`                   |
+| Method           | `POST`                                                                                                                                                |
+| Content Type     | Available content type are: `text/plain`, `application/json`, `application/logplex-1`                                                                 |
+| Content Encoding | _[optional]_ For compressed content the available content encoding are: `gzip` and `deflate`.                                                         |
 
-**Note**: If an API key is passed in both the headers and the path only the one in the headers is taken into account.
+See the [log collection documentation][1] to learn more about the different ways to collect logs from your application. If you are logging pure JSON objects, they are parsed automatically by Datadog Log management.
+
+**Note**: When logging pure JSON objects, Datadog has a set of [reserved attributes][2] with a specific behavior.
+[1]: /logs/log_collection/
+[2]: /logs/log_collection/#reserved-attributes


### PR DESCRIPTION

Adds a link to log collection documentation to list all the other ways to collect logs from a given application + direct users to the behavior of some attributes if logs logged are pure JSON objects.