### PR TITLE
Fix small typos

### DIFF
--- a/content/en/agent/cluster_agent/external_metrics.md
+++ b/content/en/agent/cluster_agent/external_metrics.md
@@ -77,7 +77,7 @@ Once you have the Datadog Cluster Agent running and the service registered, crea
 
 ```yaml
 spec:
-  metric:
+  metrics:
     - type: External
       external:
       metricName: "<METRIC_NAME>"
@@ -113,7 +113,7 @@ spec:
 Note in this manifest that:
 
 - The HPA is configured to autoscale the deployment called `nginx`.
-- The maximum number of replicas created is `5`, and the minimum is `1`.
+- The maximum number of replicas created is `3`, and the minimum is `1`.
 - The metric used is `nginx.net.request_per_s`, and the scope is `kube_container_name: nginx`. This metric format corresponds to the Datadog one.
 
 Every 30 seconds, Kubernetes queries the Datadog Cluster Agent to get the value of this metric and autoscales proportionally if necessary. For advanced use cases, it is possible to have several metrics in the same HPA. As you can see [in the Kubernetes horizontal pod autoscaling documentation][9], the largest of the proposed values is the one chosen.
@@ -184,7 +184,7 @@ Once your `DatadogMetric` is created, you need to configure your HPA to use this
 
 ```yaml
 spec:
-  metric:
+  metrics:
     - type: External
       external:
       metricName: "datadogmetric@<namespace>:<datadogmetric_name>"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Just fixing some mistakes in the docs.

1. The `metric` spec doesn't exists. it is `metrics`

```error: error validating "hpa.yaml": error validating data: ValidationError(HorizontalPodAutoscaler.spec): unknown field "metric" in io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerSpec; if you choose to ignore these errors, turn validation off with --validate=false```

2. The number of maximun replicas in the example is wrong

### Motivation

I'm trying to enable the external metrics on my hpa and when reading the docs, I found the errors

### Additional Notes
<!-- Anything else we should know when reviewing?-->
