### PR TITLE
update go documentation on manual log injection for tracer

### DIFF
--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -286,7 +286,7 @@ When configuring your traces for unified service tagging:
 
 If you're using [connected logs and traces][1], enable automatic logs injection if supported for your APM Tracer. The APM Tracer will then automatically inject `env`, `service`, and `version` into your logs, thereby eliminating manual configuration for those fields elsewhere.
 
-**Note**: The Java, PHP, and Go Tracer do not currently support configuration of unified service tagging for logs.
+**Note**: The Java and PHP Tracers do not currently support configuration of unified service tagging for logs.
 
 [1]: /tracing/connect_logs_and_traces/
 {{% /tab %}}

--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -286,7 +286,7 @@ When configuring your traces for unified service tagging:
 
 If you're using [connected logs and traces][1], enable automatic logs injection if supported for your APM Tracer. The APM Tracer will then automatically inject `env`, `service`, and `version` into your logs, thereby eliminating manual configuration for those fields elsewhere.
 
-**Note**: The Java and PHP Tracers do not currently support configuration of unified service tagging for logs.
+**Note**: The Java and PHP Tracers do not support configuration of unified service tagging for logs.
 
 [1]: /tracing/connect_logs_and_traces/
 {{% /tab %}}

--- a/content/en/tracing/connect_logs_and_traces/_index.md
+++ b/content/en/tracing/connect_logs_and_traces/_index.md
@@ -12,7 +12,7 @@ The correlation between Datadog APM and Datadog Log Management is improved by th
 
 It is recommended to configure your application's tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This will provide the best experience for adding `env`, `service`, and `version`. See the [unified service tagging][2] documentation for more details.
 
-**Note**: The Java and PHP Tracers do not currently support configuration of unified service tagging for logs.
+**Note**: The Java and PHP Tracers do not support configuration of unified service tagging for logs.
 
 Before correlating traces with logs, ensure your logs are either sent as JSON, or [parsed by the proper language level log processor][3]. Your language level logs _must_ be turned into Datadog attributes in order for traces and logs correlation to work.
 

--- a/content/en/tracing/connect_logs_and_traces/_index.md
+++ b/content/en/tracing/connect_logs_and_traces/_index.md
@@ -12,7 +12,7 @@ The correlation between Datadog APM and Datadog Log Management is improved by th
 
 It is recommended to configure your application's tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This will provide the best experience for adding `env`, `service`, and `version`. See the [unified service tagging][2] documentation for more details.
 
-**Note**: The Java, PHP and Go Tracer do not currently support configuration of unified service tagging for logs.
+**Note**: The Java and PHP Tracers do not currently support configuration of unified service tagging for logs.
 
 Before correlating traces with logs, ensure your logs are either sent as JSON, or [parsed by the proper language level log processor][3]. Your language level logs _must_ be turned into Datadog attributes in order for traces and logs correlation to work.
 

--- a/content/en/tracing/connect_logs_and_traces/go.md
+++ b/content/en/tracing/connect_logs_and_traces/go.md
@@ -23,7 +23,7 @@ Coming Soon. Reach out to [the Datadog support team][1] to learn more.
 
 ## Manually Inject Trace and Span IDs
 
-The Go tracer API allows printing span information along with log statements by using the exposed [Span.Log()][2] function:
+The Go tracer API allows printing span information along with log statements using the `%v` format specifier:
 
 ```go
 package main
@@ -40,13 +40,13 @@ func handler(w http.ResponseWriter, r *http.Request) {
     defer span.Finish()
 
     // Append span info to log messages:
-    log.Printf("my log message %s", span.Log())
+    log.Printf("my log message %v", span)
 }
 ```
 
 The above example illustrates how to use the span's context in the standard library's `log` package. Similar logic may be applied to 3rd party packages too.
 
-**Note**: If you are not using a [Datadog Log Integration][3] to parse your logs, custom log parsing rules need to ensure that `dd.trace_id`, `dd.span_id`, 'dd.service', 'dd.env' and 'dd.version' are being parsed as strings. More information can be found in the [FAQ on this topic][4].
+**Note**: If you are not using a [Datadog Log Integration][2] to parse your logs, custom log parsing rules need to ensure that `dd.trace_id`, `dd.span_id`, 'dd.service', 'dd.env' and 'dd.version' are being parsed as strings. More information can be found in the [FAQ on this topic][3].
 
 ## Further Reading
 
@@ -54,6 +54,5 @@ The above example illustrates how to use the span's context in the standard libr
 
 
 [1]: /help
-[2]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace#Span
-[3]: /logs/log_collection/go/#configure-your-logger
-[4]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/?tab=custom
+[2]: /logs/log_collection/go/#configure-your-logger
+[3]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/?tab=custom

--- a/content/en/tracing/connect_logs_and_traces/go.md
+++ b/content/en/tracing/connect_logs_and_traces/go.md
@@ -23,7 +23,7 @@ Coming Soon. Reach out to [the Datadog support team][1] to learn more.
 
 ## Manually Inject Trace and Span IDs
 
-The Go tracer exposes two API calls to allow printing [trace][2] and [span][3] identifiers along with log statements using exported methods from `SpanContext` type:
+The Go tracer API allows printing span information along with log statements by using the exposed [Span.Log()][2] function:
 
 ```go
 package main
@@ -39,25 +39,21 @@ func handler(w http.ResponseWriter, r *http.Request) {
     span := tracer.StartSpan("web.request", tracer.ResourceName("/posts"))
     defer span.Finish()
 
-    // Retrieve Trace ID and Span ID
-    traceID := span.Context().TraceID()
-    spanID := span.Context().SpanID()
-
-    // Append them to log messages as fields:
-    log.Printf("my log message dd.trace_id=%d dd.span_id=%d", traceID, spanID)
+    // Append span info to log messages:
+    log.Printf("my log message %s", span.Log())
 }
 ```
 
 The above example illustrates how to use the span's context in the standard library's `log` package. Similar logic may be applied to 3rd party packages too.
 
-**Note**: If you are not using a [Datadog Log Integration][4] to parse your logs, custom log parsing rules need to ensure that `dd.trace_id` and `dd.span_id` are being parsed as strings. More information can be found in the [FAQ on this topic][5].
+**Note**: If you are not using a [Datadog Log Integration][3] to parse your logs, custom log parsing rules need to ensure that `dd.trace_id`, `dd.span_id`, 'dd.service', 'dd.env' and 'dd.version' are being parsed as strings. More information can be found in the [FAQ on this topic][4].
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /help/
-[2]: /tracing/visualization/#trace
-[3]: /tracing/visualization/#spans
-[4]: /logs/log_collection/go/#configure-your-logger
-[5]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/?tab=custom
+
+[1]: /help
+[2]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace#Span
+[3]: /logs/log_collection/go/#configure-your-logger
+[4]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/?tab=custom

--- a/content/en/tracing/connect_logs_and_traces/go.md
+++ b/content/en/tracing/connect_logs_and_traces/go.md
@@ -17,10 +17,6 @@ further_reading:
       text: 'Correlate request logs with traces automatically'
 ---
 
-## Automatically Inject Trace and Span IDs
-
-Coming Soon. Reach out to [the Datadog support team][1] to learn more.
-
 ## Manually Inject Trace and Span IDs
 
 The Go tracer API allows printing span information along with log statements using the `%v` format specifier:
@@ -46,13 +42,12 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 The above example illustrates how to use the span's context in the standard library's `log` package. Similar logic may be applied to 3rd party packages too.
 
-**Note**: If you are not using a [Datadog Log Integration][2] to parse your logs, custom log parsing rules need to ensure that `dd.trace_id`, `dd.span_id`, 'dd.service', 'dd.env' and 'dd.version' are being parsed as strings. More information can be found in the [FAQ on this topic][3].
+**Note**: If you are not using a [Datadog Log Integration][1] to parse your logs, custom log parsing rules need to ensure that `dd.trace_id`, `dd.span_id`, 'dd.service', 'dd.env' and 'dd.version' are being parsed as strings. More information can be found in the [FAQ on this topic][2].
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 
-[1]: /help
-[2]: /logs/log_collection/go/#configure-your-logger
-[3]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/?tab=custom
+[1]: /logs/log_collection/go/#configure-your-logger
+[2]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/?tab=custom


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
In the next tracer version, we will change the way we support manual log injection. This updates the documentation to reflect that change.

### Motivation
Please see https://github.com/DataDog/dd-trace-go/pull/639

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/knusbaum/update-go-tracer-logging/tracing/connect_logs_and_traces/go

