### PR TITLE
Replace catalina.sh suggestion with setenv.sh for Tomcat

### DIFF
--- a/content/en/tracing/setup_overview/setup/java.md
+++ b/content/en/tracing/setup_overview/setup/java.md
@@ -128,13 +128,13 @@ For more information, see the [Spring Boot documentation][1].
 {{% /tab %}}
 {{% tab "Tomcat" %}}
 
-Open your Tomcat startup script file, for example `catalina.sh`, and add:
+Open your Tomcat startup script file, for example `setenv.sh` on Linux, and add:
 
 ```text
 CATALINA_OPTS="$CATALINA_OPTS -javaagent:/path/to/dd-java-agent.jar"
 ```
 
-Or on Windows, `catalina.bat`:
+Or on Windows, `setenv.bat`:
 
 ```text
 set CATALINA_OPTS_OPTS=%CATALINA_OPTS_OPTS% -javaagent:"c:\path\to\dd-java-agent.jar"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Clarify Tomcat instructions.

### Motivation
<!-- What inspired you to submit this pull request?-->

Tomcat recommends the `setenv` file be used to add additional properties instead of the `catalina` script file. IE: these instructions for Tomcat 8: https://tomcat.apache.org/tomcat-8.0-doc/RUNNING.txt . 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/wantsui/java-install-tomcat-update/tracing/setup_overview/setup/java/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
