### PR TITLE
Fix curl query string in examples

### DIFF
--- a/layouts/partials/api/curl.html
+++ b/layouts/partials/api/curl.html
@@ -36,7 +36,7 @@
 <span class="n">curl</span> <span class="o">-X</span> <span class="s1">{{ .context.actionType | upper }}</span> {{ range .dollarScratch.Get "serverURLS" }}{{ if ne .region "local" }}<span class="kn d-none" data-region="{{ .region }}">{{ .url }}</span>{{ else }}<span class="kn">{{ .url }}</span>{{ end }}{{ end }}<span class="n">{{ replace .context.pathKey "{" "${" }}</span>
 {{- range $qi, $q := $queryStrings -}}
     {{- if eq .required true -}}
-        <span class="o">{{ cond (gt $qi 1) "&" "?" }}</span><span class="n">{{ $q.name }}</span><span class="o">=</span><span class="s1">${ {{- $q.name -}} }</span>
+        <span class="o">{{ cond (gt $qi 0) "&" "?" }}</span><span class="n">{{ $q.name }}</span><span class="o">=</span><span class="s1">${ {{- $q.name -}} }</span>
     {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This fixes examples like those are https://docs.datadoghq.com/api/v1/metrics/#query-timeseries-points where we have multiple query arguments.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->