### PR TITLE
Update Serverless docs to include Lambdas deployed as container images

### DIFF
--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -215,9 +215,9 @@ npm install --save datadog-lambda-js dd-trace
 yarn add datadog-lambda-js dd-trace
 ```
 
-Note that the minor version of the `datadog-lambda-js` package always matches the layer version. E.g., datadog-lambda-js v0.5.0 matches the content of layer version 5.
+Note that the minor version of the `datadog-lambda-js` package always matches the layer version. For example, `datadog-lambda-js v0.5.0` matches the content of layer version 5.
 
-### Configure the Function
+### Configure the function
 
 1. Set your image's `CMD` value to `node_modules/datadog-lambda-js/dist/handler.handler`. You can either set this directly in your Dockerfile or override the value using AWS.
 2. Set the environment variable `DD_LAMBDA_HANDLER` to your original handler, for example, `myfunc.handler`.
@@ -225,7 +225,7 @@ Note that the minor version of the `datadog-lambda-js` package always matches th
 4. Set the environment variable `DD_FLUSH_TO_LOG` to `true`.
 5. Optionally add a `service` and `env` tag with appropriate values to your function.
 
-### Subscribe the Datadog Forwarder to the Log Groups
+### Subscribe the Datadog Forwarder to the log groups
 
 You need to subscribe the Datadog Forwarder Lambda function to each of your functions' log groups in order to send metrics, traces, and logs to Datadog.
 

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -196,6 +196,46 @@ More information and additional parameters can be found in the [CLI documentatio
 [3]: https://docs.datadoghq.com/serverless/forwarder/
 [4]: https://docs.datadoghq.com/serverless/serverless_integrations/cli
 {{% /tab %}}
+{{% tab "Container Image" %}}
+
+### Install the Datadog Lambda Library
+
+If you are deploying your Lambda function as a container image, you cannot use the Datadog Lambda Library as a layer. Instead, you must install the Datadog Lambda Library directly within the image. If you are using Datadog tracing, you must also install `dd-trace`.
+
+**NPM**:
+
+```sh
+npm install --save datadog-lambda-js dd-trace
+```
+
+**Yarn**:
+
+
+```sh
+yarn add datadog-lambda-js dd-trace
+```
+
+Note that the minor version of the `datadog-lambda-js` package always matches the layer version. E.g., datadog-lambda-js v0.5.0 matches the content of layer version 5.
+
+### Configure the Function
+
+1. Set your image's `CMD` value to `node_modules/datadog-lambda-js/dist/handler.handler`. You can either set this directly in your Dockerfile or override the value using AWS.
+2. Set the environment variable `DD_LAMBDA_HANDLER` to your original handler, for example, `myfunc.handler`.
+3. Set the environment variable `DD_TRACE_ENABLED` to `true`.
+4. Set the environment variable `DD_FLUSH_TO_LOG` to `true`.
+5. Optionally add a `service` and `env` tag with appropriate values to your function.
+
+### Subscribe the Datadog Forwarder to the Log Groups
+
+You need to subscribe the Datadog Forwarder Lambda function to each of your functions' log groups in order to send metrics, traces, and logs to Datadog.
+
+1. [Install the Datadog Forwarder if you haven't][1].
+2. [Subscribe the Datadog Forwarder to your function's log groups][2].
+
+[1]: https://docs.datadoghq.com/serverless/forwarder/
+[2]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
+
+{{% /tab %}}
 {{% tab "Custom" %}}
 
 ### Install the Datadog Lambda Library

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -233,6 +233,38 @@ More information and additional parameters can be found in the [CLI documentatio
 [3]: https://docs.datadoghq.com/serverless/forwarder/
 [4]: https://docs.datadoghq.com/serverless/serverless_integrations/cli
 {{% /tab %}}
+{{% tab "Container Image" %}}
+
+### Install the Datadog Lambda Library
+
+If you are deploying your Lambda function as a container image, you cannot use the Datadog Lambda Library as a layer. Instead, you must install the Datadog Lambda Library directly within the image.
+
+
+```sh
+pip install datadog-lambda
+```
+
+Note that the minor version of the `datadog-lambda` package always matches the layer version. E.g., datadog-lambda v0.5.0 matches the content of layer version 5.
+
+### Configure the Function
+
+1. Set your image's `CMD` value to `datadog_lambda.handler.handler`. You can either set this directly in your Dockerfile or override the value using AWS.
+2. Set the environment variable `DD_LAMBDA_HANDLER` to your original handler, for example, `myfunc.handler`.
+3. Set the environment variable `DD_TRACE_ENABLED` to `true`.
+4. Set the environment variable `DD_FLUSH_TO_LOG` to `true`.
+5. Optionally add a `service` and `env` tag with appropriate values to your function.
+
+### Subscribe the Datadog Forwarder to the Log Groups
+
+You need to subscribe the Datadog Forwarder Lambda function to each of your functions' log groups in order to send metrics, traces, and logs to Datadog.
+
+1. [Install the Datadog Forwarder if you haven't][1].
+2. [Subscribe the Datadog Forwarder to your function's log groups][2].
+
+[1]: https://docs.datadoghq.com/serverless/forwarder/
+[2]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
+
+{{% /tab %}}
 {{% tab "Custom" %}}
 
 ### Install the Datadog Lambda Library

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -244,7 +244,7 @@ If you are deploying your Lambda function as a container image, you cannot use t
 pip install datadog-lambda
 ```
 
-Note that the minor version of the `datadog-lambda` package always matches the layer version. E.g., datadog-lambda v0.5.0 matches the content of layer version 5.
+Note that the minor version of the `datadog-lambda` package always matches the layer version. For example, `datadog-lambda v0.5.0` matches the content of layer version 5.
 
 ### Configure the Function
 

--- a/content/en/serverless/installation/ruby.md
+++ b/content/en/serverless/installation/ruby.md
@@ -26,7 +26,7 @@ After you have installed the [AWS integration][1] and the [Datadog Forwarder][2]
 
 ### Install the Datadog Lambda Library
 
-The Datadog Lambda Library can be imported as a layer or a gem.
+The Datadog Lambda Library can be installed as a layer or a gem. For most functions, Datadog recommends installing the library as a layer. If your Lambda function is deployed as a container image, you must install the library as a gem.
 
 The minor version of the `datadog-lambda` gem always matches the layer version. E.g., datadog-lambda v0.5.0 matches the content of layer version 5.
 
@@ -50,31 +50,50 @@ arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby2-7:5
 
 #### Using the Gem
 
-Add the following line to your Gemfile. See the [latest release][5].
+Add the following to your Gemfile.
 
+```Gemfile
+gem 'datadog-lambda'
 ```
+
+To use Datadog APM, you must also add `ddtrace` as a second dependency in your Gemfile.
+
+```Gemfile
 gem 'datadog-lambda'
 gem 'ddtrace'
 ```
 
-Keep in mind that `ddtrace` uses native extensions, which must be compiled for Amazon Linux before being packaged and uploaded to Lambda. For this reason, Datadog recommends using the layer.
+`ddtrace` contains native extensions that must be compiled for Amazon Linux to work with AWS Lambda. Datadog therefore recommends that you build and deploy your Lambda as a container image. If your function cannot be deployed as a container image and you would like to use Datadog APM, Datadog recommends installing the Lambda Library as a layer instead of as a gem.
+
+Install `gcc`, `gmp-devel`, and `make` prior to running `bundle install` in your function’s Dockerfile to ensure that the native extensions can be successfully compiled.
+
+```dockerfile
+FROM <base image>
+
+# assemble your container image
+
+RUN yum -y install gcc gmp-devel make
+RUN bundle config set path 'vendor/bundle'
+RUN bundle install
+```
 
 ### Configure the Function
 
-1. Enable Datadog APM and wrap your Lambda handler function using the wrapper provided by the Datadog Lambda library.
-    ```ruby
-    require 'datadog/lambda'
-    
-    Datadog::Lambda.configure_apm do |c|
-    # Enable the instrumentation
-    end
+Enable Datadog APM and wrap your Lambda handler function using the wrapper provided by the Datadog Lambda library.
 
-    def handler(event:, context:)
-        Datadog::Lambda.wrap(event, context) do
-            return { statusCode: 200, body: 'Hello World' }
-        end
+```ruby
+require 'datadog/lambda'
+
+Datadog::Lambda.configure_apm do |c|
+# Enable the instrumentation
+end
+
+def handler(event:, context:)
+    Datadog::Lambda.wrap(event, context) do
+        return { statusCode: 200, body: 'Hello World' }
     end
-    ```
+end
+```
 
 ### Subscribe the Datadog Forwarder to the Log Groups
 


### PR DESCRIPTION
### What does this PR do?
Update the Serverless installation docs to include Lambda functions deployed as container images.

### Motivation
AWS has released a new feature allowing Lambda functions to be deployed as container images and we want to document how to install Datadog instrumentation for functions deployed in this way.

### Preview
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/ngh-lambda-containers/serverless/installation/nodejs
https://docs-staging.datadoghq.com/ngh-lambda-containers/serverless/installation/python
https://docs-staging.datadoghq.com/ngh-lambda-containers/serverless/installation/ruby

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
