### PR TITLE
temporarily show integrations even with a translated kind value

### DIFF
--- a/layouts/shortcodes/integrations.html
+++ b/layouts/shortcodes/integrations.html
@@ -1,7 +1,11 @@
 {{ $dot := . }}
 
 <!-- From data file -->
-{{ $integration_list := sort (where (where (where .Site.Pages "Params.kind" "=" "integration") ".Params.beta" "!=" "true") ".Params.is_public" "=" true) ".File.BaseFileName" }}
+{{ $kind := "integration" }}
+{{ if eq .Site.Language.Lang "ja"}}
+    {{ $kind = "インテグレーション"}}
+{{ end }}
+{{ $integration_list := sort (where (where (where .Site.Pages "Params.kind" "=" $kind) ".Params.beta" "!=" "true") ".Params.is_public" "=" true) ".File.BaseFileName" }}
 
 <!-- build filters -->
 {{ $.Scratch.Set "filters" (slice)}}


### PR DESCRIPTION
### What does this PR do?

`/ja/integrations/` Isn't showing all the integrations. The reason being `kind: integration` has been translated causing it to not be recognized by the existing hugo logic.

This PR adds some temporary logic to include integrations that are in this situation. While we decide on how to resolve this in a better way. e.g exclude this from being translated or refactor the site to not use `.kind` here.

### Motivation

websites channel

### Preview link

https://docs-staging.datadoghq.com/david.jones/intfix/ja/integrations/
https://docs-staging.datadoghq.com/david.jones/intfix/integrations/

### Additional Notes

