### PR TITLE
content/en/tracing/setup/go.md: remove unnecessary instruction

### DIFF
--- a/content/en/tracing/setup/go.md
+++ b/content/en/tracing/setup/go.md
@@ -44,12 +44,6 @@ Follow the [Quickstart instructions][6] within the Datadog app for the best expe
 
 Otherwise, [install and configure the Datadog Agent][7]. See the additional documentation for [tracing Docker applications][8] or [Kubernetes applications][9].
 
-Next, install the Go tracer from its canonical import path:
-
-```go
-go get gopkg.in/DataDog/dd-trace-go.v1/...
-```
-
 You are now ready to import the tracer and start instrumenting your code.
 
 ## Automatic Instrumentation


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This removes an unnecessary step in using the Go Tracer.
The `go build` command will resolve dependencies anyway, so we do not need to tell users to download it manually with `go get`. 

Telling users to do this can even cause confusion and inconvenience, since the command listed *also* downloads all of the *potential* dependencies for dd-trace-go (the libraries we provide integrations for), including multiple web frameworks, kafka libraries, grpc, etc. Some of these throw errors since specific versions need to be selected, which the command does not do.

The user can just put the import in the code and the toolchain will resolve it correctly.

### Motivation
Scanning the go documentation for consistency.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/knusbaum/update-go-doc/tracing/setup/go/#installation

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
