### PR TITLE
Update collecting logs with pagination guide

### DIFF
--- a/content/en/logs/guide/collect-multiple-logs-with-pagination.md
+++ b/content/en/logs/guide/collect-multiple-logs-with-pagination.md
@@ -30,9 +30,10 @@ To retrieve a log list longer than the maximum 1000 logs limit returned by the [
 Start by creating a query to retrieve your logs for a given context, for example, for a given query in a set timeframe:
 
 ```bash
-curl -X POST \
-'https://api.datadoghq.com/api/v1/logs-queries/list?api_key=<DATADOG_API_KEY>&application_key=<DATADOG_APPLICATION_KEY>' \
--H 'content-type: application/json' \
+curl -X POST https://api.datadoghq.com/api/v1/logs-queries/list \
+-H "Content-Type: application/json" \
+-H "DD-API-KEY: ${DD_CLIENT_API_KEY}" \
+-H "DD-APPLICATION-KEY: ${DD_CLIENT_APP_KEY}" \
 -d '{
         "limit": 50,
         "query": "*",
@@ -62,9 +63,10 @@ The `logs` parameter is an array of Log objects and at maximum it contains as ma
 To retrieve the next page of logs, re-send your query, but this time with the `startAt` parameter that takes the `nextLogId` value from the previous call:
 
 ```bash
-curl -X POST \
-'https://api.datadoghq.com/api/v1/logs-queries/list?api_key=<DATADOG_API_KEY>&application_key=<DATADOG_APPLICATION_KEY>' \
--H 'Content-Type: application/json' \
+curl -X POST https://api.datadoghq.com/api/v1/logs-queries/list \
+-H "Content-Type: application/json" \
+-H "DD-API-KEY: ${DD_CLIENT_API_KEY}" \
+-H "DD-APPLICATION-KEY: ${DD_CLIENT_APP_KEY}" \
 -d '{
         "limit": 1000,
         "query": "*",
@@ -98,9 +100,10 @@ To see every page of your logs, continue to resend your query where the `startAt
 Start by creating a query to retrieve your logs for a given context, for example, for a given query in a set timeframe:
 
 ```bash
-curl -X POST \
-'https://api.datadoghq.com/api/v2/logs/events/search?api_key=<DATADOG_API_KEY>&application_key=<DATADOG_APPLICATION_KEY>' \
--H 'content-type: application/json' \
+curl -X POST https://api.datadoghq.com/api/v2/logs/events/search \
+-H "Content-Type: application/json" \
+-H "DD-API-KEY: ${DD_CLIENT_API_KEY}" \
+-H "DD-APPLICATION-KEY: ${DD_CLIENT_APP_KEY}" \
 -d '{
       "filter": 
               {
@@ -140,9 +143,10 @@ The `data` parameter is an array of Log objects and at maximum it contains as ma
 To see next page of your logs, continue to resend your query but include the `cursor` parameter where it takes the `after` value from the previous call. When you see `data` returns `null`, you have returned all pages of logs associated with your query.
 
 ```bash
-curl -X POST \
-'https://api.datadoghq.com/api/v2/logs/events/search?api_key=<DATADOG_API_KEY>&application_key=<DATADOG_APPLICATION_KEY>' \
--H 'content-type: application/json' \
+curl -X POST https://api.datadoghq.com/api/v2/logs/events/search \
+-H "Content-Type: application/json" \
+-H "DD-API-KEY: ${DD_CLIENT_API_KEY}" \
+-H "DD-APPLICATION-KEY: ${DD_CLIENT_APP_KEY}" \
 -d '{
       "filter": 
               {

--- a/content/en/logs/guide/collect-multiple-logs-with-pagination.md
+++ b/content/en/logs/guide/collect-multiple-logs-with-pagination.md
@@ -39,8 +39,8 @@ curl -X POST https://api.datadoghq.com/api/v1/logs-queries/list \
         "query": "*",
         "sort": "desc",
         "time": {
-            "from": "2019-08-07T00:00:00Z",
-            "to": "2019-08-06T00:00:00Z"
+            "from": "2019-08-06T00:00:00Z",
+            "to": "2019-08-07T00:00:00Z"
         }
     }'
 ```
@@ -73,8 +73,8 @@ curl -X POST https://api.datadoghq.com/api/v1/logs-queries/list \
         "startAt": "AAAAAAAAAAAAAAAABBBBBBBBBBBBBBCCCCCCCCCCDDDDDDDDDD",
         "sort": "desc",
         "time": {
-            "from": "2019-08-07T00:00:00Z",
-            "to": "2019-08-06T00:00:00Z"
+            "from": "2019-08-06T00:00:00Z",
+            "to": "2019-08-07T00:00:00Z"
         }
     }'
 ```
@@ -107,8 +107,8 @@ curl -X POST https://api.datadoghq.com/api/v2/logs/events/search \
 -d '{
       "filter": 
               {
-                "from": "2019-08-07T00:00:00Z",
-                "to": "2019-08-06T00:00:00Z",
+                "from": "2019-08-06T00:00:00Z",
+                "to": "2019-08-07T00:00:00Z",
                 "query": "@datacenter:us @role:db"
                },
       "page":  
@@ -150,8 +150,8 @@ curl -X POST https://api.datadoghq.com/api/v2/logs/events/search \
 -d '{
       "filter": 
               {
-                "from": "2019-08-07T00:00:00Z",
-                "to": "2019-08-06T00:00:00Z",
+                "from": "2019-08-06T00:00:00Z",
+                "to": "2019-08-07T00:00:00Z",
                 "query": "@datacenter:us @role:db"
                },
       "page":  


### PR DESCRIPTION
Update examples use headers to pass keys & use double quotes

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Updates the examples in the guide for using the api's pagination to collect logs:  
- Use headers to pass keys & use double quotes (to allow for variable expansion)
- Make `to` date more recent than `from` date

### Motivation

- Consistency with other curl examples.
- `to` timestamp should be more recent than `from` timestamp

### Preview link

https://docs-staging.datadoghq.com/tj/update_log_pagination_guide_examples/logs/guide/collect-multiple-logs-with-pagination/

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
