### PR TITLE
Simplify Ruby code using safe navigation operator

### DIFF
--- a/content/en/tracing/setup_overview/custom_instrumentation/ruby.md
+++ b/content/en/tracing/setup_overview/custom_instrumentation/ruby.md
@@ -45,7 +45,7 @@ class ShoppingCartController < ApplicationController
     # Get the active span
     current_span = Datadog.tracer.active_span
     # customer_id -> 254889
-    current_span.set_tag('customer.id', params.permit([:customer_id])) unless current_span.nil?
+    current_span&.set_tag('customer.id', params.permit([:customer_id]))
 
     # [...]
   end


### PR DESCRIPTION
The current Ruby code example is a bit confusing since in our documentation page (<https://docs.datadoghq.com/tracing/setup_overview/custom_instrumentation>) we render the `unless` in a separate line:
 ![](https://i.imgur.com/UB4p8Rk.png)

By using the safe navigation operator, we get the same behavior, and it all fits in the same line.
This operator was introduced 5+ years ago in Ruby 2.3, so it should be usable by most customers.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

---

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Improve the code example for using `set_tag` inside an active span.

### Motivation
<!-- What inspired you to submit this pull request?-->
The current layout of the documentation with the `unless` on the next line seems a bit confusing.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Another alternative would be to switch to a regular `if`:

```ruby
if current_span
  current_span.set_tag(...)
end
```

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
