### PR TITLE
Update can-i-limit-the-number-of-vms-that-are-pulled-in-via-the-vmwar…

### DIFF
--- a/content/en/integrations/faq/can-i-limit-the-number-of-vms-that-are-pulled-in-via-the-vmware-integration.md
+++ b/content/en/integrations/faq/can-i-limit-the-number-of-vms-that-are-pulled-in-via-the-vmware-integration.md
@@ -3,5 +3,6 @@ title: Can I limit the number of VMs that are pulled in via the VMWare integrati
 kind: faq
 ---
 
-Yes you can configure this with regex in your `vsphere.yaml` file.  Refer to the `resource_filters` parameter section in [the example configuration](https://github.com/DataDog/integrations-core/blob/master/vsphere/datadog_checks/vsphere/data/conf.yaml.example) for more information.
+Yes. You can configure this with regex in your `vsphere.yaml` file. Refer to the `resource_filters` parameter section in the [example configuration][1] for more information.
 
+[1]: https://github.com/DataDog/integrations-core/blob/master/vsphere/datadog_checks/vsphere/data/conf.yaml.example

--- a/content/en/integrations/faq/can-i-limit-the-number-of-vms-that-are-pulled-in-via-the-vmware-integration.md
+++ b/content/en/integrations/faq/can-i-limit-the-number-of-vms-that-are-pulled-in-via-the-vmware-integration.md
@@ -3,9 +3,5 @@ title: Can I limit the number of VMs that are pulled in via the VMWare integrati
 kind: faq
 ---
 
-Yes you can configure this with a regex in your `vsphere.yaml` file:
-
-Refer to this example for more info:
-
-https://github.com/DataDog/integrations-core/blob/master/vsphere/datadog_checks/vsphere/data/conf.yaml.example#L87-L91
+Yes you can configure this with regex in your `vsphere.yaml` file.  Refer to the `resource_filters` parameter section in [the example configuration](https://github.com/DataDog/integrations-core/blob/master/vsphere/datadog_checks/vsphere/data/conf.yaml.example) for more information.
 


### PR DESCRIPTION
…e-integration.md

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates VMWare FAQ document about limiting the number of VMs that are pulled in via the VMWare integration:

https://docs.datadoghq.com/integrations/faq/can-i-limit-the-number-of-vms-that-are-pulled-in-via-the-vmware-integration/ 

### Motivation
The link to the example vsphere config file is out-of-date, pointing to a different section of the config that's unrelated to limited VMs or other VMWare resources.  

### Additional Notes
Instead of just updating the link with different lines, knowing that this configuration file could change regularly and the link becomes wrong again, change the language so that it references which parameter in the configuration is relevant for, in this case, limiting VMs from collection.  

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
