### PR TITLE
add .NET to the list of supported language tracers

### DIFF
--- a/content/en/synthetics/apm/_index.md
+++ b/content/en/synthetics/apm/_index.md
@@ -50,6 +50,7 @@ The following Datadog tracing libraries are supported:
 * [Ruby][7]
 * [JavaScript][8]
 * [PHP][9]
+* [.NET][12]
 
 ### How are traces linked to tests?
 
@@ -86,3 +87,4 @@ These traces are retained [just like your classical APM traces][11].
 [9]: https://github.com/DataDog/dd-trace-php/releases/tag/0.33.0
 [10]: /tracing/guide/trace_sampling_and_storage/#how-it-works
 [11]: /tracing/guide/trace_sampling_and_storage/#trace-storage
+[12]: https://github.com/DataDog/dd-trace-dotnet/releases/tag/v1.18.2


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add .NET to the list of supported language tracers.

### Motivation
A user reported .NET was missing through our [public slack](https://datadoghq.slack.com/archives/C5VNQGFF1/p1596015687049900) workspace.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/lpimentel/synthetics-dotnet-support/synthetics/apm/

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
