### PR TITLE
add host metadata field names to tags section

### DIFF
--- a/content/en/infrastructure/hostmap.md
+++ b/content/en/infrastructure/hostmap.md
@@ -45,12 +45,19 @@ A simple example is grouping your hosts by AWS availability zone. If you add a s
 
 For example, if some of your hosts are running on AWS, the following AWS-specific tags are available to you right now:
 
-* availability-zone
-* region
-* image
-* instance-type
-* security-group
-* any EC2 tags you might use, such as 'name'
+* `availability-zone`
+* `region`
+* `image`
+* `instance-type`
+* `security-group`
+* any EC2 tags you might use, such as `name`
+
+The Datadog Agent also collects host metadata, some of which can be used as a filter or for grouping terms. Host metadata fields include:
+
+- `field:metadata_agent_version`
+- `field:metadata_platform`
+- `field:metadata_processor`
+- `field:metadata_machine`
 
 ### Zoom in
 

--- a/content/en/infrastructure/hostmap.md
+++ b/content/en/infrastructure/hostmap.md
@@ -52,12 +52,13 @@ For example, if some of your hosts are running on AWS, the following AWS-specifi
 * `security-group`
 * any EC2 tags you might use, such as `name`
 
-The Datadog Agent also collects host metadata, some of which can be used as a filter or for grouping terms. Host metadata fields include:
+The Datadog Agent also collects host metadata and application information, some of which can be used as a filter or for grouping terms. Those fields include:
 
 - `field:metadata_agent_version`
 - `field:metadata_platform`
 - `field:metadata_processor`
 - `field:metadata_machine`
+- `field:apps`
 
 ### Zoom in
 


### PR DESCRIPTION
### What does this PR do?

Adds host metadata fields to list of tags people can use in the Hostmap

### Motivation
DOCS-1175

### Preview link

https://docs-staging.datadoghq.com/kari/host-metadata/infrastructure/hostmap/

