### PR TITLE
updating download link

### DIFF
--- a/content/en/agent/amazon_ecs/_index.md
+++ b/content/en/agent/amazon_ecs/_index.md
@@ -88,9 +88,9 @@ Configure the task using either the [AWS CLI tools][12] or using the Amazon Web 
 aws ecs register-task-definition --cli-input-json <path to datadog-agent-ecs.json>
 ```
 
-[1]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs.json
-[2]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs1.json
-[3]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs-win.json
+[1]: /resources/json/datadog-agent-ecs.json
+[2]: /resources/json/datadog-agent-ecs1.json
+[3]: //resources/json/datadog-agent-ecs-win.json
 [4]: https://app.datadoghq.com/account/settings#api
 [5]: /agent/amazon_ecs/logs/
 [6]: /agent/amazon_ecs/apm/


### PR DESCRIPTION
Updating download link because it doesn't work on firefox currently 

https://docs-staging.datadoghq.com/kaylyn/download-link/agent/amazon_ecs/?tab=awscli# 

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
