### PR TITLE
DOCS-1279 - java link fix

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/java.md
+++ b/content/en/tracing/connect_logs_and_traces/java.md
@@ -103,6 +103,6 @@ Then update your logger configuration to include `dd.trace_id` and `dd.span_id` 
 [1]: /tracing/setup/java/#configuration
 [2]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/?tab=jsonlogs#trace-id-option
 [3]: /tracing/connect_logs_and_traces/
-[4]: /tracing/visualization/#trace
+[4]: /logs/log_collection/java/?tab=log4j 
 [5]: /logs/log_collection/java/#raw-format
 [6]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/?tab=custom


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
fixes a link that was going to the wrong place

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
