### PR TITLE
update aix agent installation log location info to match style 

### DIFF
--- a/content/en/agent/basic_agent_usage/aix.md
+++ b/content/en/agent/basic_agent_usage/aix.md
@@ -42,7 +42,9 @@ installp -aXYgd ./datadog-unix-agent-<VEERSION>.powerpc.bff -e dd-aix-install.lo
 
 This installs the Agent in `/opt/datadog-agent`.
 
-Note: Agent installation logs can be found in the `dd-aix-install.log` file. To disable this logging, remove the `-e` parameter in the installation command.
+### Installation Log Files
+
+You can find the Agent installation log in the `dd-aix-install.log` file. To disable this logging, remove the `-e` parameter in the installation command.
 
 ## Commands
 


### PR DESCRIPTION
### What does this PR do?
Changes AIX Agent installation log location paragraph so it matches what we wrote for Windows

### Motivation
DOCS-1010

### Preview link
https://docs-staging.datadoghq.com/kari/DOCS-1010ix/agent/basic_agent_usage/aix/

