### PR TITLE
Update PHP tracer docs for 0.47.1

### DIFF
--- a/content/en/tracing/setup/php.md
+++ b/content/en/tracing/setup/php.md
@@ -148,7 +148,6 @@ DD_TRACE_DEBUG=true php -S localhost:8888
 | `DD_AUTOFINISH_SPANS`                     | `false`     | Whether spans are automatically finished when the tracer is flushed                                                                            |
 | `DD_DISTRIBUTED_TRACING`                  | `true`      | Whether to enable distributed tracing                                                                                                          |
 | `DD_ENV`                                  | `null`      | Set an application’s environment, for example: `prod`, `pre-prod`, `stage`. Added in version `0.47.0`.                                         |
-| `DD_INTEGRATIONS_DISABLED`                | `null`      | A CSV list of integrations to disable, for example: `curl,mysqli` (see [Integration names](#integration-names)).                               |
 | `DD_PRIORITY_SAMPLING`                    | `true`      | Whether to enable priority sampling                                                                                                            |
 | `DD_SERVICE`                              | `null`      | The default app name. For versions <0.47.0 this is `DD_SERVICE_NAME`.                                                                          |
 | `DD_SERVICE_MAPPING`                      | `null`      | Change the default name of an APM integration. Rename one or more integrations at a time, for example: `DD_SERVICE_MAPPING=pdo:payments-db,mysqli:orders-db` (see [Integration names](#integration-names)). |
@@ -158,6 +157,7 @@ DD_TRACE_DEBUG=true php -S localhost:8888
 | `DD_TRACE_AGENT_MAX_CONSECUTIVE_FAILURES` | `3`         | IPC-based configurable circuit breaker max consecutive failures                                                                                |
 | `DD_TRACE_AGENT_PORT`                     | `8126`      | The Agent port number                                                                                                                          |
 | `DD_TRACE_AGENT_TIMEOUT`                  | `500`       | The Agent request transfer timeout (in milliseconds)                                                                                           |
+| `DD_TRACE_AGENT_URL`                      | `null`      | The Agent URL; takes precedence over `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`; for example: `https://localhost:8126`. Added in version `0.47.1`. |
 | `DD_TRACE_ANALYTICS_ENABLED`              | `false`     | Flag to enable app analytics for relevant spans in web integrations                                                                            |
 | `DD_TRACE_AUTO_FLUSH_ENABLED`             | `false`     | Automatically flush the tracer when all the spans are closed; set to `true` in conjunction with `DD_TRACE_GENERATE_ROOT_SPAN=0` to trace long-running processes |
 | `DD_TRACE_CLI_ENABLED`                    | `false`     | Enable tracing of PHP scripts from the CLI                                                                                                     |
@@ -166,23 +166,24 @@ DD_TRACE_DEBUG=true php -S localhost:8888
 | `DD_TRACE_GENERATE_ROOT_SPAN`             | `true`      | Automatically generate a top-level span; set to `false` in conjunction with `DD_TRACE_AUTO_FLUSH_ENABLED=1` to trace long-running processes    |
 | `DD_TAGS`                                 | `null`      | Tags to be set on all spans, for example: `key1:value1,key2:value2`. Added in version `0.47.0`                                                 |
 | `DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN`    | `false`     | Set the service name of HTTP requests to `host-<hostname>`, for example a `curl_exec()` call to `https://datadoghq.com` has the service name `host-datadoghq.com` instead of the default service name of `curl`. |
+| `DD_TRACE_<INTEGRATION>_ANALYTICS_ENABLED` | `false`    | A flag to enable app analytics for relevant spans in a specific integration (see [Integration names](#integration-names)). For versions < `0.47.1`, this parameter is `DD_<INTEGRATION>_ANALYTICS_ENABLED`. |
+| `DD_TRACE_<INTEGRATION>_ANALYTICS_SAMPLE_RATE` | `1.0`  | Set the app analytics sample rate for relevant spans in a specific integration (see [Integration names](#integration-names)). For versions < `0.47.1`, this parameter is `DD_<INTEGRATION>_ANALYTICS_SAMPLE_RATE`. |
+| `DD_TRACE_<INTEGRATION>_ENABLED`          | `true`      | Enable or disable an integration; all integrations are enabled by default (see [Integration names](#integration-names)). For versions < `0.47.1`, this parameter is `DD_INTEGRATIONS_DISABLED` which takes a CSV list of integrations to disable, for example: `curl,mysqli`. |
 | `DD_TRACE_MEASURE_COMPILE_TIME`           | `true`      | Record the compile time of the request (in milliseconds) onto the top-level span                                                               |
 | `DD_TRACE_NO_AUTOLOADER`                  | `false`     | Set to `true` to enable auto instrumentation for applications that do not use an autoloader                                                    |
 | `DD_TRACE_RESOURCE_URI_FRAGMENT_REGEX`    | `null`      | CSV of regexes that identifies path fragments corresponding to IDs (see [Map resource names to normalized URI](#map-resource-names-to-normalized-uri)). |
 | `DD_TRACE_RESOURCE_URI_MAPPING_INCOMING`  | `null`      | CSV of URI mappings to normalize resource naming for incoming requests (see [Map resource names to normalized URI](#map-resource-names-to-normalized-uri)). |
 | `DD_TRACE_RESOURCE_URI_MAPPING_OUTGOING`  | `null`      | CSV of URI mappings to normalize resource naming for outgoing requests (see [Map resource names to normalized URI](#map-resource-names-to-normalized-uri)). |
-| `DD_TRACE_SAMPLE_RATE`                    | `1.0`       | The sampling rate for the traces (defaults to: between `0.0` and `1.0`). For versions <0.36.0, this parameter is `DD_SAMPLING_RATE`.           |
+| `DD_TRACE_SAMPLE_RATE`                    | `1.0`       | The sampling rate for the traces (defaults to: between `0.0` and `1.0`). For versions < `0.36.0`, this parameter is `DD_SAMPLING_RATE`.           |
 | `DD_TRACE_SAMPLING_RULES`                 | `null`      | A JSON encoded string to configure the sampling rate. Examples: Set the sample rate to 20%: `[{"sample_rate": 0.2}]`. Set the sample rate to 10% for services starting with 'a' and span name 'b' and set the sample rate to 20% for all other services: `[{"service": "a.*", "name": "b", "sample_rate": 0.1}, {"sample_rate": 0.2}]` (see [Integration names](#integration-names)). |
 | `DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED`  | `true`      | Enable URL's as resource names (see [Map resource names to normalized URI](#map-resource-names-to-normalized-uri)).                            |
-| `DD_<INTEGRATION>_ANALYTICS_ENABLED`      | `false`     | A flag to enable app analytics for relevant spans in a specific integration (see [Integration names](#integration-names)).                     |
-| `DD_<INTEGRATION>_ANALYTICS_SAMPLE_RATE`  | `1.0`       | Set the app analytics sample rate for relevant spans in a specific integration (see [Integration names](#integration-names)).                  |
 | `DD_VERSION`                              | `null`      | Set an application’s version in traces and logs, for example: `1.2.3`, `6c44da20`, `2020.02.13`. Added in version `0.47.0`.                    |
 
 #### Integration names
 
 The table below specifies the default service names for each integration. Change the service names with `DD_SERVICE_MAPPING`.
 
-Use the name when setting integration-specific configuration such as, `DD_<INTEGRATION>_ANALYTICS_ENABLED`, for example: Laravel is `DD_LARAVEL_ANALYTICS_ENABLED`.
+Use the name when setting integration-specific configuration such as, `DD_TRACE_<INTEGRATION>_ANALYTICS_ENABLED`, for example: Laravel is `DD_TRACE_LARAVEL_ANALYTICS_ENABLED`.
 
 | Integration       | Service Name      |
 |-------------------|-------------------|


### PR DESCRIPTION
### What does this PR do?

This PR includes changes in the latest release of the PHP tracer `0.47.1`.

### Preview link

https://docs-staging.datadoghq.com/sammyk/php-tracer/0.47.1/tracing/setup/php/#environment-variable-configuration