### PR TITLE
Fix KeyValue delimiter example 

### DIFF
--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -250,8 +250,8 @@ Other examples:
 | key:"/valueStr"              | `%{data::keyvalue(":", "/")}`          | {"key": "/valueStr"}                  |
 | /key:/valueStr               | `%{data::keyvalue(":", "/")}`          | {"/key": "/valueStr"}                 |
 | key:={valueStr}              | `%{data::keyvalue(":=", "", "{}")}`    | {"key": "valueStr"}                   |
-| key1=value1\|key2=value2     | `%{data::keyvalue("=", "", "", "\|")}` | {"key1": "value1", "key2": "value2"}  |
-| key1="value1"\|key2="value2" | `%{data::keyvalue("=", "", "", "\|")}` | {"key1": "value1", "key2": "value2"}  |
+| key1=value1\|key2=value2     | `%{data::keyvalue("=", "", "", "|")}` | {"key1": "value1", "key2": "value2"}  |
+| key1="value1"\|key2="value2" | `%{data::keyvalue("=", "", "", "|")}` | {"key1": "value1", "key2": "value2"}  |
 
 **Multiple QuotingString example**: When multiple quotingstring are defined, the default behavior is replaced with a defined quoting character.
 The key-value always matches inputs without any quoting characters, regardless of what is specified in `quotingStr`. When quoting characters are used, the `characterWhiteList` is ignored as everything between the quoting characters is extracted.


### PR DESCRIPTION

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fix KeyValue delimiter example 

### Motivation
I realised that the example was wrong (no need to escape pipes in markdown table if it's quoted with `). 

### Preview link

https://docs-staging.datadoghq.com/pvr/fix-keyvalue-delimiter/logs/processing/parsing/?tab=matcher#key-value-or-logfmt

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
