### PR TITLE
Update autodiscovery.md

### DIFF
--- a/content/en/getting_started/agent/autodiscovery.md
+++ b/content/en/getting_started/agent/autodiscovery.md
@@ -132,7 +132,7 @@ Autodiscovery is enabled by default on Kubernetes.
 To verify this, ensure the following environment variable is set:
 
 ```shell
-KUBERNETES=true
+KUBERNETES=yes
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

helm chart datadog-2.4.8 should have yes instead of true for the value.

https://github.com/DataDog/helm-charts/blob/fc9d6ffbc5e9f4531c9bf2b5170bf6eda7b20e37/charts/datadog/templates/containers-common-env.yaml#L38-L39

### Motivation
<!-- What inspired you to submit this pull request?-->

I wanted to have the documentation line up with what a user sees in a kubernetes cluster when showing the envars.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
