### PR TITLE
Add a glog format example

### DIFF
--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -50,33 +50,6 @@ After processing, the following structured log is generated:
 
 {{< img src="logs/processing/processors/_parser.png" alt="Parsing example 1"  style="width:80%;">}}
 
-Another example, parsing the `glog` format that Kubernetes uses (via the Kube Scheduler item in the Pipeline Library):
-
-```text
-W0424 11:47:41.605188       1 authorization.go:47] Authorization is disabled
-```
-
-Parsing rule:
-
-```text
-kube_scheduler %{regex("\\w"):level}%{date("MMdd HH:mm:ss.SSSSSS"):timestamp}\s+%{number:logger.thread_id} %{notSpace:logger.name}:%{number:lineno}\] %{data:msg}
-```
-
-And extracted JSON:
-
-```json
-{
-  "level": "W",
-  "timestamp": 1587728861605,
-  "logger": {
-    "thread_id": 1,
-    "name": "authorization.go"
-  },
-  "lineno": 47,
-  "msg": "Authorization is disabled"
-}
-```
-
 **Note**:
 
 * If you have multiple parsing rules in a single Grok parser:
@@ -201,6 +174,7 @@ Some examples demonstrating how to use parsers:
 * [Nested JSON](#nested-json)
 * [Regex](#regex)
 * [List and Arrays](#list-and-arrays)
+* [Glog format](#glog-format)
 * [XML](#parsing-xml)
 
 ### Key value or logfmt
@@ -439,6 +413,37 @@ Users {John-Oliver-Marc-Tom} have been added to the database
 
 ```text
 myParsingRule Users %{data:users:array("{}","-")} have been added to the database
+```
+
+### Glog format
+
+Kubernetes components sometimes log in the `glog` format; this example is from the Kube Scheduler item in the Pipeline Library.
+
+Example log line:
+
+```text
+W0424 11:47:41.605188       1 authorization.go:47] Authorization is disabled
+```
+
+Parsing rule:
+
+```text
+kube_scheduler %{regex("\\w"):level}%{date("MMdd HH:mm:ss.SSSSSS"):timestamp}\s+%{number:logger.thread_id} %{notSpace:logger.name}:%{number:logger.lineno}\] %{data:msg}
+```
+
+And extracted JSON:
+
+```json
+{
+  "level": "W",
+  "timestamp": 1587728861605,
+  "logger": {
+    "thread_id": 1,
+    "name": "authorization.go"
+  },
+  "lineno": 47,
+  "msg": "Authorization is disabled"
+}
 ```
 
 ### Parsing XML

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -50,6 +50,33 @@ After processing, the following structured log is generated:
 
 {{< img src="logs/processing/processors/_parser.png" alt="Parsing example 1"  style="width:80%;">}}
 
+Another example, parsing the `glog` format that Kubernetes uses (via the Kube Scheduler item in the Pipeline Library):
+
+```text
+W0424 11:47:41.605188       1 authorization.go:47] Authorization is disabled
+```
+
+Parsing rule:
+
+```text
+kube_scheduler %{regex("\\w"):level}%{date("MMdd HH:mm:ss.SSSSSS"):timestamp}\s+%{number:logger.thread_id} %{notSpace:logger.name}:%{number:lineno}\] %{data:msg}
+```
+
+And extracted JSON:
+
+```json
+{
+  "level": "W",
+  "timestamp": 1587728861605,
+  "logger": {
+    "thread_id": 1,
+    "name": "authorization.go"
+  },
+  "lineno": 47,
+  "msg": "Authorization is disabled"
+}
+```
+
 **Note**:
 
 * If you have multiple parsing rules in a single Grok parser:


### PR DESCRIPTION
`glog` is the format that Kubernetes components use, but "glog" isn't discoverable in the Pipeline Library. These examples are from the Kube Scheduler item in the Pipeline Library.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Adds an example to the Logs Parsing documentation, showing how to parse the `glog` format that Kubernetes components use for logging. 

### Motivation

Ideally this would be discoverable in the Pipeline Library for "glog", but it wasn't. Nor did it turn up on StackOverflow, etc.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.


