### PR TITLE
Add file size limit on source maps upload

### DIFF
--- a/content/en/real_user_monitoring/error_tracking/_index.md
+++ b/content/en/real_user_monitoring/error_tracking/_index.md
@@ -81,6 +81,7 @@ datadog-ci sourcemaps upload /path/to/dist \
 For more information about CLI parameters, see the [official Github repository][5].
 
 For Error Tracking to properly work, you must configure your Javascript bundler so that:
+
 -   Source maps directly include the related source code, you should make sure the <code>sourcesContent</code> attribute is not empty before uploading them.
 -   The size of each source map augmented with the size of the related minified file do not exceed our limit of 50mb. This sum can be reduced by configuring your bundler to split the source code into multiple smaller chunks ([see how yo do it with WebpackJS][6]).
 

--- a/content/en/real_user_monitoring/error_tracking/_index.md
+++ b/content/en/real_user_monitoring/error_tracking/_index.md
@@ -84,7 +84,7 @@ datadog-ci sourcemaps upload /path/to/dist \
 For Error Tracking to properly work with your source maps, you must configure your Javascript bundler so that:
 
 -   Source maps directly include the related source code. Make sure the <code>sourcesContent</code> attribute is not empty before uploading them.
--   The size of each source map augmented with the size of the related minified file does not exceed __our limit of 50mb__. This sum can be reduced by configuring your bundler to split the source code into multiple smaller chunks ([see how yo do it with WebpackJS][5]).
+-   The size of each source map augmented with the size of the related minified file does not exceed __our limit of 50mb__. This sum can be reduced by configuring your bundler to split the source code into multiple smaller chunks ([see how to do this with WebpackJS][5]).
 
 ## Further Reading
 

--- a/content/en/real_user_monitoring/error_tracking/_index.md
+++ b/content/en/real_user_monitoring/error_tracking/_index.md
@@ -6,6 +6,9 @@ further_reading:
 - link: "/real_user_monitoring/error_tracking/explorer"
   tag: "Documentation"
   text: "RUM Error Tracking Explorer"
+- link: "https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps"
+  tag: "Documentation"
+  text: "Official repository of the Datadog CLI"
 - link: "/real_user_monitoring/guide/upload-javascript-source-maps"
   tag: "Guide"
   text: "Upload javascript source maps"
@@ -78,12 +81,10 @@ datadog-ci sourcemaps upload /path/to/dist \
 {{% /tab %}}
 {{< /tabs >}}
 
-For more information about CLI parameters, see the [official Github repository][5].
-
 For Error Tracking to properly work with your source maps, you must configure your Javascript bundler so that:
 
 -   Source maps directly include the related source code, you should make sure the <code>sourcesContent</code> attribute is not empty before uploading them.
--   The size of each source map augmented with the size of the related minified file do not exceed our limit of 50mb. This sum can be reduced by configuring your bundler to split the source code into multiple smaller chunks ([see how yo do it with WebpackJS][6]).
+-   The size of each source map augmented with the size of the related minified file does not exceed __our limit of 50mb__. This sum can be reduced by configuring your bundler to split the source code into multiple smaller chunks ([see how yo do it with WebpackJS][5]).
 
 ## Further Reading
 
@@ -93,5 +94,4 @@ For Error Tracking to properly work with your source maps, you must configure yo
 [2]: https://www.npmjs.com/package/@datadog/browser-rum
 [3]: /real_user_monitoring/browser/#initialization-parameters
 [4]: https://github.com/DataDog/datadog-ci/
-[5]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps
-[6]: https://webpack.js.org/guides/code-splitting/
+[5]: https://webpack.js.org/guides/code-splitting/

--- a/content/en/real_user_monitoring/error_tracking/_index.md
+++ b/content/en/real_user_monitoring/error_tracking/_index.md
@@ -80,7 +80,7 @@ datadog-ci sourcemaps upload /path/to/dist \
 
 For more information about CLI parameters, see the [official Github repository][5].
 
-For Error Tracking to properly work, you must configure your Javascript bundler so that:
+For Error Tracking to properly work with your source maps, you must configure your Javascript bundler so that:
 
 -   Source maps directly include the related source code, you should make sure the <code>sourcesContent</code> attribute is not empty before uploading them.
 -   The size of each source map augmented with the size of the related minified file do not exceed our limit of 50mb. This sum can be reduced by configuring your bundler to split the source code into multiple smaller chunks ([see how yo do it with WebpackJS][6]).

--- a/content/en/real_user_monitoring/error_tracking/_index.md
+++ b/content/en/real_user_monitoring/error_tracking/_index.md
@@ -80,11 +80,9 @@ datadog-ci sourcemaps upload /path/to/dist \
 
 For more information about CLI parameters, see the [official Github repository][5].
 
-<div class="alert alert-warning">
-You must configure your Javascript bundler so that:
+For Error Tracking to properly work, you must configure your Javascript bundler so that:
 -   Source maps directly include the related source code, you should make sure the <code>sourcesContent</code> attribute is not empty before uploading them.
--   The size of each source map combined with the size of the related minified file do not exceed our limit of 50mb. This sum can be reduced by configuring your bundler to split the source code into multiple chunks ([see how yo do it with WebpackJS][6]).
-</div>
+-   The size of each source map augmented with the size of the related minified file do not exceed our limit of 50mb. This sum can be reduced by configuring your bundler to split the source code into multiple smaller chunks ([see how yo do it with WebpackJS][6]).
 
 ## Further Reading
 

--- a/content/en/real_user_monitoring/error_tracking/_index.md
+++ b/content/en/real_user_monitoring/error_tracking/_index.md
@@ -83,7 +83,7 @@ datadog-ci sourcemaps upload /path/to/dist \
 
 For Error Tracking to properly work with your source maps, you must configure your Javascript bundler so that:
 
--   Source maps directly include the related source code, you should make sure the <code>sourcesContent</code> attribute is not empty before uploading them.
+-   Source maps directly include the related source code. Make sure the <code>sourcesContent</code> attribute is not empty before uploading them.
 -   The size of each source map augmented with the size of the related minified file does not exceed __our limit of 50mb__. This sum can be reduced by configuring your bundler to split the source code into multiple smaller chunks ([see how yo do it with WebpackJS][5]).
 
 ## Further Reading

--- a/content/en/real_user_monitoring/error_tracking/_index.md
+++ b/content/en/real_user_monitoring/error_tracking/_index.md
@@ -32,15 +32,13 @@ Error Tracking processes errors collected from the browser by the RUM SDK (error
 
 To quickly get started with error tracking:
 
-1. Download the `v1.11.5+` version of the [RUM Browser SDK][2].
+1. Download the latest version of the [RUM Browser SDK][2].
 2. Configure the __version__, the __env__ and the __service__ when [initializing your SDK][3].
 
 ### Upload mapping files
 
 The source code of some applications is obfuscated or minified when deployed to production for performance optimization and security concerns.
-The consequence is that stack traces of errors fired from those applications are also obfuscated, making the troubleshooting process much more difficult because the stack traces cannot be used to understand which file and which line of code are responsible for a given error. 
-
-Datadog allows you to securely upload your source maps to deobfuscate your stack traces:
+The consequence is that stack traces of errors fired from those applications are also obfuscated, making the troubleshooting process much more difficult.
 
 #### Javascript source maps
 
@@ -82,7 +80,11 @@ datadog-ci sourcemaps upload /path/to/dist \
 
 For more information about CLI parameters, see the [official Github repository][5].
 
-<div class="alert alert-warning">You must configure your Javascript bundler to create <strong>source maps that directly include the related source code</strong>. You should make sure the <code>sourcesContent</code> attribute in your source maps is not empty before uploading them.</div>
+<div class="alert alert-warning">
+You must configure your Javascript bundler so that:
+-   Source maps directly include the related source code, you should make sure the <code>sourcesContent</code> attribute is not empty before uploading them.
+-   The size of each source map combined with the size of the related minified file do not exceed our limit of 50mb. This sum can be reduced by configuring your bundler to split the source code into multiple chunks ([see how yo do it with WebpackJS][6]).
+</div>
 
 ## Further Reading
 
@@ -93,3 +95,4 @@ For more information about CLI parameters, see the [official Github repository][
 [3]: /real_user_monitoring/browser/#initialization-parameters
 [4]: https://github.com/DataDog/datadog-ci/
 [5]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps
+[6]: https://webpack.js.org/guides/code-splitting/

--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -66,7 +66,7 @@ After building your application, bundlers generate a directory, most of the time
         javascript.464388.js.map
 ```
 
-<div class="alert alert-info">If, for example, the sum of the file size of <code>javascript.364758.min.js</code> and <code>javascript.364758.js.map</code> exceeds __our 50mb limit__, you could reduce it by configuring your bundler to split the source code into multiple smaller chunks ([see how yo do it with WebpackJS][https://webpack.js.org/guides/code-splitting/]).</div>
+<div class="alert alert-info">If, for example, the sum of the file size of <code>javascript.364758.min.js</code> and <code>javascript.364758.js.map</code> exceeds __the 50mb limit__, reduce it by configuring your bundler to split the source code into multiple smaller chunks ([see how to do this with WebpackJS][https://webpack.js.org/guides/code-splitting/]).</div>
 
 ## Upload your source maps
 

--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -66,7 +66,7 @@ After building your application, bundlers generate a directory, most of the time
         javascript.464388.js.map
 ```
 
-<div class="alert alert-info">If, for example, the sum of the file size of <code>javascript.364758.min.js</code> and <code>javascript.364758.js.map</code> exceeds __the 50mb limit__, reduce it by configuring your bundler to split the source code into multiple smaller chunks ([see how to do this with WebpackJS][https://webpack.js.org/guides/code-splitting/]).</div>
+<div class="alert alert-info">If, for example, the sum of the file size of <code>javascript.364758.min.js</code> and <code>javascript.364758.js.map</code> exceeds <i>the 50mb limit</i>, reduce it by configuring your bundler to split the source code into multiple smaller chunks (<a href="https://webpack.js.org/guides/code-splitting/">See how to do this with WebpackJS</a>).</div>
 
 ## Upload your source maps
 

--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -15,7 +15,7 @@ further_reading:
 If your front-end Javascript source code is minified, you will need to upload your source maps to Datadog so that we are able to deobfuscate your different stack traces. For a given error, you will then get access to the file path, the line number, as well as a code snippet for each frame of the related stack trace.
 
 ## Instrument your code
-You must configure your Javascript bundler so that, when minifying your source code, it generates source maps which directly include the related source code in the `sourcesContent` attribute. Check below some configurations for popular Javascript bundlers.
+You must configure your Javascript bundler so that, when minifying your source code, it generates source maps which directly include the related source code in the `sourcesContent` attribute. In addition, you should make sure that the size of each source map augmented with the size of the related minified file does not exceed __our limit of 50mb__. Check below some configurations for popular Javascript bundlers.
 
 {{< tabs >}}
 {{% tab "WebpackJS" %}}
@@ -65,6 +65,8 @@ After building your application, bundlers generate a directory, most of the time
         javascript.464388.min.js
         javascript.464388.js.map
 ```
+
+<div class="alert alert-info">If the sum of the size of <code>javascript.364758.min.js</code> and <code>javascript.364758.js.map</code> exceeds our 50mb limit, a good way to reduce it is to configure the bundler to split the source code into multiple smaller chunks [see how yo do it with WebpackJS][https://webpack.js.org/guides/code-splitting/].</div>
 
 ## Upload your source maps
 

--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -66,7 +66,7 @@ After building your application, bundlers generate a directory, most of the time
         javascript.464388.js.map
 ```
 
-<div class="alert alert-info">If the sum of the size of <code>javascript.364758.min.js</code> and <code>javascript.364758.js.map</code> exceeds our 50mb limit, a good way to reduce it is to configure the bundler to split the source code into multiple smaller chunks [see how yo do it with WebpackJS][https://webpack.js.org/guides/code-splitting/].</div>
+<div class="alert alert-info">If, for example, the sum of the size of <code>javascript.364758.min.js</code> and the size <code>javascript.364758.js.map</code> exceeds __our 50mb limit__, a good way to reduce it is to configure the bundler to split the source code into multiple smaller chunks ([see how yo do it with WebpackJS][https://webpack.js.org/guides/code-splitting/]).</div>
 
 ## Upload your source maps
 

--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -66,7 +66,7 @@ After building your application, bundlers generate a directory, most of the time
         javascript.464388.js.map
 ```
 
-<div class="alert alert-info">If, for example, the sum of the size of <code>javascript.364758.min.js</code> and the size <code>javascript.364758.js.map</code> exceeds __our 50mb limit__, a good way to reduce it is to configure the bundler to split the source code into multiple smaller chunks ([see how yo do it with WebpackJS][https://webpack.js.org/guides/code-splitting/]).</div>
+<div class="alert alert-info">If, for example, the sum of the file size of <code>javascript.364758.min.js</code> and <code>javascript.364758.js.map</code> exceeds __our 50mb limit__, you could reduce it by configuring your bundler to split the source code into multiple smaller chunks ([see how yo do it with WebpackJS][https://webpack.js.org/guides/code-splitting/]).</div>
 
 ## Upload your source maps
 

--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -15,7 +15,7 @@ further_reading:
 If your front-end Javascript source code is minified, you will need to upload your source maps to Datadog so that we are able to deobfuscate your different stack traces. For a given error, you will then get access to the file path, the line number, as well as a code snippet for each frame of the related stack trace.
 
 ## Instrument your code
-You must configure your Javascript bundler so that, when minifying your source code, it generates source maps which directly include the related source code in the `sourcesContent` attribute. In addition, you should make sure that the size of each source map augmented with the size of the related minified file does not exceed __our limit of 50mb__. Check below some configurations for popular Javascript bundlers.
+You must configure your Javascript bundler so that, when minifying your source code, it generates source maps which directly include the related source code in the `sourcesContent` attribute. In addition, ensure that the size of each source map augmented with the size of the related minified file does not exceed __our limit of 50mb__. Check below for some configurations for popular Javascript bundlers.
 
 {{< tabs >}}
 {{% tab "WebpackJS" %}}


### PR DESCRIPTION
### What does this PR do?
Add some information about our size limit of 50mb on source maps upload.

### Preview
https://docs-staging.datadoghq.com/maxime.matheron/error-tracking-add-sourcemaps-upload-limit/real_user_monitoring/guide/upload-javascript-source-maps/#instrument-your-code

### Additional Notes
I was not able to set a link within a callout component. Could you help?

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
