### PR TITLE
style on cards on tabs

### DIFF
--- a/src/styles/pages/_global.scss
+++ b/src/styles/pages/_global.scss
@@ -532,6 +532,9 @@ h5{
     .text-center img {
       border: 1px solid $ddgray;
     }
+    .card-body img {
+      border: 0px solid $ddgray;
+    }
   }
 }
 


### PR DESCRIPTION

### What does this PR do?
Adds style for images on cards on tabs, to remove border

### Motivation
Cards on tabs look like this: 
![image](https://user-images.githubusercontent.com/12926135/97760115-0c797580-1ac8-11eb-8231-607b6c4284c9.png)

and we want them to look like cards everywhere else: 
![image](https://user-images.githubusercontent.com/12926135/97760325-7a25a180-1ac8-11eb-82e5-a436dfb4e343.png)

### Preview
see partial cards on tab:
https://docs-staging.datadoghq.com/kari/style-cards-on-tabs/tracing/setup_overview/setup/java/?tab=containers

don't remove border on regular images on tabs:
https://docs-staging.datadoghq.com/kari/style-cards-on-tabs/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/?tab=awsconsole


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
