### PR TITLE
fix some links

### DIFF
--- a/content/en/developers/faq/deploying-the-agent-on-raspberrypi.md
+++ b/content/en/developers/faq/deploying-the-agent-on-raspberrypi.md
@@ -38,9 +38,6 @@ nohup sh /root/.datadog-agent/bin/agent &
 You now see metrics being ingested from your Raspberry PI device:
 {{< img src="developers/faq/rasberry_dashboard.png" alt="raspberry_dashboard"   >}}
 
-Thank you to Karim Vaes for the [excellent blog post][2]!
-
 **Note**: Datadog does not officially support Raspbian.
 
 [1]: https://app.datadoghq.com/account/settings#agent/source
-[2]: https://kvaes.wordpress.com/2015/12/29/datadog-on-raspberry-pi

--- a/content/en/developers/libraries.md
+++ b/content/en/developers/libraries.md
@@ -118,7 +118,7 @@ A Moogsoft [listener][44] that ingests Datadog notifications.
 ### NGINX LUA
 
 * Emit [custom metrics][45] directly from NGINX configurations using the [nginx_lua_datadog][46] module in your LUA scripts.
-* [lua-resty-dogstatsd][47] is an extension developed by [mediba inc][48] (now forked by [dailymotion][64]). It enables emiting metrics, events, and service checks to [DogStatsD][1] protocol. lua-resty-dogstatsd is released as GPLv3 and relies on the nginx cosocket API.
+* [lua-resty-dogstatsd][47] is an extension developed by [mediba inc][48] (now forked by [Dailymotion][64]). It enables emitting metrics, events, and service checks through the [DogStatsD][1] protocol. `lua-resty-dogstatsd` is released as GPLv3 and relies on the Nginx cosocket API.
 
 ### OpenVPN
 

--- a/content/en/developers/libraries.md
+++ b/content/en/developers/libraries.md
@@ -118,7 +118,7 @@ A Moogsoft [listener][44] that ingests Datadog notifications.
 ### NGINX LUA
 
 * Emit [custom metrics][45] directly from NGINX configurations using the [nginx_lua_datadog][46] module in your LUA scripts.
-* [lua-resty-dogstatsd][47] is an extension developed by [mediba inc][48], which enables emiting metrics, events, and service checks to [DogStatsD][1] protocol. lua-resty-dogstatsd is released as GPLv3 and relies on the nginx cosocket API.
+* [lua-resty-dogstatsd][47] is an extension developed by [mediba inc][48] (now forked by [dailymotion][64]). It enables emiting metrics, events, and service checks to [DogStatsD][1] protocol. lua-resty-dogstatsd is released as GPLv3 and relies on the nginx cosocket API.
 
 ### OpenVPN
 
@@ -183,7 +183,7 @@ If you've written a Datadog library and would like to add it to this page, send 
 [19]: https://www.terraform.io
 [20]: https://github.com/intercom/datadog-to-terraform
 [21]: https://github.com/intercom
-[22]: https://docs.ansible.com/ansible/list_of_monitoring_modules.html
+[22]: https://docs.ansible.com/ansible/2.9/modules/list_of_monitoring_modules.html
 [23]: https://github.com/ansible/ansible-modules-extras
 [24]: https://www.aptible.com/documentation/enclave/reference/metrics/metric-drains/datadog.html
 [25]: https://github.com/BetaProjectWave/auth0-logs-to-datadog
@@ -197,7 +197,7 @@ If you've written a Datadog library and would like to add it to this page, send 
 [33]: https://blog.bithaus.cl/2016/04/20/realtime-google-analytics-metrics-in-datadog
 [34]: /logs/guide/collect-heroku-logs/
 [35]: https://github.com/ozinc/heroku-datadog-drain
-[36]: https://corp.oz.com
+[36]: https://web.oz.com/
 [37]: https://github.com/apiaryio/heroku-datadog-drain-golang
 [38]: https://apiary.io
 [39]: https://github.com/evernote/jiradog
@@ -205,10 +205,10 @@ If you've written a Datadog library and would like to add it to this page, send 
 [41]: https://github.com/meetup/launch-dogly
 [42]: https://www.elastic.co/guide/en/logstash/current/plugins-outputs-datadog.html
 [43]: https://github.com/brigade/logstash-output-dogstatsd
-[44]: https://docs.moogsoft.com/display/060102/Datadog+Solution+Pak
+[44]: https://docs.moogsoft.com/AIOps.6.2.0/Datadog-Solution-Pak_13737047.html
 [45]: /developers/metrics/custom_metrics/
 [46]: https://github.com/simplifi/ngx_lua_datadog
-[47]: https://github.com/mediba-system/lua-resty-dogstatsd
+[47]: https://github.com/dailymotion/lua-resty-dogstatsd
 [48]: http://www.mediba.jp
 [49]: https://github.com/byronwolfman/dd-openvpn
 [50]: https://github.com/denniswebb/datadog-openvpn
@@ -225,3 +225,4 @@ If you've written a Datadog library and would like to add it to this page, send 
 [61]: https://github.com/urosgruber/dd-agent-FreeBSD
 [62]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/tools/networking/dd-agent
 [63]: mailto:opensource@datadoghq.com
+[64]: https://www.dailymotion.com/us

--- a/content/en/logs/log_collection/java.md
+++ b/content/en/logs/log_collection/java.md
@@ -357,7 +357,7 @@ Then, edit the `pom.xml` file with the following content:
 
 **note:** As a result of this migration, Log4j configuration files will no longer be picked up. Migrate your `log4j.properties` file to `logback.xml` with the [Log4j translator][1].
 
-[1]: https://logback.qos.ch/translator
+[1]: http://logback.qos.ch/translator
 {{% /tab %}}
 
 {{% tab "Log4j2" %}}

--- a/content/fr/developers/libraries.md
+++ b/content/fr/developers/libraries.md
@@ -182,7 +182,7 @@ Si vous avez rédigé une bibliothèque Datadog et que vous souhaitez l'ajouter 
 [19]: https://www.terraform.io
 [20]: https://github.com/intercom/datadog-to-terraform
 [21]: https://github.com/intercom
-[22]: https://docs.ansible.com/ansible/list_of_monitoring_modules.html
+[22]: https://docs.ansible.com/ansible/2.9/modules/list_of_monitoring_modules.html
 [23]: https://github.com/ansible/ansible-modules-extras
 [24]: https://www.aptible.com/documentation/enclave/reference/metrics/metric-drains/datadog.html
 [25]: https://github.com/BetaProjectWave/auth0-logs-to-datadog
@@ -196,7 +196,7 @@ Si vous avez rédigé une bibliothèque Datadog et que vous souhaitez l'ajouter 
 [33]: https://blog.bithaus.cl/2016/04/20/realtime-google-analytics-metrics-in-datadog
 [34]: /fr/logs/guide/collect-heroku-logs/
 [35]: https://github.com/ozinc/heroku-datadog-drain
-[36]: https://corp.oz.com
+[36]: https://web.oz.com/
 [37]: https://github.com/apiaryio/heroku-datadog-drain-golang
 [38]: https://apiary.io
 [39]: https://github.com/evernote/jiradog
@@ -204,10 +204,10 @@ Si vous avez rédigé une bibliothèque Datadog et que vous souhaitez l'ajouter 
 [41]: https://github.com/meetup/launch-dogly
 [42]: https://www.elastic.co/guide/en/logstash/current/plugins-outputs-datadog.html
 [43]: https://github.com/brigade/logstash-output-dogstatsd
-[44]: https://docs.moogsoft.com/display/060102/Datadog+Solution+Pak
+[44]: https://docs.moogsoft.com/AIOps.6.2.0/Datadog-Solution-Pak_13737047.html
 [45]: /fr/developers/metrics/custom_metrics/
 [46]: https://github.com/simplifi/ngx_lua_datadog
-[47]: https://github.com/mediba-system/lua-resty-dogstatsd
+[47]: https://github.com/dailymotion/lua-resty-dogstatsd
 [48]: http://www.mediba.jp
 [49]: https://github.com/byronwolfman/dd-openvpn
 [50]: https://github.com/denniswebb/datadog-openvpn
@@ -224,3 +224,4 @@ Si vous avez rédigé une bibliothèque Datadog et que vous souhaitez l'ajouter 
 [61]: https://github.com/urosgruber/dd-agent-FreeBSD
 [62]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/tools/networking/dd-agent
 [63]: mailto:code@datadoghq.com
+[64]: https://www.dailymotion.com/us

--- a/content/ja/developers/libraries.md
+++ b/content/ja/developers/libraries.md
@@ -182,7 +182,7 @@ Datadog ライブラリを作成し、このページに追加する場合は、
 [19]: https://www.terraform.io
 [20]: https://github.com/intercom/datadog-to-terraform
 [21]: https://github.com/intercom
-[22]: https://docs.ansible.com/ansible/list_of_monitoring_modules.html
+[22]: https://docs.ansible.com/ansible/2.9/modules/list_of_monitoring_modules.html
 [23]: https://github.com/ansible/ansible-modules-extras
 [24]: https://www.aptible.com/documentation/enclave/reference/metrics/metric-drains/datadog.html
 [25]: https://github.com/BetaProjectWave/auth0-logs-to-datadog
@@ -196,7 +196,7 @@ Datadog ライブラリを作成し、このページに追加する場合は、
 [33]: https://blog.bithaus.cl/2016/04/20/realtime-google-analytics-metrics-in-datadog
 [34]: /ja/logs/guide/collect-heroku-logs/
 [35]: https://github.com/ozinc/heroku-datadog-drain
-[36]: https://corp.oz.com
+[36]: https://web.oz.com/
 [37]: https://github.com/apiaryio/heroku-datadog-drain-golang
 [38]: https://apiary.io
 [39]: https://github.com/evernote/jiradog
@@ -204,10 +204,10 @@ Datadog ライブラリを作成し、このページに追加する場合は、
 [41]: https://github.com/meetup/launch-dogly
 [42]: https://www.elastic.co/guide/en/logstash/current/plugins-outputs-datadog.html
 [43]: https://github.com/brigade/logstash-output-dogstatsd
-[44]: https://docs.moogsoft.com/display/060102/Datadog+Solution+Pak
+[44]: https://docs.moogsoft.com/AIOps.6.2.0/Datadog-Solution-Pak_13737047.html
 [45]: /ja/developers/metrics/custom_metrics/
 [46]: https://github.com/simplifi/ngx_lua_datadog
-[47]: https://github.com/mediba-system/lua-resty-dogstatsd
+[47]: https://github.com/dailymotion/lua-resty-dogstatsd
 [48]: http://www.mediba.jp
 [49]: https://github.com/byronwolfman/dd-openvpn
 [50]: https://github.com/denniswebb/datadog-openvpn
@@ -224,3 +224,4 @@ Datadog ライブラリを作成し、このページに追加する場合は、
 [61]: https://github.com/urosgruber/dd-agent-FreeBSD
 [62]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/tools/networking/dd-agent
 [63]: mailto:code@datadoghq.com
+[64]: https://www.dailymotion.com/us


### PR DESCRIPTION
### What does this PR do?
Fixes some broken links.

### Motivation
These links were broken.

### Preview
https://docs-staging.datadoghq.com/dadgoat/fix_more_broken_links/developers/faq/deploying-the-agent-on-raspberrypi/
https://docs-staging.datadoghq.com/dadgoat/fix_more_broken_links/developers/libraries/
https://docs-staging.datadoghq.com/dadgoat/fix_more_broken_links/ja/developers/libraries/
https://docs-staging.datadoghq.com/dadgoat/fix_more_broken_links/fr/developers/libraries/
https://docs-staging.datadoghq.com/dadgoat/fix_more_broken_links/logs/log_collection/java/

### Additional Notes
The Japanese and French versions need a translation of the note about `lua-resty-dogstatsd` being forked by dailymotion. Its no longer available on mediba's github.

The raspberry pi blog post doesnt seem to exist on the internet anymore, so I removed the reference.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
