### PR TITLE
[WEB-743] - fix bug with required fields

### DIFF
--- a/src/scripts/build-api-pages.js
+++ b/src/scripts/build-api-pages.js
@@ -633,7 +633,16 @@ const descColumn = (key, value) => {
  */
 const rowRecursive = (tableType, data, isNested, requiredFields=[], level = 0, parentKey = '') => {
   let html = '';
-  let newRequiredFields = data.required || requiredFields;
+  let newRequiredFields;
+
+  // data.required must be an array of required fields e.g ['foo', 'bar']
+  // if its not then we possible have a field called required that is actually an object
+  // and we don't want this so pass in previous requirements
+  if(data.required && data.required instanceof Array) {
+    newRequiredFields = data.required;
+  } else {
+    newRequiredFields = requiredFields;
+  }
 
   // i've set a hard recurse limit of depth
   if(level > 10) return '';

--- a/src/scripts/tests/build-api-pages.test.js
+++ b/src/scripts/tests/build-api-pages.test.js
@@ -1256,6 +1256,77 @@ describe(`descColumn`, () => {
 
 describe(`rowRecursive`, () => {
 
+  it('should handle fields named required (properties->required)', () => {
+    /*
+    Required fields are usually an array of string e.g ['foo'.'bar']
+    If a field is named required then the logic should recognise this is a field object and not the array to check against
+    */
+    const mockData = {
+      "description": "A customized field defined by users and attached to a certain object type (incidents, etc).",
+      "properties": {
+        "id": {
+          "type": "string",
+          "example": "a91169ea3eb950dd85cc2a58c5a2d2c6",
+          "description": "The field's ID."
+        },
+        "attributes": {
+          "type": "object",
+          "description": "The field's attributes.",
+          "properties": {
+            "name": {
+              "type": "string",
+              "example": "state",
+              "description": "Name of the field."
+            },
+            "required": {
+              "type": "boolean",
+              "description": "If true, this field is required to create an object of the field's assigned `table_id` type.",
+              "default": false
+            },
+            "created_by_user": {
+              "description": "JSON API relationship for users.",
+              "properties": {
+                "data": {
+                  "description": "The User relationship data.",
+                  "properties": {
+                    "id": {
+                      "description": "A unique identifier that represents the user.",
+                      "example": "00000000-0000-0000-0000-000000000000",
+                      "type": "string"
+                    },
+                    "type": {
+                      "default": "users",
+                      "description": "Users resource type.",
+                      "enum": [
+                        "users"
+                      ],
+                      "type": "string",
+                      "x-enum-varnames": [
+                        "USERS"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          }
+        }
+      },
+      "required": [
+        "id",
+        "type"
+      ],
+      "type": "object"
+    };
+    const mockInitialData = mockData.properties;
+    const t = () => {
+      bp.rowRecursive("request", mockInitialData, false, mockInitialData.required || []);
+    };
+    expect(t).not.toThrow(Error);
+
+  });
 
 });
 


### PR DESCRIPTION
### What does this PR do?

In some situations a field in the api spec might be called `required` this should be treated differently than the data adjacent to properties that is the list of required fields for the upcoming fields.

This PR fixes this issue by checking that the required fields we are looking for is also an array.

### Motivation

https://datadoghq.atlassian.net/browse/WEB-743

### Preview

(Shouldn't effect preview)
https://docs-staging.datadoghq.com/david.jones/requiredbug

### Additional Notes

N/A

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
