### PR TITLE
Fix link to distribution metric docs

### DIFF
--- a/content/en/serverless/enhanced_lambda_metrics/_index.md
+++ b/content/en/serverless/enhanced_lambda_metrics/_index.md
@@ -64,3 +64,4 @@ Once you've enabled Enhanced Lambda Metrics, view your [default dashboard in the
 [7]: /serverless/datadog_lambda_library
 [8]: /logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 [9]: https://app.datadoghq.com/screen/integration/30306/aws-lambda-enhanced-metrics
+[10]: /metrics/distributions/


### PR DESCRIPTION
### What does this PR do?

Fixes a broken link in the Lambda Enhanced Metric doc

**Question for reviewer:** which distribution metric doc should we link to?

https://docs.datadoghq.com/metrics/distributions/
https://docs.datadoghq.com/developers/metrics/types/?tab=distribution#metric-types

### Motivation

Broken link


### Staging link

https://docs-staging.datadoghq.com/stephen.pinkerton/fix-link-serverless-enhanced-metric-docs/serverless/enhanced_lambda_metrics