### PR TITLE
Fix typo in Browser log collection

### DIFF
--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -28,7 +28,7 @@ With the `datadog-logs` library, you can send logs directly to Datadog from JS c
 
 ## Setup
 
-1. **Get a Datadog Client Token**: For security reasons, [API keys][1] cannot be used to configure the `datadog-logs` library, as they would be exposed client-side in the JavaScript code. To collect logs from web browsers, a [client token][2] must be used. For more information about setting up a client tolken, see the [client token documentation][2].
+1. **Get a Datadog Client Token**: For security reasons, [API keys][1] cannot be used to configure the `datadog-logs` library, as they would be exposed client-side in the JavaScript code. To collect logs from web browsers, a [client token][2] must be used. For more information about setting up a client token, see the [client token documentation][2].
 2. **Configure the Datadog browser log library** [through NPM](#npm-setup) or paste the [bundle](#bundle-setup) into the head tag directly.
 
 ### NPM setup


### PR DESCRIPTION
### What does this PR do?

Fix typo in [Browser Log Collection](https://docs.datadoghq.com/logs/log_collection/javascript/?tab=us) page, replacing `tolken` with `token`.

### Motivation

Small fix to keep docs awesome :)

### Preview link

N/A

### Additional Notes

N/A
