### PR TITLE
[support] Update `group_state` description documentation to be more explicit.

### DIFF
--- a/data/api/v1/full_spec.yaml
+++ b/data/api/v1/full_spec.yaml
@@ -12831,10 +12831,7 @@ paths:
       description: Get details about the specified monitor from your organization.
       operationId: ListMonitors
       parameters:
-      - description: 'When specified, shows additional information about the group
-          states.
-
-          Choose one or more from `all`, `alert`, `warn`, and `no data`.'
+      - description: 'If this argument is set, the returned data includes additional information (if available) regarding the specified group states, including the last notification timestamp, last resolution timestamp and details about the last time the monitor was triggered. The argument should include a string list indicating what, if any, group states to include. Choose one or more from **all**, **alert**, **warn**, or **no data**. Example: \'alert,warn\''
         in: query
         name: group_states
         required: false
@@ -13463,8 +13460,7 @@ paths:
         schema:
           format: int64
           type: integer
-      - description: When specified, shows additional information about the group
-          states. Choose one or more from `all`, `alert`, `warn`, and `no data`.
+      - description: 'If this argument is set, the returned data includes additional information (if available) regarding the specified group states, including the last notification timestamp, last resolution timestamp and details about the last time the monitor was triggered. The argument should include a string list indicating what, if any, group states to include. Choose one or more from **all**, **alert**, **warn**, or **no data**. Example: \'alert,warn\''
         in: query
         name: group_states
         required: false


### PR DESCRIPTION
### What does this PR do?
[support] Update `group_state` description documentation

### Motivation
Be more explicit about what the function of the `group_state` parameter is to limit ambiguity.

### Preview link

https://docs-staging.datadoghq.com/armcburney/update_group_status_docs/api/v1/monitors/#get-all-monitor-details