### PR TITLE
Clarify age out period for log monitors

### DIFF
--- a/content/en/monitors/faq/why-did-my-monitor-settings-change-not-take-effect.md
+++ b/content/en/monitors/faq/why-did-my-monitor-settings-change-not-take-effect.md
@@ -7,3 +7,5 @@ kind: faq
 Datadog keeps monitor groups available in the UI for 24 hours.  If you do not have *No Data* alert settings enabled and your group for a metric monitor stops reporting data, it will persist on the monitor status page until it ages out, though that group will stop being evaluated after a short absence (specific timing depends on your settings).
 
 For event monitors, however, Datadog also keeps groups for evaluations for at least 24 hours. This means that if a monitor is updated and the groups are changed in the query, some old groups may persist. If you must change the group settings on your event monitor, you may want clone or create a new monitor to reflect your new groups.  Alternatively, you can mute them if you would like to maintain the monitor but silence any alerts that would result from the changes.
+
+For log monitors, Datadog keeps monitor groups available in the UI for 4 hours.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Clarify age out period for log monitors. It's 4 hours. ([Ref](https://datadoghq.atlassian.net/browse/MNOTIF-441))

### Motivation
<!-- What inspired you to submit this pull request?-->
Clarify the doc so we can refer both internally and externally

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/mecsantos-patch-2/monitors/faq/why-did-my-monitor-settings-change-not-take-effect/#pagetitle

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
