### PR TITLE
DOCS-1244 add profiler troubleshooting page

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1093,6 +1093,11 @@ main:
     parent: profiler
     identifier: profiler_search_profiles
     weight: 1102
+  - name: Profiler Troubleshooting
+    url: tracing/profiler/profiler_troubleshooting
+    parent: profiler
+    identifier: profiler_profiler_troubleshooting
+    weight: 1103
   - name: Custom Instrumentation
     url: tracing/custom_instrumentation/
     parent: tracing

--- a/content/en/tracing/profiler/getting_started.md
+++ b/content/en/tracing/profiler/getting_started.md
@@ -7,6 +7,9 @@ further_reading:
     - link: 'tracing/profiler/search_profiles'
       tag: 'Documentation'
       text: 'Learn more about available profile types.'
+    - link: 'tracing/profiler/profiler_troubleshooting'
+      tag: 'Documentation'
+      text: 'Fix problems you encounter while using the profiler'
     - link: 'https://www.datadoghq.com/blog/introducing-datadog-profiling/'
       tags: 'Blog'
       text: 'Introducing always-on production profiling in Datadog.'
@@ -19,9 +22,9 @@ For **Node**, **Ruby**, **PHP**, or **.NET** Profilers, [sign up][1] to be on th
 {{< tabs >}}
 {{% tab "Java" %}}
 
-The Datadog Profiler requires [JDK Flight Recorder][1]. The Datadog Profiler library is supported in OpenJDK 11+, Oracle Java 11+, and Zulu Java 8+ (minor version 1.8.0_212+). All JVM-based languages, such as Scala, Groovy, Kotlin, Clojure, etc. are supported. To begin profiling applications:
+The Datadog Profiler requires [JDK Flight Recorder][1]. The Datadog Profiler library is supported in OpenJDK 11+, Oracle Java 11+, Zulu Java 8+ (minor version 1.8.0_212+), and [certain OpenJDK 8 vendor versions][2]. All JVM-based languages, such as Scala, Groovy, Kotlin, and Clojure are supported. To begin profiling applications:
 
-1. If you are already using Datadog, upgrade your agent to version [7.20.2][2]+ or [6.20.2][2]+. If you don't have APM enabled to set up your application to send data to Datadog, in your Agent, set the `DD_APM_ENABLED` environment variable to `true` and listening to the port `8126/TCP`.
+1. If you are already using Datadog, upgrade your agent to version [7.20.2][3]+ or [6.20.2][3]+. If you don't have APM enabled to set up your application to send data to Datadog, in your Agent, set the `DD_APM_ENABLED` environment variable to `true` and listening to the port `8126/TCP`.
 
 2. Download `dd-java-agent.jar`, which contains the Java Agent class files:
 
@@ -37,12 +40,12 @@ The Datadog Profiler requires [JDK Flight Recorder][1]. The Datadog Profiler lib
     java -javaagent:dd-java-agent.jar -Ddd.profiling.enabled=true -jar <YOUR_SERVICE>.jar <YOUR_SERVICE_FLAGS>
     ```
 
-4. After a minute or two, visualize your profiles on the [Datadog APM > Profiling page][3].
+4. After a minute or two, visualize your profiles on the [Datadog APM > Profiling page][4].
 
 
 **Note**:
 
-- The `-javaagent` argument needs to be before `-jar`, adding it as a JVM option rather than an application argument. For more information, see the [Oracle documentation][4]:
+- The `-javaagent` argument needs to be before `-jar`, adding it as a JVM option rather than an application argument. For more information, see the [Oracle documentation][5]:
 
     ```shell
     # Good:
@@ -56,17 +59,18 @@ The Datadog Profiler requires [JDK Flight Recorder][1]. The Datadog Profiler lib
 | Environment variable                             | Type          | Description                                                                                      |
 | ------------------------------------------------ | ------------- | ------------------------------------------------------------------------------------------------ |
 | `DD_PROFILING_ENABLED`                           | Boolean       | Alternate for `-Ddd.profiling.enabled` argument. Set to `true` to enable profiler.               |
-| `DD_SERVICE`                                     | String        | Your [service][2] name, for example, `web-backend`.     |
-| `DD_ENV`                                         | String        | Your [environment][5] name, for example: `production`.|
+| `DD_SERVICE`                                     | String        | Your [service][3] name, for example, `web-backend`.     |
+| `DD_ENV`                                         | String        | Your [environment][6] name, for example: `production`.|
 | `DD_VERSION`                                     | String        | The version of your service.                             |
 | `DD_TAGS`                                        | String        | Tags to apply to an uploaded profile. Must be a list of `<key>:<value>` separated by commas such as: `layer:api, team:intake`.  |
 
 
 [1]: https://docs.oracle.com/javacomponents/jmc-5-4/jfr-runtime-guide/about.htm
-[2]: https://app.datadoghq.com/account/settings#agent/overview
-[3]: https://app.datadoghq.com/profiling
-[4]: https://docs.oracle.com/javase/7/docs/technotes/tools/solaris/java.html
-[5]: /tracing/guide/setting_primary_tags_to_scope/#environment
+[2]: /tracing/profiler/profiler_troubleshooting/#java-8-support
+[3]: https://app.datadoghq.com/account/settings#agent/overview
+[4]: https://app.datadoghq.com/profiling
+[5]: https://docs.oracle.com/javase/7/docs/technotes/tools/solaris/java.html
+[6]: /tracing/guide/setting_primary_tags_to_scope/#environment
 {{% /tab %}}
 
 {{% tab "Python" %}}
@@ -216,17 +220,8 @@ The Datadog Profiler requires Go 1.12+. To begin profiling applications:
 
 {{< /tabs >}}
 
-## Troubleshooting
-
-If you've configured the profiler and don't see profiles in the [profile search page](#search-profiles), please turn on [debug mode][2] and [open a support ticket][3] with debug files and the following information:
-
-- OS type and version (e.g Linux Ubuntu 14.04.3)
-- Runtime type, version, and vendor (e.g Java OpenJDK 11 AdoptOpenJDK)
-
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 [1]: https://docs.google.com/forms/d/e/1FAIpQLScb9GKmKfSoY6YNV2Wa5P8IzUn02tA7afCahk7S0XHfakjYQw/viewform
-[2]: /tracing/troubleshooting/#tracer-debug-mode
-[3]: /help/

--- a/content/en/tracing/profiler/getting_started.md
+++ b/content/en/tracing/profiler/getting_started.md
@@ -22,7 +22,7 @@ For **Node**, **Ruby**, **PHP**, or **.NET** Profilers, [sign up][1] to be on th
 {{< tabs >}}
 {{% tab "Java" %}}
 
-The Datadog Profiler requires [JDK Flight Recorder][1]. The Datadog Profiler library is supported in OpenJDK 11+, Oracle Java 11+, Zulu Java 8+ (minor version 1.8.0_212+), and [certain OpenJDK 8 vendor versions][2]. All JVM-based languages, such as Scala, Groovy, Kotlin, and Clojure are supported. To begin profiling applications:
+The Datadog Profiler requires [JDK Flight Recorder][1]. The Datadog Profiler library is supported in OpenJDK 11+, Oracle Java 11+, [OpenJDK 8 for most vendors (version 8u262)][2] and Zulu Java 8+ (minor version 1.8.0_212+). All JVM-based languages, such as Scala, Groovy, Kotlin, and Clojure are supported. To begin profiling applications:
 
 1. If you are already using Datadog, upgrade your agent to version [7.20.2][3]+ or [6.20.2][3]+. If you don't have APM enabled to set up your application to send data to Datadog, in your Agent, set the `DD_APM_ENABLED` environment variable to `true` and listening to the port `8126/TCP`.
 

--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting the profiler
+title: Profiler Troubleshooting
 kind: documentation
 further_reading:
     - link: '/tracing/troubleshooting'
@@ -26,7 +26,7 @@ The following OpenJDK 8 vendors are supported for Continuous Profiling because t
 | Bell-Soft (Liberica)        | u262                                                           |
 | Upstream builds             | u272                                                           |
 
-If your vendor is not on the list, [open a support ticket][2] to ask if your vendor is supported.
+If your vendor is not on the list, [open a support ticket][2], we can let you know if we're planning to support it or if we already offer beta support.
 
 ## Removing sensitive information from profiles
 

--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -1,0 +1,52 @@
+---
+title: Troubleshooting the profiler
+kind: documentation
+further_reading:
+    - link: '/tracing/troubleshooting'
+      tag: 'Documentation'
+      text: 'APM Troubleshooting'
+---
+## Missing profiles in the profile search page
+
+If you've configured the profiler and don't see profiles in the profile search page, turn on [debug mode][1] and [open a support ticket][2] with debug files and the following information:
+
+- Operating system type and version (for example, Linux Ubuntu 14.04.3)
+- Runtime type, version, and vendor (for example, Java OpenJDK 11 AdoptOpenJDK)
+
+## Java 8 support
+
+The following OpenJDK 8 vendors are supported for Continuous Profiling because they include JDK Flight Recorder in their latest versions: 
+
+| Vendor                      | JDK version that includes Flight Recorder                      |
+| --------------------------- | -------------------------------------------------------------- |
+| Azul                        | u212 (u262 is recommended)                                     |
+| AdoptOpenJDK                | u262                                                           |
+| RedHat                      | u262                                                           |
+| Amazon (Corretto)           | u262                                                           |
+| Bell-Soft (Liberica)        | u262                                                           |
+| Upstream builds             | u272                                                           |
+
+If your vendor is not on the list, [open a support ticket][2] to ask if your vendor is supported.
+
+## Removing sensitive information from profiles
+
+If your system properties contain sensitive information such as user names or passwords, turn off the system property event by creating a `jfp` override template file with `jdk.InitialSystemProperty` disabled:
+
+{{< code-block lang="text" filename="example-template.jfp" >}}
+jdk.InitialSystemProperty#enabled=false
+{{< /code-block >}}
+
+## Exceptions overwhelming the profiler
+
+The Datadog exception profiler will normally have a very small footprint and overhead. But if a lot of exceptions are created and thrown, it can cause significant overhead for the profiler. This can happen, for example, when you use exceptions for control flow.  If you have an unusually high exception rate, temporarily turn off exception profiling until you’ve had a chance to fix what's causing them. 
+
+To disable exception profiling, start the tracer with the `-Ddd.integration.throwables.enabled=false` JVM setting.
+
+Remember to turn this setting back on after you've returned to a more typical rate of exceptions.
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /tracing/troubleshooting/#tracer-debug-logs
+[2]: /help/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a troubleshooting page for continuous profiling

### Motivation
DOCS-1244

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/kari/profiler-troubleshooting/tracing/profiler/profiler_troubleshooting/
https://docs-staging.datadoghq.com/kari/profiler-troubleshooting/tracing/profiler/getting_started/


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
