### PR TITLE
[RUMF-609] use export from rum/logs

### DIFF
--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -38,8 +38,7 @@ After adding [`@datadog/browser-logs`][3] to your `package.json` file, initializ
 {{< site-region region="us" >}}
 
 ```javascript
-import { Datacenter } from '@datadog/browser-core';
-import { datadogLogs } from '@datadog/browser-logs';
+import { Datacenter, datadogLogs } from '@datadog/browser-logs';
 
 datadogLogs.init({
   clientToken: '<DATADOG_CLIENT_TOKEN>',
@@ -53,8 +52,7 @@ datadogLogs.init({
 {{< site-region region="eu" >}}
 
 ```javascript
-import { Datacenter } from '@datadog/browser-core';
-import { datadogLogs } from '@datadog/browser-logs';
+import { Datacenter, datadogLogs } from '@datadog/browser-logs';
 
 datadogLogs.init({
   clientToken: '<DATADOG_CLIENT_TOKEN>',

--- a/content/en/real_user_monitoring/faq/proxy_rum_data.md
+++ b/content/en/real_user_monitoring/faq/proxy_rum_data.md
@@ -17,8 +17,7 @@ When you set the `proxyHost` [initialization parameter][1], all RUM data is sent
 {{% tab "NPM" %}}
 
 ```javascript
-import { Datacenter } from '@datadog/browser-core';
-import { datadogRum } from '@datadog/browser-rum';
+import { Datacenter, datadogRum } from '@datadog/browser-rum';
 
 datadogRum.init({
     applicationId: '<DATADOG_APPLICATION_ID>',

--- a/content/en/real_user_monitoring/installation/_index.md
+++ b/content/en/real_user_monitoring/installation/_index.md
@@ -33,8 +33,7 @@ After adding [`@datadog/browser-rum`][4] to your `package.json` file, initialize
 {{% tab "US" %}}
 
 ```javascript
-import { Datacenter } from '@datadog/browser-core';
-import { datadogRum } from '@datadog/browser-rum';
+import { Datacenter, datadogRum } from '@datadog/browser-rum';
 
 datadogRum.init({
     applicationId: '<DATADOG_APPLICATION_ID>',
@@ -48,8 +47,7 @@ datadogRum.init({
 {{% tab "EU" %}}
 
 ```javascript
-import { Datacenter } from '@datadog/browser-core';
-import { datadogRum } from '@datadog/browser-rum';
+import { Datacenter, datadogRum } from '@datadog/browser-rum';
 
 datadogRum.init({
     applicationId: '<DATADOG_APPLICATION_ID>',

--- a/content/en/real_user_monitoring/installation/advanced_configuration.md
+++ b/content/en/real_user_monitoring/installation/advanced_configuration.md
@@ -25,8 +25,7 @@ By default, no sampling is applied on the number of collected sessions. To apply
 {{% tab "NPM" %}}
 
 ```javascript
-import { Datacenter } from '@datadog/browser-core';
-import { datadogRum } from '@datadog/browser-rum';
+import { Datacenter, datadogRum } from '@datadog/browser-rum';
 
 datadogRum.init({
     applicationId: '<DATADOG_APPLICATION_ID>',


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Rework logs/rum setup instructions to use Datacenter export from logs/rum

### Motivation
avoid extra browser-core dependency
cf https://github.com/DataDog/browser-sdk/pull/436

### Preview link
<!-- Impacted pages preview links-->


- https://docs-staging.datadoghq.com/bcaudan/export/logs/log_collection/javascript/?tab=npm
- https://docs-staging.datadoghq.com/bcaudan/export/real_user_monitoring/installation/?tab=us
- https://docs-staging.datadoghq.com/bcaudan/export/real_user_monitoring/faq/proxy_rum_data/?tab=npm
- https://docs-staging.datadoghq.com/bcaudan/export/real_user_monitoring/installation/advanced_configuration/?tab=npm


