### PR TITLE
[WEB-213] - api translateprep

### DIFF
--- a/data/api/v1/translate_actions.json
+++ b/data/api/v1/translate_actions.json
@@ -1,0 +1,865 @@
+{
+  "GetIPRanges": {
+    "description": "Get information about Datadog IP ranges.",
+    "summary": "List IP Ranges"
+  },
+  "ListAPIKeys": {
+    "description": "Get all API keys available for your account.",
+    "summary": "Get all API keys"
+  },
+  "CreateAPIKey": {
+    "description": "Creates an API key with a given name.",
+    "summary": "Create an API key",
+    "request_description": "",
+    "request_schema_description": "Datadog API key."
+  },
+  "DeleteAPIKey": {
+    "description": "Delete a given API key.",
+    "summary": "Delete an API key"
+  },
+  "GetAPIKey": {
+    "description": "Get a given API key.",
+    "summary": "Get API key"
+  },
+  "UpdateAPIKey": {
+    "description": "Edit an API key name.",
+    "summary": "Edit an API key",
+    "request_description": "",
+    "request_schema_description": "Datadog API key."
+  },
+  "ListApplicationKeys": {
+    "description": "Get all application keys available for your Datadog account.",
+    "summary": "Get all application keys"
+  },
+  "CreateApplicationKey": {
+    "description": "Create an application key with a given name.",
+    "summary": "Create an application key",
+    "request_description": "",
+    "request_schema_description": "An application key with its associated metadata."
+  },
+  "DeleteApplicationKey": {
+    "description": "Delete a given application key.",
+    "summary": "Delete an application key"
+  },
+  "GetApplicationKey": {
+    "description": "Get a given application key.",
+    "summary": "Get an application key"
+  },
+  "UpdateApplicationKey": {
+    "description": "Edit an application key name.",
+    "summary": "Edit an application key",
+    "request_description": "",
+    "request_schema_description": "An application key with its associated metadata."
+  },
+  "SubmitServiceCheck": {
+    "description": "Submit a list of Service Checks.\n\n**Note**: A valid API key is required.",
+    "summary": "Submit a Service Check",
+    "request_description": "Service Check request body.",
+    "request_schema_description": "The service checks."
+  },
+  "GetDailyCustomReports": {
+    "description": "Get daily custom reports.",
+    "summary": "Get the list of available daily custom reports"
+  },
+  "GetSpecifiedDailyCustomReports": {
+    "description": "Get specified daily custom reports.",
+    "summary": "Get specified daily custom reports"
+  },
+  "ListDashboards": {
+    "description": "Get all dashboards.\n\n**Note**: This query will only return custom created or cloned dashboards.\nThis query will not return preset dashboards.",
+    "summary": "Get all dashboards"
+  },
+  "CreateDashboard": {
+    "description": "Create a dashboard using the specified options.",
+    "summary": "Create a new dashboard",
+    "request_description": "Create a dashboard request body.",
+    "request_schema_description": "A dashboard is Datadog’s tool for visually tracking, analyzing, and displaying\nkey performance metrics, which enable you to monitor the health of your infrastructure."
+  },
+  "ListDashboardLists": {
+    "description": "Fetch all of your existing dashboard list definitions.",
+    "summary": "Get all dashboard lists"
+  },
+  "CreateDashboardList": {
+    "description": "Create an empty dashboard list.",
+    "summary": "Create a dashboard list",
+    "request_description": "Create a dashboard list request body.",
+    "request_schema_description": "Your Datadog Dashboards."
+  },
+  "DeleteDashboardList": {
+    "description": "Delete a dashboard list.",
+    "summary": "Delete a dashboard list"
+  },
+  "GetDashboardList": {
+    "description": "Fetch an existing dashboard list's definition.",
+    "summary": "Get a dashboard list"
+  },
+  "UpdateDashboardList": {
+    "description": "Update the name of a dashboard list.",
+    "summary": "Update a dashboard list",
+    "request_description": "Update a dashboard list request body.",
+    "request_schema_description": "Your Datadog Dashboards."
+  },
+  "DeleteDashboard": {
+    "description": "Delete a dashboard using the specified ID.",
+    "summary": "Delete a dashboard"
+  },
+  "GetDashboard": {
+    "description": "Get a dashboard using the specified ID.",
+    "summary": "Get a dashboard"
+  },
+  "UpdateDashboard": {
+    "description": "Update a dashboard using the specified ID.",
+    "summary": "Update a dashboard",
+    "request_description": "Update Dashboard request body.",
+    "request_schema_description": "A dashboard is Datadog’s tool for visually tracking, analyzing, and displaying\nkey performance metrics, which enable you to monitor the health of your infrastructure."
+  },
+  "ListDowntimes": {
+    "description": "Get all scheduled downtimes.",
+    "summary": "Get all downtimes"
+  },
+  "CreateDowntime": {
+    "description": "Schedule a downtime.",
+    "summary": "Schedule a downtime",
+    "request_description": "Schedule a downtime request body.",
+    "request_schema_description": "Downtiming gives you greater control over monitor notifications by\nallowing you to globally exclude scopes from alerting.\nDowntime settings, which can be scheduled with start and end times,\nprevent all alerting related to specified Datadog tags."
+  },
+  "CancelDowntimesByScope": {
+    "description": "Delete all downtimes that match the scope of `X`.",
+    "summary": "Cancel downtimes by scope",
+    "request_description": "Scope to cancel downtimes for.",
+    "request_schema_description": "Cancel downtimes according to scope."
+  },
+  "CancelDowntime": {
+    "description": "Cancel a downtime.",
+    "summary": "Cancel a downtime"
+  },
+  "GetDowntime": {
+    "description": "Get downtime detail by `downtime_id`.",
+    "summary": "Get a downtime"
+  },
+  "UpdateDowntime": {
+    "description": "Update a single downtime by `downtime_id`.",
+    "summary": "Update a downtime",
+    "request_description": "Update a downtime request body.",
+    "request_schema_description": "Downtiming gives you greater control over monitor notifications by\nallowing you to globally exclude scopes from alerting.\nDowntime settings, which can be scheduled with start and end times,\nprevent all alerting related to specified Datadog tags."
+  },
+  "ListEvents": {
+    "description": "The event stream can be queried and filtered by time, priority, sources and tags.\n\n**Note**: If the event you’re querying contains markdown formatting of any kind, you may see characters such as %,\\,n in your output.",
+    "summary": "Query the event stream"
+  },
+  "CreateEvent": {
+    "description": "This endpoint allows you to post events to the stream.\nTag them, set priority and event aggregate them with other events.",
+    "summary": "Post an event",
+    "request_description": "Event request object",
+    "request_schema_description": "Object representing an event."
+  },
+  "GetEvent": {
+    "description": "This endpoint allows you to query for event details.\n\n**Note**: If the event you’re querying contains markdown formatting of any kind,\nyou may see characters such as `%`,`\\`,`n` in your output.",
+    "summary": "Get an event"
+  },
+  "ListEmbeddableGraphs": {
+    "description": "Gets a list of previously created embeddable graphs.",
+    "summary": "Get all embeds"
+  },
+  "CreateEmbeddableGraph": {
+    "description": "Creates a new embeddable graph.\n\nNote: If an embed already exists for the exact same query in a given organization,\nthe older embed is returned instead of creating a new embed.\n\nIf you are interested in using template variables, see\n[Embeddable Graphs with Template Variables](https://docs.datadoghq.com/dashboards/faq/embeddable-graphs-with-template-variables).",
+    "summary": "Create embed",
+    "request_description": "Embeddable Graph body",
+    "request_schema_description": "Payload to create new embeddable graph."
+  },
+  "GetEmbeddableGraph": {
+    "description": "Get the HTML fragment for a previously generated embed with `embed_id`.",
+    "summary": "Get specific embed"
+  },
+  "EnableEmbeddableGraph": {
+    "description": "Enable a specified embed.",
+    "summary": "Enable embed"
+  },
+  "RevokeEmbeddableGraph": {
+    "description": "Revoke a specified embed.",
+    "summary": "Revoke embed"
+  },
+  "GetGraphSnapshot": {
+    "description": "Take graph snapshots.\n**Note**: When a snapshot is created, there is some delay before it is available.",
+    "summary": "Take graph snapshots"
+  },
+  "MuteHost": {
+    "description": "Mute a host.",
+    "summary": "Mute a host",
+    "request_description": "Mute a host request body.",
+    "request_schema_description": "Combination of settings to mute a host."
+  },
+  "UnmuteHost": {
+    "description": "Unmutes a host. This endpoint takes no JSON arguments.",
+    "summary": "Unmute a host"
+  },
+  "ListHosts": {
+    "description": "This endpoint allows searching for hosts by name, alias, or tag.\nHosts live within the past 3 hours are included by default.\nRetention is 7 days.\nResults are paginated with a max of 1000 results at a time.",
+    "summary": "Get all hosts for your organization"
+  },
+  "GetHostTotals": {
+    "description": "This endpoint returns the total number of active and up hosts in your Datadog account.\nActive means the host has reported in the past hour, and up means it has reported in the past two hours.",
+    "summary": "Get the total number of active hosts"
+  },
+  "DeleteAWSAccount": {
+    "description": "Delete a Datadog-AWS integration matching the specified `account_id` and `role_name parameters`.",
+    "summary": "Delete an AWS integration",
+    "request_description": "AWS request object",
+    "request_schema_description": "Returns the AWS account associated with this integration."
+  },
+  "ListAWSAccounts": {
+    "description": "List all Datadog-AWS integrations available in your Datadog organization.",
+    "summary": "List all AWS integrations"
+  },
+  "CreateAWSAccount": {
+    "description": "Create a Datadog-Amazon Web Services integration.\nUsing the `POST` method updates your integration configuration\nby adding your new configuration to the existing one in your Datadog organization.\nA unique AWS Account ID for role based authentication.",
+    "summary": "Create an AWS integration",
+    "request_description": "AWS Request Object",
+    "request_schema_description": "Returns the AWS account associated with this integration."
+  },
+  "UpdateAWSAccount": {
+    "description": "Update a Datadog-Amazon Web Services integration.",
+    "summary": "Update an AWS integration",
+    "request_description": "AWS request object",
+    "request_schema_description": "Returns the AWS account associated with this integration."
+  },
+  "ListAvailableAWSNamespaces": {
+    "description": "List all namespace rules for a given Datadog-AWS integration. This endpoint takes no arguments.",
+    "summary": "List namespace rules"
+  },
+  "CreateNewAWSExternalID": {
+    "description": "Generate a new AWS external ID for a given AWS account ID and role name pair.",
+    "summary": "Generate a new external ID",
+    "request_description": "Your Datadog role delegation name.\nFor more information about your AWS account Role name,\nsee the [Datadog AWS integration configuration info](https://github.com/DataDog/documentation/blob/master/integrations/amazon_web_services/#installation).",
+    "request_schema_description": "Returns the AWS account associated with this integration."
+  },
+  "DeleteAWSLambdaARN": {
+    "description": "Delete a Datadog-AWS logs configuration by removing the specific Lambda ARN associated with a given AWS account.",
+    "summary": "Delete an AWS Logs integration",
+    "request_description": "Delete AWS Lambda ARN request body.",
+    "request_schema_description": "AWS account ID and Lambda ARN."
+  },
+  "ListAWSLogsIntegrations": {
+    "description": "List all Datadog-AWS Logs integrations configured in your Datadog account.",
+    "summary": "List all AWS Logs integrations"
+  },
+  "CreateAWSLambdaARN": {
+    "description": "Attach the Lambda ARN of the Lambda created for the Datadog-AWS log collection to your AWS account ID to enable log collection.",
+    "summary": "Add AWS Log Lambda ARN",
+    "request_description": "AWS Log Lambda Async request body.",
+    "request_schema_description": "AWS account ID and Lambda ARN."
+  },
+  "CheckAWSLogsLambdaAsync": {
+    "description": "Test if permissions are present to add a log-forwarding triggers for the given services and AWS account. The input\nis the same as for Enable an AWS service log collection. Subsequent requests will always repeat the above, so this\nendpoint can be polled intermittently instead of blocking.\n\n- Returns a status of 'created' when it's checking if the Lambda exists in the account.\n- Returns a status of 'waiting' while checking.\n- Returns a status of 'checked and ok' if the Lambda exists.\n- Returns a status of 'error' if the Lambda does not exist.",
+    "summary": "Check that an AWS Lambda Function exists",
+    "request_description": "Check AWS Log Lambda Async request body.",
+    "request_schema_description": "AWS account ID and Lambda ARN."
+  },
+  "ListAWSLogsServices": {
+    "description": "Get the list of current AWS services that Datadog offers automatic log collection. Use returned service IDs with the services parameter for the Enable an AWS service log collection API endpoint.",
+    "summary": "Get list of AWS log ready services"
+  },
+  "EnableAWSLogServices": {
+    "description": "Enable automatic log collection for a list of services. This should be run after running `CreateAWSLambdaARN` to save the configuration.",
+    "summary": "Enable an AWS Logs integration",
+    "request_description": "Enable AWS Log Services request body.",
+    "request_schema_description": "A list of current AWS services for which Datadog offers automatic log collection."
+  },
+  "CheckAWSLogsServicesAsync": {
+    "description": "Test if permissions are present to add log-forwarding triggers for the\ngiven services and AWS account. Input is the same as for `EnableAWSLogServices`.\nDone async, so can be repeatedly polled in a non-blocking fashion until\nthe async request completes.\n\n- Returns a status of `created` when it's checking if the permissions exists\n  in the AWS account.\n- Returns a status of `waiting` while checking.\n- Returns a status of `checked and ok` if the Lambda exists.\n- Returns a status of `error` if the Lambda does not exist.",
+    "summary": "Check permissions for log services",
+    "request_description": "Check AWS Logs Async Services request body.",
+    "request_schema_description": "A list of current AWS services for which Datadog offers automatic log collection."
+  },
+  "DeleteAzureIntegration": {
+    "description": "Delete a given Datadog-Azure integration from your Datadog account.",
+    "summary": "Delete an Azure integration",
+    "request_description": "Delete a given Datadog-Azure integration request body.",
+    "request_schema_description": "Datadog-Azure integrations configured for your organization."
+  },
+  "ListAzureIntegration": {
+    "description": "List all Datadog-Azure integrations configured in your Datadog account.",
+    "summary": "List all Azure integrations"
+  },
+  "CreateAzureIntegration": {
+    "description": "Create a Datadog-Azure integration.\n\nUsing the `POST` method updates your integration configuration by adding your new\nconfiguration to the existing one in your Datadog organization.\n\nUsing the `PUT` method updates your integration configuration by replacing your\ncurrent configuration with the new one sent to your Datadog organization.",
+    "summary": "Create an Azure integration",
+    "request_description": "Create a Datadog-Azure integration for your Datadog account request body.",
+    "request_schema_description": "Datadog-Azure integrations configured for your organization."
+  },
+  "UpdateAzureIntegration": {
+    "description": "Update a Datadog-Azure integration. Requires an existing `tenant_name` and `client_id`.\nAny other fields supplied will overwrite existing values. To overwrite `tenant_name` or `client_id`,\nuse `new_tenant_name` and `new_client_id`. To leave a field unchanged, do not supply that field in the payload.",
+    "summary": "Update an Azure integration",
+    "request_description": "Update a Datadog-Azure integration request body.",
+    "request_schema_description": "Datadog-Azure integrations configured for your organization."
+  },
+  "UpdateAzureHostFilters": {
+    "description": "Update the defined list of host filters for a given Datadog-Azure integration.",
+    "summary": "Update Azure integration host filters",
+    "request_description": "Update a Datadog-Azure integration's host filters request body.",
+    "request_schema_description": "Datadog-Azure integrations configured for your organization."
+  },
+  "DeleteGCPIntegration": {
+    "description": "Delete a given Datadog-GCP integration.",
+    "summary": "Delete a GCP integration",
+    "request_description": "Delete a given Datadog-GCP integration.",
+    "request_schema_description": "Your Google Cloud Platform Account."
+  },
+  "ListGCPIntegration": {
+    "description": "List all Datadog-GCP integrations configured in your Datadog account.",
+    "summary": "List all GCP integrations"
+  },
+  "CreateGCPIntegration": {
+    "description": "Create a Datadog-GCP integration.",
+    "summary": "Create a GCP integration",
+    "request_description": "Create a Datadog-GCP integration.",
+    "request_schema_description": "Your Google Cloud Platform Account."
+  },
+  "UpdateGCPIntegration": {
+    "description": "Update a Datadog-GCP integrations host_filters and/or auto-mute.\nRequires a `project_id` and `client_email`, however these fields cannot be updated.\nIf you need to update these fields, delete and use the create (`POST`) endpoint.\nThe unspecified fields will keep their original values.",
+    "summary": "Update a GCP integration",
+    "request_description": "Update a Datadog-GCP integration.",
+    "request_schema_description": "Your Google Cloud Platform Account."
+  },
+  "CreatePagerDutyIntegrationService": {
+    "description": "Create a new service object in the PagerDuty integration.",
+    "summary": "Create a new service object",
+    "request_description": "Create a new service object request body.",
+    "request_schema_description": "The PagerDuty service that is available for integration with Datadog."
+  },
+  "DeletePagerDutyIntegrationService": {
+    "description": "Delete a single service object in the Datadog-PagerDuty integration.",
+    "summary": "Delete a single service object"
+  },
+  "GetPagerDutyIntegrationService": {
+    "description": "Get service name in the Datadog-PagerDuty integration.",
+    "summary": "Get a single service object"
+  },
+  "UpdatePagerDutyIntegrationService": {
+    "description": "Update a single service object in the Datadog-PagerDuty integration.",
+    "summary": "Update a single service object",
+    "request_description": "Update an existing service object request body.",
+    "request_schema_description": "PagerDuty service object key."
+  },
+  "DeleteSlackIntegration": {
+    "description": "Delete a Datadog-Slack integration.",
+    "summary": "Delete a Slack integration"
+  },
+  "GetSlackIntegration": {
+    "description": "Get all information about your Datadog-Slack integration.",
+    "summary": "Get info about a Slack integration"
+  },
+  "CreateSlackIntegration": {
+    "description": "Create a Datadog-Slack integration. Once created, add a channel to it with the\n[Add channels to Slack integration endpoint](https://docs.datadoghq.com/api/?lang=bash#add-channels-to-slack-integration).\n\nThis method updates your integration configuration by **adding**\nyour new configuration to the existing one in your Datadog organization.",
+    "summary": "Create a Slack integration",
+    "request_description": "Create Datadog-Slack integration request body.",
+    "request_schema_description": "A new Datadog-Slack integration."
+  },
+  "UpdateSlackIntegration": {
+    "description": "Add channels to your existing Datadog-Slack integration.\n\nThis method updates your integration configuration by **replacing**\nyour current configuration with the new one sent to your Datadog organization.",
+    "summary": "Add channels to Slack integration",
+    "request_description": "Update an existing Datadog-Slack integration request body.",
+    "request_schema_description": "Configuration of your Slack channels."
+  },
+  "CreateWebhooksIntegrationCustomVariable": {
+    "description": "Creates an endpoint with the name `<CUSTOM_VARIABLE_NAME>`.",
+    "summary": "Create a custom variable",
+    "request_description": "Define a custom variable request body.",
+    "request_schema_description": "Custom variable for Webhook integration."
+  },
+  "DeleteWebhooksIntegrationCustomVariable": {
+    "description": "Deletes the endpoint with the name `<CUSTOM_VARIABLE_NAME>`.",
+    "summary": "Delete a custom variable"
+  },
+  "GetWebhooksIntegrationCustomVariable": {
+    "description": "Shows the content of the custom variable with the name `<CUSTOM_VARIABLE_NAME>`.\n\nIf the custom variable is secret, returns `null` for the `<CUSTOM_VARIABLE_VALUE>`\nin the response payload.",
+    "summary": "Get a custom variable"
+  },
+  "UpdateWebhooksIntegrationCustomVariable": {
+    "description": "Updates the endpoint with the name `<CUSTOM_VARIABLE_NAME>`.",
+    "summary": "Update a custom variable",
+    "request_description": "Update an existing custom variable request body.",
+    "request_schema_description": "Update request of a custom variable object.\n\n*All properties are optional.*"
+  },
+  "CreateWebhooksIntegration": {
+    "description": "Creates an endpoint with the name `<WEBHOOK_NAME>`.",
+    "summary": "Create a webhooks integration",
+    "request_description": "Create a webhooks integration request body.",
+    "request_schema_description": "Datadog-Webhooks integration."
+  },
+  "DeleteWebhooksIntegration": {
+    "description": "Deletes the endpoint with the name `<WEBHOOK NAME>`.",
+    "summary": "Delete a webhook"
+  },
+  "GetWebhooksIntegration": {
+    "description": "Gets the content of the webhook with the name `<WEBHOOK_NAME>`.",
+    "summary": "Get a webhook integration"
+  },
+  "UpdateWebhooksIntegration": {
+    "description": "Updates the endpoint with the name `<WEBHOOK_NAME>`.",
+    "summary": "Update a webhook",
+    "request_description": "Update an existing Datadog-Webhooks integration.",
+    "request_schema_description": "Update request of a Webhooks integration object.\n\n*All properties are optional.*"
+  },
+  "ListLogs": {
+    "description": "List endpoint returns logs that match a log search query.\n[Results are paginated][1].\n\n**If you are considering archiving logs for your organization,\nconsider use of the Datadog archive capabilities instead of the log list API.\nSee [Datadog Logs Archive documentation][2].**\n\n[1]: /logs/guide/collect-multiple-logs-with-pagination\n[2]: https://docs.datadoghq.com/logs/archives",
+    "summary": "Get a list of logs",
+    "request_description": "Logs filter",
+    "request_schema_description": "Object to send with the request to retrieve a list of logs from your Organization."
+  },
+  "GetLogsIndexOrder": {
+    "description": "Get the current order of your log indexes. This endpoint takes no JSON arguments.",
+    "summary": "Get indexes order"
+  },
+  "UpdateLogsIndexOrder": {
+    "description": "This endpoint updates the index order of your organization.\nIt returns the index order object passed in the request body when the request is successful.",
+    "summary": "Update indexes order",
+    "request_description": "Object containing the new ordered list of index names",
+    "request_schema_description": "Object containing the ordered list of log index names."
+  },
+  "ListLogIndexes": {
+    "description": "The Index object describes the configuration of a log index.\nThis endpoint returns an array of the `LogIndex` objects of your organization.",
+    "summary": "Get all indexes"
+  },
+  "GetLogsIndex": {
+    "description": "Get one log index from your organization. This endpoint takes no JSON arguments.",
+    "summary": "Get an index"
+  },
+  "UpdateLogsIndex": {
+    "description": "Update an index as identified by its name.\nReturns the Index object passed in the request body when the request is successful.\n\nUsing the `PUT` method updates your index’s configuration by **replacing**\nyour current configuration with the new one sent to your Datadog organization.",
+    "summary": "Update an index",
+    "request_description": "Object containing the new `LogsIndex`.",
+    "request_schema_description": "Object describing a Datadog Log index."
+  },
+  "GetLogsPipelineOrder": {
+    "description": "Get the current order of your pipelines.\nThis endpoint takes no JSON arguments.",
+    "summary": "Get pipeline order"
+  },
+  "UpdateLogsPipelineOrder": {
+    "description": "Update the order of your pipelines. Since logs are processed sequentially, reordering a pipeline may change\nthe structure and content of the data processed by other pipelines and their processors.\n\n**Note**: Using the `PUT` method updates your pipeline order by replacing your current order\nwith the new one sent to your Datadog organization.",
+    "summary": "Update pipeline order",
+    "request_description": "Object containing the new ordered list of pipeline IDs.",
+    "request_schema_description": "Object containing the ordered list of pipeline IDs."
+  },
+  "ListLogsPipelines": {
+    "description": "Get all pipelines from your organization.\nThis endpoint takes no JSON arguments.",
+    "summary": "Get all pipelines"
+  },
+  "CreateLogsPipeline": {
+    "description": "Create a pipeline in your organization.",
+    "summary": "Create a pipeline",
+    "request_description": "Definition of the new pipeline.",
+    "request_schema_description": "Pipelines and processors operate on incoming logs,\nparsing and transforming them into structured attributes for easier querying.\n\n**Note**: These endpoints are only available for admin users.\nMake sure to use an application key created by an admin."
+  },
+  "DeleteLogsPipeline": {
+    "description": "Delete a given pipeline from your organization.\nThis endpoint takes no JSON arguments.",
+    "summary": "Delete a pipeline"
+  },
+  "GetLogsPipeline": {
+    "description": "Get a specific pipeline from your organization.\nThis endpoint takes no JSON arguments.",
+    "summary": "Get a pipeline"
+  },
+  "UpdateLogsPipeline": {
+    "description": "Update a given pipeline configuration to change it’s processors or their order.\n\n**Note**: Using this method updates your pipeline configuration by **replacing**\nyour current configuration with the new one sent to your Datadog organization.",
+    "summary": "Update a pipeline",
+    "request_description": "New definition of the pipeline.",
+    "request_schema_description": "Pipelines and processors operate on incoming logs,\nparsing and transforming them into structured attributes for easier querying.\n\n**Note**: These endpoints are only available for admin users.\nMake sure to use an application key created by an admin."
+  },
+  "ListActiveMetrics": {
+    "description": "Get the list of actively reporting metrics from a given time until now.",
+    "summary": "Get active metrics list"
+  },
+  "GetMetricMetadata": {
+    "description": "Get metadata about a specific metric.",
+    "summary": "Get metric metadata"
+  },
+  "UpdateMetricMetadata": {
+    "description": "Edit metadata of a specific metric. Find out more about [supported types](https://docs.datadoghq.com/developers/metrics).",
+    "summary": "Edit metric metadata",
+    "request_description": "New metadata.",
+    "request_schema_description": "Object with all metric related metadata."
+  },
+  "ListMonitors": {
+    "description": "Get details about the specified monitor from your organization.",
+    "summary": "Get all monitor details"
+  },
+  "CreateMonitor": {
+    "description": "Create a monitor using the specified options.\n\n#### Monitor Types\n\nThe type of monitor chosen from:\n\n- anomaly: `query alert`\n- APM: `query alert` or `trace-analytics alert`\n- composite: `composite`\n- custom: `service check`\n- event: `event alert`\n- forecast: `query alert`\n- host: `service check`\n- integration: `query alert` or `service check`\n- live process: `process alert`\n- logs: `log alert`\n- metric: `metric alert`\n- network: `service check`\n- outlier: `query alert`\n- process: `service check`\n- rum: `rum alert`\n- watchdog: `event alert`\n\n#### Query Types\n\n**Metric Alert Query**\n\nExample: `time_aggr(time_window):space_aggr:metric{tags} [by {key}] operator #`\n\n- `time_aggr`: avg, sum, max, min, change, or pct_change\n- `time_window`: `last_#m` (with `#` being 5, 10, 15, or 30) or `last_#h`(with `#` being 1, 2, or 4), or `last_1d`\n- `space_aggr`: avg, sum, min, or max\n- `tags`: one or more tags (comma-separated), or *\n- `key`: a 'key' in key:value tag syntax; defines a separate alert for each tag in the group (multi-alert)\n- `operator`: <, <=, >, >=, ==, or !=\n- `#`: an integer or decimal number used to set the threshold\n\nIf you are using the `_change_` or `_pct_change_` time aggregator, instead use `change_aggr(time_aggr(time_window),\ntimeshift):space_aggr:metric{tags} [by {key}] operator #` with:\n\n- `change_aggr` change, pct_change\n- `time_aggr` avg, sum, max, min [Learn more](https://docs.datadoghq.com/monitors/monitor_types/#define-the-conditions)\n- `time_window` last\\_#m (1, 5, 10, 15, or 30), last\\_#h (1, 2, or 4), or last_#d (1 or 2)\n- `timeshift` #m_ago (5, 10, 15, or 30), #h_ago (1, 2, or 4), or 1d_ago\n\nUse this to create an outlier monitor using the following query:\n`avg(last_30m):outliers(avg:system.cpu.user{role:es-events-data} by {host}, 'dbscan', 7) > 0`\n\n**Service Check Query**\n\nExample: `\"check\".over(tags).last(count).count_by_status()`\n\n- **`check`** name of the check, e.g. `datadog.agent.up`\n- **`tags`** one or more quoted tags (comma-separated), or \"*\". e.g.: `.over(\"env:prod\", \"role:db\")`\n- **`count`** must be at >= your max threshold (defined in the `options`).\ne.g. if you want to notify on 1 critical, 3 ok and 2 warn statuses count should be 3. It is limited to 100.\n\n**Event Alert Query**\n\nExample: `events('sources:nagios status:error,warning priority:normal tags: \"string query\"').rollup(\"count\").last(\"1h\")\"`\n\n- **`event`**, the event query string:\n- **`string_query`** free text query to match against event title and text.\n- **`sources`** event sources (comma-separated).\n- **`status`** event statuses (comma-separated). Valid options: error, warn, and info.\n- **`priority`** event priorities (comma-separated). Valid options: low, normal, all.\n- **`host`** event reporting host (comma-separated).\n- **`tags`** event tags (comma-separated).\n- **`excluded_tags`** excluded event tags (comma-separated).\n- **`rollup`** the stats roll-up method. `count` is the only supported method now.\n- **`last`** the timeframe to roll up the counts. Examples: 60s, 4h. Supported timeframes: s, m, h and d. This value should not exceed 48 hours.\n\n**Process Alert Query**\n\nExample: `processes(search).over(tags).rollup('count').last(timeframe) operator #`\n\n- **`search`** free text search string for querying processes.\nMatching processes match results on the [Live Processes](https://docs.datadoghq.com/infrastructure/process/?tab=linuxwindows) page.\n- **`tags`** one or more tags (comma-separated)\n- **`timeframe`** the timeframe to roll up the counts. Examples: 60s, 4h. Supported timeframes: s, m, h and d\n- **`operator`** <, <=, >, >=, ==, or !=\n- **`#`** an integer or decimal number used to set the threshold\n\n**Logs Alert Query**\n\nExample: `logs(query).index(index_name).rollup(rollup_method[, measure]).last(time_window) operator #`\n\n- **`query`** The search query - following the [Log search syntax](https://docs.datadoghq.com/logs/search_syntax/).\n- **`index_name`** For multi-index organizations, the log index in which the request is performed.\n- **`rollup_method`** The stats roll-up method - supports `count`, `avg` and `cardinality`.\n- **`measure`** For `avg` and cardinality `rollup_method` - specify the measure or the facet name you want to use.\n- **`time_window`** #m (5, 10, 15, or 30), #h (1, 2, or 4, 24)\n- **`operator`** `<`, `<=`, `>`, `>=`, `==`, or `!=`.\n- **`#`** an integer or decimal number used to set the threshold.\n\n**Composite Query**\n\nExample: `12345 && 67890`, where `12345` and `67890` are the IDs of non-composite monitors\n\n* **`name`** [*required*, *default* = **dynamic, based on query**]: The name of the alert.\n* **`message`** [*required*, *default* = **dynamic, based on query**]: A message to include with notifications for this monitor.\nEmail notifications can be sent to specific users by using the same '@username' notation as events.\n* **`tags`** [*optional*, *default* = **empty list**]: A list of tags to associate with your monitor.\nWhen getting all monitor details via the API, use the `monitor_tags` argument to filter results by these tags.\nIt is only available via the API and isn't visible or editable in the Datadog UI.",
+    "summary": "Create a monitor",
+    "request_description": "Create a monitor request body.",
+    "request_schema_description": "Object describing a monitor."
+  },
+  "CheckCanDeleteMonitor": {
+    "description": "Check if the given monitors can be deleted.",
+    "summary": "Check if a monitor can be deleted"
+  },
+  "SearchMonitorGroups": {
+    "description": "Search and filter your monitor groups details.",
+    "summary": "Monitors group search"
+  },
+  "SearchMonitors": {
+    "description": "Search and filter your monitors details.",
+    "summary": "Monitors search"
+  },
+  "ValidateMonitor": {
+    "description": "Validate the monitor provided in the request.",
+    "summary": "Validate a monitor",
+    "request_description": "Monitor request object",
+    "request_schema_description": "Object describing a monitor."
+  },
+  "DeleteMonitor": {
+    "description": "Delete the specified monitor",
+    "summary": "Delete a monitor"
+  },
+  "GetMonitor": {
+    "description": "Get details about the specified monitor from your organization.",
+    "summary": "Get a monitor's details"
+  },
+  "UpdateMonitor": {
+    "description": "Edit the specified monitor.",
+    "summary": "Edit a monitor",
+    "request_description": "Edit a monitor request body.",
+    "request_schema_description": "Object describing a monitor update request."
+  },
+  "MuteMonitor": {
+    "description": "Mute the specified monitor.",
+    "summary": "Mute a monitor"
+  },
+  "UnmuteMonitor": {
+    "description": "Mute the specified monitor.",
+    "summary": "Unmute a monitor"
+  },
+  "GetMonthlyCustomReports": {
+    "description": "Get monthly custom reports.",
+    "summary": "Get the list of available monthly custom reports"
+  },
+  "GetSpecifiedMonthlyCustomReports": {
+    "description": "Get specified monthly custom reports.",
+    "summary": "Get specified monthly custom reports"
+  },
+  "ListOrgs": {
+    "description": "List your managed organizations.",
+    "summary": "List your managed organizations"
+  },
+  "CreateChildOrg": {
+    "description": "Create a child organization.\n\nThis endpoint requires the\n[multi-organization account](https://docs.datadoghq.com/account_management/multi_organization/)\nfeature and must be enabled by\n[contacting support](https://docs.datadoghq.com/help/).\n\nOnce a new child organization is created, you can interact with it\nby using the `org.public_id`, `pi_key.key`, and\n`application_key.hash` provided in the response.",
+    "summary": "Create a child organization",
+    "request_description": "Organization object that needs to be created",
+    "request_schema_description": "Object describing an organization to create."
+  },
+  "GetOrg": {
+    "description": "Get organization information.",
+    "summary": "Get organization information"
+  },
+  "UpdateOrg": {
+    "description": "Update your organization.",
+    "summary": "Update your organization",
+    "request_description": "",
+    "request_schema_description": "Create, edit, and manage organizations."
+  },
+  "UploadIdPForOrg": {
+    "description": "There are a couple of options for updating the Identity Provider (IdP)\nmetadata from your SAML IdP.\n\n* **Multipart Form-Data**: Post the IdP metadata file using a form post.\n\n* **XML Body:** Post the IdP metadata file as the body of the request.",
+    "summary": "Upload IdP metadata",
+    "request_description": ""
+  },
+  "QueryMetrics": {
+    "description": "Query timeseries points.",
+    "summary": "Query timeseries points"
+  },
+  "ListMetrics": {
+    "description": "Search for metrics from the last 24 hours in Datadog.",
+    "summary": "Search metrics"
+  },
+  "SubmitMetrics": {
+    "description": "The metrics end-point allows you to post time-series data that can be graphed on Datadog’s dashboards.\nThe maximum payload size is 3.2 megabytes (3200000). Compressed payloads must have a decompressed size of up to 62 megabytes (62914560).\n\nIf you’re submitting metrics directly to the Datadog API without using DogStatsD, expect\n\n- 64 bits for the timestamp\n- 64 bits for the value\n- 20 bytes for the metric names\n- 50 bytes for the timeseries\n- The full payload is approximately ~ 100 bytes. However, with the DogStatsD API,\ncompression is applied, which reduces the payload size.",
+    "summary": "Submit metrics",
+    "request_description": "",
+    "request_schema_description": "The metrics' payload."
+  },
+  "ListServiceDependencies": {
+    "description": "Get a list of services and their dependencies. The services retrieved are filtered by environment and a\nprimary tag, if one is defined.",
+    "summary": "Get all service dependencies"
+  },
+  "ListSingleServiceDependencies": {
+    "description": "Get a specific service's immediate upstream and downstream services.\nThe services retrieved are filtered by environment and a primary tag, if one is defined.",
+    "summary": "Get one service's dependencies"
+  },
+  "ListSLOs": {
+    "description": "Get multiple service level objective objects by their IDs.",
+    "summary": "Search SLOs"
+  },
+  "CreateSLO": {
+    "description": "Create a service level objective object.",
+    "summary": "Create a SLO object",
+    "request_description": "Service level objective request object.",
+    "request_schema_description": "A service level objective object includes a service level indicator, thresholds\nfor one or more timeframes, and metadata (`name`, `description`, `tags`, etc.)."
+  },
+  "DeleteSLOTimeframeInBulk": {
+    "description": "Delete (or partially delete) multiple service level objective objects.\n\nThis endpoint facilitates deletion of one or more thresholds for one or more\nservice level objective objects. If all thresholds are deleted, the service level\nobjective object is deleted as well.",
+    "summary": "Bulk Delete SLO Timeframes",
+    "request_description": "Delete multiple service level objective objects request body.",
+    "request_schema_description": "A map of service level objective object IDs to arrays of timeframes,\nwhich indicate the thresholds to delete for each ID."
+  },
+  "CheckCanDeleteSLO": {
+    "description": "Check if a SLO can be safely deleted. For example,\nassure an SLO can be deleted without disrupting a dashboard.",
+    "summary": "Check if SLOs can be safely deleted"
+  },
+  "DeleteSLO": {
+    "description": "Permanently delete the specified service level objective object.\n\nIf an SLO is used in a dashboard, the `DELETE /v1/slo/` endpoint returns\na 409 conflict error because the SLO is referenced in a dashboard.",
+    "summary": "Delete a SLO"
+  },
+  "GetSLO": {
+    "description": "Get a service level objective object.",
+    "summary": "Get a SLO's details"
+  },
+  "UpdateSLO": {
+    "description": "Update the specified service level objective object.",
+    "summary": "Update a SLO",
+    "request_description": "The edited service level objective request object.",
+    "request_schema_description": "A service level objective object includes a service level indicator, thresholds\nfor one or more timeframes, and metadata (`name`, `description`, `tags`, etc.)."
+  },
+  "GetSLOHistory": {
+    "description": "Get a specific SLO’s history, regardless of its SLO type.\n\nThe detailed history data is structured according to the source data type.\nFor example, metric data is included for event SLOs that use\nthe metric source, and monitor SLO types include the monitor transition history.\n\n**Note:** There are different response formats for event based and time based SLOs.\nExamples of both are shown.",
+    "summary": "Get an SLO's history"
+  },
+  "ListLocations": {
+    "description": "Get the list of public and private locations available for Synthetic\ntests. No arguments required.",
+    "summary": "Get all locations (public and private)"
+  },
+  "ListTests": {
+    "description": "Get the list of all Synthetic tests.",
+    "summary": "Get the list of all tests"
+  },
+  "CreateTest": {
+    "description": "Create a Synthetic test.",
+    "summary": "Create a test",
+    "request_description": "Details of the test to create.",
+    "request_schema_description": "Object containing details about your Synthetic test."
+  },
+  "GetBrowserTest": {
+    "description": "Get the detailed configuration (including steps) associated with\na Synthetic browser test.",
+    "summary": "Get a test configuration (browser)"
+  },
+  "GetBrowserTestLatestResults": {
+    "description": "Get the last 50 test results summaries for a given Synthetics Browser test.",
+    "summary": "Get the test's latest results summaries (browser)"
+  },
+  "GetBrowserTestResult": {
+    "description": "Get a specific full result from a given (browser) Synthetic test.",
+    "summary": "Get a test result (browser)"
+  },
+  "DeleteTests": {
+    "description": "Delete multiple Synthetic tests by ID.",
+    "summary": "Delete tests",
+    "request_description": "Public ID list of the Synthetic tests to be deleted.",
+    "request_schema_description": "A JSON list of the ID or IDs of the Synthetic tests that you want\nto delete."
+  },
+  "TriggerCITests": {
+    "description": "Trigger a set of Synthetics tests for continuous integration",
+    "summary": "Trigger some Synthetics tests for CI",
+    "request_description": "Details of the test to trigger.",
+    "request_schema_description": "Object describing the synthetics tests to trigger."
+  },
+  "GetTest": {
+    "description": "Get the detailed configuration associated with a Synthetics test.",
+    "summary": "Get a test configuration (API)"
+  },
+  "UpdateTest": {
+    "description": "Edit the configuration of a Synthetic test.",
+    "summary": "Edit a test",
+    "request_description": "New test details to be saved.",
+    "request_schema_description": "Object containing details about your Synthetic test."
+  },
+  "GetAPITestLatestResults": {
+    "description": "Get the last 50 test results summaries for a given Synthetics API test.",
+    "summary": "Get the test's latest results summaries (API)"
+  },
+  "GetAPITestResult": {
+    "description": "Get a specific full result from a given (API) Synthetic test.",
+    "summary": "Get a test result (API)"
+  },
+  "UpdateTestPauseStatus": {
+    "description": "Pause or start a Synthetics test by changing the status.",
+    "summary": "Pause or start a test",
+    "request_description": "Status to set the given Synthetic test to.",
+    "request_schema_description": "Object to start or pause an existing Synthetic test."
+  },
+  "CreateGlobalVariable": {
+    "description": "Create a Synthetics global variable.",
+    "summary": "Create a global variable",
+    "request_description": "Details of the global variable to create.",
+    "request_schema_description": "Synthetics global variable."
+  },
+  "DeleteGlobalVariable": {
+    "description": "Delete a Synthetics global variable.",
+    "summary": "Delete a global variable"
+  },
+  "GetGlobalVariable": {
+    "description": "Get the detailed configuration of a global variable.",
+    "summary": "Get a global variable"
+  },
+  "EditGlobalVariable": {
+    "description": "Edit a Synthetics global variable.",
+    "summary": "Edit a global variable",
+    "request_description": "Details of the global variable to update.",
+    "request_schema_description": "Synthetics global variable."
+  },
+  "ListHostTags": {
+    "description": "Return a mapping of tags to hosts for your whole infrastructure.",
+    "summary": "Get Tags"
+  },
+  "DeleteHostTags": {
+    "description": "This endpoint allows you to remove all user-assigned tags\nfor a single host.",
+    "summary": "Remove host tags"
+  },
+  "GetHostTags": {
+    "description": "Return the list of tags that apply to a given host.",
+    "summary": "Get host tags"
+  },
+  "CreateHostTags": {
+    "description": "This endpoint allows you to add new tags to a host,\noptionally specifying where these tags come from.",
+    "summary": "Add tags to a host",
+    "request_description": "Update host tags request body.",
+    "request_schema_description": "Set of tags to associate with your host."
+  },
+  "UpdateHostTags": {
+    "description": "This endpoint allows you to update/replace all tags in\nan integration source with those supplied in the request.",
+    "summary": "Update host tags",
+    "request_description": "Add tags to host",
+    "request_schema_description": "Set of tags to associate with your host."
+  },
+  "GetUsageAnalyzedLogs": {
+    "description": "Get hourly usage for analyzed logs (Security Monitoring).",
+    "summary": "Get hourly usage for analyzed logs"
+  },
+  "GetUsageLambda": {
+    "description": "Get hourly usage for lambda.",
+    "summary": "Get hourly usage for Lambda"
+  },
+  "GetUsageBillableSummary": {
+    "description": "Get billable usage across your multi-org account.",
+    "summary": "Get billable usage across your multi-org account"
+  },
+  "GetUsageFargate": {
+    "description": "Get hourly usage for [Fargate](https://docs.datadoghq.com/integrations/ecs_fargate/).",
+    "summary": "Get hourly usage for Fargate"
+  },
+  "GetUsageHosts": {
+    "description": "Get hourly usage for hosts and containers.",
+    "summary": "Get hourly usage for hosts and containers"
+  },
+  "GetUsageLogs": {
+    "description": "Get hourly usage for logs.",
+    "summary": "Get hourly usage for Logs"
+  },
+  "GetUsageLogsByIndex": {
+    "description": "Get hourly usage for logs by index.",
+    "summary": "Get hourly usage for Logs by Index"
+  },
+  "GetUsageNetworkFlows": {
+    "description": "Get hourly usage for network flows.",
+    "summary": "Get hourly usage for Network Flows"
+  },
+  "GetUsageNetworkHosts": {
+    "description": "Get hourly usage for network hosts.",
+    "summary": "Get hourly usage for Network Hosts"
+  },
+  "GetUsageProfiling": {
+    "description": "Get hourly usage for profiled hosts.",
+    "summary": "Get hourly usage for profiled hosts"
+  },
+  "GetUsageRumSessions": {
+    "description": "Get hourly usage for [RUM](https://docs.datadoghq.com/real_user_monitoring/) Sessions.",
+    "summary": "Get hourly usage for RUM Sessions"
+  },
+  "GetUsageSNMP": {
+    "description": "Get hourly usage for SNMP devices.",
+    "summary": "Get hourly usage for SNMP devices"
+  },
+  "GetUsageSummary": {
+    "description": "Get usage across your multi-org account.",
+    "summary": "Get usage across your multi-org account"
+  },
+  "GetUsageSynthetics": {
+    "description": "Get hourly usage for [Synthetics checks](https://docs.datadoghq.com/synthetics/).",
+    "summary": "Get hourly usage for Synthetics Checks"
+  },
+  "GetUsageSyntheticsAPI": {
+    "description": "Get hourly usage for [synthetics API checks](https://docs.datadoghq.com/synthetics/).",
+    "summary": "Get hourly usage for Synthetics API Checks"
+  },
+  "GetUsageSyntheticsBrowser": {
+    "description": "Get hourly usage for synthetics browser checks.",
+    "summary": "Get hourly usage for Synthetics Browser Checks"
+  },
+  "GetUsageTimeseries": {
+    "description": "Get hourly usage for [custom metrics](https://docs.datadoghq.com/developers/metrics/custom_metrics/).",
+    "summary": "Get hourly usage for custom metrics"
+  },
+  "GetUsageTopAvgMetrics": {
+    "description": "Get top [custom metrics](https://docs.datadoghq.com/developers/metrics/custom_metrics/) by hourly average.",
+    "summary": "Get top 500 custom metrics by hourly average"
+  },
+  "GetUsageTrace": {
+    "description": "Get hourly usage for trace search.",
+    "summary": "Get hourly usage for Trace Search"
+  },
+  "GetTracingWithoutLimits": {
+    "description": "Get hourly usage for tracing without limits.",
+    "summary": "Get hourly usage for tracing without limits"
+  },
+  "ListUsers": {
+    "description": "List all users for your organization.",
+    "summary": "List all users"
+  },
+  "CreateUser": {
+    "description": "Create a user for your organization.\n\n**Note**: Users can only be created with the admin access role\nif application keys belong to administrators.",
+    "summary": "Create a user",
+    "request_description": "User object that needs to be created.",
+    "request_schema_description": "Create, edit, and disable users."
+  },
+  "DisableUser": {
+    "description": "Delete a user from an organization.\n\n**Note**: This endpoint can only be used with application keys belonging to\nadministrators.",
+    "summary": "Disable a user"
+  },
+  "GetUser": {
+    "description": "Get a user's details.",
+    "summary": "Get user details"
+  },
+  "UpdateUser": {
+    "description": "Update a user information.\n\n**Note**: It can only be used with application keys belonging to administrators.",
+    "summary": "Update a user",
+    "request_description": "Description of the update.",
+    "request_schema_description": "Create, edit, and disable users."
+  },
+  "Validate": {
+    "description": "Check if the API key (not the APP key) is valid. If invalid, a 403 is returned.",
+    "summary": "Validate API key"
+  },
+  "ResolveMonitor": {
+    "description": "Resolve monitor.",
+    "summary": "Resolve Monitor",
+    "request_description": "Array of group(s) to resolve for a given monitor_id, e.g.:\n`{\"monitor_id\": \"group_to_resolve\"}`.\n\nIt supports multiple groups per monitor, e.g.:\n`resolve: [{\"monitor_id\": \"group_1\"}, {\"monitor_id\": \"group_2\"}]`.\n\nIt can also resolve all triggered groups with the pseudo-group `ALL_GROUPS`:\n`resolve: [{\"monitor_id\": \"ALL_GROUPS\"}]`.",
+    "request_schema_description": ""
+  },
+  "SubmitTraces": {
+    "description": "Datadog’s APM allows you to collect performance metrics by tracing your code\nto determine which parts of your application are slow or inefficient.\n\nTracing data is sent to the Datadog Agent via an HTTP API.\nWe provide some [official libraries](https://docs.datadoghq.com/tracing/#instrument-your-application)\nthat simplify sending metrics to the Datadog Agent, however you may want to\ninteract directly with the API to instrument applications that cannot use\nthe libraries or are written in languages that don’t yet have an official\nDatadog Tracing library.",
+    "summary": "Send traces",
+    "request_description": "Traces can be sent as an array of traces:\n\n    [ trace1, trace2, trace3 ]\n\nand each trace is an array of spans:\n\n    trace1 = [ span, span2, span3 ]\n\nand each span is a dictionary with a `trace_id`, `span_id`, `resource`...\n\n[Learn more about the APM & Distributed Tracing terminology](https://docs.datadoghq.com/tracing/visualization/services_list)\n\n**Note:** Each span within a trace should use the same `trace_id`.\nHowever, `trace_id` and `span_id` must have different values.",
+    "request_schema_description": "An array of traces."
+  },
+  "SubmitLog": {
+    "description": "Send your logs to your Datadog platform over HTTP. Limits per HTTP request are as follows.\n- Maximum content size per payload is 5MB.\n- Maximum size for a single log is 256kB.\n- Maximum array size if sending multiple logs in an array is 500 entries.\n\nAny log exceeding 256KB is accepted and truncated by server\n- For a single log request, the API truncates the log at 256KB and returns a 2xx.\n- For a multi-logs request, the API processes all logs,\ntruncates only logs larger than 256KB, and returns a 2xx.\n\nWe encourage you to send your logs compressed.\nAdd the `Content-Encoding: gzip` header to the request when sending compressed logs.",
+    "summary": "Send logs",
+    "request_description": "Log to send (JSON format).",
+    "request_schema_description": "Structured log message."
+  },
+  "MuteAllMonitors": {
+    "description": "Muting prevents all monitors from notifying through email and posts to the\n[event stream](https://docs.datadoghq.com/events).\nState changes are only visible by checking the alert page.",
+    "summary": "Mute all monitors"
+  },
+  "UnmuteAllMonitors": {
+    "description": "Disables muting all monitors. Throws an error if mute all\nwas not enabled previously.",
+    "summary": "Unmute all monitors"
+  }
+}

--- a/data/api/v1/translate_tags.json
+++ b/data/api/v1/translate_tags.json
@@ -1,0 +1,150 @@
+{
+  "aws-integration": {
+    "name": "AWS Integration",
+    "description": "Configure your Datadog-AWS integration directly through the Datadog API.\nFor more information, see the [AWS integration page](https://docs.datadoghq.com/integrations/amazon_web_services)."
+  },
+  "aws-logs-integration": {
+    "name": "AWS Logs Integration",
+    "description": "Configure your Datadog-AWS-Logs integration directly through Datadog API.\nFor more information, see the [AWS integration page](https://docs.datadoghq.com/api/?lang=bash#integration-aws-logs)."
+  },
+  "authentication": {
+    "name": "Authentication",
+    "description": "All requests to Datadog’s API must be authenticated.\nRequests that write data require reporting access and require an `API key`.\nRequests that read data require full access and also require an `application key`.\n\n**Note:** All Datadog API clients are configured by default to consume Datadog US site APIs.\nIf you are on the Datadog EU site, set the environment variable `DATADOG_HOST` to\n`https://api.datadoghq.eu` or override this value directly when creating your client.\n\n[Manage your account’s API and application keys](https://app.datadoghq.com/account/settings#api)."
+  },
+  "azure-integration": {
+    "name": "Azure Integration",
+    "description": "Configure your Datadog-Azure integration directly through the Datadog API.\nFor more information, see the [Datadog-Azure integration page](https://docs.datadoghq.com/integrations/azure)."
+  },
+  "dashboard-lists": {
+    "name": "Dashboard Lists",
+    "description": "This endpoint is deprecated. Use the [new dashboard list endpoint](https://docs.datadoghq.com/api/v2/dashboard-lists/) instead."
+  },
+  "dashboards": {
+    "name": "Dashboards",
+    "description": "Interact with your dashboard lists through the API to make it easier to organize,\nfind, and share all of your dashboards with your team and organization."
+  },
+  "downtimes": {
+    "name": "Downtimes",
+    "description": "[Downtiming](https://docs.datadoghq.com/monitors/downtimes) gives\nyou greater control over monitor notifications by allowing you to globally exclude\nscopes from alerting. Downtime settings, which can be scheduled with start and\nend times, prevent all alerting related to specified Datadog tags."
+  },
+  "embeddable-graphs": {
+    "name": "Embeddable Graphs",
+    "description": "Interact with embeddable graphs through the API."
+  },
+  "events": {
+    "name": "Events",
+    "description": "The events service allows you to programmatically post events to the event stream\nand fetch events from the event stream. Events are limited to 4000 characters. If an event is sent out with a message\ncontaining more than 4000 characters only the 4000 first characters are displayed."
+  },
+  "gcp-integration": {
+    "name": "GCP Integration",
+    "description": "Configure your Datadog-Google Cloud Platform (GCP) integration directly\nthrough the Datadog API. Read more about the [Datadog-Google Cloud Platform integration](https://docs.datadoghq.com/integrations/google_cloud_platform)."
+  },
+  "hosts": {
+    "name": "Hosts",
+    "description": "Get information about your live hosts in Datadog."
+  },
+  "ip-ranges": {
+    "name": "IP Ranges",
+    "description": "Get a list of IP prefixes belonging to Datadog."
+  },
+  "key-management": {
+    "name": "Key Management",
+    "description": "Manage your Datadog API and application keys.\n\nYou need an API and applications key with Admin rights\nto interact with this endpoint. The full list of keys can be seen on your\n[Datadog API page](https://app.datadoghq.com/account/settings#api)."
+  },
+  "logs": {
+    "name": "Logs",
+    "description": "Send your logs to your Datadog platform over HTTP. Limits per HTTP request are:\n\n- Maximum content size per payload: 5MB\n- Maximum size for a single log: 256kB\n- Maximum array size if sending multiple logs in an array: 500 entries\n\nAny log exceeding 256KB is accepted and truncated by Datadog:\n- For a single log request, the API truncates the log at 256KB and returns a 2xx.\n- For a multi-logs request, the API processes all logs, truncates only logs larger than 256KB, and returns a 2xx.\n\nWe encourage you to send your logs compressed.\nAdd the `Content-Encoding: gzip` header to the request when sending compressed logs."
+  },
+  "logs-archives": {
+    "name": "Logs Archives",
+    "description": "[Check API version 2](/api/v2/logs-archives/)."
+  },
+  "logs-indexes": {
+    "name": "Logs Indexes",
+    "description": "Manage configuration of [log indexes](https://docs.datadoghq.com/logs/indexes/).\nYou need an API and application key with Admin rights to interact with this endpoint."
+  },
+  "logs-pipelines": {
+    "name": "Logs Pipelines",
+    "description": "Pipelines and processors operate on incoming logs, parsing\nand transforming them into structured attributes for easier querying.\n\n- See the [pipelines configuration page](https://app.datadoghq.com/logs/pipelines)\n  for a list of the pipelines and processors currently configured in our UI.\n\n- Additional API-related information about processors can be found in the\n  [processors documentation](https://docs.datadoghq.com/logs/processing/processors/?tab=api#lookup-processor).\n\n- For more information about Pipelines, see the\n  [pipeline documentation](https://docs.datadoghq.com/logs/processing).\n\n**Note:** These endpoints are only available for admin users.\nMake sure to use an application key created by an admin."
+  },
+  "logs-restriction-queries": {
+    "name": "Logs Restriction Queries",
+    "description": "[Check API version 2](/api/v2/logs-restriction-queries/)."
+  },
+  "metrics": {
+    "name": "Metrics",
+    "description": "The metrics endpoint allows you to:\n\n- Post metrics data so it can be graphed on Datadog’s dashboards\n- Query metrics from any time period\n\n**Note**: A graph can only contain a set number of points\nand as the timeframe over which a metric is viewed increases,\naggregation between points occurs to stay below that set number.\n\nDatadog has a soft limit of 100 timeseries per host\nwhere a timeseries is defined as a unique combination of metric name and tag."
+  },
+  "monitors": {
+    "name": "Monitors",
+    "description": "[Monitors](https://docs.datadoghq.com/monitors) allow you to watch a metric or check that you care about,\nnotifying your team when some defined threshold is exceeded.\nRefer to the Creating Monitors page for more information on creating monitors."
+  },
+  "organizations": {
+    "name": "Organizations",
+    "description": "Create, edit, and manage your organizations. Read more about [multi-org accounts](https://docs.datadoghq.com/account_management/multi_organization)."
+  },
+  "pagerduty-integration": {
+    "name": "PagerDuty Integration",
+    "description": "Configure your [Datadog-PagerDuty integration](https://docs.datadoghq.com/api/?lang=bash#integration-pagerduty)\ndirectly through the Datadog API."
+  },
+  "roles": {
+    "name": "Roles",
+    "description": "[Check API version 2](/api/v2/roles/)."
+  },
+  "screenboards": {
+    "name": "Screenboards",
+    "description": "This endpoint is outdated. Use the [new Dashboard endpoint](https://docs.datadoghq.com/api/#dashboards) instead."
+  },
+  "security-monitoring": {
+    "name": "Security Monitoring",
+    "description": "[Check API version 2](/api/v2/security-monitoring/)."
+  },
+  "service-checks": {
+    "name": "Service Checks",
+    "description": "The service check endpoint allows you to post check statuses for use with monitors.\nService check messages are limited to 500 characters. If a check is posted with a message\ncontaining more than 500 characters, only the first 500 characters are displayed.\n\n- [Read more about Service Check monitors.][1]\n- [Read more about Process Check monitors.][2]\n- [Read more about Network Check monitors.][3]\n- [Read more about Custom Check monitors.][4]\n\n[1]: https://docs.datadoghq.com/monitors/monitor_types/host/?tab=checkalert\n[2]: https://docs.datadoghq.com/monitors/monitor_types/process_check/?tab=checkalert\n[3]: https://docs.datadoghq.com/monitors/monitor_types/network/?tab=checkalert\n[4]: https://docs.datadoghq.com/monitors/monitor_types/custom_check/?tab=checkalert"
+  },
+  "service-dependencies": {
+    "name": "Service Dependencies",
+    "description": "APM Service Map API. For more information, visit\nthe [services map documentation](https://docs.datadoghq.com/tracing/visualization/services_map/)."
+  },
+  "service-level-objectives": {
+    "name": "Service Level Objectives",
+    "description": "[Service Level Objectives](https://docs.datadoghq.com/monitors/service_level_objectives/#configuration)\n(or SLOs) are a key part of the site reliability engineering toolkit.\nSLOs provide a framework for defining clear targets around application performance,\nwhich ultimately help teams provide a consistent customer experience,\nbalance feature development with platform stability,\nand improve communication with internal and external users."
+  },
+  "slack-integration": {
+    "name": "Slack Integration",
+    "description": "Configure your [Datadog-Slack integration](https://docs.datadoghq.com/integrations/slack)\ndirectly through Datadog API."
+  },
+  "snapshots": {
+    "name": "Snapshots",
+    "description": "Take graph snapshots using the API."
+  },
+  "synthetics": {
+    "name": "Synthetics",
+    "description": "Datadog Synthetics uses simulated user requests and browser rendering to help you ensure uptime,\nidentify regional issues, and track your application performance. Datadog Synthetics tests come in\ntwo different flavors, [API tests](https://docs.datadoghq.com/synthetics/api_tests/?tab=httptest)\nand [browser tests](https://docs.datadoghq.com/synthetics/browser_tests). You can use Datadog’s API to\nmanage both test types programmatically.\n\nFor more information about Synthetics, see the [Synthetics overview](https://docs.datadoghq.com/synthetics/)."
+  },
+  "tags": {
+    "name": "Tags",
+    "description": "The tag endpoint allows you to assign tags to hosts,\nfor example: `role:database`. Those tags are applied to\nall metrics sent by the host. Refer to hosts by name\n(`yourhost.example.com`) when fetching and applying\ntags to a particular host.\n\nThe component of your infrastructure responsible for a tag is identified\nby a source. For example, some valid sources include nagios, hudson, jenkins,\nusers, feed, chef, puppet, git, bitbucket, fabric, capistrano, etc.\n\nRead more about tags on the dedicated\n[documentation page](https://docs.datadoghq.com/tagging)."
+  },
+  "timeboards": {
+    "name": "Timeboards",
+    "description": "This endpoint is outdated. Use the [new Dashboard endpoint](https://docs.datadoghq.com/api/#dashboards) instead."
+  },
+  "tracing": {
+    "name": "Tracing",
+    "description": "Learn more about [tracing with Datadog](https://docs.datadoghq.com/tracing)\nand [the APM terminology](https://docs.datadoghq.com/tracing/visualization/services_list).\n\nThe tracing API is an Agent API rather than a service side API.\nSubmit your traces to the `http://localhost:8126/v0.3/traces` local endpoint\nso your Agent can forward them to Datadog."
+  },
+  "usage-metering": {
+    "name": "Usage Metering",
+    "description": "The usage metering API allows you to get hourly, daily, and\nmonthly usage across multiple facets of Datadog.\nThis API is available to all Pro and Enterprise customers.\nUsage is only accessible for [parent-level organizations](https://docs.datadoghq.com/account_management/multi_organization/).\n\n**Note**: Usage data is delayed by up to 72 hours from when it was incurred.\nIt is retained for the past 15 months."
+  },
+  "users": {
+    "name": "Users",
+    "description": "Create, edit, and disable users. [Read more about team management][1].\n\n[1]: https://docs.datadoghq.com/account_management/team"
+  },
+  "webhooks-integration": {
+    "name": "Webhooks Integration",
+    "description": "Configure your Datadog-Webhooks integration directly through the Datadog API.\nFor more information about the Datadog-Webhooks integration,\nsee the [integration page](https://docs.datadoghq.com/integrations/webhooks)."
+  }
+}

--- a/data/api/v2/translate_actions.json
+++ b/data/api/v2/translate_actions.json
@@ -1,0 +1,312 @@
+{
+  "DeleteDashboardListItems": {
+    "description": "Delete dashboards from an existing dashboard list.",
+    "summary": "Delete items from a dashboard list",
+    "request_description": "Dashboards to delete from the dashboard list.",
+    "request_schema_description": "Request containing a list of dashboards to delete."
+  },
+  "GetDashboardListItems": {
+    "description": "Fetch the dashboard list’s dashboard definitions.",
+    "summary": "Get a Dashboard List"
+  },
+  "CreateDashboardListItems": {
+    "description": "Add dashboards to an existing dashboard list.",
+    "summary": "Add Items to a Dashboard List",
+    "request_description": "Dashboards to add to the dashboard list.",
+    "request_schema_description": "Request containing a list of dashboards to add."
+  },
+  "UpdateDashboardListItems": {
+    "description": "Update dashboards of an existing dashboard list.",
+    "summary": "Update items of a dashboard list",
+    "request_description": "New dashboards of the dashboard list.",
+    "request_schema_description": "Request containing the list of dashboards to update to."
+  },
+  "AggregateLogs": {
+    "description": "The API endpoint to aggregate events into buckets and compute metrics and timeseries.",
+    "summary": "Aggregate events",
+    "request_description": "",
+    "request_schema_description": "The object sent with the request to retrieve a list of logs from your organization."
+  },
+  "ListLogsArchives": {
+    "description": "Get the list of configured logs archives with their definitions.",
+    "summary": "Get all archives"
+  },
+  "CreateLogsArchive": {
+    "description": "Create an archive in your organization.",
+    "summary": "Create an archive",
+    "request_description": "The definition of the new archive.",
+    "request_schema_description": "The logs archive."
+  },
+  "DeleteLogsArchive": {
+    "description": "Delete a given archive from your organization.",
+    "summary": "Delete an archive"
+  },
+  "GetLogsArchive": {
+    "description": "Get a specific archive from your organization.",
+    "summary": "Get an archive"
+  },
+  "UpdateLogsArchive": {
+    "description": "Update a given archive configuration.\n\n**Note**: Using this method updates your archive configuration by **replacing**\nyour current configuration with the new one sent to your Datadog organization.",
+    "summary": "Update an archive",
+    "request_description": "New definition of the archive.",
+    "request_schema_description": "The logs archive."
+  },
+  "RemoveRoleFromArchive": {
+    "description": "Removes a role from an archive. ([Roles API](https://docs.datadoghq.com/api/v2/roles/))",
+    "summary": "Revoke role from an archive",
+    "request_description": "",
+    "request_schema_description": "Relationship to role."
+  },
+  "ListArchiveReadRoles": {
+    "description": "Returns all read roles a given archive is restricted to.",
+    "summary": "List read roles for an archive"
+  },
+  "AddReadRoleToArchive": {
+    "description": "Adds a read role to an archive. ([Roles API](https://docs.datadoghq.com/api/v2/roles/))",
+    "summary": "Grant role to an archive",
+    "request_description": "",
+    "request_schema_description": "Relationship to role."
+  },
+  "ListRestrictionQueries": {
+    "description": "Returns all restriction queries, including their names and IDs.",
+    "summary": "List restriction queries"
+  },
+  "CreateRestrictionQuery": {
+    "description": "Create a new restriction query for your organization.",
+    "summary": "Create a restriction query",
+    "request_description": "",
+    "request_schema_description": "Create a restriction query."
+  },
+  "GetRoleRestrictionQuery": {
+    "description": "Get restriction query for a given role.",
+    "summary": "Get restriction query for a given role"
+  },
+  "ListUserRestrictionQueries": {
+    "description": "Get all restriction queries for a given user.",
+    "summary": "Get all restriction queries for a given user"
+  },
+  "DeleteRestrictionQuery": {
+    "description": "Deletes a restriction query.",
+    "summary": "Delete a restriction query"
+  },
+  "GetRestrictionQuery": {
+    "description": "Get a restriction query in the organization specified by the restriction query's `restriction_query_id`.",
+    "summary": "Get a restriction query"
+  },
+  "UpdateRestrictionQuery": {
+    "description": "Edit a restriction query.",
+    "summary": "Update a restriction query",
+    "request_description": "",
+    "request_schema_description": "Update a restriction query."
+  },
+  "RemoveRoleFromRestrictionQuery": {
+    "description": "Removes a role from a restriction query.",
+    "summary": "Revoke role from a restriction query",
+    "request_description": "",
+    "request_schema_description": "Relationship to role."
+  },
+  "ListRestrictionQueryRoles": {
+    "description": "Returns all roles that have a given restriction query.",
+    "summary": "List roles for a restriction query"
+  },
+  "AddRoleToRestrictionQuery": {
+    "description": "Adds a role to a restriction query.",
+    "summary": "Grant role to a restriction query",
+    "request_description": "",
+    "request_schema_description": "Relationship to role."
+  },
+  "ListLogsGet": {
+    "description": "List endpoint returns logs that match a log search query.\n[Results are paginated][1].\n\nBoth this endpoint and the POST endpoint can be used interchangeably when listing\nlogs.\n\n**If you are considering archiving logs for your organization,\nconsider use of the Datadog archive capabilities instead of the log list API.\nSee [Datadog Logs Archive documentation][2].**\n\n[1]: /logs/guide/collect-multiple-logs-with-pagination\n[2]: https://docs.datadoghq.com/logs/archives",
+    "summary": "Get a quick list of logs"
+  },
+  "ListLogs": {
+    "description": "List endpoint returns logs that match a log search query.\n[Results are paginated][1].\n\nBoth this endpoint and the GET endpoint can be used interchangeably when listing\nlogs.\n\n**If you are considering archiving logs for your organization,\nconsider use of the Datadog archive capabilities instead of the log list API.\nSee [Datadog Logs Archive documentation][2].**\n\n[1]: /logs/guide/collect-multiple-logs-with-pagination\n[2]: https://docs.datadoghq.com/logs/archives",
+    "summary": "Get a list of logs",
+    "request_description": "",
+    "request_schema_description": "The request for a logs list."
+  },
+  "ListPermissions": {
+    "description": "Returns a list of all permissions, including name, description, and ID.",
+    "summary": "List permissions"
+  },
+  "ListRoles": {
+    "description": "Returns all roles, including their names and IDs.",
+    "summary": "List roles"
+  },
+  "CreateRole": {
+    "description": "Create a new role for your organization.",
+    "summary": "Create role",
+    "request_description": "",
+    "request_schema_description": "Create a role."
+  },
+  "DeleteRole": {
+    "description": "Disables a role.",
+    "summary": "Delete role"
+  },
+  "GetRole": {
+    "description": "Get a role in the organization specified by the role’s `role_id`.",
+    "summary": "Get a role"
+  },
+  "UpdateRole": {
+    "description": "Edit a role. Can only be used with application keys belonging to administrators.",
+    "summary": "Update a role",
+    "request_description": "",
+    "request_schema_description": "Update a role."
+  },
+  "RemovePermissionFromRole": {
+    "description": "Removes a permission from a role.",
+    "summary": "Revoke permission",
+    "request_description": "",
+    "request_schema_description": "Relationship to a permissions object."
+  },
+  "ListRolePermissions": {
+    "description": "Returns a list of all permissions for a single role.",
+    "summary": "List permissions for a role"
+  },
+  "AddPermissionToRole": {
+    "description": "Adds a permission to a role.",
+    "summary": "Grant permission to a role",
+    "request_description": "",
+    "request_schema_description": "Relationship to a permissions object."
+  },
+  "RemoveUserFromRole": {
+    "description": "Removes a user from a role.",
+    "summary": "Remove a user from a role",
+    "request_description": "",
+    "request_schema_description": "Relationship to user."
+  },
+  "ListRoleUsers": {
+    "description": "Gets all users of a role.",
+    "summary": "Get all users of a role"
+  },
+  "AddUserToRole": {
+    "description": "Adds a user to a role.",
+    "summary": "Add a user to a role",
+    "request_description": "",
+    "request_schema_description": "Relationship to user."
+  },
+  "ListSecurityMonitoringRules": {
+    "description": "List rules.",
+    "summary": "List rules"
+  },
+  "CreateSecurityMonitoringRule": {
+    "description": "Create a detection rule.",
+    "summary": "Create a detection rule",
+    "request_description": "",
+    "request_schema_description": "Create a new rule."
+  },
+  "DeleteSecurityMonitoringRule": {
+    "description": "Delete an existing rule. Default rules cannot be deleted.",
+    "summary": "Delete an existing rule"
+  },
+  "GetSecurityMonitoringRule": {
+    "description": "Get a rule's details.",
+    "summary": "Get a rule's details"
+  },
+  "UpdateSecurityMonitoringRule": {
+    "description": "Update an existing rule. When updating `cases`, `queries` or `options`, the whole field\nmust be included. For example, when modifying a query all queries must be included.\nDefault rules can only be updated to be enabled and to change notifications.",
+    "summary": "Update an existing rule",
+    "request_description": "",
+    "request_schema_description": "Update an existing rule."
+  },
+  "ListSecurityMonitoringSignals": {
+    "description": "The list endpoint returns security signals that match a search query.\nBoth this endpoint and the POST endpoint can be used interchangeably when listing\nsecurity signals.",
+    "summary": "Get a quick list of security signals"
+  },
+  "SearchSecurityMonitoringSignals": {
+    "description": "Returns security signals that match a search query.\nBoth this endpoint and the GET endpoint can be used interchangeably for listing\nsecurity signals.",
+    "summary": "Get a list of security signals",
+    "request_description": "",
+    "request_schema_description": "The request for a security signal list."
+  },
+  "GetServices": {
+    "description": "Get all services for the requesting user's organization. If the `include[users]` query parameter is provided, the included attribute will contain the users related to these services.",
+    "summary": "Get a list of all services"
+  },
+  "CreateService": {
+    "description": "Creates a new service.",
+    "summary": "Create a new service",
+    "request_description": "Service Payload.",
+    "request_schema_description": "Create request with a service payload."
+  },
+  "DeleteService": {
+    "description": "Deletes an existing service.",
+    "summary": "Delete an existing service"
+  },
+  "GetService": {
+    "description": "Get details of a service. If the `include[users]` query parameter is provided, the included attribute will contain the users related to these services",
+    "summary": "Get details of a service"
+  },
+  "UpdateService": {
+    "description": "Updates an existing service. Only provide the attributes which should be updated as this request is a partial update.",
+    "summary": "Update an existing service",
+    "request_description": "Service Payload.",
+    "request_schema_description": "Update request with a service payload."
+  },
+  "GetTeams": {
+    "description": "Get all teams for the requesting user's organization. If the `include[users]` query parameter is provided, the included attribute will contain the users related to these teams.",
+    "summary": "Get a list of all teams"
+  },
+  "CreateTeam": {
+    "description": "Creates a new team.",
+    "summary": "Create a new team",
+    "request_description": "Teams Payload.",
+    "request_schema_description": "Create request with a team payload."
+  },
+  "DeleteTeam": {
+    "description": "Deletes an existing team.",
+    "summary": "Delete an existing team"
+  },
+  "GetTeam": {
+    "description": "Get details of a team. If the `include[users]` query parameter is provided, the included attribute will contain the users related to these teams.",
+    "summary": "Get details of a team"
+  },
+  "UpdateTeam": {
+    "description": "Updates an existing team. Only provide the attributes which should be updated as this request is a partial update.",
+    "summary": "Update an existing team",
+    "request_description": "Teams Payload.",
+    "request_schema_description": "Update request with a team payload."
+  },
+  "SendInvitations": {
+    "description": "Sends emails to one or more users inviting them to join the organization.",
+    "summary": "Send invitation emails",
+    "request_description": "",
+    "request_schema_description": "Object to invite users to join the organization."
+  },
+  "GetInvitation": {
+    "description": "Returns a single user invitation by its UUID.",
+    "summary": "Get a user invitation"
+  },
+  "ListUsers": {
+    "description": "Get the list of all users in the organization. This list includes\nall users even if they are deactivated or unverified.",
+    "summary": "List all users"
+  },
+  "CreateUser": {
+    "description": "Create a user for your organization.",
+    "summary": "Create a user",
+    "request_description": "",
+    "request_schema_description": "Create a user."
+  },
+  "DisableUser": {
+    "description": "Disable a user. Can only be used with an application key belonging\nto an administrator user.",
+    "summary": "Disable a user"
+  },
+  "GetUser": {
+    "description": "Get a user in the organization specified by the user’s `user_id`.",
+    "summary": "Get user details"
+  },
+  "UpdateUser": {
+    "description": "Edit a user. Can only be used with an application key belonging\nto an administrator user.",
+    "summary": "Update a user",
+    "request_description": "",
+    "request_schema_description": "Update a user."
+  },
+  "ListUserOrganizations": {
+    "description": "Get a user organization. Returns the user information and all organizations\njoined by this user.",
+    "summary": "Get a user organization"
+  },
+  "ListUserPermissions": {
+    "description": "Get a user permission set. Returns a list of the user’s permissions\ngranted by the associated user's roles.",
+    "summary": "Get a user permissions"
+  }
+}

--- a/data/api/v2/translate_tags.json
+++ b/data/api/v2/translate_tags.json
@@ -1,0 +1,158 @@
+{
+  "aws-integration": {
+    "name": "AWS Integration",
+    "description": "[See API version 1](/api/v1/aws-integration/)."
+  },
+  "aws-logs-integration": {
+    "name": "AWS Logs Integration",
+    "description": "[See API version 1](/api/v1/aws-logs-integration/)."
+  },
+  "authentication": {
+    "name": "Authentication",
+    "description": "All requests to Datadog’s API must be authenticated.\nRequests that write data require reporting access and require an `API key`.\nRequests that read data require full access and also require an `application key`.\n\n**Note:** All Datadog API clients are configured by default to consume Datadog US site APIs.\nIf you are on the Datadog EU site, set the environment variable `DATADOG_HOST` to\n`https://api.datadoghq.eu` or override this value directly when creating your client.\n\n[Manage your account’s API and application keys](https://app.datadoghq.com/account/settings#api).\n\n## Validate API key\n\n[See API version 1](/api/v1/authentication/#validate-api-key)."
+  },
+  "azure-integration": {
+    "name": "Azure Integration",
+    "description": "[See API version 1](/api/v1/azure-integration/)."
+  },
+  "dashboard-lists": {
+    "name": "Dashboard Lists",
+    "description": "Interact with your dashboard lists through the API to make it easier to\norganize, find, and share all of your dashboards with your team and\norganization. Note that you can add API v1 Dashboards to Dashboard Lists\nthat you create with API v2."
+  },
+  "dashboards": {
+    "name": "Dashboards",
+    "description": "[See API version 1](/api/v1/dashboards/)."
+  },
+  "downtimes": {
+    "name": "Downtimes",
+    "description": "[See API version 1](/api/v1/downtimes/)."
+  },
+  "embeddable-graphs": {
+    "name": "Embeddable Graphs",
+    "description": "[See API version 1](/api/v1/embeddable-graphs/)."
+  },
+  "events": {
+    "name": "Events",
+    "description": "[See API version 1](/api/v1/events/)."
+  },
+  "gcp-integration": {
+    "name": "GCP Integration",
+    "description": "[See API version 1](/api/v1/gcp-integration/)."
+  },
+  "hosts": {
+    "name": "Hosts",
+    "description": "[See API version 1](/api/v1/hosts/)."
+  },
+  "ip-ranges": {
+    "name": "IP Ranges",
+    "description": "[See API version 1](/api/v1/ip-ranges/)."
+  },
+  "key-management": {
+    "name": "Key Management",
+    "description": "[See API version 1](/api/v1/key-management/)."
+  },
+  "logs": {
+    "name": "Logs",
+    "description": "Search your logs in the Datadog platform over HTTP.\n\n[See API version 1](/api/v1/logs/) for sending logs."
+  },
+  "logs-archives": {
+    "name": "Logs Archives",
+    "description": "Archives forward all the logs ingested to a cloud storage system.\n\nSee the [Archives Page](https://app.datadoghq.com/logs/pipelines/archives)\nfor a list of the archives currently configured in our UI."
+  },
+  "logs-indexes": {
+    "name": "Logs Indexes",
+    "description": "[See API version 1](/api/v1/logs-indexes/)."
+  },
+  "logs-pipelines": {
+    "name": "Logs Pipelines",
+    "description": "[See API version 1](/api/v1/logs-pipelines/)."
+  },
+  "logs-restriction-queries": {
+    "name": "Logs Restriction Queries",
+    "description": "**Note: This endpoint is in public beta. If you have any feedback, contact [Datadog support](https://docs.datadoghq.com/help/).**\n\nTo grant read access on log data at all, you must grant the `logs_read_data` permission.\nFrom there you can limit what data a role grants read access to by associating a Restriction Query with that role.\n\nA Restriction Query is a logs query that restricts which logs the `logs_read_data` permission grants read access to.\nFor users whose roles have Restriction Queries, any log query they make only returns those log events that also match\none of their Restriction Queries. This is true whether the user queries log events from any log-related feature, including\nthe log explorer, Live Tail, re-hydration, or a dashboard widget.\n\nRestriction Queries currently only support use of the following components of log events:\n\n- Reserved attributes\n- The log message\n- Tags\n\nThe recommended way to manage restricted read access on log data for customers with large or complicated organizational structures\nis to add a team tag to log events to indicate which team(s) own(s) them, and then to scope Restriction Queries to the appropriate\nvalues of the team tag. Tags can be applied to log events in many ways, and a log event can have multiple tags with the same key (like team)\nand different values—in this way the same log event can be visible to roles whose restriction queries are scoped to different team values.\n\nYou need an API and application key with Admin rights to interact with this endpoint."
+  },
+  "metrics": {
+    "name": "Metrics",
+    "description": "[See API version 1](/api/v1/metrics/)."
+  },
+  "monitors": {
+    "name": "Monitors",
+    "description": "[See API version 1](/api/v1/monitors/)."
+  },
+  "organizations": {
+    "name": "Organizations",
+    "description": "[See API version 1](/api/v1/organizations/)."
+  },
+  "pagerduty-integration": {
+    "name": "PagerDuty Integration",
+    "description": "[See API version 1](/api/v1/pagerduty-integration/)."
+  },
+  "roles": {
+    "name": "Roles",
+    "description": "The Roles API is used to create and manage Datadog roles, what\n[global permissions](https://docs.datadoghq.com/account_management/rbac/)\nthey grant, and which users belong to them.\n\nPermissions related to specific account assets can be granted to roles\nin the Datadog application without using this API. For example, granting\nread access on a specific log index to a role can be done in Datadog from the\n[Pipelines page](https://app.datadoghq.com/logs/pipelines)."
+  },
+  "screenboards": {
+    "name": "Screenboards",
+    "description": "[See API version 1](/api/v1/screenboards/)."
+  },
+  "security-monitoring": {
+    "name": "Security Monitoring",
+    "description": "Detection rules for generating signals and listing of generated\nsignals."
+  },
+  "service-checks": {
+    "name": "Service Checks",
+    "description": "[See API version 1](/api/v1/service-checks/)."
+  },
+  "service-dependencies": {
+    "name": "Service Dependencies",
+    "description": "[See API version 1](/api/v1/service-dependencies/)."
+  },
+  "service-level-objectives": {
+    "name": "Service Level Objectives",
+    "description": "[See API version 1](/api/v1/service-level-objectives/)."
+  },
+  "services": {
+    "name": "Services",
+    "description": "Create, update, delete and retrieve your organizations services."
+  },
+  "slack-integration": {
+    "name": "Slack Integration",
+    "description": "[See API version 1](/api/v1/slack-integration/)."
+  },
+  "snapshots": {
+    "name": "Snapshots",
+    "description": "[See API version 1](/api/v1/snapshots/)."
+  },
+  "synthetics": {
+    "name": "Synthetics",
+    "description": "[See API version 1](/api/v1/synthetics/)."
+  },
+  "tags": {
+    "name": "Tags",
+    "description": "[See API version 1](/api/v1/tags/)."
+  },
+  "teams": {
+    "name": "Teams",
+    "description": "Create, update, delete and retrieve your organizations Teams."
+  },
+  "timeboards": {
+    "name": "Timeboards",
+    "description": "[See API version 1](/api/v1/timeboards/)."
+  },
+  "tracing": {
+    "name": "Tracing",
+    "description": "[See API version 1](/api/v1/tracing/)."
+  },
+  "usage-metering": {
+    "name": "Usage Metering",
+    "description": "[See API version 1](/api/v1/usage-metering/)."
+  },
+  "users": {
+    "name": "Users",
+    "description": "Create, edit, and disable users."
+  },
+  "webhooks-integration": {
+    "name": "Webhooks Integration",
+    "description": "[See API version 1](/api/v1/webhooks-integration/)."
+  }
+}

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -26,6 +26,21 @@
 
     {{ $d := index $dot.Site.Data.api $apiVersion "full_spec_deref" }}
 
+    <!-- get lang specific data file -->
+    {{ $tagSlug := path.Base .File.Dir }}
+    {{ $.Scratch.Set "translate_tags" (dict) }}
+    {{ $.Scratch.Set "translate_actions" (dict) }}
+    {{ if ne $.Page.Lang "en"}}
+        {{ if (fileExists (print "data/api/" $apiVersion "/translate_tags." $.Page.Lang ".json")) }}
+          {{ $.Scratch.Set "translate_tags" (index (index $.Site.Data.api $apiVersion) (print "translate_tags." $.Page.Lang)) }}
+        {{ end }}
+        {{ if (fileExists (print "data/api/" $apiVersion "/translate_actions." $.Page.Lang ".json")) }}
+          {{ $.Scratch.Set "translate_actions" (index (index $.Site.Data.api $apiVersion) (print "translate_actions." $.Page.Lang)) }}
+        {{ end }}
+    {{ end }}
+    {{ $translate_tags := ($.Scratch.Get "translate_tags") }}
+    {{ $translate_actions := ($.Scratch.Get "translate_actions") }}
+
     <!-- Get the general API server url -->
     {{ $servers := index (index $d "servers") 0 }}
     {{ $.Scratch.Set "serverURLS" slice }}
@@ -46,6 +61,7 @@
 
     {{ range $k, $v := (index $d "tags") }}
         {{ if eq $ParamTitleEn $v.name }}
+            {{ $translate_tag := (index $translate_tags $tagSlug) | default (dict) }}
 
             {{ $.Scratch.Set "tagObject" (slice)}}
 
@@ -62,7 +78,7 @@
 
             {{ $tagObject := $.Scratch.Get "tagObject"  }}
 
-            <h1>{{ $v.name }}</h1>
+            <h1>{{ $translate_tag.name | default $v.name }}</h1>
 
             <div class="row">
                 <div class="col-12 col-lg-9">
@@ -70,13 +86,13 @@
                     <!-- If endpoint is deprecated -->
                     {{ if eq (index $v "x-deprecated") true}}
                         <div class="alert alert-danger">
-                            {{$v.description | markdownify}}
+                            {{ $translate_tag.description | default $v.description | markdownify}}
                             {{$v.externalDocs.description}} <a href="{{$v.externalDocs.url}}">{{$v.externalDocs.url}}</a>
                         </div>
                     {{ else }}
 
 
-                        {{ $markdown := $v.description | markdownify }}
+                        {{ $markdown := $translate_tag.description | default $v.description | markdownify }}
 
                         <!-- need this because hugo sometimes duplicates <p> when using markdownify -->
                         {{ if not ( strings.Contains $markdown "<p>" ) }}
@@ -93,6 +109,9 @@
             {{/* sort by action summary */}}
             {{ range sort $tagObject ".action.summary" "asc"  }}
                 {{ $context := . }}
+
+                <!-- get action strings from params, why? because they are translated here -->
+                {{ $translate_action := (index $translate_actions .action.operationId) | default (dict) }}
 
                 <!-- check if endpoint has own `server` object and set those as the server urls -->
                 {{ with .action.servers }}
@@ -128,7 +147,7 @@
                 <div class="row">
                     <div class="col-12 col-lg-9">
                         <h2 class="mb-2" id="{{ .action.summary | urlize }}">
-                            <a href="#{{ .action.summary | urlize }}">{{- .action.summary -}}</a>
+                            <a href="#{{ .action.summary | urlize }}">{{- $translate_action.summary | default .action.summary -}}</a>
                         </h2>
                         {{ with index .action "x-unstable"}}
                         <div class="alert alert-warning mb-2">
@@ -138,7 +157,7 @@
                         <p class="mb-0"><span style="padding: 3px" class="font-semibold text-api-{{ .actionType }} bg-bg-api-{{ .actionType }}">{{ .actionType | upper }}</span>&nbsp;{{ range $.Scratch.Get "serverURLS" }}<span class="d-none" data-region="{{ .region }}">{{ .url }}</span>{{ end }}<span>{{.pathKey}}</span>
                         </p>
                         <h3 class="mt-2">{{ i18n "overview" }}</h3>
-                        <p>{{.action.description | markdownify }}</p>
+                        <p>{{ $translate_action.description | default .action.description | markdownify }}</p>
 
                         {{ $.Scratch.Set "queryStrings" slice }}
                         {{ $.Scratch.Set "pathParams" slice }}
@@ -280,7 +299,7 @@
 
                             <h4 class="text-capitalize mt-0 mb-1 py-0">Body Data <span class='text-capitalize'>{{ cond (eq .action.requestBody.required true) "(required)" "" }}</span></h4>
 
-                            <p>{{ .action.requestBody.description | markdownify }}</p>
+                            <p>{{ $translate_action.request_description | default .action.requestBody.description | markdownify }}</p>
 
                             <div class="tab-content">
                                 {{ range $contentType, $content := .action.requestBody.content }}
@@ -382,10 +401,14 @@
                         <div class="tab-content mb-3">
                             {{ $count := 0}}
                             {{ range $response_code, $response := .action.responses }}
+                                {{ $translate_action_response := (dict) }}
+                                {{ with $translate_action.responses }}
+                                  {{ $translate_action_response = (index $translate_action.responses $response_code) }}
+                                {{ end }}
                                 <div role="tabpanel" class="tab-pane {{ if eq $count 0}} active {{end}}" id="{{ $context.action.operationId }}-{{ $response_code }}">
                                     {{ with $response.content }}
 
-                                        <p class="mb-2">{{$response.description}}</p>
+                                        <p class="mb-2">{{ $translate_action_response.description | default $response.description }}</p>
 
                                         {{ range $content := . }}
                                             {{ range $schema := $content }}

--- a/translate.yaml
+++ b/translate.yaml
@@ -9,6 +9,10 @@ transifex:
 sources:
 - src: "content/en/**/*.md"
   dst: "content/{lang}/**/*.md"
+- src: "data/api/**/translate_actions.json"
+  dst: "data/api/**/translate_actions.{lang}.json"
+- src: "data/api/**/translate_tags.json"
+  dst: "data/api/**/translate_tags.{lang}.json"
 - src: "data/partials/*.yaml"
   dst: "*.{lang}.yaml"
 - src: "i18n/en.json"


### PR DESCRIPTION
### What does this PR do?

This PR:

- splits out some api strings into their own datafile so that we can send just those strings to be translated
- updates the html to read from these strings or fall back to the english spec text
- updates translate.yaml so that we send the files up to be translated

### Motivation

https://datadoghq.atlassian.net/browse/WEB-213

### Preview link

Preview should look the same, however browse through various api pages to check nothing looks odd.

https://docs-staging.datadoghq.com/david.jones/api-translateprep/api/
https://docs-staging.datadoghq.com/david.jones/api-translateprep/ja/api/
https://docs-staging.datadoghq.com/david.jones/api-translateprep/fr/api/

### Additional Notes

