### PR TITLE
[WIP] Provide single setup command option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM debian:10.5
+
+RUN apt-get update && \
+    apt-get install -y curl git hugo \
+    python3-dev python3-pip python3-venv python3-wheel
+
+# install node and npm
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+    apt-get install -y nodejs
+
+
+WORKDIR /docs
+CMD ["make", "start-no-pre-build"]

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,12 @@ IMAGE_VERSION="latest"
 
 # config
 CONFIG_FILE := Makefile.config
+ifneq (${MAKECMDGOALS}, start-docker)
 ifeq ($(wildcard $(CONFIG_FILE)),)
-	$(error $(CONFIG_FILE) not found. See $(CONFIG_FILE).example.)
+	_ := $(error $(CONFIG_FILE) not found. See $(CONFIG_FILE).example.)
 endif
 include $(CONFIG_FILE)
+endif
 
 help:
 	@perl -nle'print $& if m{^[a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
@@ -164,6 +166,11 @@ start-no-pre-build: clean source-helpers ## Build the documentation without auto
 		RUN_SERVER=${RUN_SERVER} \
 		run-site-no-pre-build.sh; \
 	else @echo "\033[31m\033[1mPython 3 must be available to Build the documentation.\033[0m" ; fi
+
+start-docker:
+	if ! [ -f Makefile.config ]; then cp Makefile.config.example Makefile.config; fi
+	docker build --tag datadog-docs - < Dockerfile
+	docker run --rm -it --name datadog-docs -v $$PWD:/docs -p 127.0.0.1:1313:1313/tcp datadog-docs
 
 stop:  ## Stop wepack watch/hugo server.
 	@echo "stopping previous..."

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "prestart": "rimraf public",
         "start": "run-p start:**",
         "start:webpack": "webpack --config webpack.dev.js --progress",
-        "start:hugo": "./node_modules/.bin/hugo server -D -d ./public -s ./ --port 1313 --navigateToChanged --noHTTPCache",
+        "start:hugo": "./node_modules/.bin/hugo server -D --bind 0.0.0.0 -d ./public -s ./ --port 1313 --navigateToChanged --noHTTPCache",
         "prebuild": "rimraf public",
         "build": "run-s build:webpack build:hugo",
         "build:preview": "yarn run build:webpack:preview && yarn run build:hugo:preview",


### PR DESCRIPTION
As a contributor I want to be able to see a preview of my changes but the preview link works only for people in the Datadog organization and working off of a branch. I could try to rely on the github markdown preview but github's preview isn't that reliable for this project.

There are setup instructions available but the changes that I make usually take only a minute to prepare but following the setup instructions takes 10 times longer.

I propose we add a new `start-docker` (name TBD) make target. Here's how the workflow would look like:
1. User forks https://github.com/DataDog/documentation
2. User creates a patch branch.
3. User makes his changes and commits them.
4. User runs `make start-docker` which in turn runs build and serves the docs from inside the container.
5. User opens `http://localhost:1313` in his web browser to see his changes.
6. User can continue to commit new changes and these changes are reflected on http://localhost:1313 for as long as the container is up.

Notice the user no longer has to install `npm`, `python3`, `hugo` etc. by hand or create `Makefile.config`. This make target will create a default `Makefile.config` file if one doesn't already exist.

The only dependencies for `start-docker` are `make` and `docker` which many of us developers already have installed.

It would be best if the Datadog organization could upload the built image to their registry so that users don't have to spend time waiting for the image to build.

TODO:
1. - [ ] Start `hugo` with `--bind 0.0.0.0` only when using `start-docker`
2. - [ ] Signal handling workarounds for `make`
3. - [ ] Cleanup `Dockerfile`, use different image
4. - [ ] Maybe make it so that node_modules, virtual environment etc. only live in the container? Currently they get written to the mounted directory.
5. - [ ] `Makefile.config` tricks, e.g. create Makefile.config only in the container