### PR TITLE
Update usage_metrics.md

### DIFF
--- a/content/en/account_management/billing/usage_metrics.md
+++ b/content/en/account_management/billing/usage_metrics.md
@@ -28,9 +28,9 @@ Estimated usage metrics are generally available for the following usage types:
 | Logs Ingested Bytes  | `datadog.estimated_usage.logs.ingested_bytes`          |
 | Logs Ingested Events | `datadog.estimated_usage.logs.ingested_events`   |
 | APM Hosts            | `datadog.estimated_usage.apm_hosts`      |
-| APM Indexed Spans   | `datadog.estimated_usage.logs.apm.indexed_spans` |
-| APM Ingested Bytes   | `datadog.estimated_usage.logs.apm.ingested_bytes` |
-| APM Ingested Spans   | `datadog.estimated_usage.logs.apm.ingested_spans` |
+| APM Indexed Spans   | `datadog.estimated_usage.apm.indexed_spans` |
+| APM Ingested Bytes   | `datadog.estimated_usage.apm.ingested_bytes` |
+| APM Ingested Spans   | `datadog.estimated_usage.apm.ingested_spans` |
 | Serverless Lambda Functions | `datadog.estimated_usage.serverless.aws_lambda_functions` |
 
 Log-based usage metrics must be manually enabled from the [Generate Metrics][1] page.


### PR DESCRIPTION
Corrected the usage metrics for APM.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes .logs. from the apm usage metric names

### Motivation
The metric names for apm usage shouldn't contain logs

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

I couldn't get this to work

### Additional Notes
<!-- Anything else we should know when reviewing?-->

Minor fix!

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
