### PR TITLE
Configure Datadog sink using appsettings.json

### DIFF
--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -312,6 +312,33 @@ var log = new LoggerConfiguration()
 
 New logs are now directly sent to Datadog.
 
+Alternately, since `0.2.0`, you can configure the Datadog sink by using an `appsettings.json` file with the `Serilog.Setting.Configuration` package.
+
+In the "Serilog.WriteTo" array, add an entry for DatadogLogs. An example is shown below:
+
+```
+"Serilog": {
+  "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.Datadog.Logs" ],
+  "MinimumLevel": "Debug",
+  "WriteTo": [
+    { "Name": "Console" },
+    {
+      "Name": "DatadogLogs",
+      "Args": {
+        "apiKey": "<API_KEY>",
+        "source": "<SOURCE_NAME>",
+        "host": "<HOST_NAME>",
+        "tags": ["<TAG_1>:<VALUE_1>", "<TAG_2>:<VALUE_2>"],
+      }
+    }
+  ],
+  "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ],
+  "Properties": {
+    "Application": "Sample"
+  }
+}
+```
+
 [1]: https://www.nuget.org/packages/Serilog.Sinks.Datadog.Logs
 [2]: https://app.datadoghq.com/account/settings#api
 [3]: /logs/#reserved-attributes

--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -316,7 +316,7 @@ Alternately, since `0.2.0`, you can configure the Datadog sink by using an `apps
 
 In the "Serilog.WriteTo" array, add an entry for DatadogLogs. An example is shown below:
 
-```
+```json
 "Serilog": {
   "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.Datadog.Logs" ],
   "MinimumLevel": "Debug",

--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -314,7 +314,7 @@ New logs are now directly sent to Datadog.
 
 Alternately, since `0.2.0`, you can configure the Datadog sink by using an `appsettings.json` file with the `Serilog.Setting.Configuration` package.
 
-In the "Serilog.WriteTo" array, add an entry for DatadogLogs. An example is shown below:
+In the `Serilog.WriteTo` array, add an entry for `DatadogLogs`. An example is shown below:
 
 ```json
 "Serilog": {


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Configure Datadog sink using appsettings.json
Reference: https://github.com/DataDog/serilog-sinks-datadog-logs#configuration-from-appsettingsjson

### Motivation
<!-- What inspired you to submit this pull request?-->
Some users/customers use the `appsettings.json` file in order to configure their `C#` applications. This PR will make their life easier.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/koreissm-configure-datadog-sink-using-appsettings-file/logs/log_collection/csharp

### Additional Notes
<!-- Anything else we should know when reviewing?-->
