### PR TITLE
Fix Go App Analytics bullet list rendering

### DIFF
--- a/content/en/tracing/app_analytics/_index.md
+++ b/content/en/tracing/app_analytics/_index.md
@@ -51,6 +51,7 @@ Datadog.configure { |c| c.analytics_enabled = true }
 {{% tab "Go" %}}
 
 App Analytics is available starting in version 1.11.0 of the Go tracing client, and can be enabled globally for all **web** integrations using:
+
 * the [`WithAnalytics`][1] tracer start option, for example:
 
   ```go


### PR DESCRIPTION
Fixing the mistake made in https://github.com/DataDog/documentation/pull/8548

Before:
![go_app_analytics_before](https://user-images.githubusercontent.com/8993001/93534892-2f036500-f946-11ea-881b-4e24b7b63948.png)

After:
![go_app_analytics_after](https://user-images.githubusercontent.com/8993001/93534900-332f8280-f946-11ea-8a47-43408ba38fa4.png)
