### PR TITLE
replace `api_key` with `DD_CLIENT_API_KEY`

### DIFF
--- a/content/en/dashboards/guide/screenboard-api-doc.md
+++ b/content/en/dashboards/guide/screenboard-api-doc.md
@@ -125,7 +125,7 @@ curl -X POST -H "Content-type: application/json" \
             }
         ]
 }' \
-"https://api.datadoghq.com/api/v1/screen?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/screen?api_key=${DD_CLIENT_API_KEY}&application_key=${DD_CLIENT_APP_KEY}"
 ```
 
 {{% /tab %}}
@@ -248,7 +248,7 @@ curl -X PUT -H "Content-type: application/json" \
             }
         ]
 }' \
-"https://api.datadoghq.com/api/v1/screen/${board_id}?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/screen/${board_id}?api_key=${DD_CLIENT_API_KEY}&application_key=${DD_CLIENT_APP_KEY}"
 
 ```
 
@@ -328,10 +328,10 @@ board_id=$(curl -X POST -H "Content-type: application/json" \
             }
         ]
   }' \
-"https://api.datadoghq.com/api/v1/screen?api_key=${api_key}&application_key=${app_key}" | jq '.id')
+"https://api.datadoghq.com/api/v1/screen?api_key=${DD_CLIENT_API_KEY}&application_key=${DD_CLIENT_APP_KEY}" | jq '.id')
 
 curl -X DELETE \
-"https://api.datadoghq.com/api/v1/screen/${board_id}?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/screen/${board_id}?api_key=${DD_CLIENT_API_KEY}&application_key=${DD_CLIENT_APP_KEY}"
 ```
 
 {{% /tab %}}
@@ -408,10 +408,10 @@ board_id=$(curl -X POST -H "Content-type: application/json" \
             }
         ]
   }' \
-"https://api.datadoghq.com/api/v1/screen?api_key=${api_key}&application_key=${app_key}" | jq '.id')
+"https://api.datadoghq.com/api/v1/screen?api_key=${DD_CLIENT_API_KEY}&application_key=${DD_CLIENT_APP_KEY}" | jq '.id')
 
 curl -X GET \
-"https://api.datadoghq.com/api/v1/screen/${board_id}?api_key=${api_key}&application_key=${app_key}"
+"https://api.datadoghq.com/api/v1/screen/${board_id}?api_key=${DD_CLIENT_API_KEY}&application_key=${DD_CLIENT_APP_KEY}"
 ```
 
 {{% /tab %}}
@@ -470,7 +470,7 @@ result = dog.get_all_screenboards()
 api_key=<DATADOG_API_KEY>
 app_key=<DATADOG_APPLICATION_KEY>
 
-curl -X GET "https://api.datadoghq.com/api/v1/screen?api_key=${api_key}&application_key=${app_key}"
+curl -X GET "https://api.datadoghq.com/api/v1/screen?api_key=${DD_CLIENT_API_KEY}&application_key=${DD_CLIENT_APP_KEY}"
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
even though this document is deprecated it would be useful to have the standard from the main API match up

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
