### PR TITLE
DOCS-1547 Agent logs UTF8

### DIFF
--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -73,8 +73,6 @@ logs:
     source: "<SOURCE>"
 ```
 
-**Note**: When tailing files for logs, the Datadog Agent v6 and v7 for **Windows** requires the log files have UTF8 encoding.
-
 [1]: /agent/guide/agent-configuration-files/
 {{% /tab %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Remove note on Agent logs UTF8 for Windows

### Motivation
UTF16 is now supported

### Preview
https://docs-staging.datadoghq.com/ruth/docs-1547/agent/logs/?tab=tailfiles#custom-log-collection

### Additional Notes
N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
