### PR TITLE
Remove duplicated line

### DIFF
--- a/content/en/tracing/custom_instrumentation/go.md
+++ b/content/en/tracing/custom_instrumentation/go.md
@@ -114,9 +114,6 @@ To make use of manual instrumentation, use the `tracer` package which is documen
 There are two functions available to create spans. API details are available for `StartSpan` [here][5] and for `StartSpanFromContext` [here][6].
 
 ```go
-//Create a span
-span := tracer.StartSpan(“mainOp”, tracer.ResourceName("/user"), tracer.ChildOf(parentSpan))
-
 //Create a span with a resource name, which is the child of parentSpan.
 span := tracer.StartSpan(“mainOp”, tracer.ResourceName("/user"), tracer.ChildOf(parentSpan))
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Just removes a duplicated line on a code example.

### Motivation
<!-- What inspired you to submit this pull request?-->
Despite it's easy to spot that this line is duplicated and just ignore it. Can be misleading to newcomers

### Preview
<!-- Impacted pages preview links-->
Replaces:
```go
//Create a span	
span := tracer.StartSpan(“mainOp”, tracer.ResourceName("/user"), tracer.ChildOf(parentSpan))	

//Create a span with a resource name, which is the child of parentSpan.	//Create a span with a resource name, which is the child of parentSpan.
span := tracer.StartSpan(“mainOp”, tracer.ResourceName("/user"), tracer.ChildOf(parentSpan))
(...)
```
with:
```go
//Create a span with a resource name, which is the child of parentSpan.	//Create a span with a resource name, which is the child of parentSpan.
span := tracer.StartSpan(“mainOp”, tracer.ResourceName("/user"), tracer.ChildOf(parentSpan))
(...)
```

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
