### PR TITLE
Filtering and scrubbing doc for Lambda logs

### DIFF
--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -232,8 +232,10 @@ Any AWS service that generates logs into a S3 bucket or a CloudWatch Log Group i
 | [RedShift][36]                    | [Enable AWS Redshift logs][37]                                                                 | [Manual][38] and [automatic](#automatically-setup-triggers) log collection |
 | [VPC][39]                         | [Enable AWS VPC logs][40]                                                                      | [Manual][41] log collection                                                |
 
+## Filtering and scrubing
 
-
+Scrub emails or ip address from logs sent by the Lambda function or define a custom scrubbing rule [in the Lambda parameters][42].
+It is also possible to exclude logs matching a specific pattern or only send the one matching thanks to the [filtering option][43].
 
 [1]: /serverless/forwarder/
 [2]: /serverless/forwarder#aws-privatelink-support
@@ -276,3 +278,5 @@ Any AWS service that generates logs into a S3 bucket or a CloudWatch Log Group i
 [39]: /integrations/amazon_vpc/
 [40]: /integrations/amazon_vpc/#enable-vpc-flow-log-logging
 [41]: /integrations/amazon_vpc/#log-collection
+[42]: https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring#log-scrubbing-optional
+[43]: https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring#log-filtering-optional

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -234,8 +234,8 @@ Any AWS service that generates logs into a S3 bucket or a CloudWatch Log Group i
 
 ## Scrubbing and filtering
 
-Scrub emails or ip address from logs sent by the Lambda function or define a custom scrubbing rule [in the Lambda parameters][42].
-It is also possible to exclude logs matching a specific pattern or only send the one matching thanks to the [filtering option][43].
+You can scrub emails or IP address from logs sent by the Lambda function, or define a custom scrubbing rule [in the Lambda parameters][42].
+You can also exclude or send only those logs that match a specific pattern by using the [filtering option][43].
 
 [1]: /serverless/forwarder/
 [2]: /serverless/forwarder#aws-privatelink-support

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -232,7 +232,7 @@ Any AWS service that generates logs into a S3 bucket or a CloudWatch Log Group i
 | [RedShift][36]                    | [Enable AWS Redshift logs][37]                                                                 | [Manual][38] and [automatic](#automatically-setup-triggers) log collection |
 | [VPC][39]                         | [Enable AWS VPC logs][40]                                                                      | [Manual][41] log collection                                                |
 
-## Filtering and scrubing
+## Scrubbing and filtering
 
 Scrub emails or ip address from logs sent by the Lambda function or define a custom scrubbing rule [in the Lambda parameters][42].
 It is also possible to exclude logs matching a specific pattern or only send the one matching thanks to the [filtering option][43].


### PR DESCRIPTION
### What does this PR do?
Add link to the github docs for filtering and scrubbing.

### Motivation
It was in the github readme but not in the official documentation

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/lambda-filter-scrub/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/?tab=awsconsole#pagetitle

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
