### PR TITLE
Update docs to bump lambda extension version to 5

### DIFF
--- a/content/en/serverless/datadog_lambda_library/extension.md
+++ b/content/en/serverless/datadog_lambda_library/extension.md
@@ -24,7 +24,7 @@ The Datadog Extension is distributed as its own Lambda Layer (separate from the 
 2. Add the Lambda Layer for the Datadog Extension to your AWS Lambda function:
 
     ```
-    arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:4
+    arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:5
     ```
 
     Replace the placeholder `AWS_REGION` in the Lambda Layer ARN with appropriate values.

--- a/content/fr/serverless/datadog_lambda_library/extension.md
+++ b/content/fr/serverless/datadog_lambda_library/extension.md
@@ -23,7 +23,7 @@ L'extension Datadog est distribuée sous forme de couche Lambda autonome (distin
 2. Ajoutez la couche Lambda pour l'extension Datadog à votre fonction AWS Lambda :
 
     ```
-    arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:3
+    arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:5
     ```
 
     Remplacez le paramètre fictif `AWS_REGION` dans l'ARN de la couche Lambda par les valeurs adéquates.

--- a/content/ja/serverless/datadog_lambda_library/extension.md
+++ b/content/ja/serverless/datadog_lambda_library/extension.md
@@ -23,7 +23,7 @@ Datadog 拡張機能は、独自の Lambda レイヤー ([Datadog Lambda ライ�
 2. Datadog 拡張機能用 Lambda レイヤーを AWS Lambda 関数に追加します。
 
     ```
-    arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:4
+    arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:5
     ```
 
     Lambda レイヤー ARN のプレイスホルダー `AWS_REGION` を適切な値に置き換えます。


### PR DESCRIPTION
### What does this PR do?
Bumps the version referenced in the AWS Lambda Extension documentation to v5. Eventually we want to move this to a link to the releases tab on github.

### Motivation

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/darcy.rayner/v5-lambda-extension-version/content/en/serverless/datadog_lambda_library/extension.md 

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
