### PR TITLE
Explain how to set errors when using manual instrumentation for .NET

### DIFF
--- a/content/en/tracing/manual_instrumentation/dotnet.md
+++ b/content/en/tracing/manual_instrumentation/dotnet.md
@@ -38,7 +38,7 @@ using(var scope = Tracer.Instance.StartActive("web.request"))
 
 ### Setting Errors
 
-To recognize and mark errors that occur in your code, you can utilize the SetException method that is available to spans. In addition to marking the span as error, this will add [span metadata related to the error][4] to provide insight into the exception.
+To recognize and mark errors that occur in your code, you can utilize the `Span.SetException(Exception)` method that is available to spans. In addition to marking the span as error, this will add [span metadata related to the error][4] to provide insight into the exception.
 
 ```csharp
 try

--- a/content/en/tracing/manual_instrumentation/dotnet.md
+++ b/content/en/tracing/manual_instrumentation/dotnet.md
@@ -35,6 +35,22 @@ using(var scope = Tracer.Instance.StartActive("web.request"))
 }
 ```
 
+
+### Setting Errors
+
+To recognize and mark errors that occur in your code, you can utilize the SetException method that is available to spans. In addition to marking the span as error, this will add [span metadata related to the error][4] to provide insight into the exception.
+
+```csharp
+try
+{
+    // do work that can throw an exception
+}
+catch(Exception e)
+{
+    span.SetException(e);
+}
+```
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -42,3 +58,4 @@ using(var scope = Tracer.Instance.StartActive("web.request"))
 [1]: /tracing/setup/dotnet/#integrations
 [2]: /tracing/visualization/#spans
 [3]: /tracing/visualization/#trace
+[4]: /tracing/visualization/trace/?tab=spantags#more-information

--- a/content/en/tracing/manual_instrumentation/dotnet.md
+++ b/content/en/tracing/manual_instrumentation/dotnet.md
@@ -38,7 +38,7 @@ using(var scope = Tracer.Instance.StartActive("web.request"))
 
 ### Setting Errors
 
-To recognize and mark errors that occur in your code, you can utilize the `Span.SetException(Exception)` method that is available to spans. In addition to marking the span as error, this will add [span metadata related to the error][4] to provide insight into the exception.
+To recognize and mark errors that occur in your code, utilize the `Span.SetException(Exception)` method available to spans. The method marks the span as an error and adds [related span metadata][4] to provide insight into the exception.
 
 ```csharp
 try


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Explain what to do about errors when manually instrumenting .NET code.

### Motivation
<!-- What inspired you to submit this pull request?-->
@lucaspimentel provided an example of how to set this with C# for .NET, so I'm adding a documentation note about it.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/wantsui/errors-dotnet-manual-instrumentation/tracing/manual_instrumentation/dotnet#setting-errors

### Additional Notes
<!-- Anything else we should know when reviewing?-->
