### PR TITLE
APM/PHP release 0.53.0

### DIFF
--- a/content/en/logs/log_collection/php.md
+++ b/content/en/logs/log_collection/php.md
@@ -446,6 +446,10 @@ monolog:
 
 ### Laravel
 
+<div class="alert alert-warning">
+Note that the function <code>\DDTrace\trace_id()</code> has been introduced in version <a href="https://github.com/DataDog/dd-trace-php/releases/tag/0.53.0">0.53.0</a>.
+</div>
+
 ```php
 <?php
 

--- a/content/en/logs/log_collection/php.md
+++ b/content/en/logs/log_collection/php.md
@@ -479,19 +479,15 @@ class AppServiceProvider extends ServiceProvider
 
         // Inject the trace and span ID to connect the log entry with the APM trace
         $monolog->pushProcessor(function ($record) use ($useJson) {
-            $span = \DDTrace\GlobalTracer::get()->getActiveSpan();
-            if (null === $span) {
-                return $record;
-            }
             if ($useJson === true) {
                 $record['dd'] = [
-                    'trace_id' => $span->getTraceId(),
+                    'trace_id' => \DDTrace\trace_id(),
                     'span_id'  => \dd_trace_peek_span_id(),
                 ];
             } else {
                 $record['message'] .= sprintf(
                     ' [dd.trace_id=%d dd.span_id=%d]',
-                    $span->getTraceId(),
+                    \DDTrace\trace_id(),
                     \dd_trace_peek_span_id()
                 );
             }

--- a/content/en/tracing/connect_logs_and_traces/php.md
+++ b/content/en/tracing/connect_logs_and_traces/php.md
@@ -24,6 +24,10 @@ See the section below to learn how to connect your PHP Logs and traces manually.
 
 ## Manually Inject Trace and Span IDs
 
+<div class="alert alert-warning">
+Note that the function <code>\DDTrace\trace_id()</code> has been introduced in version <a href="https://github.com/DataDog/dd-trace-php/releases/tag/0.53.0">0.53.0</a>.
+</div>
+
 To connect your logs and traces together, your logs must contain the `dd.trace_id` and `dd.span_id` attributes that respectively contain your trace ID and your span ID.
 
 If you are not using a [Datadog Log Integration][1] to parse your logs, custom log parsing rules need to ensure that `dd.trace_id` and `dd.span_id` are being parsed as strings and remapped thanks to the [Trace Remapper][2]. More information can be found in the [Why can't I see my correlated logs in the Trace ID panel?][3] FAQ.

--- a/content/en/tracing/connect_logs_and_traces/php.md
+++ b/content/en/tracing/connect_logs_and_traces/php.md
@@ -34,7 +34,7 @@ For instance, you would append those two attributes to your logs with:
   <?php
   $append = sprintf(
       ' [dd.trace_id=%d dd.span_id=%d]',
-      \dd_trace_peek_trace_id(),
+      \DDTrace\trace_id(),
       \dd_trace_peek_span_id()
   );
   my_error_logger('Error message.' . $append);
@@ -48,7 +48,7 @@ If the logger implements the [**monolog/monolog** library][4], use `Logger::push
   $logger->pushProcessor(function ($record) {
       $record['message'] .= sprintf(
           ' [dd.trace_id=%d dd.span_id=%d]',
-          \dd_trace_peek_trace_id(),
+          \DDTrace\trace_id(),
           \dd_trace_peek_span_id()
       );
       return $record;
@@ -62,7 +62,7 @@ If your application uses json logs format instead of appending trace_id and span
 <?php
   $logger->pushProcessor(function ($record) {
       $record['dd'] = [
-          'trace_id' => \dd_trace_peek_trace_id(),
+          'trace_id' => \DDTrace\trace_id(),
           'span_id'  => \dd_trace_peek_span_id(),
       ];
 

--- a/content/en/tracing/connect_logs_and_traces/php.md
+++ b/content/en/tracing/connect_logs_and_traces/php.md
@@ -32,10 +32,9 @@ For instance, you would append those two attributes to your logs with:
 
 ```php
   <?php
-  $span = \DDTrace\GlobalTracer::get()->getActiveSpan();
   $append = sprintf(
       ' [dd.trace_id=%d dd.span_id=%d]',
-      $span->getTraceId(),
+      \dd_trace_peek_trace_id(),
       \dd_trace_peek_span_id()
   );
   my_error_logger('Error message.' . $append);
@@ -47,13 +46,9 @@ If the logger implements the [**monolog/monolog** library][4], use `Logger::push
 ```php
 <?php
   $logger->pushProcessor(function ($record) {
-      $span = \DDTrace\GlobalTracer::get()->getActiveSpan();
-      if (null === $span) {
-          return $record;
-      }
       $record['message'] .= sprintf(
           ' [dd.trace_id=%d dd.span_id=%d]',
-          $span->getTraceId(),
+          \dd_trace_peek_trace_id(),
           \dd_trace_peek_span_id()
       );
       return $record;
@@ -66,13 +61,8 @@ If your application uses json logs format instead of appending trace_id and span
 ```php
 <?php
   $logger->pushProcessor(function ($record) {
-      $span = \DDTrace\GlobalTracer::get()->getActiveSpan();
-      if (null === $span) {
-          return $record;
-      }
-
       $record['dd'] = [
-          'trace_id' => $span->getTraceId(),
+          'trace_id' => \dd_trace_peek_trace_id(),
           'span_id'  => \dd_trace_peek_span_id(),
       ];
 

--- a/content/fr/logs/log_collection/php.md
+++ b/content/fr/logs/log_collection/php.md
@@ -478,19 +478,15 @@ class AppServiceProvider extends ServiceProvider
 
         // Injecter l'ID de trace et de span afin d'associer l'entrée de log à la trace APM
         $monolog->pushProcessor(function ($record) use ($useJson) {
-            $span = \DDTrace\GlobalTracer::get()->getActiveSpan();
-            if (null === $span) {
-                return $record;
-            }
             if ($useJson === true) {
                 $record['dd'] = [
-                    'trace_id' => $span->getTraceId(),
+                    'trace_id' => \DDTrace\trace_id(),
                     'span_id'  => \dd_trace_peek_span_id(),
                 ];
             } else {
                 $record['message'] .= sprintf(
                     ' [dd.trace_id=%d dd.span_id=%d]',
-                    $span->getTraceId(),
+                    \DDTrace\trace_id(),
                     \dd_trace_peek_span_id()
                 );
             }

--- a/content/fr/tracing/connect_logs_and_traces/php.md
+++ b/content/fr/tracing/connect_logs_and_traces/php.md
@@ -31,10 +31,9 @@ Par exemple, ces deux attributs seront ajoutés à vos logs de la manière suiva
 
 ```php
   <?php
-  $span = \DDTrace\GlobalTracer::get()->getActiveSpan();
   $append = sprintf(
       ' [dd.trace_id=%d dd.span_id=%d]',
-      $span->getTraceId(),
+      \DDTrace\trace_id(),
       \dd_trace_peek_span_id()
   );
   my_error_logger('Error message.' . $append);
@@ -46,13 +45,9 @@ Si le logger implémente la [bibliothèque **monolog/monolog**][4], utilisez `Lo
 ```php
 <?php
   $logger->pushProcessor(function ($record) {
-      $span = \DDTrace\GlobalTracer::get()->getActiveSpan();
-      if (null === $span) {
-          return $record;
-      }
       $record['message'] .= sprintf(
           ' [dd.trace_id=%d dd.span_id=%d]',
-          $span->getTraceId(),
+          \DDTrace\trace_id(),
           \dd_trace_peek_span_id()
       );
       return $record;
@@ -65,13 +60,8 @@ Si votre application utilise des logs au format json, au lieu d'ajouter les ID t
 ```php
 <?php
   $logger->pushProcessor(function ($record) {
-      $span = \DDTrace\GlobalTracer::get()->getActiveSpan();
-      if (null === $span) {
-          return $record;
-      }
-
       $record['dd'] = [
-          'trace_id' => $span->getTraceId(),
+          'trace_id' => \DDTrace\trace_id(),
           'span_id'  => \dd_trace_peek_span_id(),
       ];
 

--- a/content/ja/logs/log_collection/php.md
+++ b/content/ja/logs/log_collection/php.md
@@ -477,19 +477,15 @@ class AppServiceProvider extends ServiceProvider
 
         // トレースおよびスパン ID を挿入してログエントリを APM トレースと接続
         $monolog->pushProcessor(function ($record) use ($useJson) {
-            $span = \DDTrace\GlobalTracer::get()->getActiveSpan();
-            if (null === $span) {
-                return $record;
-            }
             if ($useJson === true) {
                 $record['dd'] = [
-                    'trace_id' => $span->getTraceId(),
+                    'trace_id' => \DDTrace\trace_id(),
                     'span_id'  => \dd_trace_peek_span_id(),
                 ];
             } else {
                 $record['message'] .= sprintf(
                     ' [dd.trace_id=%d dd.span_id=%d]',
-                    $span->getTraceId(),
+                    \DDTrace\trace_id(),
                     \dd_trace_peek_span_id()
                 );
             }

--- a/content/ja/tracing/connect_logs_and_traces/php.md
+++ b/content/ja/tracing/connect_logs_and_traces/php.md
@@ -31,10 +31,9 @@ PHP ログとトレースを手動で接続する方法については、以下�
 
 ```php
   <?php
-  $span = \DDTrace\GlobalTracer::get()->getActiveSpan();
   $append = sprintf(
       ' [dd.trace_id=%d dd.span_id=%d]',
-      $span->getTraceId(),
+      \DDTrace\trace_id(),
       \dd_trace_peek_span_id()
   );
   my_error_logger('Error message.' . $append);
@@ -46,13 +45,9 @@ PHP ログとトレースを手動で接続する方法については、以下�
 ```php
 <?php
   $logger->pushProcessor(function ($record) {
-      $span = \DDTrace\GlobalTracer::get()->getActiveSpan();
-      if (null === $span) {
-          return $record;
-      }
       $record['message'] .= sprintf(
           ' [dd.trace_id=%d dd.span_id=%d]',
-          $span->getTraceId(),
+          \DDTrace\trace_id(),
           \dd_trace_peek_span_id()
       );
       return $record;
@@ -65,13 +60,8 @@ PHP ログとトレースを手動で接続する方法については、以下�
 ```php
 <?php
   $logger->pushProcessor(function ($record) {
-      $span = \DDTrace\GlobalTracer::get()->getActiveSpan();
-      if (null === $span) {
-          return $record;
-      }
-
       $record['dd'] = [
-          'trace_id' => $span->getTraceId(),
+          'trace_id' => \DDTrace\trace_id(),
           'span_id'  => \dd_trace_peek_span_id(),
       ];
 


### PR DESCRIPTION
### What does this PR do?

Expose in public documentation the new API to access the current trace id.

### Preview
[Preview](https://docs-staging.datadoghq.com/apm/php/extract-context/tracing/connect_logs_and_traces/php/)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
