### PR TITLE
Update CSP documentation about NPM setup

### DIFF
--- a/content/en/real_user_monitoring/faq/content_security_policy.md
+++ b/content/en/real_user_monitoring/faq/content_security_policy.md
@@ -43,11 +43,24 @@ connect-src https://*.logs.datadoghq.eu
 
 ## NPM Setup
 
-If you have the NPM setup for [Real User Monitoring][4] or [browser log collection][5], add only the `script-src` directive:
+If you have the NPM setup for [Real User Monitoring][4] or [browser log collection][5], add only the `connect-src` directive:
+
+{{< tabs >}}
+{{% tab "US" %}}
 
 ```txt
-script-src https://www.datadoghq-browser-agent.com
+connect-src https://*.logs.datadoghq.com
 ```
+
+{{% /tab %}}
+{{% tab "EU" %}}
+
+```txt
+connect-src https://*.logs.datadoghq.eu
+```
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
The FAQ page about Content-Security-Policy states that the **NPM Setup** only needs a `script-src`. That is false and only belongs to the **Bundle Setup**.

I have updated the NPM Setup documentation to reflect that it needs the `connect-src` directive.

### Motivation
<!-- What inspired you to submit this pull request?-->
I want to avoid people wasting their time on something that's wrong in the documentation.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
I have added an example of the error I got in our application, which uses the NPM Setup and is about the `connect-src` directive (not `script-src`):

![image](https://user-images.githubusercontent.com/793157/83495394-ebc8d780-a4b7-11ea-93d4-d6f1433b8a5b.png)
