### PR TITLE
Add extra status tag for log usage metrics

### DIFF
--- a/content/en/logs/logs_to_metrics.md
+++ b/content/en/logs/logs_to_metrics.md
@@ -64,7 +64,7 @@ Log Management usage metrics come with three tags that can be used for more gran
 |  `datadog_is_excluded`  | Indicates whether or not a log matches an exclusion query.            |
 |  `service`              | The service attribute of the log event.                               |
 
-An extra `status` tag is available on the `datadog.estimated_usage.logs.ingested_events` metric to reflect the log Status (`info`, `warning`, ...).
+An extra `status` tag is available on the `datadog.estimated_usage.logs.ingested_events` metric to reflect the log status (`info`, `warning`, etc.).
 
 ## Further Reading
 

--- a/content/en/logs/logs_to_metrics.md
+++ b/content/en/logs/logs_to_metrics.md
@@ -64,6 +64,8 @@ Log Management usage metrics come with three tags that can be used for more gran
 |  `datadog_is_excluded`  | Indicates whether or not a log matches an exclusion query.            |
 |  `service`              | The service attribute of the log event.                               |
 
+An extra `status` tag is available on the `datadog.estimated_usage.logs.ingested_events` metric to reflect the log Status (`info`, `warning`, ...).
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
### What does this PR do?
We are now adding the status tag on the ingested events usage metrics.

### Motivation
This tag is now available on those metrics.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/tag-status-log-usage-metrics/logs/logs_to_metrics/#recommended-usage-metrics

### Additional Notes
<!-- Anything else we should know when reviewing?-->
