### PR TITLE
content/en/tracing/setup/go.md: Update deprecated DD_AGENT_APM_PORT to DD_TRACE_AGENT_PORT

### DIFF
--- a/content/en/tracing/setup/go.md
+++ b/content/en/tracing/setup/go.md
@@ -90,7 +90,7 @@ func main() {
 
 ### Change Agent Hostname
 
-The Go Tracing Module automatically looks for and initializes with the environment variables `DD_AGENT_HOST` and `DD_AGENT_APM_PORT`.
+The Go Tracing Module automatically looks for and initializes with the environment variables `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`.
 
 But you can also set a custom hostname and port in code:
 


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
`DD_AGENT_APM_PORT` is no longer supported. The correct environment variable is `DD_TRACE_AGENT_PORT`


### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/knusbaum/fix-go-env-var/tracing/setup/go

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
