### PR TITLE
Add permission for cloudtrail history

### DIFF
--- a/content/en/serverless/serverless_integrations/_index.md
+++ b/content/en/serverless/serverless_integrations/_index.md
@@ -36,6 +36,7 @@ Enable the [AWS Step Functions integration][4] to automatically get additional t
     | ------------------ | -------------------------------------------- |
     | `states:ListStateMachines`     | List active Step Functions.   |
     | `states:DescribeStateMachine` | Get Step Function metadata, and tags.  |
+    | `cloudtrail:LookupEvents` | Get deployment events on lambda functions.  |
 3. Configure [distributed tracing and logging][4] for AWS Step Functions.
 4. Once done, go to the [Serverless Homepage][2] and filter your Lambda functions by `statemachinename`, `statemachinearn` or `stepname`.
 


### PR DESCRIPTION

### What does this PR do?
This adds cloudtrail:LookupEvents to the permissions required by the AWS Lambda integration. The AWS Lambda integration is about to get a brand new crawler that looks at cloudtrail history events to extract lambda deployments and configuration changes.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
