### PR TITLE
ECS Agent metrics table

### DIFF
--- a/content/en/agent/amazon_ecs/data_collected.md
+++ b/content/en/agent/amazon_ecs/data_collected.md
@@ -17,13 +17,9 @@ further_reading:
 
 ### Metrics
 
-Amazon ECS metrics are collected through the Datadog Agent or [AWS integration][1].
+Amazon ECS metrics collected with the Datadog Agent:
 
-Metrics collected using the AWS integration are prefixed with `aws.*`. Metrics collected by the Agent are prefixed with `ecs.*`. See the table below:
-
-{{< get-metrics-from-git "amazon_ecs" >}}
-
-Each of the metrics retrieved from AWS is assigned the same tags that appear in the AWS console, including but not limited to hostname, security-groups, and more.
+{{< get-metrics-from-git "amazon_ecs" "ecs." >}}
 
 **Note**: Metrics prefixed with `ecs.containerinsights.*` come from the [AWS CloudWatch agent][2].
 
@@ -34,10 +30,6 @@ To reduce noise, the Amazon ECS integration is automatically set up to include o
 {{< img src="integrations/amazon_ecs/aws_ecs_events.png" alt="AWS ECS Events" >}}
 
 To remove the whitelist and receive all events from your Datadog Amazon ECS integration, reach out to [Datadog support][3].
-
-### Service checks
-
-- **aws.ecs.agent_connected**: Returns `CRITICAL` if the Agent cannot connect, otherwise `OK`.
 
 ## Further reading
 


### PR DESCRIPTION
### What does this PR do?
Updates the ECS Agent metrics table to only pull in `ecs.*` metrics.

### Motivation
Jira request / part of content reorg

### Preview
https://docs-staging.datadoghq.com/sarina/ecs-metrics/agent/amazon_ecs/data_collected/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
