### PR TITLE
DOCS 1128 - update to UST state metrics section

### DIFF
--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -117,28 +117,32 @@ tags.datadoghq.com/<container-name>.version
 
 ###### State metrics
 
-To configure [Kubernetes State Metrics][2], add the same standard labels to the collection of labels for the parent resource (e.g., Deployment).
+To configure [Kubernetes State Metrics][2]:
 
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    tags.datadoghq.com/env: "<ENV>"
-    tags.datadoghq.com/service: "<SERVICE>"
-    tags.datadoghq.com/version: "<VERSION>"
-spec:
-  template:
-    metadata:
-      labels:
-        tags.datadoghq.com/env: "<ENV>"
-        tags.datadoghq.com/service: "<SERVICE>"
-        tags.datadoghq.com/version: "<VERSION>"
-```
+1. Set `join_standard_tags` to `true` in your [configuration file][3].
+
+2. Add the same standard labels to the collection of labels for the parent resource (e.g., Deployment).
+
+  ```yaml
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      tags.datadoghq.com/env: "<ENV>"
+      tags.datadoghq.com/service: "<SERVICE>"
+      tags.datadoghq.com/version: "<VERSION>"
+  spec:
+    template:
+      metadata:
+        labels:
+          tags.datadoghq.com/env: "<ENV>"
+          tags.datadoghq.com/service: "<SERVICE>"
+          tags.datadoghq.com/version: "<VERSION>"
+  ```
 
 ###### APM Tracer / StatsD client
 
-To configure [APM Tracer][3] and [StatsD client][4] environment variables, use the [Kubernetes's downward API][1] in the format below:
+To configure [APM Tracer][4] and [StatsD client][5] environment variables, use the [Kubernetes's downward API][1] in the format below:
 
 ```yaml
 containers:
@@ -160,8 +164,9 @@ containers:
 
 [1]: https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api
 [2]: /agent/kubernetes/data_collected/#kube-state-metrics
-[3]: /tracing/send_traces/
-[4]: /integrations/statsd/
+[3]: https://github.com/DataDog/integrations-core/blob/master/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example#L70
+[4]: /tracing/send_traces/
+[5]: /integrations/statsd/
 {{% /tab %}}
 
 {{% tab "Docker" %}}
@@ -359,6 +364,7 @@ to configure the `service` tag only in the configuration of the process check.
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
 
 [1]: /getting_started/tagging/#defining-tags
 [2]: /getting_started/agent


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
updates "state metrics" section noting you have to set a variable in the conf file

### Motivation

from @cohenyair 


### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/cswatt/ksm-unified/getting_started/tagging/unified_service_tagging

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
