### PR TITLE
Update documentation with new Datadog Helm Chart repository

### DIFF
--- a/content/en/agent/cluster_agent/clusterchecks.md
+++ b/content/en/agent/cluster_agent/clusterchecks.md
@@ -310,7 +310,7 @@ The Agent `status` command should show the check instance running and reporting 
 [1]: /agent/kubernetes/integrations/
 [2]: /agent/cluster_agent/
 [3]: /agent/cluster_agent/setup/
-[4]: https://github.com/helm/charts/tree/master/stable/datadog
+[4]: https://github.com/DataDog/helm-charts/tree/master/charts/datadog
 [5]: /developers/write_agent_check/
 [6]: /integrations/mysql/
 [7]: /agent/faq/template_variables/

--- a/content/en/agent/cluster_agent/clusterchecksrunner.md
+++ b/content/en/agent/cluster_agent/clusterchecksrunner.md
@@ -85,4 +85,4 @@ Use `podAntiAffinity` to avoid having multiple Cluster Checks Runners on the sam
 [2]: https://docs.datadoghq.com/agent/cluster_agent/clusterchecks/
 [3]: https://docs.datadoghq.com/agent/cluster_agent/setup/
 [4]: https://github.com/DataDog/datadog-operator
-[5]: https://github.com/helm/charts/blob/master/stable/datadog/values.yaml
+[5]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml

--- a/content/en/agent/faq/kubernetes-cluster-name-detection.md
+++ b/content/en/agent/faq/kubernetes-cluster-name-detection.md
@@ -18,4 +18,4 @@ For Agent v6.11+, the Datadog Agent can auto-detect the Kubernetes cluster name 
 **Note**: You can manually set this cluster name value with Agent v6.5+ thanks to the Agent configuration parameter [`clusterName`][2] or the `DD_CLUSTER_NAME` environment variable.
 
 [1]: /integrations/amazon_ec2/#configuration
-[2]: https://github.com/helm/charts/blob/a744ff8c90730d6d36698412150875fa96882b9d/stable/datadog/values.yaml#L58
+[2]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml#L66

--- a/content/en/agent/faq/kubernetes-state-cluster-check.md
+++ b/content/en/agent/faq/kubernetes-state-cluster-check.md
@@ -115,4 +115,4 @@ If you use Autodiscovery from the DaemonSet, one of your Agents (the one running
 
 [1]: /getting_started/agent/autodiscovery/
 [2]: /agent/cluster_agent/clusterchecks/
-[3]: https://github.com/helm/charts/blob/master/stable/datadog/README.md
+[3]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/README.md

--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -46,16 +46,18 @@ To install the chart with a custom release name, `<RELEASE_NAME>` (e.g. `datadog
 
 1. [Install Helm][1].
 2. Download the [Datadog `values.yaml` configuration file][2].
-3. If this is a fresh install, add the Helm stable repo:
+3. If this is a fresh install, add the Helm Datadog repo and the Helm stable repo (for Kube State Metrics chart):
     ```bash
-    helm repo add stable https://kubernetes-charts.storage.googleapis.com/ && helm repo update
+    helm repo add datadog https://helm.datadoghq.com
+    helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+    helm repo update
     ```
 4. Retrieve your Datadog API key from your [Agent installation instructions][3] and run:
 
 - **Helm v3+**
 
     ```bash
-    helm install <RELEASE_NAME> -f values.yaml  --set datadog.apiKey=<DATADOG_API_KEY> stable/datadog --set targetSystem=<TARGET_SYSTEM>
+    helm install <RELEASE_NAME> -f values.yaml  --set datadog.apiKey=<DATADOG_API_KEY> datadog/datadog --set targetSystem=<TARGET_SYSTEM>
     ```
 
     Replace `<TARGET_SYSTEM>` with the name of your OS: `linux` or `windows`.
@@ -63,7 +65,7 @@ To install the chart with a custom release name, `<RELEASE_NAME>` (e.g. `datadog
 - **Helm v1/v2**
 
     ```bash
-    helm install -f values.yaml --name <RELEASE_NAME> --set datadog.apiKey=<DATADOG_API_KEY> stable/datadog
+    helm install -f values.yaml --name <RELEASE_NAME> --set datadog.apiKey=<DATADOG_API_KEY> datadog/datadog
     ```
 
 This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally deploys the [kube-state-metrics chart][4] and uses it as an additional source of metrics about the cluster. A few minutes after installation, Datadog begins to report hosts and metrics.
@@ -80,13 +82,13 @@ If your current chart version deployed is earlier than `v2.0.0`, follow the [mig
 
 
 [1]: https://v3.helm.sh/docs/intro/install/
-[2]: https://github.com/helm/charts/blob/master/stable/datadog/values.yaml
+[2]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml
 [3]: https://app.datadoghq.com/account/settings#api
 [4]: https://github.com/helm/charts/tree/master/stable/kube-state-metrics
 [5]: /agent/kubernetes/apm?tab=helm
 [6]: /agent/kubernetes/log?tab=helm
-[7]: https://github.com/helm/charts/tree/master/stable/datadog
-[8]: https://github.com/helm/charts/blob/master/stable/datadog/docs/Migration_1.x_to_2.x.md
+[7]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog
+[8]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/docs/Migration_1.x_to_2.x.md
 {{% /tab %}}
 {{% tab "DaemonSet" %}}
 
@@ -326,7 +328,7 @@ See the [Agent Commands guides][15] to discover all the Docker Agent commands.
 [1]: /agent/faq/kubernetes-legacy/
 [2]: https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/#pod-templates
 [3]: /agent/kubernetes/integrations/
-[4]: https://github.com/helm/charts/tree/master/stable/datadog#all-configuration-options
+[4]: https://github.com/DataDog/helm-charts/tree/master/charts/datadog#all-configuration-options
 [5]: /agent/proxy/#agent-v6
 [6]: /agent/kubernetes/apm/
 [7]: /agent/kubernetes/log/

--- a/content/en/agent/kubernetes/apm.md
+++ b/content/en/agent/kubernetes/apm.md
@@ -47,7 +47,7 @@ To enable trace collection with your Agent, follow the instructions below:
 
  - Set your operating system. Add `targetSystem: linux` or `targetSystem: windows` to the top of your `values.yaml`.
 
- - Then, upgrade your Datadog Helm chart using the following command: `helm upgrade -f values.yaml <RELEASE NAME> stable/datadog`. Don't forget to set the API key in the YAML file. If you did not set your operating system in `values.yaml`, add `--set targetSystem=linux` or `--set targetSystem=windows` to this command.
+ - Then, upgrade your Datadog Helm chart using the following command: `helm upgrade -f values.yaml <RELEASE NAME> datadog/datadog`. Don't forget to set the API key in the YAML file. If you did not set your operating system in `values.yaml`, add `--set targetSystem=linux` or `--set targetSystem=windows` to this command.
 
 [1]: /agent/kubernetes/?tab=helm
 {{% /tab %}}

--- a/content/en/agent/kubernetes/log.md
+++ b/content/en/agent/kubernetes/log.md
@@ -114,7 +114,7 @@ datadog:
     containerCollectAll: true
 ```
 
-[1]: https://github.com/helm/charts/blob/master/stable/datadog/values.yaml
+[1]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/agent/troubleshooting/send_a_flare.md
+++ b/content/en/agent/troubleshooting/send_a_flare.md
@@ -78,7 +78,7 @@ kubectl exec -it <agent-pod-name> -c system-probe -- agent flare <case-id> --loc
 [1]: /agent/basic_agent_usage/#gui
 [2]: /agent/basic_agent_usage/windows/#agent-v6
 [3]: /agent/faq/heroku-troubleshooting/#send-a-flare
-[4]: https://github.com/helm/charts/blob/master/stable/datadog/CHANGELOG.md
+[4]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/CHANGELOG.md
 {{% /tab %}}
 {{% tab "Agent v5" %}}
 

--- a/content/en/developers/dogstatsd/_index.md
+++ b/content/en/developers/dogstatsd/_index.md
@@ -191,7 +191,7 @@ To gather custom metrics with [DogStatsD][1] with helm:
 2. Upgrade your Agent configuration:
 
     ``` shell
-    helm upgrade -f datadog-values.yaml <RELEASE_NAME> stable/datadog
+    helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog
     ```
 
 3. Update your application pods: Your application needs now a reliable way to determine the IP address of its host. This is made simple in Kubernetes 1.7, which expands the set of attributes you can pass to your pods as environment variables. In versions 1.7 and above, you can pass the host IP to any pod by adding an environment variable to the PodSpec. For instance, your application manifest might look like this:
@@ -207,7 +207,7 @@ To gather custom metrics with [DogStatsD][1] with helm:
      With this, any pod running your application is able to send DogStatsD metrics via port `8125` on `$DD_AGENT_HOST`.
 
 [1]: /developers/metrics/dogstatsd_metrics_submission/
-[2]: https://github.com/helm/charts/blob/master/stable/datadog/values.yaml
+[2]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml
 [3]: https://github.com/containernetworking/cni
 [4]: https://kubernetes.io/docs/setup/independent/troubleshooting-kubeadm/#hostport-services-do-not-work
 {{% /tab %}}

--- a/content/en/infrastructure/process.md
+++ b/content/en/infrastructure/process.md
@@ -106,7 +106,7 @@ datadog:
 ```
 
 
-[1]: https://github.com/helm/charts/blob/master/stable/datadog/values.yaml
+[1]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml
 {{% /tab %}}
 
 {{< /tabs >}}

--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -323,7 +323,7 @@ To set up on AWS ECS, see the [AWS ECS][1] documentation page.
 [1]: https://app.datadoghq.com/account/settings#agent
 [2]: https://www.redhat.com/en/blog/introduction-ebpf-red-hat-enterprise-linux-7
 [3]: /network_performance_monitoring/network_page#dns-resolution
-[4]: https://github.com/helm/charts/blob/master/stable/datadog/README.md#enabling-system-probe-collection
+[4]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/README.md#enabling-system-probe-collection
 [5]: https://github.com/DataDog/chef-datadog
 [6]: https://github.com/DataDog/ansible-datadog/blob/master/README.md#system-probe
 [7]: /agent/guide/agent-configuration-files/#agent-main-configuration-file


### PR DESCRIPTION
### What does this PR do?
Update documentation following migration to new Datadog Helm Chart repository

### Preview link
Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/vboulineau/helm-repo