### PR TITLE
Update DeleteTests.py

### DIFF
--- a/content/en/api/v1/synthetics/DeleteTests.py
+++ b/content/en/api/v1/synthetics/DeleteTests.py
@@ -9,4 +9,4 @@ test_ids = ['<SYNTHETICS_TEST_PUBLIC_ID_1>','<SYNTHETICS_TEST_PUBLIC_ID_2>']
 
 initialize(**options)
 
-api.Synthetics.delete_test(id=test_ids)
+api.Synthetics.delete_test(public_ids=test_ids)


### PR DESCRIPTION
The parameter for `delete_test` is `public_ids` not `id`.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fix an error in the name of a parameter

### Motivation
An error in my script

### Preview
https://docs.datadoghq.com/api/v1/synthetics/#delete-tests

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

### Additional Notes
See here for the parameter reference in the actual code: https://github.com/DataDog/datadogpy/blob/v0.39.0/datadog/api/synthetics.py#L218

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
