### PR TITLE
Remove Non-existent S3 Action

### DIFF
--- a/content/ja/integrations/amazon_cloudtrail.md
+++ b/content/ja/integrations/amazon_cloudtrail.md
@@ -49,7 +49,6 @@ AWS CloudTrail は、AWS アカウントの監査証跡を提供します。Data
     | `s3:ListBucket`             | CloudTrail バケット内のオブジェクトをリストして、有効な証跡を取得します。|
     | `s3:GetBucketLocation`      | 証跡をダウンロードするバケットのリージョンを取得します。               |
     | `s3:GetObject`              | 有効な証跡を取得します。                                     |
-    | `s3:ListObjects`            | バケット内のオブジェクトの一部またはすべて（最大 1,000）を返します。   |
 
     このポリシーを Datadog IAM の既存のメインポリシーに追加します。
 
@@ -60,7 +59,7 @@ AWS CloudTrail は、AWS アカウントの監査証跡を提供します。Data
         "Principal": {
             "AWS": "<ARN_FROM_MAIN_AWS_INTEGRATION_SETUP>"
         },
-        "Action": ["s3:ListBucket", "s3:GetBucketLocation", "s3:GetObject", "s3:ListObjects"],
+        "Action": ["s3:ListBucket", "s3:GetBucketLocation", "s3:GetObject"],
         "Resource": [
             "arn:aws:s3:::<YOUR_S3_CLOUDTRAIL_BUCKET_NAME>",
             "arn:aws:s3:::<YOUR_S3_CLOUDTRAIL_BUCKET_NAME>/*"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
There is no s3:ListObjects Action. Instead, the s3:ListBucket Action can list objects.
AWS has a S3 API named ListObject.

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fix only this document in Japanese.
### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
