### PR TITLE
Update on installation reco for K8S

### DIFF
--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -200,8 +200,9 @@ docker-compose -f docker-compose.yml up
                 - name: datadog-private-location-worker
                   image: datadog/synthetics-private-location-worker
                   volumeMounts:
-                      - mountPath: /etc/datadog/
+                      - mountPath: /etc/datadog/synthetics-check-runner.json
                         name: worker-config
+                        subPath: synthetics-check-runner.json
             volumes:
                 - name: worker-config
                   configMap:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR tweaks slightly the private location installation guidelines for Kubernetes

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
