### PR TITLE
fix link

### DIFF
--- a/src/scripts/datadog-docs.js
+++ b/src/scripts/datadog-docs.js
@@ -856,6 +856,11 @@ function getPathElement() {
             'header .nav-top-level > [data-path*="integrations"]'
         );
     }
+    
+    if (path.includes('tracing/serverless_functions')) {
+        aPath = document.querySelectorAll('.side [data-path*="tracing/serverless_functions"]')[1];
+        maPath = document.querySelectorAll('header [data-path*="tracing/serverless_functions"]')[1];
+    }
 
     if (aPath) {
         aPath.classList.add('active');


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fix sidenav active item when on https://docs.datadoghq.com/tracing/serverless_functions/
opens the TOC at https://docs.datadoghq.com/serverless/distributed_tracing


### Motivation
reported on #websites

### Preview link
https://docs-staging.datadoghq.com/zach/fix-link/tracing/serverless_functions/?tab=nodejs

should keep the nav open at `APM & Distributed Tracing`
