### PR TITLE
[clipboard] remove beta label

### DIFF
--- a/content/en/monitors/incident_management/datadog_clipboard.md
+++ b/content/en/monitors/incident_management/datadog_clipboard.md
@@ -4,10 +4,6 @@ kind: documentation
 description: Create and manage incidents
 ---
 
-<div class="alert alert-warning">
-The Datadog Clipboard is currently in public beta.
-</div>
-
 # Overview
 
 The Datadog Clipboard is a cross-platform tool for collecting and sharing signals across contexts. It is personal to each user and stores all copied graphs alongside any saved links. Signals can be grouped and exported to a dashboard, notebook, or incident.


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
removes beta message from Datadog Clipboard docs

### Motivation
<!-- What inspired you to submit this pull request?-->
clipboard is going GA! 🎉

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/stephanieniu/clipboard/monitors/incident_management/datadog_clipboard

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
