### PR TITLE
Update Agent Tab Label

### DIFF
--- a/content/en/agent/docker/apm.md
+++ b/content/en/agent/docker/apm.md
@@ -37,7 +37,7 @@ To make it available from _any host_, use `-p 8126:8126/tcp` instead.
 For example, the following command allows the Agent to receive traces from your host only:
 
 {{< tabs >}}
-{{% tab "Standard" %}}
+{{% tab "Linux" %}}
 
 ```shell
 docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \


### PR DESCRIPTION


### What does this PR do?
Updates the label of the Linux tab to 'Linux' from Standard for better parallelism.
