### PR TITLE
remove categories and tags

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -10,8 +10,8 @@ publishDir: "./public"
 
 # taxonomies
 taxonomies:
-  tag: "tags"
-  category: "categories"
+  #tag: "tags"
+  #category: "categories"
   "video-category": "video-categories"
 
 # language


### PR DESCRIPTION
### What does this PR do?

This removes the taxonmy configuration of tags/categories as its generating pages we do not need.

### Motivation

Reported in slack

### Preview

The following pages should no longer exist. 

https://docs-staging.datadoghq.com/david.jones/unused-taxonomies/categories/
https://docs-staging.datadoghq.com/david.jones/unused-taxonomies/categories/collaboration/
https://docs-staging.datadoghq.com/david.jones/unused-taxonomies/tags/

Also spot check various page that this is having no other unintended effects

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
