### PR TITLE
Update environment variables for APM and Process

### DIFF
--- a/content/en/agent/guide/environment-variables.md
+++ b/content/en/agent/guide/environment-variables.md
@@ -60,30 +60,34 @@ In general, use the following rules:
 
 ### Exceptions
 
-* Not all `datadog.yaml` options are available with environment variables. Refer to [config.go][4] in the Datadog Agent GitHub repo. Options with environment variables start with `config.BindEnv*`.
+- Not all `datadog.yaml` options are available with environment variables. Refer to [config.go][4] in the Datadog Agent GitHub repo. Options with environment variables start with `config.BindEnv*`.
 
-* Component-specific environment variables not listed in [config.go][4] may also be supported.
-  * APM Trace Agent
-    - [Docker APM Agent Environment Variables][5]
-    - [trace-agent env.go][6]
-    - example
-      ```yaml
-        apm_config:
-          enabled: true
-          env: dev
-        # DD_APM_ENABLED=true
-        # DD_APM_ENV=dev
-      ```
-  * Live Process Agent
-    - [process-agent config.go][7]
-    - example
-      ```yaml
-        process_config:
-          enabled: true
-          process_dd_url: https://process.datadoghq.com
-        # DD_PROCESS_AGENT_ENABLED=true
-        # DD_PROCESS_AGENT_URL=https://process.datadoghq.com
-      ```
+- Component-specific environment variables not listed in [config.go][4] may also be supported.
+ 
+  - **APM Trace Agent**
+
+      - [Docker APM Agent Environment Variables][5]
+      - [trace-agent env.go][6]
+      - example
+        ```yaml
+          apm_config:
+            enabled: true
+            env: dev
+          # DD_APM_ENABLED=true
+          # DD_APM_ENV=dev
+        ```
+
+  - **Live Process Agent**
+  
+      - [process-agent config.go][7]
+      - example
+        ```yaml
+          process_config:
+            enabled: true
+            process_dd_url: https://process.datadoghq.com
+          # DD_PROCESS_AGENT_ENABLED=true
+          # DD_PROCESS_AGENT_URL=https://process.datadoghq.com
+        ```
     
 
 ## Further Reading

--- a/content/en/agent/guide/environment-variables.md
+++ b/content/en/agent/guide/environment-variables.md
@@ -69,26 +69,27 @@ In general, use the following rules:
       - [Docker APM Agent Environment Variables][5]
       - [trace-agent env.go][6]
       - example
+
         ```yaml
-          apm_config:
+        apm_config:
             enabled: true
             env: dev
-          # DD_APM_ENABLED=true
-          # DD_APM_ENV=dev
+        # DD_APM_ENABLED=true
+        # DD_APM_ENV=dev
         ```
 
   - **Live Process Agent**
-  
+
       - [process-agent config.go][7]
       - example
+
         ```yaml
-          process_config:
+        process_config:
             enabled: true
             process_dd_url: https://process.datadoghq.com
-          # DD_PROCESS_AGENT_ENABLED=true
-          # DD_PROCESS_AGENT_URL=https://process.datadoghq.com
+        # DD_PROCESS_AGENT_ENABLED=true
+        # DD_PROCESS_AGENT_URL=https://process.datadoghq.com
         ```
-    
 
 ## Further Reading
 

--- a/content/en/agent/guide/environment-variables.md
+++ b/content/en/agent/guide/environment-variables.md
@@ -60,14 +60,31 @@ In general, use the following rules:
 
 ### Exceptions
 
-* For the collection Agents (APM, process, and logs), drop the `_config` in the option name, for example:
-    ```yaml
-      apm_config:
-        enabled: true
-      # DD_APM_ENABLED=true
-    ```
-
 * Not all `datadog.yaml` options are available with environment variables. Refer to [config.go][4] in the Datadog Agent GitHub repo. Options with environment variables start with `config.BindEnv*`.
+
+* Component-specific environment variables not listed in [config.go][4] may also be supported.
+  * APM Trace Agent
+    - [Docker APM Agent Environment Variables][5]
+    - [trace-agent env.go][6]
+    - example
+      ```yaml
+        apm_config:
+          enabled: true
+          env: dev
+        # DD_APM_ENABLED=true
+        # DD_APM_ENV=dev
+      ```
+  * Live Process Agent
+    - [process-agent config.go][7]
+    - example
+      ```yaml
+        process_config:
+          enabled: true
+          process_dd_url: https://process.datadoghq.com
+        # DD_PROCESS_AGENT_ENABLED=true
+        # DD_PROCESS_AGENT_URL=https://process.datadoghq.com
+      ```
+    
 
 ## Further Reading
 
@@ -77,3 +94,6 @@ In general, use the following rules:
 [2]: /getting_started/tagging/unified_service_tagging
 [3]: /agent/proxy/#environment-variables
 [4]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config.go
+[5]: https://docs.datadoghq.com/agent/docker/apm/#docker-apm-agent-environment-variables
+[6]: https://github.com/DataDog/datadog-agent/blob/master/pkg/trace/config/env.go
+[7]: https://github.com/DataDog/datadog-agent/blob/master/pkg/process/config/config.go

--- a/content/en/agent/guide/environment-variables.md
+++ b/content/en/agent/guide/environment-variables.md
@@ -70,26 +70,26 @@ In general, use the following rules:
       - [trace-agent env.go][6]
       - example
 
-        ```yaml
-        apm_config:
-            enabled: true
-            env: dev
-        # DD_APM_ENABLED=true
-        # DD_APM_ENV=dev
-        ```
+          ```yaml
+             apm_config:
+                 enabled: true
+                 env: dev
+             # DD_APM_ENABLED=true
+             # DD_APM_ENV=dev
+          ```
 
   - **Live Process Agent**
 
       - [process-agent config.go][7]
       - example
 
-        ```yaml
-        process_config:
-            enabled: true
-            process_dd_url: https://process.datadoghq.com
-        # DD_PROCESS_AGENT_ENABLED=true
-        # DD_PROCESS_AGENT_URL=https://process.datadoghq.com
-        ```
+          ```yaml
+             process_config:
+                 enabled: true
+                 process_dd_url: https://process.datadoghq.com
+             # DD_PROCESS_AGENT_ENABLED=true
+             # DD_PROCESS_AGENT_URL=https://process.datadoghq.com
+          ```
 
 ## Further Reading
 


### PR DESCRIPTION
# What does this PR do?

Corrects exception. dropping `_config` is inaccurate and actually depends if other components process other `DD_` envvars.

Logs Agent, as of this writing, does not have anything specific and follows `DD_LOGS_CONFIG_*`

### Motivation


### Preview link

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ian.bucad/DD_envvar/agent/guide/environment-variables/

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
