### PR TITLE
fix small errors with Custom Instrumentation page

### DIFF
--- a/content/en/tracing/custom_instrumentation/_index.md
+++ b/content/en/tracing/custom_instrumentation/_index.md
@@ -9,7 +9,7 @@ aliases:
     - /tracing/advanced/manual_instrumentation/
     - /tracing/advanced/opentracing/
     - /tracing/opentracing/
-    - /tracing/manual-instrumentation/
+    - /tracing/manual_instrumentation/
 further_reading:
     - link: 'tracing/guide/instrument_custom_method'
       text: 'Instrument a custom method to get deep visibility into your business logic'

--- a/content/en/tracing/custom_instrumentation/java.md
+++ b/content/en/tracing/custom_instrumentation/java.md
@@ -335,7 +335,7 @@ This can be useful for excluding any Health Checks or otherwise simulated traffi
 
 <br>
 
-## Open Tracing
+## OpenTracing
 
 Datadog integrates seamlessly with the [OpenTracing API][10].
 

--- a/content/en/tracing/custom_instrumentation/ruby.md
+++ b/content/en/tracing/custom_instrumentation/ruby.md
@@ -325,7 +325,7 @@ This can be useful for excluding any Health Checks or otherwise simulated traffi
 ```
 
 
-## Open Tracing
+## OpenTracing
 
 To set up Datadog with OpenTracing, see the Ruby [Quickstart for OpenTracing][7] for details.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update broken alias for old Manual Instrumentation page and fix two typos
