### PR TITLE
configure remapper type conversion

### DIFF
--- a/content/en/logs/processing/processors.md
+++ b/content/en/logs/processing/processors.md
@@ -274,6 +274,9 @@ Into this log:
 
 Constraints on the tag/attribute name are explained in the [Tagging documentation][5]. Some additional constraints are applied as `:` or `,` are not allowed in the target tag/attribute name.
 
+If the target of the remapper is an attribute, the remapper can also cast the value to a new type (`String`, `Long` or `Double`). If the cast is not possible, the original type is kept. 
+**Note:** The decimal separator for double need to be `.`. 
+
 {{< tabs >}}
 {{% tab "UI" %}}
 
@@ -296,6 +299,7 @@ Use the [Datadog Log Pipeline API endpoint][1] with the following Remapper JSON 
   "sources": ["<SOURCE_ATTRIBUTE>"],
   "target": "<TARGET_ATTRIBUTE>",
   "target_type": "tag",
+  "target_format": "long",
   "preserve_source": false,
   "override_on_conflict": false
 }
@@ -310,6 +314,7 @@ Use the [Datadog Log Pipeline API endpoint][1] with the following Remapper JSON 
 | `sources`              | Array of Strings | yes      | Array of source attributes or tags                                             |
 | `target`               | String           | yes      | Final attribute or tag name to remap the sources to.                           |
 | `target_type`          | String           | no       | Defines if the target is a log `attribute` or a `tag`, default: `attribute`    |
+| `target_format`        | String           | no       | Defines if the attribute value should be cast to another type. possible value: `string`, `long`  or `double`. Do not set this paramater to disable it. |
 | `preserve_source`      | Boolean          | no       | Remove or preserve the remapped source element, default: `false`               |
 | `override_on_conflict` | Boolean          | no       | Override or not the target element if already set, default: `false`            |
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Explain how to configure the remapper processor so that he cast your attribute into a new type. 

### Motivation
https://datadoghq.atlassian.net/browse/LA-307


### Preview link

https://docs-staging.datadoghq.com/pvr/attribute-remapper-type/logs/processing/processors/?tab=api#remapper

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
