### PR TITLE
DOCS-1222 Update missing_metrics.py

### DIFF
--- a/local/bin/py/missing_metrics.py
+++ b/local/bin/py/missing_metrics.py
@@ -45,7 +45,12 @@ def get_dd_metrics(csv_metrics, keys, t):
             'gcp.logging.user.',
             'gcp.custom.',
             'isatap',
-            'vsphere.'
+            'vsphere.',
+            'zookeeper.avg_',
+            'zookeeper.cnt_',
+            'zookeeper.max_',
+            'zookeeper.min_',
+            'zookeeper.sum_'
     ]
 
   # Datadog Demo account


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update `missing_metrics.py` to ignore Zookeeper metrics from Prometheus and JMX.

### Motivation
Missing metrics script

### Preview
N/A

### Additional Notes
N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
