### PR TITLE
Updates proxy configuration

### DIFF
--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -176,9 +176,8 @@ frontend metrics-forwarder
     bind *:3834
     mode http
     default_backend datadog-metrics
-    
-    use_backend datadog-api if { path_beg -i  /api/v1/validate }
 
+    use_backend datadog-api if { path_beg -i  /api/v1/validate }
     use_backend datadog-flare if { path_beg -i  /support/flare/ }
 
 # This declares the endpoint where your Agents connects for
@@ -187,6 +186,7 @@ frontend metrics-forwarder
 frontend traces-forwarder
     bind *:3835
     mode tcp
+    option tcplog
     default_backend datadog-traces
 
 # This declares the endpoint where your agents connects for
@@ -195,6 +195,7 @@ frontend traces-forwarder
 frontend processes-forwarder
     bind *:3836
     mode tcp
+    option tcplog
     default_backend datadog-processes
 
 # This declares the endpoint where your Agents connects for
@@ -202,6 +203,7 @@ frontend processes-forwarder
 frontend logs_frontend
     bind *:10514
     mode tcp
+    option tcplog
     default_backend datadog-logs
 
 # This is the Datadog server. In effect any TCP request coming
@@ -229,7 +231,6 @@ backend datadog-flare
 backend datadog-traces
     balance roundrobin
     mode tcp
-    option tcplog
     # The following configuration is for HAProxy 1.8 and newer
     server-template mothership 5 trace.agent.datadoghq.com:443 check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
@@ -238,7 +239,6 @@ backend datadog-traces
 backend datadog-processes
     balance roundrobin
     mode tcp
-    option tcplog
     # The following configuration is for HAProxy 1.8 and newer
     server-template mothership 5 process.datadoghq.com:443 check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
@@ -247,7 +247,6 @@ backend datadog-processes
 backend datadog-logs
     balance roundrobin
     mode tcp
-    option tcplog
     # The following configuration is for HAProxy 1.8 and newer
     server-template mothership 5 agent-intake.logs.datadoghq.com:10516 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
@@ -311,12 +310,16 @@ frontend metrics-forwarder
     mode tcp
     default_backend datadog-metrics
 
+    use_backend datadog-api if { path_beg -i  /api/v1/validate }
+    use_backend datadog-flare if { path_beg -i  /support/flare/ }
+
 # This declares the endpoint where your Agents connects for
 # sending traces (e.g. the value of "endpoint" in the APM
 # configuration section).
 frontend traces-forwarder
     bind *:3835
     mode tcp
+    option tcplog
     default_backend datadog-traces
 
 # This declares the endpoint where your agents connects for
@@ -325,6 +328,7 @@ frontend traces-forwarder
 frontend processes-forwarder
     bind *:3836
     mode tcp
+    option tcplog
     default_backend datadog-processes
 
 # This declares the endpoint where your Agents connects for
@@ -332,6 +336,7 @@ frontend processes-forwarder
 frontend logs_frontend
     bind *:10514
     mode tcp
+    option tcplog
     default_backend datadog-logs
 
 # This is the Datadog server. In effect any TCP request coming
@@ -359,7 +364,6 @@ backend datadog-flare
 backend datadog-traces
     balance roundrobin
     mode tcp
-    option tcplog
     # The following configuration is for HAProxy 1.8 and newer
     server-template mothership 5 trace.agent.datadoghq.eu:443 check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
@@ -368,7 +372,6 @@ backend datadog-traces
 backend datadog-processes
     balance roundrobin
     mode tcp
-    option tcplog
     # The following configuration is for HAProxy 1.8 and newer
     server-template mothership 5 process.datadoghq.eu:443 check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
@@ -377,7 +380,6 @@ backend datadog-processes
 backend datadog-logs
     balance roundrobin
     mode tcp
-    option tcplog
     # The following configuration is for HAProxy 1.8 and newer
     server-template mothership 5 agent-intake.logs.datadoghq.eu:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -177,11 +177,9 @@ frontend metrics-forwarder
     mode http
     default_backend datadog-metrics
     
-    acl dd-api path_beg -i  /api/v1/validate
-    use_backend datadog-api if dd-api
+    use_backend datadog-api if { path_beg -i  /api/v1/validate }
 
-    acl dd-flare path_beg -i  /support/flare/
-    use_backend datadog-flare if dd-flare
+    use_backend datadog-flare if { path_beg -i  /support/flare/ }
 
 # This declares the endpoint where your Agents connects for
 # sending traces (e.g. the value of "endpoint" in the APM

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -508,13 +508,13 @@ http {
         listen 3834; #listen for metrics
 
         location /api/v1/validate {
-            proxy_pass      https://api.datadoghq.com:443/api/v1/validate;
+            proxy_pass https://api.datadoghq.com:443/api/v1/validate;
         }
         location /support/flare/ {
-            proxy_pass      https://flare.datadoghq.com:443/support/flare/;
+            proxy_pass https://flare.datadoghq.com:443/support/flare/;
         }
         location / {
-            proxy_pass      https://haproxy-app.agent.datadoghq.com:443/;
+            proxy_pass https://haproxy-app.agent.datadoghq.com:443/;
         }
     }
 }
@@ -558,13 +558,13 @@ http {
         listen 3834; #listen for metrics
 
         location /api/v1/validate {
-            proxy_pass      https://api.datadoghq.eu:443/api/v1/validate;
+            proxy_pass https://api.datadoghq.eu:443/api/v1/validate;
         }
         location /support/flare/ {
-            proxy_pass      https://flare.datadoghq.eu:443/support/flare/;
+            proxy_pass https://flare.datadoghq.eu:443/support/flare/;
         }
         location / {
-            proxy_pass      https://haproxy-app.agent.datadoghq.eu:443/;
+            proxy_pass https://haproxy-app.agent.datadoghq.eu:443/;
         }
     }
 }

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -507,15 +507,15 @@ http {
     server {
         listen 3834; #listen for metrics
 
-				location /api/v1/validate {
-				    proxy_pass      https://api.datadoghq.com:443/api/v1/validate;
-				}
-				location /support/flare/ {
-				    proxy_pass      https://flare.datadoghq.com:443/support/flare/;
-				}
-				location / {
-				    proxy_pass      https://haproxy-app.agent.datadoghq.com:443/;
-				}
+        location /api/v1/validate {
+            proxy_pass      https://api.datadoghq.com:443/api/v1/validate;
+        }
+        location /support/flare/ {
+            proxy_pass      https://flare.datadoghq.com:443/support/flare/;
+        }
+        location / {
+            proxy_pass      https://haproxy-app.agent.datadoghq.com:443/;
+        }
     }
 }
 # TCP Proxy for Datadog Agent
@@ -557,15 +557,15 @@ http {
     server {
         listen 3834; #listen for metrics
 
-				location /api/v1/validate {
-				    proxy_pass      https://api.datadoghq.eu:443/api/v1/validate;
-				}
-				location /support/flare/ {
-				    proxy_pass      https://flare.datadoghq.eu:443/support/flare/;
-				}
-				location / {
-				    proxy_pass      https://haproxy-app.agent.datadoghq.eu:443/;
-				}
+        location /api/v1/validate {
+            proxy_pass      https://api.datadoghq.eu:443/api/v1/validate;
+        }
+        location /support/flare/ {
+            proxy_pass      https://flare.datadoghq.eu:443/support/flare/;
+        }
+        location / {
+            proxy_pass      https://haproxy-app.agent.datadoghq.eu:443/;
+        }
     }
 }
 # TCP Proxy for Datadog Agent

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -348,14 +348,14 @@ frontend processes-forwarder
 
 # This declares the endpoint where your Agents connects for
 # sending Logs (e.g the value of "logs.config.logs_dd_url")
-# If sending logs with use_tcp: true
+# If sending logs with use_http: true
 frontend logs_http_frontend
     bind *:3837
     mode http
     option tcplog
     default_backend datadog-logs-http
 
-# If sending logs with use_http: true
+# If sending logs with use_tcp: true
 frontend logs_frontend
     bind *:10514
     mode tcp


### PR DESCRIPTION
# What does this PR do?
Updates example Haproxy config and Nginx config to enable Datadog Agent's API validation and flare.

### Motivation

- came up in office hours that flare does not go through behind haproxy.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ian.bucad/proxy_api_flare/agent/proxy

### Additional Notes
<!-- Anything else we should know when reviewing?-->
