### PR TITLE
adding an alias for the old file

### DIFF
--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -323,6 +323,8 @@
           dependencies: ["https://github.com/DataDog/browser-sdk/blob/master/packages/rum/README.md"]
           title: RUM Browser Monitoring
           kind: documentation
+          aliases:
+            - /real_user_monitoring/setup
 
   - repo_name: datadog-cloudformation-resources
     contents:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -323,6 +323,8 @@
           dependencies: ["https://github.com/DataDog/browser-sdk/blob/master/packages/rum/README.md"]
           title: RUM Browser Monitoring
           kind: documentation
+          aliases:
+            - /real_user_monitoring/setup
 
   - repo_name: datadog-cloudformation-resources
     contents:


### PR DESCRIPTION
### What does this PR do?
Adds an alias for the old rum getting started page.

### Motivation
We're getting 404s, but it doesn't look like it's a bad link from the documentation site.


https://docs-staging.datadoghq.com/kaylyn/alias/real_user_monitoring/setup should now redirect

