### PR TITLE
[RUMF-626][RUM/Logs] use site and bundle without suffix

### DIFF
--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -38,11 +38,11 @@ After adding [`@datadog/browser-logs`][3] to your `package.json` file, initializ
 {{< site-region region="us" >}}
 
 ```javascript
-import { Datacenter, datadogLogs } from '@datadog/browser-logs';
+import { datadogLogs } from '@datadog/browser-logs';
 
 datadogLogs.init({
   clientToken: '<DATADOG_CLIENT_TOKEN>',
-  datacenter: Datacenter.US,
+  site: 'datadoghq.com',
   forwardErrorsToLogs: true,
   sampleRate: 100
 });
@@ -52,11 +52,11 @@ datadogLogs.init({
 {{< site-region region="eu" >}}
 
 ```javascript
-import { Datacenter, datadogLogs } from '@datadog/browser-logs';
+import { datadogLogs } from '@datadog/browser-logs';
 
 datadogLogs.init({
   clientToken: '<DATADOG_CLIENT_TOKEN>',
-  datacenter: Datacenter.EU,
+  site: 'datadoghq.eu',
   forwardErrorsToLogs: true,
   sampleRate: 100
 });
@@ -74,10 +74,11 @@ In order to not miss any logs or errors, you should load and configure the libra
 <html>
   <head>
     <title>Example to send logs to Datadog</title>
-    <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-logs-us.js"></script>
+    <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-logs.js"></script>
     <script>
       window.DD_LOGS && DD_LOGS.init({
         clientToken: '<CLIENT_TOKEN>',
+        site: 'datadoghq.com',
         forwardErrorsToLogs: true,
         sampleRate: 100
       });
@@ -93,10 +94,11 @@ In order to not miss any logs or errors, you should load and configure the libra
 <html>
   <head>
     <title>Example to send logs to Datadog</title>
-    <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-logs-eu.js"></script>
+    <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-logs.js"></script>
     <script>
       window.DD_LOGS && DD_LOGS.init({
         clientToken: '<CLIENT_TOKEN>',
+        site: 'datadoghq.eu',
         forwardErrorsToLogs: true,
         sampleRate: 100
       });
@@ -116,7 +118,7 @@ The following parameters can be used to configure the Datadog browser log librar
 | Parameter             | Type    | Required | Default | Description                                                                                              |
 |-----------------------|---------|----------|---------|----------------------------------------------------------------------------------------------------------|
 | `clientToken`         | String  | Yes      | `-`     | A [Datadog Client Token][2].                                                                             |
-| `datacenter`          | String  | Yes      | `us`    | The Datadog Site of your organization. `us` for Datadog US site, `eu` for Datadog EU site.               |
+| `site`               | String  | Yes      | `datadoghq.com`    | The Datadog Site of your organization. `datadoghq.com` for Datadog US site, `datadoghq.eu` for Datadog EU site.               |
 | `service`            | String  | No       | `` | The service name for this application.                             |
 | `env`                | String  | No       | `` | The application’s environment e.g. prod, pre-prod, staging.                   |
 | `version`            | String  | No       | `` | The application’s version e.g. 1.2.3, 6c44da20, 2020.02.13.                   |

--- a/content/en/real_user_monitoring/browser/_index.md
+++ b/content/en/real_user_monitoring/browser/_index.md
@@ -34,12 +34,12 @@ After adding [`@datadog/browser-rum`][4] to your `package.json` file, initialize
 {{% tab "US" %}}
 
 ```javascript
-import { Datacenter, datadogRum } from '@datadog/browser-rum';
+import { datadogRum } from '@datadog/browser-rum';
 
 datadogRum.init({
     applicationId: '<DATADOG_APPLICATION_ID>',
     clientToken: '<DATADOG_CLIENT_TOKEN>',
-    datacenter: Datacenter.US,
+    site: 'datadoghq.com',
     sampleRate: 100,
 });
 ```
@@ -48,12 +48,12 @@ datadogRum.init({
 {{% tab "EU" %}}
 
 ```javascript
-import { Datacenter, datadogRum } from '@datadog/browser-rum';
+import { datadogRum } from '@datadog/browser-rum';
 
 datadogRum.init({
     applicationId: '<DATADOG_APPLICATION_ID>',
     clientToken: '<DATADOG_CLIENT_TOKEN>',
-    datacenter: Datacenter.EU,
+    site: 'datadoghq.eu',
     sampleRate: 100,
 });
 ```
@@ -70,7 +70,7 @@ Paste the generated code snippet into the head tag (in front of any other script
 
 ```html
 <script
-    src="https://www.datadoghq-browser-agent.com/datadog-rum-us.js"
+    src="https://www.datadoghq-browser-agent.com/datadog-rum.js"
     type="text/javascript"
 ></script>
 <script>
@@ -78,6 +78,7 @@ Paste the generated code snippet into the head tag (in front of any other script
         window.DD_RUM.init({
             clientToken: '<CLIENT_TOKEN>',
             applicationId: '<APPLICATION_ID>',
+            site: 'datadoghq.com',
             sampleRate: 100,
         });
 </script>
@@ -88,7 +89,7 @@ Paste the generated code snippet into the head tag (in front of any other script
 
 ```html
 <script
-    src="https://www.datadoghq-browser-agent.com/datadog-rum-eu.js"
+    src="https://www.datadoghq-browser-agent.com/datadog-rum.js"
     type="text/javascript"
 ></script>
 <script>
@@ -96,6 +97,7 @@ Paste the generated code snippet into the head tag (in front of any other script
         window.DD_RUM.init({
             clientToken: '<CLIENT_TOKEN>',
             applicationId: '<APPLICATION_ID>',
+            site: 'datadoghq.eu',
             sampleRate: 100,
         });
 </script>
@@ -112,7 +114,7 @@ Paste the generated code snippet into the head tag (in front of any other script
 | -------------------- | ------- | -------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | `applicationId`      | String  | Yes      | `` | The RUM application ID.                                                       |
 | `clientToken`        | String  | Yes      | `` | A [Datadog Client Token][5].                                                  |
-| `datacenter`         | String  | Yes      | `us`                                                                               | The Datadog Site of your organization. `us` for Datadog US site, `eu` for Datadog EU site.                   |
+| `site`               | String  | Yes      | `datadoghq.com`                                                                    | The Datadog Site of your organization. `datadoghq.com` for Datadog US site, `datadoghq.eu` for Datadog EU site.                   |
 | `service`            | String  | No       | `` | The service name for this application.                             |
 | `env`                | String  | No       | `` | The application’s environment e.g. prod, pre-prod, staging.                   |
 | `version`            | String  | No       | `` | The application’s version e.g. 1.2.3, 6c44da20, 2020.02.13.                   |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Update config doc for logs and rum browser SDK.

### Motivation

New way to configure the SDK, cf https://github.com/DataDog/browser-sdk/pull/476

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/bcaudan/sdk-update-setup/real_user_monitoring/browser/?tab=us
https://docs-staging.datadoghq.com/bcaudan/sdk-update-setup/logs/log_collection/javascript/?tab=npm

Check preview base path using the URL in details in `preview` status check.


