### PR TITLE
Fix example typo

### DIFF
--- a/content/en/dashboards/functions/smoothing.md
+++ b/content/en/dashboards/functions/smoothing.md
@@ -109,7 +109,7 @@ Note: The span value is the number of data points. So `median_7()` uses the last
 
 | Function     | Description                      | Example                      |
 | :----        | :-------                         | :---------                   |
-| `median_9()` | Rolling median with a span of 9. | `median_3(<METRIC_NAME>{*})` |
+| `median_9()` | Rolling median with a span of 9. | `median_9(<METRIC_NAME>{*})` |
 
 Note: The span value is the number of data points. So `median_9()` uses the last 9 data points to calculate the median.
 


### PR DESCRIPTION
### What does this PR do?
Fixes a typo in the documentation
