### PR TITLE
Rephrase .NET trace id/logs injection instructions

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -21,7 +21,7 @@ further_reading:
 
 The .NET Tracer can automatically inject trace IDs, span IDs, `env`, `service`, and `version` into your application logs. If you haven't done so already, Datadog recommends configuring the .NET tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This provides the best experience when adding `env`, `service`, and `version` (see [Unified Service Tagging][3] for more details).
 
-We support [Serilog][4], [NLog][5] (version 2.0.0.2000+), or [log4net][6]. Automatic injection only displays in the application logs after enabling `LogContext` enrichment in your `Serilog` logger or `Mapped Diagnostics Context` in your `NLog` or `log4net` logger (see examples below).
+We support [Serilog][4], [NLog][5] (version 2.0.0.2000+), or [log4net][6]. Automatic injection only displays in the application logs after enabling `LogContext` enrichment in your `Serilog` logger or `Mapped Diagnostics Context` in your `NLog` or `log4net` logger.
 
 **Note**: Automatic injection only works for logs formatted as JSON.
 

--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -19,13 +19,16 @@ further_reading:
 
 ## Automatically Inject Trace and Span IDs
 
-Enable injection in the .NET Tracer’s [configuration][1] by setting `DD_LOGS_INJECTION=true` through environment variables or the configuration files.
-
 The .NET Tracer can automatically inject trace IDs, span IDs, `env`, `service`, and `version` into your application logs. If you haven't done so already, Datadog recommends configuring the .NET tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This provides the best experience when adding `env`, `service`, and `version` (see [Unified Service Tagging][3] for more details).
 
 We support [Serilog][4], [NLog][5] (version 2.0.0.2000+), or [log4net][6]. Automatic injection only displays in the application logs after enabling `LogContext` enrichment in your `Serilog` logger or `Mapped Diagnostics Context` in your `NLog` or `log4net` logger (see examples below).
 
 **Note**: Automatic injection only works for logs formatted as JSON.
+
+**To enable, follow these two steps:**
+
+1. Enable injection in the .NET Tracer’s [configuration][1] by setting `DD_LOGS_INJECTION=true` through environment variables or the configuration files.
+2. Update the logging configuration based on the logging library:
 
 {{< tabs >}}
 {{% tab "Serilog" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR reorders some of the wording for automatic trace id injection around and clarify the steps needed.

### Motivation
<!-- What inspired you to submit this pull request?-->

Make it clearer that `DD_LOGS_INJECTION=true` is required.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/wantsui/auto-traceid-injection-dotnet/tracing/connect_logs_and_traces/dotnet/?tab=serilog#automatically-inject-trace-and-span-ids

### Additional Notes
<!-- Anything else we should know when reviewing?-->

@jaycdave88 and someone from the .NET team should review this wording too!
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
