### PR TITLE
Update Go APM Documentation

### DIFF
--- a/content/en/tracing/setup/go.md
+++ b/content/en/tracing/setup/go.md
@@ -73,7 +73,7 @@ func main() {
     tracer.Start(
         tracer.WithEnv("prod"),
         tracer.WithService("test-go"),
-        tracer.WithVersion("abc123"),
+        tracer.WithServiceVersion("abc123"),
     )
     
     // When the tracer is stopped, it will flush everything it has to the Datadog Agent before quitting.


### PR DESCRIPTION
I recently added Datadog's APM to a project and realized the documentation showing how to set the service version in the tracer was wrong (I'm guessing out of date?). The correct method is `tracer.WithServiceVersion(...)` as opposed to `tracer.WithVersion(...)`.

GoDocs [ref](https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#WithServiceVersion).