### PR TITLE
Update DdForwarderLog to DdForwardLog as expected.

### DIFF
--- a/content/en/serverless/enhanced_lambda_metrics/_index.md
+++ b/content/en/serverless/enhanced_lambda_metrics/_index.md
@@ -38,7 +38,7 @@ The following real-time enhanced Lambda metrics are available, and they are tagg
 
 Follow the [installation instructions][5] to set up instrumentation of your serverless applications, and the enhanced Lambda metrics are enabled by default.
 
-**Note**: To enable enhanced Lambda metrics without sending the logs for your functions to Datadog, set the `DdForwarderLog` environment variable to `false` on the [Datadog Forwarder][2].
+**Note**: To enable enhanced Lambda metrics without sending the logs for your functions to Datadog, set the `DdForwardLog` environment variable to `false` on the [Datadog Forwarder][2].
 
 ## Viewing your dashboard
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Corrects a typo on the following page in the current docs:
https://docs.datadoghq.com/serverless/enhanced_lambda_metrics/#enable-enhanced-lambda-metrics

### Motivation
Customer has reached out via support ticket, seeing 'DdForwarderLog' was used in place of 'DdForwardLog'. The correct value can be seen here in the forwarder function repo:
https://github.com/DataDog/datadog-serverless-functions/blob/cb2eee92231ebaa2bb76361575985379302d7fe5/aws/logs_monitoring/template.yaml#L129-L134

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
