### PR TITLE
Fix HTTP Forwarder Link

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -274,7 +274,7 @@ Enabling JMX Checks forces the Agent to use more memory depending on the number 
 
 **Log Collection**:
 
-The results below are obtained from a collection of *110KB of logs per seconds* from a file with the [HTTP forwarder][1] enabled. It shows the evolution of resource usage for the different compression levels available.
+The results below are obtained from a collection of *110KB of logs per seconds* from a file with the [HTTP forwarder][12] enabled. It shows the evolution of resource usage for the different compression levels available.
 
 {{< tabs >}}
 {{% tab "HTTP compression level 6" %}}
@@ -338,7 +338,7 @@ To send your Agent data to the [Datadog EU site][9], edit your [Agent main confi
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /agent/logs/log_transport/?tab=https#enforce-a-specific-transport
+[1]: /agent/troubleshooting/send_a_flare/
 [2]: /agent/guide/agent-commands/#restart-the-agent
 [3]: /agent/guide/agent-commands/#start-the-agent
 [4]: /agent/guide/agent-commands/#service-status
@@ -349,3 +349,4 @@ To send your Agent data to the [Datadog EU site][9], edit your [Agent main confi
 [9]: https://app.datadoghq.eu
 [10]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 [11]: /agent/guide/agent-log-files/
+[12]: /agent/logs/log_transport/?tab=https#enforce-a-specific-transport

--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -338,7 +338,7 @@ To send your Agent data to the [Datadog EU site][9], edit your [Agent main confi
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /agent/troubleshooting/send_a_flare/
+[1]: /agent/logs/log_transport/?tab=https#enforce-a-specific-transport
 [2]: /agent/guide/agent-commands/#restart-the-agent
 [3]: /agent/guide/agent-commands/#start-the-agent
 [4]: /agent/guide/agent-commands/#service-status


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
The HTTP Forwarder Link currently goes to the Agent Flare page, update to Agent Log Transport Page

Old Docs: https://docs.datadoghq.com/agent/basic_agent_usage/?tab=httpuncompressed#agent-overhead

### Motivation
<!-- What inspired you to submit this pull request?-->
Broken Link

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jack.davenport/fix_log_link/agent/basic_agent_usage/?tab=agentv6v7#agent-overhead

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
