### PR TITLE
fix aliases for apm landing page

### DIFF
--- a/content/en/tracing/setup/envoy.md
+++ b/content/en/tracing/setup/envoy.md
@@ -15,7 +15,8 @@ further_reading:
   tag: "Source Code"
   text: "Datadog OpenTracing C++ Client"
 aliases:
-  - /tracing/proxies/envoy
+- /tracing/proxies/envoy
+- /tracing/envoy/
 ---
 
 Datadog APM is included in Envoy v1.9.0 and newer.
@@ -171,7 +172,7 @@ admin:
       port_value: 8001
 ```
 
-## Excluding Metrics 
+## Excluding Metrics
 
 If you are using Envoy's `dog_statsd` configuration to report metrics, you can _exclude_ activity from the `datadog_agent` cluster with this additional configuration.
 

--- a/content/en/tracing/setup/istio.md
+++ b/content/en/tracing/setup/istio.md
@@ -14,6 +14,8 @@ further_reading:
 - link: "https://github.com/DataDog/dd-opentracing-cpp"
   tag: "Source Code"
   text: "Datadog OpenTracing C++ Client"
+aliases:
+- /tracing/istio/
 ---
 
 Datadog APM is available for Istio v1.1.3+ on Kubernetes clusters.

--- a/content/en/tracing/setup/nginx.md
+++ b/content/en/tracing/setup/nginx.md
@@ -19,6 +19,7 @@ further_reading:
   text: "Datadog OpenTracing C++ Client"
 aliases:
   - /tracing/proxies/nginx
+  - /tracing/nginx/
 ---
 
 Support for Datadog APM is available for NGINX using a combination of plugins and configurations.

--- a/content/en/tracing/setup/php.md
+++ b/content/en/tracing/setup/php.md
@@ -4,6 +4,7 @@ kind: documentation
 aliases:
 - /tracing/languages/php
 - /agent/apm/php/
+- /tracing/php/
 further_reading:
 - link: "https://www.datadoghq.com/blog/monitor-php-performance/"
   tag: "Blog"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fix broken aliases on apm landing page

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
