### PR TITLE
Document Lambda layers for GovCloud

### DIFF
--- a/content/en/serverless/_index.md
+++ b/content/en/serverless/_index.md
@@ -29,9 +29,17 @@ Serverless is a concept where you write event-driven code and upload it to a clo
 
 ### 1. Install the AWS Integration
 
-Start by installing the [AWS Integration][2]. This allows Datadog to ingest Amazon CloudWatch metrics from AWS Lambda. The AWS integration installation also configures the Datadog Forwarder, which is required for ingestion of AWS Lambda traces, enhanced metrics, custom metrics, and logs.
+Install the [AWS integration][2]. This allows Datadog to ingest Lambda metrics from AWS CloudWatch. 
 
-### 2. Instrument your application
+### 2. Install the Datadog Forwarder
+
+Install the [Datadog Forwarder Lambda function][3], which is required for ingestion of AWS Lambda traces, enhanced metrics, custom metrics, and logs.
+
+Note, if you installed the AWS integration by using the Datadog-provided CloudFormation template, then you already have the Forwarder function installed as part of the AWS integration CloudFormation stack.
+
+### 3. Instrument Your Application
+
+Select the Lambda runtime below for instructions to instrument your serverless application.
 
 {{< partial name="serverless/getting-started-languages.html" >}}
 
@@ -39,11 +47,11 @@ Start by installing the [AWS Integration][2]. This allows Datadog to ingest Amaz
 
 ### Azure App Services
 
-The Datadog extension for Azure App Services provides tracing capabilities for Azure Web Apps. For more information setting up tracing in Azure, see the [Azure App Services Extension documentation][3].
+The Datadog extension for Azure App Services provides tracing capabilities for Azure Web Apps. For more information setting up tracing in Azure, see the [Azure App Services Extension documentation][4].
 
 ### Google Cloud Functions
 
-Google Cloud Functions is a lightweight, event-based, asynchronous compute solution that allows you to create small, single-purpose functions. To monitor serverless functions running on Google Cloud Platform, enable the [Google Cloud Platform integration][4].
+Google Cloud Functions is a lightweight, event-based, asynchronous compute solution that allows you to create small, single-purpose functions. To monitor serverless functions running on Google Cloud Platform, enable the [Google Cloud Platform integration][5].
 
 ## Further Reading
 
@@ -51,5 +59,6 @@ Google Cloud Functions is a lightweight, event-based, asynchronous compute solut
 
 [1]: http://app.datadoghq.com/functions
 [2]: /integrations/amazon_web_services/
-[3]: /infrastructure/serverless/azure_app_services/#overview
-[4]: /integrations/google_cloud_platform/
+[3]: /serverless/forwarder
+[4]: /infrastructure/serverless/azure_app_services/#overview
+[5]: /integrations/google_cloud_platform/

--- a/content/en/serverless/_index.md
+++ b/content/en/serverless/_index.md
@@ -27,25 +27,25 @@ Serverless is a concept where you write event-driven code and upload it to a clo
 
 ## Getting Started
 
-### 1. Install the AWS Integration
+### 1. Install the AWS integration
 
 Install the [AWS integration][2]. This allows Datadog to ingest Lambda metrics from AWS CloudWatch. 
 
 ### 2. Install the Datadog Forwarder
 
-Skip this step if you already have the Forwarder function installed as part of the [AWS integration][2] CloudFormation stack. Otherwise, install the [Datadog Forwarder Lambda function][3], which is required for ingestion of AWS Lambda traces, enhanced metrics, custom metrics, and logs.
+Install the [Datadog Forwarder Lambda function][3], which is required for ingestion of AWS Lambda traces, enhanced metrics, custom metrics, and logs. **Note**: Skip this step if you already have the forwarder function installed as part of the [AWS integration][2] CloudFormation stack.
 
-### 3. Instrument Your Application
+### 3. Instrument your application
 
 Select the Lambda runtime below for instructions to instrument your serverless application.
 
 {{< partial name="serverless/getting-started-languages.html" >}}
 
-## Not Using AWS Lambda?
+## Other services
 
-### Azure App Services
+### Azure App Service
 
-The Datadog extension for Azure App Services provides tracing capabilities for Azure Web Apps. For more information setting up tracing in Azure, see the [Azure App Services Extension documentation][4].
+The Datadog extension for Azure App Service provides tracing capabilities for Azure Web Apps. For more information setting up tracing in Azure, see the [Azure App Service Extension documentation][4].
 
 ### Google Cloud Functions
 

--- a/content/en/serverless/_index.md
+++ b/content/en/serverless/_index.md
@@ -33,9 +33,7 @@ Install the [AWS integration][2]. This allows Datadog to ingest Lambda metrics f
 
 ### 2. Install the Datadog Forwarder
 
-Install the [Datadog Forwarder Lambda function][3], which is required for ingestion of AWS Lambda traces, enhanced metrics, custom metrics, and logs.
-
-Note, if you installed the AWS integration by using the Datadog-provided CloudFormation template, then you already have the Forwarder function installed as part of the AWS integration CloudFormation stack.
+Skip this step if you already have the Forwarder function installed as part of the [AWS integration][2] CloudFormation stack. Otherwise, install the [Datadog Forwarder Lambda function][3], which is required for ingestion of AWS Lambda traces, enhanced metrics, custom metrics, and logs.
 
 ### 3. Instrument Your Application
 

--- a/content/en/serverless/installation/_index.md
+++ b/content/en/serverless/installation/_index.md
@@ -16,7 +16,7 @@ Install the [AWS integration][1]. This allows Datadog to ingest Lambda metrics f
 
 ### 2. Install the Datadog Forwarder
 
-Skip this step if you already have the Forwarder function installed as part of the [AWS integration][1] CloudFormation stack. Otherwise, install the [Datadog Forwarder Lambda function][2], which is required for ingestion of AWS Lambda traces, enhanced metrics, custom metrics, and logs.
+Install the [Datadog Forwarder Lambda function][2], which is required for ingestion of AWS Lambda traces, enhanced metrics, custom metrics, and logs. **Note**: Skip this step if you already have the Forwarder function installed as part of the [AWS integration][1] CloudFormation stack.
 
 ### 3. Instrument Your Application
 

--- a/content/en/serverless/installation/_index.md
+++ b/content/en/serverless/installation/_index.md
@@ -16,9 +16,7 @@ Install the [AWS integration][1]. This allows Datadog to ingest Lambda metrics f
 
 ### 2. Install the Datadog Forwarder
 
-Install the [Datadog Forwarder Lambda function][2], which is required for ingestion of AWS Lambda traces, enhanced metrics, custom metrics, and logs.
-
-Note, if you installed the AWS integration by using the Datadog-provided CloudFormation template, then you already have the Forwarder function installed as part of the AWS integration CloudFormation stack.
+Skip this step if you already have the Forwarder function installed as part of the [AWS integration][1] CloudFormation stack. Otherwise, install the [Datadog Forwarder Lambda function][2], which is required for ingestion of AWS Lambda traces, enhanced metrics, custom metrics, and logs.
 
 ### 3. Instrument Your Application
 

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -191,7 +191,11 @@ The minor version of the `datadog-lambda-js` package always matches the layer ve
 [Configure the layers][1] for your Lambda function using the ARN in the following format.
 
 ```
+# For regular regions
 arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:<VERSION>
+
+# For us-gov regions
+arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:<VERSION>
 ```
 
 The available `RUNTIME` options are `Node8-10`, `Node10-x`, and `Node12-x`. For `VERSION`, see the [latest release][2]. For example:

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -157,7 +157,11 @@ More information and additional parameters can be found in the [macro documentat
     ```
 1. Replace the placeholder `<AWS_REGION>`, `<RUNTIME>` and `<VERSION>` in the layer ARN with appropriate values. The available `RUNTIME` options are `Python27`, `Python36`, `Python37`, and `Python38`. For `VERSION`, see the [latest release][1]. For example:
     ```
+    # For regular regions
     arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python37:19
+    
+    # For us-gov regions
+    arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python37:19
     ```
 
 ### Subscribe the Datadog Forwarder to the Log Groups
@@ -226,7 +230,11 @@ The minor version of the `datadog-lambda` package always matches the layer versi
 [Configure the layers][1] for your Lambda function using the ARN in the following format:
 
 ```
+# For regular regions
 arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:<VERSION>
+
+# For us-gov regions
+arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:<VERSION>
 ```
 
 The available `RUNTIME` options are `Python27`, `Python36`, `Python37`, and `Python38`. For `VERSION`, see the [latest release][2]. For example:

--- a/content/en/serverless/installation/ruby.md
+++ b/content/en/serverless/installation/ruby.md
@@ -22,19 +22,21 @@ The minor version of the `datadog-lambda` gem always matches the layer version. 
 
 #### Using the Layer
 
-[Configure the layers][3] for your Lambda function using the ARN in the following format:
+[Configure the layers][3] for your Lambda function using the ARN in the following format.
 
 ```
+# For regular regions
 arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:<VERSION>
+
+# For us-gov regions
+arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:<VERSION>
 ```
 
-For example:
+The available `RUNTIME` options are `Ruby2-5` and `Ruby2-7`. For `VERSION`, see the [latest release][4]. For example:
 
 ```
 arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby2-7:5
 ```
-
-The available `RUNTIME` options are `Ruby2-5` and `Ruby2-7`. For more information, see the [latest release][4].
 
 #### Using the Gem
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Document Lambda layers for GovCloud

### Motivation
Allow GovCloud customers to use the prebuilt Lambda layers

### Preview link

https://docs-staging.datadoghq.com/tian.chu/lambda-layer-for-govcloud/serverless/installation/python/?tab=custom
https://docs-staging.datadoghq.com/tian.chu/lambda-layer-for-govcloud/serverless/installation/nodejs/?tab=custom


### Additional Notes
<!-- Anything else we should know when reviewing?-->
