### PR TITLE
zach groves correct global set tags

### DIFF
--- a/content/en/tracing/custom_instrumentation/python.md
+++ b/content/en/tracing/custom_instrumentation/python.md
@@ -176,7 +176,7 @@ from ddtrace import tracer
 from myapp import __version__
 
 # This will be applied to every span
-tracer.set_tag("version", __version__)
+tracer.set_tags({"version": __version__, "<TAG_KEY_2>": "<TAG_VALUE_2>"})
 ```
 {{% /tab %}}
 {{% tab "Errors" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes the Python setting global tags example
### Motivation
Customer reached out saying it was wrong so I found and tested this method which looks to work correctly. Taken from here: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#tracer 
