### PR TITLE
fix spacing in manifest snippet for live processes

### DIFF
--- a/content/en/infrastructure/livecontainers.md
+++ b/content/en/infrastructure/livecontainers.md
@@ -71,18 +71,18 @@ In the `dd-agent.yaml` manifest used to create the [DaemonSet][1], add the follo
 ```yaml
   env:
     - name: DD_LOGS_ENABLED
-        value: "true"
+      value: "true"
     - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
-        value: "true"
+      value: "true"
 
   volumeMounts:
     - name: pointerdir
-        mountPath: /opt/datadog-agent/run
+      mountPath: /opt/datadog-agent/run
 
 volumes:
   - hostPath:
       path: /opt/datadog-agent/run
-      name: pointerdir
+    name: pointerdir
 
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes minor syntax issues in spacing for manifest segment

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
