### PR TITLE
update describe for five-minutes to two-minutes

### DIFF
--- a/content/en/metrics/introduction.md
+++ b/content/en/metrics/introduction.md
@@ -45,7 +45,7 @@ When the selected time span is small, all data points are displayed. However, as
 
 ### Time aggregation
 
-Datadog uses time aggregation to solve the display problem. Data points are placed into buckets of time with preset start and end points. For example, when examining four hours, data points are combined into five-minute buckets. Combining data points in this way is referred to as a **rollup**:
+Datadog uses time aggregation to solve the display problem. Data points are placed into buckets of time with preset start and end points. For example, when examining four hours, data points are combined into two-minute buckets. Combining data points in this way is referred to as a **rollup**:
 
 {{< img src="metrics/introduction/time-aggregation.png" alt="Time Aggregation" >}}
 


### PR DESCRIPTION
I checked the data point in my sandbox and found the data point should be 2 minutes. 
https://a.cl.ly/Jru6LyOm
https://a.cl.ly/KourBnAv

I also searched for the document noted this. it should be 1m or 2m.
https://datadoghq.atlassian.net/wiki/spaces/TS/pages/328438482/Metrics+102+Time+and+Space+Aggregation

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
update the description for time-aggregation.
### Motivation
<!-- What inspired you to submit this pull request?-->
Might cause customers to confusion.
### Preview link
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/metrics/introduction/#time-aggregation
<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
