### PR TITLE
App Analytics configuration for Linux .NET users are case sensitive

### DIFF
--- a/content/en/tracing/app_analytics/_index.md
+++ b/content/en/tracing/app_analytics/_index.md
@@ -233,7 +233,7 @@ Or in code:
 Tracer.Instance.Settings.Integrations["AspNetMvc"].AnalyticsEnabled = true;
 ```
 
-Integration names can be found on the [integrations table][1]. **Note:** On Linux, the integration names are case sensitive.
+Integration names can be found on the [integrations table][1]. **Note:** On Linux, the names of environment variables are case-sensitive.
 
 [1]: /tracing/setup/dotnet/#integrations
 {{% /tab %}}

--- a/content/en/tracing/app_analytics/_index.md
+++ b/content/en/tracing/app_analytics/_index.md
@@ -233,7 +233,7 @@ Or in code:
 Tracer.Instance.Settings.Integrations["AspNetMvc"].AnalyticsEnabled = true;
 ```
 
-Integration names can be found on the [integrations table][1].
+Integration names can be found on the [integrations table][1]. **Note:** On Linux, the integration names are case sensitive.
 
 [1]: /tracing/setup/dotnet/#integrations
 {{% /tab %}}
@@ -306,7 +306,8 @@ tracer.use('mysql', {
 
 Database tracing is not captured by App Analytics by default and you must enable collection manually for each integration. For example, to enable App Analytics for ADO.NET:
 
-* Environment Variable or AppSetting: `DD_ADONET_ANALYTICS_ENABLED=true`
+* Windows: Environment Variable or AppSetting: `DD_ADONET_ANALYTICS_ENABLED=true`
+* Linux: Environment Variable or AppSetting: `DD_AdoNet_ANALYTICS_ENABLED=true`
 
 Or in code:
 
@@ -314,7 +315,7 @@ Or in code:
 Tracer.Instance.Settings.Integrations["AdoNet"].AnalyticsEnabled = true;
 ```
 
-Integration names can be found on the [integrations table][1].
+Integration names can be found on the [integrations table][1]. **Note:** On Linux, the integration names are case sensitive.
 
 [1]: /tracing/setup/dotnet/#integrations
 {{% /tab %}}

--- a/content/en/tracing/app_analytics/_index.md
+++ b/content/en/tracing/app_analytics/_index.md
@@ -306,8 +306,7 @@ tracer.use('mysql', {
 
 Database tracing is not captured by App Analytics by default and you must enable collection manually for each integration. For example, to enable App Analytics for ADO.NET:
 
-* Windows: Environment Variable or AppSetting: `DD_ADONET_ANALYTICS_ENABLED=true`
-* Linux and Windows: Environment Variable or AppSetting: `DD_AdoNet_ANALYTICS_ENABLED=true`
+* Environment Variable or AppSetting: `DD_AdoNet_ANALYTICS_ENABLED=true`
 
 Or in code:
 

--- a/content/en/tracing/app_analytics/_index.md
+++ b/content/en/tracing/app_analytics/_index.md
@@ -307,7 +307,7 @@ tracer.use('mysql', {
 Database tracing is not captured by App Analytics by default and you must enable collection manually for each integration. For example, to enable App Analytics for ADO.NET:
 
 * Windows: Environment Variable or AppSetting: `DD_ADONET_ANALYTICS_ENABLED=true`
-* Linux: Environment Variable or AppSetting: `DD_AdoNet_ANALYTICS_ENABLED=true`
+* Linux and Windows: Environment Variable or AppSetting: `DD_AdoNet_ANALYTICS_ENABLED=true`
 
 Or in code:
 

--- a/content/en/tracing/app_analytics/_index.md
+++ b/content/en/tracing/app_analytics/_index.md
@@ -315,7 +315,7 @@ Or in code:
 Tracer.Instance.Settings.Integrations["AdoNet"].AnalyticsEnabled = true;
 ```
 
-Integration names can be found on the [integrations table][1]. **Note:** On Linux, the integration names are case sensitive.
+Integration names can be found on the [integrations table][1]. **Note:** On Linux, the names of environment variables are case-sensitive.
 
 [1]: /tracing/setup/dotnet/#integrations
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

.NET users on Linux need to use case sensitive versions of the integration names for analytics to be enabled. For example, they would use `DD_AspNetCore_ANALYTICS_ENABLED=true` rather than `DD_ASPNETCORE_ANALYTICS_ENABLED`.
 
### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/wantsui/dotnet-linux-app-analytics-note/tracing/app_analytics/?tab=net#pagetitle


### Additional Notes
Wording should be approved by someone on the .NET Team.