### PR TITLE
Update serverless installation docs

### DIFF
--- a/content/en/serverless/installation/dotnet.md
+++ b/content/en/serverless/installation/dotnet.md
@@ -1,5 +1,5 @@
 ---
-title: Monitoring .NET Applications
+title: Instrumenting .NET Applications
 kind: documentation
 further_reading:
     - link: 'serverless/installation/node'
@@ -23,32 +23,34 @@ After you have [installed the AWS integration][1], use .NET to instrument your a
 
 ## Configuration
 
-### Enable AWS X-Ray
+### Configure the Function
 
-Navigate to the Lambda function in the AWS console you want to instrument. In the debugging and error handling section, check the box to enable AWS X-Ray.
+1. Enable [AWS X-Ray active tracing][2] for your Lambda function.
 
-**Note**: If you’re using a Customer Master Key to encrypt traces, add the `kms:Decrypt` method to your IAM policy where the Resource is the Customer Master Key used for X-Ray.
+### Subscribe the Datadog Forwarder to the Log Groups
 
-### Install the AWS X-Ray client library
+You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, in order to send metrics, traces and logs to Datadog.
 
-Install the [AWS X-Ray client library][2].
+1. [Install the Datadog Forwarder if you haven't][3].
+2. [Ensure the option DdFetchLambdaTags is enabled][4].
+3. [Subscribe the Datadog Forwarder to your function's log groups][5].
 
-### Subscribe the Forwarder to log groups
+## Quick Start
 
-You need the Datadog Forwarder to subscribe to each of your function’s log groups to send custom metrics and logs to Datadog.
+After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless page][6]. If you need to submit a custom metric, refer to the sample code below.
 
-You can quickly verify that you’ve installed the Datadog Forwarder in the [AWS console][3]. If you have not yet installed the Forwarder, you can follow the [installation instructions][4]. Make sure the Datadog Forwarder is in the same AWS region as the Lambda functions you are monitoring.
-
-1. To start, navigate to your AWS Dashboard for the Datadog Forwarder. Then, manually add a function trigger.
-2. Configure the trigger to be linked to your function’s CloudWatch Log Group, add a filter name (but feel free to leave the filter empty) and add the trigger.
-
-The Datadog Forwarder sends logs and custom metrics from your function to Datadog.
-
-## Results
-
-Now you can view your metrics, logs, and traces on the [Serverless page][2].
+```csharp
+var myMetric = new Dictionary<string, object>();
+myMetric.Add("m", "coffee_house.order_value");
+myMetric.Add("v", 12.45);
+myMetric.Add("e", (int)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds);
+myMetric.Add("t", new string[] {"product:latte", "order:online"});
+LambdaLogger.Log(JsonConvert.SerializeObject(myMetric));
+```
 
 [1]: /serverless/#1-install-the-cloud-integration
-[2]: https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-dotnet.html
-[3]: https://console.aws.amazon.com/cloudformation/home#/stacks?filteringText=forwarder
-[4]: /serverless/troubleshooting/installing_the_forwarder
+[2]: https://docs.aws.amazon.com/xray/latest/devguide/xray-services-lambda.html
+[3]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder
+[4]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder/#ddfetchlambdatags
+[5]: https://docs.datadoghq.com/integrations/amazon_web_services/?tab=automaticcloudformation#send-aws-service-logs-to-datadog
+[6]: https://app.datadoghq.com/functions

--- a/content/en/serverless/installation/dotnet.md
+++ b/content/en/serverless/installation/dotnet.md
@@ -35,7 +35,7 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 2. [Ensure the option DdFetchLambdaTags is enabled][4].
 3. [Subscribe the Datadog Forwarder to your function's log groups][5].
 
-## Quick Start
+## Explore Datadog Serverless Monitoring
 
 After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless page][6]. If you need to submit a custom metric, refer to the sample code below.
 

--- a/content/en/serverless/installation/dotnet.md
+++ b/content/en/serverless/installation/dotnet.md
@@ -29,7 +29,7 @@ After you have [installed the AWS integration][1], use .NET to instrument your a
 
 ### Subscribe the Datadog Forwarder to the Log Groups
 
-You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, in order to send metrics, traces and logs to Datadog.
+You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups to send metrics, traces, and logs to Datadog.
 
 1. [Install the Datadog Forwarder if you haven't][3].
 2. [Ensure the option DdFetchLambdaTags is enabled][4].
@@ -37,7 +37,7 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 
 ## Explore Datadog Serverless Monitoring
 
-After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless page][6]. If you need to submit a custom metric, refer to the sample code below.
+After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless page][6]. If you want to submit a custom metric, refer to the sample code below:
 
 ```csharp
 var myMetric = new Dictionary<string, object>();

--- a/content/en/serverless/installation/go.md
+++ b/content/en/serverless/installation/go.md
@@ -1,5 +1,5 @@
 ---
-title: Monitoring Go Applications
+title: Instrumenting Go Applications
 kind: documentation
 further_reading:
     - link: 'serverless/installation/node'
@@ -19,7 +19,7 @@ further_reading:
       text: 'Installing Java Serverless Monitoring'
 ---
 
-After you have [installed the AWS integration][1], use Go to instrument your application to send metrics, logs, and traces to Datadog. 
+After you have [installed the AWS integration][1], follow the steps below to instrument your application to send metrics, logs, and traces to Datadog.
 
 ## Configuration
 
@@ -31,50 +31,58 @@ You can install the [Datadog Lambda Library][2] locally by running the following
 go get github.com/DataDog/datadog-lambda-go
 ```
 
-Then, using the AWS Console or the AWS CLI, add a new `DD_FLUSH_TO_LOG` environment variable set to `true`. This step needs to be repeated for every function you wish to trace.
+### Configure the Function
 
-### Instrument your code
+1. Set environment variable `DD_FLUSH_TO_LOG` to `true`.
+1. Enable [AWS X-Ray active tracing][3] for your Lambda function.
 
-Datadog needs to be able to read headers from the incoming Lambda event. Instrument each of your Lambda handler functions that you wish to trace as outlined below:
+### Subscribe the Datadog Forwarder to the Log Groups
 
-```
+You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, in order to send metrics, traces and logs to Datadog.
+
+1. [Install the Datadog Forwarder if you haven't][4].
+2. [Ensure the option DdFetchLambdaTags is enabled][5].
+3. [Subscribe the Datadog Forwarder to your function's log groups][6].
+
+## Quick Start
+
+After you have configured your function following the steps above, check out the sample code below to get tarted, and view metrics, logs and traces on the [Serverless page][7].
+
+```go
 package main
+
 import (
   "github.com/aws/aws-lambda-go/lambda"
   "github.com/DataDog/datadog-lambda-go"
 )
+
 func main() {
-  // Wrap your lambda handler like this
+  // Wrap your handler function
   lambda.Start(ddlambda.WrapHandler(myHandler, nil))
-  /* OR with manual configuration options
-  lambda.Start(ddlambda.WrapHandler(myHandler, &ddlambda.Config{
-    BatchInterval: time.Second * 15
-    APIKey: "my-api-key",
-  }))
-  */
 }
+
 func myHandler(ctx context.Context, event MyEvent) (string, error) {
-  // ...
+  // Submit a custom metric
+  ddlambda.Metric(
+    "coffee_house.order_value", // Metric name
+    12.45, // Metric value
+    "product:latte", "order:online" // Associated tags
+  )
+
+  req, err := http.NewRequest("GET", "http://example.com/status")
+
+  // Add the datadog distributed tracing headers
+  ddlambda.AddTraceHeaders(ctx, req)
+
+  client := http.Client{}
+  client.Do(req)
 }
 ```
 
-### Subscribe the Forwarder to log groups
-
-You need the Datadog Forwarder to subscribe to each of your function’s log groups to send traces and enhanced metrics to Datadog.
-
-You can quickly verify that you’ve installed the Datadog Forwarder [Using the AWS console][3]. If you have not yet installed the Forwarder, you can follow the [installation instructions][4]. Make sure the Datadog Forwarder is in the same AWS region as the Lambda functions you are monitoring.
-
-1. To start, navigate to your AWS Dashboard for the Datadog Forwarder. Then, manually add a function trigger.
-2. Configure the trigger to be linked to your function’s CloudWatch Log Group, add a filter name (but feel free to leave the filter empty) and add the trigger.
-
-The Datadog Forwarder now sends enhanced metrics and traces from your function to Datadog.
-
-## Results
-
-Now you can view your metrics, logs, and traces on the [Serverless page][5].
-
 [1]: /serverless/#1-install-the-cloud-integration
 [2]: https://github.com/DataDog/datadog-lambda-go
-[3]: https://console.aws.amazon.com/cloudformation/home#/stacks?filteringText=forwarder
-[4]: /serverless/troubleshooting/installing_the_forwarder
-[5]: https://app.datadoghq.com/functions
+[3]: https://docs.aws.amazon.com/xray/latest/devguide/xray-services-lambda.html
+[4]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder
+[5]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder/#ddfetchlambdatags
+[6]: https://docs.datadoghq.com/integrations/amazon_web_services/?tab=automaticcloudformation#send-aws-service-logs-to-datadog
+[7]: https://app.datadoghq.com/functions

--- a/content/en/serverless/installation/go.md
+++ b/content/en/serverless/installation/go.md
@@ -44,7 +44,7 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 2. [Ensure the option DdFetchLambdaTags is enabled][5].
 3. [Subscribe the Datadog Forwarder to your function's log groups][6].
 
-## Quick Start
+## Explore Datadog Serverless Monitoring
 
 After you have configured your function following the steps above, check out the sample code below to get tarted, and view metrics, logs and traces on the [Serverless page][7].
 

--- a/content/en/serverless/installation/go.md
+++ b/content/en/serverless/installation/go.md
@@ -46,7 +46,7 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 
 ## Explore Datadog Serverless Monitoring
 
-After you have configured your function following the steps above, check out the sample code below to get tarted, and view metrics, logs and traces on the [Serverless page][7].
+After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless page][7]. If you need to submit a custom metric, refer to the sample code below:
 
 ```go
 package main

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -75,7 +75,7 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 2. [Ensure the option DdFetchLambdaTags is enabled][5].
 3. [Subscribe the Datadog Forwarder to your function's log groups][6].
 
-## Quick Start
+## Explore Datadog Serverless Monitoring
 
 After you have configured your function following the steps above, check out the sample code below to get tarted, and view metrics, logs and traces on the [Serverless page][7].
 

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -1,5 +1,5 @@
 ---
-title: Monitoring Java Applications
+title: Instrumenting Java Applications
 kind: documentation
 further_reading:
     - link: 'serverless/installation/node'
@@ -19,26 +19,26 @@ further_reading:
       text: 'Installing Go Serverless Monitoring'
 ---
 
-After you have [installed the AWS integration][1], use Java to instrument your application to send metrics, logs, and traces to Datadog. 
+After you have [installed the AWS integration][1], follow the steps below to instrument your application to send metrics, logs, and traces to Datadog.
 
 ## Configuration
 
 ### Install the Datadog Lambda Library
 
-You can install the [Datadog Lambda Library][1] locally by running one of the following commands based on your project’s configuration:
+You can install the Datadog Lambda Library locally by running one of the following commands based on your project’s configuration. For latest version, see the [latest release][2].
 
 {{< tabs >}}
 {{% tab "Maven" %}}
 
 Include the following dependency in your `pom.xml`:
 
-```
-  <repositories>
-        <repository>
-            <id>datadog-maven</id>
-            <url>https://dl.bintray.com/datadog/datadog-maven</url>
-        </repository>     
-  </repositories>
+```xml
+<repositories>
+  <repository>
+    <id>datadog-maven</id>
+    <url>https://dl.bintray.com/datadog/datadog-maven</url>
+  </repository>     
+</repositories>
 <dependency>
 	<groupId>com.datadoghq</groupId>
 	<artifactId>datadog-lambda-java</artifactId>
@@ -52,51 +52,64 @@ Include the following dependency in your `pom.xml`:
 
 Include the following in your `build.gradle`:
 
-```
+```groovy
 repositories {
-    maven { url "https://dl.bintray.com/datadog/datadog-maven" }
+  maven { url "https://dl.bintray.com/datadog/datadog-maven" }
 }
 dependencies {
-     implementation 'com.datadoghq:datadog-lambda-java:0.0.5'
+  implementation 'com.datadoghq:datadog-lambda-java:0.0.5'
 }
 ```
 {{% /tab %}}
 {{< /tabs >}}
 
-Then, using the AWS Console or the AWS CLI, add a new `DD_FLUSH_TO_LOG` environment variable set to `true`. This step needs to be repeated for every function you wish to trace.
+### Configure the Function
 
-### Instrument your code
+1. Enable [AWS X-Ray active tracing][3] for your Lambda function.
 
-Instrument your application by creating a new `DDLambda` with your request and Lambda context, as outlined below:
+### Subscribe the Datadog Forwarder to the Log Groups
 
-```
+You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, in order to send metrics, traces and logs to Datadog.
+
+1. [Install the Datadog Forwarder if you haven't][4].
+2. [Ensure the option DdFetchLambdaTags is enabled][5].
+3. [Subscribe the Datadog Forwarder to your function's log groups][6].
+
+## Quick Start
+
+After you have configured your function following the steps above, check out the sample code below to get tarted, and view metrics, logs and traces on the [Serverless page][7].
+
+
+```java
 public class Handler implements RequestHandler<APIGatewayV2ProxyRequestEvent, APIGatewayV2ProxyResponseEvent> {
     public Integer handleRequest(APIGatewayV2ProxyRequestEvent request, Context context){
-        DDLambda dd = new DDLambda(request, lambda); //Records your lambda invocation, 
-   
-        int work = DoWork();
-        dd.metric("work.done", work);
+        DDLambda dd = new DDLambda(request, lambda);
+
+        Map<String,String> myTags = new HashMap<String, String>();
+            myTags.put("product", "latte");
+            myTags.put("order","online");
         
-        return work;
+        // Submit a custom metric
+        dd.metric(
+            "coffee_house.order_value", // Metric name
+            12.45,                      // Metric value
+            myTags);                    // Associated tags
+
+        URL url = new URL("https://example.com");
+        HttpURLConnection hc = (HttpURLConnection)url.openConnection();
+
+        // Add the datadog distributed tracing headers
+        hc = (HttpURLConnection) dd.addTraceHeaders(hc);
+
+        hc.connect();
     }
 }
 ```
 
-### Subscribe the Forwarder to log groups
-
-You need the Datadog Forwarder to subscribe to each of your function’s log groups to send traces and enhanced metrics to Datadog.
-
-You can quickly verify that you’ve installed the Datadog Forwarder by using the [AWS console][2]. If you have not yet installed the Forwarder, you can follow the installation instructions here. Make sure the Datadog Forwarder is in the same AWS region as the Lambda functions you are monitoring.
-
-1. To start, navigate to your AWS Dashboard for the Datadog Forwarder. Then, manually add a function trigger.
-2. Configure the trigger to be linked to your function’s CloudWatch Log Group, add a filter name (but feel free to leave the filter empty) and add the trigger.
-
-The Datadog Forwarder now sends enhanced metrics and traces from your function to Datadog.
-
-## Results
-
-Now you can view your metrics, logs, and traces on the [Serverless page][3].
-
-[1]: https://github.com/DataDog/datadog-lambda-java
-[2]: https://console.aws.amazon.com/cloudformation/home#/stacks?filteringText=forwarder
-[3]: https://app.datadoghq.com/functions
+[1]: /serverless/#1-install-the-cloud-integration
+[2]: https://github.com/DataDog/datadog-lambda-java/releases
+[3]: https://docs.aws.amazon.com/xray/latest/devguide/xray-services-lambda.html
+[4]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder
+[5]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder/#ddfetchlambdatags
+[6]: https://docs.datadoghq.com/integrations/amazon_web_services/?tab=automaticcloudformation#send-aws-service-logs-to-datadog
+[7]: https://app.datadoghq.com/functions

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -77,7 +77,7 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 
 ## Explore Datadog Serverless Monitoring
 
-After you have configured your function following the steps above, check out the sample code below to get tarted, and view metrics, logs and traces on the [Serverless page][7].
+After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless page][7]. If you need to submit a custom metric, refer to the sample code below.
 
 
 ```java

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -10,7 +10,7 @@ further_reading:
       text: 'Installing Ruby Serverless Monitoring'
 ---
 
-After you have [installed the AWS integration][1], choose one of the following method to instrument your application to send metrics, logs, and traces to Datadog.
+After you have [installed the AWS integration][1], choose one of the following methods to instrument your application to send metrics, logs, and traces to Datadog.
 
 ## Configuration
 
@@ -115,9 +115,9 @@ See the [latest release][3].
 ### Configure the Function
 
 1. Set your function's handler to `/opt/nodejs/node_modules/datadog-lambda-js/handler.handler` if using the layer, or `node_modules/datadog-lambda-js/dist/handler.handler` if using the package.
-1. Set the environment variable `DD_LAMBDA_HANDLER` to your original handler, e.g., `myfunc.handler`.
-1. Set environment variable `DD_TRACE_ENABLED` to `true`.
-1. Set environment variable `DD_FLUSH_TO_LOG` to `true`.
+2. Set the environment variable `DD_LAMBDA_HANDLER` to your original handler, for example, `myfunc.handler`.
+3. Set the environment variable `DD_TRACE_ENABLED` to `true`.
+4. Set the environment variable `DD_FLUSH_TO_LOG` to `true`.
 5. Optionally add a `service` and `env` tag with appropriate values to your function.
 
 ### Subscribe the Datadog Forwarder to the Log Groups
@@ -138,7 +138,7 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 {{% /tab %}}
 {{< /tabs >}}
 
-## Quick Start
+## Explore Datadog Serverless Monitoring
 
 After you have configured your function following the steps above, you can view metrics, logs and traces on the [Serverless page][2]. If you would like to submit a custom metric or manually instrument a function, see the sample code below.
 

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -140,7 +140,7 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 
 ## Explore Datadog Serverless Monitoring
 
-After you have configured your function following the steps above, you can view metrics, logs and traces on the [Serverless page][2]. If you would like to submit a custom metric or manually instrument a function, see the sample code below.
+After you have configured your function following the steps above, you can view metrics, logs and traces on the [Serverless page][2]. If you would like to submit a custom metric or manually instrument a function, see the sample code below:
 
 ```javascript
 const { sendDistributionMetric } = require("datadog-lambda-js");

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -1,5 +1,5 @@
 ---
-title: Monitoring Node.js Applications
+title: Instrumenting Node.js Applications
 kind: documentation
 further_reading:
     - link: 'serverless/installation/node'
@@ -10,40 +10,38 @@ further_reading:
       text: 'Installing Ruby Serverless Monitoring'
 ---
 
-After you have [installed the AWS integration][1], use Node.js to instrument your application to send metrics, logs, and traces to Datadog. 
+After you have [installed the AWS integration][1], choose one of the following method to instrument your application to send metrics, logs, and traces to Datadog.
 
 ## Configuration
 
 {{< tabs >}}
 {{% tab "Serverless Framework" %}}
 
-### Install the Datadog Lambda Library
+Use the [Datadog Serverless Plugin][1] to send metrics, logs and traces from your application to Datadog without any code changes. The plugin automatically attaches the Datadog Lambda Library for Node.js to your functions using layers. At deploy time, it swaps your original function handler with the Datadog-provided handler that initializes the Datadog Lambda Library and invokes your original function handler. It also enables Datadog and X-Ray tracing for your Lambda functions.
 
-Use the [Datadog Serverless Plugin][1] to ingest traces from your application without any code instrumentation. The plugin automatically attaches the Datadog Lambda Library for Node.js to your functions using layers. At deploy time, it generates new handler functions that wrap your existing functions and initializes the Lambda Library.
+To install and configure the Datadog Serverless Plugin, follow these steps:
 
-To install the Datadog Lambda Library with the Serverless Framework plugin, follow these steps:
-
-1. Install the Serverless Plugin in your application package: 
-	`yarn add --dev serverless-plugin-datadog`
+1. Install the Datadog Serverless Plugin: 
+	```
+    yarn add --dev serverless-plugin-datadog
+    ```
 2. In your `serverless.yml`, add the following:
     ```
     plugins:
-		    - serverless-plugin-datadog
+      - serverless-plugin-datadog
     ```
 3. In your `serverless.yml`, also add the following section:
     ```
     custom:
-        datadog:
-            enableDDTracing: true
-            flushMetricsToLogs: true
-            # The Datadog Forwarder ARN goes here.
-            forwarder:
+      datadog:
+        flushMetricsToLogs: true
+        forwarder: # The Datadog Forwarder ARN goes here.
     ```
-    For more information on the Forwarder ARN, or to install the forwarder see the [official CloudFormation documentation][1].
+    For more information on the Forwarder ARN, or to install the forwarder see the [forwarder documentation][2].
 4. Redeploy your serverless application.
 
-[1]:https://github.com/DataDog/serverless-plugin-datadog
-[1]: https://console.aws.amazon.com/cloudformation/home#/stacks?filteringText=forwarder
+[1]: https://github.com/DataDog/serverless-plugin-datadog
+[2]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder
 {{% /tab %}}
 <!--- {{% tab "SAM" %}}
 
@@ -74,11 +72,17 @@ To install the Datadog Lambda Library with the SAM macro, follow these steps:
 
 [1]: https://console.aws.amazon.com/cloudformation/home#/stacks?filteringText=forwarder
 {{% /tab %}} --->
-{{% tab "AWS Console" %}}
+{{% tab "Custom" %}}
 
 ### Install the Datadog Lambda Library
 
-The Datadog Lambda Library can be imported as a layer. Its ARN includes a region, language runtime, and version. Construct yours in the following format:
+The Datadog Lambda Library can be imported as a layer or JavaScript package.
+
+The minor version of the `datadog-lambda-js` package always matches the layer version. E.g., datadog-lambda-js v0.5.0 matches the content of layer version 5.
+
+#### Using the Layer
+
+[Configure the layers][1] for your Lambda function using the ARN in the following format.
 
 ```
 arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:<VERSION>
@@ -87,70 +91,17 @@ arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:<VERSION>
 For example:
 
 ```
-arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python37:11
+arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node12-x:11
 ```
 
-The Python Datadog Lambda Library supports Node8-10, Node10-x, Node12-x. For more information, see the [latest release][1].
+The available `RUNTIME` options are `Node8-10`, `Node10-x`, and `Node12-x`. For more information, see the [latest release][2].
 
-To install the Datadog Lambda Library:
-
-1. Navigate to the Lambda function to which you want to add the layer in your AWS console.
-2. Click on **Layers** on the main page of your function.
-3. Scroll down, and click on **Add a Layer**.
-4. Select the option to *Provide a layer version ARN*.
-5. Enter the Datadog Lambda Library ARN from the example above.
-6. Navigate to the Environment Variables section of your function and add a new `DD_FLUSH_TO_LOG` variable set to `true`.
-
-These steps need to be repeated for every function you wish to trace.
-
-### Instrument your code
-
-Instrument your functions to ingest traces into Datadog:
-
-```
-const { datadog } = require('datadog-lambda-js');
-const tracer = require('dd-trace').init(); // Any manual tracer config goes here.
-
-// This function will be wrapped in a span
-const longCalculation = tracer.wrap('calculation-long-number', () => {
-    // An expensive calculation goes here
-});
-
-// This function will also be wrapped in a span
-module.exports.hello = datadog((event, context, callback) => {
-    longCalculation();
-
-    callback(null, {
-        statusCode: 200,
-        body: 'Hello from serverless!'
-    });
-});
-```
-
-### Subscribe the Forwarder to log groups
-
-You need the Datadog Forwarder to subscribe to each of your function’s log groups to send traces and enhanced metrics to Datadog.
-
-For more information on the Forwarder ARN, or to install the forwarder see the [documentation][1]. Make sure the Datadog Forwarder is in the same AWS region as the Lambda functions you are monitoring.
-
-1. To start, navigate to your AWS Dashboard for the Datadog Forwarder. Then, manually add a function trigger.
-2. Configure the trigger to be linked to your function’s CloudWatch Log Group, add a filter name (but feel free to leave the filter empty) and add the trigger.
-
-The Datadog Forwarder will now send enhanced metrics and traces from your function to Datadog.
-
-
-[1]: https://github.com/DataDog/datadog-lambda-layer-js/releases
-{{% /tab %}}
-{{% tab "Other" %}}
-
-### Install the Datadog Lambda Library
-
-The Datadog Lambda Library can be installed using NPM or Yarn by running one the following commands:
+#### Using the Package
 
 **NPM**:
 
 ```
-npm install datadog-lambda-js
+npm install --save datadog-lambda-js
 ```
 
 **Yarn**:
@@ -159,46 +110,62 @@ npm install datadog-lambda-js
 yarn add datadog-lambda-js
 ```
 
-Then, using the AWS Console or the AWS CLI, add a new `DD_FLUSH_TO_LOG` environment variable set to `true`. This step needs to be repeated for every function you wish to trace.
+See the [latest release][3].
 
-### Instrument your code
+### Configure the Function
 
-Instrument your functions to ingest traces into Datadog:
+1. Set your function's handler to `/opt/nodejs/node_modules/datadog-lambda-js/handler.handler` if using the layer, or `node_modules/datadog-lambda-js/dist/handler.handler` if using the package.
+1. Set the environment variable `DD_LAMBDA_HANDLER` to your original handler, e.g., `myfunc.handler`.
+1. Set environment variable `DD_TRACE_ENABLED` to `true`.
+1. Set environment variable `DD_FLUSH_TO_LOG` to `true`.
+5. Optionally add a `service` and `env` tag with appropriate values to your function.
 
-```
-const { datadog } = require('datadog-lambda-js');
-const tracer = require('dd-trace').init(); // Any manual tracer config goes here.
+### Subscribe the Datadog Forwarder to the Log Groups
 
-// This function will be wrapped in a span
-const longCalculation = tracer.wrap('calculation-long-number', () => {
-    // An expensive calculation goes here
-});
+You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, in order to send metrics, traces and logs to Datadog.
 
-// This function will also be wrapped in a span
-module.exports.hello = datadog((event, context, callback) => {
-    longCalculation();
-
-    callback(null, {
-        statusCode: 200,
-        body: 'Hello from serverless!'
-    });
-});
-```
-
-### Subscribe the Forwarder to log groups
-
-You need the Datadog Forwarder to subscribe to each of your function’s log groups to send traces and enhanced metrics to Datadog.
-
-You can quickly verify that you’ve installed the Datadog Forwarder on the [AWS Forwarder page][1] For more information on the Forwarder ARN, or to install the forwarder see the [official CloudFormation documentation][1]. Make sure the Datadog Forwarder is in the same AWS region as the Lambda functions you are monitoring.
+1. [Install the Datadog Forwarder if you haven't][4].
+2. [Ensure the option DdFetchLambdaTags is enabled][5].
+3. [Subscribe the Datadog Forwarder to your function's log groups][6].
 
 
-[1]: https://console.aws.amazon.com/cloudformation/home#/stacks?filteringText=forwarder
+[1]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
+[2]: https://github.com/DataDog/datadog-lambda-layer-js/releases
+[3]: https://www.npmjs.com/package/datadog-lambda-js
+[4]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder
+[5]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder/#ddfetchlambdatags
+[6]: https://docs.datadoghq.com/integrations/amazon_web_services/?tab=automaticcloudformation#send-aws-service-logs-to-datadog
 {{% /tab %}}
 {{< /tabs >}}
 
-## Results
+## Quick Start
 
-Now you can view your metrics, logs, and traces on the [Serverless page][2].
+After you have configured your function following the steps above, you can view metrics, logs and traces on the [Serverless page][2]. If you would like to submit a custom metric or manually instrument a function, see the sample code below.
+
+```javascript
+const { sendDistributionMetric } = require("datadog-lambda-js");
+const tracer = require("dd-trace");
+
+// This emits a span named "sleep"
+const sleep = tracer.wrap("sleep", (ms) => {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+});
+
+exports.handler = async (event) => {
+  await sleep(1000);
+  sendDistributionMetric(
+    "coffee_house.order_value", // metric name
+    12.45, // metric Value
+    "product:latte", // tag
+    "order:online", // another tag
+  );
+  const response = {
+    statusCode: 200,
+    body: JSON.stringify("Hello from serverless!"),
+  };
+  return response;
+};
+```
 
 [1]: /serverless/#1-install-the-cloud-integration
 [2]: https://app.datadoghq.com/functions

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -132,7 +132,7 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 
 ## Explore Datadog Serverless Monitoring
 
-After you have configured your function following the steps above, you can view metrics, logs and traces on the [Serverless page][2]. If you would like to submit a custom metric or manually instrument a function, see the sample code below.
+After you have configured your function following the steps above, you can view metrics, logs and traces on the [Serverless page][2]. If you would like to submit a custom metric or manually instrument a function, see the sample code below:
 
 ```python
 from ddtrace import tracer

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -10,7 +10,7 @@ further_reading:
       text: 'Installing Ruby Serverless Monitoring'
 ---
 
-After you have [installed the AWS integration][1], choose one of the following method to instrument your application to send metrics, logs, and traces to Datadog.
+After you have [installed the AWS integration][1], choose one of the following methods to instrument your application to send metrics, logs, and traces to Datadog.
 
 ## Configuration
 
@@ -37,7 +37,7 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
         flushMetricsToLogs: true
         forwarder: # The Datadog Forwarder ARN goes here.
     ```
-    For more information on the Forwarder ARN, or to install the forwarder see the [forwarder documentation][2].
+    For more information on the Forwarder ARN, or to install the forwarder see the [Forwarder documentation][2].
 4. Redeploy your serverless application.
 
 [1]: https://github.com/DataDog/serverless-plugin-datadog
@@ -82,7 +82,7 @@ The minor version of the `datadog-lambda` package always matches the layer versi
 
 #### Using the Layer
 
-[Configure the layers][1] for your Lambda function using the ARN in the following format.
+[Configure the layers][1] for your Lambda function using the ARN in the following format:
 
 ```
 arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:<VERSION>
@@ -107,16 +107,16 @@ Or add `datadog-lambda` to your project's `requirements.txt`. See the [latest re
 ### Configure the Function
 
 1. Set your function's handler to `datadog_lambda.handler.handler`.
-2. Set the environment variable `DD_LAMBDA_HANDLER` to your original handler, e.g., `myfunc.handler`.
-3. Set environment variable `DD_TRACE_ENABLED` to `true`.
-4. Set environment variable `DD_FLUSH_TO_LOG` to `true`.
+2. Set the environment variable `DD_LAMBDA_HANDLER` to your original handler, for example, `myfunc.handler`.
+3. Set the environment variable `DD_TRACE_ENABLED` to `true`.
+4. Set the environment variable `DD_FLUSH_TO_LOG` to `true`.
 5. Optionally add a `service` and `env` tag with appropriate values to your function.
 
 ### Subscribe the Datadog Forwarder to the Log Groups
 
-You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, in order to send metrics, traces and logs to Datadog.
+You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, to send metrics, traces and logs to Datadog.
 
-1. [Install the Datadog Forwarder if you haven't][4].
+1. [Install the Datadog Forwarder][4] if you haven't.
 2. [Ensure the option DdFetchLambdaTags is enabled][5].
 3. [Subscribe the Datadog Forwarder to your function's log groups][6].
 
@@ -130,7 +130,7 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 {{% /tab %}} 
 {{< /tabs >}}
 
-## Quick Start
+## Explore Datadog Serverless Monitoring
 
 After you have configured your function following the steps above, you can view metrics, logs and traces on the [Serverless page][2]. If you would like to submit a custom metric or manually instrument a function, see the sample code below.
 

--- a/content/en/serverless/installation/ruby.md
+++ b/content/en/serverless/installation/ruby.md
@@ -57,7 +57,7 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 
 ## Explore Datadog Serverless Monitoring
 
-After you have configured your function following the steps above, check out the sample code below to get started, and view metrics, logs and traces on the [Serverless page][8].
+After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless page][8]. If you need to submit a custom metric, refer to the sample code below:
 
 ```ruby
 require 'ddtrace'

--- a/content/en/serverless/installation/ruby.md
+++ b/content/en/serverless/installation/ruby.md
@@ -1,5 +1,5 @@
 ---
-title: Monitoring Ruby Applications
+title: Instrumenting Ruby Applications
 kind: documentation
 further_reading:
     - link: 'serverless/installation/node'
@@ -10,16 +10,19 @@ further_reading:
       text: 'Installing Ruby Serverless Monitoring'
 ---
 
-After you have [installed the AWS integration][1], use Ruby to instrument your application to send metrics, logs, and traces to Datadog. 
+After you have [installed the AWS integration][1], follow the steps below to instrument your application to send metrics, logs, and traces to Datadog.
 
 ## Configuration
 
-{{< tabs >}}
-{{% tab "AWS Console" %}}
-
 ### Install the Datadog Lambda Library
 
-The Datadog Lambda Library can be imported as a layer. Its ARN includes a region, language runtime, and version. Construct yours in the following format:
+The Datadog Lambda Library can be imported as a layer or a gem.
+
+The minor version of the `datadog-lambda` gem always matches the layer version. E.g., datadog-lambda v0.5.0 matches the content of layer version 5.
+
+#### Using the Layer
+
+[Configure the layers][2] for your Lambda function using the ARN in the following format.
 
 ```
 arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:<VERSION>
@@ -28,85 +31,70 @@ arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:<VERSION>
 For example:
 
 ```
-arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python37:11
+arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby2-7:5
 ```
 
-For more information on the Ruby Datadog Lambda Library, see the [latest release][1].
+The available `RUNTIME` options are `Ruby2-5` and `Ruby2-7`. For more information, see the [latest release][3].
 
-To install the Datadog Lambda Library:
+#### Using the Gem
 
-1. Navigate to the Lambda function to which you want to add the layer in your AWS console.
-2. Click on **Layers** on the main page of your function.
-3. Scroll down, and click on **Add a Layer**.
-4. Select the option to *Provide a layer version ARN*.
-5. Enter the Datadog Lambda Library ARN from the example above.
-6. Navigate to the Environment Variables section of your function and add a new `DD_FLUSH_TO_LOG` variable set to `true`.
-
-These steps need to be repeated for every function you wish to trace.
-
-### Instrument your code
-
-Instrument your functions to ingest traces into Datadog:
-
-```
-const { datadog } = require('datadog-lambda-js');
-const tracer = require('dd-trace').init(); // Any manual tracer config goes here.
-
-// This function will be wrapped in a span
-const longCalculation = tracer.wrap('calculation-long-number', () => {
-    // An expensive calculation goes here
-});
-
-// This function will also be wrapped in a span
-module.exports.hello = datadog((event, context, callback) => {
-    longCalculation();
-
-    callback(null, {
-        statusCode: 200,
-        body: 'Hello from serverless!'
-    });
-});
-```
-
-### Subscribe the Forwarder to log groups
-
-You need the Datadog Forwarder to subscribe to each of your function’s log groups to send traces and enhanced metrics to Datadog.
-
-1. To start, navigate to your AWS Dashboard for the Datadog Forwarder. Then, manually add a function trigger.
-2. Configure the trigger to be linked to your function’s CloudWatch Log Group, add a filter name (but feel free to leave the filter empty) and add the trigger.
-
-The Datadog Forwarder will now send enhanced metrics and traces from your function to Datadog.
-
-
-[1]: https://github.com/DataDog/datadog-lambda-layer-rb/releases
-{{% /tab %}}
-{{% tab "Other" %}}
-
-### Install the Datadog Lambda Library
-
-You can install the Datadog Lambda Library locally by adding the following lines to your Gemfile.
+Add the following line to your Gemfile. See the [latest release][4].
 
 ```
 gem 'datadog-lambda'
 gem 'ddtrace'
 ```
 
-Then, using the AWS Console or the AWS CLI, add a new `DD_FLUSH_TO_LOG` environment variable set to `true`. This step needs to be repeated for every function you wish to trace.
+Keep in mind that `ddtrace` uses native extensions, which must be compiled for Amazon Linux before being packaged and uploaded to Lambda. For this reason we recommend using the layer.
 
-### Subscribe the Forwarder to Log Groups
+### Subscribe the Datadog Forwarder to the Log Groups
 
-You need the Datadog Forwarder to subscribe to each of your function’s log groups to send traces and enhanced metrics to Datadog.
+You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, in order to send metrics, traces and logs to Datadog.
 
-You can quickly verify that you’ve installed the Datadog Forwarder on the [AWS Forwarder page][1] For more information on the Forwarder ARN, or to install the forwarder see the [official CloudFormation documentation][1]. Make sure the Datadog Forwarder is in the same AWS region as the Lambda functions you are monitoring.
+1. [Install the Datadog Forwarder if you haven't][5].
+2. [Ensure the option DdFetchLambdaTags is enabled][6].
+3. [Subscribe the Datadog Forwarder to your function's log groups][7].
 
+## Quick Start
 
-[1]: https://console.aws.amazon.com/cloudformation/home#/stacks?filteringText=forwarder
-{{% /tab %}}
-{{< /tabs >}}
+After you have configured your function following the steps above, check out the sample code below to get started, and view metrics, logs and traces on the [Serverless page][8].
 
-## Results
+```ruby
+require 'ddtrace'
+require 'datadog/lambda'
 
-Now you can view your metrics, logs, and traces on the [Serverless page][2].
+Datadog::Lambda.configure_apm do |c|
+# Enable the instrumentation
+end
+
+def handler(event:, context:)
+    # Apply the Datadog wrapper
+    Datadog::Lambda::wrap(event, context) do
+        some_operation()
+        # Submit a custom metric
+        Datadog::Lambda.metric(
+            'coffee_house.order_value', # metric name
+            12.45, # metric value
+            "product":"latte", # tag
+            "order":"online" # another tag
+        )
+    end
+end
+
+# Instrument the function
+def some_operation()
+    Datadog.tracer.trace('some_operation') do |span|
+        # Do something here
+    end
+end
+```
+
 
 [1]: /serverless/#1-install-the-cloud-integration
-[2]: https://app.datadoghq.com/functions
+[2]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
+[3]: https://github.com/DataDog/datadog-lambda-layer-rb/releases
+[4]: https://rubygems.org/gems/datadog-lambda
+[5]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder
+[6]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder/#ddfetchlambdatags
+[7]: https://docs.datadoghq.com/integrations/amazon_web_services/?tab=automaticcloudformation#send-aws-service-logs-to-datadog
+[8]: https://app.datadoghq.com/functions

--- a/content/en/serverless/installation/ruby.md
+++ b/content/en/serverless/installation/ruby.md
@@ -22,7 +22,7 @@ The minor version of the `datadog-lambda` gem always matches the layer version. 
 
 #### Using the Layer
 
-[Configure the layers][2] for your Lambda function using the ARN in the following format.
+[Configure the layers][2] for your Lambda function using the ARN in the following format:
 
 ```
 arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:<VERSION>
@@ -45,17 +45,17 @@ gem 'datadog-lambda'
 gem 'ddtrace'
 ```
 
-Keep in mind that `ddtrace` uses native extensions, which must be compiled for Amazon Linux before being packaged and uploaded to Lambda. For this reason we recommend using the layer.
+Keep in mind that `ddtrace` uses native extensions, which must be compiled for Amazon Linux before being packaged and uploaded to Lambda. For this reason, Datadog recommends using the layer.
 
 ### Subscribe the Datadog Forwarder to the Log Groups
 
-You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, in order to send metrics, traces and logs to Datadog.
+You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups to send metrics, traces and logs to Datadog.
 
 1. [Install the Datadog Forwarder if you haven't][5].
 2. [Ensure the option DdFetchLambdaTags is enabled][6].
 3. [Subscribe the Datadog Forwarder to your function's log groups][7].
 
-## Quick Start
+## Explore Datadog Serverless Monitoring
 
 After you have configured your function following the steps above, check out the sample code below to get started, and view metrics, logs and traces on the [Serverless page][8].
 


### PR DESCRIPTION
### What does this PR do?

Update the recently added serverless installation docs.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/tian.chu/serverless-set-up/serverless/installation/python

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
