### PR TITLE
Replace - with NOT operator for Search String exclusion

### DIFF
--- a/content/en/logs/search_syntax.md
+++ b/content/en/logs/search_syntax.md
@@ -36,7 +36,7 @@ To combine multiple terms into a complex query, you can use any of the following
 | **Operator** | **Description**                                                                                        | **Example**                  |
 | `AND`        | **Intersection**: both terms are in the selected events (if nothing is added, AND is taken by default) | authentication AND failure   |
 | `OR`         | **Union**: either term is contained in the selected events                                             | authentication OR password   |
-| `-`          | **Exclusion**: the following term is NOT in the event                                                  | authentication AND -password |
+| `NOT`          | **Exclusion**: the following term is NOT in the event                                                  | authentication AND NOT password |
 
 ## Autocomplete
 


### PR DESCRIPTION
the "-" Operator would not work for me in the search strings. "NOT" works for exclusion.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Document use of "NOT" operator for search string exclusion

### Motivation
Update documentation


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
