### PR TITLE
Correction of the Japanese translation.( CentOS/RHEL 7.6+)

### DIFF
--- a/content/ja/network_performance_monitoring/installation.md
+++ b/content/ja/network_performance_monitoring/installation.md
@@ -24,7 +24,7 @@ further_reading:
 - Amazon AMI 2016.03 以降
 - Amazon Linux 2
 
-[CentOS/RHEL 7.6 以降][2]の要件は、kernel 4.4.0 以降では適用外です。[DNS 解決][3]機能は CentOS/RHEL 7.6 ではサポートされていません。
+[CentOS/RHEL 7.6 以降][2]の要件は、kernel 4.4.0 以降では適用外のものがあります。[DNS 解決][3]機能は CentOS/RHEL 7.6 ではサポートされていません。
 
 ネットワークパフォーマンスモニタリングは、次の要件が満たされている場合、**Cilium** インストールと互換性があります。
 1) Cilium バージョン 1.6 以降、および


### PR DESCRIPTION
The Japanese translation was incorrect and has been corrected.
Before the modification, [CentOS/RHEL 7.6+] is listed as unavailable.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Corrections in the Japanese language documentation.

### Motivation
After checking with support, we found out that the Japanese translation is incorrect, so we decided to use.
