### PR TITLE
Update RBAC link for cluster agent

### DIFF
--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -36,10 +36,10 @@ The Datadog Cluster Agent needs a proper RBAC to be up and running:
 
   ```shell
   kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/rbac.yaml"
-  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-rbac.yaml"
+  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/cluster-agent-rbac.yaml"
   ```
 
-  This creates the appropriate `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding` for the Cluster Agent.
+  This creates the appropriate `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding` for the Cluster Agent and updates the `ClusterRole` for the node Agent.
 
 If you are using Azure Kubernetes Service (AKS), you may require extra permissions. See the [RBAC for DCA on AKS][3] FAQ.
 


### PR DESCRIPTION
### What does this PR do?
This updates the link to the DCA RBAC file.

### Motivation
We regenerated the RBACs for the cluster agent and changed the name of the file.
We need to update the doc accordingly.
