### PR TITLE
[PROD] add note for events per second limit with app analytics

### DIFF
--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -455,7 +455,7 @@ YYYY-MM-DD HH:MM:SS.<integer> +00:00 [ERR] An error occurred while sending trace
 
 ## APM rate limit
 
-If you happen to encounter this error message in your agent logs: 
+If you encounter the following error message in your Agent logs, your application(s) are emitting more than the default 200 trace events per second allowed by APM.
 
 ```
 Max events per second reached (current=300.00/s, max=200.00/s). Some events are now being dropped (sample rate=0.54). Consider adjusting event sampling rates.

--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -467,7 +467,7 @@ This means that your application(s) are emitting more than the default 200 trace
 To increase the APM rate limit for the Agent, configure the `max_events_per_second` attribute within the Agent's configuration file. For containerized deployments (Docker, Kubernetes, etc.), use the `DD_APM_MAX_EPS` environment variable.
 
 <div class="alert alert-warning">
-Please note that increasing this limit could result in increased costs for App Analytics.
+**Note**: Increasing the APM rate limit could result in increased costs for App Analytics.
 </div>
 
 ## Further Reading

--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -468,7 +468,6 @@ To increase the APM rate limit for the Agent, configure the `max_events_per_seco
 
 <div class="alert alert-warning">
 **Note**: Increasing the APM rate limit could result in increased costs for App Analytics.
-</div>
 
 ## Further Reading
 

--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -466,7 +466,6 @@ This means that your application(s) are emitting more than the default 200 trace
 
 To increase the APM rate limit for the Agent, configure the `max_events_per_second` attribute within the Agent's configuration file. For containerized deployments (Docker, Kubernetes, etc.), use the `DD_APM_MAX_EPS` environment variable.
 
-<div class="alert alert-warning">
 **Note**: Increasing the APM rate limit could result in increased costs for App Analytics.
 
 ## Further Reading

--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -464,7 +464,7 @@ Max events per second reached (current=300.00/s, max=200.00/s). Some events are 
 
 This means that your application(s) are emitting more than the default 200 trace events per second allowed by APM. 
 
-It is possible to increase this limit on the agent by configuring the `max_events_per_second` attribute within your Datadog agent's configuration file. For containerized deployments (e.g. Kubernetes), use the `DD_APM_MAX_EPS` environment variable.
+To increase the APM rate limit for the Agent, configure the `max_events_per_second` attribute within the Agent's configuration file. For containerized deployments (Docker, Kubernetes, etc.), use the `DD_APM_MAX_EPS` environment variable.
 
 <div class="alert alert-warning">
 Please note that increasing this limit could result in increased costs for App Analytics.

--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -453,7 +453,7 @@ YYYY-MM-DD HH:MM:SS.<integer> +00:00 [ERR] An error occurred while sending trace
 {{% /tab %}}
 {{< /tabs >}}
 
-## Increasing the APM Rate Limit
+## APM rate limit
 
 If you happen to encounter this error message in your agent logs: 
 

--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -462,7 +462,6 @@ Max events per second reached (current=300.00/s, max=200.00/s). Some events are 
 
 ```
 
-This means that your application(s) are emitting more than the default 200 trace events per second allowed by APM. 
 
 To increase the APM rate limit for the Agent, configure the `max_events_per_second` attribute within the Agent's configuration file. For containerized deployments (Docker, Kubernetes, etc.), use the `DD_APM_MAX_EPS` environment variable.
 

--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -453,6 +453,23 @@ YYYY-MM-DD HH:MM:SS.<integer> +00:00 [ERR] An error occurred while sending trace
 {{% /tab %}}
 {{< /tabs >}}
 
+## Increasing the APM Rate Limit
+
+If you happen to encounter this error message in your agent logs: 
+
+```
+Max events per second reached (current=300.00/s, max=200.00/s). Some events are now being dropped (sample rate=0.54). Consider adjusting event sampling rates.
+
+```
+
+This means that your application(s) are emitting more than the default 200 trace events per second allowed by APM. 
+
+It is possible to increase this limit on the agent by configuring the `max_events_per_second` attribute within your Datadog agent's configuration file. For containerized deployments (e.g. Kubernetes), use the `DD_APM_MAX_EPS` environment variable.
+
+<div class="alert alert-warning">
+Please note that increasing this limit could result in increased costs for App Analytics.
+</div>
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This rate limit is not mentioned anywhere in our docs; only mentioned in KBs and the agent's own config file. Wanted to include this in the APM troubleshooting page to make it easier to find. 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/morgan.lupton/add-apm-ratelimiting-info/tracing/troubleshooting/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
