### PR TITLE
update gitlab image and node engines version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:zach_deps-fix
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
   tags:
     - "runner:main"
     - "size:large"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     },
     "homepage": "https://github.com/DataDog/corp-hugo#readme",
     "engines": {
-        "node": ">= 10.0.0"
+        "node": ">= 14.8.0"
     },
     "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^8.0.0",


### PR DESCRIPTION
### What does this PR do?
use master docker image, and update node engines to require min version.
### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
http://docs-staging.datadoghq.com/zach/master-image


