### PR TITLE
set collect_dns_stats to true

### DIFF
--- a/static/resources/yaml/datadog-agent-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-all-features.yaml
@@ -44,7 +44,7 @@ data:
       bpf_debug: false
       enable_tcp_queue_length: false
       enable_oom_kill: false
-      collect_dns_stats: false
+      collect_dns_stats: true
     runtime_security_config:
       enabled: false
       debug: false

--- a/static/resources/yaml/datadog-agent-npm.yaml
+++ b/static/resources/yaml/datadog-agent-npm.yaml
@@ -44,7 +44,7 @@ data:
       bpf_debug: false
       enable_tcp_queue_length: false
       enable_oom_kill: false
-      collect_dns_stats: false
+      collect_dns_stats: true
     runtime_security_config:
       enabled: false
       debug: false


### PR DESCRIPTION
### What does this PR do?
This PR sets the default value for `collect_dns_stats` for `system-probe` to `true`


### Motivation
We have made DNS stats collection enabled by default in the agent. This PR updates the yaml file to be in sync with that change.


### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
