### PR TITLE
[rum] document beforeSend API

### DIFF
--- a/content/en/real_user_monitoring/browser/advanced_configuration.md
+++ b/content/en/real_user_monitoring/browser/advanced_configuration.md
@@ -19,6 +19,73 @@ further_reading:
 
 Find below the different initialization options available with the [Datadog Browser SDK][1].
 
+### Scrub sensitive data from your RUM data
+If your RUM data contains sensitive information that need redacting, configure the Browser SDK to scrub sensitive sequences by using the `beforeSend` callback when you initialize RUM.
+
+This callback function gives you access to every event collected by the RUM SDK before they get sent to Datadog. 
+
+For example, redact email addresses from your web application URLs:
+
+{{< tabs >}}
+{{% tab "NPM" %}}
+
+```javascript
+import { Datacenter, datadogRum } from '@datadog/browser-rum';
+
+datadogRum.init({
+    ...,
+    beforeSend: (event) => {
+        // remove email from view url
+        event.view.url = event.view.url.replace(/\S+@\S+\.\S+/, "REDACTED_EMAIL")
+    },
+    ...
+});
+```
+
+{{% /tab %}}
+{{% tab "CDN async" %}}
+```javascript
+DD_RUM.onReady(function() {
+    DD_RUM.init({
+        ...,
+        beforeSend: (event) => {
+            // remove email from view url
+            event.view.url = event.view.url.replace(/\S+@\S+\.\S+/, "REDACTED_EMAIL")
+        },
+        ...
+    })
+})
+```
+{{% /tab %}}
+{{% tab "CDN sync" %}}
+
+```javascript
+window.DD_RUM &&
+    window.DD_RUM.init({
+        ...,
+        beforeSend: (event) => {
+            // remove email from view url
+            event.view.url = event.view.url.replace(/\S+@\S+\.\S+/, "REDACTED_EMAIL")
+        },
+        ...
+    });
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+You can update the following fields:
+
+|   Attribute           |   Type    |   Description                                                                                       |
+|-----------------------|-----------|-----------------------------------------------------------------------------------------------------|
+|   `view.url`            |   String  |   The URL of the active web page.                                                                   |
+|   `view.referrer`       |   String  |   The URL of the previous web page from which a link to the currently requested page was followed.  |
+|   `action.target.name`  |   String  |   The element that the user interacted with. Only for automatically collected actions.              |
+|   `error.message`       |   String  |   A concise, human-readable, one-line message explaining the error.                                 |
+|   `error.stack `        |   String  |   The stack trace or complementary information about the error.                                     |
+|   `error.resource.url`  |   String  |   The resource URL that triggered the error.                                                        |
+|   `resource.url`        |   String  |   The resource URL.                                                                                 |
+
 ### Identify user sessions
 Adding user information to your RUM sessions makes it easy to:
 * Follow the journey of a given user

--- a/content/en/real_user_monitoring/browser/advanced_configuration.md
+++ b/content/en/real_user_monitoring/browser/advanced_configuration.md
@@ -36,7 +36,7 @@ datadogRum.init({
     ...,
     beforeSend: (event) => {
         // remove email from view url
-        event.view.url = event.view.url.replace(/\S+@\S+\.\S+/, "REDACTED_EMAIL")
+        event.view.url = event.view.url.replace(/email=[^&]*/, "email=REDACTED")
     },
     ...
 });
@@ -50,7 +50,7 @@ DD_RUM.onReady(function() {
         ...,
         beforeSend: (event) => {
             // remove email from view url
-            event.view.url = event.view.url.replace(/\S+@\S+\.\S+/, "REDACTED_EMAIL")
+            event.view.url = event.view.url.replace(/email=[^&]*/, "email=REDACTED")
         },
         ...
     })
@@ -65,7 +65,7 @@ window.DD_RUM &&
         ...,
         beforeSend: (event) => {
             // remove email from view url
-            event.view.url = event.view.url.replace(/\S+@\S+\.\S+/, "REDACTED_EMAIL")
+            event.view.url = event.view.url.replace(/email=[^&]*/, "email=REDACTED")
         },
         ...
     });
@@ -74,7 +74,7 @@ window.DD_RUM &&
 {{% /tab %}}
 {{< /tabs >}}
 
-You can update the following fields:
+You can update the following event properties:
 
 |   Attribute           |   Type    |   Description                                                                                       |
 |-----------------------|-----------|-----------------------------------------------------------------------------------------------------|
@@ -85,6 +85,8 @@ You can update the following fields:
 |   `error.stack `        |   String  |   The stack trace or complementary information about the error.                                     |
 |   `error.resource.url`  |   String  |   The resource URL that triggered the error.                                                        |
 |   `resource.url`        |   String  |   The resource URL.                                                                                 |
+
+**Note**: The RUM SDK will ignore modifications made to event properties not listed above. Find out about all event properties on the [Browser SDK repository][2].
 
 ### Identify user sessions
 Adding user information to your RUM sessions makes it easy to:
@@ -244,7 +246,7 @@ window.DD_RUM && window.DD_RUM.addRumGlobalContext('activity', {
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note**: Follow the [Datadog naming convention][2] for a better correlation of your data across the product.
+**Note**: Follow the [Datadog naming convention][3] for a better correlation of your data across the product.
 
 ### Replace global context
 
@@ -295,7 +297,7 @@ window.DD_RUM &&
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note**: Follow the [Datadog naming convention][2] for a better correlation of your data across the product.
+**Note**: Follow the [Datadog naming convention][3] for a better correlation of your data across the product.
 
 ### Read global context
 
@@ -404,7 +406,7 @@ addError(
 );
 ```
 
-**Note**: The [Error Tracking][3] feature processes errors sent with source set to `custom` or `source` and that contain a stacktrace.
+**Note**: The [Error Tracking][4] feature processes errors sent with source set to `custom` or `source` and that contain a stacktrace.
 
 {{< tabs >}}
 {{% tab "NPM" %}}
@@ -492,5 +494,6 @@ try {
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/browser-sdk
-[2]: /logs/processing/attributes_naming_convention/#user-related-attributes
-[3]: /real_user_monitoring/error_tracking
+[2]: https://github.com/DataDog/browser-sdk/blob/master/packages/rum/src/rumEvent.types.ts
+[3]: /logs/processing/attributes_naming_convention/#user-related-attributes
+[4]: /real_user_monitoring/error_tracking


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Document `beforeSend` browser SDK API

### Motivation
<!-- What inspired you to submit this pull request?-->
New feature 🎉 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hdelaby/beforesend/real_user_monitoring/browser/advanced_configuration/?tab=npm#scrub-sensitive-data-from-your-rum-data

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
