### PR TITLE
Set exit code on failure for build api pages script

### DIFF
--- a/src/scripts/build-api-pages.js
+++ b/src/scripts/build-api-pages.js
@@ -798,7 +798,10 @@ const processSpecs = (specs) => {
           updateMenu(fileData, version, supportedLangs);
           createPages(fileData, deref, version);
           createResources(fileData, JSON.parse(jsonString), version);
-        }).catch((e) => console.log(e));
+        }).catch((e) => {
+          console.log(e);
+          process.exitCode = 1;
+        })
     });
 };
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Set the exit code if we have an exception in the processSpec (main) method of the build api pages script. 

### Motivation
<!-- What inspired you to submit this pull request?-->
This should allow CI systems to properly show a failure status if this script was unsuccessful. 
Currently since we catch all, the exit code is always 0 despite errors. 

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
