### PR TITLE
Fix link for sending logs over HTTP

### DIFF
--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -211,7 +211,7 @@ Endpoints that can be used to send logs to Datadog US region:
 |--------------------------------------|---------|----------------------------------------------------------------------------------------------------------|
 | `intake.logs.datadoghq.com`          | `10514` | Used by custom forwarders to send logs in raw, Syslog, or JSON format over an unecrypted TCP connection. |
 
-[1]: /agent/logs/#send-logs-over-https
+[1]: /api/v1/logs/#send-logs
 
 {{< /site-region >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes a broken link

### Motivation
I want to send log data over HTTP but the link is broken

### Preview link
(Not applicable but here’s where the affected links are)

![image](https://user-images.githubusercontent.com/193136/93309041-3edb5600-f82d-11ea-849d-8274d33f486b.png)

### Additional Notes
This commit broke the link: 38e4ff67bb3ad71d380ddeed8116d85c5a33772f
