### PR TITLE
Adding authentication question to troubleshooting guide

### DIFF
--- a/content/en/synthetics/private_locations.md
+++ b/content/en/synthetics/private_locations.md
@@ -57,7 +57,7 @@ To pull test configurations and push test results, the private location worker n
 
 The private location worker is shipped as a Docker container. It can run on a Linux based OS or Windows OS if the [Docker engine][2] is available on your host and can run in Linux containers mode.
 
-## Setup
+## Private Location Setup
 
 ### Create a new private location
 

--- a/content/en/synthetics/troubleshooting/_index.md
+++ b/content/en/synthetics/troubleshooting/_index.md
@@ -32,15 +32,31 @@ The freshly opened incognito pop up ignores all your previous browser history: c
 
 ## API & Browser Tests
 
+### Unauthorized errors
+
+If one of your Synthetic tests is throwing a 401, it most likely means that it is unable to authenticate on the endpoint. You should consequently think about the method you generally use to authenticate on that endpoint (outside of Datadog) and replicate it when configuring your Synthetics test.
+
+* Is your endpoint using header-based authentication?
+  * Basic Authentication: specify the associated credentials in the **Advanced options** of your [HTTP][2] or [Browser test][3].
+  * Token based authentication: extract your token with a first [HTTP test][2], create a [global variable][4] by parsing the response of that first test, and re-inject that variable in a second [HTTP][5] or [Browser test][6] requiring the authentication token.
+  * Session based authentication: add the required headers or cookies in the **Advanced options** of your [HTTP][2] or [Browser test][3].
+* Is this endpoint using query parameters for authentication (e.g. do you need to add a specific API key in your URL parameters?)
+* Is this endpoint using IP-based authentication? If so, you might need to whitelist part or all of the [IPs from which Synthetics tests originate][7].
+
 ### Forbidden errors
 
 When creating Synthetics tests, you might get `403 Forbidden` errors at first. It's coming from the `Sec-Datadog: Request sent by a Datadog Synthetics Browser Test (https://docs.datadoghq.com/synthetics/) - test_id: <TEST_ID>` header that is automatically being sent by Datadog.
 Make sure this header is not blacklisted by your servers in order to remove this error.
-Additionally, you might also have to whitelist [Datadog Synthetics IP ranges][2] to make sure Datadog servers are allowed to send requests to your infrastructure.
+Additionally, you might also have to whitelist [Datadog Synthetics IP ranges][7] to make sure Datadog servers are allowed to send requests to your infrastructure.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /help/
-[2]: https://ip-ranges.datadoghq.com/synthetics.json
+[2]: /synthetics/api_tests/?tab=httptest#make-a-request
+[3]: /synthetics/browser_tests/#test-details
+[4]: /synthetics/settings/?tab=createfromhttptest#global-variables
+[5]: /synthetics/api_tests/?tab=httptest#use-global-variables
+[6]: /synthetics/browser_tests/#use-global-variables
+[7]: https://ip-ranges.datadoghq.com/synthetics.json

--- a/content/en/synthetics/troubleshooting/_index.md
+++ b/content/en/synthetics/troubleshooting/_index.md
@@ -36,12 +36,14 @@ The freshly opened incognito pop up ignores all your previous browser history: c
 
 If one of your Synthetic tests is throwing a 401, it most likely means that it is unable to authenticate on the endpoint. You should use the method that you use to authenticate on that endpoint (outside of Datadog) and replicate it when configuring your Synthetics test.
 
-* Is your endpoint using header-based authentication?
-  * Basic Authentication: specify the associated credentials in the **Advanced options** of your [HTTP][2] or [Browser test][3].
-  * Token based authentication: extract your token with a first [HTTP test][2], create a [global variable][4] by parsing the response of that first test, and re-inject that variable in a second [HTTP][5] or [Browser test][6] requiring the authentication token.
-  * Session based authentication: add the required headers or cookies in the **Advanced options** of your [HTTP][2] or [Browser test][3].
-* Is this endpoint using query parameters for authentication (e.g. do you need to add a specific API key in your URL parameters?)
-* Is this endpoint using IP-based authentication? If so, you might need to whitelist part or all of the [IPs from which Synthetics tests originate][7].
+* Is your endpoint using **header-based authentication**?
+  * **Basic Authentication**: specify the associated credentials in the **Advanced options** of your [HTTP][2] or [Browser test][3].
+  * **Token based authentication**: extract your token with a first [HTTP test][2], create a [global variable][4] by parsing the response of that first test, and re-inject that variable in a second [HTTP][5] or [Browser test][6] requiring the authentication token.
+  * **Session based authentication**: add the required headers or cookies in the **Advanced options** of your [HTTP][2] or [Browser test][3].
+  
+* Is this endpoint using **query parameters for authentication** (e.g. do you need to add a specific API key in your URL parameters?)
+
+* Is this endpoint using **IP-based authentication**? If so, you might need to whitelist part or all of the [IPs from which Synthetics tests originate][7].
 
 ### Forbidden errors
 

--- a/content/en/synthetics/troubleshooting/_index.md
+++ b/content/en/synthetics/troubleshooting/_index.md
@@ -34,7 +34,7 @@ The freshly opened incognito pop up ignores all your previous browser history: c
 
 ### Unauthorized errors
 
-If one of your Synthetic tests is throwing a 401, it most likely means that it is unable to authenticate on the endpoint. You should consequently think about the method you generally use to authenticate on that endpoint (outside of Datadog) and replicate it when configuring your Synthetics test.
+If one of your Synthetic tests is throwing a 401, it most likely means that it is unable to authenticate on the endpoint. You should use the method that you use to authenticate on that endpoint (outside of Datadog) and replicate it when configuring your Synthetics test.
 
 * Is your endpoint using header-based authentication?
   * Basic Authentication: specify the associated credentials in the **Advanced options** of your [HTTP][2] or [Browser test][3].


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR adds a question about 401 errors on Synthetics tests

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/margot.lepizzera/syn_troubleshooting/synthetics/troubleshooting/#unauthorized-errors
Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
