### PR TITLE
apm/python: move python documentation links to readthedocs

### DIFF
--- a/content/en/tracing/app_analytics/_index.md
+++ b/content/en/tracing/app_analytics/_index.md
@@ -158,7 +158,7 @@ Use this in addition to the global configuration for any integrations that submi
 
 **Note**: Several integrations require non-standard configuration due to the integration-specific implementation of the tracer. Consult the library documentation on [App Analytics][1] for details.
 
-[1]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#trace_search_analytics
+[1]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#trace_search_analytics
 {{% /tab %}}
 {{% tab "Ruby" %}}
 

--- a/content/en/tracing/compatibility_requirements/python.md
+++ b/content/en/tracing/compatibility_requirements/python.md
@@ -20,7 +20,7 @@ To request support for additional libraries, contact our awesome [support team][
 
 The `ddtrace` library includes support for a number of web frameworks, including:
 
-| Framework                 | Supported Version | PyPi Datadog Documentation                                         |
+| Framework                 | Supported Version | Library Documentation                                              |
 | ------------------------- | ----------------- | ------------------------------------------------------------------ |
 | [aiohttp][3]             | >= 1.2            | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#aiohttp |
 | [Bottle][4]              | >= 0.11           | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#bottle  |
@@ -37,7 +37,7 @@ The `ddtrace` library includes support for a number of web frameworks, including
 
 The `ddtrace` library includes support for the following data stores:
 
-| Datastore                          | Supported Version | PyPi Datadog Documentation                                                                    |
+| Datastore                          | Supported Version | Library Documentation                                                                         |
 | ---------------------------------- | ----------------- | --------------------------------------------------------------------------------------------- |
 | [Cassandra][12]                    | >= 3.5            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#cassandra                           |
 | [Elasticsearch][13]                | >= 1.6            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#elasticsearch                       |
@@ -61,7 +61,7 @@ The `ddtrace` library includes support for the following data stores:
 
 The `ddtrace` library includes support for the following libraries:
 
-| Library           | Supported Version | PyPi Datadog Documentation                                               |
+| Library           | Supported Version | Library Documentation                                                    |
 | ----------------- | ----------------- | ------------------------------------------------------------------------ |
 | [asyncio][32]     | Fully Supported   | https://ddtrace.readthedocs.io/en/stable/async_integrations.html#asyncio     |
 | [gevent][33]      | >= 1.0            | https://ddtrace.readthedocs.io/en/stable/async_integrations.html#gevent      |

--- a/content/en/tracing/compatibility_requirements/python.md
+++ b/content/en/tracing/compatibility_requirements/python.md
@@ -22,16 +22,16 @@ The `ddtrace` library includes support for a number of web frameworks, including
 
 | Framework                 | Supported Version | PyPi Datadog Documentation                                         |
 | ------------------------- | ----------------- | ------------------------------------------------------------------ |
-| [aiohttp][3]             | >= 1.2            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#aiohttp |
-| [Bottle][4]              | >= 0.11           | http://pypi.datadoghq.com/trace/docs/web_integrations.html#bottle  |
-| [Django][5]              | >= 1.8            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#django  |
-| [djangorestframework][5] | >= 3.4            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#django  |
-| [Falcon][6]              | >= 1.0            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#falcon  |
-| [Flask][7]               | >= 0.10           | http://pypi.datadoghq.com/trace/docs/web_integrations.html#flask   |
-| [Molten][8]              | >= 0.7.0          | http://pypi.datadoghq.com/trace/docs/web_integrations.html#molten  |
-| [Pylons][9]              | >= 0.9.6          | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pylons  |
-| [Pyramid][10]             | >= 1.7            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pyramid |
-| [Tornado][11]             | >= 4.0            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#tornado |
+| [aiohttp][3]             | >= 1.2            | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#aiohttp |
+| [Bottle][4]              | >= 0.11           | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#bottle  |
+| [Django][5]              | >= 1.8            | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#django  |
+| [djangorestframework][5] | >= 3.4            | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#django  |
+| [Falcon][6]              | >= 1.0            | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#falcon  |
+| [Flask][7]               | >= 0.10           | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#flask   |
+| [Molten][8]              | >= 0.7.0          | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#molten  |
+| [Pylons][9]              | >= 0.9.6          | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#pylons  |
+| [Pyramid][10]             | >= 1.7            | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#pyramid |
+| [Tornado][11]             | >= 4.0            | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#tornado |
 
 ### Datastore Compatibility
 
@@ -39,23 +39,23 @@ The `ddtrace` library includes support for the following data stores:
 
 | Datastore                          | Supported Version | PyPi Datadog Documentation                                                                    |
 | ---------------------------------- | ----------------- | --------------------------------------------------------------------------------------------- |
-| [Cassandra][12]                    | >= 3.5            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#cassandra                           |
-| [Elasticsearch][13]                | >= 1.6            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#elasticsearch                       |
-| [Flask Cache][14]                  | >= 0.12           | http://pypi.datadoghq.com/trace/docs/db_integrations.html#flask-cache                         |
-| [Memcached][15] [pylibmc][16]      | >= 1.4            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#pylibmc                             |
-| [Memcached][15] [pymemcache][17]   | >= 1.3            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#pymemcache                          |
-| [MongoDB][18] [Mongoengine][19]    | >= 0.11           | http://pypi.datadoghq.com/trace/docs/db_integrations.html#mongoengine                         |
-| [MongoDB][18] [Pymongo][20]        | >= 3.0            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#pymongo                             |
-| [MySQL][21] [MySQL-python][22]     | >= 1.2.3          | http://pypi.datadoghq.com/trace/docs/db_integrations.html#module-ddtrace.contrib.mysqldb      |
-| [MySQL][21] [mysqlclient][23]      | >= 1.3            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#module-ddtrace.contrib.mysqldb      |
-| [MySQL][21] mysql-connector        | >= 2.1            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#mysql-connector                     |
-| [Postgres][24] [aiopg][25]         | >= 0.12.0         | http://pypi.datadoghq.com/trace/docs/db_integrations.html#aiopg                               |
-| [Postgres][24] [psycopg][26]       | >= 2.4            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#module-ddtrace.contrib.psycopg      |
-| [Redis][27]                        | >= 2.6            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#redis                               |
-| [Redis][27] [redis-py-cluster][28] | >= 1.3.5          | http://pypi.datadoghq.com/trace/docs/db_integrations.html#module-ddtrace.contrib.rediscluster |
-| [SQLAlchemy][29]                   | >= 1.0            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#sqlalchemy                          |
-| [SQLite3][30]                      | Fully Supported   | http://pypi.datadoghq.com/trace/docs/db_integrations.html#sqlite                              |
-| [Vertica][31]                      | >= 0.6            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#vertica                             |
+| [Cassandra][12]                    | >= 3.5            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#cassandra                           |
+| [Elasticsearch][13]                | >= 1.6            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#elasticsearch                       |
+| [Flask Cache][14]                  | >= 0.12           | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#flask-cache                         |
+| [Memcached][15] [pylibmc][16]      | >= 1.4            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#pylibmc                             |
+| [Memcached][15] [pymemcache][17]   | >= 1.3            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#pymemcache                          |
+| [MongoDB][18] [Mongoengine][19]    | >= 0.11           | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#mongoengine                         |
+| [MongoDB][18] [Pymongo][20]        | >= 3.0            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#pymongo                             |
+| [MySQL][21] [MySQL-python][22]     | >= 1.2.3          | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#module-ddtrace.contrib.mysqldb      |
+| [MySQL][21] [mysqlclient][23]      | >= 1.3            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#module-ddtrace.contrib.mysqldb      |
+| [MySQL][21] mysql-connector        | >= 2.1            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#mysql-connector                     |
+| [Postgres][24] [aiopg][25]         | >= 0.12.0         | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#aiopg                               |
+| [Postgres][24] [psycopg][26]       | >= 2.4            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#module-ddtrace.contrib.psycopg      |
+| [Redis][27]                        | >= 2.6            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#redis                               |
+| [Redis][27] [redis-py-cluster][28] | >= 1.3.5          | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#module-ddtrace.contrib.rediscluster |
+| [SQLAlchemy][29]                   | >= 1.0            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#sqlalchemy                          |
+| [SQLite3][30]                      | Fully Supported   | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#sqlite                              |
+| [Vertica][31]                      | >= 0.6            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#vertica                             |
 
 ### Library Compatibility
 
@@ -63,19 +63,19 @@ The `ddtrace` library includes support for the following libraries:
 
 | Library           | Supported Version | PyPi Datadog Documentation                                               |
 | ----------------- | ----------------- | ------------------------------------------------------------------------ |
-| [asyncio][32]     | Fully Supported   | http://pypi.datadoghq.com/trace/docs/async_integrations.html#asyncio     |
-| [gevent][33]      | >= 1.0            | http://pypi.datadoghq.com/trace/docs/async_integrations.html#gevent      |
-| [aiobotocore][34] | >= 0.2.3          | http://pypi.datadoghq.com/trace/docs/other_integrations.html#aiobotocore |
-| [Boto2][34]       | >= 2.29.0         | http://pypi.datadoghq.com/trace/docs/other_integrations.html#boto2       |
-| [Botocore][34]    | >= 1.4.51         | http://pypi.datadoghq.com/trace/docs/other_integrations.html#botocore    |
-| [Celery][35]      | >= 4.0.2          | http://pypi.datadoghq.com/trace/docs/other_integrations.html#celery      |
-| [Futures][36]     | Fully Supported   | http://pypi.datadoghq.com/trace/docs/other_integrations.html#futures     |
-| [Grpc][37]        | >= 1.8.0          | http://pypi.datadoghq.com/trace/docs/other_integrations.html#grpc        |
-| [httplib][38]     | Fully Supported   | http://pypi.datadoghq.com/trace/docs/other_integrations.html#httplib     |
-| [Jinja2][39]      | >= 2.7            | http://pypi.datadoghq.com/trace/docs/other_integrations.html#jinja2      |
-| [Kombu][40]       | >= 4.0            | http://pypi.datadoghq.com/trace/docs/other_integrations.html#kombu       |
-| [Mako][41]        | >= 0.1.0          | http://pypi.datadoghq.com/trace/docs/other_integrations.html#mako        |
-| [Requests][42]    | >= 2.08           | http://pypi.datadoghq.com/trace/docs/other_integrations.html#requests    |
+| [asyncio][32]     | Fully Supported   | https://ddtrace.readthedocs.io/en/stable/async_integrations.html#asyncio     |
+| [gevent][33]      | >= 1.0            | https://ddtrace.readthedocs.io/en/stable/async_integrations.html#gevent      |
+| [aiobotocore][34] | >= 0.2.3          | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#aiobotocore |
+| [Boto2][34]       | >= 2.29.0         | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#boto2       |
+| [Botocore][34]    | >= 1.4.51         | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#botocore    |
+| [Celery][35]      | >= 4.0.2          | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#celery      |
+| [Futures][36]     | Fully Supported   | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#futures     |
+| [Grpc][37]        | >= 1.8.0          | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#grpc        |
+| [httplib][38]     | Fully Supported   | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#httplib     |
+| [Jinja2][39]      | >= 2.7            | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#jinja2      |
+| [Kombu][40]       | >= 4.0            | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#kombu       |
+| [Mako][41]        | >= 0.1.0          | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#mako        |
+| [Requests][42]    | >= 2.08           | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#requests    |
 
 
 ## Further Reading

--- a/content/en/tracing/custom_instrumentation/agent_customization.md
+++ b/content/en/tracing/custom_instrumentation/agent_customization.md
@@ -294,4 +294,4 @@ While this page deals with modifying data once it has reached the Datadog Agent,
 [7]: /api/v1/tracing/
 [8]: /tracing/custom_instrumentation/java/#extending-tracers
 [9]: /tracing/custom_instrumentation/ruby?tab=activespan#post-processing-traces
-[10]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#trace-filtering
+[10]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#trace-filtering

--- a/content/en/tracing/custom_instrumentation/python.md
+++ b/content/en/tracing/custom_instrumentation/python.md
@@ -58,7 +58,7 @@ def make_sandwich_request(request):
 API details for the decorator can be found for `ddtrace.Tracer.wrap()` [here][1].
 
 
-[1]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtrace.Tracer.wrap
+[1]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtrace.Tracer.wrap
 {{% /tab %}}
 {{% tab "Context Manager" %}}
 
@@ -85,8 +85,8 @@ def make_sandwich_request(request):
 
 Full API details for `ddtrace.Tracer()` can be found [here][2]
 
-[1]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtrace.Span
-[2]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#tracer
+[1]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtrace.Span
+[2]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#tracer
 {{% /tab %}}
 {{% tab "Manual" %}}
 
@@ -106,8 +106,8 @@ API details of the decorator can be found in the `ddtrace.Tracer.trace` [documen
 
 
 [1]: /tracing/visualization/#spans
-[2]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtrace.Tracer.trace
-[3]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtrace.Span.finish
+[2]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtrace.Tracer.trace
+[3]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtrace.Span.finish
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/tracing/setup/python.md
+++ b/content/en/tracing/setup/python.md
@@ -9,7 +9,7 @@ further_reading:
     - link: 'https://github.com/DataDog/dd-trace-py'
       tag: 'GitHub'
       text: 'Source code'
-    - link: 'http://pypi.datadoghq.com/trace/docs/'
+    - link: 'https://ddtrace.readthedocs.io/en/stable/'
       tag: 'Pypi'
       text: 'API Docs'
     - link: 'tracing/visualization/'
@@ -102,10 +102,10 @@ tracer.configure(
 [3]: /tracing/send_traces/
 [4]: /tracing/setup/docker/
 [5]: /agent/kubernetes/apm/
-[6]: http://pypi.datadoghq.com/trace/docs
-[7]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtracerun
+[6]: https://ddtrace.readthedocs.io/en/stable/
+[7]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtracerun
 [8]: /getting_started/tagging/unified_service_tagging
 [9]: /tracing/guide/setting_primary_tags_to_scope/
-[10]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#priority-sampling
+[10]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#priority-sampling
 [11]: /tracing/connect_logs_and_traces/python/
 [12]: /tracing/app_analytics/?tab=python#automatic-configuration

--- a/content/fr/security/tracing.md
+++ b/content/fr/security/tracing.md
@@ -64,5 +64,5 @@ Si vous avez besoin d'une instrumentation personnalisée pour une application sp
 [4]: https://github.com/DataDog/datadog-agent/blob/780caa2855a237fa731b78a1bb3ead5492f0e5c6/pkg/config/config_template.yaml#L492-L496
 [5]: https://github.com/DataDog/dd-trace-java/blob/master/dd-trace-api/src/main/java/datadog/trace/api/interceptor/TraceInterceptor.java
 [6]: http://gems.datadoghq.com/trace/docs/#Processing_Pipeline
-[7]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#trace-filtering
+[7]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#trace-filtering
 [8]: /fr/api/v1/tracing/

--- a/content/fr/tracing/app_analytics/_index.md
+++ b/content/fr/tracing/app_analytics/_index.md
@@ -153,7 +153,7 @@ Utilisez ces options en plus de la configuration globale pour les intégrations 
 
 **Remarque** : l'implémentation du traceur étant propre à chaque intégration, plusieurs intégrations nécessitent une configuration spéciale. Consultez la documentation des bibliothèques sur [App Analytics][1] pour en savoir plus.
 
-[1]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#trace_search_analytics
+[1]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#trace_search_analytics
 {{% /tab %}}
 {{% tab "Ruby" %}}
 

--- a/content/fr/tracing/compatibility_requirements/python.md
+++ b/content/fr/tracing/compatibility_requirements/python.md
@@ -21,16 +21,16 @@ La bibliothèque `ddtrace` prend en charge de nombreux frameworks Web, y compris
 
 | Framework                 | Version prise en charge | Documentation PyPi de Datadog                                         |
 | ------------------------- | ----------------- | ------------------------------------------------------------------ |
-| [aiohttp][3]             | >= 1.2            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#aiohttp |
-| [Bottle][4]              | >= 0.11           | http://pypi.datadoghq.com/trace/docs/web_integrations.html#bottle  |
-| [Django][5]              | >= 1.8            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#django  |
-| [djangorestframework][5] | >= 3.4            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#django  |
-| [Falcon][6]              | >= 1.0            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#falcon  |
-| [Flask][7]               | >= 0.10           | http://pypi.datadoghq.com/trace/docs/web_integrations.html#flask   |
-| [Molten][8]              | >= 0.7.0          | http://pypi.datadoghq.com/trace/docs/web_integrations.html#molten  |
-| [Pylons][9]              | >= 0.9.6          | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pylons  |
-| [Pyramid][10]             | >= 1.7            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pyramid |
-| [Tornado][11]             | >= 4.0            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#tornado |
+| [aiohttp][3]             | >= 1.2            | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#aiohttp |
+| [Bottle][4]              | >= 0.11           | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#bottle  |
+| [Django][5]              | >= 1.8            | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#django  |
+| [djangorestframework][5] | >= 3.4            | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#django  |
+| [Falcon][6]              | >= 1.0            | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#falcon  |
+| [Flask][7]               | >= 0.10           | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#flask   |
+| [Molten][8]              | >= 0.7.0          | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#molten  |
+| [Pylons][9]              | >= 0.9.6          | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#pylons  |
+| [Pyramid][10]             | >= 1.7            | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#pyramid |
+| [Tornado][11]             | >= 4.0            | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#tornado |
 
 ### Compatibilité des datastores
 
@@ -38,23 +38,23 @@ La bibliothèque `ddtrace` prend en charge les datastores suivants :
 
 | Datastore                          | Version prise en charge | Documentation PyPi de Datadog                                                                    |
 | ---------------------------------- | ----------------- | --------------------------------------------------------------------------------------------- |
-| [Cassandra][12]                    | >= 3.5            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#cassandra                           |
-| [Elasticsearch][13]                | >= 1.6            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#elasticsearch                       |
-| [Flask Cache][14]                  | >= 0.12           | http://pypi.datadoghq.com/trace/docs/db_integrations.html#flask-cache                         |
-| [Memcached][15] [pylibmc][16]      | >= 1.4            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#pylibmc                             |
-| [Memcached][15] [pymemcache][17]   | >= 1.3            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#pymemcache                          |
-| [MongoDB][18] [Mongoengine][19]    | >= 0.11           | http://pypi.datadoghq.com/trace/docs/db_integrations.html#mongoengine                         |
-| [MongoDB][18] [Pymongo][20]        | >= 3.0            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#pymongo                             |
-| [MySQL][21] [MySQL-python][22]     | >= 1.2.3          | http://pypi.datadoghq.com/trace/docs/db_integrations.html#module-ddtrace.contrib.mysqldb      |
-| [MySQL][21] [mysqlclient][23]      | >= 1.3            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#module-ddtrace.contrib.mysqldb      |
-| [MySQL][21] mysql-connector        | >= 2.1            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#mysql-connector                     |
-| [Postgres][24] [aiopg][25]         | >= 0.12.0         | http://pypi.datadoghq.com/trace/docs/db_integrations.html#aiopg                               |
-| [Postgres][24] [psycopg][26]       | >= 2.4            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#module-ddtrace.contrib.psycopg      |
-| [Redis][27]                        | >= 2.6            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#redis                               |
-| [Redis][27] [redis-py-cluster][28] | >= 1.3.5          | http://pypi.datadoghq.com/trace/docs/db_integrations.html#module-ddtrace.contrib.rediscluster |
-| [SQLAlchemy][29]                   | >= 1.0            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#sqlalchemy                          |
-| [SQLite3][30]                      | Prise en charge complète   | http://pypi.datadoghq.com/trace/docs/db_integrations.html#sqlite                              |
-| [Vertica][31]                      | >= 0.6            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#vertica                             |
+| [Cassandra][12]                    | >= 3.5            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#cassandra                           |
+| [Elasticsearch][13]                | >= 1.6            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#elasticsearch                       |
+| [Flask Cache][14]                  | >= 0.12           | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#flask-cache                         |
+| [Memcached][15] [pylibmc][16]      | >= 1.4            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#pylibmc                             |
+| [Memcached][15] [pymemcache][17]   | >= 1.3            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#pymemcache                          |
+| [MongoDB][18] [Mongoengine][19]    | >= 0.11           | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#mongoengine                         |
+| [MongoDB][18] [Pymongo][20]        | >= 3.0            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#pymongo                             |
+| [MySQL][21] [MySQL-python][22]     | >= 1.2.3          | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#module-ddtrace.contrib.mysqldb      |
+| [MySQL][21] [mysqlclient][23]      | >= 1.3            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#module-ddtrace.contrib.mysqldb      |
+| [MySQL][21] mysql-connector        | >= 2.1            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#mysql-connector                     |
+| [Postgres][24] [aiopg][25]         | >= 0.12.0         | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#aiopg                               |
+| [Postgres][24] [psycopg][26]       | >= 2.4            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#module-ddtrace.contrib.psycopg      |
+| [Redis][27]                        | >= 2.6            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#redis                               |
+| [Redis][27] [redis-py-cluster][28] | >= 1.3.5          | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#module-ddtrace.contrib.rediscluster |
+| [SQLAlchemy][29]                   | >= 1.0            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#sqlalchemy                          |
+| [SQLite3][30]                      | Prise en charge complète   | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#sqlite                              |
+| [Vertica][31]                      | >= 0.6            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#vertica                             |
 
 ### Compatibilité des bibliothèques
 
@@ -62,19 +62,19 @@ La bibliothèque `ddtrace` prend en charge les bibliothèques suivantes :
 
 | Bibliothèque           | Version prise en charge | Documentation PyPi de Datadog                                               |
 | ----------------- | ----------------- | ------------------------------------------------------------------------ |
-| [asyncio][32]     | Prise en charge complète   | http://pypi.datadoghq.com/trace/docs/async_integrations.html#asyncio     |
-| [gevent][33]      | >= 1.0            | http://pypi.datadoghq.com/trace/docs/async_integrations.html#gevent      |
-| [aiobotocore][34] | >= 0.2.3          | http://pypi.datadoghq.com/trace/docs/other_integrations.html#aiobotocore |
-| [Boto2][34]       | >= 2.29.0         | http://pypi.datadoghq.com/trace/docs/other_integrations.html#boto2       |
-| [Botocore][34]    | >= 1.4.51         | http://pypi.datadoghq.com/trace/docs/other_integrations.html#botocore    |
-| [Celery][35]      | >= 4.0.2          | http://pypi.datadoghq.com/trace/docs/other_integrations.html#celery      |
-| [Futures][36]     | Prise en charge complète   | http://pypi.datadoghq.com/trace/docs/other_integrations.html#futures     |
-| [Grpc][37]        | >= 1.8.0          | http://pypi.datadoghq.com/trace/docs/other_integrations.html#grpc        |
-| [httplib][38]     | Prise en charge complète   | http://pypi.datadoghq.com/trace/docs/other_integrations.html#httplib     |
-| [Jinja2][39]      | >= 2.7            | http://pypi.datadoghq.com/trace/docs/other_integrations.html#jinja2      |
-| [Kombu][40]       | >= 4.0            | http://pypi.datadoghq.com/trace/docs/other_integrations.html#kombu       |
-| [Mako][41]        | >= 0.1.0          | http://pypi.datadoghq.com/trace/docs/other_integrations.html#mako        |
-| [Requests][42]    | >= 2.08           | http://pypi.datadoghq.com/trace/docs/other_integrations.html#requests    |
+| [asyncio][32]     | Prise en charge complète   | https://ddtrace.readthedocs.io/en/stable/async_integrations.html#asyncio     |
+| [gevent][33]      | >= 1.0            | https://ddtrace.readthedocs.io/en/stable/async_integrations.html#gevent      |
+| [aiobotocore][34] | >= 0.2.3          | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#aiobotocore |
+| [Boto2][34]       | >= 2.29.0         | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#boto2       |
+| [Botocore][34]    | >= 1.4.51         | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#botocore    |
+| [Celery][35]      | >= 4.0.2          | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#celery      |
+| [Futures][36]     | Prise en charge complète   | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#futures     |
+| [Grpc][37]        | >= 1.8.0          | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#grpc        |
+| [httplib][38]     | Prise en charge complète   | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#httplib     |
+| [Jinja2][39]      | >= 2.7            | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#jinja2      |
+| [Kombu][40]       | >= 4.0            | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#kombu       |
+| [Mako][41]        | >= 0.1.0          | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#mako        |
+| [Requests][42]    | >= 2.08           | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#requests    |
 
 
 ## Pour aller plus loin

--- a/content/fr/tracing/manual_instrumentation/python.md
+++ b/content/fr/tracing/manual_instrumentation/python.md
@@ -57,7 +57,7 @@ def make_sandwich_request(request):
 Cliquez [ici][1] pour consulter les détails sur l'API concernant le décorateur pour `ddtrace.Tracer.wrap()`.
 
 
-[1]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtrace.Tracer.wrap
+[1]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtrace.Tracer.wrap
 {{% /tab %}}
 {{% tab "Gestionnaire de contextes" %}}
 
@@ -84,8 +84,8 @@ def make_sandwich_request(request):
 
 Cliquez [ici][2] pour consulter tous les détails sur l'API pour `ddtrace.Tracer()`.
 
-[1]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtrace.Span
-[2]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#tracer
+[1]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtrace.Span
+[2]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#tracer
 {{% /tab %}}
 {{% tab "Méthode manuelle" %}}
 
@@ -105,8 +105,8 @@ Pour obtenir plus de détails sur l'API pour le décorateur, consultez la docume
 
 
 [1]: /fr/tracing/visualization/#spans
-[2]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtrace.Tracer.trace
-[3]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtrace.Span.finish
+[2]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtrace.Tracer.trace
+[3]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtrace.Span.finish
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/fr/tracing/opentracing/python.md
+++ b/content/fr/tracing/opentracing/python.md
@@ -56,5 +56,5 @@ Pour consulter des informations sur une configuration et une utilisation plus av
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#opentracing
+[1]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#opentracing
 [2]: https://github.com/opentracing/opentracing-python

--- a/content/fr/tracing/setup/python.md
+++ b/content/fr/tracing/setup/python.md
@@ -9,7 +9,7 @@ further_reading:
   - link: 'https://github.com/DataDog/dd-trace-py'
     tag: GitHub
     text: Code source
-  - link: 'http://pypi.datadoghq.com/trace/docs/'
+  - link: 'https://ddtrace.readthedocs.io/en/stable/'
     tag: Pypi
     text: Documentation relative à l'API
   - link: tracing/visualization/
@@ -103,9 +103,9 @@ tracer.configure(
 [4]: /fr/tracing/setup/docker/
 [5]: /fr/agent/kubernetes/apm/
 [6]: http://pypi.datadoghq.com/trace/docs
-[7]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtracerun
+[7]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtracerun
 [8]: /fr/getting_started/tagging/unified_service_tagging
 [9]: /fr/tracing/guide/setting_primary_tags_to_scope/
-[10]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#priority-sampling
+[10]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#priority-sampling
 [11]: /fr/tracing/connect_logs_and_traces/python/
 [12]: /fr/tracing/app_analytics/?tab=python#automatic-configuration

--- a/content/fr/tracing/setup/python.md
+++ b/content/fr/tracing/setup/python.md
@@ -102,7 +102,7 @@ tracer.configure(
 [3]: /fr/tracing/send_traces/
 [4]: /fr/tracing/setup/docker/
 [5]: /fr/agent/kubernetes/apm/
-[6]: http://pypi.datadoghq.com/trace/docs
+[6]: https://ddtrace.readthedocs.io/en/stable/
 [7]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtracerun
 [8]: /fr/getting_started/tagging/unified_service_tagging
 [9]: /fr/tracing/guide/setting_primary_tags_to_scope/

--- a/content/ja/serverless/datadog_lambda_library/python.md
+++ b/content/ja/serverless/datadog_lambda_library/python.md
@@ -34,7 +34,7 @@ Datadog Lambda Library for Python (2.7、3.6、3.7、3.8) は、拡張 Lambda �
 
 トレースとログの接続の詳細については、[ログとトレースの接続](https://docs.datadoghq.com/tracing/connect_logs_and_traces/python/)をご覧ください。
 
-トレーサーの詳細については、[Datadog トレースクライアントの公式ドキュメント](http://pypi.datadoghq.com/trace/docs/index.html)をご覧ください。
+トレーサーの詳細については、[Datadog トレースクライアントの公式ドキュメント](https://ddtrace.readthedocs.io/en/stable/index.html)をご覧ください。
 
 ## 拡張メトリクス
 

--- a/content/ja/tracing/app_analytics/_index.md
+++ b/content/ja/tracing/app_analytics/_index.md
@@ -153,7 +153,7 @@ Nginx で App Analytics を有効にするには
 
 **注**: インテグレーションによっては、そのインテグレーション固有のトレーサーが実装されているため非標準の方法で設定する必要があります。詳細については、[App Analytics][1] のライブラリドキュメントを参照してください。
 
-[1]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#trace_search_analytics
+[1]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#trace_search_analytics
 {{% /tab %}}
 {{% tab "Ruby" %}}
 

--- a/content/ja/tracing/compatibility_requirements/python.md
+++ b/content/ja/tracing/compatibility_requirements/python.md
@@ -21,16 +21,16 @@ Python `2.7` および `3.4` バージョン以降がサポートされます。
 
 | フレームワーク                 | サポート対象のバージョン | PyPi Datadog ドキュメント                                         |
 | ------------------------- | ----------------- | ------------------------------------------------------------------ |
-| [aiohttp][3]             | 1.2 以降            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#aiohttp |
-| [Bottle][4]              | 0.11 以降           | http://pypi.datadoghq.com/trace/docs/web_integrations.html#bottle  |
-| [Django][5]              | 1.8 以降            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#django  |
-| [djangorestframework][5] | 3.4 以降            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#django  |
-| [Falcon][6]              | 1.0 以降            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#falcon  |
-| [Flask][7]               | 0.10 以降           | http://pypi.datadoghq.com/trace/docs/web_integrations.html#flask   |
-| [Molten][8]              | 0.7.0 以降          | http://pypi.datadoghq.com/trace/docs/web_integrations.html#molten  |
-| [Pylons][9]              | 0.9.6 以降          | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pylons  |
-| [Pyramid][10]             | 1.7 以降            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#pyramid |
-| [Tornado][11]             | 4.0 以降            | http://pypi.datadoghq.com/trace/docs/web_integrations.html#tornado |
+| [aiohttp][3]             | 1.2 以降            | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#aiohttp |
+| [Bottle][4]              | 0.11 以降           | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#bottle  |
+| [Django][5]              | 1.8 以降            | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#django  |
+| [djangorestframework][5] | 3.4 以降            | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#django  |
+| [Falcon][6]              | 1.0 以降            | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#falcon  |
+| [Flask][7]               | 0.10 以降           | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#flask   |
+| [Molten][8]              | 0.7.0 以降          | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#molten  |
+| [Pylons][9]              | 0.9.6 以降          | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#pylons  |
+| [Pyramid][10]             | 1.7 以降            | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#pyramid |
+| [Tornado][11]             | 4.0 以降            | https://ddtrace.readthedocs.io/en/stable/web_integrations.html#tornado |
 
 ### データストアの互換性
 
@@ -38,23 +38,23 @@ Python `2.7` および `3.4` バージョン以降がサポートされます。
 
 | data store                          | サポート対象のバージョン | PyPi Datadog ドキュメント                                                                    |
 | ---------------------------------- | ----------------- | --------------------------------------------------------------------------------------------- |
-| [Cassandra][12]                    | 3.5 以降            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#cassandra                           |
-| [Elasticsearch][13]                | 1.6 以降            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#elasticsearch                       |
-| [Flask Cache][14]                  | 0.12 以降           | http://pypi.datadoghq.com/trace/docs/db_integrations.html#flask-cache                         |
-| [Memcached][15] [pylibmc][16]      | 1.4 以降            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#pylibmc                             |
-| [Memcached][15] [pymemcache][17]   | 1.3 以降            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#pymemcache                          |
-| [MongoDB][18] [Mongoengine][19]    | 0.11 以降           | http://pypi.datadoghq.com/trace/docs/db_integrations.html#mongoengine                         |
-| [MongoDB][18] [Pymongo][20]        | 3.0 以降            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#pymongo                             |
-| [MySQL][21] [MySQL-python][22]     | 1.2.3 以降          | http://pypi.datadoghq.com/trace/docs/db_integrations.html#module-ddtrace.contrib.mysqldb      |
-| [MySQL][21] [mysqlclient][23]      | 1.3 以降            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#module-ddtrace.contrib.mysqldb      |
-| [MySQL][21] mysql-connector        | 2.1 以降            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#mysql-connector                     |
-| [Postgres][24] [aiopg][25]         | 0.12.0 以降         | http://pypi.datadoghq.com/trace/docs/db_integrations.html#aiopg                               |
-| [Postgres][24] [psycopg][26]       | 2.4 以降            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#module-ddtrace.contrib.psycopg      |
-| [Redis][27]                        | 2.6 以降            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#redis                               |
-| [Redis][27] [redis-py-cluster][28] | 1.3.5 以降          | http://pypi.datadoghq.com/trace/docs/db_integrations.html#module-ddtrace.contrib.rediscluster |
-| [SQLAlchemy][29]                   | 1.0 以降            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#sqlalchemy                          |
-| [SQLite3][30]                      | 完全対応   | http://pypi.datadoghq.com/trace/docs/db_integrations.html#sqlite                              |
-| [Vertica][31]                      | 0.6 以降            | http://pypi.datadoghq.com/trace/docs/db_integrations.html#vertica                             |
+| [Cassandra][12]                    | 3.5 以降            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#cassandra                           |
+| [Elasticsearch][13]                | 1.6 以降            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#elasticsearch                       |
+| [Flask Cache][14]                  | 0.12 以降           | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#flask-cache                         |
+| [Memcached][15] [pylibmc][16]      | 1.4 以降            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#pylibmc                             |
+| [Memcached][15] [pymemcache][17]   | 1.3 以降            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#pymemcache                          |
+| [MongoDB][18] [Mongoengine][19]    | 0.11 以降           | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#mongoengine                         |
+| [MongoDB][18] [Pymongo][20]        | 3.0 以降            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#pymongo                             |
+| [MySQL][21] [MySQL-python][22]     | 1.2.3 以降          | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#module-ddtrace.contrib.mysqldb      |
+| [MySQL][21] [mysqlclient][23]      | 1.3 以降            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#module-ddtrace.contrib.mysqldb      |
+| [MySQL][21] mysql-connector        | 2.1 以降            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#mysql-connector                     |
+| [Postgres][24] [aiopg][25]         | 0.12.0 以降         | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#aiopg                               |
+| [Postgres][24] [psycopg][26]       | 2.4 以降            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#module-ddtrace.contrib.psycopg      |
+| [Redis][27]                        | 2.6 以降            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#redis                               |
+| [Redis][27] [redis-py-cluster][28] | 1.3.5 以降          | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#module-ddtrace.contrib.rediscluster |
+| [SQLAlchemy][29]                   | 1.0 以降            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#sqlalchemy                          |
+| [SQLite3][30]                      | 完全対応   | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#sqlite                              |
+| [Vertica][31]                      | 0.6 以降            | https://ddtrace.readthedocs.io/en/stable/db_integrations.html#vertica                             |
 
 ### ライブラリの互換性
 
@@ -62,19 +62,19 @@ Python `2.7` および `3.4` バージョン以降がサポートされます。
 
 | ライブラリ           | サポート対象のバージョン | PyPi Datadog ドキュメント                                               |
 | ----------------- | ----------------- | ------------------------------------------------------------------------ |
-| [asyncio][32]     | 完全対応   | http://pypi.datadoghq.com/trace/docs/async_integrations.html#asyncio     |
-| [gevent][33]      | 1.0 以降            | http://pypi.datadoghq.com/trace/docs/async_integrations.html#gevent      |
-| [aiobotocore][34] | 0.2.3 以降          | http://pypi.datadoghq.com/trace/docs/other_integrations.html#aiobotocore |
-| [Boto2][34]       | 2.29.0 以降         | http://pypi.datadoghq.com/trace/docs/other_integrations.html#boto2       |
-| [Botocore][34]    | 1.4.51 以降         | http://pypi.datadoghq.com/trace/docs/other_integrations.html#botocore    |
-| [Celery][35]      | 4.0.2 以降          | http://pypi.datadoghq.com/trace/docs/other_integrations.html#celery      |
-| [Futures][36]     | 完全対応   | http://pypi.datadoghq.com/trace/docs/other_integrations.html#futures     |
-| [Grpc][37]        | 1.8.0 以降          | http://pypi.datadoghq.com/trace/docs/other_integrations.html#grpc        |
-| [httplib][38]     | 完全対応   | http://pypi.datadoghq.com/trace/docs/other_integrations.html#httplib     |
-| [Jinja2][39]      | 2.7 以降            | http://pypi.datadoghq.com/trace/docs/other_integrations.html#jinja2      |
-| [Kombu][40]       | 4.0 以降            | http://pypi.datadoghq.com/trace/docs/other_integrations.html#kombu       |
-| [Mako][41]        | 0.1.0 以降          | http://pypi.datadoghq.com/trace/docs/other_integrations.html#mako        |
-| [Requests][42]    | 2.08 以降           | http://pypi.datadoghq.com/trace/docs/other_integrations.html#requests    |
+| [asyncio][32]     | 完全対応   | https://ddtrace.readthedocs.io/en/stable/async_integrations.html#asyncio     |
+| [gevent][33]      | 1.0 以降            | https://ddtrace.readthedocs.io/en/stable/async_integrations.html#gevent      |
+| [aiobotocore][34] | 0.2.3 以降          | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#aiobotocore |
+| [Boto2][34]       | 2.29.0 以降         | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#boto2       |
+| [Botocore][34]    | 1.4.51 以降         | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#botocore    |
+| [Celery][35]      | 4.0.2 以降          | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#celery      |
+| [Futures][36]     | 完全対応   | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#futures     |
+| [Grpc][37]        | 1.8.0 以降          | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#grpc        |
+| [httplib][38]     | 完全対応   | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#httplib     |
+| [Jinja2][39]      | 2.7 以降            | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#jinja2      |
+| [Kombu][40]       | 4.0 以降            | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#kombu       |
+| [Mako][41]        | 0.1.0 以降          | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#mako        |
+| [Requests][42]    | 2.08 以降           | https://ddtrace.readthedocs.io/en/stable/other_integrations.html#requests    |
 
 
 ## その他の参考資料

--- a/content/ja/tracing/custom_instrumentation/agent_customization.md
+++ b/content/ja/tracing/custom_instrumentation/agent_customization.md
@@ -294,4 +294,4 @@ DD_APM_REPLACE_TAGS=[
 [7]: /ja/api/v1/tracing/
 [8]: /ja/tracing/custom_instrumentation/java/#extending-tracers
 [9]: /ja/tracing/custom_instrumentation/ruby?tab=activespan#post-processing-traces
-[10]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#trace-filtering
+[10]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#trace-filtering

--- a/content/ja/tracing/custom_instrumentation/python.md
+++ b/content/ja/tracing/custom_instrumentation/python.md
@@ -58,7 +58,7 @@ def make_sandwich_request(request):
 `ddtrace.Tracer.wrap()` 向けデコレータの API 詳細は、[こちら][1]で確認できます。
 
 
-[1]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtrace.Tracer.wrap
+[1]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtrace.Tracer.wrap
 {{% /tab %}}
 {{% tab "Context Manager" %}}
 
@@ -85,8 +85,8 @@ def make_sandwich_request(request):
 
 `ddtrace.Tracer()` の API 詳細は[こちら][2]で確認できます
 
-[1]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtrace.Span
-[2]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#tracer
+[1]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtrace.Span
+[2]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#tracer
 {{% /tab %}}
 {{% tab "手動" %}}
 
@@ -106,8 +106,8 @@ def make_sandwich_request(request):
 
 
 [1]: /ja/tracing/visualization/#spans
-[2]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtrace.Tracer.trace
-[3]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtrace.Span.finish
+[2]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtrace.Tracer.trace
+[3]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtrace.Span.finish
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/ja/tracing/setup/python.md
+++ b/content/ja/tracing/setup/python.md
@@ -102,7 +102,7 @@ tracer.configure(
 [3]: /ja/tracing/send_traces/
 [4]: /ja/tracing/setup/docker/
 [5]: /ja/agent/kubernetes/apm/
-[6]: http://pypi.datadoghq.com/trace/docs
+[6]: https://ddtrace.readthedocs.io/en/stable/
 [7]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtracerun
 [8]: /ja/getting_started/tagging/unified_service_tagging
 [9]: /ja/tracing/guide/setting_primary_tags_to_scope/

--- a/content/ja/tracing/setup/python.md
+++ b/content/ja/tracing/setup/python.md
@@ -9,7 +9,7 @@ further_reading:
   - link: 'https://github.com/DataDog/dd-trace-py'
     tag: GitHub
     text: ソースコード
-  - link: 'http://pypi.datadoghq.com/trace/docs/'
+  - link: 'https://ddtrace.readthedocs.io/en/stable/'
     tag: Pypi
     text: API ドキュメント
   - link: tracing/visualization/
@@ -103,9 +103,9 @@ tracer.configure(
 [4]: /ja/tracing/setup/docker/
 [5]: /ja/agent/kubernetes/apm/
 [6]: http://pypi.datadoghq.com/trace/docs
-[7]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#ddtracerun
+[7]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtracerun
 [8]: /ja/getting_started/tagging/unified_service_tagging
 [9]: /ja/tracing/guide/setting_primary_tags_to_scope/
-[10]: http://pypi.datadoghq.com/trace/docs/advanced_usage.html#priority-sampling
+[10]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#priority-sampling
 [11]: /ja/tracing/connect_logs_and_traces/python/
 [12]: /ja/tracing/app_analytics/?tab=python#automatic-configuration


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Moves all links from being http://pypi.datadoghq.com/trace/docs to https://ddtrace.readthedocs.io/

### Motivation
<!-- What inspired you to submit this pull request?-->
We're now building versioned docs for the library on readthedocs.

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
