### PR TITLE
Add modes to backends in haproxy.cfg

### DIFF
--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -222,18 +222,21 @@ frontend logs_http_frontend
 # Datadog's public endpoints.
 backend datadog-metrics
     balance roundrobin
+    mode http
     # The following configuration is for HAProxy 1.8 and newer
     server-template mothership 5 haproxy-app.agent.datadoghq.com:443 check port 443 ssl verify none check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
     # server mothership haproxy-app.agent.datadoghq.com:443 check port 443 ssl verify none
 
 backend datadog-api
+    mode http
     # The following configuration is for HAProxy 1.8 and newer
     server-template mothership 5 api.datadoghq.com:443 check port 443 ssl verify none check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
     # server mothership api.datadoghq.com:443 check port 443 ssl verify none
 
 backend datadog-flare
+    mode http
     # The following configuration is for HAProxy 1.8 and newer
     server-template mothership 5 flare.datadoghq.com:443 check port 443 ssl verify none check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
@@ -241,6 +244,7 @@ backend datadog-flare
 
 backend datadog-traces
     balance roundrobin
+    mode tcp
     # The following configuration is for HAProxy 1.8 and newer
     server-template mothership 5 trace.agent.datadoghq.com:443 check port 443 ssl verify none check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
@@ -248,6 +252,7 @@ backend datadog-traces
 
 backend datadog-processes
     balance roundrobin
+    mode tcp
     # The following configuration is for HAProxy 1.8 and newer
     server-template mothership 5 process.datadoghq.com:443 check port 443 ssl verify none check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
@@ -255,6 +260,7 @@ backend datadog-processes
 
 backend datadog-logs-http
     balance roundrobin
+    mode http
     # The following configuration is for HAProxy 1.8 and newer
     server-template mothership 5 agent-http-intake.logs.datadoghq.com:443  check port 443 ssl verify none check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Specifies modes in backends of example haproxy.cfg. @yafernandes discovered that he was getting "incompatible mode" errors without specifying these explicitly. 

### Motivation
Myself, Alex, and @hwlassow have had issues with the Haproxy config in our docs in the past and wanted to make sure the docs reflect a working config. 

I previously had to switch to Nginx due to issues. 

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
