### PR TITLE
update curl examples

### DIFF
--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -419,11 +419,17 @@
 -H "Content-Type: {{ $key }}" \{{ end }}
 {{- end -}}
 {{- end -}}
-{{- range $context.action.security -}}
+{{- with $context.action.security -}}
+{{- range . -}}
 {{- range $key, $val := . -}}
 {{ $authSchema := (index $d.components.securitySchemes $key) }}
 <span class="o">-H</span> <span class="s1">"{{ $authSchema.name }}: <span class="n">${ {{ index $authSchema "x-env-name" }} }</span>"</span>
 {{- end -}}
+{{- end -}}
+{{- else -}}
+{{ $securitySchemes := $d.components.securitySchemes }}
+<span class="o">-H</span> <span class="s1">"{{ $securitySchemes.apiKeyAuth.name }}: <span class="n">${ {{ index $securitySchemes.apiKeyAuth "x-env-name" }} }</span>"</span> \
+<span class="o">-H</span> <span class="s1">"{{ $securitySchemes.appKeyAuth.name }}: <span class="n">${ {{ index $securitySchemes.appKeyAuth "x-env-name" }} }</span>"</span> 
 {{- end -}}
 {{- if $context.action.requestBody -}} \
 <span class="o">-d</span> <span class="n">@-</span> <span class="o"><<</span> <span class="n">EOF</span>

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -416,21 +416,23 @@
 {{- with $context.action.requestBody -}}
 {{- with .content -}}
 {{range $key, $val := . }}
--H "Content-Type: {{ $key }}" \{{ end }}
+-H "Content-Type: {{ $key }}" \
+{{- end -}}
 {{- end -}}
 {{ else }}
--H "Content-Type: application/json" \{{- end -}}
+-H "Content-Type: application/json" \
+{{- end -}}
 {{- with $context.action.security -}}
 {{- range . -}}
 {{- range $key, $val := . -}}
 {{ $authSchema := (index $d.components.securitySchemes $key) }}
-<span class="o">-H</span> <span class="s1">"{{ $authSchema.name }}: <span class="n">${ {{ index $authSchema "x-env-name" }} }</span>"</span>
+<span class="o">-H</span> <span class="s1">"{{ $authSchema.name }}: <span class="n">${ {{- index $authSchema "x-env-name" -}} }</span>"</span>
 {{- end -}}
 {{- end -}}
 {{- else -}}
 {{ $securitySchemes := $d.components.securitySchemes }}
-<span class="o">-H</span> <span class="s1">"{{ $securitySchemes.apiKeyAuth.name }}: <span class="n">${ {{ index $securitySchemes.apiKeyAuth "x-env-name" }} }</span>"</span> \
-<span class="o">-H</span> <span class="s1">"{{ $securitySchemes.appKeyAuth.name }}: <span class="n">${ {{ index $securitySchemes.appKeyAuth "x-env-name" }} }</span>"</span> 
+<span class="o">-H</span> <span class="s1">"{{ $securitySchemes.apiKeyAuth.name }}: <span class="n">${ {{- index $securitySchemes.apiKeyAuth "x-env-name" -}} }</span>"</span> \
+<span class="o">-H</span> <span class="s1">"{{ $securitySchemes.appKeyAuth.name }}: <span class="n">${ {{- index $securitySchemes.appKeyAuth "x-env-name" -}} }</span>"</span> 
 {{- end -}}
 {{- if $context.action.requestBody -}}&nbsp;\
 <span class="o">-d</span> <span class="n">@-</span> <span class="o"><<</span> <span class="n">EOF</span>

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -458,7 +458,8 @@
     {{- /* Use global authentication */ -}}
     {{- $securitySchemes := $d.components.securitySchemes -}}
     &nbsp;\
-<span class="o">-H</span> <span class="s1">"{{ $securitySchemes.apiKeyAuth.name }}: <span class="n">${ {{- index $securitySchemes.apiKeyAuth "x-env-name" -}} }</span>"</span>
+<span class="o">-H</span> <span class="s1">"{{ $securitySchemes.apiKeyAuth.name }}: <span class="n">${ {{- index $securitySchemes.apiKeyAuth "x-env-name" -}} }</span>"</span> \
+<span class="o">-H</span> <span class="s1">"{{ $securitySchemes.appKeyAuth.name }}: <span class="n">${ {{- index $securitySchemes.appKeyAuth "x-env-name" -}} }</span>"</span>
 {{- end -}}
 
 {{- /* Render requestBody example JSON "-d @- << EOF ... EOF" */ -}}

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -432,7 +432,7 @@
 <span class="o">-H</span> <span class="s1">"{{ $securitySchemes.apiKeyAuth.name }}: <span class="n">${ {{ index $securitySchemes.apiKeyAuth "x-env-name" }} }</span>"</span> \
 <span class="o">-H</span> <span class="s1">"{{ $securitySchemes.appKeyAuth.name }}: <span class="n">${ {{ index $securitySchemes.appKeyAuth "x-env-name" }} }</span>"</span> 
 {{- end -}}
-{{- if $context.action.requestBody -}} \
+{{- if $context.action.requestBody -}}&nbsp;\
 <span class="o">-d</span> <span class="n">@-</span> <span class="o"><<</span> <span class="n">EOF</span>
 <span class="s1">{{ ($.Scratch.Get "jsonRequestBody") }}</span>
 <span class="n">EOF</span>

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -174,8 +174,8 @@
                                       {{ end }}
                                     </div>
                                 </div>
-                            {{ end }}  
-                         
+                            {{ end }}
+
                             {{ with $queryStrings }}
                                 <h4 class="text-capitalize">Query Strings</h4>
                                 <div class=" schema-table row">
@@ -412,7 +412,22 @@
 <span class="kn">export</span> <span class="n">{{ .name }}</span><span class="o">=</span><span class="s1">"{{ .example | default "CHANGE_ME"}}"</span>
 {{ end -}}
 {{- end -}}
-<span class="n">curl</span> <span class="o">-X</span> <span class="s1 text-uppercase">{{ $context.actionType }}</span> {{ range $.Scratch.Get "serverURLS" }}<span class="kn d-none" data-region="{{ .region }}">{{ .url }}</span>{{ end }}<span class="n">{{ replace $context.pathKey "{" "${" }}</span> \
+<span class="n">curl</span> <span class="o">-X</span> <span class="s1 text-uppercase">{{ $context.actionType }}</span> {{ range $.Scratch.Get "serverURLS" }}<span class="kn d-none" data-region="{{ .region }}">{{ .url }}</span>{{ end }}<span class="n">{{ replace $context.pathKey "{" "${" }}</span>
+
+{{- with $context.action.security -}}
+    {{- $i := 0 -}}
+    {{- range . -}}
+        {{- range $key, $val := . -}}
+            {{ $authSchema := (index $d.components.securitySchemes $key) }}
+            {{- if eq $authSchema.in "query" -}}
+                <span class="o">{{- if eq $i 0 -}}?{{- else -}}&{{- end -}}</span><span class="n">{{ $authSchema.name }}</span><span class="o">=</span><span class="n">${ {{- index $authSchema "x-env-name" -}} }</span>
+                {{- $i = add $count 1 -}}
+            {{- end -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+&nbsp;\
+
 {{- with $context.action.requestBody -}}
 {{- with .content -}}
 {{range $key, $val := . }}
@@ -426,13 +441,15 @@
 {{- range . -}}
 {{- range $key, $val := . -}}
 {{ $authSchema := (index $d.components.securitySchemes $key) }}
+{{- if eq $authSchema.in "header" -}}
 <span class="o">-H</span> <span class="s1">"{{ $authSchema.name }}: <span class="n">${ {{- index $authSchema "x-env-name" -}} }</span>"</span>
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- else -}}
 {{ $securitySchemes := $d.components.securitySchemes }}
 <span class="o">-H</span> <span class="s1">"{{ $securitySchemes.apiKeyAuth.name }}: <span class="n">${ {{- index $securitySchemes.apiKeyAuth "x-env-name" -}} }</span>"</span> \
-<span class="o">-H</span> <span class="s1">"{{ $securitySchemes.appKeyAuth.name }}: <span class="n">${ {{- index $securitySchemes.appKeyAuth "x-env-name" -}} }</span>"</span> 
+<span class="o">-H</span> <span class="s1">"{{ $securitySchemes.appKeyAuth.name }}: <span class="n">${ {{- index $securitySchemes.appKeyAuth "x-env-name" -}} }</span>"</span>
 {{- end -}}
 {{- if $context.action.requestBody -}}&nbsp;\
 <span class="o">-d</span> <span class="n">@-</span> <span class="o"><<</span> <span class="n">EOF</span>

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -418,7 +418,8 @@
 {{range $key, $val := . }}
 -H "Content-Type: {{ $key }}" \{{ end }}
 {{- end -}}
-{{- end -}}
+{{ else }}
+-H "Content-Type: application/json" \{{- end -}}
 {{- with $context.action.security -}}
 {{- range . -}}
 {{- range $key, $val := . -}}

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -416,11 +416,11 @@
 {{- with $context.action.requestBody -}}
 {{- with .content -}}
 {{range $key, $val := . }}
--H "Content-Type: {{ $key }}" \
+<span class="o">-H</span> <span class="s1">"Content-Type: {{ $key }}"</span> \
 {{- end -}}
 {{- end -}}
 {{ else }}
--H "Content-Type: application/json" \
+<span class="o">-H</span> <span class="s1">"Content-Type: application/json"</span> \
 {{- end -}}
 {{- with $context.action.security -}}
 {{- range . -}}

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -408,14 +408,16 @@
 {{/* Do not change indent of html below as it will change the indentation of the curl code block */}}
                                             <code class="language-fallback" data-lang="fallback">
 {{- with $pathParams -}}
-{{- range . -}}
-<span class="kn">export</span> <span class="n">{{ .name }}</span><span class="o">=</span><span class="s1">"{{ .example | default "CHANGE_ME"}}"</span>
+    {{- range . -}}
+        <span class="kn">export</span> <span class="n">{{ .name }}</span><span class="o">=</span><span class="s1">"{{ .example | default "CHANGE_ME"}}"</span>
+    {{- end }}
 {{ end -}}
-{{- end -}}
+
 <span class="n">curl</span> <span class="o">-X</span> <span class="s1 text-uppercase">{{ $context.actionType }}</span> {{ range $.Scratch.Get "serverURLS" }}<span class="kn d-none" data-region="{{ .region }}">{{ .url }}</span>{{ end }}<span class="n">{{ replace $context.pathKey "{" "${" }}</span>
 
+{{- /* Render authentication query parameters "?api_key=XXX" */ -}}
+{{- $i := 0 -}}
 {{- with $context.action.security -}}
-    {{- $i := 0 -}}
     {{- range . -}}
         {{- range $key, $val := . -}}
             {{ $authSchema := (index $d.components.securitySchemes $key) }}
@@ -426,32 +428,42 @@
         {{- end -}}
     {{- end -}}
 {{- end -}}
-&nbsp;\
 
+{{- /* Content-Type header based on "requestBody" */ -}}
 {{- with $context.action.requestBody -}}
-{{- with .content -}}
-{{range $key, $val := . }}
-<span class="o">-H</span> <span class="s1">"Content-Type: {{ $key }}"</span> \
-{{- end -}}
-{{- end -}}
-{{ else }}
-<span class="o">-H</span> <span class="s1">"Content-Type: application/json"</span> \
-{{- end -}}
-{{- with $context.action.security -}}
-{{- range . -}}
-{{- range $key, $val := . -}}
-{{ $authSchema := (index $d.components.securitySchemes $key) }}
-{{- if eq $authSchema.in "header" -}}
-<span class="o">-H</span> <span class="s1">"{{ $authSchema.name }}: <span class="n">${ {{- index $authSchema "x-env-name" -}} }</span>"</span>
-{{- end -}}
-{{- end -}}
-{{- end -}}
+    {{- with .content -}}
+        {{- range $key, $val := . -}}
+            &nbsp;\
+<span class="o">-H</span> <span class="s1">"Content-Type: {{ $key }}"</span>
+        {{- end -}}
+    {{- end -}}
 {{- else -}}
-{{ $securitySchemes := $d.components.securitySchemes }}
-<span class="o">-H</span> <span class="s1">"{{ $securitySchemes.apiKeyAuth.name }}: <span class="n">${ {{- index $securitySchemes.apiKeyAuth "x-env-name" -}} }</span>"</span> \
-<span class="o">-H</span> <span class="s1">"{{ $securitySchemes.appKeyAuth.name }}: <span class="n">${ {{- index $securitySchemes.appKeyAuth "x-env-name" -}} }</span>"</span>
+&nbsp;\
+<span class="o">-H</span> <span class="s1">"Content-Type: application/json"</span>
 {{- end -}}
-{{- if $context.action.requestBody -}}&nbsp;\
+
+{{- /* Render authentication in headers "DD-API-KEY: XXX" */ -}}
+{{- with $context.action.security -}}
+    {{- /* Find authentication per operationId */ -}}
+    {{- range . -}}
+        {{- range $key, $val := . -}}
+            {{ $authSchema := (index $d.components.securitySchemes $key) }}
+            {{- if eq $authSchema.in "header" -}}
+                &nbsp;\
+<span class="o">-H</span> <span class="s1">"{{ $authSchema.name }}: <span class="n">${ {{- index $authSchema "x-env-name" -}} }</span>"</span>
+            {{- end -}}
+        {{- end -}}
+    {{- end -}}
+{{- else -}}
+    {{- /* Use global authentication */ -}}
+    {{- $securitySchemes := $d.components.securitySchemes -}}
+    &nbsp;\
+<span class="o">-H</span> <span class="s1">"{{ $securitySchemes.apiKeyAuth.name }}: <span class="n">${ {{- index $securitySchemes.apiKeyAuth "x-env-name" -}} }</span>"</span>
+{{- end -}}
+
+{{- /* Render requestBody example JSON "-d @- << EOF ... EOF" */ -}}
+{{- if $context.action.requestBody -}}
+&nbsp;\
 <span class="o">-d</span> <span class="n">@-</span> <span class="o"><<</span> <span class="n">EOF</span>
 <span class="s1">{{ ($.Scratch.Get "jsonRequestBody") }}</span>
 <span class="n">EOF</span>


### PR DESCRIPTION
### What does this PR do?
Update curl examples to fall back to global DD api and app keys and content type if not specifically provided for the endpoint.

### Preview link
http://docs-staging.datadoghq.com/zach/fix-curl/api/v1/monitors/#monitors-group-search

check that all curl examples now have default
```
-H "Content-Type: application/json" \
-H "DD-API-KEY: ${DD_CLIENT_API_KEY}" \
-H "DD-APPLICATION-KEY: ${DD_CLIENT_APP_KEY}"
```

