### PR TITLE
[orchestrator_explorer] update char limit

### DIFF
--- a/content/en/infrastructure/livecontainers.md
+++ b/content/en/infrastructure/livecontainers.md
@@ -75,9 +75,9 @@ datadog:
    ...
 {{< /code-block >}}
 
-**Note**: The cluster name must be 40-characters or less.
+**Note**: The cluster name must be 80-characters or less.
 
-On Google's GKE, AWS EKS, and Azure AKS, this is unnecessary, unless the Agent and the cluster Agent don't have access to the cloud metadata APIs, or the cluster name is longer than 40 characters.
+On Google's GKE, AWS EKS, and Azure AKS, this is unnecessary, unless the Agent and the cluster Agent don't have access to the cloud metadata APIs, or the cluster name is longer than 80 characters.
 
 ## Configuration
 


### PR DESCRIPTION
With the helm update: https://github.com/DataDog/helm-charts/pull/73 `cluster-name` in the helm chart can have a length of up to 80.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
