### PR TITLE
Remove further reading from Cloudability docs

### DIFF
--- a/content/en/integrations/cloudability.md
+++ b/content/en/integrations/cloudability.md
@@ -12,10 +12,7 @@ categories:
     - cloud
     - Cost Management
 ddtype: crawler
-further_reading:
-    - link: 'https://support.cloudability.com/hc/en-us/articles/360011041074-Integration-with-Datadog-how-to-add-your-Datadog-Credentials-to-Cloudability'
-      tag: 'External Documentation'
-      text: 'How to Add Your Datadog Credentials to Cloudability'
+
 ---
 
 ## Overview
@@ -28,9 +25,5 @@ To bind your Datadog application to your Cloudability account:
 
 - Login to Cloudability >> Settings >> Vendor Credentials.
 - Add your [Datadog API and application keys][1].
-
-## Further Reading
-
-{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/account/settings#api


### PR DESCRIPTION
### What does this PR do?
Removes further reading section as it gives misleading information about rate limiting; removing for now until external documentation is resolved.

### Motivation
Docs request

### Preview
https://docs-staging.datadoghq.com/sarina/integrations/cloudability

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
