### PR TITLE
Updated monitor_status.md to include a case for low frequency metrics

### DIFF
--- a/content/en/monitors/monitor_status.md
+++ b/content/en/monitors/monitor_status.md
@@ -80,7 +80,7 @@ The status graph shows your monitor's status over time, broken out by group. **N
 
 * The monitor is newly created and has not evaluated yet.
 * The monitor's query was recently changed.
-* The monitor's timeframe is too small for metric that provides data at low frequencies.
+* The monitor's timeframe is too small for a metric that provides data at low frequencies.
 * A host's name previously included in the query has changed. Hostname changes age out of the UI within 2 hours.
 
 ### History

--- a/content/en/monitors/monitor_status.md
+++ b/content/en/monitors/monitor_status.md
@@ -80,6 +80,7 @@ The status graph shows your monitor's status over time, broken out by group. **N
 
 * The monitor is newly created and has not evaluated yet.
 * The monitor's query was recently changed.
+* The monitor's timeframe is too small for metric that provides data at low frequencies.
 * A host's name previously included in the query has changed. Hostname changes age out of the UI within 2 hours.
 
 ### History

--- a/content/en/monitors/monitor_status.md
+++ b/content/en/monitors/monitor_status.md
@@ -80,7 +80,7 @@ The status graph shows your monitor's status over time, broken out by group. **N
 
 * The monitor is newly created and has not evaluated yet.
 * The monitor's query was recently changed.
-* The monitor's timeframe is too small for a metric that provides data at low frequencies.
+* The monitor's timeframe is too short for a metric that provides data infrequently.
 * A host's name previously included in the query has changed. Hostname changes age out of the UI within 2 hours.
 
 ### History


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Added another case for `no groups found` in the monitor status docs.

My issue was that my selected timeframe was too small (15 min) for a metric that was reporting in low frequency.

This warning is shown in the UI, but it's not provided in the docs.
![image](https://user-images.githubusercontent.com/8818187/96579016-ce699e00-12de-11eb-8adb-c9c7dc0cc257.png)

### Motivation
I ran into this issue myself, checked this documentation page, but it didn't include the case mentioned.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
<!--- https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>-->

This is a fork.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
