### PR TITLE
update security info for default logs transport

### DIFF
--- a/content/en/security/logs.md
+++ b/content/en/security/logs.md
@@ -17,9 +17,9 @@ The Log Management product supports multiple [environments and formats][2], allo
 
 ## Information Security
 
-The Datadog Agent submits logs to Datadog via HTTPS when possible. Logs are sent over port `443` with compression. Datadog uses symmetric encryption at rest (AES-256) for indexed logs. Indexed logs are deleted from the Datadog platform once their retention period, as defined by the customer, expires.
+The Datadog Agent submits logs to datadog either through HTTPS or through TLS-encrypted TCP connection on port 10516, requiring outbound communication (see [Agent Transport for logs][8]).
 
-Prior to v6.19/v7.19 the agent defaults to submitting logs over a TLS-encrypted TCP connection, requiring outbound communication over port `10516`.  See the [Agent Transport for logs][8] documentation for more details.
+Datadog uses symmetric encryption at rest (AES-256) for indexed logs. Indexed logs are deleted from the Datadog platform once their retention period, as defined by the customer, expires.
 
 ## Logs Filtering
 

--- a/content/en/security/logs.md
+++ b/content/en/security/logs.md
@@ -17,9 +17,9 @@ The Log Management product supports multiple [environments and formats][2], allo
 
 ## Information Security
 
-The Datadog Agent submits logs to Datadog via HTTPS over port `443` with compression when possible. Datadog uses symmetric encryption at rest (AES-256) for indexed logs. Indexed logs are deleted from the Datadog platform once their retention period, as defined by the customer, expires.
+The Datadog Agent submits logs to Datadog via HTTPS when possible. Logs are sent over port `443` with compression. Datadog uses symmetric encryption at rest (AES-256) for indexed logs. Indexed logs are deleted from the Datadog platform once their retention period, as defined by the customer, expires.
 
-Prior to v6.19/v7.19 the agent submitted logs to Datadog over a TLS-encrypted TCP connection, requiring an outbound communication over port `10516`. See the [Agent Transport for logs][8] documentation for more details.
+Prior to v6.19/v7.19 the agent defaults to submitting logs over a TLS-encrypted TCP connection, requiring outbound communication over port `10516`.  See the [Agent Transport for logs][8] documentation for more details.
 
 ## Logs Filtering
 

--- a/content/en/security/logs.md
+++ b/content/en/security/logs.md
@@ -17,7 +17,9 @@ The Log Management product supports multiple [environments and formats][2], allo
 
 ## Information Security
 
-The Datadog Agent submits logs to Datadog over a TLS-encrypted TCP connection, requiring an outbound communication over port `10516`. The Datadog Agent can also be configured to send logs over secured HTTPS requests, requiring an outbound communication over port `443`. Datadog uses symmetric encryption at rest (AES-256) for indexed logs. Indexed logs are deleted from the Datadog platform once their retention period, as defined by the customer, expires.
+The Datadog Agent submits logs to Datadog via HTTPS over port `443` with compression when possible. Datadog uses symmetric encryption at rest (AES-256) for indexed logs. Indexed logs are deleted from the Datadog platform once their retention period, as defined by the customer, expires.
+
+Prior to v6.19/v7.19 the agent submitted logs to Datadog over a TLS-encrypted TCP connection, requiring an outbound communication over port `10516`. See the [Agent Transport for logs][8] documentation for more details.
 
 ## Logs Filtering
 
@@ -71,3 +73,4 @@ If you have any questions about how the Log Management Service satisfies the app
 [5]: /integrations/amazon_lambda/#log-collection
 [6]: /integrations/google_cloud_platform/?tab=datadogussite#log-collection
 [7]: /logs/explorer/#share-views
+[8]: /agent/logs/log_transport


### PR DESCRIPTION
https://docs.datadoghq.com/agent/logs/log_transport

https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#7190--6190

Should I include any notes about how the agent will fall back on TCP if the http check fails, or if the user has configure the agent to us a SOCKS5 proxy server? I figured that would be handled by just linking to that Agent transport doc which has more details about when TCP is used. But am not sure if I should explicitly call it out