### PR TITLE
📝 Add SLOs video to docs

### DIFF
--- a/content/en/logs/_index.md
+++ b/content/en/logs/_index.md
@@ -17,6 +17,8 @@ further_reading:
 
 {{< vimeo 293195142 >}}
 
+</br>
+
 Sometimes, your infrastructure may generate a volume of log events that is too large or has significant fluctuations. In this situation, you may need to choose which logs to send to a log management solution, and which logs to archive. Filtering your logs before sending them, however, may lead to gaps in coverage or the accidental removal of valuable data.
 
 Datadog's log management removes these limitations by decoupling log ingestion from indexing. This enables you to cost-effectively collect, process, archive, explore, and monitor all your logs with no log limits. This is called Logging without Limits\*. Logging without Limits\* also powers Datadog’s [Security Monitoring][1] by not requiring you to index your logs to detect security threats in your environment.

--- a/content/en/monitors/service_level_objectives/_index.md
+++ b/content/en/monitors/service_level_objectives/_index.md
@@ -14,6 +14,10 @@ further_reading:
   text: "Introduction to Service Level Objectives (SLOs)"
 ---
 
+{{< vimeo 382481078 >}}
+
+<br />
+
 ## Overview
 
 Service Level Objectives, or SLOs, are a key part of the site reliability engineering toolkit. SLOs provide a
@@ -50,7 +54,7 @@ Advanced search lets you query SLOs by any combination of SLO attributes:
 * `time window` - *, 7d, 30d, 90d
 * `type` - metric, monitor
 * `creator`
-* `tags` - datacenter, env, service, team, etc. 
+* `tags` - datacenter, env, service, team, etc.
 
 To run a search, use the checkboxes on the left and the search bar. When you check the boxes, the search bar updates with the equivalent query. Likewise, when you modify the search bar query (or write one from scratch), the checkboxes update to reflect the change. Query results update in real-time as you edit the query; there's no 'Search' button to click.
 
@@ -64,13 +68,13 @@ When you create or edit an SLO, you can add tags for filtering on the [SLO statu
 
 {{< img src="monitors/service_level_objectives/overall_uptime_calculation.png" alt="overall uptime calculation"  >}}
 
-The overall uptime can be considered as a percentage of the time where **all** monitors are in the `OK` state. It is not the average of the aggregated monitors. 
+The overall uptime can be considered as a percentage of the time where **all** monitors are in the `OK` state. It is not the average of the aggregated monitors.
 
 Consider the following example for 3 monitors:
 
 | Monitor            | t1 | t2 | t3    | t4 | t5    | t6 | t7 | t8 | t9    | t10 | Uptime |
 |--------------------|----|----|-------|----|-------|----|----|----|-------|-----|--------|
-| Monitor 1          | OK | OK | OK    | OK | ALERT | OK | OK | OK | OK    | OK  | 90%    | 
+| Monitor 1          | OK | OK | OK    | OK | ALERT | OK | OK | OK | OK    | OK  | 90%    |
 | Monitor 2          | OK | OK | OK    | OK | OK    | OK | OK | OK | ALERT | OK  | 90%    |
 | Monitor 3          | OK | OK | ALERT | OK | ALERT | OK | OK | OK | OK    | OK  | 80%    |
 | **Overall Uptime** | OK | OK | ALERT | OK | ALERT | OK | OK | OK | ALERT | OK  | 70%    |
@@ -83,12 +87,12 @@ You can view, edit your SLO and its properties and see the status over time and 
 
 ### SLO Default View
 
-The default SLO view is loaded when you land on the SLO list view. 
+The default SLO view is loaded when you land on the SLO list view.
 
 The default view includes:
 
 - An empty search query
-- A list of all defined SLOs in your organization 
+- A list of all defined SLOs in your organization
 - A list of available facets in left side facet list
 
 ### Saved Views
@@ -98,19 +102,19 @@ Saved views allow you to save and share customized searches in the SLO list view
 - A search query
 - A selected subset of facets
 
-After you query for a subset of SLOs on the list view, you can now add that query as a saved view. 
+After you query for a subset of SLOs on the list view, you can now add that query as a saved view.
 
 #### Add a saved view
 
 To add a saved view:
 
-1. Query for your SLOs. 
-2. Click *Save View* at the top. 
+1. Query for your SLOs.
+2. Click *Save View* at the top.
 3. Name your view and save.
 
 #### Load a Saved View
 
-To load a saved view, open the *Saved Views* panel at the top of the page and select. You can also search for views in the *Filter Saved Views* search box. 
+To load a saved view, open the *Saved Views* panel at the top of the page and select. You can also search for views in the *Filter Saved Views* search box.
 
 #### Saved Views selection
 


### PR DESCRIPTION
### What does this PR do?
- Adds the SLOs overview video to the SLOs page of the docs
- Adds a line of space below the Logs overview video (not strictly related to the point of this PR, but I noticed there was a missing space there)

> **SLOs page:**
>
> <img width="1192" alt="Screen Shot 2020-07-07 at 9 51 47 PM" src="https://user-images.githubusercontent.com/1048442/86864935-13edbc80-c09c-11ea-9d94-0ee33ce2b8d0.png">

> **Logs page:**
>
> Before | After
> --- | ---
> <img width="876" alt="Screen Shot 2020-07-07 at 9 50 57 PM" src="https://user-images.githubusercontent.com/1048442/86864975-21a34200-c09c-11ea-8019-65b2e53645e6.png"> | <img width="885" alt="Screen Shot 2020-07-07 at 9 50 36 PM (1)" src="https://user-images.githubusercontent.com/1048442/86865254-a9894c00-c09c-11ea-9716-2414bea16ea8.png">

### Motivation
We're about to release a new in-app video player for onboarding content, starting with the SLOs page. We're adding the same video to the docs as well, to ensure more touchpoints for users.

> **In-app SLO video for reference:**
>
> <img width="1440" alt="Screen Shot 2020-07-07 at 9 48 43 PM" src="https://user-images.githubusercontent.com/1048442/86864774-c4a78c00-c09b-11ea-8c13-47cd0032b08c.png">

### Preview link
- https://docs-staging.datadoghq.com/derek/slo-video/monitors/service_level_objectives
- https://docs-staging.datadoghq.com/derek/slo-video/logs