### PR TITLE
[rum] data collected page improvements

### DIFF
--- a/content/en/real_user_monitoring/browser/data_collected.md
+++ b/content/en/real_user_monitoring/browser/data_collected.md
@@ -29,10 +29,10 @@ The Datadog Real User Monitoring SDK generates six types of events:
 |----------------|-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [Session][1]   | 30 days   | A user session begins when a user starts browsing the web application. It contains high-level information about the user (browser, device, geolocation). It aggregates all RUM events collected during the user journey with a unique `session.id` attribute. |
 | [View][2]      | 30 days   | A view event is generated each time a user visits a page of the web application. While the user remains on the same page, resource, long-task, error and action events are linked to the related RUM view with the `view.id` attribute.                       |
-| [Resource][3]  | 30 days   | A resource event is generated for images, XHR, Fetch, CSS, or JS libraries loaded on a webpage. It includes detailed loading timing information.                                                                                                              |
-| [Long Task][4] | 30 days   | A long task event is generated for any task in the browser that blocks the main thread for more than 50ms.                                                                                                                                                    |
-| [Error][5]     | 15 days   | RUM collects every frontend error emitted by the browser.                                                                                                                                                                                                     |
-| [Action][6]    | 15 days   | RUM action events track user interactions during a user journey and can also be manually sent to monitor custom user actions.                                                                                                                                 |
+| [Resource][3]  | 15 days   | A resource event is generated for images, XHR, Fetch, CSS, or JS libraries loaded on a webpage. It includes detailed loading timing information.                                                                                                              |
+| [Long Task][4] | 15 days   | A long task event is generated for any task in the browser that blocks the main thread for more than 50ms.                                                                                                                                                    |
+| [Error][5]     | 30 days   | RUM collects every frontend error emitted by the browser.                                                                                                                                                                                                     |
+| [Action][6]    | 30 days   | RUM action events track user interactions during a user journey and can also be manually sent to monitor custom user actions.                                                                                                                                 |
 
 The following diagram illustrates the RUM event hierarchy:
 
@@ -105,7 +105,7 @@ The following attributes are related to the geo-location of IP addresses:
 | `geo.city`            | string | The name of the city (example `Paris`, `New York`).                                                                                   |
 ## User attributes
 
-In addition to default attributes, add user related data by [identifying user sessions][8]. This lets you follow the journey of a given user, figure out which users are the most impacted by errors and monitor performance for your most important users.
+In addition to default attributes, add user related data to all RUM event types by [identifying user sessions][8]. This lets you follow the journey of a given user, figure out which users are the most impacted by errors and monitor performance for your most important users.
 
 ## Event-specific attributes
 
@@ -176,7 +176,7 @@ RUM view performance metrics are collected from both the [Paint Timing API][2] a
 | Metric                              | Type        | Decription                                                                                                                                                                                                                 |
 |----------------------------------------|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `view.time_spent`                             | number (ns) | Time spent on the current view.                                                                                                                                                                                                  |
-| `view.loading_time`                             | number (ns) | Time until the page is ready and no network request or DOM mutation is currently occurring. [More info from the data collected documentation][4]|
+| `view.loading_time`                             | number (ns) | Time until the page is ready and no network request or DOM mutation is currently occurring. [More info on how view loading time is collected][4]|
 | `view.first_contentful_paint` | number (ns) | Time when the browser first renders any text, image (including background images), non-white canvas, or SVG. For more information about browser rendering, see the [w3 definition][5].                                                                                            |
 | `view.dom_interactive`        | number (ns) | The moment when the parser finishes its work on the main document. [More info from the MDN documentation][6]                                                                                                               |
 | `view.dom_content_loaded`     | number (ns) | Event fired when the initial HTML document is completely loaded and parsed, without waiting for non-render blocking stylesheets, images, and subframes to finish loading. [More info from the MDN documentation][7]. |
@@ -190,7 +190,7 @@ RUM view performance metrics are collected from both the [Paint Timing API][2] a
 [1]: https://developer.mozilla.org/en-US/docs/Web/API/History
 [2]: https://www.w3.org/TR/paint-timing/
 [3]: https://www.w3.org/TR/navigation-timing/#sec-navigation-timing
-[4]: /real_user_monitoring/data_collected/view/#how-is-loading-time-calculated
+[4]: /real_user_monitoring/browser/data_collected/?tab=view#how-is-loading-time-calculated
 [5]: https://www.w3.org/TR/paint-timing/#sec-terminology
 [6]: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming/domInteractive
 [7]: https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event
@@ -250,10 +250,10 @@ Detailed network timing data for the loading of an application’s resources are
 ### Error sources
 Front-end errors are split in 4 different categories depending on their `error.source`:
 
-- **network**: XHR or Fetch errors resulting from AJAX requests. Specific attributes to network errors can be found [in the documentation][1].
+- **network**: XHR or Fetch errors resulting from AJAX requests. Specific attributes to network errors can be found in the documentation.
 - **source**: Unhandled exceptions or unhandled promise rejections (source-code related).
 - **console**: `console.error()` API calls.
-- **custom**: Errors sent with the [RUM `addError` API][2] default to `custom`.
+- **custom**: Errors sent with the [RUM `addError` API][1] default to `custom`.
 
 ### Error attributes
 
@@ -283,16 +283,15 @@ Network errors include information about failing HTTP requests. The following fa
 
 #### Source errors
 
-Source errors include code-level information about the error. More information about the different error types can be found in [the MDN documentation][3].
+Source errors include code-level information about the error. More information about the different error types can be found in [the MDN documentation][2].
 
 | Attribute       | Type   | Description                                                       |
 |-----------------|--------|-------------------------------------------------------------------|
 | `error.type`    | string | The error type (or error code in some cases).                   |
 
 
-[1]: /real_user_monitoring/data_collected/error/#network-errors
-[2]: /real_user_monitoring/browser/advanced_configuration#custom-errors
-[3]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
+[1]: /real_user_monitoring/browser/collecting_browser_errors/?tab=npm#collect-errors-manually
+[2]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
 {{% /tab %}}
 {{% tab "User Action" %}}
 
@@ -325,13 +324,12 @@ Custom user actions are user actions declared and sent manually via the [`addUse
 | `action.id` | string | UUID of the user action. |
 | `action.type` | string | Type of the user action. For [Custom User Actions][5], it is set to `custom`. |
 | `action.target.name` | string | Element that the user interacted with. Only for automatically collected actions |
-| `action.name` | string | User-friendly name created (for example `Click on #checkout`). For [Custom User Actions][5], the action name given in the API call. |
+| `action.name` | string | User-friendly name created (for example `Click on #checkout`). For [Custom User Actions][3], the action name given in the API call. |
 
 [1]: /real_user_monitoring/browser/?tab=us#initialization-parameters
 [2]: /real_user_monitoring/browser/advanced_configuration/?tab=npm#add-global-context
-[3]: /real_user_monitoring/browser/advanced_configuration/?tab=npm#custom-user-actions
-[4]: /real_user_monitoring/data_collected/user_action#how-is-the-user-action-duration-calculated
-[5]: /real_user_monitoring/data_collected/user_action#custom-user-actions
+[3]: /real_user_monitoring/browser/tracking_user_actions/?tab=npm#custom-user-actions
+[4]: /real_user_monitoring/browser/data_collected/?tab=useraction#how-is-the-action-loading-time-calculated
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/real_user_monitoring/browser/data_collected.md
+++ b/content/en/real_user_monitoring/browser/data_collected.md
@@ -347,4 +347,4 @@ Custom user actions are user actions declared and sent manually via the [`addUse
 [5]: /real_user_monitoring/browser/data_collected/?tab=error
 [6]: /real_user_monitoring/browser/data_collected/?tab=useraction
 [7]: https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
-[8]: /real_user_monitoring/browser/advanced_configuration/?tab=npm#add-global-context
+[8]: /real_user_monitoring/browser/advanced_configuration/?tab=npm#identify-user-sessions

--- a/content/en/real_user_monitoring/browser/data_collected.md
+++ b/content/en/real_user_monitoring/browser/data_collected.md
@@ -27,12 +27,12 @@ The Datadog Real User Monitoring SDK generates six types of events:
 
 | Event Type     | Retention | Description                                                                                                                                                                                                                                                   |
 |----------------|-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [Session][1]   | 30 days   | A user session begins when a user starts browsing the web application. It contains high-level information about the user (browser, device, geolocation). It aggregates all RUM events collected during the user journey with a unique `session.id` attribute. |
-| [View][2]      | 30 days   | A view event is generated each time a user visits a page of the web application. While the user remains on the same page, resource, long-task, error and action events are linked to the related RUM view with the `view.id` attribute.                       |
-| [Resource][3]  | 15 days   | A resource event is generated for images, XHR, Fetch, CSS, or JS libraries loaded on a webpage. It includes detailed loading timing information.                                                                                                              |
-| [Long Task][4] | 15 days   | A long task event is generated for any task in the browser that blocks the main thread for more than 50ms.                                                                                                                                                    |
-| [Error][5]     | 30 days   | RUM collects every frontend error emitted by the browser.                                                                                                                                                                                                     |
-| [Action][6]    | 30 days   | RUM action events track user interactions during a user journey and can also be manually sent to monitor custom user actions.                                                                                                                                 |
+| Session   | 30 days   | A user session begins when a user starts browsing the web application. It contains high-level information about the user (browser, device, geolocation). It aggregates all RUM events collected during the user journey with a unique `session.id` attribute. |
+| View      | 30 days   | A view event is generated each time a user visits a page of the web application. While the user remains on the same page, resource, long-task, error and action events are linked to the related RUM view with the `view.id` attribute.                       |
+| Resource  | 15 days   | A resource event is generated for images, XHR, Fetch, CSS, or JS libraries loaded on a webpage. It includes detailed loading timing information.                                                                                                              |
+| Long Task | 15 days   | A long task event is generated for any task in the browser that blocks the main thread for more than 50ms.                                                                                                                                                    |
+| Error     | 30 days   | RUM collects every frontend error emitted by the browser.                                                                                                                                                                                                     |
+| Action    | 30 days   | RUM action events track user interactions during a user journey and can also be manually sent to monitor custom user actions.                                                                                                                                 |
 
 The following diagram illustrates the RUM event hierarchy:
 
@@ -97,15 +97,15 @@ The following attributes are related to the geo-location of IP addresses:
 | Fullname                                    | Type   | Description                                                                                                                          |
 |:--------------------------------------------|:-------|:-------------------------------------------------------------------------------------------------------------------------------------|
 | `geo.country`         | string | Name of the country                                                                                                                  |
-| `geo.country_iso_code`     | string | [ISO Code][7] of the country (for example, `US` for the United States, `FR` for France).                                                  |
+| `geo.country_iso_code`     | string | [ISO Code][1] of the country (for example, `US` for the United States, `FR` for France).                                                  |
 | `geo.country_subdivision`     | string | Name of the first subdivision level of the country (for example, `California` in the United States or the `Sarthe` department in France). |
-| `geo.country_subdivision_iso_code` | string | [ISO Code][7] of the first subdivision level of the country (for example, `CA` in the United States or the `SA` department in France).    |
+| `geo.country_subdivision_iso_code` | string | [ISO Code][1] of the first subdivision level of the country (for example, `CA` in the United States or the `SA` department in France).    |
 | `geo.continent_code`       | string | ISO code of the continent (`EU`, `AS`, `NA`, `AF`, `AN`, `SA`, `OC`).                                                                 |
 | `geo.continent`       | string | Name of the continent (`Europe`, `Australia`, `North America`, `Africa`, `Antartica`, `South America`, `Oceania`).                    |
 | `geo.city`            | string | The name of the city (example `Paris`, `New York`).                                                                                   |
 ## User attributes
 
-In addition to default attributes, add user related data to all RUM event types by [identifying user sessions][8]. This lets you follow the journey of a given user, figure out which users are the most impacted by errors and monitor performance for your most important users.
+In addition to default attributes, add user related data to all RUM event types by [identifying user sessions][2]. This lets you follow the journey of a given user, figure out which users are the most impacted by errors and monitor performance for your most important users.
 
 ## Event-specific attributes
 
@@ -190,7 +190,7 @@ RUM view performance metrics are collected from both the [Paint Timing API][2] a
 [1]: https://developer.mozilla.org/en-US/docs/Web/API/History
 [2]: https://www.w3.org/TR/paint-timing/
 [3]: https://www.w3.org/TR/navigation-timing/#sec-navigation-timing
-[4]: /real_user_monitoring/browser/data_collected/?tab=view#how-is-loading-time-calculated
+[4]: /real_user_monitoring/browser/monitoring_page_performance/#how-is-loading-time-calculated
 [5]: https://www.w3.org/TR/paint-timing/#sec-terminology
 [6]: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming/domInteractive
 [7]: https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event
@@ -322,14 +322,14 @@ Custom user actions are user actions declared and sent manually via the [`addUse
 | Attribute    | Type   | Description              |
 |--------------|--------|--------------------------|
 | `action.id` | string | UUID of the user action. |
-| `action.type` | string | Type of the user action. For [Custom User Actions][5], it is set to `custom`. |
+| `action.type` | string | Type of the user action. For [Custom User Actions][3], it is set to `custom`. |
 | `action.target.name` | string | Element that the user interacted with. Only for automatically collected actions |
 | `action.name` | string | User-friendly name created (for example `Click on #checkout`). For [Custom User Actions][3], the action name given in the API call. |
 
 [1]: /real_user_monitoring/browser/?tab=us#initialization-parameters
 [2]: /real_user_monitoring/browser/advanced_configuration/?tab=npm#add-global-context
 [3]: /real_user_monitoring/browser/tracking_user_actions/?tab=npm#custom-user-actions
-[4]: /real_user_monitoring/browser/data_collected/?tab=useraction#how-is-the-action-loading-time-calculated
+[4]: /real_user_monitoring/browser/tracking_user_actions/?tab=npm#how-action-loading-time-is-calculated
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -337,12 +337,5 @@ Custom user actions are user actions declared and sent manually via the [`addUse
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-
-[1]: /real_user_monitoring/browser/data_collected/?tab=session
-[2]: /real_user_monitoring/browser/data_collected/?tab=view
-[3]: /real_user_monitoring/browser/data_collected/?tab=resource
-[4]: /real_user_monitoring/browser/data_collected/?tab=longtask
-[5]: /real_user_monitoring/browser/data_collected/?tab=error
-[6]: /real_user_monitoring/browser/data_collected/?tab=useraction
-[7]: https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
-[8]: /real_user_monitoring/browser/advanced_configuration/?tab=npm#identify-user-sessions
+[1]: https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
+[2]: /real_user_monitoring/browser/advanced_configuration/?tab=npm#identify-user-sessions

--- a/content/en/real_user_monitoring/browser/data_collected.md
+++ b/content/en/real_user_monitoring/browser/data_collected.md
@@ -250,7 +250,7 @@ Detailed network timing data for the loading of an application’s resources are
 ### Error sources
 Front-end errors are split in 4 different categories depending on their `error.source`:
 
-- **network**: XHR or Fetch errors resulting from AJAX requests. Specific attributes to network errors can be found in the documentation.
+- **network**: XHR or Fetch errors resulting from AJAX requests.
 - **source**: Unhandled exceptions or unhandled promise rejections (source-code related).
 - **console**: `console.error()` API calls.
 - **custom**: Errors sent with the [RUM `addError` API][1] default to `custom`.

--- a/content/en/real_user_monitoring/browser/data_collected.md
+++ b/content/en/real_user_monitoring/browser/data_collected.md
@@ -25,14 +25,14 @@ further_reading:
 
 The Datadog Real User Monitoring SDK generates six types of events:
 
-| Event Type | Description                                                                                                                                                                                                                                                   |
-|------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [Session][1]    | A user session begins when a user starts browsing the web application. It contains high-level information about the user (browser, device, geolocation). It aggregates all RUM events collected during the user journey with a unique `session.id` attribute. |
-| [View][2]       | Each time a user goes on a page of the setup application, a view event is created. While the user remains on that view, all data collected is attached to that view with the `view.id` attribute.                                                             |
-| [Resource][3]   | A resource event can be generated for images, XHR/Fetch, CSS, or JS libraries. It contains information about the resource, like its name and its associated loading duration.                                                                                 |
-| [Long Task][4]  | Any task in a browser that blocks the main thread for more than 50ms is considered a long task and gets a specific event generation.                                                                                                                          |
-| [Error][5]     | Every time a frontend error is emitted by the browser, RUM catches it and sends it as an Error Event to Datadog.                                                                                                                                              |
-| [Action][6]     | A User Action event is a custom event that can be generated for a given user action.                                                                                                                                                                          |
+| Event Type     | Retention | Description                                                                                                                                                                                                                                                   |
+|----------------|-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [Session][1]   | 30 days   | A user session begins when a user starts browsing the web application. It contains high-level information about the user (browser, device, geolocation). It aggregates all RUM events collected during the user journey with a unique `session.id` attribute. |
+| [View][2]      | 30 days   | A view event is generated each time a user visits a page of the web application. While the user remains on the same page, resource, long-task, error and action events are linked to the related RUM view with the `view.id` attribute.                       |
+| [Resource][3]  | 30 days   | A resource event is generated for images, XHR, Fetch, CSS, or JS libraries loaded on a webpage. It includes detailed loading timing information.                                                                                                              |
+| [Long Task][4] | 30 days   | A long task event is generated for any task in the browser that blocks the main thread for more than 50ms.                                                                                                                                                    |
+| [Error][5]     | 15 days   | RUM collects every frontend error emitted by the browser.                                                                                                                                                                                                     |
+| [Action][6]    | 15 days   | RUM action events track user interactions during a user journey and can also be manually sent to monitor custom user actions.                                                                                                                                 |
 
 The following diagram illustrates the RUM event hierarchy:
 
@@ -41,13 +41,76 @@ The following diagram illustrates the RUM event hierarchy:
 ## Event-specific and default attributes
 
 There are metrics and attributes that are specific to a given event type. For example, the metric `view.loading_time` is associated with "view" RUM events and the attribute `resource.method` is associated with "resource" RUM events. And there are [default attributes](#default-attributes) that are present on all RUM events. For example, the URL of the page (`view.url`) and user information such as their device type (`device.type`) and their country (`geo.country`).
+## Default attributes
+
+Each of these event types has the following attributes attached by default. So you can use them regardless of the RUM event type being queried.
+
+### Core
+
+| Attribute name   | Type   | Description                 |
+|------------------|--------|-----------------------------|
+| `type`     | string | The type of the event (for example, `view` or `resource`).             |
+| `application.id` | string | The Datadog application ID. |
+
+### View attributes
+
+RUM action, error, resource and long task events contain information about the active RUM view event at the time of collection:
+
+| Attribute name                 | Type   | Description                                                                                                    |
+|--------------------------------|--------|----------------------------------------------------------------------------------------------------------------|
+| `view.id`                      | string | Randomly generated ID for each page view.                                                                      |
+| `view.loading_type`                     | string | The type of page load: `initial_load` or `route_change`. For more information, see the [single page applications support docs](#single-page-applications).|
+| `view.referrer`                | string | The URL of the previous web page from which a link to the currently requested page was followed.               |
+| `view.url`                     | string | The view URL.                                                                                                  |
+| `view.url_hash`                     | string | The hash part of the URL.|
+| `view.url_host`        | string | The host part of the URL.                                                                                |
+| `view.url_path`        | string | The path part of the URL.                                                                                 |
+| `view.url_path_group`  | string | The automatic URL group generated for similar URLs (for example, `/dashboard/?` for `/dashboard/123` and `/dashboard/456`). |
+| `view.url_query` | object | The query string parts of the URL decomposed as query params key/value attributes.                        |
+| `view.url_scheme` | object | The scheme part of the URL.                        |
+
+### Device
+
+The following device-related attributes are attached automatically to all events collected by Datadog:
+
+| Attribute name                           | Type   | Description                                     |
+|------------------------------------------|--------|-------------------------------------------------|
+| `device.type`       | string | The device type as reported by the device (User-Agent HTTP header)      |
+| `device.brand`  | string | The device brand as reported by the device (User-Agent HTTP header)  |
+| `device.model`   | string | The device model as reported by the device (User-Agent HTTP header)   |
+| `device.name` | string | The device name as reported by the device (User-Agent HTTP header) |
+
+### Operating system
+
+The following OS-related attributes are attached automatically to all events collected by Datadog:
+
+| Attribute name                           | Type   | Description                                     |
+|------------------------------------------|--------|-------------------------------------------------|
+| `os.name`       | string | The OS name as reported by the by the device (User-Agent HTTP header)       |
+| `os.version`  | string | The OS version as reported by the by the device (User-Agent HTTP header)  |
+| `os.version_major`   | string | The OS version major as reported by the by the device (User-Agent HTTP header)   |
+
+### Geo-location
+
+The following attributes are related to the geo-location of IP addresses:
+
+| Fullname                                    | Type   | Description                                                                                                                          |
+|:--------------------------------------------|:-------|:-------------------------------------------------------------------------------------------------------------------------------------|
+| `geo.country`         | string | Name of the country                                                                                                                  |
+| `geo.country_iso_code`     | string | [ISO Code][7] of the country (for example, `US` for the United States, `FR` for France).                                                  |
+| `geo.country_subdivision`     | string | Name of the first subdivision level of the country (for example, `California` in the United States or the `Sarthe` department in France). |
+| `geo.country_subdivision_iso_code` | string | [ISO Code][7] of the first subdivision level of the country (for example, `CA` in the United States or the `SA` department in France).    |
+| `geo.continent_code`       | string | ISO code of the continent (`EU`, `AS`, `NA`, `AF`, `AN`, `SA`, `OC`).                                                                 |
+| `geo.continent`       | string | Name of the continent (`Europe`, `Australia`, `North America`, `Africa`, `Antartica`, `South America`, `Oceania`).                    |
+| `geo.city`            | string | The name of the city (example `Paris`, `New York`).                                                                                   |
+## User attributes
+
+In addition to default attributes, add user related data by [identifying user sessions][8]. This lets you follow the journey of a given user, figure out which users are the most impacted by errors and monitor performance for your most important users.
 
 ## Event-specific attributes
 
 {{< tabs >}}
 {{% tab "Session" %}}
-
-A RUM session represents a real user journey on your web application. It begins when the user starts browsing the application and it is kept live as long as the user stays active. During the user journey, all RUM events generated as part of the session will share the same `session.id` attribute.
 
 ### Session metrics
 
@@ -84,13 +147,9 @@ A RUM session represents a real user journey on your web application. It begins 
 {{% /tab %}}
 {{% tab "View" %}}
 
-A page view represents a user visiting a page from your website. During that page view, [errors][1], [resources][2], [long tasks][3], and [user actions][4] get attached to that page view with a unique `view.id` attribute. Note that a page view gets updated as new events are collected.
-
-For page views, loading performance metrics are collected from both the [Paint Timing API][5] and the [Navigation Timing API][6].
-
 ### Single page applications
 
-For single page applications (SPAs), the RUM SDK differentiates between `initial_load` and `route_change` navigations with the `loading_type` attribute. If a click on your web page leads to a new page without a full refresh of the page, the RUM SDK starts a new view event with `loading_type:route_change`. RUM tracks page changes using the [History API][7].
+For single page applications (SPAs), the RUM SDK differentiates between `initial_load` and `route_change` navigations with the `loading_type` attribute. If a click on your web page leads to a new page without a full refresh of the page, the RUM SDK starts a new view event with `loading_type:route_change`. RUM tracks page changes using the [History API][1].
 
 Datadog provides a unique performance metric, `loading_time`, which calculates the time needed for a page to load. This metric works both for `initial_load` and `route_change` navigations.
 
@@ -110,45 +169,41 @@ Frameworks relying on hash (`#`) navigation are monitored with the RUM SDK autom
 
 ### View timing metrics
 
+RUM view performance metrics are collected from both the [Paint Timing API][2] and the [Navigation Timing API][3].
+
 {{< img src="real_user_monitoring/data_collected/view/timing_overview.png" alt="Timing overview"  >}}
 
 | Metric                              | Type        | Decription                                                                                                                                                                                                                 |
 |----------------------------------------|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `view.time_spent`                             | number (ns) | Time spent on the current view.                                                                                                                                                                                                  |
-| `view.loading_time`                             | number (ns) | Time until the page is ready and no network request or DOM mutation is currently occurring. [More info from the data collected documentation][8]|
-| `view.first_contentful_paint` | number (ns) | Time when the browser first renders any text, image (including background images), non-white canvas, or SVG. For more information about browser rendering, see the [w3 definition][9].                                                                                            |
-| `view.dom_interactive`        | number (ns) | The moment when the parser finishes its work on the main document. [More info from the MDN documentation][10]                                                                                                               |
-| `view.dom_content_loaded`     | number (ns) | Event fired when the initial HTML document is completely loaded and parsed, without waiting for non-render blocking stylesheets, images, and subframes to finish loading. [More info from the MDN documentation][11]. |
-| `view.dom_complete`           | number (ns) | The page and all the subresources are ready. For the user, the loading spinner has stopped spinning. [More info from the MDN documentation][12]                                                                             |
-| `view.load_event`         | number (ns) | Event fired when the page is fully loaded. Usually a trigger for additional application logic. [More info from the MDN documentation][13]                                                                                   |
+| `view.loading_time`                             | number (ns) | Time until the page is ready and no network request or DOM mutation is currently occurring. [More info from the data collected documentation][4]|
+| `view.first_contentful_paint` | number (ns) | Time when the browser first renders any text, image (including background images), non-white canvas, or SVG. For more information about browser rendering, see the [w3 definition][5].                                                                                            |
+| `view.dom_interactive`        | number (ns) | The moment when the parser finishes its work on the main document. [More info from the MDN documentation][6]                                                                                                               |
+| `view.dom_content_loaded`     | number (ns) | Event fired when the initial HTML document is completely loaded and parsed, without waiting for non-render blocking stylesheets, images, and subframes to finish loading. [More info from the MDN documentation][7]. |
+| `view.dom_complete`           | number (ns) | The page and all the subresources are ready. For the user, the loading spinner has stopped spinning. [More info from the MDN documentation][8]                                                                             |
+| `view.load_event`         | number (ns) | Event fired when the page is fully loaded. Usually a trigger for additional application logic. [More info from the MDN documentation][9]                                                                                   |
 | `view.error.count`            | number      | Count of all errors collected for this view.                                                                                                                                                                        |
 | `view.long_task.count`        | number      | Count of all long tasks collected for this view.                                                                                                                                                                           |
 | `view.resource.count`         | number      | Count of all resources collected for this view.                                                                                                                                                                            |
 | `view.action.count`      | number      | Count of all actions collected for this view.                                                                                     
 
-[1]: /real_user_monitoring/data_collected/error/
-[2]: /real_user_monitoring/data_collected/resource/
-[3]: /real_user_monitoring/data_collected/long_task/
-[4]: /real_user_monitoring/data_collected/user_action/
-[5]: https://www.w3.org/TR/paint-timing/
-[6]: https://www.w3.org/TR/navigation-timing/#sec-navigation-timing
-[7]: https://developer.mozilla.org/en-US/docs/Web/API/History
-[8]: /real_user_monitoring/data_collected/view/#how-is-loading-time-calculated
-[9]: https://www.w3.org/TR/paint-timing/#sec-terminology
-[10]: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming/domInteractive
-[11]: https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event
-[12]: https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event
-[13]: https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event
+[1]: https://developer.mozilla.org/en-US/docs/Web/API/History
+[2]: https://www.w3.org/TR/paint-timing/
+[3]: https://www.w3.org/TR/navigation-timing/#sec-navigation-timing
+[4]: /real_user_monitoring/data_collected/view/#how-is-loading-time-calculated
+[5]: https://www.w3.org/TR/paint-timing/#sec-terminology
+[6]: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming/domInteractive
+[7]: https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event
+[8]: https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event
+[9]: https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event
 {{% /tab %}}
 {{% tab "Resource" %}}
 
-All of your website’s resources are collected by default: images, XHRs, [XMLHttpRequest][1], CSS files, JS assets, and font files.
+### Resource timing metrics
 
-Detailed network timing data for the loading of an application’s resources are collected with the [Performance Resource Timing API][2].
+Detailed network timing data for the loading of an application’s resources are collected with the [Performance Resource Timing API][1].
 
 {{< img src="real_user_monitoring/data_collected/resource/resource_metric.png" alt="Resource Metrics"  >}}
-
-### Resource timing metrics
 
 | Metric                              | Type           | Description                                                                                                                               |
 |----------------------------------------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------|
@@ -178,12 +233,9 @@ Detailed network timing data for the loading of an application’s resources are
 | `resource.provider.type`      | string | The resource provider type (for example `first-party`, `cdn`, `ad`, `analytics`).                                            |
 
 
-[1]: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest
-[2]: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming
+[1]: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming
 {{% /tab %}}
 {{% tab "Long Task" %}}
-
-[Long tasks][1] are tasks that block the main thread for 50 milliseconds or more. They may cause high input latency, delayed time to interaction, etc. Understand what causes these long tasks in your browser performance profiler.
 
 ### Long task timing metrics
 
@@ -192,14 +244,11 @@ Detailed network timing data for the loading of an application’s resources are
 | `long_task.duration` | number | Duration of the long task. |
 
 
-[1]: https://developer.mozilla.org/en-US/docs/Web/API/Long_Tasks_API
 {{% /tab %}}
 {{% tab "Error" %}}
 
-Front-end errors are collected with Real User Monitoring (RUM). The error message and stack trace are included when available.
-
-### Error origins
-Front-end errors are split in 4 different categories depending on their `error.origin`:
+### Error sources
+Front-end errors are split in 4 different categories depending on their `error.source`:
 
 - **network**: XHR or Fetch errors resulting from AJAX requests. Specific attributes to network errors can be found [in the documentation][1].
 - **source**: Unhandled exceptions or unhandled promise rejections (source-code related).
@@ -285,74 +334,6 @@ Custom user actions are user actions declared and sent manually via the [`addUse
 [5]: /real_user_monitoring/data_collected/user_action#custom-user-actions
 {{% /tab %}}
 {{< /tabs >}}
-
-## Default attributes
-
-Each of these event types has the following attributes attached by default. So you can use them regardless of the RUM event type being queried.
-
-### Core
-
-| Attribute name   | Type   | Description                 |
-|------------------|--------|-----------------------------|
-| `type`     | string | The type of the event (for example, `view` or `resource`).             |
-| `application.id` | string | The Datadog application ID. |
-
-### View attributes
-
-| Attribute name                 | Type   | Description                                                                                                    |
-|--------------------------------|--------|----------------------------------------------------------------------------------------------------------------|
-| `view.id`                      | string | Randomly generated ID for each page view.                                                                      |
-| `view.loading_type`                     | string | The type of page load: `initial_load` or `route_change`. For more information, see the [single page applications support docs](#single-page-applications).|
-| `view.referrer`                | string | The URL of the previous web page from which a link to the currently requested page was followed.               |
-| `view.url`                     | string | The view URL.                                                                                                  |
-| `view.url_hash`                     | string | The hash part of the URL.|
-| `view.url_host`        | string | The host part of the URL.                                                                                |
-| `view.url_path`        | string | The path part of the URL.                                                                                 |
-| `view.url_path_group`  | string | The automatic URL group generated for similar URLs (for example, `/dashboard/?` for `/dashboard/123` and `/dashboard/456`). |
-| `view.url_query` | object | The query string parts of the URL decomposed as query params key/value attributes.                        |
-| `view.url_scheme` | object | The scheme part of the URL.                        |
-
-### Device
-
-The following device-related attributes are attached automatically to all events collected by Datadog:
-
-| Attribute name                           | Type   | Description                                     |
-|------------------------------------------|--------|-------------------------------------------------|
-| `device.type`       | string | The device type as reported by the User-Agent       |
-| `device.brand`  | string | The device brand as reported by the User-Agent.  |
-| `device.model`   | string | The device model as reported by the User-Agent.   |
-| `device.name` | string | The device name as reported by the User-Agent. |
-
-### Operating system
-
-The following OS-related attributes are attached automatically to all events collected by Datadog:
-
-| Attribute name                           | Type   | Description                                     |
-|------------------------------------------|--------|-------------------------------------------------|
-| `os.name`       | string | The OS name as reported by the User-Agent.       |
-| `os.version`  | string | The OS version as reported by the User-Agent.  |
-| `os.version_major`   | string | The OS version major as reported by the User-Agent.   |
-
-### Geo-location
-
-The following attributes are related to the geo-location of IP addresses:
-
-| Fullname                                    | Type   | Description                                                                                                                          |
-|:--------------------------------------------|:-------|:-------------------------------------------------------------------------------------------------------------------------------------|
-| `geo.country`         | string | Name of the country                                                                                                                  |
-| `geo.country_iso_code`     | string | [ISO Code][7] of the country (for example, `US` for the United States, `FR` for France).                                                  |
-| `geo.country_subdivision`     | string | Name of the first subdivision level of the country (for example, `California` in the United States or the `Sarthe` department in France). |
-| `geo.country_subdivision_iso_code` | string | [ISO Code][7] of the first subdivision level of the country (for example, `CA` in the United States or the `SA` department in France).    |
-| `geo.continent_code`       | string | ISO code of the continent (`EU`, `AS`, `NA`, `AF`, `AN`, `SA`, `OC`).                                                                 |
-| `geo.continent`       | string | Name of the continent (`Europe`, `Australia`, `North America`, `Africa`, `Antartica`, `South America`, `Oceania`).                    |
-| `geo.city`            | string | The name of the city (example `Paris`, `New York`).                                                                                   |
-
-## Extra attribute
-
-In addition to default attributes, add [specific global context][8] to all events collected. This provides the ability to analyze the data for a subset of users. For example, group errors by user email, or understand which customers have the worst performance.
-
-## Data retention
-By default, all data collected is kept at full granularity for 15 days. 
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
* have the Default Attributes at the top followed by Event specific attributes (instead of the other way round we have now) - reason: Default attributes are common to all and more applicable, also if I’m in a single tab and scrolling it is easy to miss sense of “where does the tabbed section end and common to all default attribute section begin”. This can confuse reader into thinking - hey are these default attributes only valid for session…
* tabbed section definition of RUM events should be skipped
* add difference in retention per event type
* clarify presence of view attributes in the default attributes section
* clarify User Agent

### Motivation
<!-- What inspired you to submit this pull request?-->
Better docs!

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hdelaby/data-collected-improvements/real_user_monitoring/browser/data_collected/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
