### PR TITLE
Add Watt units

### DIFF
--- a/content/en/developers/metrics/units.md
+++ b/content/en/developers/metrics/units.md
@@ -28,6 +28,7 @@ To eliminate ambiguity and help you make sense of your systems, the following un
 | LOGGING     | entry                                                                                                                                                                                                                                                                                                                      |
 | TEMPERATURE | degree celsius / degree fahrenheit                                                                                                                                                                                                                                                                                         |
 | CPU         | nanocore / microcore / millicore / core / kilocore / megacore / gigacore / teracore / petacore / exacore                                                                                                                                                                                                                   |
+| POWER         | nanowatt / microwatt / milliwatt / watt / kilowatt / megawatt / gigawatt / terrawatt                                                                                                                                                                                                                   |
 
 Units are displayed automatically on timeseries graphs, query value widgets, and toplists, as shown in the following screenshot of a Redis dashboard:
 


### PR DESCRIPTION
### What does this PR do?
This PR adds Watt units to the list of units.

### Motivation
The Watts units are missing from the documentation.

### Preview
https://docs-staging.datadoghq.com/julien.lebot/add_watt_units/developers/metrics/units/

### Additional Notes
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
