### PR TITLE
Add Docker Hub redirect for /integrations/docker

### DIFF
--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -6,6 +6,7 @@ aliases:
   - /agent/docker
   - /agent/basic_agent_usage/docker/
   - /integrations/docker_daemon/
+  - /integrations/docker/
 further_reading:
 - link: "/agent/docker/log/"
   tag: "Documentation"


### PR DESCRIPTION
### What does this PR do?
Adds redirect link to Docker Agent referenced in Docker Hub

### Motivation
Slack message to #websites 
https://dd.slack.com/archives/C3CT8QA11/p1592945648246400

### Preview link
http://docs-staging.datadoghq.com/nsollecito/docker-redirect/integrations/docker/
