### PR TITLE
Fix curl generation when securityScheme is empty array

### DIFF
--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -523,9 +523,9 @@
 {{- end -}}
 
 {{- /* Render authentication in headers "DD-API-KEY: XXX" */ -}}
-{{- with $context.action.security -}}
+{{- if isset $context.action "security" -}}
     {{- /* Find authentication per operationId */ -}}
-    {{- range . -}}
+    {{- range $context.action.security -}}
         {{- range $key, $val := . -}}
             {{ $authSchema := (index $d.components.securitySchemes $key) }}
             {{- if eq $authSchema.in "header" -}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
