### PR TITLE
Adding correct Windows Server supported version

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -146,7 +146,7 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 | [SUSE Enterprise Linux x86_64][7] with SysVinit | SUSE 11 SP4 in Agent 7.16.0+                      |
 | [Fedora x86_64][8]                              | Fedora 26+                                        |
 | [macOS][9]                                      | macOS 10.12+                                      |
-| [Windows server 64-bit][10]                     | Server Core (not Nano) |
+| [Windows server 64-bit][10]                     | Windows Server 2008r2+ (not Nano)                 |
 | [Windows 64-bit][10]                            | Windows 7+                                        |
 
 **Note**: [Source][11] install may work on operating systems not listed here and is supported on a best effort basis.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adding correct Windows Server supported version back

### Motivation
<!-- What inspired you to submit this pull request?-->

I can see that "Windows Server 2008r2+" was removed in favor of "Server Core (not Nano)" in the past PR/commit. However "Server Core" really just means a flavor of Windows Server installation, not the version of OS itself. As I believe Windows Server 2008r2 or above are still versions that our Agent supports, adding it back to the doc and also simplifying it by just mentioning "not Nano".

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
