### PR TITLE
DOCS-1319 clarify token length

### DIFF
--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -56,7 +56,7 @@ Setting the value without a secret results in the token being readable in the `P
 {{< tabs >}}
 {{% tab "Secret" %}}
 
-1. Run the following command to create a secret token:
+1. Run the following command to create a secret token. Your token must be at least 32 characters long.
 
     ```shell
     echo -n '<ThirtyX2XcharactersXlongXtoken>' | base64
@@ -78,7 +78,7 @@ Setting the value without a secret results in the token being readable in the `P
 {{% /tab %}}
 {{% tab "Environment Variable" %}}
 
-1. Run the following command to create a secret token:
+1. Run the following command to create a secret token. Your token must be at least 32 characters long.
 
     ```shell
     echo -n '<ThirtyX2XcharactersXlongXtoken>' | base64
@@ -94,7 +94,7 @@ Setting the value without a secret results in the token being readable in the `P
 {{% /tab %}}
 {{% tab "ConfigMap" %}}
 
-1. Run the following command to create a secret token:
+1. Run the following command to create a secret token. Your token must be at least 32 characters long.
 
     ```shell
     echo -n '<ThirtyX2XcharactersXlongXtoken>' | base64


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Secret tokens must be at least 32 characters long. This is stated in the dummy sample text, but not explicitly stated.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview

https://docs-staging.datadoghq.com/cswatt/token-length/agent/cluster_agent/setup/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
