### PR TITLE
java docs fixup

### DIFF
--- a/content/en/tracing/profiling/_index.md
+++ b/content/en/tracing/profiling/_index.md
@@ -54,8 +54,6 @@ The Datadog Profiler requires [Java Flight Recorder][1]. The Datadog Profiling l
     java -jar my-service.jar -javaagent:dd-java-agent.jar ...
     ```
 
-- Because profiles are sent directly to Datadog without using the Datadog Agent, you must pass a valid [Datadog API key][4].
-
 - As an alternative to passing arguments, you can use environment variable to set those parameters:
 
 | Arguments                     | Environment variable      | Description                                       |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Removes a note that is now deprecated for Java profiling. 
### Motivation
<!-- What inspired you to submit this pull request?-->
Remove false information.
### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/gaurab/profiling-java-fixup

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
