### PR TITLE
[faq/ec2-tags-agent] Update documented permission

### DIFF
--- a/content/en/integrations/faq/how-do-i-pull-my-ec2-tags-without-using-the-aws-integration.md
+++ b/content/en/integrations/faq/how-do-i-pull-my-ec2-tags-without-using-the-aws-integration.md
@@ -8,11 +8,10 @@ To pull custom AWS tags for an EC2 instance through the Datadog Agent without us
 {{< tabs >}}
 {{% tab "Agent v6 & v7" %}}
 
-1. Create a IAM role for the **instance** using the [AWS documentation][1].
-2. For the policy section, specify the permissions: `"ec2:Describe*"`, `"ec2:Get*"`.
-3. In `datadog.yaml`, set **collect_ec2_tags: true**.
-4. Optional: Add the security-groups tag by enabling this option.
-5. [Restart the Agent][2].
+1. Make sure an IAM role is assigned to the EC2 **instance**, using the [AWS documentation][1]. Create one if necessary.
+2. Attach a policy to the IAM role that includes the permission `ec2:DescribeTags`.
+3. In `datadog.yaml`, set `collect_ec2_tags: true`.
+4. [Restart the Agent][2].
 
 [1]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
 [2]: /agent/guide/agent-commands/#restart-the-agent
@@ -22,7 +21,7 @@ To pull custom AWS tags for an EC2 instance through the Datadog Agent without us
 1. Create a IAM role for the **instance** using the [AWS documentation][1].
 2. For the policy section, specify the permissions: `"ec2:Describe*"`, `"ec2:Get*"`.
 3. In `datadog.conf`, set **collect_ec2_tags: true**.
-4. Optional: Add the security-groups tag by enabling this option.
+4. Optional: Add the security-groups tag by enabling `collect_security_groups`.
 5. [Restart the Agent][2].
 
 [1]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html

--- a/content/en/integrations/faq/how-do-i-pull-my-ec2-tags-without-using-the-aws-integration.md
+++ b/content/en/integrations/faq/how-do-i-pull-my-ec2-tags-without-using-the-aws-integration.md
@@ -29,9 +29,9 @@ To pull custom AWS tags for an EC2 instance through the Datadog Agent without us
 {{% /tab %}}
 {{% tab "Docker" %}}
 
-1. Create a IAM role for the **instance** using the [AWS documentation][1].
-2. For the policy section, specify the permissions: `"ec2:Describe*"`, `"ec2:Get*"`.
-3. Start the Datadog Agent container using the environment variable `DD_COLLECT_EC2_TAGS`.
+1. Make sure an IAM role is assigned to the EC2 **instance**, using the [AWS documentation][1]. Create one if necessary.
+2. Attach a policy to the IAM role that includes the permission `ec2:DescribeTags`.
+3. Start the Datadog Agent container with the environment variable `DD_COLLECT_EC2_TAGS=true`.
 
 **Note**: With ECS, permissions are usually tied to the task, but the Datadog Agent requires permissions to be associated with the EC2 **instance** profile.
 


### PR DESCRIPTION
### What does this PR do?

Only the `ec2:DescribeTags` is needed for Agent 6/7 (at least):

* update docs accordingly, so that we only document the least amount of permissions required.
* clarify language to be more in line with AWS terminology
* remove mention of a security groups option on Agent 6/7, since that option doesn't exist for these versions of the Agent.

### Preview
https://docs-staging.datadoghq.com/olivielpeau/clarify-aws-agent-tag-collection/integrations/faq/how-do-i-pull-my-ec2-tags-without-using-the-aws-integration/?tab=agentv6v7

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
