### PR TITLE
rename Long to Integer in remapper processor 

### DIFF
--- a/content/en/logs/processing/processors.md
+++ b/content/en/logs/processing/processors.md
@@ -274,7 +274,7 @@ Into this log:
 
 Constraints on the tag/attribute name are explained in the [Tagging documentation][5]. Some additional constraints are applied as `:` or `,` are not allowed in the target tag/attribute name.
 
-If the target of the remapper is an attribute, the remapper can also try to cast the value to a new type (`String`, `Long` or `Double`). If the cast is not possible, the original type is kept (note: The decimal separator for `Double` need to be `.`) 
+If the target of the remapper is an attribute, the remapper can also try to cast the value to a new type (`String`, `Integer` or `Double`). If the cast is not possible, the original type is kept (note: The decimal separator for `Double` need to be `.`) 
 
 {{< tabs >}}
 {{% tab "UI" %}}
@@ -298,7 +298,7 @@ Use the [Datadog Log Pipeline API endpoint][1] with the following Remapper JSON 
   "sources": ["<SOURCE_ATTRIBUTE>"],
   "target": "<TARGET_ATTRIBUTE>",
   "target_type": "tag",
-  "target_format": "long",
+  "target_format": "integer",
   "preserve_source": false,
   "override_on_conflict": false
 }
@@ -313,7 +313,7 @@ Use the [Datadog Log Pipeline API endpoint][1] with the following Remapper JSON 
 | `sources`              | Array of Strings | yes      | Array of source attributes or tags                                             |
 | `target`               | String           | yes      | Final attribute or tag name to remap the sources to.                           |
 | `target_type`          | String           | no       | Defines if the target is a log `attribute` or a `tag`, default: `attribute`    |
-| `target_format`        | String           | no       | Defines if the attribute value should be cast to another type. possible value: `auto`, `string`, `long`  or `double`, default: `auto`. When set to `auto`, no cast is applied.  |
+| `target_format`        | String           | no       | Defines if the attribute value should be cast to another type. possible value: `auto`, `string`, `long`  or `integer`, default: `auto`. When set to `auto`, no cast is applied.  |
 | `preserve_source`      | Boolean          | no       | Remove or preserve the remapped source element, default: `false`               |
 | `override_on_conflict` | Boolean          | no       | Override or not the target element if already set, default: `false`            |
 


### PR DESCRIPTION
### What does this PR do?
Replace "long" by "Integer" in Remapper processor cast feature.

### Motivation
In order to be more consistent with other part of the product (facet types) we want to use "Integer" instead of "Long". 

### Preview link

https://docs-staging.datadoghq.com/pvr/remapper-type-rename/logs/processing/processors/?tab=ui#remapper

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
