### PR TITLE
DOCS 1116 - anchor link update

### DIFF
--- a/content/en/tracing/setup/php.md
+++ b/content/en/tracing/setup/php.md
@@ -73,7 +73,7 @@ If you can't find your distribution, you can [manually install][12] the PHP exte
 
 Tracing is automatically enabled by default. Once the extension is installed, **ddtrace** traces your application and sends traces to the Agent.
 
-Datadog supports all web frameworks out of the box. Automatic instrumentation works by modifying PHP's runtime to wrap certain functions and methods to trace them. The PHP tracer supports automatic instrumentation for [several libraries](#library-compatibility).
+Datadog supports all web frameworks out of the box. Automatic instrumentation works by modifying PHP's runtime to wrap certain functions and methods to trace them. The PHP tracer supports automatic instrumentation for [several libraries][16].
 
 Automatic instrumentation captures:
 
@@ -297,3 +297,4 @@ To remove the PHP tracer:
 [13]: /tracing/setup/php/#environment-variable-configuration
 [14]: https://httpd.apache.org/docs/2.4/mod/mod_env.html#setenv
 [15]: /tracing/setup/nginx/#nginx-and-fastcgi
+[16]: /tracing/compatibility_requirements/php

--- a/content/en/tracing/setup/php.md
+++ b/content/en/tracing/setup/php.md
@@ -19,7 +19,7 @@ further_reading:
   tag: "Documentation"
   text: "Advanced Usage"
 ---
-## Compatibilty Requirements
+## Compatibility Requirements
 
 For a full list of supported libraries and language versions, visit the [Compatibility Requirements][1] page.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
the "several libraries" linked to an anchor that was no longer on this page

also does one spelling fix
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
