### PR TITLE
enable process agent to see containers

### DIFF
--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -252,6 +252,8 @@ Optional collection Agents are disabled by default for security or performance r
 | `DD_PROCESS_AGENT_ENABLED` | Enable [live process collection][8] with the Process Agent. The [live container view][9] is already enabled by default if the Docker socket is available. If set to `false`, the [live process collection][8] and the [live container view][9] are disabled. |
 | `DD_COLLECT_KUBERNETES_EVENTS ` | Enable event collection with the Agent. If you are running multiple Agent in your cluster, set `DD_LEADER_ELECTION` to `true` as well. |
 
+To enable the Live Container view, make sure you are running the process agent in addition to setting DD_PROCESS_AGENT_ENABLED to `true`. 
+
 ### DogStatsD (custom metrics)
 
 Send custom metrics with [the StatsD protocol][10]:


### PR DESCRIPTION
If the process agent is not running, containers in the cluster will not show up in the Live Containers view.


### What does this PR do?

Add information that the process agent must be enabled for containers to show up on Live Containers view 

### Motivation

customer request 

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.


