### PR TITLE
Changing from Tag to Log Parsing

### DIFF
--- a/content/en/logs/processing/processors.md
+++ b/content/en/logs/processing/processors.md
@@ -272,7 +272,7 @@ Into this log:
 
 {{< img src="logs/processing/processors/attribute_post_remapping.png" alt="attribute post remapping "  style="width:40%;">}}
 
-Constraints on the tag/attribute name are explained in the [Log Parsing - Best Practices documentation][5]. Some additional constraints are applied as `:` or `,` are not allowed in the target tag/attribute name.
+Constraints on the tag/attribute name are explained in the [Tagging documentation][5]. Some additional constraints are applied as `:` or `,` are not allowed in the target tag/attribute name.
 
 {{< tabs >}}
 {{% tab "UI" %}}

--- a/content/en/logs/processing/processors.md
+++ b/content/en/logs/processing/processors.md
@@ -272,7 +272,7 @@ Into this log:
 
 {{< img src="logs/processing/processors/attribute_post_remapping.png" alt="attribute post remapping "  style="width:40%;">}}
 
-Constraints on the tag/attribute name are explained in the [Tag Best Practice documentation][5]. Some additional constraints are applied as `:` or `,` are not allowed in the target tag/attribute name.
+Constraints on the tag/attribute name are explained in the [Log Parsing - Best Practices documentation][5]. Some additional constraints are applied as `:` or `,` are not allowed in the target tag/attribute name.
 
 {{< tabs >}}
 {{% tab "UI" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Changes the word Tag to Log Parsing. 

### Motivation
<!-- What inspired you to submit this pull request?-->
The link was pointed to Log Parsing Best Practice Documentation.

### Preview link
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/logs/processing/processors/?tab=ui#remapper

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/MacarenaCarreno-patch-1_doc_processors/logs/processing/processors/?tab=ui#remapper

### Additional Notes
<!-- Anything else we should know when reviewing?-->
