### PR TITLE
Enforcing tag key wording instead of Tag group

### DIFF
--- a/content/en/dashboards/graphing_json/_index.md
+++ b/content/en/dashboards/graphing_json/_index.md
@@ -66,7 +66,7 @@ TEMPLATE_VARIABLE_SCHEMA = {
 |-----------|--------|-------------------------------------------|
 | `name`    | string | Name of your template variable.           |
 | `default` | string | Default value for your template variable. |
-| `prefix`  | string | Tag group for your template variable.     |
+| `prefix`  | string | Tag key for your template variable.       |
 
 [Learn more about template variable in the Datadog UI][4].
 

--- a/content/en/developers/service_checks/_index.md
+++ b/content/en/developers/service_checks/_index.md
@@ -2,10 +2,10 @@
 title: Service Check
 kind: documentation
 aliases:
-- /developers/faq/how-can-i-submit-a-custom-status-check
-- /developers/service_checks/visualize-your-service-check-in-the-datadog-ui
-- /guides/services_checks/
-- /monitors/guide/visualize-your-service-check-in-the-datadog-ui
+    - /developers/faq/how-can-i-submit-a-custom-status-check
+    - /developers/service_checks/visualize-your-service-check-in-the-datadog-ui
+    - /guides/services_checks/
+    - /monitors/guide/visualize-your-service-check-in-the-datadog-ui
 ---
 
 ## Overview
@@ -13,7 +13,7 @@ aliases:
 Services Checks allow you to characterize the status of a service in order to monitor it within Datadog. All status checks must have one of the following status codes:
 
 | Status Code | Description |
-|-------------|-------------|
+| ----------- | ----------- |
 | `0`         | OK          |
 | `1`         | Warning     |
 | `2`         | Critical    |
@@ -27,57 +27,57 @@ Services Checks allow you to characterize the status of a service in order to mo
 
 ## Visualize your service check in Datadog
 
-Service checks can be visualized and used in 3 Datadog sections:
+Service checks can be visualized and used in 3 Datadog sections:
 
-* [Check Summary][1]
-* [Screenboards][2]
-* [Custom check Monitor][3]
+- [Check Summary][1]
+- [Screenboards][2]
+- [Custom check Monitor][3]
 
 ### Check Summary
 
-Click on the *Monitors* tab, and then on *Check Summary* to see the [Check Summary][1] page.
+Click on the _Monitors_ tab, and then on _Check Summary_ to see the [Check Summary][1] page.
 
 {{< img src="developers/service_checks/check_summary.png" alt="Check summary"  >}}
 
-This is a list of all your checks and their statuses, reporting across your infrastructure in the past day. Select a check to get insights on the number of distinct checks for each of its associated tags.
+This is a list of all your checks and their statuses, reporting across your infrastructure in the past day. Select a check to get insights on the number of distinct checks for each of its associated tags.
 
 ### Screenboards
 
-You can visualize service checks with a *Check status* widget in a screenboard:
+You can visualize service checks with a _Check status_ widget in a screenboard:
 
 {{< img src="developers/service_checks/check_status_widget.png" alt="Check status widget"  >}}
 
-After clicking on the *Check status* widget icon, the following pop-up appears:
+After clicking on the _Check status_ widget icon, the following pop-up appears:
 
 {{< img src="developers/service_checks/check_widget_config.png" alt="Check widget config"  >}}
 
 In this form, you can:
 
-* **Check Name**: Select your service check name.
-* **Reporting Timeframe**: Select the time frame on which you want to aggregate your status.
-* **Scoping**: Select a single check or a cluster of check statuses reported by a single tag value or a tag group.
-* **Widget Title**: Set your widget title.
+- **Check Name**: Select your service check name.
+- **Reporting Timeframe**: Select the time frame on which you want to aggregate your status.
+- **Scoping**: Select a single check or a cluster of check statuses reported by a single tag value or a tag key.
+- **Widget Title**: Set your widget title.
 
 ## Custom check monitor
 
 Even if you can't graph a custom check over time as you would for metrics, you can still monitor it.
-Go to *monitor tab* > *new monitor*, then select the **custom check** section:
+Go to _monitor tab_ > _new monitor_, then select the **custom check** section:
 
 {{< img src="developers/service_checks/check_monitor.png" alt="Check monitor"  >}}
 
-Configure your custom check monitor: 
+Configure your custom check monitor:
 
 {{< img src="developers/service_checks/check_monitor_config.png" alt="Check monitor configuration"  >}}
 
 In this form, you can:
 
-* **Pick a custom check**: Select your check status name to monitor.
-* **Pick monitor scope**: Select the context for your monitor (including/excluding tags).
-* **Set alert conditions**: Choose between a simple check alert or a cluster alert.
-* **Say what's happening**: Edit the notifications sent (find more about [Datadog notifications][4]).
-* **Notify your team**: Choose who this monitor should notify.
+- **Pick a custom check**: Select your check status name to monitor.
+- **Pick monitor scope**: Select the context for your monitor (including/excluding tags).
+- **Set alert conditions**: Choose between a simple check alert or a cluster alert.
+- **Say what's happening**: Edit the notifications sent (find more about [Datadog notifications][4]).
+- **Notify your team**: Choose who this monitor should notify.
 
-Service check monitors for out-of-the-box Datadog integrations can be set in the *monitor tab* > *Integration* > *Integration status* tab on the left. For instance, with the HAProxy integration: 
+Service check monitors for out-of-the-box Datadog integrations can be set in the _monitor tab_ > _Integration_ > _Integration status_ tab on the left. For instance, with the HAProxy integration:
 
 {{< img src="developers/service_checks/haproxy_service_check.mp4" alt="Haproxy Service Check" video="true"  >}}
 

--- a/content/en/integrations/faq/both-my-jmx-and-aws-integrations-use-name-tags-what-do-i-do.md
+++ b/content/en/integrations/faq/both-my-jmx-and-aws-integrations-use-name-tags-what-do-i-do.md
@@ -33,7 +33,7 @@ To stop this from conflicting with an AWS "name" tag, you could change that metr
         bean_name: $name
 ```
 
-In this case, the same metric would be collected, but with the "name" tag applied as "bean_name:messagesinpersec" instead, which would no longer conflict with the AWS "name" tag group.
+In this case, the same metric would be collected, but with the "name" tag applied as "bean_name:messagesinpersec" instead, which would no longer conflict with the AWS "name" tag key.
 {{< img src="integrations/faq/jmx_metric_collected.png" alt="jmx_metric_collected"  >}}
 
 [1]: /integrations/amazon_web_services/

--- a/content/en/logs/explorer/facets.md
+++ b/content/en/logs/explorer/facets.md
@@ -124,7 +124,6 @@ If you see an aliased facet in your facet list, consider using the _standard_ fa
 
 You may wish to keep the non-standard _aliased_ version of the facet if you are troubleshooting against old content (before the aliasing for this facet has been setup by your organization).
 
-
 ## Manage Facets
 
 ### Out-of-the-box facets
@@ -133,13 +132,11 @@ Most common facets such as `Host`, `Service`, `URL Path`, or `Duration` come out
 
 Facets on [Reserved Attributes][23] and most [Standard Attributes][24] are available by default.
 
-
 ### The Index Facet
 
 The index facet is a specific facet that appears only if your organization has [multiple indexes][25], and/or if you have active [historical views][26]. Use this facet if you want to scope down your query to a subset of your indexes.
 
 {{< img src="logs/explorer/facet/index_facet_.png" alt="Create Facet" style="width:30%;">}}
-
 
 ### Create Facets
 
@@ -162,7 +159,7 @@ In case finding a matching log is not an option, create a new facet directly fro
 
 Define the underlying field (key) name for this facet:
 
-- Use tag group name for tags.
+- Use tag key name for tags.
 - Use the attribute path for attributes, with `@` prefix.
 
 Autocomplete based on the content in logs of the current views helps you to define the proper field name. But you can use virtually any value here, specifically in the case that you don't yet have matching logs flowing in your indexes.


### PR DESCRIPTION
### What does this PR do?
Enforces the "Tag key" wording instead of "Tag group" to be consistent with the best practice for tagging: `<KEY>:<VALUE>`

### Motivation
Reduce customer confusion.

