### PR TITLE
API's/IP's used instead of APIs/IPs

### DIFF
--- a/content/en/network_performance_monitoring/network_page.md
+++ b/content/en/network_performance_monitoring/network_page.md
@@ -95,7 +95,7 @@ TCP is a connection-oriented protocol that guarantees in-order delivery of packe
 
 ### DNS Resolution
 
-Starting with Agent 7.17+, the Agent resolves IP’s to human-readable domain names for external and internal traffic. Domain allows you to monitor cloud provider endpoints where a Datadog Agent cannot be installed, such as S3 buckets, application load balancers, and API’s. Unrecognizable domain names such as DGA domains from C&C servers may point to network security threats. **Domain is encoded as a tag in Datadog**, so you can use it in search bar queries and the facet panel to aggregate and filter traffic.
+Starting with Agent 7.17+, the Agent resolves IPs to human-readable domain names for external and internal traffic. Domain allows you to monitor cloud provider endpoints where a Datadog Agent cannot be installed, such as S3 buckets, application load balancers, and APIs. Unrecognizable domain names such as DGA domains from C&C servers may point to network security threats. **Domain is encoded as a tag in Datadog**, so you can use it in search bar queries and the facet panel to aggregate and filter traffic.
 
 {{< img src="network_performance_monitoring/network_page/domain_aggregation.png" alt="Domain aggregation" >}}
 


### PR DESCRIPTION
Swapped two instances to IPs/APIs, respectively, to match rest of doc.

### What does this PR do?
Fixes two instances of apostrophes used for pluralization (which is perhaps fine for acronyms, but is inconsistent with the rest of the doc, even if so). 

### Motivation
The apostrophes in the pluralization of API and IP stuck out to me while configuring this feature. 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
