### PR TITLE
Fix error logging in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ IMAGE_VERSION="latest"
 # config
 CONFIG_FILE := Makefile.config
 ifeq ($(wildcard $(CONFIG_FILE)),)
-	$(error $(CONFIG_FILE) not found. See $(CONFIG_FILE).example.)
+	_ := $(error $(CONFIG_FILE) not found. See $(CONFIG_FILE).example.)
 endif
 include $(CONFIG_FILE)
 


### PR DESCRIPTION
Try running `make help` while there is no `Make.config` file. Result:

```
Makefile:17: *** recipe commences before first target.  Stop.
```

With my changes:

```
Makefile:17: *** Makefile.config not found. See Makefile.config.example..  Stop
```

Other possible fix is to not use indentation or to replace the tab with a single space / multiple spaces but we risk that this change gets reverted by someone's editor.