### PR TITLE
Using new region shortcode

### DIFF
--- a/content/en/agent/logs/log_transport.md
+++ b/content/en/agent/logs/log_transport.md
@@ -32,7 +32,7 @@ To check which transport is used by the Agent, run the [Agent status command][1]
 
 {{< img src="agent/logs/agent-status.png" alt="Agent status"  style="width:70%;">}}
 
-**Note**: For older Agent versions, TCP transport is used by default. Datadog strongly recommends you to enforce HTTPS transport if you are running v6.14+/v7.14+ and HTTPS compression if you are running v6.16+/v7.16+. 
+**Note**: For older Agent versions, TCP transport is used by default. Datadog strongly recommends you to enforce HTTPS transport if you are running v6.14+/v7.14+ and HTTPS compression if you are running v6.16+/v7.16+.
 
 ## Enforce a specific transport
 
@@ -54,7 +54,6 @@ To send logs with environment variables, configure the following:
 * `DD_LOGS_ENABLED=true`
 * `DD_LOGS_CONFIG_USE_HTTP=true`
 
-
 [1]: /agent/guide/agent-configuration-files
 {{% /tab %}}
 {{% tab "TCP" %}}
@@ -66,14 +65,20 @@ logs_enabled: true
 logs_config:
   use_tcp: true
 ```
+
 To send logs with environment variables, configure the following:
 
 * `DD_LOGS_ENABLED=true`
 * `DD_LOGS_CONFIG_USE_TCP=true`
 
-By default, the Datadog Agent sends its logs to Datadog over TLS-encrypted TCP. This requires outbound communication (on port `10516` for Datadog US site and port `443`for Datadog EU site).
+By default, the Datadog Agent sends its logs to Datadog over TLS-encrypted TCP.
 
-
+{{< site-region region="us" >}}
+This requires outbound communication on port `10516` for Datadog US site
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+This requires outbound communication on port `443`for Datadog EU site.
+{{< /site-region >}}
 
 [1]: /agent/guide/agent-configuration-files
 {{% /tab %}}

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -128,8 +128,7 @@ This is the best option if you do not have a web proxy readily available in your
 
 HAProxy should be installed on a host that has connectivity to Datadog. Use the following configuration file if you do not already have it configured.
 
-{{< tabs >}}
-{{% tab "Datadog US site" %}}
+{{< site-region region="us" >}}
 
 ```conf
 # Basic configuration
@@ -156,7 +155,7 @@ listen stats
     mode http
     stats enable
     stats uri /
-    
+
 # This section is to reload DNS Records
 # Replace <DNS_SERVER_IP> and <DNS_SECONDARY_SERVER_IP> with your DNS Server IP addresses.
 # For HAProxy 1.8 and newer
@@ -248,8 +247,9 @@ The file might be located at `/etc/ssl/certs/ca-bundle.crt` for CentOS, Redhat.
 HAProxy 1.8 and newer allow DNS service discovery to detect server changes and automatically apply them to your configuration.
 If you are using older version of HAProxy, you have to reload or restart HAProxy. **It is recommended to have a `cron` job that reloads HAProxy every 10 minutes** (usually doing something like `service haproxy reload`) to force a refresh of HAProxy's DNS cache, in case `app.datadoghq.com` fails over to another IP.
 
-{{% /tab %}}
-{{% tab "Datadog EU site" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+
 
 ```conf
 # Basic configuration
@@ -370,8 +370,7 @@ The file might be located at `/etc/ssl/certs/ca-bundle.crt` for CentOS, Redhat.
 HAProxy 1.8 and newer allow DNS service discovery to detect server changes and automatically apply them to your configuration.
 If you are using older version of HAProxy, you have to reload or restart HAProxy. **It is recommended to have a `cron` job that reloads HAProxy every 10 minutes** (usually doing something like `service haproxy reload`) to force a refresh of HAProxy's DNS cache, in case `app.datadoghq.eu` fails over to another IP.
 
-{{% /tab %}}
-{{< /tabs >}}
+{{< /site-region >}}
 
 #### Datadog Agent configuration
 
@@ -464,8 +463,7 @@ To verify that everything is working properly, review the HAProxy statistics at 
 
 This example `nginx.conf` can be used to proxy Agent traffic to Datadog. The last server block in this configuration does TLS wrapping to ensure internal plaintext logs are encrypted between your proxy and Datadog's log intake API endpoint:
 
-{{< tabs >}}
-{{% tab "Datadog US site" %}}
+{{< site-region region="us" >}}
 
 ```conf
 user nginx;
@@ -502,8 +500,8 @@ stream {
 }
 ```
 
-{{% /tab %}}
-{{% tab "Datadog EU site" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
 
 ```conf
 user nginx;
@@ -540,8 +538,7 @@ stream {
 }
 ```
 
-{{% /tab %}}
-{{< /tabs >}}
+{{< /site-region >}}
 
 #### Datadog Agent configuration
 

--- a/content/en/agent/troubleshooting/site.md
+++ b/content/en/agent/troubleshooting/site.md
@@ -5,8 +5,7 @@ kind: documentation
 
 By default the Agent sends its data to Datadog US site: `app.datadoghq.com`. If your organization is on another site, you must update the `site` parameter in your [Agent main configuration file][1] accordingly or set the `DD_SITE` environment variable:
 
-{{< tabs >}}
-{{% tab "US Site" %}}
+{{< site-region region="us" >}}
 
 Set the `DD_SITE` variable to `datadoghq.com`or update the parameter `site` parameter in your `datadog.yaml`
 
@@ -18,8 +17,8 @@ Set the `DD_SITE` variable to `datadoghq.com`or update the parameter `site` par
 site: datadoghq.com
 ```
 
-{{% /tab %}}
-{{% tab "EU Site" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
 
 Set the `DD_SITE` variable to `datadoghq.eu`or update the parameter `site` parameter in your `datadog.yaml`:
 
@@ -31,7 +30,6 @@ Set the `DD_SITE` variable to `datadoghq.eu`or update the parameter `site` para
 site: datadoghq.eu
 ```
 
-{{% /tab %}}
-{{< /tabs >}}
+{{< /site-region >}}
 
 [1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file

--- a/content/en/integrations/carbon_black.md
+++ b/content/en/integrations/carbon_black.md
@@ -31,8 +31,7 @@ First, install and setup the [Carbon Black Defense log shipper][1].
 
 The configuration file below enables your Carbon Black Defense shipper to forward your logs to Datadog:
 
-{{< tabs >}}
-{{% tab "Datadog US Site" %}}
+{{< site-region region="us" >}}
 
 ```conf
 [general]
@@ -51,8 +50,8 @@ siem_connector_id=<CB_DEFENSE_API_ID>
 siem_api_key=<CB_DEFENSE_API_SECRET_KEY>
 ```
 
-{{% /tab %}}
-{{% tab "Datadog EU Site" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
 
 ```conf
 [general]
@@ -71,8 +70,7 @@ siem_connector_id=<CB_DEFENSE_API_ID>
 siem_api_key=<CB_DEFENSE_API_SECRET_KEY>
 ```
 
-{{% /tab %}}
-{{< /tabs >}}
+{{< /site-region >}}
 
 Replace the `<DATADOG_API_KEY>`, `<CB_DEFENSE_API_SECRET_KEY>`, `<CB_DEFENSE_API_ID>`, and `<CB_DEFENSE_SERVER_URL>` placeholders to complete your configuration.
 

--- a/content/en/integrations/rsyslog.md
+++ b/content/en/integrations/rsyslog.md
@@ -29,8 +29,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
 
 #### Rsyslog version >=8
 
-{{< tabs >}}
-{{% tab "Datadog US site" %}}
+{{< site-region region="us" >}}
 
 1. (Optional) Activate Rsyslog file monitoring module. If you want to watch/monitor specific log files, then you have to activate the imfile module by adding this to your `rsyslog.conf`:
 
@@ -114,8 +113,8 @@ Configure Rsyslog to gather logs from your host, containers, & services.
     sudo service rsyslog restart
     ```
 
-{{% /tab %}}
-{{% tab "Datadog EU site" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
 
 1. (Optional) Activate Rsyslog file monitoring module. If you want to watch or monitor specific log files, activate the `imfile` module by adding this to your `rsyslog.conf`:
 
@@ -199,13 +198,11 @@ Configure Rsyslog to gather logs from your host, containers, & services.
     sudo service rsyslog restart
     ```
 
-{{% /tab %}}
-{{< /tabs >}}
+{{< /site-region >}}
 
 #### Rsyslog version <8
 
-{{< tabs >}}
-{{% tab "Datadog US site" %}}
+{{< site-region region="us" >}}
 
 1. (Optional) Activate Rsyslog file monitoring module. If you want to watch or monitor specific log files, activate the `imfile` module by adding this to your `rsyslog.conf`:
 
@@ -297,8 +294,8 @@ Configure Rsyslog to gather logs from your host, containers, & services.
     sudo service rsyslog restart
     ```
 
-{{% /tab %}}
-{{% tab "Datadog EU site" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
 
 1. (Optional) Activate Rsyslog file monitoring module. If you want to watch or monitor specific log files, activate the `imfile` module by adding this to your `rsyslog.conf`:
 
@@ -390,8 +387,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
     sudo service rsyslog restart
     ```
 
-{{% /tab %}}
-{{< /tabs >}}
+{{< /site-region >}}
 
 ## Troubleshooting
 

--- a/content/en/logs/guide/collect-heroku-logs.md
+++ b/content/en/logs/guide/collect-heroku-logs.md
@@ -20,22 +20,18 @@ To send all these logs to Datadog:
 * Connect to your Heroku project.
 * Set up the HTTPS drain with the following command:
 
-{{< tabs >}}
-{{% tab "US Site" %}}
+{{< site-region region="us" >}}
 
 ```text
 heroku drains:add 'https://http-intake.logs.datadoghq.com/v1/input/<DD_API_KEY>?ddsource=heroku&service=<SERVICE>&host=<HOST>' -a <APPLICATION_NAME>
 ```
 
-{{% /tab %}}
-{{% tab "EU Site" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
 
 ```text
 heroku drains:add 'https://http-intake.logs.datadoghq.eu/v1/input/<DD_API_KEY>?ddsource=heroku&service=<SERVICE>&host=<HOST>' -a <APPLICATION_NAME>
 ```
-
-{{% /tab %}}
-{{< /tabs >}}
 
 * Replace `<DD_API_KEY>` with your [Datadog API Key][2].
 * Replace `<APPLICATION_NAME>` and `<SERVICE>` with your application name.
@@ -45,22 +41,18 @@ heroku drains:add 'https://http-intake.logs.datadoghq.eu/v1/input/<DD_API_KEY>?d
 
 Add custom attributes to logs from your application by replacing the URL in the drain as follows:
 
-{{< tabs >}}
-{{% tab "US Site" %}}
+{{< site-region region="us" >}}
 
 ```text
 https://http-intake.logs.datadoghq.com/v1/input/<DD_API_KEY>?ddsource=heroku&service=<SERVICE>&host=<HOST>&attribute_name=<VALUE>
 ```
 
-{{% /tab %}}
-{{% tab "EU Site" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
 
 ```text
 https://http-intake.logs.datadoghq.eu/v1/input/<DD_API_KEY>?ddsource=heroku&service=<SERVICE>&host=<HOST>&attribute_name=<VALUE>
 ```
-
-{{% /tab %}}
-{{< /tabs >}}
 
 [1]: https://devcenter.heroku.com/articles/log-drains#https-drains
 [2]: https://app.datadoghq.com/account/settings#api

--- a/content/en/synthetics/ci.md
+++ b/content/en/synthetics/ci.md
@@ -35,22 +35,20 @@ The trigger endpoint provides the list of triggered checks alongside their resul
 
 The test triggering endpoint supports starting up to 50 tests in one request.
 
-{{< tabs >}}
-{{% tab "Datadog US site" %}}
+{{< site-region region="us" >}}
 
 * **Endpoint**: `https://api.datadoghq.com/api/v1/synthetics/tests/trigger/ci`
 * **Method**: `POST`
 * **Argument**: A JSON object containing the list of all tests to trigger and their configuration override.
 
-{{% /tab %}}
-{{% tab "Datadog EU site" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
 
 * **Endpoint**: `https://api.datadoghq.eu/api/v1/synthetics/tests/trigger/ci`
 * **Method**: `POST`
 * **Argument**: A JSON object containing the list of all tests to trigger and their configuration override.
 
-{{% /tab %}}
-{{< /tabs >}}
+{{< /site-region >}}
 
 #### Request data structure
 
@@ -66,8 +64,7 @@ The public identifier of a test can be either the identifier of the test found i
 
 #### Example request
 
-{{< tabs >}}
-{{% tab "Datadog US site" %}}
+{{< site-region region="us" >}}
 
 ```bash
 #!/bin/sh
@@ -100,8 +97,8 @@ curl -X POST \
 }' "https://api.datadoghq.com/api/v1/synthetics/tests/trigger/ci"
 ```
 
-{{% /tab %}}
-{{% tab "Datadog EU site" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
 
 ```bash
 #!/bin/sh
@@ -134,9 +131,6 @@ curl -X POST \
 }' "https://api.datadoghq.eu/api/v1/synthetics/tests/trigger/ci"
 ```
 
-{{% /tab %}}
-{{< /tabs >}}
-
 #### Example response
 
 ```json
@@ -156,27 +150,24 @@ curl -X POST \
 
 ### Poll results endpoint
 
-{{< tabs >}}
-{{% tab "Datadog US site" %}}
+{{< site-region region="us" >}}
 
 * **Endpoint**: `https://api.datadoghq.com/api/v1/synthetics/tests/poll_results`
 * **Method**: `GET`
 * **Parameters**: A JSON array containing the list of result identifiers to obtain results from.
 
-{{% /tab %}}
-{{% tab "Datadog EU site" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
 
 * **Endpoint**: `https://api.datadoghq.eu/api/v1/synthetics/tests/poll_results`
 * **Method**: `GET`
 * **Parameters**: A JSON array containing the list of result identifiers to obtain results from.
 
-{{% /tab %}}
-{{< /tabs >}}
+{{< /site-region >}}
 
 #### Example request
 
-{{< tabs >}}
-{{% tab "Datadog US site" %}}
+{{< site-region region="us" >}}
 
 ```bash
 #!/bin/sh
@@ -191,8 +182,8 @@ curl -G \
     -d "result_ids=[%220123456789012345678%22]"
 ```
 
-{{% /tab %}}
-{{% tab "Datadog EU site" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
 
 ```bash
 #!/bin/sh
@@ -207,8 +198,7 @@ curl -G \
     -d "result_ids=[%220123456789012345678%22]"
 ```
 
-{{% /tab %}}
-{{< /tabs >}}
+{{< /site-region >}}
 
 #### Example response
 


### PR DESCRIPTION
### What does this PR do?

Leverage the region shortcode in context where there are no links issues

### Motivation

Start implementing the region logic to get some prod-usecases.

### Preview link

* https://docs-staging.datadoghq.com/gus/region-updates/agent/logs/log_transport/
* https://docs-staging.datadoghq.com/gus/region-updates/agent/troubleshooting/site/
* https://docs-staging.datadoghq.com/gus/region-updates/integrations/carbon_black/
* https://docs-staging.datadoghq.com/gus/region-updates/integrations/rsyslog/
* https://docs-staging.datadoghq.com/gus/region-updates/logs/guide/collect-heroku-logs/
* https://docs-staging.datadoghq.com/gus/region-updates/synthetics/ci/?tab=npm