### PR TITLE
Update java tracer download link

### DIFF
--- a/content/en/tracing/profiling/_index.md
+++ b/content/en/tracing/profiling/_index.md
@@ -28,7 +28,7 @@ The Datadog Profiler requires [Java Flight Recorder][1]. The Datadog Profiling l
 2. Download `dd-java-agent.jar`, which contains the Java Agent class files, and add the `dd-trace-java` version to your `pom.xml` or equivalent:
 
     ```shell
-    wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
+    wget -O dd-java-agent.jar https://dtdg.co/latest-java-tracer
     ```
 
      **Note**: Profiling is available in the `dd-java-agent.jar` library in versions 0.44+.

--- a/content/en/tracing/profiling/_index.md
+++ b/content/en/tracing/profiling/_index.md
@@ -28,7 +28,7 @@ The Datadog Profiler requires [Java Flight Recorder][1]. The Datadog Profiling l
 2. Download `dd-java-agent.jar`, which contains the Java Agent class files, and add the `dd-trace-java` version to your `pom.xml` or equivalent:
 
     ```shell
-    wget -O dd-java-agent.jar 'https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.datadoghq&a=dd-java-agent&v=LATEST'
+    wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
     ```
 
      **Note**: Profiling is available in the `dd-java-agent.jar` library in versions 0.44+.

--- a/content/en/tracing/setup/java.md
+++ b/content/en/tracing/setup/java.md
@@ -26,7 +26,7 @@ Otherwise, to begin tracing applications written in any language, first [install
 Next, download `dd-java-agent.jar` that contains the Agent class files:
 
 ```shell
-wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
+wget -O dd-java-agent.jar https://dtdg.co/latest-java-tracer
 ```
 
 Finally, add the following JVM argument when starting your application in your IDE, Maven or Gradle application script, or `java -jar` command:

--- a/content/en/tracing/setup/java.md
+++ b/content/en/tracing/setup/java.md
@@ -26,7 +26,7 @@ Otherwise, to begin tracing applications written in any language, first [install
 Next, download `dd-java-agent.jar` that contains the Agent class files:
 
 ```shell
-wget -O dd-java-agent.jar 'https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.datadoghq&a=dd-java-agent&v=LATEST'
+wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
 ```
 
 Finally, add the following JVM argument when starting your application in your IDE, Maven or Gradle application script, or `java -jar` command:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This updates the java tracer download link to use the URL shortener

### Motivation
The URL shortener gives more flexibility in the future to change things internally than directly linking to a third party

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/landerson/java-latest-tracer/tracing/setup/java
https://docs-staging.datadoghq.com/landerson/java-latest-tracer/tracing/profiling/?tab=java

