### PR TITLE
Fix link to querying for Top List widget

### DIFF
--- a/content/en/dashboards/widgets/top_list.md
+++ b/content/en/dashboards/widgets/top_list.md
@@ -29,7 +29,7 @@ The top list visualization enables you to display a list of Tag values like `hos
 ### Configuration
 
 1. Choose the data to graph:
-    * Metric: See the documentation [querying][6] to configure a metric query.
+    * Metric: See the [querying][6] documentation to configure a metric query.
     * Indexed Spans: See [the trace search documentation][2] to configure an Indexed Span query.
     * Log Events: See [the log search documentation][1] to configure a log event query.
 

--- a/content/en/dashboards/widgets/top_list.md
+++ b/content/en/dashboards/widgets/top_list.md
@@ -29,7 +29,7 @@ The top list visualization enables you to display a list of Tag values like `hos
 ### Configuration
 
 1. Choose the data to graph:
-    * Metric: See the documentation [querying][1] to configure a metric query.
+    * Metric: See the documentation [querying][6] to configure a metric query.
     * Indexed Spans: See [the trace search documentation][2] to configure an Indexed Span query.
     * Log Events: See [the log search documentation][1] to configure a log event query.
 
@@ -98,3 +98,4 @@ Additional properties allowed in the `request` object:
 [3]: /dashboards/graphing_json/widget_json/
 [4]: /dashboards/graphing_json/request_json/
 [5]: /dashboards/graphing_json/widget_json/#conditional-format-schema
+[6]: /dashboards/querying/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
Changes the link to point to the Querying section

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->
I saw that the current link takes me to the logs search syntax, which is probably not intended
### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
