### PR TITLE
include api_host in SubmitMetrics.py

### DIFF
--- a/content/en/api/v1/metrics/SubmitMetrics.py
+++ b/content/en/api/v1/metrics/SubmitMetrics.py
@@ -3,6 +3,8 @@ import time
 
 options = {
     'api_key': '<DATADOG_API_KEY>'
+    ## EU costumers need to define 'api_host' as below
+    #'api_host': 'https://api.datadoghq.eu/'
 }
 
 initialize(**options)


### PR DESCRIPTION
api_host definition needed for EU costumers

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
EU costumers need to define api_host in order to send metrics through the API

### Preview link
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/api/v1/metrics/#submit-metrics

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/rogerioshieh-python-api-docs/api/v1/metrics

Check preview base path using the URL in details in `preview` status check.
