### PR TITLE
adding an 'alt' tag to generic 'agent' icons for  the security monito…

### DIFF
--- a/layouts/security_rules/list.html
+++ b/layouts/security_rules/list.html
@@ -57,7 +57,7 @@
                             {{ if $this_img.image }}
                                 <img srcset="{{ $this_img.image }}?w=80&auto-enhance 2x" src="{{ $this_img.image }}?w=40&auto-enhance" width="40" alt="{{ htmlEscape .Params.Source }}" />
                             {{ else }}
-                                <img width="40" height="17" src="{{ partial "img-resource.html" (dict "context" $dot "src" (print "images/svg-icons/agent.svg")) }}" alt="{{ .Key }}" />
+                                <img width="40" height="17" src="{{ partial "img-resource.html" (dict "context" $dot "src" (print "images/svg-icons/agent.svg")) }}" alt="{{ $v.Key }}" />
                             {{ end }}
                             {{ .Title }}<br />
                         </a>

--- a/layouts/security_rules/list.html
+++ b/layouts/security_rules/list.html
@@ -57,7 +57,7 @@
                             {{ if $this_img.image }}
                                 <img srcset="{{ $this_img.image }}?w=80&auto-enhance 2x" src="{{ $this_img.image }}?w=40&auto-enhance" width="40" alt="{{ htmlEscape .Params.Source }}" />
                             {{ else }}
-                                <img width="40" height="17" src="{{ partial "img-resource.html" (dict "context" $dot "src" (print "images/svg-icons/agent.svg")) }}" />
+                                <img width="40" height="17" src="{{ partial "img-resource.html" (dict "context" $dot "src" (print "images/svg-icons/agent.svg")) }}" alt="{{ .Key }}" />
                             {{ end }}
                             {{ .Title }}<br />
                         </a>


### PR DESCRIPTION
…ring rules list page

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adding `alt` tags for all logos on Default Threat Detection Rules page

before:
<img width="902" alt="Screen Shot 2020-12-16 at 6 46 12 AM" src="https://user-images.githubusercontent.com/20311340/102344814-752e8b80-3f6a-11eb-87cd-c420a459108c.png">

after:
<img width="908" alt="Screen Shot 2020-12-16 at 6 46 31 AM" src="https://user-images.githubusercontent.com/20311340/102344830-78297c00-3f6a-11eb-92de-dcfbc47b38d7.png">


### Motivation
Detection rules that were using generic logo image `agent.svg` were missing `alt` tags, and we need to have it for VPAT.

### Preview
https://docs-staging.datadoghq.com/won/202012-img-alt-tag-fix/security_monitoring/default_rules/

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
