### PR TITLE
[WEB-802] fix nested list item css issue

### DIFF
--- a/src/styles/pages/_global.scss
+++ b/src/styles/pages/_global.scss
@@ -326,14 +326,6 @@ h5{
     }
   }
 
-  ol {
-    li {
-      &:before {
-        content: "" !important;
-      }
-    }
-  }
-
   ul{
     list-style-type: none;
     -webkit-padding-start: 22px;
@@ -347,6 +339,13 @@ h5{
         margin-right: 10px;
         margin-left: -20px;
         float: left;
+      }
+      ol {
+        li {
+          &:before {
+            content: '';
+          }
+        }
       }
       p {
         margin-bottom: 0;


### PR DESCRIPTION
### What does this PR do?
- fixes style issues with `<ol>` nested inside `<ul>` and vice versa.

### Motivation
- https://datadoghq.atlassian.net/browse/WEB-802

### Preview
- `<ol>` items nested within `<ul>` still don’t have the strikethrough as seen before: https://docs-staging.datadoghq.com/brian.deutsch/list-css-fixes/tracing/setup/java/?tab=websphere

- `<ul>` items nested within `<ol>` now retain bullet points: https://docs-staging.datadoghq.com/brian.deutsch/list-css-fixes/synthetics/api_tests/?tab=ssltest#make-a-requestand

### Additional Notes

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
