### PR TITLE
Add note for journald logs source

### DIFF
--- a/content/en/integrations/journald.md
+++ b/content/en/integrations/journald.md
@@ -56,6 +56,7 @@ logs:
 ```
 
 **Note**: With Agent 7.17+ if `container_mode` is set to `true`, the `source` attribute of your logs is automatically set to the corresponding short image name of the container instead of simply `docker`.
+Indeed by default, the source and service are set to the unit name in journald which by default is `docker` for all logs coming from containers.
 
 Finally, [restart the agent][2].
 


### PR DESCRIPTION
### What does this PR do?
Add details about setting the source for journald in container mode

### Motivation
Clarifying the behaviour

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/journald-log-source/integrations/journald/#log-collection

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
