### PR TITLE
Wrong node command

### DIFF
--- a/content/en/tracing/setup_overview/setup/nodejs.md
+++ b/content/en/tracing/setup_overview/setup/nodejs.md
@@ -37,7 +37,7 @@ To add the Datadog tracing library to your Node.js applications, follow these st
 1. Install the Datadog Tracing library using npm:
 
 ```sh
-npm install --save dd-trace
+npm install dd-trace --save 
 ```
 
 2. Import and initialize the tracer either in code or via command line arguments. The Node.js tracing library needs to be imported and initialized **before** any other module.


### PR DESCRIPTION
The npm tags should go at the end of the npm command

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
