### PR TITLE
Document enabling go App Analytics using env var

### DIFF
--- a/content/en/tracing/app_analytics/_index.md
+++ b/content/en/tracing/app_analytics/_index.md
@@ -50,11 +50,14 @@ Datadog.configure { |c| c.analytics_enabled = true }
 {{% /tab %}}
 {{% tab "Go" %}}
 
-App Analytics is available starting in version 1.11.0 of the Go tracing client, and can be enabled globally for all **web** integrations using the [`WithAnalytics`][1] tracer start option. For example:
+App Analytics is available starting in version 1.11.0 of the Go tracing client, and can be enabled globally for all **web** integrations using:
+* the [`WithAnalytics`][1] tracer start option, for example:
 
-```go
-tracer.Start(tracer.WithAnalytics(true))
-```
+  ```go
+  tracer.Start(tracer.WithAnalytics(true))
+  ```
+
+* starting in version 1.26.0 using environment variable: `DD_TRACE_ANALYTICS_ENABLED=true`
 
 [1]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#WithAnalytics
 {{% /tab %}}


### PR DESCRIPTION
Check release 1.26.0 notes https://github.com/DataDog/dd-trace-go/releases
> ddtrace/tracer: add support for various environment variables (#696, #691)

Starting with the release 1.26.0 you can use `DD_TRACE_ANALYTICS_ENABLED=true`.
