### PR TITLE
Add Azure Stack HCI OS to List of Supported Operating Systems

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -148,6 +148,7 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 | [macOS][9]                                      | macOS 10.12+                                      |
 | [Windows server 64-bit][10]                     | Windows Server 2008r2+ and Server Core (not Nano) |
 | [Windows 64-bit][10]                            | Windows 7+                                        |
+| [Windows Azure Stack HCI OS][10]                | Azure Stack HCI OS Version 1+                     |
 
 **Note**: [Source][11] install may work on operating systems not listed here and is supported on a best effort basis.
 

--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -148,7 +148,7 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 | [macOS][9]                                      | macOS 10.12+                                      |
 | [Windows server 64-bit][10]                     | Windows Server 2008r2+ and Server Core (not Nano) |
 | [Windows 64-bit][10]                            | Windows 7+                                        |
-| [Windows Azure Stack HCI OS][10]                | Azure Stack HCI OS Version 1+                     |
+| [Windows Azure Stack HCI OS][10]                | All Versions                                      |
 
 **Note**: [Source][11] install may work on operating systems not listed here and is supported on a best effort basis.
 


### PR DESCRIPTION
### What does this PR do?
Adds Azure Stacj HCI to list of supported operating systems. It includes a link to the standard Windows agent install docs, as this same process works for Azure Stack HCI OS. It's basically just another flavor of Windows.

### Motivation
We want to participate in launch announcement with Microsoft, and one requirement is that we list support for it in our public docs.

### Preview
None.

### Additional Notes
None.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
