### PR TITLE
APM -> Setup -> Converge Compatibility headers to "Compatibility Requirements"

### DIFF
--- a/content/en/tracing/setup/dotnet-core.md
+++ b/content/en/tracing/setup/dotnet-core.md
@@ -21,7 +21,7 @@ further_reading:
     text: "Advanced Usage"
 ---
 
-## Compatibility
+## Compatibility Requirements
 
 The .NET Tracer supports automatic instrumentation on .NET Core 2.1 and 3.1, as well as Microsoft-deprecated versions 2.0, 2.2 and 3.0.  For a full list of supported libraries, visit the [Compatibility Requirements][1] page.
 

--- a/content/en/tracing/setup/dotnet-framework.md
+++ b/content/en/tracing/setup/dotnet-framework.md
@@ -24,7 +24,7 @@ further_reading:
       tag: 'Advanced Usage'
       text: 'Advanced Usage'
 ---
-## Compatibility
+## Compatibility Requirements
 
 The .NET Tracer supports automatic instrumentation on .NET Framework 4.5 and above. For a full list of supported libraries, visit the [Compatibility Requirements][1] page.
 

--- a/content/en/tracing/setup/java.md
+++ b/content/en/tracing/setup/java.md
@@ -13,7 +13,7 @@ further_reading:
       tag: 'Documentation'
       text: 'Explore your services, resources and traces'
 ---
-## Compatibility requirements
+## Compatibility Requirements
 
 The Java Tracing Library supports all JVMs on all platforms version 7 and higher. To utililze tracing with the [Continous Profiler][17], OpenJDK 11+, Oracle Java 11+, OpenJDK 8 for most vendors (version 8u262+) and Zulu Java 8+ (minor version 1.8.0_212+) are supported. Starting in version 8u272+, all vendors will be supported for the Profiler. 
 

--- a/content/en/tracing/setup/python.md
+++ b/content/en/tracing/setup/python.md
@@ -19,7 +19,7 @@ further_reading:
       tag: 'Advanced Usage'
       text: 'Advanced Usage'
 ---
-## Compatibility requirements
+## Compatibility Requirements
 
 Python versions `2.7+` and `3.5+` are supported.  For a full list of supported libraries, visit the [Compatibility Requirements][1] page.
 


### PR DESCRIPTION
### What does this PR do?
Standardizes the compatibility header across APM languages

### Motivation
I noticed small inconsistencies across pages and thought this small change could help.

### Preview
https://docs-staging.datadoghq.com/zach.montoya/standardize-apm-compatibility-header/tracing/setup/dotnet-core/
https://docs-staging.datadoghq.com/zach.montoya/standardize-apm-compatibility-header/tracing/setup/dotnet-framework/
https://docs-staging.datadoghq.com/zach.montoya/standardize-apm-compatibility-header/tracing/setup/java/
https://docs-staging.datadoghq.com/zach.montoya/standardize-apm-compatibility-header/tracing/setup/python/

### Additional Notes
N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
