### PR TITLE
Fix link to internal repo to public docs

### DIFF
--- a/content/en/agent/amazon_ecs/data_collected.md
+++ b/content/en/agent/amazon_ecs/data_collected.md
@@ -17,6 +17,8 @@ further_reading:
 
 ### Metrics
 
+Metrics collected by the Agent when using Amazon ECS on EC2 instances:
+
 {{< get-metrics-from-git "amazon_ecs" >}}
 
 Each of the metrics retrieved from AWS is assigned the same tags that appear in the AWS console, including but not limited to hostname, security-groups, and more.

--- a/content/en/agent/amazon_ecs/data_collected.md
+++ b/content/en/agent/amazon_ecs/data_collected.md
@@ -17,7 +17,7 @@ further_reading:
 
 ### Metrics
 
-See [metadata.csv][1] for a list of metrics provided by this integration.
+See [the Amazon ECS integration documentation][1] for a list of metrics provided by this integration.
 
 Each of the metrics retrieved from AWS is assigned the same tags that appear in the AWS console, including but not limited to hostname, security-groups, and more.
 
@@ -39,6 +39,6 @@ To remove the whitelist and receive all events from your Datadog Amazon ECS inte
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/DataDog/dogweb/blob/prod/integration/amazon_ecs/amazon_ecs_metadata.csv
+[1]: /integrations/amazon_ecs/#data-collected
 [2]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/deploy-container-insights-ECS-instancelevel.html
 [3]: https://docs.datadoghq.com/help/

--- a/content/en/agent/amazon_ecs/data_collected.md
+++ b/content/en/agent/amazon_ecs/data_collected.md
@@ -17,11 +17,11 @@ further_reading:
 
 ### Metrics
 
-See [the Amazon ECS integration documentation][1] for a list of metrics provided by this integration.
+{{< get-metrics-from-git "amazon_ecs" >}}
 
 Each of the metrics retrieved from AWS is assigned the same tags that appear in the AWS console, including but not limited to hostname, security-groups, and more.
 
-**Note**: Metrics prefixed with `ecs.containerinsights.*` come from the [AWS CloudWatch agent][2].
+**Note**: Metrics prefixed with `ecs.containerinsights.*` come from the [AWS CloudWatch agent][1].
 
 ### Events
 
@@ -29,7 +29,7 @@ To reduce noise, the Amazon ECS integration is automatically set up to include o
 
 {{< img src="integrations/amazon_ecs/aws_ecs_events.png" alt="AWS ECS Events" >}}
 
-To remove the whitelist and receive all events from your Datadog Amazon ECS integration, reach out to [Datadog support][3].
+To remove the whitelist and receive all events from your Datadog Amazon ECS integration, reach out to [Datadog support][2].
 
 ### Service checks
 
@@ -39,6 +39,5 @@ To remove the whitelist and receive all events from your Datadog Amazon ECS inte
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /integrations/amazon_ecs/#data-collected
-[2]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/deploy-container-insights-ECS-instancelevel.html
-[3]: https://docs.datadoghq.com/help/
+[1]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/deploy-container-insights-ECS-instancelevel.html
+[2]: https://docs.datadoghq.com/help/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fixes link that was to an internal github repo

### Motivation
<!-- What inspired you to submit this pull request?-->
report in documentation channel

### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/kari/fix-ecs-data-collected-link/agent/amazon_ecs/data_collected/

