### PR TITLE
Fix syntax error in help command

### DIFF
--- a/content/en/developers/guide/dogwrap.md
+++ b/content/en/developers/guide/dogwrap.md
@@ -31,7 +31,7 @@ With the following placeholders:
 * `<DATADOG_API_KEY>`: [The Datadog API key associated with your organization][2].
 * `<COMMAND>`: Command to wrap and generate events from. Enclose your called command in quotes to prevent Python from thinking the command line arguments belong to the Python command instead of the wrapped one.
 
-**Note**: Use the Dogwrap help command `dogwrap help` to discover all available options.
+**Note**: Use the Dogwrap help command `dogwrap --help` to discover all available options.
 
 For an example of `dogwrap` in action, consider `cron`. If you have a cron script to vacuum a Postgres table every day:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fixes syntax error in dogwrap help command

### Motivation
<!-- What inspired you to submit this pull request?-->
I tried using the command and it was very confusing, as it actually printed out bash's `help` command output

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/patch-1/content/en/developers/guide/dogwrap.md

### Additional Notes
<!-- Anything else we should know when reviewing?-->
