### PR TITLE
Add missing field to mask sequence examples

### DIFF
--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -247,6 +247,7 @@ In a Docker environment, use the label `com.datadoghq.ad.logs` on your container
         "log_processing_rules": [{
           "type": "mask_sequences",
           "name": "mask_credit_cards",
+          "replace_placeholder": "[masked_credit_card]",
           "pattern" : "(?:4[0-9]{12}(?:[0-9]{3})?|[25][1-7][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\d{3})\\d{11})"
         }]
       }]
@@ -278,6 +279,7 @@ spec:
             "log_processing_rules": [{
               "type": "mask_sequences",
               "name": "mask_credit_cards",
+              "replace_placeholder": "[masked_credit_card]",
               "pattern" : "(?:4[0-9]{12}(?:[0-9]{3})?|[25][1-7][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\d{3})\\d{11})"
             }]
           }]


### PR DESCRIPTION
### What does this PR do?
Adds the missing `replace_placeholder` field for the Docker and Kubernetes examples.

### Motivation
The current doc is missing the `replace_placeholder` field for the Docker and Kubernetes examples.

### Preview link
https://docs-staging.datadoghq.com/michaels/mask_sequence_doc/agent/logs/advanced_log_collection/?tab=kubernetes#scrub-sensitive-data-from-your-logs

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
