### PR TITLE
Lint headings for Getting Started

### DIFF
--- a/content/en/getting_started/agent/_index.md
+++ b/content/en/getting_started/agent/_index.md
@@ -81,7 +81,7 @@ To collect metrics from other technologies, see the [Integrations][24] page.
 
 The Agent sends events to Datadog when an Agent is started or restarted.
 
-### Service Checks
+### Service checks
 
 **datadog.agent.up**:
 Returns `CRITICAL` if the Agent is unable to connect to Datadog, otherwise returns `OK`.
@@ -103,7 +103,7 @@ For help troubleshooting the Agent:
 
 <p>
 
-## Next Steps
+## Next steps
 
 {{< whatsnext desc="After the Agent is installed:">}}
 {{< nextlink href="/getting_started/integrations" tag="Documentation" >}}Learn about Integrations{{< /nextlink >}}

--- a/content/en/getting_started/agent/autodiscovery.md
+++ b/content/en/getting_started/agent/autodiscovery.md
@@ -34,7 +34,7 @@ Autodiscovery lets you define configuration templates for Agent checks and speci
 
 The Agent watches for events like container creation, destruction, starts, and stops. The Agent then enables, disables, and regenerates static check configurations on such events. As the Agent inspects each running container, it checks if the container matches any of the [Autodiscovery container identifiers][1] from any loaded templates. For each match, the Agent generates a static check configuration by substituting the [Template Variables][2] with the matching container's specific values. Then it enables the check using the static configuration.
 
-## How It Works
+## How it works
 
 {{< img src="agent/autodiscovery/ad_1.png" alt="Autodiscovery Overview"  style="width:80%;">}}
 
@@ -147,7 +147,7 @@ ECS_FARGATE=true
 {{% /tab %}}
 {{< /tabs >}}
 
-### Integration Templates
+### Integration templates
 
 Once Autodiscovery is enabled, the Datadog Agent automatically attempts Autodiscovery [for a number of services][4], including Apache and Redis, based on default Autodiscovery configuration files.
 

--- a/content/en/getting_started/api/_index.md
+++ b/content/en/getting_started/api/_index.md
@@ -78,7 +78,7 @@ Follow these steps to update to the EU instance:
 
 {{< /site-region >}}
 
-## Working with the Collection
+## Working with the collection
 
 After setup is complete, you are ready to begin making API calls. In the Postman -> Datadog folder, there are subfolders for each type of API category listed in the [Datadog API Reference][4]. Expand the subfolders to see the HTTP methods and API call names.
 

--- a/content/en/getting_started/application/_index.md
+++ b/content/en/getting_started/application/_index.md
@@ -40,18 +40,18 @@ This page gives a high level overview of the capabilities for the [Datadog site]
 - You can see the tags applied to each machine. Tagging allows you to indicate which machines have a particular purpose.
 - Datadog attempts to automatically categorize your servers. If a new machine is tagged, you can immediately see the stats for that machine based on what was previously set up for that tag. [Read more on tagging][8].
 
-## Host Map
+## Host map
 
 {{< img src="getting_started/hostmap-overview.png" alt="hostmap overview"  >}}
 
-[The Host Map][9] can be found under the Infrastructure menu. It offers the ability to:
+The [host map][9] can be found under the Infrastructure menu. It offers the ability to:
 
 - Quickly visualize your environment
 - Identify outliers
 - Detect usage patterns
 - Optimize resources
 
-To learn more about the Host Map, visit the [Host Map dedicated documentation page][9].
+To learn more about the host map, visit the [host map documentation][9].
 
 ## Events
 

--- a/content/en/getting_started/integrations/_index.md
+++ b/content/en/getting_started/integrations/_index.md
@@ -30,7 +30,7 @@ You can also build a [custom check][10] to define and send metrics to Datadog fr
 
 The Datadog Agent package includes integrations officially supported by Datadog, in [integrations core][11]. To use those integrations, download the Datadog Agent. Community-based integrations are in [integrations extras][12], and to use those, you need to download the [developer toolkit][13]. For more information on installing or managing these integrations, see the [integrations management guide][14].
 
-### API and Application keys
+### API and application keys
 
 To [install the Datadog Agent][15], you need an [API key][16]. If the Agent is already downloaded, make sure to set up the API key in the `datadog.yaml` file. To use most additional Datadog functionality besides submitting metrics and events, you need an [application key][16]. You can manage your accounts API and application keys in the [API Settings page][17].
 

--- a/content/en/getting_started/synthetics/_index.md
+++ b/content/en/getting_started/synthetics/_index.md
@@ -36,7 +36,7 @@ If you haven't already, create a [Datadog account][2].
 - [Create a browser test][4]
 - [Create an API test][5]
 
-## Next Steps
+## Next steps
 
 {{< whatsnext desc="After you set up your first Synthetic test:">}}
 {{< nextlink href="/synthetics/browser_tests" tag="Documentation" >}}Learn more about browser tests{{< /nextlink >}}

--- a/content/en/getting_started/synthetics/private_location.md
+++ b/content/en/getting_started/synthetics/private_location.md
@@ -34,7 +34,7 @@ The private location worker is available on Docker Hub:
 |---------------------------------------------------------------------------|
 | [hub.docker.com/r/datadog/synthetics-private-location-worker][3]          |
 
-## Create your Private Location
+## Create your private location
 
 1. Set up a [Vagrant Ubuntu 16.04 virtual machine][2].
 2. Install [Docker][4] on that machine.
@@ -65,7 +65,7 @@ The private location worker is available on Docker Hub:
 
 You are now able to use your new private location as any other Datadog managed locations to run Synthetic tests.
 
-## Run Synthetic Tests with your Private Location
+## Run synthetic tests with your private location
 
 1. Create an API or a Browser on any internal endpoint or application you want to monitor.
 2. Select the new private location under **Private Locations**:

--- a/content/en/getting_started/tagging/_index.md
+++ b/content/en/getting_started/tagging/_index.md
@@ -35,13 +35,13 @@ Tagging binds different data types in Datadog, allowing for correlation and call
 | `env`     | Scoping of application specific data across metrics, traces, and logs |
 | `version` | Scoping of application specific data across metrics, traces, and logs |
 
-## Why It Matters
+## Why it matters
 
 Typically, it's helpful to look at containers, VMs, and cloud infrastructure at the `service` level in aggregate. For example, it's more helpful to look at CPU usage across a collection of hosts that represents a service, rather than CPU usage for server A or server B separately.
 
 Containers and cloud environments regularly churn through hosts, so it is critical to tag these to allow for aggregation of the metrics you're getting.
 
-## Defining Tags
+## Defining tags
 
 Below are Datadog's tagging requirements:
 
@@ -69,7 +69,7 @@ Below are Datadog's tagging requirements:
 
 5. Tags shouldn't originate from unbounded sources, such as epoch timestamps, user IDs, or request IDs. Doing so may infinitely [increase the number of metrics][2] for your organization and impact your billing.
 
-## Assigning Tags
+## Assigning tags
 
 ### Tagging methods
 
@@ -86,7 +86,7 @@ Tags may be assigned using any (or all) of the following methods. Refer to the d
 
 As a best practice, Datadog recommends using unified service tagging when assigning tags. Unified service tagging ties Datadog telemetry together through the use of three standard tags: `env`, `service`, and `version`. To learn how to configure your environment with unified tagging, refer to the dedicated [unified service tagging][8] documentation.
 
-## Using Tags
+## Using tags
 
 After you have [assigned tags][3] at the host and [integration][9] level, start using them to filter and group your metrics, traces, and logs. Tags are used in the following areas of your Datadog platform. Refer to the dedicated [Using Tags documentation][1] to learn more:
 

--- a/content/en/getting_started/tagging/assigning_tags.md
+++ b/content/en/getting_started/tagging/assigning_tags.md
@@ -44,7 +44,7 @@ If Autodiscovery is not in use, the Agent automatically assigns the [host tag](#
 {{% /tab %}}
 {{< /tabs >}}
 
-## Methods for Assigning Tags
+## Methods for assigning tags
 
 ### Configuration file
 

--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -143,9 +143,9 @@ To configure [Kubernetes State Metrics][2]:
           tags.datadoghq.com/version: "<VERSION>"
   ```
 
-###### APM Tracer / StatsD client
+###### APM tracer and StatsD client
 
-To configure [APM Tracer][4] and [StatsD client][5] environment variables, use the [Kubernetes's downward API][1] in the format below:
+To configure [APM tracer][4] and [StatsD client][5] environment variables, use the [Kubernetes's downward API][1] in the format below:
 
 ```yaml
 containers:
@@ -365,7 +365,7 @@ to configure the `service` tag only in the configuration of the process check.
 
 ### Serverless environment
 
-#### AWS Lambda Functions 
+#### AWS Lambda functions
 
 Depending on how you build and deploy your AWS Lambda-based serverless applications, you may have several options available for applying the `env`, `service` and `version` tags to metrics, traces and logs.
 

--- a/content/en/getting_started/tagging/using_tags.md
+++ b/content/en/getting_started/tagging/using_tags.md
@@ -1,5 +1,5 @@
 ---
-title: Using tags
+title: Using Tags
 kind: documentation
 aliases:
 - /tagging/using_tags/
@@ -298,7 +298,7 @@ Additionally, tags are used to filter a logs [Pipeline][14]. In the example belo
 {{< img src="tagging/using_tags/logpipelinetags.png" alt="Pipeline Tags"  style="width:80%;">}}
 
 
-## Service Level Objectives
+## Service level objectives
 
 {{< tabs >}}
 {{% tab "Manage SLOs" %}}

--- a/content/en/getting_started/tracing/_index.md
+++ b/content/en/getting_started/tracing/_index.md
@@ -53,7 +53,7 @@ After a few minutes, verify the Agent is connected to your account by checking t
 
 ## Datadog APM
 
-### Follow the in-app documentation (Recommended)
+### Follow the in-app documentation (recommended)
 
 For the remaining steps, follow the [Quickstart instructions][10] within the Datadog app for the best experience, including:
 


### PR DESCRIPTION
### What does this PR do?
Lint headings for the Getting Started section, mistakes found using:

```
vale content/en/getting_started/*
```

### Motivation
Docs hackathon

### Preview
https://docs-staging.datadoghq.com/ruth/linter-getting-started/getting_started/

### Additional Notes
The following will be added to the `headings.yml` exceptions list:
- StatsD

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
