### PR TITLE
api examples update

### DIFF
--- a/content/en/api/v1/downtimes/examples.json
+++ b/content/en/api/v1/downtimes/examples.json
@@ -138,8 +138,8 @@
       "200": {
         "json": {
           "cancelled_ids": [
-            "123456789",
-            "123456790"
+            123456789,
+            123456790
           ]
         },
         "html": "<div class=\"table-response schema-table has-no-expands row \">\n    <p class=\"expand-all js-expand-all text-primary\">Expand All</p>\n    <div class=\"col-12\">\n      <div class=\"row table-header\">\n        <div class=\"col-4 column\">\n          <p class=\"font-semibold\">Field</p>\n        </div>\n        <div class=\"col-2 column\">\n          <p class=\"font-semibold\">Type</p>\n        </div>\n        <div class=\"col-6 column\">\n          <p class=\"font-semibold\">Description</p>\n        </div>\n      </div>\n      <div class=\"row   \">\n          <div class=\"col-12 first-column\">\n            <div class=\"row first-row  \">\n              <div class=\"col-4 column\">\n      <p class=\"key\">cancelled_ids</p>\n    </div>\n              <div class=\"col-2 column\"><p>[integer]</p></div>\n              <div class=\"col-6 column\"><p>ID of downtimes that were canceled.</p></div>\n            </div>\n            \n          </div>\n        </div>\n    </div>  \n  </div>"

--- a/content/en/api/v1/metrics/examples.json
+++ b/content/en/api/v1/metrics/examples.json
@@ -140,8 +140,8 @@
               "length": "integer",
               "metric": "system.cpu.idle",
               "pointlist": [
-                "1575317847",
-                "0.5"
+                1575317847,
+                0.5
               ],
               "scope": "host:foo,env:test",
               "start": "integer",

--- a/src/scripts/build-api-pages.js
+++ b/src/scripts/build-api-pages.js
@@ -307,6 +307,7 @@ const filterJson = (actionType, data, parentExample = null, requiredKeys = []) =
 
 /**
  * Takes a value.type string and returns appropriate representation
+ * NOTE: These are types as they come through in the schema
  * e.g array should be []
  * @param {object} valueType - string of type
  * @param {object} format - value type formatting e.g int32, int64, date-time
@@ -328,9 +329,34 @@ const outputValueType = (valueType, format = "") => {
   }
 };
 
+
+/**
+ * Takes a value we are straight up trying to output and determines if we should wrap with quotes or not
+ * NOTE: These are javascript types retrieved through typeof
+ * e.g { key: value } or {key: [value, value]}
+ * @param {any} value can be of any type
+ * @param {boolean} trailingComma if it should have a , on the end. Useful for arrays
+ * returns formatted value for json
+ */
+const outputValue = (value, trailingComma = false) => {
+  const t = typeof value;
+  let out;
+  switch(t) {
+    case "boolean":
+    case "bigint":
+    case "number":
+      out = `${value}`;
+      break;
+    case "string":
+    default:
+      out = `"${value}"`;
+  }
+  return (trailingComma) ? `${out},` : out;
+};
+
 /**
  * Takes a chosen example object and formats it appropriately
- * @param {object} chosenExample - object schema
+ * @param {any} chosenExample - object schema
  * @param {string} inputkey - string key
  * returns formatted string
  */
@@ -344,10 +370,10 @@ const outputExample = (chosenExample, inputkey) => {
         if(typeof item === 'object') {
           // this needs to change, currently only output 1 level of example array
           if(inputkey && inputkey in item) {
-            ex = `"${item[inputkey]}"`;
+            ex = outputValue(item[inputkey]);
           }
         } else {
-          ex += `"${  item  }",`;
+          ex += outputValue(item, true);
           if (Object.is(arr.length - 1, key)) {
             ex = ex.slice(0, -1);
           }
@@ -356,17 +382,14 @@ const outputExample = (chosenExample, inputkey) => {
     } else if(typeof chosenExample === 'object') {
       if(chosenExample.value instanceof Array) {
         chosenExample.value.forEach((item, key, arr) => {
-          ex += `"${item}",`;
+          ex += outputValue(item, true);
           if (Object.is(arr.length - 1, key)) {
             ex = ex.slice(0, -1);
           }
         });
       }
-    } else if (typeof chosenExample === "boolean" || typeof chosenExample === "number") {
-      // we don't want quotes on a bool
-      ex = `${chosenExample}`;
     } else {
-      ex = `"${chosenExample}"`;
+      ex = outputValue(chosenExample);
     }
   }
   return ex;

--- a/src/scripts/tests/build-api-pages.test.js
+++ b/src/scripts/tests/build-api-pages.test.js
@@ -947,7 +947,7 @@ describe(`filterExampleJson`, () => {
       "type": "object"
     };
     const actual = bp.filterExampleJson('curl', mockSchema);
-    const expected = {"series": [{"metric": "system.load.1", "points": ["1575317847", "0.5"]}]};
+    const expected = {"series": [{"metric": "system.load.1", "points": [1575317847, 0.5]}]};
     expect(actual).toEqual(expected);
   });
 


### PR DESCRIPTION
### What does this PR do?

Updates some api examples to be numbers instead of strings

e.g metrics had

```js
"pointlist": [
    "1575317847",
    "0.5"
],
```

but now shows with this pr

```js
"pointlist": [
    1575317847,
    0.5
],
```

### Motivation

Feedback reported 

### Preview link

https://docs-staging.datadoghq.com/david.jones/api-example-fmt/api/v1/metrics/#query-timeseries-points
see 200 example json pointlist array is now numbers not strings

### Additional Notes

