### PR TITLE
Require syslog-ng to accept only trusted certificates

### DIFF
--- a/content/en/integrations/syslog_ng.md
+++ b/content/en/integrations/syslog_ng.md
@@ -94,7 +94,7 @@ Configure Syslog-ng to gather logs from your host, containers, & services.
     - Change the definition of the destination to the following:
 
         ```conf
-        destination d_datadog { tcp("intake.logs.datadoghq.com" port(10516)     tls(peer-verify(required-untrusted)) template(DatadogFormat)); };
+        destination d_datadog { tcp("intake.logs.datadoghq.com" port(10516)     tls(peer-verify(required-trusted)) template(DatadogFormat)); };
         ```
 
     More information about the TLS parameters and possibilities for syslog-ng available in the [official documentation][1].
@@ -181,7 +181,7 @@ Configure Syslog-ng to gather logs from your host, containers, & services.
     - Change the definition of the destination to the following:
 
         ```conf
-        destination d_datadog { tcp("tcp-intake.logs.datadoghq.eu" port(443)     tls(peer-verify(required-untrusted)) template(DatadogFormat)); };
+        destination d_datadog { tcp("tcp-intake.logs.datadoghq.eu" port(443)     tls(peer-verify(required-trusted)) template(DatadogFormat)); };
         ```
 
     More information about the TLS parameters and possibilities for syslog-ng available in their [official documentation][1].

--- a/content/fr/integrations/syslog_ng.md
+++ b/content/fr/integrations/syslog_ng.md
@@ -93,7 +93,7 @@ Configurez Syslog-ng pour rassembler les logs de votre host, de vos conteneurs e
     - Modifiez la destination comme suit :
 
         ```conf
-        destination d_datadog { tcp("intake.logs.datadoghq.com" port(10516)     tls(peer-verify(required-untrusted)) template(DatadogFormat)); };
+        destination d_datadog { tcp("intake.logs.datadoghq.com" port(10516)     tls(peer-verify(required-trusted)) template(DatadogFormat)); };
         ```
 
     Pour en savoir plus sur les paramètres et les fonctionnalités de TLS pour Syslog-ng, consultez la [documentation officielle][1] (en anglais).
@@ -168,7 +168,7 @@ Configurez Syslog-ng pour rassembler les logs de votre host, de vos conteneurs e
     - Modifiez la destination comme suit :
 
         ```conf
-        destination d_datadog { tcp("tcp-intake.logs.datadoghq.eu" port(443)     tls(peer-verify(required-untrusted)) template(DatadogFormat)); };
+        destination d_datadog { tcp("tcp-intake.logs.datadoghq.eu" port(443)     tls(peer-verify(required-trusted)) template(DatadogFormat)); };
         ```
 
     Pour en savoir plus sur les paramètres et les fonctionnalités de TLS pour Syslog-ng, consultez la [documentation officielle][1] (en anglais).

--- a/content/ja/integrations/syslog_ng.md
+++ b/content/ja/integrations/syslog_ng.md
@@ -93,7 +93,7 @@ Syslog-ng を構成して、ホスト、コンテナ、サービスからログ�
     - 出力先の定義を次のように変更します。
 
         ```conf
-        destination d_datadog { tcp("intake.logs.datadoghq.com" port(10516)     tls(peer-verify(required-untrusted)) template(DatadogFormat)); };
+        destination d_datadog { tcp("intake.logs.datadoghq.com" port(10516)     tls(peer-verify(required-trusted)) template(DatadogFormat)); };
         ```
 
     TLS のパラメーターの詳細、および syslog-ng が使用可能かどうかは、[公式ドキュメント][1]を参照してください。
@@ -168,7 +168,7 @@ Syslog-ng を構成して、ホスト、コンテナ、サービスからログ�
     - 出力先の定義を次のように変更します。
 
         ```conf
-        destination d_datadog { tcp("tcp-intake.logs.datadoghq.eu" port(443)     tls(peer-verify(required-untrusted)) template(DatadogFormat)); };
+        destination d_datadog { tcp("tcp-intake.logs.datadoghq.eu" port(443)     tls(peer-verify(required-trusted)) template(DatadogFormat)); };
         ```
 
     TLS のパラメーターの詳細、および syslog-ng が使用可能かどうかは、[公式ドキュメント][1]を参照してください。


### PR DESCRIPTION
There's no purpose in downloading a root CA bundle if the instructions
go on to suggest turning off CA validation altogether.
