### PR TITLE
[WEB-1044] Security Default Rules updated filtering

### DIFF
--- a/layouts/security_rules/list.html
+++ b/layouts/security_rules/list.html
@@ -22,7 +22,7 @@
 <form id="rules">
     <div class="controls" data-ref="controls">
         <a data-ref="filter" data-filter="all" href="#all" class="mb-1 mr-1 btn btn-sm-tag btn-outline-secondary sort-reset">{{ i18n "all" }}</a>
-        {{ range $i, $e := (sort ($.Scratch.Get "filters")) }}<a data-ref="filter" data-filter=".cat-{{ replace $e "/" "" | urlize }}" href="#cat-{{ replace $e "/" "" | urlize }}" class="mb-1 mr-1 btn btn-sm-tag btn-outline-secondary sort-time sort-{{ replace $e "/" "" | urlize }}">{{ $e | upper }}</a>{{ end }}
+        {{ range $i, $e := (sort ($.Scratch.Get "filters")) }}<a data-ref="filter" data-filter="cat-{{ replace $e "/" "" | urlize }}" href="#cat-{{ replace $e "/" "" | urlize }}" class="mb-1 mr-1 btn btn-sm-tag btn-outline-secondary sort-time sort-{{ replace $e "/" "" | urlize }}">{{ $e | upper }}</a>{{ end }}
     </div>
     <div class="form-group clearfix">
         <input type="input" data-ref="search" class="form-control rule-search mb-3" id="keywords" placeholder="Search here" aria-label="keywords" />
@@ -30,8 +30,8 @@
     <div class="list-group">
         {{ range $i, $v := .Pages.GroupByParam "source" }}
             <div class="js-group js-group-{{ $i }}">
-                <div class="rule-list mb-1 active">
-                    <div class="rule-list__icon d-inline font-semibold h-100 text-uppercase px-2 py-1">
+                <div class="js-group-header mb-1 active">
+                    <div class="js-group-header__icon d-inline font-semibold h-100 text-uppercase px-2 py-1">
                         {{ range first 1 $v.Pages }}
                             {{ $this_img := partial "security-rule-map.html" (dict "source" .Params.source "ctx" $dot) }}
                             {{ if $this_img.image }}
@@ -48,11 +48,11 @@
                             {{ title $v.Key | humanize | title }}
                         {{ end }}
                     </div>
-                    <div class="rule-list__arrow">></div>
+                    <div class="js-group-header__arrow">></div>
                 </div>
                 <div class="group-{{ .Key }} mb-2 ml-5 d-none">
                     {{ range $v.Pages }}
-                        <a class="mb-1 font-semibold mix single-rule {{ range $i, $e := .Params.rule_category }} cat-{{ replace $e "/" "" | urlize }} {{ end }}" href="{{.Permalink}}" data-name="{{ lower .Title }} {{ .File.TranslationBaseName }}">
+                        <a class="mb-1 font-semibold mix js-single-rule {{ range $i, $e := .Params.rule_category }} cat-{{ replace $e "/" "" | urlize }} {{ end }}" href="{{.Permalink}}" data-name="{{ lower .Title }} {{ .File.TranslationBaseName }}">
                             {{ $this_img := partial "security-rule-map.html" (dict "source" .Params.source "scope" .Params.scope "ctx" $dot) }}
                             {{ if $this_img.image }}
                                 <img srcset="{{ $this_img.image }}?w=80&auto-enhance 2x" src="{{ $this_img.image }}?w=40&auto-enhance" width="40" alt="{{ htmlEscape .Params.Source }}" />

--- a/layouts/security_rules/list.html
+++ b/layouts/security_rules/list.html
@@ -28,6 +28,7 @@
         <input type="input" data-ref="search" class="form-control rule-search mb-3" id="keywords" placeholder="Search here" aria-label="keywords" />
     </div>
     <div class="list-group">
+        <div class="js-empty-results d-none font-semibold"></div>
         {{ range $i, $v := .Pages.GroupByParam "source" }}
             <div class="js-group js-group-{{ $i }}">
                 <div class="js-group-header mb-1 active">

--- a/layouts/security_rules/list.html
+++ b/layouts/security_rules/list.html
@@ -52,7 +52,7 @@
                 </div>
                 <div class="group-{{ .Key }} mb-2 ml-5 d-none">
                     {{ range $v.Pages }}
-                        <a class="mb-1 font-semibold mix {{ range $i, $e := .Params.rule_category }} cat-{{ replace $e "/" "" | urlize }} {{ end }}" href="{{.Permalink}}" data-name="{{ lower .Title }} {{ .File.TranslationBaseName }}">
+                        <a class="mb-1 font-semibold mix single-rule {{ range $i, $e := .Params.rule_category }} cat-{{ replace $e "/" "" | urlize }} {{ end }}" href="{{.Permalink}}" data-name="{{ lower .Title }} {{ .File.TranslationBaseName }}">
                             {{ $this_img := partial "security-rule-map.html" (dict "source" .Params.source "scope" .Params.scope "ctx" $dot) }}
                             {{ if $this_img.image }}
                                 <img srcset="{{ $this_img.image }}?w=80&auto-enhance 2x" src="{{ $this_img.image }}?w=40&auto-enhance" width="40" alt="{{ htmlEscape .Params.Source }}" />

--- a/src/scripts/components/security-rules.js
+++ b/src/scripts/components/security-rules.js
@@ -5,36 +5,27 @@ export function initializeSecurityRules() {
     const inputSearch = document.querySelector('[data-ref="search"]');
     const controls = document.querySelector('[data-ref="controls"]');
     const ruleList = Array.prototype.slice.call(document.getElementsByClassName('rule-list') || []);
+    const allSingleRules = document.querySelectorAll('.single-rule');
+    const allRuleGroups = document.querySelectorAll('.js-group');
     const urlParams = new URLSearchParams(window.location.search);
     const keyword = urlParams.get('q');
     let keyupTimeout;
     let filters;
     let mixer;
 
-    if (!containerEl) return;
-
-    if(controls) {
+    if (controls) {
        filters = controls.querySelectorAll('[data-ref="filter"]');
     }
 
-    ruleList.forEach(elm => {
-        elm.addEventListener("click", e => {
-            e.currentTarget.classList.toggle('active');
-        });
-    });
-
-    function filterByString(searchValue) {
-        if (searchValue) {
-            // Use an attribute wildcard selector to check for matches
-            mixer.filter(`[data-name*="${searchValue}"]`);
-            activateButton(controls.querySelector('[data-filter="all"]'), filters);
-        } else {
-            // If no searchValue, treat as filter('all')
-            mixer.filter('all');
+    const filterByString = (searchValue) => {
+        if (searchValue && searchValue !== '') {
+            return document.querySelectorAll(`[data-name*="${searchValue}"]`);
         }
+
+        return allSingleRules;
     }
 
-    function activateButton(activeButton, siblings) {
+    const activateButton = (activeButton, siblings) => {
         let button;
         let i;
 
@@ -51,85 +42,216 @@ export function initializeSecurityRules() {
         });
     }
 
-    if(containerEl) {
-        mixer = mixitup(containerEl, {
-            animation: {
-                duration: 350,
-                enable: false
-            },
-            callbacks: {
-                onMixClick() {
-                    // Reset the search if a filter is clicked
-                    if (this.matches('[data-filter]')) {
-                        inputSearch.value = '';
-                    }
-                },
-                onMixEnd(state){
-                    state.hide.forEach((x) => {
-                        x.closest(".js-group").style.display = 'none';
-                    });
-                    state.show.forEach((x) => {
-                        x.closest(".js-group").style.display = '';
-                    });
-                }
+    const filterResults = (filteredResultsArray) => {
+        allRuleGroups.forEach(element => {
+            element.style.display = 'none';
+        })
+
+        filteredResultsArray.forEach(element => {
+            const groupHeader = element.closest('.js-group').querySelector('.rule-list');
+            console.log(groupHeader)
+
+            if (!groupHeader.classList.contains('active')) {
+                groupHeader.classList.add('active');
+            } else {
+                groupHeader.classList.remove('active');
             }
+
+            // element.style.display = 'block';
+        })
+    }
+
+    const handleKeyup = () => {
+        const searchValue = inputSearch.value < 3 ? '' : inputSearch.value.toLowerCase().trim();
+        clearTimeout(keyupTimeout);
+
+        keyupTimeout = setTimeout(() => {
+            window.history.replaceState({q: searchValue}, '', `?q=${searchValue}`);
+            const filtered = filterByString(searchValue);
+            filterResults(filtered);
+        }, 350);
+    }
+
+    if (inputSearch) {
+        inputSearch.addEventListener('keyup', handleKeyup);
+    }
+
+    ruleList.forEach(elm => {
+        elm.addEventListener("click", e => {
+            e.currentTarget.classList.toggle('active');
         });
+    });
 
-        if (inputSearch) {
-            inputSearch.addEventListener('keyup', function () {
-                let searchValue;
-                if (inputSearch.value.length < 3) {
-                    // If the input value is less than 3 characters, don't send
-                    searchValue = '';
-                } else {
-                    searchValue = inputSearch.value.toLowerCase().trim();
-                }
-                clearTimeout(keyupTimeout);
-                keyupTimeout = setTimeout(function () {
-                    window.history.replaceState({q: searchValue}, '', `?q=${searchValue}`);
-                    filterByString(searchValue);
-                }, 350);
-            });
-        }
-
-        if (controls) {
-            controls.addEventListener('click', function (e) {
-                inputSearch.value = '';
-                const url = window.location.href.replace(window.location.search, '');
-                window.history.replaceState({q: ''}, '', url);
-                // If button is already active, or an operation is in progress, ignore the click
-                if (e.target.classList.contains('active') || !e.target.getAttribute('data-filter'))
-                    return;
-                activateButton(e.target, filters);
-            });
-        }
+        // if (controls) {
+        //     controls.addEventListener('click', function (e) {
+        //         inputSearch.value = '';
+        //         const url = window.location.href.replace(window.location.search, '');
+        //         window.history.replaceState({q: ''}, '', url);
+        //         // If button is already active, or an operation is in progress, ignore the click
+        //         if (e.target.classList.contains('active') || !e.target.getAttribute('data-filter'))
+        //             return;
+        //         activateButton(e.target, filters);
+        //     });
+        // }
 
         // Set controls the active controls on startup
-        if(controls) {
-            activateButton(controls.querySelector('[data-filter="all"]'), filters);
-        }
-        if(keyword) { filterByString(keyword); }
+        // if(controls) {
+        //     activateButton(controls.querySelector('[data-filter="all"]'), filters);
+        // }
+        // if(keyword) { filterByString(keyword); }
 
-        $(window).on('hashchange', function() {
-            let currentCat = '';
-            if (window.location.href.indexOf('#') > -1) {
-                currentCat = window.location.href.substring(
-                    window.location.href.indexOf('#')
-                );
-            }
-            const currentSelected = $('.controls .active').attr('href');
-            if (currentCat && currentSelected) {
-                if (currentCat !== currentSelected) {
-                    $(`a[href="${currentCat}"]`).get(0).click();
-                }
-            }
-            if (currentCat === '') {
-                activateButton(controls.querySelector('[data-filter="all"]'), filters);
-            }
-        });
+        // $(window).on('hashchange', function() {
+        //     let currentCat = '';
+        //     if (window.location.href.indexOf('#') > -1) {
+        //         currentCat = window.location.href.substring(
+        //             window.location.href.indexOf('#')
+        //         );
+        //     }
+        //     const currentSelected = $('.controls .active').attr('href');
+        //     if (currentCat && currentSelected) {
+        //         if (currentCat !== currentSelected) {
+        //             $(`a[href="${currentCat}"]`).get(0).click();
+        //         }
+        //     }
+        //     if (currentCat === '') {
+        //         activateButton(controls.querySelector('[data-filter="all"]'), filters);
+        //     }
+        // });
 
-        if (window.location.href.indexOf('#') > -1) {
-            $(window).trigger('hashchange');
-        }
+        // if (window.location.href.indexOf('#') > -1) {
+        //     $(window).trigger('hashchange');
+        // }
     }
-}
+
+    // const containerEl = document.querySelector('#rules .list-group');
+    // const inputSearch = document.querySelector('[data-ref="search"]');
+    // const controls = document.querySelector('[data-ref="controls"]');
+    // const ruleList = Array.prototype.slice.call(document.getElementsByClassName('rule-list') || []);
+    // const urlParams = new URLSearchParams(window.location.search);
+    // const keyword = urlParams.get('q');
+    // let keyupTimeout;
+    // let filters;
+    // let mixer;
+
+    // if (!containerEl) return;
+
+    // if(controls) {
+    //    filters = controls.querySelectorAll('[data-ref="filter"]');
+    // }
+
+    // ruleList.forEach(elm => {
+    //     elm.addEventListener("click", e => {
+    //         e.currentTarget.classList.toggle('active');
+    //     });
+    // });
+
+    // function filterByString(searchValue) {
+    //     if (searchValue) {
+    //         // Use an attribute wildcard selector to check for matches
+    //         mixer.filter(`[data-name*="${searchValue}"]`);
+    //         activateButton(controls.querySelector('[data-filter="all"]'), filters);
+    //     } else {
+    //         // If no searchValue, treat as filter('all')
+    //         mixer.filter('all');
+    //     }
+    // }
+
+    // function activateButton(activeButton, siblings) {
+    //     let button;
+    //     let i;
+
+    //     if (activeButton && siblings) {
+    //         for (i = 0; i < siblings.length; i++) {
+    //             button = siblings[i];
+    //             button.classList[button === activeButton ? 'add' : 'remove']('active');
+    //         }
+    //     }
+
+    //     // enable all
+    //     ruleList.forEach(elm => {
+    //         elm.classList.add('active');
+    //     });
+    // }
+
+    // if(containerEl) {
+    //     mixer = mixitup(containerEl, {
+    //         animation: {
+    //             duration: 350,
+    //             enable: false
+    //         },
+    //         callbacks: {
+    //             onMixClick() {
+    //                 // Reset the search if a filter is clicked
+    //                 if (this.matches('[data-filter]')) {
+    //                     inputSearch.value = '';
+    //                 }
+    //             },
+    //             onMixEnd(state){
+    //                 state.hide.forEach((x) => {
+    //                     x.closest(".js-group").style.display = 'none';
+    //                 });
+    //                 state.show.forEach((x) => {
+    //                     x.closest(".js-group").style.display = '';
+    //                 });
+    //             }
+    //         }
+    //     });
+
+    //     if (inputSearch) {
+    //         inputSearch.addEventListener('keyup', function () {
+    //             let searchValue;
+    //             if (inputSearch.value.length < 3) {
+    //                 // If the input value is less than 3 characters, don't send
+    //                 searchValue = '';
+    //             } else {
+    //                 searchValue = inputSearch.value.toLowerCase().trim();
+    //             }
+    //             clearTimeout(keyupTimeout);
+    //             keyupTimeout = setTimeout(function () {
+    //                 window.history.replaceState({q: searchValue}, '', `?q=${searchValue}`);
+    //                 filterByString(searchValue);
+    //             }, 350);
+    //         });
+    //     }
+
+    //     if (controls) {
+    //         controls.addEventListener('click', function (e) {
+    //             inputSearch.value = '';
+    //             const url = window.location.href.replace(window.location.search, '');
+    //             window.history.replaceState({q: ''}, '', url);
+    //             // If button is already active, or an operation is in progress, ignore the click
+    //             if (e.target.classList.contains('active') || !e.target.getAttribute('data-filter'))
+    //                 return;
+    //             activateButton(e.target, filters);
+    //         });
+    //     }
+
+    //     // Set controls the active controls on startup
+    //     if(controls) {
+    //         activateButton(controls.querySelector('[data-filter="all"]'), filters);
+    //     }
+    //     if(keyword) { filterByString(keyword); }
+
+    //     $(window).on('hashchange', function() {
+    //         let currentCat = '';
+    //         if (window.location.href.indexOf('#') > -1) {
+    //             currentCat = window.location.href.substring(
+    //                 window.location.href.indexOf('#')
+    //             );
+    //         }
+    //         const currentSelected = $('.controls .active').attr('href');
+    //         if (currentCat && currentSelected) {
+    //             if (currentCat !== currentSelected) {
+    //                 $(`a[href="${currentCat}"]`).get(0).click();
+    //             }
+    //         }
+    //         if (currentCat === '') {
+    //             activateButton(controls.querySelector('[data-filter="all"]'), filters);
+    //         }
+    //     });
+
+    //     if (window.location.href.indexOf('#') > -1) {
+    //         $(window).trigger('hashchange');
+    //     }
+    // }
+// }

--- a/src/scripts/components/security-rules.js
+++ b/src/scripts/components/security-rules.js
@@ -10,6 +10,7 @@ export function initializeSecurityRules() {
     const urlParams = new URLSearchParams(window.location.search);
     const urlHash = window.location.hash;
     const keyword = urlParams.get('q');
+    const form = document.getElementById('rules');
     let keyupTimeout;
     let filters;
 
@@ -119,6 +120,12 @@ export function initializeSecurityRules() {
 
     if (inputSearch) {
         inputSearch.addEventListener('keyup', handleKeyup);
+    }
+
+    if (form) {
+        form.addEventListener('submit', (e) => {
+            e.preventDefault();
+        });
     }
 
     allGroupHeaders.forEach(elm => {

--- a/src/scripts/components/security-rules.js
+++ b/src/scripts/components/security-rules.js
@@ -1,9 +1,12 @@
+import { stringToTitleCase } from '../helpers/string';
+
 export function initializeSecurityRules() {
     const inputSearch = document.querySelector('[data-ref="search"]');
     const controls = document.querySelector('[data-ref="controls"]');
     const allGroupHeaders = Array.prototype.slice.call(document.getElementsByClassName('js-group-header') || []);
     const allRules = document.querySelectorAll('.js-single-rule');
     const allRuleGroups = document.querySelectorAll('.js-group');
+    const jsEmptyResults = document.querySelector('.js-empty-results');
     const urlParams = new URLSearchParams(window.location.search);
     const urlHash = window.location.hash;
     const keyword = urlParams.get('q');
@@ -24,7 +27,7 @@ export function initializeSecurityRules() {
             results = allRules;
         }
 
-        if (searchValue && searchValue.length > 3) {
+        if (searchValue && searchValue.length > 2) {
             results = Array.from(results).filter(item => item.dataset.name.indexOf(searchValue) > -1);
         }
 
@@ -48,6 +51,14 @@ export function initializeSecurityRules() {
         });
     }
 
+    const handleEmptyResultSet = () => {
+        const searchQuery = inputSearch.value;
+        const activeCategoryFilter = stringToTitleCase(document.querySelector('.controls .active').text);
+        const message = `No results found for query "${searchQuery}" in category ${activeCategoryFilter}`;
+        jsEmptyResults.innerText = message;
+        jsEmptyResults.classList.remove('d-none');
+    }
+
     const showResults = (filteredResults) => {
         // Hide all groups, headers, and rules.
         allRules.forEach(element => {
@@ -61,6 +72,14 @@ export function initializeSecurityRules() {
         allRuleGroups.forEach(element => {
             element.style.display = 'none';
         })
+
+        // Handle empty result set
+        if (filteredResults.length < 1) {
+            handleEmptyResultSet();
+        } else {
+            jsEmptyResults.innerText = '';
+            jsEmptyResults.classList.add('d-none');
+        }
 
         // Show headers and groups for all matches
         filteredResults.forEach(element => {
@@ -77,19 +96,22 @@ export function initializeSecurityRules() {
         if (event.target.classList.contains('active') || !event.target.getAttribute('data-filter'))
             return;
             
-        const searchValue = inputSearch.value.length > 3 ? inputSearch.value.toLowerCase().trim() : '';
+        const searchValue = inputSearch.value.length > 2 ? inputSearch.value.toLowerCase().trim() : '';
         const filtered = filterResults(event.target.dataset.filter, searchValue);
         activateButton(event.target, filters);
         showResults(filtered);
     }
 
     const handleKeyup = () => {
-        const searchValue = inputSearch.value.length > 3 ? inputSearch.value.toLowerCase().trim() : '';
+        const searchValue = inputSearch.value.length > 2 ? inputSearch.value.toLowerCase().trim() : '';
         const activeCategoryFilter = document.querySelector('.controls .active').dataset.filter;
+        const { hash } = window.location;
+        const replaceUrl = hash ? `?q=${searchValue}${hash}` : `?q=${searchValue}`
+
         clearTimeout(keyupTimeout);
 
         keyupTimeout = setTimeout(() => {
-            window.history.replaceState({q: searchValue}, '', `?q=${searchValue}`);
+            window.history.replaceState({q: searchValue}, '', replaceUrl);
             const filtered = filterResults(activeCategoryFilter, searchValue);
             showResults(filtered);
         }, 350);
@@ -122,136 +144,3 @@ export function initializeSecurityRules() {
         showResults(filtered);
     }
 }
-
-    // const containerEl = document.querySelector('#rules .list-group');
-    // const inputSearch = document.querySelector('[data-ref="search"]');
-    // const controls = document.querySelector('[data-ref="controls"]');
-    // const ruleList = Array.prototype.slice.call(document.getElementsByClassName('rule-list') || []);
-    // const urlParams = new URLSearchParams(window.location.search);
-    // const keyword = urlParams.get('q');
-    // let keyupTimeout;
-    // let filters;
-    // let mixer;
-
-    // if (!containerEl) return;
-
-    // if(controls) {
-    //    filters = controls.querySelectorAll('[data-ref="filter"]');
-    // }
-
-    // ruleList.forEach(elm => {
-    //     elm.addEventListener("click", e => {
-    //         e.currentTarget.classList.toggle('active');
-    //     });
-    // });
-
-    // function filterByString(searchValue) {
-    //     if (searchValue) {
-    //         // Use an attribute wildcard selector to check for matches
-    //         mixer.filter(`[data-name*="${searchValue}"]`);
-    //         activateButton(controls.querySelector('[data-filter="all"]'), filters);
-    //     } else {
-    //         // If no searchValue, treat as filter('all')
-    //         mixer.filter('all');
-    //     }
-    // }
-
-    // function activateButton(activeButton, siblings) {
-    //     let button;
-    //     let i;
-
-    //     if (activeButton && siblings) {
-    //         for (i = 0; i < siblings.length; i++) {
-    //             button = siblings[i];
-    //             button.classList[button === activeButton ? 'add' : 'remove']('active');
-    //         }
-    //     }
-
-    //     // enable all
-    //     ruleList.forEach(elm => {
-    //         elm.classList.add('active');
-    //     });
-    // }
-
-    // if(containerEl) {
-    //     mixer = mixitup(containerEl, {
-    //         animation: {
-    //             duration: 350,
-    //             enable: false
-    //         },
-    //         callbacks: {
-    //             onMixClick() {
-    //                 // Reset the search if a filter is clicked
-    //                 if (this.matches('[data-filter]')) {
-    //                     inputSearch.value = '';
-    //                 }
-    //             },
-    //             onMixEnd(state){
-    //                 state.hide.forEach((x) => {
-    //                     x.closest(".js-group").style.display = 'none';
-    //                 });
-    //                 state.show.forEach((x) => {
-    //                     x.closest(".js-group").style.display = '';
-    //                 });
-    //             }
-    //         }
-    //     });
-
-    //     if (inputSearch) {
-    //         inputSearch.addEventListener('keyup', function () {
-    //             let searchValue;
-    //             if (inputSearch.value.length < 3) {
-    //                 // If the input value is less than 3 characters, don't send
-    //                 searchValue = '';
-    //             } else {
-    //                 searchValue = inputSearch.value.toLowerCase().trim();
-    //             }
-    //             clearTimeout(keyupTimeout);
-    //             keyupTimeout = setTimeout(function () {
-    //                 window.history.replaceState({q: searchValue}, '', `?q=${searchValue}`);
-    //                 filterByString(searchValue);
-    //             }, 350);
-    //         });
-    //     }
-
-    //     if (controls) {
-    //         controls.addEventListener('click', function (e) {
-    //             inputSearch.value = '';
-    //             const url = window.location.href.replace(window.location.search, '');
-    //             window.history.replaceState({q: ''}, '', url);
-    //             // If button is already active, or an operation is in progress, ignore the click
-    //             if (e.target.classList.contains('active') || !e.target.getAttribute('data-filter'))
-    //                 return;
-    //             activateButton(e.target, filters);
-    //         });
-    //     }
-
-    //     // Set controls the active controls on startup
-    //     if(controls) {
-    //         activateButton(controls.querySelector('[data-filter="all"]'), filters);
-    //     }
-    //     if(keyword) { filterByString(keyword); }
-
-    //     $(window).on('hashchange', function() {
-    //         let currentCat = '';
-    //         if (window.location.href.indexOf('#') > -1) {
-    //             currentCat = window.location.href.substring(
-    //                 window.location.href.indexOf('#')
-    //             );
-    //         }
-    //         const currentSelected = $('.controls .active').attr('href');
-    //         if (currentCat && currentSelected) {
-    //             if (currentCat !== currentSelected) {
-    //                 $(`a[href="${currentCat}"]`).get(0).click();
-    //             }
-    //         }
-    //         if (currentCat === '') {
-    //             activateButton(controls.querySelector('[data-filter="all"]'), filters);
-    //         }
-    //     });
-
-    //     if (window.location.href.indexOf('#') > -1) {
-    //         $(window).trigger('hashchange');
-    //     }
-    // }
-// }

--- a/src/scripts/components/security-rules.js
+++ b/src/scripts/components/security-rules.js
@@ -1,28 +1,34 @@
-import mixitup from 'mixitup';
-
 export function initializeSecurityRules() {
-    const containerEl = document.querySelector('#rules .list-group');
     const inputSearch = document.querySelector('[data-ref="search"]');
     const controls = document.querySelector('[data-ref="controls"]');
-    const ruleList = Array.prototype.slice.call(document.getElementsByClassName('rule-list') || []);
-    const allSingleRules = document.querySelectorAll('.single-rule');
+    const allGroupHeaders = Array.prototype.slice.call(document.getElementsByClassName('js-group-header') || []);
+    const allRules = document.querySelectorAll('.js-single-rule');
     const allRuleGroups = document.querySelectorAll('.js-group');
     const urlParams = new URLSearchParams(window.location.search);
+    const urlHash = window.location.hash;
     const keyword = urlParams.get('q');
     let keyupTimeout;
     let filters;
-    let mixer;
 
     if (controls) {
        filters = controls.querySelectorAll('[data-ref="filter"]');
     }
 
-    const filterByString = (searchValue) => {
-        if (searchValue && searchValue !== '') {
-            return document.querySelectorAll(`[data-name*="${searchValue}"]`);
+    // Returns array of results filtered by category and/or user search value
+    const filterResults = (filterCategoryValue, searchValue) => {
+        let results = [];
+
+        if (filterCategoryValue && filterCategoryValue !== 'all') {
+            results = document.querySelectorAll(`.${filterCategoryValue}`);
+        } else {
+            results = allRules;
         }
 
-        return allSingleRules;
+        if (searchValue && searchValue.length > 3) {
+            results = Array.from(results).filter(item => item.dataset.name.indexOf(searchValue) > -1);
+        }
+
+        return results;
     }
 
     const activateButton = (activeButton, siblings) => {
@@ -37,38 +43,55 @@ export function initializeSecurityRules() {
         }
 
         // enable all
-        ruleList.forEach(elm => {
+        allGroupHeaders.forEach(elm => {
             elm.classList.add('active');
         });
     }
 
-    const filterResults = (filteredResultsArray) => {
+    const showResults = (filteredResults) => {
+        // Hide all groups, headers, and rules.
+        allRules.forEach(element => {
+            element.style.display = 'none';
+        })
+
+        allGroupHeaders.forEach(element => {
+            element.style.display = 'none';
+        })
+
         allRuleGroups.forEach(element => {
             element.style.display = 'none';
         })
 
-        filteredResultsArray.forEach(element => {
-            const groupHeader = element.closest('.js-group').querySelector('.rule-list');
-            console.log(groupHeader)
-
-            if (!groupHeader.classList.contains('active')) {
-                groupHeader.classList.add('active');
-            } else {
-                groupHeader.classList.remove('active');
-            }
-
-            // element.style.display = 'block';
+        // Show headers and groups for all matches
+        filteredResults.forEach(element => {
+            const jsGroup = element.closest('.js-group');
+            const header = jsGroup.querySelector('.js-group-header');
+            jsGroup.style.display = 'block';
+            header.style.display = 'block';
+            element.style.display = 'inline';
         })
     }
 
+    const handleCategoryFilterClick = (event) => {       
+        // If button is already active, or an operation is in progress, ignore the click
+        if (event.target.classList.contains('active') || !event.target.getAttribute('data-filter'))
+            return;
+            
+        const searchValue = inputSearch.value.length > 3 ? inputSearch.value.toLowerCase().trim() : '';
+        const filtered = filterResults(event.target.dataset.filter, searchValue);
+        activateButton(event.target, filters);
+        showResults(filtered);
+    }
+
     const handleKeyup = () => {
-        const searchValue = inputSearch.value < 3 ? '' : inputSearch.value.toLowerCase().trim();
+        const searchValue = inputSearch.value.length > 3 ? inputSearch.value.toLowerCase().trim() : '';
+        const activeCategoryFilter = document.querySelector('.controls .active').dataset.filter;
         clearTimeout(keyupTimeout);
 
         keyupTimeout = setTimeout(() => {
             window.history.replaceState({q: searchValue}, '', `?q=${searchValue}`);
-            const filtered = filterByString(searchValue);
-            filterResults(filtered);
+            const filtered = filterResults(activeCategoryFilter, searchValue);
+            showResults(filtered);
         }, 350);
     }
 
@@ -76,52 +99,29 @@ export function initializeSecurityRules() {
         inputSearch.addEventListener('keyup', handleKeyup);
     }
 
-    ruleList.forEach(elm => {
+    allGroupHeaders.forEach(elm => {
         elm.addEventListener("click", e => {
             e.currentTarget.classList.toggle('active');
         });
     });
 
-        // if (controls) {
-        //     controls.addEventListener('click', function (e) {
-        //         inputSearch.value = '';
-        //         const url = window.location.href.replace(window.location.search, '');
-        //         window.history.replaceState({q: ''}, '', url);
-        //         // If button is already active, or an operation is in progress, ignore the click
-        //         if (e.target.classList.contains('active') || !e.target.getAttribute('data-filter'))
-        //             return;
-        //         activateButton(e.target, filters);
-        //     });
-        // }
+    // We cannot listen for a DOM loaded event due to the script loading async; this code should execute when the default rules content is loaded.
+    if (controls) {
+        controls.addEventListener('click', handleCategoryFilterClick);
+        let searchValue = '';
 
-        // Set controls the active controls on startup
-        // if(controls) {
-        //     activateButton(controls.querySelector('[data-filter="all"]'), filters);
-        // }
-        // if(keyword) { filterByString(keyword); }
+        if (keyword) {
+            searchValue = keyword;
+            inputSearch.value = keyword;
+        }
 
-        // $(window).on('hashchange', function() {
-        //     let currentCat = '';
-        //     if (window.location.href.indexOf('#') > -1) {
-        //         currentCat = window.location.href.substring(
-        //             window.location.href.indexOf('#')
-        //         );
-        //     }
-        //     const currentSelected = $('.controls .active').attr('href');
-        //     if (currentCat && currentSelected) {
-        //         if (currentCat !== currentSelected) {
-        //             $(`a[href="${currentCat}"]`).get(0).click();
-        //         }
-        //     }
-        //     if (currentCat === '') {
-        //         activateButton(controls.querySelector('[data-filter="all"]'), filters);
-        //     }
-        // });
-
-        // if (window.location.href.indexOf('#') > -1) {
-        //     $(window).trigger('hashchange');
-        // }
+        const activeCategoryFilter = urlHash ? urlHash.substring(1) : 'all';
+        const activeFilterButton = document.querySelector(`[data-filter="${activeCategoryFilter}"]`);
+        const filtered = filterResults(activeCategoryFilter, searchValue);
+        activateButton(activeFilterButton, filters);
+        showResults(filtered);
     }
+}
 
     // const containerEl = document.querySelector('#rules .list-group');
     // const inputSearch = document.querySelector('[data-ref="search"]');

--- a/src/scripts/helpers/string.js
+++ b/src/scripts/helpers/string.js
@@ -1,0 +1,5 @@
+export const stringToTitleCase = (string) => {
+  return string.split(' ')
+    .map(word => word[0].toUpperCase() + word.substr(1).toLowerCase())
+    .join(' ');
+}

--- a/src/styles/pages/_security_monitoring.scss
+++ b/src/styles/pages/_security_monitoring.scss
@@ -5,7 +5,7 @@
   }
 }
 
-.rule-list {
+.js-group-header {
   transition: box-shadow 0.125s;
   position: relative;
   box-shadow: 0 1px 3px rgba(0,0,0,0.25); 
@@ -22,16 +22,16 @@
     display: block !important;
   }
   &.active {
-    .rule-list__arrow {
+    .js-group-header__arrow {
       right: 12px !important;
       transform: rotate(-90deg) !important;
     }
   }
 }
-.rule-list__icon {
+.js-group-header__icon {
   background: rgba(0,0,0,0.05); 
 }
-.rule-list__arrow {
+.js-group-header__arrow {
   transition: transform 0.125s;
   top: 0px;
   right: 7px;
@@ -40,7 +40,7 @@
   font-size: 18px;
   transform: rotate(90deg);
   // Point arrow inwards when collapsed
-  .rule-list:not(.active) & {
+  .js-group-header:not(.active) & {
     transform: rotate(180deg);
   }
 }


### PR DESCRIPTION
### What does this PR do?
Overhauls the search/filtering system for Security Default Rules.

1. Allows the user to search and filter at the same time.  (in production currently, the filter always default to `All` as soon as the user begins to type in a search query).
2. Removes a third-party dependency, `mixitup`, from this page.
3. Refactors some jQuery code to plain JS - this is an ongoing effort to incrementally reduce jQuery usage in hopes of one day removing it as a dependency.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1044

### Preview
- https://docs-staging.datadoghq.com/brian.deutsch/security-rules-filtering/security_monitoring/default_rules/
- Supporting synthetics tests (will update with production URLs once this PR is merged): https://dd-corpsite.datadoghq.com/synthetics/details/dmu-96s-k5g

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
