### PR TITLE
WEB-294 shorten title width on large screens

### DIFF
--- a/src/styles/pages/_global.scss
+++ b/src/styles/pages/_global.scss
@@ -244,6 +244,9 @@ p {
 h1 {
   line-height: 42px;
   padding-bottom: 15.5px;
+  @media (min-width: 992px) {
+    width: 80%;
+  }
   /*&~ p {
     padding-top:10px;
   }*/


### PR DESCRIPTION
# What does this PR do?
Shorten's the `h1` title width for large desktop to prevent overlapping the region selector. 


### Motivation
https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?assignee=5d4b49d50fa6d40d14fc7b11&selectedIssue=WEB-294

### Preview link
https://docs-staging.datadoghq.com/zach/title-fix/developers/faq/data-collection-resolution-retention

