### PR TITLE
make tab ids unique to version

### DIFF
--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -159,7 +159,7 @@
                     {{ partial "api/request-body.html" (dict "context" $dot "body" $endpoint.action.requestBody "resourcePage" $resourcePage "operationid" $endpoint.action.operationId "translate_action" $translate_action) }}
 
                     <!-- response -->
-                    {{ partial "api/response.html" (dict "responses" $endpoint.action.responses "resourcePage" $resourcePage "operationid" $endpoint.action.operationId "translate_action" $translate_action) }}
+                    {{ partial "api/response.html" (dict "responses" $endpoint.action.responses "resourcePage" $resourcePage "operationid" $endpoint.action.operationId "translate_action" $translate_action "version" $versionNum) }}
 
                     <!-- code example -->
                     {{ partial "api/code-example.html" (dict "context" $dot "resourcePage" $resourcePage "operationid" $endpoint.action.operationId "securitySchemes" $adat.components.securitySchemes "endpoint" $endpoint) }}

--- a/layouts/partials/api/response.html
+++ b/layouts/partials/api/response.html
@@ -3,6 +3,7 @@
 {{ $operationid := .operationid }}
 {{ $resourcePage := .resourcePage }}
 {{ $translate_action := .translate_action }}
+{{ $version := .version }}
 {{ $s := newScratch }}
 
 <h3 class="mt-3 mb-2">{{ i18n "response" }}</h3>
@@ -11,7 +12,7 @@
     {{ $count := 0}}
     {{ range $response_code, $response := $responses }}
         <li class="nav-item">
-            <a class="nav-link mr-1  {{ if eq $count 0}}active{{end}}"  href="#{{ $operationid }}-{{ $response_code }}"  data-toggle="tab">{{ $response_code }}</a>
+            <a class="nav-link mr-1  {{ if eq $count 0}}active{{end}}"  href="#{{ $operationid }}-{{ $response_code }}-{{ $version }}"  data-toggle="tab">{{ $response_code }}</a>
         </li>
         {{ $count = add $count 1 }}
     {{ end }}
@@ -25,7 +26,7 @@
         {{ with $translate_action.responses }}
           {{ $translate_action_response = (index $translate_action.responses $response_code) }}
         {{ end }}
-        <div role="tabpanel" class="tab-pane {{ if eq $count 0}} active {{end}}" id="{{ $operationid }}-{{ $response_code }}">
+        <div role="tabpanel" class="tab-pane {{ if eq $count 0}} active {{end}}" id="{{ $operationid }}-{{ $response_code }}-{{ $version }}">
             {{ with $response.content }}
 
                 <p class="mb-2">{{ $translate_action_response.description | default $response.description }}</p>


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue where response code tabs 200,400 etc won't work.

The tab ids must be unique and currently were not when v1 and v2 endpoints are side by side.
The change in this pr adds the version to the ids too so they will always be unique.

### Motivation

slack

### Preview

https://docs-staging.datadoghq.com/david.jones/responsetabs/api/latest/users/#list-all-users

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
