### PR TITLE
Update parsing.md to move data as the last option

### DIFF
--- a/content/en/logs/processing/parsing.md
+++ b/content/en/logs/processing/parsing.md
@@ -71,7 +71,6 @@ Here is a list of all the matchers and filters natively implemented by Datadog:
 | **Pattern**                                     | **Usage**                                                                                                                          |
 | `date("pattern"[, "timezoneId"[, "localeId"]])` | Matches a date with the specified pattern and parses to produce a Unix timestamp. [See the date Matcher examples](#parsing-dates). |
 | `regex("pattern")`                              | Matches a regex. [Check the regex Matcher examples](#regex).                                                                       |
-| `data`                                          | Matches any string including spaces and newlines. Equivalent to `.*`.                                                              |
 | `notSpace`                                      | Matches any string until the next space.                                                                                           |
 | `boolean("truePattern", "falsePattern")`        | Matches and parses a Boolean, optionally defining the true and false patterns (defaults to `true` and `false`, ignoring case).     |
 | `numberStr`                                     | Matches a decimal floating point number and parses it as a string.                                                                 |
@@ -94,6 +93,7 @@ Here is a list of all the matchers and filters natively implemented by Datadog:
 | `hostname`                                      | Matches a hostname.                                                                                                                |
 | `ipOrHost`                                      | Matches a hostname or IP.                                                                                                          |
 | `port`                                          | Matches a port number.                                                                                                             |
+| `data`                                          | Matches any string including spaces and newlines. Equivalent to `.*`. Use when none of above matchers are appropriate.                                                              |
 
 {{% /tab %}}
 {{% tab "Filter" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Move data matcher as the last option for a matcher because it is more computationally expensive compared to other matchers. Having it at the end makes the customer/user read through the other possible matchers first.

### Motivation
<!-- What inspired you to submit this pull request?-->
There was a public service announcement for APAC SE's to not suggest data matcher when other matchers are available. In the [discussion](https://dd.slack.com/archives/C544KQ1CP/p1601265860180400), we realize that maybe it's a good idea to move this at the bottom and add a note.

### Preview
<!-- Impacted pages preview links-->
None

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Maybe Log PM would need to review this. Kindly consider this a suggestion and modify accordingly.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
