### PR TITLE
Entire dashboard can be shared via public URL

### DIFF
--- a/content/en/dashboards/_index.md
+++ b/content/en/dashboards/_index.md
@@ -101,7 +101,7 @@ Datadog offers two types of dashboards: [screenboards][4] and [timeboards][3]. T
 | Time scope                 | All graphs share the same time scope. | Graphs can have individual time scopes.   |
 | Layout                     | Graphs are displayed in a fixed grid. | Graphs are placed anywhere on the canvas. |
 | Share graphs individually  | Yes                                   | No                                        |
-| Share the entire dashboard | No                                    | Yes                                       |
+| Share the entire dashboard | Yes                                   | Yes                                       |
 | Sharing can be read-only   | Yes                                   | Yes                                       |
 
 ### Copy / import / export


### PR DESCRIPTION
We can share the entire timeboard via public URL since April 2020.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Correct the information about timeboards sharing.

### Motivation
<!-- What inspired you to submit this pull request?-->
I have a customer reach out clarifying this.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/dashboards/#screenboard-vs-timeboard

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
