### PR TITLE
Enrichment table s3 documentation

### DIFF
--- a/content/en/logs/guide/enrichment-tables.md
+++ b/content/en/logs/guide/enrichment-tables.md
@@ -59,7 +59,7 @@ To update enrichment tables from S3, Datadog uses the IAM role in your AWS accou
 ```
 ### Define the table
 
-Create an Enrichment Table by clicking **New Enrichment Table +**, adding a name, selecting AWS S3, filling out all the fields, clicking import, and finally defining the primary key on which all lookups will happen. It may take a few seconds between clicking import and having the preview available for setting up your primary key in the schema.
+Click **New Enrichment Table +**, then add a name, select AWS S3, fill out all fields, click import, and define the primary key for lookups.
 
 {{< img src="logs/guide/enrichment-tables/configure-s3-enrichment-table.png" alt="Create an Enrichment Table" style="width:100%;">}}
 

--- a/content/en/logs/guide/enrichment-tables.md
+++ b/content/en/logs/guide/enrichment-tables.md
@@ -21,7 +21,7 @@ Define new entities in Datadog like customer details, service names and informat
 
 {{< img src="logs/guide/enrichment-tables/overview.png" alt="Enrichment Tables" style="width:100%;">}}
 
-## Create an Enrichment Table
+## Create an enrichment table
 
 {{< tabs >}}
 {{% tab "Manual upload" %}}

--- a/content/en/logs/guide/enrichment-tables.md
+++ b/content/en/logs/guide/enrichment-tables.md
@@ -57,7 +57,7 @@ To update enrichment tables from S3, Datadog uses the IAM role in your AWS accou
 	"Version": "2012-10-17"
 }
 ```
-### Define The Table
+### Define the table
 
 Create an Enrichment Table by clicking **New Enrichment Table +**, adding a name, selecting AWS S3, filling out all the fields, clicking import, and finally defining the primary key on which all lookups will happen. It may take a few seconds between clicking import and having the preview available for setting up your primary key in the schema.
 

--- a/content/en/logs/guide/enrichment-tables.md
+++ b/content/en/logs/guide/enrichment-tables.md
@@ -26,40 +26,45 @@ Define new entities in Datadog like customer details, service names and informat
 {{< tabs >}}
 {{% tab "Manual Upload" %}}
 
-Create an Enrichment Table by uploading a CSV file, naming all the appropriate columns, and defining the primary key, on which all lookups will happen.
+Create an Enrichment Table by clicking **New Enrichment Table +** then uploading a CSV file, naming all the appropriate columns, and defining the primary key, on which all lookups will happen.
 
 {{< img src="logs/guide/enrichment-tables/configure-enrichment-table.png" alt="Create an Enrichment Table" style="width:100%;">}}
 {{% /tab %}}
 
 {{% tab "AWS S3 Upload" %}}
 
-Enrichment tables can automatically pull a csv file from an AWS S3 bucket to keep your data up to date. The integration will look for changes to the csv file in S3 and when a new version is found it will replace the enrichment table with the new data. This also enables API updating via the S3 API once you’ve set up the initial table.
+Enrichment tables can automatically pull a csv file from an AWS S3 bucket to keep your data up to date. The integration will look for changes to the csv file in S3, and when the file is updated it will replace the Enrichment Table with the new data. This also enables API updating via the S3 API once you’ve configured the initial Enrichment Table.
 
-In order to update enrichment tables from S3, Datadog uses the IAM Role in your AWS account that you configured for your [AWS integration][2]. If you have not yet created that Role, [follow these steps][3] to do so. To allow that Role to update your enrichment tables, add the following permission statement to its IAM policies. Be sure to edit the bucket names and, if desired, specify the paths that contain your csv files.
+In order to update Enrichment Tables from S3, Datadog uses the IAM Role in your AWS account that you configured for your [AWS integration][1]. If you have not yet created that Role, [follow these steps][2] to do so. To allow that Role to update your Enrichment Tables, add the following permission statement to its IAM policies. Be sure to edit the bucket names to match your environment.
 
 
 ```json
- {
-      "Sid": "EnrichmentTablesS3",
-      "Effect": "Allow",
-      "Action": ["s3:PutObject", "s3:GetObject"],
-      "Resource": [
-        "arn:aws:s3:::<MY_BUCKET_NAME_1_/_MY_OPTIONAL_BUCKET_PATH_1>/*",
-        "arn:aws:s3:::<MY_BUCKET_NAME_2_/_MY_OPTIONAL_BUCKET_PATH_2>/*"
-      ]
-    },
-    {
-      "Sid": "EnrichmentTablesS3",
-      "Effect": "Allow",
-      "Action": "s3:ListBucket",
-      "Resource": [
-        "arn:aws:s3:::<MY_BUCKET_NAME_1>",
-        "arn:aws:s3:::<MY_BUCKET_NAME_2>"
-      ]
-    }
-  ]
+{
+    "Statement": [
+        {
+            "Sid": "EnrichmentTablesS3",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::<MY_BUCKET_NAME_1/*>",
+       			 "arn:aws:s3:::<MY_BUCKET_NAME_2>"
+            ]
+        }
+    ],
+    "Version": "2012-10-17"
 }
 ```
+### Define The Table
+
+Create an Enrichment Table by clicking **New Enrichment Table +**, adding a name, selecting AWS S3, filling out all the fields, clicking import, and finally defining the primary key on which all lookups will happen. It may take a few seconds between clicking import and having the preview available for setting up your primary key in the schema.
+
+{{< img src="logs/guide/enrichment-tables/configure-s3-enrichment-table.png" alt="Create an Enrichment Table" style="width:100%;">}}
+
+[1]: https://app.datadoghq.com/account/settings#integrations/amazon-web-services
+[2]: https://docs.datadoghq.com/integrations/amazon_web_services/?tab=automaticcloudformation#installation
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -67,7 +72,7 @@ This Enrichment Table can now be used to add additional attributes to logs with 
 
 ## Modify an Enrichment Table
 
-In order to modify an existing Enrichment Table with new data, click the **Update Data +** button in the top right corner. The CSV that is selected will be upserted into the table, meaning that all existing rows with the same primary key will be updated, and all new rows will be added. Once the table is saved, the upserted rows will be processed asynchronously and will be updated in the preview. It may take up to 10 minutes for the updated rows to appear in affected logs.
+In order to modify an existing Enrichment Table with new data, select a table then click the **Update Data +** button in the top right corner. The CSV that is selected will be upserted into the table, meaning that all existing rows with the same primary key will be updated, and all new rows will be added. Once the table is saved, the upserted rows will be processed asynchronously and will be updated in the preview. It may take up to 10 minutes for the updated rows to appear in affected logs.
 
 ## Further Reading
 

--- a/content/en/logs/guide/enrichment-tables.md
+++ b/content/en/logs/guide/enrichment-tables.md
@@ -70,7 +70,7 @@ Click **New Enrichment Table +**, then add a name, select AWS S3, fill out all f
 
 This enrichment table can now be used to add additional attributes to logs with the [Lookup Processor][1].
 
-## Modify an Enrichment Table
+## Modify an enrichment table
 
 To modify an existing enrichment table with new data, select a table then click **Update Data +** in the top right corner. The selected CSV is upserted into the table, meaning that all existing rows with the same primary key are updated, and all new rows are added. Once the table is saved, the upserted rows are processed asynchronously and updated in the preview. It may take up to 10 minutes for the updated rows to appear in affected logs.
 

--- a/content/en/logs/guide/enrichment-tables.md
+++ b/content/en/logs/guide/enrichment-tables.md
@@ -31,7 +31,7 @@ Click **New Enrichment Table +**, then upload a CSV file, name the appropriate c
 {{< img src="logs/guide/enrichment-tables/configure-enrichment-table.png" alt="Create an Enrichment Table" style="width:100%;">}}
 {{% /tab %}}
 
-{{% tab "AWS S3 Upload" %}}
+{{% tab "AWS S3 upload" %}}
 
 Enrichment tables can automatically pull a csv file from an AWS S3 bucket to keep your data up to date. The integration will look for changes to the csv file in S3, and when the file is updated it will replace the Enrichment Table with the new data. This also enables API updating via the S3 API once you’ve configured the initial Enrichment Table.
 

--- a/content/en/logs/guide/enrichment-tables.md
+++ b/content/en/logs/guide/enrichment-tables.md
@@ -23,9 +23,45 @@ Define new entities in Datadog like customer details, service names and informat
 
 ## Create an Enrichment Table
 
+{{< tabs >}}
+{{% tab "Manual Upload" %}}
+
 Create an Enrichment Table by uploading a CSV file, naming all the appropriate columns, and defining the primary key, on which all lookups will happen.
 
 {{< img src="logs/guide/enrichment-tables/configure-enrichment-table.png" alt="Create an Enrichment Table" style="width:100%;">}}
+{{% /tab %}}
+
+{{% tab "AWS S3 Upload" %}}
+
+Enrichment tables can automatically pull a csv file from an AWS S3 bucket to keep your data up to date. The integration will look for changes to the csv file in S3 and when a new version is found it will replace the enrichment table with the new data. This also enables API updating via the S3 API once you’ve set up the initial table.
+
+In order to update enrichment tables from S3, Datadog uses the IAM Role in your AWS account that you configured for your [AWS integration][2]. If you have not yet created that Role, [follow these steps][3] to do so. To allow that Role to update your enrichment tables, add the following permission statement to its IAM policies. Be sure to edit the bucket names and, if desired, specify the paths that contain your csv files.
+
+
+```json
+ {
+      "Sid": "EnrichmentTablesS3",
+      "Effect": "Allow",
+      "Action": ["s3:PutObject", "s3:GetObject"],
+      "Resource": [
+        "arn:aws:s3:::<MY_BUCKET_NAME_1_/_MY_OPTIONAL_BUCKET_PATH_1>/*",
+        "arn:aws:s3:::<MY_BUCKET_NAME_2_/_MY_OPTIONAL_BUCKET_PATH_2>/*"
+      ]
+    },
+    {
+      "Sid": "EnrichmentTablesS3",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": [
+        "arn:aws:s3:::<MY_BUCKET_NAME_1>",
+        "arn:aws:s3:::<MY_BUCKET_NAME_2>"
+      ]
+    }
+  ]
+}
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 This Enrichment Table can now be used to add additional attributes to logs with the [Lookup Processor][1].
 

--- a/content/en/logs/guide/enrichment-tables.md
+++ b/content/en/logs/guide/enrichment-tables.md
@@ -68,7 +68,7 @@ Click **New Enrichment Table +**, then add a name, select AWS S3, fill out all f
 {{% /tab %}}
 {{< /tabs >}}
 
-This Enrichment Table can now be used to add additional attributes to logs with the [Lookup Processor][1].
+This enrichment table can now be used to add additional attributes to logs with the [Lookup Processor][1].
 
 ## Modify an Enrichment Table
 

--- a/content/en/logs/guide/enrichment-tables.md
+++ b/content/en/logs/guide/enrichment-tables.md
@@ -33,7 +33,7 @@ Click **New Enrichment Table +**, then upload a CSV file, name the appropriate c
 
 {{% tab "AWS S3 upload" %}}
 
-Enrichment tables can automatically pull a csv file from an AWS S3 bucket to keep your data up to date. The integration will look for changes to the csv file in S3, and when the file is updated it will replace the Enrichment Table with the new data. This also enables API updating via the S3 API once you’ve configured the initial Enrichment Table.
+Enrichment tables can automatically pull a CSV file from an AWS S3 bucket to keep your data up to date. The integration looks for changes to the CSV file in S3, and when the file is updated it replaces the enrichment table with the new data. This also enables API updating with the S3 API once the initial enrichment table is configured.
 
 To update enrichment tables from S3, Datadog uses the IAM role in your AWS account that you configured for the [AWS integration][1]. If you have not yet created that role, [follow these steps][2] to do so. To allow that role to update your enrichment tables, add the following permission statement to its IAM policies. Be sure to edit the bucket names to match your environment.
 

--- a/content/en/logs/guide/enrichment-tables.md
+++ b/content/en/logs/guide/enrichment-tables.md
@@ -24,7 +24,7 @@ Define new entities in Datadog like customer details, service names and informat
 ## Create an Enrichment Table
 
 {{< tabs >}}
-{{% tab "Manual Upload" %}}
+{{% tab "Manual upload" %}}
 
 Click **New Enrichment Table +**, then upload a CSV file, name the appropriate columns, and define the primary key for lookups.
 

--- a/content/en/logs/guide/enrichment-tables.md
+++ b/content/en/logs/guide/enrichment-tables.md
@@ -40,21 +40,21 @@ In order to update Enrichment Tables from S3, Datadog uses the IAM Role in your 
 
 ```json
 {
-    "Statement": [
-        {
-            "Sid": "EnrichmentTablesS3",
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::<MY_BUCKET_NAME_1/*>",
-       			 "arn:aws:s3:::<MY_BUCKET_NAME_2>"
-            ]
-        }
-    ],
-    "Version": "2012-10-17"
+	"Statement": [
+		{
+			"Sid": "EnrichmentTablesS3",
+			"Effect": "Allow",
+			"Action": [
+				"s3:GetObject",
+				"s3:ListBucket"
+			],
+			"Resource": [
+				"arn:aws:s3:::<MY_BUCKET_NAME_1/*>",
+				"arn:aws:s3:::<MY_BUCKET_NAME_2>"
+			]
+		}
+	],
+	"Version": "2012-10-17"
 }
 ```
 ### Define The Table

--- a/content/en/logs/guide/enrichment-tables.md
+++ b/content/en/logs/guide/enrichment-tables.md
@@ -26,7 +26,7 @@ Define new entities in Datadog like customer details, service names and informat
 {{< tabs >}}
 {{% tab "Manual Upload" %}}
 
-Create an Enrichment Table by clicking **New Enrichment Table +** then uploading a CSV file, naming all the appropriate columns, and defining the primary key, on which all lookups will happen.
+Click **New Enrichment Table +**, then upload a CSV file, name the appropriate columns, and define the primary key for lookups.
 
 {{< img src="logs/guide/enrichment-tables/configure-enrichment-table.png" alt="Create an Enrichment Table" style="width:100%;">}}
 {{% /tab %}}

--- a/content/en/logs/guide/enrichment-tables.md
+++ b/content/en/logs/guide/enrichment-tables.md
@@ -35,7 +35,7 @@ Click **New Enrichment Table +**, then upload a CSV file, name the appropriate c
 
 Enrichment tables can automatically pull a csv file from an AWS S3 bucket to keep your data up to date. The integration will look for changes to the csv file in S3, and when the file is updated it will replace the Enrichment Table with the new data. This also enables API updating via the S3 API once you’ve configured the initial Enrichment Table.
 
-In order to update Enrichment Tables from S3, Datadog uses the IAM Role in your AWS account that you configured for your [AWS integration][1]. If you have not yet created that Role, [follow these steps][2] to do so. To allow that Role to update your Enrichment Tables, add the following permission statement to its IAM policies. Be sure to edit the bucket names to match your environment.
+To update enrichment tables from S3, Datadog uses the IAM role in your AWS account that you configured for the [AWS integration][1]. If you have not yet created that role, [follow these steps][2] to do so. To allow that role to update your enrichment tables, add the following permission statement to its IAM policies. Be sure to edit the bucket names to match your environment.
 
 
 ```json

--- a/content/en/logs/guide/enrichment-tables.md
+++ b/content/en/logs/guide/enrichment-tables.md
@@ -72,7 +72,7 @@ This enrichment table can now be used to add additional attributes to logs with 
 
 ## Modify an Enrichment Table
 
-In order to modify an existing Enrichment Table with new data, select a table then click the **Update Data +** button in the top right corner. The CSV that is selected will be upserted into the table, meaning that all existing rows with the same primary key will be updated, and all new rows will be added. Once the table is saved, the upserted rows will be processed asynchronously and will be updated in the preview. It may take up to 10 minutes for the updated rows to appear in affected logs.
+To modify an existing enrichment table with new data, select a table then click **Update Data +** in the top right corner. The selected CSV is upserted into the table, meaning that all existing rows with the same primary key are updated, and all new rows are added. Once the table is saved, the upserted rows are processed asynchronously and updated in the preview. It may take up to 10 minutes for the updated rows to appear in affected logs.
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This updates the enrichment table documentation and adds instructions for configuring S3 buckets

### Motivation
The s3 integration is now available

### Preview
/logs/guide/enrichment-tables/?tab=awss3upload#create-an-enrichment-table


Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/Charlie_Meynet/Enrichment_Table_S3

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
