### PR TITLE
[NET-1022] Update network metric names

### DIFF
--- a/content/en/network_performance_monitoring/network_map.md
+++ b/content/en/network_performance_monitoring/network_map.md
@@ -36,9 +36,11 @@ Use the page header to configure your network map:
 
     - Throughput sent
     - Throughput received
-    - Retransmits
-    - Round-trip time
-    - Round-trip time variance
+    - TCP Retransmits
+    - TCP Latency
+    - TCP Jitter
+    - Established Connnections
+    - Closed Connections
 
 3. Filter the connections you want to display. You can choose whether or not to:
 

--- a/content/en/network_performance_monitoring/network_page.md
+++ b/content/en/network_performance_monitoring/network_page.md
@@ -87,11 +87,11 @@ TCP is a connection-oriented protocol that guarantees in-order delivery of packe
 
 | Metric                    |  Description                                                                                                                           |
 | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| **Retransmits**           | Retransmits represent detected failures that are retransmitted to ensure delivery. Measured in count of retransmits from the `source`. |
-| **Round-trip Time (RTT)** | Round-trip time is a proxy for latency. Measured as the time between a TCP frame being sent and acknowledged.                          |
-|  **RTT Variance**         | RTT is a proxy for jitter.                                                                                                             |
-|  **Established Connections**         | The number of TCP connections in an established state. Measured in connections per second from the `source`.                                                                                                              |
-|  **Closed Connections**         | The number of TCP connections in a closed state. Measured in connections per second from the `source`.                                                                                                            |
+| **TCP Retransmits** | TCP Retransmits represent detected failures that are retransmitted to ensure delivery. Measured in count of retransmits from the `source`. |
+| **TCP Latency** | Measured as TCP round-trip time, that is the time between a TCP frame being sent and acknowledged. |
+| **TCP Jitter** | Measured as TCP round-trip time variance. |
+| **Established Connections** | The number of TCP connections in an established state. Measured in connections per second from the `source`. |
+| **Closed Connections** | The number of TCP connections in a closed state. Measured in connections per second from the `source`. |
 
 ### DNS Resolution
 
@@ -113,11 +113,11 @@ To view pre-NAT and post-NAT IPs, use the _Show pre-NAT IPs_ toggle in the table
 
 NPM users may configure their networks to have overlapping IP spaces. For instance, you may want to deploy in multiple VPCs (virtual private clouds) which have overlapping address ranges and communicate only through load balancers or cloud gateways.
 
-To correctly classify traffic destinations, NPM uses the concept of a network ID, which is represented as a tag. A network ID is an alphanumeric identifier for a set of IP addresses that can communicate with one another. When an IP address mapping to several hosts with different network IDs is detected, this identifier is used to determine the particular host network traffic is going to or coming from. 
+To correctly classify traffic destinations, NPM uses the concept of a network ID, which is represented as a tag. A network ID is an alphanumeric identifier for a set of IP addresses that can communicate with one another. When an IP address mapping to several hosts with different network IDs is detected, this identifier is used to determine the particular host network traffic is going to or coming from.
 
 In AWS and GCP, the network ID is automatically set to the VPC ID. For other environments, the network ID may be set manually, either in `datadog.yaml` as shown below, or by adding the `DD_NETWORK_ID` to the process and core Agent containers.
 
-  ```shell 
+  ```shell
   network:
      Id: <your-network-id>
   ```

--- a/content/en/network_performance_monitoring/network_page.md
+++ b/content/en/network_performance_monitoring/network_page.md
@@ -88,8 +88,8 @@ TCP is a connection-oriented protocol that guarantees in-order delivery of packe
 | Metric                    |  Description                                                                                                                           |
 | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | **TCP Retransmits** | TCP Retransmits represent detected failures that are retransmitted to ensure delivery. Measured in count of retransmits from the `source`. |
-| **TCP Latency** | Measured as TCP round-trip time, that is the time between a TCP frame being sent and acknowledged. |
-| **TCP Jitter** | Measured as TCP round-trip time variance. |
+| **TCP Latency** | Measured as TCP smoothed round-trip time, that is the time between a TCP frame being sent and acknowledged. |
+| **TCP Jitter** | Measured as TCP smoothed round-trip time variance. |
 | **Established Connections** | The number of TCP connections in an established state. Measured in connections per second from the `source`. |
 | **Closed Connections** | The number of TCP connections in a closed state. Measured in connections per second from the `source`. |
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

This updates the Network Page and Network Map documentation pages to reflect our recent UI tweaks:
- added `Established Connections` and `Closed Connections` as available metrics on the map
- renamed RTT and RTT Variance into Latency and Jitter

### Motivation

https://datadoghq.atlassian.net/browse/NET-1022

### Preview

https://docs-staging.datadoghq.com/gauthier/rename-tcp-metrics/network_performance_monitoring/network_page/#tcp
https://docs-staging.datadoghq.com/gauthier/rename-tcp-metrics/network_performance_monitoring/network_map/#configuration

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
