### PR TITLE
[PROF-2200] add documentation on stackdepth limits

### DIFF
--- a/content/en/tracing/profiler/getting_started.md
+++ b/content/en/tracing/profiler/getting_started.md
@@ -64,6 +64,10 @@ The Datadog Profiler requires [JDK Flight Recorder][1]. The Datadog Profiler lib
 | `DD_VERSION`                                     | String        | The version of your service.                             |
 | `DD_TAGS`                                        | String        | Tags to apply to an uploaded profile. Must be a list of `<key>:<value>` separated by commas such as: `layer:api, team:intake`.  |
 
+- By default, The Datadog Profiler keeps the top 256 frames in a Java profile. If your application creates stacks deeper than 256 frames, you can increase the threshold by passing a `-XX:FlightRecorderOptions=stackdepth=` option to your JVM.  For example:
+    ```shell
+    java -javaagent:dd-java-agent.jar -XX:FlightRecorderOptions=stackdepth=512 ...
+    ```
 
 [1]: https://docs.oracle.com/javacomponents/jmc-5-4/jfr-runtime-guide/about.htm
 [2]: /tracing/profiler/profiler_troubleshooting/#java-8-support

--- a/content/en/tracing/profiler/getting_started.md
+++ b/content/en/tracing/profiler/getting_started.md
@@ -64,7 +64,7 @@ The Datadog Profiler requires [JDK Flight Recorder][1]. The Datadog Profiler lib
 | `DD_VERSION`                                     | String        | The version of your service.                             |
 | `DD_TAGS`                                        | String        | Tags to apply to an uploaded profile. Must be a list of `<key>:<value>` separated by commas such as: `layer:api, team:intake`.  |
 
-- By default, The Datadog Profiler keeps the top 256 frames in a Java profile. If your application creates stacks deeper than 256 frames, you can increase the threshold by passing a `-XX:FlightRecorderOptions=stackdepth=` option to your JVM.  For example:
+- By default, The Datadog Profiler keeps the bottom 256 frames in a Java profile. If your application creates stacks deeper than 256 frames, you can increase the threshold by passing a `-XX:FlightRecorderOptions=stackdepth=` option to your JVM.  For example:
     ```shell
     java -javaagent:dd-java-agent.jar -XX:FlightRecorderOptions=stackdepth=512 ...
     ```


### PR DESCRIPTION
We also cap the maximum frame depth at 1024 to protect our intake.
Should that be documented?

[PROF-2200]

[PROF-2200]: https://datadoghq.atlassian.net/browse/PROF-2200