### PR TITLE
clarify path needs to exist

### DIFF
--- a/content/en/developers/dogstatsd/unix_socket.md
+++ b/content/en/developers/dogstatsd/unix_socket.md
@@ -44,7 +44,7 @@ To enable the Agent DogStatsD UDS:
     ```yaml
     ## @param dogstatsd_socket - string - optional - default: ""
     ## Listen for Dogstatsd metrics on a Unix Socket (*nix only).
-    ## Set to a valid filesystem path to enable.
+    ## Set to a valid and existing filesystem path to enable.
     #
     dogstatsd_socket: '/var/run/datadog/dsd.socket'
     ```


### PR DESCRIPTION
### What does this PR do?
Clarifies that a path need to be "valid" and existing (manually created if not) prior to enabling Dogstatsd socket.

### Motivation
- 2860-k8s-uds-setup-issue
- 2036-dogstatsd-cant-bind-to-a-unix-socket-when-running-as-a-service

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
