### PR TITLE
Update dogstatsd_metrics_submission.md

### DIFF
--- a/content/en/developers/metrics/dogstatsd_metrics_submission.md
+++ b/content/en/developers/metrics/dogstatsd_metrics_submission.md
@@ -619,7 +619,7 @@ func main() {
 	}
 
 	for {
-		statsd.Histogram("example_metric.histogram", rand.Intn(20), []string{"environment:dev"}, 1)
+		statsd.Histogram("example_metric.histogram", float64(rand.Intn(20)), []string{"environment:dev"}, 1)
 		time.Sleep(2 * time.Second)
 	}
 }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
The Golang code example to submit a DogStatsD HISTOGRAM metric to Datadog currently returns this error
```cmd
Cannot use rand.Intn(20) (type int) as type float64 in argument to statsd.Histogram. 
```
Purposed changed to cast  int->float64 to resolve the issue

### Motivation
The Golang code example to submit a DogStatsD HISTOGRAM metric to Datadog was not functioning and I wanted to help out :) 


### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
