### PR TITLE
Update Log proxy instruction

### DIFF
--- a/content/en/agent/logs/log_transport.md
+++ b/content/en/agent/logs/log_transport.md
@@ -34,7 +34,7 @@ To check which transport is used by the Agent, run the [Agent status command][1]
 
 **Note**: For older Agent versions, TCP transport is used by default. Datadog strongly recommends you to enforce HTTPS transport if you are running v6.14+/v7.14+ and HTTPS compression if you are running v6.16+/v7.16+. 
 
-**Note**: If a proxy is used to forward logs, Datadog strongly recommends to overwrite this behaviour to enforce a specific Transport as described in next section.
+**Note**: If a proxy is used to forward logs, Datadog strongly recommends to overwrite this behaviour to enforce a specific transport as described in next section.
 
 ## Enforce a specific transport
 

--- a/content/en/agent/logs/log_transport.md
+++ b/content/en/agent/logs/log_transport.md
@@ -34,6 +34,8 @@ To check which transport is used by the Agent, run the [Agent status command][1]
 
 **Note**: For older Agent versions, TCP transport is used by default. Datadog strongly recommends you to enforce HTTPS transport if you are running v6.14+/v7.14+ and HTTPS compression if you are running v6.16+/v7.16+. 
 
+**Note**: If a proxy is used to forward logs, Datadog strongly recommends to overwrite this behaviour to enforce a specific Transport as described in next section.
+
 ## Enforce a specific transport
 
 Enforce the use of TCP or HTTPS transport by using the following configurations.

--- a/content/en/agent/logs/log_transport.md
+++ b/content/en/agent/logs/log_transport.md
@@ -32,9 +32,9 @@ To check which transport is used by the Agent, run the [Agent status command][1]
 
 {{< img src="agent/logs/agent-status.png" alt="Agent status"  style="width:70%;">}}
 
-**Note**: For older Agent versions, TCP transport is used by default. Datadog strongly recommends you to enforce HTTPS transport if you are running v6.14+/v7.14+ and HTTPS compression if you are running v6.16+/v7.16+. 
-
-**Note**: If a proxy is used to forward logs, Datadog strongly recommends to overwrite this behaviour to enforce a specific transport as described in next section.
+**Notes**:
+* For older Agent versions, TCP transport is used by default. Datadog strongly recommends you to enforce HTTPS transport if you are running v6.14+/v7.14+ and HTTPS compression if you are running v6.16+/v7.16+. 
+* Always enforce a specific transport (either TCP or HTTPS) when using a proxy to forwards logs to Datadog
 
 ## Enforce a specific transport
 

--- a/content/en/agent/logs/proxy.md
+++ b/content/en/agent/logs/proxy.md
@@ -15,8 +15,8 @@ further_reading:
 
 Log collection requires the Datadog Agent v6.0+. Older versions of the Agent do not include the `log collection` interface.
 
-Since agent version v6.14/v7.14 Datadog recommend to use and enforce HTTPS transport (see [agent Transport for Logs][2]). 
-If you are using the HTTPS transport for logs, please reffer to the [agent proxy documentation][1] and use the same set of proxy settings as other data types.
+As of Agent v6.14/v7.14, Datadog recommends the use of and enforcing HTTPS transport (see [agent Transport for Logs][2]). 
+If you are using the HTTPS transport for logs, please refer to the [agent proxy documentation][1] and use the same set of proxy settings as other data types.
 
 
 ## TCP log forwarding
@@ -143,7 +143,7 @@ backend datadog-logs
         * `yum install ca-certificates` (CentOS, Redhat)
 If successful, the file will be located at `/etc/ssl/certs/ca-bundle.crt` for CentOS, Redhat.
 
-Once the HAProxy configuration is in place, you can reload it or restart HAProxy. **It is recommended to have a `cron` job that reloads HAProxy every 10 minutes** (usually doing something like `service haproxy reload`) to force a refresh of HAProxy's DNS cache, in case `app.datadoghq.com` fails over to another IP.
+Once the HAProxy configuration is in place, you can reload it or restart HAProxy. **It is recommended to have a `cron` job that reloads HAProxy every 10 minutes** (for example, `service haproxy reload`) to force a refresh of HAProxy's DNS cache, in case `app.datadoghq.com` fails over to another IP.
 
 
 {{< /site-region >}}
@@ -211,13 +211,13 @@ backend datadog-logs
 
 If successful, the file will be located at `/etc/ssl/certs/ca-bundle.crt` for CentOS, Redhat.
 
-Once the HAProxy configuration is in place, you can reload it or restart HAProxy. **It is recommended to have a `cron` job that reloads HAProxy every 10 minutes** (usually doing something like `service haproxy reload`) to force a refresh of HAProxy's DNS cache, in case `app.datadoghq.eu` fails over to another IP.
+Once the HAProxy configuration is in place, you can reload it or restart HAProxy. **It is recommended to have a `cron` job that reloads HAProxy every 10 minutes** (for example, `service haproxy reload`) to force a refresh of HAProxy's DNS cache, in case `app.datadoghq.eu` fails over to another IP.
 
 {{< /site-region >}}
 
 #### Agent configuration
 
-Then edit the `datadog.yaml` Agent configuration file and set `logs_no_ssl` to `true`. This is needed as HAProxy does not simply forward the traffic and is not the Datadog backend so cannot use the same certificate.
+Edit the `datadog.yaml` Agent configuration file and set `logs_no_ssl` to `true`. This is needed as HAProxy does not forward the traffic and is not the Datadog backend, so you cannot use the same certificate.
 
 **Note**: `logs_no_ssl` might set to true because HAProxy is configured to encrypt the data. Do not set this parameter to `true` otherwise.
 
@@ -288,7 +288,7 @@ logs_config:
   logs_dd_url: myProxyServer.myDomain:10514
 ```
 
-**Note**: Do not change the `logs_no_ssl` parameter as NGINX is simply forwarding the traffic to Datadog and does not decrypt or encrypt the traffic.
+**Note**: Do not change the `logs_no_ssl` parameter as NGINX is forwarding the traffic to Datadog and does not decrypt or encrypt the traffic.
 
 ## Further Reading
 

--- a/content/en/agent/logs/proxy.md
+++ b/content/en/agent/logs/proxy.md
@@ -75,6 +75,20 @@ This example explains how to configure the Datadog Agent to send logs in TCP to 
 
 The encryption is disabled between the Agent and HAProxy which is then configured to encrypt the data before sending it to Datadog.
 
+#### Agent configuration
+
+Edit the `datadog.yaml` Agent configuration file and set `logs_no_ssl` to `true`. This is needed as HAProxy does not forward the traffic and is not the Datadog backend, so you cannot use the same certificate.
+
+**Note**: `logs_no_ssl` might set to true because HAProxy is configured to encrypt the data. Do not set this parameter to `true` otherwise.
+
+```
+logs_config:
+  use_tcp: true
+  logs_dd_url: "<PROXY_SERVER_DOMAIN>:10514"
+  logs_no_ssl: true
+```
+
+
 #### HAProxy configuration
 
 HAProxy should be installed on a host that has connectivity to Datadog. Use the following configuration file if you do not already have it configured.
@@ -215,21 +229,19 @@ Once the HAProxy configuration is in place, you can reload it or restart HAProxy
 
 {{< /site-region >}}
 
+### Using NGINX as a TCP Proxy for logs
+
 #### Agent configuration
 
-Edit the `datadog.yaml` Agent configuration file and set `logs_no_ssl` to `true`. This is needed as HAProxy does not forward the traffic and is not the Datadog backend, so you cannot use the same certificate.
+Edit the `datadog.yaml` Agent configuration file and set `logs_config.logs_dd_url` to use the newly created proxy instead of establishing a connection directly with Datadog:
 
-**Note**: `logs_no_ssl` might set to true because HAProxy is configured to encrypt the data. Do not set this parameter to `true` otherwise.
-
-```
+```yaml
 logs_config:
   use_tcp: true
-  logs_dd_url: "<PROXY_SERVER_DOMAIN>:10514"
-  logs_no_ssl: true
+  logs_dd_url: myProxyServer.myDomain:10514
 ```
 
-
-### Using NGINX as a TCP Proxy for logs
+**Note**: Do not change the `logs_no_ssl` parameter as NGINX is forwarding the traffic to Datadog and does not decrypt or encrypt the traffic.
 
 #### NGINX configuration
 
@@ -278,17 +290,6 @@ stream {
 
 {{< /site-region >}}
 
-#### Agent configuration
-
-Edit the `datadog.yaml` Agent configuration file and set `logs_config.logs_dd_url` to use the newly created proxy instead of establishing a connection directly with Datadog:
-
-```yaml
-logs_config:
-  use_tcp: true
-  logs_dd_url: myProxyServer.myDomain:10514
-```
-
-**Note**: Do not change the `logs_no_ssl` parameter as NGINX is forwarding the traffic to Datadog and does not decrypt or encrypt the traffic.
 
 ## Further Reading
 

--- a/content/en/agent/logs/proxy.md
+++ b/content/en/agent/logs/proxy.md
@@ -1,5 +1,5 @@
 ---
-title: Agent proxy for logs
+title: TCP Agent proxy for logs
 kind: documentation
 further_reading:
 - link: "/logs/"
@@ -15,8 +15,11 @@ further_reading:
 
 Log collection requires the Datadog Agent v6.0+. Older versions of the Agent do not include the `log collection` interface.
 
-By default, Datadog transports logs over TCP/SSL. Hence, there is a different [set of proxy settings][1] than other data types that the Datadog Agent forwards in HTTPS.
-Configure the Agent to send logs in HTTPS using the same set of proxy settings as other data types.
+Since agent version v6.14/v7.14 Datadog recommend to use and enforce HTTPS transport (see [agent Transport for Logs][2]). 
+If you are using the HTTPS transport for logs, please reffer to the [agent proxy documentation][1] and use the same set of proxy settings as other data types.
+
+
+## TCP log forwarding
 
 {{< tabs >}}
 {{% tab "TCP" %}}
@@ -60,17 +63,207 @@ The parameter above can also be set with the following environment variable:
 * `DD_LOGS_CONFIG_SOCKS5_PROXY_ADDRESS`
 
 {{% /tab %}}
-{{% tab "HTTPS" %}}
-
-When the Agent is [configured to send logs through HTTPS][1], use the same [set of proxy settings][2] as the other data types in order to send logs through a web proxy.
-
-[1]: /agent/logs/#send-logs-over-https
-[2]: /agent/proxy/
-{{% /tab %}}
 {{< /tabs >}}
+
+## Examples of TCP proxy
+
+### Using HAProxy as a TCP Proxy for Logs
+
+This example explains how to configure the Datadog Agent to send logs in TCP to a server with HAProxy installed and listening on port `10514` to then forward the logs to Datadog.
+
+`agent ---> haproxy ---> Datadog`
+
+The encryption is disabled between the Agent and HAProxy which is then configured to encrypt the data before sending it to Datadog.
+
+#### HAProxy configuration
+
+HAProxy should be installed on a host that has connectivity to Datadog. Use the following configuration file if you do not already have it configured.
+
+{{< site-region region="us" >}}
+
+
+```conf
+# Basic configuration
+global
+    log 127.0.0.1 local0
+    maxconn 4096
+    stats socket /tmp/haproxy
+# Some sane defaults
+defaults
+    log     global
+    option  dontlognull
+    retries 3
+    option  redispatch
+    timeout client 5s
+    timeout server 5s
+    timeout connect 5s
+# This declares a view into HAProxy statistics, on port 3833
+# You do not need credentials to view this page and you can
+# turn it off once you are done with setup.
+listen stats
+    bind *:3833
+    mode http
+    stats enable
+    stats uri /
+    
+# This declares the endpoint where your Agents connects for
+# sending Logs (e.g the value of "logs.config.logs_dd_url")
+frontend logs_frontend
+    bind *:10514
+    mode tcp
+    default_backend datadog-logs
+    
+# This is the Datadog server. In effect any TCP request coming
+# to the forwarder frontends defined above are proxied to
+# Datadog's public endpoints.
+backend datadog-logs
+    balance roundrobin
+    mode tcp
+    option tcplog
+    server datadog agent-intake.logs.datadoghq.com:10516 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt check port 10516
+```
+
+**Note**: Download the certificate with the following command:
+        * `sudo apt-get install ca-certificates` (Debian, Ubuntu)
+        * `yum install ca-certificates` (CentOS, Redhat)
+If successful, the file will be located at `/etc/ssl/certs/ca-bundle.crt` for CentOS, Redhat.
+
+Once the HAProxy configuration is in place, you can reload it or restart HAProxy. **It is recommended to have a `cron` job that reloads HAProxy every 10 minutes** (usually doing something like `service haproxy reload`) to force a refresh of HAProxy's DNS cache, in case `app.datadoghq.com` fails over to another IP.
+
+
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+
+```conf
+# Basic configuration
+global
+    log 127.0.0.1 local0
+    maxconn 4096
+    stats socket /tmp/haproxy
+# Some sane defaults
+defaults
+    log     global
+    option  dontlognull
+    retries 3
+    option  redispatch
+    timeout client 5s
+    timeout server 5s
+    timeout connect 5s
+# This declares a view into HAProxy statistics, on port 3833
+# You do not need credentials to view this page and you can
+# turn it off once you are done with setup.
+listen stats
+    bind *:3833
+    mode http
+    stats enable
+    stats uri /
+    
+# This declares the endpoint where your Agents connects for
+# sending Logs (e.g the value of "logs.config.logs_dd_url")
+frontend logs_frontend
+    bind *:10514
+    mode tcp
+    default_backend datadog-logs
+    
+# This is the Datadog server. In effect any TCP request coming
+# to the forwarder frontends defined above are proxied to
+# Datadog's public endpoints.
+backend datadog-logs
+    balance roundrobin
+    mode tcp
+    option tcplog
+    server datadog agent-intake.logs.datadoghq.eu:443 ssl verify required ca-file /etc/ssl/certs/ca-bundle.crt check port 443
+```
+
+**Note**: Download the certificate with the following command:
+
+* `sudo apt-get install ca-certificates` (Debian, Ubuntu)
+* `yum install ca-certificates` (CentOS, Redhat)
+
+If successful, the file will be located at `/etc/ssl/certs/ca-bundle.crt` for CentOS, Redhat.
+
+Once the HAProxy configuration is in place, you can reload it or restart HAProxy. **It is recommended to have a `cron` job that reloads HAProxy every 10 minutes** (usually doing something like `service haproxy reload`) to force a refresh of HAProxy's DNS cache, in case `app.datadoghq.eu` fails over to another IP.
+
+{{< /site-region >}}
+
+#### Agent configuration
+
+Then edit the `datadog.yaml` Agent configuration file and set `logs_no_ssl` to `true`. This is needed as HAProxy does not simply forward the traffic and is not the Datadog backend so cannot use the same certificate.
+
+**Note**: `logs_no_ssl` might set to true because HAProxy is configured to encrypt the data. Do not set this parameter to `true` otherwise.
+
+```
+logs_config:
+  use_tcp: true
+  logs_dd_url: "<PROXY_SERVER_DOMAIN>:10514"
+  logs_no_ssl: true
+```
+
+
+### Using NGINX as a TCP Proxy for logs
+
+#### NGINX configuration
+
+In this example, `nginx.conf` can be used to proxy Agent traffic to Datadog. The last server block in this configuration does TLS wrapping to ensure internal plaintext logs are encrypted between your proxy and Datadog's log intake API endpoint:
+
+{{< site-region region="us" >}}
+
+```conf
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+pid /run/nginx.pid;
+events {
+    worker_connections 1024;
+}
+# TCP Proxy for Datadog Agent
+stream {
+    server {
+        listen 10514; #listen for logs
+        proxy_ssl on;
+        proxy_pass agent-intake.logs.datadoghq.com:10516;
+    }
+}
+```
+
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+
+```conf
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+pid /run/nginx.pid;
+events {
+    worker_connections 1024;
+}
+# TCP Proxy for Datadog Agent
+stream {
+    server {
+        listen 10514; #listen for logs
+        proxy_ssl on;
+        proxy_pass agent-intake.logs.datadoghq.eu:443;
+    }
+}
+```
+
+{{< /site-region >}}
+
+#### Agent configuration
+
+Edit the `datadog.yaml` Agent configuration file and set `logs_config.logs_dd_url` to use the newly created proxy instead of establishing a connection directly with Datadog:
+
+```yaml
+logs_config:
+  use_tcp: true
+  logs_dd_url: myProxyServer.myDomain:10514
+```
+
+**Note**: Do not change the `logs_no_ssl` parameter as NGINX is simply forwarding the traffic to Datadog and does not decrypt or encrypt the traffic.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /agent/proxy/
+[2]: /agent/logs/log_transport?tab=https

--- a/content/en/agent/logs/proxy.md
+++ b/content/en/agent/logs/proxy.md
@@ -97,6 +97,7 @@ defaults
     timeout client 5s
     timeout server 5s
     timeout connect 5s
+
 # This declares a view into HAProxy statistics, on port 3833
 # You do not need credentials to view this page and you can
 # turn it off once you are done with setup.
@@ -105,12 +106,26 @@ listen stats
     mode http
     stats enable
     stats uri /
+
+# This section is to reload DNS Records
+# Replace <DNS_SERVER_IP> and <DNS_SECONDARY_SERVER_IP> with your DNS Server IP addresses.
+# For HAProxy 1.8 and newer
+resolvers my-dns
+    nameserver dns1 <DNS_SERVER_IP>:53
+    nameserver dns2 <DNS_SECONDARY_SERVER_IP>:53
+    resolve_retries 3
+    timeout resolve 2s
+    timeout retry 1s
+    accepted_payload_size 8192
+    hold valid 10s
+    hold obsolete 60s
     
 # This declares the endpoint where your Agents connects for
 # sending Logs (e.g the value of "logs.config.logs_dd_url")
 frontend logs_frontend
     bind *:10514
     mode tcp
+    option tcplog
     default_backend datadog-logs
     
 # This is the Datadog server. In effect any TCP request coming
@@ -149,6 +164,7 @@ defaults
     timeout client 5s
     timeout server 5s
     timeout connect 5s
+
 # This declares a view into HAProxy statistics, on port 3833
 # You do not need credentials to view this page and you can
 # turn it off once you are done with setup.
@@ -157,6 +173,19 @@ listen stats
     mode http
     stats enable
     stats uri /
+
+# This section is to reload DNS Records
+# Replace <DNS_SERVER_IP> and <DNS_SECONDARY_SERVER_IP> with your DNS Server IP addresses.
+# For HAProxy 1.8 and newer
+resolvers my-dns
+    nameserver dns1 <DNS_SERVER_IP>:53
+    nameserver dns2 <DNS_SECONDARY_SERVER_IP>:53
+    resolve_retries 3
+    timeout resolve 2s
+    timeout retry 1s
+    accepted_payload_size 8192
+    hold valid 10s
+    hold obsolete 60s
     
 # This declares the endpoint where your Agents connects for
 # sending Logs (e.g the value of "logs.config.logs_dd_url")

--- a/content/en/agent/logs/proxy.md
+++ b/content/en/agent/logs/proxy.md
@@ -15,7 +15,7 @@ further_reading:
 
 Log collection requires the Datadog Agent v6.0+. Older versions of the Agent do not include the `log collection` interface.
 
-As of Agent v6.14/v7.14, Datadog recommends the use of and enforcing HTTPS transport (see [agent Transport for Logs][2]). 
+As of Agent v6.14/v7.14, Datadog recommends the use of and enforcing **HTTPS** transport (see [agent Transport for Logs][2]). 
 If you are using the HTTPS transport for logs, please refer to the [agent proxy documentation][1] and use the same set of proxy settings as other data types.
 
 

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -356,14 +356,6 @@ frontend logs_http_frontend
     option tcplog
     default_backend datadog-logs-http
 
-# If sending logs with use_tcp: true
-# frontend logs_frontend
-#    bind *:10514
-#    mode tcp
-#    option tcplog
-#    default_backend datadog-logs
-
-
 # This is the Datadog server. In effect any TCP request coming
 # to the forwarder frontends defined above are proxied to
 # Datadog's public endpoints.

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -637,7 +637,7 @@ logs_config:
   use_http: true
 ```
 
-When choosing to send logs over TCP, refer to <a href="/agent/logs/proxy">TCP Proxy for Logs</a> page.
+When sending logs over TCP, refer to <a href="/agent/logs/proxy">TCP Proxy for Logs</a> page.
 
 
 ## Using the Agent as a Proxy

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -637,7 +637,7 @@ logs_config:
   use_http: true
 ```
 
-When choosing to send logs over TCP, refere to <a href="/agent/logs/proxy">TCP Proxy for Logs</a> page.
+When choosing to send logs over TCP, refer to <a href="/agent/logs/proxy">TCP Proxy for Logs</a> page.
 
 
 ## Using the Agent as a Proxy

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -417,7 +417,7 @@ This `dd_url` setting can be found in the `datadog.yaml` file.
 
 `dd_url: http://haproxy.example.com:3834`
 
-To send traces or processes through the proxy, setup the following in the `datadog.yaml` file:
+To send traces, processes and logs through the proxy, setup the following in the `datadog.yaml` file:
 
 ```yaml
 apm_config:
@@ -425,12 +425,9 @@ apm_config:
 
 process_config:
     process_dd_url: http://haproxy.example.com:3836
-```
-
-To send logs through the proxy, setup the following in the `datadog.yaml` file:
-
-```yaml
+    
 logs_config:
+    use_http: true
     logs_dd_url: http://haproxy.example.com:3837
 ```
 

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -260,12 +260,6 @@ backend datadog-logs-http
     # Uncomment the following configuration for older HAProxy versions
     # server datadog agent-http-intake.logs.datadoghq.com:443 check port 443 ssl verify none
 
-# backend datadog-logs
-    # balance roundrobin
-    # The following configuration is for HAProxy 1.8 and newer
-    # server-template mothership 5 agent-intake.logs.datadoghq.com:10516 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt check resolvers my-dns init-addr none resolve-prefer ipv4
-    # Uncomment the following configuration for older HAProxy versions
-    # server datadog agent-intake.logs.datadoghq.com:10516 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt check port 10516
 ```
 
 **Note**: Download the certificate with the following command:
@@ -399,12 +393,6 @@ backend datadog-logs-http
     # Uncomment the following configuration for older HAProxy versions
     # server datadog agent-http-intake.logs.datadoghq.eu:443 check port 443 ssl verify none
 
-backend datadog-logs
-    balance roundrobin
-    # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 agent-intake.logs.datadoghq.eu:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt check resolvers my-dns init-addr none resolve-prefer ipv4
-    # Uncomment the following configuration for older HAProxy versions
-    # server datadog agent-intake.logs.datadoghq.eu:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt check port 443
 ```
 
 **Note**: Download the certificate with the following command:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update log proxy instructions

### Motivation
The goal is to clearly split the instructions between TCP and HTTPS forwarding for logs.

So that the main proxy instruction can focus on HTTPS instruction and ignore TCP one.

Updating https://github.com/DataDog/documentation/pull/6734

### Preview link

https://docs-staging.datadoghq.com/pvr/log-proxy/agent/logs/proxy?tab=tcp
https://docs-staging.datadoghq.com/pvr/log-proxy/agent/proxy/?tab=agentv6v7


