### PR TITLE
Remove broken further reading links

### DIFF
--- a/content/en/tracing/profiling/getting_started.md
+++ b/content/en/tracing/profiling/getting_started.md
@@ -2,12 +2,6 @@
 title: Getting Started
 kind: Documentation
 further_reading:
-    - link: 'tracing/profiling/trace_profile'
-      tag: 'Documentation'
-      text: 'Connect traces and profiles.'
-    - link: 'tracing/profiling/code_level_metrics'
-      tag: 'Documentation'
-      text: 'View code level metrics.'  
     - link: 'tracing/profiling/search_profiles'
       tag: 'Documentation'
       text: 'Learn more about available profile types.'


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Removes broken further reading links from profiling page.

### Motivation
<!-- What inspired you to submit this pull request?-->
Links were broken.

### Preview link


### Additional Notes
<!-- Anything else we should know when reviewing?-->
