### PR TITLE
Caroline.kim/specify unaffected kubelet metrics

### DIFF
--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -174,7 +174,7 @@ Exclude containers from logs collection, metrics collection, and Autodiscovery. 
 
 Additional examples are available on the [Container Discover Management][25] page.
 
-**Note**: The `docker.containers.running`, `.stopped`, `.running.total` and `.stopped.total` metrics are not affected by these settings. All containers are counted. This does not affect your per-container billing.
+**Note**: The `kubernetes.containers.running`, `kubernetes.pods.running`, `docker.containers.running`, `.stopped`, `.running.total` and `.stopped.total` metrics are not affected by these settings. All containers are counted. This does not affect your per-container billing.
 
 ### Misc
 

--- a/content/en/agent/guide/autodiscovery-management.md
+++ b/content/en/agent/guide/autodiscovery-management.md
@@ -12,7 +12,7 @@ further_reading:
 
 Datadog Agent auto-discovers all containers available by default. To restrict its discovery perimeter and limit data collection to a subset of containers only, include or exclude them through a dedicated configuration.
 
-**Note**: The `docker.containers.running`, `.stopped`, `.running.total`, and `.stopped.total` metrics are not affected by these settings and always count all containers.
+**Note**: The `kubernetes.containers.running`, `kubernetes.pods.running`, `docker.containers.running`, `.stopped`, `.running.total`, and `.stopped.total` metrics are not affected by these settings and always count all containers.
 
 If running the Agent as a binary on a host, configure your Autodiscovery perimeter with the [Agent](?tab=agent) tab instructions. If running the Agent as a container, configure your Autodiscovery perimeter with the [Containerized Agent](?tab=containerizedagent) tab instructions.
 

--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -379,7 +379,7 @@ Exclude containers from logs collection, metrics collection, and Autodiscovery. 
 
 Additional examples are available on the [Container Discover Management][14] page.
 
-**Note**: The `docker.containers.running`, `.stopped`, `.running.total` and `.stopped.total` metrics are not affected by these settings. All containers are counted. This does not affect your per-container billing.
+**Note**: The `kubernetes.containers.running`, `kubernetes.pods.running`, `docker.containers.running`, `.stopped`, `.running.total` and `.stopped.total` metrics are not affected by these settings. All containers are counted. This does not affect your per-container billing.
 
 ### Misc
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds `kubernetes.containers.running` and `kubernetes.pods.running` to the list of metrics that will not be excluded when using the container discovery managements settings. These metrics don't take into account exclusion filters in the [kubelet check](https://github.com/DataDog/integrations-core/blob/master/kubelet/datadog_checks/kubelet/kubelet.py#L491) and this behavior was confirmed by the Container Integrations team to be intentional.

### Motivation
Customer escalation in which the customer believed the exclusion settings were not working properly

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
* https://docs-staging.datadoghq.com/caroline.kim/specify-unaffected-kubelet-metrics/agent/docker/?tab=standard#ignore-containers
* https://docs-staging.datadoghq.com/caroline.kim/specify-unaffected-kubelet-metrics/agent/kubernetes/?tab=helm#ignore-containers
* https://docs-staging.datadoghq.com/caroline.kim/specify-unaffected-kubelet-metrics/agent/guide/autodiscovery-management/?tab=containerizedagent

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
