### PR TITLE
Zach/img url

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:zach_add-deploy-deps
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:zach_upload-mp4s
   tags:
     - "runner:main"
     - "size:large"

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -48,7 +48,7 @@
            playsinline
            autoplay
            loop >
-      <source src="{{ $img }}"
+      <source src="{{ (print "/images/" $src) | relURL }}"
               type="video/mp4"
               media="(min-width: 0px)" >
       <div class="play"></div>

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -48,7 +48,7 @@
            playsinline
            autoplay
            loop >
-      <source src="{{ (print "/images/" $src) | relURL }}"
+      <source src="{{ $img }}"
               type="video/mp4"
               media="(min-width: 0px)" >
       <div class="play"></div>


### PR DESCRIPTION
### What does this PR do?
uses new `corp-ci` image which uploads mp4 files to the static buckets, (preview) `dd-staging-static-assets/documentation` and (live) `origin-static-assets/documentation`

https://github.com/DataDog/corp-ci/pull/84

### Motivation
Enables the use of the imgix domain for mp4 videos.

### Preview link
http://docs-staging.datadoghq.com/zach/img-url
