### PR TITLE
[APM][ECS] Configure host IP using ECS metadata

### DIFF
--- a/content/en/agent/amazon_ecs/apm.md
+++ b/content/en/agent/amazon_ecs/apm.md
@@ -60,29 +60,33 @@ After following the [Amazon ECS agent installation instructions][1], enable trac
 {{< tabs >}}
 {{% tab "EC2 metadata endpoint" %}}
 
-The [Amazon’s EC2 metadata endpoint][2] allows discovery of the private IP address. To get the private IP address for each host, curl the following URL:
+The [Amazon’s EC2 metadata endpoint][1] allows discovery of the private IP address. To get the private IP address for each host, curl the following URL:
 
-    {{< code-block lang="curl" >}}
-    curl http://169.254.169.254/latest/meta-data/local-ipv4
-    {{< /code-block >}}
+{{< code-block lang="curl" >}}
+curl http://169.254.169.254/latest/meta-data/local-ipv4
+{{< /code-block >}}
 
+
+[1]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
 {{% /tab %}}
 {{% tab "ECS container metadata file" %}}
 
-The [Amazon's ECS container metadata file][3] allows discovery of the private IP address. To get the private IP address for each host, run the following command:
+The [Amazon's ECS container metadata file][1] allows discovery of the private IP address. To get the private IP address for each host, run the following command:
 
-    {{< code-block lang="curl" >}}
-    cat $ECS_CONTAINER_METADATA_FILE | jq .HostPrivateIPv4Address
-    {{< /code-block >}}
+{{< code-block lang="curl" >}}
+cat $ECS_CONTAINER_METADATA_FILE | jq .HostPrivateIPv4Address
+{{< /code-block >}}
+
     
+[1]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html#metadata-file-format
 {{% /tab %}}
 {{< /tabs >}}
 
-    Set the result as your Trace Agent hostname environment variable for each application container shipping to APM:
+Set the result as your Trace Agent hostname environment variable for each application container shipping to APM:
 
-    {{< code-block lang="curl" >}}
-    os.environ['DD_AGENT_HOST'] = <EC2_PRIVATE_IP>
-    {{< /code-block >}}
+{{< code-block lang="curl" >}}
+os.environ['DD_AGENT_HOST'] = <EC2_PRIVATE_IP>
+{{< /code-block >}}
     
     
 
@@ -202,5 +206,3 @@ For more examples of setting the Agent hostname in other languages, refer to the
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /agent/amazon_ecs/
-[2]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
-[3]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html#metadata-file-format

--- a/content/en/agent/amazon_ecs/apm.md
+++ b/content/en/agent/amazon_ecs/apm.md
@@ -55,17 +55,36 @@ After following the [Amazon ECS agent installation instructions][1], enable trac
 
     [See all environment variables available for Agent trace collection][1].
 
-2. Assign the private IP address for each underlying instance your containers are running in your application container to the `DD_AGENT_HOST` environment variable. This allows your application traces to be shipped to the Agent. The [Amazon’s EC2 metadata endpoint][2] allows discovery of the private IP address. To get the private IP address for each host, curl the following URL:
+2. Assign the private IP address for each underlying instance your containers are running in your application container to the `DD_AGENT_HOST` environment variable. This allows your application traces to be shipped to the Agent. 
+
+{{< tabs >}}
+{{% tab "EC2 metadata endpoint" %}}
+
+The [Amazon’s EC2 metadata endpoint][2] allows discovery of the private IP address. To get the private IP address for each host, curl the following URL:
 
     {{< code-block lang="curl" >}}
     curl http://169.254.169.254/latest/meta-data/local-ipv4
     {{< /code-block >}}
+
+{{% /tab %}}
+{{% tab "ECS container metadata file" %}}
+
+The [Amazon's ECS container metadata file][3] allows discovery of the private IP address. To get the private IP address for each host, run the following command:
+
+    {{< code-block lang="curl" >}}
+    cat $ECS_CONTAINER_METADATA_FILE | jq .HostPrivateIPv4Address
+    {{< /code-block >}}
+    
+{{% /tab %}}
+{{< /tabs >}}
 
     Set the result as your Trace Agent hostname environment variable for each application container shipping to APM:
 
     {{< code-block lang="curl" >}}
     os.environ['DD_AGENT_HOST'] = <EC2_PRIVATE_IP>
     {{< /code-block >}}
+    
+    
 
 ## Launch time variables
 
@@ -184,3 +203,4 @@ For more examples of setting the Agent hostname in other languages, refer to the
 
 [1]: /agent/amazon_ecs/
 [2]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+[3]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html#metadata-file-format


### PR DESCRIPTION
Providing an alternative option, which is considered more secure, to configure application containers with the host IP of Datadog Agent in order to send APM traces

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
