### PR TITLE
update java dogstatsd version to 2.10.1

### DIFF
--- a/content/en/developers/dogstatsd/_index.md
+++ b/content/en/developers/dogstatsd/_index.md
@@ -247,7 +247,7 @@ The Java DataDog StatsD Client is distributed with maven central, and can be [do
 <dependency>
     <groupId>com.datadoghq</groupId>
     <artifactId>java-dogstatsd-client</artifactId>
-    <version>2.8</version>
+    <version>2.10.1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updating the java dogstatsd version

### Motivation
The current version 2.8 does not work with the code example in this doc. The new code example requires the latest library 2.10.1

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
You can check the latest version directly in Maven
updated from: https://search.maven.org/artifact/com.datadoghq/java-dogstatsd-client/2.10.1/jar
