### PR TITLE
add header params table

### DIFF
--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -135,6 +135,7 @@
 
                         {{ $.Scratch.Set "queryStrings" slice }}
                         {{ $.Scratch.Set "pathParams" slice }}
+                        {{ $.Scratch.Set "headerParams" slice }}
 
                         {{ with .action.parameters }}
 
@@ -145,11 +146,14 @@
                                     {{ $.Scratch.Add "queryStrings" .  }}
                                 {{ else if eq .in "path"}}
                                     {{ $.Scratch.Add "pathParams" .  }}
+                                {{ else if eq .in "header"}}
+                                    {{ $.Scratch.Add "headerParams" .  }}
                                 {{ end }}
                             {{ end }}
 
                             {{ $queryStrings := $.Scratch.Get "queryStrings" }}
                             {{ $pathParams := $.Scratch.Get "pathParams" }}
+                            {{ $headerParams := $.Scratch.Get "headerParams" }}
 
                             {{ with $pathParams }}
                                 <h4 class="text-capitalize">Path Parameters</h4>
@@ -222,6 +226,45 @@
                                     </div>
                                 </div>
                             {{ end }}
+
+
+                            {{ with $headerParams }}
+                                <h4 class="text-capitalize">Header Parameters</h4>
+                                <div class=" schema-table row">
+                                    <div class="col-12">
+                                      <div class="row table-header">
+                                        <div class="col-4 column">
+                                          <p class="font-semibold">Name</p>
+                                        </div>
+                                        <div class="col-2 column">
+                                          <p class="font-semibold">Type</p>
+                                        </div>
+                                        <div class="col-6 column">
+                                          <p class="font-semibold">Description</p>
+                                        </div>
+                                      </div>
+                                      {{ range . }}
+                                            <div class="row ">
+                                                <div class="col-12 first-column">
+                                                <div class="row first-row ">
+                                                    <div class="col-4 column">
+                                                        <p>{{- .name -}}{{- cond (eq .required false) "" "&nbsp;[<em>required</em>]" | safeHTML -}}</em></p>
+                                                    </div>
+                                                    <div class="col-2 column">
+                                                        <p>{{ .schema.type }}</p>
+                                                    </div>
+                                                    <div class="col-6 column">
+                                                        <p>{{ .description | markdownify }}</p>
+                                                    </div>
+                                                </div>
+                                                </div>
+                                            </div>
+                                      {{ end }}
+                                    </div>
+                                </div>
+                            {{ end }}
+
+
                         {{ end }}
 
                         {{ if .action.requestBody }}


### PR DESCRIPTION
### What does this PR do?
adds a table for parameters in the header, under Arguments. There are currently no endpoints yet that have this live, though this PR https://github.com/DataDog/datadog-api-spec/pull/425/files does.

### Preview link
http://docs-staging.datadoghq.com/zach/header-params/api

