### PR TITLE
[WEB-1043] - use kubernetes logo for source kubernetes

### DIFF
--- a/data/security_monitoring/data.yaml
+++ b/data/security_monitoring/data.yaml
@@ -9,7 +9,7 @@ base_integrations_url: https://docs.datadoghq.com/integrations/
 image_map:
   - source:
       - kubernetes
-    image: kube_apiserver_metrics
+    image: kubernetes
     append: false
   - source:
       - azure


### PR DESCRIPTION
### What does this PR do?

The security rules is using a kubernetes api metrics logo, this pr switches it to using a generic kubernetes logo

### Motivation

https://datadoghq.atlassian.net/browse/WEB-1043

### Preview

see kubernetes listings
https://docs-staging.datadoghq.com/david.jones/rules-kube/security_monitoring/default_rules/#cat-runtime-agent

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
