### PR TITLE
Disabling toc

### DIFF
--- a/content/en/developers/faq/data-collection-resolution-retention.md
+++ b/content/en/developers/faq/data-collection-resolution-retention.md
@@ -1,6 +1,7 @@
 ---
 title: Datadog Data Collection, Resolution, and Retention
 kind: faq
+disable_toc: true
 ---
 
 Find below a summary of Datadog data collection, resolution, and retention:


### PR DESCRIPTION
### What does this PR do?
Disables toc on FAQ page that is just an array to benefit from the full width of the page.