### PR TITLE
Clarify community integration names for wheel packages

### DIFF
--- a/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
+++ b/content/en/agent/guide/community-integrations-installation-with-docker-agent.md
@@ -24,7 +24,7 @@ To install the `<INTEGRATION_NAME>` check on your host:
 2. Run the following command to install the integrations with the Agent:
 
     ```
-    datadog-agent integration install -t <INTEGRATION_NAME>==<INTEGRATION_VERSION>
+    datadog-agent integration install -t datadog-<INTEGRATION_NAME>==<INTEGRATION_VERSION>
     ```
 
 3. Configure your integration like [any other packaged integration][2].
@@ -40,7 +40,7 @@ The best way to use an integration from integrations-extra with the Docker Agent
 
 ```dockerfile
 FROM gcr.io/datadoghq/agent:latest
-RUN agent integration install -r -t <INTEGRATION_NAME>==<INTEGRATION_VERSION>
+RUN agent integration install -r -t datadog-<INTEGRATION_NAME>==<INTEGRATION_VERSION>
 ```
 
 The `agent integration install` command run inside docker will issue the following harmless warning: `Error loading config: Config File "datadog" Not Found in "[/etc/datadog-agent]": warn`. This warning can be ignored.


### PR DESCRIPTION

### What does this PR do?
Community integration packages are prefixed by `datadog-`, but this is not mentioned in the documentation, which made a bit confusing when trying to install one of these.

### Motivation
I was trying to follow the instructions to create a new Docker image with the `gatekeeper` integration. What my docker file looked like was:

```
FROM gcr.io/datadoghq/agent:latest
RUN agent integration install -r -t gatekeeper==0.0.1
```

This failed as it didn't find that integration:

```
Error: invalid package name - this manager only handles datadog packages
```

It turned out that the package is called `datadog-gatekeeper` which is very confusing. Adding that prefix to the docs can help users finding the right package name.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/arapulido/agent/guide/community-integrations-installation-with-docker-agent

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
