### PR TITLE
APM > Trace/Log Correlation > .NET > Update Serilog manual trace correlation docs

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -105,16 +105,23 @@ leverage the Datadog API to retrieve correlation identifiers:
 {{< tabs >}}
 {{% tab "Serilog" %}}
 
+**Note**: The Serilog library requires message property names to be valid C# identifiers, so the property names must be:
+- `dd_env`
+- `dd_service`
+- `dd_version`
+- `dd_trace_id`
+- `dd_span_id`
+
 ```csharp
 using Datadog.Trace;
 using Serilog.Context;
 
 // there must be spans started and active before this block.
-using (LogContext.PushProperty("dd.env", CorrelationIdentifier.Env))
-using (LogContext.PushProperty("dd.service", CorrelationIdentifier.Service))
-using (LogContext.PushProperty("dd.version", CorrelationIdentifier.Version))
-using (LogContext.PushProperty("dd.trace_id", CorrelationIdentifier.TraceId.ToString()))
-using (LogContext.PushProperty("dd.span_id", CorrelationIdentifier.SpanId.ToString()))
+using (LogContext.PushProperty("dd_env", CorrelationIdentifier.Env))
+using (LogContext.PushProperty("dd_service", CorrelationIdentifier.Service))
+using (LogContext.PushProperty("dd_version", CorrelationIdentifier.Version))
+using (LogContext.PushProperty("dd_trace_id", CorrelationIdentifier.TraceId.ToString()))
+using (LogContext.PushProperty("dd_span_id", CorrelationIdentifier.SpanId.ToString()))
 {
     // Log something
 }


### PR DESCRIPTION
### What does this PR do?
This PR updates the .NET Trace / Log correlation documents to use new, updated message property names for doing manual trace id injection when using the Serilog logging library.

### Motivation
Serilog requires message property names to be valid C# identifiers, so the current property names such as `dd.trace_id` and `dd.span_id` are invalid in message templates. We've recently updated the backend to accept the following properties and map them to the corresponding property:
- `dd_trace_id` => `dd.trace_id`
- `dd_span_id` => `dd.span_id`
- `dd_env`       => `dd.env`
- `dd_service`  => `dd.service`
- `dd_version`  => `dd.version`

### Preview
https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-serilog/tracing/connect_logs_and_traces/dotnet/?tab=serilog

### Additional Notes
Resolves #7367

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
