### PR TITLE
[DOC] Corrected links for log patterns/analytics links

### DIFF
--- a/content/en/logs/explorer/facets.md
+++ b/content/en/logs/explorer/facets.md
@@ -196,8 +196,8 @@ This is the best option if you onboard logs flowing from new sources. Rather tha
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /logs/search_syntax/
-[2]: /logs/explorer/analytics/
-[3]: /logs/explorer/patterns/
+[2]: /logs/explorer/patterns/
+[3]: /logs/explorer/analytics/
 [4]: /monitors/monitor_types/log/
 [5]: /dashboards/widgets/
 [6]: /notebooks/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Correct links for log patterns/analytics links which were oppositely linked

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
