### PR TITLE
Generate the kubernetes manifests from the helm chart

### DIFF
--- a/static/resources/yaml/README.md
+++ b/static/resources/yaml/README.md
@@ -1,0 +1,1 @@
+The Kubernetes manifests found in this directory are automatically generated from our [Datadog Helm chart](https://github.com/helm/charts/tree/master/stable/datadog) with the [`generate.sh`](generate.sh) script.

--- a/static/resources/yaml/datadog-agent-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-all-features.yaml
@@ -1,10 +1,222 @@
-# datadog-agent.yaml
+# Source: datadog/templates/secrets.yaml
+# API Key
+apiVersion: v1
+kind: Secret
+metadata:
+  name: datadog-agent
+  labels: {}
+type: Opaque
+data:
+  api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
+
+# APP Key
 ---
+# Source: datadog/templates/system-probe-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-agent-system-probe-config
+  namespace: default
+  labels: {}
+data:
+  system-probe.yaml: |
+    system_probe_config:
+      enabled: true
+      debug_port:  0
+      sysprobe_socket: /opt/datadog-agent/run/sysprobe.sock
+      enable_conntrack : true
+      bpf_debug: false
+---
+# Source: datadog/templates/system-probe-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-agent-security
+  namespace: default
+  labels: {}
+data:
+  system-probe-seccomp.json: |
+    {
+      "defaultAction": "SCMP_ACT_ERRNO",
+      "syscalls": [
+        {
+          "names": [
+            "accept4",
+            "access",
+            "arch_prctl",
+            "bind",
+            "bpf",
+            "brk",
+            "capget",
+            "capset",
+            "chdir",
+            "clock_gettime",
+            "clone",
+            "close",
+            "connect",
+            "copy_file_range",
+            "creat",
+            "dup",
+            "dup2",
+            "dup3",
+            "epoll_create",
+            "epoll_create1",
+            "epoll_ctl",
+            "epoll_ctl_old",
+            "epoll_pwait",
+            "epoll_wait",
+            "epoll_wait",
+            "epoll_wait_old",
+            "execve",
+            "execveat",
+            "exit",
+            "exit_group",
+            "fchmod",
+            "fchmodat",
+            "fchown",
+            "fchown32",
+            "fchownat",
+            "fcntl",
+            "fcntl64",
+            "fstat",
+            "fstat64",
+            "fstatfs",
+            "fsync",
+            "futex",
+            "getcwd",
+            "getdents",
+            "getdents64",
+            "getegid",
+            "geteuid",
+            "getgid",
+            "getpeername",
+            "getpid",
+            "getppid",
+            "getpriority",
+            "getrandom",
+            "getresgid",
+            "getresgid32",
+            "getresuid",
+            "getresuid32",
+            "getrlimit",
+            "getrusage",
+            "getsid",
+            "getsockname",
+            "getsockopt",
+            "gettid",
+            "gettimeofday",
+            "getuid",
+            "getxattr",
+            "ioctl",
+            "ipc",
+            "listen",
+            "lseek",
+            "lstat",
+            "lstat64",
+            "mkdir",
+            "mkdirat",
+            "mmap",
+            "mmap2",
+            "mprotect",
+            "munmap",
+            "nanosleep",
+            "newfstatat",
+            "open",
+            "openat",
+            "pause",
+            "perf_event_open",
+            "pipe",
+            "pipe2",
+            "poll",
+            "ppoll",
+            "prctl",
+            "prlimit64",
+            "pselect6",
+            "read",
+            "readlink",
+            "readlinkat",
+            "recvfrom",
+            "recvmmsg",
+            "recvmsg",
+            "rename",
+            "restart_syscall",
+            "rmdir",
+            "rt_sigaction",
+            "rt_sigpending",
+            "rt_sigprocmask",
+            "rt_sigqueueinfo",
+            "rt_sigreturn",
+            "rt_sigsuspend",
+            "rt_sigtimedwait",
+            "rt_tgsigqueueinfo",
+            "sched_getaffinity",
+            "sched_yield",
+            "seccomp",
+            "select",
+            "semtimedop",
+            "send",
+            "sendmmsg",
+            "sendmsg",
+            "sendto",
+            "set_robust_list",
+            "set_tid_address",
+            "setgid",
+            "setgid32",
+            "setgroups",
+            "setgroups32",
+            "setns",
+            "setrlimit",
+            "setsid",
+            "setsidaccept4",
+            "setsockopt",
+            "setuid",
+            "setuid32",
+            "sigaltstack",
+            "socket",
+            "socketcall",
+            "socketpair",
+            "stat",
+            "stat64",
+            "statfs",
+            "sysinfo",
+            "umask",
+            "uname",
+            "unlink",
+            "unlinkat",
+            "wait4",
+            "waitid",
+            "waitpid",
+            "write"
+          ],
+          "action": "SCMP_ACT_ALLOW",
+          "args": null
+        },
+        {
+          "names": [
+            "setns"
+          ],
+          "action": "SCMP_ACT_ALLOW",
+          "args": [
+            {
+              "index": 1,
+              "value": 1073741824,
+              "valueTwo": 0,
+              "op": "SCMP_CMP_EQ"
+            }
+          ],
+          "comment": "",
+          "includes": {},
+          "excludes": {}
+        }
+      ]
+    }
+---
+# Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: datadog-agent
-  namespace: default
+  labels: {}
 spec:
   selector:
     matchLabels:
@@ -14,189 +226,285 @@ spec:
       labels:
         app: datadog-agent
       name: datadog-agent
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
+        container.seccomp.security.alpha.kubernetes.io/system-probe: localhost/system-probe
     spec:
-      serviceAccountName: datadog-agent
       containers:
-        - image: 'datadog/agent:latest'
-          imagePullPolicy: Always
-          name: datadog-agent
-          ports:
-
-            ###############
-            ## DogStatsD ##
-            ###############
-            - containerPort: 8125
-              hostPort: 8125
-              name: dogstatsdport
-              protocol: UDP
-
-            #########
-            ## APM ##
-            #########
-            - containerPort: 8126
-              hostPort: 8126
-              name: traceport
-              protocol: TCP
-          env:
-            ## The Datadog API Key related to your Organization set by secret
-            - name: DD_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: datadog-secret
-                  key: api-key
-
-            ## Set DD_SITE to 'datadoghq.eu' to send your Agent data to the Datadog EU site
-            - name: DD_SITE
-              value: 'datadoghq.com'
-
-            #######################
-            ## Metric collection ##
-            #######################
-            - name: KUBERNETES
-              value: 'true'
-            - name: DD_HEALTH_PORT
-              value: '5555'
-            - name: DD_COLLECT_KUBERNETES_EVENTS
-              value: 'true'
-            - name: DD_LEADER_ELECTION
-              value: 'true'
-            - name: DD_KUBERNETES_KUBELET_HOST
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
-
-            ###############
-            ## DogStatsD ##
-            ###############
-            - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
-              value: 'true'
-
-            #########
-            ## APM ##
-            #########
-            - name: DD_APM_ENABLED
-              value: 'true'
-            - name: DD_APM_NON_LOCAL_TRAFFIC
-              value: 'true'
-
-            ####################
-            ## Log collection ##
-            ####################
-            - name: DD_LOGS_ENABLED
-              value: 'true'
-            - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
-              value: 'true'
-            - name: DD_AC_EXCLUDE
-              value: 'name:datadog-agent'
-            - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
-              value: 'true'
-
-            ########################
-            ## Process collection ##
-            ########################
-            - name: DD_PROCESS_AGENT_ENABLED
-              value: 'true'
-
-
-            ## For secure communication with the Cluster Agent (required to use the Cluster Agent)
-            # - name: DD_CLUSTER_AGENT_AUTH_TOKEN
-            #
-            ## If using a simple env var uncomment this section
-            #
-            #   value: <THIRTY_2_CHARACTERS_LONG_TOKEN>
-            #
-            ## If using a secret uncomment this section
-            #
-            #   valueFrom:
-            #     secretKeyRef:
-            #       name: datadog-auth-token
-            #       key: token
-
-          ## Note these are the minimum suggested values for requests and limits.
-          ## The amount of resources required by the Agent varies depending on:
-          ## * The number of checks
-          ## * The number of integrations enabled
-          ## * The number of features enabled
-          resources:
-            requests:
-              memory: 256Mi
-              cpu: 200m
-            limits:
-              memory: 256Mi
-              cpu: 200m
-
-
-          volumeMounts:
-
-            #######################
-            ## Metric collection ##
-            #######################
-            - name: dockersocketdir
-              mountPath: /var/run
-            - name: procdir
-              mountPath: /host/proc
-              readOnly: true
-            - name: cgroups
-              mountPath: /host/sys/fs/cgroup
-              readOnly: true
-
-            ####################
-            ## Log collection ##
-            ####################
-            - name: pointdir
-              mountPath: /opt/datadog-agent/run
-            - name: logpodpath
-              mountPath: /var/log/pods
-
-              # Docker runtime directory, replace this path with your container runtime logs directory,
-              # or remove this configuration if `/var/log/pods` is not a symlink to any other directory.
-            - name: logcontainerpath
-              mountPath: /var/lib/docker/containers
-
-            ########################
-            ## Process collection ##
-            ########################
-            - name: passwd
-              mountPath: /etc/passwd
-              readOnly: true
-
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 5555
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            timeoutSeconds: 5
-            successThreshold: 1
-            failureThreshold: 3
-
+      - name: agent
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["agent", "start"]
+        resources: {}
+        ports:
+        - containerPort: 8125
+          name: dogstatsdport
+          protocol: UDP
+        env:
+        - name: DD_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "datadog-agent"
+              key: api-key
+        - name: DD_KUBERNETES_KUBELET_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: KUBERNETES
+          value: "yes"
+        - name: DD_LOG_LEVEL
+          value: "INFO"
+        - name: DD_DOGSTATSD_PORT
+          value: "8125"
+        - name: DD_APM_ENABLED
+          value: "false"
+        - name: DD_LOGS_ENABLED
+          value: "true"
+        - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
+          value: "true"
+        - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
+          value: "true"
+        - name: DD_HEALTH_PORT
+          value: "5555"
+        - name: SYSTEM_PROBE_CONFIG_SYSPROBE_SOCKET
+          value: /sysprobe/var/run
+        volumeMounts:
+        - name: config
+          mountPath: /etc/datadog-agent
+        - name: runtimesocket
+          mountPath: /var/run/docker.sock
+          readOnly: true
+        - name: sysprobe-socket-dir
+          mountPath: /sysprobe/var/run
+          readOnly: true
+        - name: procdir
+          mountPath: /host/proc
+          readOnly: true
+        - name: cgroups
+          mountPath: /host/sys/fs/cgroup
+          readOnly: true
+        - name: pointerdir
+          mountPath: /opt/datadog-agent/run
+        - name: logpodpath
+          mountPath: /var/log/pods
+          readOnly: true
+        - name: logdockercontainerpath
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        livenessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /health
+            port: 5555
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 5
+      - name: trace-agent
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
+        resources: {}
+        ports:
+        - containerPort: 8126
+          hostPort: 8126
+          name: traceport
+          protocol: TCP
+        env:
+        - name: DD_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "datadog-agent"
+              key: api-key
+        - name: DD_KUBERNETES_KUBELET_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: KUBERNETES
+          value: "yes"
+        - name: DD_LOG_LEVEL
+          value: "INFO"
+        - name: DD_APM_ENABLED
+          value: "true"
+        - name: DD_APM_NON_LOCAL_TRAFFIC
+          value: "true"
+        - name: DD_APM_RECEIVER_PORT
+          value: "8126"
+        volumeMounts:
+        - name: config
+          mountPath: /etc/datadog-agent
+        - name: runtimesocket
+          mountPath: /var/run/docker.sock
+          readOnly: true
+        livenessProbe:
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          tcpSocket:
+            port: 8126
+          timeoutSeconds: 5
+      - name: process-agent
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
+        resources: {}
+        env:
+        - name: DD_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "datadog-agent"
+              key: api-key
+        - name: DD_KUBERNETES_KUBELET_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: KUBERNETES
+          value: "yes"
+        - name: DD_PROCESS_AGENT_ENABLED
+          value: "true"
+        - name: DD_LOG_LEVEL
+          value: "INFO"
+        - name: DD_SYSTEM_PROBE_ENABLED
+          value: "true"
+        volumeMounts:
+        - name: config
+          mountPath: /etc/datadog-agent
+        - name: runtimesocket
+          mountPath: /var/run/docker.sock
+          readOnly: true
+        - name: cgroups
+          mountPath: /host/sys/fs/cgroup
+          readOnly: true
+        - name: passwd
+          mountPath: /etc/passwd
+        - name: procdir
+          mountPath: /host/proc
+          readOnly: true
+        - name: sysprobe-socket-dir
+          mountPath: /opt/datadog-agent/run
+          readOnly: true
+      - name: system-probe
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          capabilities:
+            add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "IPC_LOCK"]
+        command: ["/opt/datadog-agent/embedded/bin/system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
+        env:
+        - name: DD_LOG_LEVEL
+          value: "INFO"
+        resources: {}
+        volumeMounts:
+        - name: debugfs
+          mountPath: /sys/kernel/debug
+        - name: sysprobe-config
+          mountPath: /etc/datadog-agent
+        - name: sysprobe-socket-dir
+          mountPath: /opt/datadog-agent/run
+        - name: procdir
+          mountPath: /host/proc
+          readOnly: true
+      initContainers:
+      - name: init-volume
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["bash", "-c"]
+        args:
+        - cp -r /etc/datadog-agent /opt
+        volumeMounts:
+        - name: config
+          mountPath: /opt/datadog-agent
+        resources: {}
+      - name: init-config
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["bash", "-c"]
+        args:
+        - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do
+          bash $script ; done
+        volumeMounts:
+        - name: config
+          mountPath: /etc/datadog-agent
+        - name: procdir
+          mountPath: /host/proc
+          readOnly: true
+        - name: runtimesocket
+          mountPath: /var/run/docker.sock
+          readOnly: true
+        env:
+        - name: DD_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "datadog-agent"
+              key: api-key
+        - name: DD_KUBERNETES_KUBELET_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: KUBERNETES
+          value: "yes"
+        resources: {}
+      - name: seccomp-setup
+        image: "datadog/agent:7"
+        command:
+        - cp
+        - /etc/config/system-probe-seccomp.json
+        - /host/var/lib/kubelet/seccomp/system-probe
+        volumeMounts:
+        - name: datadog-agent-security
+          mountPath: /etc/config
+        - name: seccomp-root
+          mountPath: /host/var/lib/kubelet/seccomp
       volumes:
-        - hostPath:
-            path: /var/run
-          name: dockersocketdir
-        - hostPath:
-            path: /proc
-          name: procdir
-        - hostPath:
-            path: /sys/fs/cgroup
-          name: cgroups
-        #####################
-        ## Log collection  ##
-        #####################
-        - hostPath:
-            path: /var/lib/datadog-agent/logs
-          name: pointdir
-        - hostPath:
-            path: /var/log/pods
-          name: logpodpath
-        # Docker runtime directory, replace this path with your container runtime logs directory,
-        # or remove this configuration if `/var/log/pods` is not a symlink to any other directory.
-        - hostPath:
-            path: /var/lib/docker/containers
-          name: logcontainerpath
-        ########################
-        ## Process collection ##
-        ########################
-        - hostPath:
-            path: /etc/passwd
-          name: passwd
+      - name: config
+        emptyDir: {}
+      - hostPath:
+          path: /var/run/docker.sock
+        name: runtimesocket
+      - hostPath:
+          path: /proc
+        name: procdir
+      - hostPath:
+          path: /sys/fs/cgroup
+        name: cgroups
+      - name: s6-run
+        emptyDir: {}
+      - name: sysprobe-config
+        configMap:
+          name: datadog-agent-system-probe-config
+      - name: datadog-agent-security
+        configMap:
+          name: datadog-agent-security
+      - hostPath:
+          path: /var/lib/kubelet/seccomp
+        name: seccomp-root
+      - hostPath:
+          path: /sys/kernel/debug
+        name: debugfs
+      - name: sysprobe-socket-dir
+        emptyDir: {}
+      - hostPath:
+          path: /etc/passwd
+        name: passwd
+      - hostPath:
+          path: "/var/lib/datadog-agent/logs"
+        name: pointerdir
+      - hostPath:
+          path: /var/log/pods
+        name: logpodpath
+      - hostPath:
+          path: /var/lib/docker/containers
+        name: logdockercontainerpath
+      tolerations:
+      affinity: null
+      serviceAccountName: "default"
+      nodeSelector:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
+
+# Source: datadog/templates/containers-common-env.yaml
+# The purpose of this template is to define a minimal set of environment
+# variables required to operate dedicated containers in the daemonset.
+---
+{}

--- a/static/resources/yaml/datadog-agent-all-features_values.yaml
+++ b/static/resources/yaml/datadog-agent-all-features_values.yaml
@@ -1,0 +1,15 @@
+datadog:
+  kubeStateMetricsEnabled: false
+  logs:
+    enabled: true
+    containerCollectAll: true
+  apm:
+    enabled: true
+  processAgent:
+    enabled: true
+    processCollection: true
+  systemProbe:
+    enabled: true
+agents:
+  rbac:
+    create: false

--- a/static/resources/yaml/datadog-agent-apm.yaml
+++ b/static/resources/yaml/datadog-agent-apm.yaml
@@ -1,10 +1,22 @@
-# datadog-agent.yaml
+# Source: datadog/templates/secrets.yaml
+# API Key
+apiVersion: v1
+kind: Secret
+metadata:
+  name: datadog-agent
+  labels: {}
+type: Opaque
+data:
+  api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
+
+# APP Key
 ---
+# Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: datadog-agent
-  namespace: default
+  labels: {}
 spec:
   selector:
     matchLabels:
@@ -14,117 +26,172 @@ spec:
       labels:
         app: datadog-agent
       name: datadog-agent
+      annotations: {}
     spec:
-      serviceAccountName: datadog-agent
       containers:
-        - image: 'datadog/agent:latest'
-          imagePullPolicy: Always
-          name: datadog-agent
-          ports:
-
-            #########
-            ## APM ##
-            #########
-            - containerPort: 8126
-              hostPort: 8126
-              name: traceport
-              protocol: TCP
-          env:
-            ## The Datadog API Key related to your Organization set by secret
-            - name: DD_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: datadog-secret
-                  key: api-key
-
-            ## Set DD_SITE to 'datadoghq.eu' to send your Agent data to the Datadog EU site
-            - name: DD_SITE
-              value: 'datadoghq.com'
-
-            #######################
-            ## Metric collection ##
-            #######################
-            - name: KUBERNETES
-              value: 'true'
-            - name: DD_HEALTH_PORT
-              value: '5555'
-            - name: DD_COLLECT_KUBERNETES_EVENTS
-              value: 'true'
-            - name: DD_LEADER_ELECTION
-              value: 'true'
-            - name: DD_KUBERNETES_KUBELET_HOST
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
-
-            #########
-            ## APM ##
-            #########
-            - name: DD_APM_ENABLED
-              value: 'true'
-            - name: DD_APM_NON_LOCAL_TRAFFIC
-              value: 'true'
-
-          ## For secure communication with the Cluster Agent (required to use the Cluster Agent)
-          # - name: DD_CLUSTER_AGENT_AUTH_TOKEN
-          #
-          ## If using a simple env var uncomment this section
-          #
-          #   value: <THIRTY_2_CHARACTERS_LONG_TOKEN>
-          #
-          ## If using a secret uncomment this section
-          #
-          #   valueFrom:
-          #     secretKeyRef:
-          #       name: datadog-auth-token
-          #       key: token
-
-          ## Note these are the minimum suggested values for requests and limits.
-          ## The amount of resources required by the Agent varies depending on:
-          ## * The number of checks
-          ## * The number of integrations enabled
-          ## * The number of features enabled
-          resources:
-            requests:
-              memory: 256Mi
-              cpu: 200m
-            limits:
-              memory: 256Mi
-              cpu: 200m
-
-
-          volumeMounts:
-
-            #######################
-            ## Metric collection ##
-            #######################
-            - name: dockersocketdir
-              mountPath: /var/run
-            - name: procdir
-              mountPath: /host/proc
-              readOnly: true
-            - name: cgroups
-              mountPath: /host/sys/fs/cgroup
-              readOnly: true
-
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 5555
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            timeoutSeconds: 5
-            successThreshold: 1
-            failureThreshold: 3
-
+      - name: agent
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["agent", "start"]
+        resources: {}
+        ports:
+        - containerPort: 8125
+          name: dogstatsdport
+          protocol: UDP
+        env:
+        - name: DD_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "datadog-agent"
+              key: api-key
+        - name: DD_KUBERNETES_KUBELET_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: KUBERNETES
+          value: "yes"
+        - name: DD_LOG_LEVEL
+          value: "INFO"
+        - name: DD_DOGSTATSD_PORT
+          value: "8125"
+        - name: DD_APM_ENABLED
+          value: "false"
+        - name: DD_LOGS_ENABLED
+          value: "false"
+        - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
+          value: "false"
+        - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
+          value: "true"
+        - name: DD_HEALTH_PORT
+          value: "5555"
+        volumeMounts:
+        - name: config
+          mountPath: /etc/datadog-agent
+        - name: runtimesocket
+          mountPath: /var/run/docker.sock
+          readOnly: true
+        - name: procdir
+          mountPath: /host/proc
+          readOnly: true
+        - name: cgroups
+          mountPath: /host/sys/fs/cgroup
+          readOnly: true
+        livenessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /health
+            port: 5555
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 5
+      - name: trace-agent
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
+        resources: {}
+        ports:
+        - containerPort: 8126
+          hostPort: 8126
+          name: traceport
+          protocol: TCP
+        env:
+        - name: DD_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "datadog-agent"
+              key: api-key
+        - name: DD_KUBERNETES_KUBELET_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: KUBERNETES
+          value: "yes"
+        - name: DD_LOG_LEVEL
+          value: "INFO"
+        - name: DD_APM_ENABLED
+          value: "true"
+        - name: DD_APM_NON_LOCAL_TRAFFIC
+          value: "true"
+        - name: DD_APM_RECEIVER_PORT
+          value: "8126"
+        volumeMounts:
+        - name: config
+          mountPath: /etc/datadog-agent
+        - name: runtimesocket
+          mountPath: /var/run/docker.sock
+          readOnly: true
+        livenessProbe:
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          tcpSocket:
+            port: 8126
+          timeoutSeconds: 5
+      initContainers:
+      - name: init-volume
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["bash", "-c"]
+        args:
+        - cp -r /etc/datadog-agent /opt
+        volumeMounts:
+        - name: config
+          mountPath: /opt/datadog-agent
+        resources: {}
+      - name: init-config
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["bash", "-c"]
+        args:
+        - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do
+          bash $script ; done
+        volumeMounts:
+        - name: config
+          mountPath: /etc/datadog-agent
+        - name: procdir
+          mountPath: /host/proc
+          readOnly: true
+        - name: runtimesocket
+          mountPath: /var/run/docker.sock
+          readOnly: true
+        env:
+        - name: DD_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "datadog-agent"
+              key: api-key
+        - name: DD_KUBERNETES_KUBELET_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: KUBERNETES
+          value: "yes"
+        resources: {}
       volumes:
-        - hostPath:
-            path: /var/run
-          name: dockersocketdir
-        - hostPath:
-            path: /proc
-          name: procdir
-        - hostPath:
-            path: /sys/fs/cgroup
-          name: cgroups
+      - name: config
+        emptyDir: {}
+      - hostPath:
+          path: /var/run/docker.sock
+        name: runtimesocket
+      - hostPath:
+          path: /proc
+        name: procdir
+      - hostPath:
+          path: /sys/fs/cgroup
+        name: cgroups
+      - name: s6-run
+        emptyDir: {}
+      tolerations:
+      affinity: null
+      serviceAccountName: "default"
+      nodeSelector:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
 
+# Source: datadog/templates/containers-common-env.yaml
+# The purpose of this template is to define a minimal set of environment
+# variables required to operate dedicated containers in the daemonset.
+---
+{}

--- a/static/resources/yaml/datadog-agent-apm_values.yaml
+++ b/static/resources/yaml/datadog-agent-apm_values.yaml
@@ -1,0 +1,9 @@
+datadog:
+  kubeStateMetricsEnabled: false
+  apm:
+    enabled: true
+  processAgent:
+    enabled: false
+agents:
+  rbac:
+    create: false

--- a/static/resources/yaml/datadog-agent-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-logs-apm.yaml
@@ -1,10 +1,22 @@
-# datadog-agent.yaml
+# Source: datadog/templates/secrets.yaml
+# API Key
+apiVersion: v1
+kind: Secret
+metadata:
+  name: datadog-agent
+  labels: {}
+type: Opaque
+data:
+  api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
+
+# APP Key
 ---
+# Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: datadog-agent
-  namespace: default
+  labels: {}
 spec:
   selector:
     matchLabels:
@@ -14,155 +26,197 @@ spec:
       labels:
         app: datadog-agent
       name: datadog-agent
+      annotations: {}
     spec:
-      serviceAccountName: datadog-agent
       containers:
-        - image: 'datadog/agent:latest'
-          imagePullPolicy: Always
-          name: datadog-agent
-          ports:
-
-            #########
-            ## APM ##
-            #########
-            - containerPort: 8126
-              hostPort: 8126
-              name: traceport
-              protocol: TCP
-          env:
-            ## The Datadog API Key related to your Organization set by secret
-            - name: DD_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: datadog-secret
-                  key: api-key
-
-            ## Set DD_SITE to 'datadoghq.eu' to send your Agent data to the Datadog EU site
-            - name: DD_SITE
-              value: 'datadoghq.com'
-
-            #######################
-            ## Metric collection ##
-            #######################
-            - name: KUBERNETES
-              value: 'true'
-            - name: DD_HEALTH_PORT
-              value: '5555'
-            - name: DD_COLLECT_KUBERNETES_EVENTS
-              value: 'true'
-            - name: DD_LEADER_ELECTION
-              value: 'true'
-            - name: DD_KUBERNETES_KUBELET_HOST
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
-
-            #########
-            ## APM ##
-            #########
-            - name: DD_APM_ENABLED
-              value: 'true'
-            - name: DD_APM_NON_LOCAL_TRAFFIC
-              value: 'true'
-
-            ####################
-            ## Log collection ##
-            ####################
-            - name: DD_LOGS_ENABLED
-              value: 'true'
-            - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
-              value: 'true'
-            - name: DD_AC_EXCLUDE
-              value: 'name:datadog-agent'
-            - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
-              value: 'true'
-
-          ## For secure communication with the Cluster Agent (required to use the Cluster Agent)
-          # - name: DD_CLUSTER_AGENT_AUTH_TOKEN
-          #
-          ## If using a simple env var uncomment this section
-          #
-          #   value: <THIRTY_2_CHARACTERS_LONG_TOKEN>
-          #
-          ## If using a secret uncomment this section
-          #
-          #   valueFrom:
-          #     secretKeyRef:
-          #       name: datadog-auth-token
-          #       key: token
-
-          ## Note these are the minimum suggested values for requests and limits.
-          ## The amount of resources required by the Agent varies depending on:
-          ## * The number of checks
-          ## * The number of integrations enabled
-          ## * The number of features enabled
-          resources:
-            requests:
-              memory: 256Mi
-              cpu: 200m
-            limits:
-              memory: 256Mi
-              cpu: 200m
-
-
-          volumeMounts:
-
-            #######################
-            ## Metric collection ##
-            #######################
-            - name: dockersocketdir
-              mountPath: /var/run
-            - name: procdir
-              mountPath: /host/proc
-              readOnly: true
-            - name: cgroups
-              mountPath: /host/sys/fs/cgroup
-              readOnly: true
-
-            ####################
-            ## Log collection ##
-            ####################
-            - name: pointdir
-              mountPath: /var/lib/datadog-agent/logs
-            - name: logpodpath
-              mountPath: /var/log/pods
-
-              # Docker runtime directory, replace this path with your container runtime logs directory,
-              # or remove this configuration if `/var/log/pods` is not a symlink to any other directory.
-            - name: logcontainerpath
-              mountPath: /var/lib/docker/containers
-
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 5555
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            timeoutSeconds: 5
-            successThreshold: 1
-            failureThreshold: 3
-
+      - name: agent
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["agent", "start"]
+        resources: {}
+        ports:
+        - containerPort: 8125
+          name: dogstatsdport
+          protocol: UDP
+        env:
+        - name: DD_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "datadog-agent"
+              key: api-key
+        - name: DD_KUBERNETES_KUBELET_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: KUBERNETES
+          value: "yes"
+        - name: DD_LOG_LEVEL
+          value: "INFO"
+        - name: DD_DOGSTATSD_PORT
+          value: "8125"
+        - name: DD_AC_EXCLUDE
+          value: "name:datadog-agent"
+        - name: DD_LEADER_ELECTION
+          value: "true"
+        - name: DD_COLLECT_KUBERNETES_EVENTS
+          value: "true"
+        - name: DD_APM_ENABLED
+          value: "false"
+        - name: DD_LOGS_ENABLED
+          value: "true"
+        - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
+          value: "true"
+        - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
+          value: "true"
+        - name: DD_HEALTH_PORT
+          value: "5555"
+        volumeMounts:
+        - name: config
+          mountPath: /etc/datadog-agent
+        - name: runtimesocket
+          mountPath: /var/run/docker.sock
+          readOnly: true
+        - name: procdir
+          mountPath: /host/proc
+          readOnly: true
+        - name: cgroups
+          mountPath: /host/sys/fs/cgroup
+          readOnly: true
+        - name: pointerdir
+          mountPath: /opt/datadog-agent/run
+        - name: logpodpath
+          mountPath: /var/log/pods
+          readOnly: true
+        - name: logdockercontainerpath
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        livenessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /health
+            port: 5555
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 5
+      - name: trace-agent
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
+        resources: {}
+        ports:
+        - containerPort: 8126
+          hostPort: 8126
+          name: traceport
+          protocol: TCP
+        env:
+        - name: DD_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "datadog-agent"
+              key: api-key
+        - name: DD_KUBERNETES_KUBELET_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: KUBERNETES
+          value: "yes"
+        - name: DD_LOG_LEVEL
+          value: "INFO"
+        - name: DD_APM_ENABLED
+          value: "true"
+        - name: DD_APM_NON_LOCAL_TRAFFIC
+          value: "true"
+        - name: DD_APM_RECEIVER_PORT
+          value: "8126"
+        volumeMounts:
+        - name: config
+          mountPath: /etc/datadog-agent
+        - name: runtimesocket
+          mountPath: /var/run/docker.sock
+          readOnly: true
+        livenessProbe:
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          tcpSocket:
+            port: 8126
+          timeoutSeconds: 5
+      initContainers:
+      - name: init-volume
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["bash", "-c"]
+        args:
+        - cp -r /etc/datadog-agent /opt
+        volumeMounts:
+        - name: config
+          mountPath: /opt/datadog-agent
+        resources: {}
+      - name: init-config
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["bash", "-c"]
+        args:
+        - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do
+          bash $script ; done
+        volumeMounts:
+        - name: config
+          mountPath: /etc/datadog-agent
+        - name: procdir
+          mountPath: /host/proc
+          readOnly: true
+        - name: runtimesocket
+          mountPath: /var/run/docker.sock
+          readOnly: true
+        env:
+        - name: DD_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "datadog-agent"
+              key: api-key
+        - name: DD_KUBERNETES_KUBELET_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: KUBERNETES
+          value: "yes"
+        - name: DD_LEADER_ELECTION
+          value: "true"
+        resources: {}
       volumes:
-        - hostPath:
-            path: /var/run
-          name: dockersocketdir
-        - hostPath:
-            path: /proc
-          name: procdir
-        - hostPath:
-            path: /sys/fs/cgroup
-          name: cgroups
-        #####################
-        ## Log collection  ##
-        #####################
-        - hostPath:
-            path: /opt/datadog-agent/run:rw
-          name: pointdir
-        - hostPath:
-            path: /var/log/pods
-          name: logpodpath
-        # Docker runtime directory, replace this path with your container runtime logs directory,
-        # or remove this configuration if `/var/log/pods` is not a symlink to any other directory.
-        - hostPath:
-            path: /var/lib/docker/containers
-          name: logcontainerpath
+      - name: config
+        emptyDir: {}
+      - hostPath:
+          path: /var/run/docker.sock
+        name: runtimesocket
+      - hostPath:
+          path: /proc
+        name: procdir
+      - hostPath:
+          path: /sys/fs/cgroup
+        name: cgroups
+      - name: s6-run
+        emptyDir: {}
+      - hostPath:
+          path: "/var/lib/datadog-agent/logs"
+        name: pointerdir
+      - hostPath:
+          path: /var/log/pods
+        name: logpodpath
+      - hostPath:
+          path: /var/lib/docker/containers
+        name: logdockercontainerpath
+      tolerations:
+      affinity: null
+      serviceAccountName: "default"
+      nodeSelector:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
+
+# Source: datadog/templates/containers-common-env.yaml
+# The purpose of this template is to define a minimal set of environment
+# variables required to operate dedicated containers in the daemonset.
+---
+{}

--- a/static/resources/yaml/datadog-agent-logs-apm_values.yaml
+++ b/static/resources/yaml/datadog-agent-logs-apm_values.yaml
@@ -1,0 +1,15 @@
+datadog:
+  kubeStateMetricsEnabled: false
+  leaderElection: true
+  collectEvents: true
+  logs:
+    enabled: true
+    containerCollectAll: true
+  acExclude: "name:datadog-agent"
+  apm:
+    enabled: true
+  processAgent:
+    enabled: false
+agents:
+  rbac:
+    create: false

--- a/static/resources/yaml/datadog-agent-logs.yaml
+++ b/static/resources/yaml/datadog-agent-logs.yaml
@@ -1,10 +1,22 @@
-# datadog-agent.yaml
+# Source: datadog/templates/secrets.yaml
+# API Key
+apiVersion: v1
+kind: Secret
+metadata:
+  name: datadog-agent
+  labels: {}
+type: Opaque
+data:
+  api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
+
+# APP Key
 ---
+# Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: datadog-agent
-  namespace: default
+  labels: {}
 spec:
   selector:
     matchLabels:
@@ -14,139 +26,155 @@ spec:
       labels:
         app: datadog-agent
       name: datadog-agent
+      annotations: {}
     spec:
-      serviceAccountName: datadog-agent
       containers:
-        - image: 'datadog/agent:latest'
-          imagePullPolicy: Always
-          name: datadog-agent
-          env:
-            ## The Datadog API Key related to your Organization set by secret
-            - name: DD_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: datadog-secret
-                  key: api-key
-
-            ## Set DD_SITE to 'datadoghq.eu' to send your Agent data to the Datadog EU site
-            - name: DD_SITE
-              value: 'datadoghq.com'
-
-            #######################
-            ## Metric collection ##
-            #######################
-            - name: KUBERNETES
-              value: 'true'
-            - name: DD_HEALTH_PORT
-              value: '5555'
-            - name: DD_COLLECT_KUBERNETES_EVENTS
-              value: 'true'
-            - name: DD_LEADER_ELECTION
-              value: 'true'
-            - name: DD_KUBERNETES_KUBELET_HOST
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
-
-            ####################
-            ## Log collection ##
-            ####################
-            - name: DD_LOGS_ENABLED
-              value: 'true'
-            - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
-              value: 'true'
-            - name: DD_AC_EXCLUDE
-              value: 'name:datadog-agent'
-            - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
-              value: 'true'
-
-          ## For secure communication with the Cluster Agent (required to use the Cluster Agent)
-          # - name: DD_CLUSTER_AGENT_AUTH_TOKEN
-          #
-          ## If using a simple env var uncomment this section
-          #
-          #   value: <THIRTY_2_CHARACTERS_LONG_TOKEN>
-          #
-          ## If using a secret uncomment this section
-          #
-          #   valueFrom:
-          #     secretKeyRef:
-          #       name: datadog-auth-token
-          #       key: token
-
-          ## Note these are the minimum suggested values for requests and limits.
-          ## The amount of resources required by the Agent varies depending on:
-          ## * The number of checks
-          ## * The number of integrations enabled
-          ## * The number of features enabled
-          resources:
-            requests:
-              memory: 256Mi
-              cpu: 200m
-            limits:
-              memory: 256Mi
-              cpu: 200m
-
-
-          volumeMounts:
-
-            #######################
-            ## Metric collection ##
-            #######################
-            - name: dockersocketdir
-              mountPath: /var/run
-            - name: procdir
-              mountPath: /host/proc
-              readOnly: true
-            - name: cgroups
-              mountPath: /host/sys/fs/cgroup
-              readOnly: true
-
-            ####################
-            ## Log collection ##
-            ####################
-            - name: pointdir
-              mountPath: /var/lib/datadog-agent/logs
-            - name: logpodpath
-              mountPath: /var/log/pods
-
-              # Docker runtime directory, replace this path with your container runtime logs directory,
-              # or remove this configuration if `/var/log/pods` is not a symlink to any other directory.
-            - name: logcontainerpath
-              mountPath: /var/lib/docker/containers
-
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 5555
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            timeoutSeconds: 5
-            successThreshold: 1
-            failureThreshold: 3
-
+      - name: agent
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["agent", "start"]
+        resources: {}
+        ports:
+        - containerPort: 8125
+          name: dogstatsdport
+          protocol: UDP
+        env:
+        - name: DD_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "datadog-agent"
+              key: api-key
+        - name: DD_KUBERNETES_KUBELET_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: KUBERNETES
+          value: "yes"
+        - name: DD_LOG_LEVEL
+          value: "INFO"
+        - name: DD_DOGSTATSD_PORT
+          value: "8125"
+        - name: DD_AC_EXCLUDE
+          value: "name:datadog-agent"
+        - name: DD_LEADER_ELECTION
+          value: "true"
+        - name: DD_COLLECT_KUBERNETES_EVENTS
+          value: "true"
+        - name: DD_APM_ENABLED
+          value: "false"
+        - name: DD_LOGS_ENABLED
+          value: "true"
+        - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
+          value: "true"
+        - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
+          value: "true"
+        - name: DD_HEALTH_PORT
+          value: "5555"
+        volumeMounts:
+        - name: config
+          mountPath: /etc/datadog-agent
+        - name: runtimesocket
+          mountPath: /var/run/docker.sock
+          readOnly: true
+        - name: procdir
+          mountPath: /host/proc
+          readOnly: true
+        - name: cgroups
+          mountPath: /host/sys/fs/cgroup
+          readOnly: true
+        - name: pointerdir
+          mountPath: /opt/datadog-agent/run
+        - name: logpodpath
+          mountPath: /var/log/pods
+          readOnly: true
+        - name: logdockercontainerpath
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        livenessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /health
+            port: 5555
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 5
+      initContainers:
+      - name: init-volume
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["bash", "-c"]
+        args:
+        - cp -r /etc/datadog-agent /opt
+        volumeMounts:
+        - name: config
+          mountPath: /opt/datadog-agent
+        resources: {}
+      - name: init-config
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["bash", "-c"]
+        args:
+        - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do
+          bash $script ; done
+        volumeMounts:
+        - name: config
+          mountPath: /etc/datadog-agent
+        - name: procdir
+          mountPath: /host/proc
+          readOnly: true
+        - name: runtimesocket
+          mountPath: /var/run/docker.sock
+          readOnly: true
+        env:
+        - name: DD_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "datadog-agent"
+              key: api-key
+        - name: DD_KUBERNETES_KUBELET_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: KUBERNETES
+          value: "yes"
+        - name: DD_LEADER_ELECTION
+          value: "true"
+        resources: {}
       volumes:
-        - hostPath:
-            path: /var/run
-          name: dockersocketdir
-        - hostPath:
-            path: /proc
-          name: procdir
-        - hostPath:
-            path: /sys/fs/cgroup
-          name: cgroups
-        #####################
-        ## Log collection  ##
-        #####################
-        - hostPath:
-            path: /opt/datadog-agent/run:rw
-          name: pointdir
-        - hostPath:
-            path: /var/log/pods
-          name: logpodpath
-        # Docker runtime directory, replace this path with your container runtime logs directory,
-        # or remove this configuration if `/var/log/pods` is not a symlink to any other directory.
-        - hostPath:
-            path: /var/lib/docker/containers
-          name: logcontainerpath
+      - name: config
+        emptyDir: {}
+      - hostPath:
+          path: /var/run/docker.sock
+        name: runtimesocket
+      - hostPath:
+          path: /proc
+        name: procdir
+      - hostPath:
+          path: /sys/fs/cgroup
+        name: cgroups
+      - name: s6-run
+        emptyDir: {}
+      - hostPath:
+          path: "/var/lib/datadog-agent/logs"
+        name: pointerdir
+      - hostPath:
+          path: /var/log/pods
+        name: logpodpath
+      - hostPath:
+          path: /var/lib/docker/containers
+        name: logdockercontainerpath
+      tolerations:
+      affinity: null
+      serviceAccountName: "default"
+      nodeSelector:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
 
+# Source: datadog/templates/containers-common-env.yaml
+# The purpose of this template is to define a minimal set of environment
+# variables required to operate dedicated containers in the daemonset.
+---
+{}

--- a/static/resources/yaml/datadog-agent-logs_values.yaml
+++ b/static/resources/yaml/datadog-agent-logs_values.yaml
@@ -1,0 +1,13 @@
+datadog:
+  kubeStateMetricsEnabled: false
+  leaderElection: true
+  collectEvents: true
+  logs:
+    enabled: true
+    containerCollectAll: true
+  acExclude: "name:datadog-agent"
+  processAgent:
+    enabled: false
+agents:
+  rbac:
+    create: false

--- a/static/resources/yaml/datadog-agent-npm.yaml
+++ b/static/resources/yaml/datadog-agent-npm.yaml
@@ -1,134 +1,449 @@
-# datadog-agent.yaml
+# Source: datadog/templates/secrets.yaml
+# API Key
+apiVersion: v1
+kind: Secret
+metadata:
+  name: datadog-agent
+  labels: {}
+type: Opaque
+data:
+  api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
+
+# APP Key
 ---
+# Source: datadog/templates/system-probe-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-agent-system-probe-config
+  namespace: default
+  labels: {}
+data:
+  system-probe.yaml: |
+    system_probe_config:
+      enabled: true
+      debug_port:  0
+      sysprobe_socket: /opt/datadog-agent/run/sysprobe.sock
+      enable_conntrack : true
+      bpf_debug: false
+---
+# Source: datadog/templates/system-probe-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-agent-security
+  namespace: default
+  labels: {}
+data:
+  system-probe-seccomp.json: |
+    {
+      "defaultAction": "SCMP_ACT_ERRNO",
+      "syscalls": [
+        {
+          "names": [
+            "accept4",
+            "access",
+            "arch_prctl",
+            "bind",
+            "bpf",
+            "brk",
+            "capget",
+            "capset",
+            "chdir",
+            "clock_gettime",
+            "clone",
+            "close",
+            "connect",
+            "copy_file_range",
+            "creat",
+            "dup",
+            "dup2",
+            "dup3",
+            "epoll_create",
+            "epoll_create1",
+            "epoll_ctl",
+            "epoll_ctl_old",
+            "epoll_pwait",
+            "epoll_wait",
+            "epoll_wait",
+            "epoll_wait_old",
+            "execve",
+            "execveat",
+            "exit",
+            "exit_group",
+            "fchmod",
+            "fchmodat",
+            "fchown",
+            "fchown32",
+            "fchownat",
+            "fcntl",
+            "fcntl64",
+            "fstat",
+            "fstat64",
+            "fstatfs",
+            "fsync",
+            "futex",
+            "getcwd",
+            "getdents",
+            "getdents64",
+            "getegid",
+            "geteuid",
+            "getgid",
+            "getpeername",
+            "getpid",
+            "getppid",
+            "getpriority",
+            "getrandom",
+            "getresgid",
+            "getresgid32",
+            "getresuid",
+            "getresuid32",
+            "getrlimit",
+            "getrusage",
+            "getsid",
+            "getsockname",
+            "getsockopt",
+            "gettid",
+            "gettimeofday",
+            "getuid",
+            "getxattr",
+            "ioctl",
+            "ipc",
+            "listen",
+            "lseek",
+            "lstat",
+            "lstat64",
+            "mkdir",
+            "mkdirat",
+            "mmap",
+            "mmap2",
+            "mprotect",
+            "munmap",
+            "nanosleep",
+            "newfstatat",
+            "open",
+            "openat",
+            "pause",
+            "perf_event_open",
+            "pipe",
+            "pipe2",
+            "poll",
+            "ppoll",
+            "prctl",
+            "prlimit64",
+            "pselect6",
+            "read",
+            "readlink",
+            "readlinkat",
+            "recvfrom",
+            "recvmmsg",
+            "recvmsg",
+            "rename",
+            "restart_syscall",
+            "rmdir",
+            "rt_sigaction",
+            "rt_sigpending",
+            "rt_sigprocmask",
+            "rt_sigqueueinfo",
+            "rt_sigreturn",
+            "rt_sigsuspend",
+            "rt_sigtimedwait",
+            "rt_tgsigqueueinfo",
+            "sched_getaffinity",
+            "sched_yield",
+            "seccomp",
+            "select",
+            "semtimedop",
+            "send",
+            "sendmmsg",
+            "sendmsg",
+            "sendto",
+            "set_robust_list",
+            "set_tid_address",
+            "setgid",
+            "setgid32",
+            "setgroups",
+            "setgroups32",
+            "setns",
+            "setrlimit",
+            "setsid",
+            "setsidaccept4",
+            "setsockopt",
+            "setuid",
+            "setuid32",
+            "sigaltstack",
+            "socket",
+            "socketcall",
+            "socketpair",
+            "stat",
+            "stat64",
+            "statfs",
+            "sysinfo",
+            "umask",
+            "uname",
+            "unlink",
+            "unlinkat",
+            "wait4",
+            "waitid",
+            "waitpid",
+            "write"
+          ],
+          "action": "SCMP_ACT_ALLOW",
+          "args": null
+        },
+        {
+          "names": [
+            "setns"
+          ],
+          "action": "SCMP_ACT_ALLOW",
+          "args": [
+            {
+              "index": 1,
+              "value": 1073741824,
+              "valueTwo": 0,
+              "op": "SCMP_CMP_EQ"
+            }
+          ],
+          "comment": "",
+          "includes": {},
+          "excludes": {}
+        }
+      ]
+    }
+---
+# Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-    name: datadog-agent
-    namespace: default
+  name: datadog-agent
+  labels: {}
 spec:
-    selector:
-        matchLabels:
-            app: datadog-agent
-    template:
-        metadata:
-            labels:
-                app: datadog-agent
-            name: datadog-agent
-            annotations:
-                container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
-        spec:
-            serviceAccountName: datadog-agent
-            containers:
-                - image: 'datadog/agent:latest'
-                  imagePullPolicy: Always
-                  name: datadog-agent
-                  ports:
-                      - containerPort: 8125
-                        name: dogstatsdport
-                        protocol: UDP
-                      - containerPort: 8126
-                        name: traceport
-                        protocol: TCP
-                  env:
-                      - name: DD_API_KEY
-                        value: '<DATADOG_API_KEY>'
-                      - name: KUBERNETES
-                        value: 'true'
-                      - name: DD_HEALTH_PORT
-                        value: '5555'
-                      - name: DD_PROCESS_AGENT_ENABLED
-                        value: 'true'
-                      - name: DD_SYSTEM_PROBE_ENABLED
-                        value: 'true'
-                      - name: DD_SYSTEM_PROBE_EXTERNAL
-                        value: 'true'
-                      - name: DD_SYSPROBE_SOCKET
-                        value: /var/run/s6/sysprobe.sock
-                      - name: DD_KUBERNETES_KUBELET_HOST
-                        valueFrom:
-                            fieldRef:
-                                fieldPath: status.hostIP
-                      - name: DD_CRI_SOCKET_PATH
-                        value: /host/var/run/docker.sock
-                      - name: DOCKER_HOST
-                        value: unix:///host/var/run/docker.sock
-                  resources:
-                      requests:
-                          memory: 256Mi
-                          cpu: 200m
-                      limits:
-                          memory: 256Mi
-                          cpu: 200m
-                  volumeMounts:
-                      - name: dockersocketdir
-                        mountPath: /host/var/run
-                      - name: procdir
-                        mountPath: /host/proc
-                        readOnly: true
-                      - name: cgroups
-                        mountPath: /host/sys/fs/cgroup
-                        readOnly: true
-                      - name: debugfs
-                        mountPath: /sys/kernel/debug
-                      - name: s6-run
-                        mountPath: /var/run/s6
-                  livenessProbe:
-                      httpGet:
-                          path: /health
-                          port: 5555
-                      initialDelaySeconds: 15
-                      periodSeconds: 15
-                      timeoutSeconds: 5
-                      successThreshold: 1
-                      failureThreshold: 3
-                - name: system-probe
-                  image: 'datadog/agent:latest'
-                  imagePullPolicy: Always
-                  securityContext:
-                      capabilities:
-                          add:
-                              - SYS_ADMIN
-                              - SYS_RESOURCE
-                              - SYS_PTRACE
-                              - NET_ADMIN
-                              - IPC_LOCK
-                  command:
-                      - /opt/datadog-agent/embedded/bin/system-probe
-                  env:
-                      - name: DD_SYSTEM_PROBE_ENABLED
-                        value: 'true'
-                      - name: DD_SYSPROBE_SOCKET
-                        value: /var/run/s6/sysprobe.sock
-                  resources:
-                      requests:
-                          memory: 150Mi
-                          cpu: 200m
-                      limits:
-                          memory: 150Mi
-                          cpu: 200m
-                  volumeMounts:
-                      - name: procdir
-                        mountPath: /host/proc
-                        readOnly: true
-                      - name: cgroups
-                        mountPath: /host/sys/fs/cgroup
-                        readOnly: true
-                      - name: debugfs
-                        mountPath: /sys/kernel/debug
-                      - name: s6-run
-                        mountPath: /var/run/s6
-            volumes:
-                - name: dockersocketdir
-                  hostPath:
-                      path: /var/run
-                - name: procdir
-                  hostPath:
-                      path: /proc
-                - name: cgroups
-                  hostPath:
-                      path: /sys/fs/cgroup
-                - name: s6-run
-                  emptyDir: {}
-                - name: debugfs
-                  hostPath:
-                      path: /sys/kernel/debug
+  selector:
+    matchLabels:
+      app: datadog-agent
+  template:
+    metadata:
+      labels:
+        app: datadog-agent
+      name: datadog-agent
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
+        container.seccomp.security.alpha.kubernetes.io/system-probe: localhost/system-probe
+    spec:
+      containers:
+      - name: agent
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["agent", "start"]
+        resources: {}
+        ports:
+        - containerPort: 8125
+          name: dogstatsdport
+          protocol: UDP
+        env:
+        - name: DD_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "datadog-agent"
+              key: api-key
+        - name: DD_KUBERNETES_KUBELET_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: KUBERNETES
+          value: "yes"
+        - name: DD_LOG_LEVEL
+          value: "INFO"
+        - name: DD_DOGSTATSD_PORT
+          value: "8125"
+        - name: DD_APM_ENABLED
+          value: "false"
+        - name: DD_LOGS_ENABLED
+          value: "false"
+        - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
+          value: "false"
+        - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
+          value: "true"
+        - name: DD_HEALTH_PORT
+          value: "5555"
+        - name: SYSTEM_PROBE_CONFIG_SYSPROBE_SOCKET
+          value: /sysprobe/var/run
+        volumeMounts:
+        - name: config
+          mountPath: /etc/datadog-agent
+        - name: runtimesocket
+          mountPath: /var/run/docker.sock
+          readOnly: true
+        - name: sysprobe-socket-dir
+          mountPath: /sysprobe/var/run
+          readOnly: true
+        - name: procdir
+          mountPath: /host/proc
+          readOnly: true
+        - name: cgroups
+          mountPath: /host/sys/fs/cgroup
+          readOnly: true
+        livenessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /health
+            port: 5555
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 5
+      - name: process-agent
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
+        resources: {}
+        env:
+        - name: DD_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "datadog-agent"
+              key: api-key
+        - name: DD_KUBERNETES_KUBELET_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: KUBERNETES
+          value: "yes"
+        - name: DD_LOG_LEVEL
+          value: "INFO"
+        - name: DD_SYSTEM_PROBE_ENABLED
+          value: "true"
+        volumeMounts:
+        - name: config
+          mountPath: /etc/datadog-agent
+        - name: runtimesocket
+          mountPath: /var/run/docker.sock
+          readOnly: true
+        - name: cgroups
+          mountPath: /host/sys/fs/cgroup
+          readOnly: true
+        - name: passwd
+          mountPath: /etc/passwd
+        - name: procdir
+          mountPath: /host/proc
+          readOnly: true
+        - name: sysprobe-socket-dir
+          mountPath: /opt/datadog-agent/run
+          readOnly: true
+      - name: system-probe
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          capabilities:
+            add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "IPC_LOCK"]
+        command: ["/opt/datadog-agent/embedded/bin/system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
+        env:
+        - name: DD_LOG_LEVEL
+          value: "INFO"
+        resources: {}
+        volumeMounts:
+        - name: debugfs
+          mountPath: /sys/kernel/debug
+        - name: sysprobe-config
+          mountPath: /etc/datadog-agent
+        - name: sysprobe-socket-dir
+          mountPath: /opt/datadog-agent/run
+        - name: procdir
+          mountPath: /host/proc
+          readOnly: true
+      initContainers:
+      - name: init-volume
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["bash", "-c"]
+        args:
+        - cp -r /etc/datadog-agent /opt
+        volumeMounts:
+        - name: config
+          mountPath: /opt/datadog-agent
+        resources: {}
+      - name: init-config
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["bash", "-c"]
+        args:
+        - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do
+          bash $script ; done
+        volumeMounts:
+        - name: config
+          mountPath: /etc/datadog-agent
+        - name: procdir
+          mountPath: /host/proc
+          readOnly: true
+        - name: runtimesocket
+          mountPath: /var/run/docker.sock
+          readOnly: true
+        env:
+        - name: DD_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "datadog-agent"
+              key: api-key
+        - name: DD_KUBERNETES_KUBELET_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: KUBERNETES
+          value: "yes"
+        resources: {}
+      - name: seccomp-setup
+        image: "datadog/agent:7"
+        command:
+        - cp
+        - /etc/config/system-probe-seccomp.json
+        - /host/var/lib/kubelet/seccomp/system-probe
+        volumeMounts:
+        - name: datadog-agent-security
+          mountPath: /etc/config
+        - name: seccomp-root
+          mountPath: /host/var/lib/kubelet/seccomp
+      volumes:
+      - name: config
+        emptyDir: {}
+      - hostPath:
+          path: /var/run/docker.sock
+        name: runtimesocket
+      - hostPath:
+          path: /proc
+        name: procdir
+      - hostPath:
+          path: /sys/fs/cgroup
+        name: cgroups
+      - name: s6-run
+        emptyDir: {}
+      - name: sysprobe-config
+        configMap:
+          name: datadog-agent-system-probe-config
+      - name: datadog-agent-security
+        configMap:
+          name: datadog-agent-security
+      - hostPath:
+          path: /var/lib/kubelet/seccomp
+        name: seccomp-root
+      - hostPath:
+          path: /sys/kernel/debug
+        name: debugfs
+      - name: sysprobe-socket-dir
+        emptyDir: {}
+      - hostPath:
+          path: /etc/passwd
+        name: passwd
+      tolerations:
+      affinity: null
+      serviceAccountName: "default"
+      nodeSelector:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
+
+# Source: datadog/templates/containers-common-env.yaml
+# The purpose of this template is to define a minimal set of environment
+# variables required to operate dedicated containers in the daemonset.
+---
+{}

--- a/static/resources/yaml/datadog-agent-npm_values.yaml
+++ b/static/resources/yaml/datadog-agent-npm_values.yaml
@@ -1,0 +1,9 @@
+datadog:
+  kubeStateMetricsEnabled: false
+  processAgent:
+    enabled: true
+  systemProbe:
+    enabled: true
+agents:
+  rbac:
+    create: false

--- a/static/resources/yaml/datadog-agent-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-vanilla.yaml
@@ -1,8 +1,22 @@
+# Source: datadog/templates/secrets.yaml
+# API Key
+apiVersion: v1
+kind: Secret
+metadata:
+  name: datadog-agent
+  labels: {}
+type: Opaque
+data:
+  api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
+
+# APP Key
+---
+# Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: datadog-agent
-  namespace: default
+  labels: {}
 spec:
   selector:
     matchLabels:
@@ -12,93 +26,130 @@ spec:
       labels:
         app: datadog-agent
       name: datadog-agent
+      annotations: {}
     spec:
-      serviceAccountName: datadog-agent
       containers:
-      - image: datadog/agent:7
-        imagePullPolicy: Always
-        name: datadog-agent
+      - name: agent
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["agent", "start"]
+        resources: {}
         ports:
-          - containerPort: 8125
-            # Custom metrics via DogStatsD - uncomment this section to enable custom metrics collection
-            # hostPort: 8125
-            name: dogstatsdport
-            protocol: UDP
-          - containerPort: 8126
-            # Trace Collection (APM) - uncomment this section to enable APM
-            # hostPort: 8126
-            name: traceport
-            protocol: TCP
+        - containerPort: 8125
+          name: dogstatsdport
+          protocol: UDP
         env:
-          - name: DD_API_KEY
-            valueFrom:
-              secretKeyRef:
-                name: datadog-secret
-                key: api-key
-          - name: DD_COLLECT_KUBERNETES_EVENTS
-            value: "true"
-          - name: DD_LEADER_ELECTION
-            value: "true"
-          - name: KUBERNETES
-            value: "true"
-          - name: DD_HEALTH_PORT
-            value: "5555"
-          - name: DD_KUBERNETES_KUBELET_HOST
-            valueFrom:
-              fieldRef:
-                fieldPath: status.hostIP
-
-          ## For secure communication with the Cluster Agent (required to use the Cluster Agent)
-          # - name: DD_CLUSTER_AGENT_AUTH_TOKEN
-          #
-          ## If using a simple env var uncomment this section
-          #
-          #   value: <THIRTY_2_CHARACTERS_LONG_TOKEN>
-          #
-          ## If using a secret uncomment this section
-          #
-          #   valueFrom:
-          #     secretKeyRef:
-          #       name: datadog-auth-token
-          #       key: token
-
-        ## Note these are the minimum suggested values for requests and limits.
-        ## The amount of resources required by the Agent varies depending on:
-        ## * The number of checks
-        ## * The number of integrations enabled
-        ## * The number of features enabled
-        resources:
-          requests:
-            memory: "256Mi"
-            cpu: "200m"
-          limits:
-            memory: "256Mi"
-            cpu: "200m"
+        - name: DD_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "datadog-agent"
+              key: api-key
+        - name: DD_KUBERNETES_KUBELET_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: KUBERNETES
+          value: "yes"
+        - name: DD_LOG_LEVEL
+          value: "INFO"
+        - name: DD_DOGSTATSD_PORT
+          value: "8125"
+        - name: DD_APM_ENABLED
+          value: "false"
+        - name: DD_LOGS_ENABLED
+          value: "false"
+        - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
+          value: "false"
+        - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
+          value: "true"
+        - name: DD_HEALTH_PORT
+          value: "5555"
         volumeMounts:
-          - name: dockersocket
-            mountPath: /var/run/docker.sock
-          - name: procdir
-            mountPath: /host/proc
-            readOnly: true
-          - name: cgroups
-            mountPath: /host/sys/fs/cgroup
-            readOnly: true
+        - name: config
+          mountPath: /etc/datadog-agent
+        - name: runtimesocket
+          mountPath: /var/run/docker.sock
+          readOnly: true
+        - name: procdir
+          mountPath: /host/proc
+          readOnly: true
+        - name: cgroups
+          mountPath: /host/sys/fs/cgroup
+          readOnly: true
         livenessProbe:
+          failureThreshold: 6
           httpGet:
             path: /health
             port: 5555
           initialDelaySeconds: 15
           periodSeconds: 15
-          timeoutSeconds: 5
           successThreshold: 1
-          failureThreshold: 3
+          timeoutSeconds: 5
+      initContainers:
+      - name: init-volume
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["bash", "-c"]
+        args:
+        - cp -r /etc/datadog-agent /opt
+        volumeMounts:
+        - name: config
+          mountPath: /opt/datadog-agent
+        resources: {}
+      - name: init-config
+        image: "datadog/agent:7"
+        imagePullPolicy: IfNotPresent
+        command: ["bash", "-c"]
+        args:
+        - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do
+          bash $script ; done
+        volumeMounts:
+        - name: config
+          mountPath: /etc/datadog-agent
+        - name: procdir
+          mountPath: /host/proc
+          readOnly: true
+        - name: runtimesocket
+          mountPath: /var/run/docker.sock
+          readOnly: true
+        env:
+        - name: DD_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "datadog-agent"
+              key: api-key
+        - name: DD_KUBERNETES_KUBELET_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: KUBERNETES
+          value: "yes"
+        resources: {}
       volumes:
-        - hostPath:
-            path: /var/run/docker.sock
-          name: dockersocket
-        - hostPath:
-            path: /proc
-          name: procdir
-        - hostPath:
-            path: /sys/fs/cgroup
-          name: cgroups
+      - name: config
+        emptyDir: {}
+      - hostPath:
+          path: /var/run/docker.sock
+        name: runtimesocket
+      - hostPath:
+          path: /proc
+        name: procdir
+      - hostPath:
+          path: /sys/fs/cgroup
+        name: cgroups
+      - name: s6-run
+        emptyDir: {}
+      tolerations:
+      affinity: null
+      serviceAccountName: "default"
+      nodeSelector:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
+
+# Source: datadog/templates/containers-common-env.yaml
+# The purpose of this template is to define a minimal set of environment
+# variables required to operate dedicated containers in the daemonset.
+---
+{}

--- a/static/resources/yaml/datadog-agent-vanilla_values.yaml
+++ b/static/resources/yaml/datadog-agent-vanilla_values.yaml
@@ -1,0 +1,7 @@
+datadog:
+  kubeStateMetricsEnabled: false
+  processAgent:
+    enabled: false
+agents:
+  rbac:
+    create: false

--- a/static/resources/yaml/generate.sh
+++ b/static/resources/yaml/generate.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+if sed --version 2>/dev/null | grep -q "GNU sed"; then
+    SED=sed
+elif gsed --version 2>/dev/null | grep -q "GNU sed"; then
+    SED=gsed
+fi
+
+cd "$(dirname "$0")"
+
+#helm repo update
+
+TMPDIR=$(mktemp -d)
+trap 'rm -r $TMPDIR' EXIT
+
+cat > "$TMPDIR/cleanup_instructions.yaml" <<EOF
+- command: delete
+  path: metadata.labels."helm.sh/chart"
+- command: delete
+  path: metadata.labels."app.kubernetes.io/*"
+- command: delete
+  path: spec.template.metadata.annotations.checksum/*
+EOF
+
+for values in *_values.yaml; do
+    type=${values%%_values.yaml}
+    helm template --namespace default datadog-agent "${HELM_DATADOG_CHART:-stable/datadog}" --values "$values" \
+        | yq write -d'*' --script "$TMPDIR/cleanup_instructions.yaml" - \
+        | sed 's/\(api-key: \)".*"/\1PUT_YOUR_BASE64_ENCODED_API_KEY_HERE/; s/\(token: \).*/\1PUT_A_BASE64_ENCODED_RANDOM_STRING_HERE/' \
+              > "$type".yaml
+done


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR makes the kubernetes manifests found in `static/resources/yaml` automatically generated from our [public Helm chart](https://github.com/helm/charts/tree/master/stable/datadog).

### Motivation
<!-- What inspired you to submit this pull request?-->

The goal is to avoid having different sources documenting how to deploy the DataDog agent on kubernetes that are not kept in sync.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

The same kind of work has been done to have the manifests found inside the [DataDog/datadog-agent repository](https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/manifests) automatically generated: DataDog/datadog-agent#5436.
