### PR TITLE
Bumping version for dd browser/rum

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:gus_bump-version-rum
   tags:
     - "runner:main"
     - "size:large"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:gus_bump-version-rum
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
   tags:
     - "runner:main"
     - "size:large"

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^8.0.0",
         "@babel/polyfill": "^7.4.4",
-        "@datadog/browser-logs": "^1.7.5",
-        "@datadog/browser-rum": "^1.7.5",
+        "@datadog/browser-logs": "^1.12.4",
+        "@datadog/browser-rum": "^1.12.4",
         "a11y": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/a11y-v1.0.1.tgz",
         "algoliasearch": "^4.1.0",
         "bootstrap": "4.3.1",


### PR DESCRIPTION
### What does this PR do?

Bump RUM and log version of the NPM bundle to benefit from the latest feature like: https://github.com/DataDog/documentation/pull/7762/files

* https://docs-staging.datadoghq.com/gus/rum-version-bump