### PR TITLE
[rum] document addError

### DIFF
--- a/content/en/real_user_monitoring/browser/advanced_configuration.md
+++ b/content/en/real_user_monitoring/browser/advanced_configuration.md
@@ -242,9 +242,105 @@ window.DD_RUM &&
 
 With the above example, the RUM SDK would collect the amount of items within a cart, what they are, and how much the cart is worth overall.
 
+
+### Custom errors
+Monitor handled exceptions, handled promise rejections and other errors not tracked automatically by the RUM SDK with the `addError()` API:
+
+```javascript
+addError(
+    error: unknown,
+    context?: Context,
+    source: ErrorSource.CUSTOM | ErrorSource.NETWORK | ErrorSource.SOURCE = ErrorSource.CUSTOM
+);
+```
+
+**Note**: The [Error Tracking][3] feature processes errors sent with source set to `custom` or `source` and that contain a stacktrace.
+
+{{< tabs >}}
+{{% tab "NPM" %}}
+
+```javascript
+import { datadogRum } from '@datadog/browser-rum';
+
+// Send a custom error with context
+const error = new Error('Something wrong occured.');
+
+datadogRum.addError(error, {
+    pageStatus: 'beta',
+});
+
+// Send a network error
+fetch('<SOME_URL>').catch(function(error) {
+    datadogRum.addError(error, undefined, 'network');
+})
+
+// Send a handled exception error
+try {
+    //Some code logic
+} catch (error) {
+    datadogRum.addError(error, undefined, 'source');
+}
+```
+
+{{% /tab %}}
+{{% tab "CDN async" %}}
+```javascript
+// Send a custom error with context
+const error = new Error('Something wrong occured.');
+
+DD_RUM.onReady(function() {
+    DD_RUM.addError(error, {
+        pageStatus: 'beta',
+    });
+});
+
+// Send a network error
+fetch('<SOME_URL>').catch(function(error) {
+    DD_RUM.onReady(function() {
+        DD_RUM.addError(error, undefined, 'network');
+    });
+})
+
+// Send a handled exception error
+try {
+    //Some code logic
+} catch (error) {
+    DD_RUM.onReady(function() {
+        DD_RUM.addError(error, undefined, 'source');
+    })
+}
+```
+{{% /tab %}}
+{{% tab "CDN sync" %}}
+
+```javascript
+// Send a custom error with context
+const error = new Error('Something wrong occured.');
+
+window.DD_RUM && DD_RUM.addError(error, {
+    pageStatus: 'beta',
+});
+
+// Send a network error
+fetch('<SOME_URL>').catch(function(error) {
+    window.DD_RUM && DD_RUM.addError(error, undefined, 'network');
+})
+
+// Send a handled exception error
+try {
+    //Some code logic
+} catch (error) {
+    window.DD_RUM && DD_RUM.addError(error, undefined, 'source');
+}
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/browser-sdk
 [2]: /logs/processing/attributes_naming_convention/#user-related-attributes
+[3]: /real_user_monitoring/error_tracking

--- a/content/en/real_user_monitoring/browser/data_collected.md
+++ b/content/en/real_user_monitoring/browser/data_collected.md
@@ -145,11 +145,12 @@ Detailed network timing data for the loading of an application’s resources are
 Front-end errors are collected with Real User Monitoring (RUM). The error message and stack trace are included when available.
 
 ## Error Origins
-Front-end errors are split in 3 different categories depending on their `error.origin`:
+Front-end errors are split in 4 different categories depending on their `error.origin`:
 
 - **network**: XHR or Fetch errors resulting from AJAX requests. Specific attributes to network errors can be found [in the documentation][1].
 - **source**: Unhandled exceptions or unhandled promise rejections (source-code related).
 - **console**: `console.error()` API calls.
+- **custom**: Errors sent with the [RUM `addError` API][2] default to `custom`.
 
 ## Facet Collected
 
@@ -175,14 +176,16 @@ Network errors include information about failing HTTP requests. The following fa
 
 ### Source errors
 
-Source errors include code-level information about the error. More information about the different error types can be found in [the MDN documentation][2].
+Source errors include code-level information about the error. More information about the different error types can be found in [the MDN documentation][3].
 
 | Attribute       | Type   | Description                                                       |
 |-----------------|--------|-------------------------------------------------------------------|
 | `error.kind`    | string | The error type or kind (or code in some cases).                   |
 
+
 [1]: /real_user_monitoring/data_collected/error/#network-errors
-[2]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
+[2]: /real_user_monitoring/browser/advanced_configuration#custom-errors
+[3]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
 {{% /tab %}}
 {{% tab "User Action" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add documentation for the new `addError` RUM API

### Motivation
<!-- What inspired you to submit this pull request?-->
New feature

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hdelaby/addError/real_user_monitoring/browser/data_collected/?tab=error
https://docs-staging.datadoghq.com/hdelaby/addError/real_user_monitoring/browser/advanced_configuration#custom-errors

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
