### PR TITLE
Change Time aggregation to Space aggregation in text to match image

### DIFF
--- a/content/en/metrics/introduction.md
+++ b/content/en/metrics/introduction.md
@@ -91,7 +91,7 @@ Looking at the JSON, the query can be broken out by space aggregation, metric na
 
 * **Scope** is the set of tags used to choose time series for the query.
 * **Grouping** is the set of tags over which to apply space aggregation.
-* **Time aggregation** is done implicitly, but can be set manually with the rollup function:
+* **Space aggregation** is done implicitly, but can be set manually with the rollup function:
 
 {{< img src="metrics/introduction/color-query2.png" alt="Query explained"  style="width:70%;">}}
 


### PR DESCRIPTION
Do you mean "Space aggregation"?  The images above and below both have a segment for "Space aggregation" but not "Time aggregation" so, my guess, is that either the text or the image is incorrect (and the text is easier to change.)

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
