### PR TITLE
Admission Controller manual setup (without Helm)

### DIFF
--- a/content/en/agent/cluster_agent/admission_controller.md
+++ b/content/en/agent/cluster_agent/admission_controller.md
@@ -67,7 +67,7 @@ To enable the admission controller for the Datadog operator, set the parameter `
 
 To enable the admission controller without using Helm or the Datadog operator, you'll need to add a few things to your configuration:
 
-First, Download the [Cluster Agent RBAC permissions][3] manifest, and add the following under `rules`:
+First, download the [Cluster Agent RBAC permissions][3] manifest, and add the following under `rules`:
 
 {{< code-block lang="yaml" filename="cluster-agent-rbac.yaml" disable_copy="true" >}}
 - apiGroups:

--- a/content/en/agent/cluster_agent/admission_controller.md
+++ b/content/en/agent/cluster_agent/admission_controller.md
@@ -111,10 +111,12 @@ Add environment variables to the Cluster Agent deployment which enable the Admis
 {{< code-block lang="yaml" filename="cluster-agent-deployment.yaml" disable_copy="true" >}}
 - name: DD_ADMISSION_CONTROLLER_ENABLED
   value: "true"
-- name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED
-  value: "false"
 - name: DD_ADMISSION_CONTROLLER_SERVICE_NAME
   value: "datadog-cluster-agent-admission-controller"
+
+# Uncomment this to configure APM tracers automatically (see below)
+# - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED
+#   value: "true"
 {{< /code-block >}}
 
 Finally, run the following commands:

--- a/content/en/agent/cluster_agent/admission_controller.md
+++ b/content/en/agent/cluster_agent/admission_controller.md
@@ -67,7 +67,7 @@ To enable the admission controller for the Datadog operator, set the parameter `
 
 To enable the admission controller without using Helm or the Datadog operator, you'll need to add a few things to your configuration:
 
-1. Download the [Cluster Agent RBAC permissions][3] manifest, and add the following under `rules`:
+First, Download the [Cluster Agent RBAC permissions][3] manifest, and add the following under `rules`:
 
 {{< code-block lang="yaml" filename="cluster-agent-rbac.yaml" disable_copy="true" >}}
 - apiGroups:
@@ -86,7 +86,7 @@ To enable the admission controller without using Helm or the Datadog operator, y
   verbs: ["get"]
 {{< /code-block >}}
 
-2. Add the following to the bottom of `agent-services.yaml`:
+Add the following to the bottom of `agent-services.yaml`:
 
 {{< code-block lang="yaml" filename="agent-services.yaml" disable_copy="true" >}}
 ---
@@ -106,7 +106,7 @@ spec:
 
 {{< /code-block >}}
 
-3. Add environment variables to the Cluster Agent deployment which enable the Admission Controller. 
+Add environment variables to the Cluster Agent deployment which enable the Admission Controller:
 
 {{< code-block lang="yaml" filename="cluster-agent-deployment.yaml" disable_copy="true" >}}
 - name: DD_ADMISSION_CONTROLLER_ENABLED
@@ -117,9 +117,11 @@ spec:
   value: "datadog-cluster-agent-admission-controller"
 {{< /code-block >}}
 
-4. Run: `kubectl apply -f cluster-agent-rbac.yaml`
-5. Run: `kubectl apply -f agent-services.yaml`
-6. Run: `kubectl apply -f cluster-agent-deployment.yaml`
+Finally, run the following commands:
+
+- `kubectl apply -f cluster-agent-rbac.yaml`
+- `kubectl apply -f agent-services.yaml`
+- `kubectl apply -f cluster-agent-deployment.yaml`
 
 ### APM and DogStatsD
 

--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -218,5 +218,5 @@ Kubernetes events are beginning to flow into your Datadog account, and relevant 
 [5]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/secrets.yaml
 [6]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/cluster-agent-deployment.yaml
 [7]: https://app.datadoghq.com/account/settings#api
-[8]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-rbac.yaml
+[8]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/rbac.yaml
 [9]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/daemonset.yaml

--- a/static/resources/yaml/datadog-agent-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-all-features.yaml
@@ -30,7 +30,7 @@ data:
       enable_oom_kill: false
       collect_dns_stats: false
 ---
-# Source: datadog/templates/system-probe-configmap.yaml
+# Source: datadog/templates/security-configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7312,10 +7312,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-1.1.0.tgz#62504ad4d11550c942935ccc5e39d64e5a4c4e50"
-  integrity sha512-EkE7RW6KcXfMHy2PA7Jg0YJE1l8UPEZE8k45tylzmZM30/r1M1MUXWQfJlrSbsTeh7m/XTwHbWUENvAJZpp1YA==
+marked@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-1.1.1.tgz#e5d61b69842210d5df57b05856e0c91572703e6a"
+  integrity sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw==
 
 maybe-callback@^2.1.0:
   version "2.1.0"
@@ -10371,10 +10371,10 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
-slugify@^1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.4.4.tgz#2f032ffa52b1e1ca2a27737c1ce47baae3d0883a"
-  integrity sha512-N2+9NJ8JzfRMh6PQLrBeDEnVDQZSytE/W4BTC4fNNPmO90Uu58uNwSlIJSs+lmPgWsaAF79WLhVPe5tuy7spjw==
+slugify@^1.4.5:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.4.5.tgz#a7517acf5f4c02a4df41e735354b660a4ed1efcf"
+  integrity sha512-WpECLAgYaxHoEAJ8Q1Lo8HOs1ngn7LN7QjXgOLbmmfkcWvosyk4ZTXkTzKyhngK640USTZUlgoQJfED1kz5fnQ==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7312,10 +7312,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-1.1.1.tgz#e5d61b69842210d5df57b05856e0c91572703e6a"
-  integrity sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw==
+marked@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-1.1.0.tgz#62504ad4d11550c942935ccc5e39d64e5a4c4e50"
+  integrity sha512-EkE7RW6KcXfMHy2PA7Jg0YJE1l8UPEZE8k45tylzmZM30/r1M1MUXWQfJlrSbsTeh7m/XTwHbWUENvAJZpp1YA==
 
 maybe-callback@^2.1.0:
   version "2.1.0"
@@ -10371,10 +10371,10 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
-slugify@^1.4.5:
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.4.5.tgz#a7517acf5f4c02a4df41e735354b660a4ed1efcf"
-  integrity sha512-WpECLAgYaxHoEAJ8Q1Lo8HOs1ngn7LN7QjXgOLbmmfkcWvosyk4ZTXkTzKyhngK640USTZUlgoQJfED1kz5fnQ==
+slugify@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.4.4.tgz#2f032ffa52b1e1ca2a27737c1ce47baae3d0883a"
+  integrity sha512-N2+9NJ8JzfRMh6PQLrBeDEnVDQZSytE/W4BTC4fNNPmO90Uu58uNwSlIJSs+lmPgWsaAF79WLhVPe5tuy7spjw==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds instructions for orchestrating the Cluster Agent Admission Controller without a Helm chart, just like on some of the other Kubernetes pages.

I copied configs from these files, which is the same thing I did at my company do get it working:

- https://github.com/helm/charts/blob/d6da827531/stable/datadog/templates/agent-rbac.yaml
- https://github.com/helm/charts/blob/d6da827531/stable/datadog/templates/agent-services.yaml 
- https://github.com/helm/charts/blob/d6da827531/stable/datadog/templates/cluster-agent-deployment.yaml 

In addition, I've fixed a couple small bugs/typos:
- The `agent-rbac.yaml` link was broken and pointed to `rbac.yaml`
- The `datadog-agent-security` config map file was named `system-probe-configmap.yaml` instead of `security-configmap.yaml`

**One additional thing:** I didn't know where to add this in, but somewhere during the Cluster Agent setup (before applying the `deployment` file), the user needs to run `kubectl apply -f https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/agent-only/install_info-configmap.yaml`. If someone could point me to a good spot to add this in, I will gladly do so.

### Motivation
I spent a few days scratching my head at how to get this working at my company, since we're not using Helm. APM and the automatic setup of new pods using the Admission Controller were must-have features for us.

### Preview link (images)
<!-- Impacted pages preview links-->
![Screenshot from 2020-09-01 16-40-55](https://user-images.githubusercontent.com/22383534/91916449-086cdb00-ec72-11ea-88e5-bbd1fc83afbe.png)
![Screenshot from 2020-09-01 16-41-05](https://user-images.githubusercontent.com/22383534/91916448-086cdb00-ec72-11ea-9000-fbc8ed0c5913.png)
![Screenshot from 2020-09-01 16-41-12](https://user-images.githubusercontent.com/22383534/91916446-06a31780-ec72-11ea-9438-cab0ff7c2149.png)

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
I want to make sure my comment above about the additional `kubectl apply` that needs to be added isn't missed. 

I hope this pull request is helpful. 🙂 Please let me know if there is anything else I need to do. 