### PR TITLE
remove unused Further Reading sections

### DIFF
--- a/content/en/tracing/setup_overview/open_standards/dotnet.md
+++ b/content/en/tracing/setup_overview/open_standards/dotnet.md
@@ -5,7 +5,6 @@ code_lang: dotnet
 type: multi-code-lang
 code_lang_weight: 70
 description: 'Open Standards for .NET'
-further_reading:
 ---
 
 ## OpenTracing
@@ -58,11 +57,6 @@ To trace code running in an asynchronous task, create a new scope within the bac
      });
 
 ```
-
-
-## Further Reading
-
-{{< partial name="whats-next/whats-next.html" >}}
 
 
 [1]: https://github.com/opentracing/opentracing-csharp

--- a/content/en/tracing/setup_overview/open_standards/go.md
+++ b/content/en/tracing/setup_overview/open_standards/go.md
@@ -44,9 +44,6 @@ func main() {
 
 **Note**: Using the [OpenTracing API][1] in parallel with the regular API or Datadog integrations is fully supported. Under the hood, all of them make use of the same tracer. See the [API documentation][2] for more examples and details.
 
-## Further Reading
-
-{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/opentracing/opentracing-go
 [2]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer

--- a/content/en/tracing/setup_overview/open_standards/java.md
+++ b/content/en/tracing/setup_overview/open_standards/java.md
@@ -5,7 +5,6 @@ description: 'Open Standards for Java'
 code_lang: java
 type: multi-code-lang
 code_lang_weight: 0
-further_reading:
 
 ---
 
@@ -177,10 +176,6 @@ public class MyHttpRequestExtractAdapter implements TextMap {
 
 Notice the above examples only use the OpenTracing classes. Check the [OpenTracing API][1] for more details and information.
 
-
-## Further Reading
-
-{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/opentracing/opentracing-java
 [2]: https://github.com/DataDog/dd-trace-java/blob/master/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java

--- a/content/en/tracing/setup_overview/open_standards/nodejs.md
+++ b/content/en/tracing/setup_overview/open_standards/nodejs.md
@@ -5,7 +5,6 @@ description: 'Open Standards for NodeJS'
 code_lang: nodejs
 type: multi-code-lang
 code_lang_weight: 40
-further_reading:
 ---
 
 ## OpenTracing
@@ -153,9 +152,6 @@ Tags that are set directly on individual spans supersede conflicting tags define
 
 - See [npm][2] or [github][3] for more OpenTelemetry NodeJS Datadog Exporter usage.
 
-## Further Reading
-
-{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://opentracing.io/guides/javascript/
 [2]: https://www.npmjs.com/package/opentelemetry-exporter-datadog

--- a/content/en/tracing/setup_overview/open_standards/php.md
+++ b/content/en/tracing/setup_overview/open_standards/php.md
@@ -5,7 +5,6 @@ description: 'Open Standards for PHP'
 code_lang: php
 type: multi-code-lang
 code_lang_weight: 50
-further_reading:
 ---
 
 ## OpenTracing
@@ -31,9 +30,6 @@ $span->setTag('http.method', $_SERVER['REQUEST_METHOD']);
 
 <div class="alert alert-info">Before ddtrace version 0.46.0, an OpenTracing compatible tracer was automatically returned from <code>OpenTracing\GlobalTracer::get()</code> without the need to set the global tracer manually.</div>
 
-## Further Reading
-
-{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/opentracing/opentracing-php
 [2]: /tracing/setup/php/#automatic-instrumentation

--- a/content/en/tracing/setup_overview/open_standards/python.md
+++ b/content/en/tracing/setup_overview/open_standards/python.md
@@ -5,7 +5,6 @@ description: 'Open Standards for Python'
 code_lang: python
 type: multi-code-lang
 code_lang_weight: 10
-further_reading:
 ---
 
 ## OpenTracing
@@ -136,10 +135,6 @@ Tags that are set directly on individual spans supersede conflicting tags define
 ### OpenTelemetry Links
 
 - See [github][2], [opentelemetry examples][3], or [readthedocs][4] for more OpenTelemetry Python Datadog Exporter usage.
-
-## Further Reading
-
-{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://opentracing.io/guides/python/
 [2]: https://github.com/open-telemetry/opentelemetry-python/tree/master/ext/opentelemetry-ext-datadog

--- a/content/en/tracing/setup_overview/open_standards/ruby.md
+++ b/content/en/tracing/setup_overview/open_standards/ruby.md
@@ -5,7 +5,6 @@ description: 'Open Standards for Ruby'
 code_lang: ruby
 type: multi-code-lang
 code_lang_weight: 20
-further_reading:
 ---
 
 ## OpenTracing
@@ -164,10 +163,6 @@ Tags that are set directly on individual spans supersede conflicting tags define
 ### OpenTelemetry Links
 
 - See [rubygems][7] or [github][8] for more OpenTelemetry Ruby Datadog Exporter usage.
-
-## Further Reading
-
-{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /tracing/setup/ruby/#quickstart-for-opentracing
 [2]: /tracing/setup/ruby/#tracer-settings


### PR DESCRIPTION

### What does this PR do?
Removes Further Reading heading on some pages that have no further reading links (and don't need them)

### Motivation
PM spotted this

### Preview
https://docs-staging.datadoghq.com/kari/fix-further-reading-apm/tracing/setup_overview/open_standards/java/ and all the other languages

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
