### PR TITLE
Small change to doc to clarify usage of command

### DIFF
--- a/content/en/synthetics/private_locations.md
+++ b/content/en/synthetics/private_locations.md
@@ -39,7 +39,7 @@ To pull test configurations and push test results, the private location worker n
 | --------------- | ---- | ---------------------------------------------------------------------------------------------------- |
 | Datadog US site | 443  | `intake.synthetics.datadoghq.com` for version 0.1.6+, `api.datadoghq.com/api/` for versions <0.1.5   |
 
-**Note**: For version 0.1.6+, use `curl intake.synthetics.datadoghq.com` (`curl https://api.datadoghq.com` for versions <0.1.5).
+**Note**: Check if the endpoint corresponding to your Datadog `site` is available from the host running the worker using `curl intake.synthetics.datadoghq.com` for version 0.1.6+ (`curl https://api.datadoghq.com` for versions <0.1.5).
 
 {{< /site-region >}}
 
@@ -49,7 +49,7 @@ To pull test configurations and push test results, the private location worker n
 | --------------- | ---- | ---------------------------------------------------------------------------------------------------- |
 | Datadog EU site | 443  | `api.datadoghq.eu/api/`                                                                              |
 
-**Note**: For version 0.1.6+, use `curl https://api.datadoghq.eu`.
+**Note**: Check if the endpoint corresponding to your Datadog `site` is available from the host running the worker using `curl https://api.datadoghq.eu`.
 
 {{< /site-region >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR clarifies why the curl command need to be used when installing a private location.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/margot.lepizzera/pl_update/synthetics/private_locations/?tab=docker#datadog-private-locations-endpoints

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
