### PR TITLE
Fix Serverless Ruby instrumentation instructions

### DIFF
--- a/content/en/serverless/installation/ruby.md
+++ b/content/en/serverless/installation/ruby.md
@@ -61,9 +61,13 @@ Keep in mind that `ddtrace` uses native extensions, which must be compiled for A
 
 ### Configure the Function
 
-1. Wrap your Lambda handler function using the wrapper provided by the Datadog Lambda library.
+1. Enable Datadog APM and wrap your Lambda handler function using the wrapper provided by the Datadog Lambda library.
     ```ruby
     require 'datadog/lambda'
+    
+    Datadog::Lambda.configure_apm do |c|
+    # Enable the instrumentation
+    end
 
     def handler(event:, context:)
         Datadog::Lambda.wrap(event, context) do


### PR DESCRIPTION
### What does this PR do?

Fix Ruby instrumentation instructions.

### Motivation

https://github.com/DataDog/datadog-lambda-rb/issues/40

### Preview

https://docs-staging.datadoghq.com/tian.chu/update-serverless-ruby-instructions/serverless/installation/ruby/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
