### PR TITLE
Adding region logic for agentless configs

### DIFF
--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -284,20 +284,33 @@ PM> Install-Package Serilog.Sinks.Datadog.Logs
 
 Then, initialize the logger directly in your application. Do not forget to [add your `<API_KEY>`][2].
 
+{{< site-region region="us" >}}
+
 ```csharp
-var log = new LoggerConfiguration()
+var log = new LoggerConfiguration(url: "http-intake.logs.datadoghq.com")
     .WriteTo.DatadogLogs("<API_KEY>")
     .CreateLogger();
 ```
 
-**Note**: To send logs to Datadog EU site, set the `url` property to `https://http-intake.logs.datadoghq.eu`
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+
+```csharp
+var log = new LoggerConfiguration(url: "http-intake.logs.datadoghq.eu")
+    .WriteTo.DatadogLogs("<API_KEY>")
+    .CreateLogger();
+```
+
+{{< /site-region >}}
 
 You can also override the default behaviour and forward logs in TCP by manually specifying the following required properties: `url`, `port`, `useSSL`, and `useTCP`. [Optionally, specify the `source`, `service`, `host`, and custom tags.][3]
 
-For instance to forward logs to the Datadog US site in TCP you would use the following sink configuration:
+{{< site-region region="us" >}}
+
+For instance to forward logs to the Datadog US region in TCP you would use the following sink configuration:
 
 ```csharp
-var config = new DatadogConfiguration(url: "intake.logs.datadoghq.com", port: 10516, useSSL: true, useTCP: true);
+var config = new DatadogConfiguration(url: "tcp-intake.logs.datadoghq.com", port: 10516, useSSL: true, useTCP: true);
 var log = new LoggerConfiguration()
     .WriteTo.DatadogLogs(
         "<API_KEY>",
@@ -309,6 +322,27 @@ var log = new LoggerConfiguration()
     )
     .CreateLogger();
 ```
+
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+
+For instance to forward logs to the Datadog EU region in TCP you would use the following sink configuration:
+
+```csharp
+var config = new DatadogConfiguration(url: "tcp-intake.logs.datadoghq.eu", port: 443, useSSL: true, useTCP: true);
+var log = new LoggerConfiguration()
+    .WriteTo.DatadogLogs(
+        "<API_KEY>",
+        source: "<SOURCE_NAME>",
+        service: "<SERVICE_NAME>",
+        host: "<HOST_NAME>",
+        tags: new string[] {"<TAG_1>:<VALUE_1>", "<TAG_2>:<VALUE_2>"},
+        configuration: config
+    )
+    .CreateLogger();
+```
+
+{{< /site-region >}}
 
 New logs are now directly sent to Datadog.
 

--- a/content/en/logs/log_collection/java.md
+++ b/content/en/logs/log_collection/java.md
@@ -419,12 +419,14 @@ To add Logback [logstash-logback-encoder][1] into your classpath, add the follow
 
 Configure the Logback logger to stream logs directly to Datadog by adding the following in your `logback.xml` file:
 
+{{< site-region region="us" >}}
+
 ```xml
 <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
     <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
 </appender>
 <appender name="JSON_TCP" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
-    <remoteHost>intake.logs.datadoghq.com</remoteHost>
+    <remoteHost>tcp-intake.logs.datadoghq.com</remoteHost>
     <port>10514</port>
     <keepAliveDuration>1 minute</keepAliveDuration>
     <encoder class="net.logstash.logback.encoder.LogstashEncoder">
@@ -441,11 +443,37 @@ Configure the Logback logger to stream logs directly to Datadog by adding the fo
 </root>
 ```
 
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+
+```xml
+<appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+</appender>
+<appender name="JSON_TCP" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+    <remoteHost>tcp-intake.logs.datadoghq.eu</remoteHost>
+    <port>1883</port>
+    <keepAliveDuration>1 minute</keepAliveDuration>
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+        <prefix class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="ch.qos.logback.classic.PatternLayout">
+                <pattern><APIKEY> %mdc{keyThatDoesNotExist}</pattern>
+            </layout>
+          </prefix>
+    </encoder>
+</appender>
+<root level="debug">
+    <appender-ref ref="JSON_TCP" />
+    <appender-ref ref="JSON" />
+</root>
+```
+
+{{< /site-region >}}
+
 **Notes:**
 
 * Replace `<API_KEY>` with your Datadog API key value.
 * `%mdc{keyThatDoesNotExist}` is added because the XML configuration trims whitespace, as explained [here][4].
-* See the list of [available endpoints for the EU site][5].
 
 More information available on the prefix parameter in the [Logback documentation][4].
 

--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -35,8 +35,7 @@ With the `datadog-logs` library, you can send logs directly to Datadog from JS c
 
 After adding [`@datadog/browser-logs`][3] to your `package.json` file, initialize it with:
 
-{{< tabs >}}
-{{% tab "US" %}}
+{{< site-region region="us" >}}
 
 ```javascript
 import { datadogLogs } from '@datadog/browser-logs';
@@ -49,8 +48,8 @@ datadogLogs.init({
 });
 ```
 
-{{% /tab %}}
-{{% tab "EU" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
 
 ```javascript
 import { datadogLogs } from '@datadog/browser-logs';
@@ -63,15 +62,13 @@ datadogLogs.init({
 });
 ```
 
-{{% /tab %}}
-{{< /tabs >}}
+{{< /site-region >}}
 
 ### Bundle setup
 
 In order to not miss any logs or errors, you should load and configure the library at the beginning of the head section of your pages.
 
-{{< tabs >}}
-{{% tab "US" %}}
+{{< site-region region="us" >}}
 
 ```html
 <html>
@@ -89,8 +86,8 @@ In order to not miss any logs or errors, you should load and configure the libra
 </html>
 ```
 
-{{% /tab %}}
-{{% tab "EU" %}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
 
 ```html
 <html>
@@ -108,8 +105,7 @@ In order to not miss any logs or errors, you should load and configure the libra
 </html>
 ```
 
-{{% /tab %}}
-{{< /tabs >}}
+{{< /site-region >}}
 
 **Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the library.
 

--- a/content/en/logs/log_collection/nodejs.md
+++ b/content/en/logs/log_collection/nodejs.md
@@ -138,8 +138,9 @@ You can stream your logs from your application to Datadog without installing an 
 Use [Winston HTTP transport][1] to send your logs directly through the [Datadog Log API][2].
 In your bootstrap file or somewhere in your code, declare the logger as follow:
 
-```js
+{{< site-region region="us" >}}
 
+```js
 const { createLogger, format, transports } = require('winston');
 
 const httpTransportOptions = {
@@ -164,17 +165,44 @@ logger.log('info', 'Hello simple log!');
 logger.info('Hello log with metas',{color: 'blue' });
 ```
 
-**Note**: To send logs to Datadog EU site, set the host property to `http-intake.logs.datadoghq.eu`
+Note: you can also check the community supported [Datadog Transport][1].
 
-If you are using US site, you can also check the community supported [Datadog Transport][3].
+[1]: https://github.com/winstonjs/winston/blob/master/docs/transports.md#datadog-transport
 
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+
+```js
+const { createLogger, format, transports } = require('winston');
+
+const httpTransportOptions = {
+  host: 'http-intake.logs.datadoghq.eu',
+  path: '/v1/input/<APIKEY>?ddsource=nodejs&service=<APPLICATION_NAME>',
+  ssl: true
+};
+
+const logger = createLogger({
+  level: 'info',
+  exitOnError: false,
+  format: format.json(),
+  transports: [
+    new transports.Http(httpTransportOptions),
+  ],
+});
+
+module.exports = logger;
+
+// Example logs
+logger.log('info', 'Hello simple log!');
+logger.info('Hello log with metas',{color: 'blue' });
+```
+
+{{< /site-region >}}
 
 [1]: https://github.com/winstonjs/winston/blob/master/docs/transports.md#http-transport
 [2]: /api/v1/logs/#send-logs
-[3]: https://github.com/winstonjs/winston/blob/master/docs/transports.md#datadog-transport
 {{% /tab %}}
 {{< /tabs >}}
-
 
 ## Troubleshooting
 


### PR DESCRIPTION
### What does this PR do?

Adds the region shortcode logic in order to make configuration examples Region dependant.

### Motivation

EU customer got confused when trying to setup Agentless logging.

### Preview link

* [Java log collection](https://docs-staging.datadoghq.com/gus/region-log/logs/log_collection/java/?tab=log4j#agentless-logging)
* [C# log collection](https://docs-staging.datadoghq.com/gus/region-log/logs/log_collection/csharp/?tab=serilog#agentless-logging)
* [Javascript log collection](https://docs-staging.datadoghq.com/gus/region-log/logs/log_collection/javascript/?tab=npm)
* [NodeJS log collection](https://docs-staging.datadoghq.com/gus/region-log/logs/log_collection/nodejs/?tab=winston30#agentless-logging)