### PR TITLE
Update information about RUM SDK headers for APM linking

### DIFF
--- a/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
+++ b/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
@@ -121,7 +121,7 @@ Datadog uses the distributed tracing protocol and sets up the following HTTP hea
 | `x-datadog-origin: rum`          | To make sure the generated traces from Real User Monitoring don’t affect your APM Index Spans counts.  |
 | `x-datadog-sampling-priority: 1` | To make sure that the Agent keeps the trace.                                                           |
 | `x-datadog-sampling-priority: 1` | To make sure that the Agent keeps the trace.                                                           |  
-| `x-datadog-sampled: 1`           | Generated from the Real User Monitoring SDK. Indicates this request is selected for sampling           |
+| `x-datadog-sampled: 1`           | Generated from the Real User Monitoring SDK. Indicates this request is selected for sampling.          |
 
 ## How are APM quotas affected?
 

--- a/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
+++ b/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
@@ -118,9 +118,10 @@ Datadog uses the distributed tracing protocol and sets up the following HTTP hea
 | ------------------------------ | ------------------------------------------------------------------------------------------------------ |
 | `x-datadog-trace-id `            | Generated from the Real User Monitoring SDK. Allows Datadog to link the trace with the RUM resource.   |
 | `x-datadog-parent-id`            | Generated from the Real User Monitoring SDK. Allows Datadog to generate the first span from the trace. |
-| `x-datadog-origin: rum`          | To make sure the generated traces from Real User Monitoring don’t affect your APM Index Spans counts.              |
+| `x-datadog-origin: rum`          | To make sure the generated traces from Real User Monitoring don’t affect your APM Index Spans counts.  |
 | `x-datadog-sampling-priority: 1` | To make sure that the Agent keeps the trace.                                                           |
-| `x-datadog-sampling-priority: 1`       | To make sure that the Agent keeps the trace.                                                                      |  
+| `x-datadog-sampling-priority: 1` | To make sure that the Agent keeps the trace.                                                           |  
+| `x-datadog-sampled: 1`           | To indicate this request is selected for sampling                                                      |
 
 ## How are APM quotas affected?
 

--- a/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
+++ b/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
@@ -121,7 +121,7 @@ Datadog uses the distributed tracing protocol and sets up the following HTTP hea
 | `x-datadog-origin: rum`          | To make sure the generated traces from Real User Monitoring don’t affect your APM Index Spans counts.  |
 | `x-datadog-sampling-priority: 1` | To make sure that the Agent keeps the trace.                                                           |
 | `x-datadog-sampling-priority: 1` | To make sure that the Agent keeps the trace.                                                           |  
-| `x-datadog-sampled: 1`           | To indicate this request is selected for sampling                                                      |
+| `x-datadog-sampled: 1`           | Generated from the Real User Monitoring SDK. Indicates this request is selected for sampling           |
 
 ## How are APM quotas affected?
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This adds a mention of `x-datadog-sampled` header being attached to web requests by RUM SDK

### Motivation
<!-- What inspired you to submit this pull request?-->
- `x-datadog-sampled` is not mentioned on docs, it gets attached to requests.
- We faced it when configuring CORS and had RUM SDK "link APM traces" option enabled

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH>/real_user_monitoring/connect_rum_and_traces/_index.md

### Additional Notes
<!-- Anything else we should know when reviewing?-->

Please reconfirm the validity of the DESCRIPTION column for added changes.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
