### PR TITLE
composite monitor notes

### DIFF
--- a/content/en/monitors/monitor_types/composite.md
+++ b/content/en/monitors/monitor_types/composite.md
@@ -27,7 +27,7 @@ For configuration purposes, a composite monitor is independent of its constituen
 **Notes**
 
 - The terms `individual monitors`, `constituent monitors`, and `non-composite monitors` all refer to monitors used by a composite monitor to calculate its status.
-- Composite results require common groupings. If you choose monitors that do not have common groupings, note that selected monitors in the expression may not lead to a composite result.
+- Composite results require common groupings. If you choose monitors that do not have common groupings, the selected monitors in the expression may not lead to a composite result.
 - Composite monitors cannot be based on other composite monitors.
 
 ## Monitor creation

--- a/content/en/monitors/monitor_types/composite.md
+++ b/content/en/monitors/monitor_types/composite.md
@@ -27,7 +27,8 @@ For configuration purposes, a composite monitor is independent of its constituen
 **Notes**
 
 - The terms `individual monitors`, `constituent monitors`, and `non-composite monitors` all refer to monitors used by a composite monitor to calculate its status.
-- **Synthetics monitors cannot be used with other monitors within a composite monitor.**
+- Composite results require common groupings. If you choose monitors that do not have common groupings, note that selected monitors in the expression may not lead to a composite result.
+- Composite monitors cannot be based on other composite monitors.
 
 ## Monitor creation
 


### PR DESCRIPTION
### What does this PR do?
Adds notes to the composite monitor section:

- Composite monitors require common groupings
- Composite monitors can't contain other composite monitors

### Motivation
Jira request

### Preview
https://docs-staging.datadoghq.com/sarina/composite-monitor/monitors/monitor_types/composite/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
