### PR TITLE
Update Log maximum delay

### DIFF
--- a/content/en/logs/processing/processors.md
+++ b/content/en/logs/processing/processors.md
@@ -88,7 +88,7 @@ The recognized date formats are: <a href="https://www.iso.org/iso-8601-date-and-
 
 **Note**: 
 
-* **Log events can be submitted up to 6h in the past and 2h in the future**.
+* **Log events can be submitted up to 18h in the past and 2h in the future**.
 * If your logs don't contain any of the default attributes and you haven't defined your own date attribute, Datadog timestamps the logs with the date it received them.
 * If multiple log date remapper processors can be applied to a given log, only the first one (according to the pipelines order) is taken into account.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Fix the maximum delay accepted fro the log date.

### Motivation

Consistency with https://docs.datadoghq.com/logs/processing/pipelines/#limits-applied-to-ingested-log-events 

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/pvr/log-delay/logs/processing/processors/?tab=ui#log-date-remapper

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
