### PR TITLE
check integration exists before linking from rule

### DIFF
--- a/layouts/partials/security-rule-map.html
+++ b/layouts/partials/security-rule-map.html
@@ -3,12 +3,11 @@
 {{ $img_map := $data.image_map }}
 {{ $img_path := "images/integrations_logos/" }}
 {{ $img_url := printf "%s%s" $dot.ctx.Site.Params.img_url $img_path }}
-{{ $docs_url := $data.base_integrations_url }}
 {{ $source := .source }}
 {{ $scope := .scope }}
 
 {{ $src_img := printf "%s" $source }}
-{{ $src_link := printf "%s%s" $docs_url $src_img }}
+{{ $src_link := printf "integrations/%s" $src_img }}
 
 {{ range $key, $value := $img_map }}
     {{ if intersect $value.source (slice $source $scope) }}
@@ -23,9 +22,9 @@
             {{ end }}
             
             {{ if .link }}
-                {{ $src_link = printf "%s%s" $docs_url .link }}
+                {{ $src_link = printf "integrations/%s" .link }}
             {{ else }}
-                {{ $src_link = printf "%s%s" $docs_url $src_img }}
+                {{ $src_link = printf "integrations/%s" $src_img }}
             {{ end }}
         {{ end }}
     {{ end }}
@@ -39,4 +38,4 @@
     {{ $src_img = "" }}
 {{ end }}
 
-{{- return (dict "image" $src_img "link" $src_link "path" $local_img) -}}
+{{- return (dict "image" $src_img "link" ($src_link | absLangURL) "path" $local_img "rellink" $src_link ) -}}

--- a/layouts/security_rules/single.html
+++ b/layouts/security_rules/single.html
@@ -1,4 +1,5 @@
 {{ define "main" }}
+{{ $dot := .}}
 	<a class="text-uppercase font-weight-bold text-gray mb-1 d-block" href="/security_monitoring/default_rules/">&lt;&nbsp; Back to rules search</a>
 
 	<h1 id="pagetitle">{{ .Title }}</h1>
@@ -46,7 +47,9 @@
 	</div>
 
 	{{ if isset .Params "source" }}
-		<p>Set up the <a href="{{ $meta_image.link }}">{{ .Params.source }}</a> integration.</p>
+		{{ with .Site.GetPage (print "/" $meta_image.rellink) }}
+			<p>Set up the <a href="{{ $meta_image.link }}">{{ $dot.Params.source }}</a> integration.</p>
+		{{ end }}
 	{{ end }}
 
   {{ .Content }}


### PR DESCRIPTION
### What does this PR do?

Security/Compliance rules linking to an integration isn't always valid. Lets not show the integration link if there isn't a valid integration there.

### Motivation

404s / Slack discussion

### Preview link

https://docs-staging.datadoghq.com/david.jones/rule-int-link/security_monitoring/default_rules/credential_modified/

### Additional Notes
