### PR TITLE
Update setting-file-permissions-for-rotating-logs.md

### DIFF
--- a/content/en/logs/guide/setting-file-permissions-for-rotating-logs.md
+++ b/content/en/logs/guide/setting-file-permissions-for-rotating-logs.md
@@ -73,6 +73,8 @@ getfacl /var/log/apache/access.log
 
 **Note**: For **PostgreSQL v10** and older, set the permission to **0700**. For **PostgreSQL v11**, set either **0700** or **0750**. Trying to start a server with a base data folder that has permissions different from 0700 or 0750 will result in a failure of the postmater process.
 
+**Note**: The PostgreSQL logging directory cannot be located in the same directory as the base PostgreSQL installation.
+
 ## Setting permissions when ACLs are not present
 
 When ACLs are not present in a system, set your permissions based on group access.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a note indicating that the PostgreSQL logging directory cannot be located in the same directory as the base PostgreSQL installation.

### Motivation
Escalation: https://datadoghq.atlassian.net/browse/AGENT-5346
"we’ve learned a good lesson from this escalation, better crystallise this in our doc"
ZD Ticket: https://datadog.zendesk.com/agent/tickets/416360

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
