### PR TITLE
[serverless] update pvtlink forwarder doc

### DIFF
--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -128,7 +128,7 @@ Add `DD_URL: pvtlink.logs.datadoghq.com` in your [Datadog Lambda function][4] en
 
 By default, the forwarder's API key is stored in Secrets Manager. The Secrets Manager endpoint needs to be added to the VPC. You can follow the instructions [here for adding AWS services to a VPC][5].
 
-When installing the forwarder via the CloudFormation template, enable 'DdUsePrivateLink' and set at least one Subnet Id and Security Group.
+When installing the forwarder with the CloudFormation template, enable 'DdUsePrivateLink' and set at least one subnet ID and security group.
 
 [1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 [2]: /agent/logs/?tab=tailexistingfiles#send-logs-over-https

--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -126,7 +126,7 @@ To forward your logs to Datadog using this new VPC endpoint, configure `pvtlink.
 
 Add `DD_URL: pvtlink.logs.datadoghq.com` in your [Datadog Lambda function][4] environment variable to use the private link when forwarding AWS Service Logs to Datadog.
 
-By default, the forwarder's API key will be stored in Secrets Manager. The secrets manager endpoint will need to be added to the VPC. You can follow the instructions [here for adding AWS services to a VPC][5].
+By default, the forwarder's API key is stored in Secrets Manager. The Secrets Manager endpoint needs to be added to the VPC. You can follow the instructions [here for adding AWS services to a VPC][5].
 
 When installing the forwarder via the CloudFormation template, enable 'DdUsePrivateLink' and set at least one Subnet Id and Security Group.
 

--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -126,11 +126,15 @@ To forward your logs to Datadog using this new VPC endpoint, configure `pvtlink.
 
 Add `DD_URL: pvtlink.logs.datadoghq.com` in your [Datadog Lambda function][4] environment variable to use the private link when forwarding AWS Service Logs to Datadog.
 
+By default, the forwarder's API key will be stored in Secrets Manager. The secrets manager endpoint will need to be added to the VPC. You can follow the instructions [here for adding AWS services to a VPC][5].
+
+When installing the forwarder via the CloudFormation template, enable 'DdUsePrivateLink' and set at least one Subnet Id and Security Group.
 
 [1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 [2]: /agent/logs/?tab=tailexistingfiles#send-logs-over-https
 [3]: /agent/guide/agent-commands/#restart-the-agent
 [4]: /integrations/amazon_web_services/#set-up-the-datadog-lambda-function
+[5]: https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#create-interface-endpoint
 {{% /tab %}}
 {{% tab "API" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Parity between the forwarder's doc and doc app: https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring#aws-private-link-support 

### Motivation
<!-- What inspired you to submit this pull request?-->
Support case

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/dylan/forwarder-update/agent/guide/private-link/?tab=logs

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
