### PR TITLE
[WEB-840] - update frontmatter formatting on integrations

### DIFF
--- a/config/preview/config.yaml
+++ b/config/preview/config.yaml
@@ -1,6 +1,6 @@
 baseURL: https://docs-staging.datadoghq.com/$CI_COMMIT_REF_NAME/
 buildfuture: true
-builddrafts: true
+builddrafts: false
 enableGitInfo: true
 
 deployment:

--- a/config/preview/config.yaml
+++ b/config/preview/config.yaml
@@ -1,6 +1,6 @@
 baseURL: https://docs-staging.datadoghq.com/$CI_COMMIT_REF_NAME/
 buildfuture: true
-builddrafts: false
+builddrafts: true
 enableGitInfo: true
 
 deployment:

--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -573,9 +573,13 @@ class Integrations:
                     item[0]["ddtype"] = item[0].get("type")
                     del item[0]["type"]
                 item[0]["dependencies"] = dependencies
-                fm = yaml.dump(
-                    item[0], width=150, default_style='"', default_flow_style=False
+                item[0]["draft"] = not item[0].get("is_public", False)
+                fm = yaml.safe_dump(
+                    item[0], width=150, default_style='"', default_flow_style=False, allow_unicode=True
                 ).rstrip()
+                # simple bool cleanups with replace
+                fm = fm.replace('!!bool "false"', 'false')
+                fm = fm.replace('!!bool "true"', 'true')
             else:
                 fm = {"kind": "integration"}
         return template.format(


### PR DESCRIPTION
### What does this PR do?

When building integration markdown files we opted to use `default_style='"'` to wrap entries with quotes in order to avoid issues with localized text breaking yaml format. A consequence of doing this caused boolean values to be output as `!!bool "false"` or `!!bool "true"`. See related PR #6059. While this works fine Hugo doesn't respect the values in this format and we now want to make use of some of these booleans.

This PR:

- Will cause integrations defailed pages (`/integrations/some-integration/`) to not build if `is_public: false` 
- Will cause generated integration frontmatter booleans to change formatting from `!!bool "false"` to `false` etc. 

### Motivation
https://datadoghq.atlassian.net/browse/WEB-840

### Preview
https://docs-staging.datadoghq.com/david.jones/draftintegrations/integrations/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
