### PR TITLE
Add snmp usage metering API documentation

### DIFF
--- a/content/en/api/usage/code_snippets/api-billing-usage-snmp.py
+++ b/content/en/api/usage/code_snippets/api-billing-usage-snmp.py
@@ -1,0 +1,2 @@
+# This is not yet supported by the Python Client for Datadog API
+# Consult the curl example

--- a/content/en/api/usage/code_snippets/api-billing-usage-snmp.rb
+++ b/content/en/api/usage/code_snippets/api-billing-usage-snmp.rb
@@ -1,0 +1,12 @@
+require 'rubygems'
+require 'dogapi'
+
+api_key = '<DATADOG_API_KEY>'
+app_key = '<DATADOG_APPLICATION_KEY>'
+
+dog = Dogapi::Client.new(api_key, app_key)
+
+start_date= '2019-10-07T00'
+end_date='2019-10-07T02'
+
+dog.get_snmp_usage(start_date, end_date)

--- a/content/en/api/usage/code_snippets/api-billing-usage-snmp.sh
+++ b/content/en/api/usage/code_snippets/api-billing-usage-snmp.sh
@@ -1,0 +1,10 @@
+api_key="<DATADOG_API_KEY>"
+app_key="<DATADOG_APPLICATION_KEY>"
+
+start_hr=$(date -v -10d +%Y-%m-%dT%H)
+end_hr=$(date +%Y-%m-%dT%H)
+
+curl -X GET \
+-H "DD-API-KEY: ${api_key}" \
+-H "DD-APPLICATION-KEY: ${app_key}" \
+"https://api.datadoghq.com/api/v1/usage/snmp?&start_hr=${start_hr}&end_hr=${end_hr}"

--- a/content/en/api/usage/code_snippets/result.api-billing-usage-snmp.py
+++ b/content/en/api/usage/code_snippets/result.api-billing-usage-snmp.py
@@ -1,0 +1,2 @@
+# This is not yet supported by the Python Client for Datadog API
+# Consult the curl example

--- a/content/en/api/usage/code_snippets/result.api-billing-usage-snmp.rb
+++ b/content/en/api/usage/code_snippets/result.api-billing-usage-snmp.rb
@@ -1,0 +1,9 @@
+{
+  "usage" => [{
+    "snmp_devices" => 3,
+    "hour" => "2019-10-07T00"
+  }, {
+    "snmp_devices" => 2,
+    "hour" => "2019-10-07T01"
+  }]
+}

--- a/content/en/api/usage/code_snippets/result.api-billing-usage-snmp.sh
+++ b/content/en/api/usage/code_snippets/result.api-billing-usage-snmp.sh
@@ -1,0 +1,12 @@
+{
+  "usage": [
+    {
+      "snmp_devices": 2,
+      "hour": "2019-04-01T14"
+    },
+    {
+      "snmp_devices": 4,
+      "hour": "2019-04-01T15"
+    }
+  ]
+}

--- a/content/en/api/usage/usage.md
+++ b/content/en/api/usage/usage.md
@@ -25,6 +25,7 @@ The usage metering end-point allows you to:
 * Get Hourly Usage For Network Flows
 * Get Hourly Usage For RUM Sessions
 * Get Hourly Usage For Analyzed Logs
+* Get Hourly Usage For SNMP Devices
 * Get Multi-Org Usage Summary
 * Get Daily Usage Attribution Available Files
 * Get Daily Usage Attribution File URL

--- a/content/en/api/usage/usage_snmp.md
+++ b/content/en/api/usage/usage_snmp.md
@@ -1,0 +1,24 @@
+---
+title: Get hourly usage for SNMP Devices
+type: apicontent
+order: 35.933
+external_redirect: /api/#get-hourly-usage-for-snmp-devices
+---
+
+## Get hourly usage for SNMP Devices
+
+Get Hourly Usage For SNMP Devices
+
+**ARGUMENTS**:
+
+* **`start_hr`** [*required*]:
+    Datetime in ISO-8601 format, UTC, precise to hour: [YYYY-MM-DDThh] for usage beginning at this hour.
+* **`end_hr`** [*optional*, *default*=**1d+start_hr**]:
+    Datetime in ISO-8601 format, UTC, precise to hour: [YYYY-MM-DDThh] for usage ending BEFORE this hour.
+
+**RESPONSE**:
+
+* **`devices_count`**:
+	Contains the sum of SNMP devices.
+* **`hour`**:
+    The hour for the usage.

--- a/content/en/api/usage/usage_snmp.md
+++ b/content/en/api/usage/usage_snmp.md
@@ -19,6 +19,6 @@ Get Hourly Usage For SNMP Devices
 **RESPONSE**:
 
 * **`devices_count`**:
-	Contains the sum of SNMP devices.
+	Contains the total number of billable SNMP Devices reporting during a given hour.
 * **`hour`**:
     The hour for the usage.

--- a/content/en/api/usage/usage_snmp_code.md
+++ b/content/en/api/usage/usage_snmp_code.md
@@ -1,0 +1,18 @@
+---
+title: Get hourly usage for SNMP Devices
+type: apicode
+order: 35.933
+external_redirect: /api/#get-hourly-usage-for-snmp-devices
+---
+
+**SIGNATURE**:
+
+`GET /v1/usage/snmp`
+
+**EXAMPLE REQUEST**:
+
+{{< code-snippets basename="api-billing-usage-snmp" >}}
+
+**EXAMPLE RESPONSE**:
+
+{{< code-snippets basename="result.api-billing-usage-snmp" >}}


### PR DESCRIPTION
There's a new usage type called SNMP Devices that is available via the public API. This is the documentation for it.