### PR TITLE
Update documentation for status remapper behavior

### DIFF
--- a/content/en/logs/processing/processors.md
+++ b/content/en/logs/processing/processors.md
@@ -146,7 +146,7 @@ Each incoming status value is mapped as follows:
 * Strings beginning with **n** (case-insensitive) map to **notice (5)**
 * Strings beginning with **i** (case-insensitive) map to **info (6)**
 * Strings beginning with **d**, **trace** or **verbose** (case-insensitive) map to **debug (7)**
-* Strings beginning with **o** or **s** or matching **OK** or **Success** (case-insensitive) map to **OK**
+* Strings beginning with **o** or **s**, or matching **OK** or **Success** (case-insensitive) map to **OK**
 * All others map to **info (6)**
 
 **Note**: If multiple log status remapper processors can be applied to a given log, only the first one (according to the pipelines order) is taken into account.

--- a/content/en/logs/processing/processors.md
+++ b/content/en/logs/processing/processors.md
@@ -146,7 +146,7 @@ Each incoming status value is mapped as follows:
 * Strings beginning with **n** (case-insensitive) map to **notice (5)**
 * Strings beginning with **i** (case-insensitive) map to **info (6)**
 * Strings beginning with **d**, **trace** or **verbose** (case-insensitive) map to **debug (7)**
-* Strings beginning with **o** or matching **OK** or **Success** (case-insensitive) map to **OK**
+* Strings beginning with **o** or **s** or matching **OK** or **Success** (case-insensitive) map to **OK**
 * All others map to **info (6)**
 
 **Note**: If multiple log status remapper processors can be applied to a given log, only the first one (according to the pipelines order) is taken into account.


### PR DESCRIPTION
### What does this PR do?

- Adds that the status remapper maps strings starting with "s" to the status "OK"

### Motivation

- This is the behavior of the status remapper, but it was not clearly mentioned.  

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/tj/update_status_remapper_behavior/logs/processing/processors/?tab=ui#log-status-remapper

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
