### PR TITLE
document DD_RUNTIME_METRICS_ENABLED for Java tracer

### DIFF
--- a/content/en/tracing/runtime_metrics/java.md
+++ b/content/en/tracing/runtime_metrics/java.md
@@ -19,7 +19,7 @@ further_reading:
 
 ## Automatic Configuration
 
-JVM metrics collection is enabled by default for Java tracer v0.29.0+. It can be disabled with one configuration parameter in the tracing client, either through a system property, `-Ddd.jmxfetch.enabled=false`, or through an environment variable, `DD_JMXFETCH_ENABLED=false`. Since v0.64.0+ you can also use the `DD_RUNTIME_METRICS_ENABLED=false` environment variable to disable it.
+JVM metrics collection is enabled by default for Java tracer v0.29.0+. It can be disabled with one configuration parameter in the tracing client, either through a system property, `-Ddd.jmxfetch.enabled=false`, or through an environment variable, `DD_JMXFETCH_ENABLED=false`. As of v0.64.0+, you can also use the `DD_RUNTIME_METRICS_ENABLED=false` environment variable to disable it.
 
 JVM metrics can be viewed in correlation with your Java services. See the [Service page][1] in Datadog.
 

--- a/content/en/tracing/runtime_metrics/java.md
+++ b/content/en/tracing/runtime_metrics/java.md
@@ -19,7 +19,7 @@ further_reading:
 
 ## Automatic Configuration
 
-JVM metrics collection is enabled by default for Java tracer v0.29.0+. It can be disabled with one configuration parameter in the tracing client, either through a system property, `-Ddd.jmxfetch.enabled=false`, or through an environment variable, `DD_JMXFETCH_ENABLED=false`.
+JVM metrics collection is enabled by default for Java tracer v0.29.0+. It can be disabled with one configuration parameter in the tracing client, either through a system property, `-Ddd.jmxfetch.enabled=false`, or through an environment variable, `DD_JMXFETCH_ENABLED=false`. Since v0.64.0+ you can also use the `DD_RUNTIME_METRICS_ENABLED=false` environment variable to disable it.
 
 JVM metrics can be viewed in correlation with your Java services. See the [Service page][1] in Datadog.
 


### PR DESCRIPTION
### What does this PR do?
document that the DD_RUNTIME_METRICS_ENABLED environment variable is supported since 0.64.0

### Motivation
keeping docs up to date

### Preview
https://docs-staging.datadoghq.com/mcculls/runtimeMetricsEnabled/tracing/runtime_metrics/java/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
