### PR TITLE
adding documentation for host endpoint

### DIFF
--- a/data/api/v1/full_spec.yaml
+++ b/data/api/v1/full_spec.yaml
@@ -10803,6 +10803,20 @@ paths:
         schema:
           format: int64
           type: integer
+      - description: Include whether or not hosts are muted and when they will be unmuted
+          your hosts.
+        in: query
+        name: include_muted_hosts_data
+        required: false
+        schema:
+          type: boolean
+      - description: Include host metadata
+          your hosts.
+        in: query
+        name: include_hosts_metadata
+        required: false
+        schema:
+          type: boolean
       responses:
         '200':
           content:


### PR DESCRIPTION

### What does this PR do?
Adds documentation to `v1/hosts` for two new query parameters:
* `include_muted_hosts_data`
* `include_hosts_metadata`

### Motivation
To improve documentation

### Preview link
Affected page:
https://docs.datadoghq.com/api/v1/hosts/#get-all-hosts-for-your-organization

After changes:
https://docs-staging.datadoghq.com/aaron.wang/host-flags/api/v1/hosts/#get-all-hosts-for-your-organization

### Additional Notes
