### PR TITLE
Unified service tagging edits for log collection

### DIFF
--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -51,7 +51,7 @@ After you have [enabled log collection][1], configure your application language 
 
 {{< partial name="logs/logs-languages.html" >}}
 
-## Container Log collection
+## Container Log Collection
 
 The Datadog Agent can [collect logs directly from container stdout/stderr][13] without using a logging driver. When the Agent's Docker check is enabled, container and orchestrator metadata are automatically added as tags to your logs.
 It is possible to collect logs from all your containers or [only a subset filtered by container image, label, or name][14]. Autodiscovery can also be used to [configure log collection directly in the container labels][15]. In Kubernetes environments you can also leverage [the daemonset installation][16].
@@ -60,17 +60,17 @@ Choose your environment below to get dedicated log collection instructions:
 
 {{< partial name="logs/logs-containers.html" >}}
 
-## Serverless Log collection
+## Serverless Log Collection
 
 Datadog collects logs from AWS Lambda. To enable this, refer to the [AWS Lambda integration documentation][17].
 
-## Cloud Providers Log collection
+## Cloud Providers Log Collection
 
 Select your Cloud provider below to see how to automatically collect your logs and forward them to Datadog:
 
 {{< partial name="logs/logs-cloud.html" >}}
 
-## Custom Log forwarder
+## Custom Log Forwarder
 
 Any custom process or [logging library][18] able to forward logs through **TCP** or **HTTP** can be used in conjunction with Datadog Logs.
 
@@ -239,8 +239,6 @@ Endpoints that can be used to send logs to Datadog EU region:
 
 ## Reserved attributes
 
-**Note**: As a best practice for log collection, Datadog recommends using unified service tagging when assigning tags and environment variables. Unified service tagging ties Datadog telemetry together through the use of three standard tags: `env`, `service`, and `version`. To learn how to configure your environment with unified tagging, refer to the dedicated [unified service tagging][22] documentation.
-
 Here are some key attributes you should pay attention to when setting up your project:
 
 | Attribute | Description                                                                                                                                                                                                                                |
@@ -254,6 +252,10 @@ Here are some key attributes you should pay attention to when setting up your pr
 Your logs are collected and centralized into the [Log Explorer][21] view. You can also search, enrich, and alert on your logs.
 
 {{< img src="logs/log_explorer_view.png" alt="Log Explorer view"  >}}
+
+### Unified service tagging
+
+As a best practice for log collection, Datadog recommends configuring unified service tagging to tie Datadog telemetry together through the use of three standard tags: `env`, `service`, and `version`. Refer to the dedicated [unified service tagging][22] documentation to configure unified service tagging.
 
 ### How to get the most of your application logs
 


### PR DESCRIPTION
### What does this PR do?

- Moves unified service tagging into it's own section to avoid confusion during attribute assignment
- Updates to a few incorrect headers

### Motivation
Jira request

### Preview link
https://docs-staging.datadoghq.com/sarina/ust-logs/logs/log_collection/