### PR TITLE
dan.chiniara/ timeboards - clarified where snapshots go without a use…

### DIFF
--- a/content/en/dashboards/timeboards.md
+++ b/content/en/dashboards/timeboards.md
@@ -59,7 +59,7 @@ Left click on any dashboard timeseries graph to open an options menu:
 
 | Option                 | Description                                                   |
 |------------------------|---------------------------------------------------------------|
-| Annotate this graph    | Write a comment or notify members of your team about a graph. |
+| Annotate this graph    | Write a comment that will enter the event feed or notify members of your team about a graph. |
 | View in full screen    | View the graph in [full screen mode][12].                     |
 | Copy tags to clipboard | Copy the tags to your clipboard that display on hover.        |
 | View related processes | Jump to the [Live Processes][13] page scoped to your graph.   |

--- a/content/en/dashboards/timeboards.md
+++ b/content/en/dashboards/timeboards.md
@@ -59,7 +59,7 @@ Left click on any dashboard timeseries graph to open an options menu:
 
 | Option                 | Description                                                   |
 |------------------------|---------------------------------------------------------------|
-| Annotate this graph    | Write a comment that will enter the event feed or notify members of your team about a graph. |
+| Annotate this graph    | Write a comment that enters the event feed or notify members of your team about a graph. |
 | View in full screen    | View the graph in [full screen mode][12].                     |
 | Copy tags to clipboard | Copy the tags to your clipboard that display on hover.        |
 | View related processes | Jump to the [Live Processes][13] page scoped to your graph.   |


### PR DESCRIPTION
…r designated

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

clarifies that snapshots without users listed will go to the event stream

### Motivation
<!-- What inspired you to submit this pull request?-->

Zendesk Ticket: https://datadog.zendesk.com/agent/tickets/339646 

### Preview link
<!-- Impacted pages preview links-->

https://docs-staging.datadoghq.com/dan.chiniara/timeboards_clarified_where_nonuser_snapshots_go/dashboards/timeboards/#pagetitle