### PR TITLE
[SSL certs] Document v5 Windows proxy cases

### DIFF
--- a/content/en/agent/faq/certificate_verify_failed-error.md
+++ b/content/en/agent/faq/certificate_verify_failed-error.md
@@ -32,7 +32,7 @@ If you are currently running Agent 5.x on a 64-bit host, Datadog recommends upgr
 Centos/Red Hat: `sudo yum check-update && sudo yum install datadog-agent`
 Debian/Ubuntu: `sudo apt-get update && sudo apt-get install datadog-agent`
 Windows (from versions > 5.12.0): Download the Datadog [Agent installer][3]. `start /wait msiexec /qn /i ddagent-cli-latest.msi`
-More platforms and configuration management options detailed [here][4].
+More platforms and configuration management options detailed [on the Agent install page][4].
 
 The last compatible Agent released for 32-bit systems was 5.10.1. Follow the `Fixing without upgrading the Agent` instructions for 32-bit hosts.
 

--- a/content/en/agent/faq/certificate_verify_failed-error.md
+++ b/content/en/agent/faq/certificate_verify_failed-error.md
@@ -76,10 +76,10 @@ If your Agent is configured to use a proxy, see the additional step in the [dedi
 
 Delete `datadog-cert.pem`. You can locate this file in:
 
-* Agent >=5.12.x:
+* Agent `>=5.12.0`:
   * 64-bit Windows: `C:\Program Files\Datadog\Datadog Agent\agent\`
   * 32-bit Windows: The Datadog Agent was not available for 32-bit Windows systems starting in Agent 5.12
-* Agent <= 5.11.x:
+* Agent `<= 5.11.x`:
   * 64-bit Windows: `C:\Program Files (x86)\Datadog\Datadog Agent\files\`
   * 32-bit Windows: `C:\Program Files\Datadog\Datadog Agent\files\`
 
@@ -120,14 +120,14 @@ Note: `datadog.conf` is located in `C:\ProgramData\Datadog\datadog.conf`.
 
 In this case, take this additional action:
 
-* Windows Agent v5, >= 5.12.x: replace the datadog-cert.pem file with the version that is shipped in 5.32.7. Using the Powershell CLI:
+* Windows Agent v5, `>= 5.12.0`: replace the `datadog-cert.pem` file with the version that is shipped in 5.32.7. Using the Powershell CLI:
 
 ```shell
 Invoke-WebRequest -Uri f"https://raw.githubusercontent.com/DataDog/dd-agent/5.32.7/datadog-cert.pem" -OutFile "C:\Program Files\Datadog\Datadog Agent\agent\datadog-cert.pem"
 restart-service -Force datadogagent
 ```
 
-* Windows Agent v5, <= 5.11.x: set the following option in `datadog.conf`:
+* Windows Agent v5, `<= 5.11.x`: set the following option in `datadog.conf`:
   * 64-bit Windows: `ca_certs: C:\Program Files (x86)\Datadog\Datadog Agent\files\ca-certificates.crt`
   * 32-bit Windows: `ca_certs: C:\Program Files\Datadog\Datadog Agent\files\ca-certificates.crt`
 

--- a/content/en/agent/faq/certificate_verify_failed-error.md
+++ b/content/en/agent/faq/certificate_verify_failed-error.md
@@ -116,7 +116,7 @@ This section applies to the Windows Agent 5.x (`<= 5.32.6`), if the Agent is con
 
 Note: `datadog.conf` is located in `C:\ProgramData\Datadog\datadog.conf`.
 
-In this case, removing `datadog-cert.pem` will not allow the Agent to regain connectivity to Datadog. Instead, take this action:
+In this case, removing `datadog-cert.pem` does not allow the Agent to regain connectivity to Datadog. Instead, take this action:
 
 * Windows Agent v5, `>= 5.12.0`: replace the `datadog-cert.pem` file with the version that is shipped in 5.32.7. Using the Powershell CLI:
 

--- a/content/en/agent/faq/certificate_verify_failed-error.md
+++ b/content/en/agent/faq/certificate_verify_failed-error.md
@@ -46,6 +46,8 @@ sudo rm /opt/datadog-agent/agent/datadog-cert.pem && sudo service datadog-agent 
 
 #### Windows
 
+If your Agent is configured to use a proxy, follow the [dedicated section below](#windows-agent-5-x-configured-to-use-a-proxy-or-the-curl-http-client) instead.
+
 *Using the CLI*
 
 Using PowerShell, take the following actions for Agent `>= 5.12.0`:
@@ -70,8 +72,6 @@ rm "C:\Program Files\Datadog\Datadog Agent\files\datadog-cert.pem"
 restart-service -Force datadogagent
 ```
 
-If your Agent is configured to use a proxy, see the additional step in the [dedicated section below](#additional-step-if-the-windows-agent-5-x-is-configured-to-use-a-proxy-or-the-curl-http-client).
-
 *Using the Windows GUI*
 
 Delete `datadog-cert.pem`. You can locate this file in:
@@ -84,8 +84,6 @@ Delete `datadog-cert.pem`. You can locate this file in:
   * 32-bit Windows: `C:\Program Files\Datadog\Datadog Agent\files\`
 
 Once the file is removed, restart the Datadog Service from the Windows Service Manager.
-
-If your Agent is configured to use a proxy, see the additional step in the [dedicated section below](#additional-step-if-the-windows-agent-5-x-is-configured-to-use-a-proxy-or-the-curl-http-client).
 
 #### Verifying with the script
 
@@ -109,16 +107,16 @@ Datadog recommends keeping up to date and updating to the latest version of the 
 
 Yes. The certificate is just a preset for the client to use and is not necessary to connect via SSL. Datadog Agent endpoints only accept SSL traffic.
 
-### Additional step if the Windows Agent 5.x is configured to use a proxy or the curl http client
+### Windows Agent 5.x configured to use a proxy or the curl http client
 
-On Windows, with Agent 5.x, removing the certificate file alone is not enough if the Agent is configured to either:
+This section applies to the Windows Agent 5.x (`<= 5.32.6`), if the Agent is configured to either:
 
 * use a proxy with the `proxy_host` configuration option in `datadog.conf` or the `HTTPS_PROXY` environment variable, or
 * use the curl http client with the `use_curl_http_client: yes` configuration option in `datadog.conf`
 
 Note: `datadog.conf` is located in `C:\ProgramData\Datadog\datadog.conf`.
 
-In this case, take this additional action:
+In this case, removing `datadog-cert.pem` will not allow the Agent to regain connectivity to Datadog. Instead, take this action:
 
 * Windows Agent v5, `>= 5.12.0`: replace the `datadog-cert.pem` file with the version that is shipped in 5.32.7. Using the Powershell CLI:
 
@@ -127,7 +125,7 @@ Invoke-WebRequest -Uri f"https://raw.githubusercontent.com/DataDog/dd-agent/5.32
 restart-service -Force datadogagent
 ```
 
-* Windows Agent v5, `<= 5.11.x`: set the following option in `datadog.conf`:
+* Windows Agent v5, `<= 5.11.x`: set the following option in `datadog.conf` using the `Datadog Agent Manager` program provided by the Agent or by directly editing the `datadog.conf` file:
   * 64-bit Windows: `ca_certs: C:\Program Files (x86)\Datadog\Datadog Agent\files\ca-certificates.crt`
   * 32-bit Windows: `ca_certs: C:\Program Files\Datadog\Datadog Agent\files\ca-certificates.crt`
 

--- a/content/en/agent/faq/certificate_verify_failed-error.md
+++ b/content/en/agent/faq/certificate_verify_failed-error.md
@@ -128,6 +128,7 @@ restart-service -Force datadogagent
 * Windows Agent v5, `<= 5.11.x`: set the following option in `datadog.conf` using the `Datadog Agent Manager` program provided by the Agent or by directly editing the `datadog.conf` file:
   * 64-bit Windows: `ca_certs: C:\Program Files (x86)\Datadog\Datadog Agent\files\ca-certificates.crt`
   * 32-bit Windows: `ca_certs: C:\Program Files\Datadog\Datadog Agent\files\ca-certificates.crt`
+
   After `datadog.conf` has been updated, restart the Datadog Service from the Windows Service Manager.
 
 

--- a/content/en/agent/faq/certificate_verify_failed-error.md
+++ b/content/en/agent/faq/certificate_verify_failed-error.md
@@ -70,7 +70,7 @@ rm "C:\Program Files\Datadog\Datadog Agent\files\datadog-cert.pem"
 restart-service -Force datadogagent
 ```
 
-If your Agent is configured to use a proxy, see the additional step in the [dedicated section below](#additional-step-if-the-windows-agent-5.x-is-configured-to-use-a-proxy-or-the-curl-http-client).
+If your Agent is configured to use a proxy, see the additional step in the [dedicated section below](#additional-step-if-the-windows-agent-5-x-is-configured-to-use-a-proxy-or-the-curl-http-client).
 
 *Using the Windows GUI*
 
@@ -85,7 +85,7 @@ Delete `datadog-cert.pem`. You can locate this file in:
 
 Once the file is removed, restart the Datadog Service from the Windows Service Manager.
 
-If your Agent is configured to use a proxy, see the additional step in the [dedicated section below](#additional-step-if-the-windows-agent-5.x-is-configured-to-use-a-proxy-or-the-curl-http-client).
+If your Agent is configured to use a proxy, see the additional step in the [dedicated section below](#additional-step-if-the-windows-agent-5-x-is-configured-to-use-a-proxy-or-the-curl-http-client).
 
 #### Verifying with the script
 

--- a/content/en/agent/faq/certificate_verify_failed-error.md
+++ b/content/en/agent/faq/certificate_verify_failed-error.md
@@ -19,32 +19,34 @@ Datadog has published a [Python script][1] that queries your Datadog account for
 
 1. Download the [Python script][1].
 2. Run it in your local terminal or shell. The script works with Python 2 and 3.
-Datadog US: `python find_agents_with_connectivity_problems.py --api-key API_KEY --application-key APPLICATION_KEY --site us`  
-Datadog EU: `python find_agents_with_connectivity_problems.py --api-key API_KEY --application-key APPLICATION_KEY --site eu`  
+Datadog US: `python find_agents_with_connectivity_problems.py --api-key API_KEY --application-key APPLICATION_KEY --site us`
+Datadog EU: `python find_agents_with_connectivity_problems.py --api-key API_KEY --application-key APPLICATION_KEY --site eu`
 3. Find the CSV output in `hosts_agents.csv`.
 
-Get the API and application key [from your account settings page][4]. If you are using the EU site, see your [EU account settings page][5].
+Get the API and application key [from your account settings page][2]. If you are using the EU site, see your [EU account settings page][3].
 
 ### Fixing by upgrading to Agent 5.32.7
 
 If you are currently running Agent 5.x on a 64-bit host, Datadog recommends upgrading to Agent 5.32.7+. This ensures that the Agent continues to function in a variety of different scenarios, with the minimum amount of changes.
 
-Centos/Red Hat: `sudo yum check-update && sudo yum install datadog-agent`  
-Debian/Ubuntu: `sudo apt-get update && sudo apt-get install datadog-agent`  
-Windows (from versions > 5.12.0): Download the Datadog [Agent installer][7]. `start /wait msiexec /qn /i ddagent-cli-latest.msi`  
-More platforms and configuration management options detailed [here][8].
+Centos/Red Hat: `sudo yum check-update && sudo yum install datadog-agent`
+Debian/Ubuntu: `sudo apt-get update && sudo apt-get install datadog-agent`
+Windows (from versions > 5.12.0): Download the Datadog [Agent installer][4]. `start /wait msiexec /qn /i ddagent-cli-latest.msi`
+More platforms and configuration management options detailed [here][5].
 
 The last compatible Agent released for 32-bit systems was 5.10.1. Follow the `Fixing without upgrading the Agent` instructions for 32-bit hosts.
 
 ### Fixing without upgrading the Agent
 
-*Linux*
+#### Linux
 
 ```shell
 sudo rm /opt/datadog-agent/agent/datadog-cert.pem && sudo service datadog-agent restart
 ```
 
-*Windows CLI*
+#### Windows
+
+*Using the CLI*
 
 Using PowerShell, take the following actions for Agent `>= 5.12.0`:
 
@@ -68,27 +70,36 @@ rm "C:\Program Files\Datadog\Datadog Agent\files\datadog-cert.pem"
 restart-service -Force datadogagent
 ```
 
-*Windows GUI*
+If your Agent is configured to use a proxy, see the additional step in the [dedicated section below](#additional-step-if-the-windows-agent-5.x-is-configured-to-use-a-proxy-or-the-curl-http-client).
 
-Delete `datadog-cert.pem`. You can locate this in: `C:\Program Files\Datadog\Datadog Agent\agent\`. 
-(For 32-bit Agent versions `<= 5.11` on 64-bit windows, the location will be 
-`C:\Program Files(x86)\Datadog\Datadog Agent\files\`. For all other Agent versions `<= 5.11`
-the location is `C:\Program Files\Datadog\Datadog Agent\files\`).  Once removed, restart
-the Datadog Service from the Windows Service Manager.
+*Using the Windows GUI*
 
-*Verifying with the script*
+Delete `datadog-cert.pem`. You can locate this file in:
+
+* Agent >=5.12.x:
+  * 64-bit Windows: `C:\Program Files\Datadog\Datadog Agent\agent\`
+  * 32-bit Windows: The Datadog Agent was not available for 32-bit Windows systems starting in Agent 5.12
+* Agent <= 5.11.x:
+  * 64-bit Windows: `C:\Program Files (x86)\Datadog\Datadog Agent\files\`
+  * 32-bit Windows: `C:\Program Files\Datadog\Datadog Agent\files\`
+
+Once the file is removed, restart the Datadog Service from the Windows Service Manager.
+
+If your Agent is configured to use a proxy, see the additional step in the [dedicated section below](#additional-step-if-the-windows-agent-5.x-is-configured-to-use-a-proxy-or-the-curl-http-client).
+
+#### Verifying with the script
 
 You can re-run the script described above with `--check-old-agents-working` to see if those Agents have started reporting again and which still need attention:
 
 ```shell
-python find_agents_with_connectivity_problems.py --api-key API_KEY --application-key APPLICATION_KEY --site US_OR_EU --check-old-agents-working  
+python find_agents_with_connectivity_problems.py --api-key API_KEY --application-key APPLICATION_KEY --site US_OR_EU --check-old-agents-working
 ```
 
 Note that this can take a long time if you have many potentially affected hosts.
 
 ### Fixing by upgrading to Agent 6 or 7
 
-You can upgrade to [Agent 7][2] or [Agent 6][3] to resolve this issue, but *see the Agent CHANGELOG for backward incompatible changes for Agent 6 and 7.*
+You can upgrade to [Agent 7][6] or [Agent 6][7] to resolve this issue, but *see the Agent CHANGELOG for backward incompatible changes for Agent 6 and 7.*
 
 ### Should I upgrade my Agent even if I deleted the certificate?
 
@@ -98,11 +109,33 @@ Datadog recommends keeping up to date and updating to the latest version of the 
 
 Yes. The certificate is just a preset for the client to use and is not necessary to connect via SSL. Datadog Agent endpoints only accept SSL traffic.
 
+### Additional step if the Windows Agent 5.x is configured to use a proxy or the curl http client
+
+On Windows, with Agent 5.x, removing the certificate file alone is not enough if the Agent is configured to either:
+
+* use a proxy with the `proxy_host` configuration option in `datadog.conf` or the `HTTPS_PROXY` environment variable, or
+* use the curl http client with the `use_curl_http_client: yes` configuration option in `datadog.conf`
+
+Note: `datadog.conf` is located in `C:\ProgramData\Datadog\datadog.conf`.
+
+In this case, take this additional action:
+
+* Windows Agent v5, >= 5.12.x: replace the datadog-cert.pem file with the version that is shipped in 5.32.7. Using the Powershell CLI:
+
+```shell
+Invoke-WebRequest -Uri f"https://raw.githubusercontent.com/DataDog/dd-agent/5.32.7/datadog-cert.pem" -OutFile "C:\Program Files\Datadog\Datadog Agent\agent\datadog-cert.pem"
+restart-service -Force datadogagent
+```
+
+* Windows Agent v5, <= 5.11.x: set the following option in `datadog.conf`:
+  * 64-bit Windows: `ca_certs: C:\Program Files (x86)\Datadog\Datadog Agent\files\ca-certificates.crt`
+  * 32-bit Windows: `ca_certs: C:\Program Files\Datadog\Datadog Agent\files\ca-certificates.crt`
+
+
 [1]: https://static.datadoghq.com/find_agents_with_connectivity_problems.py
-[2]: /agent/versions/upgrade_to_agent_v7/?tab=linux#from-agent-v5-to-agent-v7
-[3]: /agent/versions/upgrade_to_agent_v6/?tab=linux
-[4]: https://app.datadoghq.com/account/settings#api
-[5]: https://app.datadoghq.eu/account/settings#api
-[6]: https://github.com/DataDog/dd-agent/releases/tag/5.32.7
-[7]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-latest.msi
-[8]: https://app.datadoghq.com/account/settings?agent_version=5#agent
+[2]: https://app.datadoghq.com/account/settings#api
+[3]: https://app.datadoghq.eu/account/settings#api
+[4]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-latest.msi
+[5]: https://app.datadoghq.com/account/settings?agent_version=5#agent
+[6]: /agent/versions/upgrade_to_agent_v7/?tab=linux#from-agent-v5-to-agent-v7
+[7]: /agent/versions/upgrade_to_agent_v6/?tab=linux

--- a/content/en/agent/faq/certificate_verify_failed-error.md
+++ b/content/en/agent/faq/certificate_verify_failed-error.md
@@ -112,7 +112,7 @@ Yes. The certificate is just a preset for the client to use and is not necessary
 This section applies to the Windows Agent 5.x (`<= 5.32.6`), if the Agent is configured to either:
 
 * use a proxy with the `proxy_host` configuration option in `datadog.conf` or the `HTTPS_PROXY` environment variable, or
-* use the curl http client with the `use_curl_http_client: yes` configuration option in `datadog.conf`
+* use the curl HTTP client with the `use_curl_http_client: yes` configuration option in `datadog.conf`
 
 Note: `datadog.conf` is located in `C:\ProgramData\Datadog\datadog.conf`.
 

--- a/content/en/agent/faq/certificate_verify_failed-error.md
+++ b/content/en/agent/faq/certificate_verify_failed-error.md
@@ -128,6 +128,7 @@ restart-service -Force datadogagent
 * Windows Agent v5, `<= 5.11.x`: set the following option in `datadog.conf` using the `Datadog Agent Manager` program provided by the Agent or by directly editing the `datadog.conf` file:
   * 64-bit Windows: `ca_certs: C:\Program Files (x86)\Datadog\Datadog Agent\files\ca-certificates.crt`
   * 32-bit Windows: `ca_certs: C:\Program Files\Datadog\Datadog Agent\files\ca-certificates.crt`
+  After `datadog.conf` has been updated, restart the Datadog Service from the Windows Service Manager.
 
 
 [1]: https://static.datadoghq.com/find_agents_with_connectivity_problems.py

--- a/content/en/agent/faq/certificate_verify_failed-error.md
+++ b/content/en/agent/faq/certificate_verify_failed-error.md
@@ -23,7 +23,7 @@ Datadog US: `python find_agents_with_connectivity_problems.py --api-key API_KEY 
 Datadog EU: `python find_agents_with_connectivity_problems.py --api-key API_KEY --application-key APPLICATION_KEY --site eu`
 3. Find the CSV output in `hosts_agents.csv`.
 
-Get the API and application key [from your account settings page][2]. If you are using the EU site, see your [EU account settings page][3].
+Get the API and application key [from your account settings page][2].
 
 ### Fixing by upgrading to Agent 5.32.7
 
@@ -31,8 +31,8 @@ If you are currently running Agent 5.x on a 64-bit host, Datadog recommends upgr
 
 Centos/Red Hat: `sudo yum check-update && sudo yum install datadog-agent`
 Debian/Ubuntu: `sudo apt-get update && sudo apt-get install datadog-agent`
-Windows (from versions > 5.12.0): Download the Datadog [Agent installer][4]. `start /wait msiexec /qn /i ddagent-cli-latest.msi`
-More platforms and configuration management options detailed [here][5].
+Windows (from versions > 5.12.0): Download the Datadog [Agent installer][3]. `start /wait msiexec /qn /i ddagent-cli-latest.msi`
+More platforms and configuration management options detailed [here][4].
 
 The last compatible Agent released for 32-bit systems was 5.10.1. Follow the `Fixing without upgrading the Agent` instructions for 32-bit hosts.
 
@@ -97,7 +97,7 @@ Note that this can take a long time if you have many potentially affected hosts.
 
 ### Fixing by upgrading to Agent 6 or 7
 
-You can upgrade to [Agent 7][6] or [Agent 6][7] to resolve this issue, but *see the Agent CHANGELOG for backward incompatible changes for Agent 6 and 7.*
+You can upgrade to [Agent 7][5] or [Agent 6][6] to resolve this issue, but *see the Agent CHANGELOG for backward incompatible changes for Agent 6 and 7.*
 
 ### Should I upgrade my Agent even if I deleted the certificate?
 
@@ -133,8 +133,7 @@ restart-service -Force datadogagent
 
 [1]: https://static.datadoghq.com/find_agents_with_connectivity_problems.py
 [2]: https://app.datadoghq.com/account/settings#api
-[3]: https://app.datadoghq.eu/account/settings#api
-[4]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-latest.msi
-[5]: https://app.datadoghq.com/account/settings?agent_version=5#agent
-[6]: /agent/versions/upgrade_to_agent_v7/?tab=linux#from-agent-v5-to-agent-v7
-[7]: /agent/versions/upgrade_to_agent_v6/?tab=linux
+[3]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-latest.msi
+[4]: https://app.datadoghq.com/account/settings?agent_version=5#agent
+[5]: /agent/versions/upgrade_to_agent_v7/?tab=linux#from-agent-v5-to-agent-v7
+[6]: /agent/versions/upgrade_to_agent_v6/?tab=linux


### PR DESCRIPTION
### What does this PR do?

Adds documentation on v5 Windows proxy cases for the SSL certs.

### Motivation

Clarify these cases.

### Preview link

https://docs-staging.datadoghq.com/olivielpeau/incident-4676-windows-proxies/agent/faq/certificate_verify_failed-error/

### Additional Notes

Also structured a bit more the "workaround without fix" section
