### PR TITLE
Add kubernetes example for DD_APM_REPLACE_TAGS

### DIFF
--- a/content/en/tracing/guide/security.md
+++ b/content/en/tracing/guide/security.md
@@ -102,6 +102,28 @@ DD_APM_REPLACE_TAGS=[
 ```
 
 {{% /tab %}}
+{{% tab "Kubernetes" %}}
+NOTE: Make sure you put this environment variable in the trace-agent container if you are using the recommended [daemonset configuration](https://docs.datadoghq.com/agent/kubernetes/?tab=daemonset).
+```datadog-agent.yaml
+- name: DD_APM_REPLACE_TAGS
+  value: '[
+            {
+              "name": "http.url",
+              "pattern": "token/(.*)",
+              "repl": "?"
+            },
+            {
+              "name": "*",
+              "pattern": "foo",
+              "repl": "bar"
+            },
+            {
+              "name": "error.stack",
+              "pattern": "(?s).*"
+            }
+          ]'
+```
+{{% /tab %}}
 {{< /tabs >}}
 
 [1]: /tracing/visualization/#trace


### PR DESCRIPTION
Add a kubernetes example to make the subtle differences clearer (must be defined as a string and must be in the trace-agent container for the daemonset).

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
