### PR TITLE
AWS X-Ray integration documentation and cleanup

### DIFF
--- a/content/en/serverless/installation/_index.md
+++ b/content/en/serverless/installation/_index.md
@@ -16,7 +16,9 @@ Install the [AWS integration][1]. This allows Datadog to ingest Lambda metrics f
 
 ### 2. Install the Datadog Forwarder
 
-Install the [Datadog Forwarder Lambda function][2], which is required for ingestion of AWS Lambda traces, enhanced metrics, custom metrics, and logs. **Note**: Skip this step if you already have the Forwarder function installed as part of the [AWS integration][1] CloudFormation stack.
+Install the [Datadog Forwarder Lambda function][2], which is required for ingestion of AWS Lambda traces, enhanced metrics, custom metrics, and logs. 
+
+**Note**: Skip this step if you already have the Forwarder function installed as part of the [AWS integration][1] CloudFormation stack.
 
 ### 3. Instrument Your Application
 

--- a/content/en/serverless/installation/_index.md
+++ b/content/en/serverless/installation/_index.md
@@ -16,9 +16,9 @@ Install the [AWS integration][1]. This allows Datadog to ingest Lambda metrics f
 
 ### 2. Install the Datadog Forwarder
 
-Install the [Datadog Forwarder Lambda function][2], which is required for ingestion of AWS Lambda traces, enhanced metrics, custom metrics, and logs. 
+Install the [Datadog Forwarder Lambda function][2], which is required to ingest AWS Lambda traces, enhanced metrics, custom metrics, and logs. 
 
-**Note**: Skip this step if you already have the Forwarder function installed as part of the [AWS integration][1] CloudFormation stack.
+**Note**: Skip this step if you already have the Forwarder function installed as part of the [AWS integration][1] CloudFormation Stack.
 
 ### 3. Instrument Your Application
 

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -250,6 +250,8 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 
 After you have configured your function following the steps above, you can view metrics, logs and traces on the [Serverless Homepage][2].
 
+### Monitor Custom Serverless Metrics
+
 If you would like to submit a custom metric or manually instrument a function, see the sample code below:
 
 ```javascript
@@ -278,6 +280,15 @@ exports.handler = async (event) => {
   return response;
 };
 ```
+Learn more about submitting custom metrics [here][3].
+
+### Enable the AWS X-Ray Integration
+
+Datadog’s integration with AWS X-Ray allows you to visualize serverless trace data, so you can zero in on the source of any errors or slowdowns, and see how the performance of your functions impacts your users’ experience. Depending on your language and configuration, choose between setting up Datadog APM or the AWS X-Ray integration for your tracing needs. Learn more about configuring distributed tracing [here][4].
+
+{{< img src="integrations/amazon_lambda/lambda_tracing.png" alt="Architecture diagram for tracing AWS Lambda with Datadog" >}}
 
 [1]: /integrations/amazon_web_services/
-[2]: https://app.datadoghq.com/functions
+[2]: /serverless/forwarder
+[3]: /serverless/custom_metrics
+[4]: /serverless/distributed_tracing

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -250,7 +250,7 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 
 After you have configured your function following the steps above, you can view metrics, logs and traces on the [Serverless Homepage][2].
 
-### Monitor Custom Serverless Metrics
+### Monitor Custom Business Metrics
 
 If you would like to submit a custom metric or manually instrument a function, see the sample code below:
 
@@ -280,11 +280,11 @@ exports.handler = async (event) => {
   return response;
 };
 ```
-Learn more about submitting custom metrics [here][3].
+[Enable custom metric submission][3] to get started.
 
 ### Enable the AWS X-Ray Integration
 
-Datadog’s integration with AWS X-Ray allows you to visualize serverless trace data, so you can zero in on the source of any errors or slowdowns, and see how the performance of your functions impacts your users’ experience. Depending on your language and configuration, choose between setting up Datadog APM or the AWS X-Ray integration for your tracing needs. Learn more about configuring distributed tracing [here][4].
+Datadog’s integration with AWS X-Ray allows you to visualize end-to-end serverless transactions, so you can zero in on the source of any errors or slowdowns, and see how the performance of your functions impacts your users’ experience. Depending on your language and configuration, [choose between setting up Datadog APM or the AWS X-Ray integration][4] for your tracing needs.
 
 {{< img src="integrations/amazon_lambda/lambda_tracing.png" alt="Architecture diagram for tracing AWS Lambda with Datadog" >}}
 

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -245,13 +245,13 @@ arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python37:19
 
 #### Using the Package
 
-Install `datadog-lambda` and its dependencies locally to your function project folder. **Note**: `datadog-lambda` depends on `ddtrace`, which uses native extensions; therefore they must be installed and compiled in a Linux environment. For example, you can use [dockerizePip][8] for the Serverless Framework and [--use-container][9] for AWS SAM. For more details, see [how to add dependencies to your function deployment package][3].
+Install `datadog-lambda` and its dependencies locally to your function project folder. **Note**: `datadog-lambda` depends on `ddtrace`, which uses native extensions; therefore they must be installed and compiled in a Linux environment. For example, you can use [dockerizePip][3] for the Serverless Framework and [--use-container][4] for AWS SAM. For more details, see [how to add dependencies to your function deployment package][5].
 
 ```
 pip install datadog-lambda -t ./
 ```
 
-See the [latest release][4]. 
+See the [latest release][6]. 
 
 ### Configure the Function
 
@@ -265,26 +265,28 @@ See the [latest release][4].
 
 You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, to send metrics, traces, and logs to Datadog.
 
-1. [Install the Datadog Forwarder][5] if you haven't.
-2. [Ensure the option DdFetchLambdaTags is enabled][6].
-3. [Subscribe the Datadog Forwarder to your function's log groups][7].
+1. [Install the Datadog Forwarder][7] if you haven't.
+2. [Ensure the option DdFetchLambdaTags is enabled][8].
+3. [Subscribe the Datadog Forwarder to your function's log groups][9].
 
 
 [1]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
 [2]: https://github.com/DataDog/datadog-lambda-python/releases
-[3]: https://docs.aws.amazon.com/lambda/latest/dg/python-package.html#python-package-dependencies
-[4]: https://pypi.org/project/datadog-lambda/
-[5]: https://docs.datadoghq.com/serverless/forwarder/
-[6]: https://docs.datadoghq.com/serverless/forwarder/#experimental-optional
-[7]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
-[8]: https://github.com/UnitedIncome/serverless-python-requirements#cross-compiling
-[9]: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-build.html
+[3]: https://github.com/UnitedIncome/serverless-python-requirements#cross-compiling
+[4]: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-build.html
+[5]: https://docs.aws.amazon.com/lambda/latest/dg/python-package.html#python-package-dependencies
+[6]: https://pypi.org/project/datadog-lambda/
+[7]: https://docs.datadoghq.com/serverless/forwarder/
+[8]: https://docs.datadoghq.com/serverless/forwarder/#experimental-optional
+[9]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 {{% /tab %}}
 {{< /tabs >}}
 
 ## Explore Datadog Serverless Monitoring
 
 After you have configured your function following the steps above, you can view metrics, logs and traces on the [Serverless Homepage][3].
+
+### Monitor Custom Serverless Metrics
 
 If you would like to submit a custom metric or manually instrument a function, see the sample code below:
 
@@ -310,6 +312,16 @@ def get_message():
     return "Hello from serverless!"
 ```
 
+Learn more about submitting custom metrics [here][4].
+
+### Enable the AWS X-Ray Integration
+
+Datadog’s integration with AWS X-Ray allows you to visualize serverless trace data, so you can zero in on the source of any errors or slowdowns, and see how the performance of your functions impacts your users’ experience. Depending on your language and configuration, choose between setting up Datadog APM or the AWS X-Ray integration for your tracing needs. Learn more about configuring distributed tracing [here][5].
+
+{{< img src="integrations/amazon_lambda/lambda_tracing.png" alt="Architecture diagram for tracing AWS Lambda with Datadog" >}}
+
 [1]: /integrations/amazon_web_services/
 [2]: /serverless/forwarder
 [3]: https://app.datadoghq.com/functions
+[4]: /serverless/custom_metrics
+[5]: /serverless/distributed_tracing

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -286,7 +286,7 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 
 After you have configured your function following the steps above, you can view metrics, logs and traces on the [Serverless Homepage][3].
 
-### Monitor Custom Serverless Metrics
+### Monitor Custom Business Metrics
 
 If you would like to submit a custom metric or manually instrument a function, see the sample code below:
 
@@ -312,11 +312,11 @@ def get_message():
     return "Hello from serverless!"
 ```
 
-Learn more about submitting custom metrics [here][4].
+[Enable custom metric submission][3] to get started.
 
 ### Enable the AWS X-Ray Integration
 
-Datadog’s integration with AWS X-Ray allows you to visualize serverless trace data, so you can zero in on the source of any errors or slowdowns, and see how the performance of your functions impacts your users’ experience. Depending on your language and configuration, choose between setting up Datadog APM or the AWS X-Ray integration for your tracing needs. Learn more about configuring distributed tracing [here][5].
+Datadog’s integration with AWS X-Ray allows you to visualize end-to-end serverless transactions, so you can zero in on the source of any errors or slowdowns, and see how the performance of your functions impacts your users’ experience. Depending on your language and configuration, [choose between setting up Datadog APM or the AWS X-Ray integration][5] for your tracing needs.
 
 {{< img src="integrations/amazon_lambda/lambda_tracing.png" alt="Architecture diagram for tracing AWS Lambda with Datadog" >}}
 

--- a/content/en/serverless/installation/ruby.md
+++ b/content/en/serverless/installation/ruby.md
@@ -61,6 +61,8 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 
 After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless Homepage][8].
 
+### Monitor Custom Serverless Metrics
+
 If you would like to submit a custom metric or manually instrument a function, see the sample code below:
 
 ```ruby
@@ -92,7 +94,13 @@ def some_operation()
     end
 end
 ```
+Learn more about submitting custom metrics [here][9].
 
+### Enable the AWS X-Ray Integration
+
+Datadog’s integration with AWS X-Ray allows you to visualize serverless trace data, so you can zero in on the source of any errors or slowdowns, and see how the performance of your functions impacts your users’ experience. Depending on your language and configuration, choose between setting up Datadog APM or the AWS X-Ray integration for your tracing needs. Learn more about configuring distributed tracing [here][10].
+
+{{< img src="integrations/amazon_lambda/lambda_tracing.png" alt="Architecture diagram for tracing AWS Lambda with Datadog" >}}
 
 [1]: /serverless/#1-install-the-cloud-integration
 [2]: https://docs.datadoghq.com/serverless/forwarder/
@@ -102,3 +110,5 @@ end
 [6]: https://docs.datadoghq.com/serverless/forwarder/#experimental-optional
 [7]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 [8]: https://app.datadoghq.com/functions
+[9]: /serverless/custom_metrics
+[10]: /serverless/distributed_tracing

--- a/content/en/serverless/installation/ruby.md
+++ b/content/en/serverless/installation/ruby.md
@@ -61,7 +61,7 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 
 After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless Homepage][8].
 
-### Monitor Custom Serverless Metrics
+### Monitor Custom Business Metrics
 
 If you would like to submit a custom metric or manually instrument a function, see the sample code below:
 
@@ -94,11 +94,11 @@ def some_operation()
     end
 end
 ```
-Learn more about submitting custom metrics [here][9].
+[Enable custom metric submission][3] to get started.
 
 ### Enable the AWS X-Ray Integration
 
-Datadog’s integration with AWS X-Ray allows you to visualize serverless trace data, so you can zero in on the source of any errors or slowdowns, and see how the performance of your functions impacts your users’ experience. Depending on your language and configuration, choose between setting up Datadog APM or the AWS X-Ray integration for your tracing needs. Learn more about configuring distributed tracing [here][10].
+Datadog’s integration with AWS X-Ray allows you to visualize end-to-end serverless transactions, so you can zero in on the source of any errors or slowdowns, and see how the performance of your functions impacts your users’ experience. Depending on your language and configuration, [choose between setting up Datadog APM or the AWS X-Ray integration][5] for your tracing needs.
 
 {{< img src="integrations/amazon_lambda/lambda_tracing.png" alt="Architecture diagram for tracing AWS Lambda with Datadog" >}}
 

--- a/content/en/tracing/serverless_functions/_index.md
+++ b/content/en/tracing/serverless_functions/_index.md
@@ -20,47 +20,20 @@ Depending on your language and configuration, choose between setting up Datadog 
 | Set up using your developer tools without making any changes to your code with Serverless Framework and AWS SAM Integrations. | Install the AWS X-Ray client library for your Lambda runtime. |
 | Support for Python, Node.js, Ruby. |  Support for all Lambda runtimes. |
 
-
-## Organizing your Serverless infrastructure with tags
-
-Any [tag][3] applied to your AWS Lambda function automatically becomes a new dimension on which you can slice and dice your traces.
-
-Tags are especially powerful for consistency across the Datadog platform, which has [first-class support][4] for the `env` and `service` tags.
-
-**Note**: If you are tracing with Datadog APM, set the parameter `DdFetchLambdaTags` to `true` on the forwarder CloudFormation stack to ensure your traces are tagged with the resource tags on the originating Lambda function. Lambda function resource tags are automatically surfaced to X-Ray traces in Datadog without any additional configuration.
-
-### The env tag
-
-Use `env` to separate out your staging, development, and production environments. This works for any kind of infrastructure, not just for your serverless functions. As an example, you could tag your production EU Lambda functions with `env:prod-eu`.
-
-By default, AWS Lambda functions are tagged with `env:none` in Datadog. Add your own tag to override this.
-
-### The service tag
-
-Add the `service` [tag][5] in order to group related Lambda functions into a [service][6]. The [Service Map][5] and [Services List][7] use this tag to show relationships between services and the health of their monitors. Services are represented as individual nodes on the Service Map.
-
-By default, each Lambda function is treated as its own `service`. Add your own tag to override this.
-
-**Note**: The default behavior for new Datadog customers is for all Lambda functions to be grouped under the `aws.lambda` service, and represented as a single node on the Service map. Tag your functions by `service` to override this.
-
-{{< img src="integrations/amazon_lambda/animated_service_map.gif" alt="animated service map of Lambda functions" >}}
-
 ## Augment AWS X-Ray Tracing with Datadog APM
 
 {{< img src="integrations/amazon_lambda/lambda_tracing.png" alt="Architecture diagram for tracing AWS Lambda with Datadog" >}}
 
-You might also configure _both_ AWS X-Ray Tracing and Datadog APM, which can be useful, but will result in higher usage bills. If you are unsure whether to use Datadog APM or AWS X-Ray, contact [our support team][8] to discuss.
-
-You can find setup instructions for this case when you want to do both below:
+You might also configure _both_ AWS X-Ray Tracing and Datadog APM. Note that this may result in higher usage bills. You can find setup instructions for this case when you want to do both below:
 
 - [Tracing in a serverless-first environment](#tracing-in-a-serverless-first-environment)
 - [Tracing across AWS Lambda and hosts](#tracing-across-aws-lambda-and-hosts)
 
 #### Tracing in a serverless-first environment
 
-AWS X-Ray is both a backend AWS service and a set of client libraries. The service gives you an Invocation span for your AWS Lambda functions and traces across Amazon API Gateways and message queues.
+AWS X-Ray provides both a backend AWS service and a set of client libraries. Enabling the backend AWS service alone gives you an Invocation span for your AWS Lambda functions as well as traces across Amazon API Gateways and message queues.
 
-The client libraries trace the integrations in your code. If you are using the Datadog APM client library instead of the AWS X-Ray client library to trace and visualize traces, follow the below two steps:
+Both the AWS X-Ray and Datadog APM client libraries trace the integrations in your code. If you are using the Datadog APM client library instead of the AWS X-Ray client library to trace and visualize traces, follow the below two steps:
 
 1. Enable the [AWS X-Ray integration][2] for tracing your Lambda functions.
 2. [Set up Datadog APM][1] on your Lambda functions.
@@ -103,7 +76,7 @@ Set the `DD_MERGE_DATADOG_XRAY_TRACES` environment variable to `True` on your La
 When applicable, Datadog merges AWS X-Ray traces with native Datadog APM traces. This means that your traces will show the complete picture of requests that cross infrastructure boundaries, whether it be AWS Lambda, containers, on-prem hosts, or managed services.
 
 1. Enable the [AWS X-Ray integration][2] for tracing your Lambda functions.
-2. [Set up Datadog APM][9] on your hosts and container-based infrastructure.
+2. [Set up Datadog APM][3] on your hosts and container-based infrastructure.
 
 **Note**: Distributed Tracing is supported for any runtime for your host or container-based applications.
 
@@ -117,10 +90,4 @@ When applicable, Datadog merges AWS X-Ray traces with native Datadog APM traces.
 
 [1]: /serverless/
 [2]: /tracing/serverless_functions/enable_aws_xray/
-[3]: /getting_stared/tagging/
-[4]: /getting_started/tagging/unified_service_tagging
-[5]: /tracing/visualization/services_map/#the-service-tag
-[6]: /tracing/visualization/#services
-[7]: /tracing/visualization/services_list/
-[8]: /help
-[9]: /tracing/send_traces/
+[3]: /tracing/send_traces/


### PR DESCRIPTION
- Removes duplicated tagging documentation from X-Ray page
- Highlights X-Ray as an integration in the "Explore" section of our installation docs
- Removes CTA to contact support and cleans up some language