### PR TITLE
fix table formating of keyvalue parser examples

### DIFF
--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -241,17 +241,17 @@ rule %{data::keyvalue("=","/:")}
 
 Other examples:
 
-| **Raw string**               | **Parsing rule**                       | **Result**                            |
-|:-----------------------------|:---------------------------------------|:--------------------------------------|
-| key=valueStr                 | `%{data::keyvalue}`                    | {"key": "valueStr}                    |
-| key=\<valueStr>              | `%{data::keyvalue}`                    | {"key": "valueStr"}                   |
-| "key"="valueStr"             | `%{data::keyvalue}`                    | {"key": "valueStr"}                   |
-| key:valueStr                 | `%{data::keyvalue(":")}`               | {"key": "valueStr"}                   |
-| key:"/valueStr"              | `%{data::keyvalue(":", "/")}`          | {"key": "/valueStr"}                  |
-| /key:/valueStr               | `%{data::keyvalue(":", "/")}`          | {"/key": "/valueStr"}                 |
-| key:={valueStr}              | `%{data::keyvalue(":=", "", "{}")}`    | {"key": "valueStr"}                   |
-| key1=value1\|key2=value2     | `%{data::keyvalue("=", "", "", "|")}` | {"key1": "value1", "key2": "value2"}  |
-| key1="value1"\|key2="value2" | `%{data::keyvalue("=", "", "", "|")}` | {"key1": "value1", "key2": "value2"}  |
+| **Raw string**               | **Parsing rule**                                      | **Result**                            |
+|:-----------------------------|:------------------------------------------------------|:--------------------------------------|
+| key=valueStr                 | `%{data::keyvalue}`                                   | {"key": "valueStr}                    |
+| key=\<valueStr>              | `%{data::keyvalue}`                                   | {"key": "valueStr"}                   |
+| "key"="valueStr"             | `%{data::keyvalue}`                                   | {"key": "valueStr"}                   |
+| key:valueStr                 | `%{data::keyvalue(":")}`                              | {"key": "valueStr"}                   |
+| key:"/valueStr"              | `%{data::keyvalue(":", "/")}`                         | {"key": "/valueStr"}                  |
+| /key:/valueStr               | `%{data::keyvalue(":", "/")}`                         | {"/key": "/valueStr"}                 |
+| key:={valueStr}              | `%{data::keyvalue(":=", "", "{}")}`                   | {"key": "valueStr"}                   |
+| key1=value1\|key2=value2     | <code>%{data::keyvalue("=", "", "", "&#124;")}</co    | {"key1": "value1", "key2": "value2"}  |
+| key1="value1"\|key2="value2" | <code>%{data::keyvalue("=", "", "", "&#124;")}</code> | {"key1": "value1", "key2": "value2"}  |
 
 **Multiple QuotingString example**: When multiple quotingstring are defined, the default behavior is replaced with a defined quoting character.
 The key-value always matches inputs without any quoting characters, regardless of what is specified in `quotingStr`. When quoting characters are used, the `characterWhiteList` is ignored as everything between the quoting characters is extracted.

--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -250,7 +250,7 @@ Other examples:
 | key:"/valueStr"              | `%{data::keyvalue(":", "/")}`                         | {"key": "/valueStr"}                  |
 | /key:/valueStr               | `%{data::keyvalue(":", "/")}`                         | {"/key": "/valueStr"}                 |
 | key:={valueStr}              | `%{data::keyvalue(":=", "", "{}")}`                   | {"key": "valueStr"}                   |
-| key1=value1\|key2=value2     | <code>%{data::keyvalue("=", "", "", "&#124;")}</co    | {"key1": "value1", "key2": "value2"}  |
+| key1=value1\|key2=value2     | <code>%{data::keyvalue("=", "", "", "&#124;")}</code> | {"key1": "value1", "key2": "value2"}  |
 | key1="value1"\|key2="value2" | <code>%{data::keyvalue("=", "", "", "&#124;")}</code> | {"key1": "value1", "key2": "value2"}  |
 
 **Multiple QuotingString example**: When multiple quotingstring are defined, the default behavior is replaced with a defined quoting character.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

implement https://stackoverflow.com/questions/17319940/how-to-escape-a-pipe-char-in-a-code-statement-in-a-markdown-table to fix table formating 

### Motivation
<!-- What inspired you to submit this pull request?-->


### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/pvr/fix-keyvalue-table/logs/processing/parsing/?tab=matcher#key-value-or-logfmt

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
