### PR TITLE
Removing note about unsupported Windows containers

### DIFF
--- a/content/en/infrastructure/livecontainers.md
+++ b/content/en/infrastructure/livecontainers.md
@@ -217,7 +217,6 @@ container_include: ["name:frontend.*"]
 
 ## Notes/known issues
 
-* This feature does not support Windows containers at this time.
 * Real-time (2s) data collection is turned off after 30 minutes. To resume real-time collection, refresh the page.
 * RBAC settings can restrict Kubernetes metadata collection. Refer to the [RBAC entites for the Datadog Agent][10].
 * In Kubernetes the `health` value is the containers' readiness probe, not its liveness probe.


### PR DESCRIPTION
Windows containers are now officially supported

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Datadog now supports Windows containers

### Motivation
Doc is out of date

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
