### PR TITLE
Add Security Monitoring API Documentation

### DIFF
--- a/content/en/api/usage/code_snippets/api-billing-usage-analyzed-logs.py
+++ b/content/en/api/usage/code_snippets/api-billing-usage-analyzed-logs.py
@@ -1,0 +1,2 @@
+# This is not yet supported by the Python Client for Datadog API
+# Consult the curl example

--- a/content/en/api/usage/code_snippets/api-billing-usage-analyzed-logs.rb
+++ b/content/en/api/usage/code_snippets/api-billing-usage-analyzed-logs.rb
@@ -1,0 +1,12 @@
+require 'rubygems'
+require 'dogapi'
+
+api_key = '<DATADOG_API_KEY>'
+app_key = '<DATADOG_APPLICATION_KEY>'
+
+dog = Dogapi::Client.new(api_key, app_key)
+
+start_date= '2019-10-07T00'
+end_date='2019-10-07T02'
+
+dog.get_analyzed_logs_usage(start_date, end_date)

--- a/content/en/api/usage/code_snippets/api-billing-usage-analyzed-logs.sh
+++ b/content/en/api/usage/code_snippets/api-billing-usage-analyzed-logs.sh
@@ -1,0 +1,10 @@
+api_key="<DATADOG_API_KEY>"
+app_key="<DATADOG_APPLICATION_KEY>"
+
+start_hr=$(date -v -10d +%Y-%m-%dT%H)
+end_hr=$(date +%Y-%m-%dT%H)
+
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/usage/analyzed_logs?&start_hr=${start_hr}&end_hr=${end_hr}"

--- a/content/en/api/usage/code_snippets/result.api-billing-usage-analyzed-logs.py
+++ b/content/en/api/usage/code_snippets/result.api-billing-usage-analyzed-logs.py
@@ -1,0 +1,2 @@
+# This is not yet supported by the Python Client for Datadog API
+# Consult the curl example

--- a/content/en/api/usage/code_snippets/result.api-billing-usage-analyzed-logs.rb
+++ b/content/en/api/usage/code_snippets/result.api-billing-usage-analyzed-logs.rb
@@ -1,0 +1,9 @@
+{
+  "usage" => [{
+    "analyzed_logs" => 3,
+    "hour" => "2019-10-07T00"
+  }, {
+    "analyzed_logs" => 2,
+    "hour" => "2019-10-07T01"
+  }]
+}

--- a/content/en/api/usage/code_snippets/result.api-billing-usage-analyzed-logs.sh
+++ b/content/en/api/usage/code_snippets/result.api-billing-usage-analyzed-logs.sh
@@ -1,0 +1,12 @@
+{
+  "usage": [
+    {
+      "analyzed_logs": 2,
+      "hour": "2019-04-01T14"
+    },
+    {
+      "analyzed_logs": 4,
+      "hour": "2019-04-01T15"
+    }
+  ]
+} 

--- a/content/en/api/usage/usage.md
+++ b/content/en/api/usage/usage.md
@@ -24,6 +24,7 @@ The usage metering end-point allows you to:
 * Get Hourly Usage For Network Hosts
 * Get Hourly Usage For Network Flows
 * Get Hourly Usage For RUM Sessions
+* Get Hourly Usage For Analyzed Logs
 * Get Multi-Org Usage Summary
 * Get Daily Custom Reporting Available Files
 * Get Daily Custom Reporting File URL

--- a/content/en/api/usage/usage_analyzed_logs.md
+++ b/content/en/api/usage/usage_analyzed_logs.md
@@ -1,0 +1,24 @@
+---
+title: Get hourly usage for Analyzed Logs
+type: apicontent
+order: 35.932
+external_redirect: /api/#get-hourly-usage-for-analyzed-logs
+---
+
+## Get hourly usage for Analyzed Logs
+
+Get Hourly Usage For Analyzed Logs
+
+**ARGUMENTS**:
+
+* **`start_hr`** [*required*]:
+    Datetime in ISO-8601 format, UTC, precise to hour: [YYYY-MM-DDThh] for usage beginning at this hour.
+* **`end_hr`** [*optional*, *default*=**1d+start_hr**]:
+    Datetime in ISO-8601 format, UTC, precise to hour: [YYYY-MM-DDThh] for usage ending BEFORE this hour.
+
+**RESPONSE**:
+
+* **`session_count`**: 
+	Contains the sum of analyzed logs.
+* **`hour`**:
+    The hour for the usage.

--- a/content/en/api/usage/usage_analyzed_logs_code.md
+++ b/content/en/api/usage/usage_analyzed_logs_code.md
@@ -1,0 +1,18 @@
+---
+title: Get hourly usage for Analyzed Logs
+type: apicode
+order: 35.932
+external_redirect: /api/#get-hourly-usage-for-analyzed-logs
+---
+
+**SIGNATURE**:
+
+`GET /v1/usage/analyzed_logs`
+
+**EXAMPLE REQUEST**:
+
+{{< code-snippets basename="api-billing-usage-analyzed-logs" >}}
+
+**EXAMPLE RESPONSE**:
+
+{{< code-snippets basename="result.api-billing-usage-analyzed-logs" >}}


### PR DESCRIPTION
### What does this PR do?
Add API endpoint documentation for Security Monitoring product.

### Motivation
Security Monitoring product became available.

### Preview link
 https://docs-staging.datadoghq.com/julian-leung/security-api/api/?lang=bash#get-hourly-usage-for-analyzed-logs

### Additional Notes
No
