### PR TITLE
agent 7 link

### DIFF
--- a/content/en/agent/faq/how-do-i-install-the-agent-on-a-server-with-limited-internet-connectivity.md
+++ b/content/en/agent/faq/how-do-i-install-the-agent-on-a-server-with-limited-internet-connectivity.md
@@ -16,7 +16,7 @@ For servers with no direct internet access, the Agent can be configured to route
 
 If the target system is blocked from accessing the package repository directly, download the package from the repository using another server, then transfer it over to the target system for a local install.
 
-The rpm packages for Agent 6 are available at [https://yum.datadoghq.com/stable/6/x86_64/][3] and dep packages are available at [https://apt.datadoghq.com/pool/d/da/][4].
+The RPM packages for Agent 6 are available at [https://yum.datadoghq.com/stable/6/x86_64/][3], for Agent 7 at [https://yum.datadoghq.com/stable/7/x86_64/][4], and DEB packages are available at [https://apt.datadoghq.com/pool/d/da/][5].
 
 **Note**: The package bundles all resources necessary to run the Agent and checks (whether the integration is enabled or not). In terms of hard requirements, Python 2.7+ and sysstat are required; other dependencies are mandatory depending on what checks are enabled.
 
@@ -32,13 +32,13 @@ To install a deb file in the current director for Debian based distributions:
 sudo apt install ./datadog-agent_<AGENT_VERSION>-1_amd64.deb
 ```
 
-Once installed, add a `datadog.yaml` file by copying `datadog.yaml.example`. Then update `datadog.yaml` with the [API key][5] for your organization. This can be done with a single command:
+Once installed, add a `datadog.yaml` file by copying `datadog.yaml.example`. Then update `datadog.yaml` with the [API key][6] for your organization. This can be done with a single command:
 
 ```bash
 sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_DATADOG_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml.example"
 ```
 
-Then, [start the Agent][6] using the appropriate command for your system.
+Then, [start the Agent][7] using the appropriate command for your system.
 
 ## Further Reading
 
@@ -47,6 +47,7 @@ Then, [start the Agent][6] using the appropriate command for your system.
 [1]: https://app.datadoghq.com/account/settings#agent
 [2]: /account_management/faq/can-i-use-a-proxy-to-connect-my-servers-to-datadog/
 [3]: https://yum.datadoghq.com/stable/6/x86_64
-[4]: https://apt.datadoghq.com/pool/d/da
-[5]: https://app.datadoghq.com/account/settings#api
-[6]: /agent/guide/agent-commands/#start-the-agent
+[4]: https://yum.datadoghq.com/stable/7/x86_64
+[5]: https://apt.datadoghq.com/pool/d/da
+[6]: https://app.datadoghq.com/account/settings#api
+[7]: /agent/guide/agent-commands/#start-the-agent


### PR DESCRIPTION
Adding links to RPM for agent 7

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
