### PR TITLE
Update the Kubernetes sample manifests and add an AKS specific one.

### DIFF
--- a/static/resources/yaml/datadog-agent-aks.yaml
+++ b/static/resources/yaml/datadog-agent-aks.yaml
@@ -1,0 +1,202 @@
+# Source: datadog/templates/secrets.yaml
+# API Key
+apiVersion: v1
+kind: Secret
+metadata:
+  name: datadog-agent
+  labels: {}
+type: Opaque
+data:
+  api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
+
+# APP Key
+---
+# Source: datadog/templates/install_info-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-agent-installinfo
+  labels: {}
+  annotations:
+    checksum/install_info: ee293ccedf116ce1ed6e0d9c7f7f9adabd0c230618089bb173c7acffa487e020
+data:
+  install_info: |
+    ---
+    install_method:
+      tool: kubernetes sample manifests
+      tool_version: kubernetes sample manifests
+      installer_version: kubernetes sample manifests
+---
+# Source: datadog/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: datadog-agent
+  labels: {}
+spec:
+  selector:
+    matchLabels:
+      app: datadog-agent
+  template:
+    metadata:
+      labels:
+        app: datadog-agent
+      name: datadog-agent
+      annotations: {}
+    spec:
+      containers:
+        - name: agent
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["agent", "run"]
+          resources: {}
+          ports:
+            - containerPort: 8125
+              name: dogstatsdport
+              protocol: UDP
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DOCKER_HOST
+              value: unix:///host/var/run/docker.sock
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
+            - name: DD_APM_ENABLED
+              value: "false"
+            - name: DD_LOGS_ENABLED
+              value: "false"
+            - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
+              value: "false"
+            - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
+              value: "true"
+            - name: DD_HEALTH_PORT
+              value: "5555"
+            - name: DD_KUBELET_CLIENT_CA
+              value: /etc/kubernetes/certs/kubeletserver.crt
+          volumeMounts:
+            - name: installinfo
+              subPath: install_info
+              mountPath: /etc/datadog-agent/install_info
+              readOnly: true
+            - name: config
+              mountPath: /etc/datadog-agent
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              mountPropagation: None
+              readOnly: true
+            - name: procdir
+              mountPath: /host/proc
+              mountPropagation: None
+              readOnly: true
+            - name: cgroups
+              mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
+              readOnly: true
+            - mountPath: /etc/kubernetes/certs/
+              name: kubeletserver
+              readOnly: true
+          livenessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /live
+              port: 5555
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /ready
+              port: 5555
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+      initContainers:
+        - name: init-volume
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["bash", "-c"]
+          args:
+            - cp -r /etc/datadog-agent /opt
+          volumeMounts:
+            - name: config
+              mountPath: /opt/datadog-agent
+          resources: {}
+        - name: init-config
+          image: "datadog/agent:7.21.1"
+          imagePullPolicy: IfNotPresent
+          command: ["bash", "-c"]
+          args:
+            - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+            - name: procdir
+              mountPath: /host/proc
+              mountPropagation: None
+              readOnly: true
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              mountPropagation: None
+              readOnly: true
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DOCKER_HOST
+              value: unix:///host/var/run/docker.sock
+          resources: {}
+      volumes:
+        - name: installinfo
+          configMap:
+            name: datadog-agent-installinfo
+        - name: config
+          emptyDir: {}
+        - hostPath:
+            path: /var/run
+          name: runtimesocketdir
+        - hostPath:
+            path: /proc
+          name: procdir
+        - hostPath:
+            path: /sys/fs/cgroup
+          name: cgroups
+        - name: s6-run
+          emptyDir: {}
+        - hostPath:
+            path: /etc/kubernetes/certs
+          name: kubeletserver
+      tolerations:
+      affinity: {}
+      serviceAccountName: "datadog-agent"
+      nodeSelector:
+        kubernetes.io/os: linux
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
+
+# Source: datadog/templates/containers-common-env.yaml
+# The purpose of this template is to define a minimal set of environment
+# variables required to operate dedicated containers in the daemonset

--- a/static/resources/yaml/datadog-agent-aks_values.yaml
+++ b/static/resources/yaml/datadog-agent-aks_values.yaml
@@ -1,0 +1,21 @@
+datadog:
+  kubeStateMetricsEnabled: false
+  processAgent:
+    enabled: false
+agents:
+  rbac:
+    create: false
+    serviceAccountName: datadog-agent
+  volumes:
+    - name: kubeletserver
+      hostPath:
+        path: /etc/kubernetes/certs
+  volumeMounts:
+    - name: kubeletserver
+      mountPath: /etc/kubernetes/certs/
+      readOnly: true
+  containers:
+    agent:
+      env:
+        - name: DD_KUBELET_CLIENT_CA
+          value: /etc/kubernetes/certs/kubeletserver.crt

--- a/static/resources/yaml/datadog-agent-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-all-features.yaml
@@ -11,6 +11,22 @@ data:
 
 # APP Key
 ---
+# Source: datadog/templates/install_info-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-agent-installinfo
+  labels: {}
+  annotations:
+    checksum/install_info: ee293ccedf116ce1ed6e0d9c7f7f9adabd0c230618089bb173c7acffa487e020
+data:
+  install_info: |
+    ---
+    install_method:
+      tool: kubernetes sample manifests
+      tool_version: kubernetes sample manifests
+      installer_version: kubernetes sample manifests
+---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -29,6 +45,14 @@ data:
       enable_tcp_queue_length: false
       enable_oom_kill: false
       collect_dns_stats: false
+    runtime_security_config:
+      enabled: false
+      debug: false
+      socket: /var/run/sysprobe/runtime-security.sock
+      policies:
+        dir: /etc/datadog-agent/runtime-security.d
+      syscall_monitor:
+        enabled: false
 ---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
@@ -70,6 +94,8 @@ data:
             "epoll_wait",
             "epoll_wait",
             "epoll_wait_old",
+            "eventfd",
+            "eventfd2",
             "execve",
             "execveat",
             "exit",
@@ -275,10 +301,15 @@ spec:
             - name: DD_HEALTH_PORT
               value: "5555"
           volumeMounts:
+            - name: installinfo
+              subPath: install_info
+              mountPath: /etc/datadog-agent/install_info
+              readOnly: true
             - name: config
               mountPath: /etc/datadog-agent
             - name: runtimesocketdir
               mountPath: /host/var/run
+              mountPropagation: None
               readOnly: true
             - name: sysprobe-socket-dir
               mountPath: /var/run/sysprobe
@@ -288,17 +319,22 @@ spec:
               subPath: system-probe.yaml
             - name: procdir
               mountPath: /host/proc
+              mountPropagation: None
               readOnly: true
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
               readOnly: true
             - name: pointerdir
               mountPath: /opt/datadog-agent/run
+              mountPropagation: None
             - name: logpodpath
               mountPath: /var/log/pods
+              mountPropagation: None
               readOnly: true
             - name: logdockercontainerpath
               mountPath: /var/lib/docker/containers
+              mountPropagation: None
               readOnly: true
           livenessProbe:
             failureThreshold: 6
@@ -355,6 +391,7 @@ spec:
               mountPath: /etc/datadog-agent
             - name: runtimesocketdir
               mountPath: /host/var/run
+              mountPropagation: None
               readOnly: true
           livenessProbe:
             initialDelaySeconds: 15
@@ -387,19 +424,24 @@ spec:
               value: "INFO"
             - name: DD_SYSTEM_PROBE_ENABLED
               value: "true"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
             - name: runtimesocketdir
               mountPath: /host/var/run
+              mountPropagation: None
               readOnly: true
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
               readOnly: true
             - name: passwd
               mountPath: /etc/passwd
             - name: procdir
               mountPath: /host/proc
+              mountPropagation: None
               readOnly: true
             - name: sysprobe-socket-dir
               mountPath: /var/run/sysprobe
@@ -412,7 +454,7 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
-              add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "IPC_LOCK"]
+              add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "IPC_LOCK"]
           command: ["/opt/datadog-agent/embedded/bin/system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
           env:
             - name: DD_LOG_LEVEL
@@ -421,18 +463,15 @@ spec:
           volumeMounts:
             - name: debugfs
               mountPath: /sys/kernel/debug
+              mountPropagation: None
             - name: sysprobe-config
-              mountPath: /etc/datadog-agent
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
             - name: sysprobe-socket-dir
               mountPath: /var/run/sysprobe
             - name: procdir
               mountPath: /host/proc
-              readOnly: true
-            - name: modules
-              mountPath: /lib/modules
-              readOnly: true
-            - name: src
-              mountPath: /usr/src
+              mountPropagation: None
               readOnly: true
       initContainers:
         - name: init-volume
@@ -456,9 +495,11 @@ spec:
               mountPath: /etc/datadog-agent
             - name: procdir
               mountPath: /host/proc
+              mountPropagation: None
               readOnly: true
             - name: runtimesocketdir
               mountPath: /host/var/run
+              mountPropagation: None
               readOnly: true
             - name: sysprobe-config
               mountPath: /etc/datadog-agent/system-probe.yaml
@@ -489,8 +530,12 @@ spec:
               mountPath: /etc/config
             - name: seccomp-root
               mountPath: /host/var/lib/kubelet/seccomp
+              mountPropagation: None
           resources: {}
       volumes:
+        - name: installinfo
+          configMap:
+            name: datadog-agent-installinfo
         - name: config
           emptyDir: {}
         - hostPath:
@@ -518,12 +563,6 @@ spec:
           name: debugfs
         - name: sysprobe-socket-dir
           emptyDir: {}
-        - hostPath:
-            path: /lib/modules
-          name: modules
-        - hostPath:
-            path: /usr/src
-          name: src
         - hostPath:
             path: /etc/passwd
           name: passwd

--- a/static/resources/yaml/datadog-agent-apm.yaml
+++ b/static/resources/yaml/datadog-agent-apm.yaml
@@ -11,6 +11,22 @@ data:
 
 # APP Key
 ---
+# Source: datadog/templates/install_info-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-agent-installinfo
+  labels: {}
+  annotations:
+    checksum/install_info: ee293ccedf116ce1ed6e0d9c7f7f9adabd0c230618089bb173c7acffa487e020
+data:
+  install_info: |
+    ---
+    install_method:
+      tool: kubernetes sample manifests
+      tool_version: kubernetes sample manifests
+      installer_version: kubernetes sample manifests
+---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
@@ -67,16 +83,23 @@ spec:
             - name: DD_HEALTH_PORT
               value: "5555"
           volumeMounts:
+            - name: installinfo
+              subPath: install_info
+              mountPath: /etc/datadog-agent/install_info
+              readOnly: true
             - name: config
               mountPath: /etc/datadog-agent
             - name: runtimesocketdir
               mountPath: /host/var/run
+              mountPropagation: None
               readOnly: true
             - name: procdir
               mountPath: /host/proc
+              mountPropagation: None
               readOnly: true
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
               readOnly: true
           livenessProbe:
             failureThreshold: 6
@@ -133,6 +156,7 @@ spec:
               mountPath: /etc/datadog-agent
             - name: runtimesocketdir
               mountPath: /host/var/run
+              mountPropagation: None
               readOnly: true
           livenessProbe:
             initialDelaySeconds: 15
@@ -162,9 +186,11 @@ spec:
               mountPath: /etc/datadog-agent
             - name: procdir
               mountPath: /host/proc
+              mountPropagation: None
               readOnly: true
             - name: runtimesocketdir
               mountPath: /host/var/run
+              mountPropagation: None
               readOnly: true
           env:
             - name: DD_API_KEY
@@ -182,6 +208,9 @@ spec:
               value: unix:///host/var/run/docker.sock
           resources: {}
       volumes:
+        - name: installinfo
+          configMap:
+            name: datadog-agent-installinfo
         - name: config
           emptyDir: {}
         - hostPath:

--- a/static/resources/yaml/datadog-agent-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-logs-apm.yaml
@@ -11,6 +11,22 @@ data:
 
 # APP Key
 ---
+# Source: datadog/templates/install_info-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-agent-installinfo
+  labels: {}
+  annotations:
+    checksum/install_info: ee293ccedf116ce1ed6e0d9c7f7f9adabd0c230618089bb173c7acffa487e020
+data:
+  install_info: |
+    ---
+    install_method:
+      tool: kubernetes sample manifests
+      tool_version: kubernetes sample manifests
+      installer_version: kubernetes sample manifests
+---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
@@ -73,24 +89,34 @@ spec:
             - name: DD_HEALTH_PORT
               value: "5555"
           volumeMounts:
+            - name: installinfo
+              subPath: install_info
+              mountPath: /etc/datadog-agent/install_info
+              readOnly: true
             - name: config
               mountPath: /etc/datadog-agent
             - name: runtimesocketdir
               mountPath: /host/var/run
+              mountPropagation: None
               readOnly: true
             - name: procdir
               mountPath: /host/proc
+              mountPropagation: None
               readOnly: true
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
               readOnly: true
             - name: pointerdir
               mountPath: /opt/datadog-agent/run
+              mountPropagation: None
             - name: logpodpath
               mountPath: /var/log/pods
+              mountPropagation: None
               readOnly: true
             - name: logdockercontainerpath
               mountPath: /var/lib/docker/containers
+              mountPropagation: None
               readOnly: true
           livenessProbe:
             failureThreshold: 6
@@ -149,6 +175,7 @@ spec:
               mountPath: /etc/datadog-agent
             - name: runtimesocketdir
               mountPath: /host/var/run
+              mountPropagation: None
               readOnly: true
           livenessProbe:
             initialDelaySeconds: 15
@@ -178,9 +205,11 @@ spec:
               mountPath: /etc/datadog-agent
             - name: procdir
               mountPath: /host/proc
+              mountPropagation: None
               readOnly: true
             - name: runtimesocketdir
               mountPath: /host/var/run
+              mountPropagation: None
               readOnly: true
           env:
             - name: DD_API_KEY
@@ -202,6 +231,9 @@ spec:
               value: "true"
           resources: {}
       volumes:
+        - name: installinfo
+          configMap:
+            name: datadog-agent-installinfo
         - name: config
           emptyDir: {}
         - hostPath:

--- a/static/resources/yaml/datadog-agent-logs.yaml
+++ b/static/resources/yaml/datadog-agent-logs.yaml
@@ -11,6 +11,22 @@ data:
 
 # APP Key
 ---
+# Source: datadog/templates/install_info-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-agent-installinfo
+  labels: {}
+  annotations:
+    checksum/install_info: ee293ccedf116ce1ed6e0d9c7f7f9adabd0c230618089bb173c7acffa487e020
+data:
+  install_info: |
+    ---
+    install_method:
+      tool: kubernetes sample manifests
+      tool_version: kubernetes sample manifests
+      installer_version: kubernetes sample manifests
+---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
@@ -73,24 +89,34 @@ spec:
             - name: DD_HEALTH_PORT
               value: "5555"
           volumeMounts:
+            - name: installinfo
+              subPath: install_info
+              mountPath: /etc/datadog-agent/install_info
+              readOnly: true
             - name: config
               mountPath: /etc/datadog-agent
             - name: runtimesocketdir
               mountPath: /host/var/run
+              mountPropagation: None
               readOnly: true
             - name: procdir
               mountPath: /host/proc
+              mountPropagation: None
               readOnly: true
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
               readOnly: true
             - name: pointerdir
               mountPath: /opt/datadog-agent/run
+              mountPropagation: None
             - name: logpodpath
               mountPath: /var/log/pods
+              mountPropagation: None
               readOnly: true
             - name: logdockercontainerpath
               mountPath: /var/lib/docker/containers
+              mountPropagation: None
               readOnly: true
           livenessProbe:
             failureThreshold: 6
@@ -132,9 +158,11 @@ spec:
               mountPath: /etc/datadog-agent
             - name: procdir
               mountPath: /host/proc
+              mountPropagation: None
               readOnly: true
             - name: runtimesocketdir
               mountPath: /host/var/run
+              mountPropagation: None
               readOnly: true
           env:
             - name: DD_API_KEY
@@ -156,6 +184,9 @@ spec:
               value: "true"
           resources: {}
       volumes:
+        - name: installinfo
+          configMap:
+            name: datadog-agent-installinfo
         - name: config
           emptyDir: {}
         - hostPath:

--- a/static/resources/yaml/datadog-agent-npm.yaml
+++ b/static/resources/yaml/datadog-agent-npm.yaml
@@ -11,6 +11,22 @@ data:
 
 # APP Key
 ---
+# Source: datadog/templates/install_info-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-agent-installinfo
+  labels: {}
+  annotations:
+    checksum/install_info: ee293ccedf116ce1ed6e0d9c7f7f9adabd0c230618089bb173c7acffa487e020
+data:
+  install_info: |
+    ---
+    install_method:
+      tool: kubernetes sample manifests
+      tool_version: kubernetes sample manifests
+      installer_version: kubernetes sample manifests
+---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -29,6 +45,14 @@ data:
       enable_tcp_queue_length: false
       enable_oom_kill: false
       collect_dns_stats: false
+    runtime_security_config:
+      enabled: false
+      debug: false
+      socket: /var/run/sysprobe/runtime-security.sock
+      policies:
+        dir: /etc/datadog-agent/runtime-security.d
+      syscall_monitor:
+        enabled: false
 ---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
@@ -70,6 +94,8 @@ data:
             "epoll_wait",
             "epoll_wait",
             "epoll_wait_old",
+            "eventfd",
+            "eventfd2",
             "execve",
             "execveat",
             "exit",
@@ -275,10 +301,15 @@ spec:
             - name: DD_HEALTH_PORT
               value: "5555"
           volumeMounts:
+            - name: installinfo
+              subPath: install_info
+              mountPath: /etc/datadog-agent/install_info
+              readOnly: true
             - name: config
               mountPath: /etc/datadog-agent
             - name: runtimesocketdir
               mountPath: /host/var/run
+              mountPropagation: None
               readOnly: true
             - name: sysprobe-socket-dir
               mountPath: /var/run/sysprobe
@@ -288,9 +319,11 @@ spec:
               subPath: system-probe.yaml
             - name: procdir
               mountPath: /host/proc
+              mountPropagation: None
               readOnly: true
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
               readOnly: true
           livenessProbe:
             failureThreshold: 6
@@ -333,19 +366,24 @@ spec:
               value: "INFO"
             - name: DD_SYSTEM_PROBE_ENABLED
               value: "true"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
             - name: runtimesocketdir
               mountPath: /host/var/run
+              mountPropagation: None
               readOnly: true
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
               readOnly: true
             - name: passwd
               mountPath: /etc/passwd
             - name: procdir
               mountPath: /host/proc
+              mountPropagation: None
               readOnly: true
             - name: sysprobe-socket-dir
               mountPath: /var/run/sysprobe
@@ -358,7 +396,7 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
-              add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "IPC_LOCK"]
+              add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "IPC_LOCK"]
           command: ["/opt/datadog-agent/embedded/bin/system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
           env:
             - name: DD_LOG_LEVEL
@@ -367,18 +405,15 @@ spec:
           volumeMounts:
             - name: debugfs
               mountPath: /sys/kernel/debug
+              mountPropagation: None
             - name: sysprobe-config
-              mountPath: /etc/datadog-agent
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
             - name: sysprobe-socket-dir
               mountPath: /var/run/sysprobe
             - name: procdir
               mountPath: /host/proc
-              readOnly: true
-            - name: modules
-              mountPath: /lib/modules
-              readOnly: true
-            - name: src
-              mountPath: /usr/src
+              mountPropagation: None
               readOnly: true
       initContainers:
         - name: init-volume
@@ -402,9 +437,11 @@ spec:
               mountPath: /etc/datadog-agent
             - name: procdir
               mountPath: /host/proc
+              mountPropagation: None
               readOnly: true
             - name: runtimesocketdir
               mountPath: /host/var/run
+              mountPropagation: None
               readOnly: true
             - name: sysprobe-config
               mountPath: /etc/datadog-agent/system-probe.yaml
@@ -435,8 +472,12 @@ spec:
               mountPath: /etc/config
             - name: seccomp-root
               mountPath: /host/var/lib/kubelet/seccomp
+              mountPropagation: None
           resources: {}
       volumes:
+        - name: installinfo
+          configMap:
+            name: datadog-agent-installinfo
         - name: config
           emptyDir: {}
         - hostPath:
@@ -464,12 +505,6 @@ spec:
           name: debugfs
         - name: sysprobe-socket-dir
           emptyDir: {}
-        - hostPath:
-            path: /lib/modules
-          name: modules
-        - hostPath:
-            path: /usr/src
-          name: src
         - hostPath:
             path: /etc/passwd
           name: passwd

--- a/static/resources/yaml/datadog-agent-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-vanilla.yaml
@@ -11,6 +11,22 @@ data:
 
 # APP Key
 ---
+# Source: datadog/templates/install_info-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-agent-installinfo
+  labels: {}
+  annotations:
+    checksum/install_info: ee293ccedf116ce1ed6e0d9c7f7f9adabd0c230618089bb173c7acffa487e020
+data:
+  install_info: |
+    ---
+    install_method:
+      tool: kubernetes sample manifests
+      tool_version: kubernetes sample manifests
+      installer_version: kubernetes sample manifests
+---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
@@ -67,16 +83,23 @@ spec:
             - name: DD_HEALTH_PORT
               value: "5555"
           volumeMounts:
+            - name: installinfo
+              subPath: install_info
+              mountPath: /etc/datadog-agent/install_info
+              readOnly: true
             - name: config
               mountPath: /etc/datadog-agent
             - name: runtimesocketdir
               mountPath: /host/var/run
+              mountPropagation: None
               readOnly: true
             - name: procdir
               mountPath: /host/proc
+              mountPropagation: None
               readOnly: true
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
               readOnly: true
           livenessProbe:
             failureThreshold: 6
@@ -118,9 +141,11 @@ spec:
               mountPath: /etc/datadog-agent
             - name: procdir
               mountPath: /host/proc
+              mountPropagation: None
               readOnly: true
             - name: runtimesocketdir
               mountPath: /host/var/run
+              mountPropagation: None
               readOnly: true
           env:
             - name: DD_API_KEY
@@ -138,6 +163,9 @@ spec:
               value: unix:///host/var/run/docker.sock
           resources: {}
       volumes:
+        - name: installinfo
+          configMap:
+            name: datadog-agent-installinfo
         - name: config
           emptyDir: {}
         - hostPath:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

* Regenerate the sample Kubernetes manifests from the latest version of the Helm chart;
* Add an AKS example with the mount of the kubelet CA certificate.

### Motivation

Azure AKS has been updated which blocks the agent communicating with the Kubelet unless some additional steps are taken to mount the correct certificate.
This appears to be the only way to get secure communication working once again.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes

For the [AKS example](https://github.com/DataDog/documentation/pull/8464/commits/0032a56e56b0520907d985aa0c57850241b69fc4), I copied and modified the “vanilla” example:
```shell
diff -u datadog-agent-vanilla_values.yaml datadog-agent-aks_values.yaml
```
```diff
--- datadog-agent-vanilla_values.yaml	2020-06-04 11:23:21.000000000 +0200
+++ datadog-agent-aks_values.yaml	2020-09-04 11:10:51.000000000 +0200
@@ -6,3 +6,16 @@
   rbac:
     create: false
     serviceAccountName: datadog-agent
+  volumes:
+    - name: kubeletserver
+      hostPath:
+        path: /etc/kubernetes/certs
+  volumeMounts:
+    - name: kubeletserver
+      mountPath: /etc/kubernetes/certs/
+      readOnly: true
+  containers:
+    agent:
+      env:
+        - name: DD_KUBELET_CLIENT_CA
+          value: /etc/kubernetes/certs/kubeletserver.crt
```

```shell
diff -u datadog-agent-vanilla.yaml datadog-agent-aks.yaml
```
```diff
--- datadog-agent-vanilla.yaml	2020-09-04 11:11:27.000000000 +0200
+++ datadog-agent-aks.yaml	2020-09-04 11:11:12.000000000 +0200
@@ -82,6 +82,8 @@
               value: "true"
             - name: DD_HEALTH_PORT
               value: "5555"
+            - name: DD_KUBELET_CLIENT_CA
+              value: /etc/kubernetes/certs/kubeletserver.crt
           volumeMounts:
             - name: installinfo
               subPath: install_info
@@ -101,6 +103,9 @@
               mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               readOnly: true
+            - mountPath: /etc/kubernetes/certs/
+              name: kubeletserver
+              readOnly: true
           livenessProbe:
             failureThreshold: 6
             httpGet:
@@ -179,6 +184,9 @@
           name: cgroups
         - name: s6-run
           emptyDir: {}
+        - hostPath:
+            path: /etc/kubernetes/certs
+          name: kubeletserver
       tolerations:
       affinity: {}
       serviceAccountName: "datadog-agent"
```
