### PR TITLE
Update apm.md

### DIFF
--- a/content/en/agent/kubernetes/apm.md
+++ b/content/en/agent/kubernetes/apm.md
@@ -92,6 +92,7 @@ agent:
     name: "datadog/agent:latest"
   apm:
     enabled: true
+    hostPort: 8126
 ```
 
 See the sample [manifest with APM and metrics collection enabled][1] for a complete example.


### PR DESCRIPTION
The APM enablement steps requires that the APM containerPort be mapped to a hostPort. This PR is to update the sample in the Operator tab.

PR to modify the sample manifest: https://github.com/DataDog/datadog-operator/pull/176


### Motivation
To prevent customers from encountering issues in sending APM traces using the Datadog Operator.