### PR TITLE
Add example on how to get tags from instance

### DIFF
--- a/content/en/developers/write_agent_check.md
+++ b/content/en/developers/write_agent_check.md
@@ -56,7 +56,7 @@ __version__ = "1.0.0"
 
 class HelloCheck(AgentCheck):
     def check(self, instance):
-        self.gauge('hello.world', 1, tags=['TAG_KEY:TAG_VALUE'])
+        self.gauge('hello.world', 1, tags=['TAG_KEY:TAG_VALUE'] + self.instance.get('tags', []))
 {{< /code-block >}}
 
 For more details about the interface provided by the base class, browse the [API documentation][5].
@@ -153,7 +153,7 @@ class LSCheck(AgentCheck):
     def check(self, instance):
         files, err, retcode = get_subprocess_output(["ls", "."], self.log, raise_on_empty_output=True)
         file_count = len(files.split('\n')) - 1  #len() returns an int by default
-        self.gauge("file.count", file_count,tags=['TAG_KEY:TAG_VALUE'])
+        self.gauge("file.count", file_count,tags=['TAG_KEY:TAG_VALUE'] + self.instance.get('tags', []))
 ```
 
 ## Further Reading


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
I added an example of how to get the existing tags from the instance.

### Motivation
It took me few hours to find an example of how to get the tags from the instance. I finally found it in [here](https://datadoghq.dev/integrations-core/base/basics/ ). I think the current example is insufficient and it would be more practical to write how to merge the tags from the instance.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
