### PR TITLE
Add a note to tracer.Stop()

### DIFF
--- a/content/en/tracing/setup/go.md
+++ b/content/en/tracing/setup/go.md
@@ -75,6 +75,9 @@ func main() {
         tracer.WithService("test-go"),
         tracer.WithVersion("abc123"),
     )
+    
+    // When the tracer is stopped, it will flush everything it has to the Datadog agent before quitting.
+    // Make sure this line stays in your main function.
     defer tracer.Stop()
 }
 ```
@@ -100,7 +103,7 @@ func main() {
         "1234",
     )
     tracer.Start(tracer.WithAgentAddr(addr))
-    defer tracer.Stop() // Make sure this line stays in your main function.
+    defer tracer.Stop()
 }
 ```
 

--- a/content/en/tracing/setup/go.md
+++ b/content/en/tracing/setup/go.md
@@ -76,7 +76,7 @@ func main() {
         tracer.WithVersion("abc123"),
     )
     
-    // When the tracer is stopped, it will flush everything it has to the Datadog agent before quitting.
+    // When the tracer is stopped, it will flush everything it has to the Datadog Agent before quitting.
     // Make sure this line stays in your main function.
     defer tracer.Stop()
 }

--- a/content/en/tracing/setup/go.md
+++ b/content/en/tracing/setup/go.md
@@ -100,7 +100,7 @@ func main() {
         "1234",
     )
     tracer.Start(tracer.WithAgentAddr(addr))
-    defer tracer.Stop()
+    defer tracer.Stop() // Make sure this line stays in your main function.
 }
 ```
 


### PR DESCRIPTION
Keeping this in the main function means that the tracer be able to flush any remaining data before the tracer and the application stops.

### What does this PR do?
Add a note to tracer.Stop()

### Motivation
Lack of clarity has potential to cause setup issues.
