### PR TITLE
Update go.md

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/go.md
+++ b/content/en/tracing/connect_logs_and_traces/go.md
@@ -42,7 +42,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 The above example illustrates how to use the span's context in the standard library's `log` package. Similar logic may be applied to 3rd party packages too.
 
-**Note**: If you are not using a [Datadog Log Integration][1] to parse your logs, custom log parsing rules need to ensure that `dd.trace_id`, `dd.span_id`, 'dd.service', 'dd.env' and 'dd.version' are being parsed as strings. More information can be found in the [FAQ on this topic][2].
+**Note**: If you are not using a [Datadog Log Integration][1] to parse your logs, custom log parsing rules need to ensure that `dd.trace_id`, `dd.span_id`, `dd.service`, `dd.env` and `dd.version` are being parsed as strings. More information can be found in the [FAQ on this topic][2].
 
 ## Further Reading
 


### PR DESCRIPTION
### What does this PR do?
Fixes back-ticks on https://docs.datadoghq.com/tracing/connect_logs_and_traces/go/ 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jirikuncar/fix-backticks//tracing/connect_logs_and_traces/go/ 

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
