### PR TITLE
Remove URL scheme from logs_dd_url

### DIFF
--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -452,7 +452,8 @@ process_config:
 
 logs_config:
     use_http: true
-    logs_dd_url: http://haproxy.example.com:3837
+    logs_dd_url: haproxy.example.com:3837
+    logs_no_ssl: true
 ```
 
 Then edit the `datadog.yaml` Agent configuration file and set `skip_ssl_validation` to `true`. This is needed to make the Agent ignore the discrepancy between the hostname on the SSL certificate (`app.datadoghq.com` or `app.datadoghq.eu`) and your HAProxy hostname:
@@ -633,9 +634,9 @@ To use the Datadog Agent v6/7.16+ as the logs collector, instruct the Agent to u
 
 ```yaml
 logs_config:
-  logs_no_ssl: true
-  logs_dd_url: "<PROXY_SERVER_DOMAIN>:3837"
   use_http: true
+  logs_dd_url: "<PROXY_SERVER_DOMAIN>:3837"
+  logs_no_ssl: true
 ```
 
 When sending logs over TCP, refer to <a href="/agent/logs/proxy">TCP Proxy for Logs</a> page.


### PR DESCRIPTION

### What does this PR do?
`logs_config.logs_dd_url` must have `<HOST>:<PORT>` format without the scheme since it can be either TCP or HTTPS

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ian.bucad/logs_proxy_url/agent/proxy

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
