### PR TITLE
Fix moving_rollup language

### DIFF
--- a/content/en/api/v1/dashboards/CreateDashboard.py
+++ b/content/en/api/v1/dashboards/CreateDashboard.py
@@ -39,4 +39,4 @@ api.Dashboard.create(title=title,
                      is_read_only=is_read_only,
                      notify_list=notify_list,
                      template_variables=template_variables,
-                     template_variable_presets=saved_views)
+                     template_variable_presets=saved_view)

--- a/content/en/api/v1/dashboards/CreateDashboard.py
+++ b/content/en/api/v1/dashboards/CreateDashboard.py
@@ -39,4 +39,4 @@ api.Dashboard.create(title=title,
                      is_read_only=is_read_only,
                      notify_list=notify_list,
                      template_variables=template_variables,
-                     template_variable_presets=saved_view)
+                     template_variable_presets=saved_views)

--- a/content/en/dashboards/functions/rollup.md
+++ b/content/en/dashboards/functions/rollup.md
@@ -36,7 +36,7 @@ The following bar graph displays the same metric, graphed using a day-long rollu
 |------------------|------------------------------------------------|------------------|
 | `moving_rollup` | Rollup to combine the points in the last X seconds. | `moving_rollup(<METRIC_NAME>, <TIME> , <METHOD>)` |
 
-Appending the `.moving_rollup()` function at the end of a query allows you to combine points from the most recent specified time range, i.e. the last X seconds. The function takes two parameters, `<TIME>` and `<METHOD>`: `.moving_rollup(<TIME>,<METHOD>)`.
+Applying the `.moving_rollup()` function to a query allows you to combine points from the most recent specified time range, i.e. the last X seconds. The function takes two parameters, `<TIME>` and `<METHOD>`: `.moving_rollup(<TIME>,<METHOD>)`.
 
 | Parameter        | Description                                   |
 ------------------|------------------------------------------------|


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fixes language in the `moving_rollup` docs that implies the function can be appended to a query. 

### Motivation
<!-- What inspired you to submit this pull request?-->
Customer confusion over this incorrect documentation https://datadoghq.atlassian.net/browse/WEBPS-2706

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/stephanieniu/moving_rollup/dashboards/functions/rollup

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
