### PR TITLE
Notifications only fire for automated tests

### DIFF
--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -62,7 +62,7 @@ You can customize alert conditions to define the circumstances under which you w
 
 ### Notify your team
 
-A notification is sent according to the set of alerting conditions. To configure your notifications:
+A notification is sent according to the set of alerting conditions. Notifications are only sent for automated tests. Notifications are not sent when tests are manually triggered by **Run Test Now**. To configure your notifications:
 
 1. Enter a **message** for the browser test. This field allows standard [Markdown formatting][5] and supports the following [conditional variables][6]:
 


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Added a note that Synthetic Browser Tests only trigger notifications on automated runs, not via "Run Test Now"

### Motivation
I spent quite a bit of time wondering why the notifications weren't sending, re-reading this bit of the docs to see what I missed  and then opened a support ticket for help! They told me that it's working as it's supposed to!

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Hope I've helped!