### PR TITLE
Can use JS Booleans in synthetics tests

### DIFF
--- a/content/en/synthetics/browser_tests/actions.md
+++ b/content/en/synthetics/browser_tests/actions.md
@@ -198,6 +198,8 @@ Create a variable out of a `span`, `div`, etc. content by extracting the text of
 
 Generate custom variables using your own JavaScript scripts. JavaScript steps support both synchronous and asynchronous code. By default the step is being performed on the active page, which means it can access all the objects defined at the active page level (libraries, builtins, global variables, ...).
 
+If you are using JavaScript at the assertion level, write a code snippet that evaluates  truthiness or returns a boolean. If the evaluation is deemed truthy, the step will pass. if it evaluates to falsy, the step will fail. 
+
 If you need to load external libraries, you can wrap their loading in a promise like below:
 
 ```javascript


### PR DESCRIPTION
## What does this PR do?
Adds information on how to use Booleans and truthyness in custom JS for browser tests

### Motivation
Customer request 

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
