### PR TITLE
Renaming CI integration

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1304,7 +1304,7 @@ main:
     parent: synthetics_private_location
     identifier: synthetics_private_location_configuration
     weight: 301
-  - name: Continuous Testing
+  - name: CI/CD Testing
     url: /synthetics/ci/
     parent: synthetics
     identifier: synthetics_ci

--- a/content/en/synthetics/ci.md
+++ b/content/en/synthetics/ci.md
@@ -1,5 +1,5 @@
 ---
-title: Synthetic Continuous Testing
+title: Synthetic CI/CD Testing
 kind: documentation
 description: Run Synthetic tests on-demand in your CI/CD pipelines.
 further_reading:
@@ -18,11 +18,11 @@ further_reading:
 ---
 
 In addition to running tests at predefined intervals, you can also run Datadog Synthetic tests on-demand using API endpoints. You can run Datadog Synthetic tests in your continuous integration (CI) pipelines, letting you block the deployment of branches that would break your product. 
-Datadog Continuous Testing can also be used to **run tests as part of your CD process**, evaluating the state of your production application immediately after a deployment finishes. This lets you detect potential regressions that could impact your users—and automatically trigger a rollback whenever a critical test fails.
+Synthetic CI/CD testing can also be used to **run tests as part of your CD process**, evaluating the state of your production application immediately after a deployment finishes. This lets you detect potential regressions that could impact your users—and automatically trigger a rollback whenever a critical test fails.
 
 This function allows you to avoid spending time fixing issues on production, and to catch bugs and regressions earlier in the process.
 
-On top of these API endpoints, Datadog provides and maintains a command line interface (CLI), allowing you to easily integrate Datadog Synthetic tests with your CI tooling. Synthetic Continuous Testing is open-source, and its source code is available on GitHub at [DataDog/datadog-ci][1].
+On top of these API endpoints, Datadog provides and maintains a command line interface (CLI), allowing you to easily integrate Datadog Synthetic tests with your CI tooling. Synthetic CI/CD testing is open-source, and its source code is available on GitHub at [DataDog/datadog-ci][1].
 
 ## API usage
 

--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -23,7 +23,7 @@ The access to this feature is restricted - if you don't have access, reach out t
 Private locations allow you to **monitor internal-facing applications or any private URLs** that aren’t accessible from the public internet. They can also be used to:
 
 * **Create custom Synthetic locations** in areas that are mission-critical to your business.
-* **Verify application performance in your internal CI environment** before you release new features to production with [Synthetic CI test integration][1].
+* **Verify application performance in your internal CI environment** before you release new features to production with [Synthetic CI/CD testing][1].
 * **Compare application performance** from both inside & outside your internal network.
 
 Private locations come as Docker containers that you can install wherever makes sense inside of your private network. Once created and installed, you can assign [Synthetic tests][2] to your private location just like you would with any regular managed location.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR changes one last time (for real) the naming of the CI integration inside the doc 😬 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/margot.lepizzera/ci_integration_renaming/synthetics/ci/?tab=npm
https://docs-staging.datadoghq.com/margot.lepizzera/ci_integration_renaming/synthetics/private_locations

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
