### PR TITLE
remove fm=gif

### DIFF
--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -33,7 +33,7 @@
   {{- .Get "pop_param" | $.Scratch.Add "pop_param" -}}
 {{- else -}}
   {{- if eq $image_ext "gif" -}}
-     {{- $.Scratch.Add "pop_param" "?fit=max&fm=gif" -}}
+     {{- $.Scratch.Add "pop_param" "?fit=max" -}}
   {{- else -}}
      {{- $.Scratch.Add "pop_param" "?fit=max&auto=format" -}}
   {{- end -}}
@@ -64,7 +64,7 @@
     {{- if $wide -}}
       {{ $e := (print $img_resource "?auto=format" safeURL) }}
       {{- if eq $image_ext "gif" -}}
-        <img class="img-fluid" src="{{ (print $img_resource "?fm=gif" | safeURL) }}" {{ if .Get "style" }} style="{{ with .Get "style" }}{{ . | safeCSS }}{{end}}" {{ end }} {{ if .Get "alt" }} alt="{{ with .Get "alt"}}{{ . }}{{ end }}" {{ end }} />
+        <img class="img-fluid" src="{{ (print $img_resource | safeURL) }}" {{ if .Get "style" }} style="{{ with .Get "style" }}{{ . | safeCSS }}{{end}}" {{ end }} {{ if .Get "alt" }} alt="{{ with .Get "alt"}}{{ . }}{{ end }}" {{ end }} />
       {{- else -}}
         <picture {{ if .Get "style" }} style="{{- with .Get "style" -}}{{- . | safeCSS -}}{{- end -}}" {{ end }}>
           <img class="lazyload img-fluid" srcset="{{ $e }}" {{ if .Get "style" }} style="{{ with .Get "style" }}{{ . | safeCSS }}{{end}}" {{ end }} {{ if .Get "alt" }} alt="{{ with .Get "alt"}}{{ . }}{{ end }}" {{ end }} />
@@ -73,7 +73,7 @@
     {{- else -}}
         {{ $e := (print $img_resource "?auto=format" | safeURL) }}
         {{- if eq $image_ext "gif" -}}
-            <img class="img-fluid" src="{{ (print $img_resource "?fm=gif" | safeURL) }}" {{ if .Get "style" }} style="{{- with .Get "style" -}}{{ . | safeCSS }}{{- end -}}" {{ end }} {{ if .Get "alt" }} alt="{{- with .Get "alt" -}}{{.}}{{- end -}}" {{ end }} />
+            <img class="img-fluid" src="{{ (print $img_resource | safeURL) }}" {{ if .Get "style" }} style="{{- with .Get "style" -}}{{ . | safeCSS }}{{- end -}}" {{ end }} {{ if .Get "alt" }} alt="{{- with .Get "alt" -}}{{.}}{{- end -}}" {{ end }} />
         {{- else -}}
           <picture class="" {{ if .Get "style" }} style="{{- with .Get "style" -}}{{- . | safeCSS -}}{{- end -}}" {{ end }} >
           <img class="lazyload img-fluid" srcset="{{ $e }}" {{ if .Get "style" }} style="{{ with .Get "style" }}{{ . | safeCSS }}{{ end }}" {{ end }} {{ if .Get "alt" }} alt="{{- with .Get "alt" -}}{{.}}{{- end -}}" {{ end }} />

--- a/src/scripts/datadog-docs.js
+++ b/src/scripts/datadog-docs.js
@@ -1039,6 +1039,8 @@ function loadPage(newUrl) {
             // check if loaded page has inline JS. if so, we want to return as script will not execute
             const hasScript = newContent.getElementsByTagName('script').length;
 
+            console.log('hasScript: ', hasScript)
+
             // if there is error finding the element, reload page at requested url
             if (mainContent.parentElement && !hasScript) {
                 mainContent.parentElement.replaceChild(newContent, mainContent);
@@ -1235,7 +1237,7 @@ function rulesListClickHandler(event, pathString) {
 }
 
 window.addEventListener('click', (event) => {
-    rulesListClickHandler(event, 'default_rules');
+    // rulesListClickHandler(event, 'default_rules');
 });
 
 window.onload = function () {

--- a/src/scripts/datadog-docs.js
+++ b/src/scripts/datadog-docs.js
@@ -1039,8 +1039,6 @@ function loadPage(newUrl) {
             // check if loaded page has inline JS. if so, we want to return as script will not execute
             const hasScript = newContent.getElementsByTagName('script').length;
 
-            console.log('hasScript: ', hasScript)
-
             // if there is error finding the element, reload page at requested url
             if (mainContent.parentElement && !hasScript) {
                 mainContent.parentElement.replaceChild(newContent, mainContent);
@@ -1237,7 +1235,7 @@ function rulesListClickHandler(event, pathString) {
 }
 
 window.addEventListener('click', (event) => {
-    // rulesListClickHandler(event, 'default_rules');
+    rulesListClickHandler(event, 'default_rules');
 });
 
 window.onload = function () {


### PR DESCRIPTION

### What does this PR do?
removes `fm=gif` parameter for gifs. This is an unnecessary param from imgix that's causing long load times for gifs, specifically at https://docs.datadoghq.com/tracing/

### Motivation
slow loading times, sidenav js not firing due to long image time loads

### Preview link
http://docs-staging.datadoghq.com/zach/sidenav-fix/tracing


