### PR TITLE
[rum] hash-based doc

### DIFF
--- a/content/en/real_user_monitoring/data_collected/view.md
+++ b/content/en/real_user_monitoring/data_collected/view.md
@@ -39,7 +39,7 @@ To account for modern web applications, loading time watches for network request
 
 ### Hash SPA navigation
 
-Frameworks relying on hash (`#`) navigation are monitored with the RUM SDK automatically. The SDK watches for `HashChangeEvent` and issues a new view. Events coming from an HTML anchor tag which do not affect the current view context are ignored.
+Frameworks relying on hash (`#`) navigation are monitored with the RUM SDK automatically. The SDK watches for `HashChangeEvent` and issues a new view. Hash changes coming from an HTML anchor tag are ignored.
 
 ## Metrics collected
 

--- a/content/en/real_user_monitoring/data_collected/view.md
+++ b/content/en/real_user_monitoring/data_collected/view.md
@@ -39,7 +39,7 @@ To account for modern web applications, loading time watches for network request
 
 ### Hash SPA navigation
 
-Frameworks relying on hash (`#`) navigation are monitored with the RUM SDK automatically. The SDK watches for `HashChangeEvent` and issues a new view. Hash changes coming from an HTML anchor tag are ignored.
+Frameworks relying on hash (`#`) navigation are monitored with the RUM SDK automatically. The SDK watches for `HashChangeEvent` and will consider this as a navigation, by generating a new View event. Hash changes coming from an HTML anchor tag are ignored.
 
 ## Metrics collected
 

--- a/content/en/real_user_monitoring/data_collected/view.md
+++ b/content/en/real_user_monitoring/data_collected/view.md
@@ -27,6 +27,7 @@ For Single Page Applications (SPAs), the RUM SDK differentiates between `initial
 Datadog provides a unique performance metric, `loading_time`, which calculates the time needed for a page to load. This metric works both for `initial_load` and `route_change` navigations.
 
 ### How is loading time calculated?
+
 To account for modern web applications, loading time watches for network requests and DOM mutations.
 
 * **Initial Load**: Loading Time is equal to *whichever is longer*:
@@ -35,6 +36,10 @@ To account for modern web applications, loading time watches for network request
     - Or the difference between `navigationStart` and the first time the page has no activity for more than 100ms (activity being defined as ongoing network requests, or DOM mutations are currently occurring).
 
 * **SPA Route Change**: Loading Time is equal to the difference between the user click and the first time the page has no activity for more than 100ms (activity being defined as ongoing network requests, or DOM mutations are currently occurring)
+
+### Hash SPA navigation
+
+Frameworks relying on hash (`#`) navigation are monitored with the RUM SDK automatically. The SDK watches for `HashChangeEvent` and issues a new view. Events coming from an HTML anchor tag which do not affect the current view context are ignored.
 
 ## Metrics collected
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add documentation for hash-based (`#`) SPA navigation

### Motivation
<!-- What inspired you to submit this pull request?-->
More content

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hdelaby/hash-based/real_user_monitoring/data_collected/view/#hash-spa-navigation

### Additional Notes
<!-- Anything else we should know when reviewing?-->
