### PR TITLE
Update Lambda extension supported runtimes

### DIFF
--- a/content/en/serverless/datadog_lambda_library/extension.md
+++ b/content/en/serverless/datadog_lambda_library/extension.md
@@ -17,9 +17,9 @@ The Datadog Extension supports submitting custom metrics and logs [synchronously
 
 ## Setup
 
-The Datadog Extension is distributed as its own Lambda Layer (separate from the [Datadog Lambda Library][3]) and supports Node.js, Python, and Go runtimes.
+The Datadog Extension is distributed as its own Lambda Layer (separate from the [Datadog Lambda Library][3]) and supports Node.js and Python runtimes.
 
-1. Instrument your [Python][4], [Node.js][5], or [Go][6] application.
+1. Instrument your [Python][4] or [Node.js][5] application.
 
 2. Add the Lambda Layer for the Datadog Extension to your AWS Lambda function:
 

--- a/content/en/serverless/datadog_lambda_library/extension.md
+++ b/content/en/serverless/datadog_lambda_library/extension.md
@@ -35,7 +35,7 @@ The Datadog Extension is distributed as its own Lambda Layer (separate from the 
     arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:<VERSION>
     ```
 
-    The available `RUNTIME` options are `Node8-10`, `Node10-x`, `Node12-x`, `Python27`, `Python36`, `Python37`, and `Python38`. For `VERSION`, see the latest release for [Node.js][8] or [Python][9].
+    The available `RUNTIME` options are `Node10-x`, `Node12-x`, `Python37`, and `Python38`. For `VERSION`, see the latest release for [Node.js][8] or [Python][9].
 
 4. Reference the [sample code][10] to submit a custom metric.
 


### PR DESCRIPTION
### What does this PR do?

Remove unsupported runtimes for Lambda extension. The full list can be found here https://docs.aws.amazon.com/lambda/latest/dg/using-extensions.html.

### Motivation

Customer reported the Lambda extension not working for Python 3.6.

### Preview

https://docs-staging.datadoghq.com/tian.chu/update-lambda-extension-supported-runtimes/serverless/datadog_lambda_library/extension/#configuration

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
