### PR TITLE
Log usage metrics - extra tag

### DIFF
--- a/content/en/logs/logs_to_metrics.md
+++ b/content/en/logs/logs_to_metrics.md
@@ -58,11 +58,12 @@ Usage metrics are estimates of your current Datadog usage in near real-time. The
 
 Log Management usage metrics come with three tags that can be used for more granular monitoring:
 
-| Tag                     | Description                                                           |
-| ----------------------- | --------------------------------------------------------------------- |
-|  `datadog_index`        | Indicates the routing query that matches a log to an intended index.  |
-|  `datadog_is_excluded`  | Indicates whether or not a log matches an exclusion query.            |
-|  `service`              | The service attribute of the log event.                               |
+| Tag                     | Description                                                           | Metric|
+| ----------------------- | --------------------------------------------------------------------- |-------|
+|  `datadog_index`        | Indicates the routing query that matches a log to an intended index.  | `all` |
+|  `datadog_is_excluded`  | Indicates whether or not a log matches an exclusion query.            | `all` |
+|  `service`              | The service attribute of the log event.                               | `all` |
+|  `status`               | The status attribute of the log event (info, error, ...).             | `datadog.estimated_usage.logs.ingested_events` |
 
 ## Further Reading
 


### PR DESCRIPTION
### What does this PR do?
Mention that the ingested_events metric is now tagged by status

### Motivation
This tag was added to this metric

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/usage-metrics-log-tag-status/logs/logs_to_metrics/#recommended-usage-metrics

### Additional Notes
<!-- Anything else we should know when reviewing?-->
