### PR TITLE
add hash to url

### DIFF
--- a/src/scripts/region-redirects.js
+++ b/src/scripts/region-redirects.js
@@ -84,7 +84,7 @@ function showRegionSnippet(newSiteRegion) {
 
     if (externalLinks) {
         externalLinks.forEach(link => {
-            link.href = `https://app.${config.dd_site[newSiteRegion]}${link.pathname}`;
+            link.href = `https://app.${config.dd_site[newSiteRegion]}${link.pathname}${link.hash}`;
         });
     }
 }


### PR DESCRIPTION
### What does this PR do?
urls to app are missing the hash due to the region selector swapping the url based on a region. 

### Motivation
https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-318

### Preview link
http://docs-staging.datadoghq.com/zach/region-fix

