### PR TITLE
[WEB-222] Update lang-redirects.js

### DIFF
--- a/src/scripts/lang-redirects.js
+++ b/src/scripts/lang-redirects.js
@@ -42,7 +42,7 @@ export function handleLanguageBasedRedirects() {
 		ex: /mybranch/myfeature/index.html => /mybranch/myfeature/ja/index.html
 	*/
 	if ( subdomain.includes('preview') || subdomain.includes('docs-staging') ) {
-		const commitRef = `/${document.querySelector('html').getAttribute('data-commit-ref')}`;
+		const commitRef = `/${document.documentElement.dataset.commitRef}`;
 
 		previewPath = commitRef || uri.split('/').slice(0,3).join('/');
 		uri = uri.replace(previewPath, '');

--- a/src/scripts/lang-redirects.js
+++ b/src/scripts/lang-redirects.js
@@ -42,7 +42,8 @@ export function handleLanguageBasedRedirects() {
 		ex: /mybranch/myfeature/index.html => /mybranch/myfeature/ja/index.html
 	*/
 	if ( subdomain.includes('preview') || subdomain.includes('docs-staging') ) {
-		previewPath = uri.split('/').slice(0,3).join('/');
+		const commitRef = document.querySelector('html').getAttribute('data-commit-ref'); 
+		previewPath =  commitRef || uri.split('/').slice(0,3).join('/');
 		uri = uri.replace(previewPath, '');
 		logMsg += `Preview path is ${ previewPath }, URI set to: ${ uri } `;
 	}

--- a/src/scripts/lang-redirects.js
+++ b/src/scripts/lang-redirects.js
@@ -42,9 +42,9 @@ export function handleLanguageBasedRedirects() {
 		ex: /mybranch/myfeature/index.html => /mybranch/myfeature/ja/index.html
 	*/
 	if ( subdomain.includes('preview') || subdomain.includes('docs-staging') ) {
-		const commitRef = document.querySelector('html').getAttribute('data-commit-ref');
+		const commitRef = `/${document.querySelector('html').getAttribute('data-commit-ref')}`;
 
-		previewPath =  commitRef || uri.split('/').slice(0,3).join('/');
+		previewPath = commitRef || uri.split('/').slice(0,3).join('/');
 		uri = uri.replace(previewPath, '');
 		logMsg += `Preview path is ${ previewPath }, URI set to: ${ uri } `;
 	}

--- a/src/scripts/lang-redirects.js
+++ b/src/scripts/lang-redirects.js
@@ -42,7 +42,8 @@ export function handleLanguageBasedRedirects() {
 		ex: /mybranch/myfeature/index.html => /mybranch/myfeature/ja/index.html
 	*/
 	if ( subdomain.includes('preview') || subdomain.includes('docs-staging') ) {
-		const commitRef = document.querySelector('html').getAttribute('data-commit-ref'); 
+		const commitRef = document.querySelector('html').getAttribute('data-commit-ref');
+
 		previewPath =  commitRef || uri.split('/').slice(0,3).join('/');
 		uri = uri.replace(previewPath, '');
 		logMsg += `Preview path is ${ previewPath }, URI set to: ${ uri } `;


### PR DESCRIPTION
# What does this PR do?
Updates the preview path used in lang-redirects script to use `commit-ref` data-attribute if available

### Motivation
For Open API preview sites, the preview branch takes the form datadog-api-spec/generated/377 so the preview site would be located at https://docs-staging.datadoghq.com/datadog-api-spec/generated/377/api/ for the api page. 

### Preview link
https://docs-staging.datadoghq.com/nsollecito/fix-lang-WEB-222

Test footer `lang-redirect` links to ensure they are still working as expected 
