### PR TITLE
Minor fixes for recent additions to pull config

### DIFF
--- a/local/bin/py/build/actions/pull_and_push_file.py
+++ b/local/bin/py/build/actions/pull_and_push_file.py
@@ -5,6 +5,13 @@ import yaml
 
 from os.path import basename
 
+TEMPLATE = """\
+---
+{front_matter}
+---
+{content}
+"""
+
 
 def pull_and_push_file(content, content_dir):
     """
@@ -19,11 +26,10 @@ def pull_and_push_file(content, content_dir):
         # If options include front params, then the H1 title of the source file is striped
         # and the options front params are inlined
         if "front_matters" in content["options"]:
-            front_matters = "---\n" + \
-                yaml.dump(content["options"]["front_matters"],
-                          default_flow_style=False) + "---\n"
-            file_content = re.sub(
-                r'^(#{1}).*', front_matters, file_content, count=1)
+            front_matter = yaml.dump(content["options"]["front_matters"], default_flow_style=False).strip()
+            # remove h1 if exists
+            file_content = re.sub(re.compile(r"^#{1}(?!#)(.*)", re.MULTILINE), "", file_content, count=1)
+            file_content = TEMPLATE.format(front_matter=front_matter, content=file_content.strip())
     with open(
         "{}{}{}".format(
             content_dir,


### PR DESCRIPTION
### What does this PR do?

This PR fixes the issue with

```
Error: Error building site: "/go/src/github.com/DataDog/documentation/content/en/serverless/serverless_integrations/cli.md:1:1": plain HTML documents not supported
```

Currently we are pulling a `.md` file and the config expects to replace a h1 tag and inject frontmatter.
In some situations the `.md` we are pulling doesn't have a h1 so we never inject the front matter and the build seems to fail on not allowing html in md files.

The fix updates the intentions of the script so we replace h1 only if it exists and we update frontmatter if we have it.

### Motivation

Seeing build failures

### Preview

Need to test integrations pages look good as well as other sections pulling content
https://docs-staging.datadoghq.com/david.jones/fixfm/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
