### PR TITLE
Remove Trailing Slashes

### DIFF
--- a/content/en/api/integrations_webhook/code_snippets/custom_variables_create.sh
+++ b/content/en/api/integrations_webhook/code_snippets/custom_variables_create.sh
@@ -6,7 +6,7 @@ app_key="<DATADOG_APPLICATION_KEY>"
 curl -v -X POST \
 -H "DD-API-KEY: ${api_key}" \
 -H "DD-APPLICATION-KEY: ${app_key}" \
-"https://api.datadoghq.com/api/v1/webhooks/configuration/custom-variables/" \
+"https://api.datadoghq.com/api/v1/webhooks/configuration/custom-variables" \
 -d '{
     "name": "<CUSTOM_VARIABLE_NAME>",
     "value": "<CUSTOM_VARIABLE_VALUE>",

--- a/content/en/api/integrations_webhook/code_snippets/result.custom_variables_delete.sh
+++ b/content/en/api/integrations_webhook/code_snippets/result.custom_variables_delete.sh
@@ -1,1 +1,1 @@
-`null`
+null

--- a/content/en/api/integrations_webhook/code_snippets/result.webhooks_delete.sh
+++ b/content/en/api/integrations_webhook/code_snippets/result.webhooks_delete.sh
@@ -1,1 +1,1 @@
-`null`
+null

--- a/content/en/api/integrations_webhook/code_snippets/webhooks_create.sh
+++ b/content/en/api/integrations_webhook/code_snippets/webhooks_create.sh
@@ -6,7 +6,7 @@ app_key="<DATADOG_APPLICATION_KEY>"
 curl -v -X POST \
 -H "DD-API-KEY: ${api_key}" \
 -H "DD-APPLICATION-KEY: ${app_key}" \
-"https://api.datadoghq.com/api/v1/webhooks/configuration/webhooks/" \
+"https://api.datadoghq.com/api/v1/webhooks/configuration/webhooks" \
 -d '{
     "name": "<WEBHOOK_NAME>",
     "url": "<WEBHOOK_URL>"

--- a/content/en/api/integrations_webhook/webhooks_create_code.md
+++ b/content/en/api/integrations_webhook/webhooks_create_code.md
@@ -7,7 +7,7 @@ external_redirect: /api/#create-a-webhook-for-webhooks-integration
 
 **SIGNATURE**:
 
-`POST api/v1/integration/webhooks/configuration/webhooks/`
+`POST api/v1/integration/webhooks/configuration/webhooks`
 
 **EXAMPLE REQUEST**:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->
Trailing slashes in URLs were causing API calls to fail.
Removed the trailing slashes and removed surrounding quotes for null return values

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
