### PR TITLE
Update template variable examples for log monitors

### DIFF
--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -147,10 +147,15 @@ For example, if your log monitor is grouped by the `facet`, the variable is:
 ```text
 {{ facet.name }}
 ```
+**Example**: To include the information in a multi alert log monitor group by `@machine_id`: 
 
-If your facet has periods, use brackets around the facet, for example:
 ```text
-{{ [facet.with.dot].name }}
+This alert was triggered on {{ @machine_id.name }}
+```
+If your facet has periods, use brackets around the facet, for example:
+
+```text
+{{ [@network.client.ip].name }}
 ```
 
 ### Conditional variables


### PR DESCRIPTION
### What does this PR do?
Improve the template variable documentation for log monitors and facet path

### Motivation
Better highlighting of how this should be added.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/template-variable-log-monitors/monitors/notifications/?tab=is_alert#log-facet-variables

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
