### PR TITLE
APM > .NET > Compatibility > fix typo

### DIFF
--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
@@ -13,7 +13,7 @@ further_reading:
       text: 'Instrument Your Application'
 ---
 
-## Compatiblity
+## Compatibility
 
 The .NET Datadog Trace library is open source - view the [Github repository][1] for more information.
 


### PR DESCRIPTION
### What does this PR do?
Fix typo: `Compatiblity` ➡️  `Compatibility`

### Motivation
Self-evident.

### Preview
https://docs-staging.datadoghq.com/lpimentel/apm-dotnet-compatibility-typo/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
