### PR TITLE
Add links from dashboards docs to new Sharing Dashboards blog

### DIFF
--- a/content/en/dashboards/sharing.md
+++ b/content/en/dashboards/sharing.md
@@ -6,6 +6,9 @@ aliases:
     - /graphing/faq/is-there-a-way-to-share-or-revoke-previously-shared-graphs
     - /graphing/dashboards/shared_graph/
 further_reading:
+- link: "https://www.datadoghq.com/blog/dashboard-sharing/"
+  tag: "Blog"
+  text: "Share dashboards securely with anyone outside of your organization"
 - link: "/dashboards/"
   tag: "Documentation"
   text: "Create Dashboards in Datadog"

--- a/content/en/getting_started/dashboards/_index.md
+++ b/content/en/getting_started/dashboards/_index.md
@@ -2,6 +2,9 @@
 title: Getting Started with Dashboards
 kind: documentation
 further_reading:
+- link: "https://www.datadoghq.com/blog/dashboard-sharing/"
+  tag: "Blog"
+  text: "Share dashboards securely with anyone outside of your organization"
 - link: "https://learn.datadoghq.com/enrol/index.php?id=8"
   tag: "Learning"
   text: "Self-paced online learning: Building Better Dashboards"


### PR DESCRIPTION

### What does this PR do?

Adds two links to new blog post about sharing dashboards outside an org

### Motivation

on-call tasks

### Preview

See further reading sections in: 

- https://docs-staging.datadoghq.com/kari/blog-link/getting_started/dashboards/
- https://docs-staging.datadoghq.com/kari/blog-link/dashboards/sharing/


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
