### PR TITLE
replace 10516 with 443 for log intake endpoints

### DIFF
--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -140,7 +140,7 @@ Open the following ports in order to benefit from all the Agent functionalities:
 
   - `443/tcp`: port for most Agent data. (Metrics, APM, Live Processes/Containers)
   - `123/udp`: NTP - [More details on the importance of NTP][1].
-  - `10516/tcp`: port for the [Log collection][2] over TCP for Datadog US region, `443/tcp` for the Datadog EU region.
+  - `443/tcp`: port for the [Log collection][2] over TCP for Datadog US region, `443/tcp` for the Datadog EU region.
   - `10255/tcp`: port for the [Kubernetes http kubelet][3]
   - `10250/tcp`: port for the [Kubernetes https kubelet][3]
 

--- a/content/en/agent/logs/log_transport.md
+++ b/content/en/agent/logs/log_transport.md
@@ -34,7 +34,7 @@ To check which transport is used by the Agent, run the [Agent status command][1]
 
 **Notes**:
 
-* For older Agent versions, TCP transport is used by default. Datadog strongly recommends you to enforce HTTPS transport if you are running v6.14+/v7.14+ and HTTPS compression if you are running v6.16+/v7.16+. 
+* For older Agent versions, TCP transport is used by default. Datadog strongly recommends you to enforce HTTPS transport if you are running v6.14+/v7.14+ and HTTPS compression if you are running v6.16+/v7.16+.
 * Always enforce a specific transport (either TCP or HTTPS) when using a proxy to forwards logs to Datadog
 
 ## Enforce a specific transport
@@ -74,7 +74,7 @@ To send logs with environment variables, configure the following:
 * `DD_LOGS_ENABLED=true`
 * `DD_LOGS_CONFIG_USE_TCP=true`
 
-By default, the Datadog Agent sends its logs to Datadog over TLS-encrypted TCP. This requires outbound communication (on port `10516` for Datadog US site and port `443`for Datadog EU site).
+By default, the Datadog Agent sends its logs to Datadog over TLS-encrypted TCP. This requires outbound communication (on port `443` for Datadog US site and port `443`for Datadog EU site).
 
 
 

--- a/content/en/agent/logs/proxy.md
+++ b/content/en/agent/logs/proxy.md
@@ -15,7 +15,7 @@ further_reading:
 
 Log collection requires the Datadog Agent v6.0+. Older versions of the Agent do not include the `log collection` interface.
 
-As of Agent v6.14/v7.14, Datadog recommends the use of and enforcing **HTTPS** transport (see [agent Transport for Logs][1]). 
+As of Agent v6.14/v7.14, Datadog recommends the use of and enforcing **HTTPS** transport (see [agent Transport for Logs][1]).
 If you are using the HTTPS transport for logs, please refer to the [agent proxy documentation][2] and use the same set of proxy settings as other data types.
 
 
@@ -40,7 +40,7 @@ The parameters above can also be set with the following environment variables:
 **Note**: The parameter `logs_no_ssl` is required to make the Agent ignore the discrepancy between the hostname on the SSL certificate (`agent-intake.logs.datadoghq.com` or `agent-intake.logs.datadoghq.eu`) and your proxy hostname. It is recommended to use a SSL encrypted connection between your proxy and Datadog intake endpoint.
 
 * Then configure your proxy to listen on `<PROXY_PORT>` and forward the received logs to:
-    * For `app.datadoghq.com`: `agent-intake.logs.datadoghq.com` on port `10516` and activate SSL encryption.
+    * For `app.datadoghq.com`: `agent-intake.logs.datadoghq.com` on port `443` and activate SSL encryption.
     * For `app.datadoghq.eu`: `agent-intake.logs.datadoghq.eu` on port `443` and activate SSL encryption.
 
 * Download the `CA certificates` for TLS encryption for the SSL encryption with the following command:
@@ -133,7 +133,7 @@ resolvers my-dns
     accepted_payload_size 8192
     hold valid 10s
     hold obsolete 60s
-    
+
 # This declares the endpoint where your Agents connects for
 # sending Logs (e.g the value of "logs.config.logs_dd_url")
 frontend logs_frontend
@@ -141,7 +141,7 @@ frontend logs_frontend
     mode tcp
     option tcplog
     default_backend datadog-logs
-    
+
 # This is the Datadog server. In effect any TCP request coming
 # to the forwarder frontends defined above are proxied to
 # Datadog's public endpoints.
@@ -149,7 +149,7 @@ backend datadog-logs
     balance roundrobin
     mode tcp
     option tcplog
-    server datadog agent-intake.logs.datadoghq.com:10516 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt check port 10516
+    server datadog agent-intake.logs.datadoghq.com:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt check port 443
 ```
 
 **Note**: Download the certificate with the following command:
@@ -200,14 +200,14 @@ resolvers my-dns
     accepted_payload_size 8192
     hold valid 10s
     hold obsolete 60s
-    
+
 # This declares the endpoint where your Agents connects for
 # sending Logs (e.g the value of "logs.config.logs_dd_url")
 frontend logs_frontend
     bind *:10514
     mode tcp
     default_backend datadog-logs
-    
+
 # This is the Datadog server. In effect any TCP request coming
 # to the forwarder frontends defined above are proxied to
 # Datadog's public endpoints.
@@ -262,7 +262,7 @@ stream {
     server {
         listen 10514; #listen for logs
         proxy_ssl on;
-        proxy_pass agent-intake.logs.datadoghq.com:10516;
+        proxy_pass agent-intake.logs.datadoghq.com:443;
     }
 }
 ```

--- a/content/en/integrations/nxlog.md
+++ b/content/en/integrations/nxlog.md
@@ -116,13 +116,13 @@ Configure NXLog to gather logs from your host, containers, & services.
 
 1. Download the [CA certificate][1]
 
-2. Add the `om_ssl` module in your NXLog configuration to enable secure transfer over port 10516:
+2. Add the `om_ssl` module in your NXLog configuration to enable secure transfer over port 443:
 
     ```conf
     <Output out>
       Module  om_ssl
       Host    intake.logs.datadoghq.com
-      Port    10516
+      Port    443
       Exec    to_syslog_ietf();
       Exec    $raw_event="my_api_key " + $raw_event;
       CAFile  <CERT_DIR>/ca-certificates.crt

--- a/content/en/integrations/rsyslog.md
+++ b/content/en/integrations/rsyslog.md
@@ -69,7 +69,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
         ## Define the destination for the logs
         $DefaultNetstreamDriverCAFile /etc/ssl/certs/ca-certificates.crt
         ruleset(name="infiles") {
-          action(type="omfwd" protocol="tcp" target="intake.logs.datadoghq.com" port="10516" template="DatadogFormat" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" StreamDriverPermittedPeers="*.logs.datadoghq.com" )
+          action(type="omfwd" protocol="tcp" target="intake.logs.datadoghq.com" port="443" template="DatadogFormat" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" StreamDriverPermittedPeers="*.logs.datadoghq.com" )
         }
         ```
 
@@ -251,7 +251,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
         $ActionSendStreamDriverMode 1
         $ActionSendStreamDriverAuthMode x509/name
         $ActionSendStreamDriverPermittedPeer *.logs.datadoghq.com
-        *.* @@intake.logs.datadoghq.com:10516;DatadogFormat
+        *.* @@intake.logs.datadoghq.com:443;DatadogFormat
         ```
 
 5. Restart Rsyslog and your new logs are forwarded directly to your Datadog account.

--- a/content/en/integrations/syslog_ng.md
+++ b/content/en/integrations/syslog_ng.md
@@ -94,7 +94,7 @@ Configure Syslog-ng to gather logs from your host, containers, & services.
     - Change the definition of the destination to the following:
 
         ```conf
-        destination d_datadog { tcp("intake.logs.datadoghq.com" port(10516)     tls(peer-verify(required-untrusted)) template(DatadogFormat)); };
+        destination d_datadog { tcp("intake.logs.datadoghq.com" port(443)     tls(peer-verify(required-untrusted)) template(DatadogFormat)); };
         ```
 
     More information about the TLS parameters and possibilities for syslog-ng available in the [official documentation][1].

--- a/content/en/logs/guide/docker-logs-collection-troubleshooting-guide.md
+++ b/content/en/logs/guide/docker-logs-collection-troubleshooting-guide.md
@@ -118,16 +118,16 @@ If you're using the Host Agent, the user `dd-agent` needs to be added to the Doc
 
 If the Logs Agent Status looks like the example in [Check the Agent status](#check-the-agent-status) but your logs still aren't reaching the Datadog platform, there could be a problem with one of the following:
 
-* The required port (10516) for sending logs to Datadog is being blocked.
+* The required port (443) for sending logs to Datadog is being blocked.
 * Your container is using a different logging driver than the Agent expects.
 
-### Outbound traffic on port 10516 is blocked
+### Outbound traffic on port 443 is blocked
 
-The Datadog Agent sends its logs to Datadog over tcp via port 10516. If that connection is not available, logs fail to be sent and an error is recorded in the `agent.log` file to that effect.
+The Datadog Agent sends its logs to Datadog over tcp via port 443. If that connection is not available, logs fail to be sent and an error is recorded in the `agent.log` file to that effect.
 
 Test manually your connection by running a telnet or openssl command like so (port 10514 would work too, but is less secure):
 
-* `openssl s_client -connect intake.logs.datadoghq.com:10516`
+* `openssl s_client -connect intake.logs.datadoghq.com:443`
 * `telnet intake.logs.datadoghq.com 10514`
 
 And then by sending a log like the following:
@@ -136,7 +136,7 @@ And then by sending a log like the following:
 <API_KEY> this is a test message
 ```
 
-If opening the port 10514 or 10516 is not an option, it is possible to configure the Datadog Agent to send logs through HTTPS by setting the `DD_LOGS_CONFIG_USE_HTTP` environment variable to `true`:
+If opening the port 10514 or 443 is not an option, it is possible to configure the Datadog Agent to send logs through HTTPS by setting the `DD_LOGS_CONFIG_USE_HTTP` environment variable to `true`:
 
 ### Your containers are not using the JSON logging driver
 
@@ -166,7 +166,7 @@ Docker's default is the json-file logging driver so the Container Agent tries to
 
 ## Agent doesn't send logs from containers that have persisted a large volume of logs (> 1GB)
 
-The Docker daemon can have performances issues while it is trying to retrieve logs for containers for which it has already stored large logs files on disk. This could lead to read timeouts when the Datadog Agent is gathering the containers' logs from the Docker daemon. 
+The Docker daemon can have performances issues while it is trying to retrieve logs for containers for which it has already stored large logs files on disk. This could lead to read timeouts when the Datadog Agent is gathering the containers' logs from the Docker daemon.
 
 When it occurs, the Datadog Agent outputs a log containing `Restarting reader after a read timeout` for a given container every 30 seconds and stops sending logs from that container while it is actually logging messages.
 

--- a/content/en/logs/guide/log-collection-troubleshooting-guide.md
+++ b/content/en/logs/guide/log-collection-troubleshooting-guide.md
@@ -24,13 +24,13 @@ There are a number of common issues that can get in the way when [sending new lo
 
 Changes in the configuration of the `datadog-agent` won't be taken into account until you have [restarted the Agent][3].
 
-## Outbound traffic on port 10516 is blocked
+## Outbound traffic on port 443 is blocked
 
-The Datadog Agent sends its logs to Datadog over tcp via port 10516. If that connection is not available, logs fail to be sent and an error is recorded in the `agent.log` file to that effect.
+The Datadog Agent sends its logs to Datadog over tcp via port 443. If that connection is not available, logs fail to be sent and an error is recorded in the `agent.log` file to that effect.
 
 Test manually your connection by running a telnet or openssl command like so (port 10514 would work too, but is less secure):
 
-* `openssl s_client -connect intake.logs.datadoghq.com:10516`
+* `openssl s_client -connect intake.logs.datadoghq.com:443`
 * `telnet intake.logs.datadoghq.com 10514`
 
 And then by sending a log like the following:
@@ -39,7 +39,7 @@ And then by sending a log like the following:
 <API_KEY> this is a test message
 ```
 
-- If opening the port 10514 or 10516 is not an option, it is possible to configure the Datadog Agent to send logs through HTTPS by adding the following in `datadog.yaml`:
+- If opening the port 10514 or 443 is not an option, it is possible to configure the Datadog Agent to send logs through HTTPS by adding the following in `datadog.yaml`:
 
 ```yaml
 logs_config:

--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -114,7 +114,7 @@ For more examples with JSON formats, multiple logs per request, or the use of qu
 
 {{< site-region region="us" >}}
 
-The secure TCP endpoint is `intake.logs.datadoghq.com:10516` (or port `10514` for insecure connections).
+The secure TCP endpoint is `intake.logs.datadoghq.com:443` (or port `10514` for insecure connections).
 
 You must prefix the log entry with your [Datadog API Key][1], e.g.:
 
@@ -199,13 +199,13 @@ Endpoints that can be used to send logs to Datadog US region:
 
 | Endpoints for SSL encrypted connections | Port    | Description                                                                                                                                                                 |
 |-----------------------------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `agent-intake.logs.datadoghq.com`       | `10516` | Used by the Agent to send logs in protobuf format over an SSL-encrypted TCP connection.                                                                                     |
+| `agent-intake.logs.datadoghq.com`       | `443` | Used by the Agent to send logs in protobuf format over an SSL-encrypted TCP connection.                                                                                     |
 | `agent-http-intake.logs.datadoghq.com`  | `443`   | Used by the Agent to send logs in JSON format over HTTPS. See the [How to send logs over HTTP documentation][1].                                                        |
 | `http-intake.logs.datadoghq.com`        | `443`   | Used by custom forwarder to send logs in JSON or plain text format over HTTPS. See the [How to send logs over HTTP documentation][1].                                       |
-| `intake.logs.datadoghq.com`             | `10516` | Used by custom forwarders to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection.                                                                 |
-| `lambda-intake.logs.datadoghq.com`      | `10516` | Used by Lambda functions to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection.                                                                  |
+| `intake.logs.datadoghq.com`             | `443` | Used by custom forwarders to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection.                                                                 |
+| `lambda-intake.logs.datadoghq.com`      | `443` | Used by Lambda functions to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection.                                                                  |
 | `lambda-http-intake.logs.datadoghq.com` | `443`   | Used by Lambda functions to send logs in raw, Syslog, or JSON format over HTTPS.                                                                                            |
-| `functions-intake.logs.datadoghq.com`   | `10516` | Used by Azure functions to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection. **Note**: This endpoint may be useful with other cloud providers. |
+| `functions-intake.logs.datadoghq.com`   | `443` | Used by Azure functions to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection. **Note**: This endpoint may be useful with other cloud providers. |
 
 | Endpoint for unencrypted connections | Port    | Description                                                                                              |
 |--------------------------------------|---------|----------------------------------------------------------------------------------------------------------|

--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -51,10 +51,10 @@ var log = new LoggerConfiguration()  // using Serilog;
 
     // using Serilog.Formatting.Json;
     .WriteTo.File(new JsonFormatter(renderMessage: true), "log.json")
-    
+
     // using Serilog.Formatting.Compact;
     // .WriteTo.File(new RenderedCompactJsonFormatter(), "log.json")
-    
+
     .CreateLogger();
 
 // An example
@@ -334,7 +334,7 @@ You can also override the default behaviour and forward logs in TCP by manually 
 For instance to forward logs to the Datadog US region in TCP you would use the following sink configuration:
 
 ```csharp
-var config = new DatadogConfiguration(url: "intake.logs.datadoghq.com", port: 10516, useSSL: true, useTCP: true);
+var config = new DatadogConfiguration(url: "intake.logs.datadoghq.com", port: 443, useSSL: true, useTCP: true);
 var log = new LoggerConfiguration()
     .WriteTo.DatadogLogs(
         "<API_KEY>",

--- a/content/en/security/logs.md
+++ b/content/en/security/logs.md
@@ -17,7 +17,7 @@ The Log Management product supports multiple [environments and formats][2], allo
 
 ## Information Security
 
-The Datadog Agent submits logs to datadog either through HTTPS or through TLS-encrypted TCP connection on port 10516, requiring outbound communication (see [Agent Transport for logs][3]).
+The Datadog Agent submits logs to datadog either through HTTPS or through TLS-encrypted TCP connection on port 443, requiring outbound communication (see [Agent Transport for logs][3]).
 
 Datadog uses symmetric encryption at rest (AES-256) for indexed logs. Indexed logs are deleted from the Datadog platform once their retention period, as defined by the customer, expires.
 
@@ -45,11 +45,11 @@ The following sample configuration can be used with the Datadog Agent to submit 
 ```yaml
 logs_enabled: true
 logs_config:
-  logs_dd_url: tcp-encrypted-intake.logs.datadoghq.com:10516
+  logs_dd_url: tcp-encrypted-intake.logs.datadoghq.com:443
   logs_no_ssl: false
 ```
 
-With the Docker Agent, pass in `DD_LOGS_CONFIG_LOGS_DD_URL=tcp-encrypted-intake.logs.datadoghq.com:10516` as an environment variable.
+With the Docker Agent, pass in `DD_LOGS_CONFIG_LOGS_DD_URL=tcp-encrypted-intake.logs.datadoghq.com:443` as an environment variable.
 
 Additionally, certain features are not available at the moment to customers who have signed Datadog's BAA, notably:
 


### PR DESCRIPTION
### What does this PR do?
Update the recommended port for logs intake from 10516 to 443

### Motivation
Reduce complexity and confusion 

### Preview link
https://docs-staging.datadoghq.com/michaelw/update-10516-to-443/
