### PR TITLE
[WEB-1025] fix ja footer based on corp site

### DIFF
--- a/config/_default/menus/menus.ja.yaml
+++ b/config/_default/menus/menus.ja.yaml
@@ -3685,7 +3685,7 @@ footer_product:
   - name: Synthetic の監視
     url: 'https://www.datadoghq.com/product/synthetic-monitoring/'
     weight: 130
-  - name: リアルユーザーモニタリング
+  - name: Real User Monitoring
     url: 'https://www.datadoghq.com/product/real-user-monitoring/'
     weight: 135
   - name: インシデント管理

--- a/config/_default/menus/menus.ja.yaml
+++ b/config/_default/menus/menus.ja.yaml
@@ -3730,7 +3730,7 @@ footer_product_three:
     url: 'https://www.datadoghq.com/ja/security/'
     weight: 180
 footer_about:
-  - name: COVID-19（新型コロナウイルス感染症）への対応
+  - name: COVID-19 Update
     url: 'https://www.datadoghq.com/coronavirus/'
     weight: 90
   - name: お問い合わせ


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
fix overlapped text in the footer section by applying the same style used in corp-ste
### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadoghq.atlassian.net/browse/WEB-1025?atlOrigin=eyJpIjoiNTUwNzVlNzgzZDE4NGJlOWEyN2ZhNTk3NzdlMTczNWQiLCJwIjoiaiJ9
### Preview
<!-- Impacted pages preview links-->
 https://docs-staging.datadoghq.com/ang/ja-footer-overlap/ja/

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
