### PR TITLE
Comment for US/EU option

### DIFF
--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -72,7 +72,7 @@ Select your Cloud provider below to see how to automatically collect your logs a
 
 ## Custom Log forwarder
 
-Any custom process or [logging library][18] able to forward logs through **TCP** or **HTTP** can be used in conjunction with Datadog Logs. Choose below which Datadog site you want to forward logs to:
+Any custom process or [logging library][18] able to forward logs through **TCP** or **HTTP** can be used in conjunction with Datadog Logs.
 
 {{< tabs >}}
 {{% tab "HTTP" %}}


### PR DESCRIPTION
# What does this PR do?
Removes a comment suggesting to "Choose below" for US/EU option. We've implemented the page US/EU page toggle, so this was leftover copy from tabbing.

### Motivation
Docs request

### Preview link
https://docs-staging.datadoghq.com/sarina/us-eu/logs/log_collection/?tab=tcp#datadog-logs-endpoints

Check preview base path using the URL in details in `preview` status check.