### PR TITLE
Update checks import paths

### DIFF
--- a/content/en/agent/faq/agent_v6_changes.md
+++ b/content/en/agent/faq/agent_v6_changes.md
@@ -470,7 +470,7 @@ Even though Agent v6 fully supports Python checks, some of the official Agent v5
 {{% /tab %}}
 {{% tab "Check API" %}}
 
-The base class for Python checks (`AgentCheck`) is now imported from `datadog_checks.checks`. There are a number of things that have been removed or changed in the class API. In addition, each check instance is now its own instance of the class. So you cannot share state between them.
+The base class for Python checks (`AgentCheck`) is now imported from `datadog_checks.base.checks`. There are a number of things that have been removed or changed in the class API. In addition, each check instance is now its own instance of the class. So you cannot share state between them.
 
 The following methods in the `AgentCheck` class are not implemented:
 

--- a/content/en/developers/prometheus.md
+++ b/content/en/developers/prometheus.md
@@ -66,7 +66,7 @@ instances:
 All OpenMetrics checks inherit from the `OpenMetricsBaseCheck` class found in `checks/openmetrics_check.py`:
 
 ```python
-from datadog_checks.checks.openmetrics import OpenMetricsBasicCheck
+from datadog_checks.base import OpenMetricsBasicCheck
 
 class KubeDNSCheck(OpenMetricsBasicCheck):
 ```
@@ -76,7 +76,7 @@ class KubeDNSCheck(OpenMetricsBasicCheck):
 `NAMESPACE` is the metrics prefix. It needs to be hardcoded in your check class:
 
 ```python
-from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base import OpenMetricsBaseCheck
 
 class KubeDNSCheck(OpenMetricsBaseCheck):
     def __init__(self, name, init_config, agentConfig, instances=None):
@@ -90,7 +90,7 @@ class KubeDNSCheck(OpenMetricsBaseCheck):
 The reason for the override is so that metrics reported by the OpenMetrics checks are not counted as [custom metric][5]:
 
 ```python
-from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base import OpenMetricsBaseCheck
 
 class KubeDNSCheck(OpenMetricsBaseCheck):
     def __init__(self, name, init_config, agentConfig, instances=None):
@@ -132,7 +132,7 @@ If a check cannot run because of improper configuration, a programming error, or
 Improve your `check()` method with `CheckException`:
 
 ```python
-from datadog_checks.errors import CheckException
+from datadog_checks.base.errors import CheckException
 
 def check(self, instance):
     endpoint = instance.get('prometheus_endpoint')
@@ -143,7 +143,7 @@ def check(self, instance):
 Then as soon as you have data available, flush:
 
 ```python
-from datadog_checks.errors import CheckException
+from datadog_checks.base.errors import CheckException
 
 def check(self, instance):
     endpoint = instance.get('prometheus_endpoint')
@@ -161,8 +161,8 @@ def check(self, instance):
 ### Putting It All Together
 
 ```python
-from datadog_checks.errors import CheckException
-from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base import OpenMetricsBaseCheck
+from datadog_checks.base.errors import CheckException
 
 class KubeDNSCheck(OpenMetricsBaseCheck):
     """

--- a/content/en/developers/write_agent_check.md
+++ b/content/en/developers/write_agent_check.md
@@ -119,7 +119,7 @@ sudo -u dd-agent -- dd-agent check <CHECK_NAME>
 
 It's possible to create a custom check that runs a command line program and captures its output as a custom metric. For example, a check can run the `vgs` command to report information about volume groups. A wrapper function is provided for convenience to avoid the boilerplate around shelling out another process and collecting its output and exit code.
 
-To run a subprocess within a check, use the [`get_subprocess_output()` function][6] from the module `datadog_checks.utils.subprocess_output`. The command and its arguments are passed to `get_subprocess_output()` in the form of a list, with the command and each of its arguments as a string within the list. For instance, a command that is entered at the command prompt like this:
+To run a subprocess within a check, use the [`get_subprocess_output()` function][6] from the module `datadog_checks.base.utils.subprocess_output`. The command and its arguments are passed to `get_subprocess_output()` in the form of a list, with the command and each of its arguments as a string within the list. For instance, a command that is entered at the command prompt like this:
 
 ```text
 $ vgs -o vg_free
@@ -143,7 +143,7 @@ Here is an example of a check that returns the results of a command line program
 
 ```python
 # ...
-from datadog_checks.utils.subprocess_output import get_subprocess_output
+from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
 class LSCheck(AgentCheck):
     def check(self, instance):
@@ -160,5 +160,5 @@ class LSCheck(AgentCheck):
 [2]: https://github.com/DataDog/integrations-extras
 [3]: http://app.datadoghq.com/account/settings#agent
 [4]: /help
-[5]: https://datadog-checks-base.readthedocs.io/en/latest/datadog_checks.checks.html#datadog_checks.base.checks.base.AgentCheck
+[5]: https://datadoghq.dev/integrations-core/base/api/#datadog_checks.base.checks.base.AgentCheck
 [6]: https://datadog-checks-base.readthedocs.io/en/latest/datadog_checks.utils.html#module-datadog_checks.base.utils.subprocess_output


### PR DESCRIPTION
### What does this PR do?
Updates import paths for custom checks.

### Motivation
Those paths are outdated.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/florian/update_checks_import_path

### Additional Notes
<!-- Anything else we should know when reviewing?-->
