### PR TITLE
add compatibility links back

### DIFF
--- a/content/en/tracing/compatibility_requirements/cpp.md
+++ b/content/en/tracing/compatibility_requirements/cpp.md
@@ -12,7 +12,7 @@ further_reading:
 
 The C++ Datadog Trace library is open source - view the [Github repository][1] for more information.
 
-This library requires C++14 to build, but if you use [dynamic loading][2], then  OpenTracing requires [C++11 or later][3].
+This library requires C++14 to build, but if you use [dynamic loading][2], then OpenTracing requires [C++11 or later][3].
 
 Supported platforms include Linux and Mac. To request Windows support, [contact Datadog support][4].
 

--- a/content/en/tracing/setup/cpp.md
+++ b/content/en/tracing/setup/cpp.md
@@ -16,16 +16,15 @@ further_reading:
   tag: "Advanced Usage"
   text: "Advanced Usage"
 ---
-
-**Note**: C++ does not provide integrations for OOTB instrumentation, but it's used by Proxy tracing such as [Envoy][1] and [Nginx][2].
+**Note**: C++ does not provide integrations for OOTB instrumentation, but it's used by Proxy tracing such as [Envoy][1] and [Nginx][2]. For compatibility requirements for the C++ Tracer, visit the [Compatibility Requirements][3] page.
 
 ## Getting Started
 
-If you already have a Datadog account you can find [step-by-step instructions][3] in our in-app guides for either host-based or container-based set ups.
+If you already have a Datadog account you can find [step-by-step instructions][4] in our in-app guides for either host-based or container-based set ups.
 
-Otherwise, to begin tracing applications written in any language, first [install and configure the Datadog Agent][4].
+Otherwise, to begin tracing applications written in any language, first [install and configure the Datadog Agent][5].
 
-Compile against [OpenTracing-cpp][5].
+Compile against [OpenTracing-cpp][6].
 
 ## Installation
 
@@ -197,6 +196,7 @@ To connect to the agent using Unix Domain Sockets, `DD_TRACE_AGENT_URL` can be u
 
 [1]: /tracing/setup/envoy/
 [2]: /tracing/setup/nginx/
-[3]: https://app.datadoghq.com/apm/install
-[4]: /tracing/send_traces/
-[5]: https://github.com/opentracing/opentracing-cpp
+[3]: /tracing/compatibility_requirements/cpp
+[4]: https://app.datadoghq.com/apm/install
+[5]: /tracing/send_traces/
+[6]: https://github.com/opentracing/opentracing-cpp

--- a/content/en/tracing/setup/dotnet-core.md
+++ b/content/en/tracing/setup/dotnet-core.md
@@ -21,11 +21,15 @@ further_reading:
     text: "Advanced Usage"
 ---
 
+## Compatibility
+
+The .NET Tracer supports automatic instrumentation on .NET Core 2.1 and 3.1, as well as Microsoft-deprecated versions 2.0, 2.2 and 3.0.  For a full list of supported libraries, visit the [Compatibility Requirements][1] page.
+
 ## Getting Started
 
-If you already have a Datadog account you can find [step-by-step instructions][1] in our in-app guides for either host-based or container-based set ups.
+If you already have a Datadog account you can find [step-by-step instructions][2] in our in-app guides for either host-based or container-based set ups.
 
-Otherwise, to begin tracing applications written in any language, first [install and configure the Datadog Agent][2]. The .NET Tracer runs in-process to instrument your applications and sends traces from your application to the Agent.
+Otherwise, to begin tracing applications written in any language, first [install and configure the Datadog Agent][3]. The .NET Tracer runs in-process to instrument your applications and sends traces from your application to the Agent.
 
 **Note**: The .NET Tracer supports all .NET-based languages (C#, F#, Visual Basic, etc).
 
@@ -193,9 +197,9 @@ CMD ["dotnet", "example.dll"]
 
 ## Manual Instrumentation
 
-To manually instrument your code, add the `Datadog.Trace` [NuGet package][3] to your application. In your code, access the global tracer through the `Datadog.Trace.Tracer.Instance` property to create new spans.
+To manually instrument your code, add the `Datadog.Trace` [NuGet package][4] to your application. In your code, access the global tracer through the `Datadog.Trace.Tracer.Instance` property to create new spans.
 
-For more details on manual instrumentation and custom tagging, see [Manual instrumentation documentation][4].
+For more details on manual instrumentation and custom tagging, see [Manual instrumentation documentation][5].
 
 Manual instrumentation is supported on .NET Framework 4.5 and above on Windows and on .NET Core 2.1, 3.0, and 3.1 on Windows and Linux.
 
@@ -315,7 +319,7 @@ The following table below lists configuration variables that are available for b
 | `DD_TRACE_AGENT_URL`<br/><br/>`AgentUri`            | Sets the URL endpoint where traces are sent. Overrides `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` if set. Default value is `http://<DD_AGENT_HOST>:<DD_TRACE_AGENT_PORT>`.                                         |
 | `DD_AGENT_HOST`                                     | Sets the host where traces are sent (the host running the Agent). Can be a hostname or an IP address. Ignored if `DD_TRACE_AGENT_URL` is set. Default is value `localhost`.                                       |
 | `DD_TRACE_AGENT_PORT`                               | Sets the port where traces are sent (the port where the Agent is listening for connections). Ignored if `DD_TRACE_AGENT_URL` is set. Default value is `8126`.                                                     |
-| `DD_ENV`<br/><br/>`Environment`                     | If specified, adds the `env` tag with the specified value to all generated spans. See [Agent configuration][5] for more details about the `env` tag.                                                              |
+| `DD_ENV`<br/><br/>`Environment`                     | If specified, adds the `env` tag with the specified value to all generated spans. See [Agent configuration][6] for more details about the `env` tag.                                                              |
 | `DD_SERVICE_NAME`<br/><br/>`ServiceName`            | If specified, sets the default service name. Otherwise, the .NET Tracer tries to determine service name automatically from application name (e.g. IIS application name, process entry assembly, or process name). |
 | `DD_LOGS_INJECTION`<br/><br/>`LogsInjectionEnabled` | Enables or disables automatic injection of correlation identifiers into application logs.                                                                                                                         |
 | `DD_TRACE_GLOBAL_TAGS`<br/><br/>`GlobalTags`       | If specified, adds all of the specified tags to all generated spans.                                                                                                                                              |
@@ -343,8 +347,9 @@ The following table lists configuration variables that are available only when u
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/apm/install
-[2]: /tracing/send_traces/
-[3]: https://www.nuget.org/packages/Datadog.Trace
-[4]: /tracing/manual_instrumentation/dotnet/
-[5]: /tracing/guide/setting_primary_tags_to_scope/#environment
+[1]: /tracing/compatibility_requirements/dotnet-core
+[2]: https://app.datadoghq.com/apm/install
+[3]: /tracing/send_traces/
+[4]: https://www.nuget.org/packages/Datadog.Trace
+[5]: /tracing/manual_instrumentation/dotnet/
+[6]: /tracing/guide/setting_primary_tags_to_scope/#environment

--- a/content/en/tracing/setup/dotnet-framework.md
+++ b/content/en/tracing/setup/dotnet-framework.md
@@ -24,12 +24,15 @@ further_reading:
       tag: 'Advanced Usage'
       text: 'Advanced Usage'
 ---
+## Compatibility
+
+The .NET Tracer supports automatic instrumentation on .NET Framework 4.5 and above. For a full list of supported libraries, visit the [Compatibility Requirements][1] page.
 
 ## Getting Started
 
-If you already have a Datadog account you can find [step-by-step instructions][1] in our in-app guides for either host-based or container-based set ups.
+If you already have a Datadog account you can find [step-by-step instructions][2] in our in-app guides for either host-based or container-based set ups.
 
-Otherwise, to begin tracing applications written in any language, first [install and configure the Datadog Agent][2]. The .NET Tracer runs in-process to instrument your applications and sends traces from your application to the Agent.
+Otherwise, to begin tracing applications written in any language, first [install and configure the Datadog Agent][3]. The .NET Tracer runs in-process to instrument your applications and sends traces from your application to the Agent.
 
 **Note**: The .NET Tracer supports all .NET-based languages (C#, F#, Visual Basic, etc).
 
@@ -46,7 +49,7 @@ Automatic instrumentation captures:
 
 ### Installation
 
-To use automatic instrumentation on Windows, install the .NET Tracer on the host using the [MSI installer for Windows][3]. Choose the installer for the architecture that matches the operating system (x64 or x86).
+To use automatic instrumentation on Windows, install the .NET Tracer on the host using the [MSI installer for Windows][4]. Choose the installer for the architecture that matches the operating system (x64 or x86).
 
 After installing the .NET Tracer, restart applications so they can read the new environment variables. To restart IIS, run the following commands as administrator:
 
@@ -83,9 +86,9 @@ To set environment variables for a Windows Service, use the multi-string key `HK
 
 ## Manual Instrumentation
 
-To manually instrument your code, add the `Datadog.Trace` [NuGet package][4] to your application. In your code, access the global tracer through the `Datadog.Trace.Tracer.Instance` property to create new spans.
+To manually instrument your code, add the `Datadog.Trace` [NuGet package][5] to your application. In your code, access the global tracer through the `Datadog.Trace.Tracer.Instance` property to create new spans.
 
-For more details on manual instrumentation and custom tagging, see [Manual instrumentation documentation][5].
+For more details on manual instrumentation and custom tagging, see [Manual instrumentation documentation][6].
 
 Manual instrumentation is supported on .NET Framework 4.5 and above on Windows and on .NET Core 2.1, 3.0, and 3.1 on Windows and Linux.
 
@@ -205,7 +208,7 @@ Check out the [Unified Service Tagging][9] documentation for recommendations on 
 | `DD_TRACE_AGENT_URL`<br/><br/>`AgentUri`            | Sets the URL endpoint where traces are sent. Overrides `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` if set. Default value is `http://<DD_AGENT_HOST>:<DD_TRACE_AGENT_PORT>`.                                         |
 | `DD_AGENT_HOST`                                     | Sets the host where traces are sent (the host running the Agent). Can be a hostname or an IP address. Ignored if `DD_TRACE_AGENT_URL` is set. Default is value `localhost`.                                       |
 | `DD_TRACE_AGENT_PORT`                               | Sets the port where traces are sent (the port where the Agent is listening for connections). Ignored if `DD_TRACE_AGENT_URL` is set. Default value is `8126`.                                                     |
-| `DD_ENV`<br/><br/>`Environment`                     | If specified, adds the `env` tag with the specified value to all generated spans. See [Agent configuration][6] for more details about the `env` tag.                                                              |
+| `DD_ENV`<br/><br/>`Environment`                     | If specified, adds the `env` tag with the specified value to all generated spans. See [Agent configuration][7] for more details about the `env` tag.                                                              |
 | `DD_SERVICE_NAME`<br/><br/>`ServiceName`            | If specified, sets the default service name. Otherwise, the .NET Tracer tries to determine service name automatically from application name (e.g. IIS application name, process entry assembly, or process name). |
 | `DD_LOGS_INJECTION`<br/><br/>`LogsInjectionEnabled` | Enables or disables automatic injection of correlation identifiers into application logs.                                                                                                                         |
 | `DD_TRACE_DEBUG`                                    | Enables or disables debug logging. Valid values are: `true` or `false` (default).                                                                                                                                    |
@@ -231,9 +234,10 @@ The following table lists configuration variables that are available only when u
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/apm/install
-[2]: /tracing/send_traces/
-[3]: https://github.com/DataDog/dd-trace-dotnet/releases
-[4]: https://www.nuget.org/packages/Datadog.Trace
-[5]: /tracing/manual_instrumentation/dotnet/
-[6]: /tracing/guide/setting_primary_tags_to_scope/#environment
+[1]: /tracing/compatibility_requirements/dotnet-framework
+[2]: https://app.datadoghq.com/apm/install
+[3]: /tracing/send_traces/
+[4]: https://github.com/DataDog/dd-trace-dotnet/releases
+[5]: https://www.nuget.org/packages/Datadog.Trace
+[6]: /tracing/manual_instrumentation/dotnet/
+[7]: /tracing/guide/setting_primary_tags_to_scope/#environment

--- a/content/en/tracing/setup/go.md
+++ b/content/en/tracing/setup/go.md
@@ -20,19 +20,23 @@ further_reading:
   tag: "Advanced Usage"
   text: "Advanced Usage"
 ---
+## Compatibilty Requirements
+
+The Go Tracer requires Go `1.12+` and Datadog Agent `>= 5.21.1`.  For a full list of supported libraries, visit the [Compatibility Requirements][1] page.
+
 ## Installation and Getting Started
 
-For configuration instructions and details about using the API, see the Datadog [API documentation][1]. For manual instrumentation, use the [integrations section](#integrations) below for Go libraries and frameworks supporting automatic instrumentation.
+For configuration instructions and details about using the API, see the Datadog [API documentation][2]. For manual instrumentation, use the [integrations section](#integrations) below for Go libraries and frameworks supporting automatic instrumentation.
 
-For a description of the terminology used in APM, see the [Getting started with APM section][2]. For details about contributing, check the official repository [README.md][3].
+For a description of the terminology used in APM, see the [Getting started with APM section][3]. For details about contributing, check the official repository [README.md][4].
 
-Consult the [migration document][4] if you need to migrate from an older version of the tracer (e.g. v<0.6.x) to the newest version.
+Consult the [migration document][5] if you need to migrate from an older version of the tracer (e.g. v<0.6.x) to the newest version.
 
 ### Installation
 
-If you already have a Datadog account you can find [step-by-step instructions][5] in our in-app guides for either host-based or container-based set ups.
+If you already have a Datadog account you can find [step-by-step instructions][6] in our in-app guides for either host-based or container-based set ups.
 
-First [install and configure the Datadog Agent][6]. See the additional documentation for [tracing Docker applications][7] or [Kubernetes applications][8].
+First [install and configure the Datadog Agent][7]. See the additional documentation for [tracing Docker applications][8] or [Kubernetes applications][9].
 
 Next, install the Go tracer from its canonical import path:
 
@@ -44,7 +48,7 @@ You are now ready to import the tracer and start instrumenting your code.
 
 ## Automatic Instrumentation
 
-Datadog has a series of pluggable packages which provide out-of-the-box support for instrumenting a series of libraries and frameworks. The list of supported integrations is in the [compatibility section][9]. Note that packages must be imported.
+Datadog has a series of pluggable packages which provide out-of-the-box support for instrumenting a series of libraries and frameworks. The list of supported integrations is in the [compatibility section][10]. Note that packages must be imported.
 
 
 
@@ -102,7 +106,7 @@ func main() {
 
 ## Configure APM Environment Name
 
-The [APM environment name][10] may be configured [in the agent][11] or using the [WithEnv][12] start option of the tracer.
+The [APM environment name][11] may be configured [in the agent][12] or using the [WithEnv][13] start option of the tracer.
 
 ### B3 Headers Extraction and Injection
 
@@ -130,15 +134,16 @@ extracted value is used.
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace
-[2]: /tracing/visualization/
-[3]: https://github.com/DataDog/dd-trace-go/tree/v1#contributing
-[4]: https://github.com/DataDog/dd-trace-go/tree/v1/MIGRATING.md
-[5]: /tracing/send_traces/
-[6]: https://app.datadoghq.com/apm/install
-[7]: /tracing/setup/docker/
-[8]: /agent/kubernetes/apm/
-[9]: https://docs.datadoghq.com/tracing/compatibility_requirements/go/
-[10]: /tracing/advanced/setting_primary_tags_to_scope/#environment
-[11]: /getting_started/tracing/#environment-name
-[12]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#WithEnv
+[1]: /tracing/compatibility_requirements/go
+[2]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace
+[3]: /tracing/visualization/
+[4]: https://github.com/DataDog/dd-trace-go/tree/v1#contributing
+[5]: https://github.com/DataDog/dd-trace-go/tree/v1/MIGRATING.md
+[6]: /tracing/send_traces/
+[7]: https://app.datadoghq.com/apm/install
+[8]: /tracing/setup/docker/
+[9]: /agent/kubernetes/apm/
+[10]: https://docs.datadoghq.com/tracing/compatibility_requirements/go/
+[11]: /tracing/advanced/setting_primary_tags_to_scope/#environment
+[12]: /getting_started/tracing/#environment-name
+[13]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#WithEnv

--- a/content/en/tracing/setup/java.md
+++ b/content/en/tracing/setup/java.md
@@ -13,12 +13,15 @@ further_reading:
       tag: 'Documentation'
       text: 'Explore your services, resources and traces'
 ---
+## Compatibilty Requirements
+
+The Java Tracer requires Java JRE 1.7 and higher for either Oracle JDK and OpenJDK. Datadog does not officially support any early-access versions of Java. For a full list of supported libraries, visit the [Compatibility Requirements][1] page.
 
 ## Installation and Getting Started
 
-If you already have a Datadog account you can find [step-by-step instructions][1] in our in-app guides for either host-based or container-based set ups.
+If you already have a Datadog account you can find [step-by-step instructions][2] in our in-app guides for either host-based or container-based set ups.
 
-Otherwise, to begin tracing applications written in any language, first [install and configure the Datadog Agent][2], see the additional documentation for [tracing Docker applications][3] or [Kubernetes applications][4].
+Otherwise, to begin tracing applications written in any language, first [install and configure the Datadog Agent][3], see the additional documentation for [tracing Docker applications][4] or [Kubernetes applications][5].
 
 Next, download `dd-java-agent.jar` that contains the Agent class files:
 
@@ -34,14 +37,14 @@ Finally, add the following JVM argument when starting your application in your I
 
 **Note**:
 
-- The `-javaagent` needs to be run before the `-jar` file, adding it as a JVM option, not as an application argument. For more information, see the [Oracle documentation][5].
+- The `-javaagent` needs to be run before the `-jar` file, adding it as a JVM option, not as an application argument. For more information, see the [Oracle documentation][6].
 
-- `dd-trace-java`'s artifacts (`dd-java-agent.jar`, `dd-trace-api.jar`, `dd-trace-ot.jar`) support all JVM-based languages, i.e. Scala, Groovy, Kotlin, Clojure, etc. If you need support for a particular framework, consider making an [open-source contribution][6].
+- `dd-trace-java`'s artifacts (`dd-java-agent.jar`, `dd-trace-api.jar`, `dd-trace-ot.jar`) support all JVM-based languages, i.e. Scala, Groovy, Kotlin, Clojure, etc. If you need support for a particular framework, consider making an [open-source contribution][7].
 
 ## Automatic Instrumentation
 
-Automatic instrumentation for Java uses the `java-agent` instrumentation capabilities [provided by the JVM][7]. When a `java-agent` is registered, it has the ability to modify class files at load time.
-The `java-agent` uses the [Byte Buddy framework][8] to find the classes defined for instrumentation and modify those class bytes accordingly.
+Automatic instrumentation for Java uses the `java-agent` instrumentation capabilities [provided by the JVM][8]. When a `java-agent` is registered, it has the ability to modify class files at load time.
+The `java-agent` uses the [Byte Buddy framework][9] to find the classes defined for instrumentation and modify those class bytes accordingly.
 
 Instrumentation may come from auto-instrumentation, the OpenTracing api, or a mixture of both. Instrumentation generally captures the following info:
 
@@ -64,16 +67,16 @@ System properties can be set as JVM flags.
 | `dd.tags`                              | `DD_TAGS`                              | `null`                            | (Example: `layer:api,team:intake`) A list of default tags to be added to every span, profile, and JMX metric. If DD_ENV or DD_VERSION is used, it will override any env or version tag defined in DD_TAGS. |
 |`dd.env`                              | `DD_ENV`                              | `none`                            | Your application environment (e.g. production, staging, etc.). Available for versions 0.48+.                                                    |
 | `dd.version`                              | `DD_VERSION`                              | `null`                            | Your application version (e.g. 2.5, 202003181415, 1.3-alpha, etc.). Available for versions 0.48+.             |
-| `dd.logs.injection`                    | `DD_LOGS_INJECTION`                    | false                             | Enabled automatic MDC key injection for Datadog trace and span ids. See [Advanced Usage][9] for details                                   |
+| `dd.logs.injection`                    | `DD_LOGS_INJECTION`                    | false                             | Enabled automatic MDC key injection for Datadog trace and span ids. See [Advanced Usage][10] for details                                   |
 | `dd.trace.config`                      | `DD_TRACE_CONFIG`                      | `null`                            | Optional path to a file where configuration properties are provided one per each line. For instance, the file path can be provided as via `-Ddd.trace.config=<FILE_PATH>.properties`, with setting the service name in the file with `dd.service.name=<SERVICE_NAME>` |
 | `dd.service.mapping`                   | `DD_SERVICE_MAPPING`                   | `null`                            | (Example: `mysql:my-mysql-service-name-db, postgres:my-postgres-service-name-db`) Dynamically rename services via configuration. Useful for making databases have distinct names across different services.                                                                                                       |
 | `dd.writer.type`                       | `DD_WRITER_TYPE`                       | `DDAgentWriter`                   | Default value sends traces to the Agent. Configuring with `LoggingWriter` instead writes traces out to the console.                       |
-| `dd.agent.host`                        | `DD_AGENT_HOST`                        | `localhost`                       | Hostname for where to send traces to. If using a containerized environment, configure this to be the host IP. See [Tracing Docker Applications][3] for more details.                                                                                                  |
+| `dd.agent.host`                        | `DD_AGENT_HOST`                        | `localhost`                       | Hostname for where to send traces to. If using a containerized environment, configure this to be the host IP. See [Tracing Docker Applications][4] for more details.                                                                                                  |
 | `dd.trace.agent.port`                  | `DD_TRACE_AGENT_PORT`                  | `8126`                            | Port number the Agent is listening on for configured host.                                                                                |
 | `dd.trace.agent.unix.domain.socket`    | `DD_TRACE_AGENT_UNIX_DOMAIN_SOCKET`    | `null`                            | This can be used to direct trace traffic to a proxy, to later be sent to a remote Datadog Agent.                                                            |
 | `dd.trace.agent.timeout`               | `DD_TRACE_AGENT_TIMEOUT`               | `10`                              | Timeout in seconds for network interactions with the Datadog Agent.                                                                                                                                                                                                   |
 | `dd.trace.header.tags`                 | `DD_TRACE_HEADER_TAGS`                 | `null`                            | (Example: `CASE-insensitive-Header:my-tag-name,User-ID:userId`) A map of header keys to tag names. Automatically apply header values as tags on traces.                                                                                                               |
-| `dd.trace.annotations`                 | `DD_TRACE_ANNOTATIONS`                 | ([listed here][10])               | (Example: `com.some.Trace;io.other.Trace`) A list of method annotations to treat as `@Trace`.                                            |
+| `dd.trace.annotations`                 | `DD_TRACE_ANNOTATIONS`                 | ([listed here][11])               | (Example: `com.some.Trace;io.other.Trace`) A list of method annotations to treat as `@Trace`.                                            |
 | `dd.trace.methods`                     | `DD_TRACE_METHODS`                     | `null`                            | (Example: `package.ClassName[method1,method2,...];AnonymousClass$1[call]`) List of class/interface and methods to trace. Similar to adding `@Trace`, but without changing code.                                                                                       |
 | `dd.trace.partial.flush.min.spans`     | `DD_TRACE_PARTIAL_FLUSH_MIN_SPANS`     | `1000`                            | Set a number of partial spans to flush on. Useful to reduce memory overhead when dealing with heavy traffic or long running traces.     |
 | `dd.trace.split-by-tags`               | `DD_TRACE_SPLIT_BY_TAGS`               | `null`                            | (Example: `aws.service`) Used to rename spans to be identified with the corresponding service tag                                       |
@@ -98,14 +101,14 @@ System properties can be set as JVM flags.
 
 - If the same key type is set for both, the system property configuration takes priority.
 - System properties can be used as JVM parameters.
-- By default, JMX metrics from your application are sent to the Datadog Agent thanks to DogStatsD over port `8125`. Make sure that [DogStatsD is enabled for the Agent][11].
+- By default, JMX metrics from your application are sent to the Datadog Agent thanks to DogStatsD over port `8125`. Make sure that [DogStatsD is enabled for the Agent][12].
 
-  - If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to `true`][12], and that port `8125` is open on the Agent container.
-  - In Kubernetes, [bind the DogStatsD port to a host port][13]; in ECS, [set the appropriate flags in your task definition][14].
+  - If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to `true`][13], and that port `8125` is open on the Agent container.
+  - In Kubernetes, [bind the DogStatsD port to a host port][14]; in ECS, [set the appropriate flags in your task definition][15].
 
 ### Integrations
 
-See how to disable integrations in the [integrations][15] compatability section.
+See how to disable integrations in the [integrations][16] compatability section.
 
 ### Examples
 
@@ -225,11 +228,11 @@ Would produce the following result:
 
 {{< img src="tracing/setup/java/jmxfetch_example.png" alt="JMX fetch example"  >}}
 
-See the [Java integration documentation][16] to learn more about Java metrics collection with JMX fetch.
+See the [Java integration documentation][17] to learn more about Java metrics collection with JMX fetch.
 
 ### B3 Headers Extraction and Injection
 
-Datadog APM tracer supports [B3 headers extraction][17] and injection for distributed tracing.
+Datadog APM tracer supports [B3 headers extraction][18] and injection for distributed tracing.
 
 Distributed headers injection and extraction is controlled by configuring injection/extraction styles. Currently two styles are supported:
 
@@ -321,20 +324,21 @@ java -javaagent:<DD-JAVA-AGENT-PATH>.jar \
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/apm/install
-[2]: /tracing/send_traces/
-[3]: /tracing/setup/docker/
-[4]: /agent/kubernetes/apm/
-[5]: https://docs.oracle.com/javase/7/docs/technotes/tools/solaris/java.html
-[6]: https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md
-[7]: https://docs.oracle.com/javase/8/docs/api/java/lang/instrument/package-summary.html
-[8]: http://bytebuddy.net
-[9]: /tracing/connect_logs_and_traces/java/
-[10]: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java#L37
-[11]: /developers/dogstatsd/#setup
-[12]: /agent/docker/#dogstatsd-custom-metrics
-[13]: /developers/dogstatsd/
-[14]: /integrations/amazon_ecs/?tab=python#create-an-ecs-task
-[15]: /tracing/compatibility_requirements/java#disabling-integrations
-[16]: /integrations/java/?tab=host#metric-collection
-[17]: https://github.com/openzipkin/b3-propagation
+[1]: /tracing/compatibility_requirements/java
+[2]: https://app.datadoghq.com/apm/install
+[3]: /tracing/send_traces/
+[4]: /tracing/setup/docker/
+[5]: /agent/kubernetes/apm/
+[6]: https://docs.oracle.com/javase/7/docs/technotes/tools/solaris/java.html
+[7]: https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md
+[8]: https://docs.oracle.com/javase/8/docs/api/java/lang/instrument/package-summary.html
+[9]: http://bytebuddy.net
+[10]: /tracing/connect_logs_and_traces/java/
+[11]: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java#L37
+[12]: /developers/dogstatsd/#setup
+[13]: /agent/docker/#dogstatsd-custom-metrics
+[14]: /developers/dogstatsd/
+[15]: /integrations/amazon_ecs/?tab=python#create-an-ecs-task
+[16]: /tracing/compatibility_requirements/java#disabling-integrations
+[17]: /integrations/java/?tab=host#metric-collection
+[18]: https://github.com/openzipkin/b3-propagation

--- a/content/en/tracing/setup/nodejs.md
+++ b/content/en/tracing/setup/nodejs.md
@@ -21,16 +21,19 @@ further_reading:
       tag: 'Advanced Usage'
       text: 'Advanced Usage'
 ---
+## Compatibilty Requirements
+
+The NodeJS Tracer officially supports versions `>=8`. Only even versions like 8.x and 10.x are officially supported. Odd versions like 9.x and 11.x should work but are not officially supported. For a full list of supported libraries, visit the [Compatibility Requirements][1] page.
 
 ## Installation And Getting Started
 
-If you already have a Datadog account you can find [step-by-step instructions][1] in our in-app guides for either host-based or container-based set ups.
+If you already have a Datadog account you can find [step-by-step instructions][2] in our in-app guides for either host-based or container-based set ups.
 
-For descriptions of terminology used in APM, take a look at the [official documentation][2].
+For descriptions of terminology used in APM, take a look at the [official documentation][3].
 
-For details about configuration and using the API, see Datadog's [API documentation][3].
+For details about configuration and using the API, see Datadog's [API documentation][4].
 
-For details about contributing, check out the [development guide][4].
+For details about contributing, check out the [development guide][5].
 
 ### Quickstart
 
@@ -38,7 +41,7 @@ For details about contributing, check out the [development guide][4].
 This library <strong>MUST</strong> be imported and initialized before any instrumented module. When using a transpiler, you <strong>MUST</strong> import and initialize the tracer library in an external file and then import that file as a whole when building your application. This prevents hoisting and ensures that the tracer library gets imported and initialized before importing any other instrumented module.
 </div>
 
-To begin tracing Node.js applications, first [install and configure the Datadog Agent][5], see the additional documentation for [tracing Docker applications][6] or [Kubernetes applications][7].
+To begin tracing Node.js applications, first [install and configure the Datadog Agent][6], see the additional documentation for [tracing Docker applications][7] or [Kubernetes applications][8].
 
 Next, install the Datadog Tracing library using npm:
 
@@ -67,7 +70,7 @@ tracer.init(); // initialized in a different file to avoid hoisting.
 export default tracer;
 ```
 
-See the [tracer settings][8] for the list of initialization options.
+See the [tracer settings][9] for the list of initialization options.
 
 ## Configuration
 
@@ -125,11 +128,12 @@ DD_TRACE_AGENT_URL=unix:<SOCKET_PATH> node server
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/apm/install
-[2]: /tracing/visualization/
-[3]: https://datadog.github.io/dd-trace-js
-[4]: https://github.com/DataDog/dd-trace-js/blob/master/README.md#development
-[5]: /tracing/send_traces/
-[6]: /tracing/setup/docker/
-[7]: /agent/kubernetes/apm/
-[8]: https://datadog.github.io/dd-trace-js/#tracer-settings
+[1]: /tracing/compatibility_requirements/nodejs
+[2]: https://app.datadoghq.com/apm/install
+[3]: /tracing/visualization/
+[4]: https://datadog.github.io/dd-trace-js
+[5]: https://github.com/DataDog/dd-trace-js/blob/master/README.md#development
+[6]: /tracing/send_traces/
+[7]: /tracing/setup/docker/
+[8]: /agent/kubernetes/apm/
+[9]: https://datadog.github.io/dd-trace-js/#tracer-settings

--- a/content/en/tracing/setup/php.md
+++ b/content/en/tracing/setup/php.md
@@ -19,27 +19,30 @@ further_reading:
   tag: "Documentation"
   text: "Advanced Usage"
 ---
+## Compatibilty Requirements
+
+For a full list of supported libraries and language versions, visit the [Compatibility Requirements][1] page.
 
 ## Installation and Getting Started
 
-If you already have a Datadog account you can find [step-by-step instructions][1] in our in-app guides for either host-based or container-based set ups.
+If you already have a Datadog account you can find [step-by-step instructions][2] in our in-app guides for either host-based or container-based set ups.
 
-For descriptions of terminology used in APM, take a look at the [official documentation][2].
+For descriptions of terminology used in APM, take a look at the [official documentation][3].
 
-For details about open-source contributions to the PHP tracer, refer to the [contributing guide][3].
+For details about open-source contributions to the PHP tracer, refer to the [contributing guide][4].
 
 ### Setup the Datadog Agent
 
 The PHP APM tracer sends trace data through the Datadog Agent.
 
-[Install and configure the Datadog Agent][4]. See the additional documentation for [tracing Docker applications][5] or [Kubernetes applications][6].
+[Install and configure the Datadog Agent][5]. See the additional documentation for [tracing Docker applications][6] or [Kubernetes applications][7].
 
-For Agent version [7.18.0][7] and above, APM is enabled by default for all environments without further action.
-If you are running an older version of the agent, make sure the Agent has **[APM enabled][4]**.
+For Agent version [7.18.0][8] and above, APM is enabled by default for all environments without further action.
+If you are running an older version of the agent, make sure the Agent has **[APM enabled][5]**.
 
 ### Install the extension
 
-Install the PHP extension using one of the [precompiled packages for supported distributions][8].
+Install the PHP extension using one of the [precompiled packages for supported distributions][9].
 
 Once downloaded, install the package with one of the commands below.
 
@@ -60,11 +63,11 @@ The extension will be installed for the default PHP version. To install the exte
 export DD_TRACE_PHP_BIN=$(which php-fpm7)
 ```
 
-Restart PHP (PHP-FPM or the Apache SAPI) and then visit a tracing-enabled endpoint of your application. View the [APM UI][9] to see the traces.
+Restart PHP (PHP-FPM or the Apache SAPI) and then visit a tracing-enabled endpoint of your application. View the [APM UI][10] to see the traces.
 
-**Note**: It might take a few minutes before traces appear in the UI. If traces still do not appear after a few minutes, [run the dd-doctor.php diagnostic script][10] from the host machine to help identify any issues.
+**Note**: It might take a few minutes before traces appear in the UI. If traces still do not appear after a few minutes, [run the dd-doctor.php diagnostic script][11] from the host machine to help identify any issues.
 
-If you can't find your distribution, you can [manually install][11] the PHP extension.
+If you can't find your distribution, you can [manually install][12] the PHP extension.
 
 ## Automatic Instrumentation
 
@@ -87,7 +90,7 @@ Configure your application level tracers to submit traces to a custom Agent host
 
 The PHP tracer automatically looks for and initializes with the ENV variables `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`.
 
-See [tracer configuration][12] for more information on how to set these variables.
+See [tracer configuration][13] for more information on how to set these variables.
 
 ## Configuration
 
@@ -104,7 +107,7 @@ env[DD_AGENT_HOST] = $FROM_HOST_ENV
 env[DD_TRACE_DEBUG] = true
 ```
 
-Alternatively, you can use [`SetEnv`][13] from the server config, virtual host, directory, or `.htaccess` file.
+Alternatively, you can use [`SetEnv`][14] from the server config, virtual host, directory, or `.htaccess` file.
 
 ```text
 SetEnv DD_TRACE_DEBUG true
@@ -232,7 +235,7 @@ The `$*` wildcard matches without replacement.
 
 ## Upgrading
 
-To upgrade the PHP tracer, [download the latest release][8] and follow the same steps as [installing the extension](#install-the-extension).
+To upgrade the PHP tracer, [download the latest release][9] and follow the same steps as [installing the extension](#install-the-extension).
 
 **Note**: If you are using second level caching in OPcache by setting the parameter `opcache.file_cache`, remove the cache folder.
 
@@ -250,16 +253,17 @@ To remove the PHP tracer:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/apm/install
-[2]: /tracing/visualization/
-[3]: https://github.com/DataDog/dd-trace-php/blob/master/CONTRIBUTING.md
-[4]: /tracing/send_traces/
-[5]: /tracing/setup/docker/
-[6]: /agent/kubernetes/apm/
-[7]: https://github.com/DataDog/datadog-agent/releases/tag/7.18.0
-[8]: https://github.com/DataDog/dd-trace-php/releases/latest
-[9]: https://app.datadoghq.com/apm/services
-[10]: https://raw.githubusercontent.com/DataDog/dd-trace-php/master/src/dd-doctor.php
-[11]: /tracing/faq/php-tracer-manual-installation
-[12]: /tracing/setup/php/#environment-variable-configuration
-[13]: https://httpd.apache.org/docs/2.4/mod/mod_env.html#setenv
+[1]: /tracing/compatibility_requirements/php
+[2]: https://app.datadoghq.com/apm/install
+[3]: /tracing/visualization/
+[4]: https://github.com/DataDog/dd-trace-php/blob/master/CONTRIBUTING.md
+[5]: /tracing/send_traces/
+[6]: /tracing/setup/docker/
+[7]: /agent/kubernetes/apm/
+[8]: https://github.com/DataDog/datadog-agent/releases/tag/7.18.0
+[9]: https://github.com/DataDog/dd-trace-php/releases/latest
+[10]: https://app.datadoghq.com/apm/services
+[11]: https://raw.githubusercontent.com/DataDog/dd-trace-php/master/src/dd-doctor.php
+[12]: /tracing/faq/php-tracer-manual-installation
+[13]: /tracing/setup/php/#environment-variable-configuration
+[14]: https://httpd.apache.org/docs/2.4/mod/mod_env.html#setenv

--- a/content/en/tracing/setup/python.md
+++ b/content/en/tracing/setup/python.md
@@ -19,12 +19,15 @@ further_reading:
       tag: 'Advanced Usage'
       text: 'Advanced Usage'
 ---
+## Compatibilty Requirements
+
+Python versions `2.7` and `3.4` and onwards are supported.  For a full list of supported libraries, visit the [Compatibility Requirements][1] page.
 
 ## Installation and Getting Started
 
-If you already have a Datadog account you can find [step-by-step instructions][1] in our in-app guides for either host-based or container-based set ups.
+If you already have a Datadog account you can find [step-by-step instructions][2] in our in-app guides for either host-based or container-based set ups.
 
-Otherwise, to begin tracing applications written in Python, first [install and configure the Datadog Agent][2], see the additional documentation for [tracing Docker applications][3] or [Kubernetes applications][4].
+Otherwise, to begin tracing applications written in Python, first [install and configure the Datadog Agent][3], see the additional documentation for [tracing Docker applications][4] or [Kubernetes applications][5].
 
 Next, install the Datadog Tracing library, `ddtrace`, using pip:
 
@@ -40,34 +43,34 @@ For example, if your application is started with `python app.py` then:
 ddtrace-run python app.py
 ```
 
-For more advanced usage, configuration, and fine-grain control, see Datadog's [API documentation][5].
+For more advanced usage, configuration, and fine-grain control, see Datadog's [API documentation][6].
 
 ## Configuration
 
-When using **ddtrace-run**, the following [environment variable options][6] can be used:
+When using **ddtrace-run**, the following [environment variable options][7] can be used:
 
 | Environment Variable               | Default     | Description                                                                                                                                                                                                                                                                 |
 | ---------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `DD_ENV`                           |             | Set the application’s environment e.g. `prod`, `pre-prod`, `staging`. Learn more about [how to setup your environment][7].                                                                                                                                                  |
+| `DD_ENV`                           |             | Set the application’s environment e.g. `prod`, `pre-prod`, `staging`. Learn more about [how to setup your environment][8].                                                                                                                                                  |
 | `DD_SERVICE`                       |             | The service name to be used for this application. The value is passed through when setting up middleware for web framework integrations (e.g. Pylons, Flask, Django). For tracing without a web integration, it is recommended that you [set the service name in code](#integrations).      |
 | `DD_VERSION`                       |             | Set the application’s version e.g. `1.2.3`, `6c44da20`, `2020.02.13`.                                                                                                                                                                                                       |
 | `DD_TAGS`                       |             | A list of default tags to be added to every span, profile, and runtime metric e.g. `layer:api,team:intake`.      |
 
-It is recommended to use `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` to set `env`, `service`, and `version` for your services. Refer to the [Unified Service Tagging][8] documentation for recommendations on how to configure these environment variables.
+It is recommended to use `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` to set `env`, `service`, and `version` for your services. Refer to the [Unified Service Tagging][9] documentation for recommendations on how to configure these environment variables.
 
 ### Instrumentation
 
 | Environment Variable               | Default     | Description                                                                                                                                                                                                                                                                 |
 | ---------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `DATADOG_TRACE_ENABLED`            | `true`      | Enable web framework and library instrumentation. When `false`, the application code doesn't generate any traces.                                                                                                                                                           |
-| `DATADOG_TRACE_DEBUG`              | `false`     | Enable debug logging in the tracer. Note that this is [not available with Django][9].                                                                                                                                                                                       |
+| `DATADOG_TRACE_DEBUG`              | `false`     | Enable debug logging in the tracer. Note that this is [not available with Django][10].                                                                                                                                                                                       |
 | `DATADOG_PATCH_MODULES`            |             | Override the modules patched for this application execution. It should follow this format: `DATADOG_PATCH_MODULES=module:patch,module:patch...`.                                                                                                                            |
 | `DD_AGENT_HOST`                    | `localhost` | Override the address of the trace Agent host that the default tracer attempts to submit traces to.                                                                                                                                                                          |
 | `DATADOG_TRACE_AGENT_PORT`         | `8126`      | Override the port that the default tracer submit traces to.                                                                                                                                                                                                                 |
 | `DD_TRACE_AGENT_URL`               |             | The URL of the Trace Agent that the tracer submits to. Takes priority over hostname and port, if set. Supports Unix Domain Sockets in combination with the `apm_config.receiver_socket` in your `datadog.yaml` file, or the `DD_APM_RECEIVER_SOCKET` environment variable.  |
-| `DATADOG_PRIORITY_SAMPLING`        | `true`      | Enable [Priority Sampling][10].                                                                                                                                                                                                                                              |
-| `DD_LOGS_INJECTION`                | `false`     | Enable [connecting logs and traces Injection][11].                                                                                                                                                                                                                           |
-| `DD_TRACE_ANALYTICS_ENABLED`       | `false`     | Enable App Analytics globally for [web integrations][12].                                                                                                                                                                                                                   |
+| `DATADOG_PRIORITY_SAMPLING`        | `true`      | Enable [Priority Sampling][11].                                                                                                                                                                                                                                              |
+| `DD_LOGS_INJECTION`                | `false`     | Enable [connecting logs and traces Injection][12].                                                                                                                                                                                                                           |
+| `DD_TRACE_ANALYTICS_ENABLED`       | `false`     | Enable App Analytics globally for [web integrations][13].                                                                                                                                                                                                                   |
 | `DD_INTEGRATION_ANALYTICS_ENABLED` | `false`     | Enable App Analytics for a specific integration. Example: `DD_BOTO_ANALYTICS_ENABLED=true` .                                                                                                                                                                                |
 
 ## Change Agent Hostname
@@ -90,15 +93,16 @@ tracer.configure(
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/apm/install
-[2]: /tracing/send_traces/
-[3]: /tracing/setup/docker/
-[4]: /agent/kubernetes/apm/
-[5]: http://pypi.datadoghq.com/trace/docs
-[6]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtracerun
-[7]: /tracing/guide/setting_primary_tags_to_scope/
-[8]: /getting_started/tagging/unified_service_tagging
-[9]: http://pypi.datadoghq.com/trace/docs/web_integrations.html?highlight=django#django
-[10]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#priority-sampling
-[11]: /tracing/connect_logs_and_traces/python/
-[12]: /tracing/app_analytics/?tab=python#automatic-configuration
+[1]: /tracing/compatibility_requirements/python
+[2]: https://app.datadoghq.com/apm/install
+[3]: /tracing/send_traces/
+[4]: /tracing/setup/docker/
+[5]: /agent/kubernetes/apm/
+[6]: http://pypi.datadoghq.com/trace/docs
+[7]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtracerun
+[8]: /tracing/guide/setting_primary_tags_to_scope/
+[9]: /getting_started/tagging/unified_service_tagging
+[10]: http://pypi.datadoghq.com/trace/docs/web_integrations.html?highlight=django#django
+[11]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#priority-sampling
+[12]: /tracing/connect_logs_and_traces/python/
+[13]: /tracing/app_analytics/?tab=python#automatic-configuration


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add Compatibility link back to /setup/ pages per language

### Motivation
New Compatibility Section not easy to find for users 

### Preview link
https://docs-staging.datadoghq.com/andrew.ardito/restorecompatibilitylinks/tracing/setup/