### PR TITLE
update ci image back to master

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:zach_update-hugo
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
   tags:
     - "runner:main"
     - "size:large"


### PR DESCRIPTION
### What does this PR do?
Set the ci image back to master for consistency

### Motivation
Multiple prs with ci image updates

### Preview link
Shouldn't be impacted but here is the preview url
https://docs-staging.datadoghq.com/david.jones/imgupdate/

### Additional Notes

