### PR TITLE
apdex thresholds need to be set

### DIFF
--- a/content/en/tracing/guide/configure_an_apdex_for_your_traces_with_datadog_apm.md
+++ b/content/en/tracing/guide/configure_an_apdex_for_your_traces_with_datadog_apm.md
@@ -25,9 +25,9 @@ Once the threshold is defined and your requests are categorized, the apdex is de
 
 {{< img src="tracing/faq/apdex_formula.png" alt="Apdex formula"  >}}
 
-Selecting the correct threshold is really important since the Frustrated requests are 4 times slower than "normal". If T=3 you can wait 3 seconds for a page to load by you might not tolerate waiting until 12 seconds.
+Selecting the correct threshold is really important since the Frustrated requests are 4 times slower than "normal". If T=3 you can wait 3 seconds for a page to load but you might not tolerate waiting until 12 seconds.
 
-That's why the default Apdex threshold value used by your Datadog application is 0.5 second But you can change its value directly on your service board.
+That's why the Apdex thresholds need to be set by admins, per service, before they are calculated.
 
 ## Set your Apdex for your traces
 


### PR DESCRIPTION

### What does this PR do?
Let customers know that apdex thresholds need to be set, there is no default value.
If no threshold is setup, apdex is not computed

### Motivation
https://datadoghq.atlassian.net/browse/APMS-1730:
this customer didn't understand why they didn't have apdex on their new web services

### Preview link
https://docs-staging.datadoghq.com/c%C3%A9cile/apdexthreshold/tracing/guide/configure_an_apdex_for_your_traces_with_datadog_apm/#pagetitle
