### PR TITLE
Fix `check_names` annotation in JMX autodisovery doc

### DIFF
--- a/content/en/agent/guide/autodiscovery-with-jmx.md
+++ b/content/en/agent/guide/autodiscovery-with-jmx.md
@@ -32,7 +32,7 @@ The autodiscovery annotations logic consists in applying the JMX check configura
     metadata:
         name: <POD_NAME>
         annotations:
-            ad.datadoghq.com/<CONTAINER_IDENTIFIER>.check.names: >-
+            ad.datadoghq.com/<CONTAINER_IDENTIFIER>.check_names: >-
               '["<INTEGRATION_NAME>"]'
             ad.datadoghq.com/<CONTAINER_IDENTIFIER>.init_configs: >-
               '[{"is_jmx": true, "collect_default_metrics": true}]'
@@ -90,7 +90,7 @@ kind: Pod
 metadata:
     name: tomcat-test
     annotations:
-        ad.datadoghq.com/tomcat.check.names: >-
+        ad.datadoghq.com/tomcat.check_names: >-
           '["tomcat"]'
         ad.datadoghq.com/tomcat.init_configs: >-
           '[{"is_jmx": true, "collect_default_metrics": true}]'


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR changes it to `check_names` which should be correct according to the https://docs.datadoghq.com/agent/kubernetes/integrations/?tab=kubernetes

### Motivation
There is a typo in the annotation key with dot in `check.name` instead of `check_names`

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
