### PR TITLE
[WEB-566] - add support for integrations count from shortcode

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,4 +1,8 @@
 {
+  "integration_count": {
+    "other": "400"
+  },
+
   "beta_sentence": {
     "other": "Beta - For support or to report any issues, contact"
   },

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -1,4 +1,8 @@
 {
+  "integration_count": {
+    "other": "400"
+  },
+
   "beta_sentence": {
     "other": "Bêta : pour obtenir de l'aide ou signaler tout problème, contactez"
   },

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -1,4 +1,8 @@
 {
+  "integration_count": {
+    "other": "400"
+  },
+
   "beta_sentence": {
     "other": "　ベータ - 問題についてのお問い合わせまたは報告は"
   },

--- a/layouts/shortcodes/translate.html
+++ b/layouts/shortcodes/translate.html
@@ -1,0 +1,21 @@
+{{ $dot := . }}
+{{ $key := .Get "key" }}
+<!-- attempts to load a data file at the same path/filename as md file e.g content/foo/bar.md will try look for data/foo/bar.yaml -->
+{{ $.Scratch.Set "data" "" }}
+{{ if (fileExists (print "data/" $dot.Page.Lang "/" $dot.Page.File.Dir (replace $dot.Page.File.TranslationBaseName "-" "_") ".yaml")) }}
+    {{ $.Scratch.Set "data" (index $dot.Page.Site.Data $dot.Page.Lang) }}
+    {{ range $k, $v := (split $dot.Page.File.Dir "/") }}
+        {{ if ne $v "/"}}
+            {{ if ne $v ""}}
+                {{ $.Scratch.Set "data" (index ($.Scratch.Get "data") $v) }}
+            {{ end }}
+        {{ end }}
+    {{ end }}
+    {{ $.Scratch.Set "data" (index ($.Scratch.Get "data") (replace $dot.Page.File.TranslationBaseName "-" "_")) }}
+{{ end }}
+<!-- output the value from datafile if we have it otherwise look in i18n -->
+{{ if eq ($.Scratch.Get "data") $key }}
+    {{ safeHTML (index ($.Scratch.Get "data") $key) }}
+{{ else }}
+    {{- i18n $key -}}
+{{ end }}


### PR DESCRIPTION
### What does this PR do?

Adds support to output the integration count from a shortcode like the corp site
`{{< translate key="integration_count" >}} `

### Motivation
https://datadoghq.atlassian.net/browse/WEB-566

### Preview link
https://docs-staging.datadoghq.com/david.jones/intcount/

### Additional Notes

