### PR TITLE
Document how to run the Windows Agent as Local System

### DIFF
--- a/content/en/agent/faq/windows-agent-ddagent-user.md
+++ b/content/en/agent/faq/windows-agent-ddagent-user.md
@@ -79,10 +79,12 @@ If you’re using the Attach API, the change in user context means that the Agen
 
 ### Process check
 
-Now that the Agent runs under `ddagentuser`, it does not have access to the full command line of processes running under other users and to the user of other users’ processes. This causes the following options of the check to not work:
+The Agent since v6.11 runs as `ddagentuser` instead of `Local System`. Because of this, it does not have access to the full command line of processes running under other users and to the user of other users’ processes. This causes the following options of the check to not work:
 
 * `exact_match` when set to `false`
 * `user`, which allows selecting processes that belong to a specific user
+
+To restore the old behaviour and run the Agent as `Local System` (not recommended) open an Administrator console and run the following command: `sc.exe config "datadogagent" obj= LocalSystem`. Alternatively, open the Service Manager, go to DataDog Agent > Properties and specify Log On as `Local System`.
 
 ### Cassandra Nodetool integration
 

--- a/content/en/agent/faq/windows-agent-ddagent-user.md
+++ b/content/en/agent/faq/windows-agent-ddagent-user.md
@@ -79,7 +79,7 @@ If you’re using the Attach API, the change in user context means that the Agen
 
 ### Process check
 
-The Agent since v6.11 runs as `ddagentuser` instead of `Local System`. Because of this, it does not have access to the full command line of processes running under other users and to the user of other users’ processes. This causes the following options of the check to not work:
+In v6.11 +, the Agent runs as `ddagentuser` instead of `Local System`. Because of this, it does not have access to the full command line of processes running under other users and to the user of other users’ processes. This causes the following options of the check to not work:
 
 * `exact_match` when set to `false`
 * `user`, which allows selecting processes that belong to a specific user

--- a/content/en/agent/faq/windows-agent-ddagent-user.md
+++ b/content/en/agent/faq/windows-agent-ddagent-user.md
@@ -84,7 +84,7 @@ In v6.11 +, the Agent runs as `ddagentuser` instead of `Local System`. Because o
 * `exact_match` when set to `false`
 * `user`, which allows selecting processes that belong to a specific user
 
-To restore the old behaviour and run the Agent as `Local System` (not recommended) open an Administrator console and run the following command: `sc.exe config "datadogagent" obj= LocalSystem`. Alternatively, open the Service Manager, go to DataDog Agent > Properties and specify Log On as `Local System`.
+To restore the old behavior and run the Agent as `Local System` (not recommended) open an Administrator console and run the following command: `sc.exe config "datadogagent" obj= LocalSystem`. Alternatively, open the Service Manager, go to DataDog Agent > Properties and specify Log On as `Local System`.
 
 ### Cassandra Nodetool integration
 


### PR DESCRIPTION

### What does this PR do?
Document how to restore the `exact_match` functionality on the Windows Agent by making  the Agent run as `Local System`. 

### Motivation
This came up in an issue here: https://github.com/DataDog/integrations-core/issues/7226
