### PR TITLE
Update certificate_verify_failed.md  ja

### DIFF
--- a/content/ja/agent/faq/certificate_verify_failed-error.md
+++ b/content/ja/agent/faq/certificate_verify_failed-error.md
@@ -11,23 +11,24 @@ CERTIFICATE_VERIFY_FAILEDのエラー
 エラーの詳細や原因
 
 On Saturday May 30th, 2020, at 10:48 UTC, an SSL root certificate used to cross-sign some of the Datadog certificates expired, and caused some of your agents to lose connectivity with Datadog endpoints. Because this root certificate is embedded in certain agents versions, you will need to take action to restore connectivity.
-２０２０年５月３０日１０時４５分（UTC時間）にDatadogの証明書をクロス署名されたルート証明書が有効期限切れて、一部のお客様のAgentがDatadogへの接続がなくなりました。有効期限切れるルート証明書が一部のAgentのバージョンには直接にインストールされたから、接続が有効にするために、直す方法が必要になります。
+２０２０年５月３０日１０時４５分（UTC時間）にDatadogの証明書にクロス署名されたルート証明書の有効期限切れにより、一部のお客様のAgentのDatadogエンドポイントへの接続がなくなりました。有効期限の切れのルート証明書が一部のAgentのバージョンにインストールされているため、接続を有効にするために、直す必要があります。
 
 ### What versions of the Agent are affected?
 
 影響されたバージョンは？
 Agent versions spanning 3.6.x to 5.32.6 embed the expired certificate and are affected.
 Agent versions 6.x and 7.x are fine and don’t need to be updated.
-3.6版から5.32.6版までのバージョンは有効期限切れるルート証明書が直接にインストールされたから、直す必要になります。
+3.6版から5.32.6版までのバージョンは有効期限切れのルート証明書がインストールされているため、直す必要があります。
 
-全ての６版と７版のAgentは影響されていません。影響されていないAgentが直す必要になりません。
+全ての６版と７版のAgentは影響がなく、直す必要はありません。
 
 ### How can I find a list of hosts running affected Agent versions?
 
 影響されたホストのリストを検索する方法。
 
 We have published a python script that queries your Datadog account for hosts running impacted agent versions. It finds hosts that run Datadog Agent with version less than 5.32.7, and writes their hostnames to a file ordered by version.
-お客様のDatadogアカウントにあるホストの中に影響されているAgentがインストールされているホストリストを取得するスクリプトを準備しました。Pythonのスクリプトが5.32.6版より古いAgent がインストールされているホストをファイルに書き込みます。
+お客様のDatadogアカウントにあるホストの中の影響されているAgentがインストールされているホストのリストを取得するPythonスクリプトを準備しました。スクリプトは5.32.6版より古いAgentがインストールされているホストをファイルに書き込みます。
+
 Download the python script.
 Run it in your local terminal or shell.
 US Datacenter: python3 find_agents_with_connectivity_problems.py --api-key API_KEY --application-key APPLICATION_KEY --site us
@@ -39,11 +40,12 @@ Pythonのスクリプトをダウンロードする
 USのサイト: python3 find_agents_with_connectivity_problems.py --api-key API_KEY --application-key APPLICATION_KEY --site us
 EUのサイト: python3 find_agents_with_connectivity_problems.py --api-key API_KEY --application-key APPLICATION_KEY --site eu
 CSVの出力がhosts_agents.csvというファイルにあります。
+
 Get the API and APP key here (or here for EU site).
 お客様のAPIとApp Keyはこちらのリンクにあります。（EUのサイトはこちら）
 
 ### Fixing without upgrading the Agent
-Agentをアップグレードなしでの直す方法
+Agentをアップグレードなしで直す方法
 
 We’re actively working on a new version of agent 5 but if you’d like to address this without an update, the following is the quickest path to resolution.
 Agent 5の新しいバージョンを準備していますが、アップグレードしたくない場合にはこちらの手順を参考にしてください。こちらの手順は直接にインストールされたAgentのルート証明書を削除します。
@@ -65,7 +67,7 @@ Delete datadog-cert.pem. You can locate this in: C:\Program Files (x86)\Datadog\
 C:\Program Files (x86)\Datadog\Datadog Agent\files\にあるdatadog-cert.pemというルート証明書を削除します。削除した後で、Windows Service ManagerでDatadog Agentのサービスを再起動します。
 
 ### Fixing by upgrading the Agent
-Agentをアップグレードする方法で直し方
+Agentをアップグレードして直す方法
 
 Upgrade to Agent 5.32.7.
 Agent 5.32.7版までアップグレード
@@ -78,13 +80,13 @@ NOTE: See Agent CHANGELOG for backward incompatible changes for Agent 6 and 7.
 
 ### Should I update my agent even if I deleted the certificate?
 
-証明書を削除すると、Agentをアップグレードが必要になりますか。
+証明書を削除すると、Agentのアップグレードが必要になりますか。
 We recommend keeping up to date and updating to the latest version of the agent. Deployments set to auto-update will do so with 5.32.7.
-証明書を削除しても、最新のAgentバージョに保たれていることを推薦します。自動的にアップデートする設定にしたツールがある場合、5.32.7版のAgentをリリースされたとき、普通に自動的にAgentがアップグレードされます。
+証明書を削除しても、最新のAgentバージョンに保たれていることを推薦します。自動的にアップデートする設定にしたツールがある場合、5.32.7版のAgentをリリースされたとき、普通に自動的にAgentがアップグレードされます。
  
 ### Am I still encrypting traffic with SSL even if I delete the certificate?
-証明書を削除しても、SSLの通信がエンクリプトされていますか。
+証明書を削除しても、SSLの通信が暗号化されていますか。
 
 Yes. The certificate is just a preset for the client to use and is not necessary to connect via SSL. Datadog agent endpoints only accept SSL traffic.
-証明書を削除しても、Agentからの通信がエンクリプトされています。デフォルトでクライントが使用する証明書ですので、SSLで接続する時には必要ではありません。Agentの取得したデータをDatadogのサーバまでの送信はSSLでの通信しか受信できません。
+証明書を削除しても、Agentからの通信は暗号化されています。デフォルトでクライントが使用する証明書ですので、SSLで接続する時には必要ではありません。DatadogエージェントのエンドポイントはSSLでの通信しか受信しません。
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
fix Japanese text on `certificate_verify_failed.md`

### Motivation
To read smoothly for Japanese.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/Shohei-Yamamoto:patch-1/ja/agent/faq/certificate_verify_failed-error/

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
