### PR TITLE
[DOCS-1514] Corrected Windows server file locations

### DIFF
--- a/content/en/agent/guide/agent-configuration-files.md
+++ b/content/en/agent/guide/agent-configuration-files.md
@@ -24,7 +24,7 @@ The Agent v6 configuration file uses **YAML** to better support complex configur
 | Source                               | `/etc/datadog-agent/datadog.yaml`    |
 | Suse                                 | `/etc/datadog-agent/datadog.yaml`    |
 | Ubuntu                               | `/etc/datadog-agent/datadog.yaml`    |
-| Windows Server 2008, Vista and newer | `\\ProgramData\Datadog\datadog.yaml` |
+| Windows Server 2008, Vista and newer | `%ProgramData%\Datadog\datadog.yaml` |
 | Windows Server 2003, XP or older     | *unsupported platform*               |
 
 {{% /tab %}}
@@ -41,7 +41,7 @@ The Agent v6 configuration file uses **YAML** to better support complex configur
 | Source                               | `/etc/dd-agent/datadog.conf`                                               |
 | Suse                                 | `/etc/dd-agent/datadog.conf`                                               |
 | Ubuntu                               | `/etc/dd-agent/datadog.conf`                                               |
-| Windows Server 2008, Vista and newer | `\\ProgramData\Datadog\datadog.conf`                                       |
+| Windows Server 2008, Vista and newer | `%ProgramData%\Datadog\datadog.conf`                                       |
 | Windows Server 2003, XP or older     | `\\Documents and Settings\All Users\Application Data\Datadog\datadog.conf` |
 
 {{% /tab %}}
@@ -68,7 +68,7 @@ Prior releases of Datadog Agent stored configuration files in `/dd-agent/conf.d/
 | Source                               | `/etc/datadog-agent/conf.d/`   |
 | Suse                                 | `/etc/datadog-agent/conf.d/`   |
 | Ubuntu                               | `/etc/datadog-agent/conf.d/`   |
-| Windows Server 2008, Vista and newer | `\\ProgramData\Datadog\conf.d` |
+| Windows Server 2008, Vista and newer | `%ProgramData%a\Datadog\conf.d` |
 | Windows Server 2003, XP or older     | *unsupported platform*         |
 
 ### Checks configuration files for Agent 6
@@ -109,7 +109,7 @@ To preserve backwards compatibility, the Agent still picks up configuration file
 | Source                               | `/etc/dd-agent/conf.d/`                                              |
 | Suse                                 | `/etc/dd-agent/conf.d/`                                              |
 | Ubuntu                               | `/etc/dd-agent/conf.d/`                                              |
-| Windows Server 2008, Vista and newer | `\\ProgramData\Datadog\conf.d`                                       |
+| Windows Server 2008, Vista and newer | `%ProgramData%\Datadog\conf.d`                                       |
 | Windows Server 2003, XP or older     | `\\Documents and Settings\All Users\Application Data\Datadog\conf.d` |
 
 {{% /tab %}}

--- a/content/en/agent/guide/agent-configuration-files.md
+++ b/content/en/agent/guide/agent-configuration-files.md
@@ -68,7 +68,7 @@ Prior releases of Datadog Agent stored configuration files in `/dd-agent/conf.d/
 | Source                               | `/etc/datadog-agent/conf.d/`   |
 | Suse                                 | `/etc/datadog-agent/conf.d/`   |
 | Ubuntu                               | `/etc/datadog-agent/conf.d/`   |
-| Windows Server 2008, Vista and newer | `%ProgramData%a\Datadog\conf.d` |
+| Windows Server 2008, Vista and newer | `%ProgramData%\Datadog\conf.d` |
 | Windows Server 2003, XP or older     | *unsupported platform*         |
 
 ### Checks configuration files for Agent 6


### PR DESCRIPTION
\\ProgramData is not meaningful, so replaced with the environmental variable ProgramData.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
