### PR TITLE
Add Ruby Profiler public beta docs

### DIFF
--- a/content/en/tracing/profiler/_index.md
+++ b/content/en/tracing/profiler/_index.md
@@ -35,7 +35,7 @@ Profiling your service to visualize all your stack traces in one place takes jus
 
 Add a profiler library to your application to start sending profiles to the Datadog Agent.
 
-To get notified when a private beta is available for the **Node**, **Ruby**, **PHP**, or **.NET** Profiler, [sign up here][1].
+To get notified when a private beta is available for the **Node**, **PHP**, or **.NET** Profiler, [sign up here][1].
 
 {{< partial name="profiling/profiling-languages.html" >}}
 

--- a/content/en/tracing/profiler/getting_started.md
+++ b/content/en/tracing/profiler/getting_started.md
@@ -17,7 +17,7 @@ further_reading:
 
 Profiler is shipped within the following tracing libraries. Select your language below to learn how to enable profiler for your application:
 
-To get notified when a private beta is available for the **Node**, **Ruby**, **PHP**, or **.NET** Profiler, [sign up here][1].
+To get notified when a private beta is available for the **Node**, **PHP**, or **.NET** Profiler, [sign up here][1].
 
 
 {{< tabs >}}
@@ -208,6 +208,63 @@ The Datadog Profiler requires Go 1.12+. To begin profiling applications:
 [3]: https://app.datadoghq.com/profiling
 [4]: /tracing/visualization/#services
 [5]: /tracing/guide/setting_primary_tags_to_scope/#environment
+{{% /tab %}}
+
+{{% tab "Ruby" %}}
+{{% notice Beta Notice %}}
+The Ruby Profiler is currently in public beta. We strongly advise evaluating the profiler at a smaller scale before deploying in production.
+{{% /notice %}}
+
+The Datadog Profiler requires Ruby 2.1+. To begin profiling applications:
+
+1. If you are already using Datadog, upgrade your agent to version [7.20.2][1]+ or [6.20.2][1]+.
+
+2. Add the `ddtrace`, `ffi`, and `google-protobuf` gems to your Gemfile:
+
+    ```ruby
+    source 'https://rubygems.org'
+    gem 'ddtrace'
+    gem 'ffi'
+    gem 'google-protobuf'
+    ```
+
+     **Note**: Profiler is available in the `ddtrace` library for versions 0.45+.
+
+2. Install the gem with `bundle install`
+
+3. Create a `config/initializers/datadog.rb` file with Profiling enabled:
+
+    ```ruby
+    Datadog.configure do |c|
+      # Example for Rails: following will activate auto-instrumentation
+      c.use :rails
+
+      # This will enable the profiler
+      c.profiling.enabled = true
+    end
+    ```
+
+    Alternately, you can also auto-enable the profiler by simply setting `DD_PROFILING_ENABLED` environment variable to `true`.
+
+
+4. After a minute or two of starting your Ruby application, visualize your profiles in the [Datadog APM > Profiler page][2].
+
+**Note**:
+
+- It is strongly recommended to add tags like `service` or `version` as it provides the ability to slice and dice your profiles across these dimensions, enhancing your overall product experience. Use environment variables to set the parameters:
+
+| Environment variable                             | Type          | Description                                                                                      |
+| ------------------------------------------------ | ------------- | ------------------------------------------------------------------------------------------------ |
+| `DD_PROFILING_ENABLED`                           | Boolean       | Set to `true` to enable profiler. Supported from tracer version 0.45+.              |
+| `DD_SERVICE`                                     | String        | The Datadog [service][3] name.     |
+| `DD_ENV`                                         | String        | The Datadog [environment][4] name, for example, `production`. |
+| `DD_VERSION`                                     | String        | The version of your application.                             |
+| `DD_TAGS`                                        | String        | Tags to apply to an uploaded profile. Must be a list of `<key>:<value>` separated by commas such as: `layer:api,team:intake`.   |
+
+[1]: https://app.datadoghq.com/account/settings#agent/overview
+[2]: https://app.datadoghq.com/profiling
+[3]: /tracing/visualization/#services
+[4]: /tracing/guide/setting_primary_tags_to_scope/#environment
 {{% /tab %}}
 
 {{< /tabs >}}

--- a/content/en/tracing/profiler/getting_started.md
+++ b/content/en/tracing/profiler/getting_started.md
@@ -211,9 +211,9 @@ The Datadog Profiler requires Go 1.12+. To begin profiling applications:
 {{% /tab %}}
 
 {{% tab "Ruby" %}}
-{{% notice Beta Notice %}}
+<div class="alert alert-warning">
 The Ruby Profiler is currently in public beta. We strongly advise evaluating the profiler at a smaller scale before deploying in production.
-{{% /notice %}}
+</div>
 
 The Datadog Profiler requires Ruby 2.1+. To begin profiling applications:
 

--- a/content/en/tracing/profiler/search_profiles.md
+++ b/content/en/tracing/profiler/search_profiles.md
@@ -109,6 +109,16 @@ Once enabled, the following profile types are collected:
 
 {{% /tab %}}
 
+{{% tab "Ruby" %}}
+
+Once enabled, the following profile types are collected:
+
+| Profile type             | Definition                                                                                                                                                                                                                                                                                         |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CPU         | Shows the time each function spent running on the CPU, including Ruby and native code.                                                                                                                         |
+| Wall Time | Shows the elapsed time used by each function. Elapsed time includes time when code is running on CPU, waiting for I/O, and anything else that happens while the function is running. |
+{{% /tab %}}
+
 {{< /tabs >}}
 
 ## Further Reading

--- a/layouts/partials/profiling/profiling-languages.html
+++ b/layouts/partials/profiling/profiling-languages.html
@@ -19,5 +19,13 @@
       </a>
       </div>
     </br>
+    <div class="card-deck">
+      <a class="card" href="/tracing/profiler/getting_started/?tab=ruby">
+        <div class="card-body text-center py-2 px-1">
+          {{ partial "img.html" (dict "root" . "src" "integrations_logos/ruby.png" "class" "img-fluid" "alt" "Ruby" "width" "400") }}
+        </div>
+      </a>
+      </div>
+    </br>
     </div>
 </div>

--- a/layouts/partials/profiling/profiling-languages.html
+++ b/layouts/partials/profiling/profiling-languages.html
@@ -17,9 +17,6 @@
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/golang.png" "class" "img-fluid" "alt" "Go" "width" "400") }}
         </div>
       </a>
-      </div>
-    </br>
-    <div class="card-deck">
       <a class="card" href="/tracing/profiler/getting_started/?tab=ruby">
         <div class="card-body text-center py-2 px-1">
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/ruby.png" "class" "img-fluid" "alt" "Ruby" "width" "400") }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### WIP doc for the Ruby profiler public beta. The profiler is NOT available yet. 


### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
