### PR TITLE
[DOCS-1200] link fix

### DIFF
--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -211,7 +211,7 @@ Kubernetes events are beginning to flow into your Datadog account, and relevant 
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/manifests/cluster-agent
+[1]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/cluster-agent-rbac.yaml
 [2]: /agent/kubernetes/
 [3]: /agent/faq/rbac-for-dca-running-on-aks-with-helm/
 [4]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-services.yaml


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
