### PR TITLE
Regenerate the sample k8s manifests

### DIFF
--- a/static/resources/yaml/datadog-agent-aks.yaml
+++ b/static/resources/yaml/datadog-agent-aks.yaml
@@ -18,7 +18,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: ee293ccedf116ce1ed6e0d9c7f7f9adabd0c230618089bb173c7acffa487e020
+    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
 data:
   install_info: |
     ---
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -111,6 +111,7 @@ spec:
             httpGet:
               path: /live
               port: 5555
+              scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 15
             successThreshold: 1
@@ -120,12 +121,13 @@ spec:
             httpGet:
               path: /ready
               port: 5555
+              scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
         - name: process-agent
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -145,23 +147,28 @@ spec:
               value: unix:///host/var/run/docker.sock
             - name: DD_LOG_LEVEL
               value: "INFO"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
             - name: runtimesocketdir
               mountPath: /host/var/run
+              mountPropagation: None
               readOnly: true
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
               readOnly: true
             - name: passwd
               mountPath: /etc/passwd
             - name: procdir
               mountPath: /host/proc
+              mountPropagation: None
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -171,7 +178,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -219,6 +226,9 @@ spec:
           name: cgroups
         - name: s6-run
           emptyDir: {}
+        - hostPath:
+            path: /etc/passwd
+          name: passwd
         - hostPath:
             path: /etc/kubernetes/certs
           name: kubeletserver

--- a/static/resources/yaml/datadog-agent-aks_values.yaml
+++ b/static/resources/yaml/datadog-agent-aks_values.yaml
@@ -1,7 +1,5 @@
 datadog:
   kubeStateMetricsEnabled: false
-  processAgent:
-    enabled: false
 agents:
   rbac:
     create: false

--- a/static/resources/yaml/datadog-agent-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-all-features.yaml
@@ -18,7 +18,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: ee293ccedf116ce1ed6e0d9c7f7f9adabd0c230618089bb173c7acffa487e020
+    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
 data:
   install_info: |
     ---
@@ -54,7 +54,7 @@ data:
       syscall_monitor:
         enabled: false
 ---
-# Source: datadog/templates/security-configmap.yaml
+# Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -264,7 +264,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -341,6 +341,7 @@ spec:
             httpGet:
               path: /live
               port: 5555
+              scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 15
             successThreshold: 1
@@ -350,12 +351,13 @@ spec:
             httpGet:
               path: /ready
               port: 5555
+              scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -400,7 +402,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -450,13 +452,26 @@ spec:
               mountPath: /etc/datadog-agent/system-probe.yaml
               subPath: system-probe.yaml
         - name: system-probe
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
               add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "IPC_LOCK"]
           command: ["/opt/datadog-agent/embedded/bin/system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
           env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DOCKER_HOST
+              value: unix:///host/var/run/docker.sock
             - name: DD_LOG_LEVEL
               value: "INFO"
           resources: {}
@@ -475,7 +490,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -485,7 +500,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -520,7 +535,7 @@ spec:
               value: unix:///host/var/run/docker.sock
           resources: {}
         - name: seccomp-setup
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           command:
             - cp
             - /etc/config/system-probe-seccomp.json

--- a/static/resources/yaml/datadog-agent-apm.yaml
+++ b/static/resources/yaml/datadog-agent-apm.yaml
@@ -18,7 +18,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: ee293ccedf116ce1ed6e0d9c7f7f9adabd0c230618089bb173c7acffa487e020
+    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
 data:
   install_info: |
     ---
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -106,6 +106,7 @@ spec:
             httpGet:
               path: /live
               port: 5555
+              scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 15
             successThreshold: 1
@@ -115,12 +116,13 @@ spec:
             httpGet:
               path: /ready
               port: 5555
+              scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -165,7 +167,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -185,23 +187,28 @@ spec:
               value: unix:///host/var/run/docker.sock
             - name: DD_LOG_LEVEL
               value: "INFO"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
             - name: runtimesocketdir
               mountPath: /host/var/run
+              mountPropagation: None
               readOnly: true
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
               readOnly: true
             - name: passwd
               mountPath: /etc/passwd
             - name: procdir
               mountPath: /host/proc
+              mountPropagation: None
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -211,7 +218,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -259,6 +266,9 @@ spec:
           name: cgroups
         - name: s6-run
           emptyDir: {}
+        - hostPath:
+            path: /etc/passwd
+          name: passwd
       tolerations:
       affinity: {}
       serviceAccountName: "datadog-agent"

--- a/static/resources/yaml/datadog-agent-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-logs-apm.yaml
@@ -18,7 +18,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: ee293ccedf116ce1ed6e0d9c7f7f9adabd0c230618089bb173c7acffa487e020
+    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
 data:
   install_info: |
     ---
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -123,6 +123,7 @@ spec:
             httpGet:
               path: /live
               port: 5555
+              scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 15
             successThreshold: 1
@@ -132,12 +133,13 @@ spec:
             httpGet:
               path: /ready
               port: 5555
+              scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -184,7 +186,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -200,27 +202,34 @@ spec:
                   fieldPath: status.hostIP
             - name: KUBERNETES
               value: "yes"
+            - name: DD_AC_EXCLUDE
+              value: "name:datadog-agent"
             - name: DOCKER_HOST
               value: unix:///host/var/run/docker.sock
             - name: DD_LOG_LEVEL
               value: "INFO"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
             - name: runtimesocketdir
               mountPath: /host/var/run
+              mountPropagation: None
               readOnly: true
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
               readOnly: true
             - name: passwd
               mountPath: /etc/passwd
             - name: procdir
               mountPath: /host/proc
+              mountPropagation: None
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -230,7 +239,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -282,6 +291,9 @@ spec:
           name: cgroups
         - name: s6-run
           emptyDir: {}
+        - hostPath:
+            path: /etc/passwd
+          name: passwd
         - hostPath:
             path: "/var/lib/datadog-agent/logs"
           name: pointerdir

--- a/static/resources/yaml/datadog-agent-logs.yaml
+++ b/static/resources/yaml/datadog-agent-logs.yaml
@@ -18,7 +18,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: ee293ccedf116ce1ed6e0d9c7f7f9adabd0c230618089bb173c7acffa487e020
+    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
 data:
   install_info: |
     ---
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -123,6 +123,7 @@ spec:
             httpGet:
               path: /live
               port: 5555
+              scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 15
             successThreshold: 1
@@ -132,12 +133,13 @@ spec:
             httpGet:
               path: /ready
               port: 5555
+              scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
         - name: process-agent
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -153,27 +155,34 @@ spec:
                   fieldPath: status.hostIP
             - name: KUBERNETES
               value: "yes"
+            - name: DD_AC_EXCLUDE
+              value: "name:datadog-agent"
             - name: DOCKER_HOST
               value: unix:///host/var/run/docker.sock
             - name: DD_LOG_LEVEL
               value: "INFO"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
             - name: runtimesocketdir
               mountPath: /host/var/run
+              mountPropagation: None
               readOnly: true
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
               readOnly: true
             - name: passwd
               mountPath: /etc/passwd
             - name: procdir
               mountPath: /host/proc
+              mountPropagation: None
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -183,7 +192,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -235,6 +244,9 @@ spec:
           name: cgroups
         - name: s6-run
           emptyDir: {}
+        - hostPath:
+            path: /etc/passwd
+          name: passwd
         - hostPath:
             path: "/var/lib/datadog-agent/logs"
           name: pointerdir

--- a/static/resources/yaml/datadog-agent-logs_values.yaml
+++ b/static/resources/yaml/datadog-agent-logs_values.yaml
@@ -6,8 +6,6 @@ datadog:
     enabled: true
     containerCollectAll: true
   acExclude: "name:datadog-agent"
-  processAgent:
-    enabled: false
 agents:
   rbac:
     create: false

--- a/static/resources/yaml/datadog-agent-npm.yaml
+++ b/static/resources/yaml/datadog-agent-npm.yaml
@@ -18,7 +18,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: ee293ccedf116ce1ed6e0d9c7f7f9adabd0c230618089bb173c7acffa487e020
+    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
 data:
   install_info: |
     ---
@@ -264,7 +264,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -330,6 +330,7 @@ spec:
             httpGet:
               path: /live
               port: 5555
+              scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 15
             successThreshold: 1
@@ -339,12 +340,13 @@ spec:
             httpGet:
               path: /ready
               port: 5555
+              scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
         - name: process-agent
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -392,13 +394,26 @@ spec:
               mountPath: /etc/datadog-agent/system-probe.yaml
               subPath: system-probe.yaml
         - name: system-probe
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
               add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "IPC_LOCK"]
           command: ["/opt/datadog-agent/embedded/bin/system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
           env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DOCKER_HOST
+              value: unix:///host/var/run/docker.sock
             - name: DD_LOG_LEVEL
               value: "INFO"
           resources: {}
@@ -417,7 +432,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -427,7 +442,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -462,7 +477,7 @@ spec:
               value: unix:///host/var/run/docker.sock
           resources: {}
         - name: seccomp-setup
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           command:
             - cp
             - /etc/config/system-probe-seccomp.json

--- a/static/resources/yaml/datadog-agent-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-vanilla.yaml
@@ -18,7 +18,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: ee293ccedf116ce1ed6e0d9c7f7f9adabd0c230618089bb173c7acffa487e020
+    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
 data:
   install_info: |
     ---
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -106,6 +106,7 @@ spec:
             httpGet:
               path: /live
               port: 5555
+              scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 15
             successThreshold: 1
@@ -115,12 +116,13 @@ spec:
             httpGet:
               path: /ready
               port: 5555
+              scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
         - name: process-agent
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -138,10 +140,10 @@ spec:
               value: "yes"
             - name: DOCKER_HOST
               value: unix:///host/var/run/docker.sock
-            - name: DD_PROCESS_AGENT_ENABLED
-              value: "true"
             - name: DD_LOG_LEVEL
               value: "INFO"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
@@ -161,7 +163,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -171,7 +173,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "datadog/agent:7.21.1"
+          image: "datadog/agent:7.23.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -219,6 +221,9 @@ spec:
           name: cgroups
         - name: s6-run
           emptyDir: {}
+        - hostPath:
+            path: /etc/passwd
+          name: passwd
       tolerations:
       affinity: {}
       serviceAccountName: "datadog-agent"

--- a/static/resources/yaml/datadog-agent-vanilla_values.yaml
+++ b/static/resources/yaml/datadog-agent-vanilla_values.yaml
@@ -1,7 +1,5 @@
 datadog:
   kubeStateMetricsEnabled: false
-  processAgent:
-    enabled: false
 agents:
   rbac:
     create: false

--- a/static/resources/yaml/datadog-agent-windows-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-apm.yaml
@@ -1,22 +1,54 @@
+# Source: datadog/templates/secrets.yaml
+# API Key
+apiVersion: v1
+kind: Secret
+metadata:
+  name: datadog-agent
+  labels: {}
+type: Opaque
+data:
+  api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
+
+# APP Key
+---
+# Source: datadog/templates/install_info-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-agent-installinfo
+  labels: {}
+  annotations:
+    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
+data:
+  install_info: |
+    ---
+    install_method:
+      tool: kubernetes sample manifests
+      tool_version: kubernetes sample manifests
+      installer_version: kubernetes sample manifests
+---
+# Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: datadog-agent-windows
+  name: datadog-agent
+  labels: {}
 spec:
   selector:
     matchLabels:
-      app: datadog-agent-windows
+      app: datadog-agent
   template:
     metadata:
       labels:
-        app: datadog-agent-windows
-      name: datadog-agent-windows
+        app: datadog-agent
+      name: datadog-agent
+      annotations: {}
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:latest"
-          imagePullPolicy: Always
-          command: ["agent", "start"]
+          image: "datadog/agent:7.23.0"
+          imagePullPolicy: IfNotPresent
+          command: ["agent", "run"]
           resources: {}
           ports:
             - containerPort: 8125
@@ -26,7 +58,7 @@ spec:
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: "datadog-agent-windows"
+                  name: "datadog-agent"
                   key: api-key
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
@@ -34,6 +66,8 @@ spec:
                   fieldPath: status.hostIP
             - name: KUBERNETES
               value: "yes"
+            - name: DOCKER_HOST
+              value: npipe:////./pipe/docker_engine
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
@@ -42,29 +76,41 @@ spec:
               value: "false"
             - name: DD_LOGS_ENABLED
               value: "false"
+            - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
+              value: "false"
+            - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
+              value: "true"
             - name: DD_HEALTH_PORT
               value: "5555"
           volumeMounts:
+            - name: config
+              mountPath: C:/ProgramData/Datadog
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
           livenessProbe:
             failureThreshold: 6
             httpGet:
-              path: /health
+              path: /live
               port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /ready
+              port: 5555
+              scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "datadog/agent:latest"
-          imagePullPolicy: Always
-          command:
-            [
-              "trace-agent",
-              "-foreground",
-              "-config=C:/ProgramData/Datadog/datadog.yaml",
-            ]
+          image: "datadog/agent:7.23.0"
+          imagePullPolicy: IfNotPresent
+          command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
           ports:
             - containerPort: 8126
@@ -75,7 +121,7 @@ spec:
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: "datadog-agent-windows"
+                  name: "datadog-agent"
                   key: api-key
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
@@ -83,6 +129,8 @@ spec:
                   fieldPath: status.hostIP
             - name: KUBERNETES
               value: "yes"
+            - name: DOCKER_HOST
+              value: npipe:////./pipe/docker_engine
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_APM_ENABLED
@@ -91,13 +139,64 @@ spec:
               value: "true"
             - name: DD_APM_RECEIVER_PORT
               value: "8126"
+          volumeMounts:
+            - name: config
+              mountPath: C:/ProgramData/Datadog
+            - name: runtimesocket
+              mountPath: \\.\pipe\docker_engine
           livenessProbe:
             initialDelaySeconds: 15
             periodSeconds: 15
             tcpSocket:
               port: 8126
             timeoutSeconds: 5
+      initContainers:
+        - name: init-volume
+          image: "datadog/agent:7.23.0"
+          imagePullPolicy: IfNotPresent
+          command: ["pwsh", "-Command"]
+          args:
+            - |
+              Copy-Item -Recurse -Force C:/ProgramData/Datadog C:/Temp
+              Copy-Item -Force C:/Temp/install_info/install_info C:/Temp/Datadog/install_info
+          volumeMounts:
+            - name: config
+              mountPath: C:/Temp/Datadog
+            - name: installinfo
+              mountPath: C:/Temp/install_info
+          resources: {}
+        - name: init-config
+          image: "datadog/agent:7.23.0"
+          imagePullPolicy: IfNotPresent
+          command: ["pwsh", "-Command"]
+          args:
+            - Get-ChildItem 'entrypoint-ps1' | ForEach-Object { & $_.FullName if (-Not $?) { exit 1 } }
+          volumeMounts:
+            - name: config
+              mountPath: C:/ProgramData/Datadog
+            - name: runtimesocket
+              mountPath: \\.\pipe\docker_engine
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DOCKER_HOST
+              value: npipe:////./pipe/docker_engine
+          resources: {}
       volumes:
+        - name: installinfo
+          configMap:
+            name: datadog-agent-installinfo
+        - name: config
+          emptyDir: {}
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
@@ -106,10 +205,15 @@ spec:
           key: node.kubernetes.io/os
           value: windows
           operator: Equal
-      serviceAccountName: datadog-agent-windows
+      affinity: {}
+      serviceAccountName: "datadog-agent"
       nodeSelector:
         kubernetes.io/os: windows
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
+
+# Source: datadog/templates/containers-common-env.yaml
+# The purpose of this template is to define a minimal set of environment
+# variables required to operate dedicated containers in the daemonset

--- a/static/resources/yaml/datadog-agent-windows-apm_values.yaml
+++ b/static/resources/yaml/datadog-agent-windows-apm_values.yaml
@@ -1,7 +1,10 @@
+targetSystem: windows
 datadog:
   kubeStateMetricsEnabled: false
   apm:
     enabled: true
+  processAgent:
+    enabled: false
 agents:
   rbac:
     create: false

--- a/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
@@ -1,22 +1,54 @@
+# Source: datadog/templates/secrets.yaml
+# API Key
+apiVersion: v1
+kind: Secret
+metadata:
+  name: datadog-agent
+  labels: {}
+type: Opaque
+data:
+  api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
+
+# APP Key
+---
+# Source: datadog/templates/install_info-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-agent-installinfo
+  labels: {}
+  annotations:
+    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
+data:
+  install_info: |
+    ---
+    install_method:
+      tool: kubernetes sample manifests
+      tool_version: kubernetes sample manifests
+      installer_version: kubernetes sample manifests
+---
+# Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: datadog-agent-windows
+  name: datadog-agent
+  labels: {}
 spec:
   selector:
     matchLabels:
-      app: datadog-agent-windows
+      app: datadog-agent
   template:
     metadata:
       labels:
-        app: datadog-agent-windows
-      name: datadog-agent-windows
+        app: datadog-agent
+      name: datadog-agent
+      annotations: {}
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:latest"
-          imagePullPolicy: Always
-          command: ["agent", "start"]
+          image: "datadog/agent:7.23.0"
+          imagePullPolicy: IfNotPresent
+          command: ["agent", "run"]
           resources: {}
           ports:
             - containerPort: 8125
@@ -26,7 +58,7 @@ spec:
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: "datadog-agent-windows"
+                  name: "datadog-agent"
                   key: api-key
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
@@ -34,10 +66,18 @@ spec:
                   fieldPath: status.hostIP
             - name: KUBERNETES
               value: "yes"
+            - name: DD_AC_EXCLUDE
+              value: "name:datadog-agent"
+            - name: DOCKER_HOST
+              value: npipe:////./pipe/docker_engine
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
               value: "8125"
+            - name: DD_LEADER_ELECTION
+              value: "true"
+            - name: DD_COLLECT_KUBERNETES_EVENTS
+              value: "true"
             - name: DD_APM_ENABLED
               value: "false"
             - name: DD_LOGS_ENABLED
@@ -49,6 +89,8 @@ spec:
             - name: DD_HEALTH_PORT
               value: "5555"
           volumeMounts:
+            - name: config
+              mountPath: C:/ProgramData/Datadog
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
             - name: pointerdir
@@ -62,21 +104,27 @@ spec:
           livenessProbe:
             failureThreshold: 6
             httpGet:
-              path: /health
+              path: /live
               port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /ready
+              port: 5555
+              scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "datadog/agent:latest"
-          imagePullPolicy: Always
-          command:
-            [
-              "trace-agent",
-              "-foreground",
-              "-config=C:/ProgramData/Datadog/datadog.yaml",
-            ]
+          image: "datadog/agent:7.23.0"
+          imagePullPolicy: IfNotPresent
+          command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
           ports:
             - containerPort: 8126
@@ -87,7 +135,7 @@ spec:
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: "datadog-agent-windows"
+                  name: "datadog-agent"
                   key: api-key
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
@@ -95,6 +143,10 @@ spec:
                   fieldPath: status.hostIP
             - name: KUBERNETES
               value: "yes"
+            - name: DD_AC_EXCLUDE
+              value: "name:datadog-agent"
+            - name: DOCKER_HOST
+              value: npipe:////./pipe/docker_engine
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_APM_ENABLED
@@ -103,13 +155,66 @@ spec:
               value: "true"
             - name: DD_APM_RECEIVER_PORT
               value: "8126"
+          volumeMounts:
+            - name: config
+              mountPath: C:/ProgramData/Datadog
+            - name: runtimesocket
+              mountPath: \\.\pipe\docker_engine
           livenessProbe:
             initialDelaySeconds: 15
             periodSeconds: 15
             tcpSocket:
               port: 8126
             timeoutSeconds: 5
+      initContainers:
+        - name: init-volume
+          image: "datadog/agent:7.23.0"
+          imagePullPolicy: IfNotPresent
+          command: ["pwsh", "-Command"]
+          args:
+            - |
+              Copy-Item -Recurse -Force C:/ProgramData/Datadog C:/Temp
+              Copy-Item -Force C:/Temp/install_info/install_info C:/Temp/Datadog/install_info
+          volumeMounts:
+            - name: config
+              mountPath: C:/Temp/Datadog
+            - name: installinfo
+              mountPath: C:/Temp/install_info
+          resources: {}
+        - name: init-config
+          image: "datadog/agent:7.23.0"
+          imagePullPolicy: IfNotPresent
+          command: ["pwsh", "-Command"]
+          args:
+            - Get-ChildItem 'entrypoint-ps1' | ForEach-Object { & $_.FullName if (-Not $?) { exit 1 } }
+          volumeMounts:
+            - name: config
+              mountPath: C:/ProgramData/Datadog
+            - name: runtimesocket
+              mountPath: \\.\pipe\docker_engine
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DD_AC_EXCLUDE
+              value: "name:datadog-agent"
+            - name: DOCKER_HOST
+              value: npipe:////./pipe/docker_engine
+          resources: {}
       volumes:
+        - name: installinfo
+          configMap:
+            name: datadog-agent-installinfo
+        - name: config
+          emptyDir: {}
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
@@ -127,10 +232,15 @@ spec:
           key: node.kubernetes.io/os
           value: windows
           operator: Equal
-      serviceAccountName: datadog-agent-windows
+      affinity: {}
+      serviceAccountName: "datadog-agent"
       nodeSelector:
         kubernetes.io/os: windows
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
+
+# Source: datadog/templates/containers-common-env.yaml
+# The purpose of this template is to define a minimal set of environment
+# variables required to operate dedicated containers in the daemonset

--- a/static/resources/yaml/datadog-agent-windows-logs-apm_values.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs-apm_values.yaml
@@ -1,3 +1,4 @@
+targetSystem: windows
 datadog:
   kubeStateMetricsEnabled: false
   leaderElection: true
@@ -8,6 +9,8 @@ datadog:
   acExclude: "name:datadog-agent"
   apm:
     enabled: true
+  processAgent:
+    enabled: false
 agents:
   rbac:
     create: false

--- a/static/resources/yaml/datadog-agent-windows-logs.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs.yaml
@@ -1,22 +1,54 @@
+# Source: datadog/templates/secrets.yaml
+# API Key
+apiVersion: v1
+kind: Secret
+metadata:
+  name: datadog-agent
+  labels: {}
+type: Opaque
+data:
+  api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
+
+# APP Key
+---
+# Source: datadog/templates/install_info-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-agent-installinfo
+  labels: {}
+  annotations:
+    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
+data:
+  install_info: |
+    ---
+    install_method:
+      tool: kubernetes sample manifests
+      tool_version: kubernetes sample manifests
+      installer_version: kubernetes sample manifests
+---
+# Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: datadog-agent-windows
+  name: datadog-agent
+  labels: {}
 spec:
   selector:
     matchLabels:
-      app: datadog-agent-windows
+      app: datadog-agent
   template:
     metadata:
       labels:
-        app: datadog-agent-windows
-      name: datadog-agent-windows
+        app: datadog-agent
+      name: datadog-agent
+      annotations: {}
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:latest"
-          imagePullPolicy: Always
-          command: ["agent", "start"]
+          image: "datadog/agent:7.23.0"
+          imagePullPolicy: IfNotPresent
+          command: ["agent", "run"]
           resources: {}
           ports:
             - containerPort: 8125
@@ -26,7 +58,7 @@ spec:
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: "datadog-agent-windows"
+                  name: "datadog-agent"
                   key: api-key
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
@@ -34,10 +66,18 @@ spec:
                   fieldPath: status.hostIP
             - name: KUBERNETES
               value: "yes"
+            - name: DD_AC_EXCLUDE
+              value: "name:datadog-agent"
+            - name: DOCKER_HOST
+              value: npipe:////./pipe/docker_engine
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
               value: "8125"
+            - name: DD_LEADER_ELECTION
+              value: "true"
+            - name: DD_COLLECT_KUBERNETES_EVENTS
+              value: "true"
             - name: DD_APM_ENABLED
               value: "false"
             - name: DD_LOGS_ENABLED
@@ -49,6 +89,8 @@ spec:
             - name: DD_HEALTH_PORT
               value: "5555"
           volumeMounts:
+            - name: config
+              mountPath: C:/ProgramData/Datadog
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
             - name: pointerdir
@@ -62,13 +104,72 @@ spec:
           livenessProbe:
             failureThreshold: 6
             httpGet:
-              path: /health
+              path: /live
               port: 5555
+              scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          readinessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /ready
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+      initContainers:
+        - name: init-volume
+          image: "datadog/agent:7.23.0"
+          imagePullPolicy: IfNotPresent
+          command: ["pwsh", "-Command"]
+          args:
+            - |
+              Copy-Item -Recurse -Force C:/ProgramData/Datadog C:/Temp
+              Copy-Item -Force C:/Temp/install_info/install_info C:/Temp/Datadog/install_info
+          volumeMounts:
+            - name: config
+              mountPath: C:/Temp/Datadog
+            - name: installinfo
+              mountPath: C:/Temp/install_info
+          resources: {}
+        - name: init-config
+          image: "datadog/agent:7.23.0"
+          imagePullPolicy: IfNotPresent
+          command: ["pwsh", "-Command"]
+          args:
+            - Get-ChildItem 'entrypoint-ps1' | ForEach-Object { & $_.FullName if (-Not $?) { exit 1 } }
+          volumeMounts:
+            - name: config
+              mountPath: C:/ProgramData/Datadog
+            - name: runtimesocket
+              mountPath: \\.\pipe\docker_engine
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DD_AC_EXCLUDE
+              value: "name:datadog-agent"
+            - name: DOCKER_HOST
+              value: npipe:////./pipe/docker_engine
+          resources: {}
       volumes:
+        - name: installinfo
+          configMap:
+            name: datadog-agent-installinfo
+        - name: config
+          emptyDir: {}
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
@@ -86,10 +187,15 @@ spec:
           key: node.kubernetes.io/os
           value: windows
           operator: Equal
-      serviceAccountName: datadog-agent-windows
+      affinity: {}
+      serviceAccountName: "datadog-agent"
       nodeSelector:
         kubernetes.io/os: windows
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
+
+# Source: datadog/templates/containers-common-env.yaml
+# The purpose of this template is to define a minimal set of environment
+# variables required to operate dedicated containers in the daemonset

--- a/static/resources/yaml/datadog-agent-windows-logs_values.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs_values.yaml
@@ -1,3 +1,4 @@
+targetSystem: windows
 datadog:
   kubeStateMetricsEnabled: false
   leaderElection: true
@@ -6,8 +7,8 @@ datadog:
     enabled: true
     containerCollectAll: true
   acExclude: "name:datadog-agent"
-  apm:
-    enabled: true
+  processAgent:
+    enabled: false
 agents:
   rbac:
     create: false

--- a/static/resources/yaml/datadog-agent-windows-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-windows-vanilla.yaml
@@ -1,22 +1,54 @@
+# Source: datadog/templates/secrets.yaml
+# API Key
+apiVersion: v1
+kind: Secret
+metadata:
+  name: datadog-agent
+  labels: {}
+type: Opaque
+data:
+  api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
+
+# APP Key
+---
+# Source: datadog/templates/install_info-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-agent-installinfo
+  labels: {}
+  annotations:
+    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
+data:
+  install_info: |
+    ---
+    install_method:
+      tool: kubernetes sample manifests
+      tool_version: kubernetes sample manifests
+      installer_version: kubernetes sample manifests
+---
+# Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: datadog-agent-windows
+  name: datadog-agent
+  labels: {}
 spec:
   selector:
     matchLabels:
-      app: datadog-agent-windows
+      app: datadog-agent
   template:
     metadata:
       labels:
-        app: datadog-agent-windows
-      name: datadog-agent-windows
+        app: datadog-agent
+      name: datadog-agent
+      annotations: {}
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:latest"
-          imagePullPolicy: Always
-          command: ["agent", "start"]
+          image: "datadog/agent:7.23.0"
+          imagePullPolicy: IfNotPresent
+          command: ["agent", "run"]
           resources: {}
           ports:
             - containerPort: 8125
@@ -26,7 +58,7 @@ spec:
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: "datadog-agent-windows"
+                  name: "datadog-agent"
                   key: api-key
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
@@ -34,6 +66,8 @@ spec:
                   fieldPath: status.hostIP
             - name: KUBERNETES
               value: "yes"
+            - name: DOCKER_HOST
+              value: npipe:////./pipe/docker_engine
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
@@ -42,21 +76,84 @@ spec:
               value: "false"
             - name: DD_LOGS_ENABLED
               value: "false"
+            - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
+              value: "false"
+            - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
+              value: "true"
             - name: DD_HEALTH_PORT
               value: "5555"
           volumeMounts:
+            - name: config
+              mountPath: C:/ProgramData/Datadog
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
           livenessProbe:
             failureThreshold: 6
             httpGet:
-              path: /health
+              path: /live
               port: 5555
+              scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          readinessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /ready
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+      initContainers:
+        - name: init-volume
+          image: "datadog/agent:7.23.0"
+          imagePullPolicy: IfNotPresent
+          command: ["pwsh", "-Command"]
+          args:
+            - |
+              Copy-Item -Recurse -Force C:/ProgramData/Datadog C:/Temp
+              Copy-Item -Force C:/Temp/install_info/install_info C:/Temp/Datadog/install_info
+          volumeMounts:
+            - name: config
+              mountPath: C:/Temp/Datadog
+            - name: installinfo
+              mountPath: C:/Temp/install_info
+          resources: {}
+        - name: init-config
+          image: "datadog/agent:7.23.0"
+          imagePullPolicy: IfNotPresent
+          command: ["pwsh", "-Command"]
+          args:
+            - Get-ChildItem 'entrypoint-ps1' | ForEach-Object { & $_.FullName if (-Not $?) { exit 1 } }
+          volumeMounts:
+            - name: config
+              mountPath: C:/ProgramData/Datadog
+            - name: runtimesocket
+              mountPath: \\.\pipe\docker_engine
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DOCKER_HOST
+              value: npipe:////./pipe/docker_engine
+          resources: {}
       volumes:
+        - name: installinfo
+          configMap:
+            name: datadog-agent-installinfo
+        - name: config
+          emptyDir: {}
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
@@ -65,10 +162,15 @@ spec:
           key: node.kubernetes.io/os
           value: windows
           operator: Equal
-      serviceAccountName: datadog-agent-windows
+      affinity: {}
+      serviceAccountName: "datadog-agent"
       nodeSelector:
         kubernetes.io/os: windows
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
+
+# Source: datadog/templates/containers-common-env.yaml
+# The purpose of this template is to define a minimal set of environment
+# variables required to operate dedicated containers in the daemonset

--- a/static/resources/yaml/datadog-agent-windows-vanilla_values.yaml
+++ b/static/resources/yaml/datadog-agent-windows-vanilla_values.yaml
@@ -1,7 +1,8 @@
+targetSystem: windows
 datadog:
   kubeStateMetricsEnabled: false
-  apm:
-    enabled: true
+  processAgent:
+    enabled: false
 agents:
   rbac:
     create: false


### PR DESCRIPTION
### What does this PR do?

* Regenerate from the latest helm chart
* Enable the `process-agent` in the `*_values.yaml`
* Add `values.yaml` files for the Windows manifests

### Motivation

Keep the sample manifests aligned with the latest tested Helm chart.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/lenaic/regenerate_k8s_manifests

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
