### PR TITLE
Add Custom Link to see logs by index

### DIFF
--- a/static/resources/json/estimated_log_usage_dashboard_configuration.json
+++ b/static/resources/json/estimated_log_usage_dashboard_configuration.json
@@ -241,6 +241,7 @@
                         "q": "top(sum:datadog.estimated_usage.logs.ingested_events{datadog_is_excluded:false,$service,$index} by {datadog_index}.as_count(), 50, 'sum', 'desc')"
                     }
                 ],
+                "custom_links":[{"link":"https://app.datadoghq.com/logs?index={{datadog_index.value}}","label":"See Logs in Explorer"}],
                 "title": "Indexed logs by index",
                 "title_size": "16",
                 "title_align": "left"
@@ -274,6 +275,7 @@
                     "max": "auto",
                     "include_zero": true
                 },
+                "custom_links":[{"link":"https://app.datadoghq.com/logs?index={{datadog_index.value}}","label":"See Logs in Explorer"}],
                 "title": "Indexed logs per index",
                 "title_size": "16",
                 "title_align": "left",


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a Custom Link to the "logs by index" widgets in the estimated usage dashboard JSON definition.

### Motivation
The "view related logs" links for these two dashboards currently doesn't show any logs because it generates a query with the wrong parameter (it uses the tag `datadog_index` instead of inserting `index=<value>`). This is a quick workaround so customers have a useable link as a fallback.

### Preview link

N/A
