### PR TITLE
Update C++/Envoy/Istio docs for environment variables

### DIFF
--- a/content/en/tracing/setup/cpp.md
+++ b/content/en/tracing/setup/cpp.md
@@ -173,9 +173,29 @@ g++ -std=c++11 -o tracer_example tracer_example.cpp -lopentracing
 
 **Note**: OpenTracing requires C++ 11 or higher.
 
+### Environment Variables
+
+| Variable | Version | Default | Note |
+|----------|---------|---------|------|
+| `DD_AGENT_HOST` | v0.3.6 | `localhost` | Sets the host where traces are sent (the host running the Agent). Can be a hostname or an IP address. Ignored if `DD_TRACE_AGENT_URL` is set. |
+| `DD_TRACE_AGENT_PORT` | v0.3.6 | `8126` | Sets the port where traces are sent (the port where the Agent is listening for connections). Ignored if `DD_TRACE_AGENT_URL` is set. |
+| `DD_TRACE_AGENT_URL` | v1.1.4 | | Sets the URL endpoint where traces are sent. Overrides `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` if set. This URL supports http, https and unix address schemes. |
+| `DD_ENV` | v1.0.0 | | If specified, adds the `env` tag with the specified value to all generated spans. |
+| `DD_SERVICE` | v1.1.4 | | If specified, sets the default service name. Otherwise the service name must be provided via TracerOptions or JSON configuration. |
+| `DD_TRACE_ANALYTICS_ENABLED` | v1.1.3 | `false` | Enable App Analytics globally for the application. |
+| `DD_TRACE_ANALYTICS_SAMPLE_RATE` | v1.1.3 | | Sets the App Analytics sampling rate. Overrides `DD_TRACE_ANALYTICS_ENABLED` if set. A floating point number between `0.0` and `1.0`. |
+| `DD_TRACE_REPORT_HOSTNAME` | v1.1.3 | `false` | Whether to report the system's hostname for each trace. When disabled, the hostname of the Agent is used instead. |
+| `DD_TRACE_SAMPLING_RULES` | v1.1.4 | `[{"sample_rate": 1.0}]` | A JSON array of objects. Each object must have a "sample_rate", and the "name" and "service" fields are optional. The "sample_rate" value must be between 0.0 and 1.0 (inclusive). Rules are applied in configured order to determine the trace's sample rate. |
+| `DD_VERSION` | v1.1.4 | | If specified, adds the `version` tag with the specified value to all generated spans. |
+| `DD_TAGS` | v1.1.4 | | If specified, will add tags to all generated spans. A comma-separated list of `key:value` pairs. |
+| `DD_PROPAGATION_STYLE_INJECT` | v0.4.1 | `Datadog` | Propagation style(s) to use when injecting tracing headers. `Datadog`, `B3`, or `Datadog B3`. |
+| `DD_PROPAGATION_STYLE_EXTRACT` | v0.4.1 | `Datadog` | Propagation style(s) to use when extracting tracing headers. `Datadog`, `B3`, or `Datadog B3`. |
+
 ### Change Agent Hostname
 
-Configure your application level tracers to submit traces to a custom Agent hostname:
+Configure your application level tracers to submit traces to a custom Agent hostname. The C++ Tracing Module automatically looks for and initializes with the ENV variables `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`.
+
+To connect to the agent using Unix Domain Sockets, `DD_TRACE_AGENT_URL` can be used instead. The value should match the Agent's value for `DD_APM_RECEIVER_SOCKET`.
 
 ## Further Reading
 

--- a/content/en/tracing/setup/envoy.md
+++ b/content/en/tracing/setup/envoy.md
@@ -184,8 +184,24 @@ stats_config:
       - prefix: "cluster.datadog_agent."
 ```
 
+## Environment Variables
+
+The available [environment variables][2] depend on the version of the C++ tracer embedded in Envoy.
+
+**Note**: The variables `DD_AGENT_HOST`, `DD_TRACE_AGENT_PORT` and `DD_TRACE_AGENT_URL` do not apply to Envoy, as the address of the Datadog Agent is configured using the `cluster` settings.
+
+| Envoy Version | C++ Tracer Version |
+|---------------|--------------------|
+| v1.14 | v1.1.3 |
+| v1.13 | v1.1.1 |
+| v1.12 | v1.1.1 |
+| v1.11 | v0.4.2 |
+| v1.10 | v0.4.2 |
+| v1.9 | v0.3.6 |
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/dd-opentracing-cpp/tree/master/examples/envoy-tracing
+[2]: /tracing/setup/cpp/#environment-variables

--- a/content/en/tracing/setup/istio.md
+++ b/content/en/tracing/setup/istio.md
@@ -28,6 +28,7 @@ Datadog APM is available for Istio v1.1.3+ on Kubernetes clusters.
 2. [Make sure APM is enabled for your Agent][2].
 3. Uncomment the `hostPort` setting so that Istio sidecars can connect to the Agent and submit traces.
 
+
 ### Istio Configuration and Installation
 
 To enable Datadog APM, a [custom Istio installation][3] is required to set two extra options when installing Istio.
@@ -55,12 +56,26 @@ set manually by adding an `app` label to the deployment's pod template.
 For [CronJobs][5], the `app` label should be added to the job template, as the generated name comes from the `Job` instead
 of the higher-level `CronJob`.
 
-The environment for traces can be set on a per-deployment basis using the `apm.datadoghq.com/env` annotation.
+### Environment Variables
+
+Environment variables for Istio sidecars can be set on a per-deployment basis using the `apm.datadoghq.com/env` annotation.
 ```yaml
     metadata:
       annotations:
-        apm.datadoghq.com/env: '{ "DD_ENV": "test" }'
+        apm.datadoghq.com/env: '{ "DD_ENV": "prod", "DD_TRACE_ANALYTICS_ENABLED": "true" }'
 ```
+
+The available [environment variables][6] depend on the version of the C++ tracer embedded in the Istio sidecar's proxy.
+
+| Istio Version | C++ Tracer Version |
+|---------------|--------------------|
+| v1.6.x | v1.1.3 |
+| v1.5.x | v1.1.1 |
+| v1.4.x | v1.1.1 |
+| v1.3.x | v1.1.1 |
+| v1.2.x | v0.4.2 |
+| v1.1.3 | v0.4.2 |
+
 
 ### Running Agent as Deployment and Service
 
@@ -94,7 +109,7 @@ spec:
 ```
 
 Automatic Protocol Selection may determine that traffic between the sidecar and Agent is HTTP, and enable tracing.
-This can be disabled using [manual protocol selection][6] for this specific service. The port name in the `datadog-agent` Service can be changed to `tcp-traceport`.
+This can be disabled using [manual protocol selection][7] for this specific service. The port name in the `datadog-agent` Service can be changed to `tcp-traceport`.
 If using Kubernetes 1.18+, `appProtocol: tcp` can be added to the port specification.
 
 ## Further Reading
@@ -106,4 +121,5 @@ If using Kubernetes 1.18+, `appProtocol: tcp` can be added to the port specifica
 [3]: https://istio.io/docs/setup/install/istioctl/
 [4]: https://istio.io/docs/ops/configuration/traffic-management/protocol-selection/
 [5]: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/
-[6]: https://istio.io/docs/ops/configuration/traffic-management/protocol-selection/#manual-protocol-selection
+[6]: /tracing/setup/cpp/#environment-variables
+[7]: https://istio.io/docs/ops/configuration/traffic-management/protocol-selection/#manual-protocol-selection


### PR DESCRIPTION
### What does this PR do?
Documents the environment variables supported by the C++ tracer and projects that use the tracer.

### Motivation
This was previously undocumented, and only discoverable by reading the source code or sending a query to Support.

### Preview link
https://docs-staging.datadoghq.com/cgilmour/cpp-env-vars/tracing/setup/cpp
https://docs-staging.datadoghq.com/cgilmour/cpp-env-vars/tracing/setup/envoy
https://docs-staging.datadoghq.com/cgilmour/cpp-env-vars/tracing/setup/istio

### Additional Notes