### PR TITLE
Added Configuration import to config example

### DIFF
--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -341,6 +341,7 @@ To configure the Tracer in application code, create a `TracerSettings` from the 
 
 ```csharp
 using Datadog.Trace;
+using Datadog.Trace.Configuration;
 
 // read default configuration sources (env vars, web.config, datadog.json)
 var settings = TracerSettings.FromDefaultSources();

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -164,6 +164,7 @@ To configure the Tracer in application code, create a `TracerSettings` from the 
 
 ```csharp
 using Datadog.Trace;
+using Datadog.Trace.Configuration;
 
 // read default configuration sources (env vars, web.config, datadog.json)
 var settings = TracerSettings.FromDefaultSources();


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

The proposed change is to add the need to import `using Datadog.Trace.Configuration;` to the code example in this doc. The reason being is that Configuration is a separate module from the rest of the Datadog.Trace library. As per this StackOverflow thread: https://stackoverflow.com/questions/9023465/importing-nested-namespaces-automatically-in-c-sharp#:~:text=C%23%20doesn't%20import%20nested,parts%20of%20it%20on%2Ddemand - C# is unable to auto-import derived libraries, so an explicit call must be made. 

### Motivation

This came to our attention after a customer who tried to configure their tracer via code brought up the issue. After investigating this further it was clear that this line of code was missing and was required in order for the code to compile. 

### Preview

This is the only link affected: https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core/?tab=code

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
