### PR TITLE
Recommend system probe installation on 2+ hosts

### DIFF
--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -37,7 +37,9 @@ The following provisioning systems are supported:
 
 ## Setup
 
-To enable network performance monitoring, configure it in your [Agent's main configuration file][6] based on your system setup:
+To enable Network Performance Monitoring, configure it in your [Agent's main configuration file][6] based on your system setup. 
+
+Given this tool's focus and strength is in analyzing traffic _between_ network endpoints and mapping network dependencies, we recommend installing it on a meaningful subset of your infrastructure and a **_minimum of 2 hosts_** to maximize value. 
 
 {{< tabs >}}
 {{% tab "Agent" %}}

--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -39,7 +39,7 @@ The following provisioning systems are supported:
 
 To enable Network Performance Monitoring, configure it in your [Agent's main configuration file][6] based on your system setup. 
 
-Given this tool's focus and strength is in analyzing traffic _between_ network endpoints and mapping network dependencies, we recommend installing it on a meaningful subset of your infrastructure and a **_minimum of 2 hosts_** to maximize value. 
+Given this tool's focus and strength is in analyzing traffic _between_ network endpoints and mapping network dependencies, it is recommend to install it on a meaningful subset of your infrastructure and a **_minimum of 2 hosts_** to maximize value. 
 
 {{< tabs >}}
 {{% tab "Agent" %}}


### PR DESCRIPTION
### What does this PR do?
Recommends customers install NPM on at least 2 hosts for maximum value. 

### Motivation
~25% of customers only have 1 NPM host installed. This makes it really hard for them to assess value, since the tool is intended for tracking dependencies between endpoints. 

### Preview link
https://docs-staging.datadoghq.com/Yael/installation_note/content/en/network_performance_monitoring/installation.md
