### PR TITLE
[RUM] add proxy faq page

### DIFF
--- a/content/en/real_user_monitoring/faq/content_security_policy.md
+++ b/content/en/real_user_monitoring/faq/content_security_policy.md
@@ -3,10 +3,10 @@ title: Content Security Policy (CSP)
 kind: faq
 further_reading:
     - link: '/real_user_monitoring/installation/'
-      tag: 'FAQ'
-      text: 'How to Send Logs to Datadog via External Log Shippers?'
+      tag: 'Get Started'
+      text: 'Real User Monitoring'
     - link: '/logs/log_collection/javascript/'
-      tag: 'FAQ'
+      tag: 'Get Started'
       text: 'Browser Log Collection'
 ---
 

--- a/content/en/real_user_monitoring/faq/proxy_rum_data.md
+++ b/content/en/real_user_monitoring/faq/proxy_rum_data.md
@@ -7,7 +7,7 @@ further_reading:
       text: 'Real User Monitoring'
 ---
 
-The RUM SDK can be configured to send requests through a proxy. Requests made still need to be forwarded to Datadog.
+The Real User Monitoring (RUM) SDK can be configured to send requests through a proxy. Requests made still need to be forwarded to Datadog.
 
 ## SDK initialization
 

--- a/content/en/real_user_monitoring/faq/proxy_rum_data.md
+++ b/content/en/real_user_monitoring/faq/proxy_rum_data.md
@@ -1,0 +1,61 @@
+---
+title: Proxy RUM data
+kind: faq
+further_reading:
+    - link: '/real_user_monitoring/installation/'
+      tag: 'Get Started'
+      text: 'Real User Monitoring'
+---
+
+The RUM SDK can be configured to send requests through a proxy. Requests made still need to be forwarded to Datadog.
+
+## SDK initialization
+
+When you set the `proxyHost` [initialization parameter][1], all RUM data is sent to the specified host URL.
+
+{{< tabs >}}
+{{% tab "NPM" %}}
+
+```javascript
+import { datadogRum } from '@datadog/browser-rum';
+
+datadogRum.init({
+    applicationId: '<DATADOG_APPLICATION_ID>',
+    clientToken: '<DATADOG_CLIENT_TOKEN>',
+    datacenter: 'us',
+    proxyHost: '<YOUR_PROXY_URL>',
+});
+```
+
+{{% /tab %}}
+{{% tab "Bundle" %}}
+
+```javascript
+window.DD_RUM &&
+    window.DD_RUM.init({
+        clientToken: '<CLIENT_TOKEN>',
+        applicationId: '<APPLICATION_ID>',
+        proxyHost: '<YOUR_PROXY_URL>',
+    });
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## Proxy setup
+
+When your proxy receives data from the RUM SDK, it must be forwarded to Datadog. The RUM SDK adds the `ddhost` query parameter to all requests to your proxy. This query parameter contains the host URL all data must be forwarded to.
+
+To successfully proxy request to Datadog:
+
+1. Add a `X-Forwarded-For` header containing the request client IP address, for accurate geoIP.
+2. Replace the host in the incoming requests by the host contained in the `ddhost` query parameter.
+3. Remove the `ddhost` query parameter.
+
+**Note:** The request body must remain unchanged.
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /real_user_monitoring/installation/?tab=us#initialization-parameters

--- a/content/en/real_user_monitoring/faq/proxy_rum_data.md
+++ b/content/en/real_user_monitoring/faq/proxy_rum_data.md
@@ -1,5 +1,5 @@
 ---
-title: Proxy RUM data
+title: Proxy Real User Monitoring Data
 kind: faq
 further_reading:
     - link: '/real_user_monitoring/installation/'

--- a/content/en/real_user_monitoring/installation/_index.md
+++ b/content/en/real_user_monitoring/installation/_index.md
@@ -107,14 +107,15 @@ Paste the generated code snippet into the head tag (in front of any other script
 
 ## Initialization parameters
 
-| Parameter            | Type    | Required | Default                           | Description                                                                                                  |
-| -------------------- | ------- | -------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `applicationId`      | String  | Yes      | `` | The RUM application ID.      |
-| `clientToken`        | String  | Yes      | `` | A [Datadog Client Token][5]. |
-| `datacenter`         | String  | Yes      | `us`                              | The Datadog Site of your organization. `us` for Datadog US site, `eu` for Datadog EU site.                   |
-| `resourceSampleRate` | Number  | No       | `100`                             | Percentage of tracked sessions with resources collection. `100` for all, `0` for none of them.               |
-| `sampleRate`         | Number  | No       | `100`                             | Percentage of sessions to track. Only tracked sessions send rum events. `100` for all, `0` for none of them. |
-| `silentMultipleInit` | Boolean | No       | `false`                           | Initialization fails silently if Datadog's RUM is already initialized on the page                            |
+| Parameter            | Type    | Required | Default                                                                            | Description                                                                                                  |
+| -------------------- | ------- | -------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `applicationId`      | String  | Yes      | `` | The RUM application ID.                                                       |
+| `clientToken`        | String  | Yes      | `` | A [Datadog Client Token][5].                                                  |
+| `datacenter`         | String  | Yes      | `us`                                                                               | The Datadog Site of your organization. `us` for Datadog US site, `eu` for Datadog EU site.                   |
+| `resourceSampleRate` | Number  | No       | `100`                                                                              | Percentage of tracked sessions with resources collection. `100` for all, `0` for none of them.               |
+| `sampleRate`         | Number  | No       | `100`                                                                              | Percentage of sessions to track. Only tracked sessions send rum events. `100` for all, `0` for none of them. |
+| `silentMultipleInit` | Boolean | No       | `false`                                                                            | Initialization fails silently if Datadog's RUM is already initialized on the page                            |
+| `proxyHost`          | String  | No       | `` | Optional proxy URL. See the full [proxy setup guide][6] for more information. |
 
 ## Further Reading
 
@@ -125,3 +126,4 @@ Paste the generated code snippet into the head tag (in front of any other script
 [3]: /real_user_monitoring/dashboards
 [4]: https://www.npmjs.com/package/@datadog/browser-rum
 [5]: /account_management/api-app-keys/#client-tokens
+[6]: /real_user_monitoring/faq/proxy_rum_data


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
* Create a FAQ page explaining how to proxy RUM data
* Add the `proxyHost` init parameter on RUM Get Started page

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hdelaby/add-proxy/real_user_monitoring/installation/?tab=us#initialization-parameters
https://docs-staging.datadoghq.com/hdelaby/add-proxy/real_user_monitoring/faq/proxy_rum_data

### Additional Notes
<!-- Anything else we should know when reviewing?-->
This is based on some internal document provided by the dev team: https://docs.google.com/document/d/1srf5sUD2aTp78215oyyOOHxHwf6luEng3v8hgOFU1VM/edit#

Should we add more context, more examples? Happy to rework this