### PR TITLE
Update csharp.md

### DIFF
--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -353,7 +353,7 @@ var log = new LoggerConfiguration()
 For instance to forward logs to the Datadog EU region in TCP you would use the following sink configuration:
 
 ```csharp
-var config = new DatadogConfiguration(url: "intake.logs.datadoghq.eu", port: 443, useSSL: true, useTCP: true);
+var config = new DatadogConfiguration(url: "tcp-intake.logs.datadoghq.eu", port: 443, useSSL: true, useTCP: true);
 var log = new LoggerConfiguration()
     .WriteTo.DatadogLogs(
         "<API_KEY>",


### PR DESCRIPTION
Follow up on #8912 

# What does this PR do?
Fix the tcp intake endpoing for the eu intake which should be `tcp-intake.logs.datadoghq.eu` instead of `intake.logs.datadoghq.eu` according to our [endpoint list](https://docs.datadoghq.com/logs/log_collection/?tab=http#datadog-logs-endpoints)


### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

