### PR TITLE
[Agent] Add SELinux instructions for NPM installation

### DIFF
--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -82,7 +82,8 @@ To enable network performance monitoring with the Datadog Agent, use the followi
 ### SELinux-enabled systems
 
 On systems with SELinux enabled, the system-probe binary needs special permissions to use eBPF features.
-The official Datadog Agent RPM package bundles [an SELinux policy][3] to grant these permissions to the system-probe binary.
+
+The Datadog Agent RPM package for CentOS-based systems bundles [an SELinux policy][3] to grant these permissions to the system-probe binary.
 
 If you need to use Network Performance Monitoring on other systems with SELinux enabled, do the following:
 
@@ -102,7 +103,7 @@ If you need to use Network Performance Monitoring on other systems with SELinux 
     semodule -v -i system_probe_policy.pp
     ```
 
-4. Change the system-probe binary's type to use the one defined in the policy; assuming your Agent installation directory is `system_probe_policy.te`:
+4. Change the system-probe binary type to use the one defined in the policy; assuming your Agent installation directory is `system_probe_policy.te`:
 
     ```shell
     semanage fcontext -a -t system_probe_t /opt/datadog-agent/embedded/bin/system-probe

--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -96,9 +96,6 @@ If you need to use Network Performance Monitoring on other systems with SELinux 
     semodule_package -o system_probe_policy.pp -m system_probe_policy.mod
     ```
 
-    Note: this requires the `checkmodule` and `semodule_package` utilities to be installed on your system.
-    Check your distribution for details on how to install them.
-
 3. Apply the module to your SELinux system:
 
     ```shell
@@ -113,6 +110,9 @@ If you need to use Network Performance Monitoring on other systems with SELinux 
     ```
 
 5. [Restart the Agent][2]
+
+**Note**: these instructions require to have some SELinux utilities installed on the system (`checkmodule`, `semodule`, `semodule_package`, `semanage` and `restorecon`) that are available on most standard distributions (Ubuntu, Debian, RHEL, CentOS, SUSE). Check your distribution for details on how to install them.
+If these utilities do not exist in your distribution, follow the same procedure but using the utilities provided by your distribution instead.
 
 [1]: /infrastructure/process/?tab=linuxwindows#installation
 [2]: /agent/guide/agent-commands/#restart-the-agent

--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -87,7 +87,7 @@ The Datadog Agent RPM package for CentOS-based systems bundles [an SELinux polic
 
 If you need to use Network Performance Monitoring on other systems with SELinux enabled, do the following:
 
-1. Modify the base system-probe [SELinux policy][3] to match your SELinux configuration.
+1. Modify the base [SELinux policy][3] to match your SELinux configuration.
     Depending on your system, some types or attributes may not exist (or have different names).
 
 2. Compile the policy into a module; assuming your policy file is named `system_probe_policy.te`:
@@ -113,6 +113,7 @@ If you need to use Network Performance Monitoring on other systems with SELinux 
 5. [Restart the Agent][2]
 
 **Note**: these instructions require to have some SELinux utilities installed on the system (`checkmodule`, `semodule`, `semodule_package`, `semanage` and `restorecon`) that are available on most standard distributions (Ubuntu, Debian, RHEL, CentOS, SUSE). Check your distribution for details on how to install them.
+
 If these utilities do not exist in your distribution, follow the same procedure but using the utilities provided by your distribution instead.
 
 [1]: /infrastructure/process/?tab=linuxwindows#installation


### PR DESCRIPTION
### What does this PR do?

Adds instructions to install the SELinux policy required to make NPM work on SELinux-enabled systems.

### Motivation

Show users how to install the system-probe SELinux policy to allow NPM to work on SELinux-enabled systems.

### Preview link

https://docs-staging.datadoghq.com/kylian.serrania/add-system-probe-selinux-instructions/network_performance_monitoring/installation/?tab=agent

### Additional Notes

I tried to give a general procedure that can be followed on any OS while giving a specific example that should work on common modern OS. Tell me if we should do this another way.