### PR TITLE
Adds Magento 1 support to docs

### DIFF
--- a/content/en/tracing/setup_overview/compatibility_requirements/php.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/php.md
@@ -66,7 +66,7 @@ The following table enumerates some of the frameworks and versions Datadog succe
 | Zend Framework | 1.12          | All supported PHP versions |
 | Yii            | 1.1, 2.0      | All supported PHP versions |
 | Drupal         |               | All supported PHP versions |
-| Magento        | 2             | All supported PHP versions |
+| Magento        | 1, 2          | All supported PHP versions |
 | Phalcon        | 1.3, 3.4      | All supported PHP versions |
 | Slim           | 2.x           | All supported PHP versions |
 | Neos Flow      | 1.1           | All supported PHP versions |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds Magento 1 to PHP docs.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/andrewsouthard1-patch-1/tracing/setup_overview/compatibility_requirements/php