### PR TITLE
Fix generated path for Go and Java examples

### DIFF
--- a/local/bin/awk/extract-code-blocks-go.awk
+++ b/local/bin/awk/extract-code-blocks-go.awk
@@ -12,7 +12,7 @@ function slug(value) {
     tail = value;
     while ( match(tail,/[[:upper:]][[:lower:]]/) ) {
         tgt = substr(tail,RSTART,1);
-        if ( substr(tail,RSTART-1,1) ~ /[[:lower:]]/ ) {
+        if ( substr(tail,RSTART-1,1) ~ /[[:lower:]]/ || RSTART > 1 ) {
             tgt = "-" tolower(tgt);
         }
         head = head substr(tail,1,RSTART-1) tgt;

--- a/local/bin/awk/extract-code-blocks-java.awk
+++ b/local/bin/awk/extract-code-blocks-java.awk
@@ -12,7 +12,7 @@ function slug(value) {
     tail = value;
     while ( match(tail,/[[:upper:]][[:lower:]]/) ) {
         tgt = substr(tail,RSTART,1);
-        if ( substr(tail,RSTART-1,1) ~ /[[:lower:]]/ ) {
+        if ( substr(tail,RSTART-1,1) ~ /[[:lower:]]/ || RSTART > 1 ) {
             tgt = "-" tolower(tgt);
         }
         head = head substr(tail,1,RSTART-1) tgt;


### PR DESCRIPTION
### What does this PR do?

Fixes issue with `slug` function for tags containing all-caps words (`AWS`, `GCP`, `IP`).

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jirikuncar/fix-examples/api/v1/ip-ranges/

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
