### PR TITLE
Change required agent from v7.2 to v7.20

### DIFF
--- a/content/en/agent/guide/autodiscovery-management.md
+++ b/content/en/agent/guide/autodiscovery-management.md
@@ -51,7 +51,7 @@ DD_CONTAINER_EXCLUDE = "image:dockercloud/network-daemon image:dockercloud/clean
 
 You can use a regex to ignore them all: `DD_CONTAINER_EXCLUDE = "image:dockercloud/*"`
 
-In Agent v7.2+, you can also use exclusion rules to exclude only logs or only metrics. For instance, to exclude logs from a container with the image `<IMAGE_NAME>`, add the following environment variable to the Datadog Agent:
+In Agent v7.20+, you can also use exclusion rules to exclude only logs or only metrics. For instance, to exclude logs from a container with the image `<IMAGE_NAME>`, add the following environment variable to the Datadog Agent:
 
 ```shell
 DD_CONTAINER_EXCLUDE_LOGS = "image:<IMAGE_NAME>"
@@ -84,7 +84,7 @@ To remove a given Docker container with the name `<NAME>` from Autodiscovery, ad
 container_exclude: [name:<NAME>]
 ```
 
-In Agent v7.2+, you can also use exclusion rules to exclude only logs or only metrics. For instance, to exclude logs from a container with the image `<IMAGE_NAME>`, add the following environment variable to the Datadog Agent:
+In Agent v7.20+, you can also use exclusion rules to exclude only logs or only metrics. For instance, to exclude logs from a container with the image `<IMAGE_NAME>`, add the following environment variable to the Datadog Agent:
 
 ```shell
 container_exclude_logs: [image:<IMAGE_NAME>]


### PR DESCRIPTION
https://github.com/DataDog/datadog-agent/releases/tag/7.20.0

container_exclude_metrics and container_include_metrics can be used to filter metrics collection for autodiscovered containers. container_exclude_logs and container_include_logs can be used to filter logs collection for autodiscovered containers.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

container_exclude_metrics, container_include_metrics, container_exclude_logs, container_include_logs are features introduced in 7.20.0, not 7.2.0.
https://github.com/DataDog/datadog-agent/releases/tag/7.20.0

### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadog.zendesk.com/agent/tickets/375159

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
