### PR TITLE
Update SLO Alerting Docs for Public Beta

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -740,6 +740,11 @@ main:
     parent: slos
     identifier: slos_metric
     weight: 702
+  - name: Error Budget Monitors
+    url: monitors/service_level_objectives/error_budget/
+    parent: slos
+    identifier: error_budget
+    weight: 703
   - name: Guides
     url: monitors/guide/
     weight: 100

--- a/content/en/monitors/service_level_objectives/error_budget.md
+++ b/content/en/monitors/service_level_objectives/error_budget.md
@@ -2,7 +2,6 @@
 title: Error Budget Monitors
 kind: documentation
 description: "Use Monitors to define the Service Level Objective"
-beta: true
 ---
 
 <div class="alert alert-warning">

--- a/content/en/monitors/service_level_objectives/error_budget.md
+++ b/content/en/monitors/service_level_objectives/error_budget.md
@@ -6,7 +6,7 @@ beta: true
 ---
 
 <div class="alert alert-warning">
-This feature is in closed beta. Email <a href="mailto:slo-help@datadoghq.com">slo-help@datadoghq.com</a> to request access, to ask questions, or to provide feedback on this feature.
+This feature is in open beta. Email <a href="mailto:slo-help@datadoghq.com">slo-help@datadoghq.com</a> to ask questions or to provide feedback on this feature.
 </div>
 
 ## Overview


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds the Error Budget Monitors docs page to the nav bar

### Motivation
<!-- What inspired you to submit this pull request?-->
Error budget monitors are going into public beta, so this page should be more easily accessible

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/markazerdd/slo-alerting-public-beta/monitors/service_level_objectives/error_budget/

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
