### PR TITLE
Update log archive file format

### DIFF
--- a/content/en/logs/archives/_index.md
+++ b/content/en/logs/archives/_index.md
@@ -140,7 +140,10 @@ However, after creating or updating your archive configurations, it can take sev
 
 The log archives that Datadog forwards to your storage bucket are in compressed JSON format (`.json.gz`). Under whatever prefix you indicate (or `/` if there is none), the archives are stored in a directory structure that indicates on what date and at what time the archive files were generated, like so:
 
-`/my/bucket/prefix/dt=20180515/hour=14/archive_143201.1234.7dq1a9mnSya3bFotoErfxl.json.gz`
+```
+/my/bucket/prefix/dt=20180515/hour=14/archive_143201.1234.7dq1a9mnSya3bFotoErfxl.json.gz
+/my/bucket/prefix/dt=<YYYYMMDD>/hour=<HH>/archive_<HHmmss.SSSS>.<DATADOG_ID>.json.gz
+```
 
 This directory structure simplifies the process of querying your historical log archives based on their date.
 


### PR DESCRIPTION
### What does this PR do?
add more details about the file format used for storing archived logs. 

### Motivation
It might be important when searching in archived log files to know what each value represent. This is especially helpful when looking for specific date and time.

### Preview link


<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/log-archive-file-format-generic/logs/archives/?tab=awss3#format-of-the-archives

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
