### PR TITLE
APM > Runtime metrics > Change small wording

### DIFF
--- a/content/en/tracing/runtime_metrics/nodejs.md
+++ b/content/en/tracing/runtime_metrics/nodejs.md
@@ -27,7 +27,7 @@ Runtime metrics collection can be enabled with one configuration parameter in th
 
 Runtime metrics can be viewed in correlation with your Node services. See the [Service page][1] in Datadog.
 
-By default, runtime metrics from your application are sent to the Datadog Agent thanks to DogStatsD over port `8125`. Make sure that [DogStatsD is enabled for the Agent][2].
+By default, runtime metrics from your application are sent to the Datadog Agent with DogStatsD over port `8125`. Make sure that [DogStatsD is enabled for the Agent][2].
 If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to true][3], and that port `8125` is open on the Agent.
 In Kubernetes, [bind the DogstatsD port to a host port][4]; in ECS, [set the appropriate flags in your task definition][5].
 

--- a/content/en/tracing/runtime_metrics/python.md
+++ b/content/en/tracing/runtime_metrics/python.md
@@ -29,7 +29,7 @@ Runtime metrics can be viewed in correlation with your Python services. See the 
 
 **Note**: For the runtime UI, `ddtrace` >= [`0.24.0`][2] is supported.
 
-By default, runtime metrics from your application are sent to the Datadog Agent thanks to DogStatsD over port `8125`. Make sure that [DogStatsD is enabled for the Agent][3].
+By default, runtime metrics from your application are sent to the Datadog Agent with DogStatsD over port `8125`. Make sure that [DogStatsD is enabled for the Agent][3].
 If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to true][4], and that port `8125` is open on the Agent.
 In Kubernetes, [bind the DogstatsD port to a host port][5]; in ECS, [set the appropriate flags in your task definition][6].
 

--- a/content/en/tracing/runtime_metrics/ruby.md
+++ b/content/en/tracing/runtime_metrics/ruby.md
@@ -46,7 +46,7 @@ end
 
 Runtime metrics can be viewed in correlation with your Ruby services. See the [Service page][3] in Datadog.
 
-By default, runtime metrics from your application are sent to the Datadog Agent thanks to DogStatsD over port `8125`. Make sure that [DogStatsD is enabled for the Agent][2].
+By default, runtime metrics from your application are sent to the Datadog Agent with DogStatsD over port `8125`. Make sure that [DogStatsD is enabled for the Agent][2].
 If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to true][4], and that port `8125` is open on the Agent.
 In Kubernetes, [bind the DogstatsD port to a host port][5]; in ECS, [set the appropriate flags in your task definition][6].
 


### PR DESCRIPTION
### What does this PR do?
Change text from "runtime metrics ... are sent to the Datadog Agent thanks to DogStatsD" to "runtime metrics ... are sent to the Datadog Agent with DogStatsD". This also aligns with the Java page that already has this wording.

### Motivation
Previous wording didn't seem as direct as it could be.

### Preview
https://docs.datadoghq.com/zach.montoya/runtime-metrics/fixes/tracing/runtime_metrics/python
https://docs.datadoghq.com/zach.montoya/runtime-metrics/fixes/tracing/runtime_metrics/ruby
https://docs.datadoghq.com/zach.montoya/runtime-metrics/fixes/tracing/runtime_metrics/nodejs

### Additional Notes
This is entirely up to the Docs team's discretion on wording. If the "thanks to" is preferable, then we should modify Java so the message is consistent cross languages.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
