### PR TITLE
Ignore error on copy for macos /bin/cp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,12 +181,12 @@ examples/go: examples/datadog-api-client-go clean-go-examples local/bin/awk/extr
 	#	gofmt -w $$f || rm $f; \
 	#done;
 
-	cp -Rn examples/content ./
+	-cp -Rn examples/content ./
 
 examples/java: examples/datadog-api-client-java clean-java-examples local/bin/awk/extract-code-blocks-java.awk
 	@ls examples/datadog-api-client-java/api_docs/v1/*Api.md | xargs -n1 local/bin/awk/extract-code-blocks-java.awk -v output=examples/content/en/api/v1
 	@ls examples/datadog-api-client-java/api_docs/v2/*Api.md | xargs -n1 local/bin/awk/extract-code-blocks-java.awk -v output=examples/content/en/api/v2
 
-	cp -Rn examples/content ./
+	-cp -Rn examples/content ./
 
 examples: examples/go examples/java


### PR DESCRIPTION
The macos `/bin/cp` is exiting with non zero code.

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
