### PR TITLE
Fix bulleted list for date remapper note

### DIFF
--- a/content/en/logs/processing/processors.md
+++ b/content/en/logs/processing/processors.md
@@ -86,7 +86,8 @@ The recognized date formats are: <a href="https://www.iso.org/iso-8601-date-and-
 </div>
 
 
-**Note**:
+**Note**: 
+
 * **Log events can be submitted up to 6h in the past and 2h in the future**.
 * If your logs don't contain any of the default attributes and you haven't defined your own date attribute, Datadog timestamps the logs with the date it received them.
 * If multiple log date remapper processors can be applied to a given log, only the first one (according to the pipelines order) is taken into account.


### PR DESCRIPTION
### What does this PR do?

Fixes a broken bulleted list for the date remapper note (https://a.cl.ly/Kouq42mk)

### Motivation

Noticed the list was not formatted properly.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

^ I waited for an hour but never got a slack message with the preview link 🤔 

### Additional Notes
<!-- Anything else we should know when reviewing?-->
