### PR TITLE
remove 'profiler is in beta' note from profiling docs

### DIFF
--- a/content/en/tracing/profiler/_index.md
+++ b/content/en/tracing/profiler/_index.md
@@ -15,10 +15,6 @@ further_reading:
       text: 'Introducing always-on production profiling in Datadog.'
 ---
 
-<div class="alert alert-info">
-Datadog Profiler is in beta. Reach out to <a href="/help/">Datadog Support</a> if you encounter any issues or have feedback to share.
-</div>
-
 {{< img src="tracing/profiling/profiling_flamegraph.gif" alt="Exploring profiling flame graph">}}
 
 Find CPU, memory, and IO bottlenecks, broken down by method name, class name, and line number, to significantly reduce end-user latency and infrastructure costs.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
As of DASH, profiling is no longer in Beta. Removing this note to prevent confusion

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
