### PR TITLE
Adding documentation for private locations healthchecks

### DIFF
--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -355,7 +355,7 @@ Because Datadog already integrates with Kubernetes and AWS, it is ready-made to 
 
 Add a healthcheck mechanism so your orchestrator can ensure the workers are running correctly.
 
-The `/tmp/liveness.date` file of private location containers gets updated after every successful poll from Datadog (every 500ms by default). The container can be considered unhealthy if no poll has been performed in a while (e.g., no fetch in the last minute).
+The `/tmp/liveness.date` file of private location containers gets updated after every successful poll from Datadog (500ms by default). The container is considered unhealthy if no poll has been performed in a while, for example: no fetch in the last minute.
 
 Use the below configuration to set up healthchecks on your containers with:
 

--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -353,7 +353,7 @@ Because Datadog already integrates with Kubernetes and AWS, it is ready-made to 
 
 #### Set up healthchecks
 
-You can add a healthcheck mechanism to have your orchestrator ensure your workers are always running correctly.
+Add a healthcheck mechanism so your orchestrator can ensure the workers are running correctly.
 
 The `/tmp/liveness.date` file of private location containers gets updated after every successful poll from Datadog (every 500ms by default). The container can be considered unhealthy if no poll has been performed in a while (e.g., no fetch in the last minute).
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR adds documentation for healthchecks for Synthetic private locations. It also performs a small modification on the installation guidelines for Kubernetes.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/margot.lepizzera/private_locations_healthcheck/synthetics/private_locations?tab=docker
Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
