### PR TITLE
addition of subdomain note

### DIFF
--- a/content/en/account_management/saml/okta.md
+++ b/content/en/account_management/saml/okta.md
@@ -48,7 +48,7 @@ It's recommended that you set up Datadog as an Okta application manually, as opp
 * **sn**: user.lastName
 * **givenName**: user.firstName
 
-Additional Information on configuring SAML for your Datadog account can be found [on the dedicated SAML documentation page][2]. If you are using the custom sub-domain feature, your specific details will also be found here.
+Additional information on configuring SAML for your Datadog account is available on the [SAML documentation page][2]. If you are using the custom sub-domain feature, your specific details are also available there.
 
 In the event that you need to upload an `IDP.XML` file to Datadog before being able to fully configure the application in Okta, see [acquiring the idp.xml metadata file for a SAML template App article][3] for field placeholder instructions.
 

--- a/content/en/account_management/saml/okta.md
+++ b/content/en/account_management/saml/okta.md
@@ -48,7 +48,7 @@ It's recommended that you set up Datadog as an Okta application manually, as opp
 * **sn**: user.lastName
 * **givenName**: user.firstName
 
-Additional Information on configuring SAML for your Datadog account can be found [on the dedicated SAML documentation page][2]:
+Additional Information on configuring SAML for your Datadog account can be found [on the dedicated SAML documentation page][2]. If you are using the custom sub-domain feature, your specific details will also be found here.
 
 In the event that you need to upload an `IDP.XML` file to Datadog before being able to fully configure the application in Okta, see [acquiring the idp.xml metadata file for a SAML template App article][3] for field placeholder instructions.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adding a small note to advise of the differing URL details for those using the [custom sub-domain feature](https://docs.datadoghq.com/account_management/multi_organization/#custom-sub-domains).

### Motivation
<!-- What inspired you to submit this pull request?-->
Currently, this guide does not reference that the custom sub-domain feature will change the sign on URLs. The details required in these cases require using the [the dedicated SAML documentation page](https://docs.datadoghq.com/account_management/saml/). Not mentioning this may be misleading to those using the guide. There is also a formatting error at the end of the current sentence using a : instead of full stop which this PR addresses.
### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/joel295/okta-guide-addition/account_management/saml/okta/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
