### PR TITLE
APM > .NET > Logs injection: Remove reference to LibLog library

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -21,7 +21,7 @@ further_reading:
 
 Enable injection in the .NET Tracer’s [configuration][1] by setting `DD_LOGS_INJECTION=true` through environment variables or the configuration files.
 
-The .NET Tracer uses the [LibLog][2] library to automatically inject trace IDs, span IDs, `env`, `service`, and `version` into your application logs. If you haven't done so already, it is recommended to configure the .NET tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This will provide the best experience when adding `env`, `service`, and `version` (see [Unified Service Tagging][3] for more details).
+The .NET Tracer can automatically inject trace IDs, span IDs, `env`, `service`, and `version`. If you haven't done so already, it is recommended to configure the .NET tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This will provide the best experience when adding `env`, `service`, and `version` (see [Unified Service Tagging][3] for more details).
 
 We support [Serilog][4], [NLog][5] (version 2.0.0.2000+), or [log4net][6]. Automatic injection only displays in the application logs after enabling `LogContext` enrichment in your `Serilog` logger or `Mapped Diagnostics Context` in your `NLog` or `log4net` logger (see examples below).
 

--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -21,7 +21,7 @@ further_reading:
 
 Enable injection in the .NET Tracer’s [configuration][1] by setting `DD_LOGS_INJECTION=true` through environment variables or the configuration files.
 
-The .NET Tracer can automatically inject trace IDs, span IDs, `env`, `service`, and `version` into your application logs. If you haven't done so already, it is recommended to configure the .NET tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This will provide the best experience when adding `env`, `service`, and `version` (see [Unified Service Tagging][3] for more details).
+The .NET Tracer can automatically inject trace IDs, span IDs, `env`, `service`, and `version` into your application logs. If you haven't done so already, Datadog recommends configuring the .NET tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This provides the best experience when adding `env`, `service`, and `version` (see [Unified Service Tagging][3] for more details).
 
 We support [Serilog][4], [NLog][5] (version 2.0.0.2000+), or [log4net][6]. Automatic injection only displays in the application logs after enabling `LogContext` enrichment in your `Serilog` logger or `Mapped Diagnostics Context` in your `NLog` or `log4net` logger (see examples below).
 

--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -21,7 +21,7 @@ further_reading:
 
 Enable injection in the .NET Tracer’s [configuration][1] by setting `DD_LOGS_INJECTION=true` through environment variables or the configuration files.
 
-The .NET Tracer can automatically inject trace IDs, span IDs, `env`, `service`, and `version`. If you haven't done so already, it is recommended to configure the .NET tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This will provide the best experience when adding `env`, `service`, and `version` (see [Unified Service Tagging][3] for more details).
+The .NET Tracer can automatically inject trace IDs, span IDs, `env`, `service`, and `version` into your application logs. If you haven't done so already, it is recommended to configure the .NET tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This will provide the best experience when adding `env`, `service`, and `version` (see [Unified Service Tagging][3] for more details).
 
 We support [Serilog][4], [NLog][5] (version 2.0.0.2000+), or [log4net][6]. Automatic injection only displays in the application logs after enabling `LogContext` enrichment in your `Serilog` logger or `Mapped Diagnostics Context` in your `NLog` or `log4net` logger (see examples below).
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
A small update to the .NET APM <> Logs trace_id injection documentation. 

### Motivation
Customer confusion around that statement of LibLog. 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jaycdave88-patch-2/tracing/connect_logs_and_traces/dotnet/?tab=serilog

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
