### PR TITLE
Add info on Win2008 clock drift and updates

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -180,8 +180,11 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 | [Windows server 64-bit][10]       | Windows Server 2008r2+ |
 | [Windows 64-bit][10]              | Windows 7+             |
 
-**Note**: [Source][11] install may work on operating systems not listed here and is supported on a best effort basis.
-**Note**: Windows Server 2008 R2+ is supported, but must have the most recent updates installed in order to run versions 7+ of the Datadog Agent. There is also [a known issued with clock drift and Go][12] that affects Windows Server 2008 R2+.
+**Notes**:
+
+- [Source][11] install may work on operating systems not listed here and is supported on a best effort basis.
+
+- Windows Server 2008 R2+ is supported, but must have the most recent updates installed in order to run versions 7+ of the Datadog Agent. There is also [a known issued with clock drift and Go][12] that affects Windows Server 2008 R2+.
 
 [1]: /agent/basic_agent_usage/amazonlinux/?tab=agentv5
 [2]: /agent/basic_agent_usage/deb/

--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -181,7 +181,7 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 | [Windows 64-bit][10]              | Windows 7+             |
 
 **Note**: [Source][11] install may work on operating systems not listed here and is supported on a best effort basis.
-**Note**: Windows Server 2008r2+ is supported, but must have the most recent updates installed in order to run versions 7+ of the Agent. There is also [a known issued with clock drift and Go] that affects Windows Server 2008r2+.
+**Note**: Windows Server 2008 R2+ is supported, but must have the most recent updates installed in order to run versions 7+ of the Datadog Agent. There is also [a known issued with clock drift and Go][12] that affects Windows Server 2008 R2+.
 
 [1]: /agent/basic_agent_usage/amazonlinux/?tab=agentv5
 [2]: /agent/basic_agent_usage/deb/

--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -181,6 +181,7 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 | [Windows 64-bit][10]              | Windows 7+             |
 
 **Note**: [Source][11] install may work on operating systems not listed here and is supported on a best effort basis.
+**Note**: Windows Server 2008r2+ is supported, but must have the most recent updates installed in order to run versions 7+ of the Agent. There is also [a known issued with clock drift and Go] that affects Windows Server 2008r2+.
 
 [1]: /agent/basic_agent_usage/amazonlinux/?tab=agentv5
 [2]: /agent/basic_agent_usage/deb/
@@ -193,6 +194,7 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 [9]: /agent/basic_agent_usage/osx/
 [10]: /agent/basic_agent_usage/windows/
 [11]: /agent/basic_agent_usage/source/
+[12]: https://github.com/golang/go/issues/24489
 {{% /tab %}}
 {{% tab "Unix Agent" %}}
 


### PR DESCRIPTION
Adds information on clock drift issue and updates required for running Agent 7

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Mentions that Agent 7 can't run on Windows 2008r2 without the OS having been updated first, and adds a link to the known clock drift issue with Go and that OS. 

### Motivation
Customer request 

### Preview
TK

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/laura.hampton/windows_2008_info

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
