### PR TITLE
Unified service tagging for AWS Lambda

### DIFF
--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -369,7 +369,7 @@ to configure the `service` tag only in the configuration of the process check.
 
 Depending on how you build and deploy your AWS Lambda-based serverless applications, you may have several options available for applying the `env`, `service` and `version` tags to metrics, traces and logs.
 
-Note, these tags are expected to be specified through AWS resource tags, instead of environment variables. Specifically, the `DD_ENV`, `DD_SERVICE` and `DD_VERSION` environment variables are not supported.
+*Note*: These tags are specified through AWS resource tags instead of environment variables. Specifically, the `DD_ENV`, `DD_SERVICE` and `DD_VERSION` environment variables are not supported.
 
 {{< tabs >}}
 
@@ -401,7 +401,7 @@ functions:
       version: "<VERSION>"
 ```
 
-If you have installed the [Datadog serverless plugin][2], the plugin automatically tag the Lambda functions with the `service` and `env` tags using the `service` and `stage` values from the serverless application definition, unless a `service` or `env` tag already exists.
+If you have installed the [Datadog serverless plugin][2], the plugin automatically tags the Lambda functions with the `service` and `env` tags using the `service` and `stage` values from the serverless application definition, unless a `service` or `env` tag already exists.
 
 [1]: https://www.serverless.com/framework/docs/providers/aws/guide/functions#tags
 [2]: https://docs.datadoghq.com/serverless/serverless_integrations/plugin

--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -441,6 +441,32 @@ Transform:
 {{% /tab %}}
 
 {{% tab "AWS CDK" %}}
+
+Tag your app, stack or individual Lambda functions using the [Tags class][1]. If you have installed the [Datadog serverless macro][2], you can also specify a `service` and `env` tag as parameters:
+
+```javascript
+import * as cdk from "@aws-cdk/core";
+
+class CdkStack extends cdk.Stack {
+  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    this.addTransform("DatadogServerless");
+
+    new cdk.CfnMapping(this, "Datadog", {
+      mapping: {
+        Parameters: {
+          service: "<SERVICE>",
+          env: "<ENV>",
+        },
+      },
+    });
+  }
+}
+```
+
+[1]: https://docs.aws.amazon.com/cdk/latest/guide/tagging.html
+[2]: https://docs.datadoghq.com/serverless/serverless_integrations/macro
+
 {{% /tab %}}
 
 {{% tab "Custom" %}}

--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -367,7 +367,9 @@ to configure the `service` tag only in the configuration of the process check.
 
 #### AWS Lambda Functions 
 
-Depending on how you build and deploy your AWS Lambda-based serverless applications, you may have several options available for applying the `env`, `service` and `version` tags to the metrics, traces and logs emitted from Lambda functions. 
+Depending on how you build and deploy your AWS Lambda-based serverless applications, you may have several options available for applying the `env`, `service` and `version` tags to metrics, traces and logs.
+
+Note, these tags are expected to be specified through AWS resource tags, instead of environment variables. Specifically, the `DD_ENV`, `DD_SERVICE` and `DD_VERSION` environment variables are not supported.
 
 {{< tabs >}}
 
@@ -406,6 +408,36 @@ If you have installed the [Datadog serverless plugin][2], the plugin automatical
 {{% /tab %}}
 
 {{% tab "AWS SAM" %}}
+
+Tag your Lambda functions using the [Tags][1] option:
+
+```yaml
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  MyLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Tags:
+        env: "<ENV>"
+        service: "<SERVICE>"
+        version: "<VERSION>"
+```
+
+If you have installed the [Datadog serverless macro][2], you can also specify a `service` and `env` tag as parameters:
+
+```yaml
+Transform:
+  - AWS::Serverless-2016-10-31
+  - Name: DatadogServerless
+    Parameters:
+      service: "<SERVICE>"
+      env: "<ENV>"
+```
+
+[1]: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-function.html#sam-function-tags
+[2]: https://docs.datadoghq.com/serverless/serverless_integrations/macro
+
 {{% /tab %}}
 
 {{% tab "AWS CDK" %}}

--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -470,6 +470,11 @@ class CdkStack extends cdk.Stack {
 {{% /tab %}}
 
 {{% tab "Custom" %}}
+
+Apply the `env`, `service` and `version` tags following the AWS instructions for [Tagging Lambda Functions][1].
+
+[1]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-tags.html
+
 {{% /tab %}}
 
 {{< /tabs >}}

--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -363,6 +363,59 @@ to configure the `service` tag only in the configuration of the process check.
 {{% /tab %}}
 {{< /tabs >}}
 
+### Serverless environment
+
+#### AWS Lambda Functions 
+
+Depending on how you build and deploy your AWS Lambda-based serverless applications, you may have several options available for applying the `env`, `service` and `version` tags to the metrics, traces and logs emitted from Lambda functions. 
+
+{{< tabs >}}
+
+{{% tab "Serverless Framework" %}}
+
+Tag your Lambda functions using the [tags][1] option:
+
+```yaml
+# serverless.yml
+service: service-name
+provider:
+  name: aws
+  # to apply the tags to all functions
+  tags:
+    env: "<ENV>"
+    service: "<SERVICE>"
+    version: "<VERSION>"
+
+functions:
+  hello:
+    # this function will inherit the service level tags config above
+    handler: handler.hello
+  world:
+    # this function will overwrite the tags
+    handler: handler.users
+    tags:
+      env: "<ENV>"
+      service: "<SERVICE>"
+      version: "<VERSION>"
+```
+
+If you have installed the [Datadog serverless plugin][2], the plugin automatically tag the Lambda functions with the `service` and `env` tags using the `service` and `stage` values from the serverless application definition, unless a `service` or `env` tag already exists.
+
+[1]: https://www.serverless.com/framework/docs/providers/aws/guide/functions#tags
+[2]: https://docs.datadoghq.com/serverless/serverless_integrations/plugin
+{{% /tab %}}
+
+{{% tab "AWS SAM" %}}
+{{% /tab %}}
+
+{{% tab "AWS CDK" %}}
+{{% /tab %}}
+
+{{% tab "Custom" %}}
+{{% /tab %}}
+
+{{< /tabs >}}
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/serverless/installation/dotnet.md
+++ b/content/en/serverless/installation/dotnet.md
@@ -38,7 +38,7 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 
 ### Unified Service Tagging
 
-Although it's optional, we highly recommend tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][6].
+Although it's optional, Datadog highly recommends tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][6].
 
 ## Explore Datadog Serverless Monitoring
 

--- a/content/en/serverless/installation/dotnet.md
+++ b/content/en/serverless/installation/dotnet.md
@@ -36,11 +36,15 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 1. [Install the Datadog Forwarder if you haven't][2].
 2. [Subscribe the Datadog Forwarder to your function's log groups][5].
 
+### Unified Service Tagging
+
+Although it's optional, we highly recommend tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][6].
+
 ## Explore Datadog Serverless Monitoring
 
-After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless homepage][6].
+After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless homepage][7].
 
-### Monitor Custom Business Logic
+## Monitor Custom Business Logic
 
 If you would like to submit a custom metric, see the sample code below:
 
@@ -53,7 +57,7 @@ myMetric.Add("t", new string[] {"product:latte", "order:online"});
 LambdaLogger.Log(JsonConvert.SerializeObject(myMetric));
 ```
 
-For more information on custom metric submission, see [here][7].
+For more information on custom metric submission, see [here][8].
 
 ## Further Reading
 
@@ -64,5 +68,6 @@ For more information on custom metric submission, see [here][7].
 [3]: https://docs.aws.amazon.com/xray/latest/devguide/xray-services-lambda.html
 [4]: https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-dotnet.html
 [5]: /logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
-[6]: https://app.datadoghq.com/functions
-[7]: /serverless/custom_metrics?tab=otherruntimes
+[6]: /getting_started/tagging/unified_service_tagging/#aws-lambda-functions
+[7]: https://app.datadoghq.com/functions
+[8]: /serverless/custom_metrics?tab=otherruntimes

--- a/content/en/serverless/installation/go.md
+++ b/content/en/serverless/installation/go.md
@@ -68,11 +68,15 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 1. [Install the Datadog Forwarder if you haven't][2].
 2. [Subscribe the Datadog Forwarder to your function's log groups][5].
 
+### Unified Service Tagging
+
+Although it's optional, we highly recommend tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][6].
+
 ## Explore Datadog Serverless Monitoring
 
-After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless Homepage][6].
+After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless Homepage][7].
 
-### Monitor Custom Business Logic
+## Monitor Custom Business Logic
 
 If you would like to submit a custom metric, see the sample code below:
 
@@ -115,7 +119,7 @@ func myHandler(ctx context.Context, event MyEvent) (string, error) {
 }
 ```
 
-For more information on custom metric submission, see [here][7].
+For more information on custom metric submission, see [here][8].
 
 ## Further Reading
 
@@ -126,5 +130,6 @@ For more information on custom metric submission, see [here][7].
 [3]: https://github.com/DataDog/datadog-lambda-go
 [4]: https://docs.aws.amazon.com/xray/latest/devguide/xray-services-lambda.html
 [5]: /logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
-[6]: https://app.datadoghq.com/functions
-[7]: /serverless/custom_metrics?tab=go
+[6]: /getting_started/tagging/unified_service_tagging/#aws-lambda-functions
+[7]: https://app.datadoghq.com/functions
+[8]: /serverless/custom_metrics?tab=go

--- a/content/en/serverless/installation/go.md
+++ b/content/en/serverless/installation/go.md
@@ -70,7 +70,7 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 
 ### Unified Service Tagging
 
-Although it's optional, we highly recommend tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][6].
+Although it's optional, Datadog highly recommends tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][6].
 
 ## Explore Datadog Serverless Monitoring
 

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -85,7 +85,7 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 
 ### Unified Service Tagging
 
-Although it's optional, we highly recommend tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][6].
+Although it's optional, Datadog highly recommends tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][6].
 
 ## Explore Datadog Serverless Monitoring
 

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -83,11 +83,15 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 1. [Install the Datadog Forwarder if you haven't][2].
 2. [Subscribe the Datadog Forwarder to your function's log groups][5].
 
+### Unified Service Tagging
+
+Although it's optional, we highly recommend tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][6].
+
 ## Explore Datadog Serverless Monitoring
 
-After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless Homepage][6].
+After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless Homepage][7].
 
-### Monitor Custom Business Logic
+## Monitor Custom Business Logic
 
 If you would like to submit a custom metric, see the sample code below:
 
@@ -118,7 +122,7 @@ public class Handler implements RequestHandler<APIGatewayV2ProxyRequestEvent, AP
 }
 ```
 
-For more information on custom metric submission, see [here][7].
+For more information on custom metric submission, see [here][8].
 
 ## Further Reading
 
@@ -129,5 +133,6 @@ For more information on custom metric submission, see [here][7].
 [3]: https://img.shields.io/bintray/v/datadog/datadog-maven/datadog-lambda-java
 [4]: https://docs.aws.amazon.com/xray/latest/devguide/xray-services-lambda.html
 [5]: /logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
-[6]: https://app.datadoghq.com/functions
-[7]: /serverless/custom_metrics?tab=java
+[6]: /getting_started/tagging/unified_service_tagging/#aws-lambda-functions
+[7]: https://app.datadoghq.com/functions
+[8]: /serverless/custom_metrics?tab=java

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -319,7 +319,7 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 
 ### Unified Service Tagging
 
-Although it's optional, we highly recommend tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][3].
+Although it's optional, Datadog highly recommends tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][3].
 
 ## Explore Datadog Serverless Monitoring
 

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -198,15 +198,15 @@ For example:
 datadog-ci lambda instrument -f my-function -f another-function -r us-east-1 -v 26 --forwarder arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder
 ```
 
-If your Lambda function is configured to use code signing, you must add Datadog's Signing Profile ARN (`arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc`) to your function's [Code Signing Configuration][5] before you can instrument it with the Datadog CLI. 
+If your Lambda function is configured to use code signing, you must add Datadog's Signing Profile ARN (`arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc`) to your function's [Code Signing Configuration][4] before you can instrument it with the Datadog CLI. 
 
-More information and additional parameters can be found in the [CLI documentation][4].
+More information and additional parameters can be found in the [CLI documentation][5].
 
 [1]: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html
 [2]: https://github.com/DataDog/datadog-lambda-js/releases
 [3]: https://docs.datadoghq.com/serverless/forwarder/
-[4]: https://docs.datadoghq.com/serverless/serverless_integrations/cli
-[5]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html#config-codesigning-config-update
+[4]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html#config-codesigning-config-update
+[5]: https://docs.datadoghq.com/serverless/serverless_integrations/cli
 {{% /tab %}}
 {{% tab "Container Image" %}}
 
@@ -244,9 +244,9 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 1. [Install the Datadog Forwarder if you haven't][1].
 2. [Subscribe the Datadog Forwarder to your function's log groups][2].
 
+
 [1]: https://docs.datadoghq.com/serverless/forwarder/
 [2]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
-
 {{% /tab %}}
 {{% tab "Custom" %}}
 
@@ -274,7 +274,7 @@ The available `RUNTIME` options are `Node10-x` and `Node12-x`. For `VERSION`, se
 arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node12-x:25
 ```
 
-If your Lambda function is configured to use code signing, you must add Datadog's Signing Profile ARN (`arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc`) to your function's [Code Signing Configuration][6] before you can add the Datadog Lambda library as a layer. 
+If your Lambda function is configured to use code signing, you must add Datadog's Signing Profile ARN (`arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc`) to your function's [Code Signing Configuration][3] before you can add the Datadog Lambda library as a layer. 
 
 #### Using the Package
 
@@ -290,7 +290,7 @@ npm install --save datadog-lambda-js
 yarn add datadog-lambda-js
 ```
 
-See the [latest release][3].
+See the [latest release][4].
 
 ### Configure the Function
 
@@ -304,24 +304,28 @@ See the [latest release][3].
 
 You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, in order to send metrics, traces, and logs to Datadog.
 
-1. [Install the Datadog Forwarder if you haven't][4].
-2. [Subscribe the Datadog Forwarder to your function's log groups][5].
+1. [Install the Datadog Forwarder if you haven't][5].
+2. [Subscribe the Datadog Forwarder to your function's log groups][6].
 
 
 [1]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
 [2]: https://github.com/DataDog/datadog-lambda-layer-js/releases
-[3]: https://www.npmjs.com/package/datadog-lambda-js
-[4]: https://docs.datadoghq.com/serverless/forwarder/
-[5]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
-[6]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html#config-codesigning-config-update
+[3]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html#config-codesigning-config-update
+[4]: https://www.npmjs.com/package/datadog-lambda-js
+[5]: https://docs.datadoghq.com/serverless/forwarder/
+[6]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 {{% /tab %}}
 {{< /tabs >}}
 
+### Unified Service Tagging
+
+Although it's optional, we highly recommend tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][3].
+
 ## Explore Datadog Serverless Monitoring
 
-After you have configured your function following the steps above, you can view metrics, logs and traces on the [Serverless Homepage][3].
+After you have configured your function following the steps above, you can view metrics, logs and traces on the [Serverless Homepage][4].
 
-### Monitor Custom Business Logic
+## Monitor Custom Business Logic
 
 If you would like to submit a custom metric or span, see the sample code below:
 
@@ -372,7 +376,7 @@ exports.handler = async (event) => {
 };
 ```
 
-For more information on custom metric submission, see [here][4]. For additional details on custom instrumentation, see the Datadog APM documentation for [custom instrumentation][5].
+For more information on custom metric submission, see [here][5]. For additional details on custom instrumentation, see the Datadog APM documentation for [custom instrumentation][6].
 
 ## Further Reading
 
@@ -380,6 +384,7 @@ For more information on custom metric submission, see [here][4]. For additional 
 
 [1]: /integrations/amazon_web_services/
 [2]: /serverless/forwarder
-[3]: https://app.datadoghq.com/functions
-[4]: /serverless/custom_metrics?tab=nodejs
-[5]: /tracing/custom_instrumentation/nodejs/
+[3]: /getting_started/tagging/unified_service_tagging/#aws-lambda-functions
+[4]: https://app.datadoghq.com/functions
+[5]: /serverless/custom_metrics?tab=nodejs
+[6]: /tracing/custom_instrumentation/nodejs/

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -190,20 +190,20 @@ More information and additional parameters can be found in the [macro documentat
     # For us-gov regions
     arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python37:19
     ```
-1. If your Lambda function is configured to use code signing, add Datadog's Signing Profile ARN (`arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc`) to your function's [Code Signing Configuration][4]. 
+1. If your Lambda function is configured to use code signing, add Datadog's Signing Profile ARN (`arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc`) to your function's [Code Signing Configuration][2]. 
 
 ### Subscribe the Datadog Forwarder to the Log Groups
 
 You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, to send metrics, traces, and logs to Datadog.
 
-1. [Install the Datadog Forwarder][2] if you haven't.
-2. [Subscribe the Datadog Forwarder to your function's log groups][3].
+1. [Install the Datadog Forwarder][3] if you haven't.
+2. [Subscribe the Datadog Forwarder to your function's log groups][4].
 
 
 [1]: https://github.com/DataDog/datadog-lambda-python/releases
-[2]: https://docs.datadoghq.com/serverless/forwarder/
-[3]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
-[4]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html#config-codesigning-config-update
+[2]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html#config-codesigning-config-update
+[3]: https://docs.datadoghq.com/serverless/forwarder/
+[4]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 {{% /tab %}}
 {{% tab "Datadog CLI" %}}
 
@@ -237,15 +237,15 @@ For example:
 datadog-ci lambda instrument -f my-function -f another-function -r us-east-1 -v 19 --forwarder arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder
 ```
 
-If your Lambda function is configured to use code signing, you must add Datadog's Signing Profile ARN (`arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc`) to your function's [Code Signing Configuration][5] before you can instrument it with the Datadog CLI. 
+If your Lambda function is configured to use code signing, you must add Datadog's Signing Profile ARN (`arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc`) to your function's [Code Signing Configuration][4] before you can instrument it with the Datadog CLI. 
 
-More information and additional parameters can be found in the [CLI documentation][4].
+More information and additional parameters can be found in the [CLI documentation][5].
 
 [1]: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html
 [2]: https://github.com/DataDog/datadog-lambda-python/releases
 [3]: https://docs.datadoghq.com/serverless/forwarder/
-[4]: https://docs.datadoghq.com/serverless/serverless_integrations/cli
-[5]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html#config-codesigning-config-update
+[4]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html#config-codesigning-config-update
+[5]: https://docs.datadoghq.com/serverless/serverless_integrations/cli
 {{% /tab %}}
 {{% tab "Container Image" %}}
 
@@ -275,9 +275,9 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 1. [Install the Datadog Forwarder if you haven't][1].
 2. [Subscribe the Datadog Forwarder to your function's log groups][2].
 
+
 [1]: https://docs.datadoghq.com/serverless/forwarder/
 [2]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
-
 {{% /tab %}}
 {{% tab "Custom" %}}
 
@@ -305,17 +305,17 @@ The available `RUNTIME` options are `Python27`, `Python36`, `Python37`, and `Pyt
 arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python37:19
 ```
 
-If your Lambda function is configured to use code signing, you must add Datadog's Signing Profile ARN (`arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc`) to your function's [Code Signing Configuration][9] before you can add the Datadog Lambda library as a layer.
+If your Lambda function is configured to use code signing, you must add Datadog's Signing Profile ARN (`arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc`) to your function's [Code Signing Configuration][3] before you can add the Datadog Lambda library as a layer.
 
 #### Using the Package
 
-Install `datadog-lambda` and its dependencies locally to your function project folder. **Note**: `datadog-lambda` depends on `ddtrace`, which uses native extensions; therefore they must be installed and compiled in a Linux environment. For example, you can use [dockerizePip][3] for the Serverless Framework and [--use-container][4] for AWS SAM. For more details, see [how to add dependencies to your function deployment package][5].
+Install `datadog-lambda` and its dependencies locally to your function project folder. **Note**: `datadog-lambda` depends on `ddtrace`, which uses native extensions; therefore they must be installed and compiled in a Linux environment. For example, you can use [dockerizePip][4] for the Serverless Framework and [--use-container][5] for AWS SAM. For more details, see [how to add dependencies to your function deployment package][6].
 
 ```
 pip install datadog-lambda -t ./
 ```
 
-See the [latest release][6]. 
+See the [latest release][7]. 
 
 ### Configure the Function
 
@@ -329,27 +329,31 @@ See the [latest release][6].
 
 You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, to send metrics, traces, and logs to Datadog.
 
-1. [Install the Datadog Forwarder][7] if you haven't.
-2. [Subscribe the Datadog Forwarder to your function's log groups][8].
+1. [Install the Datadog Forwarder][8] if you haven't.
+2. [Subscribe the Datadog Forwarder to your function's log groups][9].
 
 
 [1]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
 [2]: https://github.com/DataDog/datadog-lambda-python/releases
-[3]: https://github.com/UnitedIncome/serverless-python-requirements#cross-compiling
-[4]: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-build.html
-[5]: https://docs.aws.amazon.com/lambda/latest/dg/python-package.html#python-package-dependencies
-[6]: https://pypi.org/project/datadog-lambda/
-[7]: https://docs.datadoghq.com/serverless/forwarder/
-[8]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
-[9]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html#config-codesigning-config-update
+[3]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html#config-codesigning-config-update
+[4]: https://github.com/UnitedIncome/serverless-python-requirements#cross-compiling
+[5]: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-build.html
+[6]: https://docs.aws.amazon.com/lambda/latest/dg/python-package.html#python-package-dependencies
+[7]: https://pypi.org/project/datadog-lambda/
+[8]: https://docs.datadoghq.com/serverless/forwarder/
+[9]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 {{% /tab %}}
 {{< /tabs >}}
 
+### Unified Service Tagging
+
+Although it's optional, we highly recommend tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][3].
+
 ## Explore Datadog Serverless Monitoring
 
-After you have configured your function following the steps above, you can view metrics, logs and traces on the [Serverless Homepage][3].
+After you have configured your function following the steps above, you can view metrics, logs and traces on the [Serverless Homepage][4].
 
-### Monitor Custom Business Logic
+## Monitor Custom Business Logic
 
 If you would like to submit a custom metric or span, see the sample code below:
 
@@ -388,7 +392,7 @@ def get_message():
     return 'Hello from serverless!'
 ```
 
-For more information on custom metric submission, see [here][4]. For additional details on custom instrumentation, see the Datadog APM documentation for [custom instrumentation][5].
+For more information on custom metric submission, see [here][5]. For additional details on custom instrumentation, see the Datadog APM documentation for [custom instrumentation][6].
 
 ## Further Reading
 
@@ -396,6 +400,7 @@ For more information on custom metric submission, see [here][4]. For additional 
 
 [1]: /integrations/amazon_web_services/
 [2]: /serverless/forwarder
-[3]: https://app.datadoghq.com/functions
-[4]: /serverless/custom_metrics?tab=python
-[5]: /tracing/custom_instrumentation/python/
+[3]: /getting_started/tagging/unified_service_tagging/#aws-lambda-functions
+[4]: https://app.datadoghq.com/functions
+[5]: /serverless/custom_metrics?tab=python
+[6]: /tracing/custom_instrumentation/python/

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -347,7 +347,7 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 
 ### Unified Service Tagging
 
-Although it's optional, we highly recommend tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][3].
+Although it's optional, Datadog highly recommends tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][3].
 
 ## Explore Datadog Serverless Monitoring
 

--- a/content/en/serverless/installation/ruby.md
+++ b/content/en/serverless/installation/ruby.md
@@ -48,7 +48,7 @@ The available `RUNTIME` options are `Ruby2-5` and `Ruby2-7`. For `VERSION`, see 
 arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby2-7:5
 ```
 
-If your Lambda function is configured to use code signing, you must add Datadog's Signing Profile ARN (`arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc`) to your function's [Code Signing Configuration][10] before you can add the Datadog Lambda library as a layer.
+If your Lambda function is configured to use code signing, you must add Datadog's Signing Profile ARN (`arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc`) to your function's [Code Signing Configuration][5] before you can add the Datadog Lambda library as a layer.
 
 #### Using the Gem
 
@@ -104,11 +104,15 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 1. [Install the Datadog Forwarder if you haven't][2].
 2. [Subscribe the Datadog Forwarder to your function's log groups][6].
 
+### Unified Service Tagging
+
+Although it's optional, we highly recommend tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][7].
+
 ## Explore Datadog Serverless Monitoring
 
-After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless Homepage][7].
+After you have configured your function following the steps above, you should be able to view metrics, logs and traces on the [Serverless Homepage][8].
 
-### Monitor Custom Business Logic
+## Monitor Custom Business Logic
 
 If you would like to submit a custom metric or span, see the sample code below:
 
@@ -153,7 +157,7 @@ def some_operation()
 end
 ```
 
-For more information on custom metric submission, see [here][8]. For additional details on custom instrumentation, see the Datadog APM documentation for [custom instrumentation][9].
+For more information on custom metric submission, see [here][9]. For additional details on custom instrumentation, see the Datadog APM documentation for [custom instrumentation][10].
 
 ## Further Reading
 
@@ -163,9 +167,9 @@ For more information on custom metric submission, see [here][8]. For additional 
 [2]: /serverless/forwarder/
 [3]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
 [4]: https://github.com/DataDog/datadog-lambda-layer-rb/releases
-[5]: https://rubygems.org/gems/datadog-lambda
+[5]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html#config-codesigning-config-update
 [6]: /logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
-[7]: https://app.datadoghq.com/functions
-[8]: /serverless/custom_metrics?tab=ruby
-[9]: /tracing/custom_instrumentation/ruby/
-[10]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html#config-codesigning-config-update
+[7]: /getting_started/tagging/unified_service_tagging/#aws-lambda-functions
+[8]: https://app.datadoghq.com/functions
+[9]: /serverless/custom_metrics?tab=ruby
+[10]: /tracing/custom_instrumentation/ruby/

--- a/content/en/serverless/installation/ruby.md
+++ b/content/en/serverless/installation/ruby.md
@@ -106,7 +106,7 @@ You need to subscribe the Datadog Forwarder Lambda function to each of your func
 
 ### Unified Service Tagging
 
-Although it's optional, we highly recommend tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][7].
+Although it's optional, Datadog highly recommends tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][7].
 
 ## Explore Datadog Serverless Monitoring
 


### PR DESCRIPTION
### What does this PR do?
Document how to apply `env`, `service` and `version` tags to Lambda functions. Since "serverless" is a big world that has other players than just AWS Lambda functions (though Lambda dominates), I created a section for "Serverless" and put `AWS Lambda functions" under it as a subsection.

Also add a link to this doc from the serverless installation instructions.

### Motivation
The serverless team consistently get this kind of questions from our customers, and a few of them referred to this doc and complained that there were no instructions for serverless (specifically for Lambda functions).

### Preview
https://docs-staging.datadoghq.com/tian.chu/serverless-unified-service-tagging/getting_started/tagging/unified_service_tagging/

https://docs-staging.datadoghq.com/tian.chu/serverless-unified-service-tagging/serverless/installation/python
https://docs-staging.datadoghq.com/tian.chu/serverless-unified-service-tagging/serverless/installation/nodejs
https://docs-staging.datadoghq.com/tian.chu/serverless-unified-service-tagging/serverless/installation/ruby
https://docs-staging.datadoghq.com/tian.chu/serverless-unified-service-tagging/serverless/installation/go
https://docs-staging.datadoghq.com/tian.chu/serverless-unified-service-tagging/serverless/installation/java
https://docs-staging.datadoghq.com/tian.chu/serverless-unified-service-tagging/serverless/installation/dotnet

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
