### PR TITLE
Update Postman url

### DIFF
--- a/content/en/getting_started/api/_index.md
+++ b/content/en/getting_started/api/_index.md
@@ -96,7 +96,7 @@ This tab is an alternative to viewing the `param1:value1&param2:value2` structur
 - The ampersand (&) and colon (:) are not needed in the params table. Postman inserts these for you.
 - All placeholders follow the format: `<PLACEHOLDER>` . They should be replaced before running a query.
 
-[1]: https://www.getpostman.com
+[1]: https://www.postman.com/
 [2]: https://app.datadoghq.com/account/settings#api
 [3]: /resources/json/datadog_collection.json
 [4]: https://learning.postman.com/docs/postman/variables-and-environments/variables/#environments-in-postman


### PR DESCRIPTION
### What does this PR do?
Changes the Postman URL from getpostman.com to postman.com

### Motivation
https://datadog.zendesk.com/agent/tickets/381948

### Preview link
https://docs.datadoghq.com/getting_started/api/

Link does not change.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/eannamacken/postmanUrlChange


### Additional Notes
A member of the Postman team reached out informing us that they have moved from Getpostman.com to Postman.com and pointed me to this page to update the URL

