### PR TITLE
Update manual span example

### DIFF
--- a/content/en/tracing/setup_overview/custom_instrumentation/nodejs.md
+++ b/content/en/tracing/setup_overview/custom_instrumentation/nodejs.md
@@ -153,6 +153,13 @@ app.get('/make-sandwich', (req, res) => {
 
   res.end(sandwich)
 })
+
+// Note: startSpan doesn't activate the span on the current scope
+// Create a span with a resource name, which is the child of parentSpan.
+
+const span = tracer.startSpan('resource', { childOf: parentSpan })
+// do something
+span.finish()
 ```
 
 API details for `tracer.startSpan()` can be found [here][1].


### PR DESCRIPTION
### What does this PR do?
Add example of creating span with startSpan as a child of a parent span

### Motivation
Specify that startSpan doesn't activate the span on the current scope, and provide an example of creating span with startSpan as a child of a parent span

### Preview

### Additional Notes

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
