### PR TITLE
An additional step to uninstall MACOS agent

### DIFF
--- a/content/en/agent/faq/how-do-i-uninstall-the-agent.md
+++ b/content/en/agent/faq/how-do-i-uninstall-the-agent.md
@@ -133,6 +133,7 @@ This command removes the Agent, but does not remove:
 sudo rm -rf /opt/datadog-agent
 sudo rm -rf /usr/local/bin/datadog-agent
 sudo rm -rf ~/.datadog-agent/**​ #to remove broken symlinks
+launchctl remove com.datadoghq.agent
 ```
 
 Then, reboot your machine for changes to take effect.


### PR DESCRIPTION
#6719 # What does this PR do?
Adds an additional step to uninstall MACOS agent

### Motivation

Support card:  https://trello.com/c/jLUypTg2/260-residual-agent-logs-in-syslog-on-macos-after-agent-uninstall where the agent service is still getting launched after executing existing uninstall steps

Original doc: 
https://docs.datadoghq.com/agent/faq/how-do-i-uninstall-the-agent/?tab=agentv6v7#mac-os 
