### PR TITLE
Refer to APM doc to "connect Logs and Traces" for all languages

### DIFF
--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -239,6 +239,10 @@ If, despite the benefits of logging in JSON, you wish to log in raw string forma
 {{% /tab %}}
 {{< /tabs >}}
 
+**Connect Logs and Traces**
+
+If APM is enabled for this application, the correlation between application logs and traces can be improved by [following these instructions][2] to add trace and span ids in your logs.
+
 ## Configure your Datadog Agent
 
 Create a `csharp.d/conf.yaml` file in your `conf.d/` folder with the following content:
@@ -319,3 +323,4 @@ New logs are now directly sent to Datadog.
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /logs/processing/parsing
+[2]: /tracing/connect_logs_and_traces/dotnet

--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -241,7 +241,8 @@ If, despite the benefits of logging in JSON, you wish to log in raw string forma
 
 **Connect Logs and Traces**
 
-If APM is enabled for this application, the correlation between application logs and traces can be improved by [following these instructions][2] to add trace and span ids in your logs.
+If APM is enabled for this application, the correlation between application logs and traces can be improved by [following APM .NET logging instructions][] to add trace and span IDs in your logs.
+
 
 ## Configure your Datadog Agent
 

--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -241,7 +241,7 @@ If, despite the benefits of logging in JSON, you wish to log in raw string forma
 
 **Connect Logs and Traces**
 
-If APM is enabled for this application, the correlation between application logs and traces can be improved by [following APM .NET logging instructions][] to add trace and span IDs in your logs.
+If APM is enabled for this application, the correlation between application logs and traces can be improved by [following APM .NET logging instructions][2] to add trace and span IDs in your logs.
 
 ## Configure your Datadog Agent
 

--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -243,7 +243,6 @@ If, despite the benefits of logging in JSON, you wish to log in raw string forma
 
 If APM is enabled for this application, the correlation between application logs and traces can be improved by [following APM .NET logging instructions][] to add trace and span IDs in your logs.
 
-
 ## Configure your Datadog Agent
 
 Create a `csharp.d/conf.yaml` file in your `conf.d/` folder with the following content:

--- a/content/en/logs/log_collection/go.md
+++ b/content/en/logs/log_collection/go.md
@@ -78,7 +78,7 @@ func main() {
 }
 ```
 
-**Inject trace IDs in your logs**
+**Connect Logs and Traces**
 
 If APM is enabled for this application, the correlation between application logs and traces can be improved by [following APM Go logging instructions][3] to automatically add trace and span IDs in your logs.
 

--- a/content/en/logs/log_collection/go.md
+++ b/content/en/logs/log_collection/go.md
@@ -78,6 +78,10 @@ func main() {
 }
 ```
 
+**Inject trace IDs in your logs**
+
+If APM is enabled for this application, the correlation between application logs and traces can be improved by [following these instructions][3] to automatically add trace and span id in your logs.
+
 ## Configure your Datadog Agent
 
 Create a `go.d/conf.yaml` file in your `conf.d/` folder with the following content:
@@ -108,3 +112,4 @@ Here are some little advices:
 
 [1]: https://github.com/sirupsen/logrus
 [2]: /logs/processing/parsing
+[3]: /tracing/connect_logs_and_traces/go

--- a/content/en/logs/log_collection/go.md
+++ b/content/en/logs/log_collection/go.md
@@ -80,7 +80,7 @@ func main() {
 
 **Inject trace IDs in your logs**
 
-If APM is enabled for this application, the correlation between application logs and traces can be improved by [following these instructions][3] to automatically add trace and span id in your logs.
+If APM is enabled for this application, the correlation between application logs and traces can be improved by [following APM Go logging instructions][3] to automatically add trace and span IDs in your logs.
 
 ## Configure your Datadog Agent
 

--- a/content/en/logs/log_collection/nodejs.md
+++ b/content/en/logs/log_collection/nodejs.md
@@ -21,7 +21,8 @@ further_reading:
   text: "Log Collection Troubleshooting Guide"
 ---
 
-## Overview
+
+## Configure your logger
 
 Using [Winston][1] to log from your NodeJS application gets you all the features you need to build up your logging strategy.
 
@@ -45,10 +46,6 @@ npm install --save winston
   }
 }
 ```
-
-## Setup
-
-**Inject trace IDs in your logs**:  If APM is enabled for this application and you wish to improve the correlation between application logs and traces, [follow APM NodeJS logging instructions][3] to automatically add trace and span IDs in your logs.
 
 ### Log to file
 
@@ -108,6 +105,9 @@ Check the content of the `<FILE_NAME>.log` file to see that Winston already took
 {"level":"info","message":"Hello simple log!","timestamp":"2015-04-23T16:52:05.337Z"}
 {"color":"blue","level":"info","message":"Hello log with metas","timestamp":"2015-04-23T16:52:05.339Z"}
 ```
+
+**Connect Logs and Traces**
+If APM is enabled for this application, the correlation between application logs and traces can be improved by [following APM NodeJS logging instructions][3] to automatically add trace and span IDs in your logs.
 
 ## Configure your Datadog Agent
 

--- a/content/en/logs/log_collection/php.md
+++ b/content/en/logs/log_collection/php.md
@@ -178,6 +178,10 @@ Configure the formatter in your Monolog configuration: declare the formatter fie
 {{% /tab %}}
 {{< /tabs >}}
 
+**Connect Logs and Traces**
+
+If APM is enabled for this application, the correlation between application logs and traces can be improved by [following APM PHP logging instructions][8] to automatically add trace and span IDs in your logs.
+
 ### Agent Configuration
 
 Create a `php.d/conf.yaml` file in your `conf.d/` folder with the following content:
@@ -542,3 +546,4 @@ CakeLog::config('debug', array(
 [5]: /logs/log_collection/php/#silex
 [6]: /logs/log_collection/php/#lumen
 [7]: /logs/log_collection/php/#cakephp
+[8]: /tracing/connect_logs_and_traces/php

--- a/content/en/logs/log_collection/python.md
+++ b/content/en/logs/log_collection/python.md
@@ -25,7 +25,7 @@ further_reading:
 
 Use your favorite Python logger to log into a file on your host. Then monitor the file with the Datadog Agent to send your logs to Datadog.
 
-## Setup
+## Configure your logger
 
 Python logs are quite complex to handle, mainly because of tracebacks. They are split into multiple lines which make them difficult to associate with the original log event.
 To address this use case it is strongly recommended to use a JSON formatter when logging in order to:
@@ -38,9 +38,9 @@ Here are setup examples for the following logging libraries:
 * [JSON-log-formatter][1]
 * [Python-json-logger][2]
 
-### Inject trace IDs in your logs
+**Connect Logs and Traces**
 
-If APM is enabled for this application, improve the [correlation between application logs and traces][3] to automatically add trace and span IDs to your logs.
+If APM is enabled for this application, the correlation between application logs and traces can be improved by [following following APM Python logging instructions][3] to add trace and span IDs to your logs.
 
 Once this is done, the log should have the following format:
 

--- a/content/en/logs/log_collection/ruby.md
+++ b/content/en/logs/log_collection/ruby.md
@@ -107,9 +107,9 @@ This section describe the minimum setup required in order to forward your Rails 
 
 ## Getting further
 
-### Inject trace IDs in your logs
+### Connect Logs and Traces
 
-If APM is enabled for this application and you wish to improve the correlation between application logs and traces, [follow these instructions][7] to automatically add trace and span ids in your logs.
+If APM is enabled for this application, the correlation between application logs and traces can be improved by [following APM Ruby logging instructions][3] to automatically add trace and span IDs in your logs.
 
 Then [configure the Datadog Agent](#configure-your-datadog-agent) to collect ruby logs from the file.
 

--- a/content/en/logs/log_collection/ruby.md
+++ b/content/en/logs/log_collection/ruby.md
@@ -109,7 +109,7 @@ This section describe the minimum setup required in order to forward your Rails 
 
 ### Connect Logs and Traces
 
-If APM is enabled for this application, the correlation between application logs and traces can be improved by [following APM Ruby logging instructions][3] to automatically add trace and span IDs in your logs.
+If APM is enabled for this application, the correlation between application logs and traces can be improved by [following APM Ruby logging instructions][7] to automatically add trace and span IDs in your logs.
 
 Then [configure the Datadog Agent](#configure-your-datadog-agent) to collect ruby logs from the file.
 


### PR DESCRIPTION
### What does this PR do?

Unify and add a reference to APM documentation for each language specific integration.

### Motivation

Some reference were missing, then I realised that our documentation is not very consistent depending on the language.
I might do a new PR have a more templatized doc for language integrations.

### Preview link

https://docs-staging.datadoghq.com/pvr/refer-to-apm-doc-in-logs/logs/log_collection/csharp
https://docs-staging.datadoghq.com/pvr/refer-to-apm-doc-in-logs/logs/log_collection/python
https://docs-staging.datadoghq.com/pvr/refer-to-apm-doc-in-logs/logs/log_collection/java
https://docs-staging.datadoghq.com/pvr/refer-to-apm-doc-in-logs/logs/log_collection/ruby
https://docs-staging.datadoghq.com/pvr/refer-to-apm-doc-in-logs/logs/log_collection/nodejs
https://docs-staging.datadoghq.com/pvr/refer-to-apm-doc-in-logs/logs/log_collection/php
https://docs-staging.datadoghq.com/pvr/refer-to-apm-doc-in-logs/logs/log_collection/go

### Additional Notes
<!-- Anything else we should know when reviewing?-->
