### PR TITLE
[PROD] make whitelist rules more obvious in getting started guide

### DIFF
--- a/content/en/getting_started/synthetics/private_location.md
+++ b/content/en/getting_started/synthetics/private_location.md
@@ -77,7 +77,7 @@ docker run --rm datadog/synthetics-private-location-worker --help and check
 ```
 
 <div class="alert alert-warning">
-Important Note: If you are using private locations to monitor endpoints exposed on <a href="https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml">special-purpose IP addresses</a> (e.g. 10.0.0.0/8, 192.0.0.0/24, etc.), you will need to whitelist them. <a href="https://docs.datadoghq.com/synthetics/private_locations/?tab=docker#special-purpose-ipv4-whitelisting">More information in our detailed Private Location docs here.</a>
+<b>Note</b>: If you are using private locations to monitor endpoints exposed on <a href="https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml">special-purpose IP addresses</a> such as 10.0.0.0/8, 192.0.0.0/24, etc., you will need to whitelist them. For more details, see the <a href="https://docs.datadoghq.com/synthetics/private_locations/?tab=docker#special-purpose-ipv4-whitelisting">Private Location</a> documentation.
 </div>
 
 {{< whatsnext desc="After you set up your private location:">}}

--- a/content/en/getting_started/synthetics/private_location.md
+++ b/content/en/getting_started/synthetics/private_location.md
@@ -76,6 +76,10 @@ For a more advanced setup, use the command and see `Learn more about Private Loc
 docker run --rm datadog/synthetics-private-location-worker --help and check
 ```
 
+<div class="alert alert-warning">
+Important Note: If you are using private locations to monitor endpoints exposed on <a href="https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml">special-purpose IP addresses</a> (e.g. 10.0.0.0/8, 192.0.0.0/24, etc.), you will need to whitelist them. <a href="https://docs.datadoghq.com/synthetics/private_locations/?tab=docker#special-purpose-ipv4-whitelisting">More information in our detailed Private Location docs here.</a>
+</div>
+
 {{< whatsnext desc="After you set up your private location:">}}
 {{< nextlink href="/getting_started/synthetics/api_test" tag="Documentation" >}}Create your first API test{{< /nextlink >}}
 {{< nextlink href="/synthetics/private_locations" tag="Documentation" >}}Learn more about Private Locations{{< /nextlink >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Most customers I've worked with are looking to use private locations are doing so on endpoints that fall within the "special-purpose" IP address space. 

This information is listed in our more-detailed private locations docs, but is more buried. 

This should make things more obvious in the getting started guide. 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
