### PR TITLE
[APM] [PHP] Update OpenTracing usage

### DIFF
--- a/content/en/tracing/opentracing/php.md
+++ b/content/en/tracing/opentracing/php.md
@@ -24,13 +24,16 @@ When [automatic instrumentation][2] is enabled, an OpenTracing-compatible tracer
 
 ```php
 <?php
-  $otTracer = \OpenTracing\GlobalTracer::get();
+  $otWrapper = new \DDTrace\OpenTracer\Tracer(\DDTrace\GlobalTracer::get());
+  \OpenTracing\GlobalTracer::set($otWrapper);
   $span = $otTracer->startActiveSpan('web.request')->getSpan();
   $span->setTag('span.type', 'web');
   $span->setTag('http.method', $_SERVER['REQUEST_METHOD']);
   // ...Use OpenTracing as expected
 ?>
 ```
+
+<div class="alert alert-info">Before ddtrace version 0.46.0, an OpenTracing compatible tracer was automatically returned from <code>OpenTracing\GlobalTracer::get()</code> without the need to set the global tracer manually.</div>
 
 ## Further Reading
 

--- a/content/en/tracing/opentracing/php.md
+++ b/content/en/tracing/opentracing/php.md
@@ -24,8 +24,8 @@ When [automatic instrumentation][2] is enabled, an OpenTracing-compatible tracer
 
 ```php
 <?php
-  $otWrapper = new \DDTrace\OpenTracer\Tracer(\DDTrace\GlobalTracer::get());
-  \OpenTracing\GlobalTracer::set($otWrapper);
+  $otTracer = new \DDTrace\OpenTracer\Tracer(\DDTrace\GlobalTracer::get());
+  \OpenTracing\GlobalTracer::set($otTracer);
   $span = $otTracer->startActiveSpan('web.request')->getSpan();
   $span->setTag('span.type', 'web');
   $span->setTag('http.method', $_SERVER['REQUEST_METHOD']);


### PR DESCRIPTION
# What does this PR do?

The 0.46.0 release of the PHP tracer will introduce a breaking change (DataDog/dd-trace-php#899) for those instrumenting with OpenTracing. This PR updates the code snippet to reflect the proper way to initialize the OpenTracing tracer.

### Preview link

https://docs-staging.datadoghq.com/sammyk/php/open-tracing/tracing/opentracing/php/
