### PR TITLE
Include required query arguments in curl examples

### DIFF
--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -421,14 +421,14 @@
     {{- range . -}}
         {{- if eq .required true -}}
             <span class="kn">export</span> <span class="n">{{ .name }}</span><span class="o">=</span><span class="s1">"{{ .example | default (.schema.example | default "CHANGE_ME") }}"</span>
-        {{- end -}}
-    {{- end }}
-{{ end -}}
+        {{- end }}
+    {{ end -}}
+{{- end -}}
 
 <span class="n">curl</span> <span class="o">-X</span> <span class="s1 text-uppercase">{{ $context.actionType }}</span> {{ range $.Scratch.Get "serverURLS" }}<span class="kn d-none" data-region="{{ .region }}">{{ .url }}</span>{{ end }}<span class="n">{{ replace $context.pathKey "{" "${" }}</span>
-{{- range $i, $q := $queryStrings -}}
+{{- range $qi, $q := $queryStrings -}}
     {{- if eq .required true -}}
-        <span class="o">{{ cond (eq $i 0) "?" "&" }}</span><span class="n">{{ $q.name }}</span><span class="o">=</span><span class="s1">${ {{- $q.name -}} }</span>
+        <span class="o">{{ cond (gt $qi 1) "&" "?" }}</span><span class="n">{{ $q.name }}</span><span class="o">=</span><span class="s1">${ {{- $q.name -}} }</span>
     {{- end -}}
 {{- end -}}
 

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -406,17 +406,31 @@
                                         <button class="btn text-primary js-copy-button">Copy</button>
                                     </div>
                                     {{ $pathParams := $.Scratch.Get "pathParams" }}
+                                    {{ $queryStrings := $.Scratch.Get "queryStrings" }}
                                     <div class="highlight">
                                         <pre class="chroma">
 {{/* Do not change indent of html below as it will change the indentation of the curl code block */}}
                                             <code class="language-fallback" data-lang="fallback">
 {{- with $pathParams -}}
     {{- range . -}}
-        <span class="kn">export</span> <span class="n">{{ .name }}</span><span class="o">=</span><span class="s1">"{{ .example | default "CHANGE_ME"}}"</span>
+        <span class="kn">export</span> <span class="n">{{ .name }}</span><span class="o">=</span><span class="s1">"{{ .example | default (.schema.example | default "CHANGE_ME") }}"</span>
+    {{- end }}
+{{ end -}}
+
+{{- with $queryStrings -}}
+    {{- range . -}}
+        {{- if eq .required true -}}
+            <span class="kn">export</span> <span class="n">{{ .name }}</span><span class="o">=</span><span class="s1">"{{ .example | default (.schema.example | default "CHANGE_ME") }}"</span>
+        {{- end -}}
     {{- end }}
 {{ end -}}
 
 <span class="n">curl</span> <span class="o">-X</span> <span class="s1 text-uppercase">{{ $context.actionType }}</span> {{ range $.Scratch.Get "serverURLS" }}<span class="kn d-none" data-region="{{ .region }}">{{ .url }}</span>{{ end }}<span class="n">{{ replace $context.pathKey "{" "${" }}</span>
+{{- range $i, $q := $queryStrings -}}
+    {{- if eq .required true -}}
+        <span class="o">{{ cond (eq $i 0) "?" "&" }}</span><span class="n">{{ $q.name }}</span><span class="o">=</span><span class="s1">${ {{- $q.name -}} }</span>
+    {{- end -}}
+{{- end -}}
 
 {{- /* Render authentication query parameters "?api_key=XXX" */ -}}
 {{- $i := 0 -}}

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -412,19 +412,26 @@
 {{/* Do not change indent of html below as it will change the indentation of the curl code block */}}
                                             <code class="language-fallback" data-lang="fallback">
 {{- with $pathParams -}}
+    <span class="c1"># Path parameters</span><br/>
     {{- range . -}}
-        <span class="kn">export</span> <span class="n">{{ .name }}</span><span class="o">=</span><span class="s1">"{{ .example | default (.schema.example | default "CHANGE_ME") }}"</span>
-    {{- end }}
-{{ end }}
+        <span class="kn">export</span> <span class="n">{{ .name }}</span><span class="o">=</span><span class="s1">"{{ .example | default (.schema.example | default "CHANGE_ME") }}"</span><br/>
+    {{- end -}}
+{{- end -}}
 
 {{- with $queryStrings -}}
+    {{- $i := 0 -}}
     {{- range . -}}
         {{- if eq .required true -}}
-            <span class="kn">export</span> <span class="n">{{ .name }}</span><span class="o">=</span><span class="s1">"{{ .example | default (.schema.example | default "CHANGE_ME") }}"</span>
+            {{- if eq $i 0 -}}
+                <span class="c1"># Required query arguments</span><br/>
+            {{- end -}}
+            <span class="kn">export</span> <span class="n">{{ .name }}</span><span class="o">=</span><span class="s1">"{{ .example | default (.schema.example | default "CHANGE_ME") }}"</span><br/>
+            {{- $i = add $count 1 -}}
         {{- end -}}
-    {{- end }}
-{{- end }}
+    {{- end -}}
+{{- end -}}
 
+<span class="c1"># Curl command</span>
 <span class="n">curl</span> <span class="o">-X</span> <span class="s1 text-uppercase">{{ $context.actionType }}</span> {{ range $.Scratch.Get "serverURLS" }}<span class="kn d-none" data-region="{{ .region }}">{{ .url }}</span>{{ end }}<span class="n">{{ replace $context.pathKey "{" "${" }}</span>
 {{- range $qi, $q := $queryStrings -}}
     {{- if eq .required true -}}
@@ -433,8 +440,8 @@
 {{- end -}}
 
 {{- /* Render authentication query parameters "?api_key=XXX" */ -}}
-{{- $i := 0 -}}
 {{- with $context.action.security -}}
+    {{- $i := 0 -}}
     {{- range . -}}
         {{- range $key, $val := . -}}
             {{ $authSchema := (index $d.components.securitySchemes $key) }}

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -415,15 +415,15 @@
     {{- range . -}}
         <span class="kn">export</span> <span class="n">{{ .name }}</span><span class="o">=</span><span class="s1">"{{ .example | default (.schema.example | default "CHANGE_ME") }}"</span>
     {{- end }}
-{{ end -}}
+{{ end }}
 
 {{- with $queryStrings -}}
     {{- range . -}}
         {{- if eq .required true -}}
             <span class="kn">export</span> <span class="n">{{ .name }}</span><span class="o">=</span><span class="s1">"{{ .example | default (.schema.example | default "CHANGE_ME") }}"</span>
-        {{- end }}
-    {{ end -}}
-{{- end -}}
+        {{- end -}}
+    {{- end }}
+{{- end }}
 
 <span class="n">curl</span> <span class="o">-X</span> <span class="s1 text-uppercase">{{ $context.actionType }}</span> {{ range $.Scratch.Get "serverURLS" }}<span class="kn d-none" data-region="{{ .region }}">{{ .url }}</span>{{ end }}<span class="n">{{ replace $context.pathKey "{" "${" }}</span>
 {{- range $qi, $q := $queryStrings -}}


### PR DESCRIPTION
### What does this PR do?

Renders required query parameters in Curl examples:

```sh
export service="service-c"
export env="prod"
curl -X GET https://api.datadoghq.eu/api/v1/service_dependencies/${service}?env=${env} \
-H "Content-Type: application/json" \
-H "DD-API-KEY: ${DD_CLIENT_API_KEY}" \
-H "DD-APPLICATION-KEY: ${DD_CLIENT_APP_KEY}"
```

### Motivation
User feedback :)

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jirikuncar/curl-required-query-params/api/v1/service-dependencies/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
