### PR TITLE
remove documentation accidentally included

### DIFF
--- a/content/en/agent/kubernetes/tag.md
+++ b/content/en/agent/kubernetes/tag.md
@@ -37,12 +37,6 @@ annotations:
   ad.datadoghq.com/<CONTAINER_IDENTIFIER>.tags: '{"<TAG_KEY>": "<TAG_VALUE>","<TAG_KEY_1>": "<TAG_VALUE_1>"}'
 ```
 
-Starting with Agent v7.17+, the Agent can Autodiscover tags from Docker labels. This process allows the Agent to associate custom tags to all data emitted by a container, without [modifying the Agent `datadog.yaml` file][1].
-
-```yaml
-com.datadoghq.ad.tags: '["<TAG_KEY>:TAG_VALUE", "<TAG_KEY_1>:<TAG_VALUE_1>"]'
-```
-
 ## Node labels as tags
 
 Starting with Agent v6.0+, the Agent can collect labels for a given node and use them as tags to attach to all metrics emitted by all pods on this node:
@@ -186,4 +180,3 @@ kubernetes_pod_annotations_as_tags:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /agent/kubernetes/tag/?tab=agent#extract-labels-as-tags


### PR DESCRIPTION
### What does this PR do?
Removes incorrect info; this addition was reverted several weeks ago, but looks like it was accidentally included during a refactor

### Motivation

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/celene/rm_misplaced_docker_ad_tags/agent/kubernetes/tag/?tab=containerizedagent

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
