### PR TITLE
Update rehydrating.md

### DIFF
--- a/content/en/logs/archives/rehydrating.md
+++ b/content/en/logs/archives/rehydrating.md
@@ -58,7 +58,7 @@ Alternatively, teams can find the historical view from the Log Explorer directly
 
 ### Deleting historical views
 
-Historical views stay in Datadog until you opt to delete them. You can mark a historical view to be deleted by selecting and confirming the delete icon at the far right of the historical view.
+Historical views stay in Datadog until they have exceeded the selected retention period, or you can opt to delete them sooner if you no longer need the view. You can mark a historical view to be deleted by selecting and confirming the delete icon at the far right of the historical view.
 
 One hour later, the historical view is definitively deleted; until that time, the team is able to cancel the deletion.
 


### PR DESCRIPTION
Rehydrated logs are dropped once they've exceeded the selected index retention period.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
rehydrated logs cannot be retained for a undefined or open-ended timeframe. an retention period must be chosen

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
