### PR TITLE
DOCS-1458 - add note that count isn't supported in Python

### DIFF
--- a/content/en/developers/metrics/dogstatsd_metrics_submission.md
+++ b/content/en/developers/metrics/dogstatsd_metrics_submission.md
@@ -38,7 +38,7 @@ After [installing DogStatsD][1], the functions below are available for submittin
 |---------------------------------------------------------------|-----------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `increment(<METRIC_NAME>, <SAMPLE_RATE>, <TAGS>)`             | Used to increment a COUNT metric.                         | Stored as a `RATE` type in Datadog. Each value in the stored timeseries is a time-normalized delta of the metric's value over the StatsD flush period. |
 | `decrement(<METRIC_NAME>, <SAMPLE_RATE>, <TAGS>)`             | Used to decrement a COUNT metric.                         | Stored as a `RATE` type in Datadog. Each value in the stored timeseries is a time-normalized delta of the metric's value over the StatsD flush period. |
-| `count(<METRIC_NAME>, <METRIC_VALUE>, <SAMPLE_RATE>, <TAGS>)` | Use to increment a COUNT metric from an arbitrary `Value` | Stored as a `RATE` type in Datadog. Each value in the stored timeseries is a time-normalized delta of the metric's value over the StatsD flush period. |
+| `count(<METRIC_NAME>, <METRIC_VALUE>, <SAMPLE_RATE>, <TAGS>)` | Use to increment a COUNT metric from an arbitrary `Value` | Stored as a `RATE` type in Datadog. Each value in the stored timeseries is a time-normalized delta of the metric's value over the StatsD flush period. <br/><br/>**Note:** `count` is not supported in Python.</p>|
 
 **Note**: `COUNT` type metrics can show a decimal value within Datadog since they are normalized over the flush interval to report per-second units.
 
@@ -67,6 +67,9 @@ while(1):
   statsd.decrement('example_metric.decrement', tags=["environment:dev"])
   time.sleep(10)
 ```
+
+**Note:** `statsd.count` is not supported in Python.
+
 {{< /programming-lang >}}
 
 {{< programming-lang lang="ruby" >}}


### PR DESCRIPTION
### What does this PR do?
Explicitly notes the restriction that Python doesn't do `count`

### Motivation
DOCS-1458

### Preview

https://docs-staging.datadoghq.com/kari/docs-1458/developers/metrics/dogstatsd_metrics_submission/


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
