### PR TITLE
Add note about supported Terraform provider versions to SLO Alerting Docs

### DIFF
--- a/content/en/monitors/service_level_objectives/error_budget.md
+++ b/content/en/monitors/service_level_objectives/error_budget.md
@@ -40,6 +40,8 @@ error_budget("slo_id").over("time_window") > 75
 
 In addition, SLO error budget monitors can also be created using the [datadog_monitor resource in Terraform][5]. Below is an example `.tf` for configuring an error budget monitor for a metric-based SLO using the same example query as above.
 
+**Note:** SLO error budget monitors are currently only supported in v2.7.0 or earlier of the provider. Support for v2.8.0 and later will be coming at a later date.
+
 ```
 resource "datadog_monitor" "metric-based-slo" {
     name = "SLO Error Budget Alert Example"

--- a/content/en/monitors/service_level_objectives/error_budget.md
+++ b/content/en/monitors/service_level_objectives/error_budget.md
@@ -40,7 +40,7 @@ error_budget("slo_id").over("time_window") > 75
 
 In addition, SLO error budget monitors can also be created using the [datadog_monitor resource in Terraform][5]. Below is an example `.tf` for configuring an error budget monitor for a metric-based SLO using the same example query as above.
 
-**Note:** SLO error budget monitors are currently only supported in v2.7.0 or earlier of the provider. Support for v2.8.0 and later will be coming at a later date.
+**Note:** SLO error budget monitors are only supported in Terraform provider v2.7.0 or earlier.
 
 ```
 resource "datadog_monitor" "metric-based-slo" {


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds a note about which versions of the Terraform provider support SLO alerts.

### Motivation
<!-- What inspired you to submit this pull request?-->
Confusion amongst private beta users revealed that this information was missing from the docs

### Preview link
<!-- Impacted pages preview links-->


<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/markazerdd/terraform-versions/monitors/service_level_objectives/error_budget/#api-and-terraform

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
