### PR TITLE
Updated wording for systemctl services

### DIFF
--- a/content/en/tracing/setup/dotnet-core.md
+++ b/content/en/tracing/setup/dotnet-core.md
@@ -240,7 +240,7 @@ After setting these variables, restart the .NET service for the environment vari
 
 #### Systemctl (All Services)
 
-When using `systemctl` to run .NET applications as a service, you can also set environment variables to be loaded for all services under `systemctl` using [`systemctl show-environment`][2] in the service block. Before using this approach, see the note below about this instrumenting all .NET processes. 
+When using `systemctl` to run .NET applications as a service, you can also set environment variables to be loaded for all services under `systemctl` seen with  [`systemctl show-environment`][2]. Before using this approach, see the note below about this instrumenting all .NET processes. 
 
 ```bat
 systemctl set-environment CORECLR_ENABLE_PROFILING=1

--- a/content/en/tracing/setup/dotnet-core.md
+++ b/content/en/tracing/setup/dotnet-core.md
@@ -240,7 +240,7 @@ After setting these variables, restart the .NET service for the environment vari
 
 #### Systemctl (All Services)
 
-When using `systemctl` to run .NET applications as a service, you can also set environment variables to be loaded for all services under `systemctl` seen with  [`systemctl show-environment`][2]. Before using this approach, see the note below about this instrumenting all .NET processes. 
+When using `systemctl` to run .NET applications as a service, you can also set environment variables to be loaded for all services ran via `systemctl`. To confirm these variables have been set, use [`systemctl show-environment`][2]. Before using this approach, see the note below about this instrumenting all .NET processes.
 
 ```bat
 systemctl set-environment CORECLR_ENABLE_PROFILING=1


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This is a small wording change to the way we describe systemctl for multiple processes.

### Motivation
<!-- What inspired you to submit this pull request?-->
See above.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/wantsui/dotnet-systemctl-wording-update

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
This should be reviewed by the .NET APM team.