### PR TITLE
Fix links in Unified Tagging page

### DIFF
--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -280,7 +280,7 @@ When configuring your traces for unified service tagging:
 
     **Note: There can only be one service per span.** Trace metrics generally have a single service as well. However, if you have a different service defined in your hosts' tags, that configured service tag will show up on all trace metrics emitted from that host.
 
-[1]: /tracing/send_traces/
+[1]: /tracing/tracing/setup
 [2]: /developers/dogstatsd/
 {{% /tab %}}
 
@@ -310,15 +310,14 @@ If your service has access to `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`, then the
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /getting_started/tagging/#defining-tags
-[2]: /getting_started/tagging/assigning_tags?tab=noncontainerizedenvironments#environment-variables
-[3]: /getting_started/tracing/
-[4]: /getting_started/logs/
-[5]: /integrations/statsd/
-[6]: /developers/dogstatsd/
-[7]: /getting_started/tagging/
-[8]: /getting_started/tagging/assigning_tags
-[9]: /getting_started/agent/#setup
-[10]: /getting_started/agent/autodiscovery
-[11]: /tracing/connect_logs_and_traces/
-[12]: https://www.chef.io/
-[13]: https://www.ansible.com/
+[2]: /getting_started/agent
+[3]: /getting_started/tagging/
+[4]: /getting_started/tagging/assigning_tags?tab=noncontainerizedenvironments
+[5]: /getting_started/agent/autodiscovery
+[6]: /agent/docker/integrations/?tab=docker
+[7]: /agent/docker/?tab=standard#optional-collection-agents
+[8]: /getting_started/tracing/
+[9]: /getting_started/logs/
+[10]: /integrations/statsd/
+[11]: https://www.chef.io/
+[12]: https://www.ansible.com/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
