### PR TITLE
Must prefix dd_url value with "https://"

### DIFF
--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -85,7 +85,7 @@ To forward your metrics to Datadog using this new VPC endpoint, configure `pvtli
 1. Update the `dd_url` parameter in the [Agent `datadog.yaml` configuration file][1]:
 
     ```yaml
-    dd_url: pvtlink.agent.datadoghq.com
+    dd_url: https://pvtlink.agent.datadoghq.com
     ```
 
 2. [Restart your Agent][2] to send metrics to Datadog through AWS PrivateLink.


### PR DESCRIPTION
We discovered that overidding the `dd_url` (or subseqhent `DD_DD_URL`) values, they wouldn't work when the value was not prefixed with `https://`. The example datadog.yaml file in agent version 7.17.0 also contains it:

```sh
/etc/datadog-agent/datadog.yaml.example:## @param dd_url - string - optional - default: https://app.datadoghq.com
```

### What does this PR do?
This PR fixes the `dd_url` example for agent communication to PrivateLink.

### Motivation
When we utilized the example value of `dd_url: pvtlink.agent.datadoghq.com`, none of our metrics were being sent to datadog. Once we changed the value to `dd_url: https://pvtlink.agent.datadoghq.com`, our metrics started showing up again.

### Preview link
Existing page preview is [here](https://docs-staging.datadoghq.com/kr3cj:patch-1/documentation/content/en/agent/guide/private-link.md) but wasn't sure as this is my first PR and it didn't work.

