### PR TITLE
Andrew.ardito/addinfobox

### DIFF
--- a/content/en/tracing/manual_instrumentation/cpp.md
+++ b/content/en/tracing/manual_instrumentation/cpp.md
@@ -11,6 +11,10 @@ further_reading:
       text: 'Explore your services, resources, and traces'
 ---
 
+<div class="alert alert-info">
+If you have not yet read the setup instructions, please start with the <a href="https://docs.datadoghq.com/tracing/setup/cpp/">C++ Setup Instructions</a>.
+</div>
+
 ## Add tags
 
 Add custom [span tags][1] to your [spans][2] to customize your observability within Datadog.  The span tags are applied to your incoming traces, allowing you to correlate observed behavior with code-level information such as merchant tier, checkout amount, or user ID.

--- a/content/en/tracing/manual_instrumentation/cpp.md
+++ b/content/en/tracing/manual_instrumentation/cpp.md
@@ -12,7 +12,7 @@ further_reading:
 ---
 
 <div class="alert alert-info">
-If you have not yet read the setup instructions, please start with the <a href="https://docs.datadoghq.com/tracing/setup/cpp/">C++ Setup Instructions</a>.
+If you have not yet read the setup instructions, start with the <a href="https://docs.datadoghq.com/tracing/setup/cpp/">C++ Setup Instructions</a>.
 </div>
 
 ## Add tags

--- a/content/en/tracing/manual_instrumentation/dotnet.md
+++ b/content/en/tracing/manual_instrumentation/dotnet.md
@@ -16,7 +16,7 @@ further_reading:
       text: 'Explore your services, resources, and traces'
 ---
 <div class="alert alert-info">
-If you have not yet read the instructions for auto-instrumentation and setup, please start with the <a href="https://docs.datadoghq.com/tracing/setup/dotnet/">.NET Setup Instructions</a>.
+If you have not yet read the instructions for auto-instrumentation and setup, start with the <a href="https://docs.datadoghq.com/tracing/setup/dotnet/">.NET Setup Instructions</a>.
 </div>
 
 This page details common use cases for adding and customizing observability with Datadog APM.

--- a/content/en/tracing/manual_instrumentation/dotnet.md
+++ b/content/en/tracing/manual_instrumentation/dotnet.md
@@ -15,6 +15,10 @@ further_reading:
       tag: 'Documentation'
       text: 'Explore your services, resources, and traces'
 ---
+<div class="alert alert-info">
+If you have not yet read the instructions for auto-instrumentation and setup, please start with the <a href="https://docs.datadoghq.com/tracing/setup/dotnet/">.NET Setup Instructions</a>.
+</div>
+
 This page details common use cases for adding and customizing observability with Datadog APM.
 
 Add the `Datadog.Trace` [NuGet package][1] to your application. To create new spans, access the global tracer through the `Datadog.Trace.Tracer.Instance` property.

--- a/content/en/tracing/manual_instrumentation/go.md
+++ b/content/en/tracing/manual_instrumentation/go.md
@@ -12,6 +12,10 @@ further_reading:
       tag: 'Documentation'
       text: 'Explore your services, resources, and traces'
 ---
+<div class="alert alert-info">
+If you have not yet read the instructions for auto-instrumentation and setup, please start with the <a href="https://docs.datadoghq.com/tracing/setup/Go/">Go Setup Instructions</a>.
+</div>
+
 This page details common use cases for adding and customizing observability with Datadog APM.
 
 ## Adding Tags

--- a/content/en/tracing/manual_instrumentation/go.md
+++ b/content/en/tracing/manual_instrumentation/go.md
@@ -13,7 +13,7 @@ further_reading:
       text: 'Explore your services, resources, and traces'
 ---
 <div class="alert alert-info">
-If you have not yet read the instructions for auto-instrumentation and setup, please start with the <a href="https://docs.datadoghq.com/tracing/setup/go/">Go Setup Instructions</a>.
+If you have not yet read the instructions for auto-instrumentation and setup, start with the <a href="https://docs.datadoghq.com/tracing/setup/go/">Go Setup Instructions</a>.
 </div>
 
 This page details common use cases for adding and customizing observability with Datadog APM.

--- a/content/en/tracing/manual_instrumentation/go.md
+++ b/content/en/tracing/manual_instrumentation/go.md
@@ -13,7 +13,7 @@ further_reading:
       text: 'Explore your services, resources, and traces'
 ---
 <div class="alert alert-info">
-If you have not yet read the instructions for auto-instrumentation and setup, please start with the <a href="https://docs.datadoghq.com/tracing/setup/Go/">Go Setup Instructions</a>.
+If you have not yet read the instructions for auto-instrumentation and setup, please start with the <a href="https://docs.datadoghq.com/tracing/setup/go/">Go Setup Instructions</a>.
 </div>
 
 This page details common use cases for adding and customizing observability with Datadog APM.

--- a/content/en/tracing/manual_instrumentation/java.md
+++ b/content/en/tracing/manual_instrumentation/java.md
@@ -13,7 +13,7 @@ further_reading:
       text: 'Explore your services, resources, and traces'
 ---
 <div class="alert alert-info">
-If you have not yet read the instructions for auto-instrumentation and setup, please start with the <a href="https://docs.datadoghq.com/tracing/setup/Java/">Java Setup Instructions</a>.
+If you have not yet read the instructions for auto-instrumentation and setup, please start with the <a href="https://docs.datadoghq.com/tracing/setup/java/">Java Setup Instructions</a>.
 </div>
 
 This page details common use cases for adding and customizing observability with Datadog APM.

--- a/content/en/tracing/manual_instrumentation/java.md
+++ b/content/en/tracing/manual_instrumentation/java.md
@@ -13,7 +13,7 @@ further_reading:
       text: 'Explore your services, resources, and traces'
 ---
 <div class="alert alert-info">
-If you have not yet read the instructions for auto-instrumentation and setup, please start with the <a href="https://docs.datadoghq.com/tracing/setup/java/">Java Setup Instructions</a>.
+If you have not yet read the instructions for auto-instrumentation and setup, start with the <a href="https://docs.datadoghq.com/tracing/setup/java/">Java Setup Instructions</a>.
 </div>
 
 This page details common use cases for adding and customizing observability with Datadog APM.

--- a/content/en/tracing/manual_instrumentation/java.md
+++ b/content/en/tracing/manual_instrumentation/java.md
@@ -12,6 +12,10 @@ further_reading:
       tag: 'Documentation'
       text: 'Explore your services, resources, and traces'
 ---
+<div class="alert alert-info">
+If you have not yet read the instructions for auto-instrumentation and setup, please start with the <a href="https://docs.datadoghq.com/tracing/setup/Java/">Java Setup Instructions</a>.
+</div>
+
 This page details common use cases for adding and customizing observability with Datadog APM.
 
 ## Adding Tags
@@ -206,7 +210,7 @@ class SomeClass {
             span.setTag("my.tag", "value");
 
             // The code you’re tracing
-            
+
         } catch (Exception e) {
             // Set error on span
         } finally {
@@ -244,7 +248,7 @@ class FilteringInterceptor implements TraceInterceptor {
     @Override
     public int priority() {
         // some high unique number so this interceptor is last
-        return 100; 
+        return 100;
     }
 }
 

--- a/content/en/tracing/manual_instrumentation/python.md
+++ b/content/en/tracing/manual_instrumentation/python.md
@@ -12,6 +12,9 @@ further_reading:
       tag: 'Documentation'
       text: 'Explore your services, resources, and traces'
 ---
+<div class="alert alert-info">
+If you have not yet read the instructions for auto-instrumentation and setup, please start with the <a href="https://docs.datadoghq.com/tracing/setup/python/">Python Setup Instructions</a>.
+</div>
 
 If you aren't using supported library instrumentation (see [library compatibility][1]), you may want to manually instrument your code.
 

--- a/content/en/tracing/manual_instrumentation/python.md
+++ b/content/en/tracing/manual_instrumentation/python.md
@@ -246,5 +246,5 @@ The tracer can now be used like in any other OpenTracing application. See [opent
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/setup/python/#compatibility
+[1]: /tracing/compatibility_requirements/python
 [2]: https://opentracing.io/guides/python/

--- a/content/en/tracing/manual_instrumentation/python.md
+++ b/content/en/tracing/manual_instrumentation/python.md
@@ -13,7 +13,7 @@ further_reading:
       text: 'Explore your services, resources, and traces'
 ---
 <div class="alert alert-info">
-If you have not yet read the instructions for auto-instrumentation and setup, please start with the <a href="https://docs.datadoghq.com/tracing/setup/python/">Python Setup Instructions</a>.
+If you have not yet read the instructions for auto-instrumentation and setup, start with the <a href="https://docs.datadoghq.com/tracing/setup/python/">Python Setup Instructions</a>.
 </div>
 
 If you aren't using supported library instrumentation (see [library compatibility][1]), you may want to manually instrument your code.


### PR DESCRIPTION

### What does this PR do?
Add direction to per language setup pages in case of user landing on Custom Instrumentation who has not seen the setup page

### Motivation
Prevent a bad user experience

### Preview link
https://docs.datadoghq.com/tracing/manual_instrumentation/
for Java/.NET/Go/C++/Python