### PR TITLE
Adding iOS Trace Collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ content/en/agent/basic_agent_usage/saltstack.md
 # Tracing
 content/en/tracing/setup/ruby.md
 content/en/tracing/setup/android.md
+content/en/tracing/setup/ios.md
 
 # Log collection
 content/en/logs/log_collection/android.md

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -249,6 +249,27 @@
               tag: "Documentation"
               text: "Learn how to explore your logs"
 
+    - action: pull-and-push-file
+      branch: master
+      globs:
+      - 'docs/trace_collection.md'
+      options:
+        dest_path: '/tracing/setup/'
+        file_name: 'ios.md'
+        front_matters:
+          title: iOS Trace Collection
+          kind: documentation
+          beta: true
+          description: "Collect traces from your iOS applications."
+          dependencies: ["https://github.com/DataDog/dd-sdk-ios/blob/master/docs/trace_collection.md"]
+          further_reading:
+            - link: "https://github.com/DataDog/dd-sdk-ios"
+              tag: "Github"
+              text: "dd-sdk-ios Source code"
+            - link: "tracing/visualization/"
+              tag: "Documentation"
+              text: "Explore your services, resources and traces"
+
   - repo_name: security-monitoring
     contents:
     - action: security-rules

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -249,6 +249,27 @@
               tag: "Documentation"
               text: "Learn how to explore your logs"
 
+    - action: pull-and-push-file
+      branch: master
+      globs:
+      - 'docs/trace_collection.md'
+      options:
+        dest_path: '/tracing/setup/'
+        file_name: 'ios.md'
+        front_matters:
+          title: iOS Trace Collection
+          kind: documentation
+          beta: true
+          description: "Collect traces from your iOS applications."
+          dependencies: ["https://github.com/DataDog/dd-sdk-ios/blob/master/docs/trace_collection.md"]
+          further_reading:
+            - link: "https://github.com/DataDog/dd-sdk-ios"
+              tag: "Github"
+              text: "dd-sdk-ios Source code"
+            - link: "tracing/visualization/"
+              tag: "Documentation"
+              text: "Explore your services, resources and traces"
+
   - repo_name: security-monitoring
     contents:
     - action: security-rules


### PR DESCRIPTION
### What does this PR do?

As we're starting iOS Tracing **beta** in RUM team, I'm adding necessary configuration to have our doc page deployed.

### Motivation
We are starting beta, so the page should be available only through a direct link listed in [dd-sdk-ios](https://github.com/DataDog/dd-sdk-ios).

### Preview link

[iOS Trace Collection](https://docs-staging.datadoghq.com/maciek/add-ios-trace-collection/tracing/setup/ios/?tab=cocoapods)

Corresponding https://github.com/DataDog/dd-sdk-ios/pull/145 was opened to fix the issue with "support team" link rendering. 