### PR TITLE
[Doc]: Update pvt link doc for logs api endpoint

### DIFF
--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -41,9 +41,10 @@ The overall process consists of configuring an internal endpoint in your VPC tha
 {{% /tab %}}
 {{% tab "Logs" %}}
 
-| Datadog Log Service Name                                  |
-| --------------------------------------------------------- |
-| `com.amazonaws.vpce.us-east-1.vpce-svc-0a2aef8496ee043bf` |
+| Forwarder | Datadog Logs Service Name |
+| --------- | ------------------------- |
+| Datadog Agent | `com.amazonaws.vpce.us-east-1.vpce-svc-0a2aef8496ee043bf` |
+| Lambda or custom forwarder | `com.amazonaws.vpce.us-east-1.vpce-svc-06394d10ccaf6fb97` |
 
 {{% /tab %}}
 {{% tab "API" %}}
@@ -122,9 +123,9 @@ To forward your logs to Datadog using this new VPC endpoint, configure `pvtlink.
 - `DD_LOGS_CONFIG_USE_HTTP=true`
 - `DD_LOGS_CONFIG_LOGS_DD_URL="pvtlink.logs.datadoghq.com:443"`
 
-**Using the Lambda forwarder**:
+**Using the Lambda or a custom forwarder**:
 
-Add `DD_URL: pvtlink.logs.datadoghq.com` in your [Datadog Lambda function][4] environment variable to use the private link when forwarding AWS Service Logs to Datadog.
+Add `DD_URL: pvtlink-api.logs.datadoghq.com` in your [Datadog Lambda function][4] environment variable to use the private link when forwarding AWS Service Logs to Datadog.
 
 By default, the forwarder's API key is stored in Secrets Manager. The Secrets Manager endpoint needs to be added to the VPC. You can follow the instructions [here for adding AWS services to a VPC][5].
 

--- a/content/fr/agent/guide/private-link.md
+++ b/content/fr/agent/guide/private-link.md
@@ -40,9 +40,10 @@ Pour utiliser PrivateLink, vous devez configurer un endpoint interne dans votre 
 {{% /tab %}}
 {{% tab "Logs" %}}
 
-| Nom de service des logs Datadog                                  |
-| --------------------------------------------------------- |
-| `com.amazonaws.vpce.us-east-1.vpce-svc-0a2aef8496ee043bf` |
+| Forwarder | Nom de service des logs Datadog |
+| --------- | ------------------------------- |
+| Agent Datadog | `com.amazonaws.vpce.us-east-1.vpce-svc-0a2aef8496ee043bf` |
+| Lambda ou custom forwarder | `com.amazonaws.vpce.us-east-1.vpce-svc-06394d10ccaf6fb97` |
 
 {{% /tab %}}
 {{% tab "API" %}}
@@ -121,9 +122,9 @@ Pour transmettre vos logs à Datadog à l'aide du nouvel endpoint de votre VPC, 
 - `DD_LOGS_CONFIG_USE_HTTP=true`
 - `DD_LOGS_CONFIG_LOGS_DD_URL="pvtlink.logs.datadoghq.com:443"`
 
-**Avec le Forwarder Lambda** :
+**Avec le forwarder Lambda ou un custom forwarder** :
 
-Ajoutez `DD_URL: pvtlink.logs.datadoghq.com` à la variable d'environnement de votre [fonction Lambda Datadog][4] pour utiliser le PrivateLink lors de la transmission des logs des services AWS à Datadog.
+Ajoutez `DD_URL: pvtlink-api.logs.datadoghq.com` à la variable d'environnement de votre [fonction Lambda Datadog][4] pour utiliser le PrivateLink lors de la transmission des logs des services AWS à Datadog.
 
 
 [1]: /fr/agent/guide/agent-configuration-files/#agent-main-configuration-file


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update the private link docs to add the new logs api private link endpoint

### Motivation
We're adding a new logs private link for custom + api forwarder

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
