### PR TITLE
DOCS-1289 - fix misleading integration setup

### DIFF
--- a/content/en/agent/kubernetes/integrations.md
+++ b/content/en/agent/kubernetes/integrations.md
@@ -47,7 +47,7 @@ Each tab in sections below shows a different way to apply integration templates 
 * [Key-value stores](?tab=keyvaluestore#configuration)
 
 **Note**: Some supported integrations don't work with standard Autodiscovery because they require either process tree data or filesystem access: [Ceph][4], [Varnish][5], [Postfix][6], [Cassandra Nodetools][7], and [Gunicorn][8].
-To enable Autodiscovery for these integrations, use the official Prometheus exporter in the pod, and then use the OpenMetrics check with Autodiscovery in the Agent to find the pod and query the endpoint. For example, the standard pattern in Kubernetes is: side car adapter with a node-level or cluster-level collector. This setup allows the exporter to access the data, which exposes it using an HTTP endpoint, and the OpenMetrics check with Datadog Autodiscovery can then access the data.
+To set up integrations that are not compatible with standard Autodiscovery, you can use an official Prometheus exporter in the pod, and then use the OpenMetrics check with Autodiscovery in the Agent to find the pod and query the endpoint. For example, the standard pattern in Kubernetes is: side car adapter with a node-level or cluster-level collector. This setup allows the exporter to access the data, which exposes it using an HTTP endpoint, and the OpenMetrics check with Datadog Autodiscovery can then access the data.
 
 ## Configuration
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Rewords a statement about how to set up integrations which do not support standard Autodiscovery.

### Motivation
more accurate now

### Preview

https://docs-staging.datadoghq.com/cswatt/autodisco-edit/agent/kubernetes/integrations/?tab=kubernetes



---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
