### PR TITLE
Update csharp.md to fix US tcp logging endpoint

### DIFF
--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -334,7 +334,7 @@ You can also override the default behaviour and forward logs in TCP by manually 
 For instance to forward logs to the Datadog US region in TCP you would use the following sink configuration:
 
 ```csharp
-var config = new DatadogConfiguration(url: "tcp-intake.logs.datadoghq.com", port: 10516, useSSL: true, useTCP: true);
+var config = new DatadogConfiguration(url: "intake.logs.datadoghq.com", port: 10516, useSSL: true, useTCP: true);
 var log = new LoggerConfiguration()
     .WriteTo.DatadogLogs(
         "<API_KEY>",


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Corrects the logging endpoint in our csharp doc for sending logs to U.S.  (the port 10516 was correct already and doesn't need updating)

### Motivation

tcp-intake.logs.* is an EU endpoint.  For U.S., it needs to be intake.logs.datadoghq.com

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/tj/fix_us_agentless_logging_tcp_endpoint_for_csharp/logs/log_collection/csharp/?tab=serilog#agentless-logging

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
