### PR TITLE
[apm] remove docker env label from dockerfile

### DIFF
--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -183,7 +183,6 @@ The values for `service` and `version` can be provided in the Dockerfile:
 ENV DD_SERVICE <SERVICE>
 ENV DD_VERSION <VERSION>
 
-LABEL com.datadoghq.tags.env="<ENV>"
 LABEL com.datadoghq.tags.service="<SERVICE>"
 LABEL com.datadoghq.tags.version="<VERSION>"
 ```


### PR DESCRIPTION
We recommend setting `env` post-build time, perhaps in the `docker run` command or in a similar deployment command. Since the same image could be deployed to multiple envs, it does not make sense to hardcode the env in the dockerfile.
