### PR TITLE
Update cluster-agent-rbac yaml link

### DIFF
--- a/content/fr/agent/cluster_agent/setup.md
+++ b/content/fr/agent/cluster_agent/setup.md
@@ -35,7 +35,7 @@ L'Agent de cluster Datadog a besoin des autorisations RBAC adéquates pour fonct
 
   ```shell
   kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/rbac.yaml"
-  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-rbac.yaml"
+  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/cluster-agent-rbac.yaml"
   ```
 
   Cela permet de créer les objets `ServiceAccount`, `ClusterRole` et `ClusterRoleBinding` appropriés pour l'Agent de cluster.

--- a/content/ja/agent/cluster_agent/setup.md
+++ b/content/ja/agent/cluster_agent/setup.md
@@ -35,7 +35,7 @@ Datadog Cluster Agent を実行するには、適切な RBAC が必要です。
 
   ```shell
   kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/rbac.yaml"
-  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-rbac.yaml"
+  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/cluster-agent-rbac.yaml"
   ```
 
   これにより、Cluster Agent に適切な `ServiceAccount`、`ClusterRole`、`ClusterRoleBinding` が作成されます。


### PR DESCRIPTION
### What does this PR do?
This updates the link to the DCA RBAC file

### Motivation

We regenerated the RBACs for the cluster agent and changed the name of the file.
We need to update the doc accordingly.
