### PR TITLE
Changing the title to refer to scrubbing

### DIFF
--- a/content/en/agent/faq/commonly-used-log-processing-rules.md
+++ b/content/en/agent/faq/commonly-used-log-processing-rules.md
@@ -1,5 +1,5 @@
 ---
-title: Commonly Used Log Processing Rules
+title: Commonly Used Log Scrubbing Rules
 kind: faq
 further_reading:
 - link: "logs/processing"


### PR DESCRIPTION
### What does this PR do?
Change the guide title to include `scrubbing` into it.

### Motivation
There was no mention of scrubbing when the whole guilde is about scrubbing patterns.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/title-change-guide-scrubbing/agent/faq/commonly-used-log-processing-rules/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
