### PR TITLE
Vagrant changed link on their website

### DIFF
--- a/content/en/getting_started/logs/_index.md
+++ b/content/en/getting_started/logs/_index.md
@@ -213,7 +213,7 @@ This produces the following result in the [Log Explorer Page][2]:
 [1]: https://www.datadoghq.com
 [2]: https://app.datadoghq.com/logs
 [3]: https://app.vagrantup.com/ubuntu/boxes/xenial64
-[4]: https://www.vagrantup.com/downloads.html
+[4]: https://www.vagrantup.com/intro/getting-started
 [5]: https://app.datadoghq.com/account/settings#api
 [6]: https://app.datadoghq.com/account/settings#agent/ubuntu
 [7]: /agent/guide/agent-commands/#agent-information

--- a/content/en/getting_started/logs/_index.md
+++ b/content/en/getting_started/logs/_index.md
@@ -213,7 +213,7 @@ This produces the following result in the [Log Explorer Page][2]:
 [1]: https://www.datadoghq.com
 [2]: https://app.datadoghq.com/logs
 [3]: https://app.vagrantup.com/ubuntu/boxes/xenial64
-[4]: https://www.vagrantup.com/intro/getting-started/index.html
+[4]: https://www.vagrantup.com/downloads.html
 [5]: https://app.datadoghq.com/account/settings#api
 [6]: https://app.datadoghq.com/account/settings#agent/ubuntu
 [7]: /agent/guide/agent-commands/#agent-information


### PR DESCRIPTION
I have replaced https://www.vagrantup.com/intro/getting-started/index.html with https://www.vagrantup.com/intro/getting-started, as https://www.vagrantup.com/intro/getting-started/index.html is now leading to a non-existing page.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Replaces https://www.vagrantup.com/intro/getting-started/index.html with https://www.vagrantup.com/intro/getting-started, as https://www.vagrantup.com/intro/getting-started/index.html is now leading to a non-existing page.

### Motivation
Correcting links

### Preview link
https://docs.datadoghq.com/getting_started/logs/#overview

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/Iditmatas-vagrant-link/docs.datadoghq.com/getting_started/logs/#overview

Check preview base path using the URL in details in `preview` status check. --> sorry, I couldn't get a to work.

