### PR TITLE
Update folder where the security monitoring rules are

### DIFF
--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -273,7 +273,7 @@
   - repo_name: security-monitoring
     contents:
     - action: security-rules
-      branch: tanguy.lebarzic/security-monitoring-rules-cleanup
+      branch: main
       globs:
         - "security-monitoring/*.json"
       options:

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -273,8 +273,8 @@
   - repo_name: security-monitoring
     contents:
     - action: security-rules
-      branch: main
+      branch: tanguy.lebarzic/security-monitoring-rules-cleanup
       globs:
-        - "*.json"
+        - "security-monitoring/*.json"
       options:
         dest_path: '/security_monitoring/default_rules/'

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -273,7 +273,7 @@
   - repo_name: security-monitoring
     contents:
     - action: security-rules
-      branch: tanguy.lebarzic/security-monitoring-rules-cleanup
+      branch: main
       globs:
         - "security-monitoring/*.json"
       options:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -273,9 +273,9 @@
   - repo_name: security-monitoring
     contents:
     - action: security-rules
-      branch: main
+      branch: tanguy.lebarzic/security-monitoring-rules-cleanup
       globs:
-        - "*.json"
+        - "security-monitoring/*.json"
       options:
         dest_path: '/security_monitoring/default_rules/'
 


### PR DESCRIPTION
### What does this PR do?

Update the build script to fetch security monitoring rules from a dedicated folder, following https://github.com/DataDog/security-monitoring/pull/28.

Plan is:

- [X] Test the preview link
- [X] Also update pull_config.yaml (same as pull_config_preview.yaml)
- [ ] Merge this PR
- [x] Merge https://github.com/DataDog/security-monitoring/pull/28
- [ ] Create another PR that goes back to using the 'main' branch

### Preview link

https://docs-staging.datadoghq.com/tanguy.lebarzic/update-security-monitoring-path/security_monitoring/default_rules/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
