### PR TITLE
Initialize dd-trace to enable tracing

### DIFF
--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -250,7 +250,7 @@ If you would like to submit a custom metric or manually instrument a function, s
 
 ```javascript
 const { sendDistributionMetric } = require("datadog-lambda-js");
-const tracer = require("dd-trace");
+const tracer = require("dd-trace").init();
 
 // Submit a custom APM span named "sleep"
 const sleep = tracer.wrap("sleep", (ms) => {


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
`dd-trace` needs to be initialized to enable tracing. 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hghotra-patch-1/serverless/installation/nodejs/?tab=serverlessframework

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
