### PR TITLE
Add link to facet measure documentation

### DIFF
--- a/content/en/logs/logs_to_metrics.md
+++ b/content/en/logs/logs_to_metrics.md
@@ -30,7 +30,7 @@ To generate a new log-based metric, go to the [Configuration page][3] of your Da
 {{< img src="logs/processing/logs_to_metrics/create_custom_metrics.png" alt="Create a Logs to metric"  style="width:80%;">}}
 
 1. **Input a query to filter the log stream**: The query syntax is the same as for the [Log Explorer Search][5]. Only logs ingested with a timestamp within the past 20 minutes are considered for aggregation.
-2. **Select the field you would like to track**: Select `*` to generate a count of all logs matching your query or enter a log attribute (e.g., `@network.bytes_written`) to aggregate a numeric value and create its corresponding `count`, `min`, `max`, `sum`, and `avg` aggregated metrics. If the log attribute facet is a [measure][6], the value of the metric will be the value of the log attribute. 
+2. **Select the field you would like to track**: Select `*` to generate a count of all logs matching your query or enter a log attribute (e.g., `@network.bytes_written`) to aggregate a numeric value and create its corresponding `count`, `min`, `max`, `sum`, and `avg` aggregated metrics. If the log attribute facet is a [measure][6], the value of the metric is the value of the log attribute. 
 3. **Add dimensions to `group by`**: By default, metrics generated from logs will not have any tags unless explicitly added. Any attribute or tag dimension that exists in your logs can be used to create metric [Tags][7]. Log-based metrics are considered [custom metrics][8]. Avoid grouping by unbounded or extremely high cardinality attributes like timestamps, user IDs, request IDs, or session IDs to avert impacting your billing.
 4. **Name your metric**: Log-based metric names must follow the [naming metric convention][9].
 

--- a/content/en/logs/logs_to_metrics.md
+++ b/content/en/logs/logs_to_metrics.md
@@ -30,9 +30,9 @@ To generate a new log-based metric, go to the [Configuration page][3] of your Da
 {{< img src="logs/processing/logs_to_metrics/create_custom_metrics.png" alt="Create a Logs to metric"  style="width:80%;">}}
 
 1. **Input a query to filter the log stream**: The query syntax is the same as for the [Log Explorer Search][5]. Only logs ingested with a timestamp within the past 20 minutes are considered for aggregation.
-2. **Select the field you would like to track**: Select `*` to generate a count of all logs matching your query or enter a log attribute (e.g., `@network.bytes_written`) to aggregate a numeric value and create its corresponding `count`, `min`, `max`, `sum`, and `avg` aggregated metrics.
-3. **Add dimensions to `group by`**: By default, metrics generated from logs will not have any tags unless explicitly added. Any attribute or tag dimension that exists in your logs can be used to create metric [Tags][6]. Log-based metrics are considered [custom metrics][7]. Avoid grouping by unbounded or extremely high cardinality attributes like timestamps, user IDs, request IDs, or session IDs to avert impacting your billing.
-4. **Name your metric**: Log-based metric names must follow the [naming metric convention][8].
+2. **Select the field you would like to track**: Select `*` to generate a count of all logs matching your query or enter a log attribute (e.g., `@network.bytes_written`) to aggregate a numeric value and create its corresponding `count`, `min`, `max`, `sum`, and `avg` aggregated metrics. If the log attribute facet is a [measure][6], the value of the metric will be the value of the log attribute. 
+3. **Add dimensions to `group by`**: By default, metrics generated from logs will not have any tags unless explicitly added. Any attribute or tag dimension that exists in your logs can be used to create metric [Tags][7]. Log-based metrics are considered [custom metrics][8]. Avoid grouping by unbounded or extremely high cardinality attributes like timestamps, user IDs, request IDs, or session IDs to avert impacting your billing.
+4. **Name your metric**: Log-based metric names must follow the [naming metric convention][9].
 
 **Note**: Data points for Log-based metrics are generated at ten second intervals.
 
@@ -77,6 +77,7 @@ An extra `status` tag is available on the `datadog.estimated_usage.logs.ingested
 [3]: https://app.datadoghq.com/logs/pipelines
 [4]: https://app.datadoghq.com/logs/pipelines/generate-metrics
 [5]: /logs/search_syntax/
-[6]: /tagging/
-[7]: /developers/metrics/custom_metrics/
-[8]: /developers/metrics/#naming-metrics
+[6]: /logs/explorer/facets/#quantitative-facets-measures
+[7]: /tagging/
+[8]: /developers/metrics/custom_metrics/
+[9]: /developers/metrics/#naming-metrics


### PR DESCRIPTION
### What does this PR do?

Adds link to facet measure documentation. 

### Motivation

customer request

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/laura.hampton/add-measures-to-log-custom-metrics/logs/logs_to_metrics/

Check preview base path using the URL in details in `preview` status check.
