### PR TITLE
Update types.md

### DIFF
--- a/content/en/developers/metrics/types.md
+++ b/content/en/developers/metrics/types.md
@@ -41,7 +41,7 @@ These different metric submission types are mapped to four in-app metric types f
 - GAUGE
 - DISTRIBUTION
 
-**Note**: If you submit a metric to Datadog without a type, the metric type appears as `Other` within Datadog. The `Other` metric type cannot be further changed to another in-app type until an initial metric type is submitted.
+**Note**: If you submit a metric to Datadog without a type, the metric type appears as `Not Assigned` within Datadog. The `Not Assigned` metric type cannot be further changed to another in-app type until an initial metric type is submitted.
 
 ## Submission vs. In-App type
 


### PR DESCRIPTION
Changed "Other" -> "Not Assigned" in Metrics Summary  so we should update these docs accordingly

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates a sentence within the metric types doc

### Motivation
We've been improving the metrics summary page -- consequently the vague term "Other" has been updated to "Not Assigned" which motivates users to assign an initial metric type

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
