### PR TITLE
set active nav menu scroll into view

### DIFF
--- a/layouts/api/baseof.html
+++ b/layouts/api/baseof.html
@@ -34,8 +34,8 @@ data-spy="scroll" data-target="#navbar-example2" data-offset="5"
 
   {{ partial "header/header.html" . }}
 
-  <div class="container h-100">
-    <div class="row h-100">
+  <div class="container">
+    <div class="row">
       <div class="d-none d-lg-flex col-sm-3 side">
         {{ partial "sidenav/api-sidenav.html" . }}
       </div>

--- a/layouts/partials/nav/api-main-menu.html
+++ b/layouts/partials/nav/api-main-menu.html
@@ -38,7 +38,7 @@
             </ul>
         </li>
     {{ else }}
-        <li>
+        <li class="{{ if or ($currentPage.IsMenuCurrent $apiMenu .) ($currentPage.HasMenuCurrent $apiMenu .) }}active{{ end }}">
             <a href="{{ (strings.TrimLeft "/" .URL) | absLangURL }}">
                 <span>{{ .Name }}</span>
             </a>

--- a/src/scripts/components/api.js
+++ b/src/scripts/components/api.js
@@ -155,3 +155,12 @@ $('.hasChildData .js-collapse-trigger').click(function () {
     $(this).closest('.row').siblings('.isNested').toggleClass('d-none');
     $(this).find('.toggle-arrow').toggleClass('expanded');
 });
+
+// Scroll the active top level nav item into view below Docs search input
+if (document.body.classList.contains('api')) {
+    const apiSideNav = document.querySelector('.sidenav-api .sidenav-nav');
+    const sideNavActiveMenuItem = apiSideNav.querySelector('li.active');
+    const distanceToTop = sideNavActiveMenuItem.offsetTop;
+
+    apiSideNav.scrollTop = distanceToTop - 100;
+}

--- a/src/scripts/components/api.js
+++ b/src/scripts/components/api.js
@@ -160,7 +160,9 @@ $('.hasChildData .js-collapse-trigger').click(function () {
 if (document.body.classList.contains('api')) {
     const apiSideNav = document.querySelector('.sidenav-api .sidenav-nav');
     const sideNavActiveMenuItem = apiSideNav.querySelector('li.active');
-    const distanceToTop = sideNavActiveMenuItem.offsetTop;
-
-    apiSideNav.scrollTop = distanceToTop - 100;
+    if (sideNavActiveMenuItem) {
+        const distanceToTop = sideNavActiveMenuItem.offsetTop;
+        apiSideNav.scrollTop = distanceToTop - 100;
+    }
+    
 }

--- a/src/scripts/datadog-docs.js
+++ b/src/scripts/datadog-docs.js
@@ -578,15 +578,18 @@ $(document).ready(function () {
         $('.sidenav-search input[name="s"]').val(searchParam);
     }
 
-    $(window).on('resize scroll', function(e) {
-        const header_h = $('body > header').height();
-        const footer_h = $('body > footer').height();
-        const padding = 200;
-        $('.sidenav-nav').css(
-            'maxHeight',
-            document.documentElement.clientHeight - header_h - padding
-        );
-    });
+    if (!document.body.classList.contains('api')){
+        $(window).on('resize scroll', function(e) {
+            const header_h = $('body > header').height();
+            const footer_h = $('body > footer').height();
+            const padding = 200;
+            $('.sidenav-nav').css(
+                'maxHeight',
+                document.documentElement.clientHeight - header_h - padding
+            );
+        });
+    }
+    
 
     updateMainContentAnchors();
 

--- a/src/styles/components/_sidenav.scss
+++ b/src/styles/components/_sidenav.scss
@@ -237,8 +237,9 @@ body > header.scrolled ~ .container .sidenav .sticky {
 .sidenav-api {
   .sidenav-nav {
     overflow-x: hidden;
-    overflow-y: auto;
+    overflow-y: scroll;
     margin:0;
+    max-height: 800px;
     ul li.active{
       > a {
         background: transparent;


### PR DESCRIPTION
### What does this PR do?
update the api side nav so that, upon page load, the active menu item sits below the Docs search input. 

also fixed a bug where some top level pages like https://docs.datadoghq.com/api/v1/logs-archives/ that don't have any endpoints (menu children) aren't shown as 'active' i.e. no purple color.

### Motivation
requested via Slack: https://dd.slack.com/archives/C0DESMBQU/p1589790223392800

### Preview link
http://docs-staging.datadoghq.com/zach/api-nav/api

Click a menu item in the side nav, after page reload, the active top level nav text should appear below the Docs search input or as high up as it can go. 

