### PR TITLE
[DOCS-1137] add specific location for docker config file

### DIFF
--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -132,13 +132,11 @@ Launch your private location on:
 
 {{% tab "Docker" %}}
 
-Run this command to boot your private location worker by mounting your configuration file to the container:
+Run this command to boot your private location worker by mounting your configuration file to the container. Ensure that your `<MY_WORKER_CONFIG_FILE_NAME>.json` file is in `/etc/docker`, not the root home folder:
 
 ```shell
 docker run --rm -v $PWD/<MY_WORKER_CONFIG_FILE_NAME>.json:/etc/datadog/synthetics-check-runner.json datadog/synthetics-private-location-worker:latest
 ```
-
-Ensure that youre `<MY_WORKER_CONFIG_FILE_NAME>.json` file is not in the root home folder (`/root`), but in `/etc/docker`.
 
 **Note:** If you blocked reserved IPs, make sure to add the `NET_ADMIN` [Linux capabilities][1] to your private location container.
 

--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -138,6 +138,8 @@ Run this command to boot your private location worker by mounting your configura
 docker run --rm -v $PWD/<MY_WORKER_CONFIG_FILE_NAME>.json:/etc/datadog/synthetics-check-runner.json datadog/synthetics-private-location-worker:latest
 ```
 
+Ensure that youre `<MY_WORKER_CONFIG_FILE_NAME>.json` file is not in the root home folder (`/root`), but in `/etc/docker`.
+
 **Note:** If you blocked reserved IPs, make sure to add the `NET_ADMIN` [Linux capabilities][1] to your private location container.
 
 This command starts a Docker container and makes your private location ready to run tests. **We recommend running the container in detached mode with proper restart policy.**


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

adds a note about where that config file should be located i.e. in /etc/docker not in /root

### Motivation
request from @GarrettYoung510 

### Preview link


https://docs-staging.datadoghq.com/cswatt/private-locations-docker/synthetics/private_locations

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
