### PR TITLE
Update java install instructions for gradle

### DIFF
--- a/content/en/tracing/setup_overview/setup/java.md
+++ b/content/en/tracing/setup_overview/setup/java.md
@@ -454,7 +454,7 @@ Add the `dd-trace-api` dependency to your project. For Maven, add this to `pom.x
 For Gradle, add:
 
 ```gradle
-compile group: 'com.datadoghq', name: 'dd-trace-api', version: {version}
+implementation group: 'com.datadoghq', name: 'dd-trace-api', version: {version}
 ```
 
 Now add `@Trace` to methods to have them be traced when running with `dd-java-agent.jar`. If the Agent is not attached, this annotation has no effect on your application.


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Changes the gradle install instructions to be more in line with what the latest version of gradle expects.

### Motivation
<!-- What inspired you to submit this pull request?-->

The current documentation results in a warning for me, with a recommendation to switch before gradle 7 is released.

Warning message
```
The compile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. Please use the implementation configuration instead. Consult the upgrading guide for further information: https://docs.gradle.org/6.7/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations
```

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
