### PR TITLE
Add beta flag to log restriction queries API

### DIFF
--- a/content/en/api/roles_restriction_queries/roles_restriction_queries.md
+++ b/content/en/api/roles_restriction_queries/roles_restriction_queries.md
@@ -7,6 +7,10 @@ external_redirect: /api/#restriction-queries
 
 ## Roles restriction queries for logs
 
+<div class="alert alert-warning">
+This endpoint is in public beta. If you have any feedback, <a href="/help">contact Datadog support</a>.
+</div>
+
 To grant read access on log data at all, you **must** grant the `logs_read_data` permission. From there you can limit what data a role grants read access to by associating a Restriction Query with that role.
 
 A Restriction Query is a logs query that restricts which logs the `logs_read_data` permission grants read access to. For users whose roles have Restriction Queries, any log query they make only returns those log events that also match one of their Restriction Queries. This is true whether the user queries log events from any log-related feature, including the log explorer, Live Tail, rehydration, or a dashboard widget.


### PR DESCRIPTION
### What does this PR do?
Add a beta flag for the restriction queries API

### Motivation
This feature is in beta.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/beta-restriction-queries/api/?lang=bash#roles-restriction-queries-for-logs

### Additional Notes
<!-- Anything else we should know when reviewing?-->
