### PR TITLE
[static] Add configuration for Elastic Beanstalk on Amazon Linux 2

### DIFF
--- a/static/config/99datadog-amazon-linux-2.config
+++ b/static/config/99datadog-amazon-linux-2.config
@@ -1,0 +1,71 @@
+# .ebextensions/99datadog-amazon-linux-2.config
+option_settings:
+    - namespace:  aws:elasticbeanstalk:application:environment
+      option_name:  DD_API_KEY
+      value:  "<YOUR_DD_API_KEY>"
+    - namespace:  aws:elasticbeanstalk:application:environment
+      option_name:  DD_AGENT_VERSION
+      value:  "" # For example, "7.21.1". Leave empty to install the latest version. Only Agent 7 is supported.
+files:
+    "/configure_datadog_yaml.sh":
+        mode: "000700"
+        owner: root
+        group: root
+        content: |
+            #!/bin/bash
+            sed 's/api_key:.*/api_key: '$DD_API_KEY'/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+
+    "/datadog/datadog.repo":
+        mode: "000644"
+        owner: root
+        group: root
+        content: |
+            [datadog]
+            name = Datadog, Inc.
+            baseurl = https://yum.datadoghq.com/stable/7/x86_64/
+            enabled=1
+            gpgcheck=1
+            gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+            
+    "/start_datadog.sh":
+        mode: "000700"
+        owner: root
+        group: root
+        content: |
+            #!/bin/bash
+            STATUS=$(sudo systemctl status datadog-agent)
+            if [[ "$STATUS" == *"active (running)"* ]]
+              then
+                echo "Agent already running"
+              else
+                echo "Agent starting..."
+                sudo systemctl start datadog-agent
+            fi
+
+    "/stop_datadog.sh":
+        mode: "000700"
+        owner: root
+        group: root
+        content: |
+            #!/bin/bash
+            STATUS=$(sudo systemctl status datadog-agent)
+            if [[ "$STATUS" == *"active (running)"* ]]
+              then
+                echo "Agent stopping..."
+                sudo systemctl stop datadog-agent
+              else
+                echo "Agent already stopped"
+            fi
+
+
+container_commands:
+    02stop_datadog:
+        command: "/stop_datadog.sh"
+    04install_datadog:
+        test: '[ -f /datadog/datadog.repo ]'
+        command: 'cp /datadog/datadog.repo /etc/yum.repos.d/datadog.repo; yum -y makecache; yum -y install datadog-agent${DD_AGENT_VERSION:+-$DD_AGENT_VERSION-1}'
+    05setup_datadog:
+        test: '[ -x /configure_datadog_yaml.sh ]'
+        command: "/configure_datadog_yaml.sh"
+    06start_datadog:
+        command: "/start_datadog.sh"

--- a/static/config/99datadog.config
+++ b/static/config/99datadog.config
@@ -5,7 +5,7 @@ option_settings:
       value:  "<YOUR_DD_API_KEY>"
     - namespace:  aws:elasticbeanstalk:application:environment
       option_name:  DD_AGENT_VERSION
-      value:  "" # For example, "7.16.0". Leave empty to install the latest version. Only Agent 7 is supported.
+      value:  "" # For example, "7.21.1". Leave empty to install the latest version. Only Agent 7 is supported.
 files:
     "/configure_datadog_yaml.sh":
         mode: "000700"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
- Add configuration for Elastic Beanstalk Datadog Agent extension on Amazon Linux 2.

### Motivation
<!-- What inspired you to submit this pull request?-->
- Customer provided an updated version 

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

n/a

### Additional Notes
<!-- Anything else we should know when reviewing?-->

See related PR below