### PR TITLE
[rolesv2] add permissions to role update doc

### DIFF
--- a/data/api/v2/full_spec.yaml
+++ b/data/api/v2/full_spec.yaml
@@ -1099,11 +1099,18 @@ components:
           description: Name of the role.
           type: string
       type: object
+    RoleUpdateRelationships:
+      description: Relationships of role object to update
+      properties:
+        permissions:
+          $ref: '#/componetns/schemas/RelationshipToPermissions'
     RoleUpdateData:
       description: Data related to the update of a role.
       properties:
         attributes:
           $ref: '#/components/schemas/RoleUpdateAttributes'
+        relationships:
+          $ref: '#/componetns/schemas/RoleUpdateRelationships'
         id:
           description: ID of the role.
           type: string


### PR DESCRIPTION
[rolesv2] The update route of rolesv2 has been modified to allow users to add permissions to the role. This PR modifies the documentation to reflect this.