### PR TITLE
Adds on-premise monitoring to solutions menu

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -204,6 +204,11 @@ main_left:
     title: usecase
     url: 'https://www.datadoghq.com/solutions/business-analytics/'
     weight: -440
+  - name: 'On-Premises Monitoring'
+    parent: solutions
+    title: usecase
+    url: 'https://www.datadoghq.com/solutions/on-premises-monitoring/'
+    weight: -439
 main_right:
   - identifier: about
     name: About


### PR DESCRIPTION
### What does this PR do?
Adds on-premise monitoring to solutions menu

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1042

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/menu-update/

### Additional Notes
On-Premises Monitoring is in Solutions/Use-Case menu.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
