### PR TITLE
[DOCS-844] Hard coding Agent docker conf file

### DIFF
--- a/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
+++ b/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
@@ -68,7 +68,7 @@ RUN ddev -e release build <INTEGRATION_NAME>
 
 FROM datadog/agent:latest
 COPY --from=wheel_builder /wheels/integrations-extras/<INTEGRATION_NAME>/dist/ /dist
-RUN agent integration install -r -w /dist/*.whl
+RUN agent -c /etc/datadog-agent/datadog-docker.yaml integration install -r -w /dist/*.whl
 ```
 
 Then use this new Agent image in combination with [Autodiscovery][1] in order to enable the `<INTEGRATION_NAME>` check.


### PR DESCRIPTION
### What does this PR do?

After investigating it seems that we should pass the Docker agent configuration file path when running the command, otherwise the command tries to use the "classic" `datadog.yaml` file that doesn't exist with the container Agent until the container has started:

https://github.com/DataDog/datadog-agent/blob/fc7b205536a8f5fa16d814ed934ad76dfe4816e8/Dockerfiles/agent/entrypoint/51-docker.sh#L17

### Motivation
Support feedback

### Preview link

* https://docs-staging.datadoghq.com/gus/docker-int-extras/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker