### PR TITLE
Fix for tracing FAQ links

### DIFF
--- a/content/en/tracing/faq/trace-agent-from-source.md
+++ b/content/en/tracing/faq/trace-agent-from-source.md
@@ -6,7 +6,7 @@ kind: faq
 ## Install from source
 
 1. Install `Go 1.11+`. For more information, see the steps on the [official Go website][1].
-2. Clone the [Datadog Agent repo][2]
+2. Clone the [Datadog Agent repo][2].
 3. Run this command in the root of the `datadog-agent` repository:
     ```bash
     go install ./cmd/trace-agent
@@ -18,5 +18,6 @@ kind: faq
 
 Check the Agent output or logs (`/var/log/datadog/trace-agent.log` on Linux) to ensure that traces seem correct
 and that they are reaching the Datadog API.
+
 [1]: https://golang.org/dl
 [2]: https://github.com/DataDog/datadog-agent


### PR DESCRIPTION
### What does this PR do?
Fixes broken links in the trace agent source FAQ

### Motivation
Much broken, such links

### Preview
https://docs-staging.datadoghq.com/sarina/tracing-links-fix/tracing/faq/trace-agent-from-source

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
