### PR TITLE
Document possible values for `no_proxy`

### DIFF
--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -75,6 +75,20 @@ proxy:
       - host2
 ```
 
+##### NO_PROXY accepted values
+
+* A domain name matches that name and all subdomains.
+  - e.g. `datadoghq.com` matches `app.agent.datadoghq.com`, `www.datadoghq.com`, `datadoghq.com`, but **not** `www.notdatadoghq.com`
+  - e.g. `datadoghq` matches `frontend.datadoghq`, `backend.datadoghq`, but **not** `www.datadoghq.com` nor `www.datadoghq.eu`
+* A domain name with a leading "." matches subdomains only.
+  - e.g. `.datadoghq.com` matches `app.agent.datadoghq.com`, `www.datadoghq.com`, but **not** `datadoghq.com`
+* A CIDR range will match an IP address within the subnet.
+  - e.g. `192.168.1.0/24` matches IP range `192.168.1.1` through `192.168.1.254`
+* An exact IP address
+  - e.g. `169.254.169.254`
+* A hostname
+  - e.g. `webserver1`
+
 #### Environment variables
 
 Starting with Agent v6.4, you can set your proxy settings through environment variables:


### PR DESCRIPTION
### What does this PR do?
Documents possible values for `no_proxy`

https://docs.datadoghq.com/agent/proxy/?tab=agentv6v7

### Motivation
https://github.com/DataDog/integrations-core/pull/5081

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ian.bucad/no_proxy_doc/agent/proxy/?tab=agentv6v7

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
