### PR TITLE
Update _index.md

### DIFF
--- a/content/en/api/v1/rate-limits/_index.md
+++ b/content/en/api/v1/rate-limits/_index.md
@@ -16,7 +16,7 @@ Regarding the API rate limit policy:
 - Datadog **does not rate limit** on data point/metric submission (see [metrics section][2] for more info on how the metric submission rate is handled). Limits encounter is dependent on the quantity of [custom metrics][3] based on your agreement.
 - The rate limit for metric **retrieval** is `100` per hour per organization.
 - The rate limit for event submission is `1000` per aggregate per day per organization. An aggregate is a group of similar events.
-- The rate limit for the [Query a Timeseries API][4] call is `600` per hour per organization. This can be extended on demand.
+- The rate limit for the [Query a Timeseries API][4] call is `1600` per hour per organization. This can be extended on demand.
 - The rate limit for the [Log Query API][5] call is `300` per hour per organization. This can be extended on demand.
 - The rate limit for the [Graph a Snapshot API][6] call is `60` per hour per organization. This can be extended on demand.
 - The rate limit for the [Log Configuration API][7] is `6000` per minute per organization. This can be extended on demand.


### PR DESCRIPTION
As part of #incident-5952 we increased the default rate limit for batch_query from to 1600 / hour.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
