### PR TITLE
Add instructions for filtering monitors that do not contain a tag.

### DIFF
--- a/content/en/tagging/using_tags.md
+++ b/content/en/tagging/using_tags.md
@@ -114,7 +114,7 @@ Here are the filter and group by textboxes on the Live Processes page:
 {{< tabs >}}
 {{% tab "Manage Monitors" %}}
 
-To filter monitors by [assigned tags][1], use the search bar or facet checkboxes. The search bar format is `tag:<KEY>:<VALUE>`, for example `tag:service:coffee-house`. You can also filter monitors that do not have a tag, for example `tag:-service:coffee-house`. **Note**: monitor tags are different and separate from metric tags.
+To filter monitors by [assigned tags][1], use the search bar or facet checkboxes. The search bar format is `tag:<KEY>:<VALUE>`, for example `tag:service:coffee-house`. To exclude monitors with a specific tag from your search, use `-`, for example `tag:-service:coffee-house`. **Note**: Monitor tags are different and separate from metric tags.
 
 {{< img src="tagging/using_tags/managemonitorstags.png" alt="Manage Monitors Tags"  style="width:80%;">}}
 

--- a/content/en/tagging/using_tags.md
+++ b/content/en/tagging/using_tags.md
@@ -114,7 +114,7 @@ Here are the filter and group by textboxes on the Live Processes page:
 {{< tabs >}}
 {{% tab "Manage Monitors" %}}
 
-To filter monitors by [assigned tags][1], use the search bar or facet checkboxes. The search bar format is `tag:<KEY>:<VALUE>`, for example `tag:service:coffee-house`. **Note**: monitor tags are different and separate from metric tags.
+To filter monitors by [assigned tags][1], use the search bar or facet checkboxes. The search bar format is `tag:<KEY>:<VALUE>`, for example `tag:service:coffee-house`. You can also filter monitors that do not have a tag, for example `tag:-service:coffee-house`. **Note**: monitor tags are different and separate from metric tags.
 
 {{< img src="tagging/using_tags/managemonitorstags.png" alt="Manage Monitors Tags"  style="width:80%;">}}
 


### PR DESCRIPTION
### What does this PR do?
Adds instructions on how to filter monitors that do not contain a tag.

### Motivation
I had to open a ticket with support to figure out this use-case, so I decided to add it to the docs.
