### PR TITLE
fix unified_service_tagging.md example

### DIFF
--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -326,7 +326,7 @@ Set the following configuration in the Agent's [main configuration file][1]:
 ```yaml
 env: <ENV>
 tags:
-    - service: <SERVICE>
+    - service:<SERVICE>
 ```
 
 This setup guarantees consistent tagging of `env` and `service` for all data emitted by the Agent.


### PR DESCRIPTION
For "Non-containerized environment", "System Metrics" tab, example for `service` tag included a space after colon, which is not valid for a tag value.  Prospect confirmed removing the space resolved APM <> Infrastructure correlation in APM service view.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
