### PR TITLE
Correct filename of read secret helper

### DIFF
--- a/content/en/agent/guide/secrets-management.md
+++ b/content/en/agent/guide/secrets-management.md
@@ -250,7 +250,7 @@ Kubernetes supports [exposing secrets as files][5] inside a pod.
 If your secrets are mounted in `/etc/secret-volume`, use the following environment variables:
 
 ```
-DD_SECRET_BACKEND_COMMAND=/readsecret.sh
+DD_SECRET_BACKEND_COMMAND=/readsecret.py
 DD_SECRET_BACKEND_ARGUMENTS=/etc/secret-volume
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Change readsecret.sh to readsecret.py

### Motivation
<!-- What inspired you to submit this pull request?-->
Based on this doc, the script is actually readsecret.py
https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/agent/secrets-helper#kubernetes-secrets
Had a customer issue on this today.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/mecsantos-patch-2/agent/guide/secrets-management/?tab=linux

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
