### PR TITLE
Update _index.md

### DIFF
--- a/content/en/tracing/send_traces/_index.md
+++ b/content/en/tracing/send_traces/_index.md
@@ -65,6 +65,10 @@ Tracing is enabled by default when monitoring with Heroku. For more information 
 
 Tracing is enabled by default when monitoring with Cloud Foundry. For more information about configuring tracing for Cloud Foundry, see the [Cloud Foundry documentation][11].
 
+### AWS Elastic Beanstalk
+
+Tracing is enabled by default when monitoring with AWS Elastic Beanstalk. For more information about configuring tracing for AWS Elastic Beanstalk, see the [AWS Elastic Beanstalk documentation][14].
+
 ## Configure your environment
 
 See our guide on setting the [`env` tag and an additional primary tag for scoping APM data][12].
@@ -90,3 +94,4 @@ Next, [Instrument your application][13]. For the full overview of all of the ste
 [11]: /integrations/cloud_foundry/#trace-collection
 [12]: /tracing/guide/setting_primary_tags_to_scope/#definition
 [13]: /tracing/setup/
+[14]: /integrations/amazon_elasticbeanstalk/


### PR DESCRIPTION
Adding note about AWS Elastic Beanstalk being enabled by default.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Clarifies in our documentation that the Trace Agent is enabled by default in Beanstalk. 

### Motivation
<!-- What inspired you to submit this pull request?-->

This is a question from customers that comes up occasionally, and needs to be clarified in docs.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/andrewsouthard1-patch-1/tracing/send_traces/

Check preview base path using the URL in details in `preview` status check.
