### PR TITLE
Setup Log Archives for GovCloud accounts

### DIFF
--- a/content/en/logs/archives/_index.md
+++ b/content/en/logs/archives/_index.md
@@ -36,7 +36,9 @@ Go into your [AWS console][1] and [create an S3 bucket][2] to send your archives
 
 Next, grant Datadog permissions to write log archives to your S3 bucket with role delegation:
 
-1. Set up the [AWS integration][3] for the AWS account that holds your S3 bucket. This involves [creating a role][4] that Datadog can use to integrate with AWS S3.
+### Configure Accesses
+
+1. Set up the [AWS integration][3] for the AWS account that holds your S3 bucket. In the general case, this involves creating a role that Datadog can use to integrate with AWS S3.
 
 2. Add the following two permission statements to [the IAM policies of your Datadog role][4]. Edit the bucket names and, if desired, specify the paths that contain your log archives. The `GetObject` and `ListBucket` permissions allow for [Rehydrating from Archives][5]. The `PutObject` permission is sufficient for uploading archives.
 
@@ -66,9 +68,14 @@ Next, grant Datadog permissions to write log archives to your S3 bucket with rol
     }
     ```
 
-3. Go to your [Archives page][6] in Datadog and select the **Add a new archive** option at the bottom. Only Datadog users with admin status can complete this and the following step.
+https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
+https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_change-permissions.html
 
-4. Select the appropriate AWS account + role combination for your S3 bucket. Input your bucket name. Optionally input a prefix directory for all the content of your log archives. Save your archive, and you are finished.
+### Datadog Log Archive 
+
+Go to your [Archives page][6] in Datadog and select the **Add a new archive** option at the bottom. Only Datadog users with admin status can complete this and the following step.
+
+Select the appropriate AWS account + role combination for your S3 bucket. Input your bucket name. Optionally input a prefix directory for all the content of your log archives. Save your archive, and you are finished.
 
     {{< img src="logs/archives/log_archives_s3_datadog_settings_role_delegation.png" alt="Set your S3 bucket info in Datadog"  style="width:75%;">}}
 
@@ -147,7 +154,7 @@ Alternatively, Datadog supports server side encryption with a CMK from [AWS KMS]
 
 [1]: https://s3.console.aws.amazon.com/s3
 [2]: https://docs.aws.amazon.com/AmazonS3/latest/user-guide/create-bucket.html
-[3]: https://app.datadoghq.com/account/settings#integrations/amazon-web-services
+[3]: integrations/amazon_web_services/?tab=automaticcloudformation#setup
 [4]: /integrations/amazon_web_services/?tab=allpermissions#installation
 [5]: /logs/archives/rehydrating/
 [6]: https://app.datadoghq.com/logs/pipelines/archives

--- a/content/en/logs/archives/_index.md
+++ b/content/en/logs/archives/_index.md
@@ -32,13 +32,16 @@ This guide shows you how to set up an archive for forwarding ingested logs to yo
 {{< tabs >}}
 {{% tab "AWS S3" %}}
 
+
 ### Create a S3 Bucket
 
 Go into your [AWS console][1] and [create an S3 bucket][2] to send your archives to. Be careful not to make your bucket publicly readable.
 
 #### Storage Class
 
-You can [set a lifecycle configuration on your S3 bucket][7] to automatically transition your log archives to optimal storage classes. [Rehydration][5] supports all storage classes except for Glacier and Glacier Deep Archive. If you wish to rehydrate from archives in the Glacier or Glacier Deep Archive storage classes, you must first move them to a different storage class.
+You can [set a lifecycle configuration on your S3 bucket][7] to automatically transition your log archives to optimal storage classes. 
+
+[Rehydration][5] supports all storage classes except for Glacier and Glacier Deep Archive. If you wish to rehydrate from archives in the Glacier or Glacier Deep Archive storage classes, you must first move them to a different storage class.
 
 #### Server side encryption (SSE)
 
@@ -109,7 +112,6 @@ Alternatively, Datadog supports server side encryption with a CMK from [AWS KMS]
 
 3. Go to the **Properties** tab in your S3 bucket and select **Default Encryption**. Choose the "AWS-KMS" option, select your CMK ARN, and save.
 
-
 ### Configure a Log Archive
 
 #### Set AWS Integration
@@ -117,7 +119,7 @@ Alternatively, Datadog supports server side encryption with a CMK from [AWS KMS]
 If not already configured, set up the [AWS integration][3] for the AWS account that holds your S3 bucket. 
 
 * In the general case, this involves creating a role that Datadog can use to integrate with AWS S3.
-* Specifically for AWS GovCloud or China accounts, use Access Key alternative.
+* Specifically for AWS GovCloud or China accounts, use Access Keys as an alternative to Role Delegation.
 
 #### Create an Archive
 
@@ -127,9 +129,7 @@ Select the appropriate AWS account + role combination for your S3 bucket. Input 
 
     {{< img src="logs/archives/log_archives_s3_datadog_settings_role_delegation.png" alt="Set your S3 bucket info in Datadog"  style="width:75%;">}}
 
-### Permissions
-
-Next, grant Datadog permissions to write log archives to your S3 bucket with role delegation.
+### Set Permissions
 
 Add the following two permission statements to the IAM policies. Edit the bucket names and, if desired, specify the paths that contain your log archives. The `GetObject` and `ListBucket` permissions allow for [Rehydrating from Archives][5]. The `PutObject` permission is sufficient for uploading archives.
 

--- a/content/en/logs/archives/_index.md
+++ b/content/en/logs/archives/_index.md
@@ -39,22 +39,22 @@ Go into your [AWS console][1] and [create an S3 bucket][2] to send your archives
 
 #### Storage Class
 
-You can [set a lifecycle configuration on your S3 bucket][7] to automatically transition your log archives to optimal storage classes. 
+You can [set a lifecycle configuration on your S3 bucket][3] to automatically transition your log archives to optimal storage classes. 
 
-[Rehydration][5] supports all storage classes except for Glacier and Glacier Deep Archive. If you wish to rehydrate from archives in the Glacier or Glacier Deep Archive storage classes, you must first move them to a different storage class.
+[Rehydration][4] supports all storage classes except for Glacier and Glacier Deep Archive. If you wish to rehydrate from archives in the Glacier or Glacier Deep Archive storage classes, you must first move them to a different storage class.
 
 #### Server side encryption (SSE)
 
 ##### SSE-S3
 
-The easiest method to add server side encryption to your S3 log archives is with S3's native server side encryption, [SSE-S3][8]. 
+The easiest method to add server side encryption to your S3 log archives is with S3's native server side encryption, [SSE-S3][5]. 
 To enable it, go to the **Properties** tab in your S3 bucket and select **Default Encryption**. Select the `AES-256` option and **Save**.
 
 {{< img src="logs/archives/log_archives_s3_encryption.png" alt="Select the AES-256 option and Save."  style="width:75%;">}}
 
 ##### SSE-KMS
 
-Alternatively, Datadog supports server side encryption with a CMK from [AWS KMS][9]. To enable it, take the following steps:
+Alternatively, Datadog supports server side encryption with a CMK from [AWS KMS][6]. To enable it, take the following steps:
 
 1. Create your CMK
 2. Attach a CMK policy to your CMK with the following content, replacing the AWS account number and Datadog IAM role name approproiately:
@@ -116,22 +116,22 @@ Alternatively, Datadog supports server side encryption with a CMK from [AWS KMS]
 
 #### Set AWS Integration
 
-If not already configured, set up the [AWS integration][3] for the AWS account that holds your S3 bucket. 
+If not already configured, set up the [AWS integration][7] for the AWS account that holds your S3 bucket. 
 
 * In the general case, this involves creating a role that Datadog can use to integrate with AWS S3.
 * Specifically for AWS GovCloud or China accounts, use Access Keys as an alternative to Role Delegation.
 
 #### Create an Archive
 
-Go to your [Archives page][6] in Datadog and select the **Add a new archive** option at the bottom. Only Datadog users with admin status can complete this and the following step.
+Go to your [Archives page][8] in Datadog and select the **Add a new archive** option at the bottom. Only Datadog users with admin status can complete this and the following step.
 
 Select the appropriate AWS account + role combination for your S3 bucket. Input your bucket name. Optionally input a prefix directory for all the content of your log archives. Save your archive, and you are finished.
 
-    {{< img src="logs/archives/log_archives_s3_datadog_settings_role_delegation.png" alt="Set your S3 bucket info in Datadog"  style="width:75%;">}}
+  {{< img src="logs/archives/log_archives_s3_datadog_settings_role_delegation.png" alt="Set your S3 bucket info in Datadog"  style="width:75%;">}}
 
 ### Set Permissions
 
-Add the following two permission statements to the IAM policies. Edit the bucket names and, if desired, specify the paths that contain your log archives. The `GetObject` and `ListBucket` permissions allow for [Rehydrating from Archives][5]. The `PutObject` permission is sufficient for uploading archives.
+Add the following two permission statements to the IAM policies. Edit the bucket names and, if desired, specify the paths that contain your log archives. The `GetObject` and `ListBucket` permissions allow for [Rehydrating from Archives][4]. The `PutObject` permission is sufficient for uploading archives.
 
     ```json
     {
@@ -159,16 +159,15 @@ Add the following two permission statements to the IAM policies. Edit the bucket
     }
     ```
 
+
 [1]: https://s3.console.aws.amazon.com/s3
 [2]: https://docs.aws.amazon.com/AmazonS3/latest/user-guide/create-bucket.html
-[3]: integrations/amazon_web_services/?tab=automaticcloudformation#setup
-[4]: /integrations/amazon_web_services/?tab=allpermissions#installation
-[5]: /logs/archives/rehydrating/
-[6]: https://app.datadoghq.com/logs/pipelines/archives
-[7]: https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-set-lifecycle-configuration-intro.html
-[8]: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html
-[9]: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html
-
+[3]: https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-set-lifecycle-configuration-intro.html
+[4]: /logs/archives/rehydrating/
+[5]: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html
+[6]: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html
+[7]: integrations/amazon_web_services/?tab=automaticcloudformation#setup
+[8]: https://app.datadoghq.com/logs/pipelines/archives
 {{% /tab %}}
 
 {{% tab "Azure Storage" %}}

--- a/content/en/logs/archives/_index.md
+++ b/content/en/logs/archives/_index.md
@@ -32,67 +32,24 @@ This guide shows you how to set up an archive for forwarding ingested logs to yo
 {{< tabs >}}
 {{% tab "AWS S3" %}}
 
+### Create a S3 Bucket
+
 Go into your [AWS console][1] and [create an S3 bucket][2] to send your archives to. Be careful not to make your bucket publicly readable.
 
-Next, grant Datadog permissions to write log archives to your S3 bucket with role delegation:
-
-### Configure Accesses
-
-1. Set up the [AWS integration][3] for the AWS account that holds your S3 bucket. In the general case, this involves creating a role that Datadog can use to integrate with AWS S3.
-
-2. Add the following two permission statements to [the IAM policies of your Datadog role][4]. Edit the bucket names and, if desired, specify the paths that contain your log archives. The `GetObject` and `ListBucket` permissions allow for [Rehydrating from Archives][5]. The `PutObject` permission is sufficient for uploading archives.
-
-    ```json
-    {
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Sid": "DatadogUploadAndRehydrateLogArchives",
-          "Effect": "Allow",
-          "Action": ["s3:PutObject", "s3:GetObject"],
-          "Resource": [
-            "arn:aws:s3:::<MY_BUCKET_NAME_1_/_MY_OPTIONAL_BUCKET_PATH_1>/*",
-            "arn:aws:s3:::<MY_BUCKET_NAME_2_/_MY_OPTIONAL_BUCKET_PATH_2>/*"
-          ]
-        },
-        {
-          "Sid": "DatadogRehydrateLogArchivesListBucket",
-          "Effect": "Allow",
-          "Action": "s3:ListBucket",
-          "Resource": [
-            "arn:aws:s3:::<MY_BUCKET_NAME_1>",
-            "arn:aws:s3:::<MY_BUCKET_NAME_2>"
-          ]
-        }
-      ]
-    }
-    ```
-
-https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
-https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_change-permissions.html
-
-### Datadog Log Archive 
-
-Go to your [Archives page][6] in Datadog and select the **Add a new archive** option at the bottom. Only Datadog users with admin status can complete this and the following step.
-
-Select the appropriate AWS account + role combination for your S3 bucket. Input your bucket name. Optionally input a prefix directory for all the content of your log archives. Save your archive, and you are finished.
-
-    {{< img src="logs/archives/log_archives_s3_datadog_settings_role_delegation.png" alt="Set your S3 bucket info in Datadog"  style="width:75%;">}}
-
-### Storage Class
+#### Storage Class
 
 You can [set a lifecycle configuration on your S3 bucket][7] to automatically transition your log archives to optimal storage classes. [Rehydration][5] supports all storage classes except for Glacier and Glacier Deep Archive. If you wish to rehydrate from archives in the Glacier or Glacier Deep Archive storage classes, you must first move them to a different storage class.
 
-### Server side encryption (SSE)
+#### Server side encryption (SSE)
 
-#### SSE-S3
+##### SSE-S3
 
 The easiest method to add server side encryption to your S3 log archives is with S3's native server side encryption, [SSE-S3][8]. 
 To enable it, go to the **Properties** tab in your S3 bucket and select **Default Encryption**. Select the `AES-256` option and **Save**.
 
 {{< img src="logs/archives/log_archives_s3_encryption.png" alt="Select the AES-256 option and Save."  style="width:75%;">}}
 
-#### SSE-KMS
+##### SSE-KMS
 
 Alternatively, Datadog supports server side encryption with a CMK from [AWS KMS][9]. To enable it, take the following steps:
 
@@ -152,6 +109,56 @@ Alternatively, Datadog supports server side encryption with a CMK from [AWS KMS]
 
 3. Go to the **Properties** tab in your S3 bucket and select **Default Encryption**. Choose the "AWS-KMS" option, select your CMK ARN, and save.
 
+
+### Configure a Log Archive
+
+#### Set AWS Integration
+
+If not already configured, set up the [AWS integration][3] for the AWS account that holds your S3 bucket. 
+
+* In the general case, this involves creating a role that Datadog can use to integrate with AWS S3.
+* Specifically for AWS GovCloud or China accounts, use Access Key alternative.
+
+#### Create an Archive
+
+Go to your [Archives page][6] in Datadog and select the **Add a new archive** option at the bottom. Only Datadog users with admin status can complete this and the following step.
+
+Select the appropriate AWS account + role combination for your S3 bucket. Input your bucket name. Optionally input a prefix directory for all the content of your log archives. Save your archive, and you are finished.
+
+    {{< img src="logs/archives/log_archives_s3_datadog_settings_role_delegation.png" alt="Set your S3 bucket info in Datadog"  style="width:75%;">}}
+
+### Permissions
+
+Next, grant Datadog permissions to write log archives to your S3 bucket with role delegation.
+
+Add the following two permission statements to the IAM policies. Edit the bucket names and, if desired, specify the paths that contain your log archives. The `GetObject` and `ListBucket` permissions allow for [Rehydrating from Archives][5]. The `PutObject` permission is sufficient for uploading archives.
+
+    ```json
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "DatadogUploadAndRehydrateLogArchives",
+          "Effect": "Allow",
+          "Action": ["s3:PutObject", "s3:GetObject"],
+          "Resource": [
+            "arn:aws:s3:::<MY_BUCKET_NAME_1_/_MY_OPTIONAL_BUCKET_PATH_1>/*",
+            "arn:aws:s3:::<MY_BUCKET_NAME_2_/_MY_OPTIONAL_BUCKET_PATH_2>/*"
+          ]
+        },
+        {
+          "Sid": "DatadogRehydrateLogArchivesListBucket",
+          "Effect": "Allow",
+          "Action": "s3:ListBucket",
+          "Resource": [
+            "arn:aws:s3:::<MY_BUCKET_NAME_1>",
+            "arn:aws:s3:::<MY_BUCKET_NAME_2>"
+          ]
+        }
+      ]
+    }
+    ```
+
 [1]: https://s3.console.aws.amazon.com/s3
 [2]: https://docs.aws.amazon.com/AmazonS3/latest/user-guide/create-bucket.html
 [3]: integrations/amazon_web_services/?tab=automaticcloudformation#setup
@@ -161,6 +168,7 @@ Alternatively, Datadog supports server side encryption with a CMK from [AWS KMS]
 [7]: https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-set-lifecycle-configuration-intro.html
 [8]: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html
 [9]: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html
+
 {{% /tab %}}
 
 {{% tab "Azure Storage" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Detail how to configure Log Archive and Rehydration for S3 buckets held in AWS China or GovCloud.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/pcarioufr/archives_accesskeys/logs/archives/?tab=awss3

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
