### PR TITLE
Update lang-redirects.js

### DIFF
--- a/src/scripts/lang-redirects.js
+++ b/src/scripts/lang-redirects.js
@@ -58,7 +58,9 @@ export function handleLanguageBasedRedirects() {
 		ex: /mybranch/myfeature/index.html => /mybranch/myfeature/ja/index.html
 	*/
 	if ( subdomain.includes('preview') || subdomain.includes('docs-staging') ) {
-		previewPath = uri.split('/').slice(0,3).join('/');
+		const commitRef = `/${document.documentElement.dataset.commitRef}`;
+
+		previewPath = commitRef || uri.split('/').slice(0,3).join('/');
 		uri = uri.replace(previewPath, '');
 		logMsg += `Preview path is ${ previewPath }, URI set to: ${ uri } `;
 	}

--- a/src/scripts/lang-redirects.js
+++ b/src/scripts/lang-redirects.js
@@ -1,6 +1,11 @@
 /* eslint no-console: ["error", { allow: ["log", "warn"] }] */
 import Cookies from 'js-cookie';
-import datadogLogs from './components/dd-browser-logs-rum';
+/* eslint-disable no-unused-vars */
+
+// This is a placeholder array meant to filter any paths that we want to ignore redirect rules.
+const ignoredPaths = [];
+
+/* eslint-enable no-unused-vars */
 
 const allowedLanguages = ['en', 'ja', 'fr'];
 const redirectLanguages = ['ja', 'fr'];
@@ -14,13 +19,24 @@ const enabledSubdomains = [
 ];
 const cookiePath = '/';
 
-const getUrlVars = () => {
+export const getUrlVars = () => {
 	const vars = {};
 	const href = window.location.href.replace(window.location.hash, '');
     href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function(m,key,value) {
         vars[key] = value;
     });
     return vars;
+}
+
+// All query parameters should be retained with the exception of 'lang_pref', which we don't want being indexed/crawled.
+export const getQueryString = (params) => {
+	if (Object.prototype.hasOwnProperty.call(params, 'lang_pref')) {
+		delete params.lang_pref;
+	}
+
+	const queryString = Object.keys(params).map(key => `${key}=${params[key]}`).join('&');
+
+	return queryString.length > 0 ? `?${queryString}` : '';
 }
 
 export function handleLanguageBasedRedirects() {
@@ -42,28 +58,35 @@ export function handleLanguageBasedRedirects() {
 		ex: /mybranch/myfeature/index.html => /mybranch/myfeature/ja/index.html
 	*/
 	if ( subdomain.includes('preview') || subdomain.includes('docs-staging') ) {
-		const commitRef = `/${document.documentElement.dataset.commitRef}`;
-
-		previewPath = commitRef || uri.split('/').slice(0,3).join('/');
+		previewPath = uri.split('/').slice(0,3).join('/');
 		uri = uri.replace(previewPath, '');
 		logMsg += `Preview path is ${ previewPath }, URI set to: ${ uri } `;
 	}
 
 	if ( subMatch.length ) {
 		// order of precedence: url > cookie > header
-		if ( params['lang_pref'] && allowedLanguages.indexOf(params['lang_pref']) !== -1 ) {
-			acceptLanguage = params['lang_pref'];
+		if ( params['lang_pref'] ) {
+			if (allowedLanguages.indexOf(params['lang_pref']) !== -1) {
+				acceptLanguage = params['lang_pref'];
 
-			logMsg += `Change acceptLanguage based on URL Param: ${ acceptLanguage }`;
+				logMsg += `Change acceptLanguage based on URL Param: ${ acceptLanguage }`;
+	
+				Cookies.set("lang_pref", acceptLanguage, {path: cookiePath});
 
-			Cookies.set("lang_pref", acceptLanguage, {path: cookiePath});
-
-			window.location.replace( window.location.origin + `${ previewPath }/${ uri }`.replace(/\/+/g,'/') );
+				window.location.replace( window.location.origin + `${ previewPath }/${ uri }${getQueryString(params)}`.replace(/\/+/g,'/') );
+			} else {
+				// If lang_pref query parameter is present but not an accepted language, remove it from query string without redirecting.
+				const updatedUrl = window.location.origin + `${ previewPath }/${ uri }${getQueryString(params)}`.replace(/\/+/g,'/');
+				window.history.pushState({}, document.title, updatedUrl);
+			}
 		}
+
 		else if ( Cookies.get('lang_pref') && allowedLanguages.indexOf(Cookies.get('lang_pref')) !== -1 ) {
 			acceptLanguage = Cookies.get('lang_pref');
+
 			logMsg += `Change acceptLanguage based on lang_pref Cookie: ${ acceptLanguage }`;
 		}
+
 		else if ( redirectLanguages.indexOf(supportedLanguage) !== -1 ) {
 			logMsg += `Set acceptLanguage based on navigator.language header value: ${  supportedLanguage  } ; DEBUG: ${ supportedLanguage.startsWith('ja') }`;
 
@@ -75,18 +98,19 @@ export function handleLanguageBasedRedirects() {
 				logMsg += '; desired language not in URL, but dest is `EN` so this is OK';
 			}
 			else {
-				const dest = `${ previewPath }/${ acceptLanguage }/${ uri.replace(curLang, '') }`.replace(/\/+/g,'/');
+				const dest = `${ previewPath }/${ acceptLanguage }/${ uri.replace(curLang, '') }${getQueryString(params)}`.replace(/\/+/g,'/');
 
 				logMsg += `; acceptLanguage ${ acceptLanguage } not in URL, triggering redirect to ${ dest }`;
 
 				Cookies.set("lang_pref", acceptLanguage, {path: cookiePath});
+
 				window.location.replace( dest );
 			}
 		}
-
-		datadogLogs.logger.debug("Lang-Redirects", { log: logMsg, requested_url: baseURL, subdomain, uri, acceptLanguage, previewPath });
+	}
+	if ( window.DD_LOGS ) {
+		window.DD_LOGS.logger.info("Lang-Redirects", { log: logMsg, requested_url: baseURL, subdomain, uri, acceptLanguage, previewPath });
 	}
 }
 
-// window.addEventListener('load', handleLanguageBasedRedirects, false);
 handleLanguageBasedRedirects();


### PR DESCRIPTION
### What does this PR do?
We've made a couple of improvements to the lang-redirects script on corpsite and this is bringing Docs up to the same version. 
- Accounts for query string params in redirect
- Removes unnecessary logger import

### Preview link
http://docs-staging.datadoghq.com/nsollecito/upd-lang-redirects/

### Additional Notes
Pay attention to the behavior on switching languages using footer links 
