### PR TITLE
libraries: move "ddtrace-rb-method-wrapper" to ruby

### DIFF
--- a/data/libraries.yaml
+++ b/data/libraries.yaml
@@ -293,14 +293,14 @@ Tracing:
       official: true
       authors: Datadog
       notes: gem is called 'ddtrace'.
+    - name: ddtrace-rb-method-wrapper
+      link: https://github.com/brandfolder/ddtrace-rb-method-wrapper
+      authors: Brandfolder
+      notes: gem is called `ddtrace-method-wrapper`.
   - Rust:
     - name: datadog-apm
       link: https://github.com/pipefy/datadog-apm-rust
       authors: Pipefy
-    - name: ddtrace-rb-method-wrapper
-      link: https://github.com/brandfolder/ddtrace-rb-method-wrapper
-      authors: Brandfolder
-      notes: gem is called `ddtrace-method-wrapper`
   - Scala:
     - name: scala-opentracing
       link: https://github.com/Colisweb/scala-opentracing


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR moves the library to the language it is written in.

### Motivation
Currently it is under Rust.

### Additional Notes
Rust probably got added later and in the wrong place, "switching" this library between languages.