### PR TITLE
add logo mapping

### DIFF
--- a/data/security_monitoring/data.yaml
+++ b/data/security_monitoring/data.yaml
@@ -64,3 +64,19 @@ image_map:
     image: twistlock_sm
     link: twistlock
     append: false
+  - source:
+      - microsoft-365
+    image: microsoft_365
+    append: false
+  - source:
+      - azure-active-directory
+    image: azure_active_directory
+    append: false
+  - source:
+      - microsoft-teams
+    image: microsoft_teams
+    append: false
+  - source:
+      - exchange-server
+    image: exchange_server
+    append: false


### PR DESCRIPTION
### What does this PR do?
Adds some image mappings for upcoming entries in security rules

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1053

### Preview

Note there isn't anywhere to view the mappings working as of yet.
Mostly code review but a quick spot check of rules page that no other logos are affected is fine.
https://docs-staging.datadoghq.com/david.jones/ms-mapping/security_monitoring/default_rules/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
