### PR TITLE
tracing: python remove no longer true django warning

### DIFF
--- a/content/en/tracing/setup/python.md
+++ b/content/en/tracing/setup/python.md
@@ -20,10 +20,6 @@ further_reading:
       text: 'Advanced Usage'
 ---
 
-<div class="alert alert-info">
-For Python Django applications, note that tracing is disabled when your application is launched in <code>DEBUG</code> mode. Find more <a href="http://pypi.datadoghq.com/trace/docs/web_integrations.html#django">here</a>.
-</div>
-
 ## Installation and Getting Started
 
 If you already have a Datadog account you can find [step-by-step instructions][1] in our in-app guides for either host-based or container-based set ups.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Removes a notice/warning for Django tracing users that their instrumentation will be disabled in debug mode. This is no longer the case as of tracer version 0.34 (released in February)
