### PR TITLE
Add callouts for multi domains support in source maps

### DIFF
--- a/content/en/real_user_monitoring/error_tracking/_index.md
+++ b/content/en/real_user_monitoring/error_tracking/_index.md
@@ -88,6 +88,8 @@ For Error Tracking to properly work with your source maps, you must configure yo
 
 **Note**: Currently only source maps with the `.min.js` extension will work to correctly unminify stack traces in the Error Tracking UI. Source maps with other extensions (for example, `.mjs`, etc.) while accepted will not unminify stack traces. 
 
+<div class="alert alert-info">In some cases, a given JavaScript source file can be served from different subdomains depending on the environment (staging, production, ...). You can upload the related source map once and make it work for multiple subdomains by using the absolute prefix path instead of the full url (i.e: specify <code>/static/js</code> instead of <code>https://hostname.com/static/js</code>).</div>
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/real_user_monitoring/error_tracking/_index.md
+++ b/content/en/real_user_monitoring/error_tracking/_index.md
@@ -88,7 +88,7 @@ For Error Tracking to properly work with your source maps, you must configure yo
 
 **Note**: Currently only source maps with the `.min.js` extension will work to correctly unminify stack traces in the Error Tracking UI. Source maps with other extensions (for example, `.mjs`, etc.) while accepted will not unminify stack traces. 
 
-<div class="alert alert-info">In some cases, a given JavaScript source file can be served from different subdomains depending on the environment (staging, production, ...). You can upload the related source map once and make it work for multiple subdomains by using the absolute prefix path instead of the full url (i.e: specify <code>/static/js</code> instead of <code>https://hostname.com/static/js</code>).</div>
+<div class="alert alert-info">A given JavaScript source file can be served from different subdomains depending on the environment (staging, production, ...). You can upload the related source map once and make it work for multiple subdomains by using the absolute prefix path instead of the full url (i.e: specify <code>/static/js</code> instead of <code>https://hostname.com/static/js</code>).</div>
 
 ## Further Reading
 

--- a/content/en/real_user_monitoring/error_tracking/_index.md
+++ b/content/en/real_user_monitoring/error_tracking/_index.md
@@ -88,7 +88,7 @@ For Error Tracking to properly work with your source maps, you must configure yo
 
 **Note**: Currently only source maps with the `.min.js` extension will work to correctly unminify stack traces in the Error Tracking UI. Source maps with other extensions (for example, `.mjs`, etc.) while accepted will not unminify stack traces. 
 
-<div class="alert alert-info">A given JavaScript source file can be served from different subdomains depending on the environment (staging, production, ...). You can upload the related source map once and make it work for multiple subdomains by using the absolute prefix path instead of the full url (i.e: specify <code>/static/js</code> instead of <code>https://hostname.com/static/js</code>).</div>
+<div class="alert alert-info">A given JavaScript source file can be served from different subdomains depending on the environment (for example, staging or production). You can upload the related source map once and make it work for multiple subdomains by using the absolute prefix path instead of the full url (specify <code>/static/js</code> instead of <code>https://hostname.com/static/js</code>).</div>
 
 ## Further Reading
 

--- a/content/en/real_user_monitoring/error_tracking/explorer.md
+++ b/content/en/real_user_monitoring/error_tracking/explorer.md
@@ -55,5 +55,7 @@ Each event generated is tagged with the version, the service, and the environmen
 
 {{< img src="real_user_monitoring/error_tracking/export_search_query_to_monitor.gif" alt="Export to monitor in Error Tracking"  >}}
 
+<div class="alert alert-warning">This alerting capability is not fully-supported in our GovCloud and Azure data-centers.</div>
+
 [1]: /events
 [2]: /monitors/monitor_types/event/

--- a/content/en/real_user_monitoring/error_tracking/explorer.md
+++ b/content/en/real_user_monitoring/error_tracking/explorer.md
@@ -55,7 +55,7 @@ Each event generated is tagged with the version, the service, and the environmen
 
 {{< img src="real_user_monitoring/error_tracking/export_search_query_to_monitor.gif" alt="Export to monitor in Error Tracking"  >}}
 
-<div class="alert alert-warning">This alerting capability is not fully-supported in our GovCloud and Azure data-centers.</div>
+<div class="alert alert-warning">This alerting capability is not fully-supported in our <strong>GovCloud</strong> and <strong>Azure</strong> data-centers.</div>
 
 [1]: /events
 [2]: /monitors/monitor_types/event/

--- a/content/en/real_user_monitoring/error_tracking/explorer.md
+++ b/content/en/real_user_monitoring/error_tracking/explorer.md
@@ -55,7 +55,6 @@ Each event generated is tagged with the version, the service, and the environmen
 
 {{< img src="real_user_monitoring/error_tracking/export_search_query_to_monitor.gif" alt="Export to monitor in Error Tracking"  >}}
 
-<div class="alert alert-warning">This alerting capability is not fully-supported in our <strong>GovCloud</strong> and <strong>Azure</strong> data-centers.</div>
 
 [1]: /events
 [2]: /monitors/monitor_types/event/

--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -112,6 +112,8 @@ By running this command against our example `dist` directory (see previous secti
 
 **Note**: Currently only source maps with the `.min.js` extension will work to correctly unminify stack traces in the Error Tracking UI. Source maps with other extensions (for example, `.mjs`, etc.) while accepted will not unminify stack traces. 
 
+<div class="alert alert-info">In some cases, a given JavaScript source file can be served from different subdomains depending on the environment (staging, production, ...). You can upload the related source map once and make it work for multiple subdomains by using the absolute prefix path instead of the full url (i.e: specify <code>/static/js</code> instead of <code>https://hostname.com/static/js</code>).</div>
+
 ## Troubleshoot errors with ease
 
 A minified stack trace is not helpful as you don't have access to the file path and the line number. It's hard to know where something is happening in your code base. In addition, the code snippet is still minified (one long line of transformed code) which makes the troubleshooting process even harder. See below an example of an minified stack trace:

--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -112,7 +112,7 @@ By running this command against our example `dist` directory (see previous secti
 
 **Note**: Currently only source maps with the `.min.js` extension will work to correctly unminify stack traces in the Error Tracking UI. Source maps with other extensions (for example, `.mjs`, etc.) while accepted will not unminify stack traces. 
 
-<div class="alert alert-info">In some cases, a given JavaScript source file can be served from different subdomains depending on the environment (staging, production, ...). You can upload the related source map once and make it work for multiple subdomains by using the absolute prefix path instead of the full url (i.e: specify <code>/static/js</code> instead of <code>https://hostname.com/static/js</code>).</div>
+<div class="alert alert-info">A given JavaScript source file can be served from different subdomains depending on the environment (staging, production, ...). You can upload the related source map once and make it work for multiple subdomains by using the absolute prefix path instead of the full url (i.e: specify <code>/static/js</code> instead of <code>https://hostname.com/static/js</code>).</div>
 
 ## Troubleshoot errors with ease
 

--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -112,7 +112,7 @@ By running this command against our example `dist` directory (see previous secti
 
 **Note**: Currently only source maps with the `.min.js` extension will work to correctly unminify stack traces in the Error Tracking UI. Source maps with other extensions (for example, `.mjs`, etc.) while accepted will not unminify stack traces. 
 
-<div class="alert alert-info">A given JavaScript source file can be served from different subdomains depending on the environment (staging, production, ...). You can upload the related source map once and make it work for multiple subdomains by using the absolute prefix path instead of the full url (i.e: specify <code>/static/js</code> instead of <code>https://hostname.com/static/js</code>).</div>
+<div class="alert alert-info">A given JavaScript source file can be served from different subdomains depending on the environment (for example, staging or production). You can upload the related source map once and make it work for multiple subdomains by using the absolute prefix path instead of the full url (specify <code>/static/js</code> instead of <code>https://hostname.com/static/js</code>).</div>
 
 ## Troubleshoot errors with ease
 


### PR DESCRIPTION
### What does this PR do?

- Add info callouts about the support of multiple domains when uploading source maps
- Add warning callouts about a feature not being fully supported in GovCloud and Azure

### Preview

- [Here](https://docs-staging.datadoghq.com/maxime.matheron/error-tracking-multiple-domains-support/real_user_monitoring/error_tracking/?tab=us#javascript-source-maps) and [Here](https://docs-staging.datadoghq.com/maxime.matheron/error-tracking-multiple-domains-support/real_user_monitoring/guide/upload-javascript-source-maps/?tab=webpackjs#upload-your-source-maps) for multiple domains support
- [Here](https://docs-staging.datadoghq.com/maxime.matheron/error-tracking-multiple-domains-support/real_user_monitoring/error_tracking/explorer#get-alerted-on-new-errors) for GovCloud and Azure

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
