### PR TITLE
catch issues where tag mismatch and cannot load example.json as expected

### DIFF
--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -324,18 +324,21 @@
                                                 {{ with $dot.Resources.Match "examples.json" }}
                                                     {{ range . }}
                                                       {{ $data := . | unmarshal}}
-                                                      {{ $req := (index (index $data $context.action.operationId) "request") }}
-                                                      {{ if $req }}
+                                                      {{ with (index $data $context.action.operationId) }}
+                                                          {{ with (index . "request") }}
+                                                              {{ $req := . }}
+                                                              {{ $jsonifiedData := (index $req "json") | jsonify (dict "indent" "  ") }}
+                                                              {{ $jsonifiedData = replace (replace $jsonifiedData "\\u003c" "<") "\\u003e" ">"  }}
 
-                                                          {{ $jsonifiedData := (index $req "json") | jsonify (dict "indent" "  ") }}
-                                                          {{ $jsonifiedData = replace (replace $jsonifiedData "\\u003c" "<") "\\u003e" ">"  }}
+                                                              {{ $json_curl := (index $req "json_curl") | jsonify (dict "indent" "  ") }}
+                                                              {{ $json_curl = replace (replace $json_curl "\\u003c" "<") "\\u003e" ">"  }}
 
-                                                          {{ $json_curl := (index $req "json_curl") | jsonify (dict "indent" "  ") }}
-                                                          {{ $json_curl = replace (replace $json_curl "\\u003c" "<") "\\u003e" ">"  }}
-
-                                                          {{ $dot.Scratch.Set "json" (highlight ($jsonifiedData) "json" "") }}
-                                                          {{ $.Scratch.Set "jsonRequestBody" $json_curl }}
-                                                          {{ $dot.Scratch.Set "html" (index $req "html") }}
+                                                              {{ $dot.Scratch.Set "json" (highlight ($jsonifiedData) "json" "") }}
+                                                              {{ $.Scratch.Set "jsonRequestBody" $json_curl }}
+                                                              {{ $dot.Scratch.Set "html" (index $req "html") }}
+                                                          {{ else }}
+                                                              {{ warnf "Could not load html/json request for %q" $context.action.operationId }}
+                                                          {{ end }}
                                                       {{ else }}
                                                           {{ warnf "Could not load html/json request for %q" $context.action.operationId }}
                                                       {{ end }}
@@ -430,16 +433,24 @@
                                                 {{ $dot.Scratch.Set "html" "" }}
                                                 {{ with $dot.Resources.Match "examples.json" }}
                                                     {{ range . }}
-                                                    {{ $data := . | unmarshal}}
-                                                    {{ $res := (index (index (index $data $context.action.operationId) "responses") $response_code) }}
-                                                    {{ if $res }}
-                                                        {{ $jsonifiedData := (index $res "json") | jsonify (dict "indent" "  ") }}
-                                                        {{ $jsonifiedData = replace (replace $jsonifiedData "\\u003c" "<") "\\u003e" ">"  }}
-                                                        {{ $dot.Scratch.Set "json" (highlight ($jsonifiedData) "json" "") }}
-                                                        {{ $dot.Scratch.Set "html" (index $res "html") }}
-                                                    {{ else }}
-                                                        {{ warnf "Could not load html/json response code %q in %q" $response_code $context.action.operationId }}
-                                                    {{ end }}
+                                                        {{ $data := . | unmarshal}}
+                                                        {{ with (index $data $context.action.operationId) }}
+                                                            {{ with (index . "responses") }}
+                                                                {{ $res := (index . $response_code) }}
+                                                                {{ if $res }}
+                                                                    {{ $jsonifiedData := (index $res "json") | jsonify (dict "indent" "  ") }}
+                                                                    {{ $jsonifiedData = replace (replace $jsonifiedData "\\u003c" "<") "\\u003e" ">"  }}
+                                                                    {{ $dot.Scratch.Set "json" (highlight ($jsonifiedData) "json" "") }}
+                                                                    {{ $dot.Scratch.Set "html" (index $res "html") }}
+                                                                {{ else }}
+                                                                    {{ warnf "Could not load html/json response code %q in %q" $response_code $context.action.operationId }}
+                                                                {{ end }}
+                                                            {{ else }}
+                                                                {{ warnf "Could not load html/json responses in data for operation %q" $context.action.operationId }}
+                                                            {{ end }}
+                                                        {{ else }}
+                                                            {{ warnf "Could not load html/json response for %q" $context.action.operationId }}
+                                                        {{ end }}
                                                     {{ end }}
                                                 {{ end }}
                                                 {{ $json := ($dot.Scratch.Get "json") }}


### PR DESCRIPTION
### What does this PR do?

This came from troubleshooting issues with `datadog-api-spec/generated/721` branch where the build was failing. 
Certain operationIds had tags that matched already existing sections. This caused the loading of unrelated `examples.json` to fail as its trying to index keys that don't exist.

This PR uses the with statement to catch and log these errors as warnings.

### Motivation

troubleshooting issues with `datadog-api-spec/generated/721` 

### Preview

General check any request and response json/html table outputs aren't missing or doing anything different.
https://docs-staging.datadoghq.com/david.jones/api-bugfix/api/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
