### PR TITLE
[serverless] Update serverless example to use current time instead of a hardcoded timestamp

### DIFF
--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -305,6 +305,7 @@ After you have configured your function following the steps above, you can view 
 If you would like to submit a custom metric or span, see the sample code below:
 
 ```python
+import time
 from ddtrace import tracer
 from datadog_lambda.metric import lambda_metric
 
@@ -323,7 +324,7 @@ def lambda_handler(event, context):
     lambda_metric(
         metric_name='coffee_house.order_value',
         value=12.45,
-        timestamp=1602008721, # optional, must be within last 20 mins
+        timestamp=int(time.time()), # optional, must be within last 20 mins
         tags=['product:latte', 'order:online']
     )
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Updates the python example to use the current time instead of a hardcoded timestamp as some customers are copying the example and the metric submitted is ingested because it's older than 20 minutes from the submit.

### Motivation
<!-- What inspired you to submit this pull request?-->
Customer's confusion. This will avoid support cases.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
