### PR TITLE
addRumGlobalContext bundle example correction

### DIFF
--- a/content/en/real_user_monitoring/installation/advanced_configuration.md
+++ b/content/en/real_user_monitoring/installation/advanced_configuration.md
@@ -77,10 +77,10 @@ datadogRum.addRumGlobalContext('usr', {
 {{% tab "Bundle" %}}
 
 ```javascript
-window.DD_RUM && DD_RUM.addRumGlobalContext('<CONTEXT_KEY>', <CONTEXT_VALUE>);
+window.DD_RUM && window.DD_RUM.addRumGlobalContext('<CONTEXT_KEY>', <CONTEXT_VALUE>);
 
 // Code example
-datadogRum.addRumGlobalContext('usr', {
+window.DD_RUM && window.DD_RUM.addRumGlobalContext('usr', {
     id: 123,
     plan: 'premium'
 });


### PR DESCRIPTION
### What does this PR do?
The RUM advanced configuration bundle example for addRumGlobalContext was referencing an undeclared datadogRum root object. This PR updates the example to use the `window.DD_RUM` root object.

### Motivation
I noticed that the documentation was incorrect while implementing the addRumGlobalContext function into my deployment.

### Preview link
Not available via a fork. 

### Additional Notes
N/A
