### PR TITLE
profiling: deprecate pyddprofile

### DIFF
--- a/content/en/tracing/profiler/getting_started.md
+++ b/content/en/tracing/profiler/getting_started.md
@@ -104,14 +104,6 @@ The Datadog Profiler requires Python 2.7+. Memory profiling is available on Pyth
 
 4. After a minute or two, visualize your profiles on the [Datadog APM > Profiler page][2].
 
-**Note**:
-
-- Alternatively, profile your service by running it with the wrapper `pyddprofile`:
-
-    ```shell
-    $ pyddprofile server.py
-    ```
-
 - It is strongly recommended to add tags like `service` or `version` as it provides the ability to slice and dice your profiles across these dimensions, enhancing your overall product experience. Use environment variables to set the parameters:
 
 | Environment variable                             | Type          | Description                                                                                      |
@@ -128,7 +120,7 @@ Recommended for advanced usage only.
 
 - When your process forks using `os.fork`, the profiler is stopped in the child process.
 
-  For Python 3.7+ on POSIX platforms, a new profiler is started if you enabled the profiler via `pyddprofile` or `ddtrace.profiling.auto`.
+  For Python 3.7+ on POSIX platforms, a new profiler is started if you enabled the profiler via `ddtrace-run` or `ddtrace.profiling.auto`.
 
   If you manually create a `Profiler()`, use Python < 3.6, or run on a non-POSIX platform, manually restart the profiler in your child with:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Replace pyddprofile with ddtrace-run

### Motivation
<!-- What inspired you to submit this pull request?-->

See https://github.com/DataDog/dd-trace-py/pull/1816

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
