### PR TITLE
[WEB-1050] - interruptable preview pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -180,6 +180,7 @@ index_algolia_preview:
   when: manual
   only:
     - /.+?\/[a-zA-Z0-9_-]+/
+  interruptible: true
 
 sourcemaps_preview:
   <<: *base_template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -87,6 +87,7 @@ build_preview:
       - ./integrations_data
   only:
     - /.+?\/[a-zA-Z0-9_-]+/
+  interruptible: true
 
 # build_preview_legacy:
 #   <<: *base_template
@@ -140,6 +141,7 @@ link_checks_preview:
     - if [ -e ${CI_PROJECT_DIR}/broken-links.csv  ]; then aws s3 cp --content-type "text/csv; charset=utf-8" --acl "public-read" --cache-control "no-cache" ${CI_PROJECT_DIR}/broken-links.csv s3://origin-static-assets/documentation/brokenlinks/${CI_COMMIT_REF_NAME}/; fi
   only:
     - /.+?\/[a-zA-Z0-9_-]+/
+  interruptible: true
 
 missing_tms_preview:
   <<: *base_template
@@ -154,6 +156,7 @@ missing_tms_preview:
     - check_missing_tms
   only:
     - /.+?\/[a-zA-Z0-9_-]+/
+  interruptible: true
 
 index_algolia_preview:
   image:
@@ -193,6 +196,7 @@ sourcemaps_preview:
   allow_failure: true
   only:
     - /.+?\/[a-zA-Z0-9_-]+/
+  interruptible: true
 
 # ================== live ================== #
 build_live:

--- a/src/scripts/components/security-rules.js
+++ b/src/scripts/components/security-rules.js
@@ -1,6 +1,7 @@
 import mixitup from 'mixitup';
 
 export function initializeSecurityRules() {
+    // This is a Test.
     const containerEl = document.querySelector('#rules .list-group');
     const inputSearch = document.querySelector('[data-ref="search"]');
     const controls = document.querySelector('[data-ref="controls"]');

--- a/src/scripts/components/security-rules.js
+++ b/src/scripts/components/security-rules.js
@@ -1,7 +1,6 @@
 import mixitup from 'mixitup';
 
 export function initializeSecurityRules() {
-    // This is a Test.
     const containerEl = document.querySelector('#rules .list-group');
     const inputSearch = document.querySelector('[data-ref="search"]');
     const controls = document.querySelector('[data-ref="controls"]');


### PR DESCRIPTION
### What does this PR do?

Adds interruptable to preview sites pipeline jobs https://docs.gitlab.com/ee/ci/yaml/#interruptible
This will cause multiple pipelines for the same branch to be cancelled except the lastest one. 
This helps avoid race conditions during deploy

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1050

### Preview

Shouldn't impact site this is build changes
https://docs-staging.datadoghq.com/david.jones/interrupt/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
