### PR TITLE
[RUM/Logs] use Datacenter in npm instructions

### DIFF
--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -38,11 +38,12 @@ After adding [`@datadog/browser-logs`][3] to your `package.json` file, initializ
 {{< site-region region="us" >}}
 
 ```javascript
+import { Datacenter } from '@datadog/browser-core';
 import { datadogLogs } from '@datadog/browser-logs';
 
 datadogLogs.init({
   clientToken: '<DATADOG_CLIENT_TOKEN>',
-  datacenter: 'us',
+  datacenter: Datacenter.US,
   forwardErrorsToLogs: true,
   sampleRate: 100
 });
@@ -52,11 +53,12 @@ datadogLogs.init({
 {{< site-region region="eu" >}}
 
 ```javascript
+import { Datacenter } from '@datadog/browser-core';
 import { datadogLogs } from '@datadog/browser-logs';
 
 datadogLogs.init({
   clientToken: '<DATADOG_CLIENT_TOKEN>',
-  datacenter: 'eu',
+  datacenter: Datacenter.EU,
   forwardErrorsToLogs: true,
   sampleRate: 100
 });

--- a/content/en/real_user_monitoring/faq/proxy_rum_data.md
+++ b/content/en/real_user_monitoring/faq/proxy_rum_data.md
@@ -17,12 +17,13 @@ When you set the `proxyHost` [initialization parameter][1], all RUM data is sent
 {{% tab "NPM" %}}
 
 ```javascript
+import { Datacenter } from '@datadog/browser-core';
 import { datadogRum } from '@datadog/browser-rum';
 
 datadogRum.init({
     applicationId: '<DATADOG_APPLICATION_ID>',
     clientToken: '<DATADOG_CLIENT_TOKEN>',
-    datacenter: 'us',
+    datacenter: Datacenter.US,
     proxyHost: '<YOUR_PROXY_URL>',
 });
 ```

--- a/content/en/real_user_monitoring/installation/_index.md
+++ b/content/en/real_user_monitoring/installation/_index.md
@@ -33,12 +33,13 @@ After adding [`@datadog/browser-rum`][4] to your `package.json` file, initialize
 {{% tab "US" %}}
 
 ```javascript
+import { Datacenter } from '@datadog/browser-core';
 import { datadogRum } from '@datadog/browser-rum';
 
 datadogRum.init({
     applicationId: '<DATADOG_APPLICATION_ID>',
     clientToken: '<DATADOG_CLIENT_TOKEN>',
-    datacenter: 'us',
+    datacenter: Datacenter.US,
     sampleRate: 100,
 });
 ```
@@ -47,12 +48,13 @@ datadogRum.init({
 {{% tab "EU" %}}
 
 ```javascript
+import { Datacenter } from '@datadog/browser-core';
 import { datadogRum } from '@datadog/browser-rum';
 
 datadogRum.init({
     applicationId: '<DATADOG_APPLICATION_ID>',
     clientToken: '<DATADOG_CLIENT_TOKEN>',
-    datacenter: 'eu',
+    datacenter: Datacenter.EU,
     sampleRate: 100,
 });
 ```

--- a/content/en/real_user_monitoring/installation/advanced_configuration.md
+++ b/content/en/real_user_monitoring/installation/advanced_configuration.md
@@ -25,12 +25,13 @@ By default, no sampling is applied on the number of collected sessions. To apply
 {{% tab "NPM" %}}
 
 ```javascript
+import { Datacenter } from '@datadog/browser-core';
 import { datadogRum } from '@datadog/browser-rum';
 
 datadogRum.init({
     applicationId: '<DATADOG_APPLICATION_ID>',
     clientToken: '<DATADOG_CLIENT_TOKEN>',
-    datacenter: 'us',
+    datacenter: Datacenter.US,
     sampleRate: 90,
 });
 ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update setup instructions to retrieve Datacenter enum.

### Motivation
Datacenter values are now exposed in an enum.
In a typescript setup, it is required to use it to avoid compilation issues.
cf DataDog/browser-sdk#435

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->

- https://docs-staging.datadoghq.com/bcaudan/update-browser-sdk-instructions/logs/log_collection/javascript/?tab=npm
- https://docs-staging.datadoghq.com/bcaudan/update-browser-sdk-instructions/real_user_monitoring/installation/?tab=us
- https://docs-staging.datadoghq.com/bcaudan/update-browser-sdk-instructions/real_user_monitoring/faq/proxy_rum_data/?tab=npm
- https://docs-staging.datadoghq.com/bcaudan/update-browser-sdk-instructions/real_user_monitoring/installation/advanced_configuration/?tab=npm

