### PR TITLE
Add the maximum tags limit per metric

### DIFF
--- a/content/en/getting_started/tagging/_index.md
+++ b/content/en/getting_started/tagging/_index.md
@@ -69,6 +69,8 @@ Below are Datadog's tagging requirements:
 
 5. Tags shouldn't originate from unbounded sources, such as epoch timestamps, user IDs, or request IDs. Doing so may infinitely [increase the number of metrics][2] for your organization and impact your billing.
 
+6. The maximum number of tags per metric is 100.
+
 ## Assigning Tags
 
 ### Tagging methods


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Add the maximum tags limit per metric

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/olivierg/add-tag-count-limit/content/en/getting_started/tagging/_index.md

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
