### PR TITLE
DOCS-1040 Datadog Admission Controller

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -276,31 +276,35 @@ main:
     url: agent/cluster_agent/endpointschecks/
     parent: agent_cluster
     weight: 405
+  - name: Admission Controller
+    url: agent/cluster_agent/admission_controller/
+    parent: agent_cluster
+    weight: 406
   - name: Commands & Options
     url: agent/cluster_agent/commands/
     identifier: cluster_agent_commands
     parent: agent_cluster
-    weight: 406
+    weight: 407
   - name: Cluster metadata provider
     url: agent/cluster_agent/metadata_provider/
     identifier: cluster_agent_metadata_provider
     parent: agent_cluster
-    weight: 407
+    weight: 408
   - name: Build
     url: agent/cluster_agent/build/
     identifier: cluster_agent_build
     parent: agent_cluster
-    weight: 408
+    weight: 409
   - name: Cluster Checks Runner
     url: agent/cluster_agent/clusterchecksrunner
     identifier: cluster_agent_clcr
     parent: agent_cluster
-    weight: 409
+    weight: 410
   - name: Troubleshooting
     url: agent/cluster_agent/troubleshooting/
     identifier: cluster_agent_troubleshooting
     parent: agent_cluster
-    weight: 410
+    weight: 411
   - name: Log Collection
     url: agent/logs/
     identifier: agent_logs

--- a/content/en/agent/cluster_agent/admission_controller.md
+++ b/content/en/agent/cluster_agent/admission_controller.md
@@ -13,12 +13,14 @@ further_reading:
 ## Overview
 The Datadog admission controller is a component of the Datadog Cluster Agent. The main benefit of the admission controller is to simplify the user's application pod configuration. For that, It has two main functionalities:
 
-- Inject environment variables (`DD_AGENT_HOST` and `DD_ENTITY_ID`) to configure DogStatsD and APM tracer libraries into the user's app containers.
-- Inject Datadog standard tags (`env`, `service`, `version`) from app labels into the container environment variables.
+- Inject environment variables (`DD_AGENT_HOST` and `DD_ENTITY_ID`) to configure DogStatsD and APM tracer libraries into the user's application containers.
+- Inject Datadog standard tags (`env`, `service`, `version`) from application labels into the container environment variables.
+
+Datadog's admission controller is `MutatingAdmissionWebhook` type. For more details on admission controllers, see the [Kubernetes guide][1].
 
 ## Requirements
 
-- Datadog Cluster Agent 1.7.0
+- Datadog Cluster Agent v1.7.0+
 
 ## Configuration
 
@@ -63,7 +65,9 @@ To enable the admission controller for the Datadog operator, set the parameter `
 
 ### APM and DogStatsD
 
-Inject the environment variables `DD_AGENT_HOST` and `DD_ENTITY_ID` to configure DogstatsD clients and APM tracers automatically by using one of the following:
+By using the Datadog admission controller, users can skip configuring the application pods using downward API ([step 2 in Kubernetes Trace Collection setup][2]).
+
+To configure DogstatsD clients and APM tracers automatically, inject the environment variables `DD_AGENT_HOST` and `DD_ENTITY_ID` by using one of the following:
 
 - Add the label `admission.datadoghq.com/enabled: "true"` to your pod.
 - Configure the Cluster Agent admission controller by setting `mutateUnlabelled: true`.
@@ -90,3 +94,6 @@ Possible options:
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://kubernetes.io/blog/2019/03/21/a-guide-to-kubernetes-admission-controllers/
+[2]: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#setup

--- a/content/en/agent/cluster_agent/admission_controller.md
+++ b/content/en/agent/cluster_agent/admission_controller.md
@@ -65,8 +65,6 @@ To enable the admission controller for the Datadog operator, set the parameter `
 
 ### APM and DogStatsD
 
-By using the Datadog admission controller, users can skip configuring the application pods using downward API ([step 2 in Kubernetes Trace Collection setup][2]).
-
 To configure DogstatsD clients and APM tracers automatically, inject the environment variables `DD_AGENT_HOST` and `DD_ENTITY_ID` by using one of the following:
 
 - Add the label `admission.datadoghq.com/enabled: "true"` to your pod.
@@ -90,6 +88,7 @@ Possible options:
 - The admission controller needs to be deployed and configured before the creation of new application pods. It cannot update pods that already exist.
 - The admission controller doesn't inject the environment variables `DD_VERSION, DD_ENV`, and `DD_SERVICE` if they already exist.
 - To disable the admission controller injection feature, use the Cluster Agent configuration: `DD_ADMISSION_CONTROLLER_INJECT_CONFIG_ENABLED=false`
+- By using the Datadog admission controller, users can skip configuring the application pods using downward API ([step 2 in Kubernetes Trace Collection setup][2]).
 
 
 ## Further Reading

--- a/content/en/agent/cluster_agent/admission_controller.md
+++ b/content/en/agent/cluster_agent/admission_controller.md
@@ -88,6 +88,7 @@ Possible options:
 #### Notes
 
 - The admission controller needs to be deployed and configured before the creation of new application pods. It cannot update pods that already exist.
+- The admission controller doesn't inject the environment variables `DD_VERSION, DD_ENV`, and `DD_SERVICE` if they already exist.
 - To disable the admission controller injection feature, use the Cluster Agent configuration: `DD_ADMISSION_CONTROLLER_INJECT_CONFIG_ENABLED=false`
 
 

--- a/content/en/agent/cluster_agent/admission_controller.md
+++ b/content/en/agent/cluster_agent/admission_controller.md
@@ -1,0 +1,92 @@
+---
+title: Datadog Admission Controller
+kind: documentation
+further_reading:
+- link: "/agent/cluster_agent/clusterchecks/"
+  tag: "Documentation"
+  text: "Running Cluster Checks with Autodiscovery"
+- link: "/agent/cluster_agent/troubleshooting/"
+  tag: "Documentation"
+  text: "Troubleshooting the Datadog Cluster Agent"
+---
+
+## Overview
+The Datadog admission controller is a component of the Datadog Cluster Agent. The main benefit of the admission controller is to simplify the user's application pod configuration. For that, It has two main functionalities:
+
+- Inject environment variables (`DD_AGENT_HOST` and `DD_ENTITY_ID`) to configure DogStatsD and APM tracer libraries into the user's app containers.
+- Inject Datadog standard tags (`env`, `service`, `version`) from app labels into the container environment variables.
+
+## Requirements
+
+- Datadog Cluster Agent 1.7.0
+
+## Configuration
+
+### Helm chart
+
+To enable the admission controller for Helm chart, set the parameter `clusterAgent.admissionController.enabled` to `true`:
+
+{{< code-block lang="yaml" filename="values.yaml" disable_copy="true" >}}
+[...]
+ clusterAgent:
+[...]
+  ## @param admissionController - object - required
+  ## Enable the admissionController to automatically inject APM and
+  ## DogStatsD config and standard tags (env, service, version) into
+  ## your pods
+  #
+  admissionController:
+    enabled: true
+
+    ## @param mutateUnlabelled - boolean - optional
+    ## Enable injecting config without having the pod label:
+    ## admission.datadoghq.com/enabled="true"
+    #
+    mutateUnlabelled: false
+[...]
+{{< /code-block >}}
+
+### Datadog operator
+
+To enable the admission controller for the Datadog operator, set the parameter `clusterAgent.config.admissionController.enabled` to `true` in the custom resource:
+
+```yaml
+[...]
+ clusterAgent:
+[...]
+    config:
+      admissionController:
+        enabled: true
+        mutateUnlabelled: false
+[...]
+```
+
+### APM and DogStatsD
+
+Inject the environment variables `DD_AGENT_HOST` and `DD_ENTITY_ID` to configure DogstatsD clients and APM tracers automatically by using one of the following:
+
+- Add the label `admission.datadoghq.com/enabled: "true"` to your pod.
+- Configure the Cluster Agent admission controller by setting `mutateUnlabelled: true`.
+
+To prevent pods from receiving environment variables, add the label `admission.datadoghq.com/enabled: "false"`. This works even if you set `mutateUnlabelled: true`.
+
+Possible options:
+
+| mutateUnlabelled | Pod label                               | Injection |
+|------------------|-----------------------------------------|-----------|
+| `true`           | No label                                | Yes       |
+| `true`           | `admission.datadoghq.com/enabled=true`  | Yes       |
+| `true`           | `admission.datadoghq.com/enabled=false` | No        |
+| `false`          | No label                                | No        |
+| `false`          | `admission.datadoghq.com/enabled=true`  | Yes       |
+| `false`          | `admission.datadoghq.com/enabled=false` | No        |
+
+#### Notes
+
+- The admission controller needs to be deployed and configured before the creation of new application pods. It cannot update pods that already exist.
+- To disable the admission controller injection feature, use the Cluster Agent configuration: `DD_ADMISSION_CONTROLLER_INJECT_CONFIG_ENABLED=false`
+
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/agent/kubernetes/apm.md
+++ b/content/en/agent/kubernetes/apm.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes trace collection
+title: Kubernetes Trace Collection
 kind: documentation
 aliases:
     - /agent/kubernetes/apm
@@ -85,7 +85,10 @@ To enable APM trace collection, open the DaemonSet configuration file and edit t
 {{< /tabs >}}
    **Note**: On minikube, you may receive an `Unable to detect the kubelet URL automatically` error. In this case, set `DD_KUBELET_TLS_VERIFY=false`.
 
-2. **Configure your application pods to pull the host IP in order to communicate with the Datadog Agent**: Use the downward API to pull the host IP; the application container needs the `DD_AGENT_HOST` environment variable that points to `status.hostIP`.
+2. **Configure your application pods to pull the host IP in order to communicate with the Datadog Agent**:
+
+  - Automatically with the [Datadog Admission Controller][2], or
+  - Manually using the downward API to pull the host IP; the application container needs the `DD_AGENT_HOST` environment variable that points to `status.hostIP`.
 
     ```yaml
         apiVersion: apps/v1
@@ -102,19 +105,19 @@ To enable APM trace collection, open the DaemonSet configuration file and edit t
                         fieldPath: status.hostIP
     ```
 
-3. **Configure your application tracers to emit traces**: Point your application-level tracers to where the Datadog Agent host is using the environment variable `DD_AGENT_HOST`. Refer to the [language-specific APM instrumentation docs][2] for more examples.
+3. **Configure your application tracers to emit traces**: Point your application-level tracers to where the Datadog Agent host is using the environment variable `DD_AGENT_HOST`. Refer to the [language-specific APM instrumentation docs][3] for more examples.
 
 ## Agent Environment Variables
 
-**Note**: As a best practice, Datadog recommends using unified service tagging when assigning tags. Unified service tagging ties Datadog telemetry together through the use of three standard tags: `env`, `service`, and `version`. To learn how to configure your environment with unified tagging, refer to the dedicated [unified service tagging][3] documentation.
+**Note**: As a best practice, Datadog recommends using unified service tagging when assigning tags. Unified service tagging ties Datadog telemetry together through the use of three standard tags: `env`, `service`, and `version`. To learn how to configure your environment with unified tagging, refer to the dedicated [unified service tagging][4] documentation.
 
 List of all environment variables available for tracing within the Agent running in Kubernetes:
 
 | Environment variable       | Description                                                                                                                                                                                                                                                                                                                 |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `DD_API_KEY`               | [Datadog API Key][2]                                                                                                                                                                                                                                                                                                        |
+| `DD_API_KEY`               | [Datadog API Key][3]                                                                                                                                                                                                                                                                                                        |
 | `DD_PROXY_HTTPS`           | Set up the URL for the proxy to use.                                                                                                                                                                                                                                                                                        |
-| `DD_APM_REPLACE_TAGS`      | [Scrub sensitive data from your span’s tags][4].                                                                                                                                                                                                                                                                            |
+| `DD_APM_REPLACE_TAGS`      | [Scrub sensitive data from your span’s tags][5].                                                                                                                                                                                                                                                                            |
 | `DD_HOSTNAME`              | Manually set the hostname to use for metrics if autodection fails, or when running the Datadog Cluster Agent.                                                                                                                                                                                                               |
 | `DD_DOGSTATSD_PORT`        | Set the DogStatsD port.                                                                                                                                                                                                                                                                                                     |
 | `DD_APM_RECEIVER_SOCKET`  | Collect your traces through a Unix Domain Sockets and takes priority over hostname and port configuration if set. Off by default, when set it must point to a valid sock file.                                                                                                                                            |
@@ -126,8 +129,8 @@ List of all environment variables available for tracing within the Agent running
 | `DD_APM_RECEIVER_PORT`     | Port that the Datadog Agent's trace receiver listens on. Default value is `8126`.                                                                                                                                                                                                                                           |
 | `DD_APM_NON_LOCAL_TRAFFIC` | Allow non-local traffic when tracing from other containers. Default value is `true` (Agent 7.18+)                                                                                                                                                                                                                               |
 | `DD_APM_IGNORE_RESOURCES`  | Configure resources for the Agent to ignore. Format should be comma separated, regular expressions. i.e. <code>GET /ignore-me,(GET\|POST) /and-also-me</code>.                                                                                                                                                                          |
-| `DD_APM_ANALYZED_SPANS`    | Configure the spans to analyze for transactions. Format should be comma separated instances of <code>\<SERVICE_NAME>\|;\<OPERATION_NAME>=1</code>. i.e. <code>my-express-app\|;express.request=1,my-dotnet-app\|;aspnet_core_mvc.request=1</code>. You can also [enable it automatically][5] with the configuration parameter in the Tracing Client. |
-| `DD_ENV`               | Sets the global `env` for all data emitted by the Agent. If `env` is not present in your trace data, this variable will be used. See [APM environment setup][6] for more details.                                                                                                                                                                                                                                                                         |
+| `DD_APM_ANALYZED_SPANS`    | Configure the spans to analyze for transactions. Format should be comma separated instances of <code>\<SERVICE_NAME>\|;\<OPERATION_NAME>=1</code>. i.e. <code>my-express-app\|;express.request=1,my-dotnet-app\|;aspnet_core_mvc.request=1</code>. You can also [enable it automatically][6] with the configuration parameter in the Tracing Client. |
+| `DD_ENV`               | Sets the global `env` for all data emitted by the Agent. If `env` is not present in your trace data, this variable will be used. See [APM environment setup][7] for more details.                                                                                                                                                                                                                                                                         |
 | `DD_APM_MAX_EPS`           | Sets the maximum Analyzed Spans per second. Default is 200 events per second.                                                                                                                                                                                                                                               |
 | `DD_APM_MAX_TPS`           | Sets the maximum traces per second. Default is 10 traces per second.                                                                                                                                                                                                                                                        |
 
@@ -136,8 +139,9 @@ List of all environment variables available for tracing within the Agent running
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /agent/kubernetes/
-[2]: /tracing/setup/
-[3]: /getting_started/tagging/unified_service_tagging
-[4]: /tracing/guide/security/#replace-rules
-[5]: /tracing/app_analytics/#automatic-configuration
-[6]: /tracing/guide/setting_primary_tags_to_scope/#environment
+[2]: /agent/cluster_agent/admission_controller/
+[3]: /tracing/setup/
+[4]: /getting_started/tagging/unified_service_tagging
+[5]: /tracing/guide/security/#replace-rules
+[6]: /tracing/app_analytics/#automatic-configuration
+[7]: /tracing/guide/setting_primary_tags_to_scope/#environment

--- a/content/en/developers/guide/unified-tagging-advanced-usage.md
+++ b/content/en/developers/guide/unified-tagging-advanced-usage.md
@@ -7,13 +7,13 @@ aliases:
 
 ## Overview
 
-This guide suggests ways to configure and migrate to [unified service tagging][1] based on specific use cases.
+This guide shows ways to configure and migrate to [unified service tagging][1] based on specific use cases.
 
-## Using Custom Tags
+## Custom tags
 
 You can continue to use the `env` `service` and `version` tags as they are configured for unified service tagging. However, if you'd like to achieve a unified tagging experience with your own custom tags, there are several options available which are listed below.
 
-**Note**: While some products support arbitrary tags, others have more specific expectations. As such, navigation between products might be difficult if one data source has a tag that another does not have or does not support.
+**Note**: While some products support arbitrary tags, others have more specific expectations. As such, navigation between products might be difficult if one data source has a tag that another does not have or support.
 
 ### Containerized environments
 
@@ -23,28 +23,27 @@ Since tags can be appended to data points, you have a lot of freedom in setting 
 
 #### APM
 
-`env` and `service` are core tags in APM, so it is not possible to replace them with differently named tags. However, APM does allow for data to be [aggregated along more primary tags][2] than just `env`. Since host tags are added to traces and trace metrics, they can be used as well (e.g., availability-zone).
+`env` and `service` are core tags in APM, so it is not possible to replace them with differently named tags. However, APM does allow for data to be [aggregated along more primary tags][2] than just `env`. Host tags, such as `availability-zone`, that are added to traces and trace metrics can be used as well.
 
-Autodiscovered tags associated with containers are added to `container_info` in span metadata. However, these container tags are not part of the [whitelisted tags][3] for trace metrics.
-
+Autodiscovered tags associated with containers are added to `container_info` in span metadata. However, these container tags are not part of the [included list of tags][3] for trace metrics.
 
 #### Logs
 
-Similar to APM, `service` is a core tag that is used to help organize logs data. Additionally, it is not possible to link from a log to the related APM service without it.
+Similar to APM, `service` is a core tag that is used to help organize log data. Additionally, it is not possible to link from a log to the related APM service without it.
 
-Similar to metrics, however, Autodiscovered tags for the container as well as host tags for the agent are added to all logs.
+Similar to metrics, Autodiscovered tags for a container and host tags for the Agent are added to all logs.
 
-You also have the ability to add custom fields to your logs in-code, which can be mapped to tags or attributes downstream in a [Datadog log processing pipeline][4].
+Also, you can add custom fields to your logs in-code that can be mapped to tags or attributes downstream in a [Datadog log processing pipeline][4].
 
-## Using Standard Labels
+## Standard labels
 
-We recommend using both standard labels and environment variables. However, standard labels can be seen as an alternative to using environment variables, particularly for applications that will not benefit from using those variables in their runtime. 3rd party software like Redis, MySQL, and Nginx are a few examples. Since these services still generate infrastructure metrics and data from integration checks, it's valuable to have all of that data tagged with `env`, `service`, and `version`.
+Datadog recommends using both standard labels and environment variables. However, standard labels can be seen as an alternative to using environment variables, particularly for applications that do not benefit from using those variables in their runtime. Third party software like Redis, MySQL, and Nginx are a few examples. Since these services still generate infrastructure metrics and data from integration checks, it's valuable to have all of that data tagged with `env`, `service`, and `version`.
 
 If you would like to tag Kubernetes state metrics with `env`, `service`, and `version` then the standard labels offer the easiest way. The `DD` environment variables of a container cannot be used by the Agent to tag these metrics, so the labels are a more natural option.
 
 ### Declaring environment as a label
 
-Configuring `env` closer to the source of the data (e.g., APM traces, logs) helps to avoid inconsistencies where the Agent `env` might be different. Making `env` part of the service's configuration guarantees a service-centric source of truth.
+Configuring `env` closer to the source of the data, such as APM traces or logs, helps to avoid inconsistencies where the Agent `env` might be different. Making `env` part of the service's configuration guarantees a service-centric source of truth.
 
 ### Using standard labels with existing Kubernetes tags annotation
 
@@ -63,7 +62,27 @@ tags.datadoghq.com/<container>.service
 tags.datadoghq.com/<container>.version
 ```
 
+### Standard tags injection
+
+The [Datadog Admission Controller][5] converts standard tag labels into environment variables, and injects them into the user's application pod template. These environment variables are used by the APM tracers, DogStatsD clients, and the Datadog Agent. The Datadog Agent maps these values to tags:
+
+```
+tags.datadoghq.com/version -> DD_VERSION
+tags.datadoghq.com/env -> DD_ENV
+tags.datadoghq.com/service -> DD_SERVICE
+```
+
+The admission controller looks for this information in the pod labels. If not found at the pod level, the admission controller tries to get the information from the pod owner object's labels (deployment, job, cron job, statefulset).
+
+#### Notes
+
+- The admission controller needs to be deployed and configured before the creation of new application pods. It cannot update pods that already exist.
+- The admission controller doesn't inject the environment variables `DD_VERSION, DD_ENV`, and `DD_SERVICE` if they already exist.
+- To disable the admission controller injection feature, use the Cluster Agent configuration: `DD_ADMISSION_CONTROLLER_INJECT_CONFIG_ENABLED=false`
+
+
 [1]: /getting_started/tagging/unified_service_tagging
 [2]: /tracing/guide/setting_primary_tags_to_scope/
 [3]: /metrics/distributions/#customize-tagging
 [4]: /logs/processing/pipelines/
+[5]: /agent/cluster_agent/admission_controller/


### PR DESCRIPTION
### What does this PR do?
- Add page for Datadog Admission Controller
- Add info on Datadog Admission Controller to Kubernetes, APM and Unified Tagging

### Motivation
Jira request

### Preview links
https://docs-staging.datadoghq.com/ruth/docs-1040/agent/cluster_agent/admission_controller/
https://docs-staging.datadoghq.com/ruth/docs-1040/agent/kubernetes/apm/?tab=helm#setup
https://docs-staging.datadoghq.com/ruth/docs-1040/developers/guide/unified-tagging-advanced-usage/

### Additional Notes
N/A
