### PR TITLE
APM > .NET > run Windows installers as administrator

### DIFF
--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -61,7 +61,7 @@ Automatic instrumentation captures:
 
 Otherwise, to begin tracing applications written in any language, first [install and configure the Datadog Agent][1]. The .NET Tracer runs in-process to instrument your applications and sends traces from your application to the Agent.
 
-To use automatic instrumentation on Windows, install the .NET Tracer on the host using the [MSI installer for Windows][2]. Choose the installer for the architecture that matches the operating system (x64 or x86).
+To use automatic instrumentation on Windows, install the .NET Tracer on the host by running the [MSI installer for Windows][2] as administrator. Choose the installer for the architecture that matches the operating system (x64 or x86).
 
 After installing the .NET Tracer, restart applications so they can read the new environment variables. To restart IIS, run the following commands as administrator:
 

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -61,7 +61,7 @@ Automatic instrumentation captures:
 
 ### Installation
 
-To use automatic instrumentation on Windows, install the .NET Tracer on the host using the [MSI installer for Windows][4]. Choose the installer for the architecture that matches the operating system (x64 or x86).
+To use automatic instrumentation on Windows, install the .NET Tracer on the host by running the [MSI installer for Windows][4] as administrator. Choose the installer for the architecture that matches the operating system (x64 or x86).
 
 After installing the .NET Tracer, restart applications so they can read the new environment variables. To restart IIS, run the following commands as administrator:
 


### PR DESCRIPTION
### What does this PR do?
Add phrase to indicate that MSI installers for Windows should be run as administrator.

### Motivation
A support issue was raised by a user trying to run the installer with a non-administrator account.

### Preview
- [APM - Tracing .NET Framework Applications](https://docs-staging.datadoghq.com/lpimentel/apm-dotnet-installer-administrator/tracing/setup_overview/setup/dotnet-framework/)
- [APM - Tracing .NET Core Applications](https://docs-staging.datadoghq.com/lpimentel/apm-dotnet-installer-administrator/tracing/setup_overview/setup/dotnet-core/)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
