### PR TITLE
Fix forwarder and trigger docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,7 @@ content/en/security_monitoring/default_rules/*.md
 npm-debug.log*
 
 # serverless
-!content/en/serverless/installation/installing_the_forwarder.md
+!content/en/serverless/forwarder.md
 
 # Runtime data
 pids

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -156,7 +156,7 @@ build_live:
   variables:
     CONFIG: ${LIVE_CONFIG}
     URL: ${LIVE_DOMAIN}
-    UNTRACKED_EXTRAS: "data,content/en/agent/basic_agent_usage/heroku.md,content/en/agent/basic_agent_usage/ansible.md,content/en/agent/basic_agent_usage/chef.md,content/en/agent/basic_agent_usage/puppet.md,content/en/developers/integrations,content/en/agent/basic_agent_usage/saltstack.md,content/en/developers/amazon_cloudformation.md,content/en/integrations,content/en/logs/log_collection/android.md,content/en/logs/log_collection/ios.md,content/en/tracing/setup/android.md,content/en/tracing/setup/ruby.md,content/en/security_monitoring/default_rules,content/en/serverless/installation/installing_the_forwarder.md"
+    UNTRACKED_EXTRAS: "data,content/en/agent/basic_agent_usage/heroku.md,content/en/agent/basic_agent_usage/ansible.md,content/en/agent/basic_agent_usage/chef.md,content/en/agent/basic_agent_usage/puppet.md,content/en/developers/integrations,content/en/agent/basic_agent_usage/saltstack.md,content/en/developers/amazon_cloudformation.md,content/en/integrations,content/en/logs/log_collection/android.md,content/en/logs/log_collection/ios.md,content/en/tracing/setup/android.md,content/en/tracing/setup/ruby.md,content/en/security_monitoring/default_rules,content/en/serverless/forwarder.md"
     CONFIGURATION_FILE: "./local/bin/py/build/configurations/pull_config.yaml"
     LOCAL: "False"
   script:

--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,8 @@ clean-auto-doc: ##Remove all doc automatically created
 	rm -f content/en/agent/basic_agent_usage/puppet.md ;fi
 	@if [ content/en/agent/basic_agent_usage/saltstack.md ]; then \
 	rm -f content/en/agent/basic_agent_usage/saltstack.md ;fi
-	@if [ content/en/serverless/installation/installing_the_forwarder.md ]; then \
-	rm -f content/en/serverless/installation/installing_the_forwarder.md ;fi
+	@if [ content/en/serverless/forwarder.md ]; then \
+	rm -f content/en/serverless/forwarder.md ;fi
 	@if [ content/en/tracing/setup/ruby.md ]; then \
 	rm -f content/en/tracing/setup/ruby.md ;fi
 	@if [ content/en/developers/amazon_cloudformation.md ]; then \

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -570,19 +570,19 @@ main:
     parent: serverless_installation
     identifier: serverless_installation_dotnet
     weight: 106
-  - name: Datadog Forwarder
-    url: serverless/forwarder
-    parent: serverless
-    weight: 107
   - name: Datadog Lambda Library
     url: serverless/installation/installing_the_library
     parent: serverless_installation
     weight: 108
+  - name: Datadog Forwarder
+    url: serverless/forwarder
+    parent: serverless
+    weight: 2
   - name: Troubleshooting
     url: serverless/troubleshooting
     parent: serverless
     identifier: serverless_troubleshooting
-    weight: 2
+    weight: 3
   - name: Azure App Services Extension
     url: serverless/azure_app_services
     parent: serverless

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -571,8 +571,8 @@ main:
     identifier: serverless_installation_dotnet
     weight: 106
   - name: Datadog Forwarder
-    url: serverless/installation/installing_the_forwarder
-    parent: serverless_installation
+    url: serverless/forwarder
+    parent: serverless
     weight: 107
   - name: Datadog Lambda Library
     url: serverless/installation/installing_the_library

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -106,12 +106,14 @@ If you are collecting logs from a CloudWatch Log Group, configure the trigger to
 Select the corresponding CloudWatch Log Group, add a filter name (but feel free to leave the filter empty) and add the trigger:
 {{< img src="integrations/amazon_cloudwatch/cloudwatch_log_collection_2.png" alt="cloudwatch trigger" popup="true" style="width:70%;">}}
 
-Once done, go into your [Datadog Log section][6] to start exploring your logs.
+Once done, go into your [Datadog Log section][1] to start exploring your logs.
 
+
+[1]: https://app.datadoghq.com/logs
 {{% /tab %}}
 {{% tab "Terraform" %}}
 
-For Terraform users, you can provision and manage your triggers using the [aws_cloudwatch_log_subscription_filter][7] resource. See sample code below.
+For Terraform users, you can provision and manage your triggers using the [aws_cloudwatch_log_subscription_filter][1] resource. See sample code below.
 
 ```conf
 resource "aws_cloudwatch_log_subscription_filter" "datadog_log_subscription_filter" {
@@ -122,10 +124,12 @@ resource "aws_cloudwatch_log_subscription_filter" "datadog_log_subscription_filt
 }
 ```
 
+
+[1]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_subscription_filter
 {{% /tab %}}
 {{% tab "CloudFormation/SAM" %}}
 
-For AWS CloudFormation or SAM users, you can provision and manage your triggers using the CloudFormation [AWS::Logs::SubscriptionFilter][109] resource. See sample code below.
+For AWS CloudFormation or SAM users, you can provision and manage your triggers using the CloudFormation [AWS::Logs::SubscriptionFilter][1] resource. See sample code below.
 
 ```yaml
 Resources:
@@ -136,21 +140,9 @@ Resources:
       LogGroupName: "<CLOUDWATCH_LOG_GROUP_NAME>"
       FilterPattern: ""
 ```
-{{% /tab %}}
-{{% tab "Serverless Framework" %}}
 
-For Serverless Framework users, you can provision and manage your triggers using the CloudFormation [AWS::Logs::SubscriptionFilter][109] resource. See sample code below.
 
-```yaml
-resources:
-  Resources:
-    MyLogSubscriptionFilter:
-      Type: "AWS::Logs::SubscriptionFilter"
-      Properties:
-        DestinationArn: "<DATADOG_FORWARDER_ARN>"
-        LogGroupName: "<CLOUDWATCH_LOG_GROUP_NAME>"
-        FilterPattern: ""
-```
+[1]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-subscriptionfilter.html
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -170,12 +162,14 @@ If you are collecting logs from an S3 bucket, configure the trigger to the [Data
 1. Set the correct event type on S3 buckets:
    {{< img src="logs/aws/object_created.png" alt="Object Created" popup="true" style="width:80%;">}}
 
-Once done, go into your [Datadog Log section][6] to start exploring your logs!
+Once done, go into your [Datadog Log section][1] to start exploring your logs!
 
+
+[1]: https://app.datadoghq.com/logs
 {{% /tab %}}
 {{% tab "Terraform" %}}
 
-For Terraform users, you can provision and manage your triggers using the [aws_s3_bucket_notification][8] resource. See the sample code below.
+For Terraform users, you can provision and manage your triggers using the [aws_s3_bucket_notification][1] resource. See the sample code below.
 
 ```conf
 resource "aws_s3_bucket_notification" "my_bucket_notification" {
@@ -188,16 +182,18 @@ resource "aws_s3_bucket_notification" "my_bucket_notification" {
   }
 }
 ```
+
+
+[1]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification
 {{% /tab %}}
 {{% tab "CloudFormation/SAM" %}}
 
-For CloudFormation or SAM users, you can configure triggers using the CloudFormation [NotificationConfiguration][9] for your S3 bucket. See the sample code below.
+For CloudFormation or SAM users, you can configure triggers using the CloudFormation [NotificationConfiguration][1] for your S3 bucket. See the sample code below.
 
 ```yaml
 Resources:
   Bucket:
     Type: AWS::S3::Bucket
-    DependsOn: BucketPermission
     Properties:
       BucketName: "<MY_BUCKET>"
       NotificationConfiguration:
@@ -205,6 +201,9 @@ Resources:
         - Event: 's3:ObjectCreated:*'
           Function: "<DATADOG_FORWARDER_ARN>"
 ```
+
+
+[1]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig.html
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -17,29 +17,26 @@ AWS service logs can be collected with the Datadog Forwarder Lambda function. Th
 
 To start collecting logs from your AWS services:
 
-1. Set up the Datadog Forwarder Lambda function in your AWS account by following the instructions in the [DataDog/datadog-serverless-functions Github repository][1].
+1. Set up the [Datadog Forwarder Lambda function][1] in your AWS account.
 2. [Enable logging](#enable-logging-for-your-aws-service) for your AWS service (most AWS services can log to a S3 bucket or CloudWatch Log Group).
-3. Configure the triggers that cause the Lambda to execute. There are two ways to configure the triggers:
+3. [Set up the triggers](#set-up-triggers) that cause the Forwarder Lambda to execute when there are new logs to be forwarded. There are two ways to configure the triggers.
 
-    - [Automatically](#automatically-setup-triggers): Datadog automatically retrieves the logs for the selected AWS services and adds them as triggers on the Datadog Lambda function. Datadog also keeps the list up to date.
-    - [Manually](#manually-setup-triggers): Set up each trigger yourself via the AWS console.
-
-**Note**: If you are in AWS us-east-1 region, [leverage Datadog-AWS Private Link][2] to forward your logs to Datadog. If you do so, your forwarder function [must have the `VPCLambdaExecutionRole` permission][3].
+**Note**: If you are in AWS us-east-1 region, leverage [Datadog-AWS Private Link][2].
 
 
-## Send AWS service logs to Datadog
+## Set up triggers
 
-There are two options when configuring triggers on the Datadog Lambda function:
+There are two options when configuring triggers on the Datadog Forwarder Lambda function:
 
-- Manually set up triggers on S3 buckets, CloudWatch Log Groups, or CloudWatch Events.
-- Let Datadog automatically set and manage the list of triggers.
+- [Automatically](#automatically-set-up-triggers): Datadog automatically retrieves the log locations for the selected AWS services and adds them as triggers on the Datadog Forwarder Lambda function. Datadog also keeps the list up to date.
+- [Manually](#manually-set-up-triggers): Set up each trigger yourself.
 
 ### Automatically set up triggers
 
 If you are storing logs in many S3 buckets or CloudWatch Log groups, Datadog can automatically manage triggers for you.
 
-1. If you haven't already, set up the [Datadog log collection AWS Lambda function][4].
-2. Ensure the policy of the IAM role used for [Datadog-AWS integration][5] has the following permissions. Information on how these permissions are used can be found in the descriptions below:
+1. If you haven't already, set up the [Datadog log collection AWS Lambda function][1].
+2. Ensure the policy of the IAM role used for [Datadog-AWS integration][3] has the following permissions. Information on how these permissions are used can be found in the descriptions below:
 
     ```text
     "cloudfront:GetDistributionConfig",
@@ -83,20 +80,20 @@ If you are storing logs in many S3 buckets or CloudWatch Log groups, Datadog can
     | `logs:DeleteSubscriptionFilter`                             | Remove a Lambda trigger based on CloudWatch Log events                       |
     | `logs:DescribeSubscriptionFilters`                          | Lists the subscription filters for the specified log group.                  |
 
-3. Navigate to the _Collect Logs_ tab in the [AWS Integration tile][6].
+3. Navigate to the _Collect Logs_ tab in the [AWS Integration tile][4].
 4. Select the AWS Account from where you want to collect logs, and enter the ARN of the Lambda created in the previous section.
    {{< img src="logs/aws/AWSLogStep1.png" alt="Enter Lambda" popup="true" style="width:80%;" >}}
 5. Select the services from which you'd like to collect logs and hit save. To stop collecting logs from a particular service, uncheck it.
    {{< img src="logs/aws/AWSLogStep2.png" alt="Select services" popup="true" style="width:80%;" >}}
 6. If you have logs across multiple regions, you must create additional Lambda functions in those regions and enter them in this tile.
 7. To stop collecting all AWS logs, press the _x_ next to each Lambda ARN. All triggers for that function are removed.
-8. Within a few minutes of this initial setup, your AWS Logs appear in your Datadog [log explorer page][7] in near real time.
+8. Within a few minutes of this initial setup, your AWS Logs appear in your Datadog [log explorer page][5] in near real time.
 
 ## Manually set up triggers
 
 ### Collecting logs from CloudWatch Log Group
 
-If you are collecting logs from a CloudWatch Log Group, configure the trigger to the [Datadog Forwarder Lambda function][4] using one of the following method:
+If you are collecting logs from a CloudWatch Log Group, configure the trigger to the [Datadog Forwarder Lambda function][1] using one of the following method:
 
 {{< tabs >}}
 {{% tab "AWS Console" %}}
@@ -155,7 +152,7 @@ Resources:
 
 ### Collecting logs from S3 buckets
 
-If you are collecting logs from an S3 bucket, configure the trigger to the [Datadog Forwarder Lambda function][4] using one of the following method:
+If you are collecting logs from an S3 bucket, configure the trigger to the [Datadog Forwarder Lambda function][1] using one of the following method:
 
 {{< tabs >}}
 {{% tab "AWS Console" %}}
@@ -220,64 +217,62 @@ Any AWS service that generates logs into a S3 bucket or a CloudWatch Log Group i
 
 | AWS service                        | Activate AWS service logging                                                                    | Send AWS logs to Datadog                                                    |
 | ---------------------------------- | ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| [API Gateway][8]                  | [Enable AWS API Gateway logs][9]                                                               | [Manual][10] log collection                                                 |
-| [Cloudfront][11]                   | [Enable AWS Cloudfront logs][12]                                                                | [Manual][13] and [automatic](#automatically-setup-triggers) log collection  |
-| [Cloudtrail][8]                   | [Enable AWS Cloudtrail logs][14]                                                                | [Manual][15] log collection                                                 |
-| [DynamoDB][16]                     | [Enable AWS DynamoDB logs][17]                                                                  | [Manual][18] log collection                                                 |
-| [EC2][19]                          | `-`                                                                                             | Use the [Datadog Agent][19] to send your logs to Datadog                    |
-| [ECS][20]                          | `-`                                                                                             | [Use the docker agent to gather your logs][21]                              |
-| [Elastic Load Balancing (ELB)][22] | [Enable AWS ELB logs][23]                                                                       | [Manual][24] and [automatic](#automatically-setup-triggers) log collection  |
-| [Lambda][25]                       | `-`                                                                                             | [Manual][26] and [automatic](#automatically-setup-triggers) log collection |
-| [RDS][27]                         | [Enable AWS RDS logs][28]                                                                      | [Manual][29] log collection                                                |
-| [Route 53][30]                    | [Enable AWS Route 53 logs][31]                                                                 | [Manual][32] log collection                                                |
-| [S3][33]                          | [Enable AWS S3 logs][34]                                                                       | [Manual][35] and [automatic](#automatically-setup-triggers) log collection |
-| [SNS][36]                         | There is no "SNS Logs". Process logs and events that are transiting through to the SNS Service. | [Manual][37] log collection                                                |
-| [RedShift][38]                    | [Enable AWS Redshift logs][39]                                                                 | [Manual][40] and [automatic](#automatically-setup-triggers) log collection |
-| [VPC][41]                         | [Enable AWS VPC logs][42]                                                                      | [Manual][43] log collection                                                |
+| [API Gateway][6]                  | [Enable AWS API Gateway logs][7]                                                               | [Manual][8] log collection                                                 |
+| [Cloudfront][9]                   | [Enable AWS Cloudfront logs][10]                                                                | [Manual][11] and [automatic](#automatically-setup-triggers) log collection  |
+| [Cloudtrail][6]                   | [Enable AWS Cloudtrail logs][12]                                                                | [Manual][13] log collection                                                 |
+| [DynamoDB][14]                     | [Enable AWS DynamoDB logs][15]                                                                  | [Manual][16] log collection                                                 |
+| [EC2][17]                          | `-`                                                                                             | Use the [Datadog Agent][17] to send your logs to Datadog                    |
+| [ECS][18]                          | `-`                                                                                             | [Use the docker agent to gather your logs][19]                              |
+| [Elastic Load Balancing (ELB)][20] | [Enable AWS ELB logs][21]                                                                       | [Manual][22] and [automatic](#automatically-setup-triggers) log collection  |
+| [Lambda][23]                       | `-`                                                                                             | [Manual][24] and [automatic](#automatically-setup-triggers) log collection |
+| [RDS][25]                         | [Enable AWS RDS logs][26]                                                                      | [Manual][27] log collection                                                |
+| [Route 53][28]                    | [Enable AWS Route 53 logs][29]                                                                 | [Manual][30] log collection                                                |
+| [S3][31]                          | [Enable AWS S3 logs][32]                                                                       | [Manual][33] and [automatic](#automatically-setup-triggers) log collection |
+| [SNS][34]                         | There is no "SNS Logs". Process logs and events that are transiting through to the SNS Service. | [Manual][35] log collection                                                |
+| [RedShift][36]                    | [Enable AWS Redshift logs][37]                                                                 | [Manual][38] and [automatic](#automatically-setup-triggers) log collection |
+| [VPC][39]                         | [Enable AWS VPC logs][40]                                                                      | [Manual][41] log collection                                                |
 
 
 
 
-[1]: https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring#installation
-[2]: /agent/guide/private-link/?tab=logs
-[3]: https://docs.aws.amazon.com/lambda/latest/dg/lambda-intro-execution-role.html
-[4]: /serverless/forwarder/
-[5]: /integrations/amazon_web_services/
-[6]: https://app.datadoghq.com/account/settings#integrations/amazon_web_services
-[7]: https://app.datadoghq.com/logs
-[8]: /integrations/amazon_api_gateway/
-[9]: /integrations/amazon_api_gateway/#log-collection
-[10]: /integrations/amazon_api_gateway/#send-logs-to-datadog
-[11]: /integrations/amazon_cloudfront/
-[12]: /integrations/amazon_cloudfront/#enable-cloudfront-logging
-[13]: /integrations/amazon_cloudfront/#send-logs-to-datadog
-[14]: /integrations/amazon_cloudtrail/#enable-cloudtrail-logging
-[15]: /integrations/amazon_cloudtrail/#send-logs-to-datadog
-[16]: /integrations/amazon_dynamodb/#enable-dynamodb-logging
-[17]: /integrations/amazon_dynamodb/
-[18]: /integrations/amazon_dynamodb/#send-logs-to-datadog
-[19]: /integrations/amazon_ec2/
-[20]: /integrations/amazon_ecs/
-[21]: /integrations/amazon_ecs/#log-collection
-[22]: /integrations/amazon_elb/
-[23]: /integrations/amazon_elb/#enable-aws-elb-logging
-[24]: /integrations/amazon_elb/#manual-installation-steps
-[25]: /integrations/amazon_lambda/
-[26]: /integrations/amazon_lambda/#log-collection
-[27]: /integrations/amazon_rds/
-[28]: /integrations/amazon_rds/#enable-rds-logging
-[29]: /integrations/amazon_rds/#send-logs-to-datadog
-[30]: /integrations/amazon_route53/
-[31]: /integrations/amazon_route53/#enable-route53-logging
-[32]: /integrations/amazon_route53/#send-logs-to-datadog
-[33]: /integrations/amazon_s3/
-[34]: /integrations/amazon_s3/#enable-s3-access-logs
-[35]: /integrations/amazon_s3/#manual-installation-steps
-[36]: /integrations/amazon_sns/
-[37]: /integrations/amazon_sns/#send-logs-to-datadog
-[38]: /integrations/amazon_redshift/
-[39]: /integrations/amazon_redshift/#enable-aws-redshift-logging
-[40]: /integrations/amazon_redshift/#log-collection
-[41]: /integrations/amazon_vpc/
-[42]: /integrations/amazon_vpc/#enable-vpc-flow-log-logging
-[43]: /integrations/amazon_vpc/#log-collection
+[1]: /serverless/forwarder/
+[2]: /serverless/forwarder#aws-privatelink-support
+[3]: /integrations/amazon_web_services/
+[4]: https://app.datadoghq.com/account/settings#integrations/amazon_web_services
+[5]: https://app.datadoghq.com/logs
+[6]: /integrations/amazon_api_gateway/
+[7]: /integrations/amazon_api_gateway/#log-collection
+[8]: /integrations/amazon_api_gateway/#send-logs-to-datadog
+[9]: /integrations/amazon_cloudfront/
+[10]: /integrations/amazon_cloudfront/#enable-cloudfront-logging
+[11]: /integrations/amazon_cloudfront/#send-logs-to-datadog
+[12]: /integrations/amazon_cloudtrail/#enable-cloudtrail-logging
+[13]: /integrations/amazon_cloudtrail/#send-logs-to-datadog
+[14]: /integrations/amazon_dynamodb/#enable-dynamodb-logging
+[15]: /integrations/amazon_dynamodb/
+[16]: /integrations/amazon_dynamodb/#send-logs-to-datadog
+[17]: /integrations/amazon_ec2/
+[18]: /integrations/amazon_ecs/
+[19]: /integrations/amazon_ecs/#log-collection
+[20]: /integrations/amazon_elb/
+[21]: /integrations/amazon_elb/#enable-aws-elb-logging
+[22]: /integrations/amazon_elb/#manual-installation-steps
+[23]: /integrations/amazon_lambda/
+[24]: /integrations/amazon_lambda/#log-collection
+[25]: /integrations/amazon_rds/
+[26]: /integrations/amazon_rds/#enable-rds-logging
+[27]: /integrations/amazon_rds/#send-logs-to-datadog
+[28]: /integrations/amazon_route53/
+[29]: /integrations/amazon_route53/#enable-route53-logging
+[30]: /integrations/amazon_route53/#send-logs-to-datadog
+[31]: /integrations/amazon_s3/
+[32]: /integrations/amazon_s3/#enable-s3-access-logs
+[33]: /integrations/amazon_s3/#manual-installation-steps
+[34]: /integrations/amazon_sns/
+[35]: /integrations/amazon_sns/#send-logs-to-datadog
+[36]: /integrations/amazon_redshift/
+[37]: /integrations/amazon_redshift/#enable-aws-redshift-logging
+[38]: /integrations/amazon_redshift/#log-collection
+[39]: /integrations/amazon_vpc/
+[40]: /integrations/amazon_vpc/#enable-vpc-flow-log-logging
+[41]: /integrations/amazon_vpc/#log-collection

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -153,7 +153,7 @@ Resources:
 {{% /tab %}}
 {{< /tabs >}}
 
-##### Collecting logs from S3 buckets
+### Collecting logs from S3 buckets
 
 If you are collecting logs from an S3 bucket, configure the trigger to the [Datadog Forwarder Lambda function][4] using one of the following method:
 

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -129,7 +129,7 @@ resource "aws_cloudwatch_log_subscription_filter" "datadog_log_subscription_filt
 {{% /tab %}}
 {{% tab "CloudFormation/SAM" %}}
 
-For AWS CloudFormation or SAM users, you can provision and manage your triggers using the CloudFormation [AWS::Logs::SubscriptionFilter][1] resource. See sample code below.
+For AWS CloudFormation or SAM users, you can provision and manage your triggers using the CloudFormation [AWS::Logs::SubscriptionFilter][1] resource. See sample code below. The sample code also work for [Serverless Framework][2] users, put it under the [resources][3] section within your serverless.yml.
 
 ```yaml
 Resources:
@@ -143,6 +143,8 @@ Resources:
 
 
 [1]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-subscriptionfilter.html
+[2]: https://www.serverless.com/
+[3]: https://www.serverless.com/framework/docs/providers/aws/guide/resources/
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -127,9 +127,13 @@ resource "aws_cloudwatch_log_subscription_filter" "datadog_log_subscription_filt
 
 [1]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_subscription_filter
 {{% /tab %}}
-{{% tab "CloudFormation/SAM" %}}
+{{% tab "CloudFormation" %}}
 
-For AWS CloudFormation or SAM users, you can provision and manage your triggers using the CloudFormation [AWS::Logs::SubscriptionFilter][1] resource. See sample code below. The sample code also work for [Serverless Framework][2] users, put it under the [resources][3] section within your serverless.yml.
+For AWS CloudFormation users, you can provision and manage your triggers using the CloudFormation [AWS::Logs::SubscriptionFilter][1] resource. See sample code below. 
+
+The sample code also work for AWS [SAM][2] and [Serverless Framework][3]. For Serverless Framework, put the code under the [resources][4] section within your `serverless.yml`.
+
+
 
 ```yaml
 Resources:
@@ -143,8 +147,9 @@ Resources:
 
 
 [1]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-subscriptionfilter.html
-[2]: https://www.serverless.com/
-[3]: https://www.serverless.com/framework/docs/providers/aws/guide/resources/
+[2]: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html
+[3]: https://www.serverless.com/
+[4]: https://www.serverless.com/framework/docs/providers/aws/guide/resources/
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -188,9 +193,9 @@ resource "aws_s3_bucket_notification" "my_bucket_notification" {
 
 [1]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification
 {{% /tab %}}
-{{% tab "CloudFormation/SAM" %}}
+{{% tab "CloudFormation" %}}
 
-For CloudFormation or SAM users, you can configure triggers using the CloudFormation [NotificationConfiguration][1] for your S3 bucket. See the sample code below.
+For CloudFormation users, you can configure triggers using the CloudFormation [NotificationConfiguration][1] for your S3 bucket. See the sample code below.
 
 ```yaml
 Resources:

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -93,7 +93,7 @@ If you are storing logs in many S3 buckets or CloudWatch Log groups, Datadog can
 
 #### Collecting logs from CloudWatch Log Group
 
-If you are collecting logs from a CloudWatch Log Group, configure the trigger to the [Datadog Forwarder Lambda function][1] using one of the following method:
+If you are collecting logs from a CloudWatch Log Group, configure the trigger to the [Datadog Forwarder Lambda function][1] using one of the following methods:
 
 {{< tabs >}}
 {{% tab "AWS Console" %}}
@@ -152,12 +152,12 @@ Resources:
 
 #### Collecting logs from S3 buckets
 
-If you are collecting logs from an S3 bucket, configure the trigger to the [Datadog Forwarder Lambda function][1] using one of the following method:
+If you are collecting logs from an S3 bucket, configure the trigger to the [Datadog Forwarder Lambda function][1] using one of the following methods:
 
 {{< tabs >}}
 {{% tab "AWS Console" %}}
 
-1. Once the lambda function is installed, manually add a trigger on the S3 bucket that contains your logs in the AWS console:
+1. Once the Lambda function is installed, manually add a trigger on the S3 bucket that contains your logs in the AWS console:
    {{< img src="logs/aws/adding_trigger.png" alt="Adding trigger" popup="true"style="width:80%;">}}
 
 1. Select the bucket and then follow the AWS instructions:

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -235,7 +235,7 @@ Any AWS service that generates logs into a S3 bucket or a CloudWatch Log Group i
 [1]: https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring#installation
 [2]: /agent/guide/private-link/?tab=logs
 [3]: https://docs.aws.amazon.com/lambda/latest/dg/lambda-intro-execution-role.html
-[4]: /serverless/installation/installing_the_forwarder/
+[4]: /serverless/forwarder/
 [5]: https://app.datadoghq.com/account/settings#integrations/amazon_web_services
 [6]: https://app.datadoghq.com/logs
 [7]: /integrations/amazon_api_gateway/

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -211,7 +211,7 @@ Resources:
 {{% /tab %}}
 {{< /tabs >}}
 
-### Enable logging for your AWS service
+## Enable logging for your AWS service
 
 Any AWS service that generates logs into a S3 bucket or a CloudWatch Log Group is supported. Find specific setup instructions for the most used services in the table below:
 

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -89,9 +89,9 @@ If you are storing logs in many S3 buckets or CloudWatch Log groups, Datadog can
 7. To stop collecting all AWS logs, press the _x_ next to each Lambda ARN. All triggers for that function are removed.
 8. Within a few minutes of this initial setup, your AWS Logs appear in your Datadog [log explorer page][5] in near real time.
 
-## Manually set up triggers
+### Manually set up triggers
 
-### Collecting logs from CloudWatch Log Group
+#### Collecting logs from CloudWatch Log Group
 
 If you are collecting logs from a CloudWatch Log Group, configure the trigger to the [Datadog Forwarder Lambda function][1] using one of the following method:
 
@@ -150,7 +150,7 @@ Resources:
 {{% /tab %}}
 {{< /tabs >}}
 
-### Collecting logs from S3 buckets
+#### Collecting logs from S3 buckets
 
 If you are collecting logs from an S3 bucket, configure the trigger to the [Datadog Forwarder Lambda function][1] using one of the following method:
 

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -39,7 +39,7 @@ There are two options when configuring triggers on the Datadog Lambda function:
 If you are storing logs in many S3 buckets or CloudWatch Log groups, Datadog can automatically manage triggers for you.
 
 1. If you haven't already, set up the [Datadog log collection AWS Lambda function][4].
-2. Ensure the [policy](#datadog-aws-iam-policy) of the IAM role used for Datadog-AWS integration has the following permissions. Information on how these permissions are used can be found in the descriptions below:
+2. Ensure the policy of the IAM role used for [Datadog-AWS integration][5] has the following permissions. Information on how these permissions are used can be found in the descriptions below:
 
     ```text
     "cloudfront:GetDistributionConfig",
@@ -83,14 +83,14 @@ If you are storing logs in many S3 buckets or CloudWatch Log groups, Datadog can
     | `logs:DeleteSubscriptionFilter`                             | Remove a Lambda trigger based on CloudWatch Log events                       |
     | `logs:DescribeSubscriptionFilters`                          | Lists the subscription filters for the specified log group.                  |
 
-3. Navigate to the _Collect Logs_ tab in the [AWS Integration tile][5].
+3. Navigate to the _Collect Logs_ tab in the [AWS Integration tile][6].
 4. Select the AWS Account from where you want to collect logs, and enter the ARN of the Lambda created in the previous section.
    {{< img src="logs/aws/AWSLogStep1.png" alt="Enter Lambda" popup="true" style="width:80%;" >}}
 5. Select the services from which you'd like to collect logs and hit save. To stop collecting logs from a particular service, uncheck it.
    {{< img src="logs/aws/AWSLogStep2.png" alt="Select services" popup="true" style="width:80%;" >}}
 6. If you have logs across multiple regions, you must create additional Lambda functions in those regions and enter them in this tile.
 7. To stop collecting all AWS logs, press the _x_ next to each Lambda ARN. All triggers for that function are removed.
-8. Within a few minutes of this initial setup, your AWS Logs appear in your Datadog [log explorer page][6] in near real time.
+8. Within a few minutes of this initial setup, your AWS Logs appear in your Datadog [log explorer page][7] in near real time.
 
 ## Manually set up triggers
 
@@ -220,20 +220,20 @@ Any AWS service that generates logs into a S3 bucket or a CloudWatch Log Group i
 
 | AWS service                        | Activate AWS service logging                                                                    | Send AWS logs to Datadog                                                    |
 | ---------------------------------- | ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| [API Gateway][7]                  | [Enable AWS API Gateway logs][8]                                                               | [Manual][9] log collection                                                 |
-| [Cloudfront][10]                   | [Enable AWS Cloudfront logs][11]                                                                | [Manual][12] and [automatic](#automatically-setup-triggers) log collection  |
-| [Cloudtrail][7]                   | [Enable AWS Cloudtrail logs][13]                                                                | [Manual][14] log collection                                                 |
-| [DynamoDB][15]                     | [Enable AWS DynamoDB logs][16]                                                                  | [Manual][17] log collection                                                 |
-| [EC2][18]                          | `-`                                                                                             | Use the [Datadog Agent][18] to send your logs to Datadog                    |
-| [ECS][19]                          | `-`                                                                                             | [Use the docker agent to gather your logs][20]                              |
-| [Elastic Load Balancing (ELB)][21] | [Enable AWS ELB logs][22]                                                                       | [Manual][23] and [automatic](#automatically-setup-triggers) log collection  |
-| [Lambda][24]                       | `-`                                                                                             | [Manual][25] and [automatic](#automatically-setup-triggers) log collection |
-| [RDS][26]                         | [Enable AWS RDS logs][27]                                                                      | [Manual][28] log collection                                                |
-| [Route 53][29]                    | [Enable AWS Route 53 logs][30]                                                                 | [Manual][31] log collection                                                |
-| [S3][32]                          | [Enable AWS S3 logs][33]                                                                       | [Manual][34] and [automatic](#automatically-setup-triggers) log collection |
-| [SNS][35]                         | There is no "SNS Logs". Process logs and events that are transiting through to the SNS Service. | [Manual][36] log collection                                                |
-| [RedShift][37]                    | [Enable AWS Redshift logs][38]                                                                 | [Manual][39] and [automatic](#automatically-setup-triggers) log collection |
-| [VPC][40]                         | [Enable AWS VPC logs][41]                                                                      | [Manual][42] log collection                                                |
+| [API Gateway][8]                  | [Enable AWS API Gateway logs][9]                                                               | [Manual][10] log collection                                                 |
+| [Cloudfront][11]                   | [Enable AWS Cloudfront logs][12]                                                                | [Manual][13] and [automatic](#automatically-setup-triggers) log collection  |
+| [Cloudtrail][8]                   | [Enable AWS Cloudtrail logs][14]                                                                | [Manual][15] log collection                                                 |
+| [DynamoDB][16]                     | [Enable AWS DynamoDB logs][17]                                                                  | [Manual][18] log collection                                                 |
+| [EC2][19]                          | `-`                                                                                             | Use the [Datadog Agent][19] to send your logs to Datadog                    |
+| [ECS][20]                          | `-`                                                                                             | [Use the docker agent to gather your logs][21]                              |
+| [Elastic Load Balancing (ELB)][22] | [Enable AWS ELB logs][23]                                                                       | [Manual][24] and [automatic](#automatically-setup-triggers) log collection  |
+| [Lambda][25]                       | `-`                                                                                             | [Manual][26] and [automatic](#automatically-setup-triggers) log collection |
+| [RDS][27]                         | [Enable AWS RDS logs][28]                                                                      | [Manual][29] log collection                                                |
+| [Route 53][30]                    | [Enable AWS Route 53 logs][31]                                                                 | [Manual][32] log collection                                                |
+| [S3][33]                          | [Enable AWS S3 logs][34]                                                                       | [Manual][35] and [automatic](#automatically-setup-triggers) log collection |
+| [SNS][36]                         | There is no "SNS Logs". Process logs and events that are transiting through to the SNS Service. | [Manual][37] log collection                                                |
+| [RedShift][38]                    | [Enable AWS Redshift logs][39]                                                                 | [Manual][40] and [automatic](#automatically-setup-triggers) log collection |
+| [VPC][41]                         | [Enable AWS VPC logs][42]                                                                      | [Manual][43] log collection                                                |
 
 
 
@@ -242,41 +242,42 @@ Any AWS service that generates logs into a S3 bucket or a CloudWatch Log Group i
 [2]: /agent/guide/private-link/?tab=logs
 [3]: https://docs.aws.amazon.com/lambda/latest/dg/lambda-intro-execution-role.html
 [4]: /serverless/forwarder/
-[5]: https://app.datadoghq.com/account/settings#integrations/amazon_web_services
-[6]: https://app.datadoghq.com/logs
-[7]: /integrations/amazon_api_gateway/
-[8]: /integrations/amazon_api_gateway/#log-collection
-[9]: /integrations/amazon_api_gateway/#send-logs-to-datadog
-[10]: /integrations/amazon_cloudfront/
-[11]: /integrations/amazon_cloudfront/#enable-cloudfront-logging
-[12]: /integrations/amazon_cloudfront/#send-logs-to-datadog
-[13]: /integrations/amazon_cloudtrail/#enable-cloudtrail-logging
-[14]: /integrations/amazon_cloudtrail/#send-logs-to-datadog
-[15]: /integrations/amazon_dynamodb/#enable-dynamodb-logging
-[16]: /integrations/amazon_dynamodb/
-[17]: /integrations/amazon_dynamodb/#send-logs-to-datadog
-[18]: /integrations/amazon_ec2/
-[19]: /integrations/amazon_ecs/
-[20]: /integrations/amazon_ecs/#log-collection
-[21]: /integrations/amazon_elb/
-[22]: /integrations/amazon_elb/#enable-aws-elb-logging
-[23]: /integrations/amazon_elb/#manual-installation-steps
-[24]: /integrations/amazon_lambda/
-[25]: /integrations/amazon_lambda/#log-collection
-[26]: /integrations/amazon_rds/
-[27]: /integrations/amazon_rds/#enable-rds-logging
-[28]: /integrations/amazon_rds/#send-logs-to-datadog
-[29]: /integrations/amazon_route53/
-[30]: /integrations/amazon_route53/#enable-route53-logging
-[31]: /integrations/amazon_route53/#send-logs-to-datadog
-[32]: /integrations/amazon_s3/
-[33]: /integrations/amazon_s3/#enable-s3-access-logs
-[34]: /integrations/amazon_s3/#manual-installation-steps
-[35]: /integrations/amazon_sns/
-[36]: /integrations/amazon_sns/#send-logs-to-datadog
-[37]: /integrations/amazon_redshift/
-[38]: /integrations/amazon_redshift/#enable-aws-redshift-logging
-[39]: /integrations/amazon_redshift/#log-collection
-[40]: /integrations/amazon_vpc/
-[41]: /integrations/amazon_vpc/#enable-vpc-flow-log-logging
-[42]: /integrations/amazon_vpc/#log-collection
+[5]: /integrations/amazon_web_services/
+[6]: https://app.datadoghq.com/account/settings#integrations/amazon_web_services
+[7]: https://app.datadoghq.com/logs
+[8]: /integrations/amazon_api_gateway/
+[9]: /integrations/amazon_api_gateway/#log-collection
+[10]: /integrations/amazon_api_gateway/#send-logs-to-datadog
+[11]: /integrations/amazon_cloudfront/
+[12]: /integrations/amazon_cloudfront/#enable-cloudfront-logging
+[13]: /integrations/amazon_cloudfront/#send-logs-to-datadog
+[14]: /integrations/amazon_cloudtrail/#enable-cloudtrail-logging
+[15]: /integrations/amazon_cloudtrail/#send-logs-to-datadog
+[16]: /integrations/amazon_dynamodb/#enable-dynamodb-logging
+[17]: /integrations/amazon_dynamodb/
+[18]: /integrations/amazon_dynamodb/#send-logs-to-datadog
+[19]: /integrations/amazon_ec2/
+[20]: /integrations/amazon_ecs/
+[21]: /integrations/amazon_ecs/#log-collection
+[22]: /integrations/amazon_elb/
+[23]: /integrations/amazon_elb/#enable-aws-elb-logging
+[24]: /integrations/amazon_elb/#manual-installation-steps
+[25]: /integrations/amazon_lambda/
+[26]: /integrations/amazon_lambda/#log-collection
+[27]: /integrations/amazon_rds/
+[28]: /integrations/amazon_rds/#enable-rds-logging
+[29]: /integrations/amazon_rds/#send-logs-to-datadog
+[30]: /integrations/amazon_route53/
+[31]: /integrations/amazon_route53/#enable-route53-logging
+[32]: /integrations/amazon_route53/#send-logs-to-datadog
+[33]: /integrations/amazon_s3/
+[34]: /integrations/amazon_s3/#enable-s3-access-logs
+[35]: /integrations/amazon_s3/#manual-installation-steps
+[36]: /integrations/amazon_sns/
+[37]: /integrations/amazon_sns/#send-logs-to-datadog
+[38]: /integrations/amazon_redshift/
+[39]: /integrations/amazon_redshift/#enable-aws-redshift-logging
+[40]: /integrations/amazon_redshift/#log-collection
+[41]: /integrations/amazon_vpc/
+[42]: /integrations/amazon_vpc/#enable-vpc-flow-log-logging
+[43]: /integrations/amazon_vpc/#log-collection

--- a/content/en/serverless/installation/_index.md
+++ b/content/en/serverless/installation/_index.md
@@ -21,5 +21,5 @@ In addition to setup for your language, these instructions walk you through inst
 {{< partial name="serverless/getting-started-languages.html" >}}
 
 [1]: /integrations/amazon_web_services/
-[2]: /serverless/installation/installing_the_forwarder
+[2]: /serverless/forwarder
 [3]: /serverless/installation/installing_the_library

--- a/content/en/serverless/installation/dotnet.md
+++ b/content/en/serverless/installation/dotnet.md
@@ -50,7 +50,7 @@ LambdaLogger.Log(JsonConvert.SerializeObject(myMetric));
 
 [1]: /serverless/#1-install-the-cloud-integration
 [2]: https://docs.aws.amazon.com/xray/latest/devguide/xray-services-lambda.html
-[3]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
-[4]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/#experimental-optional
+[3]: https://docs.datadoghq.com/serverless/forwarder/
+[4]: https://docs.datadoghq.com/serverless/forwarder/#experimental-optional
 [5]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 [6]: https://app.datadoghq.com/functions

--- a/content/en/serverless/installation/dotnet.md
+++ b/content/en/serverless/installation/dotnet.md
@@ -50,7 +50,7 @@ LambdaLogger.Log(JsonConvert.SerializeObject(myMetric));
 
 [1]: /serverless/#1-install-the-cloud-integration
 [2]: https://docs.aws.amazon.com/xray/latest/devguide/xray-services-lambda.html
-[3]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder
-[4]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder/#experimental-optional
-[5]: https://docs.datadoghq.com/integrations/amazon_web_services/?tab=automaticcloudformation#send-aws-service-logs-to-datadog
+[3]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
+[4]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/#experimental-optional
+[5]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 [6]: https://app.datadoghq.com/functions

--- a/content/en/serverless/installation/go.md
+++ b/content/en/serverless/installation/go.md
@@ -82,7 +82,7 @@ func myHandler(ctx context.Context, event MyEvent) (string, error) {
 [1]: /serverless/#1-install-the-cloud-integration
 [2]: https://github.com/DataDog/datadog-lambda-go
 [3]: https://docs.aws.amazon.com/xray/latest/devguide/xray-services-lambda.html
-[4]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
-[5]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/#experimental-optional
+[4]: https://docs.datadoghq.com/serverless/forwarder/
+[5]: https://docs.datadoghq.com/serverless/forwarder/#experimental-optional
 [6]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 [7]: https://app.datadoghq.com/functions

--- a/content/en/serverless/installation/go.md
+++ b/content/en/serverless/installation/go.md
@@ -82,7 +82,7 @@ func myHandler(ctx context.Context, event MyEvent) (string, error) {
 [1]: /serverless/#1-install-the-cloud-integration
 [2]: https://github.com/DataDog/datadog-lambda-go
 [3]: https://docs.aws.amazon.com/xray/latest/devguide/xray-services-lambda.html
-[4]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder
-[5]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder/#experimental-optional
-[6]: https://docs.datadoghq.com/integrations/amazon_web_services/?tab=automaticcloudformation#send-aws-service-logs-to-datadog
+[4]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
+[5]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/#experimental-optional
+[6]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 [7]: https://app.datadoghq.com/functions

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -109,7 +109,7 @@ public class Handler implements RequestHandler<APIGatewayV2ProxyRequestEvent, AP
 [1]: /serverless/#1-install-the-cloud-integration
 [2]: https://github.com/DataDog/datadog-lambda-java/releases
 [3]: https://docs.aws.amazon.com/xray/latest/devguide/xray-services-lambda.html
-[4]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
-[5]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/#experimental-optional
+[4]: https://docs.datadoghq.com/serverless/forwarder/
+[5]: https://docs.datadoghq.com/serverless/forwarder/#experimental-optional
 [6]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 [7]: https://app.datadoghq.com/functions

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -109,7 +109,7 @@ public class Handler implements RequestHandler<APIGatewayV2ProxyRequestEvent, AP
 [1]: /serverless/#1-install-the-cloud-integration
 [2]: https://github.com/DataDog/datadog-lambda-java/releases
 [3]: https://docs.aws.amazon.com/xray/latest/devguide/xray-services-lambda.html
-[4]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder
-[5]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder/#experimental-optional
-[6]: https://docs.datadoghq.com/integrations/amazon_web_services/?tab=automaticcloudformation#send-aws-service-logs-to-datadog
+[4]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
+[5]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/#experimental-optional
+[6]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 [7]: https://app.datadoghq.com/functions

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -41,7 +41,7 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
 4. Redeploy your serverless application.
 
 [1]: https://github.com/DataDog/serverless-plugin-datadog
-[2]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder
+[2]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
 {{% /tab %}}
 {{% tab "AWS SAM" %}}
 
@@ -119,7 +119,7 @@ To install the Datadog Lambda Library with the CloudFormation macro, follow thes
 
 [1]: https://github.com/DataDog/datadog-cloudformation-macro
 [2]: https://console.aws.amazon.com/cloudformation/home#/stacks?filteringText=forwarder
-[3]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder
+[3]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
 {{% /tab %}}
 
 {{% tab "AWS CDK" %}}
@@ -215,7 +215,7 @@ To install the Datadog Lambda Library with the CloudFormation macro, follow thes
 
 [1]: https://github.com/DataDog/datadog-cloudformation-macro
 [2]: https://console.aws.amazon.com/cloudformation/home#/stacks?filteringText=forwarder
-[3]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder
+[3]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
 {{% /tab %}}
 {{% tab "Custom" %}}
 
@@ -275,9 +275,9 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 [1]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
 [2]: https://github.com/DataDog/datadog-lambda-layer-js/releases
 [3]: https://www.npmjs.com/package/datadog-lambda-js
-[4]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder
-[5]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder/#experimental-optional
-[6]: https://docs.datadoghq.com/integrations/amazon_web_services/?tab=automaticcloudformation#send-aws-service-logs-to-datadog
+[4]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
+[5]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/#experimental-optional
+[6]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -41,7 +41,7 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
 4. Redeploy your serverless application.
 
 [1]: https://github.com/DataDog/serverless-plugin-datadog
-[2]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
+[2]: https://docs.datadoghq.com/serverless/forwarder/
 {{% /tab %}}
 {{% tab "AWS SAM" %}}
 
@@ -119,7 +119,7 @@ To install the Datadog Lambda Library with the CloudFormation macro, follow thes
 
 [1]: https://github.com/DataDog/datadog-cloudformation-macro
 [2]: https://console.aws.amazon.com/cloudformation/home#/stacks?filteringText=forwarder
-[3]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
+[3]: https://docs.datadoghq.com/serverless/forwarder/
 {{% /tab %}}
 
 {{% tab "AWS CDK" %}}
@@ -215,7 +215,7 @@ To install the Datadog Lambda Library with the CloudFormation macro, follow thes
 
 [1]: https://github.com/DataDog/datadog-cloudformation-macro
 [2]: https://console.aws.amazon.com/cloudformation/home#/stacks?filteringText=forwarder
-[3]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
+[3]: https://docs.datadoghq.com/serverless/forwarder/
 {{% /tab %}}
 {{% tab "Custom" %}}
 
@@ -275,8 +275,8 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 [1]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
 [2]: https://github.com/DataDog/datadog-lambda-layer-js/releases
 [3]: https://www.npmjs.com/package/datadog-lambda-js
-[4]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
-[5]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/#experimental-optional
+[4]: https://docs.datadoghq.com/serverless/forwarder/
+[5]: https://docs.datadoghq.com/serverless/forwarder/#experimental-optional
 [6]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -41,7 +41,7 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
 4. Redeploy your serverless application.
 
 [1]: https://github.com/DataDog/serverless-plugin-datadog
-[2]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder
+[2]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
 {{% /tab %}}
 {{% tab "AWS SAM" %}}
 <div class="alert alert-warning">This service is in public beta. If you have any feedback, contact <a href="/help">Datadog support</a>.</div>
@@ -116,7 +116,7 @@ To install the Datadog Lambda Library with the CloudFormation macro, follow thes
 
 [1]: https://github.com/DataDog/datadog-cloudformation-macro
 [2]: https://console.aws.amazon.com/cloudformation/home#/stacks?filteringText=forwarder
-[3]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder
+[3]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
 {{% /tab %}}
 {{% tab "AWS CDK" %}}
 
@@ -206,10 +206,10 @@ To install the Datadog Lambda Library with the CloudFormation macro, follow thes
 
 2. Redeploy your serverless application.
 
+
 [1]: https://github.com/DataDog/datadog-cloudformation-macro
 [2]: https://console.aws.amazon.com/cloudformation/home#/stacks?filteringText=forwarder
-[3]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder
-
+[3]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
 {{% /tab %}}
 {{% tab "Zappa" %}}
 
@@ -244,9 +244,9 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 
 
 [1]: https://github.com/DataDog/datadog-lambda-layer-python/releases
-[2]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder
-[3]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder/#experimental-optional
-[4]: https://docs.datadoghq.com/integrations/amazon_web_services/?tab=automaticcloudformation#send-aws-service-logs-to-datadog
+[2]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
+[3]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/#experimental-optional
+[4]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 {{% /tab %}}
 {{% tab "Custom" %}}
 
@@ -301,9 +301,9 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 [2]: https://github.com/DataDog/datadog-lambda-layer-python/releases
 [3]: https://docs.aws.amazon.com/lambda/latest/dg/python-package.html#python-package-dependencies
 [4]: https://pypi.org/project/datadog-lambda/
-[5]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder
-[6]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder/#experimental-optional
-[7]: https://docs.datadoghq.com/integrations/amazon_web_services/?tab=automaticcloudformation#send-aws-service-logs-to-datadog
+[5]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
+[6]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/#experimental-optional
+[7]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 {{% /tab %}} 
 {{< /tabs >}}
 

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -41,7 +41,7 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
 4. Redeploy your serverless application.
 
 [1]: https://github.com/DataDog/serverless-plugin-datadog
-[2]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
+[2]: https://docs.datadoghq.com/serverless/forwarder/
 {{% /tab %}}
 {{% tab "AWS SAM" %}}
 <div class="alert alert-warning">This service is in public beta. If you have any feedback, contact <a href="/help">Datadog support</a>.</div>
@@ -116,7 +116,7 @@ To install the Datadog Lambda Library with the CloudFormation macro, follow thes
 
 [1]: https://github.com/DataDog/datadog-cloudformation-macro
 [2]: https://console.aws.amazon.com/cloudformation/home#/stacks?filteringText=forwarder
-[3]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
+[3]: https://docs.datadoghq.com/serverless/forwarder/
 {{% /tab %}}
 {{% tab "AWS CDK" %}}
 
@@ -209,7 +209,7 @@ To install the Datadog Lambda Library with the CloudFormation macro, follow thes
 
 [1]: https://github.com/DataDog/datadog-cloudformation-macro
 [2]: https://console.aws.amazon.com/cloudformation/home#/stacks?filteringText=forwarder
-[3]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
+[3]: https://docs.datadoghq.com/serverless/forwarder/
 {{% /tab %}}
 {{% tab "Zappa" %}}
 
@@ -244,8 +244,8 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 
 
 [1]: https://github.com/DataDog/datadog-lambda-layer-python/releases
-[2]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
-[3]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/#experimental-optional
+[2]: https://docs.datadoghq.com/serverless/forwarder/
+[3]: https://docs.datadoghq.com/serverless/forwarder/#experimental-optional
 [4]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 {{% /tab %}}
 {{% tab "Custom" %}}
@@ -301,8 +301,8 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 [2]: https://github.com/DataDog/datadog-lambda-layer-python/releases
 [3]: https://docs.aws.amazon.com/lambda/latest/dg/python-package.html#python-package-dependencies
 [4]: https://pypi.org/project/datadog-lambda/
-[5]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
-[6]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/#experimental-optional
+[5]: https://docs.datadoghq.com/serverless/forwarder/
+[6]: https://docs.datadoghq.com/serverless/forwarder/#experimental-optional
 [7]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 {{% /tab %}} 
 {{< /tabs >}}

--- a/content/en/serverless/installation/ruby.md
+++ b/content/en/serverless/installation/ruby.md
@@ -94,7 +94,7 @@ end
 [2]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
 [3]: https://github.com/DataDog/datadog-lambda-layer-rb/releases
 [4]: https://rubygems.org/gems/datadog-lambda
-[5]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder
-[6]: https://docs.datadoghq.com/serverless/troubleshooting/installing_the_forwarder/#experimental-optional
-[7]: https://docs.datadoghq.com/integrations/amazon_web_services/?tab=automaticcloudformation#send-aws-service-logs-to-datadog
+[5]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
+[6]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/#experimental-optional
+[7]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 [8]: https://app.datadoghq.com/functions

--- a/content/en/serverless/installation/ruby.md
+++ b/content/en/serverless/installation/ruby.md
@@ -94,7 +94,7 @@ end
 [2]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
 [3]: https://github.com/DataDog/datadog-lambda-layer-rb/releases
 [4]: https://rubygems.org/gems/datadog-lambda
-[5]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/
-[6]: https://docs.datadoghq.com/serverless/installation/installing_the_forwarder/#experimental-optional
+[5]: https://docs.datadoghq.com/serverless/forwarder/
+[6]: https://docs.datadoghq.com/serverless/forwarder/#experimental-optional
 [7]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 [8]: https://app.datadoghq.com/functions

--- a/content/en/serverless/troubleshooting/_index.md
+++ b/content/en/serverless/troubleshooting/_index.md
@@ -28,7 +28,7 @@ Use the following table to help troubleshoot issues you might be experiencing wi
 If you’re still unsure about the issue, you may reach out to the [Datadog support team][9]. 
 
 [1]: /serverless/#getting-started
-[2]: /serverless/installation/installing_the_forwarder
+[2]: /serverless/forwarder
 [3]: /serverless/installation/installing_the_library
 [4]: /integrations/amazon_lambda/#metric-collection
 [5]: /integrations/amazon_lambda/#real-time-enhanced-lambda-metrics

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -175,11 +175,11 @@
       globs:
       - 'aws/logs_monitoring/README.md'
       options:
-        dest_path: '/serverless/installation/'
-        file_name: 'installing_the_forwarder.md'
+        dest_path: '/serverless/'
+        file_name: 'forwarder.md'
         front_matters:
           dependencies: ["https://github.com/DataDog/datadog-serverless-functions/blob/master/aws/logs_monitoring/README.md"]
-          title: Installing the Forwarder
+          title: Datadog Forwarder
           kind: documentation
           aliases:
             - /serverless/troubleshooting/installing_the_forwarder/

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -175,11 +175,11 @@
       globs:
       - 'aws/logs_monitoring/README.md'
       options:
-        dest_path: '/serverless/installation/'
-        file_name: 'installing_the_forwarder.md'
+        dest_path: '/serverless/'
+        file_name: 'forwarder.md'
         front_matters:
           dependencies: ["https://github.com/DataDog/datadog-serverless-functions/blob/master/aws/logs_monitoring/README.md"]
-          title: Installing the Forwarder
+          title: Datadog Forwarder
           kind: documentation
           aliases:
             - /serverless/troubleshooting/installing_the_forwarder/


### PR DESCRIPTION
### What does this PR do?

With the recent doc shuffling, certain links on forwarder and its trigger set up are broken. Also taking the chance to put manual trigger set up instructions under tabs.

### Motivation

Links from https://docs.datadoghq.com/serverless/installation/python/?tab=custom#subscribe-the-datadog-forwarder-to-the-log-groups no long work.

### Preview link

https://docs-staging.datadoghq.com/tian.chu/update-forwarder-docs/serverless/installation/python/
https://docs-staging.datadoghq.com/tian.chu/update-forwarder-docs/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
