### PR TITLE
fix cap on version + code highlight

### DIFF
--- a/content/en/tracing/version_tracking/_index.md
+++ b/content/en/tracing/version_tracking/_index.md
@@ -50,7 +50,7 @@ Shadow deploys allow you to test a potential release against real production tra
 
 ## Using Version Tags within Datadog
 
-The `version` tags can be used anywhere within Datadog, whether to filter a search view to a specific version, or to compare metrics from different versions.
+The `version` tag can be used anywhere within Datadog, whether to filter a search view to a specific version, or to compare metrics from different versions.
 
 ### Service page
 

--- a/content/en/tracing/version_tracking/_index.md
+++ b/content/en/tracing/version_tracking/_index.md
@@ -24,7 +24,7 @@ Rolling deploys provide zero-downtime by directing traffic to other instances wh
 
 Using Datadog, you can monitor your rolling deploys and detect any resulting error increases.
 
-{{< img src="tracing/version_tracking/rolling.png" alt="versions on the Service Page"  style="width:100%;">}}
+{{< img src="tracing/version_tracking/rolling.png" alt="Versions on the Service Page"  style="width:100%;">}}
 
 ### Blue/green deploys
 

--- a/content/en/tracing/version_tracking/_index.md
+++ b/content/en/tracing/version_tracking/_index.md
@@ -10,13 +10,13 @@ further_reading:
 ---
 ## The Version Tag
 
-`Version` is a [reserved tag][1] within Datadog, and because of Unified Service Tagging, the `Version` tag is applied across infrastructure, traces, trace metrics, profiles, and logs.
+`version` is a [reserved tag][1] within Datadog, and because of Unified Service Tagging, the `version` tag is applied across infrastructure, traces, trace metrics, profiles, and logs.
 
-This page describes specific ways you can use the version tag to better monitor deployments and service behavior. See the [Unified Service Tagging][1] docs for instructions for setting up the tags.
+This page describes specific ways you can use the `version` tag to better monitor deployments and service behavior. See the [Unified Service Tagging][1] docs for instructions for setting up the tags.
 
 ## Version Deployment Strategies
 
-Datadog's Version Tracking gives you visibility into the performance of deployed code when you are using the following deployment strategies (or others) to detect bad code deployments, contain the impact of changes, and respond faster to incidents.
+Datadog's version tracking gives you visibility into the performance of deployed code when you are using the following deployment strategies (or others) to detect bad code deployments, contain the impact of changes, and respond faster to incidents.
 
 ### Rolling deploys
 
@@ -24,44 +24,44 @@ Rolling deploys provide zero-downtime by directing traffic to other instances wh
 
 Using Datadog, you can monitor your rolling deploys and detect any resulting error increases.
 
-{{< img src="tracing/version_tracking/rolling.png" alt="Versions on the Service Page"  style="width:100%;">}}
+{{< img src="tracing/version_tracking/rolling.png" alt="versions on the Service Page"  style="width:100%;">}}
 
 ### Blue/green deploys
 
 Blue/green (or other color combination) deployments reduce downtime by running two clusters of services that are both accepting traffic, or by keeping one on standby, ready to be activated if there are problems with the other.
 
-Setting and viewing the version tags for these services lets you compare requests and errors to detect if one of the clusters has an error rate higher than the other cluster, if a cluster is not meeting SLOs, or if a cluster that is not supposed to be receiving traffic is.
+Setting and viewing the `version` tags for these services lets you compare requests and errors to detect if one of the clusters has an error rate higher than the other cluster, if a cluster is not meeting SLOs, or if a cluster that is not supposed to be receiving traffic is.
 
 ### Canary deploys
 
 With canary deploys, a service is deployed on a limited number of hosts or for a fraction of customers, to test a new deployment with limited impact.
 
-Using Version tags within Datadog allows you to compare error rates, traces, and service behavior for the canary deployment.
+Using `version` tags within Datadog allows you to compare error rates, traces, and service behavior for the canary deployment.
 
 For example, you can see in the following image that a canary version was deployed, had a few errors, and was removed, with traces corresponding to that version available for investigation without any further impact.
 
-{{< img src="tracing/version_tracking/Canary.png" alt="Versions on the Service Page"  style="width:100%;">}}
+{{< img src="tracing/version_tracking/Canary.png" alt="versions on the Service Page"  style="width:100%;">}}
 
 ### Shadow deploys
 
 In a shadow deployment, a release candidate version is deployed alongside the production version, and incoming traffic is sent to both services, with users seeing the results only from production, but letting you collect data from both.
 
-Shadow deploys allow you to test a potential release against real production traffic. Tagging shadows with a version tag lets you compare error rates, traces, and service behavior between the two versions to determine if the shadow version should be released.
+Shadow deploys allow you to test a potential release against real production traffic. Tagging shadows with a `version` tag lets you compare error rates, traces, and service behavior between the two versions to determine if the shadow version should be released.
 
 ## Using Version Tags within Datadog
 
-Version tags can be used anywhere within Datadog, whether to filter a search view to a specific version, or to compare metrics from different versions.
+The `version` tags can be used anywhere within Datadog, whether to filter a search view to a specific version, or to compare metrics from different versions.
 
 ### Service page
 
 {{< img src="tracing/version_tracking/ServicePage.png" alt="Versions on the Service Page"  style="width:100%;">}}
 
-On the Service page, if the version tag is available, the requests widget can be scoped to either of:
+On the Service page, if the `version` tag is available, the requests widget can be scoped to either of:
 
 - Total Requests by Version
 - Requests per second by Version
 
-The errors widget can be scoped to one of three options that involve Version:
+The errors widget can be scoped to one of three options that involve the `version` tag:
 
 - Total Errors by Version
 - Errors per second by Version
@@ -78,7 +78,7 @@ On the Resource page, if the version tag is available, the requests widget can b
 - Total Requests by Version
 - Requests per second by Version
 
-The errors widget can be scoped to one of three options that involve Version:
+The errors widget can be scoped to one of three options that involve the `version` tag:
 
 - Total Errors by Version
 - Errors per second by Version
@@ -90,9 +90,9 @@ All of these can be exported to dashboards and monitors.
 
 {{< img src="tracing/version_tracking/AnalyticsErrorsByVersion.gif" alt="Versions on the Resource Page"  style="width:100%;">}}
 
-When available, Version can be used as a tag for both Trace Search and Analytics, either to filter the live search mode and indexed traces, or to filter or group analytics queries.
+When available, `version` can be used as a tag for both Trace Search and Analytics, either to filter the live search mode and indexed traces, or to filter or group analytics queries.
 
-Analytics, including filtering on the Version tag, can be exported to dashboards and monitors.
+Analytics, including filtering on the `version` tag, can be exported to dashboards and monitors.
 
 ## Further Reading
 

--- a/content/en/tracing/version_tracking/_index.md
+++ b/content/en/tracing/version_tracking/_index.md
@@ -40,7 +40,7 @@ Using `version` tags within Datadog allows you to compare error rates, traces, a
 
 For example, you can see in the following image that a canary version was deployed, had a few errors, and was removed, with traces corresponding to that version available for investigation without any further impact.
 
-{{< img src="tracing/version_tracking/Canary.png" alt="versions on the Service Page"  style="width:100%;">}}
+{{< img src="tracing/version_tracking/Canary.png" alt="Versions on the Service Page"  style="width:100%;">}}
 
 ### Shadow deploys
 


### PR DESCRIPTION
### What does this PR do?

To follow up on: https://github.com/DataDog/documentation/pull/8327

The `version` tag is all lower case according to https://docs.datadoghq.com/getting_started/tagging/
In order to reduce confusion between when we speak about the tag `version` and just a version of an entity I enforced the tag between backquotes on the whole page

### Motivation

Consistency

### Preview link

* https://docs-staging.datadoghq.com/gus/version/tracing/version_tracking/
