### PR TITLE
[docker] add docker label autodiscovery tags info

### DIFF
--- a/content/en/agent/docker/tag.md
+++ b/content/en/agent/docker/tag.md
@@ -59,6 +59,15 @@ docker_labels_as_tags:
 {{% /tab %}}
 {{< /tabs >}}
 
+
+Starting with Agent v7.20+, a containerized Agent can Autodiscover tags from Docker labels. This process allows the Agent to associate custom tags to all data emitted by a container without modifying the Agent `datadog.yaml` file.
+
+Tags should be added using the following format:
+
+```yaml
+com.datadoghq.ad.tags: '["<TAG_KEY_1>:<TAG_VALUE_1>", "<TAG_KEY_2>:<TAG_VALUE_2>"]'
+```
+
 ## Extract environment variables as tags
 
 Starting with Agent v6.0+, the Agent can collect environment variables for a given container and use them as tags to attach to all data emitted by this container.


### PR DESCRIPTION
### What does this PR do?
Documents new feature (Agent 7.20) to allow tags to be autodiscovered via Docker labels

(Re-adds contents from revert #6951 in newly refactored location)

### Motivation
Stay up to date with agent features

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/celene/docker_label_ad_tags/content/en/agent/docker/tag.md

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
