### PR TITLE
Metrics Note for ECS

### DIFF
--- a/content/en/agent/amazon_ecs/data_collected.md
+++ b/content/en/agent/amazon_ecs/data_collected.md
@@ -17,7 +17,7 @@ further_reading:
 
 ### Metrics
 
-Amazon ECS metrics can be collected by the Agent or when using the [AWS integration][1].
+Amazon ECS metrics are collected through the Datadog Agent or [AWS integration][1].
 
 Metrics collected using the AWS integration are prefixed with `aws.*`. Metrics collected by the Agent are prefixed with `ecs.*`. See the table below:
 

--- a/content/en/agent/amazon_ecs/data_collected.md
+++ b/content/en/agent/amazon_ecs/data_collected.md
@@ -19,7 +19,7 @@ further_reading:
 
 Amazon ECS metrics can be collected by the Agent or when using the [AWS integration][1].
 
-In the table below, metrics collected when using the AWS integration are prefixed with `aws.*`. Metrics collected by the Agent are prefixed with `ecs.*`.
+Metrics collected using the AWS integration are prefixed with `aws.*`. Metrics collected by the Agent are prefixed with `ecs.*`. See the table below:
 
 {{< get-metrics-from-git "amazon_ecs" >}}
 

--- a/content/en/agent/amazon_ecs/data_collected.md
+++ b/content/en/agent/amazon_ecs/data_collected.md
@@ -17,13 +17,15 @@ further_reading:
 
 ### Metrics
 
-Metrics collected by the Agent when using Amazon ECS on EC2 instances:
+Amazon ECS metrics can be collected by the Agent or when using the [AWS integration][1].
+
+In the table below, metrics collected when using the AWS integration are prefixed with `aws.*`. Metrics collected by the Agent are prefixed with `ecs.*`.
 
 {{< get-metrics-from-git "amazon_ecs" >}}
 
 Each of the metrics retrieved from AWS is assigned the same tags that appear in the AWS console, including but not limited to hostname, security-groups, and more.
 
-**Note**: Metrics prefixed with `ecs.containerinsights.*` come from the [AWS CloudWatch agent][1].
+**Note**: Metrics prefixed with `ecs.containerinsights.*` come from the [AWS CloudWatch agent][2].
 
 ### Events
 
@@ -31,7 +33,7 @@ To reduce noise, the Amazon ECS integration is automatically set up to include o
 
 {{< img src="integrations/amazon_ecs/aws_ecs_events.png" alt="AWS ECS Events" >}}
 
-To remove the whitelist and receive all events from your Datadog Amazon ECS integration, reach out to [Datadog support][2].
+To remove the whitelist and receive all events from your Datadog Amazon ECS integration, reach out to [Datadog support][3].
 
 ### Service checks
 
@@ -41,5 +43,6 @@ To remove the whitelist and receive all events from your Datadog Amazon ECS inte
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/deploy-container-insights-ECS-instancelevel.html
-[2]: https://docs.datadoghq.com/help/
+[1]: /integrations/amazon_web_services/
+[2]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/deploy-container-insights-ECS-instancelevel.html
+[3]: https://docs.datadoghq.com/help/


### PR DESCRIPTION
### What does this PR do?
Adds a note to the ECS docs that there are two sets of metrics in the existing table: AWS Integration-based metrics and Agent metrics.

### Motivation
Jira request

### Preview
https://docs-staging.datadoghq.com/sarina/ecs-metrics/agent/amazon_ecs/data_collected/

### Additional Notes
Long-term goal is to split these into individual tables
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.