### PR TITLE
slightly better linux command to remove file and restart agent

### DIFF
--- a/content/en/agent/faq/certificate_verify_failed-error.md
+++ b/content/en/agent/faq/certificate_verify_failed-error.md
@@ -35,7 +35,7 @@ The last compatible Agent released for 32-bit systems was 5.10.1. Follow the `Fi
 #### Linux
 
 ```shell
-sudo rm /opt/datadog-agent/agent/datadog-cert.pem && sudo service datadog-agent restart
+sudo rm -f /opt/datadog-agent/agent/datadog-cert.pem && sudo /etc/init.d/datadog-agent restart
 ```
 
 #### Windows

--- a/content/ja/agent/faq/certificate_verify_failed-error.md
+++ b/content/ja/agent/faq/certificate_verify_failed-error.md
@@ -24,16 +24,17 @@ Agent 6.x および 7.x は影響を受けず、アップデートの必要が�
 
 現状 Agent 5.x を使用している場合、Agent 5.32.7+ へのアップグレードを推奨します。新しいバージョンの Agent を使用することにより、様々な場面におけるより安定した稼働を期待できます。
 
-Centos/Red Hat: `sudo yum check-update && sudo yum install datadog-agent`  
-Debian/Ubuntu: `sudo apt-get update && sudo apt-get install datadog-agent`  
-Windows (5.12.0より新しいバージョン): Datadog [Agent installer][7]をダウンロードする. `start /wait msiexec /qn /i ddagent-cli-latest.msi`  
+Centos/Red Hat: `sudo yum check-update && sudo yum install datadog-agent`
+Debian/Ubuntu: `sudo apt-get update && sudo apt-get install datadog-agent`
+Windows (5.12.0より新しいバージョン): Datadog [Agent installer][7]をダウンロードする. `start /wait msiexec /qn /i ddagent-cli-latest.msi`
 その他のプラットフォームや構成については、[こちら][8]に詳細があります。
 
 ### Agent をアップグレードせずに対応する方法
 
 *Linux*
+
 ```shell
-sudo rm /opt/datadog-agent/agent/datadog-cert.pem && sudo service datadog-agent restart
+sudo rm -f /opt/datadog-agent/agent/datadog-cert.pem && sudo /etc/init.d/datadog-agent restart
 ```
 
 *Windows CLI*
@@ -72,7 +73,7 @@ restart-service -Force datadogagent
 ### 証明書を削除した後でも、Agentをアップグレードする必要はありますか。
 
 最新のAgentバージョンにアップグレードすることを推奨します。自動更新が設定されているデプロイメントについては、自動的に Agent 5.32.7 にアップグレードします。
- 
+
 ### 証明書を削除し後でも、SSL通信は暗号化されますか。
 
 証明書を削除した後でも、Agent からの通信が暗号化されます。この証明書は、クライアントのデフォルト証明書で、SSL 接続するには必須ではありません。Datadog Agent のエンドポイントは SSL での通信のみを受信しています。


### PR DESCRIPTION
### What does this PR do?

2 small changes to the workaround command on Linux:

1. use `-f` on `rm` for idempotence (i.e. so that it exits successfully when the file doesn't exist). Note that the command still fails if the file exists and can't be removed, which is good.
2. change the restart command so that it's compatible with all distros the Agent 5 supports: 

    * on CentOS/RHEL 7 and up, which use systemd, the `service` command only redirects to systemd units, but the agent 5 service is only defined as a sysvinit service on CentOS/RHEL, so using `service` doesn't work.
    * on ubuntu/debian, we do ship a systemd unit, but `/etc/init.d/datadog-agent restart` still works on all distro versions (it is either correctly redirected to the systemd unit by the distro on systemd-based distro versions, or can be run directly on sysvinit/upstart-based distro versions).

### Motivation

Reduce confusion

### Preview link

https://docs-staging.datadoghq.com/olivielpeau/better-agent5-restart-cmd/agent/faq/certificate_verify_failed-error/
