### PR TITLE
Update datadog-agent-manager-windows.md

### DIFF
--- a/content/en/agent/guide/datadog-agent-manager-windows.md
+++ b/content/en/agent/guide/datadog-agent-manager-windows.md
@@ -19,7 +19,7 @@ The Datadog Agent v6 Manager GUI is browser-based. The port the GUI runs on can 
 
 3. For security reasons, the GUI can only be accessed from the local network interface (localhost/127.0.0.1), so you must be on the same host that the Agent is running to use it. In other words, you can't run the Agent on a VM or container and access it from the host machine.
 
-#### Supported browser
+#### Supported browsers
 
 | Browser       | Supported Version (or later) | Comment                 |
 |---------------|------------------------------|-------------------------|

--- a/content/en/agent/guide/datadog-agent-manager-windows.md
+++ b/content/en/agent/guide/datadog-agent-manager-windows.md
@@ -21,7 +21,7 @@ The Datadog Agent v6 Manager GUI is browser-based. The port the GUI runs on can 
 
 #### Supported browsers
 
-| Browser       | Supported Version (or later) | Comment                 |
+| Browser       | Supported version (or later) | Comment                 |
 |---------------|------------------------------|-------------------------|
 | IE            | 11                           |                         |
 | Edge          | 12                           |  Pre-Chromium Edge |

--- a/content/en/agent/guide/datadog-agent-manager-windows.md
+++ b/content/en/agent/guide/datadog-agent-manager-windows.md
@@ -24,7 +24,7 @@ The Datadog Agent v6 Manager GUI is browser-based. The port the GUI runs on can 
 | Browser       | Supported Version (or later) | Comment                 |
 |---------------|------------------------------|-------------------------|
 | IE            | 11                           |                         |
-| Edge          | 12                           |  Old, pre-chromium Edge |
+| Edge          | 12                           |  Pre-Chromium Edge |
 | Edge-chromium | 79                           |                         |
 | Firefox       | 38                           |                         |
 | Chrome        | 60                           |                         |

--- a/content/en/agent/guide/datadog-agent-manager-windows.md
+++ b/content/en/agent/guide/datadog-agent-manager-windows.md
@@ -19,6 +19,18 @@ The Datadog Agent v6 Manager GUI is browser-based. The port the GUI runs on can 
 
 3. For security reasons, the GUI can only be accessed from the local network interface (localhost/127.0.0.1), so you must be on the same host that the Agent is running to use it. In other words, you can't run the Agent on a VM or container and access it from the host machine.
 
+#### Supported browser
+
+| Browser       | Supported Version (or later) | Comment                 |
+|---------------|------------------------------|-------------------------|
+| IE            | 11                           |                         |
+| Edge          | 12                           |  Old, pre-chromium Edge |
+| Edge-chromium | 79                           |                         |
+| Firefox       | 38                           |                         |
+| Chrome        | 60                           |                         |
+| Safari        | 8                            |                         |
+| IOS           | 12                           |  Mobile Safari          |
+ 
 ### Start the Datadog Agent Manager
 
 After the Agent is [installed][1] on your Windows host, start the Datadog Agent Manager to manage the Agent graphically.


### PR DESCRIPTION
Add supported browser section following below.
https://github.com/DataDog/web-ui/blob/89c39abcc1999c2cc04f6db433b549eb00586d77/javascript/datadog/lib/browser/warn-unsupported-browser.tsx#L6-L13

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
Related zendesk ticket: https://datadog.zendesk.com/agent/tickets/389736
Customer found the Agent manager doesn't work on IE8 and it's not documented. So I added here.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
