### PR TITLE
Update integrations.md

### DIFF
--- a/content/en/agent/kubernetes/integrations.md
+++ b/content/en/agent/kubernetes/integrations.md
@@ -451,19 +451,25 @@ In the manifest, define the `volumeMounts` and `volumes`:
 # [...]
         volumeMounts:
         # [...]
-          - name: httpd-config-map
-            mountPath: /conf.d
+          - name: apache-auto-config
+            mountPath: /conf.d/apache.d/
+          - name: http-auto-config
+            mountPath: /conf.d/http_check.d/
         # [...]
       volumes:
       # [...]
-        - name: httpd-config-map
+        - name: apache-auto-config
           configMap:
             name: httpd-config-map
             items:
               - key: apache-config
-                path: /apache.d/conf.yaml
+                path: auto_conf.yaml
+        - name: http-auto-config
+          configMap:
+            name: httpd-config-map
+            items:
               - key: http-check-config
-                path: /http_check.d/conf.yaml
+                path: auto_conf.yaml
 # [...]
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Modifies the approach to mounting multiple config from a single configmap. Using the current sample encounters this error:

```
The DaemonSet "datadog-agent" is invalid:
* spec.template.spec.volumes[4].configMap.items[0].path: Invalid value: "/apache.d/conf.yaml": must be a relative path
* spec.template.spec.volumes[4].configMap.items[1].path: Invalid value: "/http_check.d/conf.yaml": must be a relative path
* spec.template.spec.containers[0].volumeMounts[3].name: Not found: "httpd-config-map"
```

However, even correcting that, the approach simply does not work. The file 

```
# ls -lrt /conf.d/http_check.d/ /etc/datadog-agent/conf.d/http_check.d

/conf.d/http_check.d/:
total 4
-rw-r--r-- 1 root root 162 Jun 17 07:42 auto_conf.yaml

/etc/datadog-agent/conf.d/http_check.d:
total 16
-rw-rw-r-- 1 dd-agent root 14342 Jun 11 23:37 conf.yaml.example
```

```
# find . -name auto_conf.yaml | grep http
./conf.d/..2020_06_17_07_42_57.685286965/http_check.d/auto_conf.yaml
```

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
