### PR TITLE
[WEB-869] - add route53 mapping for src img & switch cat to be log not logs

### DIFF
--- a/data/security_monitoring/data.yaml
+++ b/data/security_monitoring/data.yaml
@@ -3,8 +3,8 @@
 #
 # In the template logic, scope will fallback to the source image if specific mapping is not defined
 #
-# If `append: true`, the scope or source should be appended to the defined image 
-# ex: for source and scope `cloudtrail`, the resulting image should be `amazon_cloudtail.png` 
+# If `append: true`, the scope or source should be appended to the defined image
+# ex: for source and scope `cloudtrail`, the resulting image should be `amazon_cloudtail.png`
 base_integrations_url: https://docs.datadoghq.com/integrations/
 image_map:
   - source:
@@ -44,6 +44,10 @@ image_map:
     image: amazon_guardduty
     append: false
   - source:
+      - route53
+    image: amazon_route53
+    append: false
+  - source:
       - nginx-ingress-controller
       - nginx
     image: nginx
@@ -58,7 +62,7 @@ image_map:
     image: sigsci_sm
     link: sigsci
     append: false
-  - source: 
+  - source:
       - twistlock
     image: twistlock_sm
     link: twistlock

--- a/data/security_monitoring/data.yaml
+++ b/data/security_monitoring/data.yaml
@@ -27,6 +27,7 @@ image_map:
       - rds
       - redshift
       - s3
+      - route53
     image: amazon_
     append: true
   - source:
@@ -42,10 +43,6 @@ image_map:
   - source:
       - guardduty
     image: amazon_guardduty
-    append: false
-  - source:
-      - route53
-    image: amazon_route53
     append: false
   - source:
       - nginx-ingress-controller

--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -76,7 +76,7 @@ def security_rules(content, content_dir):
                     if 'configuration' in relative_path:
                         page_data['rule_category'].append('Cloud Configuration')
                     if 'security-monitoring' in relative_path:
-                        page_data['rule_category'].append('Logs Detection')
+                        page_data['rule_category'].append('Log Detection')
                     if 'runtime' in relative_path:
                         page_data['rule_category'].append('Runtime Agent')
 


### PR DESCRIPTION
### What does this PR do?

- update the mapping for route53 image to come through in security monitoring rules
- update security monitoring category `Logs Detection` to be `Log Detection` per WEB-679

### Motivation

https://datadoghq.atlassian.net/browse/WEB-869
https://datadoghq.atlassian.net/browse/WEB-679

### Preview

Note can't view the route53 image mapping working as its not enabled but tested locally as working
https://docs-staging.datadoghq.com/david.jones/route53src/security_monitoring/default_rules/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
