### PR TITLE
Handling integrations merge

### DIFF
--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -272,7 +272,23 @@ class Integrations:
                                 content,
                                 count=0,
                             )
+                        regex_skip_sections_end = r"(```|\{\{< \/code-block >\}\})"
+                        regex_skip_sections_start = r"(```|\{\{< code-block)"
+
+                        ## Inlining all link from the file to merge
+                        ## to avoid link ref colision with the existing references.
+                        content = self.inline_references(content,regex_skip_sections_start,regex_skip_sections_end)
+
                         target_file.write(content)
+
+                    ## Formating all link as reference in the new merged integration file
+                    try:
+                        final_text = format_link_file(output_file,regex_skip_sections_start,regex_skip_sections_end)
+                        with open(output_file, 'w') as final_file:
+                            final_file.write(final_text)
+                    except Exception as e:
+                        print(e)
+
                     try:
                         remove(input_file)
                     except OSError:
@@ -401,7 +417,7 @@ class Integrations:
         :param file_name: path to a readme md file
         """
         no_integration_issue = True
-
+        tab_logic = False
         metrics = glob.glob(
             "{path}{sep}*metadata.csv".format(
                 path=dirname(file_name), sep=sep


### PR DESCRIPTION
### What does this PR do?

This is a follow up on: https://github.com/DataDog/integrations-core/pull/6378

Updates the integration merge logic:

* Inline all reference links in the content that is appended to an other integration
* Re-format all link based on the existing ref link + the inlined link.

### Motivation

* Fix current broken link
* Allows to get rid of the indentation logic that was a hack to mitigate this issue in the first place.

### Preview link

* https://docs-staging.datadoghq.com/gus/integration-merge-corner-case/integrations/gitlab/