### PR TITLE
use imgix domain for video shortcode

### DIFF
--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -48,7 +48,7 @@
            playsinline
            autoplay
            loop >
-      <source src="{{ (print "/images/" $src) | relURL }}"
+      <source src="{{ $img }}"
               type="video/mp4"
               media="(min-width: 0px)" >
       <div class="play"></div>


### PR DESCRIPTION
### What does this PR do?
use imgix domain to serve mp4s. 

### Motivation
images and videos should all be served from imgix domain for better caching, optimization purposes. 

### Preview link
http://docs-staging.datadoghq.com/zach/video-imgix

View pages that use the `img` shortcode with `video="true"` and check they are being served from imgix domain.
Should also confirm that these videos are in the `origin-static-assets/documentation` bucket for use on live site. (They should be in the bucket after this merge: https://github.com/DataDog/corp-ci/pull/84)

