### PR TITLE
fix codeblocks and links for kubernetes resources

### DIFF
--- a/content/en/infrastructure/livecontainers.md
+++ b/content/en/infrastructure/livecontainers.md
@@ -51,14 +51,14 @@ If you are using the official [Datadog Helm Chart][1]:
 
 - Set the Cluster Agent container with the following environment variable:
 
-      ```
+    ```yaml
       - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
         value: "true"
-      ```
-
-- Set the Cluster Agent ClusterRole with the following [RBAC permissions][18]:
-
     ```
+
+- Set the Cluster Agent ClusterRole with the following RBAC permissions:
+
+    ```yaml
       ClusterRole:
       - apiGroups:  # To create the datadog-cluster-id CM
         - ""
@@ -85,15 +85,15 @@ If you are using the official [Datadog Helm Chart][1]:
         - list
         - get
         - watch
-      ```
+    ```
 
     These permissions are needed to create a `datadog-cluster-id` ConfigMap in the same Namespace as the Agent DaemonSet and the Cluster Agent Deployment, as well as to collect Deployments and ReplicaSets.
 
     If the `cluster-id` ConfigMap doesn't get created by the Cluster Agent, the Agent pod will not start, and fall in `CreateContainerConfigError` status. If the Agent pod is stuck because this ConfigMap doesn't exist, update the Cluster Agent permissions and restart its pods to let it create the ConfigMap and the Agent pod will recover automatically.
 
-2. [The Process Agent][18], which runs in the Agent DaemonSet, must be enabled and running (it doesn't need to run the process collection), and configured with the following options:
+2. The Process Agent which runs in the Agent DaemonSet, must be enabled and running (it doesn't need to run the process collection), and configured with the following options:
 
-    ```
+    ```yaml
     - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
       value: "true"
     - name: DD_ORCHESTRATOR_CLUSTER_ID


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Fix codeblocks and broken links in kubernetes resources doc

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/haissam/fix-k8s-resources-doc/infrastructure/livecontainers

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
