### PR TITLE
Always show curl examples

### DIFF
--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -367,51 +367,53 @@
                             {{ end }}
                         </div>
 
-                        {{/* match all Page Resource code examples by operationId */}}
-                        {{ with $dot.Resources.Match (printf "%s%s" .action.operationId ".*" ) }}
 
-                            <h3 class="mb-2">Code Example</h3>
+                        <h3 class="mb-2">Code Example</h3>
 
-                            <div class="code-snippet-wrapper js-code-snippet-wrapper" >
-                                <ul class="nav nav-tabs border-none response-toggle">
-                                    {{ $count := 0}}
-                                    {{ $lang := index $dot.Site.Data.highlighting.languages "sh" }}
-
-                                    <li class="nav-item">
-                                        <a class="nav-link mr-1 js-code-example-link text-capitalize {{ if eq $count 0}} active {{end}}" data-code-lang="{{ $lang.pygments_name }}"  href="#" data-toggle="tab">{{ $lang.pygments_name }}</a>
-                                    </li>
-
-                                    {{ $count := 1}}
-                                    {{ range . }}
-
-                                    {{ $file_extension := index (split (path.Ext .) ".") 1 }}
-                                    {{ $lang := index $dot.Site.Data.highlighting.languages $file_extension }}
-
-                                    {{ if ne $file_extension "sh"}}
-                                    <li class="nav-item">
-                                        <a class="nav-link mr-1 js-code-example-link text-capitalize {{ if eq $count 0}} active {{end}}" data-code-lang="{{ $lang.pygments_name }}"  href="#" data-toggle="tab">{{ $lang.pygments_name }}</a>
-                                    </li>
-
-                                    {{ $count = add $count 1 }}
-                                    {{ end }}
-
-                                    {{ end }}
-
-                                </ul>
-
-                                {{ $count := 0 }}
-                                {{ $file_extension := "sh" }}
+                        <div class="code-snippet-wrapper js-code-snippet-wrapper" >
+                            <ul class="nav nav-tabs border-none response-toggle">
+                                {{ $count := 0}}
                                 {{ $lang := index $dot.Site.Data.highlighting.languages "sh" }}
-                                <div class="code-snippet js-code-block {{if eq $file_extension "sh"}} default {{end }} {{ if eq $count 0}}d-block{{else}}d-none{{end}} code-block-{{ $lang.pygments_name }}" >
-                                    <div class="code-button-wrapper position-absolute">
-                                        <button class="btn text-primary js-copy-button">Copy</button>
-                                    </div>
-                                    {{ $pathParams := $.Scratch.Get "pathParams" }}
-                                    {{ $queryStrings := $.Scratch.Get "queryStrings" }}
-                                    <div class="highlight">
-                                        <pre class="chroma">
+
+                                <li class="nav-item">
+                                    <a class="nav-link mr-1 js-code-example-link text-capitalize {{ if eq $count 0}} active {{end}}" data-code-lang="{{ $lang.pygments_name }}"  href="#" data-toggle="tab">{{ $lang.pygments_name }}</a>
+                                </li>
+
+                            {{/* match all Page Resource code examples by operationId */}}
+                            {{ with $dot.Resources.Match (printf "%s%s" .action.operationId ".*" ) }}
+
+                                {{ $count := 1}}
+                                {{ range . }}
+
+                                {{ $file_extension := index (split (path.Ext .) ".") 1 }}
+                                {{ $lang := index $dot.Site.Data.highlighting.languages $file_extension }}
+
+                                {{ if ne $file_extension "sh"}}
+                                <li class="nav-item">
+                                    <a class="nav-link mr-1 js-code-example-link text-capitalize {{ if eq $count 0}} active {{end}}" data-code-lang="{{ $lang.pygments_name }}"  href="#" data-toggle="tab">{{ $lang.pygments_name }}</a>
+                                </li>
+
+                                {{ $count = add $count 1 }}
+                                {{ end }}
+
+                                {{ end }}
+                            {{ end }}
+
+                            </ul>
+
+                            {{ $count := 0 }}
+                            {{ $file_extension := "sh" }}
+                            {{ $lang := index $dot.Site.Data.highlighting.languages "sh" }}
+                            <div class="code-snippet js-code-block {{if eq $file_extension "sh"}} default {{end }} {{ if eq $count 0}}d-block{{else}}d-none{{end}} code-block-{{ $lang.pygments_name }}" >
+                                <div class="code-button-wrapper position-absolute">
+                                    <button class="btn text-primary js-copy-button">Copy</button>
+                                </div>
+                                {{ $pathParams := $.Scratch.Get "pathParams" }}
+                                {{ $queryStrings := $.Scratch.Get "queryStrings" }}
+                                <div class="highlight">
+                                    <pre class="chroma">
 {{/* Do not change indent of html below as it will change the indentation of the curl code block */}}
-                                            <code class="language-fallback" data-lang="fallback">
+                                        <code class="language-fallback" data-lang="fallback">
 {{- with $pathParams -}}
     <span class="c1"># Path parameters</span><br/>
     {{- range . -}}
@@ -500,6 +502,7 @@
                                     </div>
                                 </div>
 
+                            {{ with $dot.Resources.Match (printf "%s%s" .action.operationId ".*" ) }}
                                 {{ $count := 1 }}
                                 {{ range . }}
 
@@ -518,8 +521,8 @@
                                     {{ end }}
 
                                 {{ end }}
-                            </div>
-                        {{ end }}
+                            {{ end }}
+                        </div>
                     </div>
                 </div>
                 <!-- endpoint section end -->


### PR DESCRIPTION
### What does this PR do?
Fixes issues with endpoints without manually written examples.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jirikuncar/always-curl/api/v1/pagerduty-integration/

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
