### PR TITLE
api nav updates for multilang

### DIFF
--- a/layouts/partials/nav/api-main-menu.html
+++ b/layouts/partials/nav/api-main-menu.html
@@ -19,11 +19,16 @@
 
 {{ $currentPage := . }}
 
+<!-- set current english url. If url in menu doesn't start with /lang/ this lets us compare still  -->
+{{ $currentEnURL := $currentPage.RelPermalink }}
+{{ if ne $currentPage.Lang "en" }}
+    {{ $currentEnURL = (print "/" (strings.TrimLeft (print "/" .Lang "/") $currentPage.RelPermalink)) }}
+{{ end }}
                 
 <ul class="list-unstyled">
 {{ range $menu }}
     {{ if .HasChildren }}
-        <li class="{{ if or ($currentPage.IsMenuCurrent $apiMenu .) ($currentPage.HasMenuCurrent $apiMenu .) }}active{{ end }}">
+        <li class="{{ if or ($currentPage.IsMenuCurrent $apiMenu .) ($currentPage.HasMenuCurrent $apiMenu .) (eq $currentEnURL .URL) }}active{{ end }}">
             <a href="{{ (strings.TrimLeft "/" .URL) | absLangURL }}">
                 <span>{{ .Name }}</span>
             </a>
@@ -38,7 +43,7 @@
             </ul>
         </li>
     {{ else }}
-        <li class="{{ if or ($currentPage.IsMenuCurrent $apiMenu .) ($currentPage.HasMenuCurrent $apiMenu .) }}active{{ end }}">
+        <li class="{{ if or ($currentPage.IsMenuCurrent $apiMenu .) ($currentPage.HasMenuCurrent $apiMenu .) (eq $currentEnURL .URL) }}active{{ end }}">
             <a href="{{ (strings.TrimLeft "/" .URL) | absLangURL }}">
                 <span>{{ .Name }}</span>
             </a>

--- a/src/scripts/build-api-pages.js
+++ b/src/scripts/build-api-pages.js
@@ -7,7 +7,7 @@ const slugify = require('slugify');
 const $RefParser = require('@apidevtools/json-schema-ref-parser');
 const safeJsonStringify = require('safe-json-stringify');
 
-const supportedLangs = ['en', 'fr', 'ja'];
+const supportedLangs = ['en'];
 
 /**
  * Update the menu yaml file with api


### PR DESCRIPTION
### What does this PR do?

This PR:
- Stops auto building api menu from spec on ja/fr
- Instead rely on the translation process to keep them up to date
- translated items unfortunately come through with their url the same as the source. e.g `/api/foo` instead of `/fr/api/foo` so this pr also includes an update to the layout to set active classes for that comparison too.

### Motivation


### Preview link
Check api nav links on various pages. They should expand to show children.

https://docs-staging.datadoghq.com/david.jones/api-nav-lang/api/v1/
https://docs-staging.datadoghq.com/david.jones/api-nav-lang/fr/api/v1/
https://docs-staging.datadoghq.com/david.jones/api-nav-lang/ja/api/v1/

### Additional Notes

