### PR TITLE
Move logs only FAQ to guides section

### DIFF
--- a/content/en/logs/guide/_index.md
+++ b/content/en/logs/guide/_index.md
@@ -21,6 +21,7 @@ private: true
     {{< nextlink href="logs/guide/docker-logs-collection-troubleshooting-guide" >}}Docker Log Collection Troubleshooting Guide{{< /nextlink >}}
     {{< nextlink href="logs/guide/lambda-logs-collection-troubleshooting-guide" >}}Lambda Log Collection Troubleshooting Guide{{< /nextlink >}}
     {{< nextlink href="logs/guide/setting-file-permissions-for-rotating-logs" >}}Setting File Permissions for Rotating Logs (Linux){{< /nextlink >}}
+    {{< nextlink href="/logs/guide/how-to-set-up-only-logs" >}}Use the Datadog Agent for Log Collection Only{{< /nextlink >}}
 {{< /whatsnext >}}
 
 <br>

--- a/content/en/logs/guide/how-to-set-up-only-logs.md
+++ b/content/en/logs/guide/how-to-set-up-only-logs.md
@@ -1,14 +1,13 @@
 ---
-title: How to set up only Logs
-kind: faq
-beta: true
+title: Use the Datadog Agent for Log Collection Only
+kind: documentation
 ---
 
 <div class="alert alert-danger">
-To setup Log collection without metrics, you have to disable some payloads. This results in the potential loss of metadata and tags on the logs you are collecting. Datadog does not recommend this. For more information about the impact of this configuration, contact <a href="/help/">Datadog Support</a>.
+To setup Log collection without metrics, you have to disable certain payloads. This results in the potential loss of metadata and tags on the logs you are collecting. Datadog does not recommend this. For more information about the impact of this configuration, contact <a href="/help/">Datadog Support</a>.
 </div>
 
-To disable payloads, you must be running Agent v6.4+. This disables metric data submission, so that hosts stop showing up in Datadog. Follow these steps:
+To disable payloads, you must be running Agent v6.4+. This disables metric data submission so that hosts stop showing up in Datadog. Follow these steps:
 
 {{< tabs >}}
 {{% tab "Host " %}}


### PR DESCRIPTION
### What does this PR do?
Moves the set up log collection only FAQ to the guides section, adds link to guide page; a few edits. 

### Motivation
Docs request

### Preview
https://docs-staging.datadoghq.com/sarina/logs-only-guide/logs/guide/
https://docs-staging.datadoghq.com/sarina/logs-only-guide/logs/guide/how-to-set-up-only-logs/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
