### PR TITLE
WEB-641 render text uppercase

### DIFF
--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -135,7 +135,7 @@
                             <p class="alert-warning">{{ . | markdownify }}</p>
                         </div>
                         {{ end }}
-                        <p class="mb-0"><span style="padding: 3px" class="text-uppercase font-semibold text-api-{{ .actionType }} bg-bg-api-{{ .actionType }}">{{ .actionType }}</span>&nbsp;{{ range $.Scratch.Get "serverURLS" }}<span class="d-none" data-region="{{ .region }}">{{ .url }}</span>{{ end }}<span>{{.pathKey}}</span>
+                        <p class="mb-0"><span style="padding: 3px" class="font-semibold text-api-{{ .actionType }} bg-bg-api-{{ .actionType }}">{{ .actionType | upper }}</span>&nbsp;{{ range $.Scratch.Get "serverURLS" }}<span class="d-none" data-region="{{ .region }}">{{ .url }}</span>{{ end }}<span>{{.pathKey}}</span>
                         </p>
                         <h3 class="mt-2">Overview</h3>
                         <p>{{.action.description | markdownify }}</p>

--- a/layouts/partials/api/curl.html
+++ b/layouts/partials/api/curl.html
@@ -33,7 +33,7 @@
 {{- end -}}
 
 <span class="c1"># Curl command</span>
-<span class="n">curl</span> <span class="o">-X</span> <span class="s1 text-uppercase">{{ .context.actionType }}</span> {{ range .dollarScratch.Get "serverURLS" }}{{ if ne .region "local" }}<span class="kn d-none" data-region="{{ .region }}">{{ .url }}</span>{{ else }}<span class="kn">{{ .url }}</span>{{ end }}{{ end }}<span class="n">{{ replace .context.pathKey "{" "${" }}</span>
+<span class="n">curl</span> <span class="o">-X</span> <span class="s1">{{ .context.actionType | upper }}</span> {{ range .dollarScratch.Get "serverURLS" }}{{ if ne .region "local" }}<span class="kn d-none" data-region="{{ .region }}">{{ .url }}</span>{{ else }}<span class="kn">{{ .url }}</span>{{ end }}{{ end }}<span class="n">{{ replace .context.pathKey "{" "${" }}</span>
 {{- range $qi, $q := $queryStrings -}}
     {{- if eq .required true -}}
         <span class="o">{{ cond (gt $qi 1) "&" "?" }}</span><span class="n">{{ $q.name }}</span><span class="o">=</span><span class="s1">${ {{- $q.name -}} }</span>


### PR DESCRIPTION
### What does this PR do?
use hugo to uppercase CURL text rather than CSS so the browser copy function works with Firefox.

### Motivation
https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?assignee=5d4b49d50fa6d40d14fc7b11&selectedIssue=WEB-641
### Preview link
<!-- Impacted pages preview links-->

http://docs-staging.datadoghq.com/zach/copy-btn-fix/api/v1/authentication/#validate-api-key

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
