### PR TITLE
Provide name to helm install command

### DIFF
--- a/content/en/agent/guide/operator-advanced.md
+++ b/content/en/agent/guide/operator-advanced.md
@@ -30,7 +30,7 @@ To use the Datadog Operator, deploy it in your Kubernetes cluster. Then create a
 
 2. Install the Datadog Operator:
   ```
-  helm install datadog/datadog-operator
+  helm install my-datadog-operator datadog/datadog-operator
   ```
   
 ## Deploy the Datadog Agents with the Operator


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Provide name to helm install command similar to this documentation:
https://github.com/DataDog/datadog-operator/blob/master/docs/getting_started.md#deploy-an-agent-with-the-operator

### Motivation
<!-- What inspired you to submit this pull request?-->
Command is not correct. Without providing the name, you will get the following error:
> Error: must either provide a name or specify --generate-name

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/mecsantos-patch-2/agent/guide/operator-advanced/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
