### PR TITLE
update info about cloudwatch metrics

### DIFF
--- a/content/en/integrations/faq/aws-integration-and-cloudwatch-faq.md
+++ b/content/en/integrations/faq/aws-integration-and-cloudwatch-faq.md
@@ -33,10 +33,11 @@ By default, Datadog collects AWS metrics every 10 minutes. See [Cloud Metric Del
 
 ### Is there a discrepancy between my data in CloudWatch and Datadog?
 
-There are two important distinctions to be aware of:
+Some important distinctions to be aware of:
 
-1. In AWS for counters, a graph set to `sum` `1 minute` shows the total number of occurrences in one minute leading up to that point (the rate per one minute). Datadog is displaying the raw data from AWS normalized to per second values, regardless of the timeframe selected in AWS. Therefore, you might see a lower value in Datadog.
-2. Overall, `min`, `max`, and `avg` have different meanings within AWS. AWS distinctly collects average latency, minimum latency, and maximum latency. When pulling metrics from AWS CloudWatch, Datadog only receives the average latency as a single timeseries per ELB. Within Datadog, when you select `min`, `max`, or `avg`, you are controlling how multiple timeseries are combined. For example, requesting `system.cpu.idle` without any filter returns one series for each host reporting that metric. Datadog combines these time series using [space aggregation][5]. Otherwise, if you requested `system.cpu.idle` from a single host, no aggregation is necessary and switching between `avg` and `max` yields the same result.
+- Datadog collects the _average_ for all CloudWatch metrics.
+- In AWS for counters, a graph set to `sum` `1 minute` shows the total number of occurrences in one minute leading up to that point (the rate per one minute). Datadog is displaying the raw data from AWS normalized to per second values, regardless of the timeframe selected in AWS. Therefore, you might see a lower value in Datadog.
+- Overall, `min`, `max`, and `avg` have different meanings within AWS. AWS distinctly collects average latency, minimum latency, and maximum latency. When pulling metrics from AWS CloudWatch, Datadog only receives the average latency as a single timeseries per ELB. Within Datadog, when you select `min`, `max`, or `avg`, you are controlling how multiple timeseries are combined. For example, requesting `system.cpu.idle` without any filter returns one series for each host reporting that metric. Datadog combines these time series using [space aggregation][5]. Otherwise, if you requested `system.cpu.idle` from a single host, no aggregation is necessary and switching between `avg` and `max` yields the same result.
 
 ### How do I adjust my data on Datadog to match the data displayed in CloudWatch?
 


### PR DESCRIPTION
### What does this PR do?

Adds a not that Datadog collects average Cloudwatch metrics

### Motivation

DOC-1301

### Preview

https://docs-staging.datadoghq.com/kari/docs-1301/integrations/faq/aws-integration-and-cloudwatch-faq/#is-there-a-discrepancy-between-my-data-in-cloudwatch-and-datadog


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
