### PR TITLE
Update to include install_info set up requirements

### DIFF
--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -118,6 +118,7 @@ Setting the value without a secret results in the token being readable in the `P
   * [`agent-services.yaml`: The Cluster Agent Service manifest][4]
   * [`secrets.yaml`: The secret holding the Datadog API key][5]
   * [`cluster-agent-deployment.yaml`: Cluster Agent manifest][6]
+  * [`install_info-configmap.yaml`: Install Info Configmap][10]
 
 2. In the `secrets.yaml` manifest, replace `PUT_YOUR_BASE64_ENCODED_API_KEY_HERE` with [your Datadog API key][7] encoded in base64:
 
@@ -128,6 +129,7 @@ Setting the value without a secret results in the token being readable in the `P
 3. In the `cluster-agent-deployment.yaml` manifest, set the token from [Step 2 - Secure Cluster-Agent-to-Agent Communication](#step-2-secure-cluster-agent-to-agent-communication). The format depends on how you set up your secret; instructions can be found in the manifest directly.
 4. Run: `kubectl apply -f agent-services.yaml`
 5. Run: `kubectl apply -f secrets.yaml`
+6. Run: `kubectl apply -f install_info-configmap.yaml`
 6. Finally, deploy the Datadog Cluster Agent: `kubectl apply -f cluster-agent-deployment.yaml`
 
 ### Step 4 - Verification
@@ -220,3 +222,4 @@ Kubernetes events are beginning to flow into your Datadog account, and relevant 
 [7]: https://app.datadoghq.com/account/settings#api
 [8]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-rbac.yaml
 [9]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/daemonset.yaml
+[10]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/install_info-configmap.yaml


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates Cluster Agent documentation to Include information on the Install_info configmap change. 

### Motivation
Our cluster-agent-deployment.yaml file was updated to include a volume mount for a configmap install-info

Change in template for DCA deployment: 
https://github.com/DataDog/helm-charts/blob/master/charts/datadog/templates/cluster-agent-deployment.yaml#L228-L230

Added Here: 
https://github.com/DataDog/helm-charts/commit/324e776fa3f84238336beb04cff94924b88aaca4

File can be found here: 
https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/install_info-configmap.yaml

This adds a requirement to apply the configmap or the deployment will throw an error as it cannot create the volume mount.

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
