### PR TITLE
Add datadog-api-client-python to the list of libraries

### DIFF
--- a/data/libraries.yaml
+++ b/data/libraries.yaml
@@ -184,6 +184,11 @@ Classic:
       dogstatsd: true
       authors: Datadog
       notes: Also includes an API client CLI tool, 'dog'.
+    - name: datadog-api-client-python
+      link: https://github.com/DataDog/datadog-api-client-python
+      official: true
+      api: true
+      authors: Datadog
   - R:
     - name: datadogr
       link: https://cran.r-project.org/package=datadogr


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR add https://github.com/DataDog/datadog-api-client-python as an official API client in the libraries table.
### Motivation
<!-- What inspired you to submit this pull request?-->
I was looking for a python API client that contains some of the newest endpoints and didn't find it on https://docs.datadoghq.com/developers/libraries/ 

### Preview
<!-- Impacted pages preview links-->
It should only update https://docs.datadoghq.com/developers/libraries/ 
<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jonathan.machado/add_python_api_lib/developers/libraries/ 

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
