### PR TITLE
add corp as a reviewer on package.json updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,4 @@
 /src/                     @DataDog/corpweb @DataDog/documentation
 /config/                  @DataDog/corpweb @DataDog/documentation
 /config/_default/menus/   @DataDog/documentation
+package.json              @DataDog/corpweb @DataDog/documentation


### PR DESCRIPTION
### What does this PR do?

PR to add corp as reviewers on`package.json` changes. This is reaction to #8979

### Motivation

yarn.lock needs updating when package.json is updated

### Preview

Should have no impact
https://docs-staging.datadoghq.com/david.jones/owner-update/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
