### PR TITLE
Generate the kubernetes manifests from the helm chart (2/3)

### DIFF
--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -35,8 +35,8 @@ The Datadog Cluster Agent needs a proper RBAC to be up and running:
 2. To configure Cluster Agent RBAC permissions, apply the following manifests. (You may have done this already when setting up the [node Agent daemonset][2].)
 
   ```shell
-  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/rbac/rbac-agent.yaml"
-  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/rbac/rbac-cluster-agent.yaml"
+  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/rbac.yaml"
+  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-rbac.yaml"
   ```
 
   This creates the appropriate `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding` for the Cluster Agent.

--- a/content/en/agent/guide/cluster-agent-custom-metrics-server.md
+++ b/content/en/agent/guide/cluster-agent-custom-metrics-server.md
@@ -35,14 +35,14 @@ To spin up the [Datadog Cluster Agent][6], perform the following steps:
 
 1. Create appropriate RBAC rules. The Datadog Cluster Agent acts as a proxy between the API Server and the Node Agent, and it needs to have access to some cluster-level resources.
 
-    `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/rbac/rbac-cluster-agent.yaml"`
+    `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-rbac.yaml"`
 
     Which should produce the following output:
 
     ```
-    clusterrole.rbac.authorization.k8s.io "dca" created
-    clusterrolebinding.rbac.authorization.k8s.io "dca" created
-    serviceaccount "dca" created
+    clusterrole.rbac.authorization.k8s.io "datadog-cluster-agent" created
+    clusterrolebinding.rbac.authorization.k8s.io "datadog-cluster-agent" created
+    serviceaccount "datadog-cluster-agent" created
     ```
 
 2. Create the Datadog Cluster Agent and its services. Add your `<API_KEY>` and `<APP_KEY>` in the Deployment manifest of the Datadog Cluster Agent.
@@ -50,9 +50,9 @@ To spin up the [Datadog Cluster Agent][6], perform the following steps:
 3. Enable HPA processing by setting the `DD_EXTERNAL_METRICS_PROVIDER_ENABLED` variable to `true`.
 
 4. Spin up the resources:
-  * `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/datadog-cluster-agent_service.yaml"`
-  * `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/hpa-example/cluster-agent-hpa-svc.yaml"`
-  * `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/cluster-agent.yaml"`
+  * `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-services.yaml"`
+  * `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/hpa-example/cluster-agent-hpa-svc.yaml"`
+  * `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/cluster-agent-deployment.yaml"`
 
 **Note**: The first service is used for the communication between the Node Agents and the Datadog Cluster Agent, but the second is used by Kubernetes to register the External Metrics Provider.
 
@@ -76,7 +76,7 @@ default       datadog-cluster-agent           ClusterIP   192.168.254.197   <non
 
 Once the Datadog Cluster Agent is up and running, register it as an External Metrics Provider with the service, exposing the port `443`. To do so, apply the following RBAC rules:
 
-`kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/hpa-example/rbac-hpa.yaml"`
+`kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/hpa-example/rbac-hpa.yaml"`
 
 Which should produce the following results:
 
@@ -115,10 +115,10 @@ Every 30 seconds, Kubernetes queries the Datadog Cluster Agent to get the value 
 For advanced use cases, it is possible to have several metrics in the same HPA, as you can see [in the Kubernetes horizontal pod autoscale documentation][8]. The largest of the proposed values is the one chosen.
 
 1. Create the NGINX deployment:
-  `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/hpa-example/nginx.yaml"`
+  `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/hpa-example/nginx.yaml"`
 
 2. Then, apply the HPA manifest.
-  `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/hpa-example/hpa-manifest.yaml"`
+  `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/hpa-example/hpa-manifest.yaml"`
 
 You should be seeing your NGINX pod running with the corresponding service:
 
@@ -188,6 +188,6 @@ default     nginxext   Deployment/nginx   30/9 (avg)     1         3         3  
 [4]: /agent/kubernetes/integrations/
 [5]: /agent/cluster_agent/setup/
 [6]: /agent/kubernetes/cluster/
-[7]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/hpa-example/hpa-manifest.yaml
+[7]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/hpa-example/hpa-manifest.yaml
 [8]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-multiple-metrics
 [9]: /agent/kubernetes/#template-source-kubernetes-pod-annotations

--- a/content/fr/agent/cluster_agent/setup.md
+++ b/content/fr/agent/cluster_agent/setup.md
@@ -34,8 +34,8 @@ L'Agent de cluster Datadog a besoin des autorisations RBAC adéquates pour fonct
 2. Pour configurer les autorisations RBAC de l'Agent de cluster, appliquez les manifestes suivants. Il se peut que vous ayez déjà effectué cette opération lors de la configuration du [daemonset de l'Agent de nœud][2].
 
   ```shell
-  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/rbac/rbac-agent.yaml"
-  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/rbac/rbac-cluster-agent.yaml"
+  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/rbac.yaml"
+  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-rbac.yaml"
   ```
 
   Cela permet de créer les objets `ServiceAccount`, `ClusterRole` et `ClusterRoleBinding` appropriés pour l'Agent de cluster.

--- a/content/fr/agent/guide/cluster-agent-custom-metrics-server.md
+++ b/content/fr/agent/guide/cluster-agent-custom-metrics-server.md
@@ -34,14 +34,14 @@ Pour lancer [l'Agent de cluster Datadog][6], effectuez les étapes suivantes :
 
 1. Créez les règles RBAC appropriées. L'Agent de cluster Datadog agit en tant que proxy entre le serveur API et l'Agent de nœud : il doit par conséquent avoir accès à certaines ressources au niveau du cluster.
 
-    `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/rbac/rbac-cluster-agent.yaml"`
+    `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-rbac.yaml"`
 
     On obtient alors le résultat suivant :
 
     ```
-    clusterrole.rbac.authorization.k8s.io "dca" created
-    clusterrolebinding.rbac.authorization.k8s.io "dca" created
-    serviceaccount "dca" created
+    clusterrole.rbac.authorization.k8s.io "datadog-cluster-agent" created
+    clusterrolebinding.rbac.authorization.k8s.io "datadog-cluster-agent" created
+    serviceaccount "datadog-cluster-agent" created
     ```
 
 2. Créez l'Agent de cluster Datadog et ses services. Ajoutez votre `<CLÉ_API>` et votre `<CLÉ_APP>` dans le manifeste de déploiement de l'Agent de cluster Datadog.
@@ -49,9 +49,9 @@ Pour lancer [l'Agent de cluster Datadog][6], effectuez les étapes suivantes :
 3. Activez le processing de l'Autoscaler de pods horizontaux en configurant la variable `DD_EXTERNAL_METRICS_PROVIDER_ENABLED` sur `true`.
 
 4. Lancez les ressources :
-  * `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/datadog-cluster-agent_service.yaml"`
-  * `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/hpa-example/cluster-agent-hpa-svc.yaml"`
-  * `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/cluster-agent.yaml"`
+  * `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-service.yaml"`
+  * `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/hpa-example/cluster-agent-hpa-svc.yaml"`
+  * `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/cluster-agent-deployment.yaml"`
 
 **Remarque** : le premier service est utilisé pour la communication entre les Agents de nœud et l'Agent de cluster Datadog, mais le second est utilisé par Kubernetes pour enregistrer le fournisseur de métriques externes.
 
@@ -75,7 +75,7 @@ default       datadog-cluster-agent           ClusterIP   192.168.254.197   <non
 
 Une fois l'Agent de cluster Datadog opérationnel, enregistrez-le en tant que fournisseur de métriques externes via le service, en exposant le port `443`. Pour ce faire, appliquez les règles RBAC suivantes :
 
-`kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/hpa-example/rbac-hpa.yaml"`
+`kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/hpa-example/rbac-hpa.yaml"`
 
 On obtient alors le résultat suivant :
 
@@ -114,10 +114,10 @@ Toutes les 30 secondes, Kubernetes interroge l'Agent de cluster Datadog pour ob
 Pour les cas d'utilisation avancés, il est possible de configurer plusieurs métriques dans le même Autoscaler de pods horizontaux, comme le décrit [la documentation sur l'autoscaling de pods horizontaux Kubernetes][8]. La plus grande des valeurs proposées est celle choisie.
 
 1. Créez le déploiement NGINX :
-  `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/hpa-example/nginx.yaml"`
+  `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/hpa-example/nginx.yaml"`
 
 2. Appliquez ensuite le manifeste de l'Autoscaler de pods horizontaux.
-  `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/hpa-example/hpa-manifest.yaml"`
+  `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/hpa-example/hpa-manifest.yaml"`
 
 Votre pod NGINX devrait maintenant être exécuté avec le service correspondant :
 
@@ -187,6 +187,6 @@ default     nginxext   Deployment/nginx   30/9 (avg)     1         3         3  
 [4]: /fr/agent/kubernetes/integrations
 [5]: /fr/agent/cluster_agent/setup
 [6]: /fr/agent/kubernetes/cluster
-[7]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/hpa-example/hpa-manifest.yaml
+[7]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/hpa-example/hpa-manifest.yaml
 [8]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-multiple-metrics
 [9]: /fr/agent/kubernetes/#template-source-kubernetes-pod-annotations

--- a/content/ja/agent/guide/cluster-agent-custom-metrics-server.md
+++ b/content/ja/agent/guide/cluster-agent-custom-metrics-server.md
@@ -34,14 +34,14 @@ Kubernetes v1.2 では、[Horizontal Pod Autoscaling][1] が導入されまし�
 
 1. 適切な RBAC ルールを作成します。Datadog Cluster Agent は、API サーバーと Node Agent の間のプロキシとして機能し、一部のクラスターレベルのリソースにアクセスする必要があります。
 
-    `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/rbac/rbac-cluster-agent.yaml"`
+    `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-rbac.yaml"`
 
    次の出力が生成されます。
 
     ```
-    clusterrole.rbac.authorization.k8s.io "dca" created
-    clusterrolebinding.rbac.authorization.k8s.io "dca" created
-    serviceaccount "dca" created
+    clusterrole.rbac.authorization.k8s.io "datadog-cluster-agent" created
+    clusterrolebinding.rbac.authorization.k8s.io "datadog-cluster-agent" created
+    serviceaccount "datadog-cluster-agent" created
     ```
 
 2. Datadog Cluster Agent とそのサービスを作成します。Datadog Cluster Agent のデプロイマニフェストに `<API_キー>` と `<アプリキー>` を追加します。
@@ -49,9 +49,9 @@ Kubernetes v1.2 では、[Horizontal Pod Autoscaling][1] が導入されまし�
 3. `DD_EXTERNAL_METRICS_PROVIDER_ENABLED` 変数を `true` に設定して HPA 処理を有効にします。
 
 4. リソースをスピンアップします。
-  * `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/datadog-cluster-agent_service.yaml"`
-  * `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/hpa-example/cluster-agent-hpa-svc.yaml"`
-  * `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/cluster-agent.yaml"`
+  * `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-services.yaml"`
+  * `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/hpa-example/cluster-agent-hpa-svc.yaml"`
+  * `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/cluster-agent-deployment.yaml"`
 
 **注**: 最初のサービスは Node Agent と Datadog Cluster Agent 間の通信に使用されますが、2 番目のサービスは External Metrics Provider を登録するために Kubernetes によって使用されます。
 
@@ -75,7 +75,7 @@ default       datadog-cluster-agent           ClusterIP   192.168.254.197   <non
 
 Datadog Cluster Agent が起動して実行されたら、これをサービスに External Metrics Provider として登録し、ポート `443` を公開します。そのためには、次の RBAC ルールを適用します。
 
-`kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/hpa-example/rbac-hpa.yaml"`
+`kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/hpa-example/rbac-hpa.yaml"`
 
 次の結果が生成されます。
 
@@ -114,10 +114,10 @@ Kubernetes は 30 秒ごとに Datadog Cluster Agent にクエリを実行して
 高度なユースケースでは、[Kubernetes 水平ポッド自動スケーリングのドキュメント][8]で確認できるように、同じ HPA に複数のメトリクスを含めることができます。提案された値の最大値は選択された値です。
 
 1. NGINX デプロイを作成します。
-  `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/hpa-example/nginx.yaml"`
+  `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/hpa-example/nginx.yaml"`
 
 2. 次に、HPA マニフェストを適用します。
-  `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/hpa-example/hpa-manifest.yaml"`
+  `kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/hpa-example/hpa-manifest.yaml"`
 
 NGINX ポッドが対応するサービスで実行されていることが表示されているはずです。
 
@@ -187,6 +187,6 @@ default     nginxext   Deployment/nginx   30/9 (avg)     1         3         3  
 [4]: /ja/agent/kubernetes/integrations
 [5]: /ja/agent/cluster_agent/setup
 [6]: /ja/agent/kubernetes/cluster
-[7]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/hpa-example/hpa-manifest.yaml
+[7]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/hpa-example/hpa-manifest.yaml
 [8]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-multiple-metrics
 [9]: /ja/agent/kubernetes/#template-source-kubernetes-pod-annotations


### PR DESCRIPTION
### What does this PR do?

Replace the kubernetes manifests by ones generated from the public helm chart.

### Motivation

Each time we add a new parameter, we have many places to update.
Having things generated from the Helm chart reduces the amount of documentation to be manually updated.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/lenaic/generate_manifest_files_in_datadog-agent

Check preview base path using the URL in details in `preview` status check.

### Additional Notes

This change is done in 3 steps:
1. Generate k8s manifests in `datadog-agent`: DataDog/datadog-agent#5436
2. Update the hyperlinks in `documentation` to reference the new generated files: #7542
3. Delete the old manually maintained k8 manifests from `datadog-agent`: DataDog/datadog-agent#5606