### PR TITLE
Add instructions for instrumenting Node Lambda deployed as container image

### DIFF
--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -196,6 +196,47 @@ More information and additional parameters can be found in the [CLI documentatio
 [3]: https://docs.datadoghq.com/serverless/forwarder/
 [4]: https://docs.datadoghq.com/serverless/serverless_integrations/cli
 {{% /tab %}}
+
+{{% tab "Container Image" %}}
+
+### Install the Datadog Lambda Library
+
+If you are deploying your Lambda function as a container image, you cannot use the Datadog Lambda Library as a layer. Instead, you must install the Datadog Lambda Library directly within the container. If you are using Datadog tracing, you must also install `dd-trace`.
+
+**NPM**:
+
+```
+npm install --save datadog-lambda-js dd-trace
+```
+
+**Yarn**:
+
+
+```
+yarn add datadog-lambda-js dd-trace
+```
+
+Note that the minor version of the `datadog-lambda-js` package always matches the layer version. E.g., datadog-lambda-js v0.5.0 matches the content of layer version 5.
+
+### Configure the Function
+
+1. Set your image's `CMD` value to `node_modules/datadog-lambda-js/dist/handler.handler`. You can either set this directly in your Dockerfile or override the value using AWS.
+2. Set the environment variable `DD_LAMBDA_HANDLER` to your original handler, for example, `myfunc.handler`.
+3. Set the environment variable `DD_TRACE_ENABLED` to `true`.
+4. Set the environment variable `DD_FLUSH_TO_LOG` to `true`.
+5. Optionally add a `service` and `env` tag with appropriate values to your function.
+
+### Subscribe the Datadog Forwarder to the Log Groups
+
+You need to subscribe the Datadog Forwarder Lambda function to each of your functions' log groups in order to send metrics, traces, and logs to Datadog.
+
+1. [Install the Datadog Forwarder if you haven't][1].
+2. [Subscribe the Datadog Forwarder to your function's log groups][2].
+
+[1]: https://docs.datadoghq.com/serverless/forwarder/
+[2]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
+
+{{% /tab %}}
 {{% tab "Custom" %}}
 
 ### Install the Datadog Lambda Library
@@ -248,7 +289,7 @@ See the [latest release][3].
 
 ### Subscribe the Datadog Forwarder to the Log Groups
 
-You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, in order to send metrics, traces, and logs to Datadog.
+You need to subscribe the Datadog Forwarder Lambda function to each of your functions' log groups in order to send metrics, traces, and logs to Datadog.
 
 1. [Install the Datadog Forwarder if you haven't][4].
 2. [Subscribe the Datadog Forwarder to your function's log groups][5].


### PR DESCRIPTION
**This PR should not be merged until the new AWS feature is released -- currently expected on December 1.**

### What does this PR do?
Update the docs for instrumenting Node Lambda functions to cover functions deployed as container images.

### Motivation
AWS is adding the ability to deploy Lambda functions as container images. When this feature ships, we want to update our documentation to be ready.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ngh-node-lambda-oci/serverless/installation/nodejs
