### PR TITLE
Updated doc for Mobile App visibility

### DIFF
--- a/content/en/monitors/manage_monitor.md
+++ b/content/en/monitors/manage_monitor.md
@@ -92,9 +92,11 @@ After searching, select one or more monitors to update using the checkboxes next
 
 To edit an individual monitor, hover over it and use the buttons to the far right: Edit, Clone, Mute, Delete. To see more details on a monitor, click its name to visit the status page.
 
+**Note**: With the [Datadog Mobile App][7], you can view, mute, and unmute monitors on your mobile device.
+
 ### Triggered monitors
 
-You can mute or [resolve][6] triggered monitors in bulk using the [Triggered Monitors][7] page. This page only shows monitors with a triggered status (Alert, Warn, or No Data).
+You can mute or [resolve][6] triggered monitors in bulk using the [Triggered Monitors][8] page. This page only shows monitors with a triggered status (Alert, Warn, or No Data).
 
 #### Grouped results
 
@@ -110,7 +112,7 @@ Attribute differences for the triggered monitors page:
 
 ### Monitor Tags
 
-Monitor tags are independent of tags sent by the Agent or integrations. Add tags directly to your monitors for filtering on the [manage monitors][1], [triggered monitors][7], or [manage downtime][8] pages. Learn more about monitor tags in the [tagging documentation][9].
+Monitor tags are independent of tags sent by the Agent or integrations. Add tags directly to your monitors for filtering on the [manage monitors][1], [triggered monitors][8], or [manage downtime][9] pages. Learn more about monitor tags in the [tagging documentation][10].
 
 ## Further Reading
 
@@ -122,6 +124,7 @@ Monitor tags are independent of tags sent by the Agent or integrations. Add tags
 [4]: https://www.elastic.co/guide/en/elasticsearch/reference/2.4/query-dsl-query-string-query.html#_fuzziness
 [5]: /monitors/monitor_types/
 [6]: /monitors/monitor_status/#resolve
-[7]: https://app.datadoghq.com/monitors/triggered
-[8]: https://app.datadoghq.com/monitors#downtime
-[9]: /getting_started/tagging/assigning_tags/?tab=monitors#ui
+[7]: /mobile/#monitors
+[8]: https://app.datadoghq.com/monitors/triggered
+[9]: https://app.datadoghq.com/monitors#downtime
+[10]: /getting_started/tagging/assigning_tags/?tab=monitors#ui


### PR DESCRIPTION
Added a quick reference to the mobile app in the Monitors #manage section for increased visibility for the features supported by the mobile app.

Updated link indices with addition of /mobile/#monitors

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nicolasmachado/adding_mobile_monitors/monitors/manage_monitor

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
