### PR TITLE
Update serverless tagging doc

### DIFF
--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -435,9 +435,9 @@ Transform:
       env: "<ENV>"
 ```
 
+
 [1]: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-function.html#sam-function-tags
 [2]: https://docs.datadoghq.com/serverless/serverless_integrations/macro
-
 {{% /tab %}}
 
 {{% tab "AWS CDK" %}}
@@ -464,20 +464,22 @@ class CdkStack extends cdk.Stack {
 }
 ```
 
+
 [1]: https://docs.aws.amazon.com/cdk/latest/guide/tagging.html
 [2]: https://docs.datadoghq.com/serverless/serverless_integrations/macro
-
 {{% /tab %}}
 
 {{% tab "Custom" %}}
 
 Apply the `env`, `service` and `version` tags following the AWS instructions for [Tagging Lambda Functions][1].
 
-[1]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-tags.html
 
+[1]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-tags.html
 {{% /tab %}}
 
 {{< /tabs >}}
+
+Ensure the `DdFetchLambdaTags` option is set to `true` on the CloudFormation stack for your [Datadog Forwarder][14]. This option defaults to `true` since version `3.19.0`.
 
 ## Further Reading
 
@@ -497,3 +499,4 @@ Apply the `env`, `service` and `version` tags following the AWS instructions for
 [11]: /integrations/statsd/
 [12]: https://www.chef.io/
 [13]: https://www.ansible.com/
+[14]: /serverless/forwarder/

--- a/content/en/serverless/serverless_tagging/_index.md
+++ b/content/en/serverless/serverless_tagging/_index.md
@@ -1,119 +1,28 @@
 ---
 title: Serverless Tagging
 kind: documentation
+further_reading:
+- link: "/getting_started/tagging/unified_service_tagging/#aws-lambda-functions"
+  tag: "Documentation"
+  text: "Unified Service Tagging"
 ---
 
 {{< img src="serverless/serverless_tagging.mp4" video="true" alt="Unified Serverless Tagging" >}}
 
 ## Overview
 
-Any tag applied to your AWS Lambda function automatically becomes a new dimension on which you can slice and dice your traces.
+Any tag applied to your AWS Lambda function automatically becomes a new dimension on which you can slice and dice your metrics, traces and logs.
 
-Tags are especially powerful when consistent across the Datadog platform. First-class support is offered for the following tags: `env` and `service`.
+Tags are especially powerful when consistent across the Datadog platform. First-class support is offered for the following tags: `env`, `service` and `version`.
 
-With these two tags, you can:
+With these tags, you can:
 
 - Navigate seamlessly across metrics, traces, and logs with consistent tags
-- View service data based on environment or version in a unified fashion within the Datadog app
 - Filter your functions on the Serverless Homepage
+- View service data based on environment or version in a unified fashion within the Datadog app
+- Organize your service map by service and environment
 
-There are a few best practices Datadog recommends for tagging in your serverless environment to keep tags consistent across your traces, metrics, and logs.
-
-## Directly tag your serverless functions
-
-To surface tags from your Lambda functions across metrics, traces, and logs, Datadog recommends that you directly tag your Lambda functions with the appropriate `env` and `service`. Below are some sample tagging configurations for common serverless developer tools:
-
-{{< tabs >}}
-{{% tab "Serverless Framework" %}}
-
-If you are using the Serverless Framework, you can choose one of several options to apply tags across Datadog:
-
-1. Tags directly added at the provider scope will be applied across Datadog:
-
-  ```yaml
-  provider:
-    name: aws
-    runtime: nodejs12.x
-    tags:
-  	service: shopist-cart-confirmation
-    	env: prod
-    	version: 1.01
-  ```
-
-2. Tags directly added on each individual Lambda resource will be applied across Datadog:
-
-  ```yaml
-  functions:
-    confirmCart:
-      handler: cart.confirm
-      tags:
-        service: shopist-cart-confirmation
-        env: prod
-        version: 1.01
-      events:
-        - http:
-            path: ping
-            method: get
-
-  ```
-
-3. If you are using the Datadog Serverless Framework Plugin, native Serverless Framework `service` and `stage` tags will be surfaced as `service` and `env` across Datadog:
-
-  ```yaml
-  service: shopist-cart-confirmation
-
-  provider:
-    name: aws
-    runtime: nodejs12.x
-    stage: prod
-  ```
-
-{{% /tab %}}
-{{% tab "AWS SAM" %}}
-
-If you are using the AWS SAM, you can choose one of several options to apply tags across Datadog:
-
-
-1. Tags directly added on each individual Lambda resource will be applied across Datadog:
-
-  ```yaml
-  Resources:
-    confirmCart:
-      Type: AWS::Serverless::Function
-      Properties:
-        Handler: src/handlers/cart.confirm
-        Tags:
-          env: prod
-          service: shopist-cart-confirmation
-  ```
-
-2. If you are using the Datadog CloudFormation Macro, tags directly added in the `Transform` scope will be applied across Datadog:
-
-  ```yaml
-  Transform:
-    - AWS::Serverless-2016-10-31
-    - Name: DatadogServerless
-      Parameters: 
-          nodeLayerVersion: 25
-          forwarderArn: "arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder"
-          stackName: !Ref "AWS::StackName"
-          service: "shopist-cart-confirmation"
-          env: "prod"
-  ```
-
-{{% /tab %}}
-{{< /tabs >}}
-
-
-### Import resource tags from your serverless Functions
-
-Datadog strongly recommends you enable the `DdFetchLambdaTags` option on the Datadog Forwarder. Setting the parameter `DdFetchLambdaTags` to `true` on the Forwarder CloudFormation stack will ensure your traces are tagged with the resource tags on the originating Lambda function. 
-
-Lambda function resource tags are automatically surfaced to X-Ray traces in Datadog without any additional configuration.
-
-## Organize your service map
-
-{{< img src="serverless/serverless_service_map.png" alt="Service Map" >}}
+To tag your serverless application with `env`, `service` and `version`, see the [unified service tagging documentation][1].
 
 ### The env tag
 
@@ -123,8 +32,27 @@ By default, AWS Lambda functions are tagged with `env:none` in Datadog. Add your
 
 ### The service tag
 
-Add the `service` tag in order to group related Lambda functions into a service. The Service Map and Services List use this tag to show relationships between services and the health of their monitors. Services are represented as individual nodes on the Service Map.
+Add the `service` tag in order to group related Lambda functions into a service. 
 
 The default behavior for new Datadog customers is for all Lambda functions to be grouped under the `aws.lambda` service, and represented as a single node on the Service map. Tag your functions by service to override this.
 
 **Note:** For some Datadog customers, each Lambda function is treated as its own service. Add your own tag to override this, or reach out to Datadog Support if you would like to your account to adopt the new behavior.
+
+### The version tag
+
+Add the `version` tag to enable [Deployment Tracking][2].
+
+## Organize your service map
+
+The [Service Map][3] groups services into maps by the `env` tag, and uses the `service` tag to show relationships between services and the health of their monitors. Services are represented as individual nodes on the Service Map. The color of the nodes represents the health of the associated monitors. Tag any monitor with the same `service` tag to associate.
+
+{{< img src="serverless/serverless_service_map.png" alt="Service Map" >}}
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+
+[1]: /getting_started/tagging/unified_service_tagging/#aws-lambda-functions
+[2]: /tracing/deployment_tracking/
+[3]: /tracing/visualization/services_map/


### PR DESCRIPTION
### What does this PR do?

Update the serverless tagging doc to mention the `version` tag and remove the tagging instructions to avoid duplications (link to https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/#aws-lambda-functions instead)

### Motivation

https://github.com/DataDog/documentation/pull/9374#issuecomment-751888857

### Preview

https://docs-staging.datadoghq.com/tian.chu/update-serverless-tagging/serverless/serverless_tagging/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
