### PR TITLE
Adding specific case for 32bit agent

### DIFF
--- a/content/en/agent/faq/certificate_verify_failed-error.md
+++ b/content/en/agent/faq/certificate_verify_failed-error.md
@@ -27,12 +27,14 @@ Get the API and application key [from your account settings page][4]. If you are
 
 ### Fixing by upgrading to Agent 5.32.7
 
-If you are currently running Agent 5.x, Datadog recommends upgrading to Agent 5.32.7+. This ensures that the Agent continues to function in a variety of different scenarios, with the minimum amount of changes.
+If you are currently running Agent 5.x on a 64-bit host, Datadog recommends upgrading to Agent 5.32.7+. This ensures that the Agent continues to function in a variety of different scenarios, with the minimum amount of changes.
 
 Centos/Red Hat: `sudo yum check-update && sudo yum install datadog-agent`  
 Debian/Ubuntu: `sudo apt-get update && sudo apt-get install datadog-agent`  
 Windows (from versions > 5.12.0): Download the Datadog [Agent installer][7]. `start /wait msiexec /qn /i ddagent-cli-latest.msi`  
 More platforms and configuration management options detailed [here][8].
+
+The last compatible Agent released for 32-bit systems was 5.10.1. Please follow the `Fixing without upgrading the Agent` instructions for 32-bit hosts.
 
 ### Fixing without upgrading the Agent
 

--- a/content/en/agent/faq/certificate_verify_failed-error.md
+++ b/content/en/agent/faq/certificate_verify_failed-error.md
@@ -34,7 +34,7 @@ Debian/Ubuntu: `sudo apt-get update && sudo apt-get install datadog-agent`
 Windows (from versions > 5.12.0): Download the Datadog [Agent installer][7]. `start /wait msiexec /qn /i ddagent-cli-latest.msi`  
 More platforms and configuration management options detailed [here][8].
 
-The last compatible Agent released for 32-bit systems was 5.10.1. Please follow the `Fixing without upgrading the Agent` instructions for 32-bit hosts.
+The last compatible Agent released for 32-bit systems was 5.10.1. Follow the `Fixing without upgrading the Agent` instructions for 32-bit hosts.
 
 ### Fixing without upgrading the Agent
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Documenting edge case of 32bit agent for incident-4676

### Motivation

To avoid support case from 32bit customers.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/maxime/incident-4676-32bit/agent/faq/certificate_verify_failed-error/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
