### PR TITLE
scrollbar css

### DIFF
--- a/src/styles/components/_sidenav.scss
+++ b/src/styles/components/_sidenav.scss
@@ -238,6 +238,18 @@ body > header.scrolled ~ .container .sidenav .sticky {
   .sidenav-nav {
     overflow-x: hidden;
     overflow-y: scroll;
+    &::-webkit-scrollbar {
+      appearance: none;
+      width: 7px;
+    }
+    &::-webkit-scrollbar-thumb {
+      border-radius: 4px;
+      background-color: rgba(0, 0, 0, .5);
+      box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+    }
+
+    scrollbar-width: thin;
+    
     margin:0;
     ul li.active{
       > a {


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Makes Api sidenav scrollbar always visible on Chrome and Safari (Firefox does not enable this ability: https://stackoverflow.com/questions/18317634/force-visible-scrollbar-in-firefox-on-mac-os-x
but you can change the appearance of the scrollbar in the Macs System Preferences. 
https://a.cl.ly/xQuW2dJ6

### Preview link
https://docs-staging.datadoghq.com/zach/scrollbar/api/
