### PR TITLE
Update doc to refer to agent-versions page

### DIFF
--- a/content/ja/agent/faq/certificate_verify_failed-error.md
+++ b/content/ja/agent/faq/certificate_verify_failed-error.md
@@ -16,15 +16,9 @@ Agent 6.x および 7.x は影響を受けず、アップデートの必要が�
 
 ### 影響を受けるホストの検索方法
 
-お客様の Datadog アカウントで影響を受けている Agent バージョンをインストールしているホストをクエリする [Python スクリプト][1]を用意しました。このスクリプトは、Datadog Agent 5.32.7 より以前のバージョンをインストールしているホストを検索し、ホスト名をバージョンの順にファイルに出力します。
+お客様の Datadog アカウントで影響を受けている Agent バージョンをインストールしているホストを検索するために、Webアプリで[Agent Versionsのページ][1]を用意しました。ホスト名やAgentバージョンやAgentの状態を表示されているページです。
 
-1. [Python スクリプト][1]をダウンロードする
-2. ローカルターミナルもしくはシェルで下記のコマンドを実行する
-US サイト: `python3 find_agents_with_connectivity_problems.py --api-key API_KEY --application-key APPLICATION_KEY --site us`
-EU サイト: `python3 find_agents_with_connectivity_problems.py --api-key API_KEY --application-key APPLICATION_KEY --site eu`
-3. CSV は hosts_agents.csv というファイルに出力される
-
-API と App Key を[こちら][4]から取得します（EU サイトは[こちら][5]）。
+注意：以前、影響を受けるホストをクエリするPythonのスクリプトを用意しましたが、アプリ内のページの正確度の方が高いですので、[Agent Versionsのページ][1]を参考にしてください。
 
 ### Agent 5.32.7 にアップグレードして対応する方法
 
@@ -71,16 +65,6 @@ restart-service -Force datadogagent
 `C:\Program Files (x86)\Datadog\Datadog Agent\files\` にある `datadog-cert.pem` を削除します。
 （64-bit の Windows において、32-bit の Agent `<= 5.11` を使用している場合、場所は `C:\Program Files(x86)\Datadog\Datadog Agent\files\` です。Agent `<= 5.11` を使用している場合、場所は`C:\Program Files\Datadog\Datadog Agent\files\`です）。証明書を削除した後に、Windows Service Manager で Datadog Agent のサービスを再起動します。
 
-*スクリプトで確認*
-
-上記のスクリプトを `--check-old-agents-working` を指定し再実行することにより、問題が解消した Agent、解消していない Agent を確認することができます。
-
-```shell
-python find_agents_with_connectivity_problems.py --api-key API_KEY --application-key APPLICATION_KEY --site US_OR_EU --check-old-agents-working  
-```
-
-こちらの実行は影響を受けている Agent 数が多い場合、より長い時間を要する場合があります。
-
 ### Agent 6 / Agent 7 にアップグレードして対応する方法
 
 [Agent 6][3] もしくは[Agent 7][2] にアップグレードして本問題を回避します。Agent 6 / Agent 7 における下位互換性のない変更点については、Agent CHANGELOG をご確認ください。
@@ -93,7 +77,7 @@ python find_agents_with_connectivity_problems.py --api-key API_KEY --application
 
 証明書を削除した後でも、Agent からの通信が暗号化されます。この証明書は、クライアントのデフォルト証明書で、SSL 接続するには必須ではありません。Datadog Agent のエンドポイントは SSL での通信のみを受信しています。
 
-[1]: https://static.datadoghq.com/find_agents_with_connectivity_problems.py
+[1]: https://app.datadoghq.com/agent-versions
 [2]: /agent/versions/upgrade_to_agent_v7/?tab=linux#from-agent-v5-to-agent-v7
 [3]: /agent/versions/upgrade_to_agent_v6/?tab=linux
 [4]: https://app.datadoghq.com/account/settings#api


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates [Japanese docs](https://docs.datadoghq.com/ja/agent/faq/certificate_verify_failed-error/#verifying-with-the-script) to recommend using the in-app agent versions page

### Motivation
to match [English docs](https://github.com/DataDog/documentation/pull/7661/files)

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
