### PR TITLE
(DOCS-1618) Add synthetic bots guide to sidebar

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1843,29 +1843,33 @@ main:
     url: synthetics/apm/
     parent: synthetics
     identifier: synthetics_apm
-    weight: 6
-  - name: Search and Manage
-    url: synthetics/search/
-    parent: synthetics
-    weight: 7
-  - name: Metrics
-    url: synthetics/metrics/
-    parent: synthetics
-    weight: 8
+    weight: 6 
   - name: Settings
     url: synthetics/settings/
     parent: synthetics
+    weight: 7
+  - name: Search and Manage
+    url: synthetics/search/
+    parent: synthetics
+    weight: 8
+  - name: Metrics
+    url: synthetics/metrics/
+    parent: synthetics
     weight: 9
+  - name: Identify Synthetic Bots
+    url: synthetics/guide/identify_synthetics_bots/
+    parent: synthetics
+    weight: 10
   - name: Guides
     url: synthetics/guide/
     parent: synthetics
     identifier: synthetics_guides
-    weight: 10
+    weight: 11
   - name: Troubleshooting
     url: synthetics/troubleshooting/
     parent: synthetics
     identifier: synthetics_troubleshooting
-    weight: 11
+    weight: 12
   - name: Real User Monitoring
     url: real_user_monitoring/
     pre: nav_rum_2


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Re-arranges and adds a link to the Synthetic Monitoring section of the sidebar nav
Intentionally left the link on Guides page for existing users who are used to seeing/finding this link from that page.
### Motivation
DOCS-1618

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jorie/DOCS-1618/synthetics/guide/identify_synthetics_bots/
### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
