### PR TITLE
[DOCS-850] Removing outdated SC

### DIFF
--- a/content/en/agent/kubernetes/data_collected.md
+++ b/content/en/agent/kubernetes/data_collected.md
@@ -97,9 +97,6 @@ The Kubernetes check includes the following service checks:
 - `kubernetes_state.node.ready`:<br>
     Returns `CRITICAL` if a cluster node is not ready. Returns `OK` otherwise.
 
-- `kubernetes_state.node.out_of_disk`:<br>
-    Returns `CRITICAL` if a cluster node is out of disk space. Returns `OK` otherwise.
-
 - `kubernetes_state.node.disk_pressure`:<br>
     Returns `CRITICAL` if a cluster node is in a disk pressure state. Returns `OK` otherwise.
 


### PR DESCRIPTION
### What does this PR do?

kubernetes_state.node.out_of_disk and other service checks were deprecated.
See here: deprecated in KSM 1.0.0: [CHANGELOG.md#v100-rc1--2017-08-02](https://github.com/kubernetes/kube-state-metrics/blob/d2f5128e2741623f273ebb2193637a085a9e6941/CHANGELOG.md#v100-rc1--2017-08-02).
They were replaced by the metric kubernetes_state.nodes.by_condition.