### PR TITLE
[dogstatsd] link to the Kubernetes documentation about setting sysctls in pods

### DIFF
--- a/content/en/developers/dogstatsd/high_throughput.md
+++ b/content/en/developers/dogstatsd/high_throughput.md
@@ -266,9 +266,7 @@ dogstatsd_so_rcvbuf: 4194304
 
 #### Note on sysctl in Kubernetes
 
-If you are using Kubernetes to deploy the Agent and/or DogStatsD, setting the `sysctl` values will need to be done for their container.
-
-The `net.*` sysctls being namespaced, you will be able to set them per pod: see [the official Kubernetes documentation][6] on how to allow access to the sysctl in the containers and how to set their value.
+If you are using Kubernetes to deploy the Agent and/or DogStatsD and you want to configure the sysctls as mentioned above, setting their value will have to be done per container. The `net.*` sysctls being namespaced, you will be able to set them per pod: see [the official Kubernetes documentation][6] on how to allow the access to the sysctls in the containers and how to set their value.
 
 ### Ensure proper packet sizes
 

--- a/content/en/developers/dogstatsd/high_throughput.md
+++ b/content/en/developers/dogstatsd/high_throughput.md
@@ -227,6 +227,8 @@ Then set the Agent `dogstatsd_so_rcvbuf` configuration option to the same number
 dogstatsd_so_rcvbuf: 26214400
 ```
 
+See the [Note on sysctl in Kubernetes][5] section if you are deploying the Agent or DogStatsD in Kubernetes.
+
 ### Over UDS (Unix Domain Socket)
 
 #### Linux
@@ -261,6 +263,12 @@ Then set the Agent `dogstatsd_so_rcvbuf` configuration option to the same number
 ```yaml
 dogstatsd_so_rcvbuf: 4194304
 ```
+
+#### Note on sysctl in Kubernetes
+
+If you are using Kubernetes to deploy the Agent and/or DogStatsD, setting the `sysctl` values will need to be done for their container.
+
+The `net.*` sysctls being namespaced, you will be able to set them per pod: see [the official Kubernetes documentation][6] on how to allow access to the sysctl in the containers and how to set their value.
 
 ### Ensure proper packet sizes
 
@@ -514,3 +522,5 @@ See [DataDog/dogstatsd-csharp-client][1] for more information about the client c
 [2]: /developers/dogstatsd/unix_socket/
 [3]: /developers/dogstatsd/#code
 [4]: /developers/metrics/dogstatsd_metrics_submission/#sample-rates
+[5]: /developers/dogstatsd/high_throughput/#note-on-sysctl-in-kubernetes
+[6]: https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/


### PR DESCRIPTION
### What does this PR do?

Mention that there is differences for setting sysctls within kubernetes pod and link to the Kubernetes documentation. 

### Motivation

We've already documented how to do it on a host and it was important to mention how to do that with Kubernetes.

### Preview link
https://docs-staging.datadoghq.com/remeh/sysctl-k8s/developers/dogstatsd/high_throughput/?tab=go#note-on-sysctl-in-kubernetes
