### PR TITLE
Update RUM Session Definition in Billing Page

### DIFF
--- a/content/en/account_management/billing/pricing.md
+++ b/content/en/account_management/billing/pricing.md
@@ -49,7 +49,7 @@ Datadog has many pricing plans to fit your needs. For more information, see the 
 
 ## Real User Monitoring
 
-* A **session** is a user journey on your web application. It expires after 15 minutes of inactivity.
+* A **session** is a user journey on your web application. It either expires after 15 minutes of inactivity or 4 hours of continuous activity.
 
 * Datadog collects all the pages visited by your end users along with the telemetry that matters: resources loading (XHRs, images, CSS files, JS scripts, etc), frontend errors, and long tasks. All of this is included in the user session. Datadog charges per ten thousand (10,000) sessions ingested in the Datadog Real User Monitoring (RUM) service.
 

--- a/content/en/account_management/billing/pricing.md
+++ b/content/en/account_management/billing/pricing.md
@@ -49,7 +49,7 @@ Datadog has many pricing plans to fit your needs. For more information, see the 
 
 ## Real User Monitoring
 
-* A **session** is a user journey on your web application. It either expires after 15 minutes of inactivity or 4 hours of continuous activity.
+* A **session** is a user journey on your web application. It expires after either 15 minutes of inactivity, or 4 hours of continuous activity.
 
 * Datadog collects all the pages visited by your end users along with the telemetry that matters: resources loading (XHRs, images, CSS files, JS scripts, etc), frontend errors, and long tasks. All of this is included in the user session. Datadog charges per ten thousand (10,000) sessions ingested in the Datadog Real User Monitoring (RUM) service.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This is an update to the Billing Page to correct the definition of RUM Sessions. This has been vetted and confirmed by @gabriel-james-safar and Aaron Fischer from Legal.

### Motivation
<!-- What inspired you to submit this pull request?-->
The previous information shared in the docs was not complete.

### Preview link
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/account_management/billing/pricing/#real-user-monitoring

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
