### PR TITLE
Update java.md

### DIFF
--- a/content/en/tracing/runtime_metrics/java.md
+++ b/content/en/tracing/runtime_metrics/java.md
@@ -36,7 +36,7 @@ If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL
 
 - For the runtime UI, `dd-trace-java` >= [`0.24.0`][6] is supported.
 - To associate JVM metrics within flame graphs, ensure the `env: tag` (case-sensitive) is set and matching across your environment.
-- For JVM metrics to appear on the service page when using Fargate, you will need to ensure that `DD_DOGSTATSD_TAGS` is set on your agent task, and matches the `env: tag` of that service.
+- For JVM metrics to appear on the service page when using Fargate, ensure that `DD_DOGSTATSD_TAGS` is set on your Agent task, and matches the `env: tag` of that service.
 
 ## Data Collected
 

--- a/content/en/tracing/runtime_metrics/java.md
+++ b/content/en/tracing/runtime_metrics/java.md
@@ -36,6 +36,7 @@ If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL
 
 - For the runtime UI, `dd-trace-java` >= [`0.24.0`][6] is supported.
 - To associate JVM metrics within flame graphs, ensure the `env: tag` (case-sensitive) is set and matching across your environment.
+- For JVM metrics to appear on the service page when using Fargate, you will need to ensure that `DD_DOGSTATSD_TAGS` is set on your agent task, and matches the `env: tag` of that service.
 
 ## Data Collected
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add a note for setting up JVM metrics on Fargate, and link them to the service page

### Motivation
Customer reached out with this issue, it turns out that there are additional steps needed to have JVM metric appear in Fargate, this was taken from this Trello card here : 
https://trello.com/c/PZb1fWCI/2056-java-runtime-metrics-not-showing?menu=filter&filter=java
and confirmed with the customer that it indeed works.
Ticket for reference : https://datadog.zendesk.com/agent/tickets/345372

### Preview link

https://docs-staging.datadoghq.com/gualt1995-Fargate-options/tracing/runtime_metrics/java

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
