### PR TITLE
Update java.md to fix US tcp logging endpoint

### DIFF
--- a/content/en/logs/log_collection/java.md
+++ b/content/en/logs/log_collection/java.md
@@ -426,7 +426,7 @@ Configure the Logback logger to stream logs directly to Datadog by adding the fo
     <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
 </appender>
 <appender name="JSON_TCP" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
-    <remoteHost>tcp-intake.logs.datadoghq.com</remoteHost>
+    <remoteHost>intake.logs.datadoghq.com</remoteHost>
     <port>10514</port>
     <keepAliveDuration>1 minute</keepAliveDuration>
     <encoder class="net.logstash.logback.encoder.LogstashEncoder">


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Corrects the logging endpoint in our java logging doc for sending logs to U.S. (the port is correct already and doesn't need updating)

### Motivation

tcp-intake.logs.* is an EU endpoint. For U.S., it needs to be intake.logs.datadoghq.com

### Preview link


https://docs-staging.datadoghq.com/tj/fix_us_agentless_logging_tcp_endpoint_for_java/logs/log_collection/java/?tab=log4j2#logback-configuration

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
