### PR TITLE
Add ECS config file for Windows

### DIFF
--- a/static/resources/json/datadog-agent-ecs-win.json
+++ b/static/resources/json/datadog-agent-ecs-win.json
@@ -1,0 +1,37 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "datadog-agent",
+      "image": "datadog/agent:latest",
+      "cpu": 10,
+      "memory": 256,
+      "essential": true,
+      "mountPoints": [
+        {
+          "containerPath": "\\\\.\\pipe\\docker_engine",
+          "sourceVolume": "docker_pipe",
+          "readOnly": true
+        }
+      ],
+      "environment": [
+        {
+          "name": "DD_API_KEY",
+          "value": "<YOUR_DATADOG_API_KEY>"
+        },
+        {
+          "name": "DD_SITE",
+          "value": "datadoghq.com"
+        }
+      ]
+    }
+  ],
+  "volumes": [
+    {
+      "host": {
+        "sourcePath": "\\\\.\\pipe\\docker_engine"
+      },
+      "name": "docker_pipe"
+    }
+  ],
+  "family": "datadog-agent-task"
+}

--- a/static/resources/json/datadog-agent-ecs-win.json
+++ b/static/resources/json/datadog-agent-ecs-win.json
@@ -9,7 +9,7 @@
       "mountPoints": [
         {
           "containerPath": "\\\\.\\pipe\\docker_engine",
-          "sourceVolume": "docker_pipe",
+          "sourceVolume": "docker_sock",
           "readOnly": true
         }
       ],
@@ -30,7 +30,7 @@
       "host": {
         "sourcePath": "\\\\.\\pipe\\docker_engine"
       },
-      "name": "docker_pipe"
+      "name": "docker_sock"
     }
   ],
   "family": "datadog-agent-task"


### PR DESCRIPTION
### What does this PR do?
Adds a sample file to be linked from https://github.com/DataDog/documentation/blob/master/static/resources/json/datadog-agent-ecs-win.json

### Motivation
Add docs for Windows on ECS.
