### PR TITLE
fix indent issue in k8s resources config

### DIFF
--- a/content/en/infrastructure/livecontainers.md
+++ b/content/en/infrastructure/livecontainers.md
@@ -99,9 +99,9 @@ In some setups, the Process Agent and Cluster Agent are unable to automatically 
       value: "true"
     - name: DD_ORCHESTRATOR_CLUSTER_ID
       valueFrom:
-      configMapKeyRef:
-        name: datadog-cluster-id
-        key: id
+        configMapKeyRef:
+          name: datadog-cluster-id
+          key: id
     ```
 
 In some setups, the Process Agent and Cluster Agent are unable to automatically detect a Kubernetes cluster name. If this happens the feature will not start, and you will see a WARN log in the Cluster Agent logs saying `Orchestrator explorer enabled but no cluster name set: disabling`. In this case you must add the following options in the `env` section of both the Cluster Agent and the Process Agent:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

fix indent issue in k8s resources config

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/haissam/fix-k8s-resources-indent/infrastructure/livecontainers/?tab=daemonset#kubernetes-resources

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
