### PR TITLE
Adding config parameter

### DIFF
--- a/content/en/synthetics/private_locations/configuration.md
+++ b/content/en/synthetics/private_locations/configuration.md
@@ -83,6 +83,7 @@ You can upload custom root certificates to your private locations to have your A
 
 | Option | Type | Default | Description |
 | -------| ---- | ------- | ----------- |
+| `config` | String | `/etc/datadog/synthetics-check-runner.json` | Path to JSON configuration file. |
 | `logFormat` | String | `pretty` | Format log output between `"pretty"`, and `"json"`. Setting your log format to `json` allows you to have these logs automatically parsed when collected by Datadog. |
 | `verbosity` | Number | `3` | Verbosity level (e.g., `-v`, `-vv`, `-vvv`, ...). |
 | `dumpConfig` | Boolean | `none` | Display worker configuration parameters without secrets. |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR adds details about the --config parameter for private locations.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/margot.lepizzera/pl_config_param/synthetics/private_locations/configuration#private-locations-admin
### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
