### PR TITLE
[PAU-19] Additional usage metrics that are GA

### DIFF
--- a/content/en/account_management/billing/usage_metrics.md
+++ b/content/en/account_management/billing/usage_metrics.md
@@ -27,6 +27,11 @@ Estimated usage metrics are generally available for the following usage types:
 | Custom Metrics       | `datadog.estimated_usage.metrics.custom` |
 | Logs Ingested Bytes  | `datadog.estimated_usage.logs.ingested_bytes`          |
 | Logs Ingested Events | `datadog.estimated_usage.logs.ingested_events`   |
+| APM Hosts            | `datadog.estimated_usage.apm_hosts`      |
+| APM Indexed Spans   | `datadog.estimated_usage.logs.apm.indexed_spans` |
+| APM Ingested Bytes   | `datadog.estimated_usage.logs.apm.ingested_bytes` |
+| APM Ingested Spans   | `datadog.estimated_usage.logs.apm.ingested_spans` |
+| Serverless Lambda Functions | `datadog.estimated_usage.serverless.aws_lambda_functions` |
 
 Log-based usage metrics must be manually enabled from the [Generate Metrics][1] page.
 


### PR DESCRIPTION
Updating list of usage types that have estimated usage metrics generally available: apm hosts, apm index/ingested spans/bytes, serverless lambda functions

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
