### PR TITLE
Security Monitoring - load the message from a dedicated markdown file

### DIFF
--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -32,6 +32,9 @@ def security_rules(content, content_dir):
     """
     logger.info("Starting security rules action...")
     for file_name in chain.from_iterable(glob.glob(pattern, recursive=True) for pattern in content["globs"]):
+        # Only loop over rules JSON files (not eg. Markdown files containing the messages)
+        if not file_name.endswith(".json"):
+            continue
         with open(file_name, mode="r+") as f:
             json_data = json.loads(f.read())
             p = Path(f.name)
@@ -44,25 +47,31 @@ def security_rules(content, content_dir):
                 else:
                     logger.info(f"skipping file {p.name}")
             else:
-                page_data = {
-                    "title": f"{json_data.get('name', '')}",
-                    "kind": "documentation",
-                    "type": "security_rules",
-                    "disable_edit": True,
-                    "aliases": [f"{json_data.get('defaultRuleId', '').strip()}"]
-                }
+                # The message of a detection rule is located in a Markdown file next to the rule definition
+                message_file_name = file_name.rsplit(".", 1)[0] + ".md"
 
-                for tag in json_data.get('tags', []):
-                    key, value = tag.split(':')
-                    page_data[key] = value
+                with open(message_file_name, mode="r+") as message_file:
+                    message = message_file.read()
 
-                front_matter = yaml.dump(page_data, default_flow_style=False).strip()
-                output_content = TEMPLATE.format(front_matter=front_matter, content=json_data.get("message", "").strip())
+                    page_data = {
+                        "title": f"{json_data.get('name', '')}",
+                        "kind": "documentation",
+                        "type": "security_rules",
+                        "disable_edit": True,
+                        "aliases": [f"{json_data.get('defaultRuleId', '').strip()}"]
+                    }
 
-                dest_dir = Path(f"{content_dir}{content['options']['dest_path']}")
-                dest_dir.mkdir(exist_ok=True)
-                dest_file = dest_dir.joinpath(p.name).with_suffix('.md')
-                logger.info(dest_file)
-                with open(dest_file, mode='w', encoding='utf-8') as out_file:
-                    out_file.write(output_content)
+                    for tag in json_data.get('tags', []):
+                        key, value = tag.split(':')
+                        page_data[key] = value
+
+                    front_matter = yaml.dump(page_data, default_flow_style=False).strip()
+                    output_content = TEMPLATE.format(front_matter=front_matter, content=message.strip())
+
+                    dest_dir = Path(f"{content_dir}{content['options']['dest_path']}")
+                    dest_dir.mkdir(exist_ok=True)
+                    dest_file = dest_dir.joinpath(p.name).with_suffix('.md')
+                    logger.info(dest_file)
+                    with open(dest_file, mode='w', encoding='utf-8') as out_file:
+                        out_file.write(output_content)
 

--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -22,14 +22,6 @@ TEMPLATE = """\
 """
 
 
-def get_tag(tag_list, key):
-    result_tag = ""
-    for tag in tag_list:
-        if tag.startswith(f"{key}:"):
-            result_tag = tag.replace(f"{key}:", "")
-    return result_tag
-
-
 def security_rules(content, content_dir):
     """
     Takes the content from a file from a github repo and
@@ -43,10 +35,6 @@ def security_rules(content, content_dir):
         with open(file_name, mode="r+") as f:
             json_data = json.loads(f.read())
             p = Path(f.name)
-
-            # get the source tag for this file
-            source_tag = get_tag(json_data.get('tags', []), "source")
-            scope_tag = get_tag(json_data.get('tags', []), "scope")
 
             # delete file or skip if staged
             if json_data.get('isStaged', False) or json_data.get('isDeleted', False) or not json_data.get('isEnabled', True):

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -287,7 +287,7 @@
   - repo_name: security-monitoring
     contents:
     - action: security-rules
-      branch: main
+      branch: tanguy.lebarzic/markdown-default-rules
       globs:
         - "security-monitoring/*.json"
         - "security-monitoring/*.md"

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -290,5 +290,6 @@
       branch: main
       globs:
         - "security-monitoring/*.json"
+        - "security-monitoring/*.md"
       options:
         dest_path: '/security_monitoring/default_rules/'

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -290,6 +290,7 @@
       branch: main
       globs:
         - "security-monitoring/*.json"
+        - "security-monitoring/*.md"
       options:
         dest_path: '/security_monitoring/default_rules/'
 

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -287,7 +287,7 @@
   - repo_name: security-monitoring
     contents:
     - action: security-rules
-      branch: main
+      branch: tanguy.lebarzic/markdown-default-rules
       globs:
         - "security-monitoring/*.json"
         - "security-monitoring/*.md"


### PR DESCRIPTION
### What does this PR do?

Load the message of security monitoring rules from a dedicated markdown file instead from the json of the rule.

Linked PR: https://github.com/DataDog/security-monitoring/pull/31

Deployment plan:
- Merge this PR
- Merge https://github.com/DataDog/security-monitoring/pull/31
- Do another PR on this repository to switch back to main.

### Motivation

Using a dedicated markdown file makes writing and reviewing the messages a lot easier.

### Preview link

https://docs-staging.datadoghq.com/tanguy.lebarzic/markdown-default-rules/security_monitoring/default_rules/ for the list
https://docs-staging.datadoghq.com/tanguy.lebarzic/markdown-default-rules/security_monitoring/default_rules/cloudtrail-aws-config-disabled/ for one rule

