### PR TITLE
Lint Headings for Agent

### DIFF
--- a/content/en/agent/amazon_ecs/_index.md
+++ b/content/en/agent/amazon_ecs/_index.md
@@ -38,7 +38,7 @@ To begin setup, run the [Datadog Agent][5] on every EC2 instance in your ECS clu
 
 **Note:** Datadog's [Autodiscovery][7] can be used in conjunction with ECS and Docker to automatically discover and monitor running tasks in your environment.
 
-### Create an ECS Task
+### Create an ECS task
 
 This task launches the Datadog container. When you need to modify the configuration, update this task definition as described [further down in this guide](#create-or-modify-your-iam-policy).
 
@@ -134,11 +134,11 @@ Add the following permissions to your [Datadog IAM policy][13] to collect Amazon
 | `ecs:ListServices`               | Lists the services that are running in a specified cluster.   |
 | `ecs:DescribeContainerInstances` | Describes Amazon ECS container instances.                     |
 
-### Run the Agent as a Daemon Service
+### Run the Agent as a daemon service
 
 Ideally, you want the Datadog Agent to load on one container on each EC2 instance. The easiest way to achieve this is to run the Datadog Agent as a [Daemon Service][15].
 
-#### Schedule a Daemon Service in AWS using Datadog's ECS Task
+#### Schedule a daemon service in AWS using Datadog's ECS task
 
 1. Log in to the AWS console and navigate to the ECS Clusters section. Click into your cluster you run the Agent on.
 2. Create a new service by clicking the **Create** button under Services.

--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -19,7 +19,7 @@ further_reading:
 
 {{< partial name="platforms/platforms.html" links="platforms" >}}
 
-## Agent Architecture
+## Agent architecture
 
 {{< tabs >}}
 {{% tab "Agent v6 & v7" %}}
@@ -51,11 +51,11 @@ By default the Agent binds 3 [ports][3] on Linux and 4 on Windows and OSX:
 | 5002 | Serves the GUI server on Windows and OSX.                                                   |
 | 8125 | Used for the DogStatsD server to receive external metrics.                                  |
 
-### The Collector
+### Collector
 
 The collector gathers all standard metrics every 15 seconds. Agent v6 embeds a Python 2.7 interpreter to run integrations and [custom checks][4].
 
-### The Forwarder
+### Forwarder
 
 The Agent forwarder send metrics over HTTPS to Datadog. Buffering prevents network splits from affecting metric reporting. Metrics are buffered in memory until a limit in size or number of outstanding send requests are reached. Afterwards, the oldest metrics are discarded to keep the forwarder's memory footprint manageable. Logs are sent over an SSL-encrypted TCP connection to Datadog.
 
@@ -83,7 +83,7 @@ Agent v5 is composed of four major components, each written in Python running as
 
 **Note**: For Windows users, all four Agent processes appear as instances of `ddagent.exe` with the description `DevOps’ best friend`.
 
-### Supervision, Privileges, and Network Ports
+### Supervision, privileges, and network ports
 
 A SupervisorD master process runs as the `dd-agent` user, and all forked subprocesses run as the same user. This also applies to any system call (`iostat`/`netstat`) initiated by the Datadog Agent. The Agent configuration resides at `/etc/dd-agent/datadog.conf` and `/etc/dd-agent/conf.d`. All configuration must be readable by `dd-agent`. The recommended permissions are 0600 since configuration files contain your API key and other credentials needed to access metrics.
 
@@ -249,7 +249,7 @@ With Agent v6+, the command line interface is based on subcommands. To run a sub
 <AGENT_BIN_PATH> check --help
 ```
 
-## Agent Overhead
+## Agent overhead
 
 An example of the Datadog Agent resource consumption is below. Tests were made on an AWS EC2 machine `c5.xlarge` instance (4 VCPU/ 8GB RAM). The vanilla `datadog-agent` was running with a process check to monitor the Agent itself. Enabling more integrations may increase Agent resource consumption.
 Enabling JMX Checks forces the Agent to use more memory depending on the number of beans exposed by the monitored JVMs. Enabling the trace and process Agents increases the resource consumption as well.

--- a/content/en/agent/basic_agent_usage/aix.md
+++ b/content/en/agent/basic_agent_usage/aix.md
@@ -42,7 +42,7 @@ installp -aXYgd ./datadog-unix-agent-<VEERSION>.powerpc.bff -e dd-aix-install.lo
 
 This installs the Agent in `/opt/datadog-agent`.
 
-### Installation Log Files
+### Installation log files
 
 You can find the Agent installation log in the `dd-aix-install.log` file. To disable this logging, remove the `-e` parameter in the installation command.
 

--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -108,7 +108,7 @@ If you're upgrading from a Datadog Agent version < 5.12.0, first upgrade to a mo
 {{% /tab %}}
 {{< /tabs >}}
 
-### Installation Log Files
+### Installation log files
 
 You can find Agent installation log files at `%TEMP%\MSI*.LOG`.
 
@@ -116,7 +116,7 @@ You can find Agent installation log files at `%TEMP%\MSI*.LOG`.
 
 To verify your installation, follow the instructions in the [Agent Status and Information](#agent-status-and-information) section.
 
-## Agent Commands
+## Agent commands
 
 The execution of the Agent is controlled by the Windows Service Control Manager.
 
@@ -210,7 +210,7 @@ Configuration files for [integrations][1] are in:
 
 ## Troubleshooting
 
-### Agent Status and Information
+### Agent status and information
 
 {{< tabs >}}
 {{% tab "Agent v6 & v7" %}}
@@ -383,9 +383,9 @@ Example:
 {{% /tab %}}
 {{< /tabs >}}
 
-## Use Cases
+## Use cases
 
-###  Monitoring a Windows Service
+###  Monitoring a Windows service
 
 On your target host, launch the Datadog Agent Manager and select the "Windows Service" Integration from the list. For this, there is an out-of-the-box example; however, this example uses DHCP.
 
@@ -407,7 +407,7 @@ The Datadog Agent collects a large number of system metrics by default. The most
 
 While Windows does not offer the `system.load.*` metrics, an equivalent option that's available by default is `system.proc.queue.length`. This metric shows the number of threads observed as delayed in the processor ready queue that are waiting to be executed.
 
-### Monitoring Windows Processes
+### Monitoring Windows processes
 
 You can monitor Windows processes with [Live Process Monitoring][9]. To enable this on Windows, edit the [Agent main configuration file][10] by setting the following parameter to true:
 

--- a/content/en/agent/cluster_agent/admission_controller.md
+++ b/content/en/agent/cluster_agent/admission_controller.md
@@ -89,7 +89,7 @@ First, download the [Cluster Agent RBAC permissions][2] manifest, and add the fo
 Add the following to the bottom of `agent-services.yaml`:
 
 {{< code-block lang="yaml" filename="agent-services.yaml" disable_copy="true" >}}
----
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/content/en/agent/cluster_agent/clusterchecks.md
+++ b/content/en/agent/cluster_agent/clusterchecks.md
@@ -9,7 +9,7 @@ further_reading:
       text: 'Cluster Agent documentation'
 ---
 
-## How it Works
+## Overview
 
 The Datadog Agent can Autodiscover containers and create check configurations with [the Autodiscovery mechanism][1].
 
@@ -79,11 +79,11 @@ Running [custom Agent checks][5] as cluster checks is supported, as long as all 
 
 The Cluster Agent can be configured to use an advanced dispatching logic for cluster checks, which takes into account the execution time and metric samples from check instances. This logic enables the Cluster Agent to optimize dispatching and distribution between cluster check runners.
 
-#### Advanced Dispatching - Cluster Agent setup
+#### Cluster Agent setup
 
 In addition to the steps mentioned in the [Cluster Agent Setup][3] section, you must set `DD_CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED` to `true`.
 
-#### Advanced Dispatching - Cluster Check Runner setup
+#### Cluster check runner setup
 
 The following environment variables are required to configure the cluster check runners (or node Agents) to expose their check stats. The stats are consumed by the Cluster Agent and are used to optimize the cluster checks' dispatching logic.
 
@@ -103,7 +103,7 @@ The following environment variables are required to configure the cluster check 
 
 When the IP of a given resource is constant (eg. external service endpoint, public URL, etc.), a static configuration can be passed to the Cluster Agent as YAML files. The file name convention and syntax are the same as the static configurations on the node-based Agent, with the addition of the `cluster_check: true` line.
 
-#### Example: MySQL check on a CloudSQL database
+#### MySQL check on a CloudSQL database
 
 After setting up a CloudSQL instance and a [Datadog user][6], mount a `/conf.d/mysql.yaml` file in the Cluster Agent container with the following content:
 
@@ -119,7 +119,7 @@ instances:
 
 The `cluster_check` field informs the Cluster Agent to delegate this check to one node-based Agent.
 
-### Template Source: Kubernetes Service Annotations
+### Template source: Kubernetes service annotations
 
 You can annotate services with the following syntax, similar to the syntax for [annotating Kubernetes Pods][1]:
 
@@ -131,7 +131,7 @@ ad.datadoghq.com/service.instances: '[<INSTANCE_CONFIG>]'
 
 The `%%host%%` [template variable][7] is supported and is replaced by the service's IP. The `kube_namespace` and `kube_service` tags are automatically added to the instance.
 
-### Template Source: Standard Labels
+### Template source: standard labels
 
 ```yaml
 tags.datadoghq.com/env: "<ENV>"

--- a/content/en/agent/cluster_agent/commands.md
+++ b/content/en/agent/cluster_agent/commands.md
@@ -29,7 +29,7 @@ The available commands for the Datadog Cluster Agents are:
 | `datadog-cluster-agent metamap <NODE_NAME>` | Queries the local cache of the mapping between the pods living on `NODE_NAME`, and the cluster level metadata they are associated with (e.g., endpoints). Not specifying the `NODE_NAME` runs the mapper on all the nodes of the cluster.           |
 | `datadog-cluster-agent flare <CASE_ID>`     | Similarly to the node-based Agent, the Cluster Agent can aggregate the logs and the configurations used and forward an archive to the support team, or be deflated and used locally. **Note**: this command runs from within the Cluster Agent pod. |
 
-## Cluster Agent Options
+## Cluster Agent options
 
 The following environment variables are supported:
 

--- a/content/en/agent/cluster_agent/endpointschecks.md
+++ b/content/en/agent/cluster_agent/endpointschecks.md
@@ -13,7 +13,7 @@ further_reading:
       text: 'Cluster Agent documentation'
 ---
 
-## How it Works
+## Overview
 
 The cluster check feature provides the ability to Autodiscover and perform checks on load-balanced cluster services (eg. Kubernetes services).
 
@@ -119,7 +119,7 @@ DD_EXTRA_CONFIG_PROVIDERS="endpointschecks clusterchecks"
 
 [Restart the Agent][5] to apply the configuration change.
 
-## Setting up Check Configurations via Kubernetes Service Annotations
+## Setting up check configurations with Kubernetes service annotations
 
 Similar to [annotating Kubernetes Pods][6], services can be annotated with the following syntax:
 
@@ -132,7 +132,7 @@ ad.datadoghq.com/endpoints.logs: '[<LOGS_CONFIG>]'
 
 The `%%host%%` [template variable][7] is supported and is replaced by the endpoints' IPs. The `kube_namespace`, `kube_service`, and `kube_endpoint_ip` tags are automatically added to the instances.
 
-### Template Source: Standard Labels
+### Template source: standard labels
 
 ```yaml
 tags.datadoghq.com/env: "<ENV>"

--- a/content/en/agent/cluster_agent/external_metrics.md
+++ b/content/en/agent/cluster_agent/external_metrics.md
@@ -43,7 +43,7 @@ To enable the Custom Metrics Server, follow the instructions to [set up the Data
 2. Configure the `<DD_APP_KEY>` as well as the `<DD_API_KEY>` in the deployment of the Datadog Cluster Agent with the Datadog [API and application keys for your account][6].
 3. Set `DATADOG_HOST` to `https://{{< region-param key="dd_full_site" >}}` (defaults to `https://app.datadoghq.com`).
 
-### Register the External Metrics Provider
+### Register the external metrics provider
 
 Once the Datadog Cluster Agent is up and running:
 
@@ -221,7 +221,7 @@ The Datadog Cluster Agent will take care of automatically creating `DatadogMetri
 
 If you choose to migrate an HPA later on to reference a `DatadogMetric`, the automatically generated resource will be cleaned up by the Datadog Cluster Agent after few hours.
 
-### Troubleshooting DatadogMetric issues
+### Troubleshooting
 
 The Datadog Cluster Agent will take care of updating the `status` subresource of all `DatadogMetric` resources to reflect results from queries to Datadog. This is the main source of information to understand what happens if something is failing.
 

--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -26,7 +26,7 @@ To set up the Datadog Cluster Agent on your Kubernetes cluster, follow these ste
 
 ## Configure the Datadog Cluster Agent
 
-### Step 1 - Configure RBAC permissions
+### Configure RBAC permissions
 
 The Datadog Cluster Agent needs a proper RBAC to be up and running:
 
@@ -43,7 +43,7 @@ The Datadog Cluster Agent needs a proper RBAC to be up and running:
 
 If you are using Azure Kubernetes Service (AKS), you may require extra permissions. See the [RBAC for DCA on AKS][3] FAQ.
 
-### Step 2 - Secure Cluster-Agent-to-Agent Communication
+### Secure Cluster Agent to Agent communication
 
 Use one of the following options to secure communication between the Datadog Agent and the Datadog Cluster Agent.
 
@@ -111,7 +111,7 @@ Setting the value without a secret results in the token being readable in the `P
 
 **Note**: This needs to be set in the manifest of the Cluster Agent **and** the node agent.
 
-### Step 3 - Create the Cluster Agent and its service
+### Create the Cluster Agent and its service
 
 1. Download the following manifests:
 
@@ -134,7 +134,7 @@ Setting the value without a secret results in the token being readable in the `P
 
 **Note**: In your Datadog Cluster Agent, set `<DD_SITE>` to your Datadog site: {{< region-param key="dd_site" code="true" >}}. The default value is `datadoghq.com`
 
-### Step 4 - Verification
+### Verification
 
 At this point, you should see:
 
@@ -167,13 +167,13 @@ After having set up the Datadog Cluster Agent, configure your Datadog Agent to c
 
 ### Setup
 
-#### Step 1 - Set Configure RBAC permissions for node-based Agents
+#### Set RBAC permissions for node-based Agents
 
 1. Download the the [agent-rbac.yaml manifest][9]. **Note**: When using the Cluster Agent, your node Agents are not able to interact with the Kubernetes API server—only the Cluster Agent is able to do so.
 
 2. Run: `kubectl apply -f agent-rbac.yaml`
 
-#### Step 2 - Enable the Datadog Agent
+#### Enable the Datadog Agent
 
 1. Download the [daemonset.yaml manifest][10].
 

--- a/content/en/agent/cluster_agent/troubleshooting.md
+++ b/content/en/agent/cluster_agent/troubleshooting.md
@@ -163,7 +163,7 @@ Or look for error logs, such as:
 2018-06-10 08:03:02 UTC | ERROR | Could not initialise the communication with the Datadog Cluster Agent, falling back to local service mapping: [...]
 ```
 
-## Custom Metric Server
+## Custom metric server
 
 ### Cluster Agent status and flare
 

--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -111,7 +111,7 @@ The Agent's [main configuration file][11] is `datadog.yaml`. For the Docker Agen
 | `DD_DD_URL`        | Optional setting to override the URL for metric submission.                                                                                                                                                                                                                                                                                      |
 | `DD_CHECK_RUNNERS` | The Agent runs all checks concurrently by default (default value = `4` runners). To run the checks sequentially, set the value to `1`. If you need to run a high number of checks (or slow checks) the `collector-queue` component might fall behind and fail the healthcheck. You can increase the number of runners to run checks in parallel. |
 
-### Proxy Settings
+### Proxy settings
 
 Starting with Agent v6.4.0 (and v6.5.0 for the Trace Agent), you can override the Agent proxy settings with the following environment variables:
 

--- a/content/en/agent/docker/apm.md
+++ b/content/en/agent/docker/apm.md
@@ -62,7 +62,7 @@ docker run -d -p 127.0.0.1:8126:8126/tcp \
 {{% /tab %}}
 {{< /tabs >}}
 
-## Docker APM Agent Environment Variables
+## Docker APM Agent environment variables
 
 List of all environment variables available for tracing within the Docker Agent:
 
@@ -89,7 +89,7 @@ List of all environment variables available for tracing within the Docker Agent:
 
 As with DogStatsD, traces can be submitted to the Agent from other containers either using [Docker networks](#docker-network) or with the [Docker host IP](#docker-host-ip).
 
-### Docker Network
+### Docker network
 
 As a first step, create a user-defined bridge network:
 

--- a/content/en/agent/docker/data_collected.md
+++ b/content/en/agent/docker/data_collected.md
@@ -24,7 +24,7 @@ The Docker Agent produces the following events:
 - Restart Daemon
 - Update
 
-## Service Checks
+## Service checks
 
 - **docker.service_up**:
     Returns `CRITICAL` if the Agent is unable to collect the list of containers from the Docker daemon, otherwise returns `OK`.

--- a/content/en/agent/docker/log.md
+++ b/content/en/agent/docker/log.md
@@ -140,7 +140,7 @@ The commands related to log collection are:
 
 - If using the _journald_ logging driver instead of Docker's default json-file logging driver, see the [journald integration][2] documentation for details regarding the setup for containerized environments. Refer to the [journald filter units][2] documentation for more information on parameters for filtering.
 
-## Log Integrations
+## Log integrations
 
 In Datadog Agent 6.8+, `source` and `service` default to the `short_image` tag value. This allows Datadog to identify the log source for each container and automatically install the corresponding integration.
 
@@ -274,7 +274,7 @@ Use Autodiscovery log labels to apply advanced log collection processing logic, 
 
 It is possible to manage from which containers you want to collect logs. This can be useful to prevent the collection of the Datadog Agent logs for instance. See the [Container Discovery Management][9] to learn more.
 
-## Short Lived containers
+## Short lived containers
 
 For a Docker environment, the Agent receives container updates in real time through Docker events. The Agent extracts and updates the configuration from the container labels (Autodiscovery) every 1 seconds.
 

--- a/content/en/agent/docker/tag.md
+++ b/content/en/agent/docker/tag.md
@@ -23,7 +23,7 @@ If you are running the Agent as a binary on a host, configure your tag extractio
 
 As a best practice in containerized environments, Datadog recommends using unified service tagging when assigning tags. Unified service tagging ties Datadog telemetry together through the use of three standard tags: `env`, `service`, and `version`. To learn how to configure your environment with unified tagging, refer to the dedicated [unified service tagging][1] documentation.
 
-## Extract Labels as Tags
+## Extract labels as tags
 
 Starting with Agent v6.0+, the Agent can collect labels for a given container and use them as tags to attach to all data emitted by this container.
 
@@ -66,7 +66,7 @@ docker_labels_as_tags:
 {{% /tab %}}
 {{< /tabs >}}
 
-## Extract Environment Variables as Tags
+## Extract environment variables as tags
 Starting with Agent v7.20+, a containerized Agent can Autodiscover tags from Docker labels. This process allows the Agent to associate custom tags to all data emitted by a container without modifying the Agent `datadog.yaml` file.
 
 Tags should be added using the following format:

--- a/content/en/agent/faq/agent-5-process-collection.md
+++ b/content/en/agent/faq/agent-5-process-collection.md
@@ -4,7 +4,7 @@ kind: faq
 private: true
 ---
 
-## Standard Agent Configuration
+## Standard Agent configuration
 
 **Live Processes is available in Datadog Agent version 5.16.0.**
 Refer to the instructions for standard [Agent installation][1] for platform-specific details.

--- a/content/en/agent/faq/agent_v6_changes.md
+++ b/content/en/agent/faq/agent_v6_changes.md
@@ -390,7 +390,7 @@ The following options and tags are deprecated:
 
 Agent v6 ships JMXFetch, with the following changes:
 
-#### JMXTerm JAR
+#### Jmxterm
 
 Agent v6 does not ship the `jmxterm` JAR. To download and use `jmxterm`, refer to the [upstream project][1].
 

--- a/content/en/agent/faq/commonly-used-log-processing-rules.md
+++ b/content/en/agent/faq/commonly-used-log-processing-rules.md
@@ -21,7 +21,7 @@ further_reading:
 
 Find on this page examples of commonly used log processing rules.
 
-## Generic String: "sensitive-info"
+## Generic string: "sensitive-info"
 
 Lines containing the string `sensitive-info` are not sent to Datadog.
 
@@ -31,7 +31,7 @@ Lines containing the string `sensitive-info` are not sent to Datadog.
     pattern: (?:sensitive\-info)
 ```
 
-## my_key=value
+## My key
 
 When the string "my_key=" is found, letters, numbers, spaces, and underscores following the string are redacted with `my_key=[VALUE REDACTED]`.
 
@@ -51,9 +51,9 @@ When the string "my_key=" is found, all characters following the string until th
   pattern: (?:my_key=[^.])
 ```
 
-## Social Security Numbers
+## Social Security numbers
 
-Redact Social Security Numbers.
+Redact Social Security numbers.
 
 ```yaml
   - type: mask_sequences
@@ -62,7 +62,7 @@ Redact Social Security Numbers.
     replace_placeholder: "[SSN REDACTED]"
 ```
 
-## Email Address
+## Email address
 
 Redact email addresses using the RFC 5322 regex specification.
 
@@ -73,7 +73,7 @@ Redact email addresses using the RFC 5322 regex specification.
     replace_placeholder: "[EMAIL REDACTED]"
 ```
 
-## Credit Card (Visa, MC, AMEX, DINERS, DISCOVER, JCB)
+## Credit card numbers
 
 Redact credit card numbers for Visa, Mastercard, American Express, Diner's Club, Discover Card, and JCB.
 
@@ -84,7 +84,7 @@ Redact credit card numbers for Visa, Mastercard, American Express, Diner's Club,
   pattern: (?:4[0-9]{12}(?:[0-9]{3})?|[25][1-7][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\d{3})\d{11})
 ```
 
-## Postal Codes
+## Postal codes
 
 Redact postal codes (US).
 
@@ -95,7 +95,7 @@ Redact postal codes (US).
   pattern: (?:\d{5}-\d{4}|\d{5}|[A-Z]\d[A-Z] \d[A-Z]\d)
 ```
 
-## Between Parentheses
+## Between parentheses
 
 Redact characters after string `ExampleConfig(` until the closing paranthesis.
 
@@ -106,7 +106,7 @@ Redact characters after string `ExampleConfig(` until the closing paranthesis.
   pattern: (?:ExampleConfig\([^\)]+)
 ```
 
-## Between Brackets
+## Between brackets
 
 Redact characters after string `on Example [` until the closing bracket.
 
@@ -117,9 +117,9 @@ Redact characters after string `on Example [` until the closing bracket.
   pattern: (?:on Example\s?[^\s]+)
 ```
 
-## Class A IP Address
+## Class A IP addresses
 
-Redact Class A IP Addresses, range 1.0.0.1 to 126.255.255.254.
+Redact Class A IP addresses, range 1.0.0.1 to 126.255.255.254.
 
 ```yaml
 - type: mask_sequences

--- a/content/en/agent/faq/how-datadog-agent-determines-the-hostname.md
+++ b/content/en/agent/faq/how-datadog-agent-determines-the-hostname.md
@@ -44,7 +44,7 @@ When pulling information on your AWS hosts from the [Datadog API][3], the follow
 | `aws_name`     | The cloud `providername` tag                        |
 | `display_name` | The canonical hostname (value of host identifier)   |
 
-### Host Aliases
+### Host aliases
 
 A single host running in EC2 might have an instance ID (i-abcd1234), a generic hostname provided by EC2 based on the host's IP address (ip-192-0-0-1), and a meaningful hostname provided by an internal DNS server or a config-managed hosts file (myhost.mydomain). Datadog creates aliases for host names when there are multiple uniquely identifiable names for a single host.
 
@@ -61,7 +61,7 @@ There are differences in hostname resolution between Agent v5 and Agent v6.
 {{< tabs >}}
 {{% tab "Agent v6 & v7" %}}
 
-### Linux/MacOS
+### Linux and macOS
 
 When upgrading from Agent v5 to Agent v6, there might be a difference in the hostname reported by your Agent. To resolve the system hostname Agent v5 uses the `hostname -f` command while Agent v6 uses the Golang API `os.Hostname()`. On upgrades, the Agent hostname could change from a Fully-Qualified Domain Name (FQDN) to a short hostname, for example:
 

--- a/content/en/agent/faq/how-do-i-uninstall-the-agent.md
+++ b/content/en/agent/faq/how-do-i-uninstall-the-agent.md
@@ -9,7 +9,7 @@ further_reading:
 
 Choose your platform to see dedicated instructions to uninstall the Agent:
 
-## Debian/Ubuntu
+## Debian and Ubuntu
 
 {{< tabs >}}
 {{% tab "Agent v6 & v7" %}}
@@ -54,7 +54,7 @@ sudo apt-get --purge remove datadog-agent -y
 {{% /tab %}}
 {{< /tabs >}}
 
-## CentOS/RHEL/Fedora/Amazon Linux
+## CentOS, RHEL, Fedora, and Amazon Linux
 
 {{< tabs >}}
 {{% tab "Agent v6 & v7" %}}
@@ -87,7 +87,7 @@ This command removes the Agent, but does not remove:
 {{% /tab %}}
 {{< /tabs >}}
 
-## openSUSE/SLES
+## openSUSE and SLES
 
 {{< tabs >}}
 {{% tab "Agent v6" %}}
@@ -120,7 +120,7 @@ This command removes the Agent, but does not remove:
 {{% /tab %}}
 {{< /tabs >}}
 
-## Mac OS
+## macOS
 
 {{< tabs >}}
 {{% tab "Agent v6 & v7" %}}

--- a/content/en/agent/faq/windows-agent-ddagent-user.md
+++ b/content/en/agent/faq/windows-agent-ddagent-user.md
@@ -18,11 +18,11 @@ The user `ddagentuser` is created at install time for the Datadog Windows Agent.
 
 ## Installation
 
-### Installation with Group Policy
+### Installation with group policy
 
 The installer changes the local group policy to allow the newly created user account, `ddagentuser`, to **run as a service**.  If the domain group policy disallows that, then the installation setting is overridden, and the domain group policy has to be updated to allow the user to run as a service.
 
-### Installation in a Domain environment
+### Installation in a domain environment
 
 The Agent installer creates the `ddagentuser` at install time, and then registers the service (with the randomly generated password). The user is created as a local user, even in a domain environment, so that every machine on which the Agent is installed has a unique user and password.
 
@@ -57,9 +57,9 @@ Msiexec /i ddagent.msi DDAGENTUSER_NAME=<DOMAIN>\<USERNAME>
 
 If you use Chef and the official `datadog` cookbook to deploy the Agent on Windows hosts, **use version 2.18.0 or above** of the cookbook to ensure that the Agent’s configuration files have the correct permissions
 
-## Agent Integrations
+## Agent integrations
 
-### General Permissions
+### General permissions
 
 Every effort has been made to ensure that the transition from `LOCAL_SYSTEM` to `ddagentuser` is seamless. However, there is a class of problems that requires specific, configuration-specific modification upon installation of the Agent. These problems arise where the Windows Agent previously relied on administrator rights that the new Agent lacks by default.
 
@@ -103,7 +103,7 @@ For the Cassandra Nodetool integration to continue working, apply the following 
 * Grant access to the Nodetool installation directory to the `ddagentuser`.
 * Set the environment variables of the Nodetool installation directory (e.g. `CASSANDRA_HOME` and `DSCINSTALLDIR`) as system-wide variables instead of variables only for the user doing the Nodetool installation.
 
-## Security Logs channel
+## Security logs channel
 
 If you are using the [Datadog- Win 32 event log Integration][10], the Datadog user `ddagentuser` must be added to the Event Log Reader Group to collect logs from the Security logs channel:
 

--- a/content/en/agent/guide/agent-5-kubernetes-basic-agent-usage.md
+++ b/content/en/agent/guide/agent-5-kubernetes-basic-agent-usage.md
@@ -27,7 +27,7 @@ You can also just [run the Datadog Agent on your host][3] and configure it to ga
 
 ### Installation
 
-#### Container Installation
+#### Container installation
 
 Thanks to Kubernetes, you can take advantage of DaemonSets to automatically deploy the Datadog Agent on all your nodes (or on specific nodes by using nodeSelectors).
 
@@ -93,7 +93,7 @@ Replace `DATADOG_API_KEY` with [your api key][6] or use [Kubernetes secrets][7] 
 
 **Note**:  This manifest enables Autodiscovery's auto-configuration feature. To disable it, remove the `SD_BACKEND` environment variable definition. To learn how to configure Autodiscovery, see the [dedicated Autodiscovery documentation][9].
 
-#### Host Installation
+#### Host installation
 
 Install the `dd-check-kubernetes` package manually or with your favorite configuration manager.
 
@@ -113,7 +113,7 @@ See the [example kubernetes.yaml][10] for all available configuration options.
 
 ### Validation
 
-#### Container Running
+#### Container running
 
 To verify the Datadog Agent is running in your environment as a DaemonSet, execute:
 
@@ -141,11 +141,11 @@ Checks
       - Collected 39 metrics, 0 events & 7 service checks
 ```
 
-## Setup Kubernetes State
+## Setup Kubernetes state
 
 ### Installation
 
-#### Container Installation
+#### Container installation
 
 If you are running Kubernetes >= 1.2.0, you can use the [kube-state-metrics][12] project to provide additional metrics (identified by the `kubernetes_state` prefix in the metrics list below) to Datadog.
 
@@ -206,7 +206,7 @@ The manifest above uses Google's publicly available `kube-state-metrics` contain
 If you configure your Kubernetes State Metrics service to run on a different URL or port, you can configure the Datadog Agent by setting the `kube_state_url` parameter in `conf.d/kubernetes_state.yaml`, then restarting the Agent.
 For more information, see the [kubernetes_state.yaml.example file][14]. If you have enabled [Autodiscovery][9], the kube state URL is configured and managed automatically.
 
-#### Host Installation
+#### Host installation
 
 Install the `dd-check-kubernetes_state` package manually or with your favorite configuration manager (On CentOS/AWS, [Find your rpm package here][15], and information on installation on [this page][16].
 Then edit the `kubernetes_state.yaml` file to point to your server and port and set the masters to monitor. See the [example kubernetes_state.yaml][14] for all available configuration options.

--- a/content/en/agent/guide/agent-commands.md
+++ b/content/en/agent/guide/agent-commands.md
@@ -15,7 +15,7 @@ further_reading:
 For Linux based systems where the <code>service</code> wrapper command is not available, <a href="/agent/faq/agent-v6-changes/?tab=linux#service-lifecycle-commands">consult the list of alternatives</a>.
 </div>
 
-## Start, Stop, and Restart the Agent
+## Start, stop, and restart the Agent
 
 ### Start the Agent
 
@@ -68,11 +68,10 @@ List of commands to stop the Datadog Agent:
 | Kubernetes | `kubectl delete pod <AGENT POD NAME>`—note: the pod is automatically rescheduled |
 | macOS    | `launchctl stop com.datadoghq.agent` *or* via the systray app |
 | Source   | `sudo service datadog-agent stop`                             |
-| Windows  | [See the dedicated Windows documentation][3].                  |
+| Windows  | [See the dedicated Windows documentation][2].                  |
 
 [1]: /agent/
-[2]: /agent/docker/?tab=standard#setup
-[3]: /agent/basic_agent_usage/windows/
+[2]: /agent/basic_agent_usage/windows/
 {{% /tab %}}
 {{% tab "Agent v5" %}}
 
@@ -124,9 +123,9 @@ List of commands to restart the Datadog Agent:
 {{% /tab %}}
 {{< /tabs >}}
 
-## Agent Status and Information
+## Agent status and information
 
-### Service Status
+### Service status
 
 List of commands to display the status of the Datadog Agent:
 
@@ -167,7 +166,7 @@ List of commands to display the status of the Datadog Agent:
 {{% /tab %}}
 {{< /tabs >}}
 
-### Agent Information
+### Agent information
 
 List of commands to display the status of your Datadog Agent and enabled integrations.
 

--- a/content/en/agent/guide/agent-log-files.md
+++ b/content/en/agent/guide/agent-log-files.md
@@ -70,7 +70,7 @@ The Datadog Agent does a logs rollover every 10MB. When a rollover occurs, one b
 {{% /tab %}}
 {{< /tabs >}}
 
-## Agent Installation Log Files
+## Agent installation log files
 
 | Platform                             | Location and file name        |
 |--------------------------------------|-------------------------------|

--- a/content/en/agent/guide/agent-status-page.md
+++ b/content/en/agent/guide/agent-status-page.md
@@ -47,7 +47,7 @@ This section displays the [NTP offset][2] and system UTC time, for example:
     System UTC time: 2019-08-29 18:16:41.526203 UTC
 ```
 
-### Host Info
+### Host info
 
 This section displays information on the host the Agent is running on, for example:
 ```text
@@ -80,7 +80,7 @@ This section displays the hostnames found by the Agent (see the example below). 
 
 ## Collector
 
-### Running Checks
+### Running checks
 
 This section displays a list of running check instances, for example:
 
@@ -108,7 +108,7 @@ Terms and descriptions:
 | Last Run               | The number during the last check run.                            |
 | Total                  | The total number since the Agent's most recent start or restart. |
 
-### Config Errors
+### Config errors
 
 This section only displays if there are checks with config errors, for example:
 
@@ -118,7 +118,7 @@ This section only displays if there are checks with config errors, for example:
       Configuration file contains no valid instances
 ```
 
-### Loading Errors
+### Loading errors
 
 This section only displays if there are checks with loading errors, for example:
 
@@ -189,7 +189,7 @@ Terms and descriptions:
 | DroppedOnInput | The number of transactions that were dropped because all workers were busy.  |
 | Dropped        | The number of transactions dropped because they were retried too many times. |
 
-### API Keys status
+### API keys status
 
 This sections shows the status of your configured API key, for example:
 

--- a/content/en/agent/guide/autodiscovery-management.md
+++ b/content/en/agent/guide/autodiscovery-management.md
@@ -134,7 +134,7 @@ container_exclude: [kube_namespace:<NAMESPACE>]
 
 **Note**: If you are using Kubernetes, the container `<NAME>` is the one in your manifest `.spec.containers[0].name`.
 
-## Include Containers
+## Include containers
 
 Include containers from the Agent Autodiscovery perimeter with an include rule based on their `name` or `image` to collect data **ONLY** from those containers. If a container matches an include rule, it's always included in the Autodiscovery perimeter.
 

--- a/content/en/agent/guide/autodiscovery-with-jmx.md
+++ b/content/en/agent/guide/autodiscovery-with-jmx.md
@@ -116,7 +116,7 @@ spec:
                 -Djava.rmi.server.hostname=$(POD_IP)
 ```
 
-## Autodiscovery Container Identifiers
+## Autodiscovery container identifiers
 
 If you need to pass a more complex configuration for your Datadog-JMX integration, leverage [Autodiscovery Container Identifiers][11] to pass custom integration configuration file or custom `metrics.yaml` file.
 
@@ -285,7 +285,7 @@ If your Agent is running on a host and you want to autodiscover your container t
 {{% /tab %}}
 {{< /tabs >}}
 
-### Container Preparation
+### Container preparation
 
 #### Docker
 

--- a/content/en/agent/guide/cluster-agent-custom-metrics-server.md
+++ b/content/en/agent/guide/cluster-agent-custom-metrics-server.md
@@ -72,7 +72,7 @@ default       datadog-cluster-agent           ClusterIP   192.168.254.197   <non
 
 ```
 
-### Register the External Metrics Provider
+### External metrics provider
 
 Once the Datadog Cluster Agent is up and running, register it as an External Metrics Provider with the service, exposing the port `443`. To do so, apply the following RBAC rules:
 

--- a/content/en/agent/guide/dogstream.md
+++ b/content/en/agent/guide/dogstream.md
@@ -17,14 +17,14 @@ Unfortunately, this value is oftentimes never realized because log files go
 ignored. The Datadog Agent can help remedy this by parsing metrics and events from
 logs, so the data within can be graphed in real-time, all the time.
 
-## Parsing Metrics
+## Parsing metrics
 
 The Datadog Agent can read metrics directly from your log files:
 
 - from the Datadog canonical log format, without any additional programming
 - from any other log format, with a customized log parsing function
 
-### Datadog Canonical Log Format
+### Datadog canonical log format
 
 Datadog logs are formatted as follows:
 
@@ -43,7 +43,7 @@ You can also specify multiple log files like this:
 
     dogstreams: /var/log/web.log, /var/log/db.log, /var/log/cache.log
 
-### Parsing Custom Log Formats
+### Parsing custom log formats
 
 If you want to parse a different log format—say for a piece of vendor or legacy software—you can use a custom Python function to extract the proper fields from the log by specifying your log file in your Agent configuration file in the following format:
 
@@ -67,7 +67,7 @@ If your custom log parser is not working, the first thing to check are the Agent
 To test that dogstreams are working, append a line-don't edit an existing one-to any log file you've configured the Agent to watch. The Agent only tails the end of each log file, so it won't notice any changes you make elsewhere in the file.
 </div>
 
-### Writing Parsing Functions
+### Writing parsing functions
 
 Custom parsing functions must:
 
@@ -80,7 +80,7 @@ Custom parsing functions must:
 
     If the line doesn't match, instead return `None`.
 
-### Example for Metrics Collecting
+### Metrics collection
 
 Let's imagine that you're collecting metrics from logs that are not canonically formatted, but which are intelligently delimited by a unique character, logged as the following:
 
@@ -120,7 +120,7 @@ This example would collect a gauge-type metric called "user.crashes" with a valu
 
 A word of warning: there is a limit to how many times the same metric can be collected in the same log-pass; effectively the Agent starts to overwrite logged metrics with the subsequent submissions of the same metric, even if they have different attributes (like tags). This can be somewhat mitigated if the metrics collected from the logs have sufficiently different timestamps, but it is generally recommended to only submit one metric to the logs for collection once every 10 seconds or so. This overwriting is not an issue for metrics collected with differing names.
 
-## Parsing Events
+## Parsing events
 
 Event parsing is done via the same custom parsing functions as described above, except if you return a
 `dict` (or a `list` of `dict`) from your custom parsing function, Datadog treats it as an event instead of a metric.
@@ -147,7 +147,7 @@ The aggregation key is a combination of the following fields:
 
 For an example of an event parser, see our [Cassandra compaction event parser][3] that is bundled with the Agent.
 
-### Example for Events Collecting
+### Events collection
 
 Imagine that you want to collect events from logging where you have enough control to add all sorts of relevant information, intelligently delimited by a unique character, logged as the following:
 
@@ -236,7 +236,7 @@ In my configuration file you would have:
 dogstreams: /Users/Documents/Parser/test.log:/Users/Documents/Parser/myparser.py:parse_web:logmetric
 ```
 
-## Troubleshooting Your Custom Log-Parser
+## Troubleshooting
 
 Bugs happen, so being able to see the traceback from your log-parsers is very important. You can do this if you are running the Agent with its [Agent logs][6] set at the "DEBUG" level. The Agent's log-level can be set in the `datadog.conf` by uncommenting and editing [this line][7], and then [restarting the Agent][8]. Once that's configured properly, traceback resulting from errors in your custom log-parser can be found in the *collector.log* file ([read here for where to find your Agent logs][6]), and it generally includes the string checks.collector(datadog.py:278) | Error while parsing line in them ([here's the Agent code where the error is likely to be thrown][9]).
 

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -80,7 +80,7 @@ Each section has a dedicated endpoint, for example:
 
 You should whitelist all of these IPs. While only a subset are active at any given moment, there are variations over time within the entire set due to regular network operation and maintenance.
 
-## Open Ports
+## Open ports
 
 **All outbound traffic is sent over SSL via TCP / UDP.**
 
@@ -141,7 +141,7 @@ Open the following ports in order to benefit from all the Agent functionalities:
 {{% /tab %}}
 {{< /tabs >}}
 
-## Using Proxies
+## Using proxies
 
 For a detailed configuration guide on proxy setup, see [Agent Proxy Configuration][8].
 

--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -194,7 +194,7 @@ To forward your trace metrics to Datadog using this new VPC endpoint, configure 
 {{% /tab %}}
 {{< /tabs >}}
 
-## Advanced Usage
+## Advanced usage
 
 ### Inter-region peering
 

--- a/content/en/agent/guide/python-3.md
+++ b/content/en/agent/guide/python-3.md
@@ -20,11 +20,11 @@ This guide provides information and best practices on migrating checks between P
 
 To provide flexibility in allowing code to run multiple on versions of the Agent, this guide focuses on retaining backwards compatibility.
 
-## Editors and Tools
+## Editors and tools
 
-### pylint
+### Pylint
 
-`pylint` contains functions to help you [verify that your custom checks are compatible with Python 3][2].
+Pylint contains functions to help you [verify that your custom checks are compatible with Python 3][2].
 
 #### Installation
 
@@ -77,9 +77,9 @@ Running 2to3 prints a diff against the original source file. For more details ab
 
 Most modern IDEs and editors provide advanced linting automatically. Make sure that they are pointed to a Python 3 executable, so that when you open a legacy Python 2–only file, any linting errors or warnings show up on the side as a colorful tick in [PyCharm][5] or as a clickable box on the bottom in [Visual Studio Code][6].
 
-## Python Migration
+## Python migration
 
-### Package Imports
+### Package imports
 
 To standardize Datadog package namespacing, with Python3, all resources live under the base subpackage. For example:
 
@@ -121,7 +121,7 @@ The `dict.has_key()` method is deprecated in Python 2 and is removed in Python 3
 |--------------------------------------|-----------------|
 | `mydict.has_key('foo') //deprecated` | `foo in mydict` |
 
-### Standard Library Changes
+### Standard library changes
 
 Python 3 features a reorganized standard library, where a number of modules and functions were renamed or moved. Importing moved modules through `six.moves` works on both Python versions.
 
@@ -160,11 +160,11 @@ In Python 3, print is explicitly treated as a function; to turn print into a fun
 |---------------|-------------------------------------------------------------------|
 | `print "foo"` | `from __future__ import print_function` <br/><br/> `print("foo")` |
 
-### Integer Division
+### Integer division
 
 In Python 2, the `/` operator performs floor division on integers.
 
-#### Python 2:
+#### Python 2
 
 ```python
 >> 5/2
@@ -173,7 +173,7 @@ In Python 2, the `/` operator performs floor division on integers.
 
 In Python 3, the `/` operator performs float division. The `//` operator performs floor division.
 
-#### Python 3:
+#### Python 3
 
 ```python
 >> 5/2
@@ -188,7 +188,7 @@ To replicate the same behavior of Python 3 regardless of the Python version, put
 
 In Python 2 the standard library round method uses the Round Half Up Strategy while Python 3 uses the Round To Even strategy.
 
-#### Python 2:
+#### Python 2
 
 ```python
 >> round(2.5)
@@ -197,7 +197,7 @@ In Python 2 the standard library round method uses the Round Half Up Strategy wh
 4
 ```
 
-#### Python 3:
+#### Python 3
 
 ```python
 >> round(2.5)
@@ -217,7 +217,7 @@ Python 3 features different syntax for except and raise.
 | `try:` <br/> &nbsp;&nbsp; `...` <br/> `except Exception, variable:` <br/> &nbsp;&nbsp; `...` | `try:` <br/> &nbsp;&nbsp; `...` <br/> `except Exception as variable:` <br/> &nbsp;&nbsp; `...` |
 | `raise Exception, args`                                                                      | `raise Exception(args)`                                                                        |
 
-### Relative Imports
+### Relative imports
 
 In Python 3, relative imports must be made explicit, using the dot (`.`) syntax.
 

--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -308,15 +308,15 @@ where `<USER_ID>` is the UID to run the agent and `<DOCKER_GROUP_ID>` is the gro
 {{% /tab %}}
 {{< /tabs >}}
 
-## Additional Configuration
+## Additional configuration
 
-### Kubernetes Resources for Live Containers
+### Kubernetes resources for live containers
 
-The [Datadog Agent][3] and [Cluster Agent][4] can be configured to retrieve Kubernetes resources for [Live Containers][5]. This feature allows you to monitor the state of pods, deployments and other Kubernetes concepts in a specific namespace or availability zone, view resource specifications for failed pods within a deployment, correlate node activity with related logs, and more.
+The [Datadog Agent][2] and [Cluster Agent][3] can be configured to retrieve Kubernetes resources for [Live Containers][4]. This feature allows you to monitor the state of pods, deployments and other Kubernetes concepts in a specific namespace or availability zone, view resource specifications for failed pods within a deployment, correlate node activity with related logs, and more.
 
-See the [Live Containers][6] documentation for configuration instructions and additional information.
+See the [Live Containers][5] documentation for configuration instructions and additional information.
 
-## Event Collection
+## Event collection
 
 {{< tabs >}}
 {{% tab "Helm" %}}
@@ -347,11 +347,11 @@ agent:
 
 ## Integrations
 
-Once the Agent is up and running in your cluster, use [Datadog's Autodiscovery feature][7] to collect metrics and logs automatically from your pods.
+Once the Agent is up and running in your cluster, use [Datadog's Autodiscovery feature][6] to collect metrics and logs automatically from your pods.
 
 ## Environment variables
 
-Find below the list of environment variables available for the Datadog Agent. If you want to setup those with Helm, see the full list of configuration options for the `datadog-value.yaml` file in the [helm/charts Github repository][8].
+Find below the list of environment variables available for the Datadog Agent. If you want to setup those with Helm, see the full list of configuration options for the `datadog-value.yaml` file in the [helm/charts Github repository][7].
 
 ### Global options
 
@@ -366,7 +366,7 @@ Find below the list of environment variables available for the Datadog Agent. If
 | `DD_CHECK_RUNNERS`   | The Agent runs all checks concurrently by default (default value = `4` runners). To run the checks sequentially, set the value to `1`. If you need to run a high number of checks (or slow checks) the `collector-queue` component might fall behind and fail the healthcheck. You can increase the number of runners to run checks in parallel. |
 | `DD_LEADER_ELECTION` | If multiple Agent are running in your cluster, set this variable to `true` to avoid the duplication of event collection.                                                                                                                                                                                                                         |
 
-### Proxy Settings
+### Proxy settings
 
 Starting with Agent v6.4.0 (and v6.5.0 for the Trace Agent), you can override the Agent proxy settings with the following environment variables:
 
@@ -377,7 +377,7 @@ Starting with Agent v6.4.0 (and v6.5.0 for the Trace Agent), you can override th
 | `DD_PROXY_NO_PROXY`      | A space-separated list of URLs for which no proxy should be used.      |
 | `DD_SKIP_SSL_VALIDATION` | An option to test if the Agent is having issues connecting to Datadog. |
 
-For more information about proxy settings, see the [Agent v6 Proxy documentation][9].
+For more information about proxy settings, see the [Agent v6 Proxy documentation][8].
 
 ### Optional collection Agents
 
@@ -385,16 +385,16 @@ Optional collection Agents are disabled by default for security or performance r
 
 | Env Variable                    | Description                                                                                                                                                                                                                                                  |
 |---------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DD_APM_ENABLED`                | Enable [trace collection][6] with the Trace Agent.                                                                                                                                                                                                           |
-| `DD_LOGS_ENABLED`               | Enable [log collection][7] with the Logs Agent.                                                                                                                                                                                                              |
-| `DD_PROCESS_AGENT_ENABLED`      | Enable [live process collection][8] with the Process Agent. The [live container view][9] is already enabled by default if the Docker socket is available. If set to `false`, the [live process collection][8] and the [live container view][9] are disabled. |
+| `DD_APM_ENABLED`                | Enable [trace collection][5] with the Trace Agent.                                                                                                                                                                                                           |
+| `DD_LOGS_ENABLED`               | Enable [log collection][6] with the Logs Agent.                                                                                                                                                                                                              |
+| `DD_PROCESS_AGENT_ENABLED`      | Enable [live process collection][7] with the Process Agent. The [live container view][8] is already enabled by default if the Docker socket is available. If set to `false`, the [live process collection][7] and the [live container view][8] are disabled. |
 | `DD_COLLECT_KUBERNETES_EVENTS ` | Enable event collection with the Agent. If you are running multiple Agent in your cluster, set `DD_LEADER_ELECTION` to `true` as well.                                                                                                                       |
 
 To enable the Live Container view, make sure you are running the process agent in addition to setting DD_PROCESS_AGENT_ENABLED to `true`.
 
 ### DogStatsD (custom metrics)
 
-Send custom metrics with [the StatsD protocol][10]:
+Send custom metrics with [the StatsD protocol][9]:
 
 | Env Variable                     | Description                                                                                                                                                |
 |----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -405,7 +405,7 @@ Send custom metrics with [the StatsD protocol][10]:
 | `DD_DOGSTATSD_ORIGIN_DETECTION`  | Enable container detection and tagging for unix socket metrics.                                                                                            |
 | `DD_DOGSTATSD_TAGS`              | Additional tags to append to all metrics, events, and service checks received by this DogStatsD server, for example: `["env:golden", "group:retrievers"]`. |
 
-Learn more about [DogStatsD over Unix Domain Sockets][11].
+Learn more about [DogStatsD over Unix Domain Sockets][10].
 
 ### Tagging
 
@@ -416,11 +416,11 @@ Datadog automatically collects common tags from Kubernetes. To extract even more
 | `DD_KUBERNETES_POD_LABELS_AS_TAGS`      | Extract pod labels      |
 | `DD_KUBERNETES_POD_ANNOTATIONS_AS_TAGS` | Extract pod annotations |
 
-See the [Kubernetes Tag Extraction][12] documentation to learn more.
+See the [Kubernetes Tag Extraction][11] documentation to learn more.
 
 ### Using secret files
 
-Integration credentials can be stored in Docker or Kubernetes secrets and used in Autodiscovery templates. For more information, see the [Secrets Management documentation][13].
+Integration credentials can be stored in Docker or Kubernetes secrets and used in Autodiscovery templates. For more information, see the [Secrets Management documentation][12].
 
 ### Ignore containers
 
@@ -437,7 +437,7 @@ Exclude containers from logs collection, metrics collection, and Autodiscovery. 
 | `DD_AC_INCLUDE` | **Deprecated**. Allowlist of containers to include (separated by spaces). Use `.*` to include all. For example: `"image:image_name_1 image:image_name_2"`, `image:.*`  |
 | `DD_AC_EXCLUDE` | **Deprecated**. Blocklist of containers to exclude (separated by spaces). Use `.*` to exclude all. For example: `"image:image_name_3 image:image_name_4"` (**Note**: This variable is only honored for Autodiscovery.), `image:.*` |
 
-Additional examples are available on the [Container Discover Management][14] page.
+Additional examples are available on the [Container Discover Management][13] page.
 
 **Note**: The `kubernetes.containers.running`, `kubernetes.pods.running`, `docker.containers.running`, `.stopped`, `.running.total` and `.stopped.total` metrics are not affected by these settings. All containers are counted. This does not affect your per-container billing.
 
@@ -453,24 +453,23 @@ You can add extra listeners and config providers using the `DD_EXTRA_LISTENERS` 
 
 ## Commands
 
-See the [Agent Commands guides][15] to discover all the Docker Agent commands.
+See the [Agent Commands guides][14] to discover all the Docker Agent commands.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /agent/faq/kubernetes-legacy/
-[2]: https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/#pod-templates
-[3]: /agent/
-[4]: /agent/cluster_agent/
-[5]: https://app.datadoghq.com/containers
-[6]: /infrastructure/livecontainers/?tab=helm#configuration
-[7]: /agent/kubernetes/integrations/
-[8]: https://github.com/DataDog/helm-charts/tree/master/charts/datadog#all-configuration-options
-[9]: /agent/proxy/#agent-v6
-[10]: /developers/dogstatsd/
-[11]: /developers/dogstatsd/unix_socket/
-[12]: /agent/kubernetes/tag/
-[13]: /security/agent/#secrets-management
-[14]: /agent/guide/autodiscovery-management/
-[15]: /agent/guide/agent-commands/
+[2]: /agent/
+[3]: /agent/cluster_agent/
+[4]: https://app.datadoghq.com/containers
+[5]: /infrastructure/livecontainers/?tab=helm#configuration
+[6]: /agent/kubernetes/integrations/
+[7]: https://github.com/DataDog/helm-charts/tree/master/charts/datadog#all-configuration-options
+[8]: /agent/proxy/#agent-v6
+[9]: /developers/dogstatsd/
+[10]: /developers/dogstatsd/unix_socket/
+[11]: /agent/kubernetes/tag/
+[12]: /security/agent/#secrets-management
+[13]: /agent/guide/autodiscovery-management/
+[14]: /agent/guide/agent-commands/

--- a/content/en/agent/kubernetes/apm.md
+++ b/content/en/agent/kubernetes/apm.md
@@ -130,7 +130,7 @@ $ kubectl apply -n $DD_NAMESPACE -f datadog-agent.yaml
 
 3. **Configure your application tracers to emit traces**: Point your application-level tracers to where the Datadog Agent host is using the environment variable `DD_AGENT_HOST`. Refer to the [language-specific APM instrumentation docs][3] for more examples.
 
-## Agent Environment Variables
+## Agent environment variables
 
 **Note**: As a best practice, Datadog recommends using unified service tagging when assigning tags. Unified service tagging ties Datadog telemetry together through the use of three standard tags: `env`, `service`, and `version`. To learn how to configure your environment with unified tagging, refer to the dedicated [unified service tagging][4] documentation.
 

--- a/content/en/agent/kubernetes/data_collected.md
+++ b/content/en/agent/kubernetes/data_collected.md
@@ -38,17 +38,17 @@ Metrics collected by the Agent when deployed on your Kubernetes cluster:
 
 {{< get-metrics-from-git "kubelet" >}}
 
-### kube-state-metrics
+### Kubernetes state
 
 Note that `kubernetes_state.*` metrics are gathered from the `kube-state-metrics` API.
 
 {{< get-metrics-from-git "kubernetes_state" >}}
 
-### kube-dns
+### Kubernetes DNS
 
 {{< get-metrics-from-git "kube_dns" >}}
 
-### Kubernetes Proxy
+### Kubernetes proxy
 
 {{< get-metrics-from-git "kube_proxy" >}}
 
@@ -83,7 +83,7 @@ As the 5.17.0 release, Datadog Agent now supports built in [leader election opti
 - Unable
 - Unhealthy
 
-## Service Checks
+## Service checks
 
 The Kubernetes check includes the following service checks:
 

--- a/content/en/agent/kubernetes/prometheus.md
+++ b/content/en/agent/kubernetes/prometheus.md
@@ -82,7 +82,7 @@ With the following configuration placeholder values:
 For a full list of available parameters for instances, including `namespace` and `metrics`, see the table in the [Prometheus host collection guide][9].
 
 
-## Getting Started
+## Getting started
 
 ### Simple metric collection
 

--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -36,7 +36,7 @@ To apply a processing rule to all logs collected by a Datadog Agent, see the [Gl
 
 To send only a specific subset of logs to Datadog use the `log_processing_rules` parameter in your configuration file with the **exclude_at_match** or **include_at_match** `type`.
 
-### exclude_at_match
+### Exclude at match
 
 | Parameter          | Description                                                                                        |
 |--------------------|----------------------------------------------------------------------------------------------------|
@@ -122,7 +122,7 @@ spec:
 {{% /tab %}}
 {{< /tabs >}}
 
-### include_at_match
+### Include at match
 
 | Parameter          | Description                                                                       |
 |--------------------|-----------------------------------------------------------------------------------|
@@ -410,7 +410,7 @@ More examples:
 
 **Note**: Regex patterns for multi-line logs must start at the **beginning** of a log. Patterns cannot be matched mid-line.
 
-## Commonly Used Log Processing Rules
+## Commonly used log processing rules
 
 See the dedicated [Commonly Used Log Processing Rules FAQ][1] to see a list of examples.
 

--- a/content/en/agent/logs/log_transport.md
+++ b/content/en/agent/logs/log_transport.md
@@ -84,7 +84,7 @@ By default, the Datadog Agent sends its logs to Datadog over TLS-encrypted TCP. 
 
 **Note**: Setting up a [SOCKS5 proxy][2] server enforces TCP transport because socks5 proxies are not yet supported in HTTPS with compression.
 
-## HTTPS Transport
+## HTTPS transport
 
 **HTTPS log forwarding is the recommended configuration** for the best log collection reliability as the`200` status code is returned by the Datadog storage system:
 
@@ -125,7 +125,7 @@ logs_config:
 
 Or use the `DD_LOGS_CONFIG_BATCH_WAIT=2` environment variable. The unit is in seconds and must be an integer between `1` and `10`.
 
-### HTTPS Proxy configuration
+### HTTPS proxy configuration
 
 When logs are sent through HTTPS, use the same [set of proxy settings][4] as the other data types to send logs through a web proxy.
 

--- a/content/en/agent/logs/proxy.md
+++ b/content/en/agent/logs/proxy.md
@@ -67,7 +67,7 @@ The parameter above can also be set with the following environment variable:
 
 {{< tabs >}}
 {{% tab "HAProxy" %}}
-### Using HAProxy as a TCP Proxy for Logs
+### Using HAProxy as a TCP proxy for logs
 
 This example explains how to configure the Datadog Agent to send logs in TCP to a server with HAProxy installed and listening on port `10514` to then forward the logs to Datadog.
 

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -15,7 +15,7 @@ further_reading:
   text: "Collect your traces"
 ---
 
-## Why use a Proxy
+## Overview
 
 If your network configuration restricted outbound traffic, proxy all Agent traffic through one or several hosts that have more permissive outbound policies.
 
@@ -25,7 +25,7 @@ A few options are available to send traffic to Datadog over SSL/TLS for hosts th
 2. Using HAProxy (if you want to proxy **more than 16-20 Agents** through the same proxy)
 3. Using the Agent as a proxy (for **up to 16 Agents** per proxy, **only on Agent v5** )
 
-## Using a Web Proxy as Proxy
+## Web proxy
 
 Traditional web proxies are supported natively by the Agent. If you need to connect to the Internet through a proxy, edit your Agent configuration file.
 
@@ -135,7 +135,7 @@ Do not forget to [restart the Agent][1] for the new settings to take effect.
 {{% /tab %}}
 {{< /tabs >}}
 
-## Using HAProxy as a Proxy
+## HAProxy
 
 [HAProxy][1] is a free, fast, and reliable solution offering proxying for TCP and HTTP applications. While HAProxy is usually used as a load balancer to distribute incoming requests to pools servers, you can also use it to proxy Agent traffic to Datadog from hosts that have no outside connectivity.
 
@@ -515,7 +515,7 @@ To verify that everything is working properly, review the HAProxy statistics at 
 {{% /tab %}}
 {{< /tabs >}}
 
-## Using NGINX as a Proxy
+## NGINX
 
 [NGINX][3] is a web server which can also be used as a reverse proxy, load balancer, mail proxy, and HTTP cache. You can also use NGINX as a proxy for your Datadog Agents:
 
@@ -642,7 +642,7 @@ logs_config:
 When sending logs over TCP, refer to <a href="/agent/logs/proxy">TCP Proxy for Logs</a> page.
 
 
-## Using the Agent as a Proxy
+## Datadog Agent
 
 **This feature is only available for Agent v5**
 

--- a/content/en/agent/troubleshooting/permissions.md
+++ b/content/en/agent/troubleshooting/permissions.md
@@ -21,7 +21,7 @@ The Agent needs a specific set of permission in order to collect your data on yo
 * [Process Metrics permission issue](#process-metrics-permission-issue)
 * [Further Reading](#further-reading)
 
-## Agent Logging permission issues
+## Agent logging permission issues
 
 When running the Datadog Agent on a given host, you may encounter some permissions related issues that would prevent the Agent from logging properly, such as:
 
@@ -55,7 +55,7 @@ sudo chown -R dd-agent:dd-agent /var/log/datadog/
 
 [More information on the Agent logs locations][2].
 
-## Agent Socket permission issues
+## Agent socket permission issues
 
 When starting the Agent, the following socket permission issue might appear:
 
@@ -79,7 +79,7 @@ chown dd-agent -R /opt/datadog-agent/run
 
 After making this change, the [Agent Start command][5] should successfully be able to start the Agent. If you continue to see this issue despite having taken these steps, contact [Datadog support][6] for additional direction.
 
-## Process Metrics permission issue
+## Process metrics permission issue
 
 If you enabled the [process check][7] in the Agent running on a Linux OS you may notice that the `system.processes.open_file_descriptors` metric is not collected or reported by default.
 This occurs when processes being monitored by the process check runs under a different user than the Agent user: `dd-agent`. In fact, `dd-agent` user doesn't have full access to all files in `/proc`, which is where the Agent looks to collect data for this metric.

--- a/content/en/agent/troubleshooting/send_a_flare.md
+++ b/content/en/agent/troubleshooting/send_a_flare.md
@@ -57,19 +57,19 @@ To get a flare from each container, run the following commands:
 kubectl exec -it <agent-pod-name> -c agent -- agent flare <case-id>
 ```
 
-### process-agent
+### Process Agent
 
 ```bash
 kubectl exec -it <AGENT_POD_NAME> -c process-agent -- agent flare <CASE_ID> --local
 ```
 
-### trace-agent
+### Trace Agent
 
 ```bash
 kubectl exec -it <AGENT_POD_NAME> -c trace-agent -- agent flare <CASE_ID> --local
 ```
   
-### system-probe
+### System probe
 
 ```bash
 kubectl exec -it <AGENT_POD_NAME> -c system-probe -- agent flare <CASE_ID> --local

--- a/content/en/agent/troubleshooting/windows_containers.md
+++ b/content/en/agent/troubleshooting/windows_containers.md
@@ -33,7 +33,7 @@ Live processes do not appear in containers (except for the Datadog Agent).
 
 Live processes do not appear in containers (except for the Datadog Agent).
 
-### Scheduling of the Datadog Agent and Kube State Metrics on mixed clusters (Linux + Windows)
+### Mixed clusters (Linux + Windows)
 
 The recommended way of deploying the Datadog Agent on a mixed cluster is to perform two installations of our Helm chart with a different `targetSystem`.
 
@@ -57,7 +57,7 @@ kube-state-metrics:
 
 **Note**: When using two Datadog installations (one with `targetSystem: linux`, one with `targetSystem: windows`), make sure the second one has `datadog.kubeStateMetricsEnabled` set to `false` to avoid deploying two instances of Kube State Metrics.
 
-### HostPort for APM/DogStatsD
+### HostPort for APM or DogStatsD
 
 `HostPort` is partially supported on Kubernetes, depending on the underlying OS version and CNI plugin.
 Requirements to have `HostPort` working are the following:

--- a/content/en/agent/versions/upgrade_to_agent_v6.md
+++ b/content/en/agent/versions/upgrade_to_agent_v6.md
@@ -14,7 +14,7 @@ Agent v7 is available. <a href="/agent/versions/upgrade_to_agent_v7">Upgrade to 
 
 If you have Agent v5 already installed, a script is available to automatically install or upgrade to the new Agent. It sets up the package repositories and installs the Agent package for you. When upgrading, the import tool also searches for an existing `datadog.conf` from a prior version, and converts Agent and check configurations according to the new v6 format. Select your platform below for specific instructions. You can either download the [DMG package and install it manually](#manual-upgrade), or use the [one-line install script](#one-step-upgrade).
 
-## One-step Upgrade
+## One-step upgrade
 
 {{< tabs >}}
 {{% tab "Linux" %}}
@@ -52,7 +52,7 @@ DD_UPGRADE=true bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/ins
 {{% /tab %}}
 {{< /tabs >}}
 
-## Manual Upgrade
+## Manual upgrade
 
 {{< tabs >}}
 {{% tab "Linux" %}}


### PR DESCRIPTION

### What does this PR do?
Lint headings for the Agent section, mistakes found using:

```
vale content/en/agent/*
```

### Motivation
Docs hackathon

### Preview
https://docs-staging.datadoghq.com/ruth/linter-agent/agent/

### Additional Notes
The following will be added to the `headings.yml` exceptions list:
  - CloudSQL
  - MySQL
  - Agents
  - DaemonSet
  - Social Security
  - Chef
  - Cassandra Nodetool
  - JMXFetch
  - Kubernetes Pod
  - Dockerfile
  - Debian
  - Ubuntu
  - openSUSE
  - Datadog Agent Manager
  - Docker Swarm
  - HostPort

The following will be added to `.vale.ini`:
```
BlockIgnores = (?s) *({{< ?code-block [^>]* >}}.*?{{< ?/ ?code-block >}})
```

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
