### PR TITLE
add cache invalidations

### DIFF
--- a/config/preview/config.yaml
+++ b/config/preview/config.yaml
@@ -8,21 +8,22 @@ deployment:
     targets: 
     - name: "preview"
       URL: "s3://datadog-docs-preview?region=us-east-1&prefix=$CI_COMMIT_REF_NAME/"
-      # cloudFrontDistributionID: E3EYIYXXL26MK1
+      exclude: "**.{go,java,sh,py,rb,json}"
+      cloudFrontDistributionID: E3EYIYXXL26MK1
     - name: "previewAssets"
       URL: "s3://dd-staging-static-assets?region=us-east-1&prefix=documentation/"
       include: "**.{jpg,jpeg,png,gif,mp4,svg,json}"
   
-    # matchers:
-    # - pattern: "^.+\\.(js|css|svg)$"
-    #   cacheControl: "max-age=31536000, no-transform, public"
-    #   gzip: true
-    # - pattern: "^.+\\.(eot|ttf|woff|woff2|ico)$"
-    #   cacheControl: "max-age=31536000, no-transform, public"
-    #   gzip: false
-    # - pattern: "^.+\\.(png|jpg|jpeg|gif|mp4|zip|pdf|txt|csv)$"
-    #   cacheControl: "max-age=31536000, no-transform, public"
-    #   gzip: false
-    # - pattern: "^.+\\.(html|xml|json)$"
-    #   gzip: true
-    #   cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
+    matchers:
+      - pattern: "^.+\\.(js|css|svg)$"
+        cacheControl: "max-age=31536000, no-transform, public"
+        gzip: true
+      - pattern: "^.+\\.(eot|ttf|woff|woff2|ico)$"
+        cacheControl: "max-age=31536000, no-transform, public"
+        gzip: false
+      - pattern: "^.+\\.(png|jpg|jpeg|gif|mp4|zip|pdf|txt|csv)$"
+        cacheControl: "max-age=31536000, no-transform, public"
+        gzip: false
+      - pattern: "^.+\\.(html|xml|json)$"
+        gzip: true
+        cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "build:hugo:live": "yarn run build:hugo -- -D -F --environment live",
         "build:live": "run-s build:webpack build:hugo:live",
         "deploy:previewAssets": "./node_modules/.bin/hugo deploy --target previewAssets -e preview --maxDeletes 0 --log --verbose --debug",
-        "deploy:preview": "./node_modules/.bin/hugo deploy --target preview -e preview --maxDeletes -1 --log --verbose --debug",
+        "deploy:preview": "./node_modules/.bin/hugo deploy --target preview -e preview --maxDeletes -1 --invalidateCDN --log --verbose --debug",
         "deploy:liveAssets": "./node_modules/.bin/hugo deploy --target liveAssets -e live --maxDeletes 0 --log --verbose --debug --dryRun",
         "deploy:live": "./node_modules/.bin/hugo deploy --target live -e live --maxDeletes -1 --log --verbose --debug --dryRun",
         "build:apiPages": "node -e 'require(\"./src/scripts/build-api-pages.js\").init()'",


### PR DESCRIPTION

### What does this PR do?
enables cache control for staging site files. 

### Motivation
need to invalidate the cache for html files when changes are made.

### Preview link
http://docs-staging.datadoghq.com/zach/add-cache-control
