### PR TITLE
zach groves switch paragraphs to clarify Java log injection steps

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/java.md
+++ b/content/en/tracing/connect_logs_and_traces/java.md
@@ -21,13 +21,13 @@ further_reading:
 
 Enable injection in the Java tracer's [configuration][1] by adding `-Ddd.logs.injection=true` as a jvm startup argument or through environment variable `DD_LOGS_INJECTION=true`.
 
+If your logs are JSON formated and you are using Logback there is nothing left to do. Otherwise with other logging libraries you need to activate MDC attributes autoinjection into your logs.
+
 If your logs are raw formatted, update your formatter to include `dd.trace_id` and `dd.span_id` in your logger configuration:
 
 ```xml
 <Pattern>"%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %X{dd.trace_id:-0} %X{dd.span_id:-0} - %m%n"</Pattern>
 ```
-
-If your logs are JSON formated and you are using Logback there is nothing left to do. Otherwise with other logging libraries you need to activate MDC attributes autoinjection into your logs.
 
 **Note**: If the `attribute.path` for your trace ID is **not** `dd.trace_id`, ensure your trace ID reserved attribute settings account for the `attribute.path`. More information can be found in the [FAQ on this topic][2].
 


### PR DESCRIPTION
### What does this PR do?
It clarifies the steps necesarry to setup trace id injection if the customer is using logback. If they're using json formatted logs, all they have to do is set -Ddd.logs.injection=true. They don't have to change their pattern at all. If the are using raw formatted logs, they have to change the pattern. The paragraph structure before made this a bit confusing. Since the step to change the pattern, came before telling the customer there was nothing left to do, it made it seem like maybe you always had to change the pattern.
### Motivation
A bit of confusion during my own setup.

