### PR TITLE
Fix causing issue for setLoggerGlobalContext Bundle

### DIFF
--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -301,7 +301,7 @@ datadogLogs.addLoggerGlobalContext('referrer', document.referrer);
 {{% tab "Bundle" %}}
 
 ```javascript
-window.DD_LOGS && DD_LOGS.setLoggerGlobalContext("{'env', 'staging'}");
+window.DD_LOGS && DD_LOGS.setLoggerGlobalContext({env: 'staging'});
 
 window.DD_LOGS && DD_LOGS.addLoggerGlobalContext('referrer', document.referrer);
 ```


### PR DESCRIPTION
### What does this PR do?
Suggests a syntax fix for setLoggerGlobalContext

### Motivation
Current syntax leads to unexpected format in logs:

`window.DD_LOGS && DD_LOGS.setLoggerGlobalContext("{'env', 'staging'}");`

(https://a.cl.ly/eDu6pxdX)

Did some testing using this,

`window.DD_LOGS && DD_LOGS.setLoggerGlobalContext({env: 'staging'});`

gives the follow formatting in logs: (https://a.cl.ly/8LujEJRj)

### Preview link
https://docs.datadoghq.com/logs/log_collection/javascript/?tab=bundle#global-context

### Additional Notes
Probably needs a double check from Engineering to confirm if this is expected or not