### PR TITLE
[RUM] add documentation for loading time and loading type

### DIFF
--- a/content/en/real_user_monitoring/data_collected/_index.md
+++ b/content/en/real_user_monitoring/data_collected/_index.md
@@ -41,6 +41,7 @@ These five event categories have attributes attached by default:
 |--------------------------------|--------|----------------------------------------------------------------------------------------------------------------|
 | `view.id`                      | string | Randomly generated ID for each page view.                                                                      |
 | `view.url`                     | string | The view URL.                                                                                                  |
+| `view.loading_type`                     | string | The type of page load: `initial_load` or `route_change`. [More information on Single Page Applications support.][1]|
 | `view.referrer`                | string | The URL of the previous web page from which a link to the currently requested page was followed.               |
 | `view.url_details.host`        | string | The HTTP host part of the URL.                                                                                 |
 | `view.url_details.path`        | string | The HTTP path part of the URL.                                                                                 |
@@ -49,7 +50,7 @@ These five event categories have attributes attached by default:
 
 ### User Agent
 
-The following contexts—following the [Datadog Standard Attributes][1] logic—are attached automatically to all events sent to Datadog:
+The following contexts—following the [Datadog Standard Attributes][2] logic—are attached automatically to all events sent to Datadog:
 
 | Attribute name                           | Type   | Description                                     |
 |------------------------------------------|--------|-------------------------------------------------|
@@ -65,21 +66,22 @@ The following attributes are related to the geolocation of IP addresses used in 
 | Fullname                                    | Type   | Description                                                                                                                          |
 |:--------------------------------------------|:-------|:-------------------------------------------------------------------------------------------------------------------------------------|
 | `network.client.geoip.country.name`         | string | Name of the country                                                                                                                  |
-| `network.client.geoip.country.iso_code`     | string | [ISO Code][2] of the country (example: `US` for the United States, `FR` for France)                                                  |
+| `network.client.geoip.country.iso_code`     | string | [ISO Code][3] of the country (example: `US` for the United States, `FR` for France)                                                  |
 | `network.client.geoip.continent.code`       | string | ISO code of the continent (`EU`, `AS`, `NA`, `AF`, `AN`, `SA`, `OC`)                                                                 |
 | `network.client.geoip.continent.name`       | string | Name of the continent (`Europe`, `Australia`, `North America`, `Africa`, `Antartica`, `South America`, `Oceania`)                    |
 | `network.client.geoip.subdivision.name`     | string | Name of the first subdivision level of the country (example: `California` in the United States or the `Sarthe` department in France) |
-| `network.client.geoip.subdivision.iso_code` | string | [ISO Code][2] of the first subdivision level of the country (example: `CA` in the United States or the `SA` department in France)    |
+| `network.client.geoip.subdivision.iso_code` | string | [ISO Code][3] of the first subdivision level of the country (example: `CA` in the United States or the `SA` department in France)    |
 | `network.client.geoip.city.name`            | string | The name of the city (example `Paris`, `New York`)                                                                                   |
 
 ## Extra Attribute
 
-In addition to default attributes, you can add your [specific global context][3] to all events collected. This provides you the ability to analyze the data for a subset of users: group errors by user email, understand which customers have the worst performance, etc.
+In addition to default attributes, you can add your [specific global context][4] to all events collected. This provides you the ability to analyze the data for a subset of users: group errors by user email, understand which customers have the worst performance, etc.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /logs/processing/attributes_naming_convention/
-[2]: /logs/processing/attributes_naming_convention/#user-agent-attributes
-[3]: /real_user_monitoring/installation/advanced_configuration/
+[1]: /real_user_monitoring/data_collected/view#single-page-applications
+[2]: /logs/processing/attributes_naming_convention/
+[3]: /logs/processing/attributes_naming_convention/#user-agent-attributes
+[4]: /real_user_monitoring/installation/advanced_configuration/

--- a/content/en/real_user_monitoring/data_collected/view.md
+++ b/content/en/real_user_monitoring/data_collected/view.md
@@ -20,20 +20,35 @@ A page view represents a user visiting a page from your website. During that pag
 
 For page views, loading performance metrics are collected from both the [Paint Timing API][5] and the [Navigation Timing API][6].
 
-For Single Page Applications (SPAs), performance metrics will only be available for the first accessed page. Modern web frameworks like ReactJS, AngularJS, or VueJS update a website’s content without reloading the page, preventing Datadog from collecting traditional performance metrics. RUM is able to track page changes using the [History API][7].
+## Single Page Applications
 
-## Measures collected
+For Single Page Applications (SPAs), the RUM SDK differentiates between `initial_load` and `route_change` navigations with the `loading_type` attribute. If a click on your web page leads to a new page without a full refresh of the page, the RUM SDK will start a new View event with `loading_type:route_change`. RUM is able to track page changes using the [History API][7].
+
+Datadog provides a unique performance metric, Loading Time, which calculates the time needed for a page to load. This metric works both for `initial_load` and `route_change` navigations.
+
+### How is Loading Time calculated?
+To account for modern web applications, Loading Time watches for network requests and long tasks.
+
+* **Initial Load**: Loading Time is equal to the difference between `navigationStart` and:
+  * the load event end\
+*or, whichever comes last,*
+  *  the first time network is idle for more than 100 milliseconds and no long task is currently occuring
+
+* **SPA Route Change**: Loading Time is equal to the difference between the user click and the first time network is idle for than 100 milliseconds and no long task is currently occuring
+
+## Metrics collected
 
 {{< img src="real_user_monitoring/data_collected/view/timing_overview.png" alt="Timing overview"  >}}
 
 | Attribute                              | Type        | Decription                                                                                                                                                                                                                 |
 |----------------------------------------|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `duration`                             | number (ns) | Time spent on the current view.                                                                                                                                                                                                  |
-| `view.measures.first_contentful_paint` | number (ns) | Time when the browser first rendered any text, image (including background images), non-white canvas, or SVG.[Learn more][8]                                                                                                |
-| `view.measures.dom_interactive`        | number (ns) | The moment when the parser finished its work on the main document. [More info from the MDN documentation][9]                                                                                                               |
-| `view.measures.dom_content_loaded`     | number (ns) | Event fired when the initial HTML document has been completely loaded and parsed, without waiting for non-render blocking stylesheets, images, and subframes to finish loading. [More info from the MDN documentation][10]. |
-| `view.measures.dom_complete`           | number (ns) | The page and all the subresources are ready. For the user, the loading spinner has stopped spinning. [More info from the MDN documentation][11]                                                                             |
-| `view.measures.load_event_end`         | number (ns) | Event fired when the page is fully loaded. Usually a trigger for additional application logic. [More info from the MDN documentation][12]                                                                                   |
+| `view.loading_time`                             | number (ns) | Time until the page is ready and no network or long task activity is currently occuring. [Learn more][8]|
+| `view.measures.first_contentful_paint` | number (ns) | Time when the browser first rendered any text, image (including background images), non-white canvas, or SVG.[Learn more][9]                                                                                                |
+| `view.measures.dom_interactive`        | number (ns) | The moment when the parser finished its work on the main document. [More info from the MDN documentation][10]                                                                                                               |
+| `view.measures.dom_content_loaded`     | number (ns) | Event fired when the initial HTML document has been completely loaded and parsed, without waiting for non-render blocking stylesheets, images, and subframes to finish loading. [More info from the MDN documentation][11]. |
+| `view.measures.dom_complete`           | number (ns) | The page and all the subresources are ready. For the user, the loading spinner has stopped spinning. [More info from the MDN documentation][12]                                                                             |
+| `view.measures.load_event_end`         | number (ns) | Event fired when the page is fully loaded. Usually a trigger for additional application logic. [More info from the MDN documentation][13]                                                                                   |
 | `view.measures.error_count`            | number      | Count of all errors collected so far for this view.                                                                                                                                                                        |
 | `view.measures.long_task_count`        | number      | Count of all long tasks collected for this view.                                                                                                                                                                           |
 | `view.measures.resource_count`         | number      | Count of all resources collected for this view.                                                                                                                                                                            |
@@ -50,8 +65,9 @@ For Single Page Applications (SPAs), performance metrics will only be available 
 [5]: https://www.w3.org/TR/paint-timing/
 [6]: https://www.w3.org/TR/navigation-timing/#sec-navigation-timing
 [7]: https://developer.mozilla.org/en-US/docs/Web/API/History
-[8]: https://www.w3.org/TR/paint-timing/#sec-terminology
-[9]: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming/domInteractive
-[10]: https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event
-[11]: https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event
-[12]: https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event
+[8]: /real_user_monitoring/data_collected/view/#how-is-loading-time-calculated
+[9]: https://www.w3.org/TR/paint-timing/#sec-terminology
+[10]: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming/domInteractive
+[11]: https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event
+[12]: https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event
+[13]: https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add documentation for new RUM view attribute `Loading Type` and the new SPA-friendly performance metric `Loading Time`.

### Motivation
<!-- What inspired you to submit this pull request?-->
New feature

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hdelaby/loading-time-type/real_user_monitoring/data_collected/view#single-page-applications

https://docs-staging.datadoghq.com/hdelaby/loading-time-type/real_user_monitoring/data_collected/view/#how-is-loading-time-calculated

https://docs-staging.datadoghq.com/hdelaby/loading-time-type/real_user_monitoring/data_collected/#view-attribute

### Additional Notes
<!-- Anything else we should know when reviewing?-->
I am not entirely sure about the `How is Loading Time Calculated?` section. There's probably a better way to simplify this rather tricky concept.
