### PR TITLE
Update collect-custom-windows-performance-counters-over-wmi.md

### DIFF
--- a/content/en/integrations/faq/collect-custom-windows-performance-counters-over-wmi.md
+++ b/content/en/integrations/faq/collect-custom-windows-performance-counters-over-wmi.md
@@ -53,4 +53,6 @@ instances:
       - [TestNameType, wmi.testnametype.count, gauge]
 ```
 
+**Note**: If you are submitting Windows Performance Counter metrics in languages other than English, these will be translated by Windows.  As such, please ensure to have the ddagentuser account set up with an English language pack.
+
 [1]: /integrations/faq/how-to-retrieve-wmi-metrics/


### PR DESCRIPTION
Hi team, I had a customer who had difficulty setting this up because their metrics were being submitted in a language other than English, and the ddagentuser had not been set up with the English language. I'm adding this here per their request, although I understand if you feel it's not a valuable addition to the page. Thanks in advance, and let me know any feedback.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add note about language sensitivity of ddagentuser when metrics are submitted in languages other than English.

### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadog.zendesk.com/agent/tickets/369445

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/buraizu-patch-1/content/en/integrations/faq/collect-custom-windows-performance-counters-over-wmi.md

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
