### PR TITLE
updates the options hash

### DIFF
--- a/content/en/api/v1/dashboards/CreateDashboard.rb
+++ b/content/en/api/v1/dashboards/CreateDashboard.rb
@@ -33,9 +33,9 @@ saved_view = [{
   ]
 
 dog.create_board(title, widgets, layout_type, {
-    'description' => description,
-    'is_read_only' => is_read_only,
-    'notify_list' => notify_list,
-    'template_variables' => template_variables,
-    'template_variable_presets' => saved_view
+    :description => description,
+    :is_read_only => is_read_only,
+    :notify_list => notify_list,
+    :template_variables => template_variables,
+    :template_variable_presets => saved_view
     })


### PR DESCRIPTION
currently this hash is using string 'keys', but when we look through this structure to append them to the request body, we search for :keys. This means that the options aren't actually sent to the api and therefor elements like db descriptions and template variables are not created.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Updates the hash values of the options argument so that the key values correspond to what the gem looks for as it builds the request body.

### Motivation
<!-- What inspired you to submit this pull request?-->

Investigation from [Zendesk Ticket](https://datadog.zendesk.com/agent/tickets/388749)

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
