### PR TITLE
fix api pages not loading in some situations

### DIFF
--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -14,6 +14,16 @@
 
     {{ $apiVersion := .Scratch.Get "apiVersion"}}
 
+    {{ $.Scratch.Set "ParamTitleEn" ($.Params.title) }}
+    {{ if $dot.IsTranslated }}
+      {{ range $dot.Translations }}
+        {{ if eq .Lang "en" }}
+            {{ $.Scratch.Set "ParamTitleEn" (.Params.title) }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ $ParamTitleEn := ($.Scratch.Get "ParamTitleEn") }}
+
     {{ $d := index $dot.Site.Data.api $apiVersion "full_spec_deref" }}
 
     <!-- Get the general API server url -->
@@ -35,7 +45,7 @@
     {{ end }}
 
     {{ range $k, $v := (index $d "tags") }}
-        {{ if eq $.Params.title $v.name }}
+        {{ if eq $ParamTitleEn $v.name }}
 
             {{ $.Scratch.Set "tagObject" (slice)}}
 


### PR DESCRIPTION
### What does this PR do?

some api pages are blank on non english because we compare the page title to the tags in the spec.

This PR updates the template to always compare the english title to the english tag.

### Motivation

Bug mentioned in #documentation

### Preview link

https://docs-staging.datadoghq.com/david.jones/bugfixapi/fr/api/v1/metrics/

### Additional Notes

