### PR TITLE
[dd-trace-rb] Use release branch for Ruby tracer doc source

### DIFF
--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -153,7 +153,7 @@
   - repo_name: dd-trace-rb
     contents:
     - action: pull-and-push-file
-      branch: master
+      branch: release
       globs:
       - 'docs/GettingStarted.md'
       options:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -153,7 +153,7 @@
   - repo_name: dd-trace-rb
     contents:
     - action: pull-and-push-file
-      branch: master
+      branch: release
       globs:
       - 'docs/GettingStarted.md'
       options:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

Affected page: https://docs.datadoghq.com/tracing/setup_overview/setup/ruby/

### What does this PR do?
Changes the source for the automatic pulling of `dd-trace-rb` documentation to a dedicated [`release`](https://github.com/DataDog/dd-trace-rb/tree/release) branch, instead of the continuously updated `master` branch.

The Ruby team will maintain, this new `release` branch, and update it with changes only when they are publicly available.

### Motivation
Unreleased changes can sit on `dd-trace-rb`'s master branch for days before a release. This can cause clients to have mismatching documentation for the currently available version of the tracer.

### Preview

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/dd-tracer-rb-use-non-master-branch/tracing/setup_overview/setup/ruby/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
