### PR TITLE
update troubleshooting link for serverless Datadog APM

### DIFF
--- a/content/en/serverless/troubleshooting/_index.md
+++ b/content/en/serverless/troubleshooting/_index.md
@@ -25,7 +25,7 @@ Use the following table to help troubleshoot issues you might be experiencing wi
 | [Lambda Custom Metrics][7]	| Custom metrics ingestion from your Lambda functions.|
 | [Datadog APM][8]       		| Distributed tracing using the Datadog Tracer or AWS X-Ray.|
 
-If you’re still unsure about the issue, you may reach out to the [Datadog support team][9]. 
+If you’re still unsure about the issue, you may reach out to the [Datadog support team][9].
 
 [1]: /serverless/#getting-started
 [2]: /serverless/forwarder
@@ -34,5 +34,5 @@ If you’re still unsure about the issue, you may reach out to the [Datadog supp
 [5]: /integrations/amazon_lambda/#real-time-enhanced-lambda-metrics
 [6]: /integrations/amazon_lambda/#log-collection
 [7]: /integrations/amazon_lambda/#custom-metrics
-[8]: /integrations/amazon_lambda/#trace-collection
+[8]: /tracing/serverless_functions/
 [9]: /help/


### PR DESCRIPTION

### What does this PR do?
Updates Troubleshooting link from Serverless docs to Datadog APM page
