### PR TITLE
update exclude null query function documentation

### DIFF
--- a/content/en/dashboards/functions/exclusion.md
+++ b/content/en/dashboards/functions/exclusion.md
@@ -15,7 +15,7 @@ Example:
 
 Let's say you have a metric with two tags: `account` and `region`. `account` has three possible values (`prod`, `build` and `N/A`) while `region` has four possible values (`us-east-1`, `us-west-1`, `eu-central-1`, and `N/A`).
 
-When you graph this metric, you would have 3 x 4 = 12 lines on your graph. Applying `exclude_null()` would remove lines with tag combinations containing _any_ N/A values, leaving you with 2 x 3 = 6 groups.
+When you graph this metric as a timeseries, you would have 3 x 4 = 12 lines on your graph. Applying `exclude_null()` would remove lines with tag combinations containing _any_ N/A values, leaving you with 2 x 3 = 6 groups.
 
 ## Other functions
 

--- a/content/en/dashboards/functions/exclusion.md
+++ b/content/en/dashboards/functions/exclusion.md
@@ -7,22 +7,27 @@ aliases:
 
 ## Exclude Null
 
-| Function         | Description                                    | Example                                        |
-|------------------|------------------------------------------------|------------------------------------------------|
-| `exclude_null()` | Remove N/A groups from your graph or top list. | `exclude_null(avg:system.load.1{*} by {host})` |
+| Function         | Description                                                    | Example                                        |
+| ---------------- | -------------------------------------------------------------- | ---------------------------------------------- |
+| `exclude_null()` | Remove groups with N/A tag values from your graph or top list. | `exclude_null(avg:system.load.1{*} by {host})` |
 
+Example:
+
+Let's say you have a metric with two tags: `account` and `region`. `account` has three possible values (`prod`, `build` and `N/A`) while `region` has four possible values (`us-east-1`, `us-west-1`, `eu-central-1`, and `N/A`).
+
+When you graph this metric, you would have 3 x 4 = 12 lines on your graph. Applying `exclude_null()` would remove lines with tag combinations containing _any_ N/A values, leaving you with 2 x 3 = 6 groups.
 
 ## Other functions
 
 {{< whatsnext desc="Consult the other available functions:" >}}
-    {{< nextlink href="/dashboards/functions/arithmetic" >}}Arithmetic: Perform Arithmetic operation on your metric.  {{< /nextlink >}}
-    {{< nextlink href="/dashboards/functions/algorithms" >}}Algorithmic: Implement Anomaly or Outlier detection on your metric.{{< /nextlink >}}
-    {{< nextlink href="/dashboards/functions/count" >}}Count: Count non zero or non null value of your metric. {{< /nextlink >}}
-    {{< nextlink href="/dashboards/functions/interpolation" >}}Interpolation: Fill or set default values for your metric.{{< /nextlink >}}
-    {{< nextlink href="/dashboards/functions/rank" >}}Rank: Select only a subset of metrics. {{< /nextlink >}}
-    {{< nextlink href="/dashboards/functions/rate" >}}Rate: Calculate custom derivative over your metric.{{< /nextlink >}}
-    {{< nextlink href="/dashboards/functions/regression" >}}Regression: Apply some machine learning function to your metric.{{< /nextlink >}}
-    {{< nextlink href="/dashboards/functions/rollup" >}}Rollup: Control the number of raw points used in your metric. {{< /nextlink >}}
-    {{< nextlink href="/dashboards/functions/smoothing" >}}Smoothing: Smooth your metric variations.{{< /nextlink >}}
-    {{< nextlink href="/dashboards/functions/timeshift" >}}Timeshift: Shift your metric data point along the timeline. {{< /nextlink >}}
+{{< nextlink href="/dashboards/functions/arithmetic" >}}Arithmetic: Perform Arithmetic operation on your metric. {{< /nextlink >}}
+{{< nextlink href="/dashboards/functions/algorithms" >}}Algorithmic: Implement Anomaly or Outlier detection on your metric.{{< /nextlink >}}
+{{< nextlink href="/dashboards/functions/count" >}}Count: Count non zero or non null value of your metric. {{< /nextlink >}}
+{{< nextlink href="/dashboards/functions/interpolation" >}}Interpolation: Fill or set default values for your metric.{{< /nextlink >}}
+{{< nextlink href="/dashboards/functions/rank" >}}Rank: Select only a subset of metrics. {{< /nextlink >}}
+{{< nextlink href="/dashboards/functions/rate" >}}Rate: Calculate custom derivative over your metric.{{< /nextlink >}}
+{{< nextlink href="/dashboards/functions/regression" >}}Regression: Apply some machine learning function to your metric.{{< /nextlink >}}
+{{< nextlink href="/dashboards/functions/rollup" >}}Rollup: Control the number of raw points used in your metric. {{< /nextlink >}}
+{{< nextlink href="/dashboards/functions/smoothing" >}}Smoothing: Smooth your metric variations.{{< /nextlink >}}
+{{< nextlink href="/dashboards/functions/timeshift" >}}Timeshift: Shift your metric data point along the timeline. {{< /nextlink >}}
 {{< /whatsnext >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Updates the documentation for the exclude_null() function to be more explicit about what the function does. Adds an example.

### Motivation
<!-- What inspired you to submit this pull request?-->
The previous wording was ambiguous -- does the function remove N/A _metric_ values or N/A _tag_ values? Initially, I thought the function removed groups with all-NaN metric values, and was only disabused of this notion through experimentation. Hopefully, these changes will help users understand the function's purpose right off the bat. 

Clarifying what the function does is especially important in light of the fact that we'll be releasing the new cutoff functions soon, which set metric values to NaN. 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/selina.wang/update-exclude-null

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
