### PR TITLE
Fix typo on profiling getting started page

### DIFF
--- a/content/en/tracing/profiling/getting_started.md
+++ b/content/en/tracing/profiling/getting_started.md
@@ -220,9 +220,9 @@ The Datadog Profiler requires Go 1.12+. To begin profiling applications:
 
 The Datadog Profiler requires Node 10.12+. To begin profiling applications:
 
-1. If you are already using Datadog, upgrade your Agent to version [7.20.2][1] or [6.20.2][1].  
+1. If you are already using Datadog, upgrade your agent to version [7.20.2][1] or [6.20.2][1].  
 
-2. Install `ddtrace` which contains both tracing and profiling:
+2. Install `dd-trace` which contains both tracing and profiling:
 
     ```shell
     npm install --save dd-trace


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes package name typo in the profiling getting started a page for Node.js. Also, I changed "Agent" to lower case to be consistent with other languages instructions.

### Motivation
Avoid end-user confusion
