### PR TITLE
WEB-579 add Continuous Profiler to nav and footer

### DIFF
--- a/data/partials/footer.fr.yaml
+++ b/data/partials/footer.fr.yaml
@@ -10,6 +10,9 @@ col1:
   - name: apm
     link: 'https://www.datadoghq.com/product/apm/'
     title: APM
+  - name: profiler
+    link: "https://www.datadoghq.com/product/code-profiling/"
+    title: "Continuous Profiler"
   - name: logs
     link: 'https://www.datadoghq.com/product/log-management/'
     title: Log Management

--- a/data/partials/footer.ja.yaml
+++ b/data/partials/footer.ja.yaml
@@ -5,37 +5,37 @@ col1:
     link: 'https://www.datadoghq.com/ja/product/'
     title: 機能
   - name: integrations
-    link: 'https://www.datadoghq.com/product/platform/integrations/'
+    link: 'https://www.datadoghq.com/ja/product/platform/integrations/'
     title: インテグレーション
   - name: ダッシュボード
-    link: 'https://www.datadoghq.com/product/platform/dashboards/'
+    link: 'https://www.datadoghq.com/ja/product/platform/dashboards/'
     title: ダッシュボード
   - name: logs
-    link: 'https://www.datadoghq.com/product/log-management/'
+    link: 'https://www.datadoghq.com/ja/product/log-management/'
     title: ログ管理
   - name: apm
-    link: 'https://www.datadoghq.com/product/apm/'
+    link: 'https://www.datadoghq.com/ja/product/apm/'
     title: APM
   - name: profiler
-    link: "https://www.datadoghq.com/product/code-profiling/"
+    link: "https://www.datadoghq.com/ja/product/code-profiling/"
     title: "Continuous Profiler"
   - name: security-monitoring
-    link: 'https://www.datadoghq.com/product/security-monitoring/'
+    link: 'https://www.datadoghq.com/ja/product/security-monitoring/'
     title: セキュリティモニタリング
   - name: ネットワーク
-    link: 'https://www.datadoghq.com/product/network-performance-monitoring/'
+    link: 'https://www.datadoghq.com/ja/product/network-performance-monitoring/'
     title: ネットワークモニタリング
   - name: synthetics
-    link: 'https://www.datadoghq.com/product/synthetic-monitoring/'
+    link: 'https://www.datadoghq.com/ja/product/synthetic-monitoring/'
     title: Synthetic の監視
   - name: rum
-    link: 'https://www.datadoghq.com/product/real-user-monitoring/'
+    link: 'https://www.datadoghq.com/ja/product/real-user-monitoring/'
     title: リアルユーザーモニタリング
   - name: サーバーレス
-    link: 'https://www.datadoghq.com/product/serverless-monitoring/'
+    link: 'https://www.datadoghq.com/ja/product/serverless-monitoring/'
     title: サーバーレス
   - name: alerts
-    link: 'https://www.datadoghq.com/product/platform/alerts/'
+    link: 'https://www.datadoghq.com/ja/product/platform/alerts/'
     title: アラート
 col2:
   - name: pricing

--- a/data/partials/footer.ja.yaml
+++ b/data/partials/footer.ja.yaml
@@ -16,6 +16,9 @@ col1:
   - name: apm
     link: 'https://www.datadoghq.com/product/apm/'
     title: APM
+  - name: profiler
+    link: "https://www.datadoghq.com/product/continuous-profiler/"
+    title: "Continuous Profiler"
   - name: security-monitoring
     link: 'https://www.datadoghq.com/product/security-monitoring/'
     title: セキュリティモニタリング

--- a/data/partials/footer.ja.yaml
+++ b/data/partials/footer.ja.yaml
@@ -17,7 +17,7 @@ col1:
     link: 'https://www.datadoghq.com/product/apm/'
     title: APM
   - name: profiler
-    link: "https://www.datadoghq.com/product/continuous-profiler/"
+    link: "https://www.datadoghq.com/product/code-profiling/"
     title: "Continuous Profiler"
   - name: security-monitoring
     link: 'https://www.datadoghq.com/product/security-monitoring/'

--- a/data/partials/footer.ja.yaml
+++ b/data/partials/footer.ja.yaml
@@ -37,9 +37,6 @@ col1:
   - name: alerts
     link: 'https://www.datadoghq.com/product/platform/alerts/'
     title: アラート
-  - name: synthetics
-    link: 'https://www.datadoghq.com/product/synthetics-monitoring/'
-    title: Synthetics
 col2:
   - name: pricing
     link: 'https://www.datadoghq.com/ja/pricing/'

--- a/data/partials/footer.yaml
+++ b/data/partials/footer.yaml
@@ -37,9 +37,6 @@ col1:
   - name: alerts
     link: "https://www.datadoghq.com/product/platform/alerts/"
     title: "Alerts"
-  - name: synthetics
-    link: "https://www.datadoghq.com/product/synthetics-monitoring/"
-    title: "Synthetics"
 col2:
   - name: pricing
     link: "https://www.datadoghq.com/pricing/"

--- a/data/partials/footer.yaml
+++ b/data/partials/footer.yaml
@@ -17,7 +17,7 @@ col1:
     link: "https://www.datadoghq.com/product/apm/"
     title: "APM"
   - name: profiler
-    link: "https://www.datadoghq.com/product/continuous-profiler/"
+    link: "https://www.datadoghq.com/product/code-profiling/"
     title: "Continuous Profiler"
   - name: security-monitoring
     link: "https://www.datadoghq.com/product/security-monitoring/"

--- a/data/partials/footer.yaml
+++ b/data/partials/footer.yaml
@@ -16,6 +16,9 @@ col1:
   - name: apm
     link: "https://www.datadoghq.com/product/apm/"
     title: "APM"
+  - name: profiler
+    link: "https://www.datadoghq.com/product/continuous-profiler/"
+    title: "Continuous Profiler"
   - name: security-monitoring
     link: "https://www.datadoghq.com/product/security-monitoring/"
     title: "Security Monitoring"

--- a/data/partials/header.fr.yaml
+++ b/data/partials/header.fr.yaml
@@ -26,7 +26,7 @@ left:
       - name: product_profiler
         link: "https://www.datadoghq.com/product/continuous-profiler/"
         title: "Continuous Profiler"
-        pre: "<img class='menu-icon mr-1' src='https://dd-staging-static-assets.imgix.net/img/navbar/menu/profiling-1.svg' alt='profiler icon'>"
+        pre: "<img class='menu-icon mr-1' src='https://imgix.datadoghq.com/img/navbar/menu/profiling-1.svg' alt='profiler icon'>"
       - name: product_security
         link: 'https://www.datadoghq.com/product/security-monitoring/'
         title: Security Monitoring

--- a/data/partials/header.fr.yaml
+++ b/data/partials/header.fr.yaml
@@ -23,6 +23,10 @@ left:
         link: 'https://www.datadoghq.com/product/apm/'
         title: APM
         pre: '<img class=''menu-icon mr-1'' src=''https://imgix.datadoghq.com/img/navbar/menu/apm.svg'' alt=''icône apm''>'
+      - name: product_profiler
+        link: "https://www.datadoghq.com/product/continuous-profiler/"
+        title: "Continuous Profiler"
+        pre: "<img class='menu-icon mr-1' src='https://dd-staging-static-assets.imgix.net/img/navbar/menu/profiling-1.svg' alt='profiler icon'>"
       - name: product_security
         link: 'https://www.datadoghq.com/product/security-monitoring/'
         title: Security Monitoring

--- a/data/partials/header.fr.yaml
+++ b/data/partials/header.fr.yaml
@@ -24,7 +24,7 @@ left:
         title: APM
         pre: '<img class=''menu-icon mr-1'' src=''https://imgix.datadoghq.com/img/navbar/menu/apm.svg'' alt=''icône apm''>'
       - name: product_profiler
-        link: "https://www.datadoghq.com/product/continuous-profiler/"
+        link: "https://www.datadoghq.com/product/code-profiling/"
         title: "Continuous Profiler"
         pre: "<img class='menu-icon mr-1' src='https://imgix.datadoghq.com/img/navbar/menu/profiling-1.svg' alt='profiler icon'>"
       - name: product_security

--- a/data/partials/header.ja.yaml
+++ b/data/partials/header.ja.yaml
@@ -23,6 +23,10 @@ left:
         link: 'https://www.datadoghq.com/product/apm/'
         title: APM
         pre: '<img class=''menu-icon mr-1'' src=''https://imgix.datadoghq.com/img/navbar/menu/apm.svg'' alt=''APM アイコン''>'
+      - name: product_profiler
+        link: "https://www.datadoghq.com/product/continuous-profiler/"
+        title: "Continuous Profiler"
+        pre: "<img class='menu-icon mr-1' src='https://dd-staging-static-assets.imgix.net/img/navbar/menu/profiling-1.svg' alt='profiler icon'>"
       - name: product_security
         link: 'https://www.datadoghq.com/product/security-monitoring/'
         title: セキュリティモニタリング

--- a/data/partials/header.ja.yaml
+++ b/data/partials/header.ja.yaml
@@ -24,7 +24,7 @@ left:
         title: APM
         pre: '<img class=''menu-icon mr-1'' src=''https://imgix.datadoghq.com/img/navbar/menu/apm.svg'' alt=''APM アイコン''>'
       - name: product_profiler
-        link: "https://www.datadoghq.com/product/continuous-profiler/"
+        link: "https://www.datadoghq.com/product/code-profiling/"
         title: "Continuous Profiler"
         pre: "<img class='menu-icon mr-1' src='https://imgix.datadoghq.com/img/navbar/menu/profiling-1.svg' alt='profiler icon'>"
       - name: product_security

--- a/data/partials/header.ja.yaml
+++ b/data/partials/header.ja.yaml
@@ -26,7 +26,7 @@ left:
       - name: product_profiler
         link: "https://www.datadoghq.com/product/continuous-profiler/"
         title: "Continuous Profiler"
-        pre: "<img class='menu-icon mr-1' src='https://dd-staging-static-assets.imgix.net/img/navbar/menu/profiling-1.svg' alt='profiler icon'>"
+        pre: "<img class='menu-icon mr-1' src='https://imgix.datadoghq.com/img/navbar/menu/profiling-1.svg' alt='profiler icon'>"
       - name: product_security
         link: 'https://www.datadoghq.com/product/security-monitoring/'
         title: セキュリティモニタリング

--- a/data/partials/header.yaml
+++ b/data/partials/header.yaml
@@ -24,7 +24,7 @@ left:
             title: "APM"
             pre: "<img class='menu-icon mr-1' src='https://imgix.datadoghq.com/img/navbar/menu/apm.svg' alt='apm icon'>"
           - name: product_profiler
-            link: "https://www.datadoghq.com/product/continuous-profiler/"
+            link: "https://www.datadoghq.com/product/code-profiling/"
             title: "Continuous Profiler"
             pre: "<img class='menu-icon mr-1' src='https://imgix.datadoghq.com/img/navbar/menu/profiling-1.svg' alt='profiler icon'>"
           - name: product_security

--- a/data/partials/header.yaml
+++ b/data/partials/header.yaml
@@ -26,7 +26,7 @@ left:
           - name: product_profiler
             link: "https://www.datadoghq.com/product/continuous-profiler/"
             title: "Continuous Profiler"
-            pre: "<img class='menu-icon mr-1' src='https://dd-staging-static-assets.imgix.net/img/navbar/menu/profiling-1.svg' alt='profiler icon'>"
+            pre: "<img class='menu-icon mr-1' src='https://imgix.datadoghq.com/img/navbar/menu/profiling-1.svg' alt='profiler icon'>"
           - name: product_security
             link: "https://www.datadoghq.com/product/security-monitoring/"
             title: "Security Monitoring"

--- a/data/partials/header.yaml
+++ b/data/partials/header.yaml
@@ -23,6 +23,10 @@ left:
             link: "https://www.datadoghq.com/product/apm/"
             title: "APM"
             pre: "<img class='menu-icon mr-1' src='https://imgix.datadoghq.com/img/navbar/menu/apm.svg' alt='apm icon'>"
+          - name: product_profiler
+            link: "https://www.datadoghq.com/product/continuous-profiler/"
+            title: "Continuous Profiler"
+            pre: "<img class='menu-icon mr-1' src='https://dd-staging-static-assets.imgix.net/img/navbar/menu/profiling-1.svg' alt='profiler icon'>"
           - name: product_security
             link: "https://www.datadoghq.com/product/security-monitoring/"
             title: "Security Monitoring"

--- a/src/styles/components/_footer.scss
+++ b/src/styles/components/_footer.scss
@@ -13,19 +13,6 @@ $footer-font-color: rgba(255, 255, 255, 0.5);
 $footer-font-color-hover: rgba(255, 255, 255, 1);
 
 body {
-    &.fr,
-    &.ja {
-        /* Margin bottom by footer height on fr page */
-        footer {
-            height: 100%;
-            @media (min-width: 992px) {
-                height: 580px;
-            }
-            @media (min-width: 1200px) {
-                height: 520px;
-            }
-        }
-    }
     footer {
         position: absolute;
         z-index: 3;

--- a/src/styles/components/_header.scss
+++ b/src/styles/components/_header.scss
@@ -158,7 +158,7 @@ body > header {
         // product menu
         &.product-menu {
           column-count: 2;
-          height: 300px;
+          height: 330px;
           column-fill: auto;
 
           .menu-icon {


### PR DESCRIPTION
### What does this PR do?
- Adds Continuous Profiler product to the nav and footer
- Fixes broken spacing on JA and FR footers
- Removes duplicate /synthetics-monitoring in JA and EN footer

### Motivation
https://datadoghq.atlassian.net/browse/WEB-579

### Preview link
https://docs-staging.datadoghq.com/ccole/add-profiler-nav-footer/
https://docs-staging.datadoghq.com/ccole/add-profiler-nav-footer/ja/
https://docs-staging.datadoghq.com/ccole/add-profiler-nav-footer/fr/

### Additional Notes
