### PR TITLE
Update nginx ingress controller section

### DIFF
--- a/content/en/tracing/setup/nginx.md
+++ b/content/en/tracing/setup/nginx.md
@@ -147,6 +147,14 @@ Additionally, ensure that your nginx-ingress controller's pod spec has the `HOST
       fieldPath: status.hostIP
 ```
 
+To set a different service name per Ingress using annotations:
+
+```yaml
+  nginx.ingress.kubernetes.io/configuration-snippet: |
+      opentracing_tag "service.name" "custom-service-name";
+```
+The above overrides the default `nginx-ingress-controller.ingress-nginx` service name.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
Instruction on overriding default service names with nginx ingress controller

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
ticket 358443

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
