### PR TITLE
Add jmxfetch.log to agent log files list

### DIFF
--- a/content/en/agent/guide/agent-log-files.md
+++ b/content/en/agent/guide/agent-log-files.md
@@ -57,6 +57,7 @@ The Datadog Agent does a logs rollover every 10MB. When a rollover occurs, one b
 * `agent.log`
 * `process-agent.log`
 * `trace-agent.log`
+* `jmxfetch.log` for Agent >= 7.24.0/6.24.0
 
 {{% /tab %}}
 {{% tab "Agent v5" %}}


### PR DESCRIPTION
### What does this PR do?
Add `jmxfetch.log` to agent log files list as jmxfetch will be logging into it's own file (agent >= 7.24).

### Motivation
Keep doc up to date.

### Preview
https://docs-staging.datadoghq.com/prognant/add-jmxfetch.log-to-log-file-list/agent/guide/agent-log-files/?tab=agentv6v7

### Additional Notes
Do not merge before the Agent release 7.24.0 is out.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
