### PR TITLE
Update link to cluster-agent-rbac

### DIFF
--- a/content/en/agent/cluster_agent/external_metrics.md
+++ b/content/en/agent/cluster_agent/external_metrics.md
@@ -147,7 +147,7 @@ To activate usage of `DatadogMetric` CRD, follow these extra steps:
 2. Update Datadog Cluster Agent RBAC manifest, it has been updated to allow usage of `DatadogMetric` CRD.
 
     ```shell
-    kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-rbac.yaml"
+    kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/cluster-agent-rbac.yaml"
     ```
 
 3. Set the `DD_EXTERNAL_METRICS_PROVIDER_USE_DATADOGMETRIC_CRD` to `true` in the deployment of the Datadog Cluster Agent.

--- a/content/fr/agent/cluster_agent/external_metrics.md
+++ b/content/fr/agent/cluster_agent/external_metrics.md
@@ -146,7 +146,7 @@ Pour tirer parti du CRD `DatadogMetric`, suivez les étapes ci-dessous :
 2. Mettez à jour le manifeste RBAC de l'Agent de cluster Datadog. La mise à jour permet d'utiliser le CRD `DatadogMetric`.
 
     ```shell
-    kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-rbac.yaml"
+    kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/cluster-agent-rbac.yaml"
     ```
 
 3. Définissez la variable `DD_EXTERNAL_METRICS_PROVIDER_USE_DATADOGMETRIC_CRD` sur `true` dans le déploiement de l'Agent de cluster Datadog.

--- a/content/ja/agent/cluster_agent/external_metrics.md
+++ b/content/ja/agent/cluster_agent/external_metrics.md
@@ -146,7 +146,7 @@ Kubernetes は 30 秒ごとに Datadog Cluster Agent にクエリを実行して
 2. Datadog Cluster Agent RBAC マニフェストを更新します (`DatadogMetric` CRD の使用を許可するために更新されています)。
 
     ```shell
-    kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-rbac.yaml"
+    kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/cluster-agent-rbac.yaml"
     ```
 
 3. Datadog Cluster Agent のデプロイで、`DD_EXTERNAL_METRICS_PROVIDER_USE_DATADOGMETRIC_CRD` を `true` に設定します。


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

fixes #8491 Broken link to Cluster Agent RBAC manifest in Custom Metrics Server page

### Motivation

I was following the documentation to get custom metrics server running in our cluster. I found this broken link when looking to see exactly what rbac changes were going to be applied. Since I was not able to locate this file I went looking in the history of the docs repo to find that it was [recently renamed](https://github.com/DataDog/datadog-agent/pull/6151/files#diff-40e36e606dc50126d3b952e545e52a3b). Motivation was to get hpas to use external metrics and to know what rbac resources were required.