### PR TITLE
Update example to better reflect the mathematical differences between as-count and as-rate in monitor

### DIFF
--- a/content/en/monitors/guide/as-count-in-monitor-evaluations.md
+++ b/content/en/monitors/guide/as-count-in-monitor-evaluations.md
@@ -58,7 +58,7 @@ Compare the result of the evaluation depending on the path:
 | **`classic_eval_path`**  | Aggregation function applied _after_ division  | **(1/1 + 1/2 + ... + 0/5)/5**           | **0.35** |
 | **`as_count_eval_path`** | Aggregation function applied _before_ division | **(1 + 1 + ... + 0)/(1 + 2 + ... + 5)** | **0.20** |
 
-_Note that both evaluations above are mathematically correct. The former weights every timestamp equality whereas the later weights every timestamp proportional to the number of requests. Choose a method that suits your intentions._
+_Note that both evaluations above are mathematically correct. The former weights every timestamp equality whereas the later weights every timestamp proportional to the number of requests per timestamp. Choose a method that suits your intentions._
 
 It may be helpful visualize the **`classic_eval_path`** as:
 


### PR DESCRIPTION
### What does this PR do?

I found the [as-count-in-monitor-evaluations](https://docs.datadoghq.com/monitors/guide/as-count-in-monitor-evaluations) document to be helpful but per the recommendations, 

> In general, avg time aggregation with .as_rate() is reasonable, but sum aggregation with .as_count() is recommended for error rates. Aggregation methods other than sum (shown as in total in-app) do not make sense to use with .as_count().

It seems like in the example the `classic_eval_path` should be using the `avg(last_5m)` time aggregation as opposed to `sum(last_5m)` which also provides a better apples-to-apples comparison with the `as_count_eval_path` metric. 

Further I tweaked the numbers (and added a comment) to better illustrate how these calculations differ, i.e., the `classic_eval_path` weights each interval (timestamp) equally whereas the `as_count_eval_path` weights each interval by the number of requests in said interval, i.e., 

```
(1 + 1 + 0 + 1 + 0) / (1 + 2 + 3 + 4 + 5) = (1/1 * 1/15 + 1/2 * 2/15 + 0 * 3/15 + 1/4 * 4/15 + 0 * 5/15)
```

### Motivation

I felt reading through the documentation a slightly different formulation of the problem would aid readers with understanding the nuances between these approaches.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
