### PR TITLE
[WEB-980] - update hugo & set html content type charset

### DIFF
--- a/config/live/config.yaml
+++ b/config/live/config.yaml
@@ -31,6 +31,10 @@ deployment:
       - pattern: "^.+\\.(png|jpg|jpeg|gif|mp4|zip|pdf|txt|csv)$"
         cacheControl: "max-age=31536000, no-transform, public"
         gzip: false
-      - pattern: "^.+\\.(html|xml|json)$"
+      - pattern: "^.+\\.(html)$"
+        gzip: true
+        contentType: "text/html; charset=utf-8"
+        cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
+      - pattern: "^.+\\.(xml|json)$"
         gzip: true
         cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"

--- a/config/preview/config.yaml
+++ b/config/preview/config.yaml
@@ -31,6 +31,10 @@ deployment:
       - pattern: "^.+\\.(png|jpg|jpeg|gif|mp4|zip|pdf|txt|csv)$"
         cacheControl: "max-age=31536000, no-transform, public"
         gzip: false
-      - pattern: "^.+\\.(html|xml|json)$"
+      - pattern: "^.+\\.(html)$"
+        gzip: true
+        contentType: "text/html; charset=utf-8"
+        cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
+      - pattern: "^.+\\.(xml|json)$"
         gzip: true
         cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "del": "4.1.1",
         "docsearch.js": "^2.6.3",
         "fancy-log": "^1.3.3",
-        "hugo-bin": "0.59.1",
+        "hugo-bin": "0.67.1",
         "jquery": "3.5.1",
         "js-cookie": "^2.2.1",
         "js-yaml": "^3.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5931,10 +5931,10 @@ https@^1.0.0:
   resolved "https://registry.yarnpkg.com/https/-/https-1.0.0.tgz#3c37c7ae1a8eeb966904a2ad1e975a194b7ed3a4"
   integrity sha1-PDfHrhqO65ZpBKKtHpdaGUt+06Q=
 
-hugo-bin@0.59.1:
-  version "0.59.1"
-  resolved "https://registry.yarnpkg.com/hugo-bin/-/hugo-bin-0.59.1.tgz#96683a522563ead42a3dd44f93dc18aa6091ce34"
-  integrity sha512-mPKgNTuvqIo98xoRYKbKxdhv+yANSDziB+6PHvPG1BHJ6pAuhi/73r21ywbAmEnAsir4gQTtkge9kXse3FvTeA==
+hugo-bin@0.67.1:
+  version "0.67.1"
+  resolved "https://registry.yarnpkg.com/hugo-bin/-/hugo-bin-0.67.1.tgz#110e7200a895a4094083d5954c17c563a836bd19"
+  integrity sha512-9PRyXRu+yZ7LCnx7s2TOVwtvIXxphEtYtQkPiLtQc/5CVu5g34JZslgCqtvrmFsjWE2OonG1YUFPZf4/p6ewPA==
   dependencies:
     bin-wrapper "^4.1.0"
     pkg-conf "^3.1.0"


### PR DESCRIPTION
### What does this PR do?

This PR:
- brings back the changes from #9154 that we reverted
- fixes the deployment content type on html files which changed due to hugo deployment changes. (They were uploading as `text/html` instead of `text/html; charset=utf-8`)

### Motivation

To unblock updating hugo (https://datadoghq.atlassian.net/browse/WEB-980)

### Preview

https://docs-staging.datadoghq.com/david.jones/hugo-update-take2/
https://docs-staging.datadoghq.com/david.jones/hugo-update-take2/ja/
https://docs-staging.datadoghq.com/david.jones/hugo-update-take2/fr/

### Additional Notes



---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
