### PR TITLE
add a known issue for Agent collect info.

### DIFF
--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -235,6 +235,34 @@ or cmd.exe:
 "%PROGRAMFILES%\Datadog\Datadog Agent\bin\agent.exe" status
 ```
 
+If you see Agent status shows below loading error and due to Python3 runtime issue, it could because your Windows system environment is old and you can try to use below URL to upgrade your system environment. 
+https://support.microsoft.com/en-us/help/2999226/update-for-universal-c-runtime-in-windows
+```cmd
+  Collector
+  =========
+    Error initializing Python
+  =========================
+    - could not load runtime python for version 3: Unable to open library libdatadog-agent-three.dll, error code: 126
+    
+  Loading Errors
+  ==============
+    disk
+    ----
+      Core Check Loader:
+        Check disk not found in Catalog
+      JMX Check Loader:
+        check is not a jmx check, or unable to determine if it's so
+      Python Check Loader:
+        python is not initialized
+    network
+    -------
+      Core Check Loader:
+        Check network not found in Catalog
+      JMX Check Loader:
+        check is not a jmx check, or unable to determine if it's so
+      Python Check Loader:
+        python is not initialized
+```
 {{% /tab %}}
 {{% tab "Agent v5" %}}
 


### PR DESCRIPTION
some customers upgrade/install Datadog Agentv7 in their Windows Server2008 R2 but fail to collect disk and network info. It's a Runtime issue and need customer upgrade Windows environment.
see https://datadoghq.atlassian.net/browse/AGENT-1334

Customers request us can update the issue on documents so they can ask end-user upgrade Windows.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
add a known issue for install Agent in the Windows system.

### Motivation
<!-- What inspired you to submit this pull request?-->
Customer need this issue noted in our documents.
### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
