### PR TITLE
RBAC wording update

### DIFF
--- a/content/en/account_management/rbac/_index.md
+++ b/content/en/account_management/rbac/_index.md
@@ -93,7 +93,7 @@ Once a role is modified, all users who have the role will have their permissions
 {{% /tab %}}
 {{% tab "API" %}}
 
-Find an example of how to create a Role in the [Datadog Create Role API documentation][1].
+Find an example of how to update a Role in the [Datadog Create Role API documentation][1].
 
 
 [1]: /api/#update-role
@@ -122,7 +122,7 @@ Once a role is deleted all users who have the role will have their permissions u
 {{% /tab %}}
 {{% tab "API" %}}
 
-Find an example of how to create a Role in the [Datadog Create Role API documentation][1].
+Find an example of how to delete a Role in the [Datadog Create Role API documentation][1].
 
 
 [1]: /api/#delete-role


### PR DESCRIPTION
### What does this PR do?

Update the wording to link to the role API when updating or removing a role

### Motivation
We were referring to role creation each time.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/rbac-wording-update/account_management/rbac/?tab=datadogapplication

### Additional Notes
<!-- Anything else we should know when reviewing?-->
