### PR TITLE
modify region params styling

### DIFF
--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -25,9 +25,9 @@ further_reading:
 - All traffic is sent over SSL
 - The destination for:
 
-  - [APM][1] data is `trace.agent.datadoghq.com`
-  - [Live Containers][2] data is `process.datadoghq.com`
-  - [Logs][3] data is `agent-intake.logs.datadoghq.com` for TCP traffic, `agent-http-intake.logs.datadoghq.com` in HTTP. Review the list of [logs endpoints][5] for more information.
+  - [APM][1] data is `trace.agent.`{{< region-param key="dd_site" code="true" >}}
+  - [Live Containers][2] data is `process.`{{< region-param key="dd_site" code="true" >}}
+  - [Logs][3] data is `agent-intake.logs`{{< region-param key="dd_site" code="true" >}} for TCP traffic, `agent-http-intake.logs.`{{< region-param key="dd_site" code="true" >}} in HTTP. Review the list of [logs endpoints][5] for more information.
   - All other Agent data:
       - **Agents < 5.2.0** `app.datadoghq.com`
       - **Agents >= 5.2.0** `<VERSION>-app.agent.datadoghq.com`
@@ -54,7 +54,7 @@ All of these domains are **CNAME** records pointing to a set of static IP addres
 - All traffic is sent over SSL
 - The destination for:
 
-  - [APM][1] data is `trace.agent.datadoghq.eu`
+  - [APM][1] data is `trace.agent.`{{< region-param key="dd_site" code="true" >}}
   - [Live Containers][2] data is `process.datadoghq.eu`
   - [Logs][3] data is `agent-intake.logs.datadoghq.eu` for TCP traffic, `agent-http-intake.logs.datadoghq.eu` in HTTP. Review the list of [logs endpoints][5] for more information.
   - All other Agent data:

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -20,64 +20,24 @@ further_reading:
 
 **Traffic is always initiated by the Agent to Datadog. No sessions are ever initiated from Datadog back to the Agent**:
 
-{{< site-region region="us" >}}
-
 - All traffic is sent over SSL
 - The destination for:
 
   - [APM][1] data is `trace.agent.`{{< region-param key="dd_site" code="true" >}}
   - [Live Containers][2] data is `process.`{{< region-param key="dd_site" code="true" >}}
-  - [Logs][3] data is `agent-intake.logs`{{< region-param key="dd_site" code="true" >}} for TCP traffic, `agent-http-intake.logs.`{{< region-param key="dd_site" code="true" >}} in HTTP. Review the list of [logs endpoints][5] for more information.
+  - [Logs][3] data is `agent-intake.logs`{{< region-param key="dd_site" code="true" >}} for TCP traffic, `agent-http-intake.logs.`{{< region-param key="dd_site" code="true" >}} in HTTP. Review the list of [logs endpoints][4] for more information.
   - All other Agent data:
-      - **Agents < 5.2.0** `app.datadoghq.com`
-      - **Agents >= 5.2.0** `<VERSION>-app.agent.datadoghq.com`
+      - **Agents < 5.2.0** `app.datadoghq.`{{< region-param key="dd_site" code="true" >}}
+      - **Agents >= 5.2.0** `<VERSION>-app.agent.datadoghq.`{{< region-param key="dd_site" code="true" >}}
 
-        This decision was taken after the POODLE problem. Versioned endpoints start with Agent v5.2.0, where each version of the Agent calls a different endpoint based on the version of the _Forwarder_. For example, Agent v5.2.0 calls `5-2-0-app.agent.datadoghq.com`. Therefore you must whitelist `*.agent.datadoghq.com` in your firewall(s).
+        This decision was taken after the POODLE problem. Versioned endpoints start with Agent v5.2.0, where each version of the Agent calls a different endpoint based on the version of the _Forwarder_. For example, Agent v5.2.0 calls `5-2-0-app.agent.datadoghq`{{< region-param key="dd_site" code="true" >}}. Therefore you must whitelist `*.agent.datadoghq.`{{< region-param key="dd_site" code="true" >}} in your firewall(s).
 
-Since v6.1.0, the Agent also queries Datadog's API to provide non-critical functionality (ex.: display validity of configured API key):
+Since v6.1.0, the Agent also queries Datadog's API to provide non-critical functionality (For example, display validity of configured API key):
 
-- **Agent >= 7.18.0/6.18.0** `api.datadoghq.com`
-- **Agent < 7.18.0/6.18.0** `app.datadoghq.com`
+- **Agent >= 7.18.0/6.18.0** `api.datadoghq`{{< region-param key="dd_site" code="true" >}}
+- **Agent < 7.18.0/6.18.0** `app.datadoghq.`{{< region-param key="dd_site" code="true" >}}
 
-All of these domains are **CNAME** records pointing to a set of static IP addresses. These addresses can be found at:
-
-- **[https://ip-ranges.datadoghq.com][4]** for Datadog US region.
-
-[1]: /tracing/
-[2]: /infrastructure/livecontainers/
-[3]: /logs/
-[4]: https://ip-ranges.datadoghq.com
-[5]: /logs/log_collection/?tab=http#datadog-logs-endpoints
-{{< /site-region >}}
-{{< site-region region="eu" >}}
-
-- All traffic is sent over SSL
-- The destination for:
-
-  - [APM][1] data is `trace.agent.`{{< region-param key="dd_site" code="true" >}}
-  - [Live Containers][2] data is `process.datadoghq.eu`
-  - [Logs][3] data is `agent-intake.logs.datadoghq.eu` for TCP traffic, `agent-http-intake.logs.datadoghq.eu` in HTTP. Review the list of [logs endpoints][5] for more information.
-  - All other Agent data:
-      - **Agents < 5.2.0** `app.datadoghq.eu`
-      - **Agents >= 5.2.0** `<VERSION>-app.agent.datadoghq.eu`
-
-        This decision was taken after the POODLE problem. Versioned endpoints start with Agent v5.2.0, where each version of the Agent calls a different endpoint based on the version of the _Forwarder_. For example, Agent v5.2.0 calls `5-2-0-app.agent.datadoghq.com`. Therefore you must whitelist `*.agent.datadoghq.eu` in your firewall(s).
-
-Since v6.1.0, the Agent also queries Datadog's API to provide non-critical functionality (ex.: display validity of configured API key):
-
-- **Agent >= 7.18.0/6.18.0** `api.datadoghq.eu`
-- **Agent < 7.18.0/6.18.0** `app.datadoghq.eu`
-
-All of these domains are **CNAME** records pointing to a set of static IP addresses. These addresses can be found at:
-
-- **[https://ip-ranges.datadoghq.eu][4]** for Datadog EU region.
-
-[1]: /tracing/
-[2]: /infrastructure/livecontainers/
-[3]: /logs/
-[4]: https://ip-ranges.datadoghq.eu
-[5]: /logs/log_collection/?tab=http#datadog-logs-endpoints
-{{< /site-region >}}
+All of these domains are **CNAME** records pointing to a set of static IP addresses. These addresses can be found at https://ip-ranges.datadoghq.{{< region-param key="dd_site" code="true" >}}.
 
 The information is structured as JSON following this schema:
 
@@ -193,10 +153,14 @@ Open the following ports in order to benefit from all the Agent functionalities:
 
 ## Using Proxies
 
-For a detailed configuration guide on proxy setup, see [Agent Proxy Configuration][1].
+For a detailed configuration guide on proxy setup, see [Agent Proxy Configuration][5].
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /agent/proxy/
+[1]: /tracing/
+[2]: /infrastructure/livecontainers/
+[3]: /logs/
+[4]: /logs/log_collection/?tab=http#datadog-logs-endpoints
+[5]: /agent/proxy/

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -37,7 +37,7 @@ Since v6.1.0, the Agent also queries Datadog's API to provide non-critical funct
 - **Agent >= 7.18.0/6.18.0** `api.datadoghq`{{< region-param key="dd_site" code="true" >}}
 - **Agent < 7.18.0/6.18.0** `app.datadoghq.`{{< region-param key="dd_site" code="true" >}}
 
-All of these domains are **CNAME** records pointing to a set of static IP addresses. These addresses can be found at https://ip-ranges.datadoghq.{{< region-param key="dd_site" code="true" >}}.
+All of these domains are **CNAME** records pointing to a set of static IP addresses. These addresses can be found at `https://ip-ranges.datadoghq.`{{< region-param key="dd_site" code="true" >}}.
 
 The information is structured as JSON following this schema:
 

--- a/layouts/shortcodes/region-param.html
+++ b/layouts/shortcodes/region-param.html
@@ -1,6 +1,6 @@
 {{- if  not (.Get "key") -}}{{ errorf "region-param shortcode error: Missing value for param 'key': %s" .Position }}{{- end -}}
 {{- if eq (.Get "code") "true" -}}
-    <code class="js-region-param" data-region-param="{{ .Get "key" }}"></code>
+    <code class="js-region-param region-param" data-region-param="{{ .Get "key" }}"></code>
 {{- else -}}
-    <span class="js-region-param" data-region-param="{{ .Get "key" }}"></span>
+    <span class="js-region-param region-param" data-region-param="{{ .Get "key" }}"></span>
 {{- end -}}

--- a/layouts/shortcodes/site-region.html
+++ b/layouts/shortcodes/site-region.html
@@ -4,6 +4,4 @@
 
 {{ $region := .Get "region" }}
 
-<div class="d-none" data-region="{{ $region }}">
-    {{ .Inner | markdownify }}
-</div>
+<div class="d-none" data-region="{{ $region }}">{{- .Inner | markdownify -}}</div>

--- a/src/scripts/region-redirects.js
+++ b/src/scripts/region-redirects.js
@@ -79,6 +79,12 @@ function showRegionSnippet(newSiteRegion) {
             );
         } else {
             param.innerHTML = config[regionParam][newSiteRegion];
+            // checks if there are two `<code>` elements next to each other, and allows them to 'blend' together(no padding or border radius in between the two)
+            if (param.previousElementSibling && param.previousElementSibling.tagName === 'CODE'){
+                param.previousElementSibling.style.paddingRight = '0';
+                param.previousElementSibling.style.borderTopRightRadius = '0';
+                param.previousElementSibling.style.borderBottomRightRadius = '0';
+            }
         }
     });
 

--- a/src/styles/pages/_global.scss
+++ b/src/styles/pages/_global.scss
@@ -159,17 +159,20 @@ tbody {
 
 code {
   color: #555555;
-  padding: 0;
+  padding: 0 5px;
   font-size: 14px;
   background-color: #F2F2F2;
-  border-left: 5px solid #f8f8f8;
-  border-right: 5px solid #f8f8f8;
-  border-bottom: 2px solid #f8f8f8;
   border-radius: 4px;
   display: inline;
   white-space: normal;
   /*font-family: 'Source Code Pro', monospace;*/
   font-family: $font-family-monospace;
+}
+
+code + code.region-param {
+  padding: 0 5px 0 0;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
 }
 
 .programming-lang-wrapper {


### PR DESCRIPTION
### What does this PR do?
Fixes space between an inline code snippet and the `region-param` shortcode. 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
https://docs-staging.datadoghq.com/zach/shortcode-fix/agent/guide/network/?tab=agentv6v7
