### PR TITLE
Log usage dashboard - fix overall ratio

### DIFF
--- a/static/resources/json/estimated_log_usage_dashboard_configuration.json
+++ b/static/resources/json/estimated_log_usage_dashboard_configuration.json
@@ -171,7 +171,7 @@
                 "type": "query_value",
                 "requests": [
                     {
-                        "q": "sum:datadog.estimated_usage.logs.ingested_events{datadog_is_excluded:true,$service,$index} by {service}.as_count()/sum:datadog.estimated_usage.logs.ingested_events{$service,$index} by {service}.as_count()*100",
+                        "q": "sum:datadog.estimated_usage.logs.ingested_events{datadog_is_excluded:true,$service,$index}.as_count()/sum:datadog.estimated_usage.logs.ingested_events{$service,$index}.as_count()*100",
                         "aggregator": "sum"
                     }
                 ],


### PR DESCRIPTION
### What does this PR do?
Fix the query value widget that is showing the global exclusion ratio

### Motivation
The ratio was always 100% as it was split by service

### Preview link

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/log-usage-dashboard-ratio-fix/logs/guide/logs-monitors-on-volumes/#monitor-indexed-logs-with-fixed-threshold

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
