### PR TITLE
exclude custom choice element from pa11y results

### DIFF
--- a/local/bin/js/pa11y.js
+++ b/local/bin/js/pa11y.js
@@ -43,7 +43,7 @@ const excludeUrls = [
 
 // some results will contain errors from third parties, or should be excluded from pa11y output.
 // If you find an error from a 3rd party, exclude it by adding the string in this array from the issue.context result
-const filterBadResults = ['bid.g.doubleclick.net', '_hj', 'https://fast.wistia.com/embed/iframe_shim?domain=com'];
+const filterBadResults = ['bid.g.doubleclick.net', '_hj', 'https://fast.wistia.com/embed/iframe_shim?domain=com', 'choices__input'];
 
 const options = {
   pa11yConfig,


### PR DESCRIPTION
### What does this PR do?
remove bad pa11y result fom a11y errors. Docs now uses a custom `<select>` element for the region and api version selectors, and the package used takes a11y into account with aria roles and labels.

### Motivation
the now 1000+ a11y errors on Docs: https://dd-corpsite.datadoghq.com/dashboard/u3m-7ve-2yv/corpsite-accessibility-pa11y-issues?from_ts=1567539920015&to_ts=1568144720015&live=true&tile_size=m

### Preview link
http://docs-staging.datadoghq.com/zach/fix-a11y

