### PR TITLE
DOCS-853 - container env vars

### DIFF
--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -156,8 +156,14 @@ Exclude containers from logs collection, metrics collection, and Autodiscovery. 
 
 | Env Variable    | Description                                                                                                                                                                                                        |
 |-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DD_AC_INCLUDE` | Whitelist of containers to include (separated by spaces). Use `.*` to include all. For example: `"image:image_name_1 image:image_name_2"`, `image:.*`                                                              |
-| `DD_AC_EXCLUDE` | Blacklist of containers to exclude (separated by spaces). Use `.*` to exclude all. For example: `"image:image_name_3 image:image_name_4"` (**Note**: This variable is only honored for Autodiscovery.), `image:.*` |
+| `DD_CONTAINER_INCLUDE` | Allowlist of containers to include (separated by spaces). Use `.*` to include all. For example: `"image:image_name_1 image:image_name_2"`, `image:.*`  |
+| `DD_CONTAINER_EXCLUDE` | Blocklist of containers to exclude (separated by spaces). Use `.*` to exclude all. For example: `"image:image_name_3 image:image_name_4"` (**Note**: This variable is only honored for Autodiscovery.), `image:.*` |
+| `DD_CONTAINER_INCLUDE_METRICS` | Allowlist of containers whose metrics you wish to include.  |
+| `DD_CONTAINER_EXCLUDE_METRICS` | Blocklist of containers whose metrics you wish to exclude. |
+| `DD_CONTAINER_INCLUDE_LOGS` | Allowlist of containers whose logs you wish to include.  |
+| `DD_CONTAINER_EXCLUDE_LOGS` | Blocklist of containers whose logs you wish to exclude. |
+| `DD_AC_INCLUDE` | **Deprecated**. Allowlist of containers to include (separated by spaces). Use `.*` to include all. For example: `"image:image_name_1 image:image_name_2"`, `image:.*`  |                                              
+| `DD_AC_EXCLUDE` | **Deprecated**. Blocklist of containers to exclude (separated by spaces). Use `.*` to exclude all. For example: `"image:image_name_3 image:image_name_4"` (**Note**: This variable is only honored for Autodiscovery.), `image:.*` |
 
 Additional examples are available on the [Container Discover Management][22] page.
 

--- a/content/en/agent/guide/autodiscovery-management.md
+++ b/content/en/agent/guide/autodiscovery-management.md
@@ -28,33 +28,45 @@ Exclude containers from the Agent Autodiscovery perimeter with an exclude rule b
 To remove a given Docker container with the image `<IMAGE_NAME>` from Autodiscovery, add the following environment variable to the Datadog Agent:
 
 ```shell
-DD_AC_EXCLUDE = "image:<IMAGE_NAME>"
+DD_CONTAINER_EXCLUDE = "image:<IMAGE_NAME>"
 ```
 
 To remove a given Docker container with the name `<NAME>` from Autodiscovery, add the following environment variable to the Datadog Agent:
 
 ```shell
-DD_AC_EXCLUDE = "name:<NAME>"
+DD_CONTAINER_EXCLUDE = "name:<NAME>"
 ```
 
 For instance, use this excluding rule to exclude the Agent container itself:
 
 ```shell
-DD_AC_EXCLUDE = "name:dd-agent"
+DD_CONTAINER_EXCLUDE = "name:dd-agent"
 ```
 
 Another example: the following configuration instructs the Agent to ignore some containers from Docker Cloud:
 
 ```shell
-DD_AC_EXCLUDE = "image:dockercloud/network-daemon image:dockercloud/cleanup image:dockercloud/logrotate image:dockercloud/events image:dockercloud/ntpd"
+DD_CONTAINER_EXCLUDE = "image:dockercloud/network-daemon image:dockercloud/cleanup image:dockercloud/logrotate image:dockercloud/events image:dockercloud/ntpd"
 ```
 
-You can also use a regex to ignore them all: `DD_AC_EXCLUDE = "image:dockercloud/*"`
+You can use a regex to ignore them all: `DD_CONTAINER_EXCLUDE = "image:dockercloud/*"`
+
+In Agent v7.2+, you can also use exclusion rules to exclude only logs or only metrics. For instance, to exclude logs from a container with the image `<IMAGE_NAME>`, add the following environment variable to the Datadog Agent:
+
+```shell
+DD_CONTAINER_EXCLUDE_LOGS = "image:<IMAGE_NAME>"
+```
+
+Similarly, to exclude metrics:
+
+```shell
+DD_CONTAINER_EXCLUDE_METRICS = "image:<IMAGE_NAME>"
+```
 
 On Kubernetes, to remove all containers of pods inside namespace `<NAMESPACE>` from Autodiscovery, add the following environment variable to the Datadog Agent:
 
 ```shell
-DD_AC_EXCLUDE = "kube_namespace:<NAMESPACE>"
+DD_CONTAINER_EXCLUDE = "kube_namespace:<NAMESPACE>"
 ```
 
 {{% /tab %}}
@@ -63,19 +75,31 @@ DD_AC_EXCLUDE = "kube_namespace:<NAMESPACE>"
 To remove a given Docker container with the image `<IMAGE_NAME>` from Autodiscovery, add the following configuration block in the [Agent `datadog.yaml` configuration file][1]:
 
 ```yaml
-ac_exclude: [image:<IMAGE_NAME>]
+container_exclude: [image:<IMAGE_NAME>]
 ```
 
 To remove a given Docker container with the name `<NAME>` from Autodiscovery, add the following configuration block in the [Agent `datadog.yaml` configuration file][1]:
 
 ```yaml
-ac_exclude: [name:<NAME>]
+container_exclude: [name:<NAME>]
+```
+
+In Agent v7.2+, you can also use exclusion rules to exclude only logs or only metrics. For instance, to exclude logs from a container with the image `<IMAGE_NAME>`, add the following environment variable to the Datadog Agent:
+
+```shell
+container_exclude_logs: [image:<IMAGE_NAME>]
+```
+
+Similarly, to exclude metrics:
+
+```shell
+container_exclude_metrics: [image:<IMAGE_NAME>]
 ```
 
 On Kubernetes, to remove all containers of pods inside namespace `<NAMESPACE>` from Autodiscovery, add the following configuration block in the [Agent `datadog.yaml` configuration file][1]:
 
 ```yaml
-ac_exclude: [kube_namespace:<NAMESPACE>]
+container_exclude: [kube_namespace:<NAMESPACE>]
 ```
 
 [1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
@@ -96,26 +120,37 @@ Include containers from the Agent Autodiscovery perimeter with an include rule b
 To include a given Docker container with the image `<IMAGE_NAME>` from Autodiscovery, add the following environment variable to the Datadog Agent:
 
 ```shell
-DD_AC_INCLUDE = "image:<IMAGE_NAME>"
+DD_CONTAINER_INCLUDE = "image:<IMAGE_NAME>"
 ```
 
 To include a given Docker container with the name `<NAME>` from Autodiscovery, add the following environment variable to the Datadog Agent:
 
 ```shell
-DD_AC_INCLUDE = "name:<NAME>"
+DD_CONTAINER_INCLUDE = "name:<NAME>"
 ```
 
 For example, if you only want to monitor `ubuntu` or `debian` images, and exclude the rest, specify:
 
 ```shell
-DD_AC_EXCLUDE = "image:.*"
-DD_AC_INCLUDE = "image:ubuntu image:debian"
+DD_CONTAINER_EXCLUDE = "image:.*"
+DD_CONTAINER_INCLUDE = "image:ubuntu image:debian"
+```
+In Agent v7.2+, you can also use inclusion rules to include only logs or only metrics. For instance, to include logs from a container with the image `<IMAGE_NAME>`, add the following environment variable to the Datadog Agent:
+
+```shell
+DD_CONTAINER_INCLUDE_LOGS = "image:<IMAGE_NAME>"
+```
+
+Similarly, to include metrics:
+
+```shell
+DD_CONTAINER_INCLUDE_METRICS = "image:<IMAGE_NAME>"
 ```
 
 On Kubernetes, to include all containers of pods inside namespace <NAMESPACE> from Autodiscovery, add the following environment variable to the Datadog Agent:
 
 ```shell
-DD_AC_INCLUDE = "kube_namespace:<NAMESPACE>"
+DD_CONTAINER_INCLUDE = "kube_namespace:<NAMESPACE>"
 ```
 
 {{% /tab %}}
@@ -124,19 +159,31 @@ DD_AC_INCLUDE = "kube_namespace:<NAMESPACE>"
 To include a given Docker container with the image `<IMAGE_NAME>` from Autodiscovery, add the following configuration block in the [Agent `datadog.yaml` configuration file][1]:
 
 ```yaml
-ac_include: [image:<IMAGE_NAME>]
+container_include: [image:<IMAGE_NAME>]
 ```
 
 To include a given Docker container with the name `<NAME>` from Autodiscovery, add the following configuration block in the [Agent `datadog.yaml` configuration file][1]:
 
 ```yaml
-ac_include: [name:<NAME>]
+container_include: [name:<NAME>]
+```
+
+In Agent v7.2+, you can also use inclusion rules to include only logs or only metrics. For instance, to include logs from a container with the image `<IMAGE_NAME>`, add the following environment variable to the Datadog Agent:
+
+```shell
+container_include_logs: [image:<IMAGE_NAME>]
+```
+
+Similarly, to include metrics:
+
+```shell
+container_include_metrics: [image:<IMAGE_NAME>]
 ```
 
 On Kubernetes, to include all containers of pods inside namespace <NAMESPACE> from Autodiscovery, add the following configuration block in the [Agent `datadog.yaml` configuration file][1]:
 
 ```yaml
-ac_include: [kube_namespace:<NAMESPACE>]
+container_include: [kube_namespace:<NAMESPACE>]
 ```
 
 [1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file

--- a/content/en/agent/guide/autodiscovery-management.md
+++ b/content/en/agent/guide/autodiscovery-management.md
@@ -192,7 +192,37 @@ container_include: [kube_namespace:<NAMESPACE>]
 
 **Note**: If you are using Kubernetes, the container `<NAME>` is the one in your manifest `.spec.containers[0].name`.
 
-### Pause containers
+## Inclusion and exclusion behavior
+
+Inclusion always takes precedence, whether the rule is global or only applies to metrics or logs.
+
+You cannot mix cross-category include/exclude rules. For instance, if you want to include a container with the image name `<IMAGE_NAME_1>` and exclude only metrics from a container with the image name `<IMAGE_NAME_2>`, use the following:
+
+{{< tabs >}}
+{{% tab "Containerized Agent" %}}
+```shell
+DD_CONTAINER_INCLUDE_METRICS = "image:<IMAGE_NAME_1>"
+DD_CONTAINER_INCLUDE_LOGS = "image:<IMAGE_NAME_1>"
+DD_CONTAINER_EXCLUDE_METRICS = "image:<IMAGE_NAME_2>"
+```
+
+That is, setting `DD_CONTAINER_INCLUDE = "image:<IMAGE_NAME_1>"` is not sufficient.
+
+{{% /tab %}}
+{{% tab "Agent" %}}
+```yaml
+container_include_metrics: [image:<IMAGE_NAME_1>]
+container_include_logs: [image:<IMAGE_NAME_1>]
+container_exclude_metrics: [image:<IMAGE_NAME_2>]
+```
+
+That is, setting `container_include: [image:<IMAGE_NAME_1>]` is not sufficient.
+{{% /tab %}}
+{{< /tabs >}}
+
+There is no interaction between the global lists and the selective (logs and metrics) lists. In other words, you cannot exclude a container globally and then include it with `container_include_logs` and `container_include_metrics`.
+
+## Pause containers
 
 Datadog Agent excludes Kubernetes and OpenShift pause containers by default. They are still counted in the container count like excluded containers.
 

--- a/content/en/agent/guide/environment-variables.md
+++ b/content/en/agent/guide/environment-variables.md
@@ -36,10 +36,10 @@ In general, use the following rules:
 
 * List values should be separated by spaces:
    ```yaml
-      ac_include:
+      container_include:
         - "image:cp-kafka"
         - "image:k8szk"
-      # DD_AC_INCLUDE="image:cp-kafka image:k8szk"
+      # DD_CONTAINER_INCLUDE="image:cp-kafka image:k8szk"
    ```
 
 * The nesting of config options with **predefined** keys should be separated with an underscore:

--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -277,8 +277,14 @@ Exclude containers from logs collection, metrics collection, and Autodiscovery. 
 
 | Env Variable    | Description                                                                                                                                                                                                        |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `DD_AC_INCLUDE` | Whitelist of containers to include (separated by spaces). Use `.*` to include all. For example: `"image:image_name_1 image:image_name_2"`, `image:.*`                                                              |
-| `DD_AC_EXCLUDE` | Blacklist of containers to exclude (separated by spaces). Use `.*` to exclude all. For example: `"image:image_name_3 image:image_name_4"` (**Note**: This variable is only honored for Autodiscovery.), `image:.*` |
+| `DD_CONTAINER_INCLUDE` | Allowed list of containers to include (separated by spaces). Use `.*` to include all. For example: `"image:image_name_1 image:image_name_2"`, `image:.*`  |
+| `DD_CONTAINER_EXCLUDE` | Disallowed list of containers to exclude (separated by spaces). Use `.*` to exclude all. For example: `"image:image_name_3 image:image_name_4"` (**Note**: This variable is only honored for Autodiscovery.), `image:.*` |
+| `DD_CONTAINER_INCLUDE_METRICS` | Allowed list of containers whose metrics you wish to include.  |
+| `DD_CONTAINER_EXCLUDE_METRICS` | Disallowed list of containers whose metrics you wish to exclude. |
+| `DD_CONTAINER_INCLUDE_LOGS` | Allowed list of containers whose logs you wish to include.  |
+| `DD_CONTAINER_EXCLUDE_LOGS` | Disallowed list of containers whose logs you wish to exclude. |
+| `DD_AC_INCLUDE` | **Deprecated**. Allowed list of containers to include (separated by spaces). Use `.*` to include all. For example: `"image:image_name_1 image:image_name_2"`, `image:.*`  |                                              
+| `DD_AC_EXCLUDE` | **Deprecated**. Disallowed list of containers to exclude (separated by spaces). Use `.*` to exclude all. For example: `"image:image_name_3 image:image_name_4"` (**Note**: This variable is only honored for Autodiscovery.), `image:.*` |
 
 Additional examples are available on the [Container Discover Management][13] page.
 

--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -277,14 +277,14 @@ Exclude containers from logs collection, metrics collection, and Autodiscovery. 
 
 | Env Variable    | Description                                                                                                                                                                                                        |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `DD_CONTAINER_INCLUDE` | Allowed list of containers to include (separated by spaces). Use `.*` to include all. For example: `"image:image_name_1 image:image_name_2"`, `image:.*`  |
-| `DD_CONTAINER_EXCLUDE` | Disallowed list of containers to exclude (separated by spaces). Use `.*` to exclude all. For example: `"image:image_name_3 image:image_name_4"` (**Note**: This variable is only honored for Autodiscovery.), `image:.*` |
-| `DD_CONTAINER_INCLUDE_METRICS` | Allowed list of containers whose metrics you wish to include.  |
-| `DD_CONTAINER_EXCLUDE_METRICS` | Disallowed list of containers whose metrics you wish to exclude. |
-| `DD_CONTAINER_INCLUDE_LOGS` | Allowed list of containers whose logs you wish to include.  |
-| `DD_CONTAINER_EXCLUDE_LOGS` | Disallowed list of containers whose logs you wish to exclude. |
-| `DD_AC_INCLUDE` | **Deprecated**. Allowed list of containers to include (separated by spaces). Use `.*` to include all. For example: `"image:image_name_1 image:image_name_2"`, `image:.*`  |                                              
-| `DD_AC_EXCLUDE` | **Deprecated**. Disallowed list of containers to exclude (separated by spaces). Use `.*` to exclude all. For example: `"image:image_name_3 image:image_name_4"` (**Note**: This variable is only honored for Autodiscovery.), `image:.*` |
+| `DD_CONTAINER_INCLUDE` | Allowlist of containers to include (separated by spaces). Use `.*` to include all. For example: `"image:image_name_1 image:image_name_2"`, `image:.*`  |
+| `DD_CONTAINER_EXCLUDE` | Blocklist of containers to exclude (separated by spaces). Use `.*` to exclude all. For example: `"image:image_name_3 image:image_name_4"` (**Note**: This variable is only honored for Autodiscovery.), `image:.*` |
+| `DD_CONTAINER_INCLUDE_METRICS` | Allowlist of containers whose metrics you wish to include.  |
+| `DD_CONTAINER_EXCLUDE_METRICS` | Blocklist of containers whose metrics you wish to exclude. |
+| `DD_CONTAINER_INCLUDE_LOGS` | Allowlist of containers whose logs you wish to include.  |
+| `DD_CONTAINER_EXCLUDE_LOGS` | Blocklist of containers whose logs you wish to exclude. |
+| `DD_AC_INCLUDE` | **Deprecated**. Allowlist of containers to include (separated by spaces). Use `.*` to include all. For example: `"image:image_name_1 image:image_name_2"`, `image:.*`  |                                              
+| `DD_AC_EXCLUDE` | **Deprecated**. Blocklist of containers to exclude (separated by spaces). Use `.*` to exclude all. For example: `"image:image_name_3 image:image_name_4"` (**Note**: This variable is only honored for Autodiscovery.), `image:.*` |
 
 Additional examples are available on the [Container Discover Management][13] page.
 

--- a/content/en/infrastructure/livecontainers.md
+++ b/content/en/infrastructure/livecontainers.md
@@ -201,16 +201,16 @@ While actively working with the containers page, metrics are collected at a 2-se
 
 It is possible to include and/or exclude containers from real-time collection:
 
-* Exclude containers either via passing the environment variable `DD_AC_EXCLUDE` or adding `ac_exclude:` in your `datadog.yaml` main configuration file.
-* Include containers either via passing the environment variable `DD_AC_INCLUDE` or adding `ac_include:` in your `datadog.yaml` main configuration file.
+* Exclude containers either via passing the environment variable `DD_CONTAINER_EXCLUDE` or adding `container_exclude:` in your `datadog.yaml` main configuration file.
+* Include containers either via passing the environment variable `DD_CONTAINER_INCLUDE` or adding `container_include:` in your `datadog.yaml` main configuration file.
 
 Both arguments take an **image name** as value; regular expressions are also supported.
 
 For example, to exclude all Debian images except containers with a name starting with *frontend*, add these two configuration lines in your `datadog.yaml` file:
 
 ```shell
-ac_exclude: ["image:debian"]
-ac_include: ["name:frontend.*"]
+container_exclude: ["image:debian"]
+container_include: ["name:frontend.*"]
 ```
 
 **Note**: For Agent 5, instead of including the above in the `datadog.conf` main configuration file, explicitly add a `datadog.yaml` file to `/etc/datadog-agent/`, as the Process Agent requires all configuration options here. This configuration only excludes containers from real-time collection, **not** from Autodiscovery.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
adds new agent 7.2 container include/exclude env vars

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->


https://docs-staging.datadoghq.com/cswatt/container-env-vars/infrastructure/livecontainers
https://docs-staging.datadoghq.com/cswatt/container-env-vars/agent/kubernetes/#ignore-containers
https://docs-staging.datadoghq.com/cswatt/container-env-vars/agent/guide/environment-variables
https://docs-staging.datadoghq.com/cswatt/container-env-vars/agent/guide/autodiscovery-management
https://docs-staging.datadoghq.com/cswatt/container-env-vars/agent/docker

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
