### PR TITLE
NPM -> Installation -> Change Windows OS name

### DIFF
--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -24,11 +24,11 @@ Supported **platforms** include:
 - SUSE 15+
 - Amazon AMI 2016.03+
 - Amazon Linux 2
-- [Windows 2016+][2] (in public beta)
+- [Windows Server 2016+][2] (in public beta)
 
 **For Linux OS:** Data collection is done using eBPF, so Datadog minimally requires platforms that have underlying Linux kernel versions of 4.4.0+.
 
-**For Windows OS:** Data collection is available in public beta for Windows versions 2016 or later.
+**For Windows OS:** Data collection is available in public beta for Windows Server 2016 or later.
 
 There is an exemption to the 4.4.0+ kernel requirement for [CentOS/RHEL 7.6+][3]. The [DNS Resolution][4] feature is not supported on CentOS/RHEL 7.6. 
 
@@ -129,7 +129,7 @@ If these utilities do not exist in your distribution, follow the same procedure 
 
 ### Windows systems
 
-Data collection for Windows systems is available in public beta for versions 2016 or later. 
+Data collection for Windows systems is available in public beta for Windows Server versions 2016 or later. 
 **Note**: NPM currently monitors Windows hosts only, and not Windows containers. DNS metric collection is not supported for Windows systems.
 
 To enable network performance monitoring for Windows hosts:


### PR DESCRIPTION
### What does this PR do?
Changes usages of "Windows 2016" to "Windows Server 2016" to match the product name.

There are actually two different versioning schemes of Windows Server operating systems now, so I also wanted bring awareness to the docs team about this and make sure we advertise the proper support. In the past, the OS name would be `Windows Server 2016` or `Windows Server 2019`. The more recent naming scheme is now `Windows Server, version 2004`  or `Windows Server, version YYMM`. For all intents and purposes, it sounds like this NPM feature supports all versions of Windows Server that are either `Windows Server 2016` or newer.

### Motivation
I wanted to make sure the Windows OS'es were properly named.

### Preview
https://docs-staging.datadoghq.com/zach/npm-windows/network_performance_monitoring/installation/?tab=agent#windows-systems

### Additional Notes
N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
