### PR TITLE
docs(helm v2): mv rbac.create agents.rbac.create

### DIFF
--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -184,7 +184,7 @@ To install the Datadog Agent on your Kubernetes cluster:
 {{< tabs >}}
 {{% tab "Helm" %}}
 
-Set the `datadog.leaderElection`, `datadog.collectEvents` and `rbac.create` options to `true` in your `value.yaml` file order to enable Kubernetes event collection.
+Set the `datadog.leaderElection`, `datadog.collectEvents` and `agents.rbac.create` options to `true` in your `value.yaml` file order to enable Kubernetes event collection.
 
 {{% /tab %}}
 {{% tab "DaemonSet" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Updates the `rbac.create` option to be `agents.rbac.create` which is documented on https://github.com/helm/charts/blob/master/stable/datadog/docs/Migration_1.x_to_2.x.md.

<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

Confusion when looking at the mix of documentation that references v1 and v2 options for the helm chart.
