### PR TITLE
Fix link

### DIFF
--- a/content/ja/tracing/setup/ruby.md
+++ b/content/ja/tracing/setup/ruby.md
@@ -54,7 +54,7 @@ title: Ruby アプリケーションのトレース
      - [http.rb](#http-rb)
      - [MongoDB](#mongodb)
      - [MySQL2](#mysql2)
-     - [Net/HTTP](#net-http)
+     - [Net/HTTP](#nethttp)
      - [Presto](#presto)
      - [Que](#que)
      - [Racecar](#racecar)


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Fix a link in content/ja/tracing/setup/ruby.md

### Motivation

The link to Net/HTTP in the table of contents is broken.
https://docs.datadoghq.com/ja/tracing/setup/ruby/

### Preview

N/A

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.