### PR TITLE
[Log collection] Using the new region shortcode

### DIFF
--- a/content/en/logs/guide/integration-pipeline-reference.md
+++ b/content/en/logs/guide/integration-pipeline-reference.md
@@ -94,7 +94,7 @@ Datadog’s integration processing Pipelines are available for the `source` tag 
 [23]: https://github.com/DataDog/integrations-core/blob/master/consul/datadog_checks/consul/data/conf.yaml.example
 [24]: /integrations/couch/#log-collection
 [25]: https://github.com/DataDog/integrations-core/blob/master/couch/datadog_checks/couch/data/conf.yaml.example
-[26]: /logs/log_collection/?tab=tailexistingfiles#custom-log-collection
+[26]: /logs/log_collection/#custom-log-collection
 [27]: /agent/docker/log/
 [28]: /agent/docker/log/?tab=environmentvariable#one-step-install-to-collect-all-the-container-logs
 [29]: /agent/docker/log/?tab=hostinstallation#one-step-install-to-collect-all-the-container-logs

--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -75,7 +75,9 @@ Select your Cloud provider below to see how to automatically collect your logs a
 Any custom process or [logging library][18] able to forward logs through **TCP** or **HTTP** can be used in conjunction with Datadog Logs. Choose below which Datadog site you want to forward logs to:
 
 {{< tabs >}}
-{{% tab "HTTP US Site" %}}
+{{% tab "HTTP" %}}
+
+{{< site-region region="us" >}}
 
 The public endpoint is `http-intake.logs.datadoghq.com`. The API key must be added either in the path or as a header, for instance:
 
@@ -89,8 +91,9 @@ curl -X POST https://http-intake.logs.datadoghq.com/v1/input \
 For more examples with JSON formats, multiple logs per request, or the use of query parameters, refer to the [Datadog Log HTTP API documentation][1].
 
 [1]: /api/v1/logs/#send-logs
-{{% /tab %}}
-{{% tab "HTTP EU Site" %}}
+
+{{< /site-region >}}
+{{< site-region region="eu" >}}
 
 The public endpoint is `http-intake.logs.datadoghq.eu`. The API key must be added either in the path or as a header, for instance:
 
@@ -104,8 +107,12 @@ curl -X POST https://http-intake.logs.datadoghq.eu/v1/input \
 For more examples with JSON formats, multiple logs per request, or the use of query parameters, refer to the [Datadog Log HTTP API documentation][1].
 
 [1]: /api/v1/logs/#send-logs
+
+{{< /site-region >}}
 {{% /tab %}}
-{{% tab "TCP US Site" %}}
+{{% tab "TCP" %}}
+
+{{< site-region region="us" >}}
 
 The secure TCP endpoint is `intake.logs.datadoghq.com:10516` (or port `10514` for insecure connections).
 
@@ -139,8 +146,10 @@ telnet intake.logs.datadoghq.com 10514
 
 [1]: https://app.datadoghq.com/account/settings#api
 [2]: https://app.datadoghq.com/logs/livetail
-{{% /tab %}}
-{{% tab "TCP EU Site" %}}
+
+{{< /site-region >}}
+
+{{< site-region region="eu" >}}
 
 The secure TCP endpoint is `tcp-intake.logs.datadoghq.eu:443` (or port `1883` for insecure connections).
 
@@ -174,6 +183,8 @@ telnet tcp-intake.logs.datadoghq.eu 1883
 
 [1]: https://app.datadoghq.com/account/settings#api
 [2]: https://app.datadoghq.com/logs/livetail
+
+{{< /site-region >}}
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -184,8 +195,8 @@ Use the encrypted endpoint when possible. The Datadog Agent uses the encrypted e
 
 Endpoints that can be used to send logs to Datadog:
 
-{{< tabs >}}
-{{% tab "US Site" %}}
+{{< site-region region="us" >}}
+
 
 | Endpoints for SSL encrypted connections | Port    | Description                                                                                                                                                                 |
 |-----------------------------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -202,8 +213,10 @@ Endpoints that can be used to send logs to Datadog:
 | `intake.logs.datadoghq.com`          | `10514` | Used by custom forwarders to send logs in raw, Syslog, or JSON format over an unecrypted TCP connection. |
 
 [1]: /agent/logs/#send-logs-over-https
-{{% /tab %}}
-{{% tab "EU Site" %}}
+
+{{< /site-region >}}
+
+{{< site-region region="eu" >}}
 
 | Endpoints for SSL encrypted connections | Port  | Description                                                                                                                                                                 |
 |-----------------------------------------|-------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -220,8 +233,8 @@ Endpoints that can be used to send logs to Datadog:
 | `tcp-intake.logs.datadoghq.eu`       | `1883` | Used by custom forwarders to send logs in raw, Syslog, or JSON format format over an unecrypted TCP connection. |
 
 [1]: /agent/logs/#send-logs-over-https
-{{% /tab %}}
-{{< /tabs >}}
+
+{{< /site-region >}}
 
 ## Reserved attributes
 

--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -193,10 +193,9 @@ telnet tcp-intake.logs.datadoghq.eu 1883
 Datadog provides logging endpoints for both SSL-encrypted connections and unencrypted connections.
 Use the encrypted endpoint when possible. The Datadog Agent uses the encrypted endpoint to send logs to Datadog. More information is available in the [Datadog security documentation][19].
 
-Endpoints that can be used to send logs to Datadog:
-
 {{< site-region region="us" >}}
 
+Endpoints that can be used to send logs to Datadog US region:
 
 | Endpoints for SSL encrypted connections | Port    | Description                                                                                                                                                                 |
 |-----------------------------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -217,6 +216,8 @@ Endpoints that can be used to send logs to Datadog:
 {{< /site-region >}}
 
 {{< site-region region="eu" >}}
+
+Endpoints that can be used to send logs to Datadog EU region:
 
 | Endpoints for SSL encrypted connections | Port  | Description                                                                                                                                                                 |
 |-----------------------------------------|-------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/content/en/logs/log_collection/java.md
+++ b/content/en/logs/log_collection/java.md
@@ -516,5 +516,5 @@ To generate this final JSON document:
 [2]: /logs/processing/parsing/
 [3]: https://github.com/logstash/logstash-logback-encoder
 [4]: https://github.com/logstash/logstash-logback-encoder#prefixsuffix
-[5]: /logs/log_collection/?tab=eusite#datadog-logs-endpoints
+[5]: /logs/log_collection/#datadog-logs-endpoints
 [6]: /logs/processing/parsing/#key-value

--- a/content/en/security_monitoring/getting_started.md
+++ b/content/en/security_monitoring/getting_started.md
@@ -12,7 +12,7 @@ To get started with Datadog Security Monitoring, follow these three steps:
 
 ## Ingest logs
 
-Datadog’s [Log Collection documentation][1] provides detailed information on collecting logs from many different sources into Datadog. All ingested logs are first parsed and enriched. In real time, Detection Rules apply to all processed logs to maximize detection coverage without any of the traditionally associated performance or cost concerns of indexing all of your log data. [Read more about Datadog’s Logging without Limits™][2]. 
+Datadog’s [Log Collection documentation][1] provides detailed information on collecting logs from many different sources into Datadog. All ingested logs are first parsed and enriched. In real time, Detection Rules apply to all processed logs to maximize detection coverage without any of the traditionally associated performance or cost concerns of indexing all of your log data. [Read more about Datadog’s Logging without Limits™][2].
 
 {{< img src="security_monitoring/getting_started/ingest_logs_overview.png" alt="Ingest Logs" >}}
 
@@ -22,11 +22,9 @@ Datadog provides out of the box [Detection Rules][3], which begin detecting thre
 
 ## Explore Security Signals
 
-When a threat is detected with a Detection Rule, a Security Signal is generated. The Security Signals can be correlated and triaged in the [Security Signals Explorer][5]. Refer to the [Security Signals Explorer][6] documentation for further details. 
+When a threat is detected with a Detection Rule, a Security Signal is generated. The Security Signals can be correlated and triaged in the [Security Signals Explorer][5]. Refer to the [Security Signals Explorer][6] documentation for further details.
 
-
-
-[1]: /logs/log_collection/?tab=tcpussite
+[1]: /logs/log_collection/
 [2]: https://www.datadoghq.com/blog/logging-without-limits/
 [3]: /security_monitoring/default_rules/
 [4]: /security_monitoring/detection_rules/


### PR DESCRIPTION
### What does this PR do?

Implements the new region shortcode on the log collection page to make it easier to read.


### Preview link

* https://docs-staging.datadoghq.com/gus/log-collection-region/logs/log_collection/

### Additional Notes

I didn't run the format_link pre-commit script as it doesn't support this new logic for now.
