### PR TITLE
Docker Hub / GCR Tables

### DIFF
--- a/content/en/agent/cluster_agent/_index.md
+++ b/content/en/agent/cluster_agent/_index.md
@@ -36,7 +36,7 @@ Using the Datadog Cluster Agent allows you to:
 * Enable the collection of cluster level data, such as the monitoring of services or SPOF and events.
 * Leverage horizontal pod autoscaling with custom Kubernetes metrics. Refer to [the dedicated guide][1] for more details about this feature.
 
-The Datadog Cluster Agent is available on Docker Hub and GCR:
+If you're using Docker, the Datadog Cluster Agent is available on Docker Hub and GCR:
 
 | Docker Hub                                       | GCR                                                       |
 |--------------------------------------------------|-----------------------------------------------------------|

--- a/content/en/agent/cluster_agent/_index.md
+++ b/content/en/agent/cluster_agent/_index.md
@@ -36,6 +36,12 @@ Using the Datadog Cluster Agent allows you to:
 * Enable the collection of cluster level data, such as the monitoring of services or SPOF and events.
 * Leverage horizontal pod autoscaling with custom Kubernetes metrics. Refer to [the dedicated guide][1] for more details about this feature.
 
+The Datadog Cluster Agent is available on Docker Hub and GCR:
+
+| Docker Hub                                       | GCR                                                       |
+|--------------------------------------------------|-----------------------------------------------------------|
+| [hub.docker.com/r/datadog/cluster-agent][2]      | [gcr.io/datadoghq/cluster-agent][3]                       |
+
 **Note**: To leverage all features from the Datadog Cluster Agent, you must run Kubernetes v1.10+.
 
 {{< whatsnext desc="This section includes the following topics:">}}
@@ -54,3 +60,5 @@ Using the Datadog Cluster Agent allows you to:
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/datadog-agent/blob/master/docs/cluster-agent/CUSTOM_METRICS_SERVER.md
+[2]: https://hub.docker.com/r/datadog/cluster-agent
+[3]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/cluster-agent

--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -31,13 +31,19 @@ further_reading:
 
 ## Overview
 
-The Datadog Docker Agent is the containerized version of the host [Agent][1]. The official [Docker image][2] is available on Docker Hub.
+The Datadog Docker Agent is the containerized version of the host [Agent][1]. The official [Docker image][2] is available on Docker Hub and GCR.
 
 Images are available for 64-bit x86 and Arm v8 architectures.
 
+| Docker Hub      | GCR             |
+|-----------------|-----------------|
+| [Agent v6+][2] | [Agent v6+][3] |
+| [Agent v5][4]  | [Agent v5][5]  |
+
+
 ## Setup
 
-If you haven’t installed the Docker Agent, follow the [in-app installation instructions][3] or see below. For [supported versions][4], see the Agent documentation. Use the one-step install command. Replace `<YOUR_DATADOG_API_KEY>` with your [Datadog API key][5].
+If you haven’t installed the Docker Agent, follow the [in-app installation instructions][6] or see below. For [supported versions][7], see the Agent documentation. Use the one-step install command. Replace `<YOUR_DATADOG_API_KEY>` with your [Datadog API key][8].
 
 {{< tabs >}}
 {{% tab "Standard" %}}
@@ -75,15 +81,15 @@ DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -v /var/run/docker.sock:/va
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note**: For Docker Compose, see [Compose and the Datadog Agent][6].
+**Note**: For Docker Compose, see [Compose and the Datadog Agent][9].
 
 ## Integrations
 
-Once the Agent is up and running, use [Datadog's Autodiscovery feature][7] to collect metrics and logs automatically from your application containers.
+Once the Agent is up and running, use [Datadog's Autodiscovery feature][10] to collect metrics and logs automatically from your application containers.
 
 ## Environment variables
 
-The Agent's [main configuration file][8] is `datadog.yaml`. For the Docker Agent, `datadog.yaml` configuration options are passed in with environment variables.
+The Agent's [main configuration file][11] is `datadog.yaml`. For the Docker Agent, `datadog.yaml` configuration options are passed in with environment variables.
 
 ### Global options
 
@@ -107,7 +113,7 @@ Starting with Agent v6.4.0 (and v6.5.0 for the Trace Agent), you can override th
 | `DD_PROXY_HTTPS`    | An HTTPS URL to use as a proxy for `https` requests.              |
 | `DD_PROXY_NO_PROXY` | A space-separated list of URLs for which no proxy should be used. |
 
-For more information about proxy settings, see the [Agent v6 Proxy documentation][9].
+For more information about proxy settings, see the [Agent v6 Proxy documentation][12].
 
 ### Optional collection Agents
 
@@ -115,13 +121,13 @@ Optional collection Agents are disabled by default for security or performance r
 
 | Env Variable               | Description                                                                                                                                                                                                                                                      |
 |----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DD_APM_ENABLED`           | Enable [trace collection][10] with the Trace Agent.                                                                                                                                                                                                               |
-| `DD_LOGS_ENABLED`          | Enable [log collection][11] with the Logs Agent.                                                                                                                                                                                                                 |
-| `DD_PROCESS_AGENT_ENABLED` | Enable [live process collection][12] with the Process Agent. The [live container view][13] is already enabled by default if the Docker socket is available. If set to `false`, the [live process collection][12] and the [live container view][13] are disabled. |
+| `DD_APM_ENABLED`           | Enable [trace collection][13] with the Trace Agent.                                                                                                                                                                                                               |
+| `DD_LOGS_ENABLED`          | Enable [log collection][14] with the Logs Agent.                                                                                                                                                                                                                 |
+| `DD_PROCESS_AGENT_ENABLED` | Enable [live process collection][15] with the Process Agent. The [live container view][16] is already enabled by default if the Docker socket is available. If set to `false`, the [live process collection][15] and the [live container view][16] are disabled. |
 
 ### DogStatsD (custom metrics)
 
-Send custom metrics with [the StatsD protocol][14]:
+Send custom metrics with [the StatsD protocol][17]:
 
 | Env Variable                     | Description                                                                                                                                                |
 |----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -132,13 +138,13 @@ Send custom metrics with [the StatsD protocol][14]:
 | `DD_DOGSTATSD_ORIGIN_DETECTION`  | Enable container detection and tagging for unix socket metrics.                                                                                            |
 | `DD_DOGSTATSD_TAGS`              | Additional tags to append to all metrics, events, and service checks received by this DogStatsD server, for example: `["env:golden", "group:retrievers"]`. |
 
-Learn more about [DogStatsD over Unix Domain Sockets][15].
+Learn more about [DogStatsD over Unix Domain Sockets][18].
 
 ### Tagging
 
-As a best practice, Datadog recommends using [unified service tagging][16] when assigning tags.
+As a best practice, Datadog recommends using [unified service tagging][19] when assigning tags.
 
-Datadog automatically collects common tags from [Docker][17], [Kubernetes][18], [ECS][19], [Swarm, Mesos, Nomad, and Rancher][17]. To extract even more tags, use the following options:
+Datadog automatically collects common tags from [Docker][20], [Kubernetes][21], [ECS][22], [Swarm, Mesos, Nomad, and Rancher][20]. To extract even more tags, use the following options:
 
 | Env Variable                            | Description                                               |
 |-----------------------------------------|-----------------------------------------------------------|
@@ -146,11 +152,11 @@ Datadog automatically collects common tags from [Docker][17], [Kubernetes][18], 
 | `DD_DOCKER_ENV_AS_TAGS`                 | Extract Docker container environment variables            |
 | `DD_COLLECT_EC2_TAGS`                   | Extract custom EC2 tags without using the AWS integration |
 
-See the [Docker Tag Extraction][20] documentation to learn more.
+See the [Docker Tag Extraction][23] documentation to learn more.
 
 ### Using secret files
 
-Integration credentials can be stored in Docker or Kubernetes secrets and used in Autodiscovery templates. For more information, see the [Secrets Management documentation][21].
+Integration credentials can be stored in Docker or Kubernetes secrets and used in Autodiscovery templates. For more information, see the [Secrets Management documentation][24].
 
 ### Ignore containers
 
@@ -167,7 +173,7 @@ Exclude containers from logs collection, metrics collection, and Autodiscovery. 
 | `DD_AC_INCLUDE` | **Deprecated**. Allowlist of containers to include (separated by spaces). Use `.*` to include all. For example: `"image:image_name_1 image:image_name_2"`, `image:.*`  |
 | `DD_AC_EXCLUDE` | **Deprecated**. Blocklist of containers to exclude (separated by spaces). Use `.*` to exclude all. For example: `"image:image_name_3 image:image_name_4"` (**Note**: This variable is only honored for Autodiscovery.), `image:.*` |
 
-Additional examples are available on the [Container Discover Management][22] page.
+Additional examples are available on the [Container Discover Management][25] page.
 
 **Note**: The `docker.containers.running`, `.stopped`, `.running.total` and `.stopped.total` metrics are not affected by these settings. All containers are counted. This does not affect your per-container billing.
 
@@ -182,7 +188,7 @@ You can add extra listeners and config providers using the `DD_EXTRA_LISTENERS` 
 
 ## Commands
 
-See the [Agent Commands guides][23] to discover all the Docker Agent commands.
+See the [Agent Commands guides][26] to discover all the Docker Agent commands.
 
 ## Data collected
 
@@ -192,16 +198,16 @@ By default, the Docker Agent collects metrics with the following core checks. To
 
 | Check       | Metrics       |
 |-------------|---------------|
-| CPU         | [System][24]  |
-| Disk        | [Disk][25]    |
-| Docker      | [Docker][26]  |
-| File Handle | [System][24]  |
-| IO          | [System][24]  |
-| Load        | [System][24]  |
-| Memory      | [System][24]  |
-| Network     | [Network][27] |
-| NTP         | [NTP][28]     |
-| Uptime      | [System][24]  |
+| CPU         | [System][27]  |
+| Disk        | [Disk][28]    |
+| Docker      | [Docker][29]  |
+| File Handle | [System][27]  |
+| IO          | [System][27]  |
+| Load        | [System][27]  |
+| Memory      | [System][27]  |
+| Network     | [Network][30] |
+| NTP         | [NTP][31]     |
+| Uptime      | [System][27]  |
 
 ### Events
 
@@ -221,29 +227,32 @@ Returns `CRITICAL` if an Agent check is unable to send metrics to Datadog, other
 
 [1]: /agent/
 [2]: https://hub.docker.com/r/datadog/agent
-[3]: https://app.datadoghq.com/account/settings#agent/docker
-[4]: /agent/basic_agent_usage/#supported-os-versions
-[5]: https://app.datadoghq.com/account/settings#api
-[6]: /integrations/faq/compose-and-the-datadog-agent/
-[7]: /agent/docker/integrations/
-[8]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
-[9]: /agent/proxy/#agent-v6
-[10]: /agent/docker/apm/
-[11]: /agent/docker/log/
-[12]: /infrastructure/process/
-[13]: /infrastructure/livecontainers/
-[14]: /developers/dogstatsd/
-[15]: /developers/dogstatsd/unix_socket/
-[16]: /getting_started/tagging/unified_service_tagging/
-[17]: https://github.com/DataDog/datadog-agent/blob/master/pkg/tagger/collectors/docker_extract.go
-[18]: https://github.com/DataDog/datadog-agent/blob/master/pkg/tagger/collectors/kubelet_extract.go
-[19]: https://github.com/DataDog/datadog-agent/blob/master/pkg/tagger/collectors/ecs_extract.go
-[20]: /agent/docker/tag/
-[21]: /agent/guide/secrets-management/?tab=linux
-[22]: /agent/guide/autodiscovery-management/
-[23]: /agent/guide/agent-commands/
-[24]: /integrations/system/#metrics
-[25]: /integrations/disk/#metrics
-[26]: /agent/docker/data_collected/#metrics
-[27]: /integrations/network/#metrics
-[28]: /integrations/ntp/#metrics
+[3]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/agent
+[4]: https://hub.docker.com/r/datadog/docker-dd-agent
+[5]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/docker-dd-agent?gcrImageListsize=30
+[6]: https://app.datadoghq.com/account/settings#agent/docker
+[7]: /agent/basic_agent_usage/#supported-os-versions
+[8]: https://app.datadoghq.com/account/settings#api
+[9]: /integrations/faq/compose-and-the-datadog-agent/
+[10]: /agent/docker/integrations/
+[11]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
+[12]: /agent/proxy/#agent-v6
+[13]: /agent/docker/apm/
+[14]: /agent/docker/log/
+[15]: /infrastructure/process/
+[16]: /infrastructure/livecontainers/
+[17]: /developers/dogstatsd/
+[18]: /developers/dogstatsd/unix_socket/
+[19]: /getting_started/tagging/unified_service_tagging/
+[20]: https://github.com/DataDog/datadog-agent/blob/master/pkg/tagger/collectors/docker_extract.go
+[21]: https://github.com/DataDog/datadog-agent/blob/master/pkg/tagger/collectors/kubelet_extract.go
+[22]: https://github.com/DataDog/datadog-agent/blob/master/pkg/tagger/collectors/ecs_extract.go
+[23]: /agent/docker/tag/
+[24]: /agent/guide/secrets-management/?tab=linux
+[25]: /agent/guide/autodiscovery-management/
+[26]: /agent/guide/agent-commands/
+[27]: /integrations/system/#metrics
+[28]: /integrations/disk/#metrics
+[29]: /agent/docker/data_collected/#metrics
+[30]: /integrations/network/#metrics
+[31]: /integrations/ntp/#metrics

--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -37,8 +37,8 @@ Images are available for 64-bit x86 and Arm v8 architectures.
 
 | Docker Hub      | GCR             |
 |-----------------|-----------------|
-| [Agent v6+][2] | [Agent v6+][3] |
-| [Agent v5][4]  | [Agent v5][5]  |
+| [Agent v6+][2]  | [Agent v6+][3]  |
+| [Agent v5][4]   | [Agent v5][5]   |
 
 
 ## Setup

--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -40,7 +40,6 @@ Images are available for 64-bit x86 and Arm v8 architectures.
 | [Agent v6+][2]  | [Agent v6+][3]  |
 | [Agent v5][4]   | [Agent v5][5]   |
 
-
 ## Setup
 
 If you haven’t installed the Docker Agent, follow the [in-app installation instructions][6] or see below. For [supported versions][7], see the Agent documentation. Use the one-step install command. Replace `<YOUR_DATADOG_API_KEY>` with your [Datadog API key][8].

--- a/content/en/agent/guide/_index.md
+++ b/content/en/agent/guide/_index.md
@@ -31,4 +31,5 @@ private: true
     {{< nextlink href="agent/guide/agent-5-kubernetes-basic-agent-usage" >}}Kubernetes Basic Agent Usage in Agent v5{{< /nextlink >}}
     {{< nextlink href="agent/guide/dogstream" >}}Dogstream{{< /nextlink >}}
     {{< nextlink href="agent/guide/upgrade-to-agent-v6" >}}Upgrade to Datadog Agent v6{{< /nextlink >}}
+    {{< nextlink href="agent/guide/agent-commands" >}}Container Images for Docker Environments{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/agent/guide/_index.md
+++ b/content/en/agent/guide/_index.md
@@ -24,6 +24,7 @@ private: true
     {{< nextlink href="agent/guide/autodiscovery-management" >}}Manage container discovery with the Agent.{{< /nextlink >}}
     {{< nextlink href="agent/guide/ad_identifiers" >}}Apply an Autodiscovery configuration file template to a given container with the ad_identifers parameter.{{< /nextlink >}}
     {{< nextlink href="agent/guide/operator-advanced" >}}Advanced setup for Datadog Operator.{{< /nextlink >}}
+    {{< nextlink href="/agent/guide/container-images-for-docker-environments" >}}Container Images for Docker Environments{{< /nextlink >}}
 {{< /whatsnext >}}
 <br>
 {{< whatsnext desc="Agent 5 Guides:" >}}
@@ -31,5 +32,4 @@ private: true
     {{< nextlink href="agent/guide/agent-5-kubernetes-basic-agent-usage" >}}Kubernetes Basic Agent Usage in Agent v5{{< /nextlink >}}
     {{< nextlink href="agent/guide/dogstream" >}}Dogstream{{< /nextlink >}}
     {{< nextlink href="agent/guide/upgrade-to-agent-v6" >}}Upgrade to Datadog Agent v6{{< /nextlink >}}
-    {{< nextlink href="agent/guide/agent-commands" >}}Container Images for Docker Environments{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/agent/guide/container-images-for-docker-environments.md
+++ b/content/en/agent/guide/container-images-for-docker-environments.md
@@ -5,25 +5,34 @@ further_reading:
 - link: "/agent/docker/"
   tag: "Documentation"
   text: "Get started with the Docker Agent"
+- link: "/agent/cluster_agent/"
+  tag: "Documentation"
+  text: "Get started with the Cluster Agent"
 ---
 
 ## Overview
 
-If you are currently using Docker, there are several container images available through Docker Hub and GCR:
+If you are currently using Docker, there are several container images available through Docker Hub and GCR that you may want to use within your environment:
 
-| Docker Hub                                   | GCR                             |
-|----------------------------------------------|---------------------------------|
-| [Datadog Agent (v6+)][1]                     | [Datadog Agent (v6+)][2]        |
-| [Datadog Agent (v5)][3]                      | [Datadog Agent (v5)][2]         |
-| [DogStatsD][4]                               | [DogStatsD][5]                  |
-| [Cluster Agent][6]                           | [Cluster Agent][7]              |
-| [Synthetics Private Location Worker][8]      | N/A                             |
+| Datadog Product                          | Docker Hub Image                             | GCR Image                            |
+|------------------------------------------|----------------------------------------------|---------------------------------|
+| [Docker Agent][1]                        | [Docker Agent (v6+)][2]                      | [Docker Agent (v6+)][3]         |
+|                                          | [Docker Agent (v5)][4]                       | [Docker Agent (v5)][3]          |
+| [DogStatsD][5]                          | [DogStatsD][6]                               | [DogStatsD][7]                  |
+| [Datadog Cluster Agent][8]              | [Cluster Agent][9]                           | [Cluster Agent][10]              |
+| [Synthetics Private Location Worker][11] | [Synthetics Private Location Worker][12]      | N/A                             |
 
-[1]: https://hub.docker.com/r/datadog/agent
-[2]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/agent
-[3]: https://hub.docker.com/r/datadog/docker-dd-agent
-[4]: https://hub.docker.com/r/datadog/dogstatsd
-[5]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/dogstatsd
-[6]: https://hub.docker.com/r/datadog/cluster-agent
-[7]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/cluster-agent
-[8]: https://hub.docker.com/r/datadog/synthetics-private-location-worker
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /agent/docker/
+[2]: https://hub.docker.com/r/datadog/agent
+[3]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/agent
+[4]: https://hub.docker.com/r/datadog/docker-dd-agent
+[5]: /developers/dogstatsd/
+[6]: https://hub.docker.com/r/datadog/dogstatsd
+[7]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/dogstatsd
+[8]: /agent/cluster_agent/
+[9]: https://hub.docker.com/r/datadog/cluster-agent
+[10]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/cluster-agent
+[11]: /getting_started/synthetics/private_location.md
+[12]: https://hub.docker.com/r/datadog/synthetics-private-location-worker

--- a/content/en/agent/guide/container-images-for-docker-environments.md
+++ b/content/en/agent/guide/container-images-for-docker-environments.md
@@ -1,0 +1,29 @@
+---
+title: Container Images for Docker Environments
+kind: documentation
+further_reading:
+- link: "/agent/docker/"
+  tag: "Documentation"
+  text: "Get started with the Docker Agent"
+---
+
+## Overview
+
+If you are currently using Docker, there are several container images available through Docker Hub and GCR:
+
+| Docker Hub                                   | GCR                             |
+|----------------------------------------------|---------------------------------|
+| [Datadog Agent (v6+)][1]                     | [Datadog Agent (v6+)][2]        |
+| [Datadog Agent (v5)][3]                      | [Datadog Agent (v5)][2]         |
+| [DogStatsD][4]                               | [DogStatsD][5]                  |
+| [Cluster Agent][6]                           | [Cluster Agent][7]              |
+| [Synthetics Private Location Worker][8]      | N/A                             |
+
+[1]: https://hub.docker.com/r/datadog/agent
+[2]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/agent
+[3]: https://hub.docker.com/r/datadog/docker-dd-agent
+[4]: https://hub.docker.com/r/datadog/dogstatsd
+[5]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/dogstatsd
+[6]: https://hub.docker.com/r/datadog/cluster-agent
+[7]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/cluster-agent
+[8]: https://hub.docker.com/r/datadog/synthetics-private-location-worker

--- a/content/en/developers/dogstatsd/_index.md
+++ b/content/en/developers/dogstatsd/_index.md
@@ -31,9 +31,15 @@ Any compliant StatsD client works with DogStatsD and the Agent, but you won't be
 
 **Note**: DogStatsD does NOT implement Timers from StatsD as a native metric type (though it [does support them via histograms][2]).
 
+DogStatsD is available on Docker Hub and GCR:
+
+| Docker Hub                                       | GCR                                                       |
+|--------------------------------------------------|-----------------------------------------------------------|
+| [hub.docker.com/r/datadog/dogstatsd][3]          | [gcr.io/datadoghq/dogstatsd][4]                          |
+
 ## How it works
 
-DogStatsD accepts [custom metrics][3], [events][4], and [service checks][5] over UDP and periodically aggregates and forwards them to Datadog.
+DogStatsD accepts [custom metrics][5], [events][6], and [service checks][7] over UDP and periodically aggregates and forwards them to Datadog.
 
 Because it uses UDP, your application can send metrics to DogStatsD and resume its work without waiting for a response. If DogStatsD ever becomes unavailable, your application won't experience an interruption.
 
@@ -217,7 +223,7 @@ To gather custom metrics with [DogStatsD][1] with helm:
 
 #### Install the DogStatsD client
 
-Official Datadog-DogStatsD client libraries are available for the following languages. You _can_ use any [generic StatsD client][6] to send metrics to DogStatsD, but you won't be able to use any of the Datadog-specific features mentioned above:
+Official Datadog-DogStatsD client libraries are available for the following languages. You _can_ use any [generic StatsD client][8] to send metrics to DogStatsD, but you won't be able to use any of the Datadog-specific features mentioned above:
 
 {{< tabs >}}
 {{% tab "Python" %}}
@@ -394,7 +400,7 @@ using (var dogStatsdService = new DogStatsdService())
 
 ### Client instantiation parameters
 
-**Note**: As a best practice, Datadog recommends using unified service tagging when assigning tags. Unified service tagging ties Datadog telemetry together through the use of three standard tags: `env`, `service`, and `version`. To learn how to unify your environment, refer to the dedicated [unified service tagging][7] documentation.
+**Note**: As a best practice, Datadog recommends using unified service tagging when assigning tags. Unified service tagging ties Datadog telemetry together through the use of three standard tags: `env`, `service`, and `version`. To learn how to unify your environment, refer to the dedicated [unified service tagging][9] documentation.
 
 In addition to the required DogStatsD configuration (`url` and `port`), the following optional parameters are available for your DogStatsD client:
 
@@ -487,13 +493,15 @@ DogStatsD and StatsD are broadly similar, however, DogStatsD contains advanced f
 {{< nextlink href="/developers/service_checks/dogstatsd_service_checks_submission/" >}}Send service checks to Datadog with DogStatsD.{{< /nextlink >}}
 {{< /whatsnext >}}
 
-If you're interested in learning more about the datagram format used by DogStatsD, or want to develop your own Datadog library, see the [datagram and shell usage][8] section, which also explains how to send metrics and events straight from the command line.
+If you're interested in learning more about the datagram format used by DogStatsD, or want to develop your own Datadog library, see the [datagram and shell usage][10] section, which also explains how to send metrics and events straight from the command line.
 
 [1]: https://github.com/etsy/statsd
 [2]: /developers/metrics/dogstatsd_metrics_submission/
-[3]: /developers/metrics/custom_metrics/
-[4]: /developers/events/dogstatsd/
-[5]: /developers/service_checks/dogstatsd_service_checks_submission/
-[6]: /developers/libraries/#api-and-dogstatsd-client-libraries
-[7]: /getting_started/tagging/unified_service_tagging
-[8]: /developers/metrics/
+[3]: https://hub.docker.com/r/datadog/dogstatsd
+[4]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/dogstatsd
+[5]: /developers/metrics/custom_metrics/
+[6]: /developers/events/dogstatsd/
+[7]: /developers/service_checks/dogstatsd_service_checks_submission/
+[8]: /developers/libraries/#api-and-dogstatsd-client-libraries
+[9]: /getting_started/tagging/unified_service_tagging
+[10]: /developers/metrics/

--- a/content/en/developers/dogstatsd/_index.md
+++ b/content/en/developers/dogstatsd/_index.md
@@ -35,7 +35,7 @@ DogStatsD is available on Docker Hub and GCR:
 
 | Docker Hub                                       | GCR                                                       |
 |--------------------------------------------------|-----------------------------------------------------------|
-| [hub.docker.com/r/datadog/dogstatsd][3]          | [gcr.io/datadoghq/dogstatsd][4]                          |
+| [hub.docker.com/r/datadog/dogstatsd][3]          | [gcr.io/datadoghq/dogstatsd][4]                           |
 
 ## How it works
 

--- a/content/en/getting_started/synthetics/private_location.md
+++ b/content/en/getting_started/synthetics/private_location.md
@@ -28,13 +28,19 @@ Your private location worker pulls your test configurations from Datadog’s ser
 
 {{< img src="synthetics/private_locations/test_results_pl.png" alt="Assign Synthetic test to private location"  style="width:100%;">}}
 
+The private location worker is available on Docker Hub:
+
+| Docker Hub                                                                |
+|---------------------------------------------------------------------------|
+| [hub.docker.com/r/datadog/synthetics-private-location-worker][3]          |
+
 ## Create your Private Location
 
 1. Set up a [Vagrant Ubuntu 16.04 virtual machine][2].
-2. Install [Docker][3] on that machine.
-3. In the Datadog app, hover over **[UX Monitoring][4]** and select *Settings* -> *Private Locations*. Click **Add Private Location**.
+2. Install [Docker][4] on that machine.
+3. In the Datadog app, hover over **[UX Monitoring][5]** and select *Settings* -> *Private Locations*. Click **Add Private Location**.
 4. Fill out your private location details (only `Name` and `API key` fields are mandatory). Click **Save Location and Generate Configuration File** to generate the configuration file associated with your private location on your worker.
-5. Specify the proxy URL if the traffic between your private location and Datadog needs to go through a proxy. You can also optionally toggle the **Block reserved IPs** button to block a default set of reserved IP ranges ([IPv4 address registry][5] and [IPv6 address registry][6]).
+5. Specify the proxy URL if the traffic between your private location and Datadog needs to go through a proxy. You can also optionally toggle the **Block reserved IPs** button to block a default set of reserved IP ranges ([IPv4 address registry][6] and [IPv6 address registry][7]).
 6. Copy and paste your private location configuration file to your working directory.
 
     **Note**: The configuration file contains secrets for private location authentication, test configuration decryption, and test result encryption. Datadog does not store the secrets, so store them locally before leaving the Private Locations screen. **You need to be able to reference these secrets again if you decide to add more workers, or to install workers on another host.**
@@ -76,7 +82,8 @@ You are now able to use your new private location as any other Datadog managed l
 
 [1]: /getting_started/synthetics/api_test/
 [2]: https://app.vagrantup.com/ubuntu/boxes/xenial64
-[3]: https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-docker-ce
-[4]: https://app.datadoghq.com/synthetics/list
-[5]: https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
-[6]: https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
+[3]: https://hub.docker.com/r/datadog/synthetics-private-location-worker
+[4]: https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-docker-ce
+[5]: https://app.datadoghq.com/synthetics/list
+[6]: https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
+[7]: https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml


### PR DESCRIPTION
### What does this PR do?
Adds Docker Hub / GCR tables to their corresponding docs

### Motivation
Jeremy 🙃 

### Preview
https://docs-staging.datadoghq.com/sarina/dockerhub-gcr-links/agent/cluster_agent/
https://docs-staging.datadoghq.com/sarina/dockerhub-gcr-links/agent/docker/
https://docs-staging.datadoghq.com/sarina/dockerhub-gcr-links/developers/dogstatsd/
https://docs-staging.datadoghq.com/sarina/dockerhub-gcr-links/getting_started/synthetics/private_location

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
