### PR TITLE
fix for opentracing link

### DIFF
--- a/content/en/tracing/manual_instrumentation/python.md
+++ b/content/en/tracing/manual_instrumentation/python.md
@@ -244,4 +244,4 @@ The tracer can now be used like in any other OpenTracing application. See [opent
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /tracing/setup/python/#compatibility
-[2]: opentracing.io/guides/python
+[2]: https://opentracing.io/guides/python/


### PR DESCRIPTION
### What does this PR do?
Adds https:// to the opentracing link

### Motivation
To fix the link checker!

### Preview link
https://docs-staging.datadoghq.com/sarina/opentracing-link/tracing/manual_instrumentation/python

Check preview base path using the URL in details in `preview` status check.