### PR TITLE
[WEB-1026] - update lang switch dropdown

### DIFF
--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -179,7 +179,7 @@
                 </div>
 
             </div>
-            
+
         </div>
     </div>
     <div class="mt-3 mt-lg-0">
@@ -196,7 +196,11 @@
                                 <label class="sr-only" for="mobile-lang-select">Language Selection</label>
                                 <select class="mobile-lang-select" id="mobile-lang-select" id="" onchange="javascript:location.href = this.value;">
                                     <option value="{{ .Permalink }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
-                                    {{ range .Translations }}
+                                    {{ if ne .Sites.First .Site }}
+                                        <!-- if non eng site manually add english entry -->
+                                        <option value="{{ replace .Permalink (printf "/%s/" $dot.Language.Lang) "/" }}?lang_pref=en">English</a>
+                                    {{ end }}
+                                    {{ range where .Translations "Language.Lang" "!=" "en" }}
                                         <option value="{{ .Permalink }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
                                     {{ end }}
                                 </select>
@@ -210,7 +214,11 @@
                                 </div>
                                 <div class="js-lang-popup lang-popup">
                                     <a class="active" href="{{ .Permalink }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</span></a>
-                                    {{ range .Translations }}
+                                    {{ if ne .Sites.First .Site }}
+                                        <!-- if non eng site manually add english entry -->
+                                        <a href="{{ replace .Permalink (printf "/%s/" $dot.Language.Lang) "/" }}?lang_pref=en">English</a>
+                                    {{ end }}
+                                    {{ range where .Translations "Language.Lang" "!=" "en" }}
                                         <a href="{{ .Permalink }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
                                     {{ end }}
                                </div>


### PR DESCRIPTION
### What does this PR do?

This PR stops relying on .translations for the english menu entry in the lang switcher.
Instead lets always show it when on a non english site as english will always be there.

### Motivation

https://datadoghq.atlassian.net/browse/WEB-1026

### Preview

check footer nav select link in multiple pages in multiple languages
given example was
https://docs-staging.datadoghq.com/david.jones/footer-langlinks/ja/tracing/setup/nginx/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
