### PR TITLE
Regenerate the kubernetes manifests from the helm chart

### DIFF
--- a/static/resources/yaml/datadog-agent-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-all-features.yaml
@@ -232,7 +232,7 @@ spec:
     spec:
       containers:
       - name: agent
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["agent", "start"]
         resources: {}
@@ -252,6 +252,8 @@ spec:
               fieldPath: status.hostIP
         - name: KUBERNETES
           value: "yes"
+        - name: DOCKER_HOST
+          value: unix:///host/var/run/docker.sock
         - name: DD_LOG_LEVEL
           value: "INFO"
         - name: DD_DOGSTATSD_PORT
@@ -271,8 +273,8 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/datadog-agent
-        - name: runtimesocket
-          mountPath: /var/run/docker.sock
+        - name: runtimesocketdir
+          mountPath: /host/var/run
           readOnly: true
         - name: sysprobe-socket-dir
           mountPath: /sysprobe/var/run
@@ -301,7 +303,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
       - name: trace-agent
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
         resources: {}
@@ -322,6 +324,8 @@ spec:
               fieldPath: status.hostIP
         - name: KUBERNETES
           value: "yes"
+        - name: DOCKER_HOST
+          value: unix:///host/var/run/docker.sock
         - name: DD_LOG_LEVEL
           value: "INFO"
         - name: DD_APM_ENABLED
@@ -333,8 +337,8 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/datadog-agent
-        - name: runtimesocket
-          mountPath: /var/run/docker.sock
+        - name: runtimesocketdir
+          mountPath: /host/var/run
           readOnly: true
         livenessProbe:
           initialDelaySeconds: 15
@@ -343,7 +347,7 @@ spec:
             port: 8126
           timeoutSeconds: 5
       - name: process-agent
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
         resources: {}
@@ -359,6 +363,8 @@ spec:
               fieldPath: status.hostIP
         - name: KUBERNETES
           value: "yes"
+        - name: DOCKER_HOST
+          value: unix:///host/var/run/docker.sock
         - name: DD_PROCESS_AGENT_ENABLED
           value: "true"
         - name: DD_LOG_LEVEL
@@ -368,8 +374,8 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/datadog-agent
-        - name: runtimesocket
-          mountPath: /var/run/docker.sock
+        - name: runtimesocketdir
+          mountPath: /host/var/run
           readOnly: true
         - name: cgroups
           mountPath: /host/sys/fs/cgroup
@@ -383,7 +389,7 @@ spec:
           mountPath: /opt/datadog-agent/run
           readOnly: true
       - name: system-probe
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         securityContext:
           capabilities:
@@ -405,7 +411,7 @@ spec:
           readOnly: true
       initContainers:
       - name: init-volume
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -415,7 +421,7 @@ spec:
           mountPath: /opt/datadog-agent
         resources: {}
       - name: init-config
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -427,8 +433,8 @@ spec:
         - name: procdir
           mountPath: /host/proc
           readOnly: true
-        - name: runtimesocket
-          mountPath: /var/run/docker.sock
+        - name: runtimesocketdir
+          mountPath: /host/var/run
           readOnly: true
         env:
         - name: DD_API_KEY
@@ -442,9 +448,11 @@ spec:
               fieldPath: status.hostIP
         - name: KUBERNETES
           value: "yes"
+        - name: DOCKER_HOST
+          value: unix:///host/var/run/docker.sock
         resources: {}
       - name: seccomp-setup
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         command:
         - cp
         - /etc/config/system-probe-seccomp.json
@@ -454,12 +462,13 @@ spec:
           mountPath: /etc/config
         - name: seccomp-root
           mountPath: /host/var/lib/kubelet/seccomp
+        resources: {}
       volumes:
       - name: config
         emptyDir: {}
       - hostPath:
-          path: /var/run/docker.sock
-        name: runtimesocket
+          path: /var/run
+        name: runtimesocketdir
       - hostPath:
           path: /proc
         name: procdir

--- a/static/resources/yaml/datadog-agent-apm.yaml
+++ b/static/resources/yaml/datadog-agent-apm.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: agent
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["agent", "start"]
         resources: {}
@@ -50,6 +50,8 @@ spec:
               fieldPath: status.hostIP
         - name: KUBERNETES
           value: "yes"
+        - name: DOCKER_HOST
+          value: unix:///host/var/run/docker.sock
         - name: DD_LOG_LEVEL
           value: "INFO"
         - name: DD_DOGSTATSD_PORT
@@ -67,8 +69,8 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/datadog-agent
-        - name: runtimesocket
-          mountPath: /var/run/docker.sock
+        - name: runtimesocketdir
+          mountPath: /host/var/run
           readOnly: true
         - name: procdir
           mountPath: /host/proc
@@ -86,7 +88,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
       - name: trace-agent
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
         resources: {}
@@ -107,6 +109,8 @@ spec:
               fieldPath: status.hostIP
         - name: KUBERNETES
           value: "yes"
+        - name: DOCKER_HOST
+          value: unix:///host/var/run/docker.sock
         - name: DD_LOG_LEVEL
           value: "INFO"
         - name: DD_APM_ENABLED
@@ -118,8 +122,8 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/datadog-agent
-        - name: runtimesocket
-          mountPath: /var/run/docker.sock
+        - name: runtimesocketdir
+          mountPath: /host/var/run
           readOnly: true
         livenessProbe:
           initialDelaySeconds: 15
@@ -129,7 +133,7 @@ spec:
           timeoutSeconds: 5
       initContainers:
       - name: init-volume
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -139,7 +143,7 @@ spec:
           mountPath: /opt/datadog-agent
         resources: {}
       - name: init-config
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -151,8 +155,8 @@ spec:
         - name: procdir
           mountPath: /host/proc
           readOnly: true
-        - name: runtimesocket
-          mountPath: /var/run/docker.sock
+        - name: runtimesocketdir
+          mountPath: /host/var/run
           readOnly: true
         env:
         - name: DD_API_KEY
@@ -166,13 +170,15 @@ spec:
               fieldPath: status.hostIP
         - name: KUBERNETES
           value: "yes"
+        - name: DOCKER_HOST
+          value: unix:///host/var/run/docker.sock
         resources: {}
       volumes:
       - name: config
         emptyDir: {}
       - hostPath:
-          path: /var/run/docker.sock
-        name: runtimesocket
+          path: /var/run
+        name: runtimesocketdir
       - hostPath:
           path: /proc
         name: procdir

--- a/static/resources/yaml/datadog-agent-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-logs-apm.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: agent
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["agent", "start"]
         resources: {}
@@ -50,6 +50,8 @@ spec:
               fieldPath: status.hostIP
         - name: KUBERNETES
           value: "yes"
+        - name: DOCKER_HOST
+          value: unix:///host/var/run/docker.sock
         - name: DD_LOG_LEVEL
           value: "INFO"
         - name: DD_DOGSTATSD_PORT
@@ -73,8 +75,8 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/datadog-agent
-        - name: runtimesocket
-          mountPath: /var/run/docker.sock
+        - name: runtimesocketdir
+          mountPath: /host/var/run
           readOnly: true
         - name: procdir
           mountPath: /host/proc
@@ -100,7 +102,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
       - name: trace-agent
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
         resources: {}
@@ -121,6 +123,8 @@ spec:
               fieldPath: status.hostIP
         - name: KUBERNETES
           value: "yes"
+        - name: DOCKER_HOST
+          value: unix:///host/var/run/docker.sock
         - name: DD_LOG_LEVEL
           value: "INFO"
         - name: DD_APM_ENABLED
@@ -132,8 +136,8 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/datadog-agent
-        - name: runtimesocket
-          mountPath: /var/run/docker.sock
+        - name: runtimesocketdir
+          mountPath: /host/var/run
           readOnly: true
         livenessProbe:
           initialDelaySeconds: 15
@@ -143,7 +147,7 @@ spec:
           timeoutSeconds: 5
       initContainers:
       - name: init-volume
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -153,7 +157,7 @@ spec:
           mountPath: /opt/datadog-agent
         resources: {}
       - name: init-config
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -165,8 +169,8 @@ spec:
         - name: procdir
           mountPath: /host/proc
           readOnly: true
-        - name: runtimesocket
-          mountPath: /var/run/docker.sock
+        - name: runtimesocketdir
+          mountPath: /host/var/run
           readOnly: true
         env:
         - name: DD_API_KEY
@@ -180,6 +184,8 @@ spec:
               fieldPath: status.hostIP
         - name: KUBERNETES
           value: "yes"
+        - name: DOCKER_HOST
+          value: unix:///host/var/run/docker.sock
         - name: DD_LEADER_ELECTION
           value: "true"
         resources: {}
@@ -187,8 +193,8 @@ spec:
       - name: config
         emptyDir: {}
       - hostPath:
-          path: /var/run/docker.sock
-        name: runtimesocket
+          path: /var/run
+        name: runtimesocketdir
       - hostPath:
           path: /proc
         name: procdir

--- a/static/resources/yaml/datadog-agent-logs.yaml
+++ b/static/resources/yaml/datadog-agent-logs.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: agent
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["agent", "start"]
         resources: {}
@@ -50,6 +50,8 @@ spec:
               fieldPath: status.hostIP
         - name: KUBERNETES
           value: "yes"
+        - name: DOCKER_HOST
+          value: unix:///host/var/run/docker.sock
         - name: DD_LOG_LEVEL
           value: "INFO"
         - name: DD_DOGSTATSD_PORT
@@ -73,8 +75,8 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/datadog-agent
-        - name: runtimesocket
-          mountPath: /var/run/docker.sock
+        - name: runtimesocketdir
+          mountPath: /host/var/run
           readOnly: true
         - name: procdir
           mountPath: /host/proc
@@ -101,7 +103,7 @@ spec:
           timeoutSeconds: 5
       initContainers:
       - name: init-volume
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -111,7 +113,7 @@ spec:
           mountPath: /opt/datadog-agent
         resources: {}
       - name: init-config
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -123,8 +125,8 @@ spec:
         - name: procdir
           mountPath: /host/proc
           readOnly: true
-        - name: runtimesocket
-          mountPath: /var/run/docker.sock
+        - name: runtimesocketdir
+          mountPath: /host/var/run
           readOnly: true
         env:
         - name: DD_API_KEY
@@ -138,6 +140,8 @@ spec:
               fieldPath: status.hostIP
         - name: KUBERNETES
           value: "yes"
+        - name: DOCKER_HOST
+          value: unix:///host/var/run/docker.sock
         - name: DD_LEADER_ELECTION
           value: "true"
         resources: {}
@@ -145,8 +149,8 @@ spec:
       - name: config
         emptyDir: {}
       - hostPath:
-          path: /var/run/docker.sock
-        name: runtimesocket
+          path: /var/run
+        name: runtimesocketdir
       - hostPath:
           path: /proc
         name: procdir

--- a/static/resources/yaml/datadog-agent-npm.yaml
+++ b/static/resources/yaml/datadog-agent-npm.yaml
@@ -232,7 +232,7 @@ spec:
     spec:
       containers:
       - name: agent
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["agent", "start"]
         resources: {}
@@ -252,6 +252,8 @@ spec:
               fieldPath: status.hostIP
         - name: KUBERNETES
           value: "yes"
+        - name: DOCKER_HOST
+          value: unix:///host/var/run/docker.sock
         - name: DD_LOG_LEVEL
           value: "INFO"
         - name: DD_DOGSTATSD_PORT
@@ -271,8 +273,8 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/datadog-agent
-        - name: runtimesocket
-          mountPath: /var/run/docker.sock
+        - name: runtimesocketdir
+          mountPath: /host/var/run
           readOnly: true
         - name: sysprobe-socket-dir
           mountPath: /sysprobe/var/run
@@ -293,7 +295,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
       - name: process-agent
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
         resources: {}
@@ -309,6 +311,8 @@ spec:
               fieldPath: status.hostIP
         - name: KUBERNETES
           value: "yes"
+        - name: DOCKER_HOST
+          value: unix:///host/var/run/docker.sock
         - name: DD_LOG_LEVEL
           value: "INFO"
         - name: DD_SYSTEM_PROBE_ENABLED
@@ -316,8 +320,8 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/datadog-agent
-        - name: runtimesocket
-          mountPath: /var/run/docker.sock
+        - name: runtimesocketdir
+          mountPath: /host/var/run
           readOnly: true
         - name: cgroups
           mountPath: /host/sys/fs/cgroup
@@ -331,7 +335,7 @@ spec:
           mountPath: /opt/datadog-agent/run
           readOnly: true
       - name: system-probe
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         securityContext:
           capabilities:
@@ -353,7 +357,7 @@ spec:
           readOnly: true
       initContainers:
       - name: init-volume
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -363,7 +367,7 @@ spec:
           mountPath: /opt/datadog-agent
         resources: {}
       - name: init-config
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -375,8 +379,8 @@ spec:
         - name: procdir
           mountPath: /host/proc
           readOnly: true
-        - name: runtimesocket
-          mountPath: /var/run/docker.sock
+        - name: runtimesocketdir
+          mountPath: /host/var/run
           readOnly: true
         env:
         - name: DD_API_KEY
@@ -390,9 +394,11 @@ spec:
               fieldPath: status.hostIP
         - name: KUBERNETES
           value: "yes"
+        - name: DOCKER_HOST
+          value: unix:///host/var/run/docker.sock
         resources: {}
       - name: seccomp-setup
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         command:
         - cp
         - /etc/config/system-probe-seccomp.json
@@ -402,12 +408,13 @@ spec:
           mountPath: /etc/config
         - name: seccomp-root
           mountPath: /host/var/lib/kubelet/seccomp
+        resources: {}
       volumes:
       - name: config
         emptyDir: {}
       - hostPath:
-          path: /var/run/docker.sock
-        name: runtimesocket
+          path: /var/run
+        name: runtimesocketdir
       - hostPath:
           path: /proc
         name: procdir

--- a/static/resources/yaml/datadog-agent-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-vanilla.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: agent
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["agent", "start"]
         resources: {}
@@ -50,6 +50,8 @@ spec:
               fieldPath: status.hostIP
         - name: KUBERNETES
           value: "yes"
+        - name: DOCKER_HOST
+          value: unix:///host/var/run/docker.sock
         - name: DD_LOG_LEVEL
           value: "INFO"
         - name: DD_DOGSTATSD_PORT
@@ -67,8 +69,8 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/datadog-agent
-        - name: runtimesocket
-          mountPath: /var/run/docker.sock
+        - name: runtimesocketdir
+          mountPath: /host/var/run
           readOnly: true
         - name: procdir
           mountPath: /host/proc
@@ -87,7 +89,7 @@ spec:
           timeoutSeconds: 5
       initContainers:
       - name: init-volume
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -97,7 +99,7 @@ spec:
           mountPath: /opt/datadog-agent
         resources: {}
       - name: init-config
-        image: "datadog/agent:7"
+        image: "datadog/agent:7.19.0"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -109,8 +111,8 @@ spec:
         - name: procdir
           mountPath: /host/proc
           readOnly: true
-        - name: runtimesocket
-          mountPath: /var/run/docker.sock
+        - name: runtimesocketdir
+          mountPath: /host/var/run
           readOnly: true
         env:
         - name: DD_API_KEY
@@ -124,13 +126,15 @@ spec:
               fieldPath: status.hostIP
         - name: KUBERNETES
           value: "yes"
+        - name: DOCKER_HOST
+          value: unix:///host/var/run/docker.sock
         resources: {}
       volumes:
       - name: config
         emptyDir: {}
       - hostPath:
-          path: /var/run/docker.sock
-        name: runtimesocket
+          path: /var/run
+        name: runtimesocketdir
       - hostPath:
           path: /proc
         name: procdir


### PR DESCRIPTION
### What does this PR do?

Regenerate the kubernetes manifests from the helm chart to use its latest version.

### Motivation

Update the way the docker socket is mounted inside the containers.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
