### PR TITLE
Reorg of ECS Content

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -248,7 +248,7 @@ main:
     parent: agent_kubernetes
     identifier: agent_kubernetes_data_collected
     weight: 306
-  - name: ECS
+  - name: Amazon ECS
     url: agent/amazon_ecs/
     parent: agent
     identifier: agent_amazon_ecs

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -248,63 +248,88 @@ main:
     parent: agent_kubernetes
     identifier: agent_kubernetes_data_collected
     weight: 306
+  - name: ECS
+    url: agent/amazon_ecs/
+    parent: agent
+    identifier: agent_amazon_ecs
+    weight: 4
+  - name: Log collection
+    url: agent/amazon_ecs/logs/
+    parent: agent_amazon_ecs
+    identifier: agent_amazon_ecs_logs
+    weight: 401
+  - name: APM
+    url: agent/amazon_ecs/apm/
+    parent: agent_amazon_ecs
+    identifier: agent_amazon_ecs_apm
+    weight: 402
+  - name: Tag extraction
+    url: agent/amazon_ecs/tags/
+    parent: agent_amazon_ecs
+    identifier: agent_amazon_ecs_tags
+    weight: 403
+  - name: Data collected
+    url: agent/amazon_ecs/data_collected/
+    parent: agent_amazon_ecs
+    identifier: agent_amazon_ecs_data_collected
+    weight: 404
   - name: Cluster Agent
     url: agent/cluster_agent/
     parent: agent
     identifier: agent_cluster
-    weight: 4
+    weight: 5
   - name: Setup
     url: agent/cluster_agent/setup/
     parent: agent_cluster
     identifier: cluster_agent_setup
-    weight: 401
+    weight: 501
   - name: Event Collection
     url: agent/cluster_agent/event_collection/
     parent: agent_cluster
     identifier: cluster_agent_event_collection
-    weight: 402
+    weight: 502
   - name: Custom & External Metrics
     url: agent/cluster_agent/external_metrics/
     parent: agent_cluster
     identifier: cluster_agent_external_metrics
-    weight: 403
+    weight: 503
   - name: Cluster Checks
     url: agent/cluster_agent/clusterchecks/
     parent: agent_cluster
-    weight: 404
+    weight: 504
   - name: Endpoints Checks
     url: agent/cluster_agent/endpointschecks/
     parent: agent_cluster
-    weight: 405
+    weight: 505
   - name: Admission Controller
     url: agent/cluster_agent/admission_controller/
     parent: agent_cluster
-    weight: 406
+    weight: 506
   - name: Commands & Options
     url: agent/cluster_agent/commands/
     identifier: cluster_agent_commands
     parent: agent_cluster
-    weight: 407
+    weight: 507
   - name: Cluster metadata provider
     url: agent/cluster_agent/metadata_provider/
     identifier: cluster_agent_metadata_provider
     parent: agent_cluster
-    weight: 408
+    weight: 508
   - name: Build
     url: agent/cluster_agent/build/
     identifier: cluster_agent_build
     parent: agent_cluster
-    weight: 409
+    weight: 509
   - name: Cluster Checks Runner
     url: agent/cluster_agent/clusterchecksrunner
     identifier: cluster_agent_clcr
     parent: agent_cluster
-    weight: 410
+    weight: 510
   - name: Troubleshooting
     url: agent/cluster_agent/troubleshooting/
     identifier: cluster_agent_troubleshooting
     parent: agent_cluster
-    weight: 411
+    weight: 511
   - name: Log Collection
     url: agent/logs/
     identifier: agent_logs

--- a/content/en/agent/amazon_ecs/_index.md
+++ b/content/en/agent/amazon_ecs/_index.md
@@ -17,7 +17,7 @@ further_reading:
 
 ## Overview
 
-Amazon ECS on EC2 is a highly scalable, high performance container management service for Docker containers running on EC2 instances.
+Amazon ECS on EC2 is a highly scalable, high-performance container management service for Docker containers running on EC2 instances.
 
 This page covers Amazon ECS setup with [Datadog Container Agent v6][1]. For other setups, see:
 
@@ -42,15 +42,19 @@ This task launches the Datadog container. When you need to modify the configurat
 
 If you're [using APM][5], [DogStatsD][6], or [log management][7], set the appropriate flags in the task definition:
 
-- If you are using APM, set `portMappings` so your downstream containers can ship traces to the Agent service. APM uses `TCP` on port `8126` to receive traces, so set this as the `hostPort` in your task's definition. Note that in order to enable trace collection from other containers, you must ensure that the `DD_APM_NON_LOCAL_TRAFFIC` environment variable is set to `true`. Learn more about [APM with containers][8].
+- If you are using APM, set `portMappings` so your downstream containers can ship traces to the Agent service. APM uses `TCP` on port `8126` to receive traces, so set this as the `hostPort` in your task's definition. 
 
-- If you are using DogStatsD, set the `hostPort` as `UDP` on port `8125` in your task's definition. Note that in order to enable DogStatsD metrics collection from other containers, you must ensure the `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` environment variable is set to `true`.
+**Note**: To enable trace collection from other containers, ensure that the `DD_APM_NON_LOCAL_TRAFFIC` environment variable is set to `true`. Learn more about [APM with containers][8].
+
+- If you are using DogStatsD, set the `hostPort` as `UDP` on port `8125` in your task's definition. 
+
+**Note**: To enable DogStatsD metrics collection from other containers, ensure the `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` environment variable is set to `true`.
 
 - If you are using log management, refer to the dedicated [Log collection documentation][5].
 
 Double check the security group settings on your EC2 instances. Make sure these ports are not open to the public. Datadog uses the private IP to route to the Agent from the containers.
 
-You may either configure the task using the [AWS CLI tools][9] or using the Amazon Web Console.
+Configure the task using either the [AWS CLI tools][9] or using the Amazon Web Console.
 
 {{< tabs >}}
 {{% tab "AWS CLI" %}}
@@ -129,7 +133,7 @@ Add the following permissions to your [Datadog IAM policy][10] to collect Amazon
 
 #### Run the Agent as a Daemon Service
 
-Ideally you want the Datadog Agent to load on one container on each EC2 instance. The easiest way to achieve this is to run the Datadog Agent as a [Daemon Service][12].
+Ideally, you want the Datadog Agent to load on one container on each EC2 instance. The easiest way to achieve this is to run the Datadog Agent as a [Daemon Service][12].
 
 ##### Schedule a Daemon Service in AWS using Datadog's ECS Task
 
@@ -142,7 +146,7 @@ Ideally you want the Datadog Agent to load on one container on each EC2 instance
 
 #### Dynamic detection and monitoring of running services
 
-Datadog's [Autodiscovery][13] can be used in conjunction with ECS and Docker to automatically discovery and monitor running tasks in your environment.
+Datadog's [Autodiscovery][13] can be used in conjunction with ECS and Docker to automatically discover and monitor running tasks in your environment.
 
 #### AWSVPC Mode
 

--- a/content/en/agent/amazon_ecs/_index.md
+++ b/content/en/agent/amazon_ecs/_index.md
@@ -1,0 +1,307 @@
+---
+title: Amazon ECS
+kind: documentation
+aliases:
+  - /integrations/amazon_ecs/
+further_reading:
+- link: "/agent/amazon_ecs/logs/"
+  tag: "Documentation"
+  text: "Collect your application logs"
+- link: "/agent/amazon_ecs/apm/"
+  tag: "Documentation"
+  text: "Collect your application traces"
+- link: "/agent/amazon_ecs/metrics/"
+  tag: "Documentation"
+  text: "Collect ECS metrics"
+---
+
+## Overview
+
+Amazon ECS on EC2 is a highly scalable, high performance container management service for Docker containers running on EC2 instances.
+
+This page covers AWS ECS setup with [Datadog Container Agent v6][1]. For other setups, see:
+
+- [Datadog Container Agent v5 setup for AWS ECS][2]
+- [Datadog Host Agent setup with Autodiscovery][3]
+
+## Setup
+
+To monitor your ECS containers and tasks with Datadog, run the Agent as a container on every EC2 instance in your ECS cluster. As detailed below, there are a few setup steps:
+
+1. Add an ECS Task
+2. Create or Modify your IAM Policy
+3. Schedule the Datadog Agent as a Daemon Service
+
+If you don't have a working EC2 Container Service cluster configured, review the [Getting Started section in the ECS documentation][4].
+
+### Metric collection
+
+#### Create an ECS Task
+
+This task launches the Datadog container. When you need to modify the configuration, update this task definition as described further down in this guide. If you're using APM, DogStatsD, or logs, set the appropriate flags in the task definition:
+
+- If you are using APM, set `portMappings` so your downstream containers can ship traces to the Agent service. APM uses port `8126` and `TCP` to receive traces, so set this as a `hostPort` in the task's definition. Note that in order to enable trace collection from other containers, you must ensure that the `DD_APM_NON_LOCAL_TRAFFIC` environment variable is set to `true`. Learn more about [APM with containers][5].
+- If you are using DogStatsD, set a `hostPort` of `8125` as `UDP` in the task's definition. Note that in order to enable DogStatsD metrics collection from other containers, you must ensure the `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` environment variable is set to `true`.
+- If you are using logs, refer to the dedicated [Log collection documentation](#log-collection).
+
+Double check the security group settings on your EC2 instances. Make sure these ports are not open to the public. Datadog uses the private IP to route to the Agent from the containers.
+
+You may either configure the task using the [AWS CLI tools][6] or using the Amazon Web Console.
+
+{{< tabs >}}
+{{% tab "AWS CLI" %}}
+
+1. For Linux containers, download [datadog-agent-ecs.json][1] ([datadog-agent-ecs1.json][2] if you are using an original Amazon Linux AMI). For Windows, download [datadog-agent-ecs-win.json][3].
+2. Edit `datadog-agent-ecs.json` and set `<YOUR_DATADOG_API_KEY>` with the [Datadog API key][4] for your account.
+3. Optionally - Add an [Agent health check](#agent-health-check).
+4. Optionally - If you are in Datadog EU site, edit `datadog-agent-ecs.json` and set `DD_SITE` to `DD_SITE:datadoghq.eu`.
+5. Optionally - See [log collection](#log-collection) to activate log collection.
+6. Optionally - See [process collection](#process-collection) to activate process collection.
+7. Optionally - See [trace collection (APM)](#trace-collection) to activate trace collection.
+8. Optionally - See [network performance monitoring (NPM)](#network-performance-monitoring-collection) to activate network collection
+9. Execute the following command:
+
+```shell
+aws ecs register-task-definition --cli-input-json <path to datadog-agent-ecs.json>
+```
+
+##### Agent health check
+
+Add the following to your ECS task definition to create an Agent health check:
+
+```json
+"healthCheck": {
+  "retries": 3,
+  "command": ["CMD-SHELL","agent health"],
+  "timeout": 5,
+  "interval": 30,
+  "startPeriod": 15
+}
+```
+
+[1]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs.json
+[2]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs1.json
+[3]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs-win.json
+[4]: https://app.datadoghq.com/account/settings#api
+{{% /tab %}}
+{{% tab "Web UI" %}}
+
+1. Log in to your AWS Console and navigate to the EC2 Container Service section.
+2. Click on the cluster you wish to add Datadog to.
+3. Click on **Task Definitions** on the left side and click the button **Create new Task Definition**.
+4. Enter a **Task Definition Name**, such as `datadog-agent-task`.
+5. Click on the **Add volume** link.
+6. For **Name** enter `docker_sock`. For **Source Path**, enter `/var/run/docker.sock` on Linux or `\\.\pipe\docker_engine` on Windows. Click **Add**.
+7. For Linux only, add another volume with the name `proc` and source path of `/proc/`.
+8. For Linux only, add another volume with the name `cgroup` and source path of `/sys/fs/cgroup/` (or `/cgroup/` if you are using an original Amazon Linux AMI).
+9. Click the large **Add container** button.
+10. For **Container name** enter `datadog-agent`.
+11. For **Image** enter `datadog/agent:latest`.
+12. For **Maximum memory** enter `256`. **Note**: For high resource usage, you may need a higher memory limit.
+13. Scroll down to the **Advanced container configuration** section and enter `10` in **CPU units**.
+14. For **Env Variables**, add a **Key** of `DD_API_KEY` and enter your Datadog API Key in the value. *If you feel more comfortable storing secrets like this in s3, take a look at the [ECS Configuration guide][1].*
+15. Add another Environment Variable for any tags you want to add using the key `DD_TAGS`.
+16. Scroll down to the **Storage and Logging** section.
+17. In **Mount points** select the **docker_sock** source volume and enter as Container path `/var/run/docker.sock` on Linux or `\\.\pipe\docker_engine` on Windows. Check the **Read only** checkbox.
+18. For Linux only, add another mount point for **proc** and enter `/host/proc/` in the Container path. Check the **Read only** checkbox.
+19. For Linux only, add a third mount point for **cgroup** and enter `/host/sys/fs/cgroup` in the Container path. Check the **Read only** checkbox (use `/host/cgroup/` if you are using an original Amazon Linux AMI).
+
+**Note**: Setting the Datadog task definition to use 10 CPU units can cause the `aws.ecs.cpuutilization` for `service:datadog-agent` to display as running at 1000%. This is a peculiarity of how AWS displays CPU utilization. You can add more CPU units to avoid skewing your graph.
+
+[1]: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html#ecs-config-s3
+{{% /tab %}}
+{{< /tabs >}}
+
+#### Create or Modify your IAM Policy
+
+Add the following permissions to your [Datadog IAM policy][7] to collect Amazon ECS metrics. For more information on ECS policies, review the [documentation on the AWS website][8].
+
+| AWS Permission                   | Description                                                   |
+| -------------------------------- | ------------------------------------------------------------- |
+| `ecs:ListClusters`               | Returns a list of existing clusters.                          |
+| `ecs:ListContainerInstances`     | Returns a list of container instances in a specified cluster. |
+| `ecs:ListServices`               | Lists the services that are running in a specified cluster.   |
+| `ecs:DescribeContainerInstances` | Describes Amazon ECS container instances.                     |
+
+#### Run the Agent as a Daemon Service
+
+Ideally you want the Datadog Agent to load on one container on each EC2 instance. The easiest way to achieve this is to run the Datadog Agent as a [Daemon Service][9].
+
+##### Schedule a Daemon Service in AWS using Datadog's ECS Task
+
+1. Log in to the AWS console and navigate to the ECS Clusters section. Click into your cluster you run the Agent on.
+2. Create a new service by clicking the **Create** button under Services.
+3. For launch type, select EC2 then the task definition created previously.
+4. For service type, select `DAEMON`, and enter a Service name. Click **Next**.
+5. Since the Service runs once on each instance, you won't need a load balancer. Select None. Click **Next**.
+6. Daemon services don't need Auto Scaling, so click **Next Step**, and then **Create Service**.
+
+#### Dynamic detection and monitoring of running services
+
+Datadog's [Autodiscovery][10] can be used in conjunction with ECS and Docker to automatically discovery and monitor running tasks in your environment.
+
+#### AWSVPC Mode
+
+For Agent v6.10+, awsvpc mode is supported for both applicative containers and the Agent container, provided:
+
+1. For the apps and the Agent in awsvpc mode, security groups must be set to allow:
+
+    - The Agent's security group to reach the applicative containers on relevant ports.
+    - The Agent's security group to reach the host instances on TCP port 51678. The ECS Agent container must either run in host network mode (default) or have a port binding on the host.
+
+2. For apps in awsvpc mode and the Agent in bridge mode, security groups must be set to allow the host instances security group to reach the applicative containers on relevant ports.
+
+### Process collection
+
+To collect processes information for all your containers and send it to Datadog:
+
+{{< tabs >}}
+{{% tab "Linux" %}}
+
+1. Follow the [above instructions](#aws-cli) to install the Datadog Agent.
+2. Update your [datadog-agent-ecs.json][1] file ([datadog-agent-ecs1.json][2] if you are using an original Amazon Linux AMI) with the following configuration:
+
+```text
+{
+  "containerDefinitions": [
+    (...)
+      "mountPoints": [
+        (...)
+        {
+          "containerPath": "/etc/passwd",
+          "sourceVolume": "passwd",
+          "readOnly": true
+        },
+        (...)
+      ],
+      "environment": [
+        (...)
+        {
+          "name": "DD_PROCESS_AGENT_ENABLED",
+          "value": "true"
+        }
+      ]
+    }
+  ],
+  "volumes": [
+    (...)
+    {
+      "host": {
+        "sourcePath": "/etc/passwd"
+      },
+      "name": "passwd"
+    },
+    (...)
+  ],
+  "family": "datadog-agent-task"
+}
+```
+
+
+
+[1]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs.json
+[2]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs1.json
+{{% /tab %}}
+{{% tab "Windows" %}}
+
+1. Follow the [above instructions](#aws-cli) to install the Datadog Agent.
+2. Update your [datadog-agent-ecs-win.json][1] file with the following configuration:
+
+```text
+{
+  "containerDefinitions": [
+    (...)
+      "environment": [
+        (...)
+        {
+          "name": "DD_PROCESS_AGENT_ENABLED",
+          "value": "true"
+        }
+      ]
+    }
+  ],
+  "family": "datadog-agent-task"
+}
+```
+
+
+[1]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs-win.json
+{{% /tab %}}
+{{< /tabs >}}
+
+### Network Performance Monitoring collection (Linux only)
+
+ 1. Follow the [above instructions](#aws-cli) to install the Datadog Agent.
+  - If you are installing for the first time, there is a `datadog-agent-ecs.json` file available, [datadog-agent-sysprobe-ecs.json][11] ([datadog-agent-sysprobe-ecs1.json][12] if you are using an original Amazon Linux AMI), for use with the [above instructions](#aws-cli). Note that initial NPM setup requires the CLI, as you cannot add `linuxParameters` in the AWS UI.
+ 2. If you already have a task definition, update your [datadog-agent-ecs.json][13] file ([datadog-agent-ecs1.json][14] if you are using an original Amazon Linux AMI) with the following configuration:
+
+ ```text
+ {
+   "containerDefinitions": [
+     (...)
+       "mountPoints": [
+         (...)
+         {
+           "containerPath": "/sys/kernel/debug",
+           "sourceVolume": "debug"
+         },
+         (...)
+       ],
+       "environment": [
+         (...)
+         {
+           "name": "DD_SYSTEM_PROBE_ENABLED",
+           "value": "true"
+         }
+       ],
+       "linuxParameters": {
+        "capabilities": {
+          "add": [
+            "SYS_ADMIN",
+            "SYS_RESOURCE",
+            "SYS_PTRACE",
+            "NET_ADMIN"
+          ]
+        }
+      },
+   ],
+   "requiresCompatibilities": [
+    "EC2"
+   ],
+   "volumes": [
+     (...)
+     {
+      "host": {
+        "sourcePath": "/sys/kernel/debug"
+      },
+      "name": "debug"
+     },
+     (...)
+   ],
+   "family": "datadog-agent-task"
+ }
+ ```
+
+## Troubleshooting
+
+Need help? Contact [Datadog support][15].
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/agent
+[2]: https://docs.datadoghq.com/integrations/faq/agent-5-amazon-ecs/
+[3]: https://docs.datadoghq.com/agent/autodiscovery/?tab=docker#how-to-set-it-up
+[4]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_GetStarted_EC2.html
+[5]: https://docs.datadoghq.com/tracing/setup/docker/
+[6]: https://aws.amazon.com/cli
+[7]: https://docs.datadoghq.com/integrations/amazon_web_services/#datadog-aws-iam-policy
+[8]: https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonelasticcontainerservice.html
+[9]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html#service_scheduler_daemon
+[10]: https://docs.datadoghq.com/agent/autodiscovery/
+[11]: https://docs.datadoghq.com/resources/json/datadog-agent-sysprobe-ecs.json
+[12]: https://docs.datadoghq.com/resources/json/datadog-agent-sysprobe-ecs1.json
+[13]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs.json
+[14]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs1.json
+[15]: https://docs.datadoghq.com/help/

--- a/content/en/agent/amazon_ecs/apm.md
+++ b/content/en/agent/amazon_ecs/apm.md
@@ -69,7 +69,7 @@ After following the [Amazon ECS agent installation instructions][1], enable trac
 
 ## Launch time variables
 
-In cases where variables on your ECS application are set at launch time, you **must** set the hostname as an environment variable with `DD_AGENT_HOST`. Otherwise, you can set the hostname in your application's source code for Python, Javascript, or Ruby. For Java and .NET you can set the hostname in the ECS task. For example:
+In cases where variables on your ECS application are set at launch time, you **must** set the hostname as an environment variable with `DD_AGENT_HOST`. Otherwise, you can set the hostname in your application's source code for Python, Javascript, or Ruby. For Java and .NET, you can set the hostname in the ECS task. For example:
 
 {{< tabs >}}
 {{% tab "Python" %}}
@@ -86,7 +86,7 @@ def get_aws_ip():
 tracer.configure(hostname=get_aws_ip())
 {{< /code-block >}}
 
-For more examples of how to set the Agent hostname in other languages, refer to the [change agent hostname documentation][1].
+For more examples of setting the Agent hostname in other languages, refer to the [change agent hostname documentation][1].
 
 
 [1]: https://docs.datadoghq.com/tracing/setup/python/#change-agent-hostname
@@ -107,7 +107,7 @@ request('http://169.254.169.254/latest/meta-data/local-ipv4', function(
 });
 {{< /code-block >}}
 
-For more examples of how to set the Agent hostname in other languages, refer to the [change agent hostname documentation][1].
+For more examples of setting the Agent hostname in other languages, refer to the [change agent hostname documentation][1].
 
 [1]: https://docs.datadoghq.com/tracing/setup/nodejs/#change-agent-hostname
 {{% /tab %}}
@@ -161,7 +161,7 @@ Copy this script into the `entryPoint` field of your ECS task definition, updati
 ]
 {{< /code-block >}}
 
-For more examples of how to set the Agent hostname in other languages, refer to the [change agent hostname documentation][1].
+For more examples of setting the Agent hostname in other languages, refer to the [change agent hostname documentation][1].
 
 [1]: https://docs.datadoghq.com/tracing/setup/java/#change-agent-hostname
 {{% /tab %}}

--- a/content/en/agent/amazon_ecs/apm.md
+++ b/content/en/agent/amazon_ecs/apm.md
@@ -1,0 +1,180 @@
+---
+title: Tracing ECS Applications
+kind: Documentation
+further_reading:
+    - link: "/agent/amazon_ecs/log/"
+      tag: "Documentation"
+      text: "Collect your application logs"
+    - link: "/agent/amazon_ecs/tag/"
+      tag: "Documentation"
+      text: "Assign tags to all data emitted by a container"
+---
+
+## Trace collection
+
+After installing the Datadog Agent, enable trace collection (optional):
+
+1. Set the following parameters in the task definition for the `datadog/agent` container:
+
+    - Port mapping: host / container port `8126`, Protocol `tcp`:
+    ```json
+    containerDefinitions": [
+    {
+      "name": "datadog-agent",
+      "image": "datadog/agent:latest",
+      "cpu": 10,
+      "memory": 256,
+      "essential": true,
+      "portMappings": [
+        {
+          "hostPort": 8126,
+          "protocol": "tcp",
+          "containerPort": 8126
+        }
+      ],
+      ...
+    ```
+    For **Agent v7.17 or lower**, add the following environment variables:
+
+    ```json
+    ...
+          "environment": [
+            ...
+          {
+            "name": "DD_APM_ENABLED",
+            "value": "true"
+          },
+          {
+            "name": "DD_APM_NON_LOCAL_TRAFFIC",
+            "value": "true"
+          },
+          ...
+          ]
+    ...
+    ```
+
+     [See all environment variables available for Agent trace collection][1].
+
+2. Assign the private IP address for each underlying instance your containers are running on in your application container to the `DD_AGENT_HOST` environment variable. This allows your application traces to be shipped to the Agent. The [Amazon’s EC2 metadata endpoint][2] allows discovery of the private IP address. To get the private IP address for each host, curl the following URL:
+
+    ```shell
+    curl http://169.254.169.254/latest/meta-data/local-ipv4
+    ```
+
+     and set the result as your Trace Agent Hostname environment variable for each application container shipping to APM:
+
+    ```text
+    os.environ['DD_AGENT_HOST'] = <EC2_PRIVATE_IP>
+    ```
+
+    In cases where variables on your ECS application are set at launch time, you _must_ set the hostname as an environment variable with `DD_AGENT_HOST`. Otherwise, you can set the hostname in your application's source code for Python, Javascript, or Ruby. For Java and .NET you can set the hostname in the ECS task. For example:
+
+{{< tabs >}}
+{{% tab "Python" %}}
+
+```python
+import requests
+from ddtrace import tracer
+
+
+def get_aws_ip():
+  r = requests.get('http://169.254.169.254/latest/meta-data/local-ipv4')
+  return r.text
+
+tracer.configure(hostname=get_aws_ip())
+```
+
+For more examples of how to set the Agent hostname in other languages, refer to the [change agent hostname documentation][1].
+
+[1]: https://docs.datadoghq.com/tracing/setup/python/#change-agent-hostname
+{{% /tab %}}
+{{% tab "Node.js" %}}
+
+```javascript
+const tracer = require('dd-trace');
+const request = require('request');
+
+request('http://169.254.169.254/latest/meta-data/local-ipv4', function(
+    error,
+    resp,
+    body
+) {
+    tracer.init({ hostname: body });
+});
+```
+
+For more examples of how to set the Agent hostname in other languages, refer to the [change agent hostname documentation][1].
+
+[1]: https://docs.datadoghq.com/tracing/setup/nodejs/#change-agent-hostname
+{{% /tab %}}
+{{% tab "Ruby" %}}
+
+```ruby
+require 'ddtrace'
+require 'net/http'
+
+Datadog.configure do |c|
+  c.tracer hostname: Net::HTTP.get(URI('http://169.254.169.254/latest/meta-data/local-ipv4'))
+end
+```
+
+{{% /tab %}}
+{{% tab "Go" %}}
+
+```go
+package main
+
+import (
+    "net/http"
+    "io/ioutil"
+    "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+resp, err := http.Get("http://169.254.169.254/latest/meta-data/local-ipv4")
+        bodyBytes, err := ioutil.ReadAll(resp.Body)
+        host := string(bodyBytes)
+   if err == nil {
+        //set the output of the curl command to the DD_Agent_host env
+        os.Setenv("DD_AGENT_HOST", host)
+         // tell the trace agent the host setting
+        tracer.Start(tracer.WithAgentAddr(host))
+        defer tracer.Stop()
+```
+
+{{% /tab %}}
+{{% tab "Java" %}}
+
+Copy this script into the `entryPoint` field of your ECS task definition, updating the values with your application jar and argument flags.
+
+```json
+"entryPoint": [
+  "sh",
+  "-c",
+  "export DD_AGENT_HOST=$(curl http://169.254.169.254/latest/meta-data/local-ipv4); java -javaagent:/app/dd-java-agent.jar <APPLICATION_ARG_FLAGS> -jar <APPLICATION_JAR_FILE/WAR_FILE>"
+]
+```
+
+For more examples of how to set the Agent hostname in other languages, refer to the [change agent hostname documentation][1].
+
+[1]: https://docs.datadoghq.com/tracing/setup/java/#change-agent-hostname
+{{% /tab %}}
+{{% tab ".NET" %}}
+
+```json
+"entryPoint": [
+  "sh",
+  "-c",
+  "export DD_AGENT_HOST=$(curl http://169.254.169.254/latest/meta-data/local-ipv4); dotnet ${APP_PATH}"
+]
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+
+[1]: /agent/docker/apm/#docker-apm-agent-environment-variables
+[2]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html

--- a/content/en/agent/amazon_ecs/apm.md
+++ b/content/en/agent/amazon_ecs/apm.md
@@ -2,22 +2,21 @@
 title: Tracing ECS Applications
 kind: Documentation
 further_reading:
-    - link: "/agent/amazon_ecs/log/"
+    - link: "/agent/amazon_ecs/logs/"
       tag: "Documentation"
       text: "Collect your application logs"
-    - link: "/agent/amazon_ecs/tag/"
+    - link: "/agent/amazon_ecs/tags/"
       tag: "Documentation"
       text: "Assign tags to all data emitted by a container"
 ---
 
-## Trace collection
+## Setup
 
-After installing the Datadog Agent, enable trace collection (optional):
+After following the [Amazon ECS agent installation instructions][1], enable trace collection per the instructions below.
 
-1. Set the following parameters in the task definition for the `datadog/agent` container:
+1. Set the following parameters in the task definition for the `datadog/agent` container. Set the `portMappings` host / container port to `8126` with protocol `tcp`:
 
-    - Port mapping: host / container port `8126`, Protocol `tcp`:
-    ```json
+    {{< code-block lang="json" >}}
     containerDefinitions": [
     {
       "name": "datadog-agent",
@@ -33,10 +32,11 @@ After installing the Datadog Agent, enable trace collection (optional):
         }
       ],
       ...
-    ```
+    {{< /code-block >}}
+
     For **Agent v7.17 or lower**, add the following environment variables:
 
-    ```json
+    {{< code-block lang="json" >}}
     ...
           "environment": [
             ...
@@ -51,28 +51,30 @@ After installing the Datadog Agent, enable trace collection (optional):
           ...
           ]
     ...
-    ```
+    {{< /code-block >}}
 
-     [See all environment variables available for Agent trace collection][1].
+    [See all environment variables available for Agent trace collection][1].
 
-2. Assign the private IP address for each underlying instance your containers are running on in your application container to the `DD_AGENT_HOST` environment variable. This allows your application traces to be shipped to the Agent. The [Amazon’s EC2 metadata endpoint][2] allows discovery of the private IP address. To get the private IP address for each host, curl the following URL:
+2. Assign the private IP address for each underlying instance your containers are running in your application container to the `DD_AGENT_HOST` environment variable. This allows your application traces to be shipped to the Agent. The [Amazon’s EC2 metadata endpoint][2] allows discovery of the private IP address. To get the private IP address for each host, curl the following URL:
 
-    ```shell
+    {{< code-block lang="curl" >}}
     curl http://169.254.169.254/latest/meta-data/local-ipv4
-    ```
+    {{< /code-block >}}
 
-     and set the result as your Trace Agent Hostname environment variable for each application container shipping to APM:
+    Set the result as your Trace Agent hostname environment variable for each application container shipping to APM:
 
-    ```text
+    {{< code-block lang="curl" >}}
     os.environ['DD_AGENT_HOST'] = <EC2_PRIVATE_IP>
-    ```
+    {{< /code-block >}}
 
-    In cases where variables on your ECS application are set at launch time, you _must_ set the hostname as an environment variable with `DD_AGENT_HOST`. Otherwise, you can set the hostname in your application's source code for Python, Javascript, or Ruby. For Java and .NET you can set the hostname in the ECS task. For example:
+## Launch time variables
+
+In cases where variables on your ECS application are set at launch time, you **must** set the hostname as an environment variable with `DD_AGENT_HOST`. Otherwise, you can set the hostname in your application's source code for Python, Javascript, or Ruby. For Java and .NET you can set the hostname in the ECS task. For example:
 
 {{< tabs >}}
 {{% tab "Python" %}}
 
-```python
+{{< code-block lang="python" >}}
 import requests
 from ddtrace import tracer
 
@@ -82,15 +84,17 @@ def get_aws_ip():
   return r.text
 
 tracer.configure(hostname=get_aws_ip())
-```
+{{< /code-block >}}
 
 For more examples of how to set the Agent hostname in other languages, refer to the [change agent hostname documentation][1].
 
+
 [1]: https://docs.datadoghq.com/tracing/setup/python/#change-agent-hostname
 {{% /tab %}}
+
 {{% tab "Node.js" %}}
 
-```javascript
+{{< code-block lang="javascript" >}}
 const tracer = require('dd-trace');
 const request = require('request');
 
@@ -101,27 +105,29 @@ request('http://169.254.169.254/latest/meta-data/local-ipv4', function(
 ) {
     tracer.init({ hostname: body });
 });
-```
+{{< /code-block >}}
 
 For more examples of how to set the Agent hostname in other languages, refer to the [change agent hostname documentation][1].
 
 [1]: https://docs.datadoghq.com/tracing/setup/nodejs/#change-agent-hostname
 {{% /tab %}}
+
 {{% tab "Ruby" %}}
 
-```ruby
+{{< code-block lang="ruby" >}}
 require 'ddtrace'
 require 'net/http'
 
 Datadog.configure do |c|
   c.tracer hostname: Net::HTTP.get(URI('http://169.254.169.254/latest/meta-data/local-ipv4'))
 end
-```
+{{< /code-block >}}
 
 {{% /tab %}}
+
 {{% tab "Go" %}}
 
-```go
+{{< code-block lang="go" >}}
 package main
 
 import (
@@ -133,40 +139,42 @@ import (
 resp, err := http.Get("http://169.254.169.254/latest/meta-data/local-ipv4")
         bodyBytes, err := ioutil.ReadAll(resp.Body)
         host := string(bodyBytes)
-   if err == nil {
+  if err == nil {
         //set the output of the curl command to the DD_Agent_host env
         os.Setenv("DD_AGENT_HOST", host)
-         // tell the trace agent the host setting
+        // tell the trace agent the host setting
         tracer.Start(tracer.WithAgentAddr(host))
         defer tracer.Stop()
-```
+{{< /code-block >}}
 
 {{% /tab %}}
+
 {{% tab "Java" %}}
 
 Copy this script into the `entryPoint` field of your ECS task definition, updating the values with your application jar and argument flags.
 
-```json
+{{< code-block lang="json" >}}
 "entryPoint": [
   "sh",
   "-c",
   "export DD_AGENT_HOST=$(curl http://169.254.169.254/latest/meta-data/local-ipv4); java -javaagent:/app/dd-java-agent.jar <APPLICATION_ARG_FLAGS> -jar <APPLICATION_JAR_FILE/WAR_FILE>"
 ]
-```
+{{< /code-block >}}
 
 For more examples of how to set the Agent hostname in other languages, refer to the [change agent hostname documentation][1].
 
 [1]: https://docs.datadoghq.com/tracing/setup/java/#change-agent-hostname
 {{% /tab %}}
+
 {{% tab ".NET" %}}
 
-```json
+{{< code-block lang="json" >}}
 "entryPoint": [
   "sh",
   "-c",
   "export DD_AGENT_HOST=$(curl http://169.254.169.254/latest/meta-data/local-ipv4); dotnet ${APP_PATH}"
 ]
-```
+{{< /code-block >}}
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -174,7 +182,6 @@ For more examples of how to set the Agent hostname in other languages, refer to 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
-
 
 [1]: /agent/docker/apm/#docker-apm-agent-environment-variables
 [2]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html

--- a/content/en/agent/amazon_ecs/data_collected.md
+++ b/content/en/agent/amazon_ecs/data_collected.md
@@ -1,5 +1,5 @@
 ---
-title: Amazon ECS Data Collected
+title: Amazon ECS Data Collection
 kind: documentation
 further_reading:
 - link: "/agent/amazon_ecs/logs/"
@@ -25,11 +25,11 @@ Each of the metrics retrieved from AWS is assigned the same tags that appear in 
 
 ### Events
 
-To reduce noise, the AWS ECS integration is automatically whitelisted to include only events that contain the following words: `drain`, `error`, `fail`, `insufficient memory`, `pending`, `reboot`, `terminate`. See example events below:
+To reduce noise, the Amazon ECS integration is automatically whitelisted to include only events that contain the following words: `drain`, `error`, `fail`, `insufficient memory`, `pending`, `reboot`, `terminate`. See example events below:
 
 {{< img src="integrations/amazon_ecs/aws_ecs_events.png" alt="AWS ECS Events" >}}
 
-To remove the whitelist and receive all events from your Datadog AWS ECS integration, reach out to [Datadog support][3].
+To remove the whitelist and receive all events from your Datadog Amazon ECS integration, reach out to [Datadog support][3].
 
 ### Service checks
 

--- a/content/en/agent/amazon_ecs/data_collected.md
+++ b/content/en/agent/amazon_ecs/data_collected.md
@@ -19,13 +19,13 @@ further_reading:
 
 See [metadata.csv][1] for a list of metrics provided by this integration.
 
-Each of the metrics retrieved from AWS is assigned the same tags that appear in the AWS console, including but not limited to host name, security-groups, and more.
+Each of the metrics retrieved from AWS is assigned the same tags that appear in the AWS console, including but not limited to hostname, security-groups, and more.
 
 **Note**: Metrics prefixed with `ecs.containerinsights.*` come from the [AWS CloudWatch agent][2].
 
 ### Events
 
-To reduce noise, the Amazon ECS integration is automatically whitelisted to include only events that contain the following words: `drain`, `error`, `fail`, `insufficient memory`, `pending`, `reboot`, `terminate`. See example events below:
+To reduce noise, the Amazon ECS integration is automatically set up to include only events that contain the following words: `drain`, `error`, `fail`, `insufficient memory`, `pending`, `reboot`, `terminate`. See example events below:
 
 {{< img src="integrations/amazon_ecs/aws_ecs_events.png" alt="AWS ECS Events" >}}
 

--- a/content/en/agent/amazon_ecs/data_collected.md
+++ b/content/en/agent/amazon_ecs/data_collected.md
@@ -1,0 +1,44 @@
+---
+title: Amazon ECS Data Collected
+kind: documentation
+further_reading:
+- link: "/agent/amazon_ecs/logs/"
+  tag: "Documentation"
+  text: "Collect your application logs"
+- link: "/agent/amazon_ecs/apm/"
+  tag: "Documentation"
+  text: "Collect your application traces"
+- link: "/agent/amazon_ecs/metrics/"
+  tag: "Documentation"
+  text: "Collect ECS metrics"
+---
+
+## Data collected
+
+### Metrics
+
+See [metadata.csv][1] for a list of metrics provided by this integration.
+
+Each of the metrics retrieved from AWS is assigned the same tags that appear in the AWS console, including but not limited to host name, security-groups, and more.
+
+**Note**: Metrics prefixed with `ecs.containerinsights.*` come from the [AWS CloudWatch agent][2].
+
+### Events
+
+To reduce noise, the AWS ECS integration is automatically whitelisted to include only events that contain the following words: `drain`, `error`, `fail`, `insufficient memory`, `pending`, `reboot`, `terminate`. See example events below:
+
+{{< img src="integrations/amazon_ecs/aws_ecs_events.png" alt="AWS ECS Events" >}}
+
+To remove the whitelist and receive all events from your Datadog AWS ECS integration, reach out to [Datadog support][3].
+
+### Service checks
+
+- **aws.ecs.agent_connected**: Returns `CRITICAL` if the Agent cannot connect, otherwise `OK`.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://github.com/DataDog/dogweb/blob/prod/integration/amazon_ecs/amazon_ecs_metadata.csv
+[2]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/deploy-container-insights-ECS-instancelevel.html
+[3]: https://docs.datadoghq.com/help/

--- a/content/en/agent/amazon_ecs/logs.md
+++ b/content/en/agent/amazon_ecs/logs.md
@@ -1,0 +1,134 @@
+---
+title: Amazon ECS Log Collection
+kind: documentation
+further_reading:
+- link: "/agent/amazon_ecs/apm/"
+  tag: "Documentation"
+  text: "Collect your application traces"
+- link: "/agent/amazon_ecs/metrics/"
+  tag: "Documentation"
+  text: "Collect ECS metrics"
+---
+
+## Setup
+
+To collect all logs written by running applications in your ECS containers and send it to your Datadog application:
+
+{{< tabs >}}
+{{% tab "Linux" %}}
+
+1. Follow the [above instructions](#aws-cli) to install the Datadog Agent.
+2. Update your [datadog-agent-ecs.json][1] file [datadog-agent-ecs1.json][2] if you are using an original Amazon Linux AMI) with the following configuration:
+
+    ```text
+    {
+        "containerDefinitions": [
+        (...)
+          "mountPoints": [
+            (...)
+            {
+              "containerPath": "/opt/datadog-agent/run",
+              "sourceVolume": "pointdir",
+              "readOnly": false
+            },
+            (...)
+          ],
+          "environment": [
+            (...)
+            {
+              "name": "DD_LOGS_ENABLED",
+              "value": "true"
+            },
+            {
+              "name": "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL",
+              "value": "true"
+            },
+            (...)
+          ]
+        }
+      ],
+      "volumes": [
+        (...)
+        {
+          "host": {
+            "sourcePath": "/opt/datadog-agent/run"
+          },
+          "name": "pointdir"
+        },
+        (...)
+      ],
+      "family": "datadog-agent-task"
+    }
+    ```
+
+3. Make sure your container definition doesn't contain a `logConfiguration.logDriver` parameter, so that the logs are written to `stdout/stderr` and collected by the Agent. If this parameter is set to `awslogs`, collect your Amazon ECS logs without the Agent by using [AWS Lambda to collect ECS logs from CloudWatch][3].
+
+
+[1]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs.json
+[2]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs1.json
+[3]: https://www.datadoghq.com/blog/monitoring-ecs-with-datadog/
+{{% /tab %}}
+{{% tab "Windows" %}}
+
+1. Follow the [above instructions](#aws-cli) to install the Datadog Agent.
+2. Update your [datadog-agent-ecs-win.json][1] file with the following configuration:
+
+    ```text
+    {
+        "containerDefinitions": [
+        (...)
+          "mountPoints": [
+            (...)
+            {
+              "containerPath": "c:\\programdata\\datadog\\run",
+              "sourceVolume": "pointdir",
+              "readOnly": false
+            },
+            (...)
+          ],
+          "environment": [
+            (...)
+            {
+              "name": "DD_LOGS_ENABLED",
+              "value": "true"
+            },
+            {
+              "name": "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL",
+              "value": "true"
+            },
+            (...)
+          ]
+        }
+      ],
+      "volumes": [
+        (...)
+        {
+          "host": {
+            "sourcePath": "c:\\programdata\\datadog\\run"
+          },
+          "name": "pointdir"
+        },
+        (...)
+      ],
+      "family": "datadog-agent-task"
+    }
+    ```
+
+3. Make sure your container definition doesn't contain a `logConfiguration.logDriver` parameter, so that the logs are written to `stdout/stderr` and collected by the Agent. If this parameter is set to `awslogs`, collect your Amazon ECS logs without the Agent by using [AWS Lambda to collect ECS logs from CloudWatch][2].
+
+
+[1]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs-win.json
+[2]: https://www.datadoghq.com/blog/monitoring-ecs-with-datadog/
+{{% /tab %}}
+{{< /tabs >}}
+
+## Activate log integrations
+
+The `source` attribute is used to identify the integration to use for each container. Override it directly in your containers labels to start using [log integrations][1]. Read Datadog's [Autodiscovery guide for logs][2] in order to learn more about this process.
+
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+[1]: https://docs.datadoghq.com/logs/processing/#log-processing
+[2]: https://docs.datadoghq.com/logs/log_collection/docker/?tab=containerinstallation#activate-log-integrations

--- a/content/en/agent/amazon_ecs/logs.md
+++ b/content/en/agent/amazon_ecs/logs.md
@@ -117,7 +117,7 @@ To collect all logs written by running applications in your ECS containers and s
 
 ## Activate log integrations
 
-The `source` attribute is used to identify the integration to use for each container. Override it directly in your containers labels to start using [log integrations][1]. Read Datadog's [Autodiscovery guide for logs][2] in order to learn more about this process.
+The `source` attribute is used to identify the integration to use for each container. Override it directly in your containers labels to start using [log integrations][1]. Read Datadog's [Autodiscovery guide for logs][2] to learn more about this process.
 
 ## Further reading
 

--- a/content/en/agent/amazon_ecs/logs.md
+++ b/content/en/agent/amazon_ecs/logs.md
@@ -20,7 +20,7 @@ To collect all logs written by running applications in your ECS containers and s
 1. Follow the [above instructions](#aws-cli) to install the Datadog Agent.
 2. Update your [datadog-agent-ecs.json][1] file [datadog-agent-ecs1.json][2] if you are using an original Amazon Linux AMI) with the following configuration:
 
-    ```json
+    ```text
     {
         "containerDefinitions": [
         (...)
@@ -72,39 +72,35 @@ To collect all logs written by running applications in your ECS containers and s
 1. Follow the [above instructions](#aws-cli) to install the Datadog Agent.
 2. Update your [datadog-agent-ecs-win.json][1] file with the following configuration:
 
-    ```json
+    ```text
     {
       "containerDefinitions": [
-      (...)
-        "mountPoints": [
-          (...)
-          {
-            "containerPath": "c:\\programdata\\datadog\\run",
-            "sourceVolume": "pointdir",
-            "readOnly": false
-          },
-          (...)
-        ],
-        "environment": [
-          (...)
-          {
-            "name": "DD_LOGS_ENABLED",
-            "value": "true"
-          },
-          {
-            "name": "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL",
-            "value": "true"
-          },
-          (...)
-        ]
+        (...)
+          "mountPoints": [
+            (...)
+            {
+              "containerPath": "/etc/passwd",
+              "sourceVolume": "passwd",
+              "readOnly": true
+            },
+            (...)
+          ],
+          "environment": [
+            (...)
+            {
+              "name": "DD_PROCESS_AGENT_ENABLED",
+              "value": "true"
+            }
+          ]
+        }
       ],
       "volumes": [
         (...)
         {
           "host": {
-            "sourcePath": "c:\\programdata\\datadog\\run"
+            "sourcePath": "/etc/passwd"
           },
-          "name": "pointdir"
+          "name": "passwd"
         },
         (...)
       ],

--- a/content/en/agent/amazon_ecs/logs.md
+++ b/content/en/agent/amazon_ecs/logs.md
@@ -20,7 +20,7 @@ To collect all logs written by running applications in your ECS containers and s
 1. Follow the [above instructions](#aws-cli) to install the Datadog Agent.
 2. Update your [datadog-agent-ecs.json][1] file [datadog-agent-ecs1.json][2] if you are using an original Amazon Linux AMI) with the following configuration:
 
-    ```text
+    ```json
     {
         "containerDefinitions": [
         (...)
@@ -63,7 +63,6 @@ To collect all logs written by running applications in your ECS containers and s
 
 3. Make sure your container definition doesn't contain a `logConfiguration.logDriver` parameter, so that the logs are written to `stdout/stderr` and collected by the Agent. If this parameter is set to `awslogs`, collect your Amazon ECS logs without the Agent by using [AWS Lambda to collect ECS logs from CloudWatch][3].
 
-
 [1]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs.json
 [2]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs1.json
 [3]: https://www.datadoghq.com/blog/monitoring-ecs-with-datadog/
@@ -73,32 +72,31 @@ To collect all logs written by running applications in your ECS containers and s
 1. Follow the [above instructions](#aws-cli) to install the Datadog Agent.
 2. Update your [datadog-agent-ecs-win.json][1] file with the following configuration:
 
-    ```text
+    ```json
     {
-        "containerDefinitions": [
-        (...)
-          "mountPoints": [
-            (...)
-            {
-              "containerPath": "c:\\programdata\\datadog\\run",
-              "sourceVolume": "pointdir",
-              "readOnly": false
-            },
-            (...)
-          ],
-          "environment": [
-            (...)
-            {
-              "name": "DD_LOGS_ENABLED",
-              "value": "true"
-            },
-            {
-              "name": "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL",
-              "value": "true"
-            },
-            (...)
-          ]
-        }
+      "containerDefinitions": [
+      (...)
+        "mountPoints": [
+          (...)
+          {
+            "containerPath": "c:\\programdata\\datadog\\run",
+            "sourceVolume": "pointdir",
+            "readOnly": false
+          },
+          (...)
+        ],
+        "environment": [
+          (...)
+          {
+            "name": "DD_LOGS_ENABLED",
+            "value": "true"
+          },
+          {
+            "name": "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL",
+            "value": "true"
+          },
+          (...)
+        ]
       ],
       "volumes": [
         (...)
@@ -116,7 +114,6 @@ To collect all logs written by running applications in your ECS containers and s
 
 3. Make sure your container definition doesn't contain a `logConfiguration.logDriver` parameter, so that the logs are written to `stdout/stderr` and collected by the Agent. If this parameter is set to `awslogs`, collect your Amazon ECS logs without the Agent by using [AWS Lambda to collect ECS logs from CloudWatch][2].
 
-
 [1]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs-win.json
 [2]: https://www.datadoghq.com/blog/monitoring-ecs-with-datadog/
 {{% /tab %}}
@@ -125,7 +122,6 @@ To collect all logs written by running applications in your ECS containers and s
 ## Activate log integrations
 
 The `source` attribute is used to identify the integration to use for each container. Override it directly in your containers labels to start using [log integrations][1]. Read Datadog's [Autodiscovery guide for logs][2] in order to learn more about this process.
-
 
 ## Further reading
 

--- a/content/en/agent/amazon_ecs/tags.md
+++ b/content/en/agent/amazon_ecs/tags.md
@@ -1,0 +1,44 @@
+---
+title: Amazon ECS Tag Extraction
+kind: documentation
+further_reading:
+- link: "/getting_started/tagging/"
+  tag: "Documentation"
+  text: "Getting started with tags"
+- link: "/getting_started/tagging/using_tags/"
+  tag: "Documentation"
+  text: "Using tags with Datadog"
+- link: "/agent/guide/autodiscovery-management/"
+  tag: "Documentation"
+  text: "Limit data collection to a subset of containers only"
+---
+
+### Resource tag collection
+
+To collect ECS resource tags:
+
+1. Verify your [Amazon ECS container instances][1] are associated to an IAM role. This can be done when creating a new cluster with the ECS cluster creation wizard or in the launch configuration used by an autoscaling group.
+2. Update the IAM role used by your [Amazon ECS container instances][1] with: `ecs:ListTagsForResource`.
+3. Update your [datadog-agent-ecs.json][2] file ([datadog-agent-ecs1.json][3] if you are using an original Amazon Linux AMI) to enable resource tag collection by adding the following environment variable:
+
+    ```json
+    {
+      "name": "DD_ECS_COLLECT_RESOURCE_TAGS_EC2",
+      "value": "true"
+    }
+    ```
+
+#### Notes
+
+- Ensure your the IAM role is associated with your [Amazon ECS container instances][1] and not the underlying EC2 instance.
+- ECS resource tags can be collected from EC2 instances, but not from AWS Fargate.
+- This feature requires Datadog Agent v6.17+ or v7.17+.
+- The Agent supports ECS tag collection from the `tasks`, `services`, and `container instances` ECS resources.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_instances.html
+[2]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs.json
+[3]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs1.json

--- a/content/en/agent/amazon_ecs/tags.md
+++ b/content/en/agent/amazon_ecs/tags.md
@@ -25,7 +25,7 @@ As a best practice in containerized environments, Datadog recommends using unifi
 
 If you do not have unified service tagging enabled, complete the following steps to collect ECS resource tags:
 
-1. Verify your [Amazon ECS container instances][2] are associated to an IAM role. This can be done when creating a new cluster with the ECS cluster creation wizard or in the launch configuration used by an autoscaling group.
+1. Verify your [Amazon ECS container instances][2] are associated with an IAM role. This can be done when creating a new cluster with the ECS cluster creation wizard or in the launch configuration used by an autoscaling group.
 2. Update the IAM role used by your [Amazon ECS container instances][2] with: `ecs:ListTagsForResource`.
 3. Update your [datadog-agent-ecs.json][3] file ([datadog-agent-ecs1.json][4] if you are using an original Amazon Linux AMI) to enable resource tag collection by adding the following environment variable:
 
@@ -38,7 +38,7 @@ If you do not have unified service tagging enabled, complete the following steps
 
 ### Notes
 
-- Ensure your the IAM role is associated with your [Amazon ECS container instances][2] and not the underlying EC2 instance.
+- Ensure the IAM role is associated with your [Amazon ECS container instances][2] and not the underlying EC2 instance.
 - ECS resource tags can be collected from EC2 instances, but not from AWS Fargate.
 - This feature requires Datadog Agent v6.17+ or v7.17+.
 - The Agent supports ECS tag collection from the `tasks`, `services`, and `container instances` ECS resources.

--- a/content/en/agent/amazon_ecs/tags.md
+++ b/content/en/agent/amazon_ecs/tags.md
@@ -13,24 +13,32 @@ further_reading:
   text: "Limit data collection to a subset of containers only"
 ---
 
-### Resource tag collection
+## Overview
 
-To collect ECS resource tags:
+The Datadog Agent can create and assign tags to all metrics, traces, and logs emitted by a container based on its labels or environment variables.
 
-1. Verify your [Amazon ECS container instances][1] are associated to an IAM role. This can be done when creating a new cluster with the ECS cluster creation wizard or in the launch configuration used by an autoscaling group.
-2. Update the IAM role used by your [Amazon ECS container instances][1] with: `ecs:ListTagsForResource`.
-3. Update your [datadog-agent-ecs.json][2] file ([datadog-agent-ecs1.json][3] if you are using an original Amazon Linux AMI) to enable resource tag collection by adding the following environment variable:
+## Unified service tagging
 
-    ```json
+As a best practice in containerized environments, Datadog recommends using unified service tagging when assigning tags. Unified service tagging ties Datadog telemetry together through the use of three standard tags: `env`, `service`, and `version`. To learn how to configure your environment with unified tagging, refer to the dedicated [Amazon ECS unified service tagging documentation][1].
+
+## Resource tag collection
+
+If you do not have unified service tagging enabled, complete the following steps to collect ECS resource tags:
+
+1. Verify your [Amazon ECS container instances][2] are associated to an IAM role. This can be done when creating a new cluster with the ECS cluster creation wizard or in the launch configuration used by an autoscaling group.
+2. Update the IAM role used by your [Amazon ECS container instances][2] with: `ecs:ListTagsForResource`.
+3. Update your [datadog-agent-ecs.json][3] file ([datadog-agent-ecs1.json][4] if you are using an original Amazon Linux AMI) to enable resource tag collection by adding the following environment variable:
+
+    {{< code-block lang="json" >}}
     {
       "name": "DD_ECS_COLLECT_RESOURCE_TAGS_EC2",
       "value": "true"
     }
-    ```
+    {{< /code-block >}}
 
-#### Notes
+### Notes
 
-- Ensure your the IAM role is associated with your [Amazon ECS container instances][1] and not the underlying EC2 instance.
+- Ensure your the IAM role is associated with your [Amazon ECS container instances][2] and not the underlying EC2 instance.
 - ECS resource tags can be collected from EC2 instances, but not from AWS Fargate.
 - This feature requires Datadog Agent v6.17+ or v7.17+.
 - The Agent supports ECS tag collection from the `tasks`, `services`, and `container instances` ECS resources.
@@ -39,6 +47,7 @@ To collect ECS resource tags:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_instances.html
-[2]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs.json
-[3]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs1.json
+[1]: /getting_started/tagging/unified_service_tagging/?tab=ecs#containerized-environment
+[2]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_instances.html
+[3]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs.json
+[4]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs1.json


### PR DESCRIPTION
### What does this PR do?
Moves the ECS page from the integrations section into it's own pages under the Agent section

### Motivation
Jira request

### Preview link
https://docs-staging.datadoghq.com/sarina/ecs-agent/agent/amazon_ecs/