### PR TITLE
Fix Kubernetes manifests url for the Datadog cluster agent RBAC

### DIFF
--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -65,16 +65,16 @@ Setting the value without a secret results in the token being readable in the `P
 2. Run this one line command:
 
     ```shell
-    kubectl create secret generic datadog-auth-token --from-literal=token=<ThirtyX2XcharactersXlongXtoken>
+    kubectl create secret generic datadog-agent-cluster-agent --from-literal=token='<ThirtyX2XcharactersXlongXtoken>'
     ```
 
-    Alternatively, modify the value of the secret in the `dca-secret.yaml` file located in the [manifest/cluster-agent directory][1] or create it with:
+    Alternatively, modify the value of the secret in the `agent-secret.yaml` file located in the [manifest/cluster-agent directory][1] or create it with:
 
-    `kubectl create -f Dockerfiles/manifests/cluster-agent/dca-secret.yaml`
+    `kubectl create -f Dockerfiles/manifests/cluster-agent/agent-secret.yaml`
 
 3. Refer to this secret with the environment variable `DD_CLUSTER_AGENT_AUTH_TOKEN` in the manifests of the Cluster Agent. See [Step 3 - Create the Cluster Agent and its service](#step-3-create-the-cluster-agent-and-its-service)) and [Step 2 - Enable the Datadog Cluster Agent](#step-2-enable-the-datadog-agent).
 
-[1]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/dca-secret.yaml
+[1]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/agent-secret.yaml
 {{% /tab %}}
 {{% tab "Environment Variable" %}}
 
@@ -115,13 +115,20 @@ Setting the value without a secret results in the token being readable in the `P
 
 1. Download the following manifests:
 
-  * [`datadog-cluster-agent_service.yaml`: The Cluster Agent Service manifest][4]
-  * [`cluster-agent.yaml`: Cluster Agent manifest][5]
+  * [`agent-service.yaml`: The Cluster Agent Service manifest][4]
+  * [`secrets.yaml`: The secret holding the Datadog API key][5]
+  * [`cluster-agent-deployment.yaml`: Cluster Agent manifest][6]
 
-2. In the `cluster-agent.yaml` manifest, replace `<YOUR_API_KEY>` with [your Datadog API key][6]:
-3. In the `cluster-agent.yaml` manifest, set the token from [Step 2 - Secure Cluster-Agent-to-Agent Communication](#step-2-secure-cluster-agent-to-agent-communication). The format depends on how you set up your secret; instructions can be found in the manifest directly.
-4. Run: `kubectl apply -f datadog-cluster-agent_service.yaml`
-5. Finally, deploy the Datadog Cluster Agent: `kubectl apply -f cluster-agent.yaml`
+2. In the `secrets.yaml` manifest, replace `PUT_YOUR_BASE64_ENCODED_API_KEY_HERE` with [your Datadog API key][7] encoded in base64:
+
+    ```shell
+    echo -n '<Your API key>' | base64
+    ```
+
+3. In the `cluster-agent-deployment.yaml` manifest, set the token from [Step 2 - Secure Cluster-Agent-to-Agent Communication](#step-2-secure-cluster-agent-to-agent-communication). The format depends on how you set up your secret; instructions can be found in the manifest directly.
+4. Run: `kubectl apply -f agent-service.yaml`
+5. Run: `kubectl apply -f secrets.yaml`
+6. Finally, deploy the Datadog Cluster Agent: `kubectl apply -f cluster-agent-deployment.yaml`
 
 ### Step 4 - Verification
 
@@ -135,8 +142,8 @@ datadog-cluster-agent   1         1         1            1           1d
 
 -> kubectl get secret
 
-NAME                   TYPE                                  DATA      AGE
-datadog-auth-token     Opaque                                1         1d
+NAME                         TYPE                                  DATA      AGE
+datadog-agent-cluster-agent  Opaque                                1         1d
 
 -> kubectl get pods -l app=datadog-cluster-agent
 
@@ -158,25 +165,23 @@ After having set up the Datadog Cluster Agent, configure your Datadog Agent to c
 
 #### Step 1 - Set Configure RBAC permissions for node-based Agents
 
-1. Download the the [rbac-agent.yaml manifest][7]. **Note**: When using the Cluster Agent, your node Agents are not able to interact with the Kubernetes API server—only the Cluster Agent is able to do so.
+1. Download the the [rbac-agent.yaml manifest][8]. **Note**: When using the Cluster Agent, your node Agents are not able to interact with the Kubernetes API server—only the Cluster Agent is able to do so.
 
 2. Run: `kubectl apply -f rbac-agent.yaml`
 
 #### Step 2 - Enable the Datadog Agent
 
-1. Download the [agent.yaml manifest][8].
+1. Download the [daemonset.yaml manifest][9].
 
-2. In the `agent.yaml` manifest, replace `<YOUR_API_KEY>` with [your Datadog API key][6]:
+3. In the `daemonset.yaml` manifest, replace `<DD_SITE>` with the Datadog site you are using, i.e. `datadoghq.com` or `datadoghq.eu`. This value defaults to `datadoghq.com`.
 
-3. In the `agent.yaml` manifest, replace `<DD_SITE>` with the Datadog site you are using, i.e. `datadoghq.com` or `datadoghq.eu`. This value defaults to `datadoghq.com`.
+4. In the `daemonset.yaml` manifest, set the token from [Step 2 - Secure Cluster-Agent-to-Agent Communication](#step-2-secure-cluster-agent-to-agent-communication). The format depends on how you set up your secret; instructions can be found in the manifest directly.
 
-4. In the `agent.yaml` manifest, set the token from [Step 2 - Secure Cluster-Agent-to-Agent Communication](#step-2-secure-cluster-agent-to-agent-communication). The format depends on how you set up your secret; instructions can be found in the manifest directly.
-
-5. In the `agent.yaml` manifest, add the environment variable `DD_CLUSTER_AGENT_ENABLED` and set it to `true`.
+5. In the `daemonset.yaml` manifest, check that the environment variable `DD_CLUSTER_AGENT_ENABLED` is set to `true`.
 
 6. (Optional) If your cluster encompasses a single environment, you can also set `<DD_ENV>` in the `agent.yaml`.
 
-7. Create the DaemonSet with this command: `kubectl apply -f agent.yaml`
+7. Create the DaemonSet with this command: `kubectl apply -f daemonset.yaml`
 
 ### Verification
 
@@ -209,8 +214,9 @@ Kubernetes events are beginning to flow into your Datadog account, and relevant 
 [1]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/manifests/cluster-agent
 [2]: /agent/kubernetes/
 [3]: /agent/faq/rbac-for-dca-running-on-aks-with-helm/
-[4]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/datadog-cluster-agent_service.yaml
-[5]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/cluster-agent.yaml
-[6]: https://app.datadoghq.com/account/settings#api
-[7]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/agent-rbac.yaml
-[8]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/agent.yaml
+[4]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-services.yaml
+[5]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/secrets.yaml
+[6]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/cluster-agent-deployment.yaml
+[7]: https://app.datadoghq.com/account/settings#api
+[8]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-rbac.yaml
+[9]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/daemonset.yaml

--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -35,8 +35,8 @@ The Datadog Cluster Agent needs a proper RBAC to be up and running:
 2. To configure Cluster Agent RBAC permissions, apply the following manifests. (You may have done this already when setting up the [node Agent daemonset][2].)
 
   ```shell
-  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/rbac/rbac-agent.yaml"
-  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/rbac/rbac-cluster-agent.yaml"
+  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/rbac.yaml"
+  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-rbac.yaml"
   ```
 
   This creates the appropriate `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding` for the Cluster Agent.
@@ -206,11 +206,11 @@ Kubernetes events are beginning to flow into your Datadog account, and relevant 
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/manifests/cluster-agent/rbac
+[1]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/manifests/cluster-agent
 [2]: /agent/kubernetes/
 [3]: /agent/faq/rbac-for-dca-running-on-aks-with-helm/
 [4]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/datadog-cluster-agent_service.yaml
 [5]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/cluster-agent.yaml
 [6]: https://app.datadoghq.com/account/settings#api
-[7]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/rbac/rbac-agent.yaml
+[7]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/agent-rbac.yaml
 [8]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/agent.yaml

--- a/content/fr/agent/cluster_agent/setup.md
+++ b/content/fr/agent/cluster_agent/setup.md
@@ -64,16 +64,16 @@ Si vous définissez la valeur sans utiliser de secret, le token est alors lisibl
 2. Exécutez cette commande d'une ligne :
 
     ```shell
-    kubectl create secret generic datadog-auth-token --from-literal=token=<ThirtyX2XcharactersXlongXtoken>
+    kubectl create secret generic datadog-agent-cluster-agent --from-literal=token='<ThirtyX2XcharactersXlongXtoken>'
     ```
 
-    Vous pouvez également modifier la valeur du secret dans le fichier `dca-secret.yaml` qui se trouve dans le [répertoire manifest/cluster-agent][1] ou le créer avec :
+    Vous pouvez également modifier la valeur du secret dans le fichier `agent-secret.yaml` qui se trouve dans le [répertoire manifest/cluster-agent][1] ou le créer avec :
 
-    `kubectl create -f Dockerfiles/manifests/cluster-agent/dca-secret.yaml`
+    `kubectl create -f Dockerfiles/manifests/cluster-agent/agent-secret.yaml`
 
 3. Utilisez ce secret avec la variable d'environnement `DD_CLUSTER_AGENT_AUTH_TOKEN` dans les manifestes de l'Agent de cluster. Consultez la section [Étape 3 : Créer l'Agent de cluster et son service](#etape-3-creer-l-agent-de-cluster-et-son-service) et la section [Étape 2 : Activer l'Agent Datadog](#etape-2-activer-l-agent-datadog).
 
-[1]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/dca-secret.yaml
+[1]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/agent-secret.yaml
 {{% /tab %}}
 {{% tab "Variable d'environnement" %}}
 
@@ -114,13 +114,20 @@ Si vous définissez la valeur sans utiliser de secret, le token est alors lisibl
 
 1. Téléchargez les manifestes suivants :
 
-  * [`datadog-cluster-agent_service.yaml` : le manifeste du service de l'Agent de cluster][4]
-  * [`cluster-agent.yaml` : le manifeste de l'Agent de cluster][5]
+  * [`agent-service.yaml` : le manifeste du service de l'Agent de cluster][4]
+  * [`secrets.yaml`: le manifeste du secret contenant la clé d’API Datadog][5]
+  * [`cluster-agent-deployment.yaml` : le manifeste de l'Agent de cluster][6]
 
-2. Dans le manifeste `cluster-agent.yaml`, remplacez `<YOUR_API_KEY>` par [votre clé d'API Datadog][6] :
-3. Dans le manifeste `cluster-agent.yaml`, définissez le token conformément à la section [Étape 2 : Sécuriser les communications entre l'Agent de cluster et l'Agent](#etape-2-securiser-les-communications-entre-l-agent-de-cluster-et-l-agent). Le format dépend de la façon dont vous configurez votre secret ; les instructions se trouvent directement dans le manifeste.
-4. Exécutez : `kubectl apply -f datadog-cluster-agent_service.yaml`
-5. Enfin, déployez l'Agent de cluster Datadog : `kubectl apply -f cluster-agent.yaml`
+2. Dans le manifeste `secrets.yaml`, remplacez `PUT_YOUR_BASE64_ENCODED_API_KEY_HERE` par [votre clé d'API Datadog][7] encodée en base64 :
+
+    ```shell
+    echo -n '<Votre clé d’API>' | base64
+    ```
+
+3. Dans le manifeste `cluster-agent-deployment.yaml`, définissez le token conformément à la section [Étape 2 : Sécuriser les communications entre l'Agent de cluster et l'Agent](#etape-2-securiser-les-communications-entre-l-agent-de-cluster-et-l-agent). Le format dépend de la façon dont vous configurez votre secret ; les instructions se trouvent directement dans le manifeste.
+4. Exécutez : `kubectl apply -f agent-service.yaml`
+5. Exécutez : `kubectl apply -f secrets.yaml`
+6. Enfin, déployez l'Agent de cluster Datadog : `kubectl apply -f cluster-agent-deployment.yaml`
 
 ### Étape 4 : Vérification
 
@@ -134,8 +141,8 @@ datadog-cluster-agent   1         1         1            1           1d
 
 -> kubectl get secret
 
-NAME                   TYPE                                  DATA      AGE
-datadog-auth-token     Opaque                                1         1d
+NAME                         TYPE                                  DATA      AGE
+datadog-agent-cluster-agent  Opaque                                1         1d
 
 -> kubectl get pods -l app=datadog-cluster-agent
 
@@ -163,17 +170,15 @@ Une fois l'Agent de cluster Datadog configuré, configurez votre Agent Datadog d
 
 #### Étape 2 : Activer l'Agent Datadog
 
-1. Téléchargez le [manifeste agent.yaml][8].
+1. Téléchargez le [manifeste daemonset.yaml][9].
 
-2. Dans le manifeste `agent.yaml`, remplacez `<YOUR_API_KEY>` par [votre clé d'API Datadog][6] :
+3. Dans le manifeste `daemonset.yaml`, remplacez `<DD_SITE>` par le site Datadog que vous utilisez, p. ex. `datadoghq.com` or `datadoghq.eu`. Cette valeur correspond par défaut à `datadoghq.com`.
 
-3. Dans le manifeste `agent.yaml`, remplacez `<DD_SITE>` par le site Datadog que vous utilisez, p. ex. `datadoghq.com` or `datadoghq.eu`. Cette valeur correspond par défaut à `datadoghq.com`.
+4. Dans le manifeste `daemonset.yaml`, définissez le token conformément à la section [Étape 2 : Sécuriser les communications entre l'Agent de cluster et l'Agent](#etape-2-securiser-les-communications-entre-l-agent-de-cluster-et-l-agent). Le format dépend de la façon dont vous configurez votre secret ; les instructions se trouvent directement dans le manifeste.
 
-4. Dans le manifeste `agent.yaml`, définissez le token conformément à la section [Étape 2 : Sécuriser les communications entre l'Agent de cluster et l'Agent](#etape-2-securiser-les-communications-entre-l-agent-de-cluster-et-l-agent). Le format dépend de la façon dont vous configurez votre secret ; les instructions se trouvent directement dans le manifeste.
+5. Dans le manifeste `daemonset.yaml`, vérifiez que la variable d'environnement `DD_CLUSTER_AGENT_ENABLED` est définie à `true`.
 
-5. Dans le manifeste `agent.yaml`, ajoutez la variable d'environnement `DD_CLUSTER_AGENT_ENABLED` et définissez-la sur `true`.
-
-6. Créez le DaemonSet avec cette commande : `kubectl apply -f agent.yaml`.
+6. Créez le DaemonSet avec cette commande : `kubectl apply -f daemon.yaml`.
 
 ### Vérification
 
@@ -206,8 +211,9 @@ La transmission des événements Kubernetes à votre compte Datadog commence alo
 [1]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/manifests/cluster-agent
 [2]: /fr/agent/kubernetes/
 [3]: /fr/agent/faq/rbac-for-dca-running-on-aks-with-helm/
-[4]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/datadog-cluster-agent_service.yaml
-[5]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/cluster-agent.yaml
-[6]: https://app.datadoghq.com/account/settings#api
-[7]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/agent-rbac.yaml
-[8]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/agent.yaml
+[4]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-services.yaml
+[5]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/secrets.yaml
+[6]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/cluster-agent-deployment.yaml
+[7]: https://app.datadoghq.com/account/settings#api
+[8]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/agent-rbac.yaml
+[9]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/daemonset.yaml

--- a/content/fr/agent/cluster_agent/setup.md
+++ b/content/fr/agent/cluster_agent/setup.md
@@ -203,11 +203,11 @@ La transmission des événements Kubernetes à votre compte Datadog commence alo
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/manifests/cluster-agent/rbac
+[1]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/manifests/cluster-agent
 [2]: /fr/agent/kubernetes/
 [3]: /fr/agent/faq/rbac-for-dca-running-on-aks-with-helm/
 [4]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/datadog-cluster-agent_service.yaml
 [5]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/cluster-agent.yaml
 [6]: https://app.datadoghq.com/account/settings#api
-[7]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/rbac/rbac-agent.yaml
+[7]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/agent-rbac.yaml
 [8]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/agent.yaml


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Fix Kubernetes manifests url for the Datadog cluster agent RBAC.

### Motivation
<!-- What inspired you to submit this pull request?-->

Kubernetes manifests files are now generated: DataDog/datadog-agent#5436
The old ones will be removed with DataDog/datadog-agent#5606

The URL in the documentation should have been updated by #7542 but it seems some changes were reverted.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/lenaic/fix_k8s_manifests_location/agent/cluster_agent/setup/?tab=secret
Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
