### PR TITLE
Describing injection of trace_id and span_id to json logs in PHP

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/php.md
+++ b/content/en/tracing/connect_logs_and_traces/php.md
@@ -61,6 +61,26 @@ If the logger implements the [**monolog/monolog** library][4], use `Logger::push
 ?>
 ```
 
+If your application uses json logs format instead of appending trace_id and span_id to the log message you can add first-level key "dd" containing these ids:
+
+```php
+<?php
+  $logger->pushProcessor(function ($record) {
+      $span = \DDTrace\GlobalTracer::get()->getActiveSpan();
+      if (null === $span) {
+          return $record;
+      }
+      
+      $record['dd'] = [
+          'trace_id' => $span->getTraceId(),
+          'span_id'  => $span->getSpanId(),
+      ];
+      
+      return $record;
+  });
+?>
+```
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR adds a description of an alternative way to inject trace_id and span_id if the application uses json logs format.

### Motivation
<!-- What inspired you to submit this pull request?-->
We were looking for this way of connecting logs for our app, didn't find it in the logs, then just replicated the way node.js logs are connected

### Preview link
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/tracing/connect_logs_and_traces/php/


### Additional Notes
<!-- Anything else we should know when reviewing?-->
