### PR TITLE
tags aren't always key:value skip those that aren't

### DIFF
--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -83,8 +83,9 @@ def security_rules(content, content_dir):
                     tags = data.get('tags', [])
                     if tags:
                         for tag in tags:
-                            key, value = tag.split(':')
-                            page_data[key] = value
+                            if ':' in tag:
+                                key, value = tag.split(':')
+                                page_data[key] = value
                     else:
                         # try build up manually
                         if content['action'] == 'compliance-rules':


### PR DESCRIPTION
### What does this PR do?

Small fix for parsing security rules. In some cases a tag might not be a `key:value`

### Motivation

Testing upcoming PRs

### Preview link

Nothing should change at the moment
https://docs-staging.datadoghq.com/david.jones/minor-rule-fix/security_monitoring/default_rules/

### Additional Notes

