### PR TITLE
Fix broken link to Grok parsing

### DIFF
--- a/content/en/logs/processing/processors.md
+++ b/content/en/logs/processing/processors.md
@@ -18,7 +18,7 @@ further_reading:
 
 {{< img src="logs/processing/processors/processors_overview.png" alt="original log" >}}
 
-A [Processor][1] executes within a [Pipeline][2] to complete a data-structuring action ([Remapping an attribute][3], [Grok parsing][4], etc.) on a log.
+A [Processor][1] executes within a [Pipeline][2] to complete a data-structuring action ([Remapping an attribute][3], [Grok parsing][12], etc.) on a log.
 
 **Note**: Structured logs should be shipped in a valid format. If the structure contains invalid characters for parsing, these should be stripped at the Agent level using the [mask_sequences][5] feature.
 
@@ -764,3 +764,4 @@ Use the [Datadog Log Pipeline API endpoint][1] with the following Trace remapper
 [9]: /logs/processing/parsing/?tab=filter#matcher-and-filter
 [10]: /logs/guide/enrichment-tables/
 [11]: /tracing/connect_logs_and_traces/
+[12]: /logs/processing/processors/?tab=ui#grok-parser


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Changes the Grok parsing link destination from a Wikipedia page on syslog severity levels to the Datadog Grok parser documentation.

### Motivation
<!-- What inspired you to submit this pull request?-->
Noticed the typo when I was going through the processor documentation.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/katyapotapov/processors-typo-fix/logs/processing/processors/?tab=ui

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Not sure if this link is very useful, since it links to the very next section on this page - but I found that it was the most useful source of information for Grok parsing.

---

### Reviewer checklist
- [X] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
