### PR TITLE
Document min TLS version assertion

### DIFF
--- a/content/en/synthetics/api_tests/ssl_tests.md
+++ b/content/en/synthetics/api_tests/ssl_tests.md
@@ -61,12 +61,14 @@ SSL tests can run:
 
 Assertions define what an expected test result is. When hitting `Test URL` basic assertions on certificate validity, expiration data, TLS version, and `response time` are added based on the response that was obtained. You must define at least one assertion for your test to monitor.
 
-| Type          | Operator                                                                               | Value type                 |
-|---------------|----------------------------------------------------------------------------------------|----------------------------|
-| certificate   | `expires in more than`, `expires in less than`                                         | _Integer (number of days)_ |
-| property      | `contains`, `does not contain`, `is`, `is not`, <br> `matches`, `does not match`       | _String_ <br> _[Regex][9]_ |
-| response time | `is less than`                                                                         | _Integer (ms)_             |
-| TLS version   | `is less than`, `is less than or equal`, `is`, `is more than`, `is more than or equal` | _Decimal_                  |
+| Type                  | Operator                                                                               | Value type                 |
+|-----------------------|----------------------------------------------------------------------------------------|----------------------------|
+| certificate           | `expires in more than`, `expires in less than`                                         | _Integer (number of days)_ |
+| property              | `contains`, `does not contain`, `is`, `is not`, <br> `matches`, `does not match`       | _String_ <br> _[Regex][9]_ |
+| response time         | `is less than`                                                                         | _Integer (ms)_             |
+| maximum TLS version   | `is less than`, `is less than or equal`, `is`, `is more than`, `is more than or equal` | _Decimal_                  |
+| minimum TLS version   | `is more than`, `is more than or equal`                                                | _Decimal_                  |
+
 
 You can create up to 10 assertions per API test by clicking on **New Assertion** or by clicking directly on the response preview:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR documents the minimum TLS version assertion for SSL tests.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/margot.lepizzera/ssl_tests/synthetics/api_tests/ssl_tests#define-assertions

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
