### PR TITLE
DOCS-1220 - note for setting dd_site in the DCA

### DIFF
--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -132,7 +132,7 @@ Setting the value without a secret results in the token being readable in the `P
 6. Run: `kubectl apply -f install_info-configmap.yaml`
 6. Finally, deploy the Datadog Cluster Agent: `kubectl apply -f cluster-agent-deployment.yaml`
 
-**Note**: In your Datadog Cluster Agent, set `<DD_SITE>` to your Datadog site: `datadoghq.`{{< region-param key="dd_site" code="true" >}}. The default value is `datadoghq.com`
+**Note**: In your Datadog Cluster Agent, set `<DD_SITE>` to your Datadog site: {{< region-param key="dd_site" code="true" >}}. The default value is `datadoghq.com`
 
 ### Step 4 - Verification
 

--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -132,7 +132,7 @@ Setting the value without a secret results in the token being readable in the `P
 6. Run: `kubectl apply -f install_info-configmap.yaml`
 6. Finally, deploy the Datadog Cluster Agent: `kubectl apply -f cluster-agent-deployment.yaml`
 
-**Note**: In your Datadog Cluster Agent, set `<DD_SITE>` to your Datadog site: datadoghq.{{< region-param key="dd_site" code="true" >}}. The default value is `datadoghq.com`
+**Note**: In your Datadog Cluster Agent, set `<DD_SITE>` to your Datadog site: `datadoghq.`{{< region-param key="dd_site" code="true" >}}. The default value is `datadoghq.com`
 
 ### Step 4 - Verification
 

--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -132,6 +132,8 @@ Setting the value without a secret results in the token being readable in the `P
 6. Run: `kubectl apply -f install_info-configmap.yaml`
 6. Finally, deploy the Datadog Cluster Agent: `kubectl apply -f cluster-agent-deployment.yaml`
 
+**Note**: In your Datadog Cluster Agent, set `<DD_SITE>` to your Datadog site: datadoghq.{{< region-param key="dd_site" code="true" >}}. The default value is `datadoghq.com`
+
 ### Step 4 - Verification
 
 At this point, you should see:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
DD_SITE needs to be set in the DCA as well as the node agent

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview

https://docs-staging.datadoghq.com/cswatt/dca-site/agent/cluster_agent/setup/?tab=secret#step-3-create-the-cluster-agent-and-its-service

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
