### PR TITLE
[rum] add service, env, version to init example

### DIFF
--- a/content/en/real_user_monitoring/browser/_index.md
+++ b/content/en/real_user_monitoring/browser/_index.md
@@ -40,7 +40,11 @@ datadogRum.init({
     applicationId: '<DATADOG_APPLICATION_ID>',
     clientToken: '<DATADOG_CLIENT_TOKEN>',
     site: 'datadoghq.com',
+//  service: 'my-web-application',
+//  env: 'production',
+//  version: '1.0.0',
     sampleRate: 100,
+    trackInteractions:true,
 });
 ```
 
@@ -54,12 +58,18 @@ datadogRum.init({
     applicationId: '<DATADOG_APPLICATION_ID>',
     clientToken: '<DATADOG_CLIENT_TOKEN>',
     site: 'datadoghq.eu',
+//  service: 'my-web-application',
+//  env: 'production',
+//  version: '1.0.0',
     sampleRate: 100,
+    trackInteractions:true,
 });
 ```
 
 {{% /tab %}}
 {{< /tabs >}}
+
+**Note**: The `trackInteractions` initialization parameter enables the automatic collection of user clicks in your application. **Sensitive and private data** contained on your pages may be included to identify the elements interacted with.
 
 ## Bundle Setup
 
@@ -79,7 +89,11 @@ Paste the generated code snippet into the head tag (in front of any other script
             clientToken: '<CLIENT_TOKEN>',
             applicationId: '<APPLICATION_ID>',
             site: 'datadoghq.com',
+        //  service: 'my-web-application',
+        //  env: 'production',
+        //  version: '1.0.0',
             sampleRate: 100,
+            trackInteractions:true,
         });
 </script>
 ```
@@ -98,13 +112,19 @@ Paste the generated code snippet into the head tag (in front of any other script
             clientToken: '<CLIENT_TOKEN>',
             applicationId: '<APPLICATION_ID>',
             site: 'datadoghq.eu',
+        //  service: 'my-web-application',
+        //  env: 'production',
+        //  version: '1.0.0',
             sampleRate: 100,
+            trackInteractions:true,
         });
 </script>
 ```
 
 {{% /tab %}}
 {{< /tabs >}}
+
+**Note**: The `trackInteractions` initialization parameter enables the automatic collection of user clicks in your application. **Sensitive and private data** contained on your pages may be included to identify the elements interacted with.
 
 **Note**: The `window.DD_RUM` check is used to prevent issues if a loading failure occurs with the RUM SDK.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add `service`, `env`, `version` and `trackInteractions` in init example.

### Motivation
<!-- What inspired you to submit this pull request?-->
Stay consistent with in-app examples.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hdelaby/more-init-params/real_user_monitoring/browser/?tab=us

