### PR TITLE
Update build-custom-reports-using-log-analytics-api.md

### DIFF
--- a/content/en/logs/guide/build-custom-reports-using-log-analytics-api.md
+++ b/content/en/logs/guide/build-custom-reports-using-log-analytics-api.md
@@ -63,7 +63,9 @@ curl -L -X POST "https://api.datadoghq.com/api/v2/logs/analytics/aggregate" -H "
            "type":"facet",
            "facet":"status",
            "sort":{
-               "order":"desc"
+               "order":"desc",
+               "type": "measure",
+               "aggregation":"count"
            },
            "limit":3
        }
@@ -140,7 +142,9 @@ curl -L -X POST "https://api.datadoghq.com/api/v2/logs/analytics/aggregate" -H "
            "type":"facet",
            "facet":"status",
            "sort":{
-               "order":"desc"
+               "order":"desc",
+               "type": "measure",
+               "aggregation":"count"
            }
        }
    ]
@@ -229,7 +233,10 @@ curl -L -X POST "https://api.datadoghq.com/api/v2/logs/analytics/aggregate" -H "
            "type":"facet",
            "facet":"status",
            "sort":{
-               "order":"desc"
+               "order":"desc",    
+               "type": "measure",
+               "aggregation":"avg",
+               "metric":"@http.response_time"
            }
        }
    ]
@@ -303,7 +310,10 @@ curl -L -X POST "https://api.datadoghq.com/api/v2/logs/analytics/aggregate" -H "
            "type":"facet",
            "facet":"service",
            "sort":{
-               "order":"desc"
+               "order":"desc",    
+               "type": "measure",
+               "aggregation":"sum",
+               "metric":"@http.response_time"
            }
        }
    ]
@@ -368,7 +378,10 @@ curl -L -X POST "https://api.datadoghq.com/api/v2/logs/analytics/aggregate" -H "
            "type":"facet",
            "facet":"service",
            "sort":{
-               "order":"desc"
+               "order":"desc",    
+               "type": "measure",
+               "aggregation":"min",
+               "metric":"@http.response_time"
            }
        }
    ]
@@ -433,7 +446,10 @@ curl -L -X POST "https://api.datadoghq.com/api/v2/logs/analytics/aggregate" -H "
            "type":"facet",
            "facet":"service",
            "sort":{
-               "order":"desc"
+               "order":"desc",    
+               "type": "measure",
+               "aggregation":"max",
+               "metric":"@http.response_time"
            }
        }
    ]
@@ -500,7 +516,10 @@ curl -L -X POST "https://api.datadoghq.com/api/v2/logs/analytics/aggregate" -H "
            "type":"facet",
            "facet":"service",
            "sort":{
-               "order":"desc"
+               "order":"desc",    
+               "type": "measure",
+               "aggregation":"pc99",
+               "metric":"@http.response_time"
            }
        }
    ]


### PR DESCRIPTION
Fixing the sort params for all examples.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Following up on LOGSS-3824, I have tested syntax for all examples again and included the type, measure and metric params in sort object. 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/pranay/update-sort-params-analytics-api/logs/guide/build-custom-reports-using-log-analytics-api/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
