### PR TITLE
Adding in a redirect for a removed page

### DIFF
--- a/content/en/integrations/_index.md
+++ b/content/en/integrations/_index.md
@@ -4,6 +4,7 @@ kind: documentation
 disable_toc: true
 aliases:
     - /integrations/verisign_openhybrid/
+    - /integrations/tcp_queue_length/
 description: Gather data from all of your systems, apps, & services
 ---
 


### PR DESCRIPTION
### What does this PR do?
The redirect for the removed page and the deploy of the removed page.

Dependent on https://github.com/DataDog/integrations-core/pull/7759 being merged.
