### PR TITLE
Fix HPA example for matchLabels

### DIFF
--- a/content/en/agent/cluster_agent/external_metrics.md
+++ b/content/en/agent/cluster_agent/external_metrics.md
@@ -83,7 +83,7 @@ spec:
       metricName: "<METRIC_NAME>"
       metricSelector:
         matchLabels:
-          "<TAG_KEY>:<TAG_VALUE>"
+          <TAG_KEY>: <TAG_VALUE>
 ```
 
 **Example**: An HPA manifest to autoscale off an NGINX deployment based off of the `nginx.net.request_per_s` Datadog metric:


### PR DESCRIPTION
Example notation evaluates incorrectly

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fix a bad example for the HPA configuration where it instructs you to create a string rather than a key/value pair.

The example:
```
matchLabels:
  "<TAG_KEY>:<TAG_VALUE>"
```
Would lead you to do 
```
matchLabels:
  "kube_container_name:nginx"
```
Which is incorrect as it is creating string. You want to create a key/value pair like so:
```
matchLabels:
  kube_container_name: nginx
```
Such as in the example immediately beneath this. 

### Motivation
<!-- What inspired you to submit this pull request?-->
Customer encountered discrepancy

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jack.davenport/hpa_example/agent/cluster_agent/external_metrics/#run-the-hpa

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
