### PR TITLE
fix(docs): change 'versions' to 'version' in unified tagging doc

### DIFF
--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -40,7 +40,7 @@ To begin configuration of unified service tagging, choose your environment:
 
 ### Containerized environment
 
-In containerized environments, `env`, `service`, and `versions` are set through environment variables or standard labels in your Datadog Agent configuration file. Since the agent associates data collected with a specific container, the configuration for these tags can reside within the container's metadata.
+In containerized environments, `env`, `service`, and `version` are set through environment variables or standard labels in your Datadog Agent configuration file. Since the agent associates data collected with a specific container, the configuration for these tags can reside within the container's metadata.
 
 To setup unified service tagging in a containerized environment:
 


### PR DESCRIPTION
### What does this PR do?
Update--what I believe to be--a typo from the tag `versions` to the tag `version` in the Unified Service Tagging doc.

### Motivation
My DataDog rep told me I can submit PRs for these types of things and I happened to come across this while reading.

### Preview link
https://docs-staging.datadoghq.com/fix_unified_tagging_typo/content/en/getting_started/tagging/unified_service_tagging.md

### Additional Notes