### PR TITLE
shortening the text on a further reading link

### DIFF
--- a/content/en/security_monitoring/detection_rules.md
+++ b/content/en/security_monitoring/detection_rules.md
@@ -4,7 +4,7 @@ kind: documentation
 further_reading:
 - link: "/security_monitoring/explorer/"
   tag: "Documentation"
-  text: "Search through all of your security signals and perform Security Analytics"
+  text: "Security Signals Explorer"
 ---
 
 ## Overview


### PR DESCRIPTION
Changing it to the name of the linked page because it's currently overflowing the button.

https://docs-staging.datadoghq.com/kaylyn/further-reading/security_monitoring/detection_rules/#further-reading

