### PR TITLE
Removing agent tags when not available

### DIFF
--- a/content/en/tracing/guide/metrics_namespace.md
+++ b/content/en/tracing/guide/metrics_namespace.md
@@ -23,18 +23,18 @@ aliases:
 
 ## Overview
 
-The [trace metrics][1] namespace is `trace.<SPAN_NAME>.<METRICS_suffix>{<TAGS>}`. Tracing application metrics are collected after [enabling trace collection][2] and [instrumenting your application][3]. These metrics are available for dashboards and monitors.
+Tracing application metrics are collected after [enabling trace collection][1] and [instrumenting your application][2]. These metrics are available for dashboards and monitors. The [trace metrics][3] namespace is formatted as:
 
-Trace metric names are formatted as:
+- `trace.<SPAN_NAME>.<METRIC_SUFFIX>`
+- `trace.<SPAN_NAME>.<METRIC_SUFFIX>.<2ND_PRIM_TAG>_service`
 
-- `trace.<SPAN_NAME>.<METRIC_SUFFIX>{<TAGS>}`
-- `trace.<SPAN_NAME>.<METRIC_SUFFIX>.<2ND_PRIM_TAG>_service{<TAGS>}`
+With the following definitions:
 
 | Parameter               | Description                                                                                                                                                                                                        |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `<SPAN_NAME>`                | The name of the operation or `span.name` (examples: `redis.command`, `pylons.request`, `rails.request`, `mysql.query`).                                                                                            |
-| `<METRIC_SUFFIX>`       | The name of the metric (examples: `duration`, `hits`, `span_count`).                                                                                                                                               |
-| `<2ND_PRIM_TAG>` | If the metric name accounts for the second primary tag, this tag is part of the metric name.                                                                                                                       |
+| `<METRIC_SUFFIX>`       | The name of the metric (examples: `duration`, `hits`, `span_count`). See the section below.                                                                                                                                               |
+| `<2ND_PRIM_TAG>` | If the metric name accounts for the [second primary tag][4], this tag is part of the metric name.                                                                                                                       |
 | `<TAGS>`                | Trace metrics tags, possible tags are: `env`, `service`, `resource`, `sublayer_type`, `sublayer_service`, `http.status_code`, `http.status_class`, Datadog Agent tags (including the host and second primary tag). |
 
 ## Metric Suffix
@@ -44,66 +44,66 @@ Trace metric names are formatted as:
 - `trace.<SPAN_NAME>.duration`:
   - *Prerequisite:* This metric exists for any APM service.
   - *Description:* Measure the total time for a collection of spans. Specifically, it is the total time spent by all spans over an interval - including time spent waiting on child processes.
-  - *Metric type:* [GAUGE][4]
-  - *Tags:* `env`, `service`, `resource`, `http.status_code`, all Datadog Agent tags, and [the second primary tag][5].
+  - *Metric type:* [GAUGE][5]
+  - *Tags:* `env`, `service`, `resource`, `http.status_code`, all Datadog Agent tags, and [the second primary tag][4].
 
 - `trace.<SPAN_NAME>.duration.by_http_status`:
   - *Prerequisite:* This metric exists for HTTP/WEB APM services if http metadata exists.
   - *Description:* Measure the total time for a collection of spans for each HTTP status. Specifically, it is the relative share of time spent by all spans over an interval and a given HTTP status - including time spent waiting on child processes.
-  - *Metric type:* [GAUGE][4]
-  - *Tags:* `env`, `service`, `resource`, `http.status_class`, `http.status_code`, all Datadog Agent tags, and [the second primary tag][5].
+  - *Metric type:* [GAUGE][5]
+  - *Tags:* `env`, `service`, `resource`, `http.status_class`, `http.status_code`, all Datadog Agent tags, and [the second primary tag][4].
 
 - `trace.<SPAN_NAME>.duration.by_service`:
   - *Prerequisite:* This metric exists for any APM service.
   - *Description:* Measures the total time spent actually processing for each service (i.e. it excludes time spent waiting on child processes).
-  - *Metric type:* [GAUGE][4]
-  - *Tags:* `env`, `service`, `resource`, `sublayer_service`, `http.status_code`, all Datadog Agent tags, and [the second primary tag][5].
+  - *Metric type:* [GAUGE][5]
+  - *Tags:* `env`, `service`, `resource`, `sublayer_service`, `http.status_code`, all Datadog Agent tags, and [the second primary tag][4].
 
 - `trace.<SPAN_NAME>.duration.by_type`:
   - *Prerequisite:* This metric exists for any APM service.
   - *Description:* Measures the total time spent actually processing for each [Service type][6].
-  - *Metric type:* [GAUGE][4]
-  - *Tags:* `env`, `service`, `resource`, `sublayer_type`, `http.status_code`, all Datadog Agent tags, and [the second primary tag][5].
+  - *Metric type:* [GAUGE][5]
+  - *Tags:* `env`, `service`, `resource`, `sublayer_type`, `http.status_code`, all Datadog Agent tags, and [the second primary tag][4].
 
 - `trace.<SPAN_NAME>.duration.by_type.by_http_status`:
   - *Prerequisite:* This metric exists for HTTP/WEB APM services if http metadata exists.
   - *Description:* Measures the total time spent actually processing for each [Service type][6] and HTTP status.
-  - *Metric type:* [GAUGE][4]
-  - *Tags:* `env`, `service`, `resource`, `sublayer_type`, `http.status_class`, `http.status_code`, all Datadog Agent tags, and [the second primary tag][5].
+  - *Metric type:* [GAUGE][5]
+  - *Tags:* `env`, `service`, `resource`, `sublayer_type`, `http.status_class`, `http.status_code`, all Datadog Agent tags, and [the second primary tag][4].
 
 - `trace.<SPAN_NAME>.duration.by_service.by_http_status`:
   - *Prerequisite:* This metric exists for HTTP/WEB APM services if http metadata exists.
   - *Description:* Measures the total time spent actually processing for each [Service][7] and HTTP status.
-  - *Metric type:* [GAUGE][4]
-  - *Tags:* `env`, `service`, `resource`, `sublayer_service`, `http.status_class`, `http.status_code`, all Datadog Agent tags, and [the second primary tag][5].
+  - *Metric type:* [GAUGE][5]
+  - *Tags:* `env`, `service`, `resource`, `sublayer_service`, `http.status_class`, `http.status_code`, all Datadog Agent tags, and [the second primary tag][4].
 
 #### Duration.by
 
 - `trace.<SPAN_NAME>.duration.by.resource_<2ND_PRIM_TAG>_service.<PERCENTILE_AGGREGATION>`:
   - *Prerequisite:* This metric exists for any APM service.
-  - *Description:* Measure the total time spent processing by resource, service, and [2nd primary tag][5].
-  - *Metric type:* [GAUGE][4]
+  - *Description:* Measure the total time spent processing by resource, service, and [2nd primary tag][4].
+  - *Metric type:* [GAUGE][5]
   - *Percentile Aggregations:* `100p`, `50p`, `75p`, `90p`, `95p`, `99p`
-  - *Tags:* `env`, `service`, `resource`, and [the second primary tag][5].
+  - *Tags:* `env`, `service`, `resource`, and [the second primary tag][4].
 
 - `trace.<SPAN_NAME>.duration.by.resource_service.<PERCENTILE_AGGREGATION>`:
   - *Prerequisite:* This metric exists for any APM service.
   - *Description:* Measure the total time spent processing for each resource and service combination.
-  - *Metric type:* [GAUGE][4]
+  - *Metric type:* [GAUGE][5]
   - *Percentile Aggregations:* `100p`, `50p`, `75p`, `90p`, `95p`, `99p`
   - *Tags:* `env`, `service`, and `resource`.
 
 - `trace.<SPAN_NAME>.duration.by.<2ND_PRIM_TAG>_service.<PERCENTILE_AGGREGATION>`
   - *Prerequisite:* This metric exists for any APM service.
-  - *Description:* Measure the total time spent processing for each [2nd primary tag][5] and service combination.
-  - *Metric type:* [GAUGE][4]
+  - *Description:* Measure the total time spent processing for each [2nd primary tag][4] and service combination.
+  - *Metric type:* [GAUGE][5]
   - *Percentile Aggregations:* `100p`, `50p`, `75p`, `90p`, `95p`, `99p`
-  - *Tags:* `env`, `service`, and [the second primary tag][5].
+  - *Tags:* `env`, `service`, and [the second primary tag][4].
 
 - `trace.<SPAN_NAME>.duration.by.service.<PERCENTILE_AGGREGATION>`
   - *Prerequisite:* This metric exists for any APM service.
   - *Description:* Represents the duration for an individual span. It's used to track latency and answer questions like, "what's the median wait time a user experienced?" or "how long do the slowest 1% of users have to wait?".
-  - *Metric type:* [GAUGE][4]
+  - *Metric type:* [GAUGE][5]
   - *Percentile Aggregations:* `100p`, `50p`, `75p`, `90p`, `95p`, `99p`
   - *Tags:* `env` and `service`.
 
@@ -113,13 +113,13 @@ Trace metric names are formatted as:
   - *Prerequisite:* This metric exists for any APM service.
   - *Description:* Represent the count of errors for a given span.
   - *Metric type:* [COUNT][8]
-  - *Tags:* `env`, `service`, `resource`, all Datadog Agent tags, and [the second primary tag][5].
+  - *Tags:* `env`, `service`, `resource`, all Datadog Agent tags, and [the second primary tag][4].
 
 - `trace.<SPAN_NAME>.errors.by_http_status`:
   - *Prerequisite:* This metric exists for any APM service.
   - *Description:* Represent the count of errors for a given span.
   - *Metric type:* [COUNT][8]
-  - *Tags:* `env`, `service`, `resource`, `http.status_class`, `http.status_code`, all Datadog Agent tags, and [the second primary tag][5].
+  - *Tags:* `env`, `service`, `resource`, `http.status_class`, `http.status_code`, all Datadog Agent tags, and [the second primary tag][4].
 
 ### Hits
 
@@ -127,13 +127,13 @@ Trace metric names are formatted as:
   - *Prerequisite:* This metric exists for any APM service.
   - *Description:* Represent the count of hits for a given span.
   - *Metric type:* [COUNT][8]
-  - *Tags:* `env`, `service`, `resource`, all Datadog Agent tags, and [the second primary tag][5].
+  - *Tags:* `env`, `service`, `resource`, all Datadog Agent tags, and [the second primary tag][4].
 
 - `trace.<SPAN_NAME>.hits.by_http_status`
   - *Prerequisite:* This metric exists for HTTP/WEB APM services if http metadata exists.
   - *Description:* Represent the count of hits for a given span break down by HTTP status code.
   - *Metric type:* [COUNT][8]
-  - *Tags:* `env`, `service`, `resource`, `http.status_class`, `http.status_code`, all Datadog Agent tags, and [the second primary tag][5].
+  - *Tags:* `env`, `service`, `resource`, `http.status_class`, `http.status_code`, all Datadog Agent tags, and [the second primary tag][4].
 
 ### Span_count
 
@@ -141,49 +141,49 @@ Trace metric names are formatted as:
   - *Prerequisite:* This metric exists for any APM service.
   - *Description:* Represent the amount of spans collected on a given interval.
   - *Metric type:* [COUNT][8]
-  - *Tags:* `env`, `service`, `resource`, all Datadog Agent tags, and [the second primary tag][5].
+  - *Tags:* `env`, `service`, `resource`, all Datadog Agent tags, and [the second primary tag][4].
 
 - `trace.<SPAN_NAME>.span_count.by_http_status`:
   - *Prerequisite:* This metric exists for HTTP/WEB APM services if http metadata exists.
   - *Description:* Represent the amount of spans collected on a given interval break down by HTTP status.
   - *Metric type:* [COUNT][8]
-  - *Tags:* `env`, `service`, `resource`, `http.status_class`, `http.status_code`, all Datadog Agent tags, and [the second primary tag][5].
+  - *Tags:* `env`, `service`, `resource`, `http.status_class`, `http.status_code`, all Datadog Agent tags, and [the second primary tag][4].
 
 ### Apdex
 
 - `trace.<SPAN_NAME>.apdex.by.resource_<2ND_PRIM_TAG>_service`:
   - *Prerequisite:* This metric exists for any HTTP/WEB APM service.
-  - *Description:* Represent the [Apdex][9] score for all combination of resources, [2nd primary tag][5]s and services.
-  - *Metric type:* [GAUGE][4]
-  - *Tags:* `env`, `service`, `resource`, and [the second primary tag][5].
+  - *Description:* Represent the [Apdex][9] score for all combination of resources, [2nd primary tag][4]s and services.
+  - *Metric type:* [GAUGE][5]
+  - *Tags:* `env`, `service`, `resource`, and [the second primary tag][4].
 
 - `trace.<SPAN_NAME>.apdex.by.resource_service`:
   - *Prerequisite:* This metric exists for any HTTP/WEB APM service.
   - *Description:* Mesure the [Apdex][9] score for each combination of resources and web services.
-  - *Metric type:* [GAUGE][4]
+  - *Metric type:* [GAUGE][5]
   - *Tags:* `env`, `service`, and `resource`
 
 - `trace.<SPAN_NAME>.apdex.by.<2ND_PRIM_TAG>_service`:
   - *Prerequisite:* This metric exists for any HTTP/WEB APM service.
-  - *Description:* Mesure the [Apdex][9] score for each combination of [2nd primary tag][5] and web services.
-  - *Metric type:* [GAUGE][4]
-  - *Tags:* `env`, `service`, and [the second primary tag][5].
+  - *Description:* Mesure the [Apdex][9] score for each combination of [2nd primary tag][4] and web services.
+  - *Metric type:* [GAUGE][5]
+  - *Tags:* `env`, `service`, and [the second primary tag][4].
 
 - `trace.<SPAN_NAME>.apdex.by.service`:
   - *Prerequisite:* This metric exists for any HTTP/WEB APM service.
   - *Description:* Mesure the [Apdex][9] score for each web services.
-  - *Metric type:* [GAUGE][4]
+  - *Metric type:* [GAUGE][5]
   - *Tags:* `env` and `service`.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/visualization/#trace-metrics
-[2]: /tracing/send_traces
-[3]: /tracing/setup
-[4]: /developers/metrics/types/?tab=gauge#metric-types
-[5]: /tracing/guide/setting_primary_tags_to_scope/#add-a-second-primary-tag-in-datadog
+[1]: /tracing/send_traces
+[2]: /tracing/setup
+[3]: /tracing/visualization/#trace-metrics
+[4]: /tracing/guide/setting_primary_tags_to_scope/#add-a-second-primary-tag-in-datadog
+[5]: /developers/metrics/types/?tab=gauge#metric-types
 [6]: /tracing/visualization/services_list/#services-types
 [7]: /tracing/visualization/#services
 [8]: /developers/metrics/types/?tab=count#metric-types

--- a/content/en/tracing/guide/metrics_namespace.md
+++ b/content/en/tracing/guide/metrics_namespace.md
@@ -55,25 +55,25 @@ With the following definitions:
 
 - `trace.<SPAN_NAME>.duration.by_service`:
   - *Prerequisite:* This metric exists for any APM service.
-  - *Description:* Measures the total time spent actually processing for each service (i.e. it excludes time spent waiting on child processes).
+  - *Description:* Measure the total time spent actually processing for each service (i.e. it excludes time spent waiting on child processes).
   - *Metric type:* [GAUGE][5]
   - *Tags:* `env`, `service`, `resource`, `sublayer_service`, `http.status_code`, all Datadog Agent tags, and [the second primary tag][4].
 
 - `trace.<SPAN_NAME>.duration.by_type`:
   - *Prerequisite:* This metric exists for any APM service.
-  - *Description:* Measures the total time spent actually processing for each [Service type][6].
+  - *Description:* Measure the total time spent actually processing for each [Service type][6].
   - *Metric type:* [GAUGE][5]
   - *Tags:* `env`, `service`, `resource`, `sublayer_type`, `http.status_code`, all Datadog Agent tags, and [the second primary tag][4].
 
 - `trace.<SPAN_NAME>.duration.by_type.by_http_status`:
   - *Prerequisite:* This metric exists for HTTP/WEB APM services if http metadata exists.
-  - *Description:* Measures the total time spent actually processing for each [Service type][6] and HTTP status.
+  - *Description:* Measure the total time spent actually processing for each [Service type][6] and HTTP status.
   - *Metric type:* [GAUGE][5]
   - *Tags:* `env`, `service`, `resource`, `sublayer_type`, `http.status_class`, `http.status_code`, all Datadog Agent tags, and [the second primary tag][4].
 
 - `trace.<SPAN_NAME>.duration.by_service.by_http_status`:
   - *Prerequisite:* This metric exists for HTTP/WEB APM services if http metadata exists.
-  - *Description:* Measures the total time spent actually processing for each [Service][7] and HTTP status.
+  - *Description:* Measure the total time spent actually processing for each [Service][7] and HTTP status.
   - *Metric type:* [GAUGE][5]
   - *Tags:* `env`, `service`, `resource`, `sublayer_service`, `http.status_class`, `http.status_code`, all Datadog Agent tags, and [the second primary tag][4].
 

--- a/content/en/tracing/guide/metrics_namespace.md
+++ b/content/en/tracing/guide/metrics_namespace.md
@@ -81,28 +81,28 @@ Trace metric names are formatted as `trace.<SPAN_NAME>.<METRIC_SUFFIX>{<TAGS>}` 
   - *Description:* Measure the total time spent processing by resource, service, and [2nd primary tag][5].
   - *Metric type:* [GAUGE][4]
   - *Percentile Aggregations:* `100p`, `50p`, `75p`, `90p`, `95p`, `99p`
-  - *Tags:* `env`, `service`, `resource`, all Datadog Agent tags, and [the second primary tag][5].
+  - *Tags:* `env`, `service`, `resource`, and [the second primary tag][5].
 
 - `trace.<SPAN_NAME>.duration.by.resource_service.<PERCENTILE_AGGREGATION>`:
   - *Prerequisite:* This metric exists for any APM service.
   - *Description:* Measure the total time spent processing for each resource and service combination.
   - *Metric type:* [GAUGE][4]
   - *Percentile Aggregations:* `100p`, `50p`, `75p`, `90p`, `95p`, `99p`
-  - *Tags:* `env`, `service`, `resource`, all Datadog Agent tags, and [the second primary tag][5].
+  - *Tags:* `env`, `service`, and `resource`.
 
 - `trace.<SPAN_NAME>.duration.by.<2ND_PRIM_TAG>_service.<PERCENTILE_AGGREGATION>`
   - *Prerequisite:* This metric exists for any APM service.
   - *Description:* Measure the total time spent processing for each [2nd primary tag][5] and service combination.
   - *Metric type:* [GAUGE][4]
   - *Percentile Aggregations:* `100p`, `50p`, `75p`, `90p`, `95p`, `99p`
-  - *Tags:* `env`, `service`, all Datadog Agent tags, and [the second primary tag][5].
+  - *Tags:* `env`, `service`, and [the second primary tag][5].
 
 - `trace.<SPAN_NAME>.duration.by.service.<PERCENTILE_AGGREGATION>`
   - *Prerequisite:* This metric exists for any APM service.
   - *Description:* Represents the duration for an individual span. It's used to track latency and answer questions like, "what's the median wait time a user experienced?" or "how long do the slowest 1% of users have to wait?".
   - *Metric type:* [GAUGE][4]
   - *Percentile Aggregations:* `100p`, `50p`, `75p`, `90p`, `95p`, `99p`
-  - *Tags:* `env`, `service`, all Datadog Agent tags, and [the second primary tag][5].
+  - *Tags:* `env` and `service`.
 
 ### Errors
 
@@ -152,25 +152,25 @@ Trace metric names are formatted as `trace.<SPAN_NAME>.<METRIC_SUFFIX>{<TAGS>}` 
   - *Prerequisite:* This metric exists for any HTTP/WEB APM service.
   - *Description:* Represent the [Apdex][9] score for all combination of resources, [2nd primary tag][5]s and services.
   - *Metric type:* [GAUGE][4]
-  - *Tags:* `env`, `service`, `resource`, all Datadog Agent tags, and [the second primary tag][5].
+  - *Tags:* `env`, `service`, `resource`, and [the second primary tag][5].
 
 - `trace.<SPAN_NAME>.apdex.by.resource_service`:
   - *Prerequisite:* This metric exists for any HTTP/WEB APM service.
   - *Description:* Mesure the [Apdex][9] score for each combination of resources and web services.
   - *Metric type:* [GAUGE][4]
-  - *Tags:* `env`, `service`, `resource`, all Datadog Agent tags, and [the second primary tag][5].
+  - *Tags:* `env`, `service`, and `resource`
 
 - `trace.<SPAN_NAME>.apdex.by.<2ND_PRIM_TAG>_service`:
   - *Prerequisite:* This metric exists for any HTTP/WEB APM service.
   - *Description:* Mesure the [Apdex][9] score for each combination of [2nd primary tag][5] and web services.
   - *Metric type:* [GAUGE][4]
-  - *Tags:* `env`, `service`, all Datadog Agent tags, and [the second primary tag][5].
+  - *Tags:* `env`, `service`, and [the second primary tag][5].
 
 - `trace.<SPAN_NAME>.apdex.by.service`:
   - *Prerequisite:* This metric exists for any HTTP/WEB APM service.
   - *Description:* Mesure the [Apdex][9] score for each web services.
   - *Metric type:* [GAUGE][4]
-  - *Tags:* `env`, `service`, all Datadog Agent tags, and [the second primary tag][5].
+  - *Tags:* `env` and `service`.
 
 ## Further Reading
 

--- a/content/en/tracing/guide/metrics_namespace.md
+++ b/content/en/tracing/guide/metrics_namespace.md
@@ -25,7 +25,10 @@ aliases:
 
 The [trace metrics][1] namespace is `trace.<SPAN_NAME>.<METRICS_suffix>{<TAGS>}`. Tracing application metrics are collected after [enabling trace collection][2] and [instrumenting your application][3]. These metrics are available for dashboards and monitors.
 
-Trace metric names are formatted as `trace.<SPAN_NAME>.<METRIC_SUFFIX>{<TAGS>}` or `trace.<SPAN_NAME>.<2ND_PRIM_TAG>{<TAGS>}`.
+Trace metric names are formatted as:
+
+- `trace.<SPAN_NAME>.<METRIC_SUFFIX>{<TAGS>}`
+- `trace.<SPAN_NAME>.<METRIC_SUFFIX>.<2ND_PRIM_TAG>_service{<TAGS>}`
 
 | Parameter               | Description                                                                                                                                                                                                        |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |


### PR DESCRIPTION
### What does this PR do?

This is a correction on https://github.com/DataDog/documentation/pull/7170/

Apdex metrics, and percentile metrics don't have the Agent tags attached.

### Motivation
Support feedback.

