### PR TITLE
update api select to use commit ref from preview params

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -14,6 +14,8 @@ code_languages:
   - display_name: Ruby
     key: ruby
 
+branch: ""
+
 header_scripts:
   - hotjar: false
   - google-tag-manager: false

--- a/layouts/_default/404-baseof.html
+++ b/layouts/_default/404-baseof.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}"
-  data-env="{{.Site.Params.environment}}" style="opacity:0"
+  data-env="{{.Site.Params.environment}}" data-commit-ref="{{ .Site.Params.branch }}" style="opacity:0"
   class="{{ if or $.Site.Params.announcement_banner.link $.Site.Params.announcement_banner.desktop_message }}banner{{ end }}">
 
 <head>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}"
-  data-env="{{.Site.Params.environment}}" style="opacity:0"
+  data-env="{{.Site.Params.environment}}" data-commit-ref="{{ .Site.Params.branch }}" style="opacity:0"
   class="{{ if or $.Site.Params.announcement_banner.link $.Site.Params.announcement_banner.desktop_message }}banner{{ end }}">
 
 <head>

--- a/layouts/api/baseof.html
+++ b/layouts/api/baseof.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}"
-  data-env="{{.Site.Params.environment}}" style="opacity:0">
+  data-env="{{.Site.Params.environment}}" data-commit-ref="{{ .Site.Params.branch }}" style="opacity:0">
 
 <head>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}" data-env="{{.Site.Params.environment}}" style="opacity:0" class="{{ if or $.Site.Params.announcement_banner.link $.Site.Params.announcement_banner.desktop_message }}banner{{ end }}">
+<html lang="{{ .Site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}" data-env="{{.Site.Params.environment}}" data-commit-ref="{{ .Site.Params.branch }}" style="opacity:0" class="{{ if or $.Site.Params.announcement_banner.link $.Site.Params.announcement_banner.desktop_message }}banner{{ end }}">
 
 <head>
         {{ partial "header-scripts.html" . }}

--- a/src/scripts/components/api.js
+++ b/src/scripts/components/api.js
@@ -8,7 +8,7 @@ function versionSelectHandler(event) {
     let previewPath = '';
 
     if (window.location.href.includes('docs-staging')) {
-        previewPath = window.location.pathname.split('/').slice(0, 3).join('/');
+        previewPath = `/${document.documentElement.dataset.commitRef}`;
     }
 
     if (event.target.value === 'v2') {


### PR DESCRIPTION
### What does this PR do?
Adds the commitRef name i.e. the branch/feature name to the `html` element for use in javascript. Sometimes we need to remove/add the commitRef to the url for redirecting purposes on staging. Adding the branch to the param files on build will allow us to easily access the commitRef with javascript (instead of parsing the url). 

### Preview link
https://docs-staging.datadoghq.com/zach/update-version-selector/
check API version select change still works

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

