### PR TITLE
bring back url with region in curl

### DIFF
--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -95,6 +95,7 @@
 
       <!-- Get the general API server url for this version -->
       {{ $generalRegions := partial "api/regions.html" (dict "servers" $adat.servers) }}
+      {{ $dot.Scratch.Set "regions" $generalRegions }}
 
       <!-- for accessing v1/v2 resources from latest -->
       {{ $resourcePage := $dot.Site.GetPage (print "/api/" $versionNum "/" (path.Base $dot.File.Dir) "") }}


### PR DESCRIPTION
### What does this PR do?

fixes missing full url in generated curl examples

### Motivation

in slack

### Preview

e.g
https://docs-staging.datadoghq.com/david.jones/curl-region/api/latest/dashboard-lists/

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
