### PR TITLE
fix python variable issue in create_dashboard example

### DIFF
--- a/content/en/api/v1/dashboards/CreateDashboard.py
+++ b/content/en/api/v1/dashboards/CreateDashboard.py
@@ -27,7 +27,7 @@ template_variables = [{
     'default': 'my-host'
 }]
 
-saved_view = [{
+saved_views = [{
     'name': 'Saved views for hostname 2',
     'template_variables': [{'name': 'host', 'value': '<HOSTNAME_2>'}]}
 ]


### PR DESCRIPTION
Dashboard.create function uses variable 'saved_views' but the variable that is created was called saved_view. Updated to fix.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

adds an 's' to the saved_view variable in order to make the example functional.

### Motivation
<!-- What inspired you to submit this pull request?-->

example didn't work

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
