### PR TITLE
Update PhpRedis for dd-trace-php v0.48.0

### DIFF
--- a/content/en/tracing/compatibility_requirements/php.md
+++ b/content/en/tracing/compatibility_requirements/php.md
@@ -88,13 +88,13 @@ To request support for additional CLI libraries, contact our awesome [support te
 | MongoDB                          | 1.4.x                      | Fully Supported |
 | MySQLi                           | *(Any Supported PHP)*      | Fully Supported |
 | PDO (MySQL, PostgreSQL, MariaDB) | *(Any Supported PHP)*      | Fully Supported |
+| PHPRedis                         | 3, 4, 5                    | Fully Supported |
 | Predis                           | 1.1                        | Fully Supported |
 | AWS Couchbase                    | AWS PHP SDK 3              | _Coming Soon_   |
 | AWS DynamoDB                     | AWS PHP SDK 3              | _Coming Soon_   |
 | AWS ElastiCache                  | AWS PHP SDK 3              | _Coming Soon_   |
 | Doctrine ORM                     | 2                          | _Coming Soon_   |
 | ODBC                             | *(Any Supported PHP)*      | _Coming Soon_   |
-| PHPredis                         | 4                          | _Coming Soon_   |
 | Solarium                         | 4.2                        | _Coming Soon_   |
 
 To request support for additional datastores, contact our awesome [support team][2].

--- a/content/en/tracing/compatibility_requirements/php.md
+++ b/content/en/tracing/compatibility_requirements/php.md
@@ -88,7 +88,7 @@ To request support for additional CLI libraries, contact our awesome [support te
 | MongoDB                          | 1.4.x                      | Fully Supported |
 | MySQLi                           | *(Any Supported PHP)*      | Fully Supported |
 | PDO (MySQL, PostgreSQL, MariaDB) | *(Any Supported PHP)*      | Fully Supported |
-| PHPRedis                         | 3, 4, 5                    | Fully Supported |
+| PhpRedis                         | 3, 4, 5                    | Fully Supported |
 | Predis                           | 1.1                        | Fully Supported |
 | AWS Couchbase                    | AWS PHP SDK 3              | _Coming Soon_   |
 | AWS DynamoDB                     | AWS PHP SDK 3              | _Coming Soon_   |

--- a/content/en/tracing/setup/php.md
+++ b/content/en/tracing/setup/php.md
@@ -199,7 +199,7 @@ Use the name when setting integration-specific configuration such as, `DD_TRACE_
 | Mongo             | `mongo`           |
 | Mysqli            | `mysqli`          |
 | PDO               | `pdo`             |
-| PHPredis          | `phpredis`        |
+| PhpRedis          | `phpredis`        |
 | Predis            | `predis`          |
 | Slim              | `slim`            |
 | Symfony           | `symfony`         |

--- a/content/en/tracing/setup/php.md
+++ b/content/en/tracing/setup/php.md
@@ -199,6 +199,7 @@ Use the name when setting integration-specific configuration such as, `DD_TRACE_
 | Mongo             | `mongo`           |
 | Mysqli            | `mysqli`          |
 | PDO               | `pdo`             |
+| PHPredis          | `phpredis`        |
 | Predis            | `predis`          |
 | Slim              | `slim`            |
 | Symfony           | `symfony`         |


### PR DESCRIPTION
### What does this PR do?
Adds PhpRedis to supported libraries for the release of PHP tracer version 0.48.0.

### Preview links
- [Integration names](https://docs-staging.datadoghq.com/apm/php/0.48.0/tracing/setup/php/#integration-names)
- [Datastore compatibility](https://docs-staging.datadoghq.com/apm/php/0.48.0/tracing/compatibility_requirements/php/#datastore-compatibility)

### Additional Notes
Version 0.48.0 of dd-trace-php is ready for release.
