### PR TITLE
Remove %22 from GET request

### DIFF
--- a/content/en/synthetics/ci.md
+++ b/content/en/synthetics/ci.md
@@ -178,7 +178,7 @@ curl -G \
     "https://api.datadoghq.com/api/v1/synthetics/tests/poll_results" \
     -H "DD-API-KEY: ${api_key}" \
     -H "DD-APPLICATION-KEY: ${app_key}" \
-    -d "result_ids=[%220123456789012345678%22]"
+    -d "result_ids=[220123456789012345678]"
 ```
 
 {{< /site-region >}}


### PR DESCRIPTION
### What does this PR do?
Using the formatting as suggested at line 197 throws an error. Just using the test id without further markup works - it's already in a string. It might also be helpful to add the option to use multiple test id's to get the result of more monitors in one request. 

-d "result_ids=[220123456789012345678]"

-d "result_ids=[7697436730754600430,2950751071008638898]"

### Motivation
Ticket of customer who encountered this issue.
https://datadog.zendesk.com/agent/tickets/393098

### Preview link
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
n/a
