### PR TITLE
APM > .NET >Update manual log correlation with new CorrelationIdentifier.<FIELD> API's

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -110,9 +110,9 @@ using Datadog.Trace;
 using Serilog.Context;
 
 // there must be spans started and active before this block.
-using (LogContext.PushProperty("dd.env", Tracer.Instance.Settings.Environment))
-using (LogContext.PushProperty("dd.service", Tracer.Instance.DefaultServiceName))
-using (LogContext.PushProperty("dd.version", Tracer.Instance.Settings.ServiceVersion))
+using (LogContext.PushProperty("dd.env", CorrelationIdentifier.Env))
+using (LogContext.PushProperty("dd.service", CorrelationIdentifier.Service))
+using (LogContext.PushProperty("dd.version", CorrelationIdentifier.Version))
 using (LogContext.PushProperty("dd.trace_id", CorrelationIdentifier.TraceId.ToString()))
 using (LogContext.PushProperty("dd.span_id", CorrelationIdentifier.SpanId.ToString()))
 {
@@ -130,9 +130,9 @@ using log4net;
 // there must be spans started and active before this block.
 try
 {
-    LogicalThreadContext.Properties["dd.env"] = Tracer.Instance.Settings.Environment;
-    LogicalThreadContext.Properties["dd.service"] = Tracer.Instance.DefaultServiceName;
-    LogicalThreadContext.Properties["dd.version"] = Tracer.Instance.Settings.ServiceVersion;
+    LogicalThreadContext.Properties["dd.env"] = CorrelationIdentifier.Env;
+    LogicalThreadContext.Properties["dd.service"] = CorrelationIdentifier.Service;
+    LogicalThreadContext.Properties["dd.version"] = CorrelationIdentifier.Version;
     LogicalThreadContext.Properties["dd.trace_id"] = CorrelationIdentifier.TraceId.ToString();
     LogicalThreadContext.Properties["dd.span_id"] = CorrelationIdentifier.SpanId.ToString();
 
@@ -157,9 +157,9 @@ using Datadog.Trace;
 using NLog;
 
 // there must be spans started and active before this block.
-using (MappedDiagnosticsLogicalContext.SetScoped("dd.env", Tracer.Instance.Settings.Environment))
-using (MappedDiagnosticsLogicalContext.SetScoped("dd.service", Tracer.Instance.DefaultServiceName))
-using (MappedDiagnosticsLogicalContext.SetScoped("dd.version", Tracer.Instance.Settings.ServiceVersion))
+using (MappedDiagnosticsLogicalContext.SetScoped("dd.env", CorrelationIdentifier.Env))
+using (MappedDiagnosticsLogicalContext.SetScoped("dd.service", CorrelationIdentifier.Service))
+using (MappedDiagnosticsLogicalContext.SetScoped("dd.version", CorrelationIdentifier.Version))
 using (MappedDiagnosticsLogicalContext.SetScoped("dd.trace_id", CorrelationIdentifier.TraceId.ToString()))
 using (MappedDiagnosticsLogicalContext.SetScoped("dd.span_id", CorrelationIdentifier.SpanId.ToString()))
 {


### PR DESCRIPTION
### What does this PR do?
Updates the manual log correlation example in the .NET APM docs to use the new CorrelationIdentifier API's introduce in .NET Tracer v1.18.0

### Motivation
This docs change shows developers how to use the new, consistent API for manually correlating logs with traces

### Preview link
Serilog example:
https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-correlationidentifiers/tracing/connect_logs_and_traces/dotnet/?tab=serilog#manually-inject-trace-and-span-ids

log4net example:
https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-correlationidentifiers/tracing/connect_logs_and_traces/dotnet/?tab=log4net#manually-inject-trace-and-span-ids

NLog example:
https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-correlationidentifiers/tracing/connect_logs_and_traces/dotnet/?tab=nlog#manually-inject-trace-and-span-ids

### Additional Notes
This supports the unified service efforts.
