### PR TITLE
[WEB-250] - fix sec rules placeholder bug

### DIFF
--- a/local/bin/py/placehold_translations.py
+++ b/local/bin/py/placehold_translations.py
@@ -99,6 +99,7 @@ def create_placeholder_file(template, new_glob, lang_as_dir, files_location):
         content = o_file.read()
         boundary = re.compile(r'^-{3,}$', re.MULTILINE)
         split = boundary.split(content, 2)
+        new_yml = {}
         if len(split) == 3:
             _, fm, content = split
             new_yml = yaml.load(fm, Loader=yaml.FullLoader)
@@ -109,6 +110,7 @@ def create_placeholder_file(template, new_glob, lang_as_dir, files_location):
         if new_yml.get('aliases', None):
             new_aliases = []
             for alias in new_yml.get('aliases'):
+                alias = alias if alias.startswith("/") else f"/{alias}"
                 new_aliases.append('/{0}{1}'.format(new_glob['name'], alias))
             new_yml['aliases'] = new_aliases
         if new_glob["disclaimer"]:

--- a/local/bin/py/placehold_translations.py
+++ b/local/bin/py/placehold_translations.py
@@ -110,7 +110,11 @@ def create_placeholder_file(template, new_glob, lang_as_dir, files_location):
         if new_yml.get('aliases', None):
             new_aliases = []
             for alias in new_yml.get('aliases'):
-                alias = alias if alias.startswith("/") else f"/{alias}"
+                # if alias is relative e.g no leading slash we need to resolve its abs path to be able to prepend /lang/
+                # e.g alias 13a-810-14c in security_monitor/default_rules/file.md
+                # becomes /ja/security_monitor/default_rules/13a-810-14c/
+                if not alias.startswith("/"):
+                    alias = f"/{sub_path}{alias}"
                 new_aliases.append('/{0}{1}'.format(new_glob['name'], alias))
             new_yml['aliases'] = new_aliases
         if new_glob["disclaimer"]:


### PR DESCRIPTION
### What does this PR do?

Fixes an issue for placeholder generation where hugo aliases might start with a `/` or might not. Currently we have a number of placeholders being created incorrectly

e.g
```
- ja088-a06-67c/
- ja098-1df-338/
```

### Motivation
https://datadoghq.atlassian.net/browse/WEB-250

### Preview link

This should work:
https://docs-staging.datadoghq.com/david.jones/placeholderfix/ja/security_monitoring/default_rules/13a-810-14c/

### Additional Notes

