### PR TITLE
[logs] Update redis metadata name in k8s log collection example

### DIFF
--- a/content/en/agent/kubernetes/log.md
+++ b/content/en/agent/kubernetes/log.md
@@ -400,7 +400,7 @@ The following ConfigMap defines the integration template for `redis` containers 
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: redis-config-map
+  name: redisdb-config-map
   namespace: default
 data:
   redisdb-config: |-


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

The metadata name differs in ConfigMap yaml, `redis-config-map`, from what is in volumeMounts and volumes yaml, `redisdb-config-map`. This PR updates the ConfigMap to `redisdb-config-map`


### Motivation
<!-- What inspired you to submit this pull request?-->

Response to bug report on twtr https://twitter.com/BioPressTwo/status/1351965081240825859

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ericmustin/fixredisk8sconfig/agent/kubernetes/log/?tab=configmap

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
