### PR TITLE
Update Helm stable repo location

### DIFF
--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -49,7 +49,7 @@ To install the chart with a custom release name, `<RELEASE_NAME>` (e.g. `datadog
 3. If this is a fresh install, add the Helm Datadog repo and the Helm stable repo (for Kube State Metrics chart):
     ```bash
     helm repo add datadog https://helm.datadoghq.com
-    helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+    helm repo add stable https://charts.helm.sh/stable
     helm repo update
     ```
 4. Retrieve your Datadog API key from your [Agent installation instructions][3] and run:


### PR DESCRIPTION
As per https://github.com/helm/charts/tree/69124f41ef7c3cca354b02e4799d653d0fb7c8fd#how-do-i-enable-the-stable-repository-for-helm-3 the new repo location is https://charts.helm.sh/stable Using the old repo location results in:
```
$ helm repo add stable https://kubernetes-charts.storage.googleapis.com
Error: repo "https://kubernetes-charts.storage.googleapis.com/" is no longer available; try "https://charts.helm.sh/stable" instead
```

The repo location changed on October 30th 2020 https://github.com/helm/charts/pull/23976/files.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
