### PR TITLE
Postgres note for logs rotation docs

### DIFF
--- a/content/en/logs/guide/setting-file-permissions-for-rotating-logs.md
+++ b/content/en/logs/guide/setting-file-permissions-for-rotating-logs.md
@@ -71,6 +71,8 @@ Check the ACL status of a file with:
 getfacl /var/log/apache/access.log
 ```
 
+**Note**: For **PostgreSQL v10** and older, set the permission to **0700**. For **PostgreSQL v11**, use either **0700** or **0750**. Trying to start a server with a base data folder that has permissions different from 0700 or 0750 will result in a failure of the postmater process.
+
 ## Setting permissions when ACLs are not present
 
 When ACLs are not present in a system, set your permissions based on group access.

--- a/content/en/logs/guide/setting-file-permissions-for-rotating-logs.md
+++ b/content/en/logs/guide/setting-file-permissions-for-rotating-logs.md
@@ -71,7 +71,7 @@ Check the ACL status of a file with:
 getfacl /var/log/apache/access.log
 ```
 
-**Note**: For **PostgreSQL v10** and older, set the permission to **0700**. For **PostgreSQL v11**, use either **0700** or **0750**. Trying to start a server with a base data folder that has permissions different from 0700 or 0750 will result in a failure of the postmater process.
+**Note**: For **PostgreSQL v10** and older, set the permission to **0700**. For **PostgreSQL v11**, set either **0700** or **0750**. Trying to start a server with a base data folder that has permissions different from 0700 or 0750 will result in a failure of the postmater process.
 
 ## Setting permissions when ACLs are not present
 


### PR DESCRIPTION
### What does this PR do?
Adds a Postgres versioning note to logs rotation docs so users are aware of the specific permissions they need to set to avoid errors.

### Motivation
Jira request

### Preview link
https://docs-staging.datadoghq.com/sarina/postgres-logs/logs/guide/setting-file-permissions-for-rotating-logs/#setting-permissions-using-acls