### PR TITLE
Use tabs to separate EU & US instructions

### DIFF
--- a/content/en/real_user_monitoring/error_tracking/_index.md
+++ b/content/en/real_user_monitoring/error_tracking/_index.md
@@ -46,7 +46,23 @@ Datadog allows you to securely upload your source maps to deobfuscate your stack
 
 Source maps are mapping files generated when minifying Javascript source code. The [Datadog CLI][4] can be used to upload those mapping files from your build directory: it scans the build directory and its subdirectories to automatically upload the source maps with their related minified files. Upload your source maps directly from your CI pipeline:
 
-{{< site-region region="eu" >}}
+{{< tabs >}}
+{{% tab "US" %}}
+
+1. Add `@datadog/datadog-ci` to your `package.json` file (make sure to use the latest version).
+2. [Create a new and dedicated Datadog API key][1] and export it as an environment variable named `DATADOG_API_KEY`.
+3. Run the following command:
+```bash
+datadog-ci sourcemaps upload /path/to/dist \
+	--service=my-service \
+	--release-version=v35.2395005 \
+	--minified-path-prefix=https://hostname.com/static/js
+```
+
+[1]: https://app.datadoghq.com/account/settings#api
+
+{{% /tab %}}
+{{% tab "EU" %}}
 
 1. Add `@datadog/datadog-ci` to your `package.json` file (make sure to use the latest version).
 2. [Create a new and dedicated Datadog API key][1] and export it as an environment variable named `DATADOG_API_KEY`.
@@ -60,22 +76,9 @@ datadog-ci sourcemaps upload /path/to/dist \
 ```
 
 [1]: https://app.datadoghq.com/account/settings#api
-{{< /site-region >}}
 
-{{< site-region region="us" >}}
-
-1. Add `@datadog/datadog-ci` to your `package.json` file (make sure to use the latest version).
-2. [Create a new and dedicated Datadog API key][1] and export it as an environment variable named `DATADOG_API_KEY`.
-3. Run the following command:
-```bash
-datadog-ci sourcemaps upload /path/to/dist \
-	--service=my-service \
-	--release-version=v35.2395005 \
-	--minified-path-prefix=https://hostname.com/static/js
-```
-
-[1]: https://app.datadoghq.com/account/settings#api
-{{< /site-region >}}
+{{% /tab %}}
+{{< /tabs >}}
 
 For more information about CLI parameters, see the [official Github repository][5].
 

--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -70,22 +70,8 @@ After building your application, bundlers generate a directory, most of the time
 
 The best way to upload source maps is to add an extra-step in your CI pipeline and to run the dedicated command from the [Datadog CLI][1]. It scans the `dist` directory and its subdirectories to automatically upload the source maps with their related minified files. The flow is the following:
 
-{{< site-region region="eu" >}}
-
-1. Add `@datadog/datadog-ci` to your `package.json` file (make sure to use the latest version).
-2. [Create a new and dedicated Datadog API key][1] and export it as an environment variable named `DATADOG_API_KEY`.
-3. Configure the CLI to upload files to the EU region by exporting two additonal environment variables: `export DATADOG_SITE="datadoghq.eu"` and `export DATADOG_API_HOST="api.datadoghq.eu"`.
-4. Run the following command:
-```bash
-datadog-ci sourcemaps upload /path/to/dist \
-	--service=my-service \
-	--release-version=v35.2395005 \
-	--minified-path-prefix=https://hostname.com/static/js
-```
-[1]: https://app.datadoghq.com/account/settings#api
-{{< /site-region >}}
-
-{{< site-region region="us" >}}
+{{< tabs >}}
+{{% tab "US" %}}
 
 1. Add `@datadog/datadog-ci` to your `package.json` file (make sure to use the latest version).
 2. [Create a new and dedicated Datadog API key][1] and export it as an environment variable named `DATADOG_API_KEY`.
@@ -98,7 +84,25 @@ datadog-ci sourcemaps upload /path/to/dist \
 ```
 
 [1]: https://app.datadoghq.com/account/settings#api
-{{< /site-region >}}
+
+{{% /tab %}}
+{{% tab "EU" %}}
+
+1. Add `@datadog/datadog-ci` to your `package.json` file (make sure to use the latest version).
+2. [Create a new and dedicated Datadog API key][1] and export it as an environment variable named `DATADOG_API_KEY`.
+3. Configure the CLI to upload files to the EU region by exporting two additonal environment variables: `export DATADOG_SITE="datadoghq.eu"` and `export DATADOG_API_HOST="api.datadoghq.eu"`.
+4. Run the following command:
+```bash
+datadog-ci sourcemaps upload /path/to/dist \
+	--service=my-service \
+	--release-version=v35.2395005 \
+	--minified-path-prefix=https://hostname.com/static/js
+```
+
+[1]: https://app.datadoghq.com/account/settings#api
+
+{{% /tab %}}
+{{< /tabs >}}
 
 **Note**: The CLI has been optimized to upload as many source maps as you need in a very short amount of time (typically a few seconds) to minimize the overhead on your CI's performance.
 


### PR DESCRIPTION
### What does this PR do?
Use tabs to separate EU & US instructions.

### Motivation
It clarifies the split between EU & US.

### Preview
https://docs-staging.datadoghq.com/maxime.matheron/error-tracking-instructions-in-tabs/real_user_monitoring/error_tracking/?tab=us#javascript-source-maps

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
