### PR TITLE
Update note for the log date attribute

### DIFF
--- a/content/en/logs/processing/_index.md
+++ b/content/en/logs/processing/_index.md
@@ -88,7 +88,7 @@ By default Datadog generates a timestamp and appends it in a date attribute when
 
 You can also specify alternate attributes to use as the source of a log's date by setting a [log date remapper processor][12].
 
-**Note**: Datadog rejects a log entry if its official date is older than 6 hours in the past.
+**Note**: Datadog rejects a log entry if its official date is older than 18 hours in the past.
 
 <div class="alert alert-warning">
 The recognized date formats are: <a href="https://www.iso.org/iso-8601-date-and-time-format.html">ISO8601</a>, <a href="https://en.wikipedia.org/wiki/Unix_time">UNIX (the milliseconds EPOCH format)</a>, and <a href="https://www.ietf.org/rfc/rfc3164.txt">RFC3164</a>.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Updates the note for the date attribute 

### Motivation

Internal discussion

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/tj/update_note_for_date_remapper/logs/processing/

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
