### PR TITLE
Swap to placeholder API Key

### DIFF
--- a/content/en/serverless/azure_app_services.md
+++ b/content/en/serverless/azure_app_services.md
@@ -99,7 +99,7 @@ using Serilog.Sinks.Datadog.Logs;
 
           Serilog.Log.Logger = new LoggerConfiguration()
               .WriteTo.DatadogLogs(
-                  "eb7c615e5fca779871203b7de9209b6c",
+                  "<DD_API_KEY>",
                   source: "<SOURCE_NAME>",
                   service: "<SERVICE_NAME>",
                   tags: new string[] { "<TAG_1>:<VALUE_1>", "<TAG_2>:<VALUE_2>" },


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Swap in the placeholder key, can see old key in link starting with `eb7c`

### Motivation
<!-- What inspired you to submit this pull request?-->
Make the documentation more clear regarding the setup process

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jack.davenport/placeholder_key/serverless/azure_app_services

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Current page:

- https://docs.datadoghq.com/serverless/azure_app_services/#overview

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
