### PR TITLE
Using new region shortcode in various places

### DIFF
--- a/content/en/account_management/authn_mapping/_index.md
+++ b/content/en/account_management/authn_mapping/_index.md
@@ -16,10 +16,20 @@ If you are using Federated Authentication mechanisms, this API allows you to aut
 
 ## Requests
 
-All the API endpoints below can have two different host endpoints:
+{{< site-region region="us" >}}
 
-* If you are on the Datadog US site: `https://api.datadoghq.com/api/`
-* If you are on the Datadog EU site: `https://api.datadoghq.eu/api/`
+All the API endpoints below are using the following host endpoint:
+
+* `https://api.datadoghq.com/api/` for the Datadog US region.
+
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+
+All the API endpoints below are using the following host endpoint:
+
+* `https://api.datadoghq.eu/api/` for the Datadog EU region.
+
+{{< /site-region >}}
 
 ### Create a new Authentication mapping
 
@@ -41,6 +51,8 @@ Create a new AuthN Mapping from a JSON body. Returns the newly created AuthN Map
 
 {{< tabs >}}
 {{% tab "Example" %}}
+
+{{< site-region region="us" >}}
 
 ```sh
 curl -X POST \
@@ -66,6 +78,36 @@ curl -X POST \
             }
         }'
 ```
+
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+
+```sh
+curl -X POST \
+    "https://api.datadoghq.eu/api/v2/authn_mappings" \
+    -H "Content-Type: application/json" \
+    -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
+    -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
+    -d '{
+            "data": {
+                "type": "authn_mappings",
+                "attributes": {
+                    "attribute_key": "member-of",
+                    "attribute_value": "Development"
+                },
+                "relationships": {
+                    "role": {
+                        "data": {
+                            "id": "123e4567-e89b-12d3-a456-426655445555",
+                            "type": "roles"
+                        }
+                    }
+                }
+            }
+        }'
+```
+
+{{< /site-region >}}
 
 Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1].
 
@@ -161,11 +203,24 @@ Returns a list of AuthN Mappings
 {{< tabs >}}
 {{% tab "Example" %}}
 
+{{< site-region region="us" >}}
+
 ```sh
 curl -X GET "https://api.datadoghq.com/api/v2/authn_mappings" \
      -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
      -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>"
 ```
+
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+
+```sh
+curl -X GET "https://api.datadoghq.eu/api/v2/authn_mappings" \
+     -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
+     -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>"
+```
+
+{{< /site-region >}}
 
 Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1].
 
@@ -259,11 +314,24 @@ Returns a specific AuthN Mapping by UUID.
 {{< tabs >}}
 {{% tab "Example" %}}
 
+{{< site-region region="us" >}}
+
 ```sh
 curl -X GET "https://api.datadoghq.com/api/v2/authn_mappings/{authn_mapping_id}" \
      -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
      -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>"
 ```
+
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+
+```sh
+curl -X GET "https://api.datadoghq.eu/api/v2/authn_mappings/{authn_mapping_id}" \
+     -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
+     -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>"
+```
+
+{{< /site-region >}}
 
 Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1].
 
@@ -361,6 +429,8 @@ Updates the AuthN Mapping `role`, `saml_assertion_attribute_id`, or both from a 
 {{< tabs >}}
 {{% tab "Example" %}}
 
+{{< site-region region="us" >}}
+
 ```sh
 curl -X PATCH \
     "https://api.datadoghq.com/api/v2/authn_mappings/{UUID}" \
@@ -386,6 +456,37 @@ curl -X PATCH \
             }
         }'
 ```
+
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+
+```sh
+curl -X PATCH \
+    "https://api.datadoghq.eu/api/v2/authn_mappings/{UUID}" \
+    -H "Content-Type: application/json" \
+    -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
+    -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
+    -d '{
+            "data": {
+                "type": "authn_mappings",
+                "id": "{authn_mapping_id}",
+                "attributes": {
+                    "attribute_key": "member-of",
+                    "attribute_value": "Developer"
+                }
+                "relationships": {
+                "role": {
+                    "data": {
+                            "id": "123e4567-e89b-12d3-a456-426655440000",
+                            "type": "roles"
+                        }
+                    }
+                }
+            }
+        }'
+```
+
+{{< /site-region >}}
 
 Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1].
 
@@ -473,12 +574,26 @@ Deletes a specific AuthN Mapping.
 {{< tabs >}}
 {{% tab "Example" %}}
 
+{{< site-region region="us" >}}
+
 ```sh
 curl -X DELETE "https://api.datadoghq.com/api/v2/authn_mappings/{UUID}" \
          -H "Content-Type: application/json" \
          -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
          -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>"
 ```
+
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+
+```sh
+curl -X DELETE "https://api.datadoghq.eu/api/v2/authn_mappings/{UUID}" \
+         -H "Content-Type: application/json" \
+         -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
+         -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>"
+```
+
+{{< /site-region >}}
 
 Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1].
 
@@ -504,6 +619,8 @@ Check whether Authn Mappings are enabled or disabled.
 {{< tabs >}}
 {{% tab "Example" %}}
 
+{{< site-region region="us" >}}
+
 ```sh
 curl -X GET \
          "https://api.datadoghq.com/api/v1/org_preferences" \
@@ -511,6 +628,19 @@ curl -X GET \
          -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
          -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
 ```
+
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+
+```sh
+curl -X GET \
+         "https://api.datadoghq.eu/api/v1/org_preferences" \
+         -H "Content-Type: application/json" \
+         -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
+         -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
+```
+
+{{< /site-region >}}
 
 Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1].
 
@@ -556,6 +686,8 @@ Enables/disables the enforcement of all AuthN Mappings.
 {{< tabs >}}
 {{% tab "Example" %}}
 
+{{< site-region region="us" >}}
+
 ```sh
 curl -X POST \
     "https://api.datadoghq.com/api/v1/org_preferences" \
@@ -573,6 +705,29 @@ curl -X POST \
     }'
 `
 ```
+
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+
+```sh
+curl -X POST \
+    "https://api.datadoghq.eu/api/v1/org_preferences" \
+    -H "Content-Type: application/json" \
+    -H "DD-API-KEY: <YOUR_DATADOG_API_KEY>" \
+    -H "DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>" \
+    -d '{
+        "data": {
+            "type": "org_preferences",
+            "attributes": {
+                "preference_type": "saml_authn_mapping_roles",
+                "preference_data": true
+            }
+        }
+    }'
+`
+```
+
+{{< /site-region >}}
 
 Replace the `<YOUR_DATADOG_API_KEY>` and `<YOUR_DATADOG_APPLICATION_KEY>` placeholders with the corresponding [API and application keys for your organization][1].
 

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -128,8 +128,7 @@ This is the best option if you do not have a web proxy readily available in your
 
 HAProxy should be installed on a host that has connectivity to Datadog. Use the following configuration file if you do not already have it configured.
 
-{{< tabs >}}
-{{% tab "Datadog US site" %}}
+{{< site-region region="us" >}}
 
 ```conf
 # Basic configuration
@@ -156,7 +155,7 @@ listen stats
     mode http
     stats enable
     stats uri /
-    
+
 # This section is to reload DNS Records
 # Replace <DNS_SERVER_IP> and <DNS_SECONDARY_SERVER_IP> with your DNS Server IP addresses.
 # For HAProxy 1.8 and newer
@@ -248,8 +247,8 @@ The file might be located at `/etc/ssl/certs/ca-bundle.crt` for CentOS, Redhat.
 HAProxy 1.8 and newer allow DNS service discovery to detect server changes and automatically apply them to your configuration.
 If you are using older version of HAProxy, you have to reload or restart HAProxy. **It is recommended to have a `cron` job that reloads HAProxy every 10 minutes** (usually doing something like `service haproxy reload`) to force a refresh of HAProxy's DNS cache, in case `app.datadoghq.com` fails over to another IP.
 
-{{% /tab %}}
-{{% tab "Datadog EU site" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
 
 ```conf
 # Basic configuration
@@ -370,8 +369,7 @@ The file might be located at `/etc/ssl/certs/ca-bundle.crt` for CentOS, Redhat.
 HAProxy 1.8 and newer allow DNS service discovery to detect server changes and automatically apply them to your configuration.
 If you are using older version of HAProxy, you have to reload or restart HAProxy. **It is recommended to have a `cron` job that reloads HAProxy every 10 minutes** (usually doing something like `service haproxy reload`) to force a refresh of HAProxy's DNS cache, in case `app.datadoghq.eu` fails over to another IP.
 
-{{% /tab %}}
-{{< /tabs >}}
+{{< /site-region >}}
 
 #### Datadog Agent configuration
 
@@ -464,8 +462,8 @@ To verify that everything is working properly, review the HAProxy statistics at 
 
 This example `nginx.conf` can be used to proxy Agent traffic to Datadog. The last server block in this configuration does TLS wrapping to ensure internal plaintext logs are encrypted between your proxy and Datadog's log intake API endpoint:
 
-{{< tabs >}}
-{{% tab "Datadog US site" %}}
+{{< site-region region="us" >}}
+
 
 ```conf
 user nginx;
@@ -502,8 +500,9 @@ stream {
 }
 ```
 
-{{% /tab %}}
-{{% tab "Datadog EU site" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+
 
 ```conf
 user nginx;
@@ -540,8 +539,7 @@ stream {
 }
 ```
 
-{{% /tab %}}
-{{< /tabs >}}
+{{< /site-region >}}
 
 #### Datadog Agent configuration
 

--- a/content/en/integrations/faq/compose-and-the-datadog-agent.md
+++ b/content/en/integrations/faq/compose-and-the-datadog-agent.md
@@ -2,12 +2,12 @@
 title: Compose and the Datadog Agent
 kind: faq
 further_reading:
-- link: "https://github.com/DataDog/docker-compose-example"
-  tag: "Github"
-  text: "Using Docker Compose with Datadog Example"
-- link: "/agent/docker/"
-  tag: "Documentation"
-  text: "Datadog Docker Agent documentation"
+    - link: 'https://github.com/DataDog/docker-compose-example'
+      tag: 'Github'
+      text: 'Using Docker Compose with Datadog Example'
+    - link: '/agent/docker/'
+      tag: 'Documentation'
+      text: 'Datadog Docker Agent documentation'
 ---
 
 [Compose][1] is a Docker tool that simplifies building applications on Docker by allowing you to define, build and run multiple containers as a single application.
@@ -18,16 +18,17 @@ While the [single container installation instructions][2] gets the stock Datadog
 
 The following is an example of how you can monitor a Redis container using Compose. The file structure is:
 
-    |- docker-compose.yml
-    |- datadog
-        |- Dockerfile
-        |- conf.d
-           |-redisdb.yaml
+```text
+|- docker-compose.yml
+|- datadog
+  |- Dockerfile
+  |- conf.d
+    |-redisdb.yaml
+```
 
 The `docker-compose.yml` file describes how your containers work together and sets some of the configuration details for the containers.
 
-{{< tabs >}}
-{{% tab "US site" %}}
+{{< site-region region="us" >}}
 
 ```yaml
 version: '3'
@@ -46,8 +47,8 @@ services:
      - /sys/fs/cgroup:/host/sys/fs/cgroup:ro
 ```
 
-{{% /tab %}}
-{{% tab "EU site" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
 
 ```yaml
 version: '3'
@@ -67,16 +68,17 @@ services:
      - /sys/fs/cgroup:/host/sys/fs/cgroup:ro
 ```
 
-{{% /tab %}}
-{{< /tabs >}}
+{{< /site-region >}}
 
 The `redisdb.yaml` is patterned after the [redisdb.yaml.example file][3] and tells the Datadog Agent to look for Redis on the host named `redis` (defined in `docker-compose.yaml` above) and to use the standard Redis port:
 
-    init_config:
+```yaml
+init_config:
 
-    instances:
-      - host: redis
-        port: 6379
+instances:
+    - host: redis
+      port: 6379
+```
 
 ## Further Reading
 

--- a/content/en/logs/guide/collect-heroku-logs.md
+++ b/content/en/logs/guide/collect-heroku-logs.md
@@ -20,22 +20,20 @@ To send all these logs to Datadog:
 * Connect to your Heroku project.
 * Set up the HTTPS drain with the following command:
 
-{{< tabs >}}
-{{% tab "US Site" %}}
+{{< site-region region="us" >}}
 
 ```text
 heroku drains:add 'https://http-intake.logs.datadoghq.com/v1/input/<DD_API_KEY>?ddsource=heroku&service=<SERVICE>&host=<HOST>' -a <APPLICATION_NAME>
 ```
 
-{{% /tab %}}
-{{% tab "EU Site" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
 
 ```text
 heroku drains:add 'https://http-intake.logs.datadoghq.eu/v1/input/<DD_API_KEY>?ddsource=heroku&service=<SERVICE>&host=<HOST>' -a <APPLICATION_NAME>
 ```
 
-{{% /tab %}}
-{{< /tabs >}}
+{{< /site-region >}}
 
 * Replace `<DD_API_KEY>` with your [Datadog API Key][2].
 * Replace `<APPLICATION_NAME>` and `<SERVICE>` with your application name.
@@ -45,22 +43,20 @@ heroku drains:add 'https://http-intake.logs.datadoghq.eu/v1/input/<DD_API_KEY>?d
 
 Add custom attributes to logs from your application by replacing the URL in the drain as follows:
 
-{{< tabs >}}
-{{% tab "US Site" %}}
+{{< site-region region="us" >}}
 
 ```text
 https://http-intake.logs.datadoghq.com/v1/input/<DD_API_KEY>?ddsource=heroku&service=<SERVICE>&host=<HOST>&attribute_name=<VALUE>
 ```
 
-{{% /tab %}}
-{{% tab "EU Site" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
 
 ```text
 https://http-intake.logs.datadoghq.eu/v1/input/<DD_API_KEY>?ddsource=heroku&service=<SERVICE>&host=<HOST>&attribute_name=<VALUE>
 ```
 
-{{% /tab %}}
-{{< /tabs >}}
+{{< /site-region >}}
 
 [1]: https://devcenter.heroku.com/articles/log-drains#https-drains
 [2]: https://app.datadoghq.com/account/settings#api

--- a/content/en/synthetics/ci.md
+++ b/content/en/synthetics/ci.md
@@ -35,22 +35,20 @@ The trigger endpoint provides the list of triggered checks alongside their resul
 
 The test triggering endpoint supports starting up to 50 tests in one request.
 
-{{< tabs >}}
-{{% tab "Datadog US site" %}}
+{{< site-region region="us" >}}
 
 * **Endpoint**: `https://api.datadoghq.com/api/v1/synthetics/tests/trigger/ci`
 * **Method**: `POST`
 * **Argument**: A JSON object containing the list of all tests to trigger and their configuration override.
 
-{{% /tab %}}
-{{% tab "Datadog EU site" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
 
 * **Endpoint**: `https://api.datadoghq.eu/api/v1/synthetics/tests/trigger/ci`
 * **Method**: `POST`
 * **Argument**: A JSON object containing the list of all tests to trigger and their configuration override.
 
-{{% /tab %}}
-{{< /tabs >}}
+{{< /site-region >}}
 
 #### Request data structure
 
@@ -66,8 +64,7 @@ The public identifier of a test can be either the identifier of the test found i
 
 #### Example request
 
-{{< tabs >}}
-{{% tab "Datadog US site" %}}
+{{< site-region region="us" >}}
 
 ```bash
 #!/bin/sh
@@ -100,8 +97,9 @@ curl -X POST \
 }' "https://api.datadoghq.com/api/v1/synthetics/tests/trigger/ci"
 ```
 
-{{% /tab %}}
-{{% tab "Datadog EU site" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+
 
 ```bash
 #!/bin/sh
@@ -134,8 +132,8 @@ curl -X POST \
 }' "https://api.datadoghq.eu/api/v1/synthetics/tests/trigger/ci"
 ```
 
-{{% /tab %}}
-{{< /tabs >}}
+{{< /site-region >}}
+
 
 #### Example response
 
@@ -156,27 +154,24 @@ curl -X POST \
 
 ### Poll results endpoint
 
-{{< tabs >}}
-{{% tab "Datadog US site" %}}
+{{< site-region region="us" >}}
 
 * **Endpoint**: `https://api.datadoghq.com/api/v1/synthetics/tests/poll_results`
 * **Method**: `GET`
 * **Parameters**: A JSON array containing the list of result identifiers to obtain results from.
 
-{{% /tab %}}
-{{% tab "Datadog EU site" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
 
 * **Endpoint**: `https://api.datadoghq.eu/api/v1/synthetics/tests/poll_results`
 * **Method**: `GET`
 * **Parameters**: A JSON array containing the list of result identifiers to obtain results from.
 
-{{% /tab %}}
-{{< /tabs >}}
+{{< /site-region >}}
 
 #### Example request
 
-{{< tabs >}}
-{{% tab "Datadog US site" %}}
+{{< site-region region="us" >}}
 
 ```bash
 #!/bin/sh
@@ -191,8 +186,8 @@ curl -G \
     -d "result_ids=[%220123456789012345678%22]"
 ```
 
-{{% /tab %}}
-{{% tab "Datadog EU site" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
 
 ```bash
 #!/bin/sh
@@ -207,8 +202,7 @@ curl -G \
     -d "result_ids=[%220123456789012345678%22]"
 ```
 
-{{% /tab %}}
-{{< /tabs >}}
+{{< /site-region >}}
 
 #### Example response
 
@@ -311,7 +305,7 @@ To setup your client, Datadog API and application keys need to be configured. Th
 
     * **apiKey**: The API key used to query the Datadog API.
     * **appKey**: The application key used to query the Datadog API.
-    * **datadogSite**: The Datadog instance to which request is sent (choices are datadoghq.com or datadoghq.eu).
+    * **datadogSite**: The Datadog instance to which request is sent (choices are `datadoghq.com` or `datadoghq.eu`).
     * **files**: Glob pattern to detect synthetics tests config files.
     * **global**: Overrides of synthetics tests applied to all tests ([see below for description of each field](#configure-tests)).
     * **timeout**: Duration after which synthetics tests are considered failed (in milliseconds).


### PR DESCRIPTION
### What does this PR do?
Use this region shortcode in places where it can be leveraged

### Motivation

Implement the region shortcode.

### Preview link

* https://docs-staging.datadoghq.com/gus/region/account_management/authn_mapping/?tab=example
* https://docs-staging.datadoghq.com/gus/region/agent/proxy/
* https://docs-staging.datadoghq.com/gus/region/integrations/faq/compose-and-the-datadog-agent/
* https://docs-staging.datadoghq.com/gus/region/logs/guide/collect-heroku-logs/
* https://docs-staging.datadoghq.com/gus/region/synthetics/ci/?tab=npm

### Additional Notes

I didn't run the format_link pre-commit script as it doesn't support this new logic for now.
