### PR TITLE
Agent-Service(s) Manifest

### DIFF
--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -115,7 +115,7 @@ Setting the value without a secret results in the token being readable in the `P
 
 1. Download the following manifests:
 
-  * [`agent-service.yaml`: The Cluster Agent Service manifest][4]
+  * [`agent-services.yaml`: The Cluster Agent Service manifest][4]
   * [`secrets.yaml`: The secret holding the Datadog API key][5]
   * [`cluster-agent-deployment.yaml`: Cluster Agent manifest][6]
 
@@ -126,7 +126,7 @@ Setting the value without a secret results in the token being readable in the `P
     ```
 
 3. In the `cluster-agent-deployment.yaml` manifest, set the token from [Step 2 - Secure Cluster-Agent-to-Agent Communication](#step-2-secure-cluster-agent-to-agent-communication). The format depends on how you set up your secret; instructions can be found in the manifest directly.
-4. Run: `kubectl apply -f agent-service.yaml`
+4. Run: `kubectl apply -f agent-services.yaml`
 5. Run: `kubectl apply -f secrets.yaml`
 6. Finally, deploy the Datadog Cluster Agent: `kubectl apply -f cluster-agent-deployment.yaml`
 


### PR DESCRIPTION
What used to be "agent-service.yaml" is now "agent-services.yaml" (linked to in [4]) - as such, the name of the link as well as the command that applies it both need to be updated.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Updates two references to `agent-service.yaml`, which should now be `agent-services.yaml`

### Motivation
<!-- What inspired you to submit this pull request?-->

Was going through the docs testing for a `1.17.9` cluster install as part of a demo scheduled for later today. This should address the error:
```bash
kubectl apply -f agent-service.yaml
error: the path "agent-service.yaml" does not exist
```

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
