### PR TITLE
Lint headings for Infrastructure

### DIFF
--- a/content/en/infrastructure/hostmap.md
+++ b/content/en/infrastructure/hostmap.md
@@ -92,7 +92,7 @@ Data in the Host Map is refreshed about once a minute—unless you are continuou
 
 ## Use cases
 
-### Resource Optimization
+### Resource optimization
 
 If you are an AWS user, you probably use a variety of instance types. Some instances are optimized for memory, some for compute, some are small, some are big.  
 If you want to reduce your AWS spend, you might start by figuring out what the expensive instances are used for. First group by `instance-type` and then group by `role` or `name`. Take a look at your expensive instance types, such as **c3.8xlarge**. Are there any host roles whose CPU is underutilized? If so, zoom in to individual hosts and see whether all that computational horsepower has been needed in the last several months, or whether this group of hosts is a candidate for migrating to a cheaper instance type.  
@@ -105,7 +105,7 @@ As seen below, by clicking on the c3.2xlarge group and then sub-grouping by role
 
 {{< img src="infrastructure/hostmap/hostmappart1image3.png" alt="Datadog Host Maps Instance-Role Groups"  style="width:80%;">}}
 
-### Availability Zone Placement
+### Availability zone placement
 
 Host maps enable you to see distributions of machines in each of your availability zones (AZ). Filter for the hosts you are interested in, group by AZ, and you can immediately see whether resources need rebalancing. 
 
@@ -113,7 +113,7 @@ In the example seen below, there is an uneven distribution of hosts with `role:d
 
 {{< img src="infrastructure/hostmap/hostmappart1image4.png" alt="Datadog Host Maps AZ Balance"  style="width:80%;" >}}
 
-### Problem Investigation
+### Problem investigation
 
 Imagine you are having a problem in production. Maybe the CPUs on some of your hosts are pegged, which is causing long response times. Host Maps can help you quickly see whether there is anything different about the loaded and not-loaded hosts. You can rapidly group by dimensions you would like to investigate, and visually determine whether the problem servers belong to a certain group.  
 For example, you can group by availability zone, region, instance type, image, or any tags that you use within your system. 

--- a/content/en/infrastructure/livecontainers.md
+++ b/content/en/infrastructure/livecontainers.md
@@ -25,7 +25,7 @@ Coupled with [Docker][2], [Kubernetes][3], [ECS][4], and other container technol
 
 ## Configuration
 
-### Kubernetes Resources
+### Kubernetes resources
 
 The Datadog Agent and Cluster Agent can be configured to retrieve Kubernetes resources for [Live Containers][5]. This feature allows you to monitor the state of pods, deployments and other Kubernetes concepts in a specific namespace or availability zone, view resource specifications for failed pods within a deployment, correlate node activity with related logs, and more.
 
@@ -225,7 +225,7 @@ Having these tags available will let you tie together APM, logs, metrics, and li
 
 ## Views
 
-### Containers View
+### Containers view
 
 The **Containers** view includes [Scatter Plot](#scatter-plot) and [Timeseries][10] views, and a table to better organize your container data by fields such as container name, status, and start time.
 
@@ -251,7 +251,7 @@ The query at the top of the scatter plot analytic allows you to control your sca
 
 While actively working with the containers page, metrics are collected at a 2-second resolution. This is important for highly volatile metrics such as CPU. In the background, for historical context, metrics are collected at 10s resolution.
 
-### Kubernetes Resources View
+### Kubernetes resources view
 
 If you have enabled Kubernetes Resources for Live Containers, toggle between the **Pods**, **Deployments**, **ReplicaSets**, and **Services** views in the **View** dropdown menu in the top left corner of the page. Each of these views includes a data table to help you better organize your data by field such as status, name, and Kubernetes labels, and a detailed Cluster Map to give you a bigger picture of your pods and Kubernetes clusters.
 
@@ -280,13 +280,13 @@ For a detailed dashboard of this resource, click the **View Dashboard** in the t
 
 ### Container logs
 
-View streaming logs for any container like `docker logs -f` or `kubectl logs -f` in Datadog. Click any container in the table to inspect it. Click the *Logs* tab to see real-time data from [Live Tail][15] or indexed logs for any time in the past.
+View streaming logs for any container like `docker logs -f` or `kubectl logs -f` in Datadog. Click any container in the table to inspect it. Click the *Logs* tab to see real-time data from [live tail][15] or indexed logs for any time in the past.
 
-#### Live Tail
+#### Live tail
 
-With Live Tail, all container logs are streamed. Pausing the stream allows you to easily read logs that are quickly being written; unpause to continue streaming.
+With live tail, all container logs are streamed. Pausing the stream allows you to easily read logs that are quickly being written; unpause to continue streaming.
 
-Streaming logs can be searched with simple string matching. For more details about Live Tail, see the [Live Tail documentation][15].
+Streaming logs can be searched with simple string matching. For more details about live tail, see the [documentation][15].
 
 **Note**: Streaming logs are not persisted, and entering a new search or refreshing the page clears the stream.
 
@@ -304,7 +304,7 @@ You can see logs that you have chosen to index and persist by selecting a corres
 * RBAC settings can restrict Kubernetes metadata collection. Refer to the [RBAC entites for the Datadog Agent][16].
 * In Kubernetes the `health` value is the containers' readiness probe, not its liveness probe.
 
-### Kubernetes Resources
+### Kubernetes resources
 
 * Data is updated automatically in constant intervals. Update intervals may change during beta.
 * In clusters with 1000+ Deployments or ReplicaSets you may notice elevated CPU usage from the Cluster Agent. There is an option to disable container scrubbing in the Helm chart, see [the Helm Chart repo][17] for more details.

--- a/content/en/infrastructure/process.md
+++ b/content/en/infrastructure/process.md
@@ -30,7 +30,7 @@ Datadog’s Live Processes gives you real-time visibility into the process runni
 
 ## Installation
 
-If you are using Agent 5, [follow this specific installation process][2]. If you are using Agent 6 or 7, [see the intructions below][1]. 
+If you are using Agent 5, [follow this specific installation process][1]. If you are using Agent 6 or 7, [see the intructions below][2]. 
 
 {{< tabs >}}
 {{% tab "Linux/Windows" %}}
@@ -120,7 +120,7 @@ datadog:
 
 {{< /tabs >}}
 
-### Process Arguments Scrubbing
+### Process arguments scrubbing
 
 In order to hide sensitive data on the Live Processes page, the Agent scrubs sensitive arguments from the process command line. This feature is enabled by default and any process argument that matches one of the following words has its value hidden.
 
@@ -155,11 +155,11 @@ process_config:
 
 ## Queries
 
-### Scoping Processes
+### Scoping processes
 
 Processes are, by nature, extremely high cardinality objects. To refine your scope to view relevant processes, you can use text and tag filters. 
 
-#### Text Filters
+#### Text filters
 
 When you input a text string into the search bar, fuzzy string search is used to query processes containing that text string in their command lines or paths. Enter a string of two or more characters to see results. Below is Datadog's demo environment, filtered with the string `postgres /9.`.
 
@@ -178,7 +178,7 @@ To combine multiple string searches into a complex query, use any of the followi
 
 Use parentheses to group operators together. For example, `(NOT (elasticsearch OR kafka) java) OR python` .
 
-#### Tag Filters
+#### Tag filters
 
 You can also filter your processes using Datadog [tags][3], such as `host`, `pod`, `user`, and `service`. Input tag filters directly into the search bar, or select them in the facet panel on the left of the page.
 
@@ -187,7 +187,7 @@ Datadog automatically generates a `command` tag, so that you can filter for
 * container management software (e.g. `command:docker`, `command:kubelet`)
 * common workloads (e.g. `command:ssh`, `command:CRON`)
 
-### Aggregating Processes
+### Aggregating processes
 
 [Tagging][3] enhances navigation. In addition to all existing host-level tags, processes are tagged by `user`.
 
@@ -197,7 +197,7 @@ Furthermore, processes in ECS containers are also tagged by:
 - `task_version`
 - `ecs_cluster`
 
-Processeses in Kubernetes containers are tagged by:
+Processes in Kubernetes containers are tagged by:
 
 - `pod_name`
 - `kube_pod_ip`
@@ -213,7 +213,7 @@ If you have configuration for [Unified Service Tagging][4] in place, `env`, `ser
 Having these tags available will let you tie together APM, logs, metrics, and process data.
 Note that this setup applies to containerized environments only.
 
-## Scatter Plot
+## Scatter plot
 
 Use the scatter plot analytic to compare two metrics with one another in order to better understand the performance of your containers.
 
@@ -231,13 +231,13 @@ The query at the top of the scatter plot analytic allows you to control your sca
 
 {{< img src="infrastructure/process/scatterplot.png" alt="container inspect"  style="width:80%;">}}
 
-## Process Monitors
+## Process monitors
 
 Use the [Live Process Monitor][6] to generate alerts based on the count of any group of processes across hosts or tags. You can configure process alerts in the [Monitors page][7]. To learn more, see our [Live Process Monitor documentation][6]. 
 
 {{< img src="infrastructure/process/process_monitor.png" alt="Process Monitor"  style="width:80%;">}}
 
-## Processes in Dashboards and Notebooks
+## Processes in dashboards and notebooks
 
 You can graph process metrics in dashboards and notebooks using the [Timeseries widget][8]. To configure: 
 1. Select Live Processes as a data source 
@@ -247,9 +247,9 @@ You can graph process metrics in dashboards and notebooks using the [Timeseries 
 
 {{< img src="infrastructure/process/process_widget.png" alt="Processes widget"  style="width:80%;">}}
 
-## Autodetected Integrations
+## Autodetected integrations
 
-Datadog uses process collection to autodetect the technologies running on your hosts. This identifies Datadog integrations that can help you monitor these technologies. These auto-detected integrations are displayed in the [Integrations search][2]:
+Datadog uses process collection to autodetect the technologies running on your hosts. This identifies Datadog integrations that can help you monitor these technologies. These auto-detected integrations are displayed in the [Integrations search][1]:
 
 {{< img src="getting_started/integrations/ad_integrations.png" alt="Autodetected integrations" >}}
 
@@ -260,19 +260,19 @@ Each integration has one of two status types:
 
 Hosts that are running the integration, but where the integration is not enabled, can be found in the **Hosts** tab of the integrations tile.
 
-## Processes across the Platform 
+## Processes across the platform
 
 {{< img src="infrastructure/process/process_platform.gif" alt="Processes across the Platform" >}}
 
-### In Live Containers
+### Live containers
 
 Live Processes adds extra visibility to your container deployments by monitoring the processes running on each of your containers. Click on a container in the [Live Containers][9] page to view its process tree, including the commands it is running and their resource consumption. Use this data alongside other container metrics to determine the root cause of failing containers or deployments.
 
-### In APM
+### APM
 
 In [APM Traces][10], you can click on a service’s span to see the processes running on its underlying infrastructure. A service’s span processes are correlated with the hosts or pods on which the service runs at the time of the request. Analyze process metrics such as CPU and RSS memory alongside code-level errors to distinguish between application-specific and wider infrastructure issues. Clicking on a process will bring you to the Live Processes page. Related processes are not currently supported for serverless and browser traces.
 
-### In Network Performance Monitoring 
+### Network Performance Monitoring 
 
 When you inspect a dependency in the [Network Overview][11], you can view processes running on the underlying infrastructure of the endpoints (e.g. services) communicating with one another. Use process metadata to determine whether poor network connectivity (indicated by a high number of TCP retransmits) or high network call latency (indicated by high TCP round-trip time) could be due to heavy workloads consuming those endpoints' resources, and thus, affecting the health and efficiency of their communication. 
 
@@ -280,7 +280,7 @@ When you inspect a dependency in the [Network Overview][11], you can view proces
 
 While actively working with the Live Processes, metrics are collected at 2s resolution. This is important for highly volatile metrics such as CPU. In the background, for historical context, metrics are collected at 10s resolution.
 
-## Additional Information
+## Additional information
 
 - Collection of open files and current working directory is limited based on the level of privilege of the user running `dd-process-agent`. In the event that `dd-process-agent` is able to access these fields, they are collected automatically.
 - Real-time (2s) data collection is turned off after 30 minutes. To resume real-time collection, refresh the page.
@@ -290,8 +290,8 @@ While actively working with the Live Processes, metrics are collected at 2s reso
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /agent/
-[2]: /agent/faq/agent-5-process-collection/
+[1]: /agent/faq/agent-5-process-collection/
+[2]: /agent/
 [3]: /getting_started/tagging/
 [4]: /getting_started/tagging/unified_service_tagging
 [5]: https://app.datadoghq.com/process


### PR DESCRIPTION
### What does this PR do?
Lint headings for the Infrastructure section, mistakes found using:

```
vale content/en/infrastructure/*
```

### Motivation
Docs hackathon

### Preview
https://docs-staging.datadoghq.com/ruth/linter-infrastructure/infrastructure/

### Additional Notes
N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
