### PR TITLE
Update dogstatsd.md with date_happened 

### DIFF
--- a/content/en/developers/events/dogstatsd.md
+++ b/content/en/developers/events/dogstatsd.md
@@ -142,7 +142,7 @@ public class DogStatsdClient
         using (var dogStatsdService = new DogStatsdService())
         {
             dogStatsdService.Configure(dogstatsdConfig);
-            dogStatsdService.Event("An error occurred", "Error message", alertType: "error", tags: new[] { "env:dev" });
+            dogStatsdService.Event("An error occurred", "Error message", alertType: "error", date_happened='TIMESTAMP', tags: new[] { "env:dev" });
         }
     }
 }


### PR DESCRIPTION
When calling the statsd.event we cannot just pass the timestamp or timestamp=<event_time> we need to pass `date_happened=<event_time>`
We need to give the clear example on how to use the timestamp parameter. Because this is confusing so better to provide example as below for clarity  `dogStatsdService.Event("An error occurred", "Error message", alertType: "error", date_happened='TIMESTAMP', tags: new[] { "env:dev" });`

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
