### PR TITLE
disabling toc to benefit from more space

### DIFF
--- a/content/en/security_monitoring/default_rules/_index.md
+++ b/content/en/security_monitoring/default_rules/_index.md
@@ -3,6 +3,7 @@ title: Default Threat Detection Rules
 kind: documentation
 type: security_rules
 description: "Datadog Security Detection Rules"
+disable_toc:true
 ---
 
 [Detection rules][1] define conditional logic that is applied to all ingested logs. When at least one case defined in a detection rule is matched over a given period of time, Datadog generates a security signal.

--- a/content/en/security_monitoring/default_rules/_index.md
+++ b/content/en/security_monitoring/default_rules/_index.md
@@ -3,7 +3,7 @@ title: Default Threat Detection Rules
 kind: documentation
 type: security_rules
 description: "Datadog Security Detection Rules"
-disable_toc:true
+disable_toc: true
 ---
 
 [Detection rules][1] define conditional logic that is applied to all ingested logs. When at least one case defined in a detection rule is matched over a given period of time, Datadog generates a security signal.


### PR DESCRIPTION
### What does this PR do?
Disables toc on the page to have more space for the content.

Old page: https://docs.datadoghq.com/security_monitoring/default_rules/
New page: https://docs-staging.datadoghq.com/gus/disabling-toc/security_monitoring/default_rules/