### PR TITLE
Clarify that deployment tracking must be opted into

### DIFF
--- a/content/en/serverless/deployment_tracking/_index.md
+++ b/content/en/serverless/deployment_tracking/_index.md
@@ -28,7 +28,7 @@ If you haven’t already, set up the [Amazon Web Services][2] integration first.
 cloudtrail:LookupEvents
 ```
 
-If you have already added the permission, but you still don't see events for any of your AWS Lambda functions, please reach out to our [support team][3].
+If you have already added the permission, but you still don't see events for any of your AWS Lambda functions, please reach out to our [support team][3] to opt into Deployment Tracking.
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR clarifies that Deployment Tracking must be opted into. Strictly speaking, it must be opted into for orgs with ID less than 501450 (US) or 1000028260 (EU). I'm open to suggestions for a good way to say that if you feel it's necessary.

### Motivation
<!-- What inspired you to submit this pull request?-->

I've had several questions about why this or that org's deployment tracking isn't working.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->

https://docs-staging.datadoghq.com/chris.agocs/opt_into_deployment_tracking/serverless/deployment_tracking/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
