### PR TITLE
Add connection churn metrics to NPM docs

### DIFF
--- a/content/en/network_performance_monitoring/network_page.md
+++ b/content/en/network_performance_monitoring/network_page.md
@@ -80,7 +80,8 @@ The following network load metrics are available:
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Volume**      | The number of bytes sent or received over a period. Measured in bytes (or orders of magnitude thereof) bidirectional.                           |
 |  **Throughput** | The rate of bytes sent or received over a period. Measured in bytes per second, bidirectional.                                                  |
-
+|  **Established Connections**         | Number of TCP connections in an established state. Measured in connections per second from the `source`.                                                                                                              |
+|  **Closed Connections**         | Number of TCP connections in a closed state. Measured in connections per second from the `source`.                                                                                                            |
 #### TCP
 
 TCP is a connection-oriented protocol that guarantees in-order delivery of packets. The following TCP metrics are available:

--- a/content/en/network_performance_monitoring/network_page.md
+++ b/content/en/network_performance_monitoring/network_page.md
@@ -81,7 +81,7 @@ The following network load metrics are available:
 | **Volume**      | The number of bytes sent or received over a period. Measured in bytes (or orders of magnitude thereof) bidirectional.                           |
 |  **Throughput** | The rate of bytes sent or received over a period. Measured in bytes per second, bidirectional.                                                  |
 |  **Established Connections**         | The number of TCP connections in an established state. Measured in connections per second from the `source`.                                                                                                              |
-|  **Closed Connections**         | Number of TCP connections in a closed state. Measured in connections per second from the `source`.                                                                                                            |
+|  **Closed Connections**         | The number of TCP connections in a closed state. Measured in connections per second from the `source`.                                                                                                            |
 #### TCP
 
 TCP is a connection-oriented protocol that guarantees in-order delivery of packets. The following TCP metrics are available:

--- a/content/en/network_performance_monitoring/network_page.md
+++ b/content/en/network_performance_monitoring/network_page.md
@@ -80,7 +80,7 @@ The following network load metrics are available:
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Volume**      | The number of bytes sent or received over a period. Measured in bytes (or orders of magnitude thereof) bidirectional.                           |
 |  **Throughput** | The rate of bytes sent or received over a period. Measured in bytes per second, bidirectional.                                                  |
-|  **Established Connections**         | Number of TCP connections in an established state. Measured in connections per second from the `source`.                                                                                                              |
+|  **Established Connections**         | The number of TCP connections in an established state. Measured in connections per second from the `source`.                                                                                                              |
 |  **Closed Connections**         | Number of TCP connections in a closed state. Measured in connections per second from the `source`.                                                                                                            |
 #### TCP
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds docs for new NPM connection churn (established vs. closed tcp connections). 

### Motivation
These metrics are to be released this week (08/28). 

### Preview link
https://docs-staging.datadoghq.com/yael/documentation/connection_churn_metrics/content/en/network_performance_monitoring/network_page.md

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
N/A
