### PR TITLE
[doc] corrected link for "Introduction to datadog"

### DIFF
--- a/content/en/getting_started/_index.md
+++ b/content/en/getting_started/_index.md
@@ -6,7 +6,7 @@ aliases:
     - /overview
     - /getting_started/faq/
 further_reading:
-    - link: 'https://learn.datadoghq.com/course/view.php?id=2'
+    - link: 'https://learn.datadoghq.com/course/view.php?id=18'
       tag: 'Learning Center'
       text: 'Introduction to Datadog'
 ---


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Correcting the link to access the "Introduction to Datadog" course on the learning platform that was broken.

### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadog.zendesk.com/agent/tickets/405765

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/MathiasGautier-doc-patch-corrected_link/getting_started/application/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
