### PR TITLE
monitor notifications - negation of condition in is_match

### DIFF
--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -239,6 +239,15 @@ To notify your DB team if a triggering host has the tag `role:db_cassandra` or `
 {{/is_match}}
 ```
 
+To send a different notification if the tag doesn't contain `db` use the negation of the condition as follows:
+
+```text
+{{^#is_match "role.name" "db"}}
+  This displays if the role tag doesn't contain `db`.
+  @slack-example
+{{/is_match}}
+```
+
 **Note**: To check if a `<TAG_VARIABLE>` is **NOT** empty, use an empty string for the `<COMPARISON_STRING>`.
 
 {{% /tab %}}

--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -239,7 +239,7 @@ To notify your DB team if a triggering host has the tag `role:db_cassandra` or `
 {{/is_match}}
 ```
 
-It also supports multiple strings match:
+The `is_match` condition also supports matching multiple strings:
 
 ```text
 {{#is_match "role.name" "db" "database"}}
@@ -248,7 +248,7 @@ It also supports multiple strings match:
 {{/is_match}}
 ```
 
-To send a different notification if the tag doesn't contain `db` use the negation of the condition as follows:
+To send a different notification if the tag doesn't contain `db`, use the negation of the condition as follows:
 
 ```text
 {{^#is_match "role.name" "db"}}

--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -239,10 +239,31 @@ To notify your DB team if a triggering host has the tag `role:db_cassandra` or `
 {{/is_match}}
 ```
 
+It also supports multiple strings match:
+
+```text
+{{#is_match "role.name" "db" "database"}}
+  This displays if the host triggering the alert contains `db` or `database`
+  in the role name. @db-team@company.com
+{{/is_match}}
+```
+
 To send a different notification if the tag doesn't contain `db` use the negation of the condition as follows:
 
 ```text
 {{^#is_match "role.name" "db"}}
+  This displays if the role tag doesn't contain `db`.
+  @slack-example
+{{/is_match}}
+```
+
+Or use the `{{else}}` parameter in the first example:
+
+```text
+{{#is_match "role.name" "db"}}
+  This displays if the host triggering the alert contains `db`
+  in the role name. @db-team@company.com
+{{else}}
   This displays if the role tag doesn't contain `db`.
   @slack-example
 {{/is_match}}


### PR DESCRIPTION
### What does this PR do?
Add an example to negate the condition when doing `is_match`

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/is_match-monitor-notif/monitors/notifications/?tab=is_match#examples

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
