### PR TITLE
Fix formatting for log timestamp guide

### DIFF
--- a/content/en/logs/faq/why-do-my-logs-not-have-the-expected-timestamp.md
+++ b/content/en/logs/faq/why-do-my-logs-not-have-the-expected-timestamp.md
@@ -30,6 +30,7 @@ However, this default timestamp does not always reflect the actual value that mi
     But we can extract the timestamp from the message to override the actual log date for both raw and JSON logs.
 
 2. **Raw logs**.
+
     2.1 **Extract the timestamp value with a parser**.
         While writing a parsing rule for your logs, you need to extract the timestamp in a specific attribute. [Refer to some specific date parsing examples to help you][2].
         For the above log, we would use the following rule with the `date()` [matcher][3] to extract the date and pass it into a custom date attribute:
@@ -44,6 +45,7 @@ However, this default timestamp does not always reflect the actual value that mi
         {{< img src="logs/faq/log_timestamp_5.png" alt="Log post processing with new timestamp"  style="width:70%;" >}}
 
 3. **JSON logs**.
+
     3.1 **Supported Date formats**.
         JSON logs are automatically parsed in Datadog.
         The log `date` attribute is one of the [reserved attributes][5] in Datadog which means JSON logs that use those attributes have their values treated specially - in this case to derive the log's date. Change the default remapping for those attribute at the top of your Pipeline as explained [in the edit reserved attributes documentation][6].


### PR DESCRIPTION
### What does this PR do?
Fix formating for the guide as the section title were on the same line as the titles

### Motivation
Bad formating

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/formating-log-timestamp-guide/logs/faq/why-do-my-logs-not-have-the-expected-timestamp/#pagetitle

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
