### PR TITLE
Update historical view deletion time

### DIFF
--- a/content/en/logs/archives/rehydrating.md
+++ b/content/en/logs/archives/rehydrating.md
@@ -60,7 +60,7 @@ Alternatively, teams can find the historical view from the Log Explorer directly
 
 Historical views stay in Datadog until you opt to delete them. You can mark a historical view to be deleted by selecting and confirming the delete icon at the far right of the historical view.
 
-24 hours later, the historical view is definitively deleted; until that time, the team is able to cancel the deletion.
+1 hour later, the historical view is definitively deleted; until that time, the team is able to cancel the deletion.
 
 {{< img src="logs/archives/log_archives_rehydrate_delete.mp4" alt="Deleting Historical Views" video="true"  width="75%" >}}
 

--- a/content/en/logs/archives/rehydrating.md
+++ b/content/en/logs/archives/rehydrating.md
@@ -60,7 +60,7 @@ Alternatively, teams can find the historical view from the Log Explorer directly
 
 Historical views stay in Datadog until you opt to delete them. You can mark a historical view to be deleted by selecting and confirming the delete icon at the far right of the historical view.
 
-1 hour later, the historical view is definitively deleted; until that time, the team is able to cancel the deletion.
+One hour later, the historical view is definitively deleted; until that time, the team is able to cancel the deletion.
 
 {{< img src="logs/archives/log_archives_rehydrate_delete.mp4" alt="Deleting Historical Views" video="true"  width="75%" >}}
 


### PR DESCRIPTION
### What does this PR do?
Update the time it takes to delete an historical view

### Motivation
We changed the historical view deletion time from 24h to 1h.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/historical-view-deletion-time/logs/archives/rehydrating/?tab=awss3#deleting-historical-views

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
