### PR TITLE
fixed extra "." in java sample code

### DIFF
--- a/content/en/developers/metrics/dogstatsd_metrics_submission.md
+++ b/content/en/developers/metrics/dogstatsd_metrics_submission.md
@@ -131,7 +131,7 @@ public class DogStatsdClient {
     public static void main(String[] args) throws Exception {
 
         StatsDClient Statsd = new NonBlockingStatsDClientBuilder()
-            .prefix("statsd").
+            .prefix("statsd")
             .hostname("localhost")
             .port(8125)
             .build();


### PR DESCRIPTION
removed extra dot "." in the java sample code

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
remove extra dot "." from the java sample code
### Motivation
<!-- What inspired you to submit this pull request?-->
the "." causes an error when copy/pasting the sample code
### Preview link
<!-- Impacted pages preview links-->

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

Check preview base path using the URL in details in `preview` status check.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
