### PR TITLE
Bump node profiler min version

### DIFF
--- a/content/en/tracing/profiling/getting_started.md
+++ b/content/en/tracing/profiling/getting_started.md
@@ -228,7 +228,7 @@ The Datadog Profiler requires Node 10.12+. To begin profiling applications:
     npm install --save dd-trace
     ```
 
-    **Note**: Profiling is available in the `dd-trace` library in versions 0.23.1+.
+    **Note**: Profiling is available in the `dd-trace` library in versions 0.23.2+.
 
 3. To automatically profile your code, import and initialize `dd-trace` with profiling enabled:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
0.23.1 had regressions so bumping node profiler min version to 0.23.2.
### Motivation
<!-- What inspired you to submit this pull request?-->
0.23.1 had regressions so bumping node profiler min version to 0.23.2.
### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
