### PR TITLE
delete the note saying we can change the default group by tag in the …

### DIFF
--- a/content/en/infrastructure/hostmap.md
+++ b/content/en/infrastructure/hostmap.md
@@ -37,8 +37,6 @@ A simple example is grouping your hosts by AWS availability zone. If you add a s
 
 {{< img src="infrastructure/hostmap/hostmappart2image2.png" alt="Datadog Host Maps AZ Instance Groups"  >}}
 
-**Note**: Your Datadog host map is automatically grouped by `availability-zone`. If you would like to change the default grouping, contact Datadog support.
-
 ### Tags
 
 [Tags][1] may be applied automatically by [Datadog integrations][2] or manually applied. You can use these to filter your hosts.


### PR DESCRIPTION
…host map page

This is no longer supported, so better delete it from the docs.

The internal doc : https://datadoghq.atlassian.net/wiki/spaces/TS/pages/328665669/Enable+a+Custom+Infra+Map+Link

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
