### PR TITLE
Troubleshooting missing Syn notification

### DIFF
--- a/content/en/synthetics/troubleshooting/_index.md
+++ b/content/en/synthetics/troubleshooting/_index.md
@@ -51,6 +51,10 @@ If you observe `403 Forbidden` errors returned by Synthetic tests, it may be the
 
 Additionally, you might also have to ensure [Datadog Synthetics' IP ranges][7] are allowed as traffic sources by your firewalls.
 
+### Missing notifications
+
+Synthetic tests by default do not [renotify][8]. This means that if you add your notification handle (email address, Slack handle, etc.) after a transition got generated (e.g., test going into alert or recovering from a previous alert), no notification is sent for that very transition. A notification will be sent for the next transition.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -62,3 +66,4 @@ Additionally, you might also have to ensure [Datadog Synthetics' IP ranges][7] a
 [5]: /synthetics/api_tests/?tab=httptest#use-global-variables
 [6]: /synthetics/browser_tests/#use-global-variables
 [7]: https://ip-ranges.datadoghq.com/synthetics.json
+[8]: /synthetics/api_tests/?tab=httptest#notify-your-team


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR adds a note on a possible root cause of missing notifs

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
