### PR TITLE
Updating Incidents API 'notification_handles' examples

### DIFF
--- a/content/en/api/v2/incidents/examples.json
+++ b/content/en/api/v2/incidents/examples.json
@@ -17,8 +17,9 @@
                   "<any-key>": {}
                 },
                 "modified": "2019-09-19T10:00:00.000Z",
-                "notification_handles": [
-                  "@test.user@test.com"
+                "notification_handles": [{
+                    "handle":"@test.user@example.com"
+                  }
                 ],
                 "postmortem_id": "00000000-0000-0000-0000-000000000000",
                 "public_id": 1,
@@ -134,8 +135,9 @@
                 "<any-key>": {}
               },
               "modified": "2019-09-19T10:00:00.000Z",
-              "notification_handles": [
-                "@test.user@test.com"
+              "notification_handles": [{
+                  "handle":"@test.user@example.com"
+                }
               ],
               "postmortem_id": "00000000-0000-0000-0000-000000000000",
               "public_id": 1,
@@ -246,8 +248,9 @@
               "<any-key>": {}
             },
             "initial_timeline_cells": [],
-            "notification_handles": [
-              "@test.user@test.com"
+            "notification_handles": [{
+                "handle":"@test.user@example.com"
+              }
             ],
             "title": "A test incident title"
           },
@@ -323,8 +326,9 @@
                 "<any-key>": {}
               },
               "modified": "2019-09-19T10:00:00.000Z",
-              "notification_handles": [
-                "@test.user@test.com"
+              "notification_handles": [{
+                  "handle":"@test.user@example.com"
+                }
               ],
               "postmortem_id": "00000000-0000-0000-0000-000000000000",
               "public_id": 1,
@@ -432,8 +436,9 @@
                 "<any-key>": {}
               },
               "modified": "2019-09-19T10:00:00.000Z",
-              "notification_handles": [
-                "@test.user@test.com"
+              "notification_handles": [{
+                  "handle":"@test.user@example.com"
+                }
               ],
               "postmortem_id": "00000000-0000-0000-0000-000000000000",
               "public_id": 1,
@@ -570,8 +575,9 @@
             "fields": {
               "<any-key>": {}
             },
-            "notification_handles": [
-              "@test.user@test.com"
+            "notification_handles": [{
+                "handle":"@test.user@example.com"
+              }
             ],
             "resolved": "2019-09-19T10:00:00.000Z",
             "title": "A test incident title"


### PR DESCRIPTION




<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
In the incidents/examples.json file, replace all instances of:
` "notification_handles": [ "@test.user@test.com" ],`
with:
` "notification_handles": [ {"handle":"@test.user@example.com"} ],`

### Motivation
A customer raised this issue in Ticket: https://datadog.zendesk.com/agent/tickets/424969

### Preview
https://docs-staging.datadoghq.com/gullwings13-update-notification-handle-examples-in-incidents-docs/api/v2/incidents/

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
