### PR TITLE
Regenerate the sample kubernetes manifest files from the latest version of the Helm chart

### DIFF
--- a/static/resources/yaml/datadog-agent-aks.yaml
+++ b/static/resources/yaml/datadog-agent-aks.yaml
@@ -18,7 +18,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
+    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
 data:
   install_info: |
     ---
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -127,7 +127,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: process-agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -166,9 +166,12 @@ spec:
               mountPath: /host/proc
               mountPropagation: None
               readOnly: true
+            - mountPath: /etc/kubernetes/certs/
+              name: kubeletserver
+              readOnly: true
       initContainers:
         - name: init-volume
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -178,7 +181,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:

--- a/static/resources/yaml/datadog-agent-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-all-features.yaml
@@ -18,7 +18,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
+    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
 data:
   install_info: |
     ---
@@ -264,7 +264,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -357,7 +357,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -402,7 +402,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -452,7 +452,7 @@ spec:
               mountPath: /etc/datadog-agent/system-probe.yaml
               subPath: system-probe.yaml
         - name: system-probe
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -490,7 +490,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -500,7 +500,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -535,7 +535,7 @@ spec:
               value: unix:///host/var/run/docker.sock
           resources: {}
         - name: seccomp-setup
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           command:
             - cp
             - /etc/config/system-probe-seccomp.json

--- a/static/resources/yaml/datadog-agent-apm.yaml
+++ b/static/resources/yaml/datadog-agent-apm.yaml
@@ -18,7 +18,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
+    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
 data:
   install_info: |
     ---
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -122,7 +122,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -167,7 +167,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -208,7 +208,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -218,7 +218,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:

--- a/static/resources/yaml/datadog-agent-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-logs-apm.yaml
@@ -18,7 +18,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
+    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
 data:
   install_info: |
     ---
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -139,7 +139,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -186,7 +186,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -229,7 +229,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -239,7 +239,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:

--- a/static/resources/yaml/datadog-agent-logs.yaml
+++ b/static/resources/yaml/datadog-agent-logs.yaml
@@ -18,7 +18,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
+    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
 data:
   install_info: |
     ---
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -139,7 +139,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: process-agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -182,7 +182,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -192,7 +192,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:

--- a/static/resources/yaml/datadog-agent-npm.yaml
+++ b/static/resources/yaml/datadog-agent-npm.yaml
@@ -18,7 +18,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
+    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
 data:
   install_info: |
     ---
@@ -264,7 +264,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -346,7 +346,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: process-agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -394,7 +394,7 @@ spec:
               mountPath: /etc/datadog-agent/system-probe.yaml
               subPath: system-probe.yaml
         - name: system-probe
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -432,7 +432,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -442,7 +442,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -477,7 +477,7 @@ spec:
               value: unix:///host/var/run/docker.sock
           resources: {}
         - name: seccomp-setup
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           command:
             - cp
             - /etc/config/system-probe-seccomp.json

--- a/static/resources/yaml/datadog-agent-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-vanilla.yaml
@@ -18,7 +18,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
+    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
 data:
   install_info: |
     ---
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -122,7 +122,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: process-agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -163,7 +163,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -173,7 +173,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:

--- a/static/resources/yaml/datadog-agent-windows-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-windows-all-features.yaml
@@ -18,7 +18,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
+    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
 data:
   install_info: |
     ---
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -122,7 +122,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -167,7 +167,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -200,7 +200,7 @@ spec:
               mountPath: \\.\pipe\docker_engine
       initContainers:
         - name: init-volume
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -214,7 +214,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:

--- a/static/resources/yaml/datadog-agent-windows-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-apm.yaml
@@ -18,7 +18,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
+    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
 data:
   install_info: |
     ---
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -108,7 +108,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -152,7 +152,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -166,7 +166,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:

--- a/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
@@ -18,7 +18,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
+    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
 data:
   install_info: |
     ---
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -122,7 +122,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -168,7 +168,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -182,7 +182,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:

--- a/static/resources/yaml/datadog-agent-windows-logs.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs.yaml
@@ -18,7 +18,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
+    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
 data:
   install_info: |
     ---
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -123,7 +123,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -137,7 +137,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:

--- a/static/resources/yaml/datadog-agent-windows-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-windows-vanilla.yaml
@@ -18,7 +18,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 0b4b93ab3a64d6b6dd8f6b9954ef7628e2faf03f1c6b5a0145077b1f281d21bc
+    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
 data:
   install_info: |
     ---
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -109,7 +109,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -123,7 +123,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "datadog/agent:7.23.0"
+          image: "gcr.io/datadoghq/agent:7.23.1"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Regenerate the sample kubernetes manifest files from the latest version of the Helm chart

### Motivation

Keep them up-to-date and in particular update the default agent docker image to point to the GCR one instead of the DockerHub one (because of the DockerHub rate limitation).

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
