### PR TITLE
tracing/setup/go: update minimum go version to 1.12

### DIFF
--- a/content/en/tracing/setup/go.md
+++ b/content/en/tracing/setup/go.md
@@ -50,7 +50,7 @@ Datadog has a series of pluggable packages which provide out-of-the-box support 
 To begin tracing your Go applications, your environment must first meet the following requirements:
 
 * Running the Datadog Agent `>= 5.21.1`.
-* Using Go `1.9+`
+* Using Go `1.12+`
 
 ### Integrations
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This corrects the documented minimum supported go language version from 1.9 to 1.12.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/knusbaum/update-go-version/tracing/setup/go/#compatibility
