### PR TITLE
Update ruby.md

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/ruby.md
+++ b/content/en/tracing/connect_logs_and_traces/ruby.md
@@ -46,7 +46,7 @@ config.lograge.custom_options = lambda do |event|
 end
 ```
 
-[1]: /logs/log_collection/python/#configure-the-datadog-agent
+[1]: /logs/log_collection/ruby/#configure-the-datadog-agent
 {{% /tab %}}
 {{% tab "Default" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates the link on the datadog ruby documentation to point to the correct (ruby) docs page for setting up Ruby on Rails collection

### Motivation
The original link points me, reading about the Ruby on Rails configuration, to a Python page. A more relevant Ruby on Rails page exists, however

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jaydorsey:patch-1/content/en/tracing/connect_logs_and_traces/ruby.md

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
