### PR TITLE
Update rsyslog doc immark syntax for >v8

### DIFF
--- a/content/en/integrations/rsyslog.md
+++ b/content/en/integrations/rsyslog.md
@@ -104,8 +104,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
 8. (Optional) Datadog cuts inactive connections after a period of inactivity. Some Rsyslog versions are not able to reconnect properly when necessary. To mitigate this issue, use time markers so the connection never stops. To achieve this, add the following 2 lines in your Rsyslog configuration:
 
     ```conf
-    $ModLoad immark
-    $MarkMessagePeriod 20
+    module(load="immark" interval="20")
     ```
 
     And don't forget to restart:
@@ -189,8 +188,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
    Some Rsyslog versions are not able to reconnect properly when necessary. To mitigate this issue, use time markers so the connection never stops. To achieve this, add the following 2 lines in your Rsyslog configuration:
 
     ```conf
-    $ModLoad immark
-    $MarkMessagePeriod 20
+    module(load="immark" interval="20")
     ```
 
     And don't forget to restart:

--- a/content/en/integrations/rsyslog.md
+++ b/content/en/integrations/rsyslog.md
@@ -101,7 +101,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
     $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\"<MY_SOURCE_NAME>\" ddtags=\"env:dev,<KEY:VALUE>\"] %msg%\n"
     ```
 
-8. (Optional) Datadog cuts inactive connections after a period of inactivity. Some Rsyslog versions are not able to reconnect properly when necessary. To mitigate this issue, use time markers so the connection never stops. To achieve this, add the following 2 lines in your Rsyslog configuration:
+8. (Optional) Datadog cuts inactive connections after a period of inactivity. Some Rsyslog versions are not able to reconnect properly when necessary. To mitigate this issue, use time markers so the connection never stops. To achieve this, add the following line in your Rsyslog configuration:
 
     ```conf
     module(load="immark" interval="20")
@@ -185,7 +185,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
     ```
 
 8. (Optional) Datadog cuts inactive connections after a period of inactivity.
-   Some Rsyslog versions are not able to reconnect properly when necessary. To mitigate this issue, use time markers so the connection never stops. To achieve this, add the following 2 lines in your Rsyslog configuration:
+   Some Rsyslog versions are not able to reconnect properly when necessary. To mitigate this issue, use time markers so the connection never stops. To achieve this, add the following line in your Rsyslog configuration:
 
     ```conf
     module(load="immark" interval="20")


### PR DESCRIPTION
### What does this PR do?

Changes the documented syntax for specifying a mark message interval for rsyslog versions >= 8. 

### Motivation

https://www.rsyslog.com/doc/v8-stable/configuration/modules/immark.html#configuration-parameters

The legacy parameter / syntax is not allowed in current stable versions (>=8) of rsyslog

### Preview link


### Additional Notes
<!-- Anything else we should know when reviewing?-->
