### PR TITLE
[rum] addTiming docs

### DIFF
--- a/content/en/real_user_monitoring/browser/monitoring_page_performance.md
+++ b/content/en/real_user_monitoring/browser/monitoring_page_performance.md
@@ -91,10 +91,13 @@ Or when users first scroll:
 
 ```javascript
 document.addEventListener("scroll", function handler(e) {
-    e.currentTarget.removeEventListener(e.type, handler); //Remove the event listener so that it only triggers once
+    //Remove the event listener so that it only triggers once
+    e.currentTarget.removeEventListener(e.type, handler);
     DD_RUM.addTiming('first_scroll');
 });
 ```
+
+Once the timing is sent, you must [create a measure][15] before graphing it in RUM analytics or in dashboards.
 
 **Note**: For Single Page Applications, the `addTiming` API issues a timing relative to the start of the current RUM view. For example, if a user lands on your application (initial load), then goes on a different page after 5 seconds (route change) and finally triggers `addTiming` after 8 seconds, the timing will equal 8-5 = 3 seconds.
 ## Further Reading
@@ -115,3 +118,4 @@ document.addEventListener("scroll", function handler(e) {
 [12]: https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event
 [13]: https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event
 [14]: https://developer.mozilla.org/en-US/docs/Web/API/History
+[15]: /real_user_monitoring/explorer/?tab=measures#setup-facets-and-measures

--- a/content/en/real_user_monitoring/browser/monitoring_page_performance.md
+++ b/content/en/real_user_monitoring/browser/monitoring_page_performance.md
@@ -97,7 +97,7 @@ document.addEventListener("scroll", function handler() {
 });
 ```
 
-Once the timing is sent, the timing will be accessible as `@view.custom_timings.<timing_name>` (e.g. `@view.custom_timings.first_scroll`). You must [create a measure][15] before graphing it in RUM analytics or in dashboards.
+Once the timing is sent, the timing will be accessible as `@view.custom_timings.<timing_name>` (For example, `@view.custom_timings.first_scroll`). You must [create a measure][15] before graphing it in RUM analytics or in dashboards.
 
 **Note**: For Single Page Applications, the `addTiming` API issues a timing relative to the start of the current RUM view. For example, if a user lands on your application (initial load), then goes on a different page after 5 seconds (route change) and finally triggers `addTiming` after 8 seconds, the timing will equal 8-5 = 3 seconds.
 ## Further Reading

--- a/content/en/real_user_monitoring/browser/monitoring_page_performance.md
+++ b/content/en/real_user_monitoring/browser/monitoring_page_performance.md
@@ -90,9 +90,9 @@ On top of RUM's default performance timing, you may measure where your applicati
 Or when users first scroll:
 
 ```javascript
-document.addEventListener("scroll", function handler(e) {
+document.addEventListener("scroll", function handler() {
     //Remove the event listener so that it only triggers once
-    e.currentTarget.removeEventListener(e.type, handler);
+    document.removeEventListener("scroll", handler);
     DD_RUM.addTiming('first_scroll');
 });
 ```

--- a/content/en/real_user_monitoring/browser/monitoring_page_performance.md
+++ b/content/en/real_user_monitoring/browser/monitoring_page_performance.md
@@ -97,7 +97,7 @@ document.addEventListener("scroll", function handler(e) {
 });
 ```
 
-Once the timing is sent, you must [create a measure][15] before graphing it in RUM analytics or in dashboards.
+Once the timing is sent, the timing will be accessible as `@view.custom_timings.<timing_name>` (e.g. `@view.custom_timings.first_scroll`). You must [create a measure][15] before graphing it in RUM analytics or in dashboards.
 
 **Note**: For Single Page Applications, the `addTiming` API issues a timing relative to the start of the current RUM view. For example, if a user lands on your application (initial load), then goes on a different page after 5 seconds (route change) and finally triggers `addTiming` after 8 seconds, the timing will equal 8-5 = 3 seconds.
 ## Further Reading

--- a/content/en/real_user_monitoring/browser/monitoring_page_performance.md
+++ b/content/en/real_user_monitoring/browser/monitoring_page_performance.md
@@ -76,6 +76,27 @@ To account for modern web applications, loading time watches for network request
 
 The RUM SDK automatically monitors frameworks that rely on hash (`#`) navigation. The SDK watches for `HashChangeEvent` and issues a new view. Events coming from an HTML anchor tag which do not affect the current view context are ignored.
 
+## Add your own performance timing
+On top of RUM's default performance timing, you may measure where your application is spending its time with greater flexibility. The `addTiming` API provides you with a simple way to add extra performance timing. For example, you can add a timing when your hero image has appeared:
+
+```html
+<html>
+  <body>
+    <img onload="DD_RUM.addTiming('hero_image')" src="/path/to/img.png" />
+  </body>
+</html>
+```
+
+Or when users first scroll:
+
+```javascript
+document.addEventListener("scroll", function handler(e) {
+    e.currentTarget.removeEventListener(e.type, handler); //Remove the event listener so that it only triggers once
+    DD_RUM.addTiming('first_scroll');
+});
+```
+
+**Note**: For Single Page Applications, the `addTiming` API issues a timing relative to the start of the current RUM view. For example, if a user lands on your application (initial load), then goes on a different page after 5 seconds (route change) and finally triggers `addTiming` after 8 seconds, the timing will equal 8-5 = 3 seconds.
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Document RUM `addTiming` API

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hdelaby/addTiming-doc/real_user_monitoring/browser/monitoring_page_performance/#add-your-own-performance-timing

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
