### PR TITLE
Edit regex example to show correct syntax

### DIFF
--- a/content/en/agent/guide/autodiscovery-management.md
+++ b/content/en/agent/guide/autodiscovery-management.md
@@ -37,7 +37,7 @@ As an example, the following configuration instructs the Agent to ignore some co
 DD_CONTAINER_EXCLUDE = "image:dockercloud/network-daemon image:dockercloud/cleanup image:dockercloud/logrotate image:dockercloud/events image:dockercloud/ntpd"
 ```
 
-You can use a regex to ignore them all: `DD_CONTAINER_EXCLUDE = "image:dockercloud/*"`
+You can use a regex to ignore them all: `DD_CONTAINER_EXCLUDE = "image:dockercloud/.*"`
 
 In **Agent <= v7.19+**, to remove a given Docker container with the **image** `<IMAGE_NAME>` from Autodiscovery, add the following environment variable to the Datadog Agent:
 


### PR DESCRIPTION
### What does this PR do?
Our doc shows `DD_CONTAINER_EXCLUDE = "image:dockercloud/*"` as a regex example for excluding containers by image but this configuration doesn't work since it's missing the `.` in front of `*`. `*` by itself is actually glob syntax which isn't supported for this env variable. Source: https://en.wikipedia.org/wiki/Glob_%28programming%29

### Motivation
Some customers were trying to use glob syntax in their Helm settings based on this example.

### Preview link

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/NoisomePossum-patch-1/agent/guide/autodiscovery-management/?tab=containerizedagent

