### PR TITLE
DOCS-955 Unprivileged installation

### DIFF
--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -41,24 +41,15 @@ If you haven’t installed the Docker Agent, follow the [in-app installation ins
 {{% tab "Standard" %}}
 
 ```shell
-DOCKER_CONTENT_TRUST=1 \
-docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
-              -v /proc/:/host/proc/:ro \
-              -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-              -e DD_API_KEY="<DATADOG_API_KEY>" \
-              datadog/agent:latest
+DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<DATADOG_API_KEY> datadog/agent:7
 ```
 
+
 {{% /tab %}}
-{{% tab "Amazon Linux version <2" %}}
+{{% tab "Amazon Linux < v2" %}}
 
 ```shell
-DOCKER_CONTENT_TRUST=1 \
-docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro \
-                              -v /proc/:/host/proc/:ro \
-                              -v /cgroup/:/host/sys/fs/cgroup:ro \
-                              -e DD_API_KEY="<DATADOG_API_KEY>" \
-                              datadog/agent:latest
+DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<DATADOG_API_KEY> datadog/agent:7
 ```
 
 {{% /tab %}}
@@ -68,6 +59,15 @@ The Datadog Agent is supported in Windows Server 2019 (LTSC) and version 1909 (S
 
 ```shell
 docker run -d --name dd-agent -e DD_API_KEY=<API_KEY> -v \\.\pipe\docker_engine:\\.\pipe\docker_engine datadog/agent:latest
+```
+
+{{% /tab %}}
+{{% tab "Unprivileged" %}}
+
+(Optional) To run an unprivileged installation, add `--group-add=<DOCKER_GROUP_ID>` to the install command, for example:
+
+```shell
+DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<DATADOG_API_KEY> datadog/agent:7 --group-add=<DOCKER_GROUP_ID>
 ```
 
 {{% /tab %}}

--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -180,6 +180,17 @@ To install the Datadog Agent on your Kubernetes cluster:
 {{% /tab %}}
 {{< /tabs >}}
 
+### Unprivileged
+
+(Optional) To run an unprivileged installation, add the following to your [pod template][2]:
+
+```text
+  spec:
+    securityContext:
+      runAsUser: <USER_ID>
+      fsGroup: <DOCKER_GROUP_ID>
+```
+
 ## Event Collection
 
 {{< tabs >}}
@@ -199,11 +210,11 @@ If you want to collect events from your kubernetes cluster set the environment v
 
 ## Integrations
 
-Once the Agent is up and running in your cluster, use [Datadog's Autodiscovery feature][2] to collect metrics and logs automatically from your pods.
+Once the Agent is up and running in your cluster, use [Datadog's Autodiscovery feature][3] to collect metrics and logs automatically from your pods.
 
 ## Environment variables
 
-Find below the list of environment variables available for the Datadog Agent. If you want to setup those with Helm, see the full list of configuration options for the `datadog-value.yaml` file in the [helm/charts Github repository][3].
+Find below the list of environment variables available for the Datadog Agent. If you want to setup those with Helm, see the full list of configuration options for the `datadog-value.yaml` file in the [helm/charts Github repository][4].
 
 ### Global options
 
@@ -228,7 +239,7 @@ Starting with Agent v6.4.0 (and v6.5.0 for the Trace Agent), you can override th
 | `DD_PROXY_HTTPS`    | An HTTPS URL to use as a proxy for `https` requests.              |
 | `DD_PROXY_NO_PROXY` | A space-separated list of URLs for which no proxy should be used. |
 
-For more information about proxy settings, see the [Agent v6 Proxy documentation][4].
+For more information about proxy settings, see the [Agent v6 Proxy documentation][5].
 
 ### Optional collection Agents
 
@@ -236,14 +247,14 @@ Optional collection Agents are disabled by default for security or performance r
 
 | Env Variable               | Description                                                                                                                                                                                                                                                  |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `DD_APM_ENABLED`           | Enable [trace collection][5] with the Trace Agent.                                                                                                                                                                                                           |
-| `DD_LOGS_ENABLED`          | Enable [log collection][6] with the Logs Agent.                                                                                                                                                                                                              |
-| `DD_PROCESS_AGENT_ENABLED` | Enable [live process collection][7] with the Process Agent. The [live container view][8] is already enabled by default if the Docker socket is available. If set to `false`, the [live process collection][7] and the [live container view][8] are disabled. |
+| `DD_APM_ENABLED`           | Enable [trace collection][6] with the Trace Agent.                                                                                                                                                                                                           |
+| `DD_LOGS_ENABLED`          | Enable [log collection][7] with the Logs Agent.                                                                                                                                                                                                              |
+| `DD_PROCESS_AGENT_ENABLED` | Enable [live process collection][8] with the Process Agent. The [live container view][9] is already enabled by default if the Docker socket is available. If set to `false`, the [live process collection][8] and the [live container view][9] are disabled. |
 | `DD_COLLECT_KUBERNETES_EVENTS ` | Enable event collection with the Agent. If you are running multiple Agent in your cluster, set `DD_LEADER_ELECTION` to `true` as well. |
 
 ### DogStatsD (custom metrics)
 
-Send custom metrics with [the StatsD protocol][9]:
+Send custom metrics with [the StatsD protocol][10]:
 
 | Env Variable                     | Description                                                                                                                                                |
 | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -254,7 +265,7 @@ Send custom metrics with [the StatsD protocol][9]:
 | `DD_DOGSTATSD_ORIGIN_DETECTION`  | Enable container detection and tagging for unix socket metrics.                                                                                            |
 | `DD_DOGSTATSD_TAGS`              | Additional tags to append to all metrics, events, and service checks received by this DogStatsD server, for example: `["env:golden", "group:retrievers"]`. |
 
-Learn more about [DogStatsD over Unix Domain Sockets][10].
+Learn more about [DogStatsD over Unix Domain Sockets][11].
 
 ### Tagging
 
@@ -265,11 +276,11 @@ Datadog automatically collects common tags from Kubernetes. To extract even more
 | `DD_KUBERNETES_POD_LABELS_AS_TAGS`      | Extract pod labels      |
 | `DD_KUBERNETES_POD_ANNOTATIONS_AS_TAGS` | Extract pod annotations |
 
-See the [Kubernetes Tag Extraction][11] documentation to learn more.
+See the [Kubernetes Tag Extraction][12] documentation to learn more.
 
 ### Using secret files
 
-Integration credentials can be stored in Docker or Kubernetes secrets and used in Autodiscovery templates. For more information, see the [Secrets Management documentation][12].
+Integration credentials can be stored in Docker or Kubernetes secrets and used in Autodiscovery templates. For more information, see the [Secrets Management documentation][13].
 
 ### Ignore containers
 
@@ -280,7 +291,7 @@ Exclude containers from logs collection, metrics collection, and Autodiscovery. 
 | `DD_AC_INCLUDE` | Whitelist of containers to include (separated by spaces). Use `.*` to include all. For example: `"image:image_name_1 image:image_name_2"`, `image:.*`                                                              |
 | `DD_AC_EXCLUDE` | Blacklist of containers to exclude (separated by spaces). Use `.*` to exclude all. For example: `"image:image_name_3 image:image_name_4"` (**Note**: This variable is only honored for Autodiscovery.), `image:.*` |
 
-Additional examples are available on the [Container Discover Management][13] page.
+Additional examples are available on the [Container Discover Management][14] page.
 
 **Note**: The `docker.containers.running`, `.stopped`, `.running.total` and `.stopped.total` metrics are not affected by these settings. All containers are counted. This does not affect your per-container billing.
 
@@ -297,23 +308,24 @@ You can add extra listeners and config providers using the `DD_EXTRA_LISTENERS` 
 
 ## Commands
 
-See the [Agent Commands guides][14] to discover all the Docker Agent commands.
+See the [Agent Commands guides][15] to discover all the Docker Agent commands.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /agent/faq/kubernetes-legacy/
-[2]: /agent/kubernetes/integrations/
-[3]: https://github.com/helm/charts/tree/master/stable/datadog#all-configuration-options
-[4]: /agent/proxy/#agent-v6
-[5]: /agent/kubernetes/apm/
-[6]: /agent/kubernetes/log/
-[7]: /infrastructure/process/
-[8]: /infrastructure/livecontainers/
-[9]: /developers/dogstatsd/
-[10]: /developers/dogstatsd/unix_socket/
-[11]: /agent/kubernetes/tag/
-[12]: /security/agent/#secrets-management
-[13]: /agent/guide/autodiscovery-management/
-[14]: /agent/guide/agent-commands/
+[2]: https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/#pod-templates
+[3]: /agent/kubernetes/integrations/
+[4]: https://github.com/helm/charts/tree/master/stable/datadog#all-configuration-options
+[5]: /agent/proxy/#agent-v6
+[6]: /agent/kubernetes/apm/
+[7]: /agent/kubernetes/log/
+[8]: /infrastructure/process/
+[9]: /infrastructure/livecontainers/
+[10]: /developers/dogstatsd/
+[11]: /developers/dogstatsd/unix_socket/
+[12]: /agent/kubernetes/tag/
+[13]: /security/agent/#secrets-management
+[14]: /agent/guide/autodiscovery-management/
+[15]: /agent/guide/agent-commands/


### PR DESCRIPTION

### What does this PR do?
- Add instructions for installing the container Agent as unprivileged.
- Update 1-line install instructions to match the in-app instructions.

### Motivation
PM request

### Preview link

https://docs-staging.datadoghq.com/ruth/docs-955/agent/docker/?tab=unprivileged
https://docs-staging.datadoghq.com/ruth/docs-955/agent/kubernetes/#unprivileged

### Additional Notes
N/A
