### PR TITLE
Remove "etc" in watchdog feature

### DIFF
--- a/content/en/watchdog.md
+++ b/content/en/watchdog.md
@@ -28,7 +28,7 @@ Watchdog is an algorithmic feature for APM performances and infrastructure metri
   * Latency
 
 * Infrastructure metrics from integrations:
-  * [System][1], for the Host-level memory usage (memory leaks), TCP retransmit rate, etc.
+  * [System][1], for the Host-level memory usage (memory leaks), TCP retransmit rate.
   * [Redis][2]
   * [PostgreSQL][3]
   * [NGINX][4]

--- a/content/en/watchdog.md
+++ b/content/en/watchdog.md
@@ -28,7 +28,7 @@ Watchdog is an algorithmic feature for APM performances and infrastructure metri
   * Latency
 
 * Infrastructure metrics from integrations:
-  * [System][1], for the Host-level memory usage (memory leaks), TCP retransmit rate.
+  * [System][1], for the Host-level memory usage (memory leaks) and TCP retransmit rate.
   * [Redis][2]
   * [PostgreSQL][3]
   * [NGINX][4]


### PR DESCRIPTION
### What does this PR do?
Remove a wording that was misleading for customers.

### Motivation
As explained here : https://www.datadoghq.com/blog/watchdog-for-infra/#auto-detect-infrastructure-problems, for now we are only using memory usage and TCP retransmit.

