### PR TITLE
APM > .NET > Configuration settings update

### DIFF
--- a/content/en/tracing/setup/dotnet-core.md
+++ b/content/en/tracing/setup/dotnet-core.md
@@ -359,9 +359,9 @@ The following table lists configuration variables that are available only when u
 
 | Setting Name                                                            | Description                                                                                                           |
 |-------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| `DD_<INTEGRATION>_ENABLED`<br/><br/>`Enabled`                           | Enables or disables a specific integration. Valid values are: `true` (default) or `false`.                            |
-| `DD_<INTEGRATION>_ANALYTICS_ENABLED`<br/><br/>`AnalyticsEnabled`        | Enables or disable App Analytics for a specific integration. Valid values are: `true` or `false` (default).           |
-| `DD_<INTEGRATION>_ANALYTICS_SAMPLE_RATE`<br/><br/>`AnalyticsSampleRate` | Sets the App Analytics sampling rate for a specific integration. A floating number between `0.0` and `1.0` (default). |
+| `DD_TRACE_<INTEGRATION>_ENABLED`<br/><br/>`Enabled`                           | Enables or disables a specific integration. Valid values are: `true` (default) or `false`.                            |
+| `DD_TRACE_<INTEGRATION>_ANALYTICS_ENABLED`<br/><br/>`AnalyticsEnabled`        | Enables or disable App Analytics for a specific integration. Valid values are: `true` or `false` (default).           |
+| `DD_TRACE_<INTEGRATION>_ANALYTICS_SAMPLE_RATE`<br/><br/>`AnalyticsSampleRate` | Sets the App Analytics sampling rate for a specific integration. A floating number between `0.0` and `1.0` (default). |
 
 ## Further Reading
 

--- a/content/en/tracing/setup/dotnet-framework.md
+++ b/content/en/tracing/setup/dotnet-framework.md
@@ -244,9 +244,9 @@ The following table lists configuration variables that are available only when u
 
 | Setting Name                                                            | Description                                                                                                           |
 | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `DD_<INTEGRATION>_ENABLED`<br/><br/>`Enabled`                           | Enables or disables a specific integration. Valid values are: `true` (default) or `false`.                            |
-| `DD_<INTEGRATION>_ANALYTICS_ENABLED`<br/><br/>`AnalyticsEnabled`        | Enables or disable App Analytics for a specific integration. Valid values are: `true` or `false` (default).           |
-| `DD_<INTEGRATION>_ANALYTICS_SAMPLE_RATE`<br/><br/>`AnalyticsSampleRate` | Sets the App Analytics sampling rate for a specific integration. A floating number between `0.0` and `1.0` (default). |
+| `DD_TRACE_<INTEGRATION>_ENABLED`<br/><br/>`Enabled`                           | Enables or disables a specific integration. Valid values are: `true` (default) or `false`.                            |
+| `DD_TRACE_<INTEGRATION>_ANALYTICS_ENABLED`<br/><br/>`AnalyticsEnabled`        | Enables or disable App Analytics for a specific integration. Valid values are: `true` or `false` (default).           |
+| `DD_TRACE_<INTEGRATION>_ANALYTICS_SAMPLE_RATE`<br/><br/>`AnalyticsSampleRate` | Sets the App Analytics sampling rate for a specific integration. A floating number between `0.0` and `1.0` (default). |
 
 ## Further Reading
 

--- a/content/fr/tracing/setup/dotnet-framework.md
+++ b/content/fr/tracing/setup/dotnet-framework.md
@@ -235,9 +235,9 @@ Le tableau suivant énumère les variables de configuration qui sont uniquement 
 
 | Nom du paramètre                                                            | Description                                                                                                           |
 | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `DD_<INTEGRATION>_ENABLED`<br/><br/>`Enabled`                           | Active ou désactive une intégration spécifique. Valeurs acceptées : `true` (par défaut) ou `false`.                            |
-| `DD_<INTEGRATION>_ANALYTICS_ENABLED`<br/><br/>`AnalyticsEnabled`        | Active ou désactive App Analytics pour une intégration spécifique. Valeurs acceptées : `true` ou `false` (par défaut).           |
-| `DD_<INTEGRATION>_ANALYTICS_SAMPLE_RATE`<br/><br/>`AnalyticsSampleRate` | Définit le taux d'échantillonnage App Analytics pour une intégration spécifique. Doit être un nombre flottant entre `0.0` et `1.0` (par défaut). |
+| `DD_TRACE_<INTEGRATION>_ENABLED`<br/><br/>`Enabled`                           | Active ou désactive une intégration spécifique. Valeurs acceptées : `true` (par défaut) ou `false`.                            |
+| `DD_TRACE_<INTEGRATION>_ANALYTICS_ENABLED`<br/><br/>`AnalyticsEnabled`        | Active ou désactive App Analytics pour une intégration spécifique. Valeurs acceptées : `true` ou `false` (par défaut).           |
+| `DD_TRACE_<INTEGRATION>_ANALYTICS_SAMPLE_RATE`<br/><br/>`AnalyticsSampleRate` | Définit le taux d'échantillonnage App Analytics pour une intégration spécifique. Doit être un nombre flottant entre `0.0` et `1.0` (par défaut). |
 
 ## Pour aller plus loin
 

--- a/content/ja/tracing/setup/dotnet-core.md
+++ b/content/ja/tracing/setup/dotnet-core.md
@@ -358,9 +358,9 @@ JSON ファイルを使ってトレーサーを構成するには、インスツ
 
 | 設定名                                                            | 説明                                                                                                           |
 |-------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| `DD_<INTEGRATION>_ENABLED`<br/><br/>`Enabled`                           | 特定のインテグレーションを有効または無効にします。有効な値は `true` (デフォルト) または `false` です。                            |
-| `DD_<INTEGRATION>_ANALYTICS_ENABLED`<br/><br/>`AnalyticsEnabled`        | 特定のインテグレーションの App Analytics を有効または無効にします。有効な値は `true` または `false` (デフォルト) です。           |
-| `DD_<INTEGRATION>_ANALYTICS_SAMPLE_RATE`<br/><br/>`AnalyticsSampleRate` | 特定のインテグレーションの App Analytics サンプリングレートを設定します。`0.0`〜`1.0` (デフォルト) の浮動小数点数。 |
+| `DD_TRACE_<INTEGRATION>_ENABLED`<br/><br/>`Enabled`                           | 特定のインテグレーションを有効または無効にします。有効な値は `true` (デフォルト) または `false` です。                            |
+| `DD_TRACE_<INTEGRATION>_ANALYTICS_ENABLED`<br/><br/>`AnalyticsEnabled`        | 特定のインテグレーションの App Analytics を有効または無効にします。有効な値は `true` または `false` (デフォルト) です。           |
+| `DD_TRACE_<INTEGRATION>_ANALYTICS_SAMPLE_RATE`<br/><br/>`AnalyticsSampleRate` | 特定のインテグレーションの App Analytics サンプリングレートを設定します。`0.0`〜`1.0` (デフォルト) の浮動小数点数。 |
 
 ## その他の参考資料
 

--- a/content/ja/tracing/setup/dotnet-framework.md
+++ b/content/ja/tracing/setup/dotnet-framework.md
@@ -244,9 +244,9 @@ JSON ファイルを使ってトレーサーを構成するには、インスツ
 
 | 設定名                                                            | 説明                                                                                                           |
 | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `DD_<INTEGRATION>_ENABLED`<br/><br/>`Enabled`                           | 特定のインテグレーションを有効または無効にします。有効な値は `true` (デフォルト) または `false` です。                            |
-| `DD_<INTEGRATION>_ANALYTICS_ENABLED`<br/><br/>`AnalyticsEnabled`        | 特定のインテグレーションの App Analytics を有効または無効にします。有効な値は `true` または `false` (デフォルト) です。           |
-| `DD_<INTEGRATION>_ANALYTICS_SAMPLE_RATE`<br/><br/>`AnalyticsSampleRate` | 特定のインテグレーションの App Analytics サンプリングレートを設定します。`0.0`〜`1.0` (デフォルト) の浮動小数点数。 |
+| `DD_TRACE_<INTEGRATION>_ENABLED`<br/><br/>`Enabled`                           | 特定のインテグレーションを有効または無効にします。有効な値は `true` (デフォルト) または `false` です。                            |
+| `DD_TRACE_<INTEGRATION>_ANALYTICS_ENABLED`<br/><br/>`AnalyticsEnabled`        | 特定のインテグレーションの App Analytics を有効または無効にします。有効な値は `true` または `false` (デフォルト) です。           |
+| `DD_TRACE_<INTEGRATION>_ANALYTICS_SAMPLE_RATE`<br/><br/>`AnalyticsSampleRate` | 特定のインテグレーションの App Analytics サンプリングレートを設定します。`0.0`〜`1.0` (デフォルト) の浮動小数点数。 |
 
 ## その他の参考資料
 


### PR DESCRIPTION
Update usages of `DD_<INTEGRATION>` with `DD_TRACE_<INTEGRATION>` in the APM > .NET docs

### What does this PR do?
This updates the documented .NET APM configuration settings to be consistent with other tracers by using the `DD_TRACE_` prefix

### Motivation
Cross-language APM consistency

### Preview link
https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-configuration-settings/tracing/setup/dotnet-framework/?tab=environmentvariables#configuration-variables

### Additional Notes
N/A
