### PR TITLE
Fix urls for serilog C#

### DIFF
--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -311,8 +311,8 @@ Then, initialize the logger directly in your application. Do not forget to [add 
 {{< site-region region="us" >}}
 
 ```csharp
-var log = new LoggerConfiguration(url: "http-intake.logs.datadoghq.com")
-    .WriteTo.DatadogLogs("<API_KEY>")
+var log = new LoggerConfiguration()
+    .WriteTo.DatadogLogs("<API_KEY>", configuration: new DatadogConfiguration { Url = "https://http-intake.logs.datadoghq.com" })
     .CreateLogger();
 ```
 
@@ -320,8 +320,8 @@ var log = new LoggerConfiguration(url: "http-intake.logs.datadoghq.com")
 {{< site-region region="eu" >}}
 
 ```csharp
-var log = new LoggerConfiguration(url: "http-intake.logs.datadoghq.eu")
-    .WriteTo.DatadogLogs("<API_KEY>")
+var log = new LoggerConfiguration()
+    .WriteTo.DatadogLogs("<API_KEY>", configuration: new DatadogConfiguration { Url = "https://http-intake.logs.datadoghq.eu" })
     .CreateLogger();
 ```
 
@@ -353,7 +353,7 @@ var log = new LoggerConfiguration()
 For instance to forward logs to the Datadog EU region in TCP you would use the following sink configuration:
 
 ```csharp
-var config = new DatadogConfiguration(url: "tcp-intake.logs.datadoghq.eu", port: 443, useSSL: true, useTCP: true);
+var config = new DatadogConfiguration(url: "intake.logs.datadoghq.eu", port: 443, useSSL: true, useTCP: true);
 var log = new LoggerConfiguration()
     .WriteTo.DatadogLogs(
         "<API_KEY>",


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fix the urls for C# serilog example codes.
### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/olivierg/fix-serilog-url/content/en/logs/log_collection/csharp.md

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
