### PR TITLE
JSON files for ECS docs

### DIFF
--- a/static/resources/json/datadog-agent-ecs-win.json
+++ b/static/resources/json/datadog-agent-ecs-win.json
@@ -3,14 +3,14 @@
     {
       "name": "datadog-agent",
       "image": "datadog/agent:latest",
-      "cpu": 10,
-      "memory": 256,
+      "cpu": 100,
+      "memory": 512,
       "essential": true,
       "mountPoints": [
         {
           "containerPath": "\\\\.\\pipe\\docker_engine",
           "sourceVolume": "docker_sock",
-          "readOnly": true
+          "readOnly": null
         }
       ],
       "environment": [

--- a/static/resources/json/datadog-agent-ecs.json
+++ b/static/resources/json/datadog-agent-ecs.json
@@ -3,24 +3,24 @@
     {
       "name": "datadog-agent",
       "image": "datadog/agent:latest",
-      "cpu": 10,
-      "memory": 256,
+      "cpu": 100,
+      "memory": 512,
       "essential": true,
       "mountPoints": [
         {
           "containerPath": "/var/run/docker.sock",
           "sourceVolume": "docker_sock",
-          "readOnly": true
+          "readOnly": null
         },
         {
           "containerPath": "/host/sys/fs/cgroup",
           "sourceVolume": "cgroup",
-          "readOnly": true
+          "readOnly": null
         },
         {
           "containerPath": "/host/proc",
           "sourceVolume": "proc",
-          "readOnly": true
+          "readOnly": null
         }
       ],
       "environment": [

--- a/static/resources/json/datadog-agent-ecs1.json
+++ b/static/resources/json/datadog-agent-ecs1.json
@@ -3,24 +3,24 @@
     {
       "name": "datadog-agent",
       "image": "datadog/agent:latest",
-      "cpu": 10,
-      "memory": 256,
+      "cpu": 100,
+      "memory": 512,
       "essential": true,
       "mountPoints": [
         {
           "containerPath": "/var/run/docker.sock",
           "sourceVolume": "docker_sock",
-          "readOnly": true
+          "readOnly": null
         },
         {
           "containerPath": "/host/sys/fs/cgroup",
           "sourceVolume": "cgroup",
-          "readOnly": true
+          "readOnly": null
         },
         {
           "containerPath": "/host/proc",
           "sourceVolume": "proc",
-          "readOnly": true
+          "readOnly": null
         }
       ],
       "environment": [


### PR DESCRIPTION
### What does this PR do?
Updates the JSON files associated with the Amazon ECS logs docs:

- Ups CPU and memory to accommodate the process and logs agent if in use
- Sets readOnly to `null` as failure occurs when set to true

### Motivation
Jira request

### Preview
https://docs-staging.datadoghq.com/sarina/agent-ecs-config/agent/amazon_ecs/logs

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
