### PR TITLE
Typo in metric name

### DIFF
--- a/content/en/tracing/guide/apm_dashboard.md
+++ b/content/en/tracing/guide/apm_dashboard.md
@@ -67,7 +67,7 @@ This guides walks you through adding trace metrics to a dashboard, correlating t
 
     In this example two different types of metrics are added to a graph, a `trace.*` and a `runtime.*` one. Combined, these metrics allow you to correlate information between requests and code runtime performances. Specificallly, the latency of a service is displayed next to the thread count, knowing that latency spikes might be assocaited with an increase in the thraed count:
 
-    1. First, add `trace.rack.reqesusts.errors` metric into the widget:
+    1. First, add `trace.rack.requests.errors` metric into the widget:
 
         | Parameter | Value                                        | Description                                                                                                          |
         | ------    | -----                                        | -----                                                                                                                |


### PR DESCRIPTION
### What does this PR do?
Corrects a typo in a metric name.