### PR TITLE
[security-monitoring] switch back to main

### DIFF
--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -287,7 +287,7 @@
   - repo_name: security-monitoring
     contents:
     - action: security-rules
-      branch: tanguy.lebarzic/markdown-default-rules
+      branch: main
       globs:
         - "security-monitoring/*.json"
         - "security-monitoring/*.md"

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -287,7 +287,7 @@
   - repo_name: security-monitoring
     contents:
     - action: security-rules
-      branch: tanguy.lebarzic/markdown-default-rules
+      branch: main
       globs:
         - "security-monitoring/*.json"
         - "security-monitoring/*.md"


### PR DESCRIPTION
### What does this PR do?
Switch back to the main branch as a follow up of https://github.com/DataDog/documentation/pull/8157, as https://github.com/DataDog/security-monitoring/pull/31 has been merged.

### Preview link

https://docs-staging.datadoghq.com/tanguy.lebarzic/markdown-default-rules-main/security_monitoring/default_rules/cloudtrail-aws-cloudtrail-configuration-modified/
