### PR TITLE
turn off openapi job for now

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -1,35 +1,35 @@
-name: Openapi
-on:
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'data/api/**/full_spec.yaml'
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-      with:
-        ref: ${{ github.event.pull_request.head.ref }}
-        persist-credentials: false
-        fetch-depth: 0
-    - name: Install dependencies
-      run: npm install js-yaml@^3.13.1 slugify@^1.4.0 @apidevtools/json-schema-ref-parser safe-json-stringify marked
-    - name: Create local changes
-      run: |
-        npm run build:apiPages
-        git add ./content ./data ./config
-    - name: Commit files
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git commit -m "full spec processed"
-    - name: Push changes
-      uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        # push changes to the branch that did the PR
-        branch: refs/heads/${{ github.head_ref }}
-        force: false
+#name: Openapi
+#on:
+#  pull_request:
+#    branches:
+#      - master
+#    paths:
+#      - 'data/api/**/full_spec.yaml'
+#
+#jobs:
+#  build:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - uses: actions/checkout@master
+#      with:
+#        ref: ${{ github.event.pull_request.head.ref }}
+#        persist-credentials: false
+#        fetch-depth: 0
+#    - name: Install dependencies
+#      run: npm install js-yaml@^3.13.1 slugify@^1.4.0 @apidevtools/json-schema-ref-parser safe-json-stringify marked
+#    - name: Create local changes
+#      run: |
+#        npm run build:apiPages
+#        git add ./content ./data ./config
+#    - name: Commit files
+#      run: |
+#        git config --local user.email "action@github.com"
+#        git config --local user.name "GitHub Action"
+#        git commit -m "full spec processed"
+#    - name: Push changes
+#      uses: ad-m/github-push-action@master
+#      with:
+#        github_token: ${{ secrets.GITHUB_TOKEN }}
+#        # push changes to the branch that did the PR
+#        branch: refs/heads/${{ github.head_ref }}
+#        force: false


### PR DESCRIPTION
### What does this PR do?

Turns off the openapi github job. It is no longer needed to run on our side and is causing errors with no files to commit.

### Motivation

Is actually causing errors when there are no files to commit.

### Preview link
N/A

### Additional Notes
