### PR TITLE
Rollup link 404

### DIFF
--- a/content/en/dashboards/faq/why-does-zooming-out-a-timeframe-also-smooth-out-my-graphs.md
+++ b/content/en/dashboards/faq/why-does-zooming-out-a-timeframe-also-smooth-out-my-graphs.md
@@ -5,7 +5,7 @@ further_reading:
 - link: "/developers/metrics/types/"
   tag: "Documentation"
   text: "Discover Datadog metrics types"
-- link: "/functions/rollup/"
+- link: "dashboards/functions/rollup/"
   tag: "Documentation"
   text: "Learn more about the rollup function"
 aliases:


### PR DESCRIPTION
### What does this PR do?
Adds /dashboards/ to rollup further reading link

### Motivation
It's giving me a 404, so I'm giving it some love.

### Preview link
https://docs-staging.datadoghq.com/sarina/rollup-404/dashboards/faq/why-does-zooming-out-a-timeframe-also-smooth-out-my-graphs

### Additional Notes
That long preview url... 👀