### PR TITLE
Adding real_user_monitoring guides into algolia

### DIFF
--- a/local/etc/algolia/docs_datadoghq.json
+++ b/local/etc/algolia/docs_datadoghq.json
@@ -51,6 +51,7 @@
                     "monitors",
                     "tracing",
                     "logs",
+                    "real_user_monitoring",
                     "synthetics",
                     "developers"
                 ],

--- a/local/etc/algolia/docs_datadoghq_preview.json
+++ b/local/etc/algolia/docs_datadoghq_preview.json
@@ -52,6 +52,7 @@
                     "tracing",
                     "logs",
                     "synthetics",
+                    "real_user_monitoring",
                     "developers"
                 ],
                 "localisation": ["", "/fr", "/ja"]


### PR DESCRIPTION
### What does this PR do?

Updates Algolia configuration to include content from: https://github.com/DataDog/documentation/pull/7742