### PR TITLE
add istio v1.7 cpp tracer version

### DIFF
--- a/content/en/tracing/setup/istio.md
+++ b/content/en/tracing/setup/istio.md
@@ -77,6 +77,7 @@ The available [environment variables][6] depend on the version of the C++ tracer
 
 | Istio Version | C++ Tracer Version |
 |---------------|--------------------|
+| v1.7.x | v1.1.5 |
 | v1.6.x | v1.1.3 |
 | v1.5.x | v1.1.1 |
 | v1.4.x | v1.1.1 |


### PR DESCRIPTION
This is motivated by a conversation with Caleb Gilmour, who specified that Istio 1.7 picks up latest Envoy releases, which use C++ tracer v1.1.5.

https://docs.datadoghq.com/tracing/setup/istio/#environment-variables

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
