### PR TITLE
Update java agentless logging keepAliveDuration

### DIFF
--- a/content/en/logs/log_collection/java.md
+++ b/content/en/logs/log_collection/java.md
@@ -428,7 +428,7 @@ Configure the Logback logger to stream logs directly to Datadog by adding the fo
 <appender name="JSON_TCP" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
     <remoteHost>intake.logs.datadoghq.com</remoteHost>
     <port>10514</port>
-    <keepAliveDuration>1 minute</keepAliveDuration>
+    <keepAliveDuration>20 seconds</keepAliveDuration>
     <encoder class="net.logstash.logback.encoder.LogstashEncoder">
         <prefix class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="ch.qos.logback.classic.PatternLayout">
@@ -453,7 +453,7 @@ Configure the Logback logger to stream logs directly to Datadog by adding the fo
 <appender name="JSON_TCP" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
     <remoteHost>tcp-intake.logs.datadoghq.eu</remoteHost>
     <port>1883</port>
-    <keepAliveDuration>1 minute</keepAliveDuration>
+    <keepAliveDuration>20 seconds</keepAliveDuration>
     <encoder class="net.logstash.logback.encoder.LogstashEncoder">
         <prefix class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="ch.qos.logback.classic.PatternLayout">


### PR DESCRIPTION


### What does this PR do?

Changes the keepAliveDuration value for LogstashTcpSocketAppender in our java agentless logging from 1 minutes to 20 seconds, which matches what we have in our rsyslog doc for the immark module.  

### Motivation

The value of 1 minute is too high and will result in the connection being closed after 1 minute of no activity.  For consistency with what we specify in our rsyslog doc, I changed to 20 seconds.  

### Preview link

https://docs-staging.datadoghq.com/tj/update_java_agentless_logging_keepaliveduration/logs/log_collection/java/?tab=log4j

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
