### PR TITLE
Corrected link for Kubermetes short lived containers

### DIFF
--- a/content/en/agent/docker/log.md
+++ b/content/en/agent/docker/log.md
@@ -270,4 +270,4 @@ For Kubernetes environments, refer to the [Kubernetes short lived container docu
 [7]: /getting_started/tagging/unified_service_tagging
 [8]: /agent/logs/advanced_log_collection/?tab=docker#filter-logs
 [9]: /agent/logs/advanced_log_collection/?tab=docker#scrub-sensitive-data-from-your-logs
-[10]: /agent/logs/advanced_log_collection/?tab=docker#multi-line-aggregation
+[10]: /agent/kubernetes/log/?tab=daemonset#short-lived-containers


### PR DESCRIPTION
Updated link to Kubernetes short lived containers documentation

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Updated the link for the short lived containers docs for kubernetes.

### Motivation
<!-- What inspired you to submit this pull request?-->
Due to customer feedback

### Preview
<!-- Impacted pages preview links-->


<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/mkdatadog-patch-1/agent/docker/log/?tab=containerinstallation

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
