### PR TITLE
command -> binary typo

### DIFF
--- a/content/en/agent/faq/agent_v6_changes.md
+++ b/content/en/agent/faq/agent_v6_changes.md
@@ -269,7 +269,7 @@ The major changes for Agent v6 on Windows are:
 The major changes for Agent v6 on MacOS are:
 
 * The _lifecycle commands_ (formerly `datadog-agent start`/`stop`/`restart`/`status`) are replaced by `launchctl` commands on the `com.datadoghq.agent` service, and should be run under the logged-in user. For these commands, you can also use the Datadog Agent systray app.
-* All the other commands can still be run with the `datadog-agent` command located in the `PATH` (`/usr/local/bin/`) by default.
+* All the other commands can still be run with the `datadog-agent` binary located in the `PATH` (`/usr/local/bin/`) by default.
 * The `info` command has been renamed to `status`.
 * The configuration GUI is now a web-based application, which can be accessed by running the command `datadog-agent launch-gui` or using the systray app.
 


### PR DESCRIPTION
it's not a command
it's a binary
a binary that enables you to run commands

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
