### PR TITLE
no_proxy_nonexact_match docs for agent 7.26

### DIFF
--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -92,7 +92,11 @@ proxy:
 * A hostname
   - e.g. `webserver1`
 
-**Note**: `NO_PROXY` must match endpoints exactly for agent HTTP(S) requests.  The accepted values above only apply to integrations.
+`NO_PROXY` must match endpoints exactly for agent HTTP(S) requests. Enable `no_proxy_nonexact_match` to allow the agent to match `NO_PROXY` values with the same rules (above) used for integrations. 
+
+```yaml
+no_proxy_nonexact_match: true
+```
 
 #### Environment variables
 

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -92,7 +92,7 @@ proxy:
 * A hostname
   - e.g. `webserver1`
 
-`NO_PROXY` must match endpoints exactly for agent HTTP(S) requests. Enable `no_proxy_nonexact_match` to allow the agent to match `NO_PROXY` values with the same rules (above) used for integrations. 
+`NO_PROXY` must match endpoints exactly for Agent HTTP(S) requests. Enable `no_proxy_nonexact_match` to allow the Agent to match `NO_PROXY` values with the same rules (above) used for integrations. 
 
 ```yaml
 no_proxy_nonexact_match: true


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add documentation for new `no_proxy_nonexact_match` that will be available in agent `7.26.0`. 
We should hold this PR until 7.26.0 is released

### Motivation
Document new feature. 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/brian/no-proxy-nonexact-match-doc/agent/proxy/?tab=agentv6v7#no_proxy-accepted-values

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
