### PR TITLE
zach groves add config to enable trace annotation analytics

### DIFF
--- a/content/en/tracing/app_analytics/_index.md
+++ b/content/en/tracing/app_analytics/_index.md
@@ -364,6 +364,7 @@ class MyClass {
   }
 }
 ```
+**Note:** If using [dd.trace.methods][8] or [trace annotations][9], app analytics for those spans can be enabled by setting `-Ddd.trace-annotation.analytics.enabled=true` .
 
 {{% /tab %}}
 {{% tab "Python" %}}
@@ -479,3 +480,8 @@ Changes to the filtering rates are queued, by service & environment, allowing to
 [5]: https://app.datadoghq.com/apm/settings
 [6]: /tracing/visualization/#trace
 [7]: /account_management/billing/apm_distributed_tracing/
+[8]: https://docs.datadoghq.com/tracing/custom_instrumentation/java/#dd-trace-methods
+[9]: https://docs.datadoghq.com/tracing/custom_instrumentation/java/#trace-annotations
+
+
+


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds the config -Ddd.trace-annotation.analytics.enabled=true which enables app analytics for spans that are traced via trace annotations or via DD Trace Methods. 

### Motivation
Customers ask about it a few times a month and it doesn't need to be hidden knowledge. Makes it much easier for customers to get analytics on some of the spans they really want it for rather than having to modify their code.
### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
