### PR TITLE
updating postman spec to include automatically importing the env

### DIFF
--- a/content/en/api/_index.md
+++ b/content/en/api/_index.md
@@ -18,7 +18,7 @@ The Datadog API is an HTTP REST API. The API uses resource-oriented URLs to call
 
 Authenticate to the API with an [API key][1], and depending on the endpoint, an [Application key][2].
 
-To try out the API [![Run in Postman][3]](https://app.getpostman.com/run-collection/add08e16382f7e11a59a)
+To try out the API [![Run in Postman][3]](https://app.getpostman.com/run-collection/bf4ac0b68b8ff47419c1#?env%5BDatadog%20Authentication%5D=W3sia2V5IjoiYXBwbGljYXRpb25fa2V5IiwidmFsdWUiOiIiLCJlbmFibGVkIjp0cnVlfSx7ImtleSI6ImFwaV9rZXkiLCJ2YWx1ZSI6IiIsImVuYWJsZWQiOnRydWV9XQ==)
 
 [Using the API][4] is a guide to the endpoints.
 

--- a/content/en/api/v1/_index.md
+++ b/content/en/api/v1/_index.md
@@ -18,7 +18,7 @@ The Datadog API is an HTTP REST API. The API uses resource-oriented URLs to call
 
 Authenticate to the API with an [API key][1], and depending on the endpoint, an [Application key][2].
 
-To try out the API [![Run in Postman][3]](https://app.getpostman.com/run-collection/add08e16382f7e11a59a)
+To try out the API [![Run in Postman][3]](https://app.getpostman.com/run-collection/bf4ac0b68b8ff47419c1#?env%5BDatadog%20Authentication%5D=W3sia2V5IjoiYXBwbGljYXRpb25fa2V5IiwidmFsdWUiOiIiLCJlbmFibGVkIjp0cnVlfSx7ImtleSI6ImFwaV9rZXkiLCJ2YWx1ZSI6IiIsImVuYWJsZWQiOnRydWV9XQ==)
 
 [Using the API][4] is a guide to the endpoints.
 

--- a/content/en/api/v2/_index.md
+++ b/content/en/api/v2/_index.md
@@ -18,7 +18,7 @@ The Datadog API is an HTTP REST API. The API uses resource-oriented URLs to call
 
 Authenticate to the API with an [API key][1], and depending on the endpoint, an [Application key][2].
 
-To try out the API [![Run in Postman][3]](https://app.getpostman.com/run-collection/add08e16382f7e11a59a)
+To try out the API [![Run in Postman][3]](https://app.getpostman.com/run-collection/bf4ac0b68b8ff47419c1#?env%5BDatadog%20Authentication%5D=W3sia2V5IjoiYXBwbGljYXRpb25fa2V5IiwidmFsdWUiOiIiLCJlbmFibGVkIjp0cnVlfSx7ImtleSI6ImFwaV9rZXkiLCJ2YWx1ZSI6IiIsImVuYWJsZWQiOnRydWV9XQ==)
 
 [Using the API][4] is a guide to the endpoints.
 

--- a/content/en/getting_started/api/_index.md
+++ b/content/en/getting_started/api/_index.md
@@ -24,7 +24,6 @@ You have:
 ## Setup
 
 ### Import the Datadog collection into Postman
-</br>
 <div class="postman-run-button"
 data-postman-action="collection/import"
 data-postman-var-1="bf4ac0b68b8ff47419c1"
@@ -47,7 +46,7 @@ After the Postman collection is imported, a full list of available Datadog API c
 
 #### Authentication
 
-The collection includes a [Postman environment][3] called `Datadog Authentication`, where you add your Datadog API, and application keys for authentication. 
+The collection includes a [Postman environment][3] called `Datadog Authentication`, where you add your Datadog API, and application keys for authentication.
 
 Follow these steps to set up your environment:
 
@@ -57,7 +56,7 @@ Follow these steps to set up your environment:
 
 3. Click **Edit**.
 
-4. Add in your Datadog [API key][2] as the value for the `api_key` variable, and add your Datadog [Application key][2] as the value for the `application_key` variable.
+4. Add in your Datadog [API key][2] as the initial value and current value for the `api_key` variable, and add your Datadog [Application key][2] as the initial value and current value for the `application_key` variable.
 
 {{< site-region region="eu" >}}
 

--- a/content/en/getting_started/api/_index.md
+++ b/content/en/getting_started/api/_index.md
@@ -27,7 +27,8 @@ You have:
 </br>
 <div class="postman-run-button"
 data-postman-action="collection/import"
-data-postman-var-1="add08e16382f7e11a59a"></div>
+data-postman-var-1="bf4ac0b68b8ff47419c1"
+data-postman-param="env%5BDatadog%20Authentication%5D=W3sia2V5IjoiYXBwbGljYXRpb25fa2V5IiwidmFsdWUiOiIiLCJlbmFibGVkIjp0cnVlfSx7ImtleSI6ImFwaV9rZXkiLCJ2YWx1ZSI6IiIsImVuYWJsZWQiOnRydWV9XQ=="></div>
 <script type="text/javascript">
   (function (p,o,s,t,m,a,n) {
     !p[s] && (p[s] = function () { (p[t] || (p[t] = [])).push(arguments); });


### PR DESCRIPTION
When you open up the postman spec on this page, it should give you an environment option called `Datadog Authentication` 
https://docs-staging.datadoghq.com/postman/update/getting_started/api/

This has already been tested, for more information, see the slack thread in #documentation 


