### PR TITLE
Update Private Locations Public doc- Feature not supported

### DIFF
--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -464,6 +464,8 @@ You can then go to any of your API or Browser test creation form, and tick your 
 
 Your private locations can be used just like any other Datadog managed locations: assign [Synthetic tests][2] to private locations, visualize test results, get [Synthetic metrics][10], etc.
 
+ **Note:** The "Go to email and click link" feature is not currently supported for browser tests running on private locations.
+
 ## Scale your private locations
 
 You can easily **horizontally scale** your private locations by adding or removing workers to it. You can run several containers for one private location with one single configuration file. Each worker would then request `N` tests to run depending on its number of free slots: when worker 1 is processing tests, worker 2 requests the following tests, etc.

--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -464,7 +464,7 @@ You can then go to any of your API or Browser test creation form, and tick your 
 
 Your private locations can be used just like any other Datadog managed locations: assign [Synthetic tests][2] to private locations, visualize test results, get [Synthetic metrics][10], etc.
 
- **Note:** The "Go to email and click link" feature is not currently supported for browser tests running on private locations.
+ **Note:** The "Go to email and click link" feature is not supported for browser tests running on private locations.
 
 ## Scale your private locations
 


### PR DESCRIPTION
Noting that the "Go to email and click link" feature is currently not supported for synthetics test running on PL

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Our documentation on browser tests based in private locations do not reflect that this particular feature is not currently supported. This PR adds a note to reflect this

### Motivation
<!-- What inspired you to submit this pull request?-->

An escalation for a browser test not working with this feature, whereas public location tests in a similar context worked as expected. https://datadoghq.atlassian.net/browse/SYN-1396?focusedCommentId=301131

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
