### PR TITLE
add agent to "How do I submit metrics to Datadog?" section

### DIFF
--- a/content/en/metrics/_index.md
+++ b/content/en/metrics/_index.md
@@ -41,6 +41,8 @@ Metrics can be sent to Datadog from several places.
 
 - Often, you’ll need to track metrics related to your business (e.g. number of user logins/signups). In these cases, you can create [custom metrics][10]. Custom metrics can be submitted through the [agent][11], [DogStatsD][12], or the [HTTP API][13].
 
+- Additionally, the [Datadog Agent][21] automatically sends several standard metrics (such as CPU and disk usage).
+
 For a summary of all metric submission sources and methods, please refer to our [Metrics Types documentation][14].
 
 ## Querying Metrics
@@ -161,3 +163,4 @@ Please see the [full Metrics Summary documentation][20] for more details.
 [18]: https://app.datadoghq.com/metric/summary
 [19]: /account_management/billing/usage_details/
 [20]: /metrics/summary/
+[21]: https://docs.datadoghq.com/agent/basic_agent_usage/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds a bullet to the list under "How do I submit metrics to Datadog?" The bullet clarifies that some metrics are automatically sent from the agent.

### Motivation
<!-- What inspired you to submit this pull request?-->
I was reading the metrics base page and didn't see a reference to the metrics sent by the agent. I think a short description belongs here.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/samcip-metrics-addition/content/en/metrics/_index.md

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
