### PR TITLE
Remove empty tags from postman specific full_spec

### DIFF
--- a/src/scripts/build-api-pages.js
+++ b/src/scripts/build-api-pages.js
@@ -791,11 +791,7 @@ const processSpecs = (specs) => {
           // the postman copy needs to not include the empty "tags" that we
           // included to ensure redirection in the docs page from v2 <-> v1
           const derefStripEmptyTags = lodash.cloneDeep(deref);
-          for (let i = derefStripEmptyTags.tags.length - 1; i >= 0; i -= 1) {
-              if (derefStripEmptyTags.tags[i].description.toLowerCase().includes("see api version")) {
-                derefStripEmptyTags.tags.splice(i, 1);
-              }
-          }
+          derefStripEmptyTags.tags = derefStripEmptyTags.tags.filter((tag) => !tag.description.toLowerCase().includes("see api version"));
           const jsonStringStripEmptyTags = safeJsonStringify(derefStripEmptyTags, null, 2);
           fs.writeFileSync(`./static/resources/json/full_spec_${version}.json`, jsonStringStripEmptyTags, 'utf8');
 

--- a/src/scripts/build-api-pages.js
+++ b/src/scripts/build-api-pages.js
@@ -790,9 +790,8 @@ const processSpecs = (specs) => {
           // make a copy in static for postman
           // the postman copy needs to not include the empty "tags" that we
           // included to ensure redirection in the docs page from v2 <-> v1
-          var i;
-          var derefStripEmptyTags = lodash.cloneDeep(deref);
-          for (i = derefStripEmptyTags.tags.length - 1; i >= 0; i -= 1) {
+          const derefStripEmptyTags = lodash.cloneDeep(deref);
+          for (let i = derefStripEmptyTags.tags.length - 1; i >= 0; i -= 1) {
               if (derefStripEmptyTags.tags[i].description.toLowerCase().includes("see api version")) {
                 derefStripEmptyTags.tags.splice(i, 1);
               }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This takes the dereferenced api spec and removes the tags that simply have a description of "See API version X" before writing the full_spec files that get used for postman. 

### Motivation
<!-- What inspired you to submit this pull request?-->
This ensures that, when imported into postman, you don't get empty folders for endpoints that don't exist in that version of the API

### Preview link
<!-- Impacted pages preview links-->
This shouldn't impact the api documentation

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
