### PR TITLE
fix bad link rendering

### DIFF
--- a/content/en/agent/kubernetes/operator_configuration.md
+++ b/content/en/agent/kubernetes/operator_configuration.md
@@ -212,6 +212,7 @@ spec:
 | site                                                                                                       | Set the site of the Datadog intake for Agent data: {{< region-param key="dd_site" code="true" >}}. Defaults to `datadoghq.com`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 
 {{< /table >}}
+
 [1]: https://github.com/DataDog/docker-dd-agent#tracing-from-the-host
 [2]: https://docs.datadoghq.com/agent/docker/?tab=standard#environment-variables
 [3]: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/


### PR DESCRIPTION
the links in the table were not rendering right because you need a newline between the end of the table and the links (checked on local)