### PR TITLE
[WEB-420] Check for isDeleted flag on Security Rules

### DIFF
--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -49,7 +49,7 @@ def security_rules(content, content_dir):
             scope_tag = get_tag(json_data.get('tags', []), "scope")
 
             # delete file or skip if staged
-            if json_data.get('isStaged', False):
+            if json_data.get('isStaged', False) or json_data.get('isDeleted', False):
                 if p.exists():
                     logger.info(f"removing file {p.name}")
                     p.unlink()


### PR DESCRIPTION
### What does this PR do?
Checks for isDeleted flag on Security Rules in pipeline. Remove associated files from repo if exists

### Motivation
https://datadoghq.atlassian.net/browse/WEB-420

### Preview link
https://docs-staging.datadoghq.com/nsollecito/security-rules-isdeleted/security_monitoring/default_rules/

