### PR TITLE
Add .NET 5 support information to .NET Tracer documentation

### DIFF
--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
@@ -17,7 +17,7 @@ further_reading:
 
 The .NET Datadog Trace library is open source - view the [Github repository][1] for more information.
 
-The .NET Tracer supports automatic instrumentation on .NET 5 (starting with .NET Tracer `1.20.0`) and on LTS .NET Core versions 2.1 and 3.1. It also supports [.NET Framework][2].
+The .NET Tracer supports automatic instrumentation on .NET 5, .NET Core 3.1, and .NET Core 2.1. It also supports [.NET Framework][2].
 
 The .NET Tracer works on .NET Core 2.0, 2.2, and 3.0, but these versions reached their end of life and are no longer supported by Microsoft. See [Microsoft's support policy][3] for more details. We recommend using the latest patch version of .NET Core 2.1 or 3.1.  Older versions of .NET Core on Linux/x64 have JIT compiler bugs that can cause applications to throw exceptions when using automatic instrumentation. If your application is running on .NET Core 2.0, 2.1.0-2.1.11, or 2.2.0-2.2.5, we strongly recommend you update your .NET Core runtime. If you cannot update, you may need to set the environment variable `DD_CLR_DISABLE_OPTIMIZATIONS=true` to work around the issue. See [DataDog/dd-trace-dotnet/issues/302][4] for more details.
 

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
@@ -17,7 +17,7 @@ further_reading:
 
 The .NET Datadog Trace library is open source - view the [Github repository][1] for more information.
 
-The .NET Tracer supports automatic instrumentation on .NET Core 2.1 and 3.1. It also supports [.NET Framework][2].
+The .NET Tracer supports automatic instrumentation on .NET 5 (starting with .NET Tracer `1.20.0`) and on LTS .NET Core versions 2.1 and 3.1. It also supports [.NET Framework][2].
 
 The .NET Tracer works on .NET Core 2.0, 2.2, and 3.0, but these versions reached their end of life and are no longer supported by Microsoft. See [Microsoft's support policy][3] for more details. We recommend using the latest patch version of .NET Core 2.1 or 3.1.  Older versions of .NET Core on Linux/x64 have JIT compiler bugs that can cause applications to throw exceptions when using automatic instrumentation. If your application is running on .NET Core 2.0, 2.1.0-2.1.11, or 2.2.0-2.2.5, we strongly recommend you update your .NET Core runtime. If you cannot update, you may need to set the environment variable `DD_CLR_DISABLE_OPTIMIZATIONS=true` to work around the issue. See [DataDog/dd-trace-dotnet/issues/302][4] for more details.
 

--- a/content/en/tracing/setup_overview/custom_instrumentation/dotnet.md
+++ b/content/en/tracing/setup_overview/custom_instrumentation/dotnet.md
@@ -30,7 +30,7 @@ This page details common use cases for adding and customizing observability with
 
 Add the `Datadog.Trace` [NuGet package][1] to your application. To create new spans, access the global tracer through the `Datadog.Trace.Tracer.Instance` property.
 
-Custom instrumentation is supported on **.NET Framework 4.5+** for Windows and on **.NET Core 2.1, 3.0, and 3.1** for Windows and Linux.
+Custom instrumentation is supported on **.NET Framework 4.5+** for Windows, on **.NET Core 2.0+** for Windows and Linux, and on **.NET 5** for Windows and Linux.
 
 
 ## Add tags and spans

--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -28,7 +28,7 @@ further_reading:
 
 ## Compatibility Requirements
 
-The .NET Tracer supports automatic instrumentation on .NET 5 (starting with .NET Tracer `1.20.0`), LTS .NET Core versions 2.1 and 3.1, and Microsoft-deprecated .NET Core versions 2.0, 2.2 and 3.0.  For a full list of supported libraries, visit the [Compatibility Requirements][1] page.
+The .NET Tracer supports automatic instrumentation on .NET 5, .NET Core 3.1, and .NET Core 2.1. It also supports [.NET Framework][2]. For a full list of supported libraries, visit the [Compatibility Requirements][1] page.
 
 ## Getting started
 

--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -28,7 +28,7 @@ further_reading:
 
 ## Compatibility Requirements
 
-The .NET Tracer supports automatic instrumentation on .NET Core 2.1 and 3.1, as well as Microsoft-deprecated versions 2.0, 2.2 and 3.0.  For a full list of supported libraries, visit the [Compatibility Requirements][1] page.
+The .NET Tracer supports automatic instrumentation on .NET 5 (starting with .NET Tracer `1.20.0`), LTS .NET Core versions 2.1 and 3.1, and Microsoft-deprecated .NET Core versions 2.0, 2.2 and 3.0.  For a full list of supported libraries, visit the [Compatibility Requirements][1] page.
 
 ## Getting started
 
@@ -284,7 +284,7 @@ To manually instrument your code, add the `Datadog.Trace` [NuGet package][3] to 
 
 For more details on manual instrumentation and custom tagging, see [Manual instrumentation documentation][4].
 
-Manual instrumentation is supported on .NET Framework 4.5 and above on Windows and on .NET Core 2.1, 3.0, and 3.1 on Windows and Linux.
+Manual instrumentation is supported on .NET Framework 4.5 and above on Windows, on .NET Core 2.0 and above on Windows and Linux, and on .NET 5 on Windows and Linux.
 
 **Note:** When using both manual and automatic instrumentation, it is important to keep the MSI installer and NuGet package versions in sync.
 

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -119,7 +119,7 @@ To manually instrument your code, add the `Datadog.Trace` [NuGet package][5] to 
 
 For more details on manual instrumentation and custom tagging, see [Manual instrumentation documentation][6].
 
-Manual instrumentation is supported on .NET Framework 4.5 and above on Windows and on .NET Core 2.1, 3.0, and 3.1 on Windows and Linux.
+Manual instrumentation is supported on .NET Framework 4.5 and above on Windows, on .NET Core 2.0 and above on Windows and Linux, and on .NET 5 on Windows and Linux.
 
 **Note:** When using both manual and automatic instrumentation, it is important to keep the MSI installer and NuGet package versions in sync.
 


### PR DESCRIPTION
### What does this PR do?
This PR notes the following support in our .NET Tracer:
- Automatic instrumentation fully supports .NET 5 beginning with .NET Tracer version 1.20.0
- Custom instrumentation fully supports .NET 5 (no .NET Tracer version requirement)

### Motivation
.NET 5 is the upcoming release of .NET and it is being released on November 10. This docs update indicates our support of the platform and that the soon-to-be-released version 1.20.0 of the .NET Tracer has full automatic instrumentation support for the new platform.

### Preview
.NET Core Compatibility requirements: https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-core/net5/tracing/setup_overview/compatibility_requirements/dotnet-core

.NET Core Automatic Instrumentation: https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-core/net5/tracing/setup_overview/setup/dotnet-core/?tab=windows

.NET Framework Automatic Instrumentation: https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-core/net5/tracing/setup_overview/setup/dotnet-framework?tab=environmentvariables

.NET Custom Instrumentation: https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-core/net5/tracing/setup_overview/custom_instrumentation/dotnet

### Additional Notes
The .NET versioning scheme is taking a new direction. There was legacy .NET Framework 1-4, and then .NET Core 1-3. From here on out, even though the tech is based on .NET Core 3, the platform will be named .NET 5, .NET 6, .NET 7, etc. Since it requires the same environment variables and setup as .NET Core, the setup information has just been added into the .NET Core pages instead of broken out into a separate page.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
