### PR TITLE
Allowing indexation of logs only guide

### DIFF
--- a/local/etc/algolia/docs_datadoghq.json
+++ b/local/etc/algolia/docs_datadoghq.json
@@ -136,7 +136,6 @@
         "/agent/guide/dogstream/$",
         "/integrations/faq/agent-5-amazon-ecs/$",
         "/integrations/faq/list-of-api-source-attribute-value/$",
-        "/logs/faq/how-to-set-up-only-logs/$",
         "/tracing/guide/agent-5-tracing-setup/$",
         "docs.datadoghq.com/fr/.*/faq/",
         "docs.datadoghq.com/ja/.*/faq/",

--- a/local/etc/algolia/docs_datadoghq_preview.json
+++ b/local/etc/algolia/docs_datadoghq_preview.json
@@ -136,7 +136,6 @@
         "/agent/guide/dogstream/$",
         "/integrations/faq/agent-5-amazon-ecs/$",
         "/integrations/faq/list-of-api-source-attribute-value/$",
-        "/logs/faq/how-to-set-up-only-logs/$",
         "/tracing/guide/agent-5-tracing-setup/$",
         "docs.datadoghq.com/fr/.*/faq/",
         "docs.datadoghq.com/ja/.*/faq/",


### PR DESCRIPTION
Following https://github.com/DataDog/documentation/pull/9486

This PR allows the new log guide to be indexed by the doc search