### PR TITLE
Document `agent config` command

### DIFF
--- a/content/en/agent/guide/agent-commands.md
+++ b/content/en/agent/guide/agent-commands.md
@@ -249,26 +249,29 @@ Some options have flags and options detailed under `--help`. For example, use he
 <AGENT_BINARY> check --help
 ```
 
-| Command           | Notes                                                                         |
-|-------------------|-------------------------------------------------------------------------------|
-| `check`           | Runs the specified check.                                                     |
-| `configcheck`     | Prints all configurations loaded and resolved of a running Agent.             |
-| `diagnose`        | Executes some connectivity diagnosis on your system.                          |
-| `flare`           | Collects a flare and send it to Datadog.                                      |
-| `health`          | Prints the current Agent health.                                              |
-| `help`            | Help about any command.                                                       |
-| `hostname`        | Prints the hostname used by the Agent.                                        |
-| `import`          | Imports and converts configuration files from previous versions of the Agent. |
-| `installservice`  | Installs the Agent within the service control manager.                        |
-| `launch-gui`      | Starts the Datadog Agent GUI.                                                 |
-| `regimport`       | Imports the registry settings into `datadog.yaml`.                            |
-| `remove-service`  | Removes the Agent from the service control manager.                           |
-| `restart-service` | Restarts the Agent within the service control manager.                        |
-| `start-service`   | Starts the Agent within the service control manager.                          |
-| `stopservice`     | Stops the Agent within the service control manager.                           |
-| `jmx`             | JMX troubleshooting.                                                          |
-| `version`         | Prints the version info.                                                      |
+| Subcommand        | Notes                                                                      |
+|-------------------|----------------------------------------------------------------------------|
+| `check`           | Run the specified check.                                                   |
+| `config`          | [Runtime configuration management][1].                                     |
+| `configcheck`     | Print all configurations loaded & resolved of a running Agent.             |
+| `diagnose`        | Execute connectivity diagnosis on your system.                             |
+| `flare`           | [Collect a flare and send it to Datadog][2].                               |
+| `health`          | Print the current Agent health.                                            |
+| `help`            | Help about any command.                                                    |
+| `hostname`        | Print the hostname used by the Agent.                                      |
+| `import`          | Import and convert configuration files from previous versions of the Agent.|
+| `installservice`  | Install the Agent within the service control manager. Windows only.        |
+| `jmx`             | JMX troubleshooting.                                                       |
+| `launch-gui`      | Start the Datadog Agent GUI.                                               |
+| `regimport`       | Import the registry settings into `datadog.yaml`. Windows only.            |
+| `remove-service`  | Remove the Agent from the service control manager. Windows only.           |
+| `restart-service` | Restart the Agent within the service control manager. Windows only.        |
+| `start-service`   | Start the Agent within the service control manager. Windows only.          |
+| `stopservice`     | Stop the Agent within the service control manager. Windows only.           |
+| `version`         | Print version info.                                                        |
 
+[1]: /agent/troubleshooting/config/
+[2]: /agent/troubleshooting/send_a_flare/
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/agent/troubleshooting/config.md
+++ b/content/en/agent/troubleshooting/config.md
@@ -1,0 +1,49 @@
+---
+title: Agent Runtime Configuration Management
+kind: documentation
+further_reading:
+- link: "/agent/troubleshooting/debug_mode/"
+  tag: "Agent Troubleshooting"
+  text: "Agent Debug Mode"
+---
+
+If you are running Agent 6.19+/7.19+, you can dynamically change some settings at runtime without having to restart the Agent to account for the configuration change. 
+
+**Note**: Changes made that way are not persisted, they will be lost as soon as the Agent is restarted.
+
+The configuration parameters that can be changed at runtime can be listed using the `config list-runtime` command. See the table below for the complete command on different platforms.
+
+| Platform   | Command                                                |
+|------------|--------------------------------------------------------|
+| Docker     | `docker exec datadog-agent agent config list-runtime`  |
+| macOS      | `datadog-agent config list-runtime`                    |
+| CentOS     | `sudo datadog-agent config list-runtime`               |
+| Debian     | `sudo datadog-agent config list-runtime`               |
+| Kubernetes | `kubectl exec <POD_NAME> agent config list-runtime`    |
+| Fedora     | `sudo datadog-agent config list-runtime`               |
+| Redhat     | `sudo datadog-agent config list-runtime`               |
+| Suse       | `sudo datadog-agent config list-runtime`               |
+| Source     | `sudo datadog-agent config list-runtime`               |
+| Windows    | Consult the dedicated [Windows documentation][1]       |
+
+One parameter that can be changed at runtime is the log level. It is convenient for debug purpose in containerized environment where the Agent configuation cannot beanged easily without having to destroy then recreate the container running the Agent. To dynamically set the log level to debug on a Kubernetes deployment invoke the following command:
+
+```text
+kubectl exec <POD_NAME> agent config set log_level debug
+```
+
+It is possible to get the current value of runtime-editable settings by using tge `config get <SETTING>`, for example on a Linux system to get the current log level you may use:
+
+```text
+sudo datadog-agent config get log_level
+```
+
+The complete runtime configuration can also be show by just using the `config` command.
+
+[1]: /agent/basic_agent_usage/windows/#agent-v6
+{{% /tab %}}
+{{< /tabs >}}
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/agent/troubleshooting/config.md
+++ b/content/en/agent/troubleshooting/config.md
@@ -9,9 +9,9 @@ further_reading:
 
 If you are running Agent 6.19+/7.19+, you can dynamically change some settings at runtime without having to restart the Agent to account for the configuration change. 
 
-**Note**: Changes made that way are not persisted, they will be lost as soon as the Agent is restarted.
+**Note**: Changes made dynamically do not persist. They are lost as soon as the Agent is restarted.
 
-The configuration parameters that can be changed at runtime can be listed using the `config list-runtime` command. See the table below for the complete command on different platforms.
+Use the command `config list-runtime` to list configuration parameters that can be changed at runtime. See the table below for the complete command on different platforms.
 
 | Platform   | Command                                                |
 |------------|--------------------------------------------------------|
@@ -26,23 +26,21 @@ The configuration parameters that can be changed at runtime can be listed using 
 | Source     | `sudo datadog-agent config list-runtime`               |
 | Windows    | Consult the dedicated [Windows documentation][1]       |
 
-One parameter that can be changed at runtime is the log level. It is convenient for debug purpose in containerized environment where the Agent configuation cannot beanged easily without having to destroy then recreate the container running the Agent. To dynamically set the log level to debug on a Kubernetes deployment invoke the following command:
+One parameter that can be changed at runtime is the log level. It is convenient for debug purposes in a containerized environment, where the Agent configuation cannot be changed easily without having to destroy then recreate the container running the Agent. To dynamically set the log level to debug on a Kubernetes deployment, invoke the following command:
 
 ```text
 kubectl exec <POD_NAME> agent config set log_level debug
 ```
 
-It is possible to get the current value of runtime-editable settings by using tge `config get <SETTING>`, for example on a Linux system to get the current log level you may use:
+It is possible to get the current value of runtime-editable settings by using `config get <SETTING>`. For example, to get the current log level on a Linux system, use:
 
 ```text
 sudo datadog-agent config get log_level
 ```
 
-The complete runtime configuration can also be show by just using the `config` command.
+The complete runtime configuration can also be show by using the `config` command.
 
 [1]: /agent/basic_agent_usage/windows/#agent-v6
-{{% /tab %}}
-{{< /tabs >}}
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Document the `agent config` command.

### Motivation
A new useful extension has been added (since 7.19) that allows some settings (one for the moment a second is coming for 7.20, and more will come) to be change at runtime. The main idea is to ease troubleshooting.

### Preview link

https://docs-staging.datadoghq.com/prognant/agent-cli-update/agent/troubleshooting/config/
https://docs-staging.datadoghq.com/prognant/agent-cli-update/agent/guide/agent-commands/?tab=agentv6v7#other-commands

### Additional Notes
Agent CLI documentation is a little bit duplicated:
https://docs.datadoghq.com/agent/basic_agent_usage/?tab=agentv6v7#cli
and
https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6v7#other-commands
plus some platform specific stuff (mostly windows) 
