### PR TITLE
Fix data_collected.md links

### DIFF
--- a/content/en/real_user_monitoring/browser/data_collected.md
+++ b/content/en/real_user_monitoring/browser/data_collected.md
@@ -299,17 +299,18 @@ The following attributes are related to the geolocation of IP addresses:
 
 ## Extra Attribute
 
-In addition to default attributes, add [specific global context][1] to all events collected. This provides the ability to analyze the data for a subset of users. For example, group errors by user email, or understand which customers have the worst performance.
+In addition to default attributes, add [specific global context][8] to all events collected. This provides the ability to analyze the data for a subset of users. For example, group errors by user email, or understand which customers have the worst performance.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 
-[1]: /real_user_monitoring/browser/advanced_configuration/
+[1]: /real_user_monitoring/browser/data_collected/?tab=view
 [2]: /real_user_monitoring/browser/data_collected/?tab=resource
 [3]: /real_user_monitoring/browser/data_collected/?tab=longtask
 [4]: /real_user_monitoring/browser/data_collected/?tab=error
 [5]: /real_user_monitoring/browser/data_collected/?tab=useraction
 [6]: /real_user_monitoring/data_collected/view#single-page-applications
-[7]: /logs/processing/attributes_naming_convention/#user-agent-attributes
+[7]: https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
+[8]: /real_user_monitoring/browser/advanced_configuration/?tab=npm#add-global-context


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Fix various links on the RUM Browser Data Collected docs page.
https://docs.datadoghq.com/real_user_monitoring/browser/data_collected/?tab=view

1. View link should go to View tab instead of advanced configuration page
2. Change ISO code link to link to https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes like it does here (https://docs.datadoghq.com/logs/processing/attributes_naming_convention/#geolocation)
3. Change "specific global context" link to link to advanced configuration

### Motivation
Was browsing docs and noticed links the view link didn't go where I expected. Then tried to scan the document and fix other possibly broken links.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
