### PR TITLE
Add link to Serverless Blog post in Serverless docs page

### DIFF
--- a/content/en/serverless/_index.md
+++ b/content/en/serverless/_index.md
@@ -15,6 +15,9 @@ further_reading:
 - link: "/integrations/amazon_lambda/"
   tag: "AWS Lambda Integration"
   text: "AWS Lambda Integration"
+- link: "https://www.datadoghq.com/blog/monitoring-lambda-containers/"
+  tag: "Blog"
+  text: "Monitor AWS Lambda functions deployed using container images"
 ---
 
 {{< img src="serverless/datadog_serverless_overview.png" alt="Datadog Serverless Overview"  style="width:100%;">}}


### PR DESCRIPTION

### What does this PR do?

Adds link to new blog post in Serverless docs page Further Reading section

### Motivation

on-call tasks

### Preview

https://docs-staging.datadoghq.com/kari/serverless-blog-link/serverless/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
