### PR TITLE
Update Jetty to "fully supported"

### DIFF
--- a/content/en/tracing/setup_overview/compatibility_requirements/java.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/java.md
@@ -44,7 +44,7 @@ Beta integrations are disabled by default but can be enabled individually:
 | Grizzly-HTTP            | 2.3.20+    | [Beta][2]       | `grizzly-filterchain`                          |
 | Java Servlet Compatible | 2.3+, 3.0+ | Fully Supported | `servlet`, `servlet-2`, `servlet-3`            |
 | Jax-RS Annotations      | JSR311-API | Fully Supported | `jax-rs`, `jaxrs`, `jax-rs-annotations`, `jax-rs-filter` |
-| Jetty (non-Servlet)     | 8.x, 9.x   | [Beta][2]       | `jetty`, `jetty-8`                             |
+| Jetty                   | 7.0-9.x    | Fully Supported | `jetty`                                        |
 | Netty HTTP Server       | 3.8+       | Fully Supported | `netty`, `netty-3.8`, `netty-4.0`, `netty-4.1` |
 | Play                    | 2.3-2.8    | Fully Supported | `play`, `play-action`                          |
 | Ratpack                 | 1.5+       | Fully Supported | `ratpack`                                      |


### PR DESCRIPTION
Improved jetty support introduced in `0.71.0` version of the tracer:
https://github.com/DataDog/dd-trace-java/releases/tag/v0.71.0

This integration now takes precedence over the servlet integration (but is modified to behave as closely as possible to avoid changing metric names inadvertently).

### Preview
https://docs-staging.datadoghq.com/tyler/java-docs/tracing/setup_overview/compatibility_requirements/java#web-framework-compatibility

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
