### PR TITLE
Fix for DaemonSet tab in Live Containers

### DIFF
--- a/content/en/infrastructure/livecontainers.md
+++ b/content/en/infrastructure/livecontainers.md
@@ -49,49 +49,49 @@ If you are using the official [Datadog Helm Chart][1]:
 
 1. [Cluster Agent][1] version >= 1.9.0 is required before configuring the DaemonSet. The Cluster Agent must be running, and the Agent must be able to communicate with it. See the [Cluster Agent Setup documentation][2] for configuration.
 
-- Set the Cluster Agent container with the following environment variable:
+    - Set the Cluster Agent container with the following environment variable:
 
-    ```yaml
-      - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
-        value: "true"
-    ```
+        ```yaml
+          - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+            value: "true"
+        ```
 
-- Set the Cluster Agent ClusterRole with the following RBAC permissions:
+    - Set the Cluster Agent ClusterRole with the following RBAC permissions:
 
-    ```yaml
-      ClusterRole:
-      - apiGroups:  # To create the datadog-cluster-id CM
-        - ""
-        resources:
-        - configmaps
-        verbs:
-        - create
-        - get
-        - update
-      ...
-      - apiGroups:  # Required to get the kube-system namespace UID and generate a cluster ID
-        - ""
-        resources:
-        - namespaces
-        verbs:
-        - get
-      ...
-      - apiGroups:  # to collect new resource types
-        - "apps"
-        resources:
-        - deployments
-        - replicasets
-        verbs:
-        - list
-        - get
-        - watch
-    ```
+        ```yaml
+          ClusterRole:
+          - apiGroups:  # To create the datadog-cluster-id CM
+            - ""
+            resources:
+            - configmaps
+            verbs:
+            - create
+            - get
+            - update
+          ...
+          - apiGroups:  # Required to get the kube-system namespace UID and generate a cluster ID
+            - ""
+            resources:
+            - namespaces
+            verbs:
+            - get
+          ...
+          - apiGroups:  # to collect new resource types
+            - "apps"
+            resources:
+            - deployments
+            - replicasets
+            verbs:
+            - list
+            - get
+            - watch
+        ```
 
     These permissions are needed to create a `datadog-cluster-id` ConfigMap in the same Namespace as the Agent DaemonSet and the Cluster Agent Deployment, as well as to collect Deployments and ReplicaSets.
 
     If the `cluster-id` ConfigMap doesn't get created by the Cluster Agent, the Agent pod will not start, and fall in `CreateContainerConfigError` status. If the Agent pod is stuck because this ConfigMap doesn't exist, update the Cluster Agent permissions and restart its pods to let it create the ConfigMap and the Agent pod will recover automatically.
 
-2. The Process Agent which runs in the Agent DaemonSet, must be enabled and running (it doesn't need to run the process collection), and configured with the following options:
+2. The Process Agent, which runs in the Agent DaemonSet, must be enabled and running (it doesn't need to run the process collection), and configured with the following options:
 
     ```yaml
     - name: DD_ORCHESTRATOR_EXPLORER_ENABLED


### PR DESCRIPTION
### What does this PR do?

Formats the DaemonSet tab correctly (indents for formatting, adds space between bottom paragraphs in step 1; adds comma to step 2 instructions)
 
### Motivation
Resolve to earlier fixes

### Preview
https://docs-staging.datadoghq.com/sarina/live-containers-edit/infrastructure/livecontainers/?tab=daemonset

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
