### PR TITLE
Add telemetry for .NET

### DIFF
--- a/content/en/developers/dogstatsd/high_throughput.md
+++ b/content/en/developers/dogstatsd/high_throughput.md
@@ -400,7 +400,36 @@ See [DataDog/php-datadogstatsd](https://github.com/DataDog/php-datadogstatsd) fo
 {{% /tab %}}
 {{% tab ".NET" %}}
 
-Telemetry will soon be added to the .NET client.
+Starting with version `5.0.0` of the .NET client.
+
+| Metric name                                          | Metric Type | Description                                                                                                                                                     |
+| ---------------------------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `datadog.dogstatsd.client.metrics`                   | count       | Number of `metrics` sent to the DogStatsD client by your application (before sampling).                                                                         |
+| `datadog.dogstatsd.client.events`                    | count       | Number of `events` sent to the DogStatsD client by your application.                                                                                            |
+| `datadog.dogstatsd.client.service_checks`            | count       | Number of `service_checks` sent to the DogStatsD client by your application.                                                                                    |
+| `datadog.dogstatsd.client.bytes_sent`                | count       | Number of bytes successfully sent to the Agent.                                                                                                                 |
+| `datadog.dogstatsd.client.bytes_dropped`             | count       | Number of bytes dropped by the DogStatsD client.                                                                                                                |
+| `datadog.dogstatsd.client.packets_sent`              | count       | Number of datagrams successfully sent to the Agent.                                                                                                             |
+| `datadog.dogstatsd.client.packets_dropped`           | count       | Number of datagrams dropped by the DogStatsD client.                                                                                                            |
+| `datadog.dogstatsd.client.packets_dropped_queue`     | count       | Number of datagrams dropped because the DogStatsD client queue was full.                                                                                        |
+
+To disable telemetry, set `TelemetryFlushInterval` at `null`:
+
+```csharp
+var dogstatsdConfig = new StatsdConfig
+{
+    StatsdServerName = "127.0.0.1",
+    StatsdPort = 8125,
+};
+
+// Disable Telemetry
+dogstatsdConfig.Advanced.TelemetryFlushInterval = null;
+```
+
+See [DataDog/dogstatsd-csharp-client][1] for more information about the client configuration.
+
+
+[1]: https://github.com/DataDog/dogstatsd-csharp-client
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Add .NET section for [Client side telemetry](https://docs.datadoghq.com/developers/dogstatsd/high_throughput/?tab=go#client-side-telemetry)

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/olivierg/Telemetry/developers/dogstatsd/high_throughput/
Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
