### PR TITLE
Document DD_TRACE_STARTUP_LOGS for Java tracer

### DIFF
--- a/content/en/tracing/setup/java.md
+++ b/content/en/tracing/setup/java.md
@@ -200,7 +200,7 @@ System properties can be set as JVM flags.
 | `dd.integration.opentracing.enabled`              | `DD_INTEGRATION_OPENTRACING_ENABLED`              | true                              | By default the tracing client detects if a GlobalTracer is being loaded and dynamically registers a tracer into it. By turning this to false, this removes any tracer dependency on OpenTracing.                                                                                                                                                                                                                              |
 | `dd.hystrix.tags.enabled` | `DD_HYSTRIX_TAGS_ENABLED` | False | By default the Hystrix group, command, and circuit state tags are not enabled. This property enables them. |
 | `dd.trace.servlet.async-timeout.error` | `DD_TRACE_SERVLET_ASYNC_TIMEOUT_ERROR` | True | By default, long running asynchronous requests will be marked as an error, setting this value to false allows to mark all timeouts as successful requests. |
-| `dd.trace.startup.logs`                | `DD_TRACE_STARTUP_LOGS`                | True | When `false` informational startup logging is disabled. Available for versions 0.64+. |
+| `dd.trace.startup.logs`                | `DD_TRACE_STARTUP_LOGS`                | True | When `false`, informational startup logging is disabled. Available for versions 0.64+. |
 
 
 **Note**:

--- a/content/en/tracing/setup/java.md
+++ b/content/en/tracing/setup/java.md
@@ -200,6 +200,7 @@ System properties can be set as JVM flags.
 | `dd.integration.opentracing.enabled`              | `DD_INTEGRATION_OPENTRACING_ENABLED`              | true                              | By default the tracing client detects if a GlobalTracer is being loaded and dynamically registers a tracer into it. By turning this to false, this removes any tracer dependency on OpenTracing.                                                                                                                                                                                                                              |
 | `dd.hystrix.tags.enabled` | `DD_HYSTRIX_TAGS_ENABLED` | False | By default the Hystrix group, command, and circuit state tags are not enabled. This property enables them. |
 | `dd.trace.servlet.async-timeout.error` | `DD_TRACE_SERVLET_ASYNC_TIMEOUT_ERROR` | True | By default, long running asynchronous requests will be marked as an error, setting this value to false allows to mark all timeouts as successful requests. |
+| `dd.trace.startup.logs`                | `DD_TRACE_STARTUP_LOGS`                | True | When `false` informational startup logging is disabled. Available for versions 0.64+. |
 
 
 **Note**:


### PR DESCRIPTION

### What does this PR do?
document that the DD_TRACE_STARTUP_LOGS environment variable is supported since 0.64.0

### Motivation
keeping docs up to date

### Preview
https://docs-staging.datadoghq.com/mcculls/traceStartupLogs/tracing/setup/java/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
