### PR TITLE
Reset path and query params

### DIFF
--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -122,12 +122,13 @@
                         </p>
                         <h3 class="mt-2">Overview</h3>
                         <p>{{.action.description | markdownify }}</p>
+
+                        {{ $.Scratch.Set "queryStrings" slice }}
+                        {{ $.Scratch.Set "pathParams" slice }}
+
                         {{ with .action.parameters }}
 
                             <h3 class="mb-2">Arguments</h3>
-
-                            {{ $.Scratch.Set "queryStrings" slice }}
-                            {{ $.Scratch.Set "pathParams" slice }}
 
                             {{ range . }}
                                 {{ if eq .in "query"}}


### PR DESCRIPTION
### What does this PR do?

Fixes incorrect path/query arguments.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jirikuncar/path-params/api/v1/events/#post-an-event

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
