### PR TITLE
remove rehydration from prohibit list

### DIFF
--- a/content/en/security/logs.md
+++ b/content/en/security/logs.md
@@ -54,7 +54,6 @@ With the Docker Agent, pass in `DD_LOGS_CONFIG_LOGS_DD_URL=tcp-encrypted-intake.
 Additionally, certain features are not available at the moment to customers who have signed Datadog's BAA, notably:
 
 * Users cannot request support via chat
-* Rehydration from Log Archives is disabled
 * Generation of metrics from logs is disabled
 * Notifications from Log Monitors cannot include log samples
 * Log Monitors cannot be configured with a `group-by` clause


### PR DESCRIPTION
### What does this PR do?
removes rehydration from restriction list for hipaa orgs now that it is available everywhere

### Preview link
https://docs-staging.datadoghq.com/michaelw/rehydration-now-available/security/logs/#configuration-requirements-for-hipaa-enabled-customers
