### PR TITLE
making `Node` `Node.js` instead

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -547,7 +547,7 @@ main:
     parent: serverless_installation
     identifier: serverless_installation_python
     weight: 101
-  - name: Node
+  - name: Node.js
     url: serverless/installation/nodejs
     parent: serverless_installation
     weight: 102


### PR DESCRIPTION
Changing the menu under Serverless>Installation to Node.js

- https://docs-staging.datadoghq.com/kaylyn/node/serverless/installation/nodejs