### PR TITLE
Document Datadog Serverless CLI

### DIFF
--- a/content/en/serverless/distributed_tracing/_index.md
+++ b/content/en/serverless/distributed_tracing/_index.md
@@ -23,7 +23,7 @@ Datadog APM sends trace data to Datadog in real-time, allowing you to monitor tr
 
 The Datadog Python, Node.js, and Ruby tracing libraries support distributed tracing for AWS Lambda, with more runtimes coming soon. The easiest way to add tracing to your application is with the [Datadog Lambda Library][2], which includes the Datadog tracing library as a dependency.
 
-Visualize your traces on the [Serverless page][3], in [App Analytics][4], and on the [Service Map][5].
+Visualize your traces on the [Serverless Homepage][3], in [App Analytics][4], and on the [Service Map][5].
 
 ### Correlate Logs and Traces
 

--- a/content/en/serverless/installation/_index.md
+++ b/content/en/serverless/installation/_index.md
@@ -12,14 +12,19 @@ further_reading:
 
 ### 1. Install the AWS Integration
 
-Start by installing the [AWS Integration][1]. This allows Datadog to ingest Amazon CloudWatch metrics from AWS Lambda. The AWS integration installation also configures the [Datadog Forwarder][2], which is required for ingestion of AWS Lambda traces, enhanced metrics, custom metrics, and logs.
+Install the [AWS integration][1]. This allows Datadog to ingest Lambda metrics from AWS CloudWatch. 
 
-### 2. Instrument your application
+### 2. Install the Datadog Forwarder
 
-In addition to setup for your language, these instructions walk you through installation of the [Datadog Forwarder][2] and the [Datadog Lambda Library][3], which you need regardless of language.
+Install the [Datadog Forwarder Lambda function][2], which is required for ingestion of AWS Lambda traces, enhanced metrics, custom metrics, and logs.
+
+Note, if you installed the AWS integration by using the Datadog-provided CloudFormation template, then you already have the Forwarder function installed as part of the AWS integration CloudFormation stack.
+
+### 3. Instrument Your Application
+
+Select the Lambda runtime below for instructions to instrument your serverless application.
 
 {{< partial name="serverless/getting-started-languages.html" >}}
 
 [1]: /integrations/amazon_web_services/
 [2]: /serverless/forwarder
-[3]: /serverless/installation/installing_the_library

--- a/content/en/serverless/installation/dotnet.md
+++ b/content/en/serverless/installation/dotnet.md
@@ -19,25 +19,27 @@ further_reading:
       text: 'Installing Java Serverless Monitoring'
 ---
 
-After you have [installed the AWS integration][1], use .NET to instrument your application to send metrics, logs, and traces to Datadog. 
+After you have installed the [AWS integration][1] and the [Datadog Forwarder][2], follow the steps below to instrument your application to send metrics, logs, and traces to Datadog.
 
 ## Configuration
 
 ### Configure the Function
 
-1. Enable [AWS X-Ray active tracing][2] for your Lambda function.
+1. Enable [AWS X-Ray active tracing][3] for your Lambda function.
 
 ### Subscribe the Datadog Forwarder to the Log Groups
 
 You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups to send metrics, traces, and logs to Datadog.
 
-1. [Install the Datadog Forwarder if you haven't][3].
+1. [Install the Datadog Forwarder if you haven't][2].
 2. [Ensure the option DdFetchLambdaTags is enabled][4].
 3. [Subscribe the Datadog Forwarder to your function's log groups][5].
 
 ## Explore Datadog Serverless Monitoring
 
-After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless page][6]. If you want to submit a custom metric, refer to the sample code below:
+After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless Homepage][6].
+
+If you would like to submit a custom metric, see the sample code below:
 
 ```csharp
 var myMetric = new Dictionary<string, object>();
@@ -49,8 +51,8 @@ LambdaLogger.Log(JsonConvert.SerializeObject(myMetric));
 ```
 
 [1]: /serverless/#1-install-the-cloud-integration
-[2]: https://docs.aws.amazon.com/xray/latest/devguide/xray-services-lambda.html
-[3]: https://docs.datadoghq.com/serverless/forwarder/
+[2]: https://docs.datadoghq.com/serverless/forwarder/
+[3]: https://docs.aws.amazon.com/xray/latest/devguide/xray-services-lambda.html
 [4]: https://docs.datadoghq.com/serverless/forwarder/#experimental-optional
 [5]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 [6]: https://app.datadoghq.com/functions

--- a/content/en/serverless/installation/go.md
+++ b/content/en/serverless/installation/go.md
@@ -19,13 +19,13 @@ further_reading:
       text: 'Installing Java Serverless Monitoring'
 ---
 
-After you have [installed the AWS integration][1], follow the steps below to instrument your application to send metrics, logs, and traces to Datadog.
+After you have installed the [AWS integration][1] and the [Datadog Forwarder][2], follow the steps below to instrument your application to send metrics, logs, and traces to Datadog.
 
 ## Configuration
 
 ### Install the Datadog Lambda Library
 
-You can install the [Datadog Lambda Library][2] locally by running the following command:
+You can install the [Datadog Lambda Library][3] locally by running the following command:
 
 ```
 go get github.com/DataDog/datadog-lambda-go
@@ -34,19 +34,21 @@ go get github.com/DataDog/datadog-lambda-go
 ### Configure the Function
 
 1. Set environment variable `DD_FLUSH_TO_LOG` to `true`.
-1. Enable [AWS X-Ray active tracing][3] for your Lambda function.
+1. Enable [AWS X-Ray active tracing][4] for your Lambda function.
 
 ### Subscribe the Datadog Forwarder to the Log Groups
 
 You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, in order to send metrics, traces and logs to Datadog.
 
-1. [Install the Datadog Forwarder if you haven't][4].
+1. [Install the Datadog Forwarder if you haven't][2].
 2. [Ensure the option DdFetchLambdaTags is enabled][5].
 3. [Subscribe the Datadog Forwarder to your function's log groups][6].
 
 ## Explore Datadog Serverless Monitoring
 
-After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless page][7]. If you need to submit a custom metric, refer to the sample code below:
+After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless Homepage][7].
+
+If you would like to submit a custom metric, see the sample code below:
 
 ```go
 package main
@@ -80,9 +82,9 @@ func myHandler(ctx context.Context, event MyEvent) (string, error) {
 ```
 
 [1]: /serverless/#1-install-the-cloud-integration
-[2]: https://github.com/DataDog/datadog-lambda-go
-[3]: https://docs.aws.amazon.com/xray/latest/devguide/xray-services-lambda.html
-[4]: https://docs.datadoghq.com/serverless/forwarder/
+[2]: https://docs.datadoghq.com/serverless/forwarder/
+[3]: https://github.com/DataDog/datadog-lambda-go
+[4]: https://docs.aws.amazon.com/xray/latest/devguide/xray-services-lambda.html
 [5]: https://docs.datadoghq.com/serverless/forwarder/#experimental-optional
 [6]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 [7]: https://app.datadoghq.com/functions

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -19,13 +19,13 @@ further_reading:
       text: 'Installing Go Serverless Monitoring'
 ---
 
-After you have [installed the AWS integration][1], follow the steps below to instrument your application to send metrics, logs, and traces to Datadog.
+After you have installed the [AWS integration][1] and the [Datadog Forwarder][2], follow the steps below to instrument your application to send metrics, logs, and traces to Datadog.
 
 ## Configuration
 
 ### Install the Datadog Lambda Library
 
-You can install the Datadog Lambda Library locally by running one of the following commands based on your project’s configuration. For latest version, see the [latest release][2].
+You can install the Datadog Lambda Library locally by running one of the following commands based on your project’s configuration. For latest version, see the [latest release][3].
 
 {{< tabs >}}
 {{% tab "Maven" %}}
@@ -65,19 +65,21 @@ dependencies {
 
 ### Configure the Function
 
-1. Enable [AWS X-Ray active tracing][3] for your Lambda function.
+1. Enable [AWS X-Ray active tracing][4] for your Lambda function.
 
 ### Subscribe the Datadog Forwarder to the Log Groups
 
 You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, in order to send metrics, traces and logs to Datadog.
 
-1. [Install the Datadog Forwarder if you haven't][4].
+1. [Install the Datadog Forwarder if you haven't][2].
 2. [Ensure the option DdFetchLambdaTags is enabled][5].
 3. [Subscribe the Datadog Forwarder to your function's log groups][6].
 
 ## Explore Datadog Serverless Monitoring
 
-After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless page][7]. If you need to submit a custom metric, refer to the sample code below.
+After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless Homepage][7].
+
+If you would like to submit a custom metric, see the sample code below:
 
 
 ```java
@@ -107,9 +109,9 @@ public class Handler implements RequestHandler<APIGatewayV2ProxyRequestEvent, AP
 ```
 
 [1]: /serverless/#1-install-the-cloud-integration
-[2]: https://github.com/DataDog/datadog-lambda-java/releases
-[3]: https://docs.aws.amazon.com/xray/latest/devguide/xray-services-lambda.html
-[4]: https://docs.datadoghq.com/serverless/forwarder/
+[2]: https://docs.datadoghq.com/serverless/forwarder/
+[3]: https://github.com/DataDog/datadog-lambda-java/releases
+[4]: https://docs.aws.amazon.com/xray/latest/devguide/xray-services-lambda.html
 [5]: https://docs.datadoghq.com/serverless/forwarder/#experimental-optional
 [6]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 [7]: https://app.datadoghq.com/functions

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -10,14 +10,14 @@ further_reading:
       text: 'Installing Ruby Serverless Monitoring'
 ---
 
-After you have [installed the AWS integration][1], choose one of the following methods to instrument your application to send metrics, logs, and traces to Datadog.
+After you have installed the [AWS integration][1] and the [Datadog Forwarder][2], choose one of the following methods to instrument your application to send metrics, logs, and traces to Datadog.
 
 ## Configuration
 
 {{< tabs >}}
 {{% tab "Serverless Framework" %}}
 
-Use the [Datadog Serverless Plugin][1] to send metrics, logs and traces from your application to Datadog without any code changes. The plugin automatically attaches the Datadog Lambda Library for Node.js to your functions using layers. At deploy time, it swaps your original function handler with the Datadog-provided handler that initializes the Datadog Lambda Library and invokes your original function handler. It also enables Datadog and X-Ray tracing for your Lambda functions.
+The [Datadog Serverless Plugin][1] automatically adds the Datadog Lambda library to your functions using layers, and configures your functions to send metrics, traces, and logs to Datadog through the [Datadog Forwarder][2].
 
 To install and configure the Datadog Serverless Plugin, follow these steps:
 
@@ -37,185 +37,146 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
         flushMetricsToLogs: true
         forwarder: # The Datadog Forwarder ARN goes here.
     ```
-    For more information on the Forwarder ARN, or to install the forwarder see the [forwarder documentation][2].
-4. Redeploy your serverless application.
+    More information on the Datadog Forwarder ARN or installation can be found [here][2]. For additional settings, see the [plugin documentation][1].
 
 [1]: https://github.com/DataDog/serverless-plugin-datadog
 [2]: https://docs.datadoghq.com/serverless/forwarder/
 {{% /tab %}}
 {{% tab "AWS SAM" %}}
-
 <div class="alert alert-warning">This service is in public beta. If you have any feedback, contact <a href="/help">Datadog support</a>.</div>
 
-### Deploy the Datadog CloudFormation Macro
+The [Datadog CloudFormation macro][1] automatically transforms your SAM application template to add the Datadog Lambda library to your functions using layers, and configure your functions to send metrics, traces, and logs to Datadog through the [Datadog Forwarder][2].
 
-Use the [Datadog CloudFormation macro][1] to ingest traces from your application without any code instrumentation. The macro automatically attaches the Datadog Lambda Library for Node.js and Python to your functions using layers. At deploy time, it generates new handler functions that wrap your existing functions and initializes the Lambda Library.
+### Install the Datadog CloudFormation Macro
 
-To install the macro, follow these steps:
+Run the following command with your [AWS credentials][3] to deploy a CloudFormation stack that installs the macro AWS resource. You only need to install the macro once for a given region in your account. Replace `create-stack` with `update-stack` to update the macro to the latest version.
 
-1. Clone the Datadog CloudFormation macro repository in your local environment:
+```sh
+aws cloudformation create-stack \
+  --stack-name datadog-serverless-macro \
+  --template-url https://datadog-cloudformation-template.s3.amazonaws.com/aws/serverless-macro/latest.yml \
+  --capabilities CAPABILITY_AUTO_EXPAND CAPABILITY_IAM
 ```
-git clone https://github.com/DataDog/datadog-cloudformation-macro.git
-```
-2. Install the macro and it's dependencies:
-```
-yarn install # Yarn users
-npm install  # NPM users
-```
-3. Run the build script:
-```
-yarn build    # Yarn users
-npm run build # NPM users
-```
-
-Deploy the macro to the same region as your Lambda functions. You need to deploy the macro in every region where you are monitoring Lambda functions:
-
-4. You will need an S3 bucket to store the CloudFormation artifacts for the macro. If you don't have one already, you can create one with:
-
-    ```bash
-      aws s3 mb s3://<bucket name>
-    ```
-
-5. Package the provided CloudFormation template (`macro_template.yml`). This includes a Lambda function and a CloudFormation macro resource. The provided template uses the AWS Serverless Application Model (SAM), so it must be transformed before deployment:
-
- ```bash
-    aws cloudformation package \
-        --template-file macro_template.yml \
-        --s3-bucket <your bucket name here> \
-        --output-template-file packaged.template
-    ```
-
-6. Deploy the packaged CloudFormation template to a CloudFormation stack:
-
-    ```bash
-    aws cloudformation deploy \
-        --stack-name datadog-cfn-macro \
-        --template-file packaged.template \
-        --capabilities CAPABILITY_IAM
-    ```
 
 The macro is now deployed and ready to use.
 
-### Install the Datadog Lambda Library
+### Instrument the Function
 
-Use the Datadog CloudFormation macro to ingest traces, logs, and enhanced metrics from your application without any code instrumentation. The macro automatically attaches the Datadog Lambda Library for Node.js and Python to your functions using layers. At deploy time, it generates new handler functions that wrap your existing functions and initializes the Lambda Library.
+In your `template.yml`, add the following under the `Transform` section, **after** the `AWS::Serverless` transform for SAM.
 
-To install the Datadog Lambda Library with the CloudFormation macro, follow these steps:
+```yaml
+Transform:
+  - AWS::Serverless-2016-10-31
+  - Name: DatadogServerless
+    Parameters:
+      stackName: !Ref "AWS::StackName"
+      nodeLayerVersion: "<LAYER_VERSION>"
+      forwarderArn: "<FORWARDER_ARN>"
+      service: "<SERVICE>" # Optional
+      env: "<ENV>" # Optional
+```
 
-1. In your `template.yml`, add the following:
-  ```
-  Transform:
-	  - Name: DatadogCfnMacro
-      Parameters:
-        enableDDTracing: true
-			  flushMetricsToLogs: true
-        stackName: !Ref "AWS::StackName"
-			  forwarderArn: "arn:aws:lambda:<REGION>:<ACCOUNT-ID>:function:datadog-forwarder"
-  ```
-  Find your Datadog Forwarder ARN in the [AWS Console][2]. For more information on installing the Forwarder, see the [official documentation][3].
+Replace `<SERVICE>` and `<ENV>` with appropriate values, `<LAYER_VERSION>` with the desired version of Datadog Lambda layer (see the [latest releases][4]), and `<FORWARDER_ARN>` with Forwarder ARN (see the [Forwarder documentation][2]).
 
-2. Redeploy your serverless application.
-
+More information and additional parameters can be found in the [macro documentation][1].
 
 [1]: https://github.com/DataDog/datadog-cloudformation-macro
-[2]: https://console.aws.amazon.com/cloudformation/home#/stacks?filteringText=forwarder
-[3]: https://docs.datadoghq.com/serverless/forwarder/
+[2]: https://docs.datadoghq.com/serverless/forwarder/
+[3]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html
+[4]: https://github.com/DataDog/datadog-lambda-js/releases
 {{% /tab %}}
-
 {{% tab "AWS CDK" %}}
 
 <div class="alert alert-warning">This service is in public beta. If you have any feedback, contact <a href="/help">Datadog support</a>.</div>
 
-### Deploy the Datadog CloudFormation Macro
+The [Datadog CloudFormation macro][1] automatically transforms the CloudFormation template generated by the AWS CDK to add the Datadog Lambda library to your functions using layers, and configure your functions to send metrics, traces, and logs to Datadog through the [Datadog Forwarder][2].
 
-Use the [Datadog CloudFormation macro][1] to ingest traces from your application without any code instrumentation. The macro automatically attaches the Datadog Lambda Library for Node.js and Python to your functions using layers. At deploy time, it generates new handler functions that wrap your existing functions and initializes the Lambda Library.
+### Install the Datadog CloudFormation Macro
 
-To install the macro, follow these steps:
+Run the following command with your [AWS credentials][3] to deploy a CloudFormation stack that installs the macro AWS resource. You only need to install the macro **once** for a given region in your account. Replace `create-stack` with `update-stack` to update the macro to the latest version.
 
-1. Clone the Datadog CloudFormation macro repository in your local environment:
-
-    ```
-    git clone https://github.com/DataDog/datadog-cloudformation-macro.git
-    ```
-
-2. Install the macro and it's dependencies:
-
-    ```
-    yarn install # Yarn users
-    npm install  # NPM users
-    ```
-
-3. Run the build script:
-
-    ```
-    yarn build    # Yarn users
-    npm run build # NPM users
-    ```
-
-Deploy the macro to the same region as your Lambda functions. You need to deploy the macro in every region where you are monitoring Lambda functions.
-
-4. You will need an S3 bucket to store the CloudFormation artifacts for the macro. If you don't have one already, you can create one with:
-
-    ```bash
-      aws s3 mb s3://<bucket name>
-    ```
-
-5. Package the provided CloudFormation template (`macro_template.yml`). This includes a Lambda function and a CloudFormation macro resource. The provided template uses the AWS Serverless Application Model (SAM), so it must be transformed before deployment:
-
-    ```bash
-    aws cloudformation package \
-        --template-file macro_template.yml \
-        --s3-bucket <your bucket name here> \
-        --output-template-file packaged.template
-    ```
-
-6. Deploy the packaged CloudFormation template to a CloudFormation stack:
-
-    ```bash
-    aws cloudformation deploy \
-        --stack-name datadog-cfn-macro \
-        --template-file packaged.template \
-        --capabilities CAPABILITY_IAM
-    ```
+```sh
+aws cloudformation create-stack \
+  --stack-name datadog-serverless-macro \
+  --template-url https://datadog-cloudformation-template.s3.amazonaws.com/aws/serverless-macro/latest.yml \
+  --capabilities CAPABILITY_AUTO_EXPAND CAPABILITY_IAM
+```
 
 The macro is now deployed and ready to use.
 
-### Install the Datadog Lambda Library
+### Instrument the Function
 
-Use the Datadog CloudFormation macro to ingest traces, logs, and enhanced metrics from your application without any code instrumentation. The macro automatically attaches the Datadog Lambda Library for Node.js and Python to your functions using layers. At deploy time, it generates new handler functions that wrap your existing functions and initializes the Lambda Library.
+Add the `DatadogServerless` transform and the `CfnMapping` to your `Stack` object in your AWS CDK app. See the sample code below in TypeScript (the usage in other language should be similar).
 
-To install the Datadog Lambda Library with the CloudFormation macro, follow these steps:
+```typescript
+import * as cdk from "@aws-cdk/core";
 
-1. Add a `CfnMapping` to your `Stack` object in your AWS CDK app:
-  ```typescript
-      import * as cdk from "@aws-cdk/core";
+class CdkStack extends cdk.Stack {
+  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    this.addTransform("DatadogServerless");
 
-      class CdkStack extends cdk.Stack {
-        constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
-          super(scope, id, props);
-          this.addTransform("DatadogCfnMacro");
+    new cdk.CfnMapping(this, "Datadog", {
+      mapping: {
+        Parameters: {
+          nodeLayerVersion: "<LAYER_VERSION>",
+          forwarderArn: "<FORWARDER_ARN>",
+          stackName: this.stackName,
+          service: "<SERVICE>", // Optional
+          env: "<ENV>", // Optional
+        },
+      },
+    });
+  }
+}
+```
 
-          new cdk.CfnMapping(this, "Datadog", {
-            mapping: {
-              Parameters: {
-                forwarderArn: "arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder",
-                stackName: this.stackName,
-                enableDDTracing: true,
-                flushMetricsToLogs: true,
-              },
-            },
-          });
-        }
-      }
-  ```
-    Find your Datadog Forwarder ARN in the [AWS Console][2]. For more information on installing the Forwarder, see the [official documentation][3].
+Replace `<SERVICE>` and `<ENV>` with appropriate values, `<LAYER_VERSION>` with the desired version of Datadog Lambda layer (see the [latest releases][3]), and `<FORWARDER_ARN>` with Forwarder ARN (see the [Forwarder documentation][2]).
 
-2. Redeploy your serverless application.
-
+More information and additional parameters can be found in the [macro documentation][1].
 
 [1]: https://github.com/DataDog/datadog-cloudformation-macro
-[2]: https://console.aws.amazon.com/cloudformation/home#/stacks?filteringText=forwarder
+[2]: https://docs.datadoghq.com/serverless/forwarder/
+[3]: https://github.com/DataDog/datadog-lambda-js/releases
+{{% /tab %}}
+{{% tab "Datadog CLI" %}}
+
+<div class="alert alert-warning">This service is in public beta. If you have any feedback, contact <a href="/help">Datadog support</a>.</div>
+
+Use the Datadog CLI to set up instrumentation on your Lambda functions in your CI/CD pipelines. The CLI command automatically adds the Datadog Lambda library to your functions using layers, and configures your functions to send metrics, traces, and logs to Datadog.
+
+### Install the Datadog CLI
+
+Install the Datadog CLI with NPM or Yarn:
+
+```sh
+# NPM
+npm install -g @datadog/datadog-ci
+
+# Yarn
+yarn global add @datadog/datadog-ci
+```
+
+### Instrument the Function
+
+Run the following command with your [AWS credentials][1]. Replace `<functionname>` and `<another_functionname>` with your Lambda function names, `<aws_region>` with the AWS region name, `<layer_version>` with the desired version of the Datadog Lambda layer (see [latest releases][2]) and `<forwarder_arn>` with Forwarder ARN (see the [Forwarder documentation][3]).
+
+```sh
+datadog-ci lambda instrument -f <functionname> -f <another_functionname> -r <aws_region> -v <layer_version> --forwarder	<forwarder_arn>
+```
+
+For example:
+
+```sh
+datadog-ci lambda instrument -f my-function -f another-function -r us-east-1 -v 26 --forwarder arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder
+```
+
+More information and additional parameters can be found in the [CLI documentation][4].
+
+[1]: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html
+[2]: https://github.com/DataDog/datadog-lambda-js/releases
 [3]: https://docs.datadoghq.com/serverless/forwarder/
+[4]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/lambda
 {{% /tab %}}
 {{% tab "Custom" %}}
 
@@ -265,7 +226,7 @@ See the [latest release][3].
 
 ### Subscribe the Datadog Forwarder to the Log Groups
 
-You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, in order to send metrics, traces and logs to Datadog.
+You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, in order to send metrics, traces, and logs to Datadog.
 
 1. [Install the Datadog Forwarder if you haven't][4].
 2. [Ensure the option DdFetchLambdaTags is enabled][5].
@@ -283,19 +244,23 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 
 ## Explore Datadog Serverless Monitoring
 
-After you have configured your function following the steps above, you can view metrics, logs and traces on the [Serverless page][2]. If you would like to submit a custom metric or manually instrument a function, see the sample code below:
+After you have configured your function following the steps above, you can view metrics, logs and traces on the [Serverless Homepage][2].
+
+If you would like to submit a custom metric or manually instrument a function, see the sample code below:
 
 ```javascript
 const { sendDistributionMetric } = require("datadog-lambda-js");
 const tracer = require("dd-trace");
 
-// This emits a span named "sleep"
+// Submit a custom APM span named "sleep"
 const sleep = tracer.wrap("sleep", (ms) => {
   return new Promise((resolve) => setTimeout(resolve, ms));
 });
 
 exports.handler = async (event) => {
   await sleep(1000);
+
+  // Submit a custom metric
   sendDistributionMetric(
     "coffee_house.order_value", // metric name
     12.45, // metric Value
@@ -310,5 +275,5 @@ exports.handler = async (event) => {
 };
 ```
 
-[1]: /serverless/#1-install-the-cloud-integration
+[1]: /integrations/amazon_web_services/
 [2]: https://app.datadoghq.com/functions

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -10,14 +10,14 @@ further_reading:
       text: 'Installing Ruby Serverless Monitoring'
 ---
 
-After you have [installed the AWS integration][1], choose one of the following methods to instrument your application to send metrics, logs, and traces to Datadog.
+After you have installed the [AWS integration][1] and the [Datadog Forwarder][2], choose one of the following methods to instrument your application to send metrics, logs, and traces to Datadog.
 
 ## Configuration
 
 {{< tabs >}}
 {{% tab "Serverless Framework" %}}
 
-Use the [Datadog Serverless Plugin][1] to send metrics, logs and traces from your application to Datadog without any code changes. The plugin automatically attaches the Datadog Lambda Library for Python to your functions using layers. At deploy time, it swaps your original function handler with the Datadog-provided handler that initializes the Datadog Lambda Library and invokes your original function handler. It also enables Datadog and X-Ray tracing for your Lambda functions.
+The [Datadog Serverless Plugin][1] automatically adds the Datadog Lambda library to your functions using layers, and configures your functions to send metrics, traces, and logs to Datadog through the [Datadog Forwarder][2].
 
 To install and configure the Datadog Serverless Plugin, follow these steps:
 
@@ -37,8 +37,7 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
         flushMetricsToLogs: true
         forwarder: # The Datadog Forwarder ARN goes here.
     ```
-    For more information on the Forwarder ARN, or to install the forwarder see the [Forwarder documentation][2].
-4. Redeploy your serverless application.
+    More information on the Datadog Forwarder ARN or installation can be found [here][2]. For additional settings, see the [plugin documentation][1].
 
 [1]: https://github.com/DataDog/serverless-plugin-datadog
 [2]: https://docs.datadoghq.com/serverless/forwarder/
@@ -46,170 +45,97 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
 {{% tab "AWS SAM" %}}
 <div class="alert alert-warning">This service is in public beta. If you have any feedback, contact <a href="/help">Datadog support</a>.</div>
 
-### Deploy the Datadog CloudFormation Macro
+The [Datadog CloudFormation macro][1] automatically transforms your SAM application template to add the Datadog Lambda library to your functions using layers, and configure your functions to send metrics, traces, and logs to Datadog through the [Datadog Forwarder][2].
 
-Use the [Datadog CloudFormation macro][1] to ingest traces from your application without any code instrumentation. The macro automatically attaches the Datadog Lambda Library for Node.js and Python to your functions using layers. At deploy time, it generates new handler functions that wrap your existing functions and initializes the Lambda Library.
+### Install the Datadog CloudFormation Macro
 
-To install the macro, follow these steps:
+Run the following command with your [AWS credentials][3] to deploy a CloudFormation stack that installs the macro AWS resource. You only need to install the macro **once** for a given region in your account. Replace `create-stack` with `update-stack` to update the macro to the latest version.
 
-1. Clone the Datadog CloudFormation macro repository in your local environment:
+```sh
+aws cloudformation create-stack \
+  --stack-name datadog-serverless-macro \
+  --template-url https://datadog-cloudformation-template.s3.amazonaws.com/aws/serverless-macro/latest.yml \
+  --capabilities CAPABILITY_AUTO_EXPAND CAPABILITY_IAM
 ```
-git clone https://github.com/DataDog/datadog-cloudformation-macro.git
-```
-2. Install the macro and it's dependencies:
-```
-yarn install # Yarn users
-npm install  # NPM users
-```
-3. Run the build script:
-```
-yarn build    # Yarn users
-npm run build # NPM users
-```
-
-Deploy the macro to the same region as your Lambda functions. You need to deploy the macro in every region where you are monitoring Lambda functions:
-
-4. You will need an S3 bucket to store the CloudFormation artifacts for the macro. If you don't have one already, you can create one with:
-
-   ```bash
-      aws s3 mb s3://<bucket name>
-   ```
-5. Package the provided CloudFormation template (`macro_template.yml`). This includes a Lambda function and a CloudFormation macro resource. The provided template uses the AWS Serverless Application Model (SAM), so it must be transformed before deployment:
-
-  ```bash
-    aws cloudformation package \
-        --template-file macro_template.yml \
-        --s3-bucket <your bucket name here> \
-        --output-template-file packaged.template
-    ```
-
-6. Deploy the packaged CloudFormation template to a CloudFormation stack:
-
-    ```bash
-    aws cloudformation deploy \
-        --stack-name datadog-cfn-macro \
-        --template-file packaged.template \
-        --capabilities CAPABILITY_IAM
-    ```
 
 The macro is now deployed and ready to use.
 
-### Install the Datadog Lambda Library
+### Instrument the Function
 
-Use the Datadog CloudFormation macro to ingest traces, logs, and enhanced metrics from your application without any code instrumentation. The macro automatically attaches the Datadog Lambda Library for Node.js and Python to your functions using layers. At deploy time, it generates new handler functions that wrap your existing functions and initializes the Lambda Library.
+In your `template.yml`, add the following under the `Transform` section, **after** the `AWS::Serverless` transform for SAM.
 
-To install the Datadog Lambda Library with the CloudFormation macro, follow these steps:
+```yaml
+Transform:
+  - AWS::Serverless-2016-10-31
+  - Name: DatadogServerless
+    Parameters:
+      pythonLayerVersion: "<LAYER_VERSION>"
+      stackName: !Ref "AWS::StackName"
+      forwarderArn: "<FORWARDER_ARN>"
+      service: "<SERVICE>" # Optional
+      env: "<ENV>" # Optional
+```
 
-1. In your `template.yml`, add the following:
-  ```
-  Transform:
-    - Name: DatadogCfnMacro
-      Parameters:
-        enableDDTracing: true
-        flushMetricsToLogs: true
-        stackName: !Ref "AWS::StackName"
-        forwarderArn: "arn:aws:lambda:<REGION>:<ACCOUNT-ID>:function:datadog-forwarder"
-  ```
-  Find your Datadog Forwarder ARN in the [AWS Console][2]. For more information on installing the Forwarder, see the [official documentation][3].
+Replace `<SERVICE>` and `<ENV>` with appropriate values, `<LAYER_VERSION>` with the desired version of Datadog Lambda layer (see the [latest releases][4]), and `<FORWARDER_ARN>` with Forwarder ARN (see the [Forwarder documentation][2]).
 
-2. Redeploy your serverless application.
+More information and additional parameters can be found in the [macro documentation][1].
 
 [1]: https://github.com/DataDog/datadog-cloudformation-macro
-[2]: https://console.aws.amazon.com/cloudformation/home#/stacks?filteringText=forwarder
-[3]: https://docs.datadoghq.com/serverless/forwarder/
+[2]: https://docs.datadoghq.com/serverless/forwarder/
+[3]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html
+[4]: https://github.com/DataDog/datadog-lambda-python/releases
 {{% /tab %}}
 {{% tab "AWS CDK" %}}
 
 <div class="alert alert-warning">This service is in public beta. If you have any feedback, contact <a href="/help">Datadog support</a>.</div>
 
-### Deploy the Datadog CloudFormation Macro
+The [Datadog CloudFormation macro][1] automatically transforms the CloudFormation template generated by the AWS CDK to add the Datadog Lambda library to your functions using layers, and configure your functions to send metrics, traces, and logs to Datadog through the [Datadog Forwarder][2].
 
-Use the [Datadog CloudFormation macro][1] to ingest traces from your application without any code instrumentation. The macro automatically attaches the Datadog Lambda Library for Node.js and Python to your functions using layers. At deploy time, it generates new handler functions that wrap your existing functions and initializes the Lambda Library.
+### Install the Datadog CloudFormation Macro
 
-To install the macro, follow these steps:
+Run the following command with your [AWS credentials][3] to deploy a CloudFormation stack that installs the macro AWS resource. You only need to install the macro **once** for a given region in your account. Replace `create-stack` with `update-stack` to update the macro to the latest version.
 
-1. Clone the Datadog CloudFormation macro repository in your local environment:
-
-    ```
-    git clone https://github.com/DataDog/datadog-cloudformation-macro.git
-    ```
-
-2. Install the macro and it's dependencies:
-
-    ```
-    yarn install # Yarn users
-    npm install  # NPM users
-    ```
-
-3. Run the build script:
-
-    ```
-    yarn build    # Yarn users
-    npm run build # NPM users
-    ```
-
-Deploy the macro to the same region as your Lambda functions. You need to deploy the macro in every region where you are monitoring Lambda functions.
-
-4. You will need an S3 bucket to store the CloudFormation artifacts for the macro. If you don't have one already, you can create one with:
-
-    ```bash
-      aws s3 mb s3://<bucket name>
-    ```
-
-5. Package the provided CloudFormation template (`macro_template.yml`). This includes a Lambda function and a CloudFormation macro resource. The provided template uses the AWS Serverless Application Model (SAM), so it must be transformed before deployment:
-
-    ```bash
-    aws cloudformation package \
-        --template-file macro_template.yml \
-        --s3-bucket <your bucket name here> \
-        --output-template-file packaged.template
-    ```
-
-6. Deploy the packaged CloudFormation template to a CloudFormation stack:
-
-    ```bash
-    aws cloudformation deploy \
-        --stack-name datadog-cfn-macro \
-        --template-file packaged.template \
-        --capabilities CAPABILITY_IAM
-    ```
+```sh
+aws cloudformation create-stack \
+  --stack-name datadog-serverless-macro \
+  --template-url https://datadog-cloudformation-template.s3.amazonaws.com/aws/serverless-macro/latest.yml \
+  --capabilities CAPABILITY_AUTO_EXPAND CAPABILITY_IAM
+```
 
 The macro is now deployed and ready to use.
 
-### Install the Datadog Lambda Library
+### Instrument the Function
 
-Use the Datadog CloudFormation macro to ingest traces, logs, and enhanced metrics from your application without any code instrumentation. The macro automatically attaches the Datadog Lambda Library for Node.js and Python to your functions using layers. At deploy time, it generates new handler functions that wrap your existing functions and initializes the Lambda Library.
+Add the `DatadogServerless` transform and the `CfnMapping` to your `Stack` object in your AWS CDK app. See the sample code below in Python (the usage in other language should be similar).
 
-To install the Datadog Lambda Library with the CloudFormation macro, follow these steps:
+```python
+from aws_cdk import core
 
-1. Add a `CfnMapping` to your `Stack` object in your AWS CDK app:
-  ```python
-    from aws_cdk import core
-  ```
+class CdkStack(core.Stack):
+  def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
+    super().__init__(scope, id, **kwargs)
+    self.add_transform("DatadogServerless")
 
-  ```python
+    mapping = core.CfnMapping(self, "Datadog",
+      mapping={
+        "Parameters": {
+          "pythonLayerVersion": "<LAYER_VERSION>",
+          "forwarderArn": "<FORWARDER_ARN>",
+          "stackName": self.stackName,
+          "service": "<SERVICE>",  # Optional
+          "env": "<ENV>",  # Optional
+        }
+      })
+```
 
-        self.add_transform("DatadogCfnMacro")
+Replace `<SERVICE>` and `<ENV>` with appropriate values, `<LAYER_VERSION>` with the desired version of Datadog Lambda layer (see the [latest releases][4]), and `<FORWARDER_ARN>` with Forwarder ARN (see the [Forwarder documentation][2]).
 
-        mapping = core.CfnMapping(self, "Datadog",
-          mapping={
-            "Parameters": {
-              "forwarderArn": "arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder",
-              "stackName": self.stackName,
-              "enableDDTracing": "true",
-              "flushMetricsToLogs": "true",
-            }
-          })
-  ```
-
-    Find your Datadog Forwarder ARN in the [AWS Console][2]. For more information on installing the Forwarder, see the [official documentation][3].
-
-2. Redeploy your serverless application.
-
+More information and additional parameters can be found in the [macro documentation][1].
 
 [1]: https://github.com/DataDog/datadog-cloudformation-macro
-[2]: https://console.aws.amazon.com/cloudformation/home#/stacks?filteringText=forwarder
-[3]: https://docs.datadoghq.com/serverless/forwarder/
+[2]: https://docs.datadoghq.com/serverless/forwarder/
+[3]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html
+[4]: https://github.com/DataDog/datadog-lambda-python/releases
 {{% /tab %}}
 {{% tab "Zappa" %}}
 
@@ -236,17 +162,56 @@ To install the Datadog Lambda Library with the CloudFormation macro, follow thes
 
 ### Subscribe the Datadog Forwarder to the Log Groups
 
-You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, to send metrics, traces and logs to Datadog.
+You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, to send metrics, traces, and logs to Datadog.
 
 1. [Install the Datadog Forwarder][2] if you haven't.
 2. [Ensure the option DdFetchLambdaTags is enabled][3].
 3. [Subscribe the Datadog Forwarder to your function's log groups][4].
 
 
-[1]: https://github.com/DataDog/datadog-lambda-layer-python/releases
+[1]: https://github.com/DataDog/datadog-lambda-python/releases
 [2]: https://docs.datadoghq.com/serverless/forwarder/
 [3]: https://docs.datadoghq.com/serverless/forwarder/#experimental-optional
 [4]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
+{{% /tab %}}
+{{% tab "Datadog CLI" %}}
+
+<div class="alert alert-warning">This service is in public beta. If you have any feedback, contact <a href="/help">Datadog support</a>.</div>
+
+Use the Datadog CLI to set up instrumentation on your Lambda functions in your CI/CD pipelines. The CLI command automatically adds the Datadog Lambda library to your functions using layers, and configures your functions to send metrics, traces, and logs to Datadog.
+
+### Install the Datadog CLI
+
+Install the Datadog CLI with NPM or Yarn:
+
+```sh
+# NPM
+npm install -g @datadog/datadog-ci
+
+# Yarn
+yarn global add @datadog/datadog-ci
+```
+
+### Instrument the Function
+
+Run the following command with your [AWS credentials][1]. Replace `<functionname>` and `<another_functionname>` with your Lambda function names, `<aws_region>` with the AWS region name, `<layer_version>` with the desired version of the Datadog Lambda layer (see [latest releases][2]) and `<forwarder_arn>` with Forwarder ARN (see the [Forwarder documentation][3]).
+
+```sh
+datadog-ci lambda instrument -f <functionname> -f <another_functionname> -r <aws_region> -v <layer_version> --forwarder	<forwarder_arn>
+```
+
+For example:
+
+```sh
+datadog-ci lambda instrument -f my-function -f another-function -r us-east-1 -v 19 --forwarder arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder
+```
+
+More information and additional parameters can be found in the [CLI documentation][4].
+
+[1]: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html
+[2]: https://github.com/DataDog/datadog-lambda-python/releases
+[3]: https://docs.datadoghq.com/serverless/forwarder/
+[4]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/lambda
 {{% /tab %}}
 {{% tab "Custom" %}}
 
@@ -290,7 +255,7 @@ See the [latest release][4].
 
 ### Subscribe the Datadog Forwarder to the Log Groups
 
-You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, to send metrics, traces and logs to Datadog.
+You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, to send metrics, traces, and logs to Datadog.
 
 1. [Install the Datadog Forwarder][5] if you haven't.
 2. [Ensure the option DdFetchLambdaTags is enabled][6].
@@ -298,24 +263,27 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 
 
 [1]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
-[2]: https://github.com/DataDog/datadog-lambda-layer-python/releases
+[2]: https://github.com/DataDog/datadog-lambda-python/releases
 [3]: https://docs.aws.amazon.com/lambda/latest/dg/python-package.html#python-package-dependencies
 [4]: https://pypi.org/project/datadog-lambda/
 [5]: https://docs.datadoghq.com/serverless/forwarder/
 [6]: https://docs.datadoghq.com/serverless/forwarder/#experimental-optional
 [7]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
-{{% /tab %}} 
+{{% /tab %}}
 {{< /tabs >}}
 
 ## Explore Datadog Serverless Monitoring
 
-After you have configured your function following the steps above, you can view metrics, logs and traces on the [Serverless page][2]. If you would like to submit a custom metric or manually instrument a function, see the sample code below:
+After you have configured your function following the steps above, you can view metrics, logs and traces on the [Serverless Homepage][3].
+
+If you would like to submit a custom metric or manually instrument a function, see the sample code below:
 
 ```python
 from ddtrace import tracer
 from datadog_lambda.metric import lambda_metric
 
 def lambda_handler(event, context):
+    # submit a custom metric
     lambda_metric(
         "coffee_house.order_value",  # metric name
         12.45,  # metric value
@@ -326,10 +294,12 @@ def lambda_handler(event, context):
         "body": get_message()
     }
 
+# submit a custom span
 @tracer.wrap()
 def get_message():
     return "Hello from serverless!"
 ```
 
-[1]: /serverless/#1-install-the-cloud-integration
-[2]: https://app.datadoghq.com/functions
+[1]: /integrations/amazon_web_services/
+[2]: /serverless/forwarder
+[3]: https://app.datadoghq.com/functions

--- a/content/en/serverless/installation/ruby.md
+++ b/content/en/serverless/installation/ruby.md
@@ -10,7 +10,7 @@ further_reading:
       text: 'Installing Ruby Serverless Monitoring'
 ---
 
-After you have [installed the AWS integration][1], follow the steps below to instrument your application to send metrics, logs, and traces to Datadog.
+After you have installed the [AWS integration][1] and the [Datadog Forwarder][2], choose one of the following methods to instrument your application to send metrics, logs, and traces to Datadog.
 
 ## Configuration
 
@@ -22,7 +22,7 @@ The minor version of the `datadog-lambda` gem always matches the layer version. 
 
 #### Using the Layer
 
-[Configure the layers][2] for your Lambda function using the ARN in the following format:
+[Configure the layers][3] for your Lambda function using the ARN in the following format:
 
 ```
 arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:<VERSION>
@@ -34,11 +34,11 @@ For example:
 arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby2-7:5
 ```
 
-The available `RUNTIME` options are `Ruby2-5` and `Ruby2-7`. For more information, see the [latest release][3].
+The available `RUNTIME` options are `Ruby2-5` and `Ruby2-7`. For more information, see the [latest release][4].
 
 #### Using the Gem
 
-Add the following line to your Gemfile. See the [latest release][4].
+Add the following line to your Gemfile. See the [latest release][5].
 
 ```
 gem 'datadog-lambda'
@@ -51,13 +51,15 @@ Keep in mind that `ddtrace` uses native extensions, which must be compiled for A
 
 You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups to send metrics, traces and logs to Datadog.
 
-1. [Install the Datadog Forwarder if you haven't][5].
+1. [Install the Datadog Forwarder if you haven't][2].
 2. [Ensure the option DdFetchLambdaTags is enabled][6].
 3. [Subscribe the Datadog Forwarder to your function's log groups][7].
 
 ## Explore Datadog Serverless Monitoring
 
-After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless page][8]. If you need to submit a custom metric, refer to the sample code below:
+After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless Homepage][8].
+
+If you would like to submit a custom metric or manually instrument a function, see the sample code below:
 
 ```ruby
 require 'ddtrace'
@@ -91,10 +93,10 @@ end
 
 
 [1]: /serverless/#1-install-the-cloud-integration
-[2]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
-[3]: https://github.com/DataDog/datadog-lambda-layer-rb/releases
-[4]: https://rubygems.org/gems/datadog-lambda
-[5]: https://docs.datadoghq.com/serverless/forwarder/
+[2]: https://docs.datadoghq.com/serverless/forwarder/
+[3]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
+[4]: https://github.com/DataDog/datadog-lambda-layer-rb/releases
+[5]: https://rubygems.org/gems/datadog-lambda
 [6]: https://docs.datadoghq.com/serverless/forwarder/#experimental-optional
 [7]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 [8]: https://app.datadoghq.com/functions


### PR DESCRIPTION
# What does this PR do?

- Document Serverless instrumentation using Datadog CLI
- Update SAM/CDK installation steps

### Motivation
- Datadog CLI now in beta.
- CFN macro installation got simplified

### Preview link
https://docs-staging.datadoghq.com/tian.chu/serverless-cli/serverless/installation/python/?tab=datadogcli
https://docs-staging.datadoghq.com/tian.chu/serverless-cli/serverless/installation/python/?tab=awssam

### Additional Notes
<!-- Anything else we should know when reviewing?-->
