### PR TITLE
Lint headings for Developers

### DIFF
--- a/content/en/developers/dogstatsd/dogstatsd_mapper.md
+++ b/content/en/developers/dogstatsd/dogstatsd_mapper.md
@@ -56,7 +56,7 @@ With the following placeholders:
 | `<TAG_KEY>`             | The Tag key to associate to the tags collected.                                                                                           | no                      |
 | `<TAG_VALUE_TO_EXPAND>` | The tags collected from the `<MATCH_TYPE>` to inline.                                                                                     | no                      |
 
-## Wildcard Match Pattern
+## Wildcard match pattern
 
 The wildcard match pattern matches dot-separated metric names using `*` as wildcard. The metric name must be only composed of alphanumeric, `.`, and `_` characters for this pattern to work. Groups extracted can then be expanded with the `$n` format e.g. `$1`, `$2`, `$3`... or the `${n}` format e.g. `${1}`, `${2}`, `${3}`, ...
 
@@ -79,7 +79,7 @@ It would send the metric `custom_metric.process` to Datadog with the tags `tag_k
 
 **Note**: If the incoming metric have already at least one tag, no mapping is applied.
 
-## Regex Match Pattern
+## Regex match pattern
 
 The regex match pattern matches metric names using regex patterns. Compared to the wildcard match pattern, it allows to define captured groups that contain `.`. Groups extracted can then be expanded with the `$n` format e.g. `$1`, `$2`, `$3`... or the `${n}` format e.g. `${1}`, `${2}`, `${3}`, ...
 

--- a/content/en/developers/dogstatsd/high_throughput.md
+++ b/content/en/developers/dogstatsd/high_throughput.md
@@ -194,7 +194,7 @@ For more information and code examples, see [DogStatsD "Sample Rate" Parameter E
 
 UDS is an inter-process communication protocol used to [transport DogStatsD payloads][2]. It has very little overhead when compared to UDP and lowers the general footprint of DogStatsD on your system.
 
-## Operating System kernel buffers
+## Operating system kernel buffers
 
 Most operating systems add incoming UDP and UDS datagrams containing your metrics to a buffer with a maximum size. Once the max is reached, datagrams containing your metrics start getting dropped. It is possible to adjust the values to give the Agent more time to process incoming metrics:
 

--- a/content/en/developers/events/email.md
+++ b/content/en/developers/events/email.md
@@ -1,77 +1,77 @@
 ---
-title: Events with Email
+title: Events with email
 kind: documentation
 aliases:
 - /guides/eventsemail
 ---
 
-If your application does not have an existing [Datadog integration][1], and you don't want to create a [custom Agent check][2], you can send events with Email.
+If your application does not have an existing [Datadog integration][1], and you don't want to create a [custom Agent check][2], you can send events with email.
 
 ## Setup
 
-Before you can send events with Email, you need a dedicated Email address from Datadog:
+Before you can send events with email, you need a dedicated email address from Datadog:
 
 1. Log in to your [Datadog account][3].
 2. Go to the **Integrations** menu, choose **APIs**.
-3. Expand **Events API Emails**.
+3. Expand **Events API emails**.
 4. Choose the format for your messages from the **Format** dropdown (`Plain text` or `JSON`).
-5. Click the **Create API Email** button.
+5. Click the **Create API email** button.
 
-The **Events API Emails** section displays all the Emails available for your applications and who created them.
+The **Events API emails** section displays all the emails available for your applications and who created them.
 
 ## Submission
 
-There are two different ways to send events with Email:
+There are two different ways to send events with email:
 
 {{< tabs >}}
 {{% tab "JSON" %}}
 
-If you have complete control over the Email sent by an application, then you can use configure a JSON-formatted message. This format allows you to set everything in the event that appears in Datadog.
+If you have complete control over the email sent by an application, then you can use configure a JSON-formatted message. This format allows you to set everything in the event that appears in Datadog.
 
-### Source Email {#source-email-1}
+### Source email {#source-email-1}
 
-With a JSON-formatted Email, the following fields are controllable:
+With a JSON-formatted email, the following fields are controllable:
 
-* The sender's Email address
+* The sender's email address
 * All arguments from the [Datadog Events API][1]
 
-**Note**: If your JSON is not properly formatted, or the Email is sent without a subject, the event won't show in your event stream.
+**Note**: If your JSON is not properly formatted, or the email is sent without a subject, the event won't show in your event stream.
 
 ### Datadog event {#datadog-event-1}
 
-In a JSON-formatted Email, the subject of the Email doesn't appear in the event. The value of the title attribute is used for the event title. All data that appears in the event should be defined in JSON in the body of the Email. Furthermore, the body must be pure, well-formed JSON—if not, the message is ignored. Example event sent with JSON:
+In a JSON-formatted email, the subject of the email doesn't appear in the event. The value of the title attribute is used for the event title. All data that appears in the event should be defined in JSON in the body of the email. Furthermore, the body must be pure, well-formed JSON—if not, the message is ignored. Example event sent with JSON:
 
 {{< img src="developers/events/json-event.png" alt="json event"  >}}
 
-**Note**: If you are testing the Email with a standard Email client, the body may be converted to HTML. This causes the body to no longer be pure JSON, resulting in an ignored Email.
+**Note**: If you are testing the email with a standard email client, the body may be converted to HTML. This causes the body to no longer be pure JSON, resulting in an ignored email.
 
 [1]: /api/v1/events/
 {{% /tab %}}
 {{% tab "Plain text" %}}
 
-If you have little control over the Email sent by an application, use a plain text formatted message.
+If you have little control over the email sent by an application, use a plain text formatted message.
 
-### Source Email {#source-email-2}
+### Source email {#source-email-2}
 
-With a plain text formatted Email, the following fields are controllable:
+With a plain text formatted email, the following fields are controllable:
 
 | Field                | Required | Description                     |
 |----------------------|----------|---------------------------------|
-| Sender Email address | Yes      | The Email address of the sender |
-| Subject              | Yes      | The subject of the Email        |
-| Body                 | No       | The body of the Email           |
+| Sender email address | Yes      | The email address of the sender |
+| Subject              | Yes      | The subject of the email        |
+| Body                 | No       | The body of the email           |
 
-For example, the Email below is a valid submission:
+For example, the email below is a valid submission:
 
 ```text
-Sender's Email: matt@datadog.com
+Sender's email: matt@datadog.com
 Subject: Env:Test - System at 50% CPU - #test
 Body: This is a test message showing that env:test is at 50% CPU - #test
 ```
 
 ### Datadog event {#datadog-event-2}
 
-The subject of the Email becomes the title of the event and the body of the Email becomes the event message. The sender of the Email appears at the bottom of the event. Example event sent with plain text:
+The subject of the email becomes the title of the event and the body of the email becomes the event message. The sender of the email appears at the bottom of the event. Example event sent with plain text:
 
 {{< img src="developers/events/plain-event.png" alt="plain event"  >}}
 

--- a/content/en/developers/faq/_index.md
+++ b/content/en/developers/faq/_index.md
@@ -8,7 +8,7 @@ private: true
 
 * [Datadog data collection, resolution, and retention][1]
 
-## APIs, Libraries and Community Contributions
+## APIs, libraries, and community contributions
 
 ### API
 
@@ -17,7 +17,7 @@ private: true
 * [Data aggregation with DogStatsD/Threadstats][4]
 * [Is there an alternative to DogStatsD and the api to submit metrics? Threadstats][5]
 
-### Libraries and Community Contributions
+### Libraries and community contributions
 
 * [OmniOS (and possibly OpenIndiana/Nexenta): install from source by tweaking the Agent install script ][6]
 * [Is it possible to integrate with ThousandEyes?][7]

--- a/content/en/developers/faq/use-our-webhook-integration-to-create-a-trello-card.md
+++ b/content/en/developers/faq/use-our-webhook-integration-to-create-a-trello-card.md
@@ -26,7 +26,7 @@ To get the Trello app key and token, [navigate to Trello's application key page]
 To get the token, click the token link (green arrow) above, authorize a token with the Trello account you are currently logged into, and grab the token in the subsequent link:
 {{< img src="developers/faq/trello_api_key.png" alt="trello_api_key"  >}}
 
-## Designate the Trello List
+## Designate the Trello list
 
 Click on a card in the list you'd like to add cards to. Append `.json` to the URL, and then navigate to that URL.
 {{< img src="developers/faq/card_url.png" alt="card_url"  >}}

--- a/content/en/developers/guide/dogshell-quickly-use-datadog-s-api-from-terminal-shell.md
+++ b/content/en/developers/guide/dogshell-quickly-use-datadog-s-api-from-terminal-shell.md
@@ -53,7 +53,7 @@ apikey = <DATADOG_API_KEY>
 appkey = <YOUR_APPLICATION_KEY>
 ```
 
-## The Dogshell Commands:
+## Dogshell commands
 
 For reference, [find the code for Dogshell][4]. But once you have Dogshell installed and initialized, you can append the `-h` option to the following commands to get more information on specific Dogshell usage:
 
@@ -69,7 +69,7 @@ For reference, [find the code for Dogshell][4]. But once you have Dogshell insta
 * `dog search`
 * `dog comment`
 
-### Example: Dogshell in Use
+### Dogshell in use
 
 You can post metrics to your Datadog account by using:
 

--- a/content/en/developers/libraries.md
+++ b/content/en/developers/libraries.md
@@ -63,7 +63,7 @@ Enclave delivers your metrics to a Datadog account. [Consult the dedicated Aptib
 
 [This extension][25] takes your Auth0 logs and ships them to Datadog.
 
-### CLI Management
+### CLI management
 
 A [set of tools][26] to backup/restore dashboards and monitors, and configure users via a command line interface.
 
@@ -106,10 +106,10 @@ K6, a load and performance regression testing tool developed by Load Impact, can
 
 A [LaunchDarkly][41] webhook handler that records changes as Datadog events.
 
-### Logstash Output
+### Logstash output
 
-* [Logstash Output for Datadog][42]
-* [Logstash Output for DogStatsD][43]
+* [Logstash output for Datadog][42]
+* [Logstash output for DogStatsD][43]
 
 ### Moogsoft
 

--- a/content/en/developers/metrics/types.md
+++ b/content/en/developers/metrics/types.md
@@ -43,7 +43,7 @@ These different metric submission types are mapped to four in-app metric types f
 
 **Note**: If you submit a metric to Datadog without a type, the metric type appears as `Not Assigned` within Datadog. The `Not Assigned` metric type cannot be further changed to another in-app type until an initial metric type is submitted.
 
-## Submission vs. In-App type
+## Submission vs. in-app type
 
 Metrics are submitted to Datadog in three main ways:
 
@@ -55,7 +55,7 @@ The majority of data that Datadog receives is submitted by the Agent, either thr
 
 Data submitted directly to the Datadog API is not aggregated by Datadog, with the exception of distribution metrics. The raw values sent to Datadog are stored as-is.
 
-Refer to the [Submission and In-App Types](#submission-types-and-datadog-in-app-types) section to see how different metric submission types are mapped to their corresponding in-app types.
+Refer to the [Submission types and Datadog in-app types](#submission-types-and-datadog-in-app-types) section to see how different metric submission types are mapped to their corresponding in-app types.
 
 ## Metric types
 

--- a/content/en/developers/office_hours.md
+++ b/content/en/developers/office_hours.md
@@ -14,7 +14,7 @@ Office hours will be held in #integrations in the [Datadog Community Slack][1] (
 * 2nd Wednesday of each month at 10:00 AM Eastern Time (New York).
 * 4th Wednesday of each month at 3:00 PM Eastern Time (New York).
 
-### Guidelines and Caveats
+### Guidelines and caveats
 
 - Review and feedback during office hours is offered on a first come, first served basis. We may not get to every review each week. We appreciate your patience and understanding.
 

--- a/content/en/developers/prometheus.md
+++ b/content/en/developers/prometheus.md
@@ -175,7 +175,7 @@ def check(self, instance):
     self.process(instance)
 ```
 
-### Putting It All Together
+### Putting it all together
 
 ```python
 from datadog_checks.base import ConfigurationError, OpenMetricsBaseCheck

--- a/content/en/developers/service_checks/_index.md
+++ b/content/en/developers/service_checks/_index.md
@@ -33,7 +33,7 @@ Service checks can be visualized and used in 3 Datadog sections:
 - [Screenboards][2]
 - [Custom check Monitor][3]
 
-### Check Summary
+### Check summary
 
 Click on the _Monitors_ tab, and then on _Check Summary_ to see the [Check Summary][1] page.
 


### PR DESCRIPTION
### What does this PR do?
Lint headings for the Developers section, mistakes found using:

```
vale content/en/developers/*
```

### Motivation
Docs hackathon

### Preview
https://docs-staging.datadoghq.com/ruth/linter-developers/developers/

### Additional Notes
The following will be added to the `headings.yml` exceptions list:
  - socat
  - Unix Domain Socket
  - User Datagram Protocol
  - Webhook
  - APM & Distributed Tracing
  - FreeSwitch
  - Google Analytics
  - LaunchDarkly
  - OpenVPN
  - Phusion Passenger
  - StackStorm
  - FreeBSD
  - NixOS
  - OpenMetrics
  - Prometheus

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
