### PR TITLE
Update certificate_verify_failed-error.md

### DIFF
--- a/content/en/agent/faq/certificate_verify_failed-error.md
+++ b/content/en/agent/faq/certificate_verify_failed-error.md
@@ -37,13 +37,23 @@ sudo rm /opt/datadog-agent/agent/datadog-cert.pem && sudo service datadog-agent 
 On Windows:
 
 Using PowerShell, take the following actions:
+
+```shell
+rm "C:\Program Files\Datadog\Datadog Agent\files\datadog-cert.pem"
+restart-service -Force datadogagent
+```
+
+Note that for Agent versions <= 5.10, when running on 64 bit windows, the steps will be:
+
 ```shell
 rm "C:\Program Files (x86)\Datadog\Datadog Agent\files\datadog-cert.pem"
-net stop /y datadogagent ; net start /y datadogagent
+restart-service -Force datadogagent
 ```
+
 Or through the Windows GUI:
 
-Delete `datadog-cert.pem`. You can locate this in: `C:\Program Files (x86)\Datadog\Datadog Agent\files\`. 
+Delete `datadog-cert.pem`. You can locate this in: `C:\Program Files\Datadog\Datadog Agent\files\`. 
+(For Agent versions <= 5.10, the location is `C:\Program Files(x86)\Datadog\Datadog Agent\Files\`.)
 Once removed, simply restart the Datadog Service from the Windows Service Manager.
 
 ### Fixing by upgrading the Agent                                                                   


### PR DESCRIPTION
Clarify location of files for different OSes.  Location for >=5.12 is
`C:\program files\datadog\datadog agent\files\` (note no x86)
Location for <= 5.10 on 32 bit windows is 
`C:\program files\datadog\datadog agent\files\` (note no x86)
Location for<= 5.10 on 64 bit windows is
`C:\program files (x86)\datadog\datadog agent\files\` (note this has the x86)

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
