### PR TITLE
Generate preview link in status check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,10 +9,12 @@
 ### Preview link
 <!-- Impacted pages preview links-->
 
-<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 
+<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.
 
 Replace the branch name and add the complete path: -->
 https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>
+
+Check preview base path using the URL in details in `preview` status check.
 
 ### Additional Notes
 <!-- Anything else we should know when reviewing?-->

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -3,10 +3,24 @@ on: [pull_request]
 
 jobs:
   label:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: DataDog/labeler@glob-all
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
+    - name: Set documentation preview
+      if: github.event.pull_request.head.repo.fork == false
+      uses: actions/github-script@0.9.0
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          github.repos.createStatus({
+            "owner": context.repo.owner,
+            "repo": context.repo.repo,
+            "sha": context.payload.pull_request.head.sha,
+            "state": "success",
+            "context": "preview",
+            "description": `Check preview branch "${context.payload.pull_request.head.ref}"`,
+            "target_url": `https://docs-staging.datadoghq.com/${context.payload.pull_request.head.ref}/api/`
+          })


### PR DESCRIPTION
### What does this PR do?

Adds status check with a link to documentation preview.

### Motivation

The URL is always available for non-forked PRs.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes

![image](https://user-images.githubusercontent.com/189798/81409725-e8079680-913f-11ea-90c4-08b72d77a33b.png)

It would be even better if the build process sets the status from "pending" to "success" when it finishes.