### PR TITLE
[WEB-254] Update image map, rule page dimensions

### DIFF
--- a/data/security_monitoring/data.yaml
+++ b/data/security_monitoring/data.yaml
@@ -8,6 +8,14 @@
 base_integrations_url: https://docs.datadoghq.com/integrations/
 image_map:
   - source:
+      - kubernetes
+    image: kube_apiserver_metrics
+    append: false
+  - source:
+      - azure
+    image: azure.active_directory
+    append: false
+  - source:
       - cloudtrail
       - ec2
       - ecs

--- a/layouts/security_rules/single.html
+++ b/layouts/security_rules/single.html
@@ -10,7 +10,7 @@
 		{{ if and $meta_image .Params.scope }}
 			<div class="col-3 col-lg-2 d-flex justify-content-center">
 				{{ $meta_img := partial "security-rule-map.html" (dict "source" .Params.source "scope" .Params.scope) }}
-				<img src="{{ $meta_image.image }}?auto=format&width=120" width="auto" height="100px" alt="{{ htmlEscape .Params.Source }}" />
+				<img src="{{ $meta_image.image }}?auto=format&width=120" width="120px" max-height="100px" alt="{{ htmlEscape .Params.Source }}" />
 			</div>
 		{{ end }}
 		<div class="col-9 col-lg-10">


### PR DESCRIPTION
### What does this PR do?
Updates security rules image map data file in Hugo, markup/style fixes for stretched images on detail view 

### Motivation
https://datadoghq.atlassian.net/browse/WEB-254

### Preview link
https://docs-staging.datadoghq.com/nsollecito/security-rules-254/security_monitoring/default_rules/

### Additional Notes
Confirm images in detail view are rendered properly 
