### PR TITLE
Adding DogStatsD to the list of exceptions for cap

### DIFF
--- a/.github/styles/Datadog/headings.yml
+++ b/.github/styles/Datadog/headings.yml
@@ -10,6 +10,7 @@ exceptions:
   - CLI
   - Datadog
   - Docker
+  - DogStatsD
   - GitHub
   - I
   - Kubernetes


### PR DESCRIPTION
Adding DogStatsD to the list of lint exceptions to solve lint report from: https://github.com/DataDog/documentation/pull/9446