### PR TITLE
DOCS-1428 - start/stop commands for docker

### DIFF
--- a/content/en/agent/guide/agent-commands.md
+++ b/content/en/agent/guide/agent-commands.md
@@ -27,12 +27,12 @@ List of commands to start the Datadog Agent:
 | Platform | Command                                                        |
 |----------|----------------------------------------------------------------|
 | AIX      | `startsrc -s datadog-agent`                                    |
-| Linux    | [See the dedicated documentation for your OS][1]               |
-| Docker   | [See the dedicated Docker documentation][2]                    |
+| Linux    | [See the dedicated documentation for your OS][1].               |
+| Docker   | Use the [installation command][2].                    |
 | Kubernetes | `kubectl create -f datadog-agent.yaml`                        |
 | macOS    | `launchctl start com.datadoghq.agent` *or* via the systray app |
 | Source   | `sudo service datadog-agent start`                             |
-| Windows  | [See the dedicated Windows documentation][3]                   |
+| Windows  | [See the dedicated Windows documentation][3].                   |
 
 [1]: /agent/
 [2]: /agent/docker/
@@ -43,10 +43,10 @@ List of commands to start the Datadog Agent:
 | Platform | Command                                      |
 |----------|----------------------------------------------|
 | Linux    | `sudo service datadog-agent start`           |
-| Docker   | [See the dedicated Docker documentation][1]  |
+| Docker   | [See the dedicated Docker documentation][1].  |
 | macOS    | `/usr/local/bin/datadog-agent start`         |
 | Source   | `sudo ~/.datadog-agent/bin/agent start`      |
-| Windows  | [See the dedicated Windows documentation][2] |
+| Windows  | [See the dedicated Windows documentation][2]. |
 
 [1]: https://github.com/DataDog/docker-dd-agent/blob/master/README.md
 [2]: /agent/basic_agent_usage/windows/
@@ -63,15 +63,15 @@ List of commands to stop the Datadog Agent:
 | Platform | Command                                                       |
 |----------|---------------------------------------------------------------|
 | AIX      | `stopsrc -s datadog-agent`                                    |
-| Linux    | [See the dedicated documentation for your OS][1]              |
-| Docker   | [See the dedicated Docker documentation][2]                   |
+| Linux    | [See the dedicated documentation for your OS][1].              |
+| Docker   | `docker exec -it <CONTAINER_NAME> agent stop`                   |
 | Kubernetes | `kubectl delete pod <AGENT POD NAME>`—note: the pod is automatically rescheduled |
 | macOS    | `launchctl stop com.datadoghq.agent` *or* via the systray app |
 | Source   | `sudo service datadog-agent stop`                             |
-| Windows  | [See the dedicated Windows documentation][3]                  |
+| Windows  | [See the dedicated Windows documentation][3].                  |
 
 [1]: /agent/
-[2]: /agent/docker/
+[2]: /agent/docker/?tab=standard#setup
 [3]: /agent/basic_agent_usage/windows/
 {{% /tab %}}
 {{% tab "Agent v5" %}}
@@ -79,10 +79,10 @@ List of commands to stop the Datadog Agent:
 | Platform | Command                                      |
 |----------|----------------------------------------------|
 | Linux    | `sudo service datadog-agent stop`            |
-| Docker   | [See the dedicated Docker documentation][1]  |
+| Docker   | [See the dedicated Docker documentation][1].  |
 | macOS    | `/usr/local/bin/datadog-agent stop`          |
 | Source   | `sudo ~/.datadog-agent/bin/agent stop`       |
-| Windows  | [See the dedicated Windows documentation][2] |
+| Windows  | [See the dedicated Windows documentation][2]. |
 
 [1]: https://github.com/DataDog/docker-dd-agent/blob/master/README.md
 [2]: /agent/basic_agent_usage/windows/
@@ -98,15 +98,15 @@ List of commands to restart the Datadog Agent:
 
 | Platform | Command                                           |
 |----------|---------------------------------------------------|
-| Linux    | [See the dedicated documentation for your OS][1]  |
-| Docker   | [See the dedicated Docker documentation][2]       |
+| Linux    | [See the dedicated documentation for your OS][1].  |
+| Docker   | Use the [installation command][2].       |
 | Kubernetes | `kubectl delete pod <AGENT POD NAME>`—note: the pod is automatically rescheduled |
 | macOS    | run `stop` then `start`, *or* via the systray app |
 | Source   | *unsupported Platform*                            |
-| Windows  | [See the dedicated Windows documentation][3]      |
+| Windows  | [See the dedicated Windows documentation][3].      |
 
 [1]: /agent/
-[2]: /agent/docker/
+[2]: /agent/docker/?tab=standard#setup
 [3]: /agent/basic_agent_usage/windows/
 {{% /tab %}}
 {{% tab "Agent v5" %}}
@@ -114,10 +114,10 @@ List of commands to restart the Datadog Agent:
 | Platform | Command                                      |
 |----------|----------------------------------------------|
 | Linux    | `sudo service datadog-agent restart`         |
-| Docker   | [See the dedicated Docker documentation][1]  |
+| Docker   | [See the dedicated Docker documentation][1].  |
 | macOS    | `/usr/local/bin/datadog-agent restart`       |
 | Source   | `sudo ~/.datadog-agent/bin/agent restart`    |
-| Windows  | [See the dedicated Windows documentation][2] |
+| Windows  | [See the dedicated Windows documentation][2]. |
 
 [1]: https://github.com/DataDog/docker-dd-agent/blob/master/README.md
 [2]: /agent/basic_agent_usage/windows/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
these got lost in a shuffle, found them in github history and putting them back in

### Motivation
support request

### Preview

https://docs-staging.datadoghq.com/cswatt/docker-start-stop/agent/guide/agent-commands

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
