### PR TITLE
DOCS-1010 add docs for agent install log locations

### DIFF
--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -98,6 +98,10 @@ If you're upgrading from a Datadog Agent version < 5.12.0, first upgrade to a mo
 {{% /tab %}}
 {{< /tabs >}}
 
+### Installation Log Files
+
+You can find agent installation log files at `%TEMP%\MSI*.LOG`.
+
 ### Validation
 
 To verify your installation, follow the instructions in the [Agent Status and Information](#agent-status-and-information) section.

--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -100,7 +100,7 @@ If you're upgrading from a Datadog Agent version < 5.12.0, first upgrade to a mo
 
 ### Installation Log Files
 
-You can find agent installation log files at `%TEMP%\MSI*.LOG`.
+You can find Agent installation log files at `%TEMP%\MSI*.LOG`.
 
 ### Validation
 

--- a/content/en/agent/guide/agent-log-files.md
+++ b/content/en/agent/guide/agent-log-files.md
@@ -69,6 +69,14 @@ The Datadog Agent does a logs rollover every 10MB. When a rollover occurs, one b
 {{% /tab %}}
 {{< /tabs >}}
 
+## Agent Installation Log Files
+
+| Platform                             | Location and file name        |
+|--------------------------------------|-------------------------------|
+| Linux                                | `/tmp/dd_agent.log`           |
+| macOS                                | `/tmp/dd_agent.log`           |
+| Windows                              | `%TEMP%\MSI*.LOG`             |
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
### What does this PR do?
adds info about where agent installation log files are stored 

### Motivation
DOCS-1010

### Preview link

https://docs-staging.datadoghq.com/kari/DOCS-1010/agent/basic_agent_usage/windows/
https://docs-staging.datadoghq.com/kari/DOCS-1010/agent/guide/agent-log-files/

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
Thinking I should also update the in-app linux and macos pages with log file location. What do you think?
