### PR TITLE
add warning/note for use of parenetheses

### DIFF
--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -87,7 +87,7 @@ Notify your team through connected integrations by using the format `@<INTEGRATI
 
 See the [list of integrations][11] that can be used to notify your team.
 
-**Note**: Currently handles which include parentheses (`(`, `)`) are not supported. When a handle with parentheses is used the handle will not be parsed and no alert will be created.
+**Note**: Handles that include parentheses (`(`, `)`) are not supported. When a handle with parentheses is used, the handle is not be parsed and no alert is created.
 
 ### Modifications
 

--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -85,7 +85,9 @@ Notify your team through connected integrations by using the format `@<INTEGRATI
 | [Slack][7]     | `@slack`     | [Examples][8]  |
 | [Webhooks][9]  | `@webhook`   | [Examples][10] |
 
-See the [list of integrations][11] that can be used to notify your team. 
+See the [list of integrations][11] that can be used to notify your team.
+
+**Note**: Currently handles which include parentheses (`(`, `)`) are not supported. When a handle with parentheses is used the handle will not be parsed and no alert will be created.
 
 ### Modifications
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

It appears that handles which include parentheses: `(`,  `)` are not supported by the "Say what's happening" field in monitors. When using a handle (@jira, @slack, etc.) that includes parentheses no alert/event is created for the integration used.

### Motivation
<!-- What inspired you to submit this pull request?-->

When trying to create an issue into Jira (using the Jira integration) the following handle: `@jira-dev-test(staging)` fails to create the issue and does not signal any events/errors.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/daniel_ju/add_note_notifications_page/monitors/notifications

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
