### PR TITLE
Update wording on the names of the .NET Tracer logs

### DIFF
--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -145,8 +145,8 @@ Logs files are saved in the following directories by default. Use the `DD_TRACE_
 For more details on how to configure the .NET Tracer, see the [Configuration][1] section.
 
 There are two types of logs that are created in these paths:
-1. **Native Logs:** In 1.21.0 and higher, these logs are saved as `dotnet-tracer-native.log`. In 1.20.x and older versions, this was stored as `dotnet-profiler.log`.
-2. **Managed Logs:** In 1.21.0 and higher, these logs are saved `dotnet-tracer-managed-<processname>-<date>.log`. In 1.20.x and older versions, this was stored as `dotnet-tracer-<processname>-<date>.log`.
+1. **Logs from native code:** In 1.21.0 and higher, these logs are saved as `dotnet-tracer-native.log`. In 1.20.x and older versions, this was stored as `dotnet-profiler.log`.
+2. **Logs from managed code:** In 1.21.0 and higher, these logs are saved `dotnet-tracer-managed-<processname>-<date>.log`. In 1.20.x and older versions, this was stored as `dotnet-tracer-<processname>-<date>.log`.
 
 
 [1]: /tracing/setup/dotnet/#configuration
@@ -334,14 +334,14 @@ YYYY/MM/DD 16:06:35 Datadog Tracer <version> DEBUG: Sending payload: size: <size
 {{% /tab %}}
 {{% tab ".NET" %}}
 
-### Native log
+### Logs from native code
 
 ```shell
 [dotnet] 19861: [debug] JITCompilationStarted: function_id=<function id> token=<token id> name=System.Net.Http.Headers.HttpHeaders.RemoveParsedValue()
 ```
 
 
-### Managed logs showing spans were generated
+### Logs from managed code showing spans were generated
 
 ```shell
 { MachineName: ".", ProcessName: "dotnet", PID: <process id>, AppDomainName: "test-webapi" }
@@ -351,7 +351,7 @@ YYYY-MM-DD HH:MM:SS.<integer> +00:00 [DBG] Span closed: [s_id: <span id>, p_id: 
 ```
 
 
-### Managed logs showing traces couldn't be sent to the Datadog Agent
+### Logs from managed code showing traces couldn't be sent to the Datadog Agent
 
 ```shell
 YYYY-MM-DD HH:MM:SS.<integer> +00:00 [ERR] An error occurred while sending traces to the agent at System.Net.Http.HttpRequestException: Connection refused ---> System.Net.Sockets.SocketException: Connection refused

--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -144,6 +144,10 @@ Logs files are saved in the following directories by default. Use the `DD_TRACE_
 
 For more details on how to configure the .NET Tracer, see the [Configuration][1] section.
 
+There are two types of logs that are created in these paths:
+1. **Native Logs:** In 1.21.0 and higher, these logs are saved as `dotnet-tracer-native.log`. In 1.20.x and older versions, this was stored as `dotnet-profiler.log`.
+2. **Managed Logs:** In 1.21.0 and higher, these logs are saved `dotnet-tracer-managed-<processname>-<date>.log`. In 1.20.x and older versions, this was stored as `dotnet-tracer-<processname>-<date>.log`.
+
 
 [1]: /tracing/setup/dotnet/#configuration
 {{% /tab %}}
@@ -330,14 +334,14 @@ YYYY/MM/DD 16:06:35 Datadog Tracer <version> DEBUG: Sending payload: size: <size
 {{% /tab %}}
 {{% tab ".NET" %}}
 
-### Profiler log
+### Native log
 
 ```shell
 [dotnet] 19861: [debug] JITCompilationStarted: function_id=<function id> token=<token id> name=System.Net.Http.Headers.HttpHeaders.RemoveParsedValue()
 ```
 
 
-### Tracer logs showing spans were generated
+### Managed logs showing spans were generated
 
 ```shell
 { MachineName: ".", ProcessName: "dotnet", PID: <process id>, AppDomainName: "test-webapi" }
@@ -347,7 +351,7 @@ YYYY-MM-DD HH:MM:SS.<integer> +00:00 [DBG] Span closed: [s_id: <span id>, p_id: 
 ```
 
 
-### Tracer logs showing traces couldn't be sent to the Datadog Agent
+### Managed logs showing traces couldn't be sent to the Datadog Agent
 
 ```shell
 YYYY-MM-DD HH:MM:SS.<integer> +00:00 [ERR] An error occurred while sending traces to the agent at System.Net.Http.HttpRequestException: Connection refused ---> System.Net.Sockets.SocketException: Connection refused


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

As of 1.21.0: https://github.com/DataDog/dd-trace-dotnet/releases/tag/v1.21.0, the file paths for the .NET Tracer's debug logs were updated. I added a note about the naming of the files to this PR, as well as change the title of the example.

### Motivation
<!-- What inspired you to submit this pull request?-->

To make it more clear what the files are.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/wantsui/dotnet-debug-logs-update/tracing/troubleshooting/tracer_debug_logs/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

The .NET Team should be reviewing this first, so looping in @jaycdave88 for awareness.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
