### PR TITLE
Fix YAML spacing for HPA example

### DIFF
--- a/content/en/agent/cluster_agent/external_metrics.md
+++ b/content/en/agent/cluster_agent/external_metrics.md
@@ -187,7 +187,7 @@ spec:
   metrics:
     - type: External
       external:
-      metricName: "datadogmetric@<namespace>:<datadogmetric_name>"
+        metricName: "datadogmetric@<namespace>:<datadogmetric_name>"
 ```
 
 **Example**: An HPA using the `DatadogMetric` named `nginx-requests`, assuming both objects are in namespace `nginx-demo`:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes the YAML spacing for the HPA example

### Motivation
`metricName` should be a key under `external` like in the full HPA manifest example right below it

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/caroline.kim/fix-hpa-yaml-spacing/agent/cluster_agent/external_metrics/#set-up-an-hpa-to-use-a-datadogmetric-object

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
