### PR TITLE
Widget setup image fix

### DIFF
--- a/content/en/dashboards/widgets/note.md
+++ b/content/en/dashboards/widgets/note.md
@@ -20,7 +20,7 @@ The notes and links widget is similar to [free text widget][1], but allows for m
 
 ## Setup
 
-{{< img src="dashboards/widgets/note/using_link_note_widget.gif" alt="Notes and links widget setup"   style="width:80%;">}}
+{{< img src="dashboards/widgets/note/using_link_note_widget.mp4" alt="Notes and links widget setup" style="width:80%;" >}}
 
 1. Enter the text you want to display. Note that Markdown is supported.
 2. Choose the text size and the note background color.

--- a/content/en/dashboards/widgets/note.md
+++ b/content/en/dashboards/widgets/note.md
@@ -20,7 +20,7 @@ The notes and links widget is similar to [free text widget][1], but allows for m
 
 ## Setup
 
-{{< img src="dashboards/widgets/note/using_link_note_widget.mp4" alt="Notes and links widget setup" style="width:80%;" >}}
+{{< img src="dashboards/widgets/note/using_link_note_widget.mp4" alt="Notes and links widget setup" video="true" style="width:80%;" >}}
 
 1. Enter the text you want to display. Note that Markdown is supported.
 2. Choose the text size and the note background color.


### PR DESCRIPTION
### What does this PR do?
Fixes the broken image for notes and links widget setup

### Motivation
Github issue #7828 

### Preview link
https://docs-staging.datadoghq.com/sarina/broken-img/dashboards/widgets/note/

Check preview base path using the URL in details in `preview` status check.