### PR TITLE
fix indentation in config snippet

### DIFF
--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -326,7 +326,7 @@ Set the following configuration in the Agent's [main configuration file][1]:
 
 ```yaml
 env: <ENV>
-  tags:
+tags:
     - service: <SERVICE>
 ```
 


### PR DESCRIPTION
Fixes a small indentation bug that can cause the agent to fail on reading config.
