### PR TITLE
Update syslog_ng.md

### DIFF
--- a/content/en/integrations/syslog_ng.md
+++ b/content/en/integrations/syslog_ng.md
@@ -99,7 +99,19 @@ Configure Syslog-ng to gather logs from your host, containers, & services.
 
     More information about the TLS parameters and possibilities for syslog-ng available in the [official documentation][1].
 
-5. Restart syslog-ng.
+5. (Optional) Set the source on your logs. To set the source, use the following format (if you have several sources, change the name of the format in each file):
+
+    ```conf
+    template DatadogFormat { template("<API_KEY> <${PRI}>1 ${ISODATE} ${HOST:--} ${PROGRAM:--} ${PID:--} ${MSGID:--} [metas@0 ddsource=\"test\"] $MSG\n"); };
+    ```
+    
+    You can also add custom tags with the `ddtags` attribute:
+    
+    ```conf
+    template DatadogFormat { template("<API_KEY> <${PRI}>1 ${ISODATE} ${HOST:--} ${PROGRAM:--} ${PID:--} ${MSGID:--} [metas@0 ddsource=\"test\" ddtags=\"env:test,user:test_user,<KEY:VALUE>\"] $MSG\n"); };
+    ```
+
+6. Restart syslog-ng.
 
 
 [1]: https://syslog-ng.com/documents/html/syslog-ng-ose-latest-guides/en/syslog-ng-ose-guide-admin/html/tlsoptions.html


### PR DESCRIPTION
Getting the logs into Datadog without the source or any tags set is not very helpful. This information is difficult to find on the web. Similar information is already included on the rsyslog docs found here: https://docs.datadoghq.com/integrations/rsyslog/?tab=datadogussite

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds an optional step to the instructions for using syslog-ng that shows how to add ddsource and ddtags to a forwarded log. A corresponding step is included in the rsyslog instructions. 

### Motivation
It took me two hours to chase down the approach and format required to provide this critical data to datadog. I hope to make it easier for others.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
