### PR TITLE
Update supported Symfony versions

### DIFF
--- a/content/en/tracing/compatibility_requirements/php.md
+++ b/content/en/tracing/compatibility_requirements/php.md
@@ -52,7 +52,7 @@ The following table enumerates some of the frameworks and versions Datadog succe
 | Laravel        | 4.2, 5.x, 6.x | All supported PHP versions |
 | Lumen          | 5.2+          | All supported PHP versions |
 | Slim           | 3.x           | All supported PHP versions |
-| Symfony        | 3.3, 3.4, 4.x | All supported PHP versions |
+| Symfony        | 3.3+, 4, 5    | All supported PHP versions |
 | WordPress      | 4.x, 5.x      | PHP 7+                     |
 | Zend Framework | 1.12          | All supported PHP versions |
 | Yii            | 1.1, 2.0      | All supported PHP versions |


### PR DESCRIPTION
### What does this PR do?
I recently tested that newer versions of Symfony work, and they do.
This isn't blocked on a release of the PHP tracer.

### Motivation
I was working on a hobby project that uses Symfony 5 and noticed we don't specifically mention Symfony 5 as supported. I added tests for it this weekend to ensure it's supported: https://github.com/DataDog/dd-trace-php/pull/1062

### Preview
https://docs-staging.datadoghq.com/LeviM/symfony-versions/tracing/compatibility_requirements/php

It's been 40 minutes since opening the PR and I don't see the changes reflected in the preview; perhaps I did something wrong?

### Additional Notes
This is not blocked on a release of the PHP tracer; the existing integration works on Symfony 5 and the other PR only added tests for this specific version to ensure it is supported.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
