### PR TITLE
Revert a short-term workaround that we documented now that a proper fix is in the agent codebase.

### DIFF
--- a/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
+++ b/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
@@ -68,7 +68,7 @@ RUN ddev -e release build <INTEGRATION_NAME>
 
 FROM datadog/agent:latest
 COPY --from=wheel_builder /wheels/integrations-extras/<INTEGRATION_NAME>/dist/ /dist
-RUN agent -c /etc/datadog-agent/datadog-docker.yaml integration install -r -w /dist/*.whl
+RUN agent integration install -r -w /dist/*.whl
 ```
 
 Then use this new Agent image in combination with [Autodiscovery][1] in order to enable the `<INTEGRATION_NAME>` check.

--- a/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
+++ b/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
@@ -20,55 +20,27 @@ Community developed integrations for the Datadog Agent are stored in the [Integr
 
 To install the `<INTEGRATION_NAME>` check on your host:
 
-1. Install the [developer toolkit][1].
-2. Clone the integrations-extras repository:
+1. [Download and launch the Datadog Agent][1].
+2. Run the following command to install the integrations with the Agent:
 
     ```
-    git clone https://github.com/DataDog/integrations-extras.git.
+    datadog-agent integration install -t <INTEGRATION_NAME>==<INTEGRATION_VERSION>
     ```
 
-3. Update your `ddev` config with the `integrations-extras/` path:
+3. Configure your integration like [any other packaged integration][2].
+4. [Restart the Agent][3].
 
-    ```
-    ddev config set extras ./integrations-extras
-    ```
-
-4. To build the `<INTEGRATION_NAME>` package, run:
-
-    ```
-    ddev -e release build <INTEGRATION_NAME>
-    ```
-
-5. [Download and launch the Datadog Agent][2].
-6. Run the following command to install the integrations wheel with the Agent:
-
-    ```
-    datadog-agent integration install -w <PATH_OF_INTEGRATION_NAME_PACKAGE>/<ARTIFACT_NAME>.whl
-    ```
-
-7. Configure your integration like [any other packaged integration][3].
-8. [Restart the Agent][4].
-
-[1]: /developers/integrations/new_check_howto/#developer-toolkit
-[2]: https://app.datadoghq.com/account/settings#agent
-[3]: /getting_started/integrations/
-[4]: /agent/guide/agent-commands/#restart-the-agent
+[1]: https://app.datadoghq.com/account/settings#agent
+[2]: /getting_started/integrations/
+[3]: /agent/guide/agent-commands/#restart-the-agent
 {{% /tab %}}
 {{% tab "Docker" %}}
 
 The best way to use an integration from integrations-extra with the Docker Agent is to build the Agent with this integration installed. Use the following Dockerfile to build an updated version of the Agent that includes the `<INTEGRATION_NAME>` integration from integrations-extras.
 
-```text
-FROM python:3.8 AS wheel_builder
-WORKDIR /wheels
-RUN pip install "datadog-checks-dev[cli]"
-RUN git clone https://github.com/DataDog/integrations-extras.git
-RUN ddev config set extras ./integrations-extras
-RUN ddev -e release build <INTEGRATION_NAME>
-
+```dockerfile
 FROM datadog/agent:latest
-COPY --from=wheel_builder /wheels/integrations-extras/<INTEGRATION_NAME>/dist/ /dist
-RUN agent integration install -r -w /dist/*.whl
+RUN agent integration install -r -t <INTEGRATION_NAME>==<INTEGRATION_VERSION>
 ```
 
 Then use this new Agent image in combination with [Autodiscovery][1] in order to enable the `<INTEGRATION_NAME>` check.

--- a/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
+++ b/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
@@ -43,6 +43,8 @@ FROM datadog/agent:latest
 RUN agent integration install -r -t <INTEGRATION_NAME>==<INTEGRATION_VERSION>
 ```
 
+The `agent integration install` command run inside docker will issue the following harmless warning: `Error loading config: Config File "datadog" Not Found in "[/etc/datadog-agent]": warn`. This warning can be ignored.
+
 Then use this new Agent image in combination with [Autodiscovery][1] in order to enable the `<INTEGRATION_NAME>` check.
 
 [1]: /agent/autodiscovery/

--- a/content/fr/agent/guide/community-integrations-installation-with-docker-agent.md
+++ b/content/fr/agent/guide/community-integrations-installation-with-docker-agent.md
@@ -67,7 +67,7 @@ RUN ddev -e release build <NOM_INTÉGRATION>
 
 FROM datadog/agent:latest
 COPY --from=wheel_builder /wheels/integrations-extras/<NOM_INTÉGRATION>/dist/ /dist
-RUN agent -c /etc/datadog-agent/datadog-docker.yaml integration install -r -w /dist/*.whl
+RUN agent integration install -r -w /dist/*.whl
 ```
 
 Utilisez ensuite la nouvelle image de l'Agent en combinaison avec [Autodiscovery][1] pour activer le check `<NOM_INTÉGRATION>`.

--- a/content/fr/agent/guide/community-integrations-installation-with-docker-agent.md
+++ b/content/fr/agent/guide/community-integrations-installation-with-docker-agent.md
@@ -19,55 +19,27 @@ Les intégrations développées par la communauté pour l'Agent Datadog sont sto
 
 Pour installer le check `<NOM_INTÉGRATION>` sur votre host :
 
-1. Installez le [kit de développement logiciel][1].
-2. Clonez le dépôt integrations-extras :
+1. [Téléchargez et lancez l'Agent Datadog][1].
+2. Exécutez la commande suivante pour installer le wheel de l'intégration à l'aide de l'Agent :
 
     ```
-    git clone https://github.com/DataDog/integrations-extras.git.
+    datadog-agent integration install -t <NOM_INTÉGRATION>==<VERSION_INTEGRATION>
     ```
 
-3. Mettez à jour votre configuration `ddev` avec le chemin `integrations-extras/` :
+3. Configurez votre intégration comme [n'importe quelle autre intégration du paquet][2].
+4. [Redémarrez l'Agent][3].
 
-    ```
-    ddev config set extras ./integrations-extras
-    ```
-
-4. Pour créer le paquet `<NOM_INTÉGRATION>`, exécutez :
-
-    ```
-    ddev -e release build <INTEGRATION_NAME>
-    ```
-
-5. [Téléchargez et lancez l'Agent Datadog][2].
-6. Exécutez la commande suivante pour installer le wheel de l'intégration à l'aide de l'Agent :
-
-    ```
-    datadog-agent integration install -w <PATH_OF_INTEGRATION_NAME_PACKAGE>/<ARTIFACT_NAME>.whl
-    ```
-
-7. Configurez votre intégration comme [n'importe quelle autre intégration du paquet][3].
-8. [Redémarrez l'Agent][4].
-
-[1]: /fr/developers/integrations/new_check_howto/#developer-toolkit
-[2]: https://app.datadoghq.com/account/settings#agent
-[3]: /fr/getting_started/integrations/
-[4]: /fr/agent/guide/agent-commands/#restart-the-agent
+[1]: https://app.datadoghq.com/account/settings#agent
+[2]: /fr/getting_started/integrations/
+[3]: /fr/agent/guide/agent-commands/#restart-the-agent
 {{% /tab %}}
 {{% tab "Docker" %}}
 
 Le meilleur moyen d'utiliser une intégration provenant du dépôt integrations-extra avec l'Agent Docker est de générer une image de l'Agent avec cette intégration installée. Utilisez le Dockerfile suivant pour créer une version mise à jour de l'Agent comprenant l'intégration `<NOM_INTÉGRATION>` issue de integrations-extras.
 
-```text
-FROM python:3.8 AS wheel_builder
-WORKDIR /wheels
-RUN pip install "datadog-checks-dev[cli]"
-RUN git clone https://github.com/DataDog/integrations-extras.git
-RUN ddev config set extras ./integrations-extras
-RUN ddev -e release build <NOM_INTÉGRATION>
-
+```dockerfile
 FROM datadog/agent:latest
-COPY --from=wheel_builder /wheels/integrations-extras/<NOM_INTÉGRATION>/dist/ /dist
-RUN agent integration install -r -w /dist/*.whl
+RUN agent integration install -r -t <INTEGRATION_NAME>==<INTEGRATION_VERSION>
 ```
 
 Utilisez ensuite la nouvelle image de l'Agent en combinaison avec [Autodiscovery][1] pour activer le check `<NOM_INTÉGRATION>`.

--- a/content/ja/agent/guide/community-integrations-installation-with-docker-agent.md
+++ b/content/ja/agent/guide/community-integrations-installation-with-docker-agent.md
@@ -67,7 +67,7 @@ RUN ddev -e release build  <インテグレーション名>
 
 FROM datadog/agent:latest
 COPY --from=wheel_builder /wheels/integrations-extras/<インテグレーション名>/dist/ /dist
-RUN agent -c /etc/datadog-agent/datadog-docker.yaml integration install -r -w /dist/*.whl
+RUN agent integration install -r -w /dist/*.whl
 ```
 
 次に、この新しい Agent イメージを[オートディスカバリー][1]と組み合わせて使用して、`<インテグレーション名>` チェックを有効にします。

--- a/content/ja/agent/guide/community-integrations-installation-with-docker-agent.md
+++ b/content/ja/agent/guide/community-integrations-installation-with-docker-agent.md
@@ -19,55 +19,27 @@ Datadog Agent のコミュニティ開発のインテグレーションは、[In
 
 `<インテグレーション名>` チェックをホストにインストールするには
 
-1. [開発ツールキット][1]をインストールします。
-2. integrations-extras リポジトリを複製します。
+1. [Datadog Agent をダウンロードして起動][1]します。
+2. 次のコマンドを実行して、Agent でインテグレーション Wheel をインストールします。
 
     ```
-    git clone https://github.com/DataDog/integrations-extras.git.
+    datadog-agent integration install -t <インテグレーション名>==<統合バージョン>
     ```
 
-3. `ddev` 構成を `integrations-extras/` パスで更新します。
+3. [他のパッケージ化されたインテグレーション][2]と同様にインテグレーションを構成します。
+4. [Agent を再起動します][3]。
 
-    ```
-    ddev config set extras ./integrations-extras
-    ```
-
-4. `<インテグレーション名>` パッケージをビルドします。
-
-    ```
-    ddev -e release build <INTEGRATION_NAME>
-    ```
-
-5. [Datadog Agent をダウンロードして起動][2]します。
-6. 次のコマンドを実行して、Agent でインテグレーション Wheel をインストールします。
-
-    ```
-    datadog-agent integration install -w <PATH_OF_INTEGRATION_NAME_PACKAGE>/<ARTIFACT_NAME>.whl
-    ```
-
-7. [他のパッケージ化されたインテグレーション][3]と同様にインテグレーションを構成します。
-8. [Agent を再起動します][4]。
-
-[1]: /ja/developers/integrations/new_check_howto/#developer-toolkit
-[2]: https://app.datadoghq.com/account/settings#agent
-[3]: /ja/getting_started/integrations/
-[4]: /ja/agent/guide/agent-commands/#restart-the-agent
+[1]: https://app.datadoghq.com/account/settings#agent
+[2]: /ja/getting_started/integrations/
+[3]: /ja/agent/guide/agent-commands/#restart-the-agent
 {{% /tab %}}
 {{% tab "Docker" %}}
 
 integrations-extra からの Docker Agent とのインテグレーションを使用する最良の方法は、このインテグレーションがインストールされた Agent をビルドすることです。次の Dockerfile を使用して、integrations-extra からの `<インテグレーション名>` インテグレーションを含む Agent の更新バージョンをビルドします。
 
-```text
-FROM python:3.8 AS wheel_builder
-WORKDIR /wheels
-RUN pip install "datadog-checks-dev[cli]"
-RUN git clone https://github.com/DataDog/integrations-extras.git
-RUN ddev config set extras ./integrations-extras
-RUN ddev -e release build  <インテグレーション名>
-
+```dockerfile
 FROM datadog/agent:latest
-COPY --from=wheel_builder /wheels/integrations-extras/<インテグレーション名>/dist/ /dist
-RUN agent integration install -r -w /dist/*.whl
+RUN agent integration install -r -t <インテグレーション名>==<統合バージョン>
 ```
 
 次に、この新しい Agent イメージを[オートディスカバリー][1]と組み合わせて使用して、`<インテグレーション名>` チェックを有効にします。


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Reverts a short-term workaround that we documented until a proper fix was merged into the agent codebase.

In the process of building custom datadog agent docker images, it is needed to run `agent integration install` inside the Dockerfile.
At some point, this procedure was broken and we put a workaround in the documentation: https://github.com/DataDog/documentation/pull/7208.
A proper fix has now been submitted to the agent codebase: https://github.com/DataDog/datadog-agent/pull/6333.
So that the workaround can be removed from the documentation.

### Motivation
<!-- What inspired you to submit this pull request?-->

Revert to simpler instructions in the doc.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/lenaic/fix_integration_install_in_docker_build

Check preview base path using the URL in details in `preview` status check.

### Additional Notes

⚠️ This documentation PR can only be merged once:
1. https://github.com/DataDog/datadog-agent/pull/6333 has been merged and;
2. the change has been released. (Hopefully agent release 7.23.0)
