### PR TITLE
WEB-868 add hmtl select for lang mobile

### DIFF
--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -191,7 +191,18 @@
                 <div class="col-12">
                     <div class="row mb-1 align-items-center">
                         <div class="col-6 col-lg-1 offset-lg-3 mb-1 mb-lg-0">
-                            <div class="footer-menu d-flex align-items-center js-footer-lang-toggle footer-lang-toggle">
+                            <div class="d-flex d-lg-none mobile-lang-select-container">
+                                <span class="d-flex align-items-center">{{ partial "svg" (dict "context" $dot "src" "world.svg" "size" "15px" "color" "#ffffff"  )}}&nbsp;</span>
+                                <label class="sr-only" for="mobile-lang-select">Language Selection</label>
+                                <select class="mobile-lang-select" id="mobile-lang-select" id="" onchange="javascript:location.href = this.value;">
+                                    <option value="{{ .Permalink }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
+                                    {{ range .Translations }}
+                                        <option value="{{ .Permalink }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
+                                    {{ end }}
+                                </select>
+                                {{ partial "svg" (dict "context" $dot "src" "arrow.svg" "size" "15px" "color" "#ffffff"  )}}
+                            </div>
+                            <div class="footer-menu d-none d-lg-flex align-items-center js-footer-lang-toggle footer-lang-toggle">
                                 <div class="d-flex align-items-center text-white cursor-pointer selected-lang">
                                     <span class="d-flex align-items-center">{{ partial "svg" (dict "context" $dot "src" "world.svg" "size" "15px" "color" "#ffffff"  )}}&nbsp;</span>
                                     <span class="d-flex align-items-center" style="transform: translateY(-1px);">{{ .Language.LanguageName }}</span>

--- a/src/styles/components/_footer.scss
+++ b/src/styles/components/_footer.scss
@@ -142,7 +142,13 @@ footer {
 
       & + svg {
         transform: translateY(6px) rotate(180deg);
-        margin-left: 5px;
+        &:lang(ja) {
+          margin-left: -7px;
+        }
+        &:lang(fr) {
+          margin-left: 5px;
+        }
+        margin-left: -1px;
       }
     }
     

--- a/src/styles/components/_footer.scss
+++ b/src/styles/components/_footer.scss
@@ -108,13 +108,49 @@ footer {
       cursor: pointer;
       font-size: 18px;
       color: #fff;
-
       &:lang(ja),
       &:lang(ko) {
         font-size: 16px;
       }
     }
   }
+
+  .mobile-lang-select-container {
+
+    position: relative;
+    max-width: 100px;
+
+    .mobile-lang-select {
+      appearance: none;
+      color: white;
+      background-color: transparent;
+      transform: translateY(-1px);
+      border: none;
+      outline: none;
+      padding: 0 15px;
+      margin: 0 -15px;
+      max-width: fit-content;
+
+      &:focus {
+        outline: none;
+        border: none;
+      }
+      &:lang(ja),
+      &:lang(ko) {
+        font-size: 16px;
+      }
+
+      & + svg {
+        transform: translateY(6px) rotate(180deg);
+        margin-left: 5px;
+      }
+    }
+    
+    &:hover {
+      opacity: 0.5;
+    }
+  }
+  
 
   .footer-lang-toggle {
 


### PR DESCRIPTION
### What does this PR do?
Adds native html select for language selection on mobile.

### Motivation
https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?assignee=5d4b49d50fa6d40d14fc7b11&selectedIssue=WEB-868

### Preview
http://docs-staging.datadoghq.com/zach/footer-mobile-lang

test on mobile, clicking language will bring up native select ui.

