### PR TITLE
Logs facet search note

### DIFF
--- a/content/en/logs/search_syntax.md
+++ b/content/en/logs/search_syntax.md
@@ -64,11 +64,14 @@ For instance, if your facet name is **url** and you want to filter on the **url*
 
 `@url:www.datadoghq.com`
 
-**Notes**: 
+Note:
+The current workaround to match spaces in a facet value is to use the single character wildcard ?. So, for a facet my_facet and a value hello world today is a new day, you can match spaces like so: @my_facet:hello?world*.
+
+**Notes**:
 
 1. Facet searches are case sensitive. Use free text search to get case insensitive results. Another option is to use the `lowercase` filter with your Grok parser while parsing to get case insensitive results during search.
 
-2. Searching on a facet value that contains special characters requires escaping or double quotes. The same logic is applied to spaces within log facet names. Log facets should not contain spaces, but if they do, spaces must be escaped. If a facet is named `user.first name`, perform a facet search by escaping the space: `@user.first\ name:myvalue`.
+2. Searching on a facet value that contains special characters requires escaping or double quotes. Log facets should not contain spaces, but if they do, spaces must be escaped. If a facet is named `user.first name`, perform a facet search by escaping the space: `@user.first?name:myvalue`. You can also use `?` to escape spaces in a search query string. For example, `@error.message:Error?message?here`
 
 Examples:
 

--- a/content/en/logs/search_syntax.md
+++ b/content/en/logs/search_syntax.md
@@ -64,14 +64,14 @@ For instance, if your facet name is **url** and you want to filter on the **url*
 
 `@url:www.datadoghq.com`
 
-Note:
-The current workaround to match spaces in a facet value is to use the single character wildcard ?. So, for a facet my_facet and a value hello world today is a new day, you can match spaces like so: @my_facet:hello?world*.
 
 **Notes**:
 
 1. Facet searches are case sensitive. Use free text search to get case insensitive results. Another option is to use the `lowercase` filter with your Grok parser while parsing to get case insensitive results during search.
 
-2. Searching on a facet value that contains special characters requires escaping or double quotes. Log facets should not contain spaces, but if they do, spaces must be escaped. If a facet is named `user.first name`, perform a facet search by escaping the space: `@user.first?name:myvalue`. You can also use `?` to escape spaces in a search query string. For example, `@error.message:Error?message?here`
+2. Searching for a facet value that contains special characters requires escaping or double quotes. To match a single special character or space, use the `?` wildcard. For example, a facet `my_facet` with the value `hello world`, search using: `@my_facet:hello?world`.
+
+3. Avoid using spaces in log facets. If a log facet does contain a space, perform a facet search by escaping the space: `@user.first\ name:myvalue` or using the single character wildcard: `@user.first?name:myvalue`.
 
 Examples:
 


### PR DESCRIPTION
### What does this PR do?
Updates the logs facet search notes to let customers know they can use `?` to match a space if spaces are included in a facet or query string.

### Motivation
Jira request

### Preview
https://docs-staging.datadoghq.com/sarina/logs-facet-search/logs/search_syntax/#facets-search

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
