### PR TITLE
Fix Golang example StatsD code for SET metric type

### DIFF
--- a/content/en/developers/metrics/dogstatsd_metrics_submission.md
+++ b/content/en/developers/metrics/dogstatsd_metrics_submission.md
@@ -419,9 +419,9 @@ end
 package main
 
 import (
+	"fmt"
 	"log"
 	"math/rand"
-	"strconv"
 	"time"
 
 	"github.com/DataDog/datadog-go/statsd"
@@ -435,8 +435,8 @@ func main() {
 	var i float64
 	for {
 		i += 1
-		statsd.Set("example_metric.set", strconv.Itoa(i), []string{"environment:dev"}, 1)
-		time.Sleep(rand.Intn(10) * time.Second)
+		statsd.Set("example_metric.set", fmt.Sprintf("%f", i), []string{"environment:dev"}, 1)
+		time.Sleep(time.Duration(rand.Intn(10)) * time.Second)
 	}
 }
 ```

--- a/content/fr/developers/metrics/dogstatsd_metrics_submission.md
+++ b/content/fr/developers/metrics/dogstatsd_metrics_submission.md
@@ -415,9 +415,9 @@ end
 package main
 
 import (
+    "fmt"
     "log"
     "math/rand"
-    "strconv"
     "time"
 
     "github.com/DataDog/datadog-go/statsd"
@@ -431,8 +431,8 @@ func main() {
     var i float64
     for {
         i += 1
-        statsd.Set("exemple_métrique.set", strconv.Itoa(i), []string{"environment:dev"}, 1)
-        time.Sleep(rand.Intn(10) * time.Second)
+        statsd.Set("exemple_métrique.set", fmt.Sprintf("%f", i), []string{"environment:dev"}, 1)
+        time.Sleep(time.Duration(rand.Intn(10)) * time.Second)
     }
 }
 ```

--- a/content/ja/developers/metrics/dogstatsd_metrics_submission.md
+++ b/content/ja/developers/metrics/dogstatsd_metrics_submission.md
@@ -415,9 +415,9 @@ end
 package main
 
 import (
+    "fmt"
     "log"
     "math/rand"
-    "strconv"
     "time"
 
     "github.com/DataDog/datadog-go/statsd"
@@ -431,8 +431,8 @@ func main() {
     var i float64
     for {
         i += 1
-        statsd.Set("example_metric.set", strconv.Itoa(i), []string{"environment:dev"}, 1)
-        time.Sleep(rand.Intn(10) * time.Second)
+        statsd.Set("example_metric.set", fmt.Sprintf("%f", i), []string{"environment:dev"}, 1)
+        time.Sleep(time.Duration(rand.Intn(10)) * time.Second)
     }
 }
 ```


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fixes the Golang examples for the SET metric type when submitting via DogStatsD.

### Motivation
<!-- What inspired you to submit this pull request?-->
The code examples as they current exist do not compile.  They generate the following errors:
```
go build
./main.go:20:48: cannot use i (type float64) as type int in argument to strconv.Itoa
./main.go:21:28: invalid operation: rand.Intn(10) * time.Second (mismatched types int and time.Duration)
```
### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
N/A - external contributor

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
