### PR TITLE
Move connection churn metrics to TCP section

### DIFF
--- a/content/en/network_performance_monitoring/network_page.md
+++ b/content/en/network_performance_monitoring/network_page.md
@@ -80,8 +80,7 @@ The following network load metrics are available:
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Volume**      | The number of bytes sent or received over a period. Measured in bytes (or orders of magnitude thereof) bidirectional.                           |
 |  **Throughput** | The rate of bytes sent or received over a period. Measured in bytes per second, bidirectional.                                                  |
-|  **Established Connections**         | The number of TCP connections in an established state. Measured in connections per second from the `source`.                                                                                                              |
-|  **Closed Connections**         | The number of TCP connections in a closed state. Measured in connections per second from the `source`.                                                                                                            |
+
 #### TCP
 
 TCP is a connection-oriented protocol that guarantees in-order delivery of packets. The following TCP metrics are available:
@@ -91,6 +90,8 @@ TCP is a connection-oriented protocol that guarantees in-order delivery of packe
 | **Retransmits**           | Retransmits represent detected failures that are retransmitted to ensure delivery. Measured in count of retransmits from the `source`. |
 | **Round-trip Time (RTT)** | Round-trip time is a proxy for latency. Measured as the time between a TCP frame being sent and acknowledged.                          |
 |  **RTT Variance**         | RTT is a proxy for jitter.                                                                                                             |
+|  **Established Connections**         | The number of TCP connections in an established state. Measured in connections per second from the `source`.                                                                                                              |
+|  **Closed Connections**         | The number of TCP connections in a closed state. Measured in connections per second from the `source`.                                                                                                            |
 
 ### DNS Resolution
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Moves established and closed connection metrics to be listed under TCP metrics. 

### Motivation
Connection churn metrics are TCP metrics. 

### Preview link
https://docs-staging.datadoghq.com/yael/connection_churn_edit/documentation/content/en/network_performance_monitoring/network_page.md

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
