### PR TITLE
Update buffered datadog-go statsd client

### DIFF
--- a/content/en/developers/dogstatsd/high_throughput.md
+++ b/content/en/developers/dogstatsd/high_throughput.md
@@ -39,11 +39,7 @@ Here are a few examples for [official DogStatsD supported clients][3]:
 {{< tabs >}}
 {{% tab "Go" %}}
 
-By default the Datadog's official Golang library [DataDog/datadog-go][1] uses
-buffering. The size of each packets and number of messages in it will use a
-different default for `UDS` and `UDP`. See [DataDog/datadog-go][1] for more
-information about the client configuration.
-.
+By default, Datadog's official Golang library [DataDog/datadog-go][1] uses buffering. The size of each packet and the number of messages use different default values for `UDS` and `UDP`. See [DataDog/datadog-go][1] for more information about the client configuration.
 
 ```go
 package main

--- a/content/en/developers/dogstatsd/high_throughput.md
+++ b/content/en/developers/dogstatsd/high_throughput.md
@@ -50,7 +50,7 @@ import (
 )
 
 func main() {
-  // In this example, metrics will be buffered by default with the correct default configuration for UDP.
+  // In this example, metrics are buffered by default with the correct default configuration for UDP.
   statsd, err := statsd.New("127.0.0.1:8125")
   if err != nil {
     log.Fatal(err)

--- a/content/en/developers/dogstatsd/high_throughput.md
+++ b/content/en/developers/dogstatsd/high_throughput.md
@@ -39,30 +39,30 @@ Here are a few examples for [official DogStatsD supported clients][3]:
 {{< tabs >}}
 {{% tab "Go" %}}
 
-By using Datadog's official Golang library [datadog-go][1], the example below creates a buffered DogStatsD client instance with `256` maximum buffered metrics which means that all metrics sent from this instance of the client are buffered and sent in packets containing a maximum of `256` metrics:
+By default the Datadog's official Golang library [DataDog/datadog-go][1] uses
+buffering. The size of each packets and number of messages in it will use a
+different default for `UDS` and `UDP`. See [DataDog/datadog-go][1] for more
+information about the client configuration.
+.
 
 ```go
 package main
 
 import (
-	"log"
-	"github.com/DataDog/datadog-go/statsd"
+        "log"
+        "github.com/DataDog/datadog-go/statsd"
 )
 
 func main() {
-
-  statsd, err := statsd.New("127.0.0.1:8125",
-                 statsd.Buffered(),
-                 statsd.WithMaxMessagesPerPayload(256),
-                )
-	if err != nil {
-    		log.Fatal(err)
-	}
+  // In this example, metrics will be buffered by default with the correct default configuration for UDP.
+  statsd, err := statsd.New("127.0.0.1:8125")
+  if err != nil {
+    log.Fatal(err)
+  }
 
   statsd.Gauge("example_metric.gauge", 1, []string{"env:dev"}, 1)
 }
 ```
-
 
 [1]: https://github.com/DataDog/datadog-go
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Update buffered datadog-go statsd client. The documenation and code are out of sync (the buffered option no longer exists).

### Motivation
<!-- What inspired you to submit this pull request?-->

Keeping documentation and code in sync.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/[maxime/fix-datadoggo-buffered-doc/developers/dogstatsd/high_throughput/?tab=go

### Additional Notes
<!-- Anything else we should know when reviewing?-->
