### PR TITLE
[forecast] Add an explanation of the format of a forecast query string

### DIFF
--- a/content/en/monitors/monitor_types/anomaly.md
+++ b/content/en/monitors/monitor_types/anomaly.md
@@ -113,7 +113,7 @@ For detailed instructions on the **Say what's happening** and **Notify your team
 
 ## API
 
-Enterprise-level customers can create anomaly detection monitors using the [create-monitor API endpoint][9]. Datadog **strongly recommends** [exporting a monitor's JSON][10] to build the query for the API. By using the [monitor creation page][1] in the Datadog, customers benefit from the preview graph and automatic parameter tuning to help avoid a poorly configured monitor.
+Enterprise-level customers can create anomaly detection monitors using the [create-monitor API endpoint][9]. Datadog **strongly recommends** [exporting a monitor's JSON][10] to build the query for the API. By using the [monitor creation page][1] in Datadog, customers benefit from the preview graph and automatic parameter tuning to help avoid a poorly configured monitor.
 
 **Note**: Anomaly detection monitors are only available to enterprise-level customers. Pro-level customers interested in anomaly detection monitors should reach out to their customer success representative or email the [Datadog billing team][11].
 
@@ -124,7 +124,7 @@ Anomaly monitors are managed using the [same API][12] as other monitors. These f
 The `query` property in the request body should contain a query string in the following format:
 
 ```text
-avg(<query_window>):anomalies(<metric_query>, ‘<algorithm>’, <deviations>, direction=’<direction>’, alert_window=’<alert_window>’, interval=<interval>, count_default_zero=’<default_zero>’ [, seasonality=’<seasonality>’]) >= <threshold>
+avg(<query_window>):anomalies(<metric_query>, '<algorithm>', <deviations>, direction='<direction>', alert_window='<alert_window>', interval=<interval>, count_default_zero='<default_zero>' [, seasonality='<seasonality>']) >= <threshold>
 ```
 
 * `query_window`: a timeframe like `last_4h` or `last_7d`; the time window displayed in graphs in notifications; must be at least as large as the `alert_window` and is recommended to be around 5 times the `alert_window`

--- a/content/en/monitors/monitor_types/forecasts.md
+++ b/content/en/monitors/monitor_types/forecasts.md
@@ -110,17 +110,17 @@ The `query` property in the request body should contain a query string in the fo
 <aggregator>(<query_window>):forecast(<metric_query>, '<algorithm>', <deviations>, interval=<interval>[, history='<history>'][, model='<model>'][, seasonality='<seasonality>']) <comparator> <threshold>
 ```
 
-* `aggregator`: `min` if the alert should trigger when the forecast goes below the threshold, and `max` if the alert should trigger when the forecast goes above the threshold 
-* `query_window`: a timeframe like `last_4h` or `last_7d`; the time window displayed in graphs in notifications; must be at least as large as the `alert_window` and is recommended to be around 5 times the `alert_window`
-* `metric_query`: a standard Datadog metric query, for example: `min:system.disk.free{service:database,device:/data}by{host}`
+* `aggregator`: Use `min` if the alert should trigger when the forecast goes below the threshold. Use `max` if the alert should trigger when the forecast goes above the threshold.
+* `query_window`: A timeframe, for example: `last_4h` or `last_7d`. The timeframe is recommended to be around five times the `alert_window`, but it must be at least as large as `alert_window`. This parameter controls the time range displayed in graphs included in notifications. 
+* `metric_query`: A standard Datadog metric query, for example: `min:system.disk.free{service:database,device:/data}by{host}`.
 * `algorithm`: `linear` or `seasonal`
-* `deviations`: a number greater than or equal to 1; controls the size of the confidence bounds, allowing a monitor to be made more or less sensitive
-* `interval`: a positive integer representing the number of seconds in the rollup interval
-* `history`: a string representing the amount of past data that should be used for making the forecast, for example: `1w`, `3d`. This parameter is only used with the `linear` algorithm.
+* `deviations`: A number greater than or equal to one. This parameter controls the size of the confidence bounds, allowing a monitor to be made more or less sensitive.
+* `interval`: A positive integer representing the number of seconds in the rollup interval.
+* `history`: A string representing the amount of past data that should be used for making the forecast, for example: `1w`, `3d`. This parameter is only used with the `linear` algorithm.
 * `model`: The type of model to use: `default`, `simple`, or `reactive`. This parameter is only used with the `linear` algorithm.
 * `seasonality`: The seasonality to use: `hourly`, `daily`, or `weekly`. This parameter is only used with the `seasonal` algorithm
 * `comparator`: Use `<=` to alert when the forecast goes below the threshold. Use `>=` to alert when the forecast goes above the threshold.
-* `threshold`: a number; a critical alert will trigger when the confidence bounds around the forecast reach this threshold
+* `threshold`: A critical alert will trigger when the forecast's confidence bounds reach this threshold.
 
 ## Troubleshooting
 

--- a/content/en/monitors/monitor_types/forecasts.md
+++ b/content/en/monitors/monitor_types/forecasts.md
@@ -112,14 +112,14 @@ The `query` property in the request body should contain a query string in the fo
 
 * `aggregator`: `min` if the alert should trigger when the forecast goes below the threshold, and `max` if the alert should trigger when the forecast goes above the threshold 
 * `query_window`: a timeframe like `last_4h` or `last_7d`; the time window displayed in graphs in notifications; must be at least as large as the `alert_window` and is recommended to be around 5 times the `alert_window`
-* `metric_query`: a standard Datadog metric query (e.g., `min:system.disk.free{service:database,device:/data}by{host}`)
+* `metric_query`: a standard Datadog metric query, for example: `min:system.disk.free{service:database,device:/data}by{host}`
 * `algorithm`: `linear` or `seasonal`
 * `deviations`: a number greater than or equal to 1; controls the size of the confidence bounds, allowing a monitor to be made more or less sensitive
 * `interval`: a positive integer representing the number of seconds in the rollup interval
-* `history`: a string representing the amount past data that should be used when making the forecast (e.g., `1w`, `3d`); this parameter is only for use with the `linear` algorithm
-* `model`: `default`, `simple`, or `reactive`; this parameter is only for use with the `linear` algorithm
-* `seasonality`: `hourly`, `daily`, or `weekly`; this parameter is only for use with the `seasonal` algorithm
-* `comparator`: `<=` to alert when the forecast goes below the threshold; `>=` to alert when the forecast goes above the threshold
+* `history`: a string representing the amount of past data that should be used for making the forecast, for example: `1w`, `3d`. This parameter is only used with the `linear` algorithm.
+* `model`: The type of model to use: `default`, `simple`, or `reactive`. This parameter is only used with the `linear` algorithm.
+* `seasonality`: The seasonality to use: `hourly`, `daily`, or `weekly`. This parameter is only used with the `seasonal` algorithm
+* `comparator`: Use `<=` to alert when the forecast goes below the threshold. Use `>=` to alert when the forecast goes above the threshold.
 * `threshold`: a number; a critical alert will trigger when the confidence bounds around the forecast reach this threshold
 
 ## Troubleshooting

--- a/content/en/monitors/monitor_types/forecasts.md
+++ b/content/en/monitors/monitor_types/forecasts.md
@@ -100,7 +100,27 @@ For detailed instructions on the **Say what's happening** and **Notify your team
 
 ## API
 
-To create forecast monitors programmatically, see the [Datadog API reference][7]. Datadog recommends [exporting a monitor's JSON][8] to build the query for the API.
+To create forecast monitors programmatically, see the [Datadog API reference][7]. Datadog **strongly recommends** [exporting a monitor's JSON][8] to build the query for the API. By using the [monitor creation page][1] in Datadog, customers benefit from the preview graph and automatic parameter tuning to help avoid a poorly configured monitor.
+
+Forecast monitors are managed using the [same API][9] as other monitors, but the contents of the `query` property deserves further explanation.
+
+The `query` property in the request body should contain a query string in the following format:
+
+```text
+<aggregator>(<query_window>):forecast(<metric_query>, '<algorithm>', <deviations>, interval=<interval>[, history='<history>'][, model='<model>'][, seasonality='<seasonality>']) <comparator> <threshold>
+```
+
+* `aggregator`: `min` if the alert should trigger when the forecast goes below the threshold, and `max` if the alert should trigger when the forecast goes above the threshold 
+* `query_window`: a timeframe like `last_4h` or `last_7d`; the time window displayed in graphs in notifications; must be at least as large as the `alert_window` and is recommended to be around 5 times the `alert_window`
+* `metric_query`: a standard Datadog metric query (e.g., `min:system.disk.free{service:database,device:/data}by{host}`)
+* `algorithm`: `linear` or `seasonal`
+* `deviations`: a number greater than or equal to 1; controls the size of the confidence bounds, allowing a monitor to be made more or less sensitive
+* `interval`: a positive integer representing the number of seconds in the rollup interval
+* `history`: a string representing the amount past data that should be used when making the forecast (e.g., `1w`, `3d`); this parameter is only for use with the `linear` algorithm
+* `model`: `default`, `simple`, or `reactive`; this parameter is only for use with the `linear` algorithm
+* `seasonality`: `hourly`, `daily`, or `weekly`; this parameter is only for use with the `seasonal` algorithm
+* `comparator`: `<=` to alert when the forecast goes below the threshold; `>=` to alert when the forecast goes above the threshold
+* `threshold`: a number; a critical alert will trigger when the confidence bounds around the forecast reach this threshold
 
 ## Troubleshooting
 
@@ -119,3 +139,4 @@ The following functions cannot be nested inside calls to the `forecast()` functi
 [6]: /monitors/notifications/
 [7]: /api/v1/monitors/#create-a-monitor
 [8]: /monitors/monitor_status/#settings
+[9]: /api/v1/monitors/


### PR DESCRIPTION
### What does this PR do?

Like #7900 , this PR adds more details about how to configure a data science monitor via the API. These monitors are more complicated than the "standard" monitors and when customers try to use tf or similar to manage their monitors in code, a lack of good documentation about how to configure these monitors leads to confusion.

### Preview link

https://docs-staging.datadoghq.com/StephenKappel-patch-1/monitors/monitor_types/anomaly/#api
https://docs-staging.datadoghq.com/StephenKappel-patch-1/monitors/monitor_types/forecasts/#api
