### PR TITLE
Small typo in agent/troubleshooting/config

### DIFF
--- a/content/en/agent/troubleshooting/config.md
+++ b/content/en/agent/troubleshooting/config.md
@@ -26,7 +26,7 @@ Use the command `config list-runtime` to list configuration parameters that can 
 | Source     | `sudo datadog-agent config list-runtime`               |
 | Windows    | Consult the dedicated [Windows documentation][1]       |
 
-One parameter that can be changed at runtime is the log level. It is convenient for debug purposes in a containerized environment, where the Agent configuation cannot be changed easily without having to destroy then recreate the container running the Agent. To dynamically set the log level to debug on a Kubernetes deployment, invoke the following command:
+One parameter that can be changed at runtime is the log level. It is convenient for debug purposes in a containerized environment, where the Agent configuration cannot be changed easily without having to destroy then recreate the container running the Agent. To dynamically set the log level to debug on a Kubernetes deployment, invoke the following command:
 
 ```text
 kubectl exec <POD_NAME> agent config set log_level debug


### PR DESCRIPTION
### What does this PR do?
It fixes a small typo.

### Motivation
Readability.

### Preview link
https://docs-staging.datadoghq.com/prognant/agent-config-typo/agent/troubleshooting/config/
### Additional Notes
N/A