### PR TITLE
apm/php: remove fastcgi_params as a config method in favor of env[*]

### DIFF
--- a/content/en/tracing/setup/php.md
+++ b/content/en/tracing/setup/php.md
@@ -218,12 +218,6 @@ env[DD_AGENT_HOST] = $FROM_HOST_ENV
 env[DD_TRACE_DEBUG] = true
 ```
 
-Alternatively you can use [`fastcgi_param`][14] from the `http`, `server`, or `location` contexts.
-
-```text
-fastcgi_param DD_TRACE_DEBUG true;
-```
-
 ### PHP CLI server
 
 Set in the command line to start the server.
@@ -336,4 +330,3 @@ To remove the PHP tracer:
 [11]: /tracing/setup/php/#environment-variable-configuration
 [12]: /help
 [13]: https://httpd.apache.org/docs/2.4/mod/mod_env.html#setenv
-[14]: http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_param


### PR DESCRIPTION
### What does this PR do?
Before: we offered two ways to configure nginx+php-fpm: `env[*]` and `fastcgi_param`.
After: we only recommend `env[*]`.


### Motivation

1. It is easier to verify
2. Values over there are available at startup, while fastcgi params only after the first request
3. If any value changes, only fpm requires a restart, not nginx (which might also serve other instances)
4. It is more in line with the term that we always use: environment variable

### Preview link

[Preview](https://docs-staging.datadoghq.com/labbati/remove-fastcgi-params/tracing/setup/php/)

### Additional Notes
<!-- Anything else we should know when reviewing?-->
