### PR TITLE
Lint Headings for Account Management

### DIFF
--- a/content/en/account_management/api-app-keys.md
+++ b/content/en/account_management/api-app-keys.md
@@ -64,11 +64,11 @@ Using multiple API keys lets you rotate keys as part of your security practice, 
 
 If your organization needs more than the built-in limit of five API keys, contact [Support][6] to ask about increasing your limit.
 
-## Disabling a User Account
+## Disabling a user account
 
 If a user's account is disabled, any application keys that the user created are deleted. Any API keys that were created by the disabled account are not deleted, and are still valid.
 
-## Transferring API/Application Keys
+## Transferring keys
 
 Due to security reasons, Datadog does not transfer API/application keys from one user to another. The recommended best practice is to keep track of API/application keys and rotate those keys once a user has left the company. This way, a user that has left the company no longer has access to your account and Datadog’s API. Transferring the API/application key allows a user that no longer remains with the company to continue to send and receive data from the Datadog API. Customers have also asked to change the handle that the API/application keys are associated with. This, however, does not resolve the inherent issue: that a user that no longer remains with the company continues to have the ability to send and retrieve data from the Datadog API.
 

--- a/content/en/account_management/authn_mapping/_index.md
+++ b/content/en/account_management/authn_mapping/_index.md
@@ -22,7 +22,7 @@ All the API endpoints below are using the following host endpoint:
 
 * `https://api.{{< region-param key="dd_site" >}}/api/` for your Datadog region.
 
-### Create a new Authentication mapping
+### Create a new authentication mapping
 
 Create a new AuthN Mapping from a JSON body. Returns the newly created AuthN Mapping.
 
@@ -141,7 +141,7 @@ curl -X POST \
 {{% /tab %}}
 {{< /tabs >}}
 
-### Get all AuthN Mappings
+### Get all AuthN mappings
 
 Returns a list of AuthN Mappings
 
@@ -246,7 +246,7 @@ curl -X GET "https://api.<YOUR_DD_SITE>/api/v2/authn_mappings" \
 {{% /tab %}}
 {{< /tabs >}}
 
-### Get a specific AuthN Mapping
+### Get a specific AuthN mapping
 
 Returns a specific AuthN Mapping by UUID.
 
@@ -499,9 +499,9 @@ HTTP/2 204
 {{% /tab %}}
 {{< /tabs >}}
 
-### Get Authn Mapping Enablement
+### Get AuthN mapping enablement
 
-Check whether Authn Mappings are enabled or disabled.
+Check whether AuthN Mappings are enabled or disabled.
 
 | Method   | Endpoint path              | Required payload |
 |----------|----------------------------|------------------|
@@ -541,7 +541,7 @@ curl -X GET \
 {{% /tab %}}
 {{< /tabs >}}
 
-### Enable/Disable All Mappings
+### Enable or disable all mappings
 
 <div class="alert alert-warning">
 When enabled all users logging in with SAML will be stripped of any roles they have currently and reassigned roles based on the values in their SAML Assertion. It's important that you confirm you are receiving the expected SAML Assertions in your login before enabling the Mapping enforcement.

--- a/content/en/account_management/billing/apm_distributed_tracing.md
+++ b/content/en/account_management/billing/apm_distributed_tracing.md
@@ -18,11 +18,11 @@ Note: If you're using a container based environment, you get billed for underlyi
 
 For more information, see the [Pricing page][6].
 
-## Sample Deployment Scenarios
+## Deployment scenarios
 
 **Sample cases illustrate annual billing rates with default 15 days Indexed Span retention. Contact [Sales][6] or your [Customer Success][7] Manager to discuss volume discounts for your account.**
 
-### Case 1: Hosts, Indexed Spans, and extra Ingested Spans
+### Hosts, indexed spans, and extra ingested Spans
 
 Using 5 hosts and sending 30 million Indexed Spans, with 900 GB of total Ingested Spans.
 
@@ -33,7 +33,7 @@ Using 5 hosts and sending 30 million Indexed Spans, with 900 GB of total Ingeste
 | Ingested Spans | 900 GB          | 750 GB included with 5 APM hosts. $.10 per GB for additional 150 GB of Ingested Spans.                                                                                 | 150 * $.10      | $15                  |
 | Total          |            |                                                                                                 | $155 + $42.50 + $15 | **$212.50 per month** |
 
-### Case 2: Hosts, Fargate, and Indexed Spans
+### Hosts, Fargate, and indexed spans
 
 Using 5 hosts, sending 20 million Indexed Spans, and have deployed APM on average 20 Fargate Tasks over the month.
 
@@ -44,7 +44,7 @@ Using 5 hosts, sending 20 million Indexed Spans, and have deployed APM on averag
 | Indexed Spans | 20 million | 5 million included with 5 APM hosts. 1.3 million included with 20 Fargate tasks. $1.70 per million for additional 13.7 million Indexed Spans | 13.7 * $1.70          | $23.29                |
 | Total          |            |                                                                                                 | $155 + $40 + $23.29 | **$218.29 per month** |
 
-### Case 3: Services, Containers and Indexed Spans
+### Services, containers, and indexed spans
 
 Service 1 running on container 1, service 2 running on container 2. Both Containers are running on 1 host and are sending 20 million Indexed Spans on App Analytics.
 
@@ -54,7 +54,7 @@ Service 1 running on container 1, service 2 running on container 2. Both Contain
 | Indexed Spans | 20 million | 1 million included with 1 APM host. $1.70 per million for additional 19 million Indexed Spans | 19 * $1.70   | $32.30               |
 | Total          |            |                                                                                                | $31 + $32.30 | **$63.30 per month** |
 
-### Case 4: Dynamic Scaling Hosts, Containers, Fargate and no Indexed Spans
+### Dynamic scaling hosts, containers, Fargate, and no indexed spans
 
 App 1 running on 20-40 containers which are deployed on 4-8 host instances, app 2 running on 10-30 Fargate tasks and you're not using App Analytics. Assuming, the 99th percentile usage of EC2 instances is 7, and average of Fargate Tasks over the month is 28.
 
@@ -66,7 +66,7 @@ App 1 running on 20-40 containers which are deployed on 4-8 host instances, app 
 
 Note that the container count will not matter if the deployed agent is on the EC2 instances.
 
-### Case 5: Kubernetes Nodes and Indexed Spans
+### Kubernetes nodes and indexed spans
 
 Agent running on 20 worker nodes in Kubernetes sending 20 million Indexed Spans.
 
@@ -78,7 +78,7 @@ Agent running on 20 worker nodes in Kubernetes sending 20 million Indexed Spans.
 
 For Kubernetes, APM is priced by nodes not by pods.
 
-### Case 6: Lambda Functions and Indexed Spans
+### Lambda functions and indexed spans
 
 Continuously invoking 20 Lambda functions every hour for an entire month while sending 10 million Indexed Spans.
 
@@ -89,7 +89,7 @@ Continuously invoking 20 Lambda functions every hour for an entire month while s
 | Total             |            |                                                                             | $100 + $11.90 | **$119.90 per month** |
 
 
-## FAQs
+## FAQ
 
 **1. What is classified as an APM host for billing?**
 

--- a/content/en/account_management/billing/custom_metrics.md
+++ b/content/en/account_management/billing/custom_metrics.md
@@ -9,7 +9,7 @@ If a metric is not submitted from one of the [more than {{< translate key="integ
 
 **A custom metric is uniquely identified by a combination of a metric name and tag values (including the host tag)**.
 
-## Counting Custom Metrics
+## Counting custom metrics
 
 The number of custom metrics associated with a particular metric name depends on its metric [submission type][3]. Below are examples of how to count your custom metrics based on the following scenario below:
 

--- a/content/en/account_management/billing/google_cloud.md
+++ b/content/en/account_management/billing/google_cloud.md
@@ -9,7 +9,7 @@ Datadog bills for hosts running the Agent and all GCE instances picked up by the
 
 Other Google Cloud resources (CloudSQL, Google App Engine, Pub/Sub, etc.) are not part of monthly billing.
 
-## Google Cloud Metric exclusion
+## Google Cloud metric exclusion
 
 Use the [Google Cloud integration tile][1] to control your metric collection. Go to the **Configuration** tab and select a project or add a new one. Each project is controlled under **Optionally Limit Metrics Collection to hosts with tag**. Limit metrics by [host tag][2]:
 

--- a/content/en/account_management/billing/log_management.md
+++ b/content/en/account_management/billing/log_management.md
@@ -10,7 +10,7 @@ At the end of the month, we compute the total number of log events that have bee
 - If you are below commitment, your bill stays the same.
 - If you over-consume, we subtract the committed amount and **on demand usage** is charged with a 50% premium.
 
-### On Demand
+### On demand
 
 With Datadog log management, you define a monthly commitment on indexed log events. However, during troubling times the number of logs can spike and you may go above your commitment. Because it's important to keep visibility on your infrastructure health, you are not limited to your monthly commitment.
 

--- a/content/en/account_management/billing/profiler.md
+++ b/content/en/account_management/billing/profiler.md
@@ -12,11 +12,11 @@ kind: documentation
 
 **Note:** One profiled container is a container that is running the Continuous Profiler service. This does not include containers that are not being profiled. For instance, a DNS service container that is NOT profiled, running concurrently with your application container that IS profiled, will not be counted towards the four profiler containers allotment.
 
-## Sample Deployment Scenarios
+## Deployment scenarios
 
 These sample cases demonstrate common use cases using annual billing rates. Contact Sales or your [Customer Success Manager][3] to discuss volume discounts for your account.
 
-### Case 1: Hosts with no Containers
+### Hosts with no containers
 
 Using five hosts running one application being profiled in each host. No containers.  
 
@@ -27,7 +27,7 @@ Using five hosts running one application being profiled in each host. No contain
 | Total          |            |                                                                                                 | $60 + $0      | **$60 per month**    |
 
 
-### Case 2: Hosts with four Profiled Containers
+### Hosts with four profiled containers
 
 Using five hosts with four profiled containers each. A profiled container is a container that is running the Continuous Profiler service by sending profiling data from the container to the Datadog Agent. This does not include containers that are not being profiled.
 
@@ -38,7 +38,7 @@ Using five hosts with four profiled containers each. A profiled container is a c
 | Total          |            |                                                                                                 | $60 + $0      | **$60 per month**    |
 
 
-### Case 3: Hosts with 6 Profiled Containers
+### Hosts with six profiled containers
 
 Using five hosts with six profiled containers per each host. A profiled container is a container that is running the Continuous Profiler service by sending profiling data from the container to the Datadog Agent. This does not include containers that are not being profiled.
 
@@ -49,7 +49,7 @@ Using five hosts with six profiled containers per each host. A profiled containe
 | Total          |            |                                                                                                 | $60 + $20      | **$80 per month**    |
 
 
-### Case 4: Hosts with 5 Containers but only 2 are Profiled
+### Hosts with five containers but only two are profiled
 
 Using four hosts with five containers per host but only two of them are profiled containers . A profiled container is a container that is running the Continuous Profiler service by sending profiling data from the container to the Datadog Agent. This does not include containers that are not being profiled.
 
@@ -60,7 +60,7 @@ Using four hosts with five containers per host but only two of them are profiled
 | Total          |            |                                                                                                 | $60 + $0      | **$60 per month**    |
 
 
-### Case 5: Hosts with Varying Numbers of Profiled Containers
+### Hosts with varying numbers of profiled containers
 
 Using two profiled hosts - Host A and Host B.
 
@@ -79,7 +79,7 @@ In this scenario, we aggregate all containers across all hosts (so two hosts, 10
 | Total          |            |                                                                                                 | $24 + $4      | **$28 per month**    |
 
 
-## FAQs
+## FAQ
 **1. What is classified as a Continuous Profiler host for billing?**
 
 A host is a physical or virtual operating system instance. Datadog records the number of hosts you are concurrently monitoring in the Datadog Infrastructure service once an hour. For billing a Continuous Profiler, the number of hosts with a Profiler library installed and sending profiles are calculated every hour. These hourly measurements are ordered from highest to lowest at the end of the month, and Datadog charges based on the ninth-highest measurement (eighth-highest only in February).

--- a/content/en/account_management/billing/serverless.md
+++ b/content/en/account_management/billing/serverless.md
@@ -9,7 +9,7 @@ Purchase Serverless functions on [Datadog Pro and Enterprise plans][1]. Datadog 
 
 **Note:** Indexed Spans were formerly known as Analyzed Spans and renamed with the launch of Tracing Without Limits on October 20th, 2020.
 
-## Serverless Functions
+## Serverless functions
 
 Every hour, Datadog records the number of functions that were executed one or more times and monitored by your Datadog account. At the end of the month, Datadog charges by calculating the average of the hourly number of functions recorded.
 
@@ -17,7 +17,7 @@ The billed number of functions is almost always significantly lower than the num
 
 For Serverless pricing information, see the infrastructure section in [Datadog's pricing page][1].
 
-## Tracking Usage
+## Tracking usage
 
 You can track the number of billable Serverless functions in your account by checking the [Datadog Usage Page][4]. You can see both the Month-To-Date summary, as well as usage over time.
 

--- a/content/en/account_management/billing/usage_attribution.md
+++ b/content/en/account_management/billing/usage_attribution.md
@@ -45,7 +45,7 @@ The **Applied Tags** section enables the following:
 - If tags are changed, the new reports will reflect the new tags. However, the previous reports will keep the old ones.
 - Monthly reports reflect the latest set of tags. If you change tags mid-month, the usage percentages might not match up.
 
-### Monthly Usage Attribution
+### Monthly usage attribution
 
 Once the reports start being generated, they are updated daily and aggregated monthly in this table.
 
@@ -59,7 +59,7 @@ Once the reports start being generated, they are updated daily and aggregated mo
 
 Monthly data can also be pulled using the tool's public API. (See the [API endpoint documentation][1]).
 
-### Daily Usage Attribution
+### Daily usage attribution
 
 This section provides daily reports at an hourly granularity to dig into timeframes. It also provides a concatenation of all reports during a given month.
 
@@ -85,7 +85,7 @@ The table below shows a sample daily report for Custom Metrics usage two tags: `
 - `|` (pipe) separated values (for example, `service1 | service2`) mean that a particular tag was applied multiple times on the resource.
 - A valid tag value (see the [Defining Tags documentation][3]) refers to the actual value of the respective tag.
 
-#### Further Data Analysis
+#### Further data analysis
 
 When using multiple tags, both the Daily and Monthly Usage Attribution reports contain data for all possible combinations of those tags, and are suitable to use as base datasets for further data analysis tasks. For instance, you can use grouping or pivoting to produce views focused on a subset of the tags, or to perform aggregations across custom date ranges.
 

--- a/content/en/account_management/billing/usage_details.md
+++ b/content/en/account_management/billing/usage_details.md
@@ -18,7 +18,7 @@ Certain product tabs also contain additional tools:
 * Custom Metrics Tab: Top Custom Metrics
 * Log Management Tab: Logs Usage by Index
 
-## Month-to-Date Summary
+## Month-to-date summary
 
 This section summarizes your month-to-date usage. In the "All" tab, you will see your month-to-date usage of infrastructure hosts, containers, custom metrics, APM hosts, logs and any other part of the platform you've used during the month. 
 
@@ -56,7 +56,7 @@ Month-to-date usage of each product is calculated as follows:
 | Synthetic Browser Tests  | Shows the sum of all Synthetic browser tests over all hours in the current month.                                           |
 | RUM Sessions             | Shows the sum of all distinct RUM sessions over all hours in the current month.                                             |
 
-## Overall Usage
+## Overall usage
 
 This section contains hourly, daily, monthly, and annual usage:
 
@@ -73,7 +73,7 @@ In product specific tabs, you will see your hourly, daily, monthly, and annual u
 
 {{< img src="account_management/billing/usage-details-v2-04.png" alt="Hourly Usage - Infra Hosts" >}}
 
-## Top Custom Metrics
+## Top custom metrics
 
 In the Custom Metrics tab, this table lists the following information about your Top 5000 custom metrics month-to-date usage and most recent day usage (i.e., usage on the date of the last update):
 
@@ -86,7 +86,7 @@ This data can be downloaded as a CSV file.
 
 {{< img src="account_management/billing/usage-details-v2-05.png" alt="Custom Metrics" >}}
 
-## Logs Usage by Index
+## Logs usage by index
 
 In the Log Management tab, this table displays your hourly, daily, monthly, and annual indexed log usage by index name and retention period. The following information is provided:
 

--- a/content/en/account_management/billing/usage_monitor_apm.md
+++ b/content/en/account_management/billing/usage_monitor_apm.md
@@ -8,7 +8,7 @@ Read APM documentation on [APM Billing][2] to understand how billing works for A
 
 **Note:** Indexed Spans were formerly known as Analyzed Spans and renamed with the launch of Tracing Without Limits on October 20th, 2020.
 
-## Usage Page
+## Usage page
 
 If you are an admin of your account, you can view your account usage using the [Usage Page][3] which gets updated every 72 hours.
 
@@ -18,7 +18,7 @@ If you are an admin of your account, you can view your account usage using the [
 | Indexed Spans | Shows the sum of all Indexed Spans indexed over all hours in the current month.         |
 | Fargate Tasks  | Shows the average of all Fargate tasks over all hours in the current month.              |
 
-## Set Alert on APM Hosts
+## Set alert on APM hosts
 
 To get alerts in case a code deployment scales the number of hosts sending traces, set up monitor on APM host count. Get notified if the host volumes in any scope (`prod`, `availablity-zone`, etc…) of your infrastructure is growing unexpectedly:
 
@@ -29,7 +29,7 @@ To get alerts in case a code deployment scales the number of hosts sending trace
 3. Define the rate you would like to set as a warning or error.
 4. Define an explicit notification: The volume of hosts on this env just got too high has exceeded the allocated threshold value. Scale down the number of APM enabled hosts.
 
-## Set Alert on Indexed Spans
+## Set alert on indexed spans
 
 To get alerts in case a code deployment causes a spike in Indexed Spans generated, set up [Analytics monitors][5] on Indexed Spans. Get notified at any moment if the Indexed Span volumes in any infrastructure scope (for example,`service`, `availability-zone`) is growing unexpectedly:
 

--- a/content/en/account_management/faq/_index.md
+++ b/content/en/account_management/faq/_index.md
@@ -4,7 +4,7 @@ kind: faq
 private: true
 ---
 
-## Account Management
+## Account management
 
 * [Are my data and credentials safe?][1]
 * [Help! My Password email never came through!][2]
@@ -12,13 +12,13 @@ private: true
 * [What are Datadog's password requirements?][4]
 * [How do I access my support ticket?][5]
 
-## Service Providers
+## Service providers
 
 * [How do I add new users to sub-organizations?][6]
 * [As a parent account admin, how do I create new sub-organizations?][7]
 * [Do you support custom domains for each of my sub-organizations?][8]
 
-## Communication and Security
+## Communication and security
 
 * [How do I configure Azure AD as a SAML IdP?][9]
 * [Why are users being added as "none none"?][10]

--- a/content/en/account_management/faq/usage_control_apm.md
+++ b/content/en/account_management/faq/usage_control_apm.md
@@ -14,7 +14,7 @@ Read APM documentation on [APM Billing][2] to understand how billing works for A
 
 App Analytics is billed on the basis of [Indexed Span][3] count. You can choose to configure [App Analytics][4] per service to manually control the number of Indexed Spans being generated using the following tools. Note that this, however, limits App Analytics functionality on those services or integration.
 
-## Choose Indexed Span Retention
+## Indexed span retention
 
 App Analytics Pricing depends on the retention policy of Indexed Spans. You can control your bill by choosing the duration Indexed Spans are retained for.
 
@@ -27,7 +27,7 @@ App Analytics Pricing depends on the retention policy of Indexed Spans. You can 
 
 Prices reflect annual billing. Contact [Sales][5] or your [Customer Success][6] Manager to discuss volume discounts for your account.
 
-## Indexed Span Estimator
+## Indexed span estimator
 
 [Indexed Span Estimator][7] is designed to help you decide which services to configure with App Analytics while keeping usage and cost in your control.
 
@@ -45,7 +45,7 @@ For example, if you have 1,750,000,000 Indexed Spans per month for 15 days (defa
 
 1,750,000,000 Indexed Spans per month * $1.70 / 1 million Indexed Spans = **$2,975 per month** for App Analytics
 
-## Indexed Span Filtering
+## Indexed span filtering
 
 [Span filtering][9] is configured to send Indexed Spans at 100% throughput by default. For example, a Java service with 100 requests generates 100 Indexed Spans from its `servlet.request` spans, as each `servlet.request` span generates an Indexed Span.
 

--- a/content/en/account_management/multi_organization.md
+++ b/content/en/account_management/multi_organization.md
@@ -60,7 +60,7 @@ To configure SAML for multi-organizations:
 2. Invite SAML users.
 3. Login as a SAML user and set SAML.
 
-## Multi-Org Usage
+## Multi-org usage
 
 The parent-organization can view the total and billable usage of all their organizations (child and parent organizations) by hovering over their username at the bottom left and then navigating to: `Plan & Usage`--> `Multi-Org Usage`.
 
@@ -69,7 +69,7 @@ The Multi-Org Usage tab shows the aggregate usage of the parent-organization and
 * Month-to-date Usage
 * Long-Term Trends
 
-### Month-to-Date Usage
+### Month-to-date usage
 
 This view contains an Overall Usage section and an Individual Organization Usage section.
 
@@ -85,13 +85,13 @@ To view only the usage that will count toward your bill, you can switch to the "
 
 The month-to-date usage and last month’s usage can be downloaded as a CSV file.
 
-### Long-Term Trends
+### Long-term trends
 
 This tab shows the monthly aggregate usage across all organizations over the past 6 months. The usage shown here is "All" usage not "Billable" usage, which means it does not adjust for trial periods or other billing changes used to calculate your final bill.
 
 This information can be downloaded as a CSV file.
 
-## Usage Attribution
+## Usage attribution
 
 The parent-organization can view the usage of child-organizations by existing tag keys in the [Usage Attribution][10] page. Admins can hover over their username at the bottom left, then navigate to: `Plan & Usage`--> `Usage Attribution`.
 

--- a/content/en/account_management/rbac/_index.md
+++ b/content/en/account_management/rbac/_index.md
@@ -28,7 +28,7 @@ By granting permissions to roles, any user who is associated with that role rece
 
   **Note** If you use a SAML identity provider, you can integrate it with Datadog for authentication, and you can map identity attributes to Datadog default and custom roles. For more information, see [Single Sign On With SAML][1].
 
-## Datadog Default Roles
+## Datadog default roles
 
 | Role                       | Description                                                                                                                                                                                                                                  |
 | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -36,7 +36,7 @@ By granting permissions to roles, any user who is associated with that role rece
 | **Datadog Standard Role**  | Users are allowed to view and modify all monitoring features that Datadog offers, such as [dashboards][2], [monitors][3], [events][4], and [notebooks][5]. Standard users can also invite other users to organizations.                      |
 | **Datadog Read Only Role** | Users do not have access to edit within Datadog. This comes in handy when you'd like to share specific read-only views with a client, or when a member of one business unit needs to share a [dashboard][2] with someone outside their unit. |
 
-## Custom Roles
+## Custom roles
 
 <div class="alert alert-warning">
 Creating and modifying custom roles is an opt-in Enterprise feature. <a href="/help">Contact Datadog support</a> to get it enabled for your account.
@@ -76,7 +76,7 @@ Find an example of how to create a Role in the [Datadog Create Role API document
 {{% /tab %}}
 {{< /tabs >}}
 
-### Update a Role
+### Update a role
 
 {{< tabs >}}
 {{% tab "Datadog application" %}}
@@ -105,7 +105,7 @@ Find an example of how to update a Role in the [Datadog Create Role API document
 {{% /tab %}}
 {{< /tabs >}}
 
-### Delete a Role
+### Delete a role
 
 {{< tabs >}}
 {{% tab "Datadog application" %}}

--- a/content/en/account_management/rbac/permissions.md
+++ b/content/en/account_management/rbac/permissions.md
@@ -35,7 +35,7 @@ By default, existing users are already associated with one of the three out-of-t
 
 In addition of the general permissions, it is possible to define more granular permissions for specific assets or data types. Permissions can be either global or scoped to a subset of elements. Find below the details of these options and the impact they have on each available permission.
 
-## Access Management
+## Access management
 
 Find below the list of permissions for Access Management:
 

--- a/content/en/account_management/saml/_index.md
+++ b/content/en/account_management/saml/_index.md
@@ -140,7 +140,7 @@ If you do not use the updated SP Metadata, Datadog is not able to associate the 
 
 ### SAML strict
 
-With SAML Strict mode enabled, all users must log in with SAML. An existing username/password or Google OAuth login does not work. This ensures that all users with access to Datadog must have valid credentials in your company’s identity provider/directory service to access your Datadog account.
+With SAML strict mode enabled, all users must log in with SAML. An existing username/password or Google OAuth login does not work. This ensures that all users with access to Datadog must have valid credentials in your company’s identity provider/directory service to access your Datadog account.
 
 ## Further Reading
 

--- a/content/en/account_management/saml/_index.md
+++ b/content/en/account_management/saml/_index.md
@@ -69,7 +69,7 @@ You can make changes to a mapping by clicking the pencil icon, or remove it by c
 
 Alternatively, you can create and change mappings of SAML attributes to Datadog roles by using the `authn_mappings` endpoint. See [Federated Authentication to Role Mapping API][8] for more information.
 
-## Datadog Service Provider Details
+## Datadog service provider details
 
 * Datadog supports the **HTTP-POST** binding for **SAML2**:
 `urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST`.
@@ -78,7 +78,7 @@ Alternatively, you can create and change mappings of SAML attributes to Datadog 
 * Assertions can be encrypted, but unencrypted assertions are accepted.
 * Reference [Datadog's SP Metadata][5].
 
-## Setting Attributes
+## Setting attributes
 
 Attributes may be included with the Assertion. Datadog looks for 3 Attributes in the AttributeStatement:
 
@@ -116,21 +116,21 @@ For more information about configuring specific IdP's, refer to the following do
 * [Okta][14]
 * [SafeNet][15]
 
-## Additional Features
+## Additional features
 
 The following features can be enabled through the [SAML Configuration dialog][4].
 
-### Just-in-Time (JIT) Provisioning
+### Just in time (JIT) provisioning
 
-With Just-in-Time provisioning, a user is created within Datadog the first time they try to log in. This eliminates the need for administrators to manually create user accounts one at a time. The invitation email is not sent in this case.
+With JIT provisioning, a user is created within Datadog the first time they try to log in. This eliminates the need for administrators to manually create user accounts one at a time. The invitation email is not sent in this case.
 
 Some organizations might not want to invite all of their users to Datadog. If you would like to make changes to how SAML works for your account, contact [Datadog support][2]. It is up to the organization to configure their IdP to not send assertions to Datadog if they don't want a particular user to access Datadog.
 
-Administrators can set the default role for new Just-in-Time users. The default role is **Standard**, but you can choose to add new JIT users as **Read-Only** or even **Administrators**.
+Administrators can set the default role for new JIT users. The default role is **Standard**, but you can choose to add new JIT users as **Read-Only** or even **Administrators**.
 
 {{< img src="account_management/saml/saml_jit_default.png" alt="saml JIT Default"  style="width:50%;" >}}
 
-### IdP Initiated Login
+### IdP initiated login
 
 When the Datadog URL is loaded, the browser is redirected to the customer IdP where the user enters their credentials, then the IdP redirects back to Datadog. Some IdPs have the ability to send an assertion directly to Datadog without first getting an AuthnRequest (IdP Initiated Login).
 
@@ -138,7 +138,7 @@ After enabling the IdP Initiated Login feature (and waiting for caches to clear)
 
 If you do not use the updated SP Metadata, Datadog is not able to associate the assertion with your organization and displays an error page with a message that the SAML response is missing the "InResponseTo" attribute.
 
-### SAML Strict
+### SAML strict
 
 With SAML Strict mode enabled, all users must log in with SAML. An existing username/password or Google OAuth login does not work. This ensures that all users with access to Datadog must have valid credentials in your company’s identity provider/directory service to access your Datadog account.
 

--- a/content/en/account_management/saml/google.md
+++ b/content/en/account_management/saml/google.md
@@ -16,7 +16,7 @@ further_reading:
 
 [See the dedicated Google instructions][1]
 
-## For the "Service Provider Details"
+## Service provider details
 
 **Pre-requisite**: IDP initiated SSO must be checked on Datadog SAML Configuration page
 
@@ -28,7 +28,7 @@ further_reading:
 * **Signed Response**: Leave unchecked
 * **Name ID**: "Basic Information" "Primary Email"
 
-## For the "Attribute Mapping"
+## Attribute mapping
 
 * "urn:oid:1.3.6.1.4.1.5923.1.1.1.6" "Basic Information" "Primary Email"
 

--- a/content/en/account_management/saml/okta.md
+++ b/content/en/account_management/saml/okta.md
@@ -14,7 +14,7 @@ further_reading:
 
 It's recommended that you set up Datadog as an Okta application manually, as opposed to using a 'pre-configured' configuration.
 
-## General Details
+## General details
 
 * **Single Sign On URL**: https://app.datadoghq.com/account/saml/assertion
     (NOTE: If using IdP initiated login, use a public ID-specific URL which is generated after enabling IdP initiated login in Datadog. Find this URL at the '[Configure SAML][1]' page, in the 'Assertion Consumer Service URL' field. Example URL: `https://app.datadoghq.com/account/saml/assertion/id/` This also applies to the **Recipient URL** and the **Destination URL** fields respectively.)
@@ -42,7 +42,7 @@ It's recommended that you set up Datadog as an Okta application manually, as opp
 * **Honor Force Authentication**: Yes
 * **SAML Issuer ID**: `http://www.okta.com/`
 
-## Attribute Statements Details
+## Attribute statements details
 
 * **NameFormat**: urn:oasis:names:tc:SAML:2.0:attrname-format:uri
 * **sn**: user.lastName

--- a/content/en/account_management/saml/safenet.md
+++ b/content/en/account_management/saml/safenet.md
@@ -26,7 +26,7 @@ Follow the [main SAML configuration instructions][2].
 3. On the **Metadata upload** window, click **Browse** to search and select the Datadog metadata obtained previously. The service provider metadata information displays under **Account Details**.
 4. Click **Save Configuration** to save the details and activate the Datadog application in SafeNet Trusted Access.
 
-## Verify Authentication
+## Verify authentication
 
 ### Using STA console
 


### PR DESCRIPTION


### What does this PR do?
Lint headings for the Account Management section, mistakes found using:

```
vale content/en/account_management/*
```

### Motivation
Docs hackathon

### Preview
https://docs-staging.datadoghq.com/ruth/linter-account-management/account_management/

### Additional Notes
The following will be added to the `headings.yml` exceptions list:
  - AuthN
  - Azure App Service Plan
  - Continuous Profiler
  - Fargate
  - Google Cloud
  - Incident Management
  - vSphere
  - Security Monitoring
  - Log Management

Created DOCS-1628 to discuss the RBAC Permissions page

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
