### PR TITLE
Update Ruby Trace-ID Injection Docs

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/ruby.md
+++ b/content/en/tracing/connect_logs_and_traces/ruby.md
@@ -19,15 +19,34 @@ further_reading:
 
 ## Manually Inject Trace and Span IDs
 
-Use one of the following options to inject Ruby trace information into your logs:
+In many cases, such as logging, it may be useful to correlate trace IDs to other events or data streams, for easier cross-referencing. The tracer can produce a correlation identifier for the currently active trace via `active_correlation`, which can be used to decorate these other data sources.
 
-- [Trace ID Injection for Rails Applications using Lograge is recommended](?tab=lograge).
-- [Trace ID Injection for default Rails Applications](?tab=default).
+```ruby
+# When a trace is active...
+Datadog.tracer.trace('correlation.example') do
+  # Returns #<Datadog::Correlation::Identifier>
+  correlation = Datadog.tracer.active_correlation
+  correlation.trace_id # => 5963550561812073440
+  correlation.span_id # => 2232727802607726424
+  correlation.env # => 'production' (derived from DD_ENV)
+  correlation.service # => 'billing-api' (derived from DD_SERVICE)
+  correlation.version # => '2.5.17' (derived from DD_VERSION)
+end
 
-{{< tabs >}}
-{{% tab "Lograge" %}}
+# When a trace isn't active...
+correlation = Datadog.tracer.active_correlation
+# Returns #<Datadog::Correlation::Identifier>
+correlation = Datadog.tracer.active_correlation
+correlation.trace_id # => 0
+correlation.span_id # => 0
+correlation.env # => 'production' (derived from DD_ENV)
+correlation.service # => 'billing-api' (derived from DD_SERVICE)
+correlation.version # => '2.5.17' (derived from DD_VERSION)
+```
 
-After [setting up Lograge in a Rails application][1], modify the `custom_options` block in your environment configuration file (e.g. `config/environments/production.rb`) to add the trace IDs:
+#### For logging in Rails applications using Lograge (recommended)
+
+After [setting up Lograge in a Rails application](https://docs.datadoghq.com/logs/log_collection/ruby/), modify the `custom_options` block in your environment configuration file (e.g. `config/environments/production.rb`) to add the trace IDs:
 
 ```ruby
 config.lograge.custom_options = lambda do |event|
@@ -37,8 +56,12 @@ config.lograge.custom_options = lambda do |event|
   {
     # Adds IDs as tags to log output
     :dd => {
+      # To preserve precision during JSON serialization, use strings for large numbers
       :trace_id => correlation.trace_id.to_s,
-      :span_id => correlation.span_id.to_s
+      :span_id => correlation.span_id.to_s,
+      :env => correlation.env.to_s,
+      :service => correlation.service.to_s,
+      :version => correlation.version.to_s
     },
     :ddsource => ["ruby"],
     :params => event.payload[:params].reject { |k| %w(controller action).include? k }
@@ -46,46 +69,54 @@ config.lograge.custom_options = lambda do |event|
 end
 ```
 
-[1]: /logs/log_collection/ruby/#configure-the-datadog-agent
-{{% /tab %}}
-{{% tab "Default" %}}
+#### For logging in Rails applications
 
-Rails applications which are configured with a `ActiveSupport::TaggedLogging` logger can append trace IDs as tags to log output. The default Rails logger implements this tagged logging, making it easier to add trace tags.
+Rails applications which are configured with an `ActiveSupport::TaggedLogging` logger can append correlation IDs as tags to log output. The default Rails logger implements this tagged logging, making it easier to add correlation tags.
 
-In your Rails environment configuration file (e.g. `config/environments/production.rb`), add the following:
+In your Rails environment configuration file, add the following:
 
 ```ruby
 Rails.application.configure do
   config.log_tags = [proc { Datadog.tracer.active_correlation.to_s }]
 end
+
+# Given:
+# DD_ENV = 'production' (The name of the environment your application is running in.)
+# DD_SERVICE = 'billing-api' (Default service name of your application.)
+# DD_VERSION = '2.5.17' (The version of your application.)
+
+# Web requests will produce:
+# [dd.env=production dd.service=billing-api dd.version=2.5.17 dd.trace_id=7110975754844687674 dd.span_id=7518426836986654206] Started GET "/articles" for 172.22.0.1 at 2019-01-16 18:50:57 +0000
+# [dd.env=production dd.service=billing-api dd.version=2.5.17 dd.trace_id=7110975754844687674 dd.span_id=7518426836986654206] Processing by ArticlesController#index as */*
+# [dd.env=production dd.service=billing-api dd.version=2.5.17 dd.trace_id=7110975754844687674 dd.span_id=7518426836986654206]   Article Load (0.5ms)  SELECT "articles".* FROM "articles"
+# [dd.env=production dd.service=billing-api dd.version=2.5.17 dd.trace_id=7110975754844687674 dd.span_id=7518426836986654206] Completed 200 OK in 7ms (Views: 5.5ms | ActiveRecord: 0.5ms)
 ```
 
-This appends trace tags to web requests:
+#### For logging in Ruby applications
 
-```text
-# [dd.trace_id=7110975754844687674 dd.span_id=7518426836986654206] Started GET "/articles" for 172.22.0.1 at 2019-01-16 18:50:57 +0000
-# [dd.trace_id=7110975754844687674 dd.span_id=7518426836986654206] Processing by ArticlesController#index as */*
-# [dd.trace_id=7110975754844687674 dd.span_id=7518426836986654206] Article Load (0.5ms)  SELECT "articles".* FROM "articles"
-# [dd.trace_id=7110975754844687674 dd.span_id=7518426836986654206] Completed 200 OK in 7ms (Views: 5.5ms | ActiveRecord: 0.5ms)
-```
+To add correlation IDs to your logger, add a log formatter which retrieves the correlation IDs with `Datadog.tracer.active_correlation`, then add them to the message.
 
-{{% /tab %}}
-{{< /tabs >}}
+To properly correlate with Datadog logging, be sure the following is present in the log message, in order as they appear:
 
-To add trace IDs to your own logger, add a log formatter which retrieves the trace IDs with `Datadog.tracer.active_correlation`, then add the trace IDs to the message.
+ - `dd.env=<ENV>`: Where `<ENV>` is equal to `Datadog.tracer.active_correlation.env`. Omit if no environment is configured.
+ - `dd.service=<SERVICE>`: Where `<SERVICE>` is equal to `Datadog.tracer.active_correlation.service`. Omit if no default service name is configured.
+ - `dd.version=<VERSION>`: Where `<VERSION>` is equal to `Datadog.tracer.active_correlation.version`. Omit if no application version is configured.
+ - `dd.trace_id=<TRACE_ID>`: Where `<TRACE_ID>` is equal to `Datadog.tracer.active_correlation.trace_id` or `0` if no trace is active during logging.
+ - `dd.span_id=<SPAN_ID>`: Where `<SPAN_ID>` is equal to `Datadog.tracer.active_correlation.span_id` or `0` if no trace is active during logging.
 
-To ensure proper log correlation, verify the following is present in each message:
+By default, `Datadog::Correlation::Identifier#to_s` will return `dd.env=<ENV> dd.service=<SERVICE> dd.version=<VERSION> dd.trace_id=<TRACE_ID> dd.span_id=<SPAN_ID>`.
 
-- `dd.trace_id=<TRACE_ID>`: Where `<TRACE_ID>` is equal to `Datadog.tracer.active_correlation.trace_id` or `0` if no trace is active during logging.
-- `dd.span_id=<SPAN_ID>`: Where `<SPAN_ID>` is equal to `Datadog.tracer.active_correlation.span_id` or `0` if no trace is active during logging.
-
-By default, `Datadog::Correlation::Identifier#to_s` returns `dd.trace_id=<TRACE_ID> dd.span_id=<SPAN_ID>`.
+If a trace is not active and the application environment & version is not configured, it will return `dd.trace_id=0 dd.span_id=0 dd.env= dd.version=`.
 
 An example of this in practice:
 
 ```ruby
 require 'ddtrace'
 require 'logger'
+
+ENV['DD_ENV'] = 'production'
+ENV['DD_SERVICE'] = 'billing-api'
+ENV['DD_VERSION'] = '2.5.17'
 
 logger = Logger.new(STDOUT)
 logger.progname = 'my_app'
@@ -95,11 +126,11 @@ end
 
 # When no trace is active
 logger.warn('This is an untraced operation.')
-# [2019-01-16 18:38:41 +0000][my_app][WARN][dd.trace_id=0 dd.span_id=0] This is an untraced operation.
+# [2019-01-16 18:38:41 +0000][my_app][WARN][dd.env=production dd.service=billing-api dd.version=2.5.17 dd.trace_id=0 dd.span_id=0] This is an untraced operation.
 
 # When a trace is active
 Datadog.tracer.trace('my.operation') { logger.warn('This is a traced operation.') }
-# [2019-01-16 18:38:41 +0000][my_app][WARN][dd.trace_id=8545847825299552251 dd.span_id=3711755234730770098] This is a traced operation.
+# [2019-01-16 18:38:41 +0000][my_app][WARN][dd.env=production dd.service=billing-api dd.version=2.5.17 dd.trace_id=8545847825299552251 dd.span_id=3711755234730770098] This is a traced operation.
 ```
 
 **Note**: If you are not using a [Datadog Log Integration][1] to parse your logs, custom log parsing rules need to ensure that `dd.trace_id` and `dd.span_id` are being parsed as strings. More information can be found in the [FAQ on this topic][2].


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This page, https://docs.datadoghq.com/tracing/connect_logs_and_traces/ruby/?tab=lograge is inconsistent with this page https://docs.datadoghq.com/tracing/setup/ruby/#trace-correlation, which is sourced directly from github. https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md#trace-correlation The key issue here is the missing instructions on injecting `service`, `env`, and `version` for using unified tags across the product. Longer term we need to have a smoother plan for when we source from github and how it's reflected in other pages, this is a short term manual replacement.  

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/andrewsouthard1-update-ruby-trace-docs/connect_logs_and_traces/ruby/

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
