### PR TITLE
Remove custom error handler from default behavior example

### DIFF
--- a/content/en/tracing/setup_overview/custom_instrumentation/ruby.md
+++ b/content/en/tracing/setup_overview/custom_instrumentation/ruby.md
@@ -136,7 +136,7 @@ def example_method
   raise StandardError.new "This is a exception"
 end
 
-Datadog.tracer.trace('example.trace', on_error: custom_error_handler) do |span|
+Datadog.tracer.trace('example.trace') do |span|
   example_method()
 end
 ```


### PR DESCRIPTION
The `custom_error_handler` reference only makes sense within the "custom behavior" example, not in the "default behavior one".

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fix one of the Ruby code examples.

### Motivation
<!-- What inspired you to submit this pull request?-->
Was going through the documentation to learn.

### Preview
<!-- Impacted pages preview links-->

https://docs-staging.datadoghq.com/ivoanjo/remove-custom-handler-from-default-example/tracing/setup_overview/custom_instrumentation/ruby/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
