### PR TITLE
Error tracking supports custom errors from RUM

### DIFF
--- a/content/en/real_user_monitoring/error_tracking/_index.md
+++ b/content/en/real_user_monitoring/error_tracking/_index.md
@@ -31,7 +31,7 @@ Error Tracking makes it easier to monitor these errors by:
 
 ## Getting started
 
-Error Tracking processes errors collected from the browser by the RUM SDK (errors with [source origin][1]).
+Error Tracking processes errors collected from the browser by the RUM SDK: whenever a [source][1] or [custom][2] error containing a stack trace is collected, Error Tracking will process it and group it under an issue (group of similar errors).
 
 To quickly get started with error tracking:
 
@@ -91,7 +91,8 @@ For Error Tracking to properly work with your source maps, you must configure yo
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /real_user_monitoring/data_collected/error#error-origins
-[2]: https://www.npmjs.com/package/@datadog/browser-rum
-[3]: /real_user_monitoring/browser/#initialization-parameters
-[4]: https://github.com/DataDog/datadog-ci/
-[5]: https://webpack.js.org/guides/code-splitting/
+[2]: /real_user_monitoring/browser/advanced_configuration#custom-errors
+[3]: https://www.npmjs.com/package/@datadog/browser-rum
+[4]: /real_user_monitoring/browser/#initialization-parameters
+[5]: https://github.com/DataDog/datadog-ci/
+[6]: https://webpack.js.org/guides/code-splitting/

--- a/content/en/real_user_monitoring/error_tracking/_index.md
+++ b/content/en/real_user_monitoring/error_tracking/_index.md
@@ -31,7 +31,7 @@ Error Tracking makes it easier to monitor these errors by:
 
 ## Getting started
 
-Error Tracking processes errors collected from the browser by the RUM SDK: whenever a [source][1] or [custom][2] error containing a stack trace is collected, Error Tracking will process it and group it under an issue (group of similar errors).
+Error Tracking processes errors collected from the browser by the RUM SDK: whenever a [source][1] or [custom][2] error containing a stack trace is collected, Error Tracking processes and groups it under an issue (group of similar errors).
 
 To quickly get started with error tracking:
 

--- a/content/en/real_user_monitoring/error_tracking/_index.md
+++ b/content/en/real_user_monitoring/error_tracking/_index.md
@@ -90,7 +90,7 @@ For Error Tracking to properly work with your source maps, you must configure yo
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /real_user_monitoring/data_collected/error#error-origins
+[1]: /real_user_monitoring/browser/data_collected/?tab=error#error-origins
 [2]: /real_user_monitoring/browser/advanced_configuration#custom-errors
 [3]: https://www.npmjs.com/package/@datadog/browser-rum
 [4]: /real_user_monitoring/browser/#initialization-parameters

--- a/content/en/real_user_monitoring/error_tracking/_index.md
+++ b/content/en/real_user_monitoring/error_tracking/_index.md
@@ -35,8 +35,8 @@ Error Tracking processes errors collected from the browser by the RUM SDK: whene
 
 To quickly get started with error tracking:
 
-1. Download the latest version of the [RUM Browser SDK][2].
-2. Configure the __version__, the __env__ and the __service__ when [initializing your SDK][3].
+1. Download the latest version of the [RUM Browser SDK][3].
+2. Configure the __version__, the __env__ and the __service__ when [initializing your SDK][4].
 
 ### Upload mapping files
 
@@ -45,7 +45,7 @@ The consequence is that stack traces of errors fired from those applications are
 
 #### Javascript source maps
 
-Source maps are mapping files generated when minifying Javascript source code. The [Datadog CLI][4] can be used to upload those mapping files from your build directory: it scans the build directory and its subdirectories to automatically upload the source maps with their related minified files. Upload your source maps directly from your CI pipeline:
+Source maps are mapping files generated when minifying Javascript source code. The [Datadog CLI][5] can be used to upload those mapping files from your build directory: it scans the build directory and its subdirectories to automatically upload the source maps with their related minified files. Upload your source maps directly from your CI pipeline:
 
 {{< tabs >}}
 {{% tab "US" %}}
@@ -84,7 +84,7 @@ datadog-ci sourcemaps upload /path/to/dist \
 For Error Tracking to properly work with your source maps, you must configure your Javascript bundler so that:
 
 -   Source maps directly include the related source code. Make sure the <code>sourcesContent</code> attribute is not empty before uploading them.
--   The size of each source map augmented with the size of the related minified file does not exceed __our limit of 50mb__. This sum can be reduced by configuring your bundler to split the source code into multiple smaller chunks ([see how to do this with WebpackJS][5]).
+-   The size of each source map augmented with the size of the related minified file does not exceed __our limit of 50mb__. This sum can be reduced by configuring your bundler to split the source code into multiple smaller chunks ([see how to do this with WebpackJS][6]).
 
 ## Further Reading
 


### PR DESCRIPTION
### What does this PR do?
Error tracking supports custom errors from RUM.

### Preview
Preview [link](https://docs-staging.datadoghq.com/maxime.matheron/error-tracking-custom-errors/real_user_monitoring/error_tracking/?tab=us#getting-started)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
