### PR TITLE
Clarify behavior of scopes in downtimes

### DIFF
--- a/content/en/monitors/downtimes.md
+++ b/content/en/monitors/downtimes.md
@@ -38,7 +38,7 @@ Schedule a downtime based on one or more [monitor tags][1]. You must select at l
 
 If you choose to silence monitors constrained by scope, click **Preview affected monitors** to see the monitors included. Any monitors created or edited after the downtime is scheduled are automatically included in the downtime if they match the scope.
 
-**Note**: If a multi-alert monitor is included, it is only silenced for groups covered by the scope. For example, if a downtime is scoped for `host:X` and a multi-alert is triggered on both `host:X` and `host:Y`, Datadog generates a monitor notification for `host:Y`, but not `host:X`. 
+**Note**: If a multi-alert monitor is included, it is only silenced for groups covered by the scope. For example, if a downtime is scoped for `host:X` and a multi-alert is triggered on both `host:X` and `host:Y`, Datadog generates a monitor notification for `host:Y`, but not `host:X`.
 
 ### Schedule
 

--- a/content/en/monitors/downtimes.md
+++ b/content/en/monitors/downtimes.md
@@ -25,7 +25,7 @@ To schedule a [monitor downtime][1] in Datadog use the main navigation: _Monitor
 {{< tabs >}}
 {{% tab "By Monitor Name" %}}
 
-Search or use the drop-down to choose monitors to silence. If the field is left empty, all monitors are silenced by default. You can also select a scope to constrain your downtime to a specific host, device, or arbitrary tag.
+Search or use the drop-down to choose monitors to silence. If the field is left empty, all monitors are silenced by default. You can also select a scope to constrain your downtime to a specific host, device, or arbitrary tag. Only monitors that have **ALL selected scopes** are silenced.
 
 {{% /tab %}}
 {{% tab "By Monitor Tags" %}}
@@ -38,7 +38,7 @@ Schedule a downtime based on one or more [monitor tags][1]. You must select at l
 
 If you choose to silence monitors constrained by scope, click **Preview affected monitors** to see the monitors included. Any monitors created or edited after the downtime is scheduled are automatically included in the downtime if they match the scope.
 
-**Note**: If a multi-alert monitor is included, it is only silenced for groups covered by the scope. For example, if a downtime is scoped for `host:X` and a multi-alert is triggered on both `host:X` and `host:Y`, Datadog generates a monitor notification for `host:Y`, but not `host:X`.
+**Note**: If a multi-alert monitor is included, it is only silenced for groups covered by the scope. For example, if a downtime is scoped for `host:X` and a multi-alert is triggered on both `host:X` and `host:Y`, Datadog generates a monitor notification for `host:Y`, but not `host:X`. 
 
 ### Schedule
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR clarifies that scopes in monitor downtimes apply AND logic, similar to what the API documentation says here:
_The scope(s) to which the downtime applies. For example, host:app2. Provide multiple scopes as a comma-separated list like env:dev,env:prod. The resulting downtime applies to sources that matches ALL provided scopes (env:dev AND env:prod)._
https://docs.datadoghq.com/api/v1/downtimes/#schedule-a-downtime

### Motivation
I had a customer asking help about setting up Downtimes. It turns out that they were specifying multiple groups in a downtime which while not find anything because of the AND logic. (Support ticket number 421353)

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/monitors/downtimes/?tab=bymonitorname

### Additional Notes
<!-- Anything else we should know when reviewing?-->
In the by monitor tags tab of the same page, we explicitly say "Only monitors that have ALL selected tags are silenced." As such, the PR makes the two tabs there have more parallel information.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
