### PR TITLE
[WEB-924] fix api anchors with accents

### DIFF
--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -146,8 +146,8 @@
                 <!-- endpoint section start -->
                 <div class="row">
                     <div class="col-12 col-lg-9">
-                        <h2 class="mb-2" id="{{ .action.summary | urlize }}">
-                            <a href="#{{ .action.summary | urlize }}">{{- $translate_action.summary | default .action.summary -}}</a>
+                        <h2 class="mb-2" id="{{ ($translate_action.summary | default .action.summary) | urlize }}">
+                            <a href="#{{ ($translate_action.summary | default .action.summary) | urlize }}">{{- $translate_action.summary | default .action.summary -}}</a>
                         </h2>
                         {{ with index .action "x-unstable"}}
                         <div class="alert alert-warning mb-2">
@@ -569,7 +569,7 @@
                                         <div class="code-button-wrapper position-absolute">
                                             <button class="btn text-primary js-copy-button">{{ i18n "copy" }}</button>
                                         </div>
-                                    
+
                                         {{ highlight $file_content $lang.name "" }}
                                     </div>
                                     </div>

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -146,8 +146,8 @@
                 <!-- endpoint section start -->
                 <div class="row">
                     <div class="col-12 col-lg-9">
-                        <h2 class="mb-2" id="{{ ($translate_action.summary | default .action.summary) | urlize }}">
-                            <a href="#{{ ($translate_action.summary | default .action.summary) | urlize }}">{{- $translate_action.summary | default .action.summary -}}</a>
+                        <h2 class="mb-2" id="{{ ($translate_action.summary | default .action.summary) | anchorize }}">
+                            <a href="#{{ ($translate_action.summary | default .action.summary) | anchorize }}">{{- $translate_action.summary | default .action.summary -}}</a>
                         </h2>
                         {{ with index .action "x-unstable"}}
                         <div class="alert alert-warning mb-2">

--- a/layouts/partials/nav/api-main-menu.html
+++ b/layouts/partials/nav/api-main-menu.html
@@ -36,7 +36,7 @@
             <ul class="nav">
                 {{ range .Children }}
                     <li class="nav-item {{ if $currentPage.IsMenuCurrent $apiMenu . }}active{{ end }}">
-                        <a class="nav-link" href="{{ if hasPrefix .ConfiguredURL "#" }}#{{ .Name | urlize }}{{ else }}{{ .URL }}{{ end }}" data-target="#{{.Identifier}}">
+                        <a class="nav-link" href="{{ if hasPrefix .URL "#" }}#{{ .Name | anchorize }}{{ else }}{{ .URL | absLangURL }}{{ end }}" data-target="#{{.Identifier}}">
                             <span class="d-inline-block">{{ .Name }}</span>
                         </a>
                     </li>

--- a/layouts/partials/nav/api-main-menu.html
+++ b/layouts/partials/nav/api-main-menu.html
@@ -36,7 +36,7 @@
             <ul class="nav">
                 {{ range .Children }}
                     <li class="nav-item {{ if $currentPage.IsMenuCurrent $apiMenu . }}active{{ end }}">
-                        <a class="nav-link" href="{{ if hasPrefix .URL "#" }}#{{ .Name | anchorize }}{{ else }}{{ .URL | absLangURL }}{{ end }}" data-target="#{{.Identifier}}">
+                        <a class="nav-link" href="{{ if hasPrefix .URL "#" }}#{{ .Name | anchorize }}{{ else }}{{ (strings.TrimLeft "/" .URL) | absLangURL }}{{ end }}" data-target="#{{.Identifier}}">
                             <span class="d-inline-block">{{ .Name }}</span>
                         </a>
                     </li>

--- a/layouts/partials/nav/api-main-menu.html
+++ b/layouts/partials/nav/api-main-menu.html
@@ -24,7 +24,7 @@
 {{ if ne $currentPage.Lang "en" }}
     {{ $currentEnURL = (print "/" (strings.TrimLeft (print "/" .Lang "/") $currentPage.RelPermalink)) }}
 {{ end }}
-                
+
 <ul class="list-unstyled">
 {{ range $menu }}
     <!-- check if on /api/ top level section page, don't generate sub anchors if true -->
@@ -33,10 +33,10 @@
             <a href="{{ (strings.TrimLeft "/" .URL) | absLangURL }}">
                 <span>{{ .Name }}</span>
             </a>
-            <ul class="nav"> 
+            <ul class="nav">
                 {{ range .Children }}
                     <li class="nav-item {{ if $currentPage.IsMenuCurrent $apiMenu . }}active{{ end }}">
-                        <a class="nav-link" href="{{ .URL }}" data-target="#{{.Identifier}}">
+                        <a class="nav-link" href="{{ if hasPrefix .ConfiguredURL "#" }}#{{ .Name | urlize }}{{ else }}{{ .URL }}{{ end }}" data-target="#{{.Identifier}}">
                             <span class="d-inline-block">{{ .Name }}</span>
                         </a>
                     </li>


### PR DESCRIPTION
### What does this PR do?

The anchor in the nav e.g https://docs.datadoghq.com/fr/api/v1/dashboards/#recuperer-un-dashboard is french but the actual a tag is english ```<h2 class="mb-2" id="get-a-dashboard"><a href="#get-a-dashboard">Récupérer un dashboard</a></h2>``` 

This pr makes links and anchors more consistent and works across languages with special characters.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-924

### Preview

Test french anchors from the left nav work
https://docs-staging.datadoghq.com/david.jones/anchorfix/fr/api/v1/dashboards/

Test english navigation on api page
Also test api overview page subnav links as these are not anchors and should still work like prod

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
