### PR TITLE
Fix generated kubernetes manifests

### DIFF
--- a/static/resources/yaml/datadog-agent-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-all-features.yaml
@@ -515,5 +515,3 @@ spec:
 # Source: datadog/templates/containers-common-env.yaml
 # The purpose of this template is to define a minimal set of environment
 # variables required to operate dedicated containers in the daemonset.
----
-{}

--- a/static/resources/yaml/datadog-agent-apm.yaml
+++ b/static/resources/yaml/datadog-agent-apm.yaml
@@ -199,5 +199,3 @@ spec:
 # Source: datadog/templates/containers-common-env.yaml
 # The purpose of this template is to define a minimal set of environment
 # variables required to operate dedicated containers in the daemonset.
----
-{}

--- a/static/resources/yaml/datadog-agent-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-logs-apm.yaml
@@ -228,5 +228,3 @@ spec:
 # Source: datadog/templates/containers-common-env.yaml
 # The purpose of this template is to define a minimal set of environment
 # variables required to operate dedicated containers in the daemonset.
----
-{}

--- a/static/resources/yaml/datadog-agent-logs.yaml
+++ b/static/resources/yaml/datadog-agent-logs.yaml
@@ -182,5 +182,3 @@ spec:
 # Source: datadog/templates/containers-common-env.yaml
 # The purpose of this template is to define a minimal set of environment
 # variables required to operate dedicated containers in the daemonset.
----
-{}

--- a/static/resources/yaml/datadog-agent-npm.yaml
+++ b/static/resources/yaml/datadog-agent-npm.yaml
@@ -452,5 +452,3 @@ spec:
 # Source: datadog/templates/containers-common-env.yaml
 # The purpose of this template is to define a minimal set of environment
 # variables required to operate dedicated containers in the daemonset.
----
-{}

--- a/static/resources/yaml/datadog-agent-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-vanilla.yaml
@@ -155,5 +155,3 @@ spec:
 # Source: datadog/templates/containers-common-env.yaml
 # The purpose of this template is to define a minimal set of environment
 # variables required to operate dedicated containers in the daemonset.
----
-{}

--- a/static/resources/yaml/generate.sh
+++ b/static/resources/yaml/generate.sh
@@ -28,6 +28,8 @@ for values in *_values.yaml; do
     type=${values%%_values.yaml}
     helm template --namespace default datadog-agent "${HELM_DATADOG_CHART:-stable/datadog}" --values "$values" \
         | yq write -d'*' --script "$TMPDIR/cleanup_instructions.yaml" - \
-        | sed 's/\(api-key: \)".*"/\1PUT_YOUR_BASE64_ENCODED_API_KEY_HERE/; s/\(token: \).*/\1PUT_A_BASE64_ENCODED_RANDOM_STRING_HERE/' \
+        | sed 's/\(api-key: \)".*"/\1PUT_YOUR_BASE64_ENCODED_API_KEY_HERE/;
+               s/\(token: \).*/\1PUT_A_BASE64_ENCODED_RANDOM_STRING_HERE/;
+               /---/{N;/---\n{}/d;}' \
               > "$type".yaml
 done


### PR DESCRIPTION
### What does this PR do?

Because of the Helm chart structure, the kubernetes manifests files that are generated from it are containing an empty document.
This change filters that empty document out.

### Motivation

`kubectl` expects to find a `Kind` property in every yaml document it has to instantiate. As a consequence, it raises the following error:
```
unable to decode "dd-vanilla.yaml": Object 'Kind' is missing in '{}'
```

### Preview link

https://docs-staging.datadoghq.com/lenaic/fix_generated_manifest_files

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
