### PR TITLE
container path on Amazon Linux AMI

### DIFF
--- a/content/en/agent/amazon_ecs/_index.md
+++ b/content/en/agent/amazon_ecs/_index.md
@@ -114,7 +114,7 @@ Add the following to your ECS task definition to create an Agent health check:
 16. Scroll down to the **Storage and Logging** section.
 17. In **Mount points** select the **docker_sock** source volume and enter as Container path `/var/run/docker.sock` on Linux or `\\.\pipe\docker_engine` on Windows. Check the **Read only** checkbox.
 18. For Linux only, add another mount point for **proc** and enter `/host/proc/` in the Container path. Check the **Read only** checkbox.
-19. For Linux only, add a third mount point for **cgroup** and enter `/host/sys/fs/cgroup` in the Container path. Check the **Read only** checkbox (use `/host/cgroup/` if you are using an original Amazon Linux AMI).
+19. For Linux only, add a third mount point for **cgroup** and enter `/host/sys/fs/cgroup` in the Container path. Check the **Read only** checkbox.
 
 **Note**: Setting the Datadog task definition to use 10 CPU units can cause the `aws.ecs.cpuutilization` for `service:datadog-agent` to display as running at 1000%. This is a peculiarity of how AWS displays CPU utilization. You can add more CPU units to avoid skewing your graph.
 


### PR DESCRIPTION
We should use /sys/sys/fs/cgroup even on Amazon Linux AMI
There is also a ticket talked about it
https://datadog.zendesk.com/agent/tickets/381882

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Remove the misguide for people using Amazon Linux AMI

### Motivation
<!-- What inspired you to submit this pull request?-->
exist ticket and customer feedback.
Spend time on this for more than one time.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
