### PR TITLE
Amazon ECS Agent metrics

### DIFF
--- a/content/en/agent/amazon_ecs/data_collected.md
+++ b/content/en/agent/amazon_ecs/data_collected.md
@@ -17,11 +17,9 @@ further_reading:
 
 ### Metrics
 
-Amazon ECS metrics collected with the Datadog Agent:
+Amazon ECS on EC2 is a container management service for Docker containers running on EC2 instances. Metrics collected by the Agent when deployed in a Docker container are the same metrics collected by the Docker integration. Refer to the [Docker integration metrics][1] for a complete list of metrics.
 
-{{< get-metrics-from-git "amazon_ecs" "ecs." >}}
-
-**Note**: Metrics prefixed with `ecs.containerinsights.*` come from the [AWS CloudWatch agent][2].
+**Note**: Docker metrics are tagged accordingly with ECS task tags. No further configuration is required.
 
 ### Events
 
@@ -29,12 +27,11 @@ To reduce noise, the Amazon ECS integration is automatically set up to include o
 
 {{< img src="integrations/amazon_ecs/aws_ecs_events.png" alt="AWS ECS Events" >}}
 
-To remove the whitelist and receive all events from your Datadog Amazon ECS integration, reach out to [Datadog support][3].
+To remove the whitelist and receive all events from your Datadog Amazon ECS integration, reach out to [Datadog support][2].
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /integrations/amazon_web_services/
-[2]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/deploy-container-insights-ECS-instancelevel.html
-[3]: https://docs.datadoghq.com/help/
+[1]: https://docs.datadoghq.com/agent/docker/data_collected/#metrics
+[2]: https://docs.datadoghq.com/help/

--- a/content/en/agent/amazon_ecs/data_collected.md
+++ b/content/en/agent/amazon_ecs/data_collected.md
@@ -27,7 +27,7 @@ To reduce noise, the Amazon ECS integration is automatically set up to include o
 
 {{< img src="integrations/amazon_ecs/aws_ecs_events.png" alt="AWS ECS Events" >}}
 
-To remove the whitelist and receive all events from your Datadog Amazon ECS integration, reach out to [Datadog support][2].
+To remove this include list and receive all events from your Datadog Amazon ECS integration, reach out to [Datadog support][2].
 
 ## Further reading
 

--- a/content/en/agent/amazon_ecs/data_collected.md
+++ b/content/en/agent/amazon_ecs/data_collected.md
@@ -19,7 +19,7 @@ further_reading:
 
 Amazon ECS on EC2 is a container management service for Docker containers running on EC2 instances. Metrics collected by the Agent when deployed in a Docker container are the same metrics collected by the Docker integration. Refer to the [Docker integration metrics][1] for a complete list of metrics.
 
-**Note**: Docker metrics are tagged accordingly with ECS task tags. No further configuration is required.
+**Note**: Docker metrics are tagged accordingly with the following tags: `container_name`, `task_arn`, `task_family`, `task_name`, `task_version`. No further configuration is required.
 
 ### Events
 


### PR DESCRIPTION
### What does this PR do?
Updates the Amazon ECS Agent data collected docs to forward users to the Docker integration metrics section

### Motivation
ECS metrics come from the Docker integration and are tagged accordingly with ECS task tags

### Preview
https://docs-staging.datadoghq.com/sarina/ecs-agent-docs/agent/amazon_ecs/data_collected/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
