### PR TITLE
remove_duplicate_envvar_DDSERVICEMAPPING

### DIFF
--- a/content/en/tracing/setup/php.md
+++ b/content/en/tracing/setup/php.md
@@ -243,7 +243,6 @@ DD_TRACE_DEBUG=true php -S localhost:8888
 | `DD_PRIORITY_SAMPLING`                    | `true`      | Whether to enable priority sampling                                                                                                            |
 | `DD_TRACE_SAMPLE_RATE`                    | `1.0`       | The sampling rate for the traces. Between `0.0` and `1.0` (default). It was `DD_SAMPLING_RATE` before v0.36.0                                  |
 | `DD_SERVICE_NAME`                         | `none`      | The default app name                                                                                                                           |
-| `DD_SERVICE_MAPPING`                      | `none`      | Service renaming rules, for example: `pdo:payments-db,host-10.10.10.10:internal-api`                                                                   |
 | `DD_TRACE_AGENT_ATTEMPT_RETRY_TIME_MSEC`  | `5000`      | IPC-based configurable circuit breaker retry time (in milliseconds)                                                                            |
 | `DD_TRACE_AGENT_CONNECT_TIMEOUT`          | `100`       | Maximum time the allowed for Agent connection setup (in milliseconds)                                                                          |
 | `DD_TRACE_AGENT_CONNECT_TIMEOUT`          | `100`       | The Agent connection timeout (in milliseconds)                                                                                                 |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

removes a duplicate definition for DD_SERVICE_MAPPING in the env var table

### Motivation
<!-- What inspired you to submit this pull request?-->

confirmed this was a duplicate with cake-(support)

### Preview link
<!-- Impacted pages preview links-->

https://docs.datadoghq.com/tracing/setup/php/#environment-variable-configuration

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
