### PR TITLE
Add ScalikeJDBC note under supported jdbc drivers

### DIFF
--- a/content/en/tracing/compatibility_requirements/java.md
+++ b/content/en/tracing/compatibility_requirements/java.md
@@ -126,6 +126,7 @@ Don't see your desired networking framework? Datadog is continually adding addit
 - MySQL
 - Oracle
 - Postgres SQL
+- ScalikeJDBC
 
 Don't see your desired datastores? Datadog is continually adding additional support. Contact [Datadog support][2] if you need help.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add ScalikeJDBC note under supported jdbc drivers.

### Motivation
<!-- What inspired you to submit this pull request?-->
Support was added for this db here in 0.61.0 of the Java Agent.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/andrewsouthard1-patch-1/tracing/compatibility_requirements/java/

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
