### PR TITLE
Fix typo in the Proxy.md documentation page

### DIFF
--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -54,7 +54,7 @@ Setting an HTTPS proxy for both `https` and `http` requests:
 ```yaml
 proxy:
     https: "https://<SSL_PROXY_SERVER_FOR_HTTPS>:<PORT>"
-    http: "https://<SSL_PROXY_SERVER_FOR_HTTP>:<PORT>"
+    http: "http://<SSL_PROXY_SERVER_FOR_HTTP>:<PORT>"
 ```
 
 Setting a `<USERNAME>` and `<PASSWORD>` to contact the proxy server for both `https` and `http` requests:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fix a little typo that doesn't match with the rest of the page.

### Motivation
<!-- What inspired you to submit this pull request?-->
I want to ensure customers do not get confused with this typo. 
I suspect the customer that raised this Zendesk ticket made a mistake in their configuration because of this little typo:
https://datadog.zendesk.com/agent/tickets/410000


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
