### PR TITLE
[WEB-677] announce failure to list sha from github api

### DIFF
--- a/local/bin/py/build/github_connect.py
+++ b/local/bin/py/build/github_connect.py
@@ -114,6 +114,13 @@ class GitHub:
                     listing = self.extract(
                         tree_response.json()
                     )
+        else:
+            msg = sha_response.json().get('message', '') or sha_response.text
+            print(
+                "\x1b[33mWARNING\x1b[0m: Could not get latest sha from {}/{} response {}, {}..".format(
+                    repo, branch, sha_response.status_code, msg
+                )
+            )
 
         if globs:
             filtered_listing = []


### PR DESCRIPTION
### What does this PR do?

During local dev if you are pulling from github and there is an issue like SSO isn't enabled or the key is incorrect. 
Its not very obvious this is the issue. 

This PR adds a warning output so you know that an issue occurred. 
e.g Here is an example when the key is incorrect

```python
WARNING: "Could not get latest sha from datadog-plugin/master response 401, Bad credentials.."
```

### Motivation

https://datadoghq.atlassian.net/browse/WEB-677

### Preview link

N/A - for local

### Additional Notes

