### PR TITLE
Clarify NO_PROXY for agent http(s) calls

### DIFF
--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -92,6 +92,7 @@ proxy:
 * A hostname
   - e.g. `webserver1`
 
+**Note**: `NO_PROXY` must match endpoints exactly for agent HTTP(S) requests.  The accepted values above only apply to integrations.
 
 #### Environment variables
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
It was not originally clear from this doc that `NO_PROXY`'s matching criteria did not apply to HTTP calls made from the agent itself. 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/brian/clarify-agent-no_proxy/agent/proxy

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
