### PR TITLE
Many service checks were deprecated.

### DIFF
--- a/content/en/agent/kubernetes/data_collected.md
+++ b/content/en/agent/kubernetes/data_collected.md
@@ -97,7 +97,7 @@ The Kubernetes check includes the following service checks:
 - `kubernetes_state.node.ready`:<br>
     Returns `CRITICAL` if a cluster node is not ready. Returns `OK` otherwise.
 
-- `kubernetes_state.node.out_of_disk`:<br>
+- `kubernetes_state.node.out_of_disk`:<br> 
     Returns `CRITICAL` if a cluster node is out of disk space. Returns `OK` otherwise.
 
 - `kubernetes_state.node.disk_pressure`:<br>


### PR DESCRIPTION
kubernetes_state.node.out_of_disk and other service checks were deprecated.
See here: deprecated in KSM 1.0.0: https://github.com/kubernetes/kube-state-metrics/blob/d2f5128e2741623f273ebb2193637a085a9e6941/CHANGELOG.md#v100-rc1--2017-08-02.
They were replaced by the **metric** kubernetes_state.nodes.by_condition. 

This article needs to be revamped, but I'm not an expert on the technical details unfortunately.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
