### PR TITLE
Update monitor notifications doc with sub-monitor value info

### DIFF
--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -162,6 +162,16 @@ If your facet has periods, use brackets around the facet, for example:
 {{ [@network.client.ip].name }}
 ```
 
+#### Composite monitor variables
+
+Composite monitors can access the value associated with the sub-monitors at the time the alert triggers. 
+
+For example, if your composite monitor has sub-monitor `a`, you can include the value of `a` with:
+
+```text
+{{ a.value }}
+```
+
 ### Conditional variables
 
 Conditional variables use `if-else` logic to display a different message depending on the state of the monitor and the details of how it was triggered. These variables can be used within the subject or body of the notification message.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add documentation around how to access the value variable for sub-monitors associated with a composite monitor.

### Motivation
Lack of documentation around this.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
