### PR TITLE
add clipboard blog to existing docs

### DIFF
--- a/content/en/dashboards/_index.md
+++ b/content/en/dashboards/_index.md
@@ -23,6 +23,9 @@ further_reading:
 - link: "/mobile/#dashboards"
   tag: "Documentation"
   text: "View your Dashboards on the Mobile App"
+- link: "https://www.datadoghq.com/blog/datadog-clipboard/"
+  tag: "Blog"
+  text: "Add Dashboard widgets to your clipboard"
 ---
 
 ## Overview

--- a/content/en/logs/explorer/_index.md
+++ b/content/en/logs/explorer/_index.md
@@ -17,6 +17,9 @@ further_reading:
     - link: 'logs/explorer/patterns'
       tag: Documentation
       text: 'Detect patterns inside your logs'
+    - link: 'https://www.datadoghq.com/blog/datadog-clipboard/'
+      tag: Blog
+      text: 'Add a Log Explorer url to your clipboard'
 ---
 
 ## Overview

--- a/content/en/tracing/visualization/service.md
+++ b/content/en/tracing/visualization/service.md
@@ -14,6 +14,9 @@ further_reading:
 - link: "/tracing/visualization/trace/"
   tag: "Documentation"
   text: "Understand how to read a Datadog Trace"
+- link: "https://www.datadoghq.com/blog/datadog-clipboard/"
+  tag: "Blog"
+  text: "Add an APM service page url to your clipboard"
 ---
 
 {{< img src="tracing/visualization/service/detailed_service_page.png" alt="Detailed service page"  style="width:90%;">}}


### PR DESCRIPTION
### What does this PR do?
Adds the new clipboard blog link to existing docs

### Motivation
We <3 clipboard

### Preview
https://docs-staging.datadoghq.com/sarina/clipboard-blog/dashboards/
https://docs-staging.datadoghq.com/sarina/clipboard-blog/logs/explorer/
https://docs-staging.datadoghq.com/sarina/clipboard-blog/tracing/visualization/service

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
