### PR TITLE
[NET-962][NPM] Make sysprobe socket paths consistent

### DIFF
--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -14,7 +14,7 @@ further_reading:
       text: 'Network Widget'
 ---
 
-Network performance monitoring requires [Datadog Agent v6.14+][1]. 
+Network performance monitoring requires [Datadog Agent v6.14+][1].
 
 Supported **platforms** include:
 
@@ -30,7 +30,7 @@ Supported **platforms** include:
 
 **For Windows OS:** Data collection is available in public beta for Windows Server 2016 or later.
 
-There is an exemption to the 4.4.0+ kernel requirement for [CentOS/RHEL 7.6+][3]. The [DNS Resolution][4] feature is not supported on CentOS/RHEL 7.6. 
+There is an exemption to the 4.4.0+ kernel requirement for [CentOS/RHEL 7.6+][3]. The [DNS Resolution][4] feature is not supported on CentOS/RHEL 7.6.
 
 Network Performance Monitoring is compatible with **Cilium** installations, provided the following requirements are met:
 1) Cilium version 1.6 and above, and
@@ -129,7 +129,7 @@ If these utilities do not exist in your distribution, follow the same procedure 
 
 ### Windows systems
 
-Data collection for Windows systems is available in public beta for Windows Server versions 2016 or later. 
+Data collection for Windows systems is available in public beta for Windows Server versions 2016 or later.
 **Note**: NPM currently monitors Windows hosts only, and not Windows containers. DNS metric collection is not supported for Windows systems.
 
 To enable network performance monitoring for Windows hosts:
@@ -155,11 +155,11 @@ To enable network performance monitoring for Windows hosts:
     ```
 4. [Restart the Agent][2].
 
-    For PowerShell (`powershell.exe`): 
+    For PowerShell (`powershell.exe`):
     ```shell
     restart-service -f datadogagent
     ```
-    For Command Prompt (`cmd.exe`): 
+    For Command Prompt (`cmd.exe`):
     ```shell
     net /y stop datadogagent && net start datadoagagent
     ```
@@ -213,7 +213,7 @@ If you already have the [Agent running with a manifest][3]:
                           - name: DD_SYSTEM_PROBE_EXTERNAL
                             value: 'true'
                           - name: DD_SYSPROBE_SOCKET
-                            value: /var/run/s6/sysprobe.sock
+                            value: /var/run/sysprobe/sysprobe.sock
     ```
 
 3. Mount the following extra volumes into the `datadog-agent` container:
@@ -235,8 +235,8 @@ If you already have the [Agent running with a manifest][3]:
                         readOnly: true
                       - name: debugfs
                         mountPath: /sys/kernel/debug
-                      - name: s6-run
-                        mountPath: /var/run/s6
+                      - name: sysprobe-socket-dir
+                        mountPath: /var/run/sysprobe
     ```
 
 4. Add a new system-probe as a side car to the Agent:
@@ -264,7 +264,7 @@ If you already have the [Agent running with a manifest][3]:
                           - /opt/datadog-agent/embedded/bin/system-probe
                       env:
                           - name: DD_SYSPROBE_SOCKET
-                            value: /var/run/s6/sysprobe.sock
+                            value: /var/run/sysprobe/sysprobe.sock
                       resources:
                           requests:
                               memory: 150Mi
@@ -281,8 +281,8 @@ If you already have the [Agent running with a manifest][3]:
                             readOnly: true
                           - name: debugfs
                             mountPath: /sys/kernel/debug
-                          - name: s6-run
-                            mountPath: /var/run/s6
+                          - name: sysprobe-socket-dir
+                            mountPath: /var/run/sysprobe
     ```
 
 5. Finally, add the following volumes to your manifest:

--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -289,8 +289,6 @@ If you already have the [Agent running with a manifest][3]:
 
     ```yaml
                 volumes:
-                    - name: s6-run
-                      emptyDir: {}
                     - name: sysprobe-socket-dir
                       emptyDir: {}
                     - name: debugfs

--- a/content/en/network_performance_monitoring/installation.md
+++ b/content/en/network_performance_monitoring/installation.md
@@ -291,6 +291,8 @@ If you already have the [Agent running with a manifest][3]:
                 volumes:
                     - name: s6-run
                       emptyDir: {}
+                    - name: sysprobe-socket-dir
+                      emptyDir: {}
                     - name: debugfs
                       hostPath:
                           path: /sys/kernel/debug

--- a/content/fr/network_performance_monitoring/installation.md
+++ b/content/fr/network_performance_monitoring/installation.md
@@ -170,7 +170,7 @@ Si l'[Agent est déjà exécuté avec un manifeste][3] :
                           - name: DD_SYSTEM_PROBE_EXTERNAL
                             value: 'true'
                           - name: DD_SYSPROBE_SOCKET
-                            value: /var/run/s6/sysprobe.sock
+                            value: /var/run/sysprobe/sysprobe.sock
     ```
 
     Si l'Agent de processus s'exécute dans un conteneur distinct, les variables d'environnement ci-dessus doivent être définies dans ce conteneur.
@@ -194,8 +194,8 @@ Si l'[Agent est déjà exécuté avec un manifeste][3] :
                         readOnly: true
                       - name: debugfs
                         mountPath: /sys/kernel/debug
-                      - name: s6-run
-                        mountPath: /var/run/s6
+                      - name: sysprobe-socket-dir
+                        mountPath: /var/run/sysprobe
     ```
 
 4. Ajoutez un nouveau system-probe en tant que sidecar de l'Agent :
@@ -223,7 +223,7 @@ Si l'[Agent est déjà exécuté avec un manifeste][3] :
                           - /opt/datadog-agent/embedded/bin/system-probe
                       env:
                           - name: DD_SYSPROBE_SOCKET
-                            value: /var/run/s6/sysprobe.sock
+                            value: /var/run/sysprobe/sysprobe.sock
                       resources:
                           requests:
                               memory: 150Mi
@@ -240,8 +240,8 @@ Si l'[Agent est déjà exécuté avec un manifeste][3] :
                             readOnly: true
                           - name: debugfs
                             mountPath: /sys/kernel/debug
-                          - name: s6-run
-                            mountPath: /var/run/s6
+                          - name: sysprobe-socket-dir
+                            mountPath: /var/run/sysprobe
     ```
 
 5. Enfin, ajoutez les volumes suivants à votre manifeste :

--- a/content/fr/network_performance_monitoring/installation.md
+++ b/content/fr/network_performance_monitoring/installation.md
@@ -250,6 +250,8 @@ Si l'[Agent est déjà exécuté avec un manifeste][3] :
                 volumes:
                     - name: s6-run
                       emptyDir: {}
+                    - name: sysprobe-socket-dir
+                      emptyDir: {}
                     - name: debugfs
                       hostPath:
                           path: /sys/kernel/debug

--- a/content/ja/network_performance_monitoring/installation.md
+++ b/content/ja/network_performance_monitoring/installation.md
@@ -291,6 +291,8 @@ Kubernetes を使用してネットワークパフォーマンスのモニタリ
                 volumes:
                     - name: s6-run
                       emptyDir: {}
+                    - name: sysprobe-socket-dir
+                      emptyDir: {}
                     - name: debugfs
                       hostPath:
                           path: /sys/kernel/debug

--- a/content/ja/network_performance_monitoring/installation.md
+++ b/content/ja/network_performance_monitoring/installation.md
@@ -154,7 +154,7 @@ Windows ホストのネットワークパフォーマンスモニタリングを
     ```
 4. [Agent を再起動します][2]。
 
-   PowerShell (`powershell.exe`) の場合: 
+   PowerShell (`powershell.exe`) の場合:
     ```shell
     restart-service -f datadogagent
     ```
@@ -212,7 +212,7 @@ Kubernetes を使用してネットワークパフォーマンスのモニタリ
                           - name: DD_SYSTEM_PROBE_EXTERNAL
                             value: 'true'
                           - name: DD_SYSPROBE_SOCKET
-                            value: /var/run/s6/sysprobe.sock
+                            value: /var/run/sysprobe/sysprobe.sock
     ```
 
 3. 以下の追加ボリュームを `datadog-agent` コンテナにマウントします。
@@ -234,8 +234,9 @@ Kubernetes を使用してネットワークパフォーマンスのモニタリ
                         readOnly: true
                       - name: debugfs
                         mountPath: /sys/kernel/debug
-                      - name: s6-run
                         mountPath: /var/run/s6
+                      - name: sysprobe-socket-dir
+                        mountPath: /var/run/sysprobe
     ```
 
 4. 新しいシステムプローブを Agent のサイドカーとして追加します。
@@ -263,7 +264,7 @@ Kubernetes を使用してネットワークパフォーマンスのモニタリ
                           - /opt/datadog-agent/embedded/bin/system-probe
                       env:
                           - name: DD_SYSPROBE_SOCKET
-                            value: /var/run/s6/sysprobe.sock
+                            value: /var/run/sysprobe/sysprobe.sock
                       resources:
                           requests:
                               memory: 150Mi
@@ -280,8 +281,8 @@ Kubernetes を使用してネットワークパフォーマンスのモニタリ
                             readOnly: true
                           - name: debugfs
                             mountPath: /sys/kernel/debug
-                          - name: s6-run
-                            mountPath: /var/run/s6
+                          - name: sysprobe-socket-dir
+                            mountPath: /var/run/sysprobe
     ```
 
 5. 最後に、お使いのマニフェストに以下のボリュームを追加します。

--- a/static/resources/yaml/datadog-agent-npm.yaml
+++ b/static/resources/yaml/datadog-agent-npm.yaml
@@ -504,8 +504,6 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
-        - name: s6-run
-          emptyDir: {}
         - name: sysprobe-config
           configMap:
             name: datadog-agent-system-probe-config


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

- Update `DD_SYSPROBE_SOCKET` value from `/var/run/s6/sysprobe.sock` to `/var/run/sysprobe/sysprobe.sock`
- Mount `/var/run/sysprobe`

### Motivation
<!-- What inspired you to submit this pull request?-->
Make the values consistent with `https://docs.datadoghq.com/resources/yaml/datadog-agent-npm.yaml`


### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
