### PR TITLE
Add example for docker-compose

### DIFF
--- a/content/en/tracing/custom_instrumentation/agent_customization.md
+++ b/content/en/tracing/custom_instrumentation/agent_customization.md
@@ -246,6 +246,13 @@ DD_APM_REPLACE_TAGS=[
 
 [1]: /agent/kubernetes/?tab=daemonset
 {{% /tab %}}
+{{% tab "docker-compose" %}}
+
+```docker-compose.yaml
+- DD_APM_REPLACE_TAGS=[{"name":"http.url","pattern":"token/(.*)","repl":"?"},{"name":"*","pattern":"foo","repl":"bar"},{"name":"error.stack","pattern":"(?s).*"}]
+```
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ## Exclude Resources from being collected


### PR DESCRIPTION
Docker compose is a popular use case and the syntax is significantly different to other examples.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
