### PR TITLE
Use Vale linter for headings in /metrics docs

### DIFF
--- a/content/en/metrics/_index.md
+++ b/content/en/metrics/_index.md
@@ -41,15 +41,15 @@ Metrics can be sent to Datadog from several places.
 
 - Often, you’ll need to track metrics related to your business (e.g. number of user logins/signups). In these cases, you can create [custom metrics][10]. Custom metrics can be submitted through the [agent][11], [DogStatsD][12], or the [HTTP API][13].
 
-- Additionally, the [Datadog Agent][21] automatically sends several standard metrics (such as CPU and disk usage).
+- Additionally, the [Datadog Agent][14] automatically sends several standard metrics (such as CPU and disk usage).
 
-For a summary of all metric submission sources and methods, please refer to our [Metrics Types documentation][14].
+For a summary of all metric submission sources and methods, please refer to our [Metrics Types documentation][15].
 
-## Querying Metrics
+## Querying metrics
 
 Whether you are using metrics, monitors, dashboards, notebooks, etc., all graphs in Datadog have the same basic functionality. You can create graphs either by using the graphing editor UI or by directly changing the raw query string. To edit the query string, hit the `</>` button on the far right.
 
-### Breaking Down the Metric Query
+### Anatomy of a metric query
 
 A metric query in Datadog looks like this:
 
@@ -57,19 +57,19 @@ A metric query in Datadog looks like this:
 
 We can break this query into a few steps:
 
-#### 1. Metric name
+#### Metric name
 
 First, choose the specific metric that you’d like to graph by searching or selecting it from the dropdown next to Metric. If you’re not sure which metric to use, start with the Metrics Explorer or a notebook. You can also see a list of metrics on the Metrics Summary page.
 
-#### 2. Filter your metric
+#### Filter your metric
 
-After selecting a metric, you can filter your query based on tag(s). For instance, you can use `account:prod` to _scope_ your query to include only the metrics from your production hosts. For more information, please refer to our [Tagging][15] documentation.
+After selecting a metric, you can filter your query based on tag(s). For instance, you can use `account:prod` to _scope_ your query to include only the metrics from your production hosts. For more information, please refer to our [Tagging][16] documentation.
 
-#### 3. Configure Time
+#### Configure time
 
 Next, choose the granularity of your data using time rollup. In this example, we’ve defined that there will be one data point for every six minutes (360 seconds). You can also choose how you want to aggregate the data in each time bucket. By default, _avg_ is applied, but other available options are _sum_, _min_, _max_, and _count_. If you wanted to apply max, you would use `.rollup(max, 60)`.
 
-#### 4. Configure Space
+#### Configure space
 
 In Datadog, “space” refers to the way metrics are distributed over different hosts and tags. There are two different aspects of space that you can control: grouping and aggregation.
 
@@ -77,15 +77,15 @@ _Grouping_ defines what constitutes a line on the graph. For example, if you hav
 
 _Aggregation_ defines how the metrics in each group are combined. There are four aggregations available: sum, min, max, and avg.
 
-#### 5. (optional) Apply Functions
+#### Apply functions (optional)
 
-You can modify your graph values with mathematical [functions][16]. This can mean performing arithmetic between an integer and a metric (e.g. multiply a metric by 2), or between two metrics (e.g. create a new timeseries for the memory utilization rate like this: `jvm.heap_memory / jvm.heap_memory_max`).
+You can modify your graph values with mathematical [functions][17]. This can mean performing arithmetic between an integer and a metric (e.g. multiply a metric by 2), or between two metrics (e.g. create a new timeseries for the memory utilization rate like this: `jvm.heap_memory / jvm.heap_memory_max`).
 
-### Time and Space Aggregation
+### Time and space aggregation
 
 _Time aggregation_ and _space aggregation_ are two important components of any query. Because understanding how these aggregations work will help you avoid misinterpreting your graphs, these concepts are explained in more detail below.
 
-#### Time Aggregation
+#### Time aggregation
 
 Datadog stores a large volume of points, and in most cases it’s not possible to display them all on a graph---there would be more datapoints than pixels. Therefore, we use time aggregation to solve this problem by combining data points into time buckets. This is called a _rollup_. As the time interval you’ve defined for your query increases, the granularity of your data becomes coarser.
 
@@ -93,13 +93,13 @@ There are five aggregations you can apply to combine your data in each time buck
 
 It’s important to remember that time aggregation is _always_ applied in every query you make because we can’t display every point we store.
 
-#### Space Aggregation
+#### Space aggregation
 
 Space aggregation splits a single metric into multiple time series by tags such as host, container, region, etc. For instance, if you were interested in viewing the latency of your EC2 instances by region, you would need to use space aggregation to combine each region’s hosts.
 
 There are four aggregations that can be applied when using space aggregation: _sum_, _min_, _max_, and _avg_. Using the above example, let’s say that your hosts are spread across four regions: us-east-1, us-east-2, us-west-1, and us-west-2. The hosts in each region need to be combined using an aggregator function. Using the _max_ aggregator would result in the maximum latency experienced across hosts in each region, while the _avg_ aggregator would yield the average latency per region.
 
-## Metric Types and Real-time Metrics Visibility
+## Metric types and real-time metrics visibility
 
 ### What metric types can I submit to Datadog?
 
@@ -117,23 +117,23 @@ A **_gauge_** type will take the last value reported during the interval. This t
 
 A **_histogram_** will report five different values summarizing the submitted values: the average, count, median, 95th percentile, and max. This produces five different timeseries. This metric type is suitable for things like latency, for which it’s not enough to know the average value. Histograms allow you to understand how your data was spread out without recording every single data point.
 
-A **_distribution_** is similar to a histogram, but it summarizes values submitted during a time interval across all hosts in your environment. You can also choose to report multiple percentiles: p50, p75, p90, p95, and p99. You can learn more about this powerful feature [here][17].
+A **_distribution_** is similar to a histogram, but it summarizes values submitted during a time interval across all hosts in your environment. You can also choose to report multiple percentiles: p50, p75, p90, p95, and p99. You can learn more about this powerful feature [here][18].
 
 To make this concrete with an example, suppose your host reported metric values of [1,1,1,2,2,2,3,3] during a ten-second interval. Depending on the metric type you chose, Datadog would store completely different values:
 
 _Count_ would add them up and send the value 15 over to our servers, while _rate_ would take the total sum and divide it by 10 seconds to report a value of 1.5. _Gauge_ would simply report the last value, 3. If your metric is a _histogram_, Datadog would receive five different values: avg = 1.88, count = 8, median = 2, p95 = 3, max = 3.
 
-Metric types also determine which graphs and functions are available to use with the metric in the app. Please see the [metrics types][14] documentation for more detailed examples of each metric type and submission instructions.
+Metric types also determine which graphs and functions are available to use with the metric in the app. Please see the [metrics types][15] documentation for more detailed examples of each metric type and submission instructions.
 
 ### How do I view real-time information about my metrics?
 
-The [Metrics Summary page][18] displays a list of your metrics reported to Datadog under a specified time frame: the past hour, day, or week. Metrics can be filtered by metric name or tag.
+The [Metrics Summary page][19] displays a list of your metrics reported to Datadog under a specified time frame: the past hour, day, or week. Metrics can be filtered by metric name or tag.
 
 Click on any metric name to display a sidepanel with more detailed information. The metric panel displays key information for a given metric, including its metadata (type, unit, interval), number of distinct metrics, number of reporting hosts, number of tags submitted, and a table containing all tags submitted on a metric. Seeing which tags are being submitted on a metric helps you understand the number of distinct metrics reporting from it, since this number depends on your tag value combinations.
 
-Note: The number of distinct metrics reported in the details sidepanel on Metrics Summary does not define your bill. Please see your [usage details][19] for a precise accounting of your usage over the past month.
+Note: The number of distinct metrics reported in the details sidepanel on Metrics Summary does not define your bill. Please see your [usage details][20] for a precise accounting of your usage over the past month.
 
-Please see the [full Metrics Summary documentation][20] for more details.
+Please see the [full Metrics Summary documentation][21] for more details.
 
 ## Further reading
 
@@ -156,11 +156,11 @@ Please see the [full Metrics Summary documentation][20] for more details.
 [11]: /agent/
 [12]: /developers/metrics/dogstatsd_metrics_submission/
 [13]: /api/
-[14]: /developers/metrics/types/
-[15]: /getting_started/tagging/using_tags/
-[16]: /dashboards/functions/
-[17]: /metrics/distributions/
-[18]: https://app.datadoghq.com/metric/summary
-[19]: /account_management/billing/usage_details/
-[20]: /metrics/summary/
-[21]: https://docs.datadoghq.com/agent/basic_agent_usage/
+[14]: https://docs.datadoghq.com/agent/basic_agent_usage/
+[15]: /developers/metrics/types/
+[16]: /getting_started/tagging/using_tags/
+[17]: /dashboards/functions/
+[18]: /metrics/distributions/
+[19]: https://app.datadoghq.com/metric/summary
+[20]: /account_management/billing/usage_details/
+[21]: /metrics/summary/

--- a/content/en/metrics/faq/updating-to-distribution-metrics-faq.md
+++ b/content/en/metrics/faq/updating-to-distribution-metrics-faq.md
@@ -8,7 +8,7 @@ further_reading:
   text: "How to Send Logs to Datadog via External Log Shippers?"
 ---
 
-## Why has my Distribution Metrics page been deprecated?
+## Why has my distribution metrics page been deprecated?
 
 Datadog has released a new pipeline for calculating globally accurate percentiles for your distribution metrics --- this unlocks more query functionality and an easier configuration workflow for distributions.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Addresses headers identified by the vale linter's sentence case rules in the metrics folder.

### Motivation
Docs team hackathon

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
