### PR TITLE
Make the generated kubernetes manifests use the `datadog-agent` service account

### DIFF
--- a/static/resources/yaml/datadog-agent-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-all-features.yaml
@@ -505,7 +505,7 @@ spec:
         name: logdockercontainerpath
       tolerations:
       affinity: null
-      serviceAccountName: "default"
+      serviceAccountName: "datadog-agent"
       nodeSelector:
   updateStrategy:
     rollingUpdate:

--- a/static/resources/yaml/datadog-agent-all-features_values.yaml
+++ b/static/resources/yaml/datadog-agent-all-features_values.yaml
@@ -13,3 +13,4 @@ datadog:
 agents:
   rbac:
     create: false
+    serviceAccountName: datadog-agent

--- a/static/resources/yaml/datadog-agent-apm.yaml
+++ b/static/resources/yaml/datadog-agent-apm.yaml
@@ -189,7 +189,7 @@ spec:
         emptyDir: {}
       tolerations:
       affinity: null
-      serviceAccountName: "default"
+      serviceAccountName: "datadog-agent"
       nodeSelector:
   updateStrategy:
     rollingUpdate:

--- a/static/resources/yaml/datadog-agent-apm_values.yaml
+++ b/static/resources/yaml/datadog-agent-apm_values.yaml
@@ -7,3 +7,4 @@ datadog:
 agents:
   rbac:
     create: false
+    serviceAccountName: datadog-agent

--- a/static/resources/yaml/datadog-agent-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-logs-apm.yaml
@@ -50,14 +50,14 @@ spec:
               fieldPath: status.hostIP
         - name: KUBERNETES
           value: "yes"
+        - name: DD_AC_EXCLUDE
+          value: "name:datadog-agent"
         - name: DOCKER_HOST
           value: unix:///host/var/run/docker.sock
         - name: DD_LOG_LEVEL
           value: "INFO"
         - name: DD_DOGSTATSD_PORT
           value: "8125"
-        - name: DD_AC_EXCLUDE
-          value: "name:datadog-agent"
         - name: DD_LEADER_ELECTION
           value: "true"
         - name: DD_COLLECT_KUBERNETES_EVENTS
@@ -123,6 +123,8 @@ spec:
               fieldPath: status.hostIP
         - name: KUBERNETES
           value: "yes"
+        - name: DD_AC_EXCLUDE
+          value: "name:datadog-agent"
         - name: DOCKER_HOST
           value: unix:///host/var/run/docker.sock
         - name: DD_LOG_LEVEL
@@ -184,6 +186,8 @@ spec:
               fieldPath: status.hostIP
         - name: KUBERNETES
           value: "yes"
+        - name: DD_AC_EXCLUDE
+          value: "name:datadog-agent"
         - name: DOCKER_HOST
           value: unix:///host/var/run/docker.sock
         - name: DD_LEADER_ELECTION
@@ -214,7 +218,7 @@ spec:
         name: logdockercontainerpath
       tolerations:
       affinity: null
-      serviceAccountName: "default"
+      serviceAccountName: "datadog-agent"
       nodeSelector:
   updateStrategy:
     rollingUpdate:

--- a/static/resources/yaml/datadog-agent-logs-apm_values.yaml
+++ b/static/resources/yaml/datadog-agent-logs-apm_values.yaml
@@ -13,3 +13,4 @@ datadog:
 agents:
   rbac:
     create: false
+    serviceAccountName: datadog-agent

--- a/static/resources/yaml/datadog-agent-logs.yaml
+++ b/static/resources/yaml/datadog-agent-logs.yaml
@@ -50,14 +50,14 @@ spec:
               fieldPath: status.hostIP
         - name: KUBERNETES
           value: "yes"
+        - name: DD_AC_EXCLUDE
+          value: "name:datadog-agent"
         - name: DOCKER_HOST
           value: unix:///host/var/run/docker.sock
         - name: DD_LOG_LEVEL
           value: "INFO"
         - name: DD_DOGSTATSD_PORT
           value: "8125"
-        - name: DD_AC_EXCLUDE
-          value: "name:datadog-agent"
         - name: DD_LEADER_ELECTION
           value: "true"
         - name: DD_COLLECT_KUBERNETES_EVENTS
@@ -140,6 +140,8 @@ spec:
               fieldPath: status.hostIP
         - name: KUBERNETES
           value: "yes"
+        - name: DD_AC_EXCLUDE
+          value: "name:datadog-agent"
         - name: DOCKER_HOST
           value: unix:///host/var/run/docker.sock
         - name: DD_LEADER_ELECTION
@@ -170,7 +172,7 @@ spec:
         name: logdockercontainerpath
       tolerations:
       affinity: null
-      serviceAccountName: "default"
+      serviceAccountName: "datadog-agent"
       nodeSelector:
   updateStrategy:
     rollingUpdate:

--- a/static/resources/yaml/datadog-agent-logs_values.yaml
+++ b/static/resources/yaml/datadog-agent-logs_values.yaml
@@ -11,3 +11,4 @@ datadog:
 agents:
   rbac:
     create: false
+    serviceAccountName: datadog-agent

--- a/static/resources/yaml/datadog-agent-npm.yaml
+++ b/static/resources/yaml/datadog-agent-npm.yaml
@@ -442,7 +442,7 @@ spec:
         name: passwd
       tolerations:
       affinity: null
-      serviceAccountName: "default"
+      serviceAccountName: "datadog-agent"
       nodeSelector:
   updateStrategy:
     rollingUpdate:

--- a/static/resources/yaml/datadog-agent-npm_values.yaml
+++ b/static/resources/yaml/datadog-agent-npm_values.yaml
@@ -7,3 +7,4 @@ datadog:
 agents:
   rbac:
     create: false
+    serviceAccountName: datadog-agent

--- a/static/resources/yaml/datadog-agent-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-vanilla.yaml
@@ -145,7 +145,7 @@ spec:
         emptyDir: {}
       tolerations:
       affinity: null
-      serviceAccountName: "default"
+      serviceAccountName: "datadog-agent"
       nodeSelector:
   updateStrategy:
     rollingUpdate:

--- a/static/resources/yaml/datadog-agent-vanilla_values.yaml
+++ b/static/resources/yaml/datadog-agent-vanilla_values.yaml
@@ -5,3 +5,4 @@ datadog:
 agents:
   rbac:
     create: false
+    serviceAccountName: datadog-agent


### PR DESCRIPTION
### What does this PR do?

Change the ServiceAccount used in the generated kubernetes manifests to use `datadog-agent`.

### Motivation

The documentation instructs customers to to create the service account from https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/rbac/serviceaccount.yaml. The DaemonSet must use that service account instead of `default`.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/lenaic/datadog-agent_serviceaccount


### Additional Notes
<!-- Anything else we should know when reviewing?-->
