### PR TITLE
[agent] Give more specific Agent service commands

### DIFF
--- a/content/en/agent/basic_agent_usage/amazonlinux.md
+++ b/content/en/agent/basic_agent_usage/amazonlinux.md
@@ -71,7 +71,7 @@ In Agent v6 and v7, the service manager provided by the operating system is resp
 
 **Note**: If the `service` wrapper is not available on your system, use:
 
-* On `upstart`-based systems: `sudo initctl start/stop/restart/status datadog-agent`
+* On `upstart`-based systems: `sudo start/stop/restart/status datadog-agent`
 * On `systemd`-based systems: `sudo systemctl start/stop/restart/status datadog-agent`
 
 [Learn more about Service lifecycle commands][2]

--- a/content/en/agent/basic_agent_usage/amazonlinux.md
+++ b/content/en/agent/basic_agent_usage/amazonlinux.md
@@ -29,12 +29,27 @@ In Agent v6 and v7, the service manager provided by the operating system is resp
 {{< tabs >}}
 {{% tab "Agent v6 & v7" %}}
 
+### Amazon Linux 2
+
 | Description                        | Command                                                |
 |------------------------------------|--------------------------------------------------------|
-| Start Agent as a service           | `sudo service datadog-agent start`                     |
-| Stop Agent running as a service    | `sudo service datadog-agent stop`                      |
-| Restart Agent running as a service | `sudo service datadog-agent restart`                   |
-| Status of Agent service            | `sudo service datadog-agent status`                    |
+| Start Agent as a service           | `sudo systemctl start datadog-agent`                   |
+| Stop Agent running as a service    | `sudo systemctl stop datadog-agent`                    |
+| Restart Agent running as a service | `sudo systemctl restart datadog-agent`                 |
+| Status of Agent service            | `sudo systemctl status datadog-agent`                  |
+| Status page of running Agent       | `sudo datadog-agent status`                            |
+| Send flare                         | `sudo datadog-agent flare`                             |
+| Display command usage              | `sudo datadog-agent --help`                            |
+| Run a check                        | `sudo -u dd-agent -- datadog-agent check <CHECK_NAME>` |
+
+### Amazon Linux
+
+| Description                        | Command                                                |
+|------------------------------------|--------------------------------------------------------|
+| Start Agent as a service           | `sudo start datadog-agent`                             |
+| Stop Agent running as a service    | `sudo stop datadog-agent`                              |
+| Restart Agent running as a service | `sudo stop datadog-agent && sudo start datadog-agent`  |
+| Status of Agent service            | `sudo status datadog-agent`                            |
 | Status page of running Agent       | `sudo datadog-agent status`                            |
 | Send flare                         | `sudo datadog-agent flare`                             |
 | Display command usage              | `sudo datadog-agent --help`                            |
@@ -54,15 +69,15 @@ In Agent v6 and v7, the service manager provided by the operating system is resp
 | Display command usage              | `sudo service datadog-agent`                      |
 | Run a check                        | `sudo -u dd-agent -- dd-agent check <CHECK_NAME>` |
 
-{{% /tab %}}
-{{< /tabs >}}
-
 **Note**: If the `service` wrapper is not available on your system, use:
 
 * On `upstart`-based systems: `sudo initctl start/stop/restart/status datadog-agent`
 * On `systemd`-based systems: `sudo systemctl start/stop/restart/status datadog-agent`
 
 [Learn more about Service lifecycle commands][2]
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Configuration
 

--- a/content/en/agent/basic_agent_usage/amazonlinux.md
+++ b/content/en/agent/basic_agent_usage/amazonlinux.md
@@ -48,7 +48,7 @@ In Agent v6 and v7, the service manager provided by the operating system is resp
 |------------------------------------|--------------------------------------------------------|
 | Start Agent as a service           | `sudo start datadog-agent`                             |
 | Stop Agent running as a service    | `sudo stop datadog-agent`                              |
-| Restart Agent running as a service | `sudo stop datadog-agent && sudo start datadog-agent`  |
+| Restart Agent running as a service | `sudo restart datadog-agent`                           |
 | Status of Agent service            | `sudo status datadog-agent`                            |
 | Status page of running Agent       | `sudo datadog-agent status`                            |
 | Send flare                         | `sudo datadog-agent flare`                             |

--- a/content/en/agent/basic_agent_usage/centos.md
+++ b/content/en/agent/basic_agent_usage/centos.md
@@ -71,7 +71,7 @@ In Agent v6 and v7, the service manager provided by the operating system is resp
 
 **Note**: If the `service` wrapper is not available on your system, use:
 
-* On `upstart`-based systems: `sudo initctl start/stop/restart/status datadog-agent`
+* On `upstart`-based systems: `sudo start/stop/restart/status datadog-agent`
 * On `systemd`-based systems: `sudo systemctl start/stop/restart/status datadog-agent`
 
 [Learn more about Service lifecycle commands][2]

--- a/content/en/agent/basic_agent_usage/centos.md
+++ b/content/en/agent/basic_agent_usage/centos.md
@@ -29,12 +29,27 @@ In Agent v6 and v7, the service manager provided by the operating system is resp
 {{< tabs >}}
 {{% tab "Agent v6 & v7" %}}
 
+### CentOS 7 and higher
+
 | Description                        | Command                                                |
 |------------------------------------|--------------------------------------------------------|
-| Start Agent as a service           | `sudo service datadog-agent start`                     |
-| Stop Agent running as a service    | `sudo service datadog-agent stop`                      |
-| Restart Agent running as a service | `sudo service datadog-agent restart`                   |
-| Status of Agent service            | `sudo service datadog-agent status`                    |
+| Start Agent as a service           | `sudo systemctl start datadog-agent`                   |
+| Stop Agent running as a service    | `sudo systemctl stop datadog-agent`                    |
+| Restart Agent running as a service | `sudo systemctl restart datadog-agent`                 |
+| Status of Agent service            | `sudo systemctl status datadog-agent`                  |
+| Status page of running Agent       | `sudo datadog-agent status`                            |
+| Send flare                         | `sudo datadog-agent flare`                             |
+| Display command usage              | `sudo datadog-agent --help`                            |
+| Run a check                        | `sudo -u dd-agent -- datadog-agent check <CHECK_NAME>` |
+
+### CentOS 6
+
+| Description                        | Command                                                |
+|------------------------------------|--------------------------------------------------------|
+| Start Agent as a service           | `sudo start datadog-agent`                             |
+| Stop Agent running as a service    | `sudo stop datadog-agent`                              |
+| Restart Agent running as a service | `sudo stop datadog-agent && sudo start datadog-agent`  |
+| Status of Agent service            | `sudo status datadog-agent`                            |
 | Status page of running Agent       | `sudo datadog-agent status`                            |
 | Send flare                         | `sudo datadog-agent flare`                             |
 | Display command usage              | `sudo datadog-agent --help`                            |
@@ -54,15 +69,16 @@ In Agent v6 and v7, the service manager provided by the operating system is resp
 | Display command usage              | `sudo service datadog-agent`                      |
 | Run a check                        | `sudo -u dd-agent -- dd-agent check <CHECK_NAME>` |
 
-{{% /tab %}}
-{{< /tabs >}}
-
 **Note**: If the `service` wrapper is not available on your system, use:
 
 * On `upstart`-based systems: `sudo initctl start/stop/restart/status datadog-agent`
 * On `systemd`-based systems: `sudo systemctl start/stop/restart/status datadog-agent`
 
 [Learn more about Service lifecycle commands][2]
+
+{{% /tab %}}
+{{< /tabs >}}
+
 
 ## Configuration
 

--- a/content/en/agent/basic_agent_usage/centos.md
+++ b/content/en/agent/basic_agent_usage/centos.md
@@ -48,7 +48,7 @@ In Agent v6 and v7, the service manager provided by the operating system is resp
 |------------------------------------|--------------------------------------------------------|
 | Start Agent as a service           | `sudo start datadog-agent`                             |
 | Stop Agent running as a service    | `sudo stop datadog-agent`                              |
-| Restart Agent running as a service | `sudo stop datadog-agent && sudo start datadog-agent`  |
+| Restart Agent running as a service | `sudo restart datadog-agent`                           |
 | Status of Agent service            | `sudo status datadog-agent`                            |
 | Status page of running Agent       | `sudo datadog-agent status`                            |
 | Send flare                         | `sudo datadog-agent flare`                             |

--- a/content/en/agent/basic_agent_usage/deb.md
+++ b/content/en/agent/basic_agent_usage/deb.md
@@ -63,7 +63,7 @@ In Agent v6 and v7, the service manager provided by the operating system is resp
 
 **Note**: If the `service` wrapper is not available on your system, use:
 
-* On `upstart`-based systems: `sudo initctl start/stop/restart/status datadog-agent`
+* On `upstart`-based systems: `sudo start/stop/restart/status datadog-agent`
 * On `systemd`-based systems: `sudo systemctl start/stop/restart/status datadog-agent`
 
 [Learn more about Service lifecycle commands][2]

--- a/content/en/agent/basic_agent_usage/fedora.md
+++ b/content/en/agent/basic_agent_usage/fedora.md
@@ -31,10 +31,10 @@ In Agent v6 and v7, the service manager provided by the operating system is resp
 
 | Description                        | Command                                                |
 |------------------------------------|--------------------------------------------------------|
-| Start Agent as a service           | `sudo service datadog-agent start`                     |
-| Stop Agent running as a service    | `sudo service datadog-agent stop`                      |
-| Restart Agent running as a service | `sudo service datadog-agent restart`                   |
-| Status of Agent service            | `sudo service datadog-agent status`                    |
+| Start Agent as a service           | `sudo systemctl start datadog-agent`                   |
+| Stop Agent running as a service    | `sudo systemctl stop datadog-agent`                    |
+| Restart Agent running as a service | `sudo systemctl restart datadog-agent`                 |
+| Status of Agent service            | `sudo systemctl status datadog-agent`                  |
 | Status page of running Agent       | `sudo datadog-agent status`                            |
 | Send flare                         | `sudo datadog-agent flare`                             |
 | Display command usage              | `sudo datadog-agent --help`                            |

--- a/content/en/agent/basic_agent_usage/fedora.md
+++ b/content/en/agent/basic_agent_usage/fedora.md
@@ -54,15 +54,15 @@ In Agent v6 and v7, the service manager provided by the operating system is resp
 | Display command usage              | `sudo service datadog-agent`                      |
 | Run a check                        | `sudo -u dd-agent -- dd-agent check <CHECK_NAME>` |
 
-{{% /tab %}}
-{{< /tabs >}}
-
 **Note**: If the `service` wrapper is not available on your system, use:
 
-* On `upstart`-based systems: `sudo initctl start/stop/restart/status datadog-agent`
+* On `upstart`-based systems: `sudo start/stop/restart/status datadog-agent`
 * On `systemd`-based systems: `sudo systemctl start/stop/restart/status datadog-agent`
 
 [Learn more about Service lifecycle commands][2]
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Configuration
 

--- a/content/en/agent/basic_agent_usage/redhat.md
+++ b/content/en/agent/basic_agent_usage/redhat.md
@@ -69,15 +69,15 @@ In Agent v6 and v7, the service manager provided by the operating system is resp
 | Display command usage              | `sudo service datadog-agent`                      |
 | Run a check                        | `sudo -u dd-agent -- dd-agent check <CHECK_NAME>` |
 
-{{% /tab %}}
-{{< /tabs >}}
-
 **Note**: If the `service` wrapper is not available on your system, use:
 
-* On `upstart`-based systems: `sudo initctl start/stop/restart/status datadog-agent`
+* On `upstart`-based systems: `sudo start/stop/restart/status datadog-agent`
 * On `systemd`-based systems: `sudo systemctl start/stop/restart/status datadog-agent`
 
 [Learn more about Service lifecycle commands][2]
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Configuration
 

--- a/content/en/agent/basic_agent_usage/redhat.md
+++ b/content/en/agent/basic_agent_usage/redhat.md
@@ -29,12 +29,27 @@ In Agent v6 and v7, the service manager provided by the operating system is resp
 {{< tabs >}}
 {{% tab "Agent v6 & v7" %}}
 
+### Red Hat 7 and higher
+
 | Description                        | Command                                                |
 |------------------------------------|--------------------------------------------------------|
-| Start Agent as a service           | `sudo service datadog-agent start`                     |
-| Stop Agent running as a service    | `sudo service datadog-agent stop`                      |
-| Restart Agent running as a service | `sudo service datadog-agent restart`                   |
-| Status of Agent service            | `sudo service datadog-agent status`                    |
+| Start Agent as a service           | `sudo systemctl start datadog-agent`                   |
+| Stop Agent running as a service    | `sudo systemctl stop datadog-agent`                    |
+| Restart Agent running as a service | `sudo systemctl restart datadog-agent`                 |
+| Status of Agent service            | `sudo systemctl status datadog-agent`                  |
+| Status page of running Agent       | `sudo datadog-agent status`                            |
+| Send flare                         | `sudo datadog-agent flare`                             |
+| Display command usage              | `sudo datadog-agent --help`                            |
+| Run a check                        | `sudo -u dd-agent -- datadog-agent check <CHECK_NAME>` |
+
+### Red Hat 6
+
+| Description                        | Command                                                |
+|------------------------------------|--------------------------------------------------------|
+| Start Agent as a service           | `sudo start datadog-agent`                             |
+| Stop Agent running as a service    | `sudo stop datadog-agent`                              |
+| Restart Agent running as a service | `sudo stop datadog-agent && sudo start datadog-agent`  |
+| Status of Agent service            | `sudo status datadog-agent`                            |
 | Status page of running Agent       | `sudo datadog-agent status`                            |
 | Send flare                         | `sudo datadog-agent flare`                             |
 | Display command usage              | `sudo datadog-agent --help`                            |

--- a/content/en/agent/basic_agent_usage/redhat.md
+++ b/content/en/agent/basic_agent_usage/redhat.md
@@ -48,7 +48,7 @@ In Agent v6 and v7, the service manager provided by the operating system is resp
 |------------------------------------|--------------------------------------------------------|
 | Start Agent as a service           | `sudo start datadog-agent`                             |
 | Stop Agent running as a service    | `sudo stop datadog-agent`                              |
-| Restart Agent running as a service | `sudo stop datadog-agent && sudo start datadog-agent`  |
+| Restart Agent running as a service | `sudo restart datadog-agent`                           |
 | Status of Agent service            | `sudo status datadog-agent`                            |
 | Status page of running Agent       | `sudo datadog-agent status`                            |
 | Send flare                         | `sudo datadog-agent flare`                             |

--- a/content/en/agent/basic_agent_usage/suse.md
+++ b/content/en/agent/basic_agent_usage/suse.md
@@ -29,6 +29,21 @@ In Agent v6 and v7, the service manager provided by the operating system is resp
 {{< tabs >}}
 {{% tab "Agent v6 & v7" %}}
 
+### SUSE 12 and higher
+
+| Description                        | Command                                                |
+|------------------------------------|--------------------------------------------------------|
+| Start Agent as a service           | `sudo systemctl start datadog-agent`                   |
+| Stop Agent running as a service    | `sudo systemctl stop datadog-agent`                    |
+| Restart Agent running as a service | `sudo systemctl restart datadog-agent`                 |
+| Status of Agent service            | `sudo systemctl status datadog-agent`                  |
+| Status page of running Agent       | `sudo datadog-agent status`                            |
+| Send flare                         | `sudo datadog-agent flare`                             |
+| Display command usage              | `sudo datadog-agent --help`                            |
+| Run a check                        | `sudo -u dd-agent -- datadog-agent check <CHECK_NAME>` |
+
+### SUSE 11
+
 | Description                        | Command                                                |
 |------------------------------------|--------------------------------------------------------|
 | Start Agent as a service           | `sudo service datadog-agent start`                     |

--- a/content/en/agent/basic_agent_usage/suse.md
+++ b/content/en/agent/basic_agent_usage/suse.md
@@ -74,7 +74,7 @@ In Agent v6 and v7, the service manager provided by the operating system is resp
 
 **Note**: If the `service` wrapper is not available on your system, use:
 
-* On `upstart`-based systems: `sudo initctl start/stop/restart/status datadog-agent`
+* On `upstart`-based systems: `sudo start/stop/restart/status datadog-agent`
 * On `systemd`-based systems: `sudo systemctl start/stop/restart/status datadog-agent`
 
 [Learn more about Service lifecycle commands][2]

--- a/content/en/agent/basic_agent_usage/ubuntu.md
+++ b/content/en/agent/basic_agent_usage/ubuntu.md
@@ -61,7 +61,7 @@ In Agent v6 and v7, the service manager provided by the operating system is resp
 
 **Note**: If the `service` wrapper is not available on your system, use:
 
-* On `upstart`-based systems: `sudo initctl start/stop/restart/status datadog-agent`
+* On `upstart`-based systems: `sudo start/stop/restart/status datadog-agent`
 * On `systemd`-based systems: `sudo systemctl start/stop/restart/status datadog-agent`
 
 [Learn more about Service lifecycle commands][2]

--- a/content/en/agent/guide/agent-commands.md
+++ b/content/en/agent/guide/agent-commands.md
@@ -27,15 +27,16 @@ List of commands to start the Datadog Agent:
 | Platform | Command                                                        |
 |----------|----------------------------------------------------------------|
 | AIX      | `startsrc -s datadog-agent`                                    |
-| Linux    | `sudo service datadog-agent start`                             |
-| Docker   | [See the dedicated Docker documentation][1]                    |
+| Linux    | [See the dedicated documentation for your OS][1]               |
+| Docker   | [See the dedicated Docker documentation][2]                    |
 | Kubernetes | `kubectl create -f datadog-agent.yaml`                        |
 | macOS    | `launchctl start com.datadoghq.agent` *or* via the systray app |
 | Source   | `sudo service datadog-agent start`                             |
-| Windows  | [See the dedicated Windows documentation][2]                   |
+| Windows  | [See the dedicated Windows documentation][3]                   |
 
-[1]: /agent/docker/
-[2]: /agent/basic_agent_usage/windows/
+[1]: /agent/
+[2]: /agent/docker/
+[3]: /agent/basic_agent_usage/windows/
 {{% /tab %}}
 {{% tab "Agent v5" %}}
 
@@ -62,15 +63,16 @@ List of commands to stop the Datadog Agent:
 | Platform | Command                                                       |
 |----------|---------------------------------------------------------------|
 | AIX      | `stopsrc -s datadog-agent`                                    |
-| Linux    | `sudo service datadog-agent stop`                             |
-| Docker   | [See the dedicated Docker documentation][1]                   |
+| Linux    | [See the dedicated documentation for your OS][1]              |
+| Docker   | [See the dedicated Docker documentation][2]                   |
 | Kubernetes | `kubectl delete pod <AGENT POD NAME>`—note: the pod is automatically rescheduled |
 | macOS    | `launchctl stop com.datadoghq.agent` *or* via the systray app |
 | Source   | `sudo service datadog-agent stop`                             |
-| Windows  | [See the dedicated Windows documentation][2]                  |
+| Windows  | [See the dedicated Windows documentation][3]                  |
 
-[1]: /agent/docker/
-[2]: /agent/basic_agent_usage/windows/
+[1]: /agent/
+[2]: /agent/docker/
+[3]: /agent/basic_agent_usage/windows/
 {{% /tab %}}
 {{% tab "Agent v5" %}}
 
@@ -96,15 +98,16 @@ List of commands to restart the Datadog Agent:
 
 | Platform | Command                                           |
 |----------|---------------------------------------------------|
-| Linux    | `sudo service datadog-agent restart`              |
-| Docker   | [See the dedicated Docker documentation][1]       |
+| Linux    | [See the dedicated documentation for your OS][1]  |
+| Docker   | [See the dedicated Docker documentation][2]       |
 | Kubernetes | `kubectl delete pod <AGENT POD NAME>`—note: the pod is automatically rescheduled |
 | macOS    | run `stop` then `start`, *or* via the systray app |
 | Source   | *unsupported Platform*                            |
-| Windows  | [See the dedicated Windows documentation][2]      |
+| Windows  | [See the dedicated Windows documentation][3]      |
 
-[1]: /agent/docker/
-[2]: /agent/basic_agent_usage/windows/
+[1]: /agent/
+[2]: /agent/docker/
+[3]: /agent/basic_agent_usage/windows/
 {{% /tab %}}
 {{% tab "Agent v5" %}}
 
@@ -133,11 +136,13 @@ List of commands to display the status of the Datadog Agent:
 | Platform        | Command                                                                       |
 |-----------------|-------------------------------------------------------------------------------|
 | AIX             | `lssrc -s datadog-agent`                                                      |
-| Linux           | `sudo service datadog-agent status`                                           |
+| Linux           | [See the dedicated documentation for your OS][1]                              |
 | Docker (Debian) | `sudo docker exec -it <CONTAINER_NAME> s6-svstat /var/run/s6/services/agent/` |
 | Kubernetes      | `kubectl exec -it <POD_NAME> s6-svstat /var/run/s6/services/agent/`           |
 | macOS           | `launchctl list com.datadoghq.agent` *or* via the systray app                 |
 | Source          | `sudo service datadog-agent status`                                           |
+
+[1]: /agent/
 
 {{% /tab %}}
 {{% tab "Agent v5" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Give more precise Agent service commands for given platforms / versions (`service` does not work everywhere, and the `initctl` workaround for upstart doesn't work in all cases).
Update the general Agent commands page with a redirection to the main Agent page for Linux.

### Motivation
<!-- What inspired you to submit this pull request?-->

Prevent some cases where the commands wouldn't work because they're too generic.

### Preview link

[Amazon Linux](https://docs-staging.datadoghq.com/kylian.serrania/clearer-agent-commands/agent/basic_agent_usage/amazonlinux/?tab=agentv6v7)
[CentOS](https://docs-staging.datadoghq.com/kylian.serrania/clearer-agent-commands/agent/basic_agent_usage/centos/?tab=agentv6v7)
[Fedora](https://docs-staging.datadoghq.com/kylian.serrania/clearer-agent-commands/agent/basic_agent_usage/fedora/?tab=agentv6v7)
[Red Hat](https://docs-staging.datadoghq.com/kylian.serrania/clearer-agent-commands/agent/basic_agent_usage/redhat/?tab=agentv6v7)
[SUSE](https://docs-staging.datadoghq.com/kylian.serrania/clearer-agent-commands/agent/basic_agent_usage/suse/?tab=agentv6v7)
[Agent commands page](https://docs-staging.datadoghq.com/kylian.serrania/clearer-agent-commands/agent/guide/agent-commands/?tab=agentv6v7)

### Additional Notes
<!-- Anything else we should know when reviewing?-->

- For now, only Agent 6/7 commands have been updated.
- I'm currently testing that the commands do work on all supported systems.
  - Update: I tested the commands on CentOS 6, CentOS 7, Fedora 30, Amazon Linux 1 and Amazon Linux 2, and they work.
- I've updated the general Agent page with a redirection to the main Agent page (which has a list of platforms), because I couldn't find a better generic place that would send them to the service commands. There might be a better place to redirect to, and/or we maybe should split "Linux" into separate OSes.
- Should Ubuntu and Debian use the `systemctl` / `upstart`-specific commands, even though we know `service` is correctly supported there by default?