### PR TITLE
fix env flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "build:live": "run-s build:webpack build:hugo:live",
         "deploy:previewAssets": "./node_modules/.bin/hugo deploy --target previewAssets -e preview --maxDeletes 0 --log --verbose --debug --dryRun",
         "deploy:preview": "./node_modules/.bin/hugo deploy --target preview -e preview --maxDeletes -1 --log --verbose --debug --dryRun",
-        "deploy:liveAssets": "./node_modules/.bin/hugo deploy --target liveAssets -e preview --maxDeletes 0 --log --verbose --debug --dryRun",
+        "deploy:liveAssets": "./node_modules/.bin/hugo deploy --target liveAssets -e live --maxDeletes 0 --log --verbose --debug --dryRun",
         "deploy:live": "./node_modules/.bin/hugo deploy --target live -e live --maxDeletes -1 --log --verbose --debug --dryRun",
         "build:apiPages": "node -e 'require(\"./src/scripts/build-api-pages.js\").init()'",
         "dereference": "node ./src/scripts/dereference.js",


### PR DESCRIPTION
### What does this PR do?
hugo deploy env flag fix

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
