### PR TITLE
clarify which Datadog Agent is needed for unified service tagging

### DIFF
--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -28,7 +28,7 @@ With these three tags you can:
 
 ### Requirements
 
-- Unified service tagging requires setup of a [Datadog Agent][2] that is 6.18.x/7.18.x or higher.
+- Unified service tagging requires setup of a [Datadog Agent][2] that is 6.19.x/7.19.x or higher.
 
 - Unified service tagging requires a tracer version that supports new configurations of the [reserved tags][1]. More information can be found per language in the [setup instructions][3].
 

--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -28,7 +28,7 @@ With these three tags you can:
 
 ### Requirements
 
-- Unified service tagging requires setup of the [Datadog Agent][2].
+- Unified service tagging requires setup of a [Datadog Agent][2] that is 6.18.x/7.18.x or higher.
 
 - Unified service tagging requires a tracer version that supports new configurations of the [reserved tags][1]. More information can be found per language in the [setup instructions][3].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Explains in the requirements that Datadog Agent 6.19.x/7.19.x or higher is needed to use unified service tagging.

### Motivation
<!-- What inspired you to submit this pull request?-->

Clarify the exact version of the Datadog Agent used in this feature.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/wantsui/unified-service-tagging-dd-agent/getting_started/tagging/unified_service_tagging/?tab=kubernetes#overview

### Additional Notes
<!-- Anything else we should know when reviewing?-->

Check with @andrewardito for wording.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
