### PR TITLE
Removing reference to token

### DIFF
--- a/content/en/synthetics/ci.md
+++ b/content/en/synthetics/ci.md
@@ -241,14 +241,7 @@ The package is published under [@datadog/datadog-ci][2] in the NPM registry.
 {{< tabs >}}
 {{% tab "NPM" %}}
 
-Set the below in your `~/.npmrc` file:
-
-```conf
-registry=https://registry.npmjs.org/
-//registry.npmjs.org/:_authToken=<TOKEN>
-```
-
-Then, install the package through NPM:
+Install the package through NPM:
 
 ```bash
 npm install --save-dev @datadog/datadog-ci
@@ -257,16 +250,7 @@ npm install --save-dev @datadog/datadog-ci
 {{% /tab %}}
 {{% tab "Yarn" %}}
 
-In Yarn v2, you can scope the token to the `@datadog` scope in the `.yarnrc` file:
-
-```yaml
-npmScopes:
-  datadog:
-    npmRegistryServer: "https://registry.npmjs.org"
-    npmAuthToken: "<TOKEN>"
-```
-
-Then, install the package through Yarn:
+Install the package through Yarn:
 
 ```bash
 yarn add --dev @datadog/datadog-ci


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR removes the reference to token in the CI/CD testing doc page

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/margot.lepizzera/cicd_testing/synthetics/ci/?tab=npm#cli-usage

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
