### PR TITLE
Private Locations page reorg

### DIFF
--- a/content/en/synthetics/private_locations.md
+++ b/content/en/synthetics/private_locations.md
@@ -1,7 +1,7 @@
 ---
 title: Run Synthetics Tests from Private Locations
 kind: documentation
-description: Run Synthetics API and Browser Tests from Private Locations
+description: Run Synthetics API and browser tests from private locations
 beta: true
 further_reading:
     - link: 'synthetics/'

--- a/content/en/synthetics/private_locations.md
+++ b/content/en/synthetics/private_locations.md
@@ -33,15 +33,25 @@ Once you created a private location, configuring a [Synthetics test][1] to run f
 
 To pull test configurations and push test results, the private location worker needs access to one of the Datadog API endpoints.
 
+{{< site-region region="us" >}}
+
 | Datadog site    | Port | Endpoint                                                                                             |
 | --------------- | ---- | ---------------------------------------------------------------------------------------------------- |
 | Datadog US site | 443  | `intake.synthetics.datadoghq.com` for version 0.1.6+, `api.datadoghq.com/api/` for versions <0.1.5   |
-| Datadog EU site | 443  | `api.datadoghq.eu/api/`                                                                               |
 
-Check if the endpoint corresponding to your Datadog `site` is available from the host running the worker:
+**Note**: For version 0.1.6+, use `curl intake.synthetics.datadoghq.com` (`curl https://api.datadoghq.com` for versions <0.1.5).
 
-- For the Datadog US site: for version 0.1.6+ use `curl intake.synthetics.datadoghq.com` (`curl https://api.datadoghq.com` for versions <0.1.5).
-- For the Datadog EU site: `curl https://api.datadoghq.eu`.
+{{< /site-region >}}
+
+{{< site-region region="eu" >}}
+
+| Datadog site    | Port | Endpoint                                                                                             |
+| --------------- | ---- | ---------------------------------------------------------------------------------------------------- |
+| Datadog EU site | 443  | `api.datadoghq.eu/api/`                                                                              |
+
+**Note**: For version 0.1.6+, use `curl https://api.datadoghq.eu`.
+
+{{< /site-region >}}
 
 ### Docker
 
@@ -92,7 +102,7 @@ If traffic between your private location and Datadog has to go through a proxy, 
 
 #### DNS configuration
 
-By default, the Datadog workers use `8.8.8.8` to perform DNS resolution. If it fails, it makes a second attempt to communicate with `1.1.1.1`.   
+By default, the Datadog workers use `8.8.8.8` to perform DNS resolution. If it fails, it makes a second attempt to communicate with `1.1.1.1`.
 If you are testing an internal URL and need to use an internal DNS server, you can set the `dnsServer` option to a specific DNS IP address. Alternatively leverage the `dnsUseHost` parameter to have your worker use your local DNS config from the `etc/resolv.conf` file.
 
 #### Special-purpose IPv4 whitelisting


### PR DESCRIPTION
### What does this PR do?
Reorganizes the Synthetics PL page:

- Moves configuration section up to step 3 as configuration is required prior to launching the worker
- Adds proxy url example to existing table
- Adds prerequisites section to help users avoid common configuration issues

### Motivation
Jira request

### Preview link
https://docs-staging.datadoghq.com/sarina/plg-reorg/synthetics/private_locations/