### PR TITLE
[WEB-485] Remove `isEnabled:False` from rendered Security Monitoring Default Rules

### DIFF
--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -49,7 +49,7 @@ def security_rules(content, content_dir):
             scope_tag = get_tag(json_data.get('tags', []), "scope")
 
             # delete file or skip if staged
-            if json_data.get('isStaged', False) or json_data.get('isDeleted', False):
+            if json_data.get('isStaged', False) or json_data.get('isDeleted', False) or not json_data.get('isEnabled', True):
                 if p.exists():
                     logger.info(f"removing file {p.name}")
                     p.unlink()

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -275,6 +275,6 @@
     - action: security-rules
       branch: main
       globs:
-        - "*.json"
+        - "security_monitoring/*.json"
       options:
         dest_path: '/security_monitoring/default_rules/'

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -275,6 +275,6 @@
     - action: security-rules
       branch: main
       globs:
-        - "security_monitoring/*.json"
+        - "security-monitoring/*.json"
       options:
         dest_path: '/security_monitoring/default_rules/'

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -275,7 +275,7 @@
     - action: security-rules
       branch: main
       globs:
-        - "security_monitoring/*.json"
+        - "security-monitoring/*.json"
       options:
         dest_path: '/security_monitoring/default_rules/'
 

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -275,7 +275,7 @@
     - action: security-rules
       branch: main
       globs:
-        - "*.json"
+        - "security_monitoring/*.json"
       options:
         dest_path: '/security_monitoring/default_rules/'
 


### PR DESCRIPTION
### What does this PR do?
Adds isEnabled to exlclude condition for building md from json data files on security rules repo

### Motivation
https://datadoghq.atlassian.net/browse/WEB-485

### Preview link
https://docs-staging.datadoghq.com/nsollecito/security-isenabled/security_monitoring/default_rules/