### PR TITLE
DOCS-1519/hotjar: Add a link to API docs in Getting Started w Synthetics

### DIFF
--- a/content/en/getting_started/synthetics/api_test.md
+++ b/content/en/getting_started/synthetics/api_test.md
@@ -13,7 +13,7 @@ further_reading:
       text: 'Configure advanced Synthetic Monitoring settings'
     - link: '/api/v1/synthetics/#create-a-test'
       tag: 'API Docs'
-      text: 'Create an Synthetic test programmatically'
+      text: 'Create a Synthetic test programmatically'
 
 ---
 
@@ -80,6 +80,7 @@ Datadog also has an [APM integration with Synthetic Monitoring][7] which allows 
 {{< nextlink href="/synthetics/api_tests" tag="Documentation" >}}Learn more about API tests{{< /nextlink >}}
 {{< nextlink href="/synthetics/identify_synthetics_bots" tag="Documentation" >}}Learn how to identify Synthetic bots for API tests{{< /nextlink >}}
 {{< nextlink href="/synthetics/settings/" tag="Documentation" >}}Configure advanced Synthetic Monitoring settings{{< /nextlink >}}
+{{< nextlink href="/api/v1/synthetics/#create-a-test" tag="API Docs" >}}Create a Synthetic test programmatically{{< /nextlink >}}
 {{< /whatsnext >}}
 
 [1]: /synthetics/api_tests/

--- a/content/en/getting_started/synthetics/api_test.md
+++ b/content/en/getting_started/synthetics/api_test.md
@@ -11,6 +11,10 @@ further_reading:
     - link: '/synthetics/settings/'
       tag: 'Documentation'
       text: 'Configure advanced Synthetic Monitoring settings'
+    - link: '/api/v1/synthetics/#create-a-test'
+      tag: 'API Docs'
+      text: 'Create an Synthetic test programmatically'
+
 ---
 
 ## Create an API test


### PR DESCRIPTION

### What does this PR do?
Adds a link for further reading in the Synthetics API test Getting Started

### Motivation
Hotjar feedback in DOCS-1519

### Preview
https://docs-staging.datadoghq.com/kari/docs-1519/getting_started/synthetics/api_test/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
