### PR TITLE
add update time for alert history page

### DIFF
--- a/content/en/monitors/faq/how-can-i-export-alert-history.md
+++ b/content/en/monitors/faq/how-can-i-export-alert-history.md
@@ -3,7 +3,7 @@ title: Export Monitor Alerts to CSV
 kind: faq
 ---
 
-Download a history of monitor alerts through the [hourly monitor data][1], which generates a CSV for the past 6 months (182 days). This CSV is **not** live; it is updated once a week.
+Download a history of monitor alerts through the [hourly monitor data][1], which generates a CSV for the past 6 months (182 days). This CSV is **not** live; it is updated once a week on Monday at 11:59AM UTC. 
 
 **Note**: You need to be an administrator of your organization to access the CSV file.
 


### PR DESCRIPTION
### What does this PR do?
Add the time at which the report is updated on a weekly basis.

### Motivation
The page was saying weekly but not when it was happening. 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/update-time-alert-history/monitors/faq/how-can-i-export-alert-history/?tab=us#pagetitle

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
