### PR TITLE
Improve Secrets doc

### DIFF
--- a/content/en/agent/guide/secrets-management.md
+++ b/content/en/agent/guide/secrets-management.md
@@ -111,7 +111,7 @@ On Windows, the executable set as `secret_backend_command` must:
 
 * Have read/exec for `ddagentuser` (the user used to run the Agent).
 * Have no rights for any user or group except for the `Administrators` group, the built-in Local System account, or the Agent user context (`ddagentuser` by default)
-* Be a valid Win32 application so the Agent can execute it.
+* Be a valid Win32 application so the Agent can execute it (a PowerShell or Python script would not work for example).
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
### What does this PR do?

We now explicitly say that PowerShell or Python script are not valid Win32 app

### Motivation

Some customers contacted support about powershell script not working with the secrets feature

### Preview

https://docs-staging.datadoghq.com/maxime/secret-powershell

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
