### PR TITLE
[WEB-367] - api menu generation update

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1042,7 +1042,7 @@ main:
     identifier: log_collection_ruby
     weight: 110
   - name: Other Integrations
-    url: integrations/#cat-log-collection
+    url: 'integrations/#cat-log-collection'
     identifier: other_integrations
     parent: log_collection
     weight: 111
@@ -1126,7 +1126,7 @@ main:
     identifier: logs_traces_connection
     weight: 8
   - name: Correlate Logs with Metrics
-    url: dashboards/timeboards/#graph-menu
+    url: 'dashboards/timeboards/#graph-menu'
     parent: log_management
     identifier: logs_metrics_correlation
     weight: 9
@@ -1371,7 +1371,7 @@ main:
     identifier: dev_tools_metrics_powershell
     weight: 204
   - name: 'Submission - API '
-    url: api/v1/metrics/#submit-metrics
+    url: 'api/v1/metrics/#submit-metrics'
     parent: dev_tools_metrics
     identifier: dev_tools_metrics_api
     weight: 205
@@ -1406,7 +1406,7 @@ main:
     identifier: dev_tools_events_mail
     weight: 303
   - name: API
-    url: api/v1/events/#post-an-event
+    url: 'api/v1/events/#post-an-event'
     parent: dev_tools_events
     identifier: dev_tools_events_api
     weight: 304
@@ -1609,618 +1609,823 @@ api_v1:
   - name: AWS Integration
     url: /api/v1/aws-integration/
     identifier: AWS Integration
+    generated: true
   - name: Delete an AWS integration
     parent: AWS Integration
     url: delete-an-aws-integration
+    generated: true
   - name: List all AWS integrations
     parent: AWS Integration
     url: list-all-aws-integrations
+    generated: true
   - name: Create an AWS integration
     parent: AWS Integration
     url: create-an-aws-integration
+    generated: true
   - name: Update an AWS integration
     parent: AWS Integration
     url: update-an-aws-integration
+    generated: true
   - name: List namespace rules
     parent: AWS Integration
     url: list-namespace-rules
+    generated: true
   - name: Generate a new external ID
     parent: AWS Integration
     url: generate-a-new-external-id
+    generated: true
   - name: AWS Logs Integration
     url: /api/v1/aws-logs-integration/
     identifier: AWS Logs Integration
+    generated: true
   - name: Delete an AWS Logs integration
     parent: AWS Logs Integration
     url: delete-an-aws-logs-integration
+    generated: true
   - name: List all AWS Logs integrations
     parent: AWS Logs Integration
     url: list-all-aws-logs-integrations
+    generated: true
   - name: Add AWS Log Lambda ARN
     parent: AWS Logs Integration
     url: add-aws-log-lambda-arn
+    generated: true
   - name: Check that an AWS Lambda Function exists
     parent: AWS Logs Integration
     url: check-that-an-aws-lambda-function-exists
+    generated: true
   - name: Get list of AWS log ready services
     parent: AWS Logs Integration
     url: get-list-of-aws-log-ready-services
+    generated: true
   - name: Enable an AWS Logs integration
     parent: AWS Logs Integration
     url: enable-an-aws-logs-integration
+    generated: true
   - name: Check permissions for log services
     parent: AWS Logs Integration
     url: check-permissions-for-log-services
+    generated: true
   - name: Authentication
     url: /api/v1/authentication/
     identifier: Authentication
+    generated: true
   - name: Validate API key
     parent: Authentication
     url: validate-api-key
+    generated: true
   - name: Azure Integration
     url: /api/v1/azure-integration/
     identifier: Azure Integration
+    generated: true
   - name: Delete an Azure integration
     parent: Azure Integration
     url: delete-an-azure-integration
+    generated: true
   - name: List all Azure integrations
     parent: Azure Integration
     url: list-all-azure-integrations
+    generated: true
   - name: Create an Azure integration
     parent: Azure Integration
     url: create-an-azure-integration
+    generated: true
   - name: Update an Azure integration
     parent: Azure Integration
     url: update-an-azure-integration
+    generated: true
   - name: Update Azure integration host filters
     parent: Azure Integration
     url: update-azure-integration-host-filters
+    generated: true
   - name: Dashboard Lists
     url: /api/v1/dashboard-lists/
     identifier: Dashboard Lists
+    generated: true
   - name: Get all dashboard lists
     parent: Dashboard Lists
     url: get-all-dashboard-lists
+    generated: true
   - name: Create a dashboard list
     parent: Dashboard Lists
     url: create-a-dashboard-list
+    generated: true
   - name: Delete a dashboard list
     parent: Dashboard Lists
     url: delete-a-dashboard-list
+    generated: true
   - name: Get a dashboard list
     parent: Dashboard Lists
     url: get-a-dashboard-list
+    generated: true
   - name: Update a dashboard list
     parent: Dashboard Lists
     url: update-a-dashboard-list
+    generated: true
   - name: Dashboards
     url: /api/v1/dashboards/
     identifier: Dashboards
+    generated: true
   - name: Get all dashboards
     parent: Dashboards
     url: get-all-dashboards
+    generated: true
   - name: Create a new dashboard
     parent: Dashboards
     url: create-a-new-dashboard
+    generated: true
   - name: Delete a dashboard
     parent: Dashboards
     url: delete-a-dashboard
+    generated: true
   - name: Get a dashboard
     parent: Dashboards
     url: get-a-dashboard
+    generated: true
   - name: Update a dashboard
     parent: Dashboards
     url: update-a-dashboard
+    generated: true
   - name: Downtimes
     url: /api/v1/downtimes/
     identifier: Downtimes
+    generated: true
   - name: Get all downtimes
     parent: Downtimes
     url: get-all-downtimes
+    generated: true
   - name: Schedule a downtime
     parent: Downtimes
     url: schedule-a-downtime
+    generated: true
   - name: Cancel downtimes by scope
     parent: Downtimes
     url: cancel-downtimes-by-scope
+    generated: true
   - name: Cancel a downtime
     parent: Downtimes
     url: cancel-a-downtime
+    generated: true
   - name: Get a downtime
     parent: Downtimes
     url: get-a-downtime
+    generated: true
   - name: Update a downtime
     parent: Downtimes
     url: update-a-downtime
+    generated: true
   - name: Embeddable Graphs
     url: /api/v1/embeddable-graphs/
     identifier: Embeddable Graphs
+    generated: true
   - name: Get all embeds
     parent: Embeddable Graphs
     url: get-all-embeds
+    generated: true
   - name: Create embed
     parent: Embeddable Graphs
     url: create-embed
+    generated: true
   - name: Get specific embed
     parent: Embeddable Graphs
     url: get-specific-embed
+    generated: true
   - name: Enable embed
     parent: Embeddable Graphs
     url: enable-embed
+    generated: true
   - name: Revoke embed
     parent: Embeddable Graphs
     url: revoke-embed
+    generated: true
   - name: Events
     url: /api/v1/events/
     identifier: Events
+    generated: true
   - name: Query the event stream
     parent: Events
     url: query-the-event-stream
+    generated: true
   - name: Post an event
     parent: Events
     url: post-an-event
+    generated: true
   - name: Get an event
     parent: Events
     url: get-an-event
+    generated: true
   - name: GCP Integration
     url: /api/v1/gcp-integration/
     identifier: GCP Integration
+    generated: true
   - name: Delete a GCP integration
     parent: GCP Integration
     url: delete-a-gcp-integration
+    generated: true
   - name: List all GCP integrations
     parent: GCP Integration
     url: list-all-gcp-integrations
+    generated: true
   - name: Create a GCP integration
     parent: GCP Integration
     url: create-a-gcp-integration
+    generated: true
   - name: Update a GCP integration
     parent: GCP Integration
     url: update-a-gcp-integration
+    generated: true
   - name: Hosts
     url: /api/v1/hosts/
     identifier: Hosts
+    generated: true
   - name: Mute a host
     parent: Hosts
     url: mute-a-host
+    generated: true
   - name: Unmute a host
     parent: Hosts
     url: unmute-a-host
+    generated: true
   - name: Get all hosts for your organization
     parent: Hosts
     url: get-all-hosts-for-your-organization
+    generated: true
   - name: Get the total number of active hosts
     parent: Hosts
     url: get-the-total-number-of-active-hosts
+    generated: true
   - name: IP Ranges
     url: /api/v1/ip-ranges/
     identifier: IP Ranges
+    generated: true
   - name: List IP Ranges
     parent: IP Ranges
     url: list-ip-ranges
+    generated: true
   - name: Key Management
     url: /api/v1/key-management/
     identifier: Key Management
+    generated: true
   - name: Get all API keys
     parent: Key Management
     url: get-all-api-keys
+    generated: true
   - name: Create an API key
     parent: Key Management
     url: create-an-api-key
+    generated: true
   - name: Delete an API key
     parent: Key Management
     url: delete-an-api-key
+    generated: true
   - name: Get API key
     parent: Key Management
     url: get-api-key
+    generated: true
   - name: Edit an API key
     parent: Key Management
     url: edit-an-api-key
+    generated: true
   - name: Get all application keys
     parent: Key Management
     url: get-all-application-keys
+    generated: true
   - name: Create an application key
     parent: Key Management
     url: create-an-application-key
+    generated: true
   - name: Delete an application key
     parent: Key Management
     url: delete-an-application-key
+    generated: true
   - name: Get an application key
     parent: Key Management
     url: get-an-application-key
+    generated: true
   - name: Edit an application key
     parent: Key Management
     url: edit-an-application-key
+    generated: true
   - name: Logs
     url: /api/v1/logs/
     identifier: Logs
+    generated: true
   - name: Get a list of logs
     parent: Logs
     url: get-a-list-of-logs
+    generated: true
   - name: Send logs
     parent: Logs
     url: send-logs
+    generated: true
   - name: Logs Archives
     url: /api/v1/logs-archives/
     identifier: Logs Archives
+    generated: true
   - name: Logs Indexes
     url: /api/v1/logs-indexes/
     identifier: Logs Indexes
+    generated: true
   - name: Get indexes order
     parent: Logs Indexes
     url: get-indexes-order
+    generated: true
   - name: Update indexes order
     parent: Logs Indexes
     url: update-indexes-order
+    generated: true
   - name: Get all indexes
     parent: Logs Indexes
     url: get-all-indexes
+    generated: true
   - name: Get an index
     parent: Logs Indexes
     url: get-an-index
+    generated: true
   - name: Update an index
     parent: Logs Indexes
     url: update-an-index
+    generated: true
   - name: Logs Pipelines
     url: /api/v1/logs-pipelines/
     identifier: Logs Pipelines
+    generated: true
   - name: Get pipeline order
     parent: Logs Pipelines
     url: get-pipeline-order
+    generated: true
   - name: Update pipeline order
     parent: Logs Pipelines
     url: update-pipeline-order
+    generated: true
   - name: Get all pipelines
     parent: Logs Pipelines
     url: get-all-pipelines
+    generated: true
   - name: Create a pipeline
     parent: Logs Pipelines
     url: create-a-pipeline
+    generated: true
   - name: Delete a pipeline
     parent: Logs Pipelines
     url: delete-a-pipeline
+    generated: true
   - name: Get a pipeline
     parent: Logs Pipelines
     url: get-a-pipeline
+    generated: true
   - name: Update a pipeline
     parent: Logs Pipelines
     url: update-a-pipeline
+    generated: true
   - name: Logs Restriction Queries
     url: /api/v1/logs-restriction-queries/
     identifier: Logs Restriction Queries
+    generated: true
   - name: Metrics
     url: /api/v1/metrics/
     identifier: Metrics
+    generated: true
   - name: Get active metrics list
     parent: Metrics
     url: get-active-metrics-list
+    generated: true
   - name: Get metric metadata
     parent: Metrics
     url: get-metric-metadata
+    generated: true
   - name: Edit metric metadata
     parent: Metrics
     url: edit-metric-metadata
+    generated: true
   - name: Query timeseries points
     parent: Metrics
     url: query-timeseries-points
+    generated: true
   - name: Search metrics
     parent: Metrics
     url: search-metrics
+    generated: true
   - name: Submit metrics
     parent: Metrics
     url: submit-metrics
+    generated: true
   - name: Monitors
     url: /api/v1/monitors/
     identifier: Monitors
+    generated: true
   - name: Get all monitor details
     parent: Monitors
     url: get-all-monitor-details
+    generated: true
   - name: Create a monitor
     parent: Monitors
     url: create-a-monitor
+    generated: true
   - name: Check if a monitor can be deleted
     parent: Monitors
     url: check-if-a-monitor-can-be-deleted
+    generated: true
   - name: Monitors group search
     parent: Monitors
     url: monitors-group-search
+    generated: true
   - name: Monitors search
     parent: Monitors
     url: monitors-search
+    generated: true
   - name: Validate a monitor
     parent: Monitors
     url: validate-a-monitor
+    generated: true
   - name: Delete a monitor
     parent: Monitors
     url: delete-a-monitor
+    generated: true
   - name: Get a monitor's details
     parent: Monitors
     url: get-a-monitors-details
+    generated: true
   - name: Edit a monitor
     parent: Monitors
     url: edit-a-monitor
+    generated: true
   - name: Mute a monitor
     parent: Monitors
     url: mute-a-monitor
+    generated: true
   - name: Unmute a monitor
     parent: Monitors
     url: unmute-a-monitor
+    generated: true
   - name: Resolve Monitor
     parent: Monitors
     url: resolve-monitor
+    generated: true
   - name: Mute all monitors
     parent: Monitors
     url: mute-all-monitors
+    generated: true
   - name: Unmute all monitors
     parent: Monitors
     url: unmute-all-monitors
+    generated: true
   - name: Organizations
     url: /api/v1/organizations/
     identifier: Organizations
+    generated: true
   - name: List your managed organizations
     parent: Organizations
     url: list-your-managed-organizations
+    generated: true
   - name: Create a child organization
     parent: Organizations
     url: create-a-child-organization
+    generated: true
   - name: Get organization information
     parent: Organizations
     url: get-organization-information
+    generated: true
   - name: Update your organization
     parent: Organizations
     url: update-your-organization
+    generated: true
   - name: Upload IdP metadata
     parent: Organizations
     url: upload-idp-metadata
+    generated: true
   - name: PagerDuty Integration
     url: /api/v1/pagerduty-integration/
     identifier: PagerDuty Integration
+    generated: true
   - name: Create a new service object
     parent: PagerDuty Integration
     url: create-a-new-service-object
+    generated: true
   - name: Delete a single service object
     parent: PagerDuty Integration
     url: delete-a-single-service-object
+    generated: true
   - name: Get a single service object
     parent: PagerDuty Integration
     url: get-a-single-service-object
+    generated: true
   - name: Update a single service object
     parent: PagerDuty Integration
     url: update-a-single-service-object
+    generated: true
   - name: Roles
     url: /api/v1/roles/
     identifier: Roles
+    generated: true
   - name: Screenboards
     url: /api/v1/screenboards/
     identifier: Screenboards
+    generated: true
   - name: Security Monitoring
     url: /api/v1/security-monitoring/
     identifier: Security Monitoring
+    generated: true
   - name: Service Checks
     url: /api/v1/service-checks/
     identifier: Service Checks
+    generated: true
   - name: Submit a Service Check
     parent: Service Checks
     url: submit-a-service-check
+    generated: true
   - name: Service Dependencies
     url: /api/v1/service-dependencies/
     identifier: Service Dependencies
+    generated: true
   - name: Get all service dependencies
     parent: Service Dependencies
     url: get-all-service-dependencies
+    generated: true
   - name: Get one service's dependencies
     parent: Service Dependencies
     url: get-one-services-dependencies
+    generated: true
   - name: Service Level Objectives
     url: /api/v1/service-level-objectives/
     identifier: Service Level Objectives
+    generated: true
   - name: Search SLOs
     parent: Service Level Objectives
     url: search-slos
+    generated: true
   - name: Create a SLO object
     parent: Service Level Objectives
     url: create-a-slo-object
+    generated: true
   - name: Bulk Delete SLO Timeframes
     parent: Service Level Objectives
     url: bulk-delete-slo-timeframes
+    generated: true
   - name: Check if SLOs can be safely deleted
     parent: Service Level Objectives
     url: check-if-slos-can-be-safely-deleted
+    generated: true
   - name: Delete a SLO
     parent: Service Level Objectives
     url: delete-a-slo
+    generated: true
   - name: Get a SLO's details
     parent: Service Level Objectives
     url: get-a-slos-details
+    generated: true
   - name: Update a SLO
     parent: Service Level Objectives
     url: update-a-slo
+    generated: true
   - name: Get an SLO's history
     parent: Service Level Objectives
     url: get-an-slos-history
+    generated: true
   - name: Slack Integration
     url: /api/v1/slack-integration/
     identifier: Slack Integration
+    generated: true
   - name: Delete a Slack integration
     parent: Slack Integration
     url: delete-a-slack-integration
+    generated: true
   - name: Get info about a Slack integration
     parent: Slack Integration
     url: get-info-about-a-slack-integration
+    generated: true
   - name: Create a Slack integration
     parent: Slack Integration
     url: create-a-slack-integration
+    generated: true
   - name: Add channels to Slack integration
     parent: Slack Integration
     url: add-channels-to-slack-integration
+    generated: true
   - name: Snapshots
     url: /api/v1/snapshots/
     identifier: Snapshots
+    generated: true
   - name: Take graph snapshots
     parent: Snapshots
     url: take-graph-snapshots
+    generated: true
   - name: Synthetics
     url: /api/v1/synthetics/
     identifier: Synthetics
+    generated: true
   - name: Get a list of tests
     parent: Synthetics
     url: get-a-list-of-tests
+    generated: true
   - name: Create a test
     parent: Synthetics
     url: create-a-test
+    generated: true
   - name: Get a browser test configuration
     parent: Synthetics
     url: get-a-browser-test-configuration
+    generated: true
   - name: Get the test's latest results summaries (browser)
     parent: Synthetics
     url: get-the-tests-latest-results-summaries-browser
+    generated: true
   - name: Get a test result (browser)
     parent: Synthetics
     url: get-a-test-result-browser
+    generated: true
   - name: Delete tests
     parent: Synthetics
     url: delete-tests
+    generated: true
   - name: Get a test configuration
     parent: Synthetics
     url: get-a-test-configuration
+    generated: true
   - name: Edit a test
     parent: Synthetics
     url: edit-a-test
+    generated: true
   - name: Get the test's latest results summaries (API)
     parent: Synthetics
     url: get-the-tests-latest-results-summaries-api
+    generated: true
   - name: Get a test result (API)
     parent: Synthetics
     url: get-a-test-result-api
+    generated: true
   - name: Pause or start a test
     parent: Synthetics
     url: pause-or-start-a-test
+    generated: true
   - name: Tags
     url: /api/v1/tags/
     identifier: Tags
+    generated: true
   - name: Get Tags
     parent: Tags
     url: get-tags
+    generated: true
   - name: Remove host tags
     parent: Tags
     url: remove-host-tags
+    generated: true
   - name: Get host tags
     parent: Tags
     url: get-host-tags
+    generated: true
   - name: Add tags to a host
     parent: Tags
     url: add-tags-to-a-host
+    generated: true
   - name: Update host tags
     parent: Tags
     url: update-host-tags
+    generated: true
   - name: Timeboards
     url: /api/v1/timeboards/
     identifier: Timeboards
+    generated: true
   - name: Tracing
     url: /api/v1/tracing/
     identifier: Tracing
+    generated: true
   - name: Send traces
     parent: Tracing
     url: send-traces
+    generated: true
   - name: Usage Metering
     url: /api/v1/usage-metering/
     identifier: Usage Metering
+    generated: true
   - name: Get hourly usage for analyzed logs
     parent: Usage Metering
     url: get-hourly-usage-for-analyzed-logs
+    generated: true
   - name: Get hourly usage for Lambda
     parent: Usage Metering
     url: get-hourly-usage-for-lambda
+    generated: true
   - name: Get hourly usage for Fargate
     parent: Usage Metering
     url: get-hourly-usage-for-fargate
+    generated: true
   - name: Get hourly usage for hosts and containers
     parent: Usage Metering
     url: get-hourly-usage-for-hosts-and-containers
+    generated: true
   - name: Get hourly usage for Logs
     parent: Usage Metering
     url: get-hourly-usage-for-logs
+    generated: true
   - name: Get hourly usage for Logs by Index
     parent: Usage Metering
     url: get-hourly-usage-for-logs-by-index
+    generated: true
   - name: Get hourly usage for Network Flows
     parent: Usage Metering
     url: get-hourly-usage-for-network-flows
+    generated: true
   - name: Get hourly usage for Network Hosts
     parent: Usage Metering
     url: get-hourly-usage-for-network-hosts
+    generated: true
   - name: Get hourly usage for RUM Sessions
     parent: Usage Metering
     url: get-hourly-usage-for-rum-sessions
+    generated: true
   - name: Get hourly usage for SNMP devices
     parent: Usage Metering
     url: get-hourly-usage-for-snmp-devices
+    generated: true
   - name: Get usage across your multi-org account
     parent: Usage Metering
     url: get-usage-across-your-multi-org-account
+    generated: true
   - name: Get hourly usage for Synthetics API Checks
     parent: Usage Metering
     url: get-hourly-usage-for-synthetics-api-checks
+    generated: true
   - name: Get hourly usage for Synthetics API Checks
     parent: Usage Metering
     url: get-hourly-usage-for-synthetics-api-checks
+    generated: true
   - name: Get hourly usage for Synthetics Browser Checks
     parent: Usage Metering
     url: get-hourly-usage-for-synthetics-browser-checks
+    generated: true
   - name: Get hourly usage for custom metrics
     parent: Usage Metering
     url: get-hourly-usage-for-custom-metrics
+    generated: true
   - name: Get top 500 custom metrics by hourly average
     parent: Usage Metering
     url: get-top-500-custom-metrics-by-hourly-average
+    generated: true
   - name: Get hourly usage for Trace Search
     parent: Usage Metering
     url: get-hourly-usage-for-trace-search
+    generated: true
   - name: Users
     url: /api/v1/users/
     identifier: Users
+    generated: true
   - name: Get all users
     parent: Users
     url: get-all-users
+    generated: true
   - name: Create a user
     parent: Users
     url: create-a-user
+    generated: true
   - name: Disable a user
     parent: Users
     url: disable-a-user
+    generated: true
   - name: Get user details
     parent: Users
     url: get-user-details
+    generated: true
   - name: Update a user
     parent: Users
     url: update-a-user
+    generated: true
   - name: Webhooks Integration
     url: /api/v1/webhooks-integration/
     identifier: Webhooks Integration
+    generated: true
   - name: Create a custom variable
     parent: Webhooks Integration
     url: create-a-custom-variable
+    generated: true
   - name: Delete a custom variable
     parent: Webhooks Integration
     url: delete-a-custom-variable
+    generated: true
   - name: Get a custom variable
     parent: Webhooks Integration
     url: get-a-custom-variable
+    generated: true
   - name: Update a custom variable
     parent: Webhooks Integration
     url: update-a-custom-variable
+    generated: true
   - name: Create a webhooks integration
     parent: Webhooks Integration
     url: create-a-webhooks-integration
+    generated: true
   - name: Delete a webhook
     parent: Webhooks Integration
     url: delete-a-webhook
+    generated: true
   - name: Get a webhook integration
     parent: Webhooks Integration
     url: get-a-webhook-integration
+    generated: true
   - name: Update a webhook
     parent: Webhooks Integration
     url: update-a-webhook
+    generated: true
 api_v2:
   - name: Overview
     url: /api/v2/
@@ -2249,255 +2454,340 @@ api_v2:
   - name: AWS Integration
     url: /api/v2/aws-integration/
     identifier: AWS Integration
+    generated: true
   - name: AWS Logs Integration
     url: /api/v2/aws-logs-integration/
     identifier: AWS Logs Integration
+    generated: true
   - name: Authentication
     url: /api/v2/authentication/
     identifier: Authentication
+    generated: true
   - name: Azure Integration
     url: /api/v2/azure-integration/
     identifier: Azure Integration
+    generated: true
   - name: Dashboard Lists
     url: /api/v2/dashboard-lists/
     identifier: Dashboard Lists
+    generated: true
   - name: Delete items from a dashboard list
     parent: Dashboard Lists
     url: delete-items-from-a-dashboard-list
+    generated: true
   - name: Get a Dashboard List
     parent: Dashboard Lists
     url: get-a-dashboard-list
+    generated: true
   - name: Add Items to a Dashboard List
     parent: Dashboard Lists
     url: add-items-to-a-dashboard-list
+    generated: true
   - name: Update items of a dashboard list
     parent: Dashboard Lists
     url: update-items-of-a-dashboard-list
+    generated: true
   - name: Dashboards
     url: /api/v2/dashboards/
     identifier: Dashboards
+    generated: true
   - name: Downtimes
     url: /api/v2/downtimes/
     identifier: Downtimes
+    generated: true
   - name: Embeddable Graphs
     url: /api/v2/embeddable-graphs/
     identifier: Embeddable Graphs
+    generated: true
   - name: Events
     url: /api/v2/events/
     identifier: Events
+    generated: true
   - name: GCP Integration
     url: /api/v2/gcp-integration/
     identifier: GCP Integration
+    generated: true
   - name: Hosts
     url: /api/v2/hosts/
     identifier: Hosts
+    generated: true
   - name: IP Ranges
     url: /api/v2/ip-ranges/
     identifier: IP Ranges
+    generated: true
   - name: Key Management
     url: /api/v2/key-management/
     identifier: Key Management
+    generated: true
   - name: Logs
     url: /api/v2/logs/
     identifier: Logs
+    generated: true
   - name: Logs Archives
     url: /api/v2/logs-archives/
     identifier: Logs Archives
+    generated: true
   - name: Get all archives
     parent: Logs Archives
     url: get-all-archives
+    generated: true
   - name: Create an archive
     parent: Logs Archives
     url: create-an-archive
+    generated: true
   - name: Delete an archive
     parent: Logs Archives
     url: delete-an-archive
+    generated: true
   - name: Get an archive
     parent: Logs Archives
     url: get-an-archive
+    generated: true
   - name: Update an archive
     parent: Logs Archives
     url: update-an-archive
+    generated: true
   - name: Revoke role from an archive
     parent: Logs Archives
     url: revoke-role-from-an-archive
+    generated: true
   - name: List read roles for an archive
     parent: Logs Archives
     url: list-read-roles-for-an-archive
+    generated: true
   - name: Grant role to an archive
     parent: Logs Archives
     url: grant-role-to-an-archive
+    generated: true
   - name: Logs Indexes
     url: /api/v2/logs-indexes/
     identifier: Logs Indexes
+    generated: true
   - name: Logs Pipelines
     url: /api/v2/logs-pipelines/
     identifier: Logs Pipelines
+    generated: true
   - name: Logs Restriction Queries
     url: /api/v2/logs-restriction-queries/
     identifier: Logs Restriction Queries
+    generated: true
   - name: List restriction queries
     parent: Logs Restriction Queries
     url: list-restriction-queries
+    generated: true
   - name: Create a restriction query
     parent: Logs Restriction Queries
     url: create-a-restriction-query
+    generated: true
   - name: Get restriction query for a given role
     parent: Logs Restriction Queries
     url: get-restriction-query-for-a-given-role
+    generated: true
   - name: Get all restriction queries for a given user
     parent: Logs Restriction Queries
     url: get-all-restriction-queries-for-a-given-user
+    generated: true
   - name: Delete a restriction query
     parent: Logs Restriction Queries
     url: delete-a-restriction-query
+    generated: true
   - name: Get a restriction query
     parent: Logs Restriction Queries
     url: get-a-restriction-query
+    generated: true
   - name: Update a restriction query
     parent: Logs Restriction Queries
     url: update-a-restriction-query
+    generated: true
   - name: Revoke role from a restriction query
     parent: Logs Restriction Queries
     url: revoke-role-from-a-restriction-query
+    generated: true
   - name: List roles for a restriction query
     parent: Logs Restriction Queries
     url: list-roles-for-a-restriction-query
+    generated: true
   - name: Grant role to a restriction query
     parent: Logs Restriction Queries
     url: grant-role-to-a-restriction-query
+    generated: true
   - name: Metrics
     url: /api/v2/metrics/
     identifier: Metrics
+    generated: true
   - name: Monitors
     url: /api/v2/monitors/
     identifier: Monitors
+    generated: true
   - name: Organizations
     url: /api/v2/organizations/
     identifier: Organizations
+    generated: true
   - name: PagerDuty Integration
     url: /api/v2/pagerduty-integration/
     identifier: PagerDuty Integration
+    generated: true
   - name: Roles
     url: /api/v2/roles/
     identifier: Roles
+    generated: true
   - name: List permissions
     parent: Roles
     url: list-permissions
+    generated: true
   - name: List roles
     parent: Roles
     url: list-roles
+    generated: true
   - name: Create role
     parent: Roles
     url: create-role
+    generated: true
   - name: Delete role
     parent: Roles
     url: delete-role
+    generated: true
   - name: Get a role
     parent: Roles
     url: get-a-role
+    generated: true
   - name: Update a role
     parent: Roles
     url: update-a-role
+    generated: true
   - name: Revoke permission
     parent: Roles
     url: revoke-permission
+    generated: true
   - name: List permissions for a role
     parent: Roles
     url: list-permissions-for-a-role
+    generated: true
   - name: Grant permission to a role
     parent: Roles
     url: grant-permission-to-a-role
+    generated: true
   - name: Remove a user from a role
     parent: Roles
     url: remove-a-user-from-a-role
+    generated: true
   - name: Get all users of a role
     parent: Roles
     url: get-all-users-of-a-role
+    generated: true
   - name: Add a user to a role
     parent: Roles
     url: add-a-user-to-a-role
+    generated: true
   - name: Screenboards
     url: /api/v2/screenboards/
     identifier: Screenboards
+    generated: true
   - name: Security Monitoring
     url: /api/v2/security-monitoring/
     identifier: Security Monitoring
+    generated: true
   - name: List rules
     parent: Security Monitoring
     url: list-rules
+    generated: true
   - name: Create a detection rule
     parent: Security Monitoring
     url: create-a-detection-rule
+    generated: true
   - name: Delete an existing rule
     parent: Security Monitoring
     url: delete-an-existing-rule
+    generated: true
   - name: Get a rule's details
     parent: Security Monitoring
     url: get-a-rules-details
+    generated: true
   - name: Update an existing rule
     parent: Security Monitoring
     url: update-an-existing-rule
+    generated: true
   - name: Service Checks
     url: /api/v2/service-checks/
     identifier: Service Checks
+    generated: true
   - name: Service Dependencies
     url: /api/v2/service-dependencies/
     identifier: Service Dependencies
+    generated: true
   - name: Service Level Objectives
     url: /api/v2/service-level-objectives/
     identifier: Service Level Objectives
+    generated: true
   - name: Slack Integration
     url: /api/v2/slack-integration/
     identifier: Slack Integration
+    generated: true
   - name: Snapshots
     url: /api/v2/snapshots/
     identifier: Snapshots
+    generated: true
   - name: Synthetics
     url: /api/v2/synthetics/
     identifier: Synthetics
+    generated: true
   - name: Tags
     url: /api/v2/tags/
     identifier: Tags
+    generated: true
   - name: Timeboards
     url: /api/v2/timeboards/
     identifier: Timeboards
+    generated: true
   - name: Tracing
     url: /api/v2/tracing/
     identifier: Tracing
+    generated: true
   - name: Usage Metering
     url: /api/v2/usage-metering/
     identifier: Usage Metering
+    generated: true
   - name: Users
     url: /api/v2/users/
     identifier: Users
+    generated: true
   - name: Send invitation emails
     parent: Users
     url: send-invitation-emails
+    generated: true
   - name: Get a user invitation
     parent: Users
     url: get-a-user-invitation
+    generated: true
   - name: List all users
     parent: Users
     url: list-all-users
+    generated: true
   - name: Create a user
     parent: Users
     url: create-a-user
+    generated: true
   - name: Disable a user
     parent: Users
     url: disable-a-user
+    generated: true
   - name: Get a user
     parent: Users
     url: get-a-user
+    generated: true
   - name: Update a user
     parent: Users
     url: update-a-user
+    generated: true
   - name: Get a user organization
     parent: Users
     url: get-a-user-organization
+    generated: true
   - name: Get a user permissions
     parent: Users
     url: get-a-user-permissions
+    generated: true
   - name: Webhooks Integration
     url: /api/v2/webhooks-integration/
     identifier: Webhooks Integration
+    generated: true

--- a/config/_default/menus/menus.fr.yaml
+++ b/config/_default/menus/menus.fr.yaml
@@ -985,7 +985,7 @@ main:
     identifier: log_collection_ruby
     weight: 109
   - name: Autres intégrations
-    url: integrations/#collecte-de-logs-cat
+    url: 'integrations/#collecte-de-logs-cat'
     identifier: other_integrations
     parent: log_collection
     weight: 110
@@ -1066,7 +1066,7 @@ main:
     identifier: logs_traces_connection
     weight: 8
   - name: Corrélation entre les logs et les métriques
-    url: dashboards/timeboards/#graph-menu
+    url: 'dashboards/timeboards/#graph-menu'
     parent: log_management
     identifier: logs_metrics_correlation
     weight: 9
@@ -1294,7 +1294,7 @@ main:
     identifier: dev_tools_metrics_powershell
     weight: 204
   - name: Envoi de métriques - API
-    url: api/#envoyer-des-points-de-series-temporelles
+    url: 'api/#envoyer-des-points-de-series-temporelles'
     parent: dev_tools_metrics
     identifier: dev_tools_metrics_api
     weight: 205
@@ -1329,7 +1329,7 @@ main:
     identifier: dev_tools_events_mail
     weight: 303
   - name: API
-    url: api/#envoyer-un-evenement
+    url: 'api/#envoyer-un-evenement'
     parent: dev_tools_events
     identifier: dev_tools_events_api
     weight: 304
@@ -1522,618 +1522,823 @@ api_v1:
   - name: AWS Integration
     url: /fr/api/v1/aws-integration/
     identifier: AWS Integration
+    generated: true
   - name: Delete an AWS integration
     parent: AWS Integration
     url: delete-an-aws-integration
+    generated: true
   - name: List all AWS integrations
     parent: AWS Integration
     url: list-all-aws-integrations
+    generated: true
   - name: Create an AWS integration
     parent: AWS Integration
     url: create-an-aws-integration
+    generated: true
   - name: Update an AWS integration
     parent: AWS Integration
     url: update-an-aws-integration
+    generated: true
   - name: List namespace rules
     parent: AWS Integration
     url: list-namespace-rules
+    generated: true
   - name: Generate a new external ID
     parent: AWS Integration
     url: generate-a-new-external-id
+    generated: true
   - name: AWS Logs Integration
     url: /fr/api/v1/aws-logs-integration/
     identifier: AWS Logs Integration
+    generated: true
   - name: Delete an AWS Logs integration
     parent: AWS Logs Integration
     url: delete-an-aws-logs-integration
+    generated: true
   - name: List all AWS Logs integrations
     parent: AWS Logs Integration
     url: list-all-aws-logs-integrations
+    generated: true
   - name: Add AWS Log Lambda ARN
     parent: AWS Logs Integration
     url: add-aws-log-lambda-arn
+    generated: true
   - name: Check that an AWS Lambda Function exists
     parent: AWS Logs Integration
     url: check-that-an-aws-lambda-function-exists
+    generated: true
   - name: Get list of AWS log ready services
     parent: AWS Logs Integration
     url: get-list-of-aws-log-ready-services
+    generated: true
   - name: Enable an AWS Logs integration
     parent: AWS Logs Integration
     url: enable-an-aws-logs-integration
+    generated: true
   - name: Check permissions for log services
     parent: AWS Logs Integration
     url: check-permissions-for-log-services
+    generated: true
   - name: Authentication
     url: /fr/api/v1/authentication/
     identifier: Authentication
+    generated: true
   - name: Validate API key
     parent: Authentication
     url: validate-api-key
+    generated: true
   - name: Azure Integration
     url: /fr/api/v1/azure-integration/
     identifier: Azure Integration
+    generated: true
   - name: Delete an Azure integration
     parent: Azure Integration
     url: delete-an-azure-integration
+    generated: true
   - name: List all Azure integrations
     parent: Azure Integration
     url: list-all-azure-integrations
+    generated: true
   - name: Create an Azure integration
     parent: Azure Integration
     url: create-an-azure-integration
+    generated: true
   - name: Update an Azure integration
     parent: Azure Integration
     url: update-an-azure-integration
+    generated: true
   - name: Update Azure integration host filters
     parent: Azure Integration
     url: update-azure-integration-host-filters
+    generated: true
   - name: Dashboard Lists
     url: /fr/api/v1/dashboard-lists/
     identifier: Dashboard Lists
+    generated: true
   - name: Get all dashboard lists
     parent: Dashboard Lists
     url: get-all-dashboard-lists
+    generated: true
   - name: Create a dashboard list
     parent: Dashboard Lists
     url: create-a-dashboard-list
+    generated: true
   - name: Delete a dashboard list
     parent: Dashboard Lists
     url: delete-a-dashboard-list
+    generated: true
   - name: Get a dashboard list
     parent: Dashboard Lists
     url: get-a-dashboard-list
+    generated: true
   - name: Update a dashboard list
     parent: Dashboard Lists
     url: update-a-dashboard-list
+    generated: true
   - name: Dashboards
     url: /fr/api/v1/dashboards/
     identifier: Dashboards
+    generated: true
   - name: Get all dashboards
     parent: Dashboards
     url: get-all-dashboards
+    generated: true
   - name: Create a new dashboard
     parent: Dashboards
     url: create-a-new-dashboard
+    generated: true
   - name: Delete a dashboard
     parent: Dashboards
     url: delete-a-dashboard
+    generated: true
   - name: Get a dashboard
     parent: Dashboards
     url: get-a-dashboard
+    generated: true
   - name: Update a dashboard
     parent: Dashboards
     url: update-a-dashboard
+    generated: true
   - name: Downtimes
     url: /fr/api/v1/downtimes/
     identifier: Downtimes
+    generated: true
   - name: Get all downtimes
     parent: Downtimes
     url: get-all-downtimes
+    generated: true
   - name: Schedule a downtime
     parent: Downtimes
     url: schedule-a-downtime
+    generated: true
   - name: Cancel downtimes by scope
     parent: Downtimes
     url: cancel-downtimes-by-scope
+    generated: true
   - name: Cancel a downtime
     parent: Downtimes
     url: cancel-a-downtime
+    generated: true
   - name: Get a downtime
     parent: Downtimes
     url: get-a-downtime
+    generated: true
   - name: Update a downtime
     parent: Downtimes
     url: update-a-downtime
+    generated: true
   - name: Embeddable Graphs
     url: /fr/api/v1/embeddable-graphs/
     identifier: Embeddable Graphs
+    generated: true
   - name: Get all embeds
     parent: Embeddable Graphs
     url: get-all-embeds
+    generated: true
   - name: Create embed
     parent: Embeddable Graphs
     url: create-embed
+    generated: true
   - name: Get specific embed
     parent: Embeddable Graphs
     url: get-specific-embed
+    generated: true
   - name: Enable embed
     parent: Embeddable Graphs
     url: enable-embed
+    generated: true
   - name: Revoke embed
     parent: Embeddable Graphs
     url: revoke-embed
+    generated: true
   - name: Events
     url: /fr/api/v1/events/
     identifier: Events
+    generated: true
   - name: Query the event stream
     parent: Events
     url: query-the-event-stream
+    generated: true
   - name: Post an event
     parent: Events
     url: post-an-event
+    generated: true
   - name: Get an event
     parent: Events
     url: get-an-event
+    generated: true
   - name: GCP Integration
     url: /fr/api/v1/gcp-integration/
     identifier: GCP Integration
+    generated: true
   - name: Delete a GCP integration
     parent: GCP Integration
     url: delete-a-gcp-integration
+    generated: true
   - name: List all GCP integrations
     parent: GCP Integration
     url: list-all-gcp-integrations
+    generated: true
   - name: Create a GCP integration
     parent: GCP Integration
     url: create-a-gcp-integration
+    generated: true
   - name: Update a GCP integration
     parent: GCP Integration
     url: update-a-gcp-integration
+    generated: true
   - name: Hosts
     url: /fr/api/v1/hosts/
     identifier: Hosts
+    generated: true
   - name: Mute a host
     parent: Hosts
     url: mute-a-host
+    generated: true
   - name: Unmute a host
     parent: Hosts
     url: unmute-a-host
+    generated: true
   - name: Get all hosts for your organization
     parent: Hosts
     url: get-all-hosts-for-your-organization
+    generated: true
   - name: Get the total number of active hosts
     parent: Hosts
     url: get-the-total-number-of-active-hosts
+    generated: true
   - name: IP Ranges
     url: /fr/api/v1/ip-ranges/
     identifier: IP Ranges
+    generated: true
   - name: List IP Ranges
     parent: IP Ranges
     url: list-ip-ranges
+    generated: true
   - name: Key Management
     url: /fr/api/v1/key-management/
     identifier: Key Management
+    generated: true
   - name: Get all API keys
     parent: Key Management
     url: get-all-api-keys
+    generated: true
   - name: Create an API key
     parent: Key Management
     url: create-an-api-key
+    generated: true
   - name: Delete an API key
     parent: Key Management
     url: delete-an-api-key
+    generated: true
   - name: Get API key
     parent: Key Management
     url: get-api-key
+    generated: true
   - name: Edit an API key
     parent: Key Management
     url: edit-an-api-key
+    generated: true
   - name: Get all application keys
     parent: Key Management
     url: get-all-application-keys
+    generated: true
   - name: Create an application key
     parent: Key Management
     url: create-an-application-key
+    generated: true
   - name: Delete an application key
     parent: Key Management
     url: delete-an-application-key
+    generated: true
   - name: Get an application key
     parent: Key Management
     url: get-an-application-key
+    generated: true
   - name: Edit an application key
     parent: Key Management
     url: edit-an-application-key
+    generated: true
   - name: Logs
     url: /fr/api/v1/logs/
     identifier: Logs
+    generated: true
   - name: Get a list of logs
     parent: Logs
     url: get-a-list-of-logs
+    generated: true
   - name: Send logs
     parent: Logs
     url: send-logs
+    generated: true
   - name: Logs Archives
     url: /fr/api/v1/logs-archives/
     identifier: Logs Archives
+    generated: true
   - name: Logs Indexes
     url: /fr/api/v1/logs-indexes/
     identifier: Logs Indexes
+    generated: true
   - name: Get indexes order
     parent: Logs Indexes
     url: get-indexes-order
+    generated: true
   - name: Update indexes order
     parent: Logs Indexes
     url: update-indexes-order
+    generated: true
   - name: Get all indexes
     parent: Logs Indexes
     url: get-all-indexes
+    generated: true
   - name: Get an index
     parent: Logs Indexes
     url: get-an-index
+    generated: true
   - name: Update an index
     parent: Logs Indexes
     url: update-an-index
+    generated: true
   - name: Logs Pipelines
     url: /fr/api/v1/logs-pipelines/
     identifier: Logs Pipelines
+    generated: true
   - name: Get pipeline order
     parent: Logs Pipelines
     url: get-pipeline-order
+    generated: true
   - name: Update pipeline order
     parent: Logs Pipelines
     url: update-pipeline-order
+    generated: true
   - name: Get all pipelines
     parent: Logs Pipelines
     url: get-all-pipelines
+    generated: true
   - name: Create a pipeline
     parent: Logs Pipelines
     url: create-a-pipeline
+    generated: true
   - name: Delete a pipeline
     parent: Logs Pipelines
     url: delete-a-pipeline
+    generated: true
   - name: Get a pipeline
     parent: Logs Pipelines
     url: get-a-pipeline
+    generated: true
   - name: Update a pipeline
     parent: Logs Pipelines
     url: update-a-pipeline
+    generated: true
   - name: Logs Restriction Queries
     url: /fr/api/v1/logs-restriction-queries/
     identifier: Logs Restriction Queries
+    generated: true
   - name: Metrics
     url: /fr/api/v1/metrics/
     identifier: Metrics
+    generated: true
   - name: Get active metrics list
     parent: Metrics
     url: get-active-metrics-list
+    generated: true
   - name: Get metric metadata
     parent: Metrics
     url: get-metric-metadata
+    generated: true
   - name: Edit metric metadata
     parent: Metrics
     url: edit-metric-metadata
+    generated: true
   - name: Query timeseries points
     parent: Metrics
     url: query-timeseries-points
+    generated: true
   - name: Search metrics
     parent: Metrics
     url: search-metrics
+    generated: true
   - name: Submit metrics
     parent: Metrics
     url: submit-metrics
+    generated: true
   - name: Monitors
     url: /fr/api/v1/monitors/
     identifier: Monitors
+    generated: true
   - name: Get all monitor details
     parent: Monitors
     url: get-all-monitor-details
+    generated: true
   - name: Create a monitor
     parent: Monitors
     url: create-a-monitor
+    generated: true
   - name: Check if a monitor can be deleted
     parent: Monitors
     url: check-if-a-monitor-can-be-deleted
+    generated: true
   - name: Monitors group search
     parent: Monitors
     url: monitors-group-search
+    generated: true
   - name: Monitors search
     parent: Monitors
     url: monitors-search
+    generated: true
   - name: Validate a monitor
     parent: Monitors
     url: validate-a-monitor
+    generated: true
   - name: Delete a monitor
     parent: Monitors
     url: delete-a-monitor
+    generated: true
   - name: Get a monitor's details
     parent: Monitors
     url: get-a-monitors-details
+    generated: true
   - name: Edit a monitor
     parent: Monitors
     url: edit-a-monitor
+    generated: true
   - name: Mute a monitor
     parent: Monitors
     url: mute-a-monitor
+    generated: true
   - name: Unmute a monitor
     parent: Monitors
     url: unmute-a-monitor
+    generated: true
   - name: Resolve Monitor
     parent: Monitors
     url: resolve-monitor
+    generated: true
   - name: Mute all monitors
     parent: Monitors
     url: mute-all-monitors
+    generated: true
   - name: Unmute all monitors
     parent: Monitors
     url: unmute-all-monitors
+    generated: true
   - name: Organizations
     url: /fr/api/v1/organizations/
     identifier: Organizations
+    generated: true
   - name: List your managed organizations
     parent: Organizations
     url: list-your-managed-organizations
+    generated: true
   - name: Create a child organization
     parent: Organizations
     url: create-a-child-organization
+    generated: true
   - name: Get organization information
     parent: Organizations
     url: get-organization-information
+    generated: true
   - name: Update your organization
     parent: Organizations
     url: update-your-organization
+    generated: true
   - name: Upload IdP metadata
     parent: Organizations
     url: upload-idp-metadata
+    generated: true
   - name: PagerDuty Integration
     url: /fr/api/v1/pagerduty-integration/
     identifier: PagerDuty Integration
+    generated: true
   - name: Create a new service object
     parent: PagerDuty Integration
     url: create-a-new-service-object
+    generated: true
   - name: Delete a single service object
     parent: PagerDuty Integration
     url: delete-a-single-service-object
+    generated: true
   - name: Get a single service object
     parent: PagerDuty Integration
     url: get-a-single-service-object
+    generated: true
   - name: Update a single service object
     parent: PagerDuty Integration
     url: update-a-single-service-object
+    generated: true
   - name: Roles
     url: /fr/api/v1/roles/
     identifier: Roles
+    generated: true
   - name: Screenboards
     url: /fr/api/v1/screenboards/
     identifier: Screenboards
+    generated: true
   - name: Security Monitoring
     url: /fr/api/v1/security-monitoring/
     identifier: Security Monitoring
+    generated: true
   - name: Service Checks
     url: /fr/api/v1/service-checks/
     identifier: Service Checks
+    generated: true
   - name: Submit a Service Check
     parent: Service Checks
     url: submit-a-service-check
+    generated: true
   - name: Service Dependencies
     url: /fr/api/v1/service-dependencies/
     identifier: Service Dependencies
+    generated: true
   - name: Get all service dependencies
     parent: Service Dependencies
     url: get-all-service-dependencies
+    generated: true
   - name: Get one service's dependencies
     parent: Service Dependencies
     url: get-one-services-dependencies
+    generated: true
   - name: Service Level Objectives
     url: /fr/api/v1/service-level-objectives/
     identifier: Service Level Objectives
+    generated: true
   - name: Search SLOs
     parent: Service Level Objectives
     url: search-slos
+    generated: true
   - name: Create a SLO object
     parent: Service Level Objectives
     url: create-a-slo-object
+    generated: true
   - name: Bulk Delete SLO Timeframes
     parent: Service Level Objectives
     url: bulk-delete-slo-timeframes
+    generated: true
   - name: Check if SLOs can be safely deleted
     parent: Service Level Objectives
     url: check-if-slos-can-be-safely-deleted
+    generated: true
   - name: Delete a SLO
     parent: Service Level Objectives
     url: delete-a-slo
+    generated: true
   - name: Get a SLO's details
     parent: Service Level Objectives
     url: get-a-slos-details
+    generated: true
   - name: Update a SLO
     parent: Service Level Objectives
     url: update-a-slo
+    generated: true
   - name: Get an SLO's history
     parent: Service Level Objectives
     url: get-an-slos-history
+    generated: true
   - name: Slack Integration
     url: /fr/api/v1/slack-integration/
     identifier: Slack Integration
+    generated: true
   - name: Delete a Slack integration
     parent: Slack Integration
     url: delete-a-slack-integration
+    generated: true
   - name: Get info about a Slack integration
     parent: Slack Integration
     url: get-info-about-a-slack-integration
+    generated: true
   - name: Create a Slack integration
     parent: Slack Integration
     url: create-a-slack-integration
+    generated: true
   - name: Add channels to Slack integration
     parent: Slack Integration
     url: add-channels-to-slack-integration
+    generated: true
   - name: Snapshots
     url: /fr/api/v1/snapshots/
     identifier: Snapshots
+    generated: true
   - name: Take graph snapshots
     parent: Snapshots
     url: take-graph-snapshots
+    generated: true
   - name: Synthetics
     url: /fr/api/v1/synthetics/
     identifier: Synthetics
+    generated: true
   - name: Get a list of tests
     parent: Synthetics
     url: get-a-list-of-tests
+    generated: true
   - name: Create a test
     parent: Synthetics
     url: create-a-test
+    generated: true
   - name: Get a browser test configuration
     parent: Synthetics
     url: get-a-browser-test-configuration
+    generated: true
   - name: Get the test's latest results summaries (browser)
     parent: Synthetics
     url: get-the-tests-latest-results-summaries-browser
+    generated: true
   - name: Get a test result (browser)
     parent: Synthetics
     url: get-a-test-result-browser
+    generated: true
   - name: Delete tests
     parent: Synthetics
     url: delete-tests
+    generated: true
   - name: Get a test configuration
     parent: Synthetics
     url: get-a-test-configuration
+    generated: true
   - name: Edit a test
     parent: Synthetics
     url: edit-a-test
+    generated: true
   - name: Get the test's latest results summaries (API)
     parent: Synthetics
     url: get-the-tests-latest-results-summaries-api
+    generated: true
   - name: Get a test result (API)
     parent: Synthetics
     url: get-a-test-result-api
+    generated: true
   - name: Pause or start a test
     parent: Synthetics
     url: pause-or-start-a-test
+    generated: true
   - name: Tags
     url: /fr/api/v1/tags/
     identifier: Tags
+    generated: true
   - name: Get Tags
     parent: Tags
     url: get-tags
+    generated: true
   - name: Remove host tags
     parent: Tags
     url: remove-host-tags
+    generated: true
   - name: Get host tags
     parent: Tags
     url: get-host-tags
+    generated: true
   - name: Add tags to a host
     parent: Tags
     url: add-tags-to-a-host
+    generated: true
   - name: Update host tags
     parent: Tags
     url: update-host-tags
+    generated: true
   - name: Timeboards
     url: /fr/api/v1/timeboards/
     identifier: Timeboards
+    generated: true
   - name: Tracing
     url: /fr/api/v1/tracing/
     identifier: Tracing
+    generated: true
   - name: Send traces
     parent: Tracing
     url: send-traces
+    generated: true
   - name: Usage Metering
     url: /fr/api/v1/usage-metering/
     identifier: Usage Metering
+    generated: true
   - name: Get hourly usage for analyzed logs
     parent: Usage Metering
     url: get-hourly-usage-for-analyzed-logs
+    generated: true
   - name: Get hourly usage for Lambda
     parent: Usage Metering
     url: get-hourly-usage-for-lambda
+    generated: true
   - name: Get hourly usage for Fargate
     parent: Usage Metering
     url: get-hourly-usage-for-fargate
+    generated: true
   - name: Get hourly usage for hosts and containers
     parent: Usage Metering
     url: get-hourly-usage-for-hosts-and-containers
+    generated: true
   - name: Get hourly usage for Logs
     parent: Usage Metering
     url: get-hourly-usage-for-logs
+    generated: true
   - name: Get hourly usage for Logs by Index
     parent: Usage Metering
     url: get-hourly-usage-for-logs-by-index
+    generated: true
   - name: Get hourly usage for Network Flows
     parent: Usage Metering
     url: get-hourly-usage-for-network-flows
+    generated: true
   - name: Get hourly usage for Network Hosts
     parent: Usage Metering
     url: get-hourly-usage-for-network-hosts
+    generated: true
   - name: Get hourly usage for RUM Sessions
     parent: Usage Metering
     url: get-hourly-usage-for-rum-sessions
+    generated: true
   - name: Get hourly usage for SNMP devices
     parent: Usage Metering
     url: get-hourly-usage-for-snmp-devices
+    generated: true
   - name: Get usage across your multi-org account
     parent: Usage Metering
     url: get-usage-across-your-multi-org-account
+    generated: true
   - name: Get hourly usage for Synthetics API Checks
     parent: Usage Metering
     url: get-hourly-usage-for-synthetics-api-checks
+    generated: true
   - name: Get hourly usage for Synthetics API Checks
     parent: Usage Metering
     url: get-hourly-usage-for-synthetics-api-checks
+    generated: true
   - name: Get hourly usage for Synthetics Browser Checks
     parent: Usage Metering
     url: get-hourly-usage-for-synthetics-browser-checks
+    generated: true
   - name: Get hourly usage for custom metrics
     parent: Usage Metering
     url: get-hourly-usage-for-custom-metrics
+    generated: true
   - name: Get top 500 custom metrics by hourly average
     parent: Usage Metering
     url: get-top-500-custom-metrics-by-hourly-average
+    generated: true
   - name: Get hourly usage for Trace Search
     parent: Usage Metering
     url: get-hourly-usage-for-trace-search
+    generated: true
   - name: Users
     url: /fr/api/v1/users/
     identifier: Users
+    generated: true
   - name: Get all users
     parent: Users
     url: get-all-users
+    generated: true
   - name: Create a user
     parent: Users
     url: create-a-user
+    generated: true
   - name: Disable a user
     parent: Users
     url: disable-a-user
+    generated: true
   - name: Get user details
     parent: Users
     url: get-user-details
+    generated: true
   - name: Update a user
     parent: Users
     url: update-a-user
+    generated: true
   - name: Webhooks Integration
     url: /fr/api/v1/webhooks-integration/
     identifier: Webhooks Integration
+    generated: true
   - name: Create a custom variable
     parent: Webhooks Integration
     url: create-a-custom-variable
+    generated: true
   - name: Delete a custom variable
     parent: Webhooks Integration
     url: delete-a-custom-variable
+    generated: true
   - name: Get a custom variable
     parent: Webhooks Integration
     url: get-a-custom-variable
+    generated: true
   - name: Update a custom variable
     parent: Webhooks Integration
     url: update-a-custom-variable
+    generated: true
   - name: Create a webhooks integration
     parent: Webhooks Integration
     url: create-a-webhooks-integration
+    generated: true
   - name: Delete a webhook
     parent: Webhooks Integration
     url: delete-a-webhook
+    generated: true
   - name: Get a webhook integration
     parent: Webhooks Integration
     url: get-a-webhook-integration
+    generated: true
   - name: Update a webhook
     parent: Webhooks Integration
     url: update-a-webhook
+    generated: true
 api_v2:
   - name: Overview
     url: /fr/api/v2/
@@ -2162,255 +2367,340 @@ api_v2:
   - name: AWS Integration
     url: /fr/api/v2/aws-integration/
     identifier: AWS Integration
+    generated: true
   - name: AWS Logs Integration
     url: /fr/api/v2/aws-logs-integration/
     identifier: AWS Logs Integration
+    generated: true
   - name: Authentication
     url: /fr/api/v2/authentication/
     identifier: Authentication
+    generated: true
   - name: Azure Integration
     url: /fr/api/v2/azure-integration/
     identifier: Azure Integration
+    generated: true
   - name: Dashboard Lists
     url: /fr/api/v2/dashboard-lists/
     identifier: Dashboard Lists
+    generated: true
   - name: Delete items from a dashboard list
     parent: Dashboard Lists
     url: delete-items-from-a-dashboard-list
+    generated: true
   - name: Get a Dashboard List
     parent: Dashboard Lists
     url: get-a-dashboard-list
+    generated: true
   - name: Add Items to a Dashboard List
     parent: Dashboard Lists
     url: add-items-to-a-dashboard-list
+    generated: true
   - name: Update items of a dashboard list
     parent: Dashboard Lists
     url: update-items-of-a-dashboard-list
+    generated: true
   - name: Dashboards
     url: /fr/api/v2/dashboards/
     identifier: Dashboards
+    generated: true
   - name: Downtimes
     url: /fr/api/v2/downtimes/
     identifier: Downtimes
+    generated: true
   - name: Embeddable Graphs
     url: /fr/api/v2/embeddable-graphs/
     identifier: Embeddable Graphs
+    generated: true
   - name: Events
     url: /fr/api/v2/events/
     identifier: Events
+    generated: true
   - name: GCP Integration
     url: /fr/api/v2/gcp-integration/
     identifier: GCP Integration
+    generated: true
   - name: Hosts
     url: /fr/api/v2/hosts/
     identifier: Hosts
+    generated: true
   - name: IP Ranges
     url: /fr/api/v2/ip-ranges/
     identifier: IP Ranges
+    generated: true
   - name: Key Management
     url: /fr/api/v2/key-management/
     identifier: Key Management
+    generated: true
   - name: Logs
     url: /fr/api/v2/logs/
     identifier: Logs
+    generated: true
   - name: Logs Archives
     url: /fr/api/v2/logs-archives/
     identifier: Logs Archives
+    generated: true
   - name: Get all archives
     parent: Logs Archives
     url: get-all-archives
+    generated: true
   - name: Create an archive
     parent: Logs Archives
     url: create-an-archive
+    generated: true
   - name: Delete an archive
     parent: Logs Archives
     url: delete-an-archive
+    generated: true
   - name: Get an archive
     parent: Logs Archives
     url: get-an-archive
+    generated: true
   - name: Update an archive
     parent: Logs Archives
     url: update-an-archive
+    generated: true
   - name: Revoke role from an archive
     parent: Logs Archives
     url: revoke-role-from-an-archive
+    generated: true
   - name: List read roles for an archive
     parent: Logs Archives
     url: list-read-roles-for-an-archive
+    generated: true
   - name: Grant role to an archive
     parent: Logs Archives
     url: grant-role-to-an-archive
+    generated: true
   - name: Logs Indexes
     url: /fr/api/v2/logs-indexes/
     identifier: Logs Indexes
+    generated: true
   - name: Logs Pipelines
     url: /fr/api/v2/logs-pipelines/
     identifier: Logs Pipelines
+    generated: true
   - name: Logs Restriction Queries
     url: /fr/api/v2/logs-restriction-queries/
     identifier: Logs Restriction Queries
+    generated: true
   - name: List restriction queries
     parent: Logs Restriction Queries
     url: list-restriction-queries
+    generated: true
   - name: Create a restriction query
     parent: Logs Restriction Queries
     url: create-a-restriction-query
+    generated: true
   - name: Get restriction query for a given role
     parent: Logs Restriction Queries
     url: get-restriction-query-for-a-given-role
+    generated: true
   - name: Get all restriction queries for a given user
     parent: Logs Restriction Queries
     url: get-all-restriction-queries-for-a-given-user
+    generated: true
   - name: Delete a restriction query
     parent: Logs Restriction Queries
     url: delete-a-restriction-query
+    generated: true
   - name: Get a restriction query
     parent: Logs Restriction Queries
     url: get-a-restriction-query
+    generated: true
   - name: Update a restriction query
     parent: Logs Restriction Queries
     url: update-a-restriction-query
+    generated: true
   - name: Revoke role from a restriction query
     parent: Logs Restriction Queries
     url: revoke-role-from-a-restriction-query
+    generated: true
   - name: List roles for a restriction query
     parent: Logs Restriction Queries
     url: list-roles-for-a-restriction-query
+    generated: true
   - name: Grant role to a restriction query
     parent: Logs Restriction Queries
     url: grant-role-to-a-restriction-query
+    generated: true
   - name: Metrics
     url: /fr/api/v2/metrics/
     identifier: Metrics
+    generated: true
   - name: Monitors
     url: /fr/api/v2/monitors/
     identifier: Monitors
+    generated: true
   - name: Organizations
     url: /fr/api/v2/organizations/
     identifier: Organizations
+    generated: true
   - name: PagerDuty Integration
     url: /fr/api/v2/pagerduty-integration/
     identifier: PagerDuty Integration
+    generated: true
   - name: Roles
     url: /fr/api/v2/roles/
     identifier: Roles
+    generated: true
   - name: List permissions
     parent: Roles
     url: list-permissions
+    generated: true
   - name: List roles
     parent: Roles
     url: list-roles
+    generated: true
   - name: Create role
     parent: Roles
     url: create-role
+    generated: true
   - name: Delete role
     parent: Roles
     url: delete-role
+    generated: true
   - name: Get a role
     parent: Roles
     url: get-a-role
+    generated: true
   - name: Update a role
     parent: Roles
     url: update-a-role
+    generated: true
   - name: Revoke permission
     parent: Roles
     url: revoke-permission
+    generated: true
   - name: List permissions for a role
     parent: Roles
     url: list-permissions-for-a-role
+    generated: true
   - name: Grant permission to a role
     parent: Roles
     url: grant-permission-to-a-role
+    generated: true
   - name: Remove a user from a role
     parent: Roles
     url: remove-a-user-from-a-role
+    generated: true
   - name: Get all users of a role
     parent: Roles
     url: get-all-users-of-a-role
+    generated: true
   - name: Add a user to a role
     parent: Roles
     url: add-a-user-to-a-role
+    generated: true
   - name: Screenboards
     url: /fr/api/v2/screenboards/
     identifier: Screenboards
+    generated: true
   - name: Security Monitoring
     url: /fr/api/v2/security-monitoring/
     identifier: Security Monitoring
+    generated: true
   - name: List rules
     parent: Security Monitoring
     url: list-rules
+    generated: true
   - name: Create a detection rule
     parent: Security Monitoring
     url: create-a-detection-rule
+    generated: true
   - name: Delete an existing rule
     parent: Security Monitoring
     url: delete-an-existing-rule
+    generated: true
   - name: Get a rule's details
     parent: Security Monitoring
     url: get-a-rules-details
+    generated: true
   - name: Update an existing rule
     parent: Security Monitoring
     url: update-an-existing-rule
+    generated: true
   - name: Service Checks
     url: /fr/api/v2/service-checks/
     identifier: Service Checks
+    generated: true
   - name: Service Dependencies
     url: /fr/api/v2/service-dependencies/
     identifier: Service Dependencies
+    generated: true
   - name: Service Level Objectives
     url: /fr/api/v2/service-level-objectives/
     identifier: Service Level Objectives
+    generated: true
   - name: Slack Integration
     url: /fr/api/v2/slack-integration/
     identifier: Slack Integration
+    generated: true
   - name: Snapshots
     url: /fr/api/v2/snapshots/
     identifier: Snapshots
+    generated: true
   - name: Synthetics
     url: /fr/api/v2/synthetics/
     identifier: Synthetics
+    generated: true
   - name: Tags
     url: /fr/api/v2/tags/
     identifier: Tags
+    generated: true
   - name: Timeboards
     url: /fr/api/v2/timeboards/
     identifier: Timeboards
+    generated: true
   - name: Tracing
     url: /fr/api/v2/tracing/
     identifier: Tracing
+    generated: true
   - name: Usage Metering
     url: /fr/api/v2/usage-metering/
     identifier: Usage Metering
+    generated: true
   - name: Users
     url: /fr/api/v2/users/
     identifier: Users
+    generated: true
   - name: Send invitation emails
     parent: Users
     url: send-invitation-emails
+    generated: true
   - name: Get a user invitation
     parent: Users
     url: get-a-user-invitation
+    generated: true
   - name: List all users
     parent: Users
     url: list-all-users
+    generated: true
   - name: Create a user
     parent: Users
     url: create-a-user
+    generated: true
   - name: Disable a user
     parent: Users
     url: disable-a-user
+    generated: true
   - name: Get a user
     parent: Users
     url: get-a-user
+    generated: true
   - name: Update a user
     parent: Users
     url: update-a-user
+    generated: true
   - name: Get a user organization
     parent: Users
     url: get-a-user-organization
+    generated: true
   - name: Get a user permissions
     parent: Users
     url: get-a-user-permissions
+    generated: true
   - name: Webhooks Integration
     url: /fr/api/v2/webhooks-integration/
     identifier: Webhooks Integration
+    generated: true

--- a/config/_default/menus/menus.ja.yaml
+++ b/config/_default/menus/menus.ja.yaml
@@ -1005,7 +1005,7 @@ main:
     identifier: log_collection_ruby
     weight: 109
   - name: その他のインテグレーション
-    url: integrations/#cat-log-collection
+    url: 'integrations/#cat-log-collection'
     identifier: other_integrations
     parent: log_collection
     weight: 110
@@ -1089,7 +1089,7 @@ main:
     identifier: logs_traces_connection
     weight: 8
   - name: ログとメトリクスの相関
-    url: dashboards/timeboards/#graph-menu
+    url: 'dashboards/timeboards/#graph-menu'
     parent: log_management
     identifier: logs_metrics_correlation
     weight: 9
@@ -1332,7 +1332,7 @@ main:
     identifier: dev_tools_metrics_powershell
     weight: 204
   - name: '送信 - API '
-    url: api/#post-timeseries-points
+    url: 'api/#post-timeseries-points'
     parent: dev_tools_metrics
     identifier: dev_tools_metrics_api
     weight: 205
@@ -1367,7 +1367,7 @@ main:
     identifier: dev_tools_events_mail
     weight: 303
   - name: API
-    url: api/#post-an-event
+    url: 'api/#post-an-event'
     parent: dev_tools_events
     identifier: dev_tools_events_api
     weight: 304
@@ -1560,618 +1560,823 @@ api_v1:
   - name: AWS Integration
     url: /ja/api/v1/aws-integration/
     identifier: AWS Integration
+    generated: true
   - name: Delete an AWS integration
     parent: AWS Integration
     url: delete-an-aws-integration
+    generated: true
   - name: List all AWS integrations
     parent: AWS Integration
     url: list-all-aws-integrations
+    generated: true
   - name: Create an AWS integration
     parent: AWS Integration
     url: create-an-aws-integration
+    generated: true
   - name: Update an AWS integration
     parent: AWS Integration
     url: update-an-aws-integration
+    generated: true
   - name: List namespace rules
     parent: AWS Integration
     url: list-namespace-rules
+    generated: true
   - name: Generate a new external ID
     parent: AWS Integration
     url: generate-a-new-external-id
+    generated: true
   - name: AWS Logs Integration
     url: /ja/api/v1/aws-logs-integration/
     identifier: AWS Logs Integration
+    generated: true
   - name: Delete an AWS Logs integration
     parent: AWS Logs Integration
     url: delete-an-aws-logs-integration
+    generated: true
   - name: List all AWS Logs integrations
     parent: AWS Logs Integration
     url: list-all-aws-logs-integrations
+    generated: true
   - name: Add AWS Log Lambda ARN
     parent: AWS Logs Integration
     url: add-aws-log-lambda-arn
+    generated: true
   - name: Check that an AWS Lambda Function exists
     parent: AWS Logs Integration
     url: check-that-an-aws-lambda-function-exists
+    generated: true
   - name: Get list of AWS log ready services
     parent: AWS Logs Integration
     url: get-list-of-aws-log-ready-services
+    generated: true
   - name: Enable an AWS Logs integration
     parent: AWS Logs Integration
     url: enable-an-aws-logs-integration
+    generated: true
   - name: Check permissions for log services
     parent: AWS Logs Integration
     url: check-permissions-for-log-services
+    generated: true
   - name: Authentication
     url: /ja/api/v1/authentication/
     identifier: Authentication
+    generated: true
   - name: Validate API key
     parent: Authentication
     url: validate-api-key
+    generated: true
   - name: Azure Integration
     url: /ja/api/v1/azure-integration/
     identifier: Azure Integration
+    generated: true
   - name: Delete an Azure integration
     parent: Azure Integration
     url: delete-an-azure-integration
+    generated: true
   - name: List all Azure integrations
     parent: Azure Integration
     url: list-all-azure-integrations
+    generated: true
   - name: Create an Azure integration
     parent: Azure Integration
     url: create-an-azure-integration
+    generated: true
   - name: Update an Azure integration
     parent: Azure Integration
     url: update-an-azure-integration
+    generated: true
   - name: Update Azure integration host filters
     parent: Azure Integration
     url: update-azure-integration-host-filters
+    generated: true
   - name: Dashboard Lists
     url: /ja/api/v1/dashboard-lists/
     identifier: Dashboard Lists
+    generated: true
   - name: Get all dashboard lists
     parent: Dashboard Lists
     url: get-all-dashboard-lists
+    generated: true
   - name: Create a dashboard list
     parent: Dashboard Lists
     url: create-a-dashboard-list
+    generated: true
   - name: Delete a dashboard list
     parent: Dashboard Lists
     url: delete-a-dashboard-list
+    generated: true
   - name: Get a dashboard list
     parent: Dashboard Lists
     url: get-a-dashboard-list
+    generated: true
   - name: Update a dashboard list
     parent: Dashboard Lists
     url: update-a-dashboard-list
+    generated: true
   - name: Dashboards
     url: /ja/api/v1/dashboards/
     identifier: Dashboards
+    generated: true
   - name: Get all dashboards
     parent: Dashboards
     url: get-all-dashboards
+    generated: true
   - name: Create a new dashboard
     parent: Dashboards
     url: create-a-new-dashboard
+    generated: true
   - name: Delete a dashboard
     parent: Dashboards
     url: delete-a-dashboard
+    generated: true
   - name: Get a dashboard
     parent: Dashboards
     url: get-a-dashboard
+    generated: true
   - name: Update a dashboard
     parent: Dashboards
     url: update-a-dashboard
+    generated: true
   - name: Downtimes
     url: /ja/api/v1/downtimes/
     identifier: Downtimes
+    generated: true
   - name: Get all downtimes
     parent: Downtimes
     url: get-all-downtimes
+    generated: true
   - name: Schedule a downtime
     parent: Downtimes
     url: schedule-a-downtime
+    generated: true
   - name: Cancel downtimes by scope
     parent: Downtimes
     url: cancel-downtimes-by-scope
+    generated: true
   - name: Cancel a downtime
     parent: Downtimes
     url: cancel-a-downtime
+    generated: true
   - name: Get a downtime
     parent: Downtimes
     url: get-a-downtime
+    generated: true
   - name: Update a downtime
     parent: Downtimes
     url: update-a-downtime
+    generated: true
   - name: Embeddable Graphs
     url: /ja/api/v1/embeddable-graphs/
     identifier: Embeddable Graphs
+    generated: true
   - name: Get all embeds
     parent: Embeddable Graphs
     url: get-all-embeds
+    generated: true
   - name: Create embed
     parent: Embeddable Graphs
     url: create-embed
+    generated: true
   - name: Get specific embed
     parent: Embeddable Graphs
     url: get-specific-embed
+    generated: true
   - name: Enable embed
     parent: Embeddable Graphs
     url: enable-embed
+    generated: true
   - name: Revoke embed
     parent: Embeddable Graphs
     url: revoke-embed
+    generated: true
   - name: Events
     url: /ja/api/v1/events/
     identifier: Events
+    generated: true
   - name: Query the event stream
     parent: Events
     url: query-the-event-stream
+    generated: true
   - name: Post an event
     parent: Events
     url: post-an-event
+    generated: true
   - name: Get an event
     parent: Events
     url: get-an-event
+    generated: true
   - name: GCP Integration
     url: /ja/api/v1/gcp-integration/
     identifier: GCP Integration
+    generated: true
   - name: Delete a GCP integration
     parent: GCP Integration
     url: delete-a-gcp-integration
+    generated: true
   - name: List all GCP integrations
     parent: GCP Integration
     url: list-all-gcp-integrations
+    generated: true
   - name: Create a GCP integration
     parent: GCP Integration
     url: create-a-gcp-integration
+    generated: true
   - name: Update a GCP integration
     parent: GCP Integration
     url: update-a-gcp-integration
+    generated: true
   - name: Hosts
     url: /ja/api/v1/hosts/
     identifier: Hosts
+    generated: true
   - name: Mute a host
     parent: Hosts
     url: mute-a-host
+    generated: true
   - name: Unmute a host
     parent: Hosts
     url: unmute-a-host
+    generated: true
   - name: Get all hosts for your organization
     parent: Hosts
     url: get-all-hosts-for-your-organization
+    generated: true
   - name: Get the total number of active hosts
     parent: Hosts
     url: get-the-total-number-of-active-hosts
+    generated: true
   - name: IP Ranges
     url: /ja/api/v1/ip-ranges/
     identifier: IP Ranges
+    generated: true
   - name: List IP Ranges
     parent: IP Ranges
     url: list-ip-ranges
+    generated: true
   - name: Key Management
     url: /ja/api/v1/key-management/
     identifier: Key Management
+    generated: true
   - name: Get all API keys
     parent: Key Management
     url: get-all-api-keys
+    generated: true
   - name: Create an API key
     parent: Key Management
     url: create-an-api-key
+    generated: true
   - name: Delete an API key
     parent: Key Management
     url: delete-an-api-key
+    generated: true
   - name: Get API key
     parent: Key Management
     url: get-api-key
+    generated: true
   - name: Edit an API key
     parent: Key Management
     url: edit-an-api-key
+    generated: true
   - name: Get all application keys
     parent: Key Management
     url: get-all-application-keys
+    generated: true
   - name: Create an application key
     parent: Key Management
     url: create-an-application-key
+    generated: true
   - name: Delete an application key
     parent: Key Management
     url: delete-an-application-key
+    generated: true
   - name: Get an application key
     parent: Key Management
     url: get-an-application-key
+    generated: true
   - name: Edit an application key
     parent: Key Management
     url: edit-an-application-key
+    generated: true
   - name: Logs
     url: /ja/api/v1/logs/
     identifier: Logs
+    generated: true
   - name: Get a list of logs
     parent: Logs
     url: get-a-list-of-logs
+    generated: true
   - name: Send logs
     parent: Logs
     url: send-logs
+    generated: true
   - name: Logs Archives
     url: /ja/api/v1/logs-archives/
     identifier: Logs Archives
+    generated: true
   - name: Logs Indexes
     url: /ja/api/v1/logs-indexes/
     identifier: Logs Indexes
+    generated: true
   - name: Get indexes order
     parent: Logs Indexes
     url: get-indexes-order
+    generated: true
   - name: Update indexes order
     parent: Logs Indexes
     url: update-indexes-order
+    generated: true
   - name: Get all indexes
     parent: Logs Indexes
     url: get-all-indexes
+    generated: true
   - name: Get an index
     parent: Logs Indexes
     url: get-an-index
+    generated: true
   - name: Update an index
     parent: Logs Indexes
     url: update-an-index
+    generated: true
   - name: Logs Pipelines
     url: /ja/api/v1/logs-pipelines/
     identifier: Logs Pipelines
+    generated: true
   - name: Get pipeline order
     parent: Logs Pipelines
     url: get-pipeline-order
+    generated: true
   - name: Update pipeline order
     parent: Logs Pipelines
     url: update-pipeline-order
+    generated: true
   - name: Get all pipelines
     parent: Logs Pipelines
     url: get-all-pipelines
+    generated: true
   - name: Create a pipeline
     parent: Logs Pipelines
     url: create-a-pipeline
+    generated: true
   - name: Delete a pipeline
     parent: Logs Pipelines
     url: delete-a-pipeline
+    generated: true
   - name: Get a pipeline
     parent: Logs Pipelines
     url: get-a-pipeline
+    generated: true
   - name: Update a pipeline
     parent: Logs Pipelines
     url: update-a-pipeline
+    generated: true
   - name: Logs Restriction Queries
     url: /ja/api/v1/logs-restriction-queries/
     identifier: Logs Restriction Queries
+    generated: true
   - name: Metrics
     url: /ja/api/v1/metrics/
     identifier: Metrics
+    generated: true
   - name: Get active metrics list
     parent: Metrics
     url: get-active-metrics-list
+    generated: true
   - name: Get metric metadata
     parent: Metrics
     url: get-metric-metadata
+    generated: true
   - name: Edit metric metadata
     parent: Metrics
     url: edit-metric-metadata
+    generated: true
   - name: Query timeseries points
     parent: Metrics
     url: query-timeseries-points
+    generated: true
   - name: Search metrics
     parent: Metrics
     url: search-metrics
+    generated: true
   - name: Submit metrics
     parent: Metrics
     url: submit-metrics
+    generated: true
   - name: Monitors
     url: /ja/api/v1/monitors/
     identifier: Monitors
+    generated: true
   - name: Get all monitor details
     parent: Monitors
     url: get-all-monitor-details
+    generated: true
   - name: Create a monitor
     parent: Monitors
     url: create-a-monitor
+    generated: true
   - name: Check if a monitor can be deleted
     parent: Monitors
     url: check-if-a-monitor-can-be-deleted
+    generated: true
   - name: Monitors group search
     parent: Monitors
     url: monitors-group-search
+    generated: true
   - name: Monitors search
     parent: Monitors
     url: monitors-search
+    generated: true
   - name: Validate a monitor
     parent: Monitors
     url: validate-a-monitor
+    generated: true
   - name: Delete a monitor
     parent: Monitors
     url: delete-a-monitor
+    generated: true
   - name: Get a monitor's details
     parent: Monitors
     url: get-a-monitors-details
+    generated: true
   - name: Edit a monitor
     parent: Monitors
     url: edit-a-monitor
+    generated: true
   - name: Mute a monitor
     parent: Monitors
     url: mute-a-monitor
+    generated: true
   - name: Unmute a monitor
     parent: Monitors
     url: unmute-a-monitor
+    generated: true
   - name: Resolve Monitor
     parent: Monitors
     url: resolve-monitor
+    generated: true
   - name: Mute all monitors
     parent: Monitors
     url: mute-all-monitors
+    generated: true
   - name: Unmute all monitors
     parent: Monitors
     url: unmute-all-monitors
+    generated: true
   - name: Organizations
     url: /ja/api/v1/organizations/
     identifier: Organizations
+    generated: true
   - name: List your managed organizations
     parent: Organizations
     url: list-your-managed-organizations
+    generated: true
   - name: Create a child organization
     parent: Organizations
     url: create-a-child-organization
+    generated: true
   - name: Get organization information
     parent: Organizations
     url: get-organization-information
+    generated: true
   - name: Update your organization
     parent: Organizations
     url: update-your-organization
+    generated: true
   - name: Upload IdP metadata
     parent: Organizations
     url: upload-idp-metadata
+    generated: true
   - name: PagerDuty Integration
     url: /ja/api/v1/pagerduty-integration/
     identifier: PagerDuty Integration
+    generated: true
   - name: Create a new service object
     parent: PagerDuty Integration
     url: create-a-new-service-object
+    generated: true
   - name: Delete a single service object
     parent: PagerDuty Integration
     url: delete-a-single-service-object
+    generated: true
   - name: Get a single service object
     parent: PagerDuty Integration
     url: get-a-single-service-object
+    generated: true
   - name: Update a single service object
     parent: PagerDuty Integration
     url: update-a-single-service-object
+    generated: true
   - name: Roles
     url: /ja/api/v1/roles/
     identifier: Roles
+    generated: true
   - name: Screenboards
     url: /ja/api/v1/screenboards/
     identifier: Screenboards
+    generated: true
   - name: Security Monitoring
     url: /ja/api/v1/security-monitoring/
     identifier: Security Monitoring
+    generated: true
   - name: Service Checks
     url: /ja/api/v1/service-checks/
     identifier: Service Checks
+    generated: true
   - name: Submit a Service Check
     parent: Service Checks
     url: submit-a-service-check
+    generated: true
   - name: Service Dependencies
     url: /ja/api/v1/service-dependencies/
     identifier: Service Dependencies
+    generated: true
   - name: Get all service dependencies
     parent: Service Dependencies
     url: get-all-service-dependencies
+    generated: true
   - name: Get one service's dependencies
     parent: Service Dependencies
     url: get-one-services-dependencies
+    generated: true
   - name: Service Level Objectives
     url: /ja/api/v1/service-level-objectives/
     identifier: Service Level Objectives
+    generated: true
   - name: Search SLOs
     parent: Service Level Objectives
     url: search-slos
+    generated: true
   - name: Create a SLO object
     parent: Service Level Objectives
     url: create-a-slo-object
+    generated: true
   - name: Bulk Delete SLO Timeframes
     parent: Service Level Objectives
     url: bulk-delete-slo-timeframes
+    generated: true
   - name: Check if SLOs can be safely deleted
     parent: Service Level Objectives
     url: check-if-slos-can-be-safely-deleted
+    generated: true
   - name: Delete a SLO
     parent: Service Level Objectives
     url: delete-a-slo
+    generated: true
   - name: Get a SLO's details
     parent: Service Level Objectives
     url: get-a-slos-details
+    generated: true
   - name: Update a SLO
     parent: Service Level Objectives
     url: update-a-slo
+    generated: true
   - name: Get an SLO's history
     parent: Service Level Objectives
     url: get-an-slos-history
+    generated: true
   - name: Slack Integration
     url: /ja/api/v1/slack-integration/
     identifier: Slack Integration
+    generated: true
   - name: Delete a Slack integration
     parent: Slack Integration
     url: delete-a-slack-integration
+    generated: true
   - name: Get info about a Slack integration
     parent: Slack Integration
     url: get-info-about-a-slack-integration
+    generated: true
   - name: Create a Slack integration
     parent: Slack Integration
     url: create-a-slack-integration
+    generated: true
   - name: Add channels to Slack integration
     parent: Slack Integration
     url: add-channels-to-slack-integration
+    generated: true
   - name: Snapshots
     url: /ja/api/v1/snapshots/
     identifier: Snapshots
+    generated: true
   - name: Take graph snapshots
     parent: Snapshots
     url: take-graph-snapshots
+    generated: true
   - name: Synthetics
     url: /ja/api/v1/synthetics/
     identifier: Synthetics
+    generated: true
   - name: Get a list of tests
     parent: Synthetics
     url: get-a-list-of-tests
+    generated: true
   - name: Create a test
     parent: Synthetics
     url: create-a-test
+    generated: true
   - name: Get a browser test configuration
     parent: Synthetics
     url: get-a-browser-test-configuration
+    generated: true
   - name: Get the test's latest results summaries (browser)
     parent: Synthetics
     url: get-the-tests-latest-results-summaries-browser
+    generated: true
   - name: Get a test result (browser)
     parent: Synthetics
     url: get-a-test-result-browser
+    generated: true
   - name: Delete tests
     parent: Synthetics
     url: delete-tests
+    generated: true
   - name: Get a test configuration
     parent: Synthetics
     url: get-a-test-configuration
+    generated: true
   - name: Edit a test
     parent: Synthetics
     url: edit-a-test
+    generated: true
   - name: Get the test's latest results summaries (API)
     parent: Synthetics
     url: get-the-tests-latest-results-summaries-api
+    generated: true
   - name: Get a test result (API)
     parent: Synthetics
     url: get-a-test-result-api
+    generated: true
   - name: Pause or start a test
     parent: Synthetics
     url: pause-or-start-a-test
+    generated: true
   - name: Tags
     url: /ja/api/v1/tags/
     identifier: Tags
+    generated: true
   - name: Get Tags
     parent: Tags
     url: get-tags
+    generated: true
   - name: Remove host tags
     parent: Tags
     url: remove-host-tags
+    generated: true
   - name: Get host tags
     parent: Tags
     url: get-host-tags
+    generated: true
   - name: Add tags to a host
     parent: Tags
     url: add-tags-to-a-host
+    generated: true
   - name: Update host tags
     parent: Tags
     url: update-host-tags
+    generated: true
   - name: Timeboards
     url: /ja/api/v1/timeboards/
     identifier: Timeboards
+    generated: true
   - name: Tracing
     url: /ja/api/v1/tracing/
     identifier: Tracing
+    generated: true
   - name: Send traces
     parent: Tracing
     url: send-traces
+    generated: true
   - name: Usage Metering
     url: /ja/api/v1/usage-metering/
     identifier: Usage Metering
+    generated: true
   - name: Get hourly usage for analyzed logs
     parent: Usage Metering
     url: get-hourly-usage-for-analyzed-logs
+    generated: true
   - name: Get hourly usage for Lambda
     parent: Usage Metering
     url: get-hourly-usage-for-lambda
+    generated: true
   - name: Get hourly usage for Fargate
     parent: Usage Metering
     url: get-hourly-usage-for-fargate
+    generated: true
   - name: Get hourly usage for hosts and containers
     parent: Usage Metering
     url: get-hourly-usage-for-hosts-and-containers
+    generated: true
   - name: Get hourly usage for Logs
     parent: Usage Metering
     url: get-hourly-usage-for-logs
+    generated: true
   - name: Get hourly usage for Logs by Index
     parent: Usage Metering
     url: get-hourly-usage-for-logs-by-index
+    generated: true
   - name: Get hourly usage for Network Flows
     parent: Usage Metering
     url: get-hourly-usage-for-network-flows
+    generated: true
   - name: Get hourly usage for Network Hosts
     parent: Usage Metering
     url: get-hourly-usage-for-network-hosts
+    generated: true
   - name: Get hourly usage for RUM Sessions
     parent: Usage Metering
     url: get-hourly-usage-for-rum-sessions
+    generated: true
   - name: Get hourly usage for SNMP devices
     parent: Usage Metering
     url: get-hourly-usage-for-snmp-devices
+    generated: true
   - name: Get usage across your multi-org account
     parent: Usage Metering
     url: get-usage-across-your-multi-org-account
+    generated: true
   - name: Get hourly usage for Synthetics API Checks
     parent: Usage Metering
     url: get-hourly-usage-for-synthetics-api-checks
+    generated: true
   - name: Get hourly usage for Synthetics API Checks
     parent: Usage Metering
     url: get-hourly-usage-for-synthetics-api-checks
+    generated: true
   - name: Get hourly usage for Synthetics Browser Checks
     parent: Usage Metering
     url: get-hourly-usage-for-synthetics-browser-checks
+    generated: true
   - name: Get hourly usage for custom metrics
     parent: Usage Metering
     url: get-hourly-usage-for-custom-metrics
+    generated: true
   - name: Get top 500 custom metrics by hourly average
     parent: Usage Metering
     url: get-top-500-custom-metrics-by-hourly-average
+    generated: true
   - name: Get hourly usage for Trace Search
     parent: Usage Metering
     url: get-hourly-usage-for-trace-search
+    generated: true
   - name: Users
     url: /ja/api/v1/users/
     identifier: Users
+    generated: true
   - name: Get all users
     parent: Users
     url: get-all-users
+    generated: true
   - name: Create a user
     parent: Users
     url: create-a-user
+    generated: true
   - name: Disable a user
     parent: Users
     url: disable-a-user
+    generated: true
   - name: Get user details
     parent: Users
     url: get-user-details
+    generated: true
   - name: Update a user
     parent: Users
     url: update-a-user
+    generated: true
   - name: Webhooks Integration
     url: /ja/api/v1/webhooks-integration/
     identifier: Webhooks Integration
+    generated: true
   - name: Create a custom variable
     parent: Webhooks Integration
     url: create-a-custom-variable
+    generated: true
   - name: Delete a custom variable
     parent: Webhooks Integration
     url: delete-a-custom-variable
+    generated: true
   - name: Get a custom variable
     parent: Webhooks Integration
     url: get-a-custom-variable
+    generated: true
   - name: Update a custom variable
     parent: Webhooks Integration
     url: update-a-custom-variable
+    generated: true
   - name: Create a webhooks integration
     parent: Webhooks Integration
     url: create-a-webhooks-integration
+    generated: true
   - name: Delete a webhook
     parent: Webhooks Integration
     url: delete-a-webhook
+    generated: true
   - name: Get a webhook integration
     parent: Webhooks Integration
     url: get-a-webhook-integration
+    generated: true
   - name: Update a webhook
     parent: Webhooks Integration
     url: update-a-webhook
+    generated: true
 api_v2:
   - name: Overview
     url: /ja/api/v2/
@@ -2200,255 +2405,340 @@ api_v2:
   - name: AWS Integration
     url: /ja/api/v2/aws-integration/
     identifier: AWS Integration
+    generated: true
   - name: AWS Logs Integration
     url: /ja/api/v2/aws-logs-integration/
     identifier: AWS Logs Integration
+    generated: true
   - name: Authentication
     url: /ja/api/v2/authentication/
     identifier: Authentication
+    generated: true
   - name: Azure Integration
     url: /ja/api/v2/azure-integration/
     identifier: Azure Integration
+    generated: true
   - name: Dashboard Lists
     url: /ja/api/v2/dashboard-lists/
     identifier: Dashboard Lists
+    generated: true
   - name: Delete items from a dashboard list
     parent: Dashboard Lists
     url: delete-items-from-a-dashboard-list
+    generated: true
   - name: Get a Dashboard List
     parent: Dashboard Lists
     url: get-a-dashboard-list
+    generated: true
   - name: Add Items to a Dashboard List
     parent: Dashboard Lists
     url: add-items-to-a-dashboard-list
+    generated: true
   - name: Update items of a dashboard list
     parent: Dashboard Lists
     url: update-items-of-a-dashboard-list
+    generated: true
   - name: Dashboards
     url: /ja/api/v2/dashboards/
     identifier: Dashboards
+    generated: true
   - name: Downtimes
     url: /ja/api/v2/downtimes/
     identifier: Downtimes
+    generated: true
   - name: Embeddable Graphs
     url: /ja/api/v2/embeddable-graphs/
     identifier: Embeddable Graphs
+    generated: true
   - name: Events
     url: /ja/api/v2/events/
     identifier: Events
+    generated: true
   - name: GCP Integration
     url: /ja/api/v2/gcp-integration/
     identifier: GCP Integration
+    generated: true
   - name: Hosts
     url: /ja/api/v2/hosts/
     identifier: Hosts
+    generated: true
   - name: IP Ranges
     url: /ja/api/v2/ip-ranges/
     identifier: IP Ranges
+    generated: true
   - name: Key Management
     url: /ja/api/v2/key-management/
     identifier: Key Management
+    generated: true
   - name: Logs
     url: /ja/api/v2/logs/
     identifier: Logs
+    generated: true
   - name: Logs Archives
     url: /ja/api/v2/logs-archives/
     identifier: Logs Archives
+    generated: true
   - name: Get all archives
     parent: Logs Archives
     url: get-all-archives
+    generated: true
   - name: Create an archive
     parent: Logs Archives
     url: create-an-archive
+    generated: true
   - name: Delete an archive
     parent: Logs Archives
     url: delete-an-archive
+    generated: true
   - name: Get an archive
     parent: Logs Archives
     url: get-an-archive
+    generated: true
   - name: Update an archive
     parent: Logs Archives
     url: update-an-archive
+    generated: true
   - name: Revoke role from an archive
     parent: Logs Archives
     url: revoke-role-from-an-archive
+    generated: true
   - name: List read roles for an archive
     parent: Logs Archives
     url: list-read-roles-for-an-archive
+    generated: true
   - name: Grant role to an archive
     parent: Logs Archives
     url: grant-role-to-an-archive
+    generated: true
   - name: Logs Indexes
     url: /ja/api/v2/logs-indexes/
     identifier: Logs Indexes
+    generated: true
   - name: Logs Pipelines
     url: /ja/api/v2/logs-pipelines/
     identifier: Logs Pipelines
+    generated: true
   - name: Logs Restriction Queries
     url: /ja/api/v2/logs-restriction-queries/
     identifier: Logs Restriction Queries
+    generated: true
   - name: List restriction queries
     parent: Logs Restriction Queries
     url: list-restriction-queries
+    generated: true
   - name: Create a restriction query
     parent: Logs Restriction Queries
     url: create-a-restriction-query
+    generated: true
   - name: Get restriction query for a given role
     parent: Logs Restriction Queries
     url: get-restriction-query-for-a-given-role
+    generated: true
   - name: Get all restriction queries for a given user
     parent: Logs Restriction Queries
     url: get-all-restriction-queries-for-a-given-user
+    generated: true
   - name: Delete a restriction query
     parent: Logs Restriction Queries
     url: delete-a-restriction-query
+    generated: true
   - name: Get a restriction query
     parent: Logs Restriction Queries
     url: get-a-restriction-query
+    generated: true
   - name: Update a restriction query
     parent: Logs Restriction Queries
     url: update-a-restriction-query
+    generated: true
   - name: Revoke role from a restriction query
     parent: Logs Restriction Queries
     url: revoke-role-from-a-restriction-query
+    generated: true
   - name: List roles for a restriction query
     parent: Logs Restriction Queries
     url: list-roles-for-a-restriction-query
+    generated: true
   - name: Grant role to a restriction query
     parent: Logs Restriction Queries
     url: grant-role-to-a-restriction-query
+    generated: true
   - name: Metrics
     url: /ja/api/v2/metrics/
     identifier: Metrics
+    generated: true
   - name: Monitors
     url: /ja/api/v2/monitors/
     identifier: Monitors
+    generated: true
   - name: Organizations
     url: /ja/api/v2/organizations/
     identifier: Organizations
+    generated: true
   - name: PagerDuty Integration
     url: /ja/api/v2/pagerduty-integration/
     identifier: PagerDuty Integration
+    generated: true
   - name: Roles
     url: /ja/api/v2/roles/
     identifier: Roles
+    generated: true
   - name: List permissions
     parent: Roles
     url: list-permissions
+    generated: true
   - name: List roles
     parent: Roles
     url: list-roles
+    generated: true
   - name: Create role
     parent: Roles
     url: create-role
+    generated: true
   - name: Delete role
     parent: Roles
     url: delete-role
+    generated: true
   - name: Get a role
     parent: Roles
     url: get-a-role
+    generated: true
   - name: Update a role
     parent: Roles
     url: update-a-role
+    generated: true
   - name: Revoke permission
     parent: Roles
     url: revoke-permission
+    generated: true
   - name: List permissions for a role
     parent: Roles
     url: list-permissions-for-a-role
+    generated: true
   - name: Grant permission to a role
     parent: Roles
     url: grant-permission-to-a-role
+    generated: true
   - name: Remove a user from a role
     parent: Roles
     url: remove-a-user-from-a-role
+    generated: true
   - name: Get all users of a role
     parent: Roles
     url: get-all-users-of-a-role
+    generated: true
   - name: Add a user to a role
     parent: Roles
     url: add-a-user-to-a-role
+    generated: true
   - name: Screenboards
     url: /ja/api/v2/screenboards/
     identifier: Screenboards
+    generated: true
   - name: Security Monitoring
     url: /ja/api/v2/security-monitoring/
     identifier: Security Monitoring
+    generated: true
   - name: List rules
     parent: Security Monitoring
     url: list-rules
+    generated: true
   - name: Create a detection rule
     parent: Security Monitoring
     url: create-a-detection-rule
+    generated: true
   - name: Delete an existing rule
     parent: Security Monitoring
     url: delete-an-existing-rule
+    generated: true
   - name: Get a rule's details
     parent: Security Monitoring
     url: get-a-rules-details
+    generated: true
   - name: Update an existing rule
     parent: Security Monitoring
     url: update-an-existing-rule
+    generated: true
   - name: Service Checks
     url: /ja/api/v2/service-checks/
     identifier: Service Checks
+    generated: true
   - name: Service Dependencies
     url: /ja/api/v2/service-dependencies/
     identifier: Service Dependencies
+    generated: true
   - name: Service Level Objectives
     url: /ja/api/v2/service-level-objectives/
     identifier: Service Level Objectives
+    generated: true
   - name: Slack Integration
     url: /ja/api/v2/slack-integration/
     identifier: Slack Integration
+    generated: true
   - name: Snapshots
     url: /ja/api/v2/snapshots/
     identifier: Snapshots
+    generated: true
   - name: Synthetics
     url: /ja/api/v2/synthetics/
     identifier: Synthetics
+    generated: true
   - name: Tags
     url: /ja/api/v2/tags/
     identifier: Tags
+    generated: true
   - name: Timeboards
     url: /ja/api/v2/timeboards/
     identifier: Timeboards
+    generated: true
   - name: Tracing
     url: /ja/api/v2/tracing/
     identifier: Tracing
+    generated: true
   - name: Usage Metering
     url: /ja/api/v2/usage-metering/
     identifier: Usage Metering
+    generated: true
   - name: Users
     url: /ja/api/v2/users/
     identifier: Users
+    generated: true
   - name: Send invitation emails
     parent: Users
     url: send-invitation-emails
+    generated: true
   - name: Get a user invitation
     parent: Users
     url: get-a-user-invitation
+    generated: true
   - name: List all users
     parent: Users
     url: list-all-users
+    generated: true
   - name: Create a user
     parent: Users
     url: create-a-user
+    generated: true
   - name: Disable a user
     parent: Users
     url: disable-a-user
+    generated: true
   - name: Get a user
     parent: Users
     url: get-a-user
+    generated: true
   - name: Update a user
     parent: Users
     url: update-a-user
+    generated: true
   - name: Get a user organization
     parent: Users
     url: get-a-user-organization
+    generated: true
   - name: Get a user permissions
     parent: Users
     url: get-a-user-permissions
+    generated: true
   - name: Webhooks Integration
     url: /ja/api/v2/webhooks-integration/
     identifier: Webhooks Integration
+    generated: true

--- a/src/scripts/build-api-pages.js
+++ b/src/scripts/build-api-pages.js
@@ -18,53 +18,18 @@ const updateMenu = (apiYaml, apiVersion, languages) => {
 
   languages.forEach((language) => {
     const currentMenuYaml = yaml.safeLoad(fs.readFileSync(`./config/_default/menus/menus.${language}.yaml`, 'utf8'));
-  const newMenuArray = [];
 
-  // need to add hardcoded menu items
-  const mainOverviewSections = [
-    {
-        name: 'Overview',
-        url: (language === 'en' ? `/api/${apiVersion}/` : `/${language}/api/${apiVersion}/`),
-        identifier: `API ${apiVersion.toUpperCase()} overview`,
-        weight: -10
-    },
-    {
-        name: 'Install the Datadog Agent',
-        url: 'install-the-datadog-agent',
-        weight: 1,
-        parent: `API ${apiVersion.toUpperCase()} overview`
-    },
-    {   name: 'Send data to Datadog',
-        url: 'send-data-to-datadog',
-        weight: 2,
-        parent: `API ${apiVersion.toUpperCase()} overview`
-    },
-    {   name: 'Visualize your data',
-        url: 'visualize-your-data',
-        weight: 3,
-        parent: `API ${apiVersion.toUpperCase()} overview`
-    },
-    {   name: 'Manage your account',
-        url: 'manage-your-account',
-        weight: 4,
-        parent: `API ${apiVersion.toUpperCase()} overview`
-    },
-    {
-        name: 'Rate Limiting',
-        url: `rate-limiting`,
-        parent: `API ${apiVersion.toUpperCase()} overview`,
-        weight: 5
-    }
-  ];
+  // filter out auto generated menu items so we just have hardcoded ones
+  const newMenuArray = currentMenuYaml[`api_${apiVersion}`].filter((entry => !entry.hasOwnProperty("generated")));
 
-  newMenuArray.push(...mainOverviewSections);
-
+  // now add back in all the auto generated menu items from specs
   apiYaml.tags.forEach((tag) => {
 
     newMenuArray.push({
       name: tag.name,
       url: (language === 'en' ? `/api/${apiVersion}/${getTagSlug(tag.name)}/` : `/${language}/api/${apiVersion}/${getTagSlug(tag.name)}/` ),
-      identifier: tag.name
+      identifier: tag.name,
+      generated: true
     });
 
     // just get this sections data
@@ -76,7 +41,8 @@ const updateMenu = (apiYaml, apiVersion, languages) => {
         newMenuArray.push({
           name: action.summary,
           parent: tag.name,
-          url: getTagSlug(action.summary)
+          url: getTagSlug(action.summary),
+          generated: true
         });
     });
 


### PR DESCRIPTION
### What does this PR do?

This PR removes the need for menu items to be hardcoded in the javascript build pages script. Allowing contributors to update the menu yaml as normal.

**How does it work?**
All api generated menu items now have the attribute `generated: true`. When running the build script we now only remove the menu items with this attribute and then add the api menu items again. This allows us to still have manual entries in the menu.yaml file and not have them touched by the script.

### Motivation

There were git conflicts when a user updated the nav but the script changed the nav too.
See #7672 for the temporary fix

### Preview link

http://docs-staging.datadoghq.com/david.jones/menu-improve/api/

### Additional Notes


