### PR TITLE
Add configuration for Service Mapping for PHP

### DIFF
--- a/content/en/tracing/setup/php.md
+++ b/content/en/tracing/setup/php.md
@@ -241,6 +241,7 @@ DD_TRACE_DEBUG=true php -S localhost:8888
 | `DD_TRACE_RESOURCE_URI_MAPPING`           | `null`      | CSV of URL-to-resource-name mapping rules; e.g., `/foo/*,/bar/$*/baz`; [see "Custom URL-To-Resource Mapping"](#custom-url-to-resource-mapping) |
 | `DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED`  | `false`     | Enable URL's as resource names; [see "Map Resource Names To Normalized URI"](#map-resource-names-to-normalized-uri)                            |
 | `DD_<INTEGRATION>_ANALYTICS_ENABLED`      | `false`     | Flag to enable app analytics for relevant spans in a specific integration                                                                      |
+| `DD_SERVICE_MAPPING`      | `null`     | Allows the default name of an APM integration to be renamed. Can be used to rename several integrations at a time. Example:`DD_SERVICE_MAPPING=pdo:payments-db,mysqli:orders-db`                                                                      |
 
 #### Map Resource Names To Normalized URI
 

--- a/content/en/tracing/setup/php.md
+++ b/content/en/tracing/setup/php.md
@@ -241,7 +241,7 @@ DD_TRACE_DEBUG=true php -S localhost:8888
 | `DD_TRACE_RESOURCE_URI_MAPPING`           | `null`      | CSV of URL-to-resource-name mapping rules; e.g., `/foo/*,/bar/$*/baz`; [see "Custom URL-To-Resource Mapping"](#custom-url-to-resource-mapping) |
 | `DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED`  | `false`     | Enable URL's as resource names; [see "Map Resource Names To Normalized URI"](#map-resource-names-to-normalized-uri)                            |
 | `DD_<INTEGRATION>_ANALYTICS_ENABLED`      | `false`     | Flag to enable app analytics for relevant spans in a specific integration                                                                      |
-| `DD_SERVICE_MAPPING`      | `null`     | Allows the default name of an APM integration to be renamed. Can be used to rename several integrations at a time. Example:`DD_SERVICE_MAPPING=pdo:payments-db,mysqli:orders-db`                                                                      |
+| `DD_SERVICE_MAPPING`      | `null`     | Change the default name of an APM integration. Rename one or more integrations at a time, for example: `DD_SERVICE_MAPPING=pdo:payments-db,mysqli:orders-db`                                                                      |
 
 #### Map Resource Names To Normalized URI
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Explains that Service Mapping is available with the PHP tracer and how to use it.

### Motivation
<!-- What inspired you to submit this pull request?-->

Available due to these PRs (https://github.com/DataDog/dd-trace-php/pull/801 and  https://github.com/DataDog/dd-trace-php/pull/817). 

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/wantsui/add-service-mapping-note-to-php/content/en/tracing/setup/php.md/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

Requesting review from @priyanshi-gupta  for final wording.
