### PR TITLE
Removing reference to RBAc on index doc

### DIFF
--- a/content/en/logs/indexes/_index.md
+++ b/content/en/logs/indexes/_index.md
@@ -29,8 +29,8 @@ You can use indexed logs for [faceted searching][2], [patterns][3], [analytics][
 
 By default, each account has a single index representing a monolithic set of all your logs. Datadog also offers multiple indexes if you require:
 
-* Multiple [retention periods](#update-retention) and/or multiple [daily quotas](#set-daily-quota), for finer budget control.
-* Multiple permissions, for finer user [role based access controls (RBAC)][7].
+* Multiple [retention periods](#update-retention) 
+* Multiple [daily quotas](#set-daily-quota), for finer budget control.
 
 The Log Explorer supports [queries across multiple indexes][8].
 
@@ -128,7 +128,6 @@ Update or remove this quota at any time when editing the Index:
 [4]: /logs/explorer/analytics/
 [5]: /logs/explorer/analytics/#dashboard
 [6]: /monitors/monitor_types/log/
-[7]: /account_management/rbac/
 [8]: /logs/explorer/facets/#the-index-facet
 [9]: /logs/live_tail/
 [10]: /logs/archives/


### PR DESCRIPTION
### What does this PR do?
Removing reference to RBAC in the multi index use case.

### Motivation
We are now relying on query based RBAC instead of multiple indexes which is why we needed to remove that reference.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/rbac-indexes/logs/indexes#add-indexes

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
