### PR TITLE
[kubernetes resources] add cluster name setting instructions

### DIFF
--- a/content/en/infrastructure/livecontainers.md
+++ b/content/en/infrastructure/livecontainers.md
@@ -66,7 +66,7 @@ agents:
 ...
 {{< /code-block >}}
 
-In cases where the agent is not able to automatically detect the Kubernetes cluster name, you must set it in `values.yaml` as well:
+In cases where the Agent is not able to automatically detect the Kubernetes cluster name, you must set it in `values.yaml`:
 
 {{< code-block lang="yaml" >}}
 datadog:

--- a/content/en/infrastructure/livecontainers.md
+++ b/content/en/infrastructure/livecontainers.md
@@ -68,7 +68,7 @@ agents:
 
 In cases where the Agent is not able to automatically detect the Kubernetes cluster name, you must set it in `values.yaml`:
 
-{{< code-block lang="yaml" >}}
+{{< code-block lang="yaml" filename="values.yaml" >}}
 datadog:
    ...
    clusterName: <PLACEHOLDER>

--- a/content/en/infrastructure/livecontainers.md
+++ b/content/en/infrastructure/livecontainers.md
@@ -42,7 +42,7 @@ Follow the [Docker][6] or [Kubernetes][7] Agent installation instructions. Conta
 
 To enable Kubernetes Resources for Live Containers, follow the [Helm instructions][10] and add the following changes to your `values.yaml` file:
 
-{{< code-block lang="yaml" >}}
+{{< code-block lang="yaml" filename="values.yaml" >}}
 datadog:
   ...
   processAgent:

--- a/content/en/infrastructure/livecontainers.md
+++ b/content/en/infrastructure/livecontainers.md
@@ -27,7 +27,7 @@ Coupled with integrations for [Docker][2], [Kubernetes][3], [ECS][4], and other 
 
 [Kubernetes Resources for Live Containers][1] is currently in private beta. Fill out [this form][5] to request access.
 
-If you're using Kubernetes, enable Kubernetes Resources for Live Containers to gain multi-dimensional visibility into all Kubernetes workloads across your clusters. Inspired by the `kubectl` tool, this feature gives you complete coverage of your Kubernetes infrastructure in a continuously updated table with curated resource metrics, faceted search, pre-workload detailed view, and visualized maps.
+If you're using Kubernetes, enable Kubernetes Resources for Live Containers to gain multi-dimensional visibility into all Kubernetes workloads across your clusters. Inspired by the `kubectl` tool, this feature gives you complete coverage of your Kubernetes infrastructure in a continuously updated table with curated resource metrics, faceted search, per-workload detailed view, and visualized maps.
 
 ## Installation
 

--- a/content/en/infrastructure/livecontainers.md
+++ b/content/en/infrastructure/livecontainers.md
@@ -71,7 +71,7 @@ In cases where the agent is not able to automatically detect the Kubernetes clus
 {{< code-block lang="yaml" >}}
 datadog:
    ...
-   clusterName: "<your Kubernetes cluster's name>"
+   clusterName: <PLACEHOLDER>
    ...
 {{< /code-block >}}
 

--- a/content/en/infrastructure/livecontainers.md
+++ b/content/en/infrastructure/livecontainers.md
@@ -61,6 +61,17 @@ datadog:
    ...
 {{< /code-block >}}
 
+In cases where the agent is not able to automatically detect the Kubernetes cluster name, you must set it in `values.yaml` as well:
+
+{{< code-block lang="yaml" >}}
+datadog:
+   ...
+   clusterName: "<your Kubernetes cluster's name>"
+   ...
+{{< /code-block >}}
+
+On Google's GKE, AWS EKS, and Azure AKS, this is unnecessary, unless the agent and the cluster agent don't have access to the cloud metadata APIs.
+
 ## Configuration
 
 ### Include or exclude containers

--- a/content/en/infrastructure/livecontainers.md
+++ b/content/en/infrastructure/livecontainers.md
@@ -75,7 +75,7 @@ datadog:
    ...
 {{< /code-block >}}
 
-**Note**: the cluster name must be 40-character long or less. We are working on relaxing this constraint.
+**Note**: The cluster name must be 40-characters or less.
 
 On Google's GKE, AWS EKS, and Azure AKS, this is unnecessary, unless the agent and the cluster agent don't have access to the cloud metadata APIs, or the cluster name is longer than 40 characters.
 

--- a/content/en/infrastructure/livecontainers.md
+++ b/content/en/infrastructure/livecontainers.md
@@ -77,7 +77,7 @@ datadog:
 
 **Note**: The cluster name must be 40-characters or less.
 
-On Google's GKE, AWS EKS, and Azure AKS, this is unnecessary, unless the agent and the cluster agent don't have access to the cloud metadata APIs, or the cluster name is longer than 40 characters.
+On Google's GKE, AWS EKS, and Azure AKS, this is unnecessary, unless the Agent and the cluster Agent don't have access to the cloud metadata APIs, or the cluster name is longer than 40 characters.
 
 ## Configuration
 

--- a/content/en/infrastructure/livecontainers.md
+++ b/content/en/infrastructure/livecontainers.md
@@ -44,21 +44,26 @@ To enable Kubernetes Resources for Live Containers, follow the [Helm instruction
 
 {{< code-block lang="yaml" >}}
 datadog:
-   ...
-   orchestratorExplorer:
-      enabled: true
-   ...
-   agents:
-      image:
-        repository: datadog/agent
-        tag: latest
-        pullPolicy: Always
-   ...
-   clusterAgent:
-      repository: datadog/cluster-agent
-      tag: latest
-      pullPolicy: Always
-   ...
+  ...
+  processAgent:
+    enabled: true
+  ...
+  orchestratorExplorer:
+    enabled: true
+...
+clusterAgent:
+  enabled: true
+  image:
+    repository: datadog/cluster-agent
+    tag: latest
+    pullPolicy: Always
+...
+agents:
+  image:
+    repository: datadog/agent
+    tag: latest
+    pullPolicy: Always
+...
 {{< /code-block >}}
 
 In cases where the agent is not able to automatically detect the Kubernetes cluster name, you must set it in `values.yaml` as well:

--- a/content/en/infrastructure/livecontainers.md
+++ b/content/en/infrastructure/livecontainers.md
@@ -75,7 +75,9 @@ datadog:
    ...
 {{< /code-block >}}
 
-On Google's GKE, AWS EKS, and Azure AKS, this is unnecessary, unless the agent and the cluster agent don't have access to the cloud metadata APIs.
+**Note**: the cluster name must be 40-character long or less. We are working on relaxing this constraint.
+
+On Google's GKE, AWS EKS, and Azure AKS, this is unnecessary, unless the agent and the cluster agent don't have access to the cloud metadata APIs, or the cluster name is longer than 40 characters.
 
 ## Configuration
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Mention that in some cases, configuring a kubernetes cluster name is necessary.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/haissam/add-cluster-name-setting/infrastructure/livecontainers/#kubernetes-resources-1

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
