### PR TITLE
Update the OpenMetrics dev docs

### DIFF
--- a/content/en/developers/prometheus.md
+++ b/content/en/developers/prometheus.md
@@ -129,7 +129,7 @@ class KubeDNSCheck(OpenMetricsBaseCheck):
 
 #### Implementing the check method
 
-In some cases, you may want to override the `check()` function to implement additional features. 
+If you want to implement additional features, override the `check()` function. 
 
 From `instance`, use `endpoint`, which is the Prometheus or OpenMetrics metrics endpoint to poll metrics from:
 

--- a/content/en/developers/prometheus.md
+++ b/content/en/developers/prometheus.md
@@ -93,7 +93,7 @@ class KubeDNSCheck(OpenMetricsBaseCheck):
 A default instance is the basic configuration used for the check. The default instance should override `namespace`, `metrics`, and `prometheus_url`.
 
 
-Note that we also overrode some of the default values for certain config options in the `OpenMetricsBaseCheck`, we can expect to see better metric behavior correlation between [Prometheus and Datadog metric types][7]. 
+Note that we also override the default values for some config options in the `OpenMetricsBaseCheck`, so there is increased metric behavior correlation between [Prometheus and Datadog metric types][7]. 
 
 ```python
 from datadog_checks.base import OpenMetricsBaseCheck

--- a/content/en/developers/prometheus.md
+++ b/content/en/developers/prometheus.md
@@ -51,52 +51,34 @@ instances:
 The names of the configuration and check files must match. If your check is called <code>mycheck.py</code> your configuration file <em>must</em> be named <code>mycheck.yaml</code>.
 </div>
 
-Configuration for a Prometheus check is almost the same as a regular [Agent check][4]. The main difference is to include the variable `prometheus_endpoint` in your `check.yaml` file. This goes into `conf.d/kube_dns.yaml`:
+Configuration for a Prometheus check is almost the same as a regular [Agent check][4]. The main difference is to include the variable `prometheus_url` in your `check.yaml` file. This goes into `conf.d/kube_dns.yaml`:
 
 ```yaml
 init_config:
 
 instances:
     # URL of the metrics endpoint of Prometheus
-  - prometheus_endpoint: http://localhost:10055/metrics
+  - prometheus_url: http://localhost:10055/metrics
 ```
 
 ### Writing the check
 
-All OpenMetrics checks inherit from the `OpenMetricsBaseCheck` class found in `checks/openmetrics_check.py`:
-
-```python
-from datadog_checks.base import OpenMetricsBasicCheck
-
-class KubeDNSCheck(OpenMetricsBasicCheck):
-```
-
-#### Overriding `self.NAMESPACE`
-
-`NAMESPACE` is the metrics prefix. It needs to be hardcoded in your check class:
+All OpenMetrics checks inherit from the [`OpenMetricsBaseCheck` class][8]:
 
 ```python
 from datadog_checks.base import OpenMetricsBaseCheck
 
 class KubeDNSCheck(OpenMetricsBaseCheck):
-    def __init__(self, name, init_config, agentConfig, instances=None):
-        super(KubeDNSCheck, self).__init__(name, init_config, agentConfig, instances)
-        self.NAMESPACE = 'kubedns'
 ```
 
-#### Overriding `self.metrics_mapper`
-
-`metrics_mapper` is a dictionary where the key is the metric to capture, and the value is the corresponding metric name in Datadog.
-The reason for the override is so that metrics reported by the OpenMetrics checks are not counted as [custom metric][5]:
+#### Define a metrics mapping
 
 ```python
 from datadog_checks.base import OpenMetricsBaseCheck
 
 class KubeDNSCheck(OpenMetricsBaseCheck):
-    def __init__(self, name, init_config, agentConfig, instances=None):
-        super(KubeDNSCheck, self).__init__(name, init_config, agentConfig, instances)
-        self.NAMESPACE = 'kubedns'
-        self.metrics_mapper = {
+    def __init__(self, name, init_config, instances=None):
+        METRICS_MAP = {
             #metrics have been renamed to kubedns in kubernetes 1.6.0
             'kubedns_kubedns_dns_response_size_bytes': 'response_size.bytes',
             'kubedns_kubedns_dns_request_duration_seconds': 'request_duration.seconds',
@@ -106,13 +88,54 @@ class KubeDNSCheck(OpenMetricsBaseCheck):
         }
 ```
 
+#### Define a default instance
+
+A default instance is the basic configuration used for the check. The default instance should override `namespace`, `metrics`, and `prometheus_url`.
+
+
+Note that we also overrode some of the default values for certain config options in the `OpenMetricsBaseCheck`, we can expect to see better metric behavior correlation between [Prometheus and Datadog metric types][7]. 
+
+```python
+from datadog_checks.base import OpenMetricsBaseCheck
+
+class KubeDNSCheck(OpenMetricsBaseCheck):
+    def __init__(self, name, init_config, instances=None):
+        METRICS_MAP = {
+            #metrics have been renamed to kubedns in kubernetes 1.6.0
+            'kubedns_kubedns_dns_response_size_bytes': 'response_size.bytes',
+            'kubedns_kubedns_dns_request_duration_seconds': 'request_duration.seconds',
+            'kubedns_kubedns_dns_request_count_total': 'request_count',
+            'kubedns_kubedns_dns_error_count_total': 'error_count',
+            'kubedns_kubedns_dns_cachemiss_count_total': 'cachemiss_count'
+        }
+        super(KubeDNSCheck, self).__init__(
+            name,
+            init_config,
+            instances,
+            default_instances={
+                'kubedns': {
+                    'prometheus_url': 'http://localhost:8404/metrics',
+                    'namespace': 'kubedns',
+                    'metrics': [METRIC_MAP],
+                    'send_histograms_buckets': True,
+                    'send_distribution_counts_as_monotonic': True,
+                    'send_distribution_sums_as_monotonic': True,
+                }
+            },
+            default_namespace='kubedns',
+        )
+```
+
+
 #### Implementing the check method
+
+In some cases, you may want to override the `check()` function to implement additional features. 
 
 From `instance`, use `endpoint`, which is the Prometheus or OpenMetrics metrics endpoint to poll metrics from:
 
 ```python
 def check(self, instance):
-    endpoint = instance.get('prometheus_endpoint')
+    endpoint = instance.get('prometheus_url')
 ```
 
 ##### Exceptions
@@ -126,78 +149,79 @@ If a check cannot run because of improper configuration, a programming error, or
 
         my_custom_check
         ---------------
-          - instance #0 [ERROR]: Unable to find prometheus_endpoint in config file.
+          - instance #0 [ERROR]: Unable to find prometheus_url in config file.
           - Collected 0 metrics & 0 events
 
-Improve your `check()` method with `CheckException`:
+Improve your `check()` method with `ConfigurationError`:
 
 ```python
-from datadog_checks.base.errors import CheckException
+from datadog_checks.base import ConfigurationError
 
 def check(self, instance):
-    endpoint = instance.get('prometheus_endpoint')
+    endpoint = instance.get('prometheus_url')
     if endpoint is None:
-        raise CheckException("Unable to find prometheus_endpoint in config file.")
+        raise ConfigurationError("Unable to find prometheus_url in config file.")
 ```
 
 Then as soon as you have data available, flush:
 
 ```python
-from datadog_checks.base.errors import CheckException
+from datadog_checks.base import ConfigurationError
 
 def check(self, instance):
-    endpoint = instance.get('prometheus_endpoint')
+    endpoint = instance.get('prometheus_url')
     if endpoint is None:
-        raise CheckException("Unable to find prometheus_endpoint in config file.")
-    # By default, we send the buckets.
-    if send_buckets is not None and str(send_buckets).lower() == 'false':
-        send_buckets = False
-    else:
-        send_buckets = True
+        raise ConfigurationError("Unable to find prometheus_url in config file.")
 
-    self.process(endpoint, send_histograms_buckets=send_buckets, instance=instance)
+    self.process(instance)
 ```
 
 ### Putting It All Together
 
 ```python
-from datadog_checks.base import OpenMetricsBaseCheck
-from datadog_checks.base.errors import CheckException
+from datadog_checks.base import ConfigurationError, OpenMetricsBaseCheck
 
 class KubeDNSCheck(OpenMetricsBaseCheck):
     """
     Collect kube-dns metrics from Prometheus endpoint
     """
-    def __init__(self, name, init_config, agentConfig, instances=None):
-        super(KubeDNSCheck, self).__init__(name, init_config, agentConfig, instances)
-        self.NAMESPACE = 'kubedns'
-
-        self.metrics_mapper = {
-            # metrics have been renamed to kubedns in kubernetes 1.6.0
+    def __init__(self, name, init_config, instances=None):
+        METRICS_MAP = {
+            #metrics have been renamed to kubedns in kubernetes 1.6.0
             'kubedns_kubedns_dns_response_size_bytes': 'response_size.bytes',
             'kubedns_kubedns_dns_request_duration_seconds': 'request_duration.seconds',
             'kubedns_kubedns_dns_request_count_total': 'request_count',
             'kubedns_kubedns_dns_error_count_total': 'error_count',
-            'kubedns_kubedns_dns_cachemiss_count_total': 'cachemiss_count',
+            'kubedns_kubedns_dns_cachemiss_count_total': 'cachemiss_count'
         }
+        super(KubeDNSCheck, self).__init__(
+            name,
+            init_config,
+            instances,
+            default_instances={
+                'kubedns': {
+                    'prometheus_url': 'http://localhost:8404/metrics',
+                    'namespace': 'kubedns',
+                    'metrics': [METRIC_MAP],
+                    'send_histograms_buckets': True,
+                    'send_distribution_counts_as_monotonic': True,
+                    'send_distribution_sums_as_monotonic': True,
+                }
+            },
+            default_namespace='kubedns',
+        )
 
     def check(self, instance):
-        endpoint = instance.get('prometheus_endpoint')
+        endpoint = instance.get('prometheus_url')
         if endpoint is None:
-            raise CheckException("Unable to find prometheus_endpoint in config file.")
+            raise ConfigurationError("Unable to find prometheus_url in config file.")
 
-        send_buckets = instance.get('send_histograms_buckets', True)
-        # By default, we send the buckets.
-        if send_buckets is not None and str(send_buckets).lower() == 'false':
-            send_buckets = False
-        else:
-            send_buckets = True
-
-        self.process(endpoint, send_histograms_buckets=send_buckets, instance=instance)
+        self.process(instance)
 ```
 
 ## Going further
 
+To read more about Prometheus and OpenMetrics base integrations, see the integrations [developer docs][9]
 You can improve your OpenMetrics check with the following methods:
 
 ### `self.ignore_metrics`
@@ -229,3 +253,6 @@ Available types are: `counter`, `gauge`, `summary`, `untyped`, and `histogram`.
 [4]: /agent/agent_checks/#configuration
 [5]: /developers/metrics/custom_metrics/
 [6]: /agent/guide/agent-commands/#agent-status-and-information
+[7]: https://docs.datadoghq.com/integrations/guide/prometheus-metrics/
+[8]: https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+[9]: https://datadoghq.dev/integrations-core/base/prometheus/

--- a/content/en/developers/prometheus.md
+++ b/content/en/developers/prometheus.md
@@ -221,22 +221,23 @@ class KubeDNSCheck(OpenMetricsBaseCheck):
 
 ## Going further
 
-To read more about Prometheus and OpenMetrics base integrations, see the integrations [developer docs][9]
-You can improve your OpenMetrics check with the following methods:
+To read more about Prometheus and OpenMetrics base integrations, see the integrations [developer docs][9].
 
-### `self.ignore_metrics`
+You can improve your OpenMetrics check by including default values for additional configuration options:
+
+### `ignore_metrics`
 
 Some metrics are ignored because they are duplicates or introduce a very high cardinality. Metrics included in this list are silently skipped without an `Unable to handle metric` debug line in the logs.
 
-### `self.labels_mapper`
+### `labels_mapper`
 
 If the `labels_mapper` dictionary is provided, the metrics labels in `labels_mapper` use the corresponding value as tag name when sending the gauges.
 
-### `self.exclude_labels`
+### `exclude_labels`
 
 `exclude_labels` is an array of labels to exclude. Those labels will not be added as tags when submitting the metric.
 
-### `self.type_overrides`
+### `type_overrides`
 
 `type_overrides` is a dictionary where the keys are Prometheus or OpenMetrics metric names, and the values are a metric type (name as string) to use instead of the one listed in the payload. This can be used to force a type on untyped metrics.
 Available types are: `counter`, `gauge`, `summary`, `untyped`, and `histogram`.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR updates the OpenMetrics custom check tutorial.
- remove references to Agent 5 (`agentConfig` in signature)
- use OpenMetrics style (`prometheus_endpoint` references the PrometheusBaseCheck)
- Fix typos
- Use the simplified default instances configuration style, see recent [implementation examples](https://github.com/DataDog/integrations-core/blob/master/haproxy/datadog_checks/haproxy/check.py)
- Use `ConfigurationError` instead of `CheckException`, it's more specific and accurate.
- Fix `process()` function use. In OpenMetricsBaseCheck it only takes a `scraper_config` field equivalent to `instance`. See [code](https://github.com/DataDog/integrations-core/blob/6d71b3d2670da9ccbcdf7c6610d7e720bad1d1c6/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L495)
- the properties referenced in `Going Further` are now only config options and not properties of the class.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/cc/add-prometheus-options/developers/prometheus/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
