### PR TITLE
[faq] updating instructions for A5 cert issue

### DIFF
--- a/content/en/agent/faq/certificate_verify_failed-error.md
+++ b/content/en/agent/faq/certificate_verify_failed-error.md
@@ -44,7 +44,7 @@ sudo rm /opt/datadog-agent/agent/datadog-cert.pem && sudo service datadog-agent 
 
 *Windows CLI*
 
-Using PowerShell, take the following actions for agent `>= 5.12.0`:
+Using PowerShell, take the following actions for Agent `>= 5.12.0`:
 
 ```shell
 rm "C:\Program Files\Datadog\Datadog Agent\agent\datadog-cert.pem"
@@ -52,14 +52,14 @@ restart-service -Force datadogagent
 ```
 
 Note that for Agent versions `<= 5.11`, the location will be different.
-For users on the 32-bit agent `<= 5.11` on 64-bit windows the steps are:
+For users on the 32-bit Agent `<= 5.11` on 64-bit Windows the steps are:
 
 ```shell
 rm "C:\Program Files (x86)\Datadog\Datadog Agent\files\datadog-cert.pem"
 restart-service -Force datadogagent
 ```
 
-For all other users on agent `<= 5.11` agent the steps are:
+For all other users on Agent `<= 5.11` the steps are:
 
 ```shell
 rm "C:\Program Files\Datadog\Datadog Agent\files\datadog-cert.pem"

--- a/content/en/agent/faq/certificate_verify_failed-error.md
+++ b/content/en/agent/faq/certificate_verify_failed-error.md
@@ -44,25 +44,35 @@ sudo rm /opt/datadog-agent/agent/datadog-cert.pem && sudo service datadog-agent 
 
 *Windows CLI*
 
-Using PowerShell, take the following actions:
+Using PowerShell, take the following actions for agent `>= 5.12.0`:
 
 ```shell
-rm "C:\Program Files\Datadog\Datadog Agent\files\datadog-cert.pem"
+rm "C:\Program Files\Datadog\Datadog Agent\agent\datadog-cert.pem"
 restart-service -Force datadogagent
 ```
 
-Note that for Agent versions <= 5.10, when running on 64 bit windows, the steps are:
+Note that for Agent versions `<= 5.11`, the location will be different.
+For users on the 32-bit agent `<= 5.11` on 64-bit windows the steps are:
 
 ```shell
 rm "C:\Program Files (x86)\Datadog\Datadog Agent\files\datadog-cert.pem"
 restart-service -Force datadogagent
 ```
 
+For all other users on agent `<= 5.11` agent the steps are:
+
+```shell
+rm "C:\Program Files\Datadog\Datadog Agent\files\datadog-cert.pem"
+restart-service -Force datadogagent
+```
+
 *Windows GUI*
 
-Delete `datadog-cert.pem`. You can locate this in: `C:\Program Files\Datadog\Datadog Agent\files\`. 
-(For Agent versions <= 5.10, the location is `C:\Program Files(x86)\Datadog\Datadog Agent\Files\`.)
-Once removed, restart the Datadog Service from the Windows Service Manager.
+Delete `datadog-cert.pem`. You can locate this in: `C:\Program Files\Datadog\Datadog Agent\agent\`. 
+(For 32-bit Agent versions `<= 5.11` on 64-bit windows, the location will be 
+`C:\Program Files(x86)\Datadog\Datadog Agent\files\`.  For all other Agent versions `<= 5.11`
+the location is `C:\Program Files\Datadog\Datadog Agent\files\`).  Once removed, restart
+the Datadog Service from the Windows Service Manager.
 
 *Verifying with the script*
 

--- a/content/en/agent/faq/certificate_verify_failed-error.md
+++ b/content/en/agent/faq/certificate_verify_failed-error.md
@@ -70,7 +70,7 @@ restart-service -Force datadogagent
 
 Delete `datadog-cert.pem`. You can locate this in: `C:\Program Files\Datadog\Datadog Agent\agent\`. 
 (For 32-bit Agent versions `<= 5.11` on 64-bit windows, the location will be 
-`C:\Program Files(x86)\Datadog\Datadog Agent\files\`.  For all other Agent versions `<= 5.11`
+`C:\Program Files(x86)\Datadog\Datadog Agent\files\`. For all other Agent versions `<= 5.11`
 the location is `C:\Program Files\Datadog\Datadog Agent\files\`).  Once removed, restart
 the Datadog Service from the Windows Service Manager.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Updates the instructions currently have some imprecisions. 

### Motivation
<!-- What inspired you to submit this pull request?-->
Correct and clarify instructions. 

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jaime/fixtypo5327/agent/faq/certificate_verify_failed-error/

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Japanese instructions must be updated too with these changes.