### PR TITLE
Add limits back into each part

### DIFF
--- a/content/en/logs/explorer/facets.md
+++ b/content/en/logs/explorer/facets.md
@@ -142,7 +142,7 @@ The index facet is a specific facet that appears only if your organization has [
 
 As a matter of good practice, always consider using an existing facet rather than creating a new one (see the [alias facets](#alias-facets) section). Using a unique facet for information of a similar nature fosters cross-team collaboration.
 
-**Note**: Once a facet is created, its content is populated **for all new logs** flowing in **either** index. For an optimal usage of the Log Management solution, we recommend using at most 1000 facets.
+**Note**: Once a facet is created, its content is populated **for all new logs** flowing in **either** index. For an optimal usage of the Log Management solution, Datadog recommends using at most 1000 facets.
 
 #### From log side panel
 

--- a/content/en/logs/explorer/facets.md
+++ b/content/en/logs/explorer/facets.md
@@ -142,7 +142,7 @@ The index facet is a specific facet that appears only if your organization has [
 
 As a matter of good practice, always consider using an existing facet rather than creating a new one (see the [alias facets](#alias-facets) section). Using a unique facet for information of a similar nature fosters cross-team collaboration.
 
-**Note**: Once a facet is created, its content is populated **for all new logs** flowing in **either** index.
+**Note**: Once a facet is created, its content is populated **for all new logs** flowing in **either** index. For an optimal usage of the Log Management solution, we recommend using at most 1000 facets.
 
 #### From log side panel
 

--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -283,6 +283,15 @@ For integration frameworks, Datadog provides guidelines on how to log JSON into 
 
 Datadog automatically parses JSON-formatted logs. For this reason, if you have control over the log format you send to Datadog, it is recommended to format these logs as JSON to avoid the need for custom parsing rules.
 
+### Limits applied to ingested log events
+
+* For an optimal use of the platform, we recommend that the size of a log event should not exceed 25K bytes. When using the Datadog Agent, log events larger than 256KB are split into several entries. When using the Datadog TCP or HTTP API directly, log events up to 1MB are accepted by the API.
+* Log events can be submitted up to 18h in the past and 2h in the future.
+* A log event once converted to JSON format should contain less than 256 attributes. Each of those attribute's keys should be less than 50 characters, be nested in less than 10 successive levels, and their respective value should be less than 1024 characters if promoted as a facet.
+* A log event should not have more than 100 tags and each tag should not exceed 256 characters for a maximum of 10 million unique tags per day.
+
+Log events which do not comply with these limits might be transformed or truncated by the system-or simply not indexed if outside of the provided time range. However, Datadog always tries to do its best to preserve as much as possible to preserve provided user data.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -285,12 +285,12 @@ Datadog automatically parses JSON-formatted logs. For this reason, if you have c
 
 ### Limits applied to ingested log events
 
-* For an optimal use of the platform, we recommend that the size of a log event should not exceed 25K bytes. When using the Datadog Agent, log events larger than 256KB are split into several entries. When using the Datadog TCP or HTTP API directly, log events up to 1MB are accepted by the API.
+* For optimal use, Datadog recommends a log event should not exceed 25K bytes in size. When using the Datadog Agent, log events greater than 256KB are split into several entries. When using the Datadog TCP or HTTP API directly, log events up to 1MB are accepted.
 * Log events can be submitted up to 18h in the past and 2h in the future.
-* A log event once converted to JSON format should contain less than 256 attributes. Each of those attribute's keys should be less than 50 characters, be nested in less than 10 successive levels, and their respective value should be less than 1024 characters if promoted as a facet.
+* A log event converted to JSON format should contain less than 256 attributes. Each of those attribute's keys should be less than 50 characters, nested in less than 10 successive levels, and their respective value should be less than 1024 characters if promoted as a facet.
 * A log event should not have more than 100 tags and each tag should not exceed 256 characters for a maximum of 10 million unique tags per day.
 
-Log events which do not comply with these limits might be transformed or truncated by the system-or simply not indexed if outside of the provided time range. However, Datadog always tries to do its best to preserve as much as possible to preserve provided user data.
+Log events that do not comply with these limits might be transformed or truncated by the system or not indexed if outside the provided time range. However, Datadog tries to preserve as much user data as possible.
 
 ## Further Reading
 

--- a/content/en/logs/processing/_index.md
+++ b/content/en/logs/processing/_index.md
@@ -69,6 +69,9 @@ To discover the full list of Processors available, refer to the dedicated [Proce
 
 If you want to learn more about pure parsing possibilities of the Datadog application, follow the [parsing training guide][9]. There is also a [parsing best practice][10] and [parsing troubleshooting][11] guide.
 
+For an optimal usage of the Log Management solution, we recommend using at most 20 Processors per Pipeline and using at most 10 parsing rules within a grok Processor. 
+We reserve the right to disable underperforming parsing rules, processors, or pipelines that might impact Datadog's service performance.
+
 ## Reserved attributes
 
 If your logs are formatted as JSON, be aware that some attributes are reserved for use by Datadog and are faceted by default:

--- a/content/en/logs/processing/_index.md
+++ b/content/en/logs/processing/_index.md
@@ -69,8 +69,8 @@ To discover the full list of Processors available, refer to the dedicated [Proce
 
 If you want to learn more about pure parsing possibilities of the Datadog application, follow the [parsing training guide][9]. There is also a [parsing best practice][10] and [parsing troubleshooting][11] guide.
 
-For an optimal usage of the Log Management solution, we recommend using at most 20 Processors per Pipeline and using at most 10 parsing rules within a grok Processor. 
-We reserve the right to disable underperforming parsing rules, processors, or pipelines that might impact Datadog's service performance.
+For optimal usage of the Log Management solution, Datadog recommends using at most 20 processors per pipeline and 10 parsing rules within a grok processor. 
+Datadog reserves the right to disable underperforming parsing rules, processors, or pipelines that might impact Datadog's service performance.
 
 ## Reserved attributes
 


### PR DESCRIPTION
### What does this PR do?
Add limit instruction back into each specific page of the documentation where it make sense.

### Motivation
It is important to be aware of what can be done.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/limits/logs/

https://docs-staging.datadoghq.com/nils/limits/logs/processing/#custom-logs

https://docs-staging.datadoghq.com/nils/limits/logs/explorer/facets/

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
