### PR TITLE
Removing "Enterprise" cuz it's misleading

### DIFF
--- a/content/en/logs/guide/logs-rbac.md
+++ b/content/en/logs/guide/logs-rbac.md
@@ -25,7 +25,7 @@ Logs might contain **sensitive information** that could either get [scrubbed][1]
 This guide provides a methodology in developing customized Datadog roles that allows users to access logs and log features in a compliant manner.
 
 <div class="alert alert-warning">
-Creating and modifying custom roles is an opt-in Enterprise feature. <a href="/help">Contact Datadog support</a> to get it enabled for your account.
+Creating and modifying custom roles is an opt-in feature. <a href="/help">Contact Datadog support</a> to get it enabled for your account.
 </div>
 
 ### The "ACME" Team


### PR DESCRIPTION
The feature is not limited to Datadog enterprise customers and is throws off CSMs and support engineers. It was supposed to mean that typically large enterprises have this requirement but it misleads people into thinking that it's only available to DD Enterprise customers.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
