### PR TITLE
Tracing link fix

### DIFF
--- a/content/en/tracing/app_analytics/search.md
+++ b/content/en/tracing/app_analytics/search.md
@@ -211,7 +211,7 @@ Use Facets to filter on your Traces. The search bar and url automatically reflec
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /integrations/
+[1]: /tracing/setup/java/#integrations
 [2]: /tagging/#tags-best-practices
 [3]: /dashboards/guide/custom_time_frames/
 [4]: /tracing/visualization/#services


### PR DESCRIPTION
### What does this PR do?
Fixes a link that went to the wrong integrations page. It should link to the tracing setup integrations page.

### Motivation
JIRA request

### Preview link
https://docs-staging.datadoghq.com/sarina/tracing-link/tracing/app_analytics/search/#tags-search