### PR TITLE
Fix typo in Monitor Status Overview

### DIFF
--- a/content/en/monitors/monitor_status.md
+++ b/content/en/monitors/monitor_status.md
@@ -18,7 +18,7 @@ further_reading:
 
 After [creating your monitor][1], use the monitor status page to view the status over time.
 
-The page sections are expanded by default. All sections (excpet the header) can be closed by using the toggle (&or;) icon to the left of each section name.
+The page sections are expanded by default. All sections (except the header) can be closed by using the toggle (&or;) icon to the left of each section name.
 
 {{< img src="monitors/monitor_status/monitor_status_page.png" alt="monitor status page"  >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fix a typo in the [Monitor Status Overview](https://docs.datadoghq.com/monitors/monitor_status/#overview) page.

### Motivation
<!-- What inspired you to submit this pull request?-->
Better spelling for a better world!

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/florimondmanca/monitor-status-typo/monitors/monitor_status#overview

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
