### PR TITLE
Regenerate the kubernetes sample manifests from the latest version of the Helm chart

### DIFF
--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -155,7 +155,7 @@ NAME                    TYPE           CLUSTER-IP       EXTERNAL-IP        PORT(
 datadog-cluster-agent   ClusterIP      10.100.202.234   none               5005/TCP         1d
 ```
 
-**Note**: If you already have the Datadog Agent running, you may need to apply the [rbac-agent.yaml manifest](#step-1-set-configure-rbac-permissions-for-node-based-agents) before the Cluster Agent can start running.
+**Note**: If you already have the Datadog Agent running, you may need to apply the [agent-rbac.yaml manifest](#step-1-set-configure-rbac-permissions-for-node-based-agents) before the Cluster Agent can start running.
 
 ## Configure the Datadog Agent
 
@@ -165,9 +165,9 @@ After having set up the Datadog Cluster Agent, configure your Datadog Agent to c
 
 #### Step 1 - Set Configure RBAC permissions for node-based Agents
 
-1. Download the the [rbac-agent.yaml manifest][8]. **Note**: When using the Cluster Agent, your node Agents are not able to interact with the Kubernetes API server—only the Cluster Agent is able to do so.
+1. Download the the [agent-rbac.yaml manifest][8]. **Note**: When using the Cluster Agent, your node Agents are not able to interact with the Kubernetes API server—only the Cluster Agent is able to do so.
 
-2. Run: `kubectl apply -f rbac-agent.yaml`
+2. Run: `kubectl apply -f agent-rbac.yaml`
 
 #### Step 2 - Enable the Datadog Agent
 

--- a/content/fr/agent/cluster_agent/setup.md
+++ b/content/fr/agent/cluster_agent/setup.md
@@ -154,7 +154,7 @@ NAME                    TYPE           CLUSTER-IP       EXTERNAL-IP        PORT(
 datadog-cluster-agent   ClusterIP      10.100.202.234   none               5005/TCP         1d
 ```
 
-**Remarque** : si l'Agent Datadog s'exécute déjà, vous devrez peut-être appliquer le [manifeste rbac-agent.yaml](#etape-1-configurer-les-autorisations-rbac) avant que l'Agent de cluster ne puisse s'exécuter.
+**Remarque** : si l'Agent Datadog s'exécute déjà, vous devrez peut-être appliquer le [manifeste agent-rbac.yaml](#etape-1-configurer-les-autorisations-rbac) avant que l'Agent de cluster ne puisse s'exécuter.
 
 ## Configurer l'Agent Datadog
 
@@ -164,9 +164,9 @@ Une fois l'Agent de cluster Datadog configuré, configurez votre Agent Datadog d
 
 #### Étape 1 : Configurer les autorisations RBAC des Agents de nœud
 
-1. Téléchargez le [manifeste rbac-agent.yaml][7]. **Remarque** : lorsque vous utilisez l'Agent de cluster, vos Agents de nœud ne peuvent pas interagir avec le serveur d'API Kubernetes ; seul l'Agent de cluster peut le faire.
+1. Téléchargez le [manifeste agent-rbac.yaml][8]. **Remarque** : lorsque vous utilisez l'Agent de cluster, vos Agents de nœud ne peuvent pas interagir avec le serveur d'API Kubernetes ; seul l'Agent de cluster peut le faire.
 
-2. Exécutez : `kubectl apply -f rbac-agent.yaml`.
+2. Exécutez : `kubectl apply -f agent-rbac.yaml`.
 
 #### Étape 2 : Activer l'Agent Datadog
 

--- a/static/resources/yaml/datadog-agent-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-all-features.yaml
@@ -23,9 +23,12 @@ data:
     system_probe_config:
       enabled: true
       debug_port:  0
-      sysprobe_socket: /opt/datadog-agent/run/sysprobe.sock
-      enable_conntrack : true
+      sysprobe_socket: /var/run/sysprobe/sysprobe.sock
+      enable_conntrack: true
       bpf_debug: false
+      enable_tcp_queue_length: false
+      enable_oom_kill: false
+      collect_dns_stats: false
 ---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
@@ -113,11 +116,13 @@ data:
             "lseek",
             "lstat",
             "lstat64",
+            "madvise",
             "mkdir",
             "mkdirat",
             "mmap",
             "mmap2",
             "mprotect",
+            "mremap",
             "munmap",
             "nanosleep",
             "newfstatat",
@@ -130,6 +135,7 @@ data:
             "poll",
             "ppoll",
             "prctl",
+            "pread64",
             "prlimit64",
             "pselect6",
             "read",
@@ -231,282 +237,310 @@ spec:
         container.seccomp.security.alpha.kubernetes.io/system-probe: localhost/system-probe
     spec:
       containers:
-      - name: agent
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["agent", "start"]
-        resources: {}
-        ports:
-        - containerPort: 8125
-          name: dogstatsdport
-          protocol: UDP
-        env:
-        - name: DD_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: "datadog-agent"
-              key: api-key
-        - name: DD_KUBERNETES_KUBELET_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: KUBERNETES
-          value: "yes"
-        - name: DOCKER_HOST
-          value: unix:///host/var/run/docker.sock
-        - name: DD_LOG_LEVEL
-          value: "INFO"
-        - name: DD_DOGSTATSD_PORT
-          value: "8125"
-        - name: DD_APM_ENABLED
-          value: "false"
-        - name: DD_LOGS_ENABLED
-          value: "true"
-        - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
-          value: "true"
-        - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
-          value: "true"
-        - name: DD_HEALTH_PORT
-          value: "5555"
-        - name: SYSTEM_PROBE_CONFIG_SYSPROBE_SOCKET
-          value: /sysprobe/var/run
-        volumeMounts:
-        - name: config
-          mountPath: /etc/datadog-agent
-        - name: runtimesocketdir
-          mountPath: /host/var/run
-          readOnly: true
-        - name: sysprobe-socket-dir
-          mountPath: /sysprobe/var/run
-          readOnly: true
-        - name: procdir
-          mountPath: /host/proc
-          readOnly: true
-        - name: cgroups
-          mountPath: /host/sys/fs/cgroup
-          readOnly: true
-        - name: pointerdir
-          mountPath: /opt/datadog-agent/run
-        - name: logpodpath
-          mountPath: /var/log/pods
-          readOnly: true
-        - name: logdockercontainerpath
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-        livenessProbe:
-          failureThreshold: 6
-          httpGet:
-            path: /health
-            port: 5555
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          successThreshold: 1
-          timeoutSeconds: 5
-      - name: trace-agent
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
-        resources: {}
-        ports:
-        - containerPort: 8126
-          hostPort: 8126
-          name: traceport
-          protocol: TCP
-        env:
-        - name: DD_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: "datadog-agent"
-              key: api-key
-        - name: DD_KUBERNETES_KUBELET_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: KUBERNETES
-          value: "yes"
-        - name: DOCKER_HOST
-          value: unix:///host/var/run/docker.sock
-        - name: DD_LOG_LEVEL
-          value: "INFO"
-        - name: DD_APM_ENABLED
-          value: "true"
-        - name: DD_APM_NON_LOCAL_TRAFFIC
-          value: "true"
-        - name: DD_APM_RECEIVER_PORT
-          value: "8126"
-        volumeMounts:
-        - name: config
-          mountPath: /etc/datadog-agent
-        - name: runtimesocketdir
-          mountPath: /host/var/run
-          readOnly: true
-        livenessProbe:
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          tcpSocket:
-            port: 8126
-          timeoutSeconds: 5
-      - name: process-agent
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
-        resources: {}
-        env:
-        - name: DD_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: "datadog-agent"
-              key: api-key
-        - name: DD_KUBERNETES_KUBELET_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: KUBERNETES
-          value: "yes"
-        - name: DOCKER_HOST
-          value: unix:///host/var/run/docker.sock
-        - name: DD_PROCESS_AGENT_ENABLED
-          value: "true"
-        - name: DD_LOG_LEVEL
-          value: "INFO"
-        - name: DD_SYSTEM_PROBE_ENABLED
-          value: "true"
-        volumeMounts:
-        - name: config
-          mountPath: /etc/datadog-agent
-        - name: runtimesocketdir
-          mountPath: /host/var/run
-          readOnly: true
-        - name: cgroups
-          mountPath: /host/sys/fs/cgroup
-          readOnly: true
-        - name: passwd
-          mountPath: /etc/passwd
-        - name: procdir
-          mountPath: /host/proc
-          readOnly: true
-        - name: sysprobe-socket-dir
-          mountPath: /opt/datadog-agent/run
-          readOnly: true
-      - name: system-probe
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        securityContext:
-          capabilities:
-            add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "IPC_LOCK"]
-        command: ["/opt/datadog-agent/embedded/bin/system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
-        env:
-        - name: DD_LOG_LEVEL
-          value: "INFO"
-        resources: {}
-        volumeMounts:
-        - name: debugfs
-          mountPath: /sys/kernel/debug
-        - name: sysprobe-config
-          mountPath: /etc/datadog-agent
-        - name: sysprobe-socket-dir
-          mountPath: /opt/datadog-agent/run
-        - name: procdir
-          mountPath: /host/proc
-          readOnly: true
+        - name: agent
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["agent", "run"]
+          resources: {}
+          ports:
+            - containerPort: 8125
+              name: dogstatsdport
+              protocol: UDP
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DOCKER_HOST
+              value: unix:///host/var/run/docker.sock
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
+            - name: DD_APM_ENABLED
+              value: "false"
+            - name: DD_LOGS_ENABLED
+              value: "true"
+            - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
+              value: "true"
+            - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
+              value: "true"
+            - name: DD_HEALTH_PORT
+              value: "5555"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              readOnly: true
+            - name: sysprobe-socket-dir
+              mountPath: /var/run/sysprobe
+              readOnly: true
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
+            - name: procdir
+              mountPath: /host/proc
+              readOnly: true
+            - name: cgroups
+              mountPath: /host/sys/fs/cgroup
+              readOnly: true
+            - name: pointerdir
+              mountPath: /opt/datadog-agent/run
+            - name: logpodpath
+              mountPath: /var/log/pods
+              readOnly: true
+            - name: logdockercontainerpath
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+          livenessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /live
+              port: 5555
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /ready
+              port: 5555
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+        - name: trace-agent
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
+          resources: {}
+          ports:
+            - containerPort: 8126
+              hostPort: 8126
+              name: traceport
+              protocol: TCP
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DOCKER_HOST
+              value: unix:///host/var/run/docker.sock
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_APM_ENABLED
+              value: "true"
+            - name: DD_APM_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_APM_RECEIVER_PORT
+              value: "8126"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            tcpSocket:
+              port: 8126
+            timeoutSeconds: 5
+        - name: process-agent
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
+          resources: {}
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DOCKER_HOST
+              value: unix:///host/var/run/docker.sock
+            - name: DD_PROCESS_AGENT_ENABLED
+              value: "true"
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_SYSTEM_PROBE_ENABLED
+              value: "true"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              readOnly: true
+            - name: cgroups
+              mountPath: /host/sys/fs/cgroup
+              readOnly: true
+            - name: passwd
+              mountPath: /etc/passwd
+            - name: procdir
+              mountPath: /host/proc
+              readOnly: true
+            - name: sysprobe-socket-dir
+              mountPath: /var/run/sysprobe
+              readOnly: true
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
+        - name: system-probe
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "IPC_LOCK"]
+          command: ["/opt/datadog-agent/embedded/bin/system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
+          env:
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+          resources: {}
+          volumeMounts:
+            - name: debugfs
+              mountPath: /sys/kernel/debug
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent
+            - name: sysprobe-socket-dir
+              mountPath: /var/run/sysprobe
+            - name: procdir
+              mountPath: /host/proc
+              readOnly: true
+            - name: modules
+              mountPath: /lib/modules
+              readOnly: true
+            - name: src
+              mountPath: /usr/src
+              readOnly: true
       initContainers:
-      - name: init-volume
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["bash", "-c"]
-        args:
-        - cp -r /etc/datadog-agent /opt
-        volumeMounts:
-        - name: config
-          mountPath: /opt/datadog-agent
-        resources: {}
-      - name: init-config
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["bash", "-c"]
-        args:
-        - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do
-          bash $script ; done
-        volumeMounts:
-        - name: config
-          mountPath: /etc/datadog-agent
-        - name: procdir
-          mountPath: /host/proc
-          readOnly: true
-        - name: runtimesocketdir
-          mountPath: /host/var/run
-          readOnly: true
-        env:
-        - name: DD_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: "datadog-agent"
-              key: api-key
-        - name: DD_KUBERNETES_KUBELET_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: KUBERNETES
-          value: "yes"
-        - name: DOCKER_HOST
-          value: unix:///host/var/run/docker.sock
-        resources: {}
-      - name: seccomp-setup
-        image: "datadog/agent:7.19.0"
-        command:
-        - cp
-        - /etc/config/system-probe-seccomp.json
-        - /host/var/lib/kubelet/seccomp/system-probe
-        volumeMounts:
-        - name: datadog-agent-security
-          mountPath: /etc/config
-        - name: seccomp-root
-          mountPath: /host/var/lib/kubelet/seccomp
-        resources: {}
+        - name: init-volume
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["bash", "-c"]
+          args:
+            - cp -r /etc/datadog-agent /opt
+          volumeMounts:
+            - name: config
+              mountPath: /opt/datadog-agent
+          resources: {}
+        - name: init-config
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["bash", "-c"]
+          args:
+            - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+            - name: procdir
+              mountPath: /host/proc
+              readOnly: true
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              readOnly: true
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DOCKER_HOST
+              value: unix:///host/var/run/docker.sock
+          resources: {}
+        - name: seccomp-setup
+          image: "datadog/agent:7.21.1"
+          command:
+            - cp
+            - /etc/config/system-probe-seccomp.json
+            - /host/var/lib/kubelet/seccomp/system-probe
+          volumeMounts:
+            - name: datadog-agent-security
+              mountPath: /etc/config
+            - name: seccomp-root
+              mountPath: /host/var/lib/kubelet/seccomp
+          resources: {}
       volumes:
-      - name: config
-        emptyDir: {}
-      - hostPath:
-          path: /var/run
-        name: runtimesocketdir
-      - hostPath:
-          path: /proc
-        name: procdir
-      - hostPath:
-          path: /sys/fs/cgroup
-        name: cgroups
-      - name: s6-run
-        emptyDir: {}
-      - name: sysprobe-config
-        configMap:
-          name: datadog-agent-system-probe-config
-      - name: datadog-agent-security
-        configMap:
-          name: datadog-agent-security
-      - hostPath:
-          path: /var/lib/kubelet/seccomp
-        name: seccomp-root
-      - hostPath:
-          path: /sys/kernel/debug
-        name: debugfs
-      - name: sysprobe-socket-dir
-        emptyDir: {}
-      - hostPath:
-          path: /etc/passwd
-        name: passwd
-      - hostPath:
-          path: "/var/lib/datadog-agent/logs"
-        name: pointerdir
-      - hostPath:
-          path: /var/log/pods
-        name: logpodpath
-      - hostPath:
-          path: /var/lib/docker/containers
-        name: logdockercontainerpath
+        - name: config
+          emptyDir: {}
+        - hostPath:
+            path: /var/run
+          name: runtimesocketdir
+        - hostPath:
+            path: /proc
+          name: procdir
+        - hostPath:
+            path: /sys/fs/cgroup
+          name: cgroups
+        - name: s6-run
+          emptyDir: {}
+        - name: sysprobe-config
+          configMap:
+            name: datadog-agent-system-probe-config
+        - name: datadog-agent-security
+          configMap:
+            name: datadog-agent-security
+        - hostPath:
+            path: /var/lib/kubelet/seccomp
+          name: seccomp-root
+        - hostPath:
+            path: /sys/kernel/debug
+          name: debugfs
+        - name: sysprobe-socket-dir
+          emptyDir: {}
+        - hostPath:
+            path: /lib/modules
+          name: modules
+        - hostPath:
+            path: /usr/src
+          name: src
+        - hostPath:
+            path: /etc/passwd
+          name: passwd
+        - hostPath:
+            path: "/var/lib/datadog-agent/logs"
+          name: pointerdir
+        - hostPath:
+            path: /var/log/pods
+          name: logpodpath
+        - hostPath:
+            path: /var/lib/docker/containers
+          name: logdockercontainerpath
       tolerations:
-      affinity: null
+      affinity: {}
       serviceAccountName: "datadog-agent"
       nodeSelector:
+        kubernetes.io/os: linux
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%
@@ -514,4 +548,4 @@ spec:
 
 # Source: datadog/templates/containers-common-env.yaml
 # The purpose of this template is to define a minimal set of environment
-# variables required to operate dedicated containers in the daemonset.
+# variables required to operate dedicated containers in the daemonset

--- a/static/resources/yaml/datadog-agent-apm.yaml
+++ b/static/resources/yaml/datadog-agent-apm.yaml
@@ -29,168 +29,177 @@ spec:
       annotations: {}
     spec:
       containers:
-      - name: agent
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["agent", "start"]
-        resources: {}
-        ports:
-        - containerPort: 8125
-          name: dogstatsdport
-          protocol: UDP
-        env:
-        - name: DD_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: "datadog-agent"
-              key: api-key
-        - name: DD_KUBERNETES_KUBELET_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: KUBERNETES
-          value: "yes"
-        - name: DOCKER_HOST
-          value: unix:///host/var/run/docker.sock
-        - name: DD_LOG_LEVEL
-          value: "INFO"
-        - name: DD_DOGSTATSD_PORT
-          value: "8125"
-        - name: DD_APM_ENABLED
-          value: "false"
-        - name: DD_LOGS_ENABLED
-          value: "false"
-        - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
-          value: "false"
-        - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
-          value: "true"
-        - name: DD_HEALTH_PORT
-          value: "5555"
-        volumeMounts:
-        - name: config
-          mountPath: /etc/datadog-agent
-        - name: runtimesocketdir
-          mountPath: /host/var/run
-          readOnly: true
-        - name: procdir
-          mountPath: /host/proc
-          readOnly: true
-        - name: cgroups
-          mountPath: /host/sys/fs/cgroup
-          readOnly: true
-        livenessProbe:
-          failureThreshold: 6
-          httpGet:
-            path: /health
-            port: 5555
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          successThreshold: 1
-          timeoutSeconds: 5
-      - name: trace-agent
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
-        resources: {}
-        ports:
-        - containerPort: 8126
-          hostPort: 8126
-          name: traceport
-          protocol: TCP
-        env:
-        - name: DD_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: "datadog-agent"
-              key: api-key
-        - name: DD_KUBERNETES_KUBELET_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: KUBERNETES
-          value: "yes"
-        - name: DOCKER_HOST
-          value: unix:///host/var/run/docker.sock
-        - name: DD_LOG_LEVEL
-          value: "INFO"
-        - name: DD_APM_ENABLED
-          value: "true"
-        - name: DD_APM_NON_LOCAL_TRAFFIC
-          value: "true"
-        - name: DD_APM_RECEIVER_PORT
-          value: "8126"
-        volumeMounts:
-        - name: config
-          mountPath: /etc/datadog-agent
-        - name: runtimesocketdir
-          mountPath: /host/var/run
-          readOnly: true
-        livenessProbe:
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          tcpSocket:
-            port: 8126
-          timeoutSeconds: 5
+        - name: agent
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["agent", "run"]
+          resources: {}
+          ports:
+            - containerPort: 8125
+              name: dogstatsdport
+              protocol: UDP
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DOCKER_HOST
+              value: unix:///host/var/run/docker.sock
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
+            - name: DD_APM_ENABLED
+              value: "false"
+            - name: DD_LOGS_ENABLED
+              value: "false"
+            - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
+              value: "false"
+            - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
+              value: "true"
+            - name: DD_HEALTH_PORT
+              value: "5555"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              readOnly: true
+            - name: procdir
+              mountPath: /host/proc
+              readOnly: true
+            - name: cgroups
+              mountPath: /host/sys/fs/cgroup
+              readOnly: true
+          livenessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /live
+              port: 5555
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /ready
+              port: 5555
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+        - name: trace-agent
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
+          resources: {}
+          ports:
+            - containerPort: 8126
+              hostPort: 8126
+              name: traceport
+              protocol: TCP
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DOCKER_HOST
+              value: unix:///host/var/run/docker.sock
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_APM_ENABLED
+              value: "true"
+            - name: DD_APM_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_APM_RECEIVER_PORT
+              value: "8126"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            tcpSocket:
+              port: 8126
+            timeoutSeconds: 5
       initContainers:
-      - name: init-volume
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["bash", "-c"]
-        args:
-        - cp -r /etc/datadog-agent /opt
-        volumeMounts:
-        - name: config
-          mountPath: /opt/datadog-agent
-        resources: {}
-      - name: init-config
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["bash", "-c"]
-        args:
-        - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do
-          bash $script ; done
-        volumeMounts:
-        - name: config
-          mountPath: /etc/datadog-agent
-        - name: procdir
-          mountPath: /host/proc
-          readOnly: true
-        - name: runtimesocketdir
-          mountPath: /host/var/run
-          readOnly: true
-        env:
-        - name: DD_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: "datadog-agent"
-              key: api-key
-        - name: DD_KUBERNETES_KUBELET_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: KUBERNETES
-          value: "yes"
-        - name: DOCKER_HOST
-          value: unix:///host/var/run/docker.sock
-        resources: {}
+        - name: init-volume
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["bash", "-c"]
+          args:
+            - cp -r /etc/datadog-agent /opt
+          volumeMounts:
+            - name: config
+              mountPath: /opt/datadog-agent
+          resources: {}
+        - name: init-config
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["bash", "-c"]
+          args:
+            - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+            - name: procdir
+              mountPath: /host/proc
+              readOnly: true
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              readOnly: true
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DOCKER_HOST
+              value: unix:///host/var/run/docker.sock
+          resources: {}
       volumes:
-      - name: config
-        emptyDir: {}
-      - hostPath:
-          path: /var/run
-        name: runtimesocketdir
-      - hostPath:
-          path: /proc
-        name: procdir
-      - hostPath:
-          path: /sys/fs/cgroup
-        name: cgroups
-      - name: s6-run
-        emptyDir: {}
+        - name: config
+          emptyDir: {}
+        - hostPath:
+            path: /var/run
+          name: runtimesocketdir
+        - hostPath:
+            path: /proc
+          name: procdir
+        - hostPath:
+            path: /sys/fs/cgroup
+          name: cgroups
+        - name: s6-run
+          emptyDir: {}
       tolerations:
-      affinity: null
+      affinity: {}
       serviceAccountName: "datadog-agent"
       nodeSelector:
+        kubernetes.io/os: linux
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%
@@ -198,4 +207,4 @@ spec:
 
 # Source: datadog/templates/containers-common-env.yaml
 # The purpose of this template is to define a minimal set of environment
-# variables required to operate dedicated containers in the daemonset.
+# variables required to operate dedicated containers in the daemonset

--- a/static/resources/yaml/datadog-agent-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-logs-apm.yaml
@@ -29,197 +29,206 @@ spec:
       annotations: {}
     spec:
       containers:
-      - name: agent
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["agent", "start"]
-        resources: {}
-        ports:
-        - containerPort: 8125
-          name: dogstatsdport
-          protocol: UDP
-        env:
-        - name: DD_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: "datadog-agent"
-              key: api-key
-        - name: DD_KUBERNETES_KUBELET_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: KUBERNETES
-          value: "yes"
-        - name: DD_CONTAINER_EXCLUDE
-          value: "name:datadog-agent"
-        - name: DOCKER_HOST
-          value: unix:///host/var/run/docker.sock
-        - name: DD_LOG_LEVEL
-          value: "INFO"
-        - name: DD_DOGSTATSD_PORT
-          value: "8125"
-        - name: DD_LEADER_ELECTION
-          value: "true"
-        - name: DD_COLLECT_KUBERNETES_EVENTS
-          value: "true"
-        - name: DD_APM_ENABLED
-          value: "false"
-        - name: DD_LOGS_ENABLED
-          value: "true"
-        - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
-          value: "true"
-        - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
-          value: "true"
-        - name: DD_HEALTH_PORT
-          value: "5555"
-        volumeMounts:
-        - name: config
-          mountPath: /etc/datadog-agent
-        - name: runtimesocketdir
-          mountPath: /host/var/run
-          readOnly: true
-        - name: procdir
-          mountPath: /host/proc
-          readOnly: true
-        - name: cgroups
-          mountPath: /host/sys/fs/cgroup
-          readOnly: true
-        - name: pointerdir
-          mountPath: /opt/datadog-agent/run
-        - name: logpodpath
-          mountPath: /var/log/pods
-          readOnly: true
-        - name: logdockercontainerpath
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-        livenessProbe:
-          failureThreshold: 6
-          httpGet:
-            path: /health
-            port: 5555
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          successThreshold: 1
-          timeoutSeconds: 5
-      - name: trace-agent
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
-        resources: {}
-        ports:
-        - containerPort: 8126
-          hostPort: 8126
-          name: traceport
-          protocol: TCP
-        env:
-        - name: DD_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: "datadog-agent"
-              key: api-key
-        - name: DD_KUBERNETES_KUBELET_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: KUBERNETES
-          value: "yes"
-        - name: DD_CONTAINER_EXCLUDE
-          value: "name:datadog-agent"
-        - name: DOCKER_HOST
-          value: unix:///host/var/run/docker.sock
-        - name: DD_LOG_LEVEL
-          value: "INFO"
-        - name: DD_APM_ENABLED
-          value: "true"
-        - name: DD_APM_NON_LOCAL_TRAFFIC
-          value: "true"
-        - name: DD_APM_RECEIVER_PORT
-          value: "8126"
-        volumeMounts:
-        - name: config
-          mountPath: /etc/datadog-agent
-        - name: runtimesocketdir
-          mountPath: /host/var/run
-          readOnly: true
-        livenessProbe:
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          tcpSocket:
-            port: 8126
-          timeoutSeconds: 5
+        - name: agent
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["agent", "run"]
+          resources: {}
+          ports:
+            - containerPort: 8125
+              name: dogstatsdport
+              protocol: UDP
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DD_AC_EXCLUDE
+              value: "name:datadog-agent"
+            - name: DOCKER_HOST
+              value: unix:///host/var/run/docker.sock
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
+            - name: DD_LEADER_ELECTION
+              value: "true"
+            - name: DD_COLLECT_KUBERNETES_EVENTS
+              value: "true"
+            - name: DD_APM_ENABLED
+              value: "false"
+            - name: DD_LOGS_ENABLED
+              value: "true"
+            - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
+              value: "true"
+            - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
+              value: "true"
+            - name: DD_HEALTH_PORT
+              value: "5555"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              readOnly: true
+            - name: procdir
+              mountPath: /host/proc
+              readOnly: true
+            - name: cgroups
+              mountPath: /host/sys/fs/cgroup
+              readOnly: true
+            - name: pointerdir
+              mountPath: /opt/datadog-agent/run
+            - name: logpodpath
+              mountPath: /var/log/pods
+              readOnly: true
+            - name: logdockercontainerpath
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+          livenessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /live
+              port: 5555
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /ready
+              port: 5555
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+        - name: trace-agent
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
+          resources: {}
+          ports:
+            - containerPort: 8126
+              hostPort: 8126
+              name: traceport
+              protocol: TCP
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DD_AC_EXCLUDE
+              value: "name:datadog-agent"
+            - name: DOCKER_HOST
+              value: unix:///host/var/run/docker.sock
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_APM_ENABLED
+              value: "true"
+            - name: DD_APM_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_APM_RECEIVER_PORT
+              value: "8126"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            tcpSocket:
+              port: 8126
+            timeoutSeconds: 5
       initContainers:
-      - name: init-volume
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["bash", "-c"]
-        args:
-        - cp -r /etc/datadog-agent /opt
-        volumeMounts:
-        - name: config
-          mountPath: /opt/datadog-agent
-        resources: {}
-      - name: init-config
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["bash", "-c"]
-        args:
-        - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do
-          bash $script ; done
-        volumeMounts:
-        - name: config
-          mountPath: /etc/datadog-agent
-        - name: procdir
-          mountPath: /host/proc
-          readOnly: true
-        - name: runtimesocketdir
-          mountPath: /host/var/run
-          readOnly: true
-        env:
-        - name: DD_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: "datadog-agent"
-              key: api-key
-        - name: DD_KUBERNETES_KUBELET_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: KUBERNETES
-          value: "yes"
-        - name: DD_CONTAINER_EXCLUDE
-          value: "name:datadog-agent"
-        - name: DOCKER_HOST
-          value: unix:///host/var/run/docker.sock
-        - name: DD_LEADER_ELECTION
-          value: "true"
-        resources: {}
+        - name: init-volume
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["bash", "-c"]
+          args:
+            - cp -r /etc/datadog-agent /opt
+          volumeMounts:
+            - name: config
+              mountPath: /opt/datadog-agent
+          resources: {}
+        - name: init-config
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["bash", "-c"]
+          args:
+            - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+            - name: procdir
+              mountPath: /host/proc
+              readOnly: true
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              readOnly: true
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DD_AC_EXCLUDE
+              value: "name:datadog-agent"
+            - name: DOCKER_HOST
+              value: unix:///host/var/run/docker.sock
+            - name: DD_LEADER_ELECTION
+              value: "true"
+          resources: {}
       volumes:
-      - name: config
-        emptyDir: {}
-      - hostPath:
-          path: /var/run
-        name: runtimesocketdir
-      - hostPath:
-          path: /proc
-        name: procdir
-      - hostPath:
-          path: /sys/fs/cgroup
-        name: cgroups
-      - name: s6-run
-        emptyDir: {}
-      - hostPath:
-          path: "/var/lib/datadog-agent/logs"
-        name: pointerdir
-      - hostPath:
-          path: /var/log/pods
-        name: logpodpath
-      - hostPath:
-          path: /var/lib/docker/containers
-        name: logdockercontainerpath
+        - name: config
+          emptyDir: {}
+        - hostPath:
+            path: /var/run
+          name: runtimesocketdir
+        - hostPath:
+            path: /proc
+          name: procdir
+        - hostPath:
+            path: /sys/fs/cgroup
+          name: cgroups
+        - name: s6-run
+          emptyDir: {}
+        - hostPath:
+            path: "/var/lib/datadog-agent/logs"
+          name: pointerdir
+        - hostPath:
+            path: /var/log/pods
+          name: logpodpath
+        - hostPath:
+            path: /var/lib/docker/containers
+          name: logdockercontainerpath
       tolerations:
-      affinity: null
+      affinity: {}
       serviceAccountName: "datadog-agent"
       nodeSelector:
+        kubernetes.io/os: linux
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%
@@ -227,4 +236,4 @@ spec:
 
 # Source: datadog/templates/containers-common-env.yaml
 # The purpose of this template is to define a minimal set of environment
-# variables required to operate dedicated containers in the daemonset.
+# variables required to operate dedicated containers in the daemonset

--- a/static/resources/yaml/datadog-agent-logs.yaml
+++ b/static/resources/yaml/datadog-agent-logs.yaml
@@ -29,151 +29,160 @@ spec:
       annotations: {}
     spec:
       containers:
-      - name: agent
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["agent", "start"]
-        resources: {}
-        ports:
-        - containerPort: 8125
-          name: dogstatsdport
-          protocol: UDP
-        env:
-        - name: DD_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: "datadog-agent"
-              key: api-key
-        - name: DD_KUBERNETES_KUBELET_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: KUBERNETES
-          value: "yes"
-        - name: DD_CONTAINER_EXCLUDE
-          value: "name:datadog-agent"
-        - name: DOCKER_HOST
-          value: unix:///host/var/run/docker.sock
-        - name: DD_LOG_LEVEL
-          value: "INFO"
-        - name: DD_DOGSTATSD_PORT
-          value: "8125"
-        - name: DD_LEADER_ELECTION
-          value: "true"
-        - name: DD_COLLECT_KUBERNETES_EVENTS
-          value: "true"
-        - name: DD_APM_ENABLED
-          value: "false"
-        - name: DD_LOGS_ENABLED
-          value: "true"
-        - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
-          value: "true"
-        - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
-          value: "true"
-        - name: DD_HEALTH_PORT
-          value: "5555"
-        volumeMounts:
-        - name: config
-          mountPath: /etc/datadog-agent
-        - name: runtimesocketdir
-          mountPath: /host/var/run
-          readOnly: true
-        - name: procdir
-          mountPath: /host/proc
-          readOnly: true
-        - name: cgroups
-          mountPath: /host/sys/fs/cgroup
-          readOnly: true
-        - name: pointerdir
-          mountPath: /opt/datadog-agent/run
-        - name: logpodpath
-          mountPath: /var/log/pods
-          readOnly: true
-        - name: logdockercontainerpath
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-        livenessProbe:
-          failureThreshold: 6
-          httpGet:
-            path: /health
-            port: 5555
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          successThreshold: 1
-          timeoutSeconds: 5
+        - name: agent
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["agent", "run"]
+          resources: {}
+          ports:
+            - containerPort: 8125
+              name: dogstatsdport
+              protocol: UDP
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DD_AC_EXCLUDE
+              value: "name:datadog-agent"
+            - name: DOCKER_HOST
+              value: unix:///host/var/run/docker.sock
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
+            - name: DD_LEADER_ELECTION
+              value: "true"
+            - name: DD_COLLECT_KUBERNETES_EVENTS
+              value: "true"
+            - name: DD_APM_ENABLED
+              value: "false"
+            - name: DD_LOGS_ENABLED
+              value: "true"
+            - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
+              value: "true"
+            - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
+              value: "true"
+            - name: DD_HEALTH_PORT
+              value: "5555"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              readOnly: true
+            - name: procdir
+              mountPath: /host/proc
+              readOnly: true
+            - name: cgroups
+              mountPath: /host/sys/fs/cgroup
+              readOnly: true
+            - name: pointerdir
+              mountPath: /opt/datadog-agent/run
+            - name: logpodpath
+              mountPath: /var/log/pods
+              readOnly: true
+            - name: logdockercontainerpath
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+          livenessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /live
+              port: 5555
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /ready
+              port: 5555
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
       initContainers:
-      - name: init-volume
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["bash", "-c"]
-        args:
-        - cp -r /etc/datadog-agent /opt
-        volumeMounts:
-        - name: config
-          mountPath: /opt/datadog-agent
-        resources: {}
-      - name: init-config
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["bash", "-c"]
-        args:
-        - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do
-          bash $script ; done
-        volumeMounts:
-        - name: config
-          mountPath: /etc/datadog-agent
-        - name: procdir
-          mountPath: /host/proc
-          readOnly: true
-        - name: runtimesocketdir
-          mountPath: /host/var/run
-          readOnly: true
-        env:
-        - name: DD_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: "datadog-agent"
-              key: api-key
-        - name: DD_KUBERNETES_KUBELET_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: KUBERNETES
-          value: "yes"
-        - name: DD_CONTAINER_EXCLUDE
-          value: "name:datadog-agent"
-        - name: DOCKER_HOST
-          value: unix:///host/var/run/docker.sock
-        - name: DD_LEADER_ELECTION
-          value: "true"
-        resources: {}
+        - name: init-volume
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["bash", "-c"]
+          args:
+            - cp -r /etc/datadog-agent /opt
+          volumeMounts:
+            - name: config
+              mountPath: /opt/datadog-agent
+          resources: {}
+        - name: init-config
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["bash", "-c"]
+          args:
+            - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+            - name: procdir
+              mountPath: /host/proc
+              readOnly: true
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              readOnly: true
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DD_AC_EXCLUDE
+              value: "name:datadog-agent"
+            - name: DOCKER_HOST
+              value: unix:///host/var/run/docker.sock
+            - name: DD_LEADER_ELECTION
+              value: "true"
+          resources: {}
       volumes:
-      - name: config
-        emptyDir: {}
-      - hostPath:
-          path: /var/run
-        name: runtimesocketdir
-      - hostPath:
-          path: /proc
-        name: procdir
-      - hostPath:
-          path: /sys/fs/cgroup
-        name: cgroups
-      - name: s6-run
-        emptyDir: {}
-      - hostPath:
-          path: "/var/lib/datadog-agent/logs"
-        name: pointerdir
-      - hostPath:
-          path: /var/log/pods
-        name: logpodpath
-      - hostPath:
-          path: /var/lib/docker/containers
-        name: logdockercontainerpath
+        - name: config
+          emptyDir: {}
+        - hostPath:
+            path: /var/run
+          name: runtimesocketdir
+        - hostPath:
+            path: /proc
+          name: procdir
+        - hostPath:
+            path: /sys/fs/cgroup
+          name: cgroups
+        - name: s6-run
+          emptyDir: {}
+        - hostPath:
+            path: "/var/lib/datadog-agent/logs"
+          name: pointerdir
+        - hostPath:
+            path: /var/log/pods
+          name: logpodpath
+        - hostPath:
+            path: /var/lib/docker/containers
+          name: logdockercontainerpath
       tolerations:
-      affinity: null
+      affinity: {}
       serviceAccountName: "datadog-agent"
       nodeSelector:
+        kubernetes.io/os: linux
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%
@@ -181,4 +190,4 @@ spec:
 
 # Source: datadog/templates/containers-common-env.yaml
 # The purpose of this template is to define a minimal set of environment
-# variables required to operate dedicated containers in the daemonset.
+# variables required to operate dedicated containers in the daemonset

--- a/static/resources/yaml/datadog-agent-npm.yaml
+++ b/static/resources/yaml/datadog-agent-npm.yaml
@@ -23,9 +23,12 @@ data:
     system_probe_config:
       enabled: true
       debug_port:  0
-      sysprobe_socket: /opt/datadog-agent/run/sysprobe.sock
-      enable_conntrack : true
+      sysprobe_socket: /var/run/sysprobe/sysprobe.sock
+      enable_conntrack: true
       bpf_debug: false
+      enable_tcp_queue_length: false
+      enable_oom_kill: false
+      collect_dns_stats: false
 ---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
@@ -113,11 +116,13 @@ data:
             "lseek",
             "lstat",
             "lstat64",
+            "madvise",
             "mkdir",
             "mkdirat",
             "mmap",
             "mmap2",
             "mprotect",
+            "mremap",
             "munmap",
             "nanosleep",
             "newfstatat",
@@ -130,6 +135,7 @@ data:
             "poll",
             "ppoll",
             "prctl",
+            "pread64",
             "prlimit64",
             "pselect6",
             "read",
@@ -231,219 +237,247 @@ spec:
         container.seccomp.security.alpha.kubernetes.io/system-probe: localhost/system-probe
     spec:
       containers:
-      - name: agent
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["agent", "start"]
-        resources: {}
-        ports:
-        - containerPort: 8125
-          name: dogstatsdport
-          protocol: UDP
-        env:
-        - name: DD_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: "datadog-agent"
-              key: api-key
-        - name: DD_KUBERNETES_KUBELET_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: KUBERNETES
-          value: "yes"
-        - name: DOCKER_HOST
-          value: unix:///host/var/run/docker.sock
-        - name: DD_LOG_LEVEL
-          value: "INFO"
-        - name: DD_DOGSTATSD_PORT
-          value: "8125"
-        - name: DD_APM_ENABLED
-          value: "false"
-        - name: DD_LOGS_ENABLED
-          value: "false"
-        - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
-          value: "false"
-        - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
-          value: "true"
-        - name: DD_HEALTH_PORT
-          value: "5555"
-        - name: SYSTEM_PROBE_CONFIG_SYSPROBE_SOCKET
-          value: /sysprobe/var/run
-        volumeMounts:
-        - name: config
-          mountPath: /etc/datadog-agent
-        - name: runtimesocketdir
-          mountPath: /host/var/run
-          readOnly: true
-        - name: sysprobe-socket-dir
-          mountPath: /sysprobe/var/run
-          readOnly: true
-        - name: procdir
-          mountPath: /host/proc
-          readOnly: true
-        - name: cgroups
-          mountPath: /host/sys/fs/cgroup
-          readOnly: true
-        livenessProbe:
-          failureThreshold: 6
-          httpGet:
-            path: /health
-            port: 5555
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          successThreshold: 1
-          timeoutSeconds: 5
-      - name: process-agent
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
-        resources: {}
-        env:
-        - name: DD_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: "datadog-agent"
-              key: api-key
-        - name: DD_KUBERNETES_KUBELET_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: KUBERNETES
-          value: "yes"
-        - name: DOCKER_HOST
-          value: unix:///host/var/run/docker.sock
-        - name: DD_LOG_LEVEL
-          value: "INFO"
-        - name: DD_SYSTEM_PROBE_ENABLED
-          value: "true"
-        volumeMounts:
-        - name: config
-          mountPath: /etc/datadog-agent
-        - name: runtimesocketdir
-          mountPath: /host/var/run
-          readOnly: true
-        - name: cgroups
-          mountPath: /host/sys/fs/cgroup
-          readOnly: true
-        - name: passwd
-          mountPath: /etc/passwd
-        - name: procdir
-          mountPath: /host/proc
-          readOnly: true
-        - name: sysprobe-socket-dir
-          mountPath: /opt/datadog-agent/run
-          readOnly: true
-      - name: system-probe
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        securityContext:
-          capabilities:
-            add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "IPC_LOCK"]
-        command: ["/opt/datadog-agent/embedded/bin/system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
-        env:
-        - name: DD_LOG_LEVEL
-          value: "INFO"
-        resources: {}
-        volumeMounts:
-        - name: debugfs
-          mountPath: /sys/kernel/debug
-        - name: sysprobe-config
-          mountPath: /etc/datadog-agent
-        - name: sysprobe-socket-dir
-          mountPath: /opt/datadog-agent/run
-        - name: procdir
-          mountPath: /host/proc
-          readOnly: true
+        - name: agent
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["agent", "run"]
+          resources: {}
+          ports:
+            - containerPort: 8125
+              name: dogstatsdport
+              protocol: UDP
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DOCKER_HOST
+              value: unix:///host/var/run/docker.sock
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
+            - name: DD_APM_ENABLED
+              value: "false"
+            - name: DD_LOGS_ENABLED
+              value: "false"
+            - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
+              value: "false"
+            - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
+              value: "true"
+            - name: DD_HEALTH_PORT
+              value: "5555"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              readOnly: true
+            - name: sysprobe-socket-dir
+              mountPath: /var/run/sysprobe
+              readOnly: true
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
+            - name: procdir
+              mountPath: /host/proc
+              readOnly: true
+            - name: cgroups
+              mountPath: /host/sys/fs/cgroup
+              readOnly: true
+          livenessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /live
+              port: 5555
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /ready
+              port: 5555
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+        - name: process-agent
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
+          resources: {}
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DOCKER_HOST
+              value: unix:///host/var/run/docker.sock
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_SYSTEM_PROBE_ENABLED
+              value: "true"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              readOnly: true
+            - name: cgroups
+              mountPath: /host/sys/fs/cgroup
+              readOnly: true
+            - name: passwd
+              mountPath: /etc/passwd
+            - name: procdir
+              mountPath: /host/proc
+              readOnly: true
+            - name: sysprobe-socket-dir
+              mountPath: /var/run/sysprobe
+              readOnly: true
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
+        - name: system-probe
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "IPC_LOCK"]
+          command: ["/opt/datadog-agent/embedded/bin/system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
+          env:
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+          resources: {}
+          volumeMounts:
+            - name: debugfs
+              mountPath: /sys/kernel/debug
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent
+            - name: sysprobe-socket-dir
+              mountPath: /var/run/sysprobe
+            - name: procdir
+              mountPath: /host/proc
+              readOnly: true
+            - name: modules
+              mountPath: /lib/modules
+              readOnly: true
+            - name: src
+              mountPath: /usr/src
+              readOnly: true
       initContainers:
-      - name: init-volume
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["bash", "-c"]
-        args:
-        - cp -r /etc/datadog-agent /opt
-        volumeMounts:
-        - name: config
-          mountPath: /opt/datadog-agent
-        resources: {}
-      - name: init-config
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["bash", "-c"]
-        args:
-        - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do
-          bash $script ; done
-        volumeMounts:
-        - name: config
-          mountPath: /etc/datadog-agent
-        - name: procdir
-          mountPath: /host/proc
-          readOnly: true
-        - name: runtimesocketdir
-          mountPath: /host/var/run
-          readOnly: true
-        env:
-        - name: DD_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: "datadog-agent"
-              key: api-key
-        - name: DD_KUBERNETES_KUBELET_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: KUBERNETES
-          value: "yes"
-        - name: DOCKER_HOST
-          value: unix:///host/var/run/docker.sock
-        resources: {}
-      - name: seccomp-setup
-        image: "datadog/agent:7.19.0"
-        command:
-        - cp
-        - /etc/config/system-probe-seccomp.json
-        - /host/var/lib/kubelet/seccomp/system-probe
-        volumeMounts:
-        - name: datadog-agent-security
-          mountPath: /etc/config
-        - name: seccomp-root
-          mountPath: /host/var/lib/kubelet/seccomp
-        resources: {}
+        - name: init-volume
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["bash", "-c"]
+          args:
+            - cp -r /etc/datadog-agent /opt
+          volumeMounts:
+            - name: config
+              mountPath: /opt/datadog-agent
+          resources: {}
+        - name: init-config
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["bash", "-c"]
+          args:
+            - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+            - name: procdir
+              mountPath: /host/proc
+              readOnly: true
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              readOnly: true
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DOCKER_HOST
+              value: unix:///host/var/run/docker.sock
+          resources: {}
+        - name: seccomp-setup
+          image: "datadog/agent:7.21.1"
+          command:
+            - cp
+            - /etc/config/system-probe-seccomp.json
+            - /host/var/lib/kubelet/seccomp/system-probe
+          volumeMounts:
+            - name: datadog-agent-security
+              mountPath: /etc/config
+            - name: seccomp-root
+              mountPath: /host/var/lib/kubelet/seccomp
+          resources: {}
       volumes:
-      - name: config
-        emptyDir: {}
-      - hostPath:
-          path: /var/run
-        name: runtimesocketdir
-      - hostPath:
-          path: /proc
-        name: procdir
-      - hostPath:
-          path: /sys/fs/cgroup
-        name: cgroups
-      - name: s6-run
-        emptyDir: {}
-      - name: sysprobe-config
-        configMap:
-          name: datadog-agent-system-probe-config
-      - name: datadog-agent-security
-        configMap:
-          name: datadog-agent-security
-      - hostPath:
-          path: /var/lib/kubelet/seccomp
-        name: seccomp-root
-      - hostPath:
-          path: /sys/kernel/debug
-        name: debugfs
-      - name: sysprobe-socket-dir
-        emptyDir: {}
-      - hostPath:
-          path: /etc/passwd
-        name: passwd
+        - name: config
+          emptyDir: {}
+        - hostPath:
+            path: /var/run
+          name: runtimesocketdir
+        - hostPath:
+            path: /proc
+          name: procdir
+        - hostPath:
+            path: /sys/fs/cgroup
+          name: cgroups
+        - name: s6-run
+          emptyDir: {}
+        - name: sysprobe-config
+          configMap:
+            name: datadog-agent-system-probe-config
+        - name: datadog-agent-security
+          configMap:
+            name: datadog-agent-security
+        - hostPath:
+            path: /var/lib/kubelet/seccomp
+          name: seccomp-root
+        - hostPath:
+            path: /sys/kernel/debug
+          name: debugfs
+        - name: sysprobe-socket-dir
+          emptyDir: {}
+        - hostPath:
+            path: /lib/modules
+          name: modules
+        - hostPath:
+            path: /usr/src
+          name: src
+        - hostPath:
+            path: /etc/passwd
+          name: passwd
       tolerations:
-      affinity: null
+      affinity: {}
       serviceAccountName: "datadog-agent"
       nodeSelector:
+        kubernetes.io/os: linux
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%
@@ -451,4 +485,4 @@ spec:
 
 # Source: datadog/templates/containers-common-env.yaml
 # The purpose of this template is to define a minimal set of environment
-# variables required to operate dedicated containers in the daemonset.
+# variables required to operate dedicated containers in the daemonset

--- a/static/resources/yaml/datadog-agent-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-vanilla.yaml
@@ -29,124 +29,133 @@ spec:
       annotations: {}
     spec:
       containers:
-      - name: agent
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["agent", "start"]
-        resources: {}
-        ports:
-        - containerPort: 8125
-          name: dogstatsdport
-          protocol: UDP
-        env:
-        - name: DD_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: "datadog-agent"
-              key: api-key
-        - name: DD_KUBERNETES_KUBELET_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: KUBERNETES
-          value: "yes"
-        - name: DOCKER_HOST
-          value: unix:///host/var/run/docker.sock
-        - name: DD_LOG_LEVEL
-          value: "INFO"
-        - name: DD_DOGSTATSD_PORT
-          value: "8125"
-        - name: DD_APM_ENABLED
-          value: "false"
-        - name: DD_LOGS_ENABLED
-          value: "false"
-        - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
-          value: "false"
-        - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
-          value: "true"
-        - name: DD_HEALTH_PORT
-          value: "5555"
-        volumeMounts:
-        - name: config
-          mountPath: /etc/datadog-agent
-        - name: runtimesocketdir
-          mountPath: /host/var/run
-          readOnly: true
-        - name: procdir
-          mountPath: /host/proc
-          readOnly: true
-        - name: cgroups
-          mountPath: /host/sys/fs/cgroup
-          readOnly: true
-        livenessProbe:
-          failureThreshold: 6
-          httpGet:
-            path: /health
-            port: 5555
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          successThreshold: 1
-          timeoutSeconds: 5
+        - name: agent
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["agent", "run"]
+          resources: {}
+          ports:
+            - containerPort: 8125
+              name: dogstatsdport
+              protocol: UDP
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DOCKER_HOST
+              value: unix:///host/var/run/docker.sock
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
+            - name: DD_APM_ENABLED
+              value: "false"
+            - name: DD_LOGS_ENABLED
+              value: "false"
+            - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
+              value: "false"
+            - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
+              value: "true"
+            - name: DD_HEALTH_PORT
+              value: "5555"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              readOnly: true
+            - name: procdir
+              mountPath: /host/proc
+              readOnly: true
+            - name: cgroups
+              mountPath: /host/sys/fs/cgroup
+              readOnly: true
+          livenessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /live
+              port: 5555
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /ready
+              port: 5555
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
       initContainers:
-      - name: init-volume
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["bash", "-c"]
-        args:
-        - cp -r /etc/datadog-agent /opt
-        volumeMounts:
-        - name: config
-          mountPath: /opt/datadog-agent
-        resources: {}
-      - name: init-config
-        image: "datadog/agent:7.19.0"
-        imagePullPolicy: IfNotPresent
-        command: ["bash", "-c"]
-        args:
-        - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do
-          bash $script ; done
-        volumeMounts:
-        - name: config
-          mountPath: /etc/datadog-agent
-        - name: procdir
-          mountPath: /host/proc
-          readOnly: true
-        - name: runtimesocketdir
-          mountPath: /host/var/run
-          readOnly: true
-        env:
-        - name: DD_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: "datadog-agent"
-              key: api-key
-        - name: DD_KUBERNETES_KUBELET_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: KUBERNETES
-          value: "yes"
-        - name: DOCKER_HOST
-          value: unix:///host/var/run/docker.sock
-        resources: {}
+        - name: init-volume
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["bash", "-c"]
+          args:
+            - cp -r /etc/datadog-agent /opt
+          volumeMounts:
+            - name: config
+              mountPath: /opt/datadog-agent
+          resources: {}
+        - name: init-config
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["bash", "-c"]
+          args:
+            - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+            - name: procdir
+              mountPath: /host/proc
+              readOnly: true
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              readOnly: true
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DOCKER_HOST
+              value: unix:///host/var/run/docker.sock
+          resources: {}
       volumes:
-      - name: config
-        emptyDir: {}
-      - hostPath:
-          path: /var/run
-        name: runtimesocketdir
-      - hostPath:
-          path: /proc
-        name: procdir
-      - hostPath:
-          path: /sys/fs/cgroup
-        name: cgroups
-      - name: s6-run
-        emptyDir: {}
+        - name: config
+          emptyDir: {}
+        - hostPath:
+            path: /var/run
+          name: runtimesocketdir
+        - hostPath:
+            path: /proc
+          name: procdir
+        - hostPath:
+            path: /sys/fs/cgroup
+          name: cgroups
+        - name: s6-run
+          emptyDir: {}
       tolerations:
-      affinity: null
+      affinity: {}
       serviceAccountName: "datadog-agent"
       nodeSelector:
+        kubernetes.io/os: linux
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%
@@ -154,4 +163,4 @@ spec:
 
 # Source: datadog/templates/containers-common-env.yaml
 # The purpose of this template is to define a minimal set of environment
-# variables required to operate dedicated containers in the daemonset.
+# variables required to operate dedicated containers in the daemonset


### PR DESCRIPTION
### What does this PR do?

Regenerate the kubernetes sample manifests from the latest version of the Helm chart.

### Motivation

The [public Helm chart](https://github.com/helm/charts/tree/master/stable/datadog) has evolved since the last time the sample kubernetes manifests were generated.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/lenaic/regenerate_sample_manifests

Check preview base path using the URL in details in `preview` status check.

### Additional Notes

The kubernetes sample manifests have also been regenerated in the [`datadog-agent` repository](https://github.com/DataDog/datadog-agent): DataDog/datadog-agent#6060.