### PR TITLE
Fix incorrect AWS Service in Log Archives page

### DIFF
--- a/content/en/logs/archives/_index.md
+++ b/content/en/logs/archives/_index.md
@@ -36,7 +36,7 @@ Go into your [AWS console][1] and [create an S3 bucket][2] to send your archives
 
 Next, grant Datadog permissions to write log archives to your S3 bucket with role delegation:
 
-1. Set up the [AWS integration][3] for the AWS account that holds your S3 bucket. This involves [creating a role][4] that Datadog can use to integrate with AWS Cloudwatch.
+1. Set up the [AWS integration][3] for the AWS account that holds your S3 bucket. This involves [creating a role][4] that Datadog can use to integrate with AWS S3.
 
 2. Add the following two permission statements to [the IAM policies of your Datadog role][4]. Edit the bucket names and, if desired, specify the paths that contain your log archives. The `GetObject` and `ListBucket` permissions allow for [Rehydrating from Archives][5]. The `PutObject` permission is sufficient for uploading archives.
 


### PR DESCRIPTION
The role created to integrate with AWS is for S3, not Cloudwatch.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fix a typo in documentation

### Motivation
<!-- What inspired you to submit this pull request?-->
Documentation is incorrect

### Additional Notes
<!-- Anything else we should know when reviewing?-->
