### PR TITLE
correct app analytics for C++

### DIFF
--- a/content/en/tracing/app_analytics/_index.md
+++ b/content/en/tracing/app_analytics/_index.md
@@ -94,7 +94,7 @@ App Analytics is available starting in version 0.17.0 of the PHP tracing client,
 {{% /tab %}}
 {{% tab "C++" %}}
 
-App Analytics is available starting in version 1.0.0 of the C++ tracing client, and can be enabled globally for all spans by setting the environment variable: `DD_TRACE_ANALYTICS_ENABLED` to `true`. Note that this setting can also be set in the code directly:
+App Analytics is available starting in version 1.0.0 of the C++ tracing client, and can be enabled globally for all top level spans by setting the environment variable: `DD_TRACE_ANALYTICS_ENABLED` to `true`. Note that this setting can also be set in the code directly:
 
 ```csharp
 datadog::opentracing::TracerOptions tracer_options;

--- a/content/en/tracing/app_analytics/_index.md
+++ b/content/en/tracing/app_analytics/_index.md
@@ -94,7 +94,7 @@ App Analytics is available starting in version 0.17.0 of the PHP tracing client,
 {{% /tab %}}
 {{% tab "C++" %}}
 
-App Analytics is available starting in version 1.0.0 of the C++ tracing client, and can be enabled globally for all **web** integrations by setting the environment variable: `DD_TRACE_ANALYTICS_ENABLED` to `true`. Note that this setting can also be set in the code directly:
+App Analytics is available starting in version 1.0.0 of the C++ tracing client, and can be enabled globally for all spans by setting the environment variable: `DD_TRACE_ANALYTICS_ENABLED` to `true`. Note that this setting can also be set in the code directly:
 
 ```csharp
 datadog::opentracing::TracerOptions tracer_options;


### PR DESCRIPTION
C++ does not have any web integrations that are automatically instrumented. Instead it's all done manually and therefore when activated will be enabled for all manually instrumented spans.


### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
changes the wording for what app analytics does for C++ to a more correct description.
### Motivation
Having customers better understand this feature
### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/Zach-Groves/correct-app-analytics-for-C++/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
