### PR TITLE
Proposed library addition

### DIFF
--- a/data/libraries.yaml
+++ b/data/libraries.yaml
@@ -276,6 +276,10 @@ Tracing:
       official: true
       authors: Datadog
       notes: gem is called 'ddtrace'.
+    - name: ddtrace-rb-method-wrapper
+      link: https://github.com/brandfolder/ddtrace-rb-method-wrapper
+      authors: Brandfolder
+      notes: gem is called `ddtrace-method-wrapper`
   - Scala:
     - name: scala-opentracing
       link: https://github.com/Colisweb/scala-opentracing


### PR DESCRIPTION
This library complements `dd-trace-rb`, and adds convenience methods for tracing class/module methods
```
trace :method_name, span_type: 'layer_name'
```

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a library to the APM libraries list, complementing the `dd-trace-rb` library from Datadog

### Motivation
Need for easy custom instrumentation

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
