### PR TITLE
fix link to ipranges and all other auto-populated datadoghq.com that …

### DIFF
--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -25,19 +25,19 @@ further_reading:
 
   - [APM][1] data is `trace.agent.`{{< region-param key="dd_site" code="true" >}}
   - [Live Containers][2] data is `process.`{{< region-param key="dd_site" code="true" >}}
-  - [Logs][3] data is `agent-intake.logs`{{< region-param key="dd_site" code="true" >}} for TCP traffic, `agent-http-intake.logs.`{{< region-param key="dd_site" code="true" >}} in HTTP. Review the list of [logs endpoints][4] for more information.
+  - [Logs][3] data is `agent-intake.logs.`{{< region-param key="dd_site" code="true" >}} for TCP traffic, `agent-http-intake.logs.`{{< region-param key="dd_site" code="true" >}} in HTTP. Review the list of [logs endpoints][4] for more information.
   - All other Agent data:
-      - **Agents < 5.2.0** `app.datadoghq.`{{< region-param key="dd_site" code="true" >}}
-      - **Agents >= 5.2.0** `<VERSION>-app.agent.datadoghq.`{{< region-param key="dd_site" code="true" >}}
+      - **Agents < 5.2.0** `app.`{{< region-param key="dd_site" code="true" >}}
+      - **Agents >= 5.2.0** `<VERSION>-app.agent.`{{< region-param key="dd_site" code="true" >}}
 
-        This decision was taken after the POODLE problem. Versioned endpoints start with Agent v5.2.0, where each version of the Agent calls a different endpoint based on the version of the _Forwarder_. For example, Agent v5.2.0 calls `5-2-0-app.agent.datadoghq`{{< region-param key="dd_site" code="true" >}}. Therefore you must whitelist `*.agent.datadoghq.`{{< region-param key="dd_site" code="true" >}} in your firewall(s).
+        This decision was taken after the POODLE problem. Versioned endpoints start with Agent v5.2.0, where each version of the Agent calls a different endpoint based on the version of the _Forwarder_. For example, Agent v5.2.0 calls `5-2-0-app.agent.`{{< region-param key="dd_site" code="true" >}}. Therefore you must whitelist `*.agent.`{{< region-param key="dd_site" code="true" >}} in your firewall(s).
 
 Since v6.1.0, the Agent also queries Datadog's API to provide non-critical functionality (For example, display validity of configured API key):
 
-- **Agent >= 7.18.0/6.18.0** `api.datadoghq`{{< region-param key="dd_site" code="true" >}}
-- **Agent < 7.18.0/6.18.0** `app.datadoghq.`{{< region-param key="dd_site" code="true" >}}
+- **Agent >= 7.18.0/6.18.0** `api.`{{< region-param key="dd_site" code="true" >}}
+- **Agent < 7.18.0/6.18.0** `app.`{{< region-param key="dd_site" code="true" >}}
 
-All of these domains are **CNAME** records pointing to a set of static IP addresses. These addresses can be found at `https://ip-ranges.datadoghq.`{{< region-param key="dd_site" code="true" >}}.
+All of these domains are **CNAME** records pointing to a set of static IP addresses. These addresses can be found at `https://ip-ranges.`{{< region-param key="dd_site" code="true" >}}.
 
 The information is structured as JSON following this schema:
 


### PR DESCRIPTION
…have been garbled

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Auto generated dd_site URLs have been duplicating datadoghq.com in many places which has made the networking docs very difficult to work with. 

With docs the current way they are, it's very easy for someone to misconstruct their firewall rules (which I almost did with a customer today). 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/morgan.lupton/fix-link-to-ip-ranges/
### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
