### PR TITLE
Gaurab/profiling updates

### DIFF
--- a/content/en/tracing/profiling/_index.md
+++ b/content/en/tracing/profiling/_index.md
@@ -54,20 +54,26 @@ The Datadog Profiler requires [Java Flight Recorder][1]. The Datadog Profiling l
 
 - Because profiles are sent directly to Datadog without using the Datadog Agent, you must pass a valid [Datadog API key][4].
 
-- As an alternative to passing arguments, you can use environment variable to set those parameters:
+- For advanced setup of the profiler or to add tags like `service` or `version`, use environment variables to set the parameters:
 
-| Arguments                     | Environment variable      | Description                                       |
-| ----------------------------- | ------------------------- | ------------------------------------------------- |
-| `-Ddd.profiling.enabled`      | DD_PROFILING_ENABLED      | Set to `true` to enable profiling.                |
-| `-Ddd.profiling.api-key-file` | DD_PROFILING_API_KEY_FILE | File that should contain the API key as a string. |
-|                               | DD_PROFILING_API_KEY      | Datadog API key.                                  |
-| `-Ddd.site`                   | DD_SITE                   | Destination site for your profiles (versions 0.48+). Valid options are `datadoghq.com` for Datadog US site (default), and `datadoghq.eu` for the Datadog EU site. |
+| Environment variable                             | Type          | Description                                                                                      |
+| ------------------------------------------------ | ------------- | ------------------------------------------------------------------------------------------------ |
+| `DD_PROFILING_ENABLED`                           | Boolean       | Alternate for `-Ddd.profiling.enabled` argument. Set to `true` to enable profiling.               |
+| `DD_API_KEY`                                     | String        | Alternate for `-Ddd.profiling.api-key-file` argument. The [Datadog API key][4] to use when uploading profiles. |
+| `DD_PROFILING_API_KEY_FILE`                      | String        | Replacement for `-Ddd.profiling.api-key-file` argument. File that should contain the [Datadog API key][4].  |
+| `DD_SITE`                                        | String        | Destination site for your profiles (versions 0.48+). Valid options are `datadoghq.com` for Datadog US site (default), and `datadoghq.eu` for the Datadog EU site. |
+| `DD_SERVICE`                                     | String        | The Datadog [service][5] name.     |
+| `DD_ENV`                                         | String        | The Datadog [environment][6] name, for example `production`.|
+| `DD_VERSION`                                     | String        | The version of your application.                             |
+| `DD_TAGS`                                        | String        | Tags to apply to an uploaded profile. Must be a list of `<key>:<value>` separated by commas such as: `layer:api, team:intake`.  |
 
 
 [1]: https://docs.oracle.com/javacomponents/jmc-5-4/jfr-runtime-guide/about.htm
 [2]: https://app.datadoghq.com/profiling
 [3]: https://docs.oracle.com/javase/7/docs/technotes/tools/solaris/java.html
 [4]: /account_management/api-app-keys/#api-keys
+[5]: /tracing/visualization/#services
+[6]: /tracing/guide/setting_primary_tags_to_scope/#environment
 {{% /tab %}}
 
 {{% tab "Python" %}}
@@ -82,7 +88,11 @@ The Datadog Profiler requires Python 2.7+. Memory profiling only works on Python
 
      **Note**: Profiling is available in the `ddtrace` library for versions 0.36+.
 
-2. Add a valid [Datadog API key][1] in your environment variable: `DD_PROFILING_API_KEY`.
+2. Add a valid [Datadog API key][1] in your environment variable: `DD_API_KEY`.
+
+    ```shell
+    export DD_API_KEY=<YOUR_API_KEY>
+    ```
 
 3. Set `env`, `service`, and `version` as Datadog tags in your environment variables.
 
@@ -110,14 +120,13 @@ The Datadog Profiler requires Python 2.7+. Memory profiling only works on Python
 
 | Environment variable                             | Type          | Description                                                                                      |
 | ------------------------------------------------ | ------------- | ------------------------------------------------------------------------------------------------ |
-| `DD_API_KEY`                                     | String        | The [Datadog API key][1] to use when uploading profiles. New in version 0.37.                                        |
+| `DD_API_KEY`                                     | String        | The [Datadog API key][1] to use when uploading profiles.                                        |
 | `DD_PROFILING_API_KEY`                           | String        | The [Datadog API key][1] to use when uploading profiles. Changed in 0.37: deprecated in favor of `DD_API_KEY`. |
 | `DD_SITE`                                        | String        | If your organization is on Datadog EU site, set this to `datadoghq.eu`.                          |
 | `DD_SERVICE`                                     | String        | The Datadog [service][3] name.     |
 | `DD_ENV`                                         | String        | The Datadog [environment][4] name, for example `production`, which can be set here, or in `DD_PROFILING_TAGS` with `DD_PROFILING_TAGS="env:production"`. |
-| `DD_VERSION`                                     | String        | The version of your application, which can be set here, or in `DD_PROFILING_TAGS` with `DD_PROFILING_TAGS="version:<APPLICATION_VERSION>"`                              |
-| `DD_TAGS`                                        | String        | Tags to apply to an uploaded profile. Must be a list a `key:value` comma separated list like: `<KEY1>:<VALUE1>,<KEY2>:<VALUE2>`. New in version 0.38.   |
-| `DD_PROFILING_TAGS`                              | String        | Tags to apply to an uploaded profile. Must be a list a `key:value` comma separated list like: `<KEY1>:<VALUE1>,<KEY2>:<VALUE2>`. Changed in 0.38: deprecated in favor of `DD_TAGS`.|
+| `DD_VERSION`                                     | String        | The version of your application.                             |
+| `DD_TAGS`                                        | String        | Tags to apply to an uploaded profile. Must be a list of `<key>:<value>` separated by commas such as: `layer:api, team:intake`.   |
 
 <div class="alert alert-info">
 Recommended for advanced usage only.
@@ -181,10 +190,24 @@ Profiler configuration:
 | Method | Type          | Description                                                                                                  |
 | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------ |
 |  WithAPIKey      | String        | The Datadog [Datadog API key][2]                                                                             |
-|  WithService     | String        | The Datadog [service][4] name, for example `my-web-app`, which can be set here, or in `DD_TAGS`.             |
-|  WithEnv         | String        | The Datadog [environment][5] name, for example `production`, which can be set here, or in `DD_TAGS`.         |
-|  WithTags        | String        | The tags to apply to an uploaded profile. Must be a list of in the format `<KEY1>:<VALUE1>,<KEY2>:<VALUE2>`. |
+|  WithService     | String        | The Datadog [service][4] name, for example `my-web-app`, which can be set here, or in `DD_SERVICE`.             |
+|  WithEnv         | String        | The Datadog [environment][5] name, for example `production`, which can be set here, or in `DD_ENV`.         |
+|  WithTags        | String        | The tags to apply to an uploaded profile. Must be a list of in the format `<KEY1>:<VALUE1>,<KEY2>:<VALUE2>`. You can also set this in `DD_TAGS`. |
+|  WithSite        | String        | If your organization is on Datadog EU site, set this to `datadoghq.eu`. You can also set this in `DD_SITE`. |
 
+
+- For advanced setup of the profiler or to add tags like `service` or `version`, use environment variables to set the parameters:
+
+| Environment variable                             | Type          | Description                                                                                      |
+| ------------------------------------------------ | ------------- | ------------------------------------------------------------------------------------------------ |
+| `DD_PROFILING_ENABLED`                           | Boolean       | Alternate for `-Ddd.profiling.enabled` argument. Set to `true` to enable profiling.               |
+| `DD_API_KEY`                                     | String        | Alternate for `-Ddd.profiling.api-key-file` argument. The [Datadog API key][2] to use when uploading profiles. |
+| `DD_PROFILING_API_KEY_FILE`                      | String        | Replacement for `-Ddd.profiling.api-key-file` argument. File that should contain the [Datadog API key][2].  |
+| `DD_SITE`                                        | String        | If your organization is on Datadog EU site, set this to `datadoghq.eu`.                          |
+| `DD_SERVICE`                                     | String        | The Datadog [service][4] name.     |
+| `DD_ENV`                                         | String        | The Datadog [environment][5] name, for example `production`.|
+| `DD_VERSION`                                     | String        | The version of your application.                              |
+| `DD_TAGS`                                        | String        | Tags to apply to an uploaded profile. Must be a list of `<key>:<value>` separated by commas such as: `layer:api, team:intake`.  |
 
 [1]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/profiler#pkg-constants
 [2]: /account_management/api-app-keys/#api-keys


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Following updates to the profiling docs for further consistency across languages and cleaned up extra details :
- Full env variable table on Java & Go tab
- Add shell example to python API key and update the env variable to `DD_API_KEY`. 
- Removed `DD_PROFILING_API_KEY`
- Removed `DD_PROFILING_TAGS` from all the languages to the default `DD_TAGS`

### Motivation
<!-- What inspired you to submit this pull request?-->
Regular cleanup and updates on the page. 

### Preview link
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/gaurab/profiling-updates/tracing/profiling/?tab=java
https://docs-staging.datadoghq.com/gaurab/profiling-updates/tracing/profiling/?tab=go
https://docs-staging.datadoghq.com/gaurab/profiling-updates/tracing/profiling/?tab=python

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
