### PR TITLE
Error Tracking is available in EU

### DIFF
--- a/content/en/real_user_monitoring/error_tracking/_index.md
+++ b/content/en/real_user_monitoring/error_tracking/_index.md
@@ -6,16 +6,13 @@ further_reading:
 - link: "/real_user_monitoring/error_tracking/explorer"
   tag: "Documentation"
   text: "RUM Error Tracking Explorer"
+- link: "/real_user_monitoring/guide/upload-javascript-source-maps"
+  tag: "Guide"
+  text: "Upload javascript source maps"
 - link: "https://app.datadoghq.com/error-tracking"
   tag: "UI"
   text: "Error tracking"
 ---
-
-{{< site-region region="eu" >}}
-
-<div class="alert alert-warning"> The EU region is not yet available for Error Tracking. If you have any feedback or question, contact <a href="/help">Datadog support</a>.</div>
-
-{{< /site-region >}}
 
 {{< img src="real_user_monitoring/error_tracking/page.png" alt="Error Tracking Page"  >}}
 
@@ -49,6 +46,21 @@ Datadog allows you to securely upload your source maps to deobfuscate your stack
 
 Source maps are mapping files generated when minifying Javascript source code. The [Datadog CLI][4] can be used to upload those mapping files from your build directory: it scans the build directory and its subdirectories to automatically upload the source maps with their related minified files. Upload your source maps directly from your CI pipeline:
 
+{{< site-region region="eu" >}}
+
+1. Add `@datadog/datadog-ci` to your `package.json` file, you must use the `v0.5.2` version and onwards of the CLI.
+2. Export your Datadog API key as an environment variable named `DATADOG_API_KEY`.
+3. Configure the CLI to upload files to the EU region by exporting two additonal environment variables: `export DATADOG_SITE="datadoghq.eu"` and `export DATADOG_API_HOST="api.datadoghq.eu"`.
+4. Run the following command:
+   {{< code-block lang="curl">}}datadog-ci sourcemaps upload /path/to/build/directory \
+  --service=my-service \
+  --release-version=v35.2395005 \
+  --minified-path-prefix=https://hostname.com/static/js{{< /code-block >}}
+
+{{< /site-region >}}
+
+{{< site-region region="us" >}}
+
 1. Add `@datadog/datadog-ci` to your `package.json` file, you must use the `v0.5.2` version and onwards of the CLI.
 2. Export your Datadog API key as an environment variable named `DATADOG_API_KEY`.
 3. Run the following command:
@@ -57,6 +69,8 @@ Source maps are mapping files generated when minifying Javascript source code. T
   --release-version=v35.2395005 \
   --minified-path-prefix=https://hostname.com/static/js{{< /code-block >}}
 
+{{< /site-region >}}
+
 For more information about CLI parameters, see the [official Github repository][5].
 
 <div class="alert alert-warning">You must configure your Javascript bundler to create <strong>source maps that directly include the related source code</strong>. You should make sure the <code>sourcesContent</code> attribute in your source maps is not empty before uploading them.</div>
@@ -64,7 +78,6 @@ For more information about CLI parameters, see the [official Github repository][
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
-
 
 [1]: /real_user_monitoring/data_collected/error#error-origins
 [2]: https://www.npmjs.com/package/@datadog/browser-rum

--- a/content/en/real_user_monitoring/error_tracking/_index.md
+++ b/content/en/real_user_monitoring/error_tracking/_index.md
@@ -49,7 +49,7 @@ Source maps are mapping files generated when minifying Javascript source code. T
 {{< site-region region="eu" >}}
 
 1. Add `@datadog/datadog-ci` to your `package.json` file (make sure to use the latest version).
-2. [Create a new and dedicated Datadog API key][5] and export it as an environment variable named `DATADOG_API_KEY`.
+2. [Create a new and dedicated Datadog API key][1] and export it as an environment variable named `DATADOG_API_KEY`.
 3. Configure the CLI to upload files to the EU region by exporting two additonal environment variables: `export DATADOG_SITE="datadoghq.eu"` and `export DATADOG_API_HOST="api.datadoghq.eu"`.
 4. Run the following command:
 ```bash
@@ -59,12 +59,13 @@ datadog-ci sourcemaps upload /path/to/dist \
 	--minified-path-prefix=https://hostname.com/static/js
 ```
 
+[1]: https://app.datadoghq.com/account/settings#api
 {{< /site-region >}}
 
 {{< site-region region="us" >}}
 
 1. Add `@datadog/datadog-ci` to your `package.json` file (make sure to use the latest version).
-2. [Create a new and dedicated Datadog API key][5] and export it as an environment variable named `DATADOG_API_KEY`.
+2. [Create a new and dedicated Datadog API key][1] and export it as an environment variable named `DATADOG_API_KEY`.
 3. Run the following command:
 ```bash
 datadog-ci sourcemaps upload /path/to/dist \
@@ -73,9 +74,10 @@ datadog-ci sourcemaps upload /path/to/dist \
 	--minified-path-prefix=https://hostname.com/static/js
 ```
 
+[1]: https://app.datadoghq.com/account/settings#api
 {{< /site-region >}}
 
-For more information about CLI parameters, see the [official Github repository][6].
+For more information about CLI parameters, see the [official Github repository][5].
 
 <div class="alert alert-warning">You must configure your Javascript bundler to create <strong>source maps that directly include the related source code</strong>. You should make sure the <code>sourcesContent</code> attribute in your source maps is not empty before uploading them.</div>
 
@@ -87,5 +89,4 @@ For more information about CLI parameters, see the [official Github repository][
 [2]: https://www.npmjs.com/package/@datadog/browser-rum
 [3]: /real_user_monitoring/installation/?tab=us#initialization-parameters
 [4]: https://github.com/DataDog/datadog-ci/
-[5]: https://app.datadoghq.com/account/settings#api
-[6]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps
+[5]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps

--- a/content/en/real_user_monitoring/error_tracking/_index.md
+++ b/content/en/real_user_monitoring/error_tracking/_index.md
@@ -48,26 +48,30 @@ Source maps are mapping files generated when minifying Javascript source code. T
 
 {{< site-region region="eu" >}}
 
-1. Add `@datadog/datadog-ci` to your `package.json` file, you must use the `v0.5.2` version and onwards of the CLI.
-2. Export your Datadog API key as an environment variable named `DATADOG_API_KEY`.
+1. Add `@datadog/datadog-ci` to your `package.json` file (make sure to use the latest version).
+2. [Create a new and dedicated Datadog API key][2] and export it as an environment variable named `DATADOG_API_KEY`.
 3. Configure the CLI to upload files to the EU region by exporting two additonal environment variables: `export DATADOG_SITE="datadoghq.eu"` and `export DATADOG_API_HOST="api.datadoghq.eu"`.
 4. Run the following command:
-   {{< code-block lang="curl">}}datadog-ci sourcemaps upload /path/to/build/directory \
-  --service=my-service \
-  --release-version=v35.2395005 \
-  --minified-path-prefix=https://hostname.com/static/js{{< /code-block >}}
+```bash
+datadog-ci sourcemaps upload /path/to/dist \
+	--service=my-service \
+	--release-version=v35.2395005 \
+	--minified-path-prefix=https://hostname.com/static/js
+```
 
 {{< /site-region >}}
 
 {{< site-region region="us" >}}
 
-1. Add `@datadog/datadog-ci` to your `package.json` file, you must use the `v0.5.2` version and onwards of the CLI.
-2. Export your Datadog API key as an environment variable named `DATADOG_API_KEY`.
+1. Add `@datadog/datadog-ci` to your `package.json` file (make sure to use the latest version).
+2. [Create a new and dedicated Datadog API key][2] and export it as an environment variable named `DATADOG_API_KEY`.
 3. Run the following command:
-   {{< code-block lang="curl">}}datadog-ci sourcemaps upload /path/to/build/directory \
-  --service=my-service \
-  --release-version=v35.2395005 \
-  --minified-path-prefix=https://hostname.com/static/js{{< /code-block >}}
+```bash
+datadog-ci sourcemaps upload /path/to/dist \
+	--service=my-service \
+	--release-version=v35.2395005 \
+	--minified-path-prefix=https://hostname.com/static/js
+```
 
 {{< /site-region >}}
 

--- a/content/en/real_user_monitoring/error_tracking/_index.md
+++ b/content/en/real_user_monitoring/error_tracking/_index.md
@@ -49,7 +49,7 @@ Source maps are mapping files generated when minifying Javascript source code. T
 {{< site-region region="eu" >}}
 
 1. Add `@datadog/datadog-ci` to your `package.json` file (make sure to use the latest version).
-2. [Create a new and dedicated Datadog API key][2] and export it as an environment variable named `DATADOG_API_KEY`.
+2. [Create a new and dedicated Datadog API key][5] and export it as an environment variable named `DATADOG_API_KEY`.
 3. Configure the CLI to upload files to the EU region by exporting two additonal environment variables: `export DATADOG_SITE="datadoghq.eu"` and `export DATADOG_API_HOST="api.datadoghq.eu"`.
 4. Run the following command:
 ```bash
@@ -64,7 +64,7 @@ datadog-ci sourcemaps upload /path/to/dist \
 {{< site-region region="us" >}}
 
 1. Add `@datadog/datadog-ci` to your `package.json` file (make sure to use the latest version).
-2. [Create a new and dedicated Datadog API key][2] and export it as an environment variable named `DATADOG_API_KEY`.
+2. [Create a new and dedicated Datadog API key][5] and export it as an environment variable named `DATADOG_API_KEY`.
 3. Run the following command:
 ```bash
 datadog-ci sourcemaps upload /path/to/dist \
@@ -75,7 +75,7 @@ datadog-ci sourcemaps upload /path/to/dist \
 
 {{< /site-region >}}
 
-For more information about CLI parameters, see the [official Github repository][5].
+For more information about CLI parameters, see the [official Github repository][6].
 
 <div class="alert alert-warning">You must configure your Javascript bundler to create <strong>source maps that directly include the related source code</strong>. You should make sure the <code>sourcesContent</code> attribute in your source maps is not empty before uploading them.</div>
 
@@ -87,4 +87,5 @@ For more information about CLI parameters, see the [official Github repository][
 [2]: https://www.npmjs.com/package/@datadog/browser-rum
 [3]: /real_user_monitoring/installation/?tab=us#initialization-parameters
 [4]: https://github.com/DataDog/datadog-ci/
-[5]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps
+[5]: https://app.datadoghq.com/account/settings#api
+[6]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps

--- a/content/en/real_user_monitoring/error_tracking/explorer.md
+++ b/content/en/real_user_monitoring/error_tracking/explorer.md
@@ -4,12 +4,6 @@ kind: documentation
 beta: true
 ---
 
-{{< site-region region="eu" >}}
-
-<div class="alert alert-warning"> The EU region is not yet available for Error Tracking. If you have any feedback or question, contact <a href="/help">Datadog support</a>.</div>
-
-{{< /site-region >}}
-
 {{< img src="real_user_monitoring/error_tracking/explorer.png" alt="Error Tracking Explorer"  >}}
 
 ## Explore your issues

--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -70,6 +70,23 @@ After building your application, bundlers generate a directory, most of the time
 
 The best way to upload source maps is to add an extra-step in your CI pipeline and to run the dedicated command from the [Datadog CLI][1]. It scans the `dist` directory and its subdirectories to automatically upload the source maps with their related minified files. The flow is the following:
 
+{{< site-region region="eu" >}}
+
+1. Add `@datadog/datadog-ci` to your `package.json` file (make sure to use the latest version).
+2. [Create a new and dedicated Datadog API key][2] and export it as an environment variable named `DATADOG_API_KEY`.
+3. Configure the CLI to upload files to the EU region by exporting two additonal environment variables: `export DATADOG_SITE="datadoghq.eu"` and `export DATADOG_API_HOST="api.datadoghq.eu"`.
+4. Run the following command:
+```bash
+datadog-ci sourcemaps upload /path/to/dist \
+	--service=my-service \
+	--release-version=v35.2395005 \
+	--minified-path-prefix=https://hostname.com/static/js
+```
+
+{{< /site-region >}}
+
+{{< site-region region="us" >}}
+
 1. Add `@datadog/datadog-ci` to your `package.json` file (make sure to use the latest version).
 2. [Create a new and dedicated Datadog API key][2] and export it as an environment variable named `DATADOG_API_KEY`.
 3. Run the following command:
@@ -79,6 +96,8 @@ datadog-ci sourcemaps upload /path/to/dist \
 	--release-version=v35.2395005 \
 	--minified-path-prefix=https://hostname.com/static/js
 ```
+
+{{< /site-region >}}
 
 **Note**: The CLI has been optimized to upload as many source maps as you need in a very short amount of time (typically a few seconds) to minimize the overhead on your CI's performance.
 

--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -73,7 +73,7 @@ The best way to upload source maps is to add an extra-step in your CI pipeline a
 {{< site-region region="eu" >}}
 
 1. Add `@datadog/datadog-ci` to your `package.json` file (make sure to use the latest version).
-2. [Create a new and dedicated Datadog API key][2] and export it as an environment variable named `DATADOG_API_KEY`.
+2. [Create a new and dedicated Datadog API key][1] and export it as an environment variable named `DATADOG_API_KEY`.
 3. Configure the CLI to upload files to the EU region by exporting two additonal environment variables: `export DATADOG_SITE="datadoghq.eu"` and `export DATADOG_API_HOST="api.datadoghq.eu"`.
 4. Run the following command:
 ```bash
@@ -82,13 +82,13 @@ datadog-ci sourcemaps upload /path/to/dist \
 	--release-version=v35.2395005 \
 	--minified-path-prefix=https://hostname.com/static/js
 ```
-
+[1]: https://app.datadoghq.com/account/settings#api
 {{< /site-region >}}
 
 {{< site-region region="us" >}}
 
 1. Add `@datadog/datadog-ci` to your `package.json` file (make sure to use the latest version).
-2. [Create a new and dedicated Datadog API key][2] and export it as an environment variable named `DATADOG_API_KEY`.
+2. [Create a new and dedicated Datadog API key][1] and export it as an environment variable named `DATADOG_API_KEY`.
 3. Run the following command:
 ```bash
 datadog-ci sourcemaps upload /path/to/dist \
@@ -97,6 +97,7 @@ datadog-ci sourcemaps upload /path/to/dist \
 	--minified-path-prefix=https://hostname.com/static/js
 ```
 
+[1]: https://app.datadoghq.com/account/settings#api
 {{< /site-region >}}
 
 **Note**: The CLI has been optimized to upload as many source maps as you need in a very short amount of time (typically a few seconds) to minimize the overhead on your CI's performance.
@@ -118,4 +119,3 @@ On the contrary, an unminified stack trace gives you all the context you need fo
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps
-[2]: https://app.datadoghq.com/account/settings#api


### PR DESCRIPTION
### What does this PR do?
- Remove callouts for the EU region
- Add different instructions for uploading source maps in EU
- Add a new "Further reading" link (this should have been done in another PR)

### Preview
https://docs-staging.datadoghq.com/maxime.matheron/error-tracking-in-eu/real_user_monitoring/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
