### PR TITLE
Fix typo on kubernetes logging

### DIFF
--- a/content/en/agent/kubernetes/log.md
+++ b/content/en/agent/kubernetes/log.md
@@ -28,7 +28,7 @@ The Docker API is optimized to get logs from one container at a time, when there
 
 ## Log collection
 
-In order to start collecting your application logs you must be [runing the Datadog Agent in your Kubernetes cluster][2]. To enable log collection with your Agent, follow the instructions below:
+In order to start collecting your application logs you must be [running the Datadog Agent in your Kubernetes cluster][2]. To enable log collection with your Agent, follow the instructions below:
 
 {{< tabs >}}
 {{% tab "DaemonSet " %}}


### PR DESCRIPTION
### What does this PR do?
Fixes a typo on the kubernetes Log Collection page

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.
