### PR TITLE
build errors with package and lock

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,6 +48,8 @@ install_dependencies:
   cache:
     <<: *cache
   script:
+    # avoid conflicts in package.json by removing and always install pinned from lockfile
+    - rm package.json
     - yarn install --frozen-lockfile
   only:
     changes:


### PR DESCRIPTION
### What does this PR do?

This PR avoids the error message

`error Your lockfile needs to be updated, but yarn was run with '--frozen-lockfile'.`

it does this by removing the package.json file before installing via the frozen lockfile.
We only want to install the pinned versions anyway so we don't care about potential changes in the package.json

### Motivation

Build issues

### Preview

preview should be the same
https://docs-staging.datadoghq.com/david.jones/buildlockfix/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
