### PR TITLE
Simplify JSON block for the Docker Compose example

### DIFF
--- a/content/en/agent/docker/prometheus.md
+++ b/content/en/agent/docker/prometheus.md
@@ -95,12 +95,17 @@ LABEL "com.datadoghq.ad.instances"='["{\"prometheus_url\":\"http://%%host%%:<PRO
 labels:
     com.datadoghq.ad.check_names: '["openmetrics"]'
     com.datadoghq.ad.init_configs: '[{}]'
-    com.datadoghq.ad.instances:  >
+    com.datadoghq.ad.instances: |
     [
-      "{\
-        "prometheus_url\":\"http://%%host%%:<PROMETHEUS_PORT>/<PROMETHEUS_ENDPOINT> \",\"namespace\":\"<NAMESPACE>\",
-        \"metrics\":[{\"<METRIC_TO_FETCH>\": \"<NEW_METRIC_NAME>\"}]
-      }"
+      {
+        "prometheus_url": "http://%%host%%:<PROMETHEUS_PORT>/<PROMETHEUS_ENDPOINT>",
+        "namespace": "<NAMESPACE>",
+        "metrics": [
+          {
+            "<METRIC_TO_FETCH>": "<NEW_METRIC_NAME>"
+          }
+        ]
+      }
     ]
 ```
 


### PR DESCRIPTION
Remove unnecessary escaping from the JSON block of the Docker Compose example.  This makes the YAML easier to read and keeps the reader from wondering whether the escaping is required.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Simplifies the Docker Compose example for OpenMetrics integration.

### Motivation
The existing example is hard to read.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
