### PR TITLE
[agent+integrations] jmxterm no longer shipped with agent 5.32.8+

### DIFF
--- a/content/en/integrations/faq/collecting-composite-type-jmx-attributes.md
+++ b/content/en/integrations/faq/collecting-composite-type-jmx-attributes.md
@@ -75,7 +75,7 @@ The best way to achieve this would be using JMXterm (see below).
 java -jar /opt/datadog-agent/agent/checks/libs/jmxterm-1.0-DATADOG-uber.jar -l localhost:<PORT> -u <USER> -p <PASSWORD>
 ```
 
-Note, for all versions of **Agent v6**, the `jmxterm` JAR is not shipped with the Agent. To download and use `jmxterm`, see the [upstream project][7].
+Note, for all versions of **Agent v5.32.8 or greater**, the `jmxterm` JAR is not shipped with the Agent. To download and use `jmxterm`, see the [upstream project][7].
 
 Then use the get command to pull up a specific metric.
 

--- a/content/en/integrations/faq/troubleshooting-jmx-integrations.md
+++ b/content/en/integrations/faq/troubleshooting-jmx-integrations.md
@@ -10,7 +10,7 @@ further_reading:
 To verify you have access to JMX, test using JConsole or equivalent if possible. If you're unable to connect using JConsole [this article][1] may help to get you sorted. Also, if the metrics listed in your YAML aren't 1:1 with those listed in JConsole you'll need to correct this.
 
 <div class="alert alert-warning">
-For all versions of <strong>Agent v6</strong>, the <code>jmxterm</code> JAR is not shipped with the agent. To download and use <code>jmxterm</code>, see the <a href="https://github.com/jiaqi/jmxterm">upstream project</a>.
+For all versions of <strong>Agent v5.32.8 or greater</strong>, the <code>jmxterm</code> JAR is not shipped with the agent. To download and use <code>jmxterm</code>, see the <a href="https://github.com/jiaqi/jmxterm">upstream project</a>. You may substitute <code>/opt/datadog-agent/agent/checks/libs/jmxterm-1.0-DATADOG-uber.jar</code> in the examples below to the jmxterm JAR path you downloaded from the upstream project.
 </div>
 
 If you're able to connect using JConsole, run the following:

--- a/content/en/integrations/faq/troubleshooting-jmx-integrations.md
+++ b/content/en/integrations/faq/troubleshooting-jmx-integrations.md
@@ -10,7 +10,7 @@ further_reading:
 To verify you have access to JMX, test using JConsole or equivalent if possible. If you're unable to connect using JConsole [this article][1] may help to get you sorted. Also, if the metrics listed in your YAML aren't 1:1 with those listed in JConsole you'll need to correct this.
 
 <div class="alert alert-warning">
-For all versions of <strong>Agent v5.32.8 or greater</strong>, the <code>jmxterm</code> JAR is not shipped with the agent. To download and use <code>jmxterm</code>, see the <a href="https://github.com/jiaqi/jmxterm">upstream project</a>. You may substitute <code>/opt/datadog-agent/agent/checks/libs/jmxterm-1.0-DATADOG-uber.jar</code> in the examples below to the jmxterm JAR path you downloaded from the upstream project.
+For all versions of <strong>Agent v5.32.8 or greater</strong>, the <code>jmxterm</code> JAR is not shipped with the agent. To download and use <code>jmxterm</code>, see the <a href="https://github.com/jiaqi/jmxterm">upstream project</a>. Change <code>/opt/datadog-agent/agent/checks/libs/jmxterm-1.0-DATADOG-uber.jar</code> in the examples below to the `jmxterm` JAR path you downloaded from the upstream project.
 </div>
 
 If you're able to connect using JConsole, run the following:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Updates the JMX troubleshooting instructions to address the fact `jmxterm` is no longer available on version 5.32.8+ of the agent.

### Motivation
<!-- What inspired you to submit this pull request?-->
`jmxterm` has been removed from the agent.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jaime/a5_jmxterm/integrations/faq/troubleshooting-jmx-integrations/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
