### PR TITLE
Fix for Azure image source / map in security rules 

### DIFF
--- a/data/security_monitoring/data.yaml
+++ b/data/security_monitoring/data.yaml
@@ -13,7 +13,7 @@ image_map:
     append: false
   - source:
       - azure
-    image: azure.active_directory
+    image: azure
     append: false
   - source:
       - cloudtrail


### PR DESCRIPTION
### What does this PR do?
Updates image/source map for Azure

### Motivation
Reported via Slack - https://dd.slack.com/archives/C3CT8QA11/p1607561270000700
Change in file name 

### Preview
https://docs-staging.datadoghq.com/nsollecito/fix-azure-security-rule/security_monitoring/default_rules/?q=azure

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
