### PR TITLE
Update Laravel log examples

### DIFF
--- a/content/en/logs/log_collection/php.md
+++ b/content/en/logs/log_collection/php.md
@@ -373,7 +373,7 @@ Monolog is a part of the following frameworks:
 
 * [Symfony2, Symfony3][3]
 * [PPI][4]
-* [Laravel 4 & 5][5]
+* [Laravel][5]
 * [Silex][6]
 * [Lumen][7]
 * [CakePHP][8]
@@ -458,15 +458,67 @@ monolog:
 
 ```php
 <?php
-  //file: bootstrap/app.php
-  $app->configureMonologUsing(function($monolog) {
-      $monolog->pushHandler(...);
 
-    // configure your logger below
-  });
+namespace App\Providers;
 
-  return $app;
-?>
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        // Get the Monolog instance
+        $monolog = logger()->getLogger();
+        if (!$monolog instanceof \Monolog\Logger) {
+            return;
+        }
+
+        // Optional: Use JSON formatting
+        $useJson = false;
+        foreach ($monolog->getHandlers() as $handler) {
+            if (method_exists($handler, 'setFormatter')) {
+                $handler->setFormatter(new \Monolog\Formatter\JsonFormatter());
+                $useJson = true;
+            }
+        }
+
+        // Inject the trace and span ID to connect the log entry with the APM trace
+        $monolog->pushProcessor(function ($record) use ($useJson) {
+            $span = \DDTrace\GlobalTracer::get()->getActiveSpan();
+            if (null === $span) {
+                return $record;
+            }
+            if ($useJson === true) {
+                $record['dd'] = [
+                    'trace_id' => $span->getTraceId(),
+                    'span_id'  => \dd_trace_peek_span_id(),
+                ];
+            } else {
+                $record['message'] .= sprintf(
+                    ' [dd.trace_id=%d dd.span_id=%d]',
+                    $span->getTraceId(),
+                    \dd_trace_peek_span_id()
+                );
+            }
+            return $record;
+        });
+    }
+
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        //
+    }
+}
 ```
 
 ### Silex

--- a/content/en/tracing/connect_logs_and_traces/php.md
+++ b/content/en/tracing/connect_logs_and_traces/php.md
@@ -36,7 +36,7 @@ For instance, you would append those two attributes to your logs with:
   $append = sprintf(
       ' [dd.trace_id=%d dd.span_id=%d]',
       $span->getTraceId(),
-      $span->getSpanId()
+      \dd_trace_peek_span_id()
   );
   my_error_logger('Error message.' . $append);
 ?>
@@ -54,7 +54,7 @@ If the logger implements the [**monolog/monolog** library][4], use `Logger::push
       $record['message'] .= sprintf(
           ' [dd.trace_id=%d dd.span_id=%d]',
           $span->getTraceId(),
-          $span->getSpanId()
+          \dd_trace_peek_span_id()
       );
       return $record;
   });
@@ -70,12 +70,12 @@ If your application uses json logs format instead of appending trace_id and span
       if (null === $span) {
           return $record;
       }
-      
+
       $record['dd'] = [
           'trace_id' => $span->getTraceId(),
-          'span_id'  => $span->getSpanId(),
+          'span_id'  => \dd_trace_peek_span_id(),
       ];
-      
+
       return $record;
   });
 ?>


### PR DESCRIPTION
### What does this PR do?

The existing Laravel log example does not work on the latest versions of Laravel. This PR updates the example with a more complete example that will work on all supported versions of Laravel.

### Preview

https://docs-staging.datadoghq.com/sammyk/logs/laravel-example/logs/log_collection/php/?tab=phpmonolog#laravel

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
