### PR TITLE
Serverless APM Documentation Update

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -942,6 +942,10 @@ main:
     identifier: serverless_distributed_tracing
     parent: serverless
     weight: 5
+  - name: Trace Merging (Advanced)
+    url: serverless/distributed_tracing/serverless_trace_merging
+    parent: serverless_distributed_tracing
+    weight: 501
   - name: Custom Metrics
     url: serverless/custom_metrics
     parent: serverless

--- a/content/en/serverless/distributed_tracing/_index.md
+++ b/content/en/serverless/distributed_tracing/_index.md
@@ -14,7 +14,7 @@ further_reading:
 
 By connecting your serverless traces to metrics, Datadog provides a context-rich picture of your application’s performance, allowing you to better troubleshoot performance issues given the distributed nature of serverless applications. 
 
-The Datadog Python, Node.js, Ruby, Go and Java tracing libraries support distributed tracing for AWS Lambda. The easiest way to add tracing to your application is with the [Datadog Lambda Library][2], which includes the Datadog tracing librarsy as a dependency.
+The Datadog Python, Node.js, Ruby, Go and Java tracing libraries support distributed tracing for AWS Lambda. The easiest way to add tracing to your application is with the [Datadog Lambda Library][2], which includes the Datadog tracing library as a dependency.
 
 ## Choose your Tracing Library
 
@@ -85,6 +85,14 @@ Learn more about tracing through .NET Azure serverless applications [here][16].
 
 *Looking to trace through .NET AWS Lambda serverless applications with Datadog tracing libraries? Open a feature request [here][9].*
 
+### Hybrid Environments
+
+If you have installed Datadog's tracing libraries (`dd-trace`) on both your Lambda functions and hosts, your traces will automatically show you the complete picture of requests that cross infrastructure boundaries, whether it be AWS Lambda, containers, on-prem hosts, or managed services. 
+
+If `dd-trace` is installed on your hosts with the Datadog Agent, and your serverless functions are traced with AWS X-Ray, trace merging is required to see a single, connected trace across your infrastructure. Learn more about merging traces from `dd-trace` and AWS X-Ray [here][10].
+
+Datadog's [AWS X-Ray integration][12] only provides traces for Lambda functions. Learn more about tracing in container or host-based environments [here][17].
+
 ## Enable Datadog APM
 
 {{< img src="tracing/live_search/livesearchmain.gif" alt="Live Search" >}}
@@ -113,3 +121,4 @@ To enable Datadog APM without enabling logging for your functions, ensure the `D
 [14]: /tracing/setup_overview/compatibility_requirements/go
 [15]: /serverless/datadog_lambda_library/java#distributed-tracing
 [16]: /serverless/azure_app_services
+[17]: /tracing/setup_overview/

--- a/content/en/serverless/distributed_tracing/_index.md
+++ b/content/en/serverless/distributed_tracing/_index.md
@@ -45,7 +45,7 @@ The Datadog Lambda Library and tracing libraries for Python and Node.js support:
 - Tracing asynchronous Lambda invocations through AWS SQS (coming soon for Node.js).
 - Tracing dozens of additional out-of-the-box [Python][7] and [Node.js][11] libraries.
 
-For Python and Node.js serverless applications, we recommend you [install Datadog's tracing libraries][8]. If your application requires AWS X-Ray active tracing in AWS managed services such as API Gateway or Step Functions, we recommend you augment AWS X-Ray traces with Datadog APM by configuring _both_ AWS X-Ray and Datadog APM tracing libraries as described [here][10].
+For Python and Node.js serverless applications, Datadog recommends you [install Datadog's tracing libraries][8]. If your application requires AWS X-Ray active tracing in AWS managed services such as API Gateway or Step Functions, we recommend you augment AWS X-Ray traces with Datadog APM by configuring _both_ AWS X-Ray and Datadog APM tracing libraries as described [here][10].
 
 If you are already tracing your serverless functions with X-Ray and want to continue using X-Ray, you can [install our AWS X-Ray integration][12].
 

--- a/content/en/serverless/distributed_tracing/_index.md
+++ b/content/en/serverless/distributed_tracing/_index.md
@@ -20,7 +20,9 @@ The Datadog Python, Node.js, Ruby, Go and Java tracing libraries support distrib
 
 {{< img src="integrations/amazon_lambda/lambda_tracing.png" alt="architecture diagram for tracing AWS Lambda with Datadog" >}}
 
-To start using Datadog APM with your serverless application, you need to first choose between installing Datadog's tracing libraries (`dd-trace`) or AWS X-Ray tracing libraries based on your Lambda runtime and individual requirements. To see all of your traces in Datadog in real-time in the Live Search view, you need to use Datadog's tracing libraries.
+<div class="alert alert-info"> New to serverless monitoring? Follow the installation steps <a href="/serverless/installation/">here</a> to get started.</div>
+
+To start using Datadog APM with your serverless application, you can choose between installing Datadog's tracing libraries (`dd-trace`) or AWS X-Ray tracing libraries based on your Lambda runtime and individual requirements. To see all of your traces in Datadog in real-time in the Live Search view, you need to use Datadog's tracing libraries.
 
 | [Datadog APM with dd-trace][1]          | [Datadog APM with AWS X-Ray][2]           |
 |---------------------------------|-------------------------------------------------------------------------|

--- a/content/en/serverless/distributed_tracing/_index.md
+++ b/content/en/serverless/distributed_tracing/_index.md
@@ -31,7 +31,7 @@ To start using Datadog APM with your serverless application, you can choose betw
 | Tail-based sampling and fully customizable tag-based retention filters. | Sampling rate cannot be configured. |
 | Support for Python, Node.js, Ruby, Go, Java. |  Support for all Lambda runtimes. |
 
-### Runtime Recommendations
+### Runtime recommendations
 
 {{< partial name="serverless/serverless-apm-recommendations.html" >}}
 
@@ -81,13 +81,13 @@ The Datadog Lambda Library for Java supports manual correlation of Lambda logs a
 
 #### .NET
 
-We recommend you configure tracing for your .NET AWS Lambda serverless applications by [installing our AWS X-Ray integration][12].
+Datadog recommends you configure tracing for your .NET AWS Lambda serverless applications by [installing our AWS X-Ray integration][12].
 
 Learn more about tracing through .NET Azure serverless applications [here][16].
 
 *Looking to trace through .NET AWS Lambda serverless applications with Datadog tracing libraries? Open a feature request [here][9].*
 
-### Hybrid Environments
+### Hybrid environments
 
 If you have installed Datadog's tracing libraries (`dd-trace`) on both your Lambda functions and hosts, your traces will automatically show you the complete picture of requests that cross infrastructure boundaries, whether it be AWS Lambda, containers, on-prem hosts, or managed services. 
 

--- a/content/en/serverless/distributed_tracing/_index.md
+++ b/content/en/serverless/distributed_tracing/_index.md
@@ -2,48 +2,114 @@
 title: Distributed Tracing
 kind: documentation
 further_reading:
-    - link: 'tracing/serverless_functions'
-      tag: 'Documentation'
-      text: 'Installing AWS X-Ray'
+- link: "/tracing/"
+  tag: "Documentation"
+  text: "Explore Datadog APM"
+- link: "/tracing/trace_search_and_analytics/#live-search-for-15-minutes"
+  tag: "Documentation"
+  text: "Live Search"
 ---
 
 {{< img src="tracing/serverless_functions/ServerlessDistributedTrace.png" alt="Trace Serverless Functions"  style="width:100%;">}}
 
-By connecting your serverless traces to metrics, Datadog provides a context-rich picture of your application’s performance, allowing you to better troubleshoot performance issues given the distributed nature of serverless applications.
+By connecting your serverless traces to metrics, Datadog provides a context-rich picture of your application’s performance, allowing you to better troubleshoot performance issues given the distributed nature of serverless applications. 
+
+The Datadog Python, Node.js, Ruby, Go and Java tracing libraries support distributed tracing for AWS Lambda. The easiest way to add tracing to your application is with the [Datadog Lambda Library][2], which includes the Datadog tracing librarsy as a dependency.
 
 ## Choose your Tracing Library
 
 {{< img src="integrations/amazon_lambda/lambda_tracing.png" alt="architecture diagram for tracing AWS Lambda with Datadog" >}}
 
-Depending on your language and configuration, choose between setting up Datadog APM or AWS X-Ray for your tracing needs. [Read this page][1] to learn more about tracing with AWS X-Ray.
+To start using Datadog APM with your serverless application, you need to first choose between installing Datadog's tracing libraries (`dd-trace`) or AWS X-Ray tracing libraries based on your Lambda runtime and individual requirements. To see all of your traces in Datadog in real-time in the Live Search view, you need to use Datadog's tracing libraries.
 
-## Distributed Tracing with Datadog APM
+| [Datadog APM with dd-trace][1]          | [Datadog APM with AWS X-Ray][2]           |
+|---------------------------------|-------------------------------------------------------------------------|
+| Uses Datadog APM's integration libraries for end-to-end tracing.  | Pulls traces from AWS X-Ray. |
+| Visualize your traces in Datadog in real-time. | Trace data available in Datadog after 2-5 minutes. |
+| Tail-based sampling and fully customizable tag-based retention filters. | Sampling can be modified from the AWS X-Ray console. |
+| Support for Python, Node.js, Ruby, Go, Java. |  Support for all Lambda runtimes. |
 
-Datadog APM sends trace data to Datadog in real-time, allowing you to monitor traces with little to no latency in the Live Search view. Datadog APM also uses tail-based sampling to make better sampling decisions.
+### Runtime Recommendations
 
-The Datadog Python, Node.js, and Ruby tracing libraries support distributed tracing for AWS Lambda, with more runtimes coming soon. The easiest way to add tracing to your application is with the [Datadog Lambda Library][2], which includes the Datadog tracing library as a dependency.
+{{< partial name="serverless/serverless-apm-recommendations.html" >}}
 
-Visualize your traces on the [Serverless Homepage][3], in [Trace Search and Analytics][4], and on the [Service Map][5].
+#### Python and Node.js
 
-### Correlate Logs and Traces
+The Datadog Lambda Library and tracing libraries for Python and Node.js support:
+- Automatic correlation of Lambda logs and traces with trace ID and tag injection.
+- Installation without any code changes using Serverless Framework, AWS SAM and AWS CDK integrations.
+- Tracing HTTP requests invoking downstream Lambda functions or containers.
+- Tracing synchronous Lambda invokes with the AWS SDK.
+- Tracing asynchronous Lambda invocations through AWS SQS.
+- Tracing dozens of additional out-of-the-box [Python][7] and [Node.js][11] libraries.
 
-The correlation between Datadog APM and Datadog Log Management is improved by the injection of trace IDs, span IDs, env, service, and version as attributes in your logs. With these fields, you can find the exact logs associated with a specific service and version or all logs correlated to an observed trace.
+For Python and Node.js serverless applications, we recommend you [install Datadog's tracing libraries][8]. If your application requires AWS X-Ray active tracing in AWS managed services such as API Gateway or Step Functions, we recommend you augment AWS X-Ray traces with Datadog APM by configuring _both_ AWS X-Ray and Datadog APM tracing libraries as described [here][10].
 
-### Live Search
+If you are already tracing your serverless functions with X-Ray and want to continue using X-Ray, you can [install our AWS X-Ray integration][12].
 
-{{< img src="tracing/live_search/livesearchmain.gif" alt="Live Search" >}}
+*Looking to trace through serverless resources not listed above? Open a feature request [here][9].*
 
-The APM Live Search gives you the ability to search all ingested spans using any tag in real-time for the past 15 minutes. It displays spans as soon as they are sent by the Datadog agent and before they are indexed by Datadog.
+#### Ruby
+
+The Datadog Lambda Library and tracing libraries for Ruby support:
+- Automatic correlation of Lambda logs and traces with trace ID and tag injection.
+- Tracing HTTP requests invoking downstream Lambda functions or containers.
+- Tracing dozens of additional out-of-the-box [Ruby][13] libraries.
+
+You can trace your serverless functions in Datadog with [Datadog's tracing libraries][8] or by [installing our AWS X-Ray integration][12]. If you are using [Datadog's tracing libraries][8], and need to connect Lambda function traces across AWS managed services, we recommend you augment your traces by configuring _both_ AWS X-Ray and Datadog APM tracing libraries as described [here][10].
+
+*Looking to trace through serverless resources not listed above? Open a feature request [here][9].*
+
+#### Go
+
+The Datadog Lambda Library and tracing libraries for Go support:
+- Manual correlation of Lambda logs and traces with trace ID and tag injection.
+- Tracing HTTP requests invoking downstream Lambda functions or containers.
+- Tracing dozens of additional out-of-the-box [Go][14] libraries.
+
+You can trace your serverless functions in Datadog with [Datadog's tracing libraries][8] or by [installing our AWS X-Ray integration][12]. If you are using [Datadog's tracing libraries][8], and need to connect multiple Lambda function traces in event-driven architectures, we recommend you augment your traces by configuring _both_ AWS X-Ray and Datadog APM tracing libraries as described [here][10].
+
+*Looking to trace through serverless resources not listed above? Open a feature request [here][9].*
+
+#### Java
+
+The Datadog Lambda Library for Java supports manual correlation of Lambda logs and AWS X-Ray traces with trace ID and tag injection. Datadog's tracing library for Java is currently in [beta][15]. We recommend you configure tracing for your Java serverless applications by [installing our AWS X-Ray integration][12].
+
+*Have feedback on the Datadog's tracing libraries for Java Lambda functions? Make sure to check out discussions going on in the <a href="https://datadoghq.slack.com/archives/CFDPB83M4">#serverless</a> channel in the <a href="https://chat.datadoghq.com/">Datadog Slack community</a>.*
+
+#### .NET
+
+We recommend you configure tracing for your .NET AWS Lambda serverless applications by [installing our AWS X-Ray integration][12].
+
+Learn more about tracing through .NET Azure serverless applications [here][16].
+
+*Looking to trace through .NET AWS Lambda serverless applications with Datadog tracing libraries? Open a feature request [here][9].*
 
 ## Enable Datadog APM
 
-The Datadog Python, Node.js, and Ruby tracing libraries support distributed tracing for AWS Lambda, with more runtimes coming soon. To enable tracing on your functions, follow [the installation instructions][6].
+{{< img src="tracing/live_search/livesearchmain.gif" alt="Live Search" >}}
+
+The Datadog Python, Node.js, Ruby, Go and Java tracing libraries support distributed tracing for AWS Lambda. To enable tracing on your functions, follow [the installation instructions][8].
 
 To enable Datadog APM without enabling logging for your functions, ensure the `DdForwarderLog` environment variable is set to `false` on your Datadog Forwarder.
 
-[1]: /tracing/serverless_functions/
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /serverless/distributed_tracing#distributed-tracing-with-datadog-apm
+[2]: /integrations/amazon_xray/#overview
 [2]: /serverless/datadog_lambda_library/
 [3]: https://app.datadoghq.com/functions
 [4]: https://app.datadoghq.com/apm/traces
 [5]: https://app.datadoghq.com/apm/map
-[6]: https://docs.datadoghq.com/serverless/installation
+[7]: /tracing/setup_overview/compatibility_requirements/python
+[8]: /serverless/installation/
+[9]: https://docs.datadoghq.com/help/
+[10]: /tracing/setup_overview/serverless_functions/#augment-aws-x-ray-tracing-with-datadog-apm
+[11]: /tracing/setup_overview/compatibility_requirements/nodejs
+[12]: /integrations/amazon_xray/#overview
+[13]: /tracing/setup_overview/compatibility_requirements/ruby
+[14]: /tracing/setup_overview/compatibility_requirements/go
+[15]: /serverless/datadog_lambda_library/java#distributed-tracing
+[16]: /serverless/azure_app_services

--- a/content/en/serverless/distributed_tracing/_index.md
+++ b/content/en/serverless/distributed_tracing/_index.md
@@ -106,7 +106,7 @@ To enable Datadog APM without enabling logging for your functions, ensure the `D
 [7]: /tracing/setup_overview/compatibility_requirements/python
 [8]: /serverless/installation/
 [9]: https://docs.datadoghq.com/help/
-[10]: /tracing/setup_overview/serverless_functions/#augment-aws-x-ray-tracing-with-datadog-apm
+[10]: /serverless/distributed_tracing/serverless_trace_merging
 [11]: /tracing/setup_overview/compatibility_requirements/nodejs
 [12]: /integrations/amazon_xray/#overview
 [13]: /tracing/setup_overview/compatibility_requirements/ruby

--- a/content/en/serverless/distributed_tracing/_index.md
+++ b/content/en/serverless/distributed_tracing/_index.md
@@ -25,8 +25,8 @@ To start using Datadog APM with your serverless application, you need to first c
 | [Datadog APM with dd-trace][1]          | [Datadog APM with AWS X-Ray][2]           |
 |---------------------------------|-------------------------------------------------------------------------|
 | Uses Datadog APM's integration libraries for end-to-end tracing.  | Pulls traces from AWS X-Ray. |
-| Visualize your traces in Datadog in real-time. | Trace data available in Datadog after 2-5 minutes. |
-| Tail-based sampling and fully customizable tag-based retention filters. | Sampling can be modified from the AWS X-Ray console. |
+| Visualize your traces in Datadog in real-time. | Trace data available in Datadog after a few minutes. |
+| Tail-based sampling and fully customizable tag-based retention filters. | Sampling rate cannot be configured. |
 | Support for Python, Node.js, Ruby, Go, Java. |  Support for all Lambda runtimes. |
 
 ### Runtime Recommendations
@@ -39,8 +39,8 @@ The Datadog Lambda Library and tracing libraries for Python and Node.js support:
 - Automatic correlation of Lambda logs and traces with trace ID and tag injection.
 - Installation without any code changes using Serverless Framework, AWS SAM and AWS CDK integrations.
 - Tracing HTTP requests invoking downstream Lambda functions or containers.
-- Tracing synchronous Lambda invokes with the AWS SDK.
-- Tracing asynchronous Lambda invocations through AWS SQS.
+- Tracing synchronous Lambda invokes with the AWS SDK (coming soon for Node.js).
+- Tracing asynchronous Lambda invocations through AWS SQS (coming soon for Node.js).
 - Tracing dozens of additional out-of-the-box [Python][7] and [Node.js][11] libraries.
 
 For Python and Node.js serverless applications, we recommend you [install Datadog's tracing libraries][8]. If your application requires AWS X-Ray active tracing in AWS managed services such as API Gateway or Step Functions, we recommend you augment AWS X-Ray traces with Datadog APM by configuring _both_ AWS X-Ray and Datadog APM tracing libraries as described [here][10].
@@ -75,7 +75,7 @@ You can trace your serverless functions in Datadog with [Datadog's tracing libra
 
 The Datadog Lambda Library for Java supports manual correlation of Lambda logs and AWS X-Ray traces with trace ID and tag injection. Datadog's tracing library for Java is currently in [beta][15]. We recommend you configure tracing for your Java serverless applications by [installing our AWS X-Ray integration][12].
 
-*Have feedback on the Datadog's tracing libraries for Java Lambda functions? Make sure to check out discussions going on in the <a href="https://datadoghq.slack.com/archives/CFDPB83M4">#serverless</a> channel in the <a href="https://chat.datadoghq.com/">Datadog Slack community</a>.*
+*Have feedback on the Datadog's tracing libraries for Java Lambda functions? Make sure to check out discussions going on in the [#serverless][18] channel in the [Datadog Slack community][19].*
 
 #### .NET
 
@@ -122,3 +122,5 @@ To enable Datadog APM without enabling logging for your functions, ensure the `D
 [15]: /serverless/datadog_lambda_library/java#distributed-tracing
 [16]: /serverless/azure_app_services
 [17]: /tracing/setup_overview/
+[18]: https://datadoghq.slack.com/archives/CFDPB83M4
+[19]: https://chat.datadoghq.com/

--- a/content/en/serverless/distributed_tracing/serverless_trace_merging.md
+++ b/content/en/serverless/distributed_tracing/serverless_trace_merging.md
@@ -14,8 +14,8 @@ further_reading:
 Serverless trace merging is required to see a single, connected trace when you configure both Datadog's tracing libraries (`dd-trace`) and AWS X-Ray tracing libraries in your application. If you aren't sure which tracing library to use, [read this page on choosing your tracing library][1].
 
 There are two primary reasons for instrumenting both `dd-trace` and AWS X-Ray tracing libraries:
-- In a serverless-first environment, your application requires AWS X-Ray active tracing in AWS managed services such as API Gateway or Step Functions, you are tracing your Lambda functions with `dd-trace`, and you want to visualize connected traces across your serverless resources.
-- In a hybrid environment with both Lambda functions and hosts, `dd-trace` is installed on your hosts with the Datadog Agent, your serverless functions are traced with AWS X-Ray, and you want to visualize connected traces for transactions across Lambda functions and hosts.
+- In an AWS serverless environment, you are already tracing your Lambda functions with `dd-trace`, you require AWS X-Ray active tracing for AWS managed services such as API Gateway or Step Functions, and you want to visualize the `dd-trace` and AWS X-Ray spans in one single trace.
+- In a hybrid environment with both Lambda functions and hosts, `dd-trace` instruments your hosts, AWS X-Ray instruments your Lambda functions, and you want to visualize connected traces for transactions across Lambda functions and hosts.
 
 Note that this may result in higher usage bills. X-Ray spans will continue to be available in your merged traces after 2-5 minutes. In many cases, we recommend only using a single tracing library. Learn more about choosing your tracing library [here][1].
 
@@ -24,7 +24,7 @@ You can find setup instructions for each of the above use cases below:
 - [Trace merging in a serverless-first environment](#trace-merging-in-a-serverless-first-environment)
 - [Trace merging across AWS Lambda and hosts](#trace-merging-across-aws-lambda-and-hosts)
 
-### Trace merging in a serverless-first environment
+### Trace merging in an AWS serverless environment
 
 AWS X-Ray provides both a backend AWS service (AWS X-Ray active tracing) and a set of client libraries. [Enabling the backend AWS service alone in the Lambda console][2] gives you `Initialization` and `Invocation` spans for your AWS Lambda functions. You can also enable AWS X-Ray active tracing from the API Gateway and Step Function consoles.
 
@@ -32,40 +32,8 @@ Both the AWS X-Ray SDK and Datadog APM client libraries (`dd-trace`) add medatad
 
 1. You have enabled [AWS X-Ray active tracing][2] on your Lambda functions from the AWS Lambda console and our [AWS X-Ray integration within Datadog][3].
 2. You have instrumented your Lambda functions with Datadog APM (`dd-trace`) by following the [installation instructions for your Lambda runtime][4].
-3. The AWS X-Ray client libraries should not be installed on your Lambda functions. Otherwise, you will see duplicate traces.
-
-To merge the traces, set the corresponding environment variable as outlined below:
-
-{{< tabs >}}
-{{% tab "Node.js" %}}
-```javascript
-module.exports.hello = datadog(
-    (event, context, callback) => {
-        longCalculation();
-
-        callback(null, {
-            statusCode: 200,
-            body: 'Hello from serverless!'
-        });
-    },
-    { mergeDatadogXrayTraces: true }
-);
-```
-{{% /tab %}}
-
-{{% tab "Python" %}}
-
-Set the `DD_MERGE_XRAY_TRACES` environment variable to `True` on your Lambda function.
-
-{{% /tab %}}
-
-{{% tab "Ruby" %}}
-
-Set the `DD_MERGE_DATADOG_XRAY_TRACES` environment variable to `True` on your Lambda function.
-
-{{% /tab %}}
-
-{{< /tabs >}}
+3. Third-party libraries are automatically patched by `dd-trace`, so the AWS X-Ray client libraries do not need to be installed.
+4. Set the `DD_MERGE_XRAY_TRACES` environment variable to `true` on your Lambda functions to merge the X-Ray and `dd-trace` traces (`DD_MERGE_DATADOG_XRAY_TRACES` in Ruby).
 
 ### Tracing across AWS Lambda and hosts
 

--- a/content/en/serverless/distributed_tracing/serverless_trace_merging.md
+++ b/content/en/serverless/distributed_tracing/serverless_trace_merging.md
@@ -1,0 +1,94 @@
+---
+title: Serverless Trace Merging
+kind: documentation
+description: 'Augment AWS X-Ray Tracing with Datadog APM'
+further_reading:
+    - link: 'serverless'
+      text: 'Serverless Monitoring with Datadog'
+---
+
+{{< img src="tracing/serverless_functions/ServerlessDistributedTrace.png" alt="Trace Serverless Functions"  style="width:100%;" >}}
+
+## Use Cases
+
+Serverless trace merging is required to see a single, connected trace when you configure both Datadog's tracing libraries (`dd-trace`) and AWS X-Ray tracing libraries in your application. If you aren't sure which tracing library to use, [read this page on choosing your tracing library][1].
+
+There are two primary reasons for instrumenting both `dd-trace` and AWS X-Ray tracing libraries:
+- In a serverless-first environment, your application requires AWS X-Ray active tracing in AWS managed services such as API Gateway or Step Functions, you are tracing your Lambda functions with `dd-trace`, and you want to visualize connected traces across your serverless resources.
+- In a hybrid environment with both Lambda functions and hosts, `dd-trace` is installed on your hosts with the Datadog Agent, your serverless functions are traced with AWS X-Ray, and you want to visualize connected traces for transactions across Lambda functions and hosts.
+
+Note that this may result in higher usage bills. X-Ray spans will continue to be available in your merged traces after 2-5 minutes. In many cases, we recommend only using a single tracing library. Learn more about choosing your tracing library [here][1].
+
+You can find setup instructions for each of the above use cases below:
+
+- [Trace merging in a serverless-first environment](#trace-merging-in-a-serverless-first-environment)
+- [Trace merging across AWS Lambda and hosts](#trace-merging-across-aws-lambda-and-hosts)
+
+### Trace merging in a serverless-first environment
+
+AWS X-Ray provides both a backend AWS service (AWS X-Ray active tracing) and a set of client libraries. [Enabling the backend AWS service alone in the Lambda console][2] gives you `Initialization` and `Invocation` spans for your AWS Lambda functions. You can also enable AWS X-Ray active tracing from the API Gateway and Step Function consoles.
+
+Both the AWS X-Ray SDK and Datadog APM client libraries (`dd-trace`) add medatada and spans for downstream calls by accessing the function directly. Assuming you are using `dd-trace` to trace at the handler level, your setup should be similar to the following:
+
+1. You have enabled [AWS X-Ray active tracing][2] on your Lambda functions from the AWS Lambda console and our [AWS X-Ray integration within Datadog][3].
+2. You have instrumented your Lambda functions with Datadog APM (`dd-trace`) by following the [installation instructions for your Lambda runtime][4].
+3. The AWS X-Ray client libraries should not be installed on your Lambda functions. Otherwise, you will see duplicate traces.
+
+To merge the traces, set the corresponding environment variable as outlined below:
+
+{{< tabs >}}
+{{% tab "Node.js" %}}
+```javascript
+module.exports.hello = datadog(
+    (event, context, callback) => {
+        longCalculation();
+
+        callback(null, {
+            statusCode: 200,
+            body: 'Hello from serverless!'
+        });
+    },
+    { mergeDatadogXrayTraces: true }
+);
+```
+{{% /tab %}}
+
+{{% tab "Python" %}}
+
+Set the `DD_MERGE_XRAY_TRACES` environment variable to `True` on your Lambda function.
+
+{{% /tab %}}
+
+{{% tab "Ruby" %}}
+
+Set the `DD_MERGE_DATADOG_XRAY_TRACES` environment variable to `True` on your Lambda function.
+
+{{% /tab %}}
+
+{{< /tabs >}}
+
+### Tracing across AWS Lambda and hosts
+
+If you have installed Datadog's tracing libraries (`dd-trace`) on both your Lambda functions and hosts, your traces will automatically show you the complete picture of requests that cross infrastructure boundaries, whether it be AWS Lambda, containers, on-prem hosts, or managed services. 
+
+If `dd-trace` is installed on your hosts with the Datadog Agent, and your serverless functions are traced with AWS X-Ray, your setup should be similar to the following:
+
+1. You have installed the [AWS X-Ray integration][2] for tracing your Lambda functions, enabling both AWS X-Ray active tracing and installing the X-Ray client libraries.
+2. You have installed the [Datadog Lambda Library for your Lambda runtime][4], and the `DD_TRACE_ENABLED` environment variable is set to `false`.
+3. [Datadog APM][5] is configured on your hosts and container-based infrastructure.
+
+Then, for X-Ray and Datadog APM traces to appear in the same flame graph, all services must have the same `env` tag.
+
+**Note**: Distributed Tracing is supported for any runtime for your host or container-based applications. Your hosts and Lambda functions do not need to be in the same runtime. 
+
+{{< img src="integrations/amazon_lambda/lambda_host_trace.png" alt="trace of a request from a host to a Lambda function" >}}
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /serverless/distributed_tracing/
+[2]: https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html
+[3]: https://app.datadoghq.com/account/settings#integrations/amazon_xray
+[4]: /serverless/installation/
+[5]: /tracing/send_traces/

--- a/content/en/serverless/distributed_tracing/serverless_trace_merging.md
+++ b/content/en/serverless/distributed_tracing/serverless_trace_merging.md
@@ -9,7 +9,7 @@ further_reading:
 
 {{< img src="tracing/serverless_functions/ServerlessDistributedTrace.png" alt="Trace Serverless Functions"  style="width:100%;" >}}
 
-## Use Cases
+## Use cases
 
 Serverless trace merging is required to see a single, connected trace when you configure both Datadog's tracing libraries (`dd-trace`) and AWS X-Ray tracing libraries in your application. If you aren't sure which tracing library to use, [read this page on choosing your tracing library][1].
 

--- a/layouts/partials/serverless/serverless-apm-recommendations.html
+++ b/layouts/partials/serverless/serverless-apm-recommendations.html
@@ -1,0 +1,41 @@
+{{ $dot := . }}
+<div class="logs-containers">
+    <div class="container cards-dd">
+        <div class="card-deck">
+            <a class="card" href="/serverless/distributed_tracing#python-and-nodejs">
+                <div class="card-body text-center py-2 px-1">
+                    {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}
+                </div>
+            </a>
+            <a class="card" href="/serverless/distributed_tracing#python-and-nodejs">
+                <div class="card-body text-center py-2 px-1">
+                    {{ partial "img.html" (dict "root" . "src" "integrations_logos/nodejs.png" "class" "img-fluid" "alt" "Node.js" "width" "400") }}
+                </div>
+            </a>
+            <a class="card" href="/serverless/distributed_tracing#ruby">
+                <div class="card-body text-center py-2 px-1">
+                    {{ partial "img.html" (dict "root" . "src" "integrations_logos/ruby.png" "class" "img-fluid" "alt" "Ruby" "width" "400") }}
+                </div>
+            </a>
+        </div>
+    </br>
+        <div class="card-deck">
+            <a class="card" href="/serverless/distributed_tracing#java">
+                <div class="card-body text-center py-2 px-1">
+                    {{ partial "img.html" (dict "root" . "src" "integrations_logos/java.png" "class" "img-fluid" "alt" "Java" "width" "400") }}
+                </div>
+            </a>
+            <a class="card" href="/serverless/distributed_tracing#go">
+                <div class="card-body text-center py-2 px-1">
+                    {{ partial "img.html" (dict "root" . "src" "integrations_logos/golang.png" "class" "img-fluid" "alt" "Go" "width" "400") }}
+                </div>
+            </a>
+            <a class="card" href="/serverless/distributed_tracing#net">
+                <div class="card-body text-center py-2 px-1">
+                    {{ partial "img.html" (dict "root" . "src" "integrations_logos/net.png" "class" "img-fluid" "alt" ".NET" "width" "400") }}
+                </div>
+            </a>
+        </div>
+    </div>
+</div>
+<br>


### PR DESCRIPTION
## Serverless APM Documentation Update

We did a first pass at adding a documentation section for serverless a few months back. Since then, we've learned lots on how to improve these docs, and now need to update our serverless APM docs to properly guide customers through the tracing configuration process for serverless applications.

Staging link: https://docs-staging.datadoghq.com/alex.cuoci/serverless-apm-docs-update/serverless/distributed_tracing

- [x] Update https://docs.datadoghq.com/serverless/distributed_tracing to walk the customer through the differences between dd-trace and X-Ray so they can decide which tracing library is best for them.
- [x] Create a new page in the /serverless/distributed_tracing directory containing the content from  https://docs.datadoghq.com/tracing/setup_overview/serverless_functions/ in the #augment-aws-x-ray-tracing-with-datadog-apm header.
- [ ] Redirect https://docs.datadoghq.com/tracing/setup_overview/serverless_functions/ to https://docs.datadoghq.com/serverless/distributed_tracing while keeping the existing link in the APM nav. This way we only maintain one page and customers don't land on the wrong page for their use case.
- [x] Update the content currently stored at  https://docs.datadoghq.com/tracing/setup_overview/serverless_functions/ in the #tracing-in-a-serverless-first-environment header since it is misleading.