### PR TITLE
Remove ruby tracer from unified tagging note

### DIFF
--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -288,7 +288,7 @@ When configuring your traces for unified service tagging:
 
 If you're using [connected logs and traces][1], enable automatic logs injection if supported for your APM Tracer. The APM Tracer will then automatically inject `env`, `service`, and `version` into your logs, thereby eliminating manual configuration for those fields elsewhere.
 
-**Note**: The Java, Ruby, PHP, and Go Tracer do not currently support configuration of unified service tagging for logs.
+**Note**: The Java, PHP, and Go Tracer do not currently support configuration of unified service tagging for logs.
 
 [1]: /tracing/connect_logs_and_traces/
 {{% /tab %}}

--- a/content/en/tracing/connect_logs_and_traces/_index.md
+++ b/content/en/tracing/connect_logs_and_traces/_index.md
@@ -12,7 +12,7 @@ The correlation between Datadog APM and Datadog Log Management is improved by th
 
 It is recommended to configure your application's tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This will provide the best experience for adding `env`, `service`, and `version`. See the [unified service tagging][2] documentation for more details.
 
-**Note**: The Java, Ruby, PHP and Go Tracer do not currently support configuration of unified service tagging for logs.
+**Note**: The Java, PHP and Go Tracer do not currently support configuration of unified service tagging for logs.
 
 Before correlating traces with logs, ensure your logs are either sent as JSON, or [parsed by the proper language level log processor][3]. Your language level logs _must_ be turned into Datadog attributes in order for traces and logs correlation to work.
 


### PR DESCRIPTION
### What does this PR do?
The Ruby tracer now supports unified tagging. Removing ruby from all tracer notes pertaining to unified tagging.

### Preview link
https://docs-staging.datadoghq.com/sarina/ruby-edits/getting_started/tagging/unified_service_tagging
https://docs-staging.datadoghq.com/sarina/ruby-edits/tracing/connect_logs_and_traces/

Check preview base path using the URL in details in `preview` status check.