### PR TITLE
[rum/logs] add service env version doc

### DIFF
--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -117,6 +117,9 @@ The following parameters can be used to configure the Datadog browser log librar
 |-----------------------|---------|----------|---------|----------------------------------------------------------------------------------------------------------|
 | `clientToken`         | String  | Yes      | `-`     | A [Datadog Client Token][2].                                                                             |
 | `datacenter`          | String  | Yes      | `us`    | The Datadog Site of your organization. `us` for Datadog US site, `eu` for Datadog EU site.               |
+| `service`            | String  | No       | `` | The service name to be used for this application.                             |
+| `env`                | String  | No       | `` | The application’s environment e.g. prod, pre-prod, staging.                   |
+| `version`            | String  | No       | `` | The application’s version e.g. 1.2.3, 6c44da20, 2020.02.13.                   |
 | `forwardErrorsToLogs` | Boolean | no       | `true`  | Set to `false` to stop forwarding console.error logs, uncaught exceptions and network errors to Datadog. |
 | `sampleRate`          | Number  | no       | `100`   | Percentage of sessions to track. Only tracked sessions send logs. `100` for all, `0` for none of them.   |
 

--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -117,7 +117,7 @@ The following parameters can be used to configure the Datadog browser log librar
 |-----------------------|---------|----------|---------|----------------------------------------------------------------------------------------------------------|
 | `clientToken`         | String  | Yes      | `-`     | A [Datadog Client Token][2].                                                                             |
 | `datacenter`          | String  | Yes      | `us`    | The Datadog Site of your organization. `us` for Datadog US site, `eu` for Datadog EU site.               |
-| `service`            | String  | No       | `` | The service name to be used for this application.                             |
+| `service`            | String  | No       | `` | The service name for this application.                             |
 | `env`                | String  | No       | `` | The application’s environment e.g. prod, pre-prod, staging.                   |
 | `version`            | String  | No       | `` | The application’s version e.g. 1.2.3, 6c44da20, 2020.02.13.                   |
 | `forwardErrorsToLogs` | Boolean | no       | `true`  | Set to `false` to stop forwarding console.error logs, uncaught exceptions and network errors to Datadog. |

--- a/content/en/real_user_monitoring/installation/_index.md
+++ b/content/en/real_user_monitoring/installation/_index.md
@@ -112,7 +112,7 @@ Paste the generated code snippet into the head tag (in front of any other script
 | `applicationId`      | String  | Yes      | `` | The RUM application ID.                                                       |
 | `clientToken`        | String  | Yes      | `` | A [Datadog Client Token][5].                                                  |
 | `datacenter`         | String  | Yes      | `us`                                                                               | The Datadog Site of your organization. `us` for Datadog US site, `eu` for Datadog EU site.                   |
-| `service`            | String  | No       | `` | The service name to be used for this application.                             |
+| `service`            | String  | No       | `` | The service name for this application.                             |
 | `env`                | String  | No       | `` | The application’s environment e.g. prod, pre-prod, staging.                   |
 | `version`            | String  | No       | `` | The application’s version e.g. 1.2.3, 6c44da20, 2020.02.13.                   |
 | `resourceSampleRate` | Number  | No       | `100`                                                                              | Percentage of tracked sessions with resources collection. `100` for all, `0` for none of them.               |

--- a/content/en/real_user_monitoring/installation/_index.md
+++ b/content/en/real_user_monitoring/installation/_index.md
@@ -112,6 +112,9 @@ Paste the generated code snippet into the head tag (in front of any other script
 | `applicationId`      | String  | Yes      | `` | The RUM application ID.                                                       |
 | `clientToken`        | String  | Yes      | `` | A [Datadog Client Token][5].                                                  |
 | `datacenter`         | String  | Yes      | `us`                                                                               | The Datadog Site of your organization. `us` for Datadog US site, `eu` for Datadog EU site.                   |
+| `service`            | String  | No       | `` | The service name to be used for this application.                             |
+| `env`                | String  | No       | `` | The application’s environment e.g. prod, pre-prod, staging.                   |
+| `version`            | String  | No       | `` | The application’s version e.g. 1.2.3, 6c44da20, 2020.02.13.                   |
 | `resourceSampleRate` | Number  | No       | `100`                                                                              | Percentage of tracked sessions with resources collection. `100` for all, `0` for none of them.               |
 | `sampleRate`         | Number  | No       | `100`                                                                              | Percentage of sessions to track. Only tracked sessions send rum events. `100` for all, `0` for none of them. |
 | `silentMultipleInit` | Boolean | No       | `false`                                                                            | Initialization fails silently if Datadog's RUM is already initialized on the page                            |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add service, env, version to documentation.

### Motivation
<!-- What inspired you to submit this pull request?-->
New feature

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hdelaby/service-env-version/real_user_monitoring/installation/?tab=us
https://docs-staging.datadoghq.com/hdelaby/service-env-version/logs/log_collection/javascript/?tab=npm

### Additional Notes
<!-- Anything else we should know when reviewing?-->
