### PR TITLE
[doc] kris-casey/Edit link 7: Metrics Intro

### DIFF
--- a/content/en/developers/metrics/_index.md
+++ b/content/en/developers/metrics/_index.md
@@ -76,7 +76,7 @@ You can also use one of the [Datadog official and community contributed API and 
 [4]: /developers/metrics/agent_metrics_submission/
 [5]: https://app.datadoghq.com/account/usage/hourly
 [6]: /account_management/billing/custom_metrics/#counting-custom-metrics
-[7]: /graphing/metrics/introduction/
+[7]: /metrics
 [8]: /developers/metrics/types/
 [9]: /developers/metrics/types/?tab=rate#metric-types
 [10]: /developers/metrics/types/?tab=count#metric-types


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes link 7, which was a deadlink from when metrics was under "Graphing." /metrics/introduction also works, but it re-routes to /metrics.

### Motivation
Deadlink 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/CoderCarrot-patch-1/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
