### PR TITLE
import `initialize` to instantiate in Python

### DIFF
--- a/content/en/developers/dogstatsd/_index.md
+++ b/content/en/developers/dogstatsd/_index.md
@@ -286,7 +286,7 @@ Once your DogStatsD client is installed, instantiate it in your code:
 {{% tab "Python" %}}
 
 ```python
-from datadog import statsd
+from datadog import initialize, statsd
 
 options = {
     'statsd_host':'127.0.0.1',


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds `initialize` to the import statement for instantiating the DogStatsD client in Python.

### Motivation
<!-- What inspired you to submit this pull request?-->
The `initialize` function is not in the import but it is used in the code block [on this page](https://docs.datadoghq.com/developers/dogstatsd/?tab=python#instantiate-the-dogstatsd-client). It is also in the import on a [subsequent page](https://docs.datadoghq.com/developers/metrics/dogstatsd_metrics_submission/?tab=python#code-examples). This change makes clear where that method comes from.

### Preview link
<!-- Impacted pages preview links-->
BEFORE
![image](https://user-images.githubusercontent.com/2243944/81478323-1ccc2a00-91e2-11ea-9a09-ee3fc983bdbb.png)

AFTER
![image](https://user-images.githubusercontent.com/2243944/81478325-23f33800-91e2-11ea-91d9-445a3e67fc98.png)

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
