### PR TITLE
Lint headings in /monitors for sentence case

### DIFF
--- a/content/en/monitors/guide/as-count-in-monitor-evaluations.md
+++ b/content/en/monitors/guide/as-count-in-monitor-evaluations.md
@@ -9,7 +9,7 @@ aliases:
 
 Queries using **`as_count()`** and **`as_rate()`** modifiers are calculated in ways that can yield different results in monitor evaluations. Monitors involving arithmetic and at least 1 **`as_count()`** modifier use a separate evaluation path that changes the order in which arithmetic and time aggregation are performed.
 
-## Error Rate Example
+## Error rate example
 
 Suppose you want to monitor an error rate over 5 minutes using the metrics, `requests.error` and `requests.total`. Consider a single evaluation performed with these aligned timeseries points for the 5 min timeframe:
 

--- a/content/en/monitors/guide/monitor-arithmetic-and-sparse-metrics.md
+++ b/content/en/monitors/guide/monitor-arithmetic-and-sparse-metrics.md
@@ -9,7 +9,7 @@ aliases:
 
 Creating an alert based on a query with arithmetic is a common practice. There are some tools and behaviors that should be considered to ensure a monitor's settings are appropriate for evaluating these queries as intended.
 
-## Sparse Metrics
+## Sparse metrics
 
 In the case of sparse or _0_ metrics in the denominator, some results can be rejected.
 

--- a/content/en/monitors/guide/monitor_api_options.md
+++ b/content/en/monitors/guide/monitor_api_options.md
@@ -24,7 +24,7 @@ kind: guide
   - `True`: `[Triggered on {host:h1}] Monitor Title`
   - `False`: `[Triggered] Monitor Title`
 
-## Anomaly Options
+## Anomaly options
 
 _These options only apply to anomaly monitors and are ignored for other monitor types._
 
@@ -35,7 +35,7 @@ _These options only apply to anomaly monitors and are ignored for other monitor 
 
 Example: `{'threshold_windows': {'recovery_window': 'last_15m', 'trigger_window': 'last_15m'}}`
 
-## Metric Alert Options
+## Metric alert options
 
 _These options only apply to metric alerts._
 
@@ -45,7 +45,7 @@ Example: `{'critical': 90, 'warning': 80,  'critical_recovery': 70, 'warning_rec
 
 - **`evaluation_delay`** Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min), the timeframe is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55. This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
 
-## Service Check Options
+## Service check options
 
 _These options only apply to service checks and are ignored for other monitor types._
 
@@ -53,7 +53,7 @@ _These options only apply to service checks and are ignored for other monitor ty
 
 Example: `{'ok': 1, 'critical': 1, 'warning': 1}`
 
-## Logs Alert Options
+## Logs alert options
 
 _These options only apply to logs alerts._
 

--- a/content/en/monitors/guide/slo-checklist.md
+++ b/content/en/monitors/guide/slo-checklist.md
@@ -14,7 +14,7 @@ further_reading:
 Click <a href="https://www.datadoghq.com/pdf/SLOChecklist_200619.pdf">here</a> to find a PDF version of this page.
 </div>
 
-## 1. Getting Started
+## Getting started
 
 1. Navigate to the SLO page: [Monitors › Service Level Objectives][1]
 
@@ -25,7 +25,7 @@ Click <a href="https://www.datadoghq.com/pdf/SLOChecklist_200619.pdf">here</a> t
     * Which parts of your infrastructure do these journeys interact with?
     * What are they expecting from your systems and what are they hoping to accomplish?
 
-## 2. Select the relevant SLI(s)
+## Select the relevant SLI(s)
 
 ### STEP 1
 
@@ -72,25 +72,25 @@ If you need to create a new monitor go to the [Monitor create][2] page.
 
 _Example: 99% of requests should complete in less than 250 ms over a 30-day window._
 
-## 3. Implementing your SLIs
+## Implementing your SLIs
 
 1. [Custom metrics][3] (e.g., counters)
 2. [Integration metrics][4] (e.g., load balancer, http requests)
 3. [Datadog APM][5] (e.g., errors, latency on services and resources)
 4. [Datadog Logs][6] (e.g., metrics generated from logs for a count of particular occurence)
 
-## 4. Set your target objective and time window
+## Set your target objective and time window
 
 1. Select your target: `99%`, `99.5%`, `99.9%`, `99.95%`, or whatever makes sense for your requirements.
 2. Select your time window: over the last `7`, `30`, or `90 days`
 
-## 5. Name, describe, and tag your SLOs
+## Name, describe, and tag your SLOs
 
 1. Name your SLO.
 2. Add a description: describe what the SLO is tracking and why it is important for your end user experience. You can also add links to dashboards for reference.
 3. Add tags: tagging by `team` and `service` is a common practice.
 
-## 6. View and Search
+## View and search
 
 [Use tags to search for your SLOs from the SLO list view][7].
 

--- a/content/en/monitors/incident_management/_index.md
+++ b/content/en/monitors/incident_management/_index.md
@@ -129,19 +129,19 @@ Assessment fields are the metadata and context that you can define per incident.
 
 ## Example workflow
 
-### 1. Discover an issue
+### Discover an issue
 
 Consider a scenario in which you are looking at a dashboard, and you notice that one particular service is showing an especially high error count. Using the Export button in the upper right of a widget, you can declare an incident.
 
 {{< img src="monitors/incidents/workflow-1-graph-1.png" alt="From Graph"  style="width:80%;">}}
 
-### 2. Declare an incident and assemble your team
+### Declare an incident and assemble your team
 
 Use the New Incident modal to assemble your team and notify them. The graph from which you created the incident is automatically attached as a signal. Attach any other signals that would give your team the necessary context to begin resolving this issue. The Slack and PagerDuty integrations enable you to send notifications through those services.
 
 {{< img src="monitors/incidents/workflow-2-modal-1.png" alt="New Incident"  style="width:60%;">}}
 
-### 3. Communicate and begin troubleshooting
+### Communicate and begin troubleshooting
 
 If you have the [Datadog Slack app][3] installed, the Slack integration can automatically create a new channel dedicated to the incident, so you can consolidate communication with your team and begin troubleshooting.
 
@@ -149,7 +149,7 @@ For non-EU customers who use Slack, [sign up for beta access][6] to the Datadog 
 
 {{< img src="monitors/incidents/workflow-3-slack-1-1.png" alt="Communicate"  style="width:80%;">}}
 
-### 4. Update the incident and generate a postmortem
+### Update the incident and generate a postmortem
 
 Update the incident as the situation evolves. Set the status to `Stable` to indicate the problem has been mitigated and set the customer impact field so that your organization knows how this issue has affected customers. Then, set the status to `Resolved` once the incident is completely fixed. There is an optional fourth status, `Completed`, that can be used to track if all remediation steps are complete. This status can be enabled in [Incident Settings][2].
 
@@ -169,7 +169,7 @@ Once an incident is moved to resolved, you will be able to generate a postmortem
 
 {{< img src="monitors/incidents/postmortem.png" alt="Automatically generate a postmortem" style="width:80%;">}}
 
-### 5. Follow up and learn from the incident
+### Follow up and learn from the incident
 
 Create mitigation or post-incident remediation tasks. You can track any of your tasks here by adding tasks in the text field, setting a due date, and assigning a team member. You can complete them by checking off the box when they are done.
 

--- a/content/en/monitors/incident_management/datadog_clipboard.md
+++ b/content/en/monitors/incident_management/datadog_clipboard.md
@@ -14,7 +14,7 @@ The Datadog Clipboard is a cross-platform tool for collecting and sharing signal
 
 {{< img src="monitors/incidents/clipboard-full.png" alt="The main clipboard">}}
 
-## Cross-Page Exploration
+## Cross-page exploration
 
 The Clipboard works on all pages in Datadog and keeps a record of all graphs copied by an individual user. The Clipboard does not automatically copy query text, event JSON, or other text-based content. 
 
@@ -28,7 +28,7 @@ Or, click “`Cmd/Ctrl + Shift + X` to open” on the minimized Clipboard.
 
 The Clipboard can also be opened and closed using `Cmd/Ctrl + Shift + X`. To minimize the Clipboard, click the Minimize icon. The minimized Clipboard persists on all pages of Datadog.
 
-## Adding Clips
+## Adding clips
 
 To add a graph, copy it with `Cmd/Ctrl + C` or click “Copy” in the export menu. Once the Clipboard is open, copied graphs get added automatically. 
 
@@ -36,7 +36,7 @@ To add a URL, open the Clipboard and click “Add Current URL.”
 
 {{< img src="monitors/incidents/add-dashboard.png" alt="Add a dashboard to the Clipboard"  style="width:80%;">}}
 
-## Managing Clips
+## Managing clips
 
 Each item in the Clipboard can be opened, cloned, or deleted; these options are available when you hover over any signal. Opening an item navigates to the link of the original signal. Open the source of any graph (like the dashboard it was clipped from) by clicking the title at the bottom of the item.
 

--- a/content/en/monitors/manage_monitor.md
+++ b/content/en/monitors/manage_monitor.md
@@ -110,7 +110,7 @@ Attribute differences for the triggered monitors page:
 * The `triggered` attribute lets you filter monitors by how long they have been triggered.
 * The `group` attribute helps you narrow down search results for monitors grouped by more than one tag. For example, a monitor is grouped by `host` and `env`. After searching, you see four rows with the groups `host:web01,env:dev`, `host:web02,env:dev`, `host:web01,env:prod`, and `host:web02,env:prod`. Use the `group` attribute to only show prod hosts (`group:"env:prod"`) or web02 hosts (`group:"host:web02"`).
 
-### Monitor Tags
+### Monitor tags
 
 Monitor tags are independent of tags sent by the Agent or integrations. Add up to 32 tags directly to your monitors for filtering on the [manage monitors][1], [triggered monitors][8], or [manage downtime][9] pages. Learn more about monitor tags in the [tagging documentation][10].
 

--- a/content/en/monitors/monitor_status.md
+++ b/content/en/monitors/monitor_status.md
@@ -70,7 +70,7 @@ The properties section is the overview of your monitor's:
 | Query        | Learn more about [querying][4].                                                       |
 | Message      | The message specified in the [notification][5] section of the monitor.                |
 
-## Status & History
+## Status and history
 
 The status and history section displays the query and state changes of your monitor over time. To filter the information, use the search box, statuses, and time selector above the section.
 

--- a/content/en/monitors/monitor_types/anomaly.md
+++ b/content/en/monitors/monitor_types/anomaly.md
@@ -49,7 +49,7 @@ After defining the metric, the anomaly detection monitor provides two preview gr
 
 **Recovery window** - How much time is required for the metric to not be considered anomalous so the alert recovers.
 
-#### Advanced Options
+#### Advanced options
 
 Datadog automatically analyzes your chosen metric and sets several parameters for you. However, the options are available for you to edit under **Advanced Options**.
 
@@ -74,7 +74,7 @@ Datadog automatically analyzes your chosen metric and sets several parameters fo
 
 **Note**: Machine learning algorithms require at least twice as much historical data time as the chosen seasonality time to be fully efficient.
 
-##### Anomaly Detection Algorithms
+##### Anomaly detection algorithms
 
 | Option | Use case                                                                                       | Description                                                                                                                                                                                                                                                           |
 |--------|------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -84,7 +84,7 @@ Datadog automatically analyzes your chosen metric and sets several parameters fo
 
 All of the seasonal algorithms may use up to a couple of months of historical data when calculating a metric's expected normal range of behavior. By using a significant amount of past data, the algorithms can avoid giving too much weight to abnormal behavior that might have occurred in the recent past.
 
-**Examples**:<br>
+**Examples:**<br>
 The graphs below illustrate how and when these three algorithms behave differently from one another.
 
 In this example, `basic` successfully identifies anomalies that spike out of the normal range of values, but it does not incorporate the repeating, seasonal pattern into its predicted range of values. By contrast, `robust` and `agile` both recognize the seasonal pattern and can detect more nuanced anomalies, for example if the metric was to flat-line near its minimum value.

--- a/content/en/monitors/monitor_types/apm.md
+++ b/content/en/monitors/monitor_types/apm.md
@@ -40,7 +40,7 @@ Choose your [primary tags][1], [service][2], and [resource][3] from the drop-dow
 
 Choose a **Threshold** or **Anomaly** alert:
 
-#### Threshold Alert
+#### Threshold alert
 
 An alert is triggered whenever a metric crosses a threshold.
 
@@ -50,7 +50,7 @@ An alert is triggered whenever a metric crosses a threshold.
 * Warning threshold `<NUMBER>`
 * over the last `5 minutes`, `15 minutes`, `1 hour`, etc. or `custom` to set a value between 1 minute and 48 hours.
 
-#### Anomaly Alert
+#### Anomaly alert
 
 An alert is triggered whenever a metric deviates from an expected pattern.
 

--- a/content/en/monitors/monitor_types/custom_check.md
+++ b/content/en/monitors/monitor_types/custom_check.md
@@ -22,7 +22,7 @@ Custom check monitors include any service check not reported by one of the [more
 
 To create a [custom check monitor][5] in Datadog, use the main navigation: *Monitors --> New Monitor --> Custom Check*.
 
-### Pick a Custom Check
+### Pick a custom check
 
 Choose a custom check from the drop-down box.
 

--- a/content/en/monitors/monitor_types/event.md
+++ b/content/en/monitors/monitor_types/event.md
@@ -63,7 +63,7 @@ Event monitors have specific template variables you can include in the notificat
 | `{{event.tags}}`           | A list of tags attached to the event.                                          |
 | `{{event.tags.<TAG_KEY>}}` | The value for a specific tag key attached to the event. See the example below. |
 
-##### {{event.tags.&lt;TAG_KEY&gt;}}
+##### Tags `key:value` syntax
 
 For the tags `env:test`, `env:staging`, and `env:prod`:
 

--- a/content/en/monitors/monitor_types/forecasts.md
+++ b/content/en/monitors/monitor_types/forecasts.md
@@ -40,7 +40,7 @@ After defining the metric, the forecast monitor provides two preview graphs in t
 * Alert threshold: >= `<NUMBER>`
 * Alert [recovery threshold][3]: < `<NUMBER>`
 
-#### Advanced Options
+#### Advanced options
 
 Datadog automatically analyzes your chosen metric and sets several parameters for you. However, the options are available to edit under **Advanced Options**:
 

--- a/content/en/monitors/monitor_types/integration.md
+++ b/content/en/monitors/monitor_types/integration.md
@@ -27,11 +27,11 @@ To create an [integration monitor][2] in Datadog:
 3. Choose an **Integration Metric** or **Integration Status** monitor:
     {{< img src="monitors/monitor_types/integration/metric_or_status.png" alt="Metric or Status"  style="width:90%;">}}
 
-### Integration Metric
+### Integration metric
 
 Create an integration metric monitor by following the instructions in the [metric monitor][3] documentation. Using the integration metric monitor type ensures the monitor can be selected by the integration monitor type facet on the [Manage Monitors][4] page.
 
-### Integration Status
+### Integration status
 
 If the integration has a service check, the **Integration Status** tab is active.
 

--- a/content/en/monitors/monitor_types/metric.md
+++ b/content/en/monitors/monitor_types/metric.md
@@ -181,7 +181,7 @@ Alternatively, if you are monitoring a metric over an auto-scaling group of host
 
 For a monitor that does not notify on missing data, if a group does not report data, the monitor skips evaluations and eventually drops the group. During this period, the bar in the results page stays green. When there is data and groups start reporting again, the green bar shows an OK status and backfills to make it look like there was no interruption.
 
-#### Auto Resolve
+#### Auto resolve
 
 `[Never]`, `After 1 hour`, `After 2 hours`, etc. automatically resolve this event from a triggered state.
 

--- a/content/en/monitors/monitor_types/network.md
+++ b/content/en/monitors/monitor_types/network.md
@@ -22,7 +22,7 @@ Network monitors cover the TCP and HTTP checks available in the Agent. For detai
 
 To create a [network monitor][3] in Datadog, use the main navigation: *Monitors --> New Monitor --> Network*.
 
-### Network Status
+### Network status
 
 #### Pick a check
 
@@ -79,7 +79,7 @@ See the [metric monitor][4] documentation for information on [No data][5], [Auto
 
 For detailed instructions on the **Say what's happening** and **Notify your team** sections, see the [Notifications][8] page.
 
-### Network Metric
+### Network metric
 
 Create a network metric monitor by following the instructions in the [metric monitor][8] documentation. Using the network metric monitor type ensures the monitor can be selected by the network monitor type facet on the [Manage Monitors][9] page.
 

--- a/content/en/monitors/service_level_objectives/_index.md
+++ b/content/en/monitors/service_level_objectives/_index.md
@@ -67,11 +67,11 @@ To run a search, use the facet checkboxes on the left and the search bar at the 
 
 To edit an individual SLO, hover over it and use the buttons that appear at the right of its row: **Edit**, **Clone**, **Delete**. To see more details on a SLO, click its table row to open its details side panel.
 
-### SLO Tags
+### SLO tags
 
 When you create or edit an SLO, you can add tags for filtering on the [SLO status page][1] or for creating [SLO saved views][7].
 
-### SLO Default View
+### SLO default view
 
 The default SLO view is loaded when you land on the SLO list view.
 
@@ -81,7 +81,7 @@ The default view includes:
 - A list of all defined SLOs in your organization
 - A list of available facets in left side facet list
 
-### Saved Views
+### Saved views
 
 Saved views allow you to save and share customized searches in the SLO list view for SLOs that are most relevant for you and your team by sharing:
 
@@ -98,19 +98,19 @@ To add a saved view:
 2. Click **Save View +** at the top left of the page.
 3. Name your view and save.
 
-#### Load a Saved View
+#### Load a saved view
 
 To load a saved view, open the *Saved Views* panel by pressing the **Show Views** button at the top left of the page and select a saved view from the list. You can also search for saved views in the *Filter Saved Views* search box at the top of that same *Saved Views* panel.
 
-#### Share a Saved View
+#### Share a saved view
 
 Hover over a saved view from the list and select the hyperlink icon to copy the link to the saved view to share it with your teammates.
 
-#### Manage Saved Views
+#### Manage saved views
 
 Once you are using a saved view, you can update it by selecting that saved view, modifying the query, and clicking the *Update* button below its name in the *Saved Views* panel. To change the saved view's name or delete a saved view, hover over its row in the *Saved Views* panel and click the pencil icon or trash can icon, respectively.
 
-## SLO Audit Events
+## SLO audit events
 
 SLO audit events allow you to track the history of your SLO configurations using the Event Stream. Audit events are added to the Event Stream every time you create, modify or delete an SLO. Each event includes information on an SLO's configuration, and the stream provides a history of the SLO's configuration changes over time.
 
@@ -141,7 +141,7 @@ For example, if you wish to be notified when a specific SLO's configuration is m
 
 {{< img src="monitors/service_level_objectives/slo-event-monitor.png" alt="SLO event monitor"  >}}
 
-## SLO Widgets
+## SLO widgets
 
 After creating your SLO, you can use the SLO Summary dashboard widget to visualize the status of an SLO along with your dashboard metrics, logs and APM data. For more information about SLO Widgets, see the [SLO Widgets documentation][2] page.
 

--- a/content/en/monitors/service_level_objectives/error_budget.md
+++ b/content/en/monitors/service_level_objectives/error_budget.md
@@ -16,7 +16,7 @@ SLO error budget monitors are threshold based and notify you when a certain perc
 **Note:** Error budget monitors are only available for [metric-based SLOs][1].
 
 
-## Monitor Creation
+## Monitor creation
 
 1. Navigate to the [SLO status page][2].
 2. Create a new metric-based SLO or edit an existing one, then click the ‘Save and Set Alert’ button. For existing SLOs, you can also click the “Enable Alerts” link in the SLO detail side panel to take you directly to the alert configuration.
@@ -60,7 +60,7 @@ resource "datadog_monitor" "metric-based-slo" {
 
 Replace `slo_id` with the alphanumeric ID of the metric-based SLO you wish to configure an error budget monitor on and replace `time_window` with one of `7d`, `30d` or `90d`- depending on which target is used to configure your metric-based SLO.
 
-## Beta Restrictions
+## Beta restrictions
 
 - Alerting is available for only metric-based SLOs.
 - The alert status of an SLO monitor is available in the **Alerts** tab in the SLO’s detail panel.

--- a/content/en/monitors/service_level_objectives/monitor.md
+++ b/content/en/monitors/service_level_objectives/monitor.md
@@ -48,7 +48,7 @@ While the SLO remains above the target percentage, the SLO's status will be disp
 
 Here you can add contextual information about the purpose of the SLO, including any related information or resources in the description and tags you would like to associate with the SLO.
 
-## Overall Status Calculation
+## Overall status calculation
 
 {{< img src="monitors/service_level_objectives/overall_uptime_calculation.png" alt="overall uptime calculation"  >}}
 
@@ -65,7 +65,7 @@ Consider the following example for 3 monitors (this is also applicable to a moni
 
 This can result in the overall status being lower than the average of the individual statuses.
 
-### Exceptions for Synthetic Tests
+### Exceptions for synthetic tests
 In certain cases, there is an exception to the status calculation for monitor-based SLOs that are comprised of one grouped Synthetic test. Synthetic tests have optional special alerting conditions that change the behavior of when the test enters the ALERT state and consequently impact the overall uptime:
 
 - Wait until the groups are failing for a specified number of minutes (default: 0)


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Lint headings in /monitors for sentence case

### Motivation
Docs team hackathon!

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes

There's one heading that is `@notification` and it makes sense as a heading to me, but because of the format of the linter I couldn't add it to the rules file with any success. It throws an error if you just put it in plain, and doesn't actually work if wrapped in single or double quotes. There might be another way to add it that I don't know about though?

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
