### PR TITLE
Documenting support of custom certificates

### DIFF
--- a/content/en/synthetics/private_locations/configuration.md
+++ b/content/en/synthetics/private_locations/configuration.md
@@ -73,6 +73,15 @@ docker run --rm -v $PWD/<MY_WORKER_CONFIG_FILE_NAME>.json:/etc/datadog/synthetic
 | `concurrency` | Number | `10` | Maximum number of tests executed in parallel. |
 | `maxTimeout` | Number | `60000` | Maximum test execution duration for API tests (in milliseconds). |
 
+## Private Certificates
+
+You can upload custom certificates to your private locations to have your API and Browser tests perform SSL handshake using your own `.pem` files. To do so:
+
+* Mount your certificates (ie. all the relevant `.pem` files) to `/etc/datadog/certs` when spinning up your private location containers. This can be done the same way your private location configuration file is mounted. 
+* These certificates will then be considered trusted CA and used as such at test runtime;
+
+**Note**: This feature is supported for versions >1.5.3 of the image.
+
 ## Private Locations Admin
 
 | Option | Type | Default | Description |

--- a/content/en/synthetics/private_locations/configuration.md
+++ b/content/en/synthetics/private_locations/configuration.md
@@ -75,10 +75,7 @@ docker run --rm -v $PWD/<MY_WORKER_CONFIG_FILE_NAME>.json:/etc/datadog/synthetic
 
 ## Private Certificates
 
-You can upload custom certificates to your private locations to have your API and Browser tests perform SSL handshake using your own `.pem` files. To do so:
-
-* Mount your certificates (all the relevant `.pem` files) to `/etc/datadog/certs` when spinning up your private location containers. This can be done the same way your private location configuration file is mounted. 
-* These certificates are then considered trusted CA and used as such at test runtime;
+You can upload custom certificates to your private locations to have your API and Browser tests perform SSL handshake using your own `.pem` files. When spinning up your private location containers, mount the relevant certificate `.pem` files to `/etc/datadog/certs`, the same way your private location configuration file is mounted. These certificates are then considered trusted CA and used as such at test runtime.
 
 **Note**: This feature is supported for versions >1.5.3 of the image.
 

--- a/content/en/synthetics/private_locations/configuration.md
+++ b/content/en/synthetics/private_locations/configuration.md
@@ -77,7 +77,7 @@ docker run --rm -v $PWD/<MY_WORKER_CONFIG_FILE_NAME>.json:/etc/datadog/synthetic
 
 You can upload custom certificates to your private locations to have your API and Browser tests perform SSL handshake using your own `.pem` files. When spinning up your private location containers, mount the relevant certificate `.pem` files to `/etc/datadog/certs`, the same way your private location configuration file is mounted. These certificates are then considered trusted CA and used as such at test runtime.
 
-**Note**: This feature is supported for versions >1.5.3 of the image.
+**Note**: This feature is supported for versions >1.5.3 of the private location Docker image.
 
 ## Private Locations Admin
 

--- a/content/en/synthetics/private_locations/configuration.md
+++ b/content/en/synthetics/private_locations/configuration.md
@@ -77,7 +77,7 @@ docker run --rm -v $PWD/<MY_WORKER_CONFIG_FILE_NAME>.json:/etc/datadog/synthetic
 
 You can upload custom certificates to your private locations to have your API and Browser tests perform SSL handshake using your own `.pem` files. To do so:
 
-* Mount your certificates (ie. all the relevant `.pem` files) to `/etc/datadog/certs` when spinning up your private location containers. This can be done the same way your private location configuration file is mounted. 
+* Mount your certificates (all the relevant `.pem` files) to `/etc/datadog/certs` when spinning up your private location containers. This can be done the same way your private location configuration file is mounted. 
 * These certificates will then be considered trusted CA and used as such at test runtime;
 
 **Note**: This feature is supported for versions >1.5.3 of the image.

--- a/content/en/synthetics/private_locations/configuration.md
+++ b/content/en/synthetics/private_locations/configuration.md
@@ -78,7 +78,7 @@ docker run --rm -v $PWD/<MY_WORKER_CONFIG_FILE_NAME>.json:/etc/datadog/synthetic
 You can upload custom certificates to your private locations to have your API and Browser tests perform SSL handshake using your own `.pem` files. To do so:
 
 * Mount your certificates (all the relevant `.pem` files) to `/etc/datadog/certs` when spinning up your private location containers. This can be done the same way your private location configuration file is mounted. 
-* These certificates will then be considered trusted CA and used as such at test runtime;
+* These certificates are then considered trusted CA and used as such at test runtime;
 
 **Note**: This feature is supported for versions >1.5.3 of the image.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR documents the support of custom certificates on private locations. Adding the do not merge label as we're currently fixing a bug on the feature.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/margot.lepizzera/pl_custom_cert/synthetics/private_locations/configuration#private-certificates

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
