### PR TITLE
[aws-ints] restrict access to the kinesis firehose s3 backup bucket

### DIFF
--- a/static/resources/json/kinesis-logs-cloudformation-template.json
+++ b/static/resources/json/kinesis-logs-cloudformation-template.json
@@ -31,7 +31,7 @@
     "FailedDataBucket": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
-        "AccessControl": "AuthenticatedRead",
+        "AccessControl": "Private",
         "PublicAccessBlockConfiguration": {
           "BlockPublicAcls": true,
           "BlockPublicPolicy": true,


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This cloudformation template is used to setup a Kinesis firehose to send logs from AWS to Datadog. As part of the setup, we also setup an S3 bucket that stores those logs if the firehose fails to submit them to Datadog's intake. The S3 bucket has all the hooks in place to restrict public access but this PR further restricts the access to that S3 bucket and makes it private as it does not have to be open even for authenticated reads.

### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadoghq.atlassian.net/browse/CLOUDS-1053

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ashwin/change-s3-bucket-perms/resources/json/kinesis-logs-cloudformation-template.json

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
