### PR TITLE
Update collect-custom-windows-performance-counters-over-wmi.md

### DIFF
--- a/content/en/integrations/faq/collect-custom-windows-performance-counters-over-wmi.md
+++ b/content/en/integrations/faq/collect-custom-windows-performance-counters-over-wmi.md
@@ -53,4 +53,7 @@ instances:
       - [TestNameType, wmi.testnametype.count, gauge]
 ```
 
+**Note**: If you are submitting performance counters in languages other than English, set up the ddagentuser account with the en-US language pack.
+
+
 [1]: /integrations/faq/how-to-retrieve-wmi-metrics/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add note about the need for an English language buildpack in the ddagentuser account when submitting performance counters in languages other than English.

### Preview link
<!-- Impacted pages preview links-->

https://docs-staging.datadoghq.com/buraizu-patch-1/content/en/integrations/faq/collect-custom-windows-performance-counters-over-wmi.md


### Additional Notes
Hi team, I had a customer who had difficulty setting this up because their metrics were being submitted in a language other than English, and the ddagentuser had not been set up with the English language.  I'm adding this here per their request, although I understand if you feel it's not a valuable addition to the page. Thanks in advance, and let me know any feedback
