### PR TITLE
Update Error Budget Monitor supported Terraform versions

### DIFF
--- a/content/en/monitors/service_level_objectives/error_budget.md
+++ b/content/en/monitors/service_level_objectives/error_budget.md
@@ -39,7 +39,7 @@ error_budget("slo_id").over("time_window") > 75
 
 In addition, SLO error budget monitors can also be created using the [datadog_monitor resource in Terraform][5]. Below is an example `.tf` for configuring an error budget monitor for a metric-based SLO using the same example query as above.
 
-**Note:** SLO error budget monitors are only supported in Terraform provider v2.7.0 or earlier.
+**Note:** SLO error budget monitors are only supported in Terraform provider v2.7.0 or earlier and in provider v2.13.0 or later. Versions between v2.7.0 and v2.13.0 will not be supported.
 
 ```
 resource "datadog_monitor" "metric-based-slo" {

--- a/content/en/monitors/service_level_objectives/error_budget.md
+++ b/content/en/monitors/service_level_objectives/error_budget.md
@@ -39,7 +39,7 @@ error_budget("slo_id").over("time_window") > 75
 
 In addition, SLO error budget monitors can also be created using the [datadog_monitor resource in Terraform][5]. Below is an example `.tf` for configuring an error budget monitor for a metric-based SLO using the same example query as above.
 
-**Note:** SLO error budget monitors are only supported in Terraform provider v2.7.0 or earlier and in provider v2.13.0 or later. Versions between v2.7.0 and v2.13.0 will not be supported.
+**Note:** SLO error budget monitors are only supported in Terraform provider v2.7.0 or earlier and in provider v2.13.0 or later. Versions between v2.7.0 and v2.13.0 are not supported.
 
 ```
 resource "datadog_monitor" "metric-based-slo" {


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Updates the supported versions of Terraform for Error Budget Monitors

### Motivation
<!-- What inspired you to submit this pull request?-->
Recent release of v2.13.0 of the Terraform provider

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/markazerdd/error-budget-monitor-terraform/monitors/service_level_objectives/error_budget

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
