### PR TITLE
Add info about OpenTel collector option 

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1266,7 +1266,7 @@ main:
     identifier: tracing_setup_overview_setup_dotnet_framework
     weight: 109
   - name: OpenTracing and OpenTelemetry
-    url: tracing/setup_overview/open_standards/java
+    url: tracing/setup_overview/open_standards/
     parent: tracing_setup_overview
     identifier: tracing_open_standards_open_standards
     weight: 103

--- a/content/en/tracing/setup_overview/open_standards/_index.md
+++ b/content/en/tracing/setup_overview/open_standards/_index.md
@@ -2,9 +2,98 @@
 title: OpenTracing and OpenTelemetry
 kind: documentation
 description: 'Use open standards to generate your application traces'
+further_reading:
+- link: "https://opentelemetry.io/docs/collector/"
+  tag: "OpenTelemetry"
+  text: "Collector documentation"
+- link: "https://www.datadoghq.com/blog/opentelemetry-instrumentation/"
+  tag: "Blog"
+  text: "Datadog's partnership with OpenTelemetry"
 aliases:
+
+
 ---
-Datadog supports a variety of open standards, including OpenTracing and OpenTelemetry. For language-specific instructions, select your language:
+Datadog supports a variety of open standards, including [OpenTracing][1] and [OpenTelemetry][2]. Each of the following languages has support for sending Open Tracing data to Datadog. Python, Ruby, and Go also have OpenTelemetry Datadog span exporters, which export traces from OpenTelemetry to the Datadog Agent. 
+
+Click your language to see instructions for setting these up:
 
 {{< partial name="apm/apm-opentracing.html" >}}
 
+<br>
+
+## OpenTelemetry Collector
+
+Alternatively, Datadog has [an exporter that uses the OpenTelemetry Collector][3] to receive traces and metrics data from the OpenTelemetry SDKs, and to forward the data on to Datadog (without the Agent). It works with all supported languages, and you configure it by supplying the [Datadog API key][4]:
+
+```
+datadog:
+  api:
+    key: "<API key>"
+```
+To send the data to the Datadog EU site, also set the `site` parameter:
+```
+datadog:
+  api:
+    key: "<API key>"
+    site: datadoghq.eu
+```
+
+On each OpenTelemetry-instrumented application, set the resource attributes `development.environment`, `service.name`, and `service.version` using the language's SDK. As a fall-back, you can also configure hostname (optionally), environment, service name, and service version at the collector level for unified service tagging by following the [example configuration file][5]. If you don't specify the hostname explicitly, the exporter attempts to get an automatic default by checking the following sources in order, falling back to the next one if the current one is unavailable or invalid:
+
+<!--- 1. Hostname set by another OpenTelemetry component -->
+2. Manually set hostname in configuration
+3. EC2 non-default hostname (if in EC2 instance)
+4. EC2 instance id (if in EC2 instance)
+5. Fully qualified domain name
+6. Operating system host name
+
+### Ingesting OpenTelemetry Traces with the Collector
+
+The exporter assumes you have a pipeline that not only uses the exporter, but also includes a batch processor configured with the following:
+  - A `timeout` setting of `10s` (10 seconds). A batch representing 10 seconds of traces is a constraint of Datadog's API Intake for Trace Related Statistics. Without this setting, trace related metrics including `.hits`, `.errors`, and `.duration` for different services and service resources may be inaccurate over periods of time.
+
+<div class="alert alert-warning">
+The Datadog exporter for the OpenTelemetry Collector is currently in beta. It may consume high CPU and memory resources. Configuring particularly the pipeline and batch processor may take some iteration before it responds with accurate metrics given your production environment. <a href="https://docs.datadoghq.com/help/">Reach out to support</a> if it doesn't work as you expect.
+</div>
+
+Here is an example pipeline:
+
+```
+receivers:
+  examplereceiver:
+
+processors:
+  batch:
+    timeout: 10s
+
+exporters:
+  datadog/api:
+    hostname: customhostname
+    env: prod
+    service: myservice
+    version: myversion
+
+    tags:
+      - example:tag
+
+    api:
+      key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      site: datadoghq.eu
+
+service:
+  pipelines:
+    traces:
+      receivers: [examplereceiver]
+      processors: [batch]
+      exporters: [datadog/api]
+```
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://opentracing.io/docs/
+[2]: https://opentelemetry.io/docs/
+[3]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/datadogexporter
+[4]: https://app.datadoghq.com/account/settings#api
+[5]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/master/exporter/datadogexporter/example/config.yaml

--- a/content/en/tracing/setup_overview/open_standards/_index.md
+++ b/content/en/tracing/setup_overview/open_standards/_index.md
@@ -13,17 +13,19 @@ aliases:
 
 
 ---
-Datadog supports a variety of open standards, including [OpenTracing][1] and [OpenTelemetry][2]. Each of the following languages has support for sending Open Tracing data to Datadog. Python, Ruby, and Go also have OpenTelemetry Datadog span exporters, which export traces from OpenTelemetry to the Datadog Agent. 
+Datadog supports a variety of open standards, including [OpenTracing][1] and [OpenTelemetry][2]. Each of the following languages has support for sending Open Tracing data to Datadog. They all also have support for sending OpenTelemetry data to Datadog via the [OpenTelemetry Collector Datadog exporter](#opentelemetry-collector-datadog-exporter). Additionally, Python, Ruby, and NodeJS have dedicated OpenTelemetry Datadog span exporters, which export traces from OpenTelemetry tracing clients to a Datadog Agent. 
 
-Click your language to see instructions for setting these up:
+Click your language to see instructions for setting up OpenTracing or language-specific OpenTelemetry exporters. See below for setting up the [OpenTelemetry Collector Datadog exporter](#opentelemetry-collector-datadog-exporter):
 
 {{< partial name="apm/apm-opentracing.html" >}}
 
 <br>
 
-## OpenTelemetry Collector
+## OpenTelemetry Collector Datadog exporter
 
-Alternatively, Datadog has [an exporter that uses the OpenTelemetry Collector][3] to receive traces and metrics data from the OpenTelemetry SDKs, and to forward the data on to Datadog (without the Agent). It works with all supported languages, and you configure it by supplying the [Datadog API key][4]:
+The OpenTelemetry Collector is a vendor-agnostic separate agent process for collecting and exporting telemetry data emitted by many processes. Datadog has [an exporter available within the OpenTelemetry Collector][3] to receive traces and metrics data from the OpenTelemetry SDKs, and to forward the data on to Datadog (without the Datadog Agent). It works with all supported languages. 
+
+You can [deploy the OpenTelemetry Collector via any of the supported methods][4], and configure it by adding a `datadog` exporter to your [OpenTelemetry configuration YAML file][5] along with your [Datadog API key][6]:
 
 ```
 datadog:
@@ -38,7 +40,7 @@ datadog:
     site: datadoghq.eu
 ```
 
-On each OpenTelemetry-instrumented application, set the resource attributes `development.environment`, `service.name`, and `service.version` using the language's SDK. As a fall-back, you can also configure hostname (optionally), environment, service name, and service version at the collector level for unified service tagging by following the [example configuration file][5]. If you don't specify the hostname explicitly, the exporter attempts to get an automatic default by checking the following sources in order, falling back to the next one if the current one is unavailable or invalid:
+On each OpenTelemetry-instrumented application, set the resource attributes `development.environment`, `service.name`, and `service.version` using [the language's SDK][2]. As a fall-back, you can also configure hostname (optionally), environment, service name, and service version at the collector level for unified service tagging by following the [example configuration file][7]. If you don't specify the hostname explicitly, the exporter attempts to get an automatic default by checking the following sources in order, falling back to the next one if the current one is unavailable or invalid:
 
 <!--- 1. Hostname set by another OpenTelemetry component -->
 1. Manually set hostname in configuration
@@ -49,18 +51,21 @@ On each OpenTelemetry-instrumented application, set the resource attributes `dev
 
 ### Ingesting OpenTelemetry Traces with the Collector
 
-The exporter assumes you have a pipeline that not only uses the exporter, but also includes a batch processor configured with the following:
-  - A `timeout` setting of `10s` (10 seconds). A batch representing 10 seconds of traces is a constraint of Datadog's API Intake for Trace Related Statistics. Without this setting, trace related metrics including `.hits`, `.errors`, and `.duration` for different services and service resources may be inaccurate over periods of time.
+The OpenTelemetry Collector is configured by adding a [pipeline][8] to your `otel-collector-configuration.yml` file. Supply the relative path to this configuration file when you start the collector by passing it in via the `--config=<path/to/configuration_file>` command line argument. For examples of supplying a configuration file, see the [OpenTelemetry Collector documentation][9].
+
+The exporter assumes you have a pipeline that uses the `datadog` exporter, and includes a [batch processor][10] configured with the following:
+  - A required `timeout` setting of `10s` (10 seconds). A batch representing 10 seconds of traces is a constraint of Datadog's API Intake for Trace Related Statistics. 
+  <div class="alert alert-info"><strong>Important!</strong> Without this <code>timeout</code> setting, trace related metrics including <code>.hits</code>, <code>.errors</code>, and <code>.duration</code> for different services and service resources will be inaccurate over periods of time.</div>
 
 <div class="alert alert-warning">
 The Datadog exporter for the OpenTelemetry Collector is currently in beta. It may consume high CPU and memory resources. Configuring particularly the pipeline and batch processor may take some iteration before it responds with accurate metrics given your production environment. <a href="https://docs.datadoghq.com/help/">Reach out to support</a> if it doesn't work as you expect.
 </div>
 
-Here is an example pipeline:
+Here is an example trace pipeline configured with an `otlp` receiver, `batch` processor, and `datadog` exporter:
 
 ```
 receivers:
-  examplereceiver:
+  otlp:
 
 processors:
   batch:
@@ -83,10 +88,12 @@ exporters:
 service:
   pipelines:
     traces:
-      receivers: [examplereceiver]
+      receivers: [otlp]
       processors: [batch]
       exporters: [datadog/api]
 ```
+
+To see more information and additional examples of how you might configure your collector, see [the OpenTelemetry Collector configuration documentation][5].
 
 ## Further Reading
 
@@ -95,5 +102,10 @@ service:
 [1]: https://opentracing.io/docs/
 [2]: https://opentelemetry.io/docs/
 [3]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/datadogexporter
-[4]: https://app.datadoghq.com/account/settings#api
-[5]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/master/exporter/datadogexporter/example/config.yaml
+[4]: https://opentelemetry.io/docs/collector/getting-started/#deployment
+[5]: https://opentelemetry.io/docs/collector/configuration/
+[6]: https://app.datadoghq.com/account/settings#api
+[7]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/master/exporter/datadogexporter/example/config.yaml
+[8]: https://github.com/open-telemetry/opentelemetry-collector/blob/master/docs/design.md#pipelines
+[9]: https://github.com/open-telemetry/opentelemetry-collector/tree/master/examples
+[10]: https://github.com/open-telemetry/opentelemetry-collector/tree/master/processor/batchprocessor#batch-processor

--- a/content/en/tracing/setup_overview/open_standards/_index.md
+++ b/content/en/tracing/setup_overview/open_standards/_index.md
@@ -41,11 +41,11 @@ datadog:
 On each OpenTelemetry-instrumented application, set the resource attributes `development.environment`, `service.name`, and `service.version` using the language's SDK. As a fall-back, you can also configure hostname (optionally), environment, service name, and service version at the collector level for unified service tagging by following the [example configuration file][5]. If you don't specify the hostname explicitly, the exporter attempts to get an automatic default by checking the following sources in order, falling back to the next one if the current one is unavailable or invalid:
 
 <!--- 1. Hostname set by another OpenTelemetry component -->
-2. Manually set hostname in configuration
-3. EC2 non-default hostname (if in EC2 instance)
-4. EC2 instance id (if in EC2 instance)
-5. Fully qualified domain name
-6. Operating system host name
+1. Manually set hostname in configuration
+1. EC2 non-default hostname (if in EC2 instance)
+1. EC2 instance id (if in EC2 instance)
+1. Fully qualified domain name
+1. Operating system host name
 
 ### Ingesting OpenTelemetry Traces with the Collector
 


### PR DESCRIPTION

### What does this PR do?
Adds info about using the Datadog exporter for OpenTel Collector.

### Motivation
DOCS-1409

### Preview

https://docs-staging.datadoghq.com/kari/open-tel-intro/tracing/setup_overview/open_standards/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
