### PR TITLE
Update file order on deploy

### DIFF
--- a/config/live/config.yaml
+++ b/config/live/config.yaml
@@ -10,6 +10,7 @@ deployment:
       - ".jpg$"
       - ".png$"
       - ".gif$"
+      - ".mp4$"
 
     targets: 
     - name: "live"

--- a/config/live/config.yaml
+++ b/config/live/config.yaml
@@ -4,6 +4,12 @@ builddrafts: false
 enableGitInfo: true
 
 deployment: 
+    order: 
+      - ".css$"
+      - ".js$"
+      - ".jpg$"
+      - ".png$"
+      - ".gif$"
 
     targets: 
     - name: "live"

--- a/config/preview/config.yaml
+++ b/config/preview/config.yaml
@@ -4,6 +4,12 @@ builddrafts: true
 enableGitInfo: true
 
 deployment: 
+    order: 
+      - ".css$"
+      - ".js$"
+      - ".jpg$"
+      - ".png$"
+      - ".gif$"
 
     targets: 
     - name: "preview"

--- a/config/preview/config.yaml
+++ b/config/preview/config.yaml
@@ -10,6 +10,7 @@ deployment:
       - ".jpg$"
       - ".png$"
       - ".gif$"
+      - ".mp4$"
 
     targets: 
     - name: "preview"


### PR DESCRIPTION
### What does this PR do?
Sets order of preference for uploads by `hugo deploy`. This should upload JS, CSS, and image files first to prevent situations that can occur where HTML is updated with references to assets that do not yet exist in the S3 bucket

### Motivation
Incident reported where Docs pages were not properly loading JS files after a recent deploy. A manual CF invalidation corrected the issue and the deploy logs show that the HTML was uploaded at least 30 seconds before the assets existed

https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/33750809/raw

### Preview link
https://docs-staging.datadoghq.com/nsollecito/deploy-order/
