### PR TITLE
Disable CloudFront purge after deploy

### DIFF
--- a/config/live/config.yaml
+++ b/config/live/config.yaml
@@ -9,7 +9,7 @@ deployment:
     - name: "live"
       URL: "s3://datadog-docs-live-hugo?region=us-east-1"
       exclude: "**.{go,java,sh,py,rb,json}"
-      cloudFrontDistributionID: E2B2OODXRYOXSA
+      # cloudFrontDistributionID: E2B2OODXRYOXSA
     - name: "liveAssets"
       URL: "s3://origin-static-assets?region=us-east-1&prefix=documentation/"
       include: "**.{jpg,jpeg,png,gif,mp4,svg,json}"

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -273,7 +273,7 @@
   - repo_name: security-monitoring
     contents:
     - action: security-rules
-      branch: master
+      branch: main
       globs:
         - "*.json"
       options:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -273,7 +273,7 @@
   - repo_name: security-monitoring
     contents:
     - action: security-rules
-      branch: master
+      branch: main
       globs:
         - "*.json"
       options:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "deploy:previewAssets": "./node_modules/.bin/hugo deploy --target previewAssets -e preview --maxDeletes 0 --log --verbose --debug",
         "deploy:preview": "./node_modules/.bin/hugo deploy --target preview -e preview --maxDeletes -1 --invalidateCDN --log --verbose --debug",
         "deploy:liveAssets": "./node_modules/.bin/hugo deploy --target liveAssets -e live --maxDeletes 0 --log --verbose --debug",
-        "deploy:live": "./node_modules/.bin/hugo deploy --target live -e live --maxDeletes -1 --invalidateCDN --log --verbose --debug",
+        "deploy:live": "./node_modules/.bin/hugo deploy --target live -e live --maxDeletes -1 --log --verbose --debug",
         "build:apiPages": "node -e 'require(\"./src/scripts/build-api-pages.js\").init()'",
         "dereference": "node ./src/scripts/dereference.js",
         "analyze": "webpack --config webpack.prod.js --env.BUNDLE_ANALYZE=true",


### PR DESCRIPTION
### What does this PR do?
- Disables the CloudFront cache purge by hugo deploy on the live deployment target 
- Updates `security-monitoring` pull_config rules to use "main" branch per Justin via Slack

### Motivation
Docs is reporting an increase of 404 logs after a deploy. It seems the new Hugo Deploy function to purge the CloudFront distribution cache immediately upon deploy is causing requests in-flight to request assets that were purged and expired. 

https://dd-corpsite.datadoghq.com/logs?agg_m=count&agg_q=%40http.url_details.path&agg_t=count&cols=core_host%2Ccore_service%2Clog_network.client.ip&event=AQAAAXMLTw2IquiJRgAAAABBWE1MVWFMQjUzTWtiRDN3WjhDNw&from_ts=1593622580000&index=main&live=false&messageDisplay=inline&query=%40http.url_details.host%3Adocs.datadoghq.com+%40http.status_code%3A404+-%40http.useragent_details.browser.major%3A%288+OR+6%29+-%40http.url_details.path%3A%28%22%2Fadmin%2Findex.php%22+OR+%22%2Fgen204%22+OR+%22%2Ftracing%2Fconnect_logs_and_traces%2Fnodejs%2Fhttps%3A%2F%2Fwww.datadoghq.com%2Fblog%2Frequest-log-correlation%2F%22%29+%40network.client.geoip.ipAddress%3A68.251.60.33&stream_sort=desc&to_ts=1593622600000

### Preview link
https://docs-staging.datadoghq.com/nsollecito/rm-cf-purge/

No apparent changes to preview site 