### PR TITLE
Document that the Windows user is always added to groups

### DIFF
--- a/content/en/agent/faq/windows-agent-ddagent-user.md
+++ b/content/en/agent/faq/windows-agent-ddagent-user.md
@@ -35,6 +35,10 @@ Msiexec /i ddagent.msi DDAGENTUSER_NAME=<DOMAIN>\<USERNAME> DDAGENTUSER_PASSWORD
 
 For installs on a domain controller, the `<USERNAME>` and `<PASSWORD>` supplied should **never** be an existing "real" (human) user. The installation process changes the rights of the user and they are denied login access.
 
+Additonally the installer will add the user to the following groups:
+- Performance Monitoring
+- Event Log Viewer
+
 **Note**: These options are honored even in a non-domain environment, if the user wishes to supply a username/password to use rather than have the installer generate one.
 
 **Note**: When upgrading the Datadog Agent on a domain controller or host where the user has supplied a username for the Agent, you need to supply the `<DDAGENTUSER_NAME>` but not the `<DDAGENTUSER_PASSWORD>`:

--- a/content/en/agent/faq/windows-agent-ddagent-user.md
+++ b/content/en/agent/faq/windows-agent-ddagent-user.md
@@ -36,7 +36,7 @@ Msiexec /i ddagent.msi DDAGENTUSER_NAME=<DOMAIN>\<USERNAME> DDAGENTUSER_PASSWORD
 
 For installs on a domain controller, the `<USERNAME>` and `<PASSWORD>` supplied should **never** be an existing "real" (human) user. The installation process changes the rights of the user and they are denied login access.
 
-Additonally the installer will add the user to the following groups:
+Additionally, the installer adds the user to the following groups:
 
 * Performance Monitoring
 * Event Log Viewer

--- a/content/en/agent/faq/windows-agent-ddagent-user.md
+++ b/content/en/agent/faq/windows-agent-ddagent-user.md
@@ -37,6 +37,7 @@ Msiexec /i ddagent.msi DDAGENTUSER_NAME=<DOMAIN>\<USERNAME> DDAGENTUSER_PASSWORD
 For installs on a domain controller, the `<USERNAME>` and `<PASSWORD>` supplied should **never** be an existing "real" (human) user. The installation process changes the rights of the user and they are denied login access.
 
 Additonally the installer will add the user to the following groups:
+
 * Performance Monitoring
 * Event Log Viewer
 

--- a/content/en/agent/faq/windows-agent-ddagent-user.md
+++ b/content/en/agent/faq/windows-agent-ddagent-user.md
@@ -11,6 +11,7 @@ The user `ddagentuser` is created at install time for the Datadog Windows Agent.
 * It becomes a member of the “Performance Monitor Users” group
   * Necessary to access WMI information
   * Necessary to access Windows performance counter data
+* It becomes a member of the “Event Log Readers” group
 * It has local login disabled
 * It has remote login disabled
 * It has network login disabled
@@ -36,8 +37,8 @@ Msiexec /i ddagent.msi DDAGENTUSER_NAME=<DOMAIN>\<USERNAME> DDAGENTUSER_PASSWORD
 For installs on a domain controller, the `<USERNAME>` and `<PASSWORD>` supplied should **never** be an existing "real" (human) user. The installation process changes the rights of the user and they are denied login access.
 
 Additonally the installer will add the user to the following groups:
-- Performance Monitoring
-- Event Log Viewer
+* Performance Monitoring
+* Event Log Viewer
 
 **Note**: These options are honored even in a non-domain environment, if the user wishes to supply a username/password to use rather than have the installer generate one.
 


### PR DESCRIPTION
### What does this PR do?
Document that for Windows Agent installation, the installer always add the user to the "Performance Monitor Users" and "Event Log Readers" groups.

### Motivation
The following PR motivated this change: https://github.com/DataDog/datadog-agent/pull/5903

### Preview link
https://docs-staging.datadoghq.com/julien.lebot/specify_user_always_added_to_groups/agent/faq/windows-agent-ddagent-user/#installation-in-a-domain-environment