### PR TITLE
Remove need for HIPAA specific log endpoints

### DIFF
--- a/content/en/security/logs.md
+++ b/content/en/security/logs.md
@@ -46,7 +46,7 @@ If you have any questions about how the Log Management Service satisfies the app
 
 **Note:**
 
-HIPAA-enabled custommer used to require the use of specific endpoints to submit logs in order to enforce some specific encryptions. This is not needed anymore as that those encryptions are now enabled on all log submission endpoints.
+Previously, HIPAA-enabled customers needed to use specific endpoints to submit logs in order to enforce specific encryptions. This is no longer necessary. The encryptions are enabled on all log submission endpoints.
 
 These are the legacy endpoints that are not supported after version {edit suggestion to add version}:
 

--- a/content/en/security/logs.md
+++ b/content/en/security/logs.md
@@ -48,7 +48,7 @@ If you have any questions about how the Log Management Service satisfies the app
 
 Previously, HIPAA-enabled customers needed to use specific endpoints to submit logs in order to enforce specific encryptions. This is no longer necessary. The encryptions are enabled on all log submission endpoints.
 
-These are the legacy endpoints that are not supported after version {edit suggestion to add version}:
+These legacy endpoints are still supported:
 
 * `tcp-encrypted-intake.logs.datadoghq.com`
 * `lambda-tcp-encrypted-intake.logs.datadoghq.com`

--- a/content/en/security/logs.md
+++ b/content/en/security/logs.md
@@ -33,7 +33,7 @@ For customers using release 6, the Agent can be configured to obfuscate specific
 
 Datadog will sign a Business Associate Agreement (BAA) with customers that transmit protected health information (ePHI) via Datadog’s Log Management Service.
 
-Some features are not available at the moment to customers who have signed Datadog's BAA, notably:
+These features are not available to customers who have signed Datadog's BAA:
 
 * Users cannot request support via chat
 * Rehydration from Log Archives is disabled
@@ -48,12 +48,12 @@ If you have any questions about how the Log Management Service satisfies the app
 
 HIPAA-enabled custommer used to require the use of specific endpoints to submit logs in order to enforce some specific encryptions. This is not needed anymore as that those encryptions are now enabled on all log submission endpoints.
 
-Here are the historical endpoints which are now deprecated : 
+These are the legacy endpoints that are not supported after version {edit suggestion to add version}:
 
-* tcp-encrypted-intake.logs.datadoghq.com
-* lambda-tcp-encrypted-intake.logs.datadoghq.com
-* gcp-encrypted-intake.logs.datadoghq.com
-* http-encrypted-intake.logs.datadoghq.com
+* `tcp-encrypted-intake.logs.datadoghq.com`
+* `lambda-tcp-encrypted-intake.logs.datadoghq.com`
+* `gcp-encrypted-intake.logs.datadoghq.com`
+* `http-encrypted-intake.logs.datadoghq.com`
 
 ### Further Reading
 

--- a/content/en/security/logs.md
+++ b/content/en/security/logs.md
@@ -29,29 +29,11 @@ For customers using release 6 or above, the Agent can be configured to filter lo
 
 For customers using release 6, the Agent can be configured to obfuscate specific patterns within logs sent by the Agent to the Datadog application. To mask sensitive sequences within your logs, use the `log_processing_rules` [setting][5], with the  **mask_sequences** `type`. This setting enables the creation of a list containing one or more regular expressions, which instructs the Agent to redact sensitive data within your logs.
 
-## Configuration Requirements for HIPAA-enabled Customers
+## HIPAA-enabled Customers
 
 Datadog will sign a Business Associate Agreement (BAA) with customers that transmit protected health information (ePHI) via Datadog’s Log Management Service.
 
-Prior to executing a BAA, customers transmitting ePHI to the Datadog Log Management Service must implement the following configurations:
-
-* The Datadog Agent must be configured to submit logs to `tcp-encrypted-intake.logs.datadoghq.com`
-* The Datadog [log collection AWS Lambda function][6] must be configured to submit logs to `lambda-tcp-encrypted-intake.logs.datadoghq.com` by setting the `DD_URL` environment variable as well as setting `DD_USE_TCP` to `true`
-* The [GCP push forwarder][7] must be configured to submit logs to `gcp-encrypted-intake.logs.datadoghq.com`
-* Other log sources besides the Datadog Agent must be configured to submit logs to `http-encrypted-intake.logs.datadoghq.com`
-
-The following sample configuration can be used with the Datadog Agent to submit logs to a HIPAA-ready endpoint directly (i.e. without a proxy):
-
-```yaml
-logs_enabled: true
-logs_config:
-  logs_dd_url: tcp-encrypted-intake.logs.datadoghq.com:10516
-  logs_no_ssl: false
-```
-
-With the Docker Agent, pass in `DD_LOGS_CONFIG_LOGS_DD_URL=tcp-encrypted-intake.logs.datadoghq.com:10516` as an environment variable.
-
-Additionally, certain features are not available at the moment to customers who have signed Datadog's BAA, notably:
+Some features are not available at the moment to customers who have signed Datadog's BAA, notably:
 
 * Users cannot request support via chat
 * Rehydration from Log Archives is disabled
@@ -61,6 +43,17 @@ Additionally, certain features are not available at the moment to customers who 
 * You cannot [share][8] logs (nor traces) from the explorer through web integrations.
 
 If you have any questions about how the Log Management Service satisfies the applicable requirements under HIPAA, please contact your account manager.
+
+**Note:**
+
+HIPAA-enabled custommer used to require the use of specific endpoints to submit logs in order to enforce some specific encryptions. This is not needed anymore as that those encryptions are now enabled on all log submission endpoints.
+
+Here are the historical endpoints which are now deprecated : 
+
+* tcp-encrypted-intake.logs.datadoghq.com
+* lambda-tcp-encrypted-intake.logs.datadoghq.com
+* gcp-encrypted-intake.logs.datadoghq.com
+* http-encrypted-intake.logs.datadoghq.com
 
 ### Further Reading
 


### PR DESCRIPTION
### What does this PR do?
Now that all our log endpoint are HIPAA compliant, remove the the Hipaa specific endpoint from the requirement. 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link

https://docs-staging.datadoghq.com/pvr/hipaa-log-compliance/security/logs/

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
