### PR TITLE
Change to double quotes for curl examples

### DIFF
--- a/content/en/logs/guide/build-custom-reports-using-log-analytics-api.md
+++ b/content/en/logs/guide/build-custom-reports-using-log-analytics-api.md
@@ -47,7 +47,7 @@ With the following API call, build a `table` with `count` of log events grouped 
 **API call:**
 
 ```bash
-curl -L -X POST 'https://api.datadoghq.com/api/v2/logs/analytics/aggregate' -H 'Content-Type: application/json' -H 'DD-API-KEY: <DATADOG_API_KEY>' -H 'DD-APPLICATION-KEY: <DATADOG_APP_KEY>' --data-raw '{
+curl -L -X POST "https://api.datadoghq.com/api/v2/logs/analytics/aggregate" -H "Content-Type: application/json" -H "DD-API-KEY: <DATADOG_API_KEY>" -H "DD-APPLICATION-KEY: <DATADOG_APP_KEY>" --data-raw '{
    "compute":[
    {
        "type":"total",
@@ -123,7 +123,7 @@ With the following API call, build a `timeseries` with `count` of log events gro
 **API call:**
 
 ```bash
-curl -L -X POST 'https://api.datadoghq.com/api/v2/logs/analytics/aggregate' -H 'Content-Type: application/json' -H 'DD-API-KEY: <DATADOG_API_KEY>' -H 'DD-APPLICATION-KEY: <DATADOG_APP_KEY>' --data-raw '{
+curl -L -X POST "https://api.datadoghq.com/api/v2/logs/analytics/aggregate" -H "Content-Type: application/json" -H "DD-API-KEY: <DATADOG_API_KEY>" -H "DD-APPLICATION-KEY: <DATADOG_APP_KEY>" --data-raw '{
    "compute":[
    {
        "type":"timeseries",
@@ -212,7 +212,7 @@ With the following API call, build a `table` with `avg` of values in a `metric` 
 **API call:**
 
 ```bash
-curl -L -X POST 'https://api.datadoghq.com/api/v2/logs/analytics/aggregate' -H 'Content-Type: application/json' -H 'DD-API-KEY: <DATADOG_API_KEY>' -H 'DD-APPLICATION-KEY: <DATADOG_APP_KEY>' --data-raw '{
+curl -L -X POST "https://api.datadoghq.com/api/v2/logs/analytics/aggregate" -H "Content-Type: application/json" -H "DD-API-KEY: <DATADOG_API_KEY>" -H "DD-APPLICATION-KEY: <DATADOG_APP_KEY>" --data-raw '{
    "compute":[
    {
        "type":"total",
@@ -286,7 +286,7 @@ With the following API call, build a `table` with `sum` of values in a `metric` 
 **API call:**
 
 ```bash
-curl -L -X POST 'https://api.datadoghq.com/api/v2/logs/analytics/aggregate' -H 'Content-Type: application/json' -H 'DD-API-KEY: <DATADOG_API_KEY>' -H 'DD-APPLICATION-KEY: <DATADOG_APP_KEY>' --data-raw '{
+curl -L -X POST "https://api.datadoghq.com/api/v2/logs/analytics/aggregate" -H "Content-Type: application/json" -H "DD-API-KEY: <DATADOG_API_KEY>" -H "DD-APPLICATION-KEY: <DATADOG_APP_KEY>" --data-raw '{
    "compute":[
    {
        "type":"total",
@@ -351,7 +351,7 @@ With the following API call, build a `table` with `min` of values in a `metric` 
 **API call:**
 
 ```bash
-curl -L -X POST 'https://api.datadoghq.com/api/v2/logs/analytics/aggregate' -H 'Content-Type: application/json' -H 'DD-API-KEY: <DATADOG_API_KEY>' -H 'DD-APPLICATION-KEY: <DATADOG_APP_KEY>' --data-raw '{
+curl -L -X POST "https://api.datadoghq.com/api/v2/logs/analytics/aggregate" -H "Content-Type: application/json" -H "DD-API-KEY: <DATADOG_API_KEY>" -H "DD-APPLICATION-KEY: <DATADOG_APP_KEY>" --data-raw '{
    "compute":[
    {
        "type":"total",
@@ -416,7 +416,7 @@ With the following API call, build a `table` with `max` of values in a `metric` 
 **API call:**
 
 ```bash
-curl -L -X POST 'https://api.datadoghq.com/api/v2/logs/analytics/aggregate' -H 'Content-Type: application/json' -H 'DD-API-KEY: <DATADOG_API_KEY>' -H 'DD-APPLICATION-KEY: <DATADOG_APP_KEY>' --data-raw '{
+curl -L -X POST "https://api.datadoghq.com/api/v2/logs/analytics/aggregate" -H "Content-Type: application/json" -H "DD-API-KEY: <DATADOG_API_KEY>" -H "DD-APPLICATION-KEY: <DATADOG_APP_KEY>" --data-raw '{
    "compute":[
    {
        "type":"total",
@@ -483,7 +483,7 @@ With the following API call, build a `table` with `percentiles` of values in a `
 **API call:**
 
 ```bash
-curl -L -X POST 'https://api.datadoghq.com/api/v2/logs/analytics/aggregate' -H 'Content-Type: application/json' -H 'DD-API-KEY: <DATADOG_API_KEY>' -H 'DD-APPLICATION-KEY: <DATADOG_APP_KEY>' --data-raw '{
+curl -L -X POST "https://api.datadoghq.com/api/v2/logs/analytics/aggregate" -H "Content-Type: application/json" -H "DD-API-KEY: <DATADOG_API_KEY>" -H "DD-APPLICATION-KEY: <DATADOG_APP_KEY>" --data-raw '{
    "compute":[
    {
        "type":"total",
@@ -547,7 +547,7 @@ With the following API call, build a `table` to display the breakdown of your lo
 **API call:**
 
 ```bash
-curl -L -X POST 'https://api.datadoghq.com/api/v2/logs/analytics/aggregate' -H 'Content-Type: application/json' -H 'DD-API-KEY: <DATADOG_API_KEY>' -H 'DD-APPLICATION-KEY: <DATADOG_APP_KEY>' --data-raw '{
+curl -L -X POST "https://api.datadoghq.com/api/v2/logs/analytics/aggregate" -H "Content-Type: application/json" -H "DD-API-KEY: <DATADOG_API_KEY>" -H "DD-APPLICATION-KEY: <DATADOG_APP_KEY>" --data-raw '{
    "compute":[
    {
        "type":"total",


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Changes to use double quotes instead of single quotes in curl examples for the log analytics curl examples

### Motivation
<!-- What inspired you to submit this pull request?-->

- Previous support cases and to be in line with https://github.com/DataDog/documentation/pull/4898
- variable expansion needs double rather than single quotes to work properly.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/tj/change_to_double_quotes_for_log_analytics_curl_examples/logs/guide/build-custom-reports-using-log-analytics-api/?tab=table

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
