### PR TITLE
[otel]: update links to opentelemetry repos from master to main

### DIFF
--- a/content/en/tracing/setup_overview/open_standards/_index.md
+++ b/content/en/tracing/setup_overview/open_standards/_index.md
@@ -179,9 +179,9 @@ The OpenTelemetry Collector can be run in two types of [deployment scenarios][4]
 
 To accurately track the appropriate metadata in Datadog, run the OpenTelemetry Collector in agent mode on each of the Kubernetes nodes.
 
-When deploying the OpenTelemetry Collector as a daemonset, refer to [the example configuration below](#opentelemetry-kubernetes-example-collector-configuration) as a guide.
+When deploying the OpenTelemetry Collector as a daemonset, refer to [the example configuration below](#example-kubernetes-opentelemetry-collector-configuration) as a guide.
 
-On the application container, use the downward API to pull the host IP. The application container needs an environment variable that points to `status.hostIP`. The OpenTelemetry Application SDKs expect this to be named `OTEL_EXPORTER_OTLP_ENDPOINT`. Use the [below example snippet](#opentelemetry-kubernetes-example-application-configuration) as a guide.
+On the application container, use the downward API to pull the host IP. The application container needs an environment variable that points to `status.hostIP`. The OpenTelemetry Application SDKs expect this to be named `OTEL_EXPORTER_OTLP_ENDPOINT`. Use the [below example snippet](#example-kubernetes-opentelemetry-application-configuration) as a guide.
 
 ##### Example Kubernetes OpenTelemetry Collector configuration
 
@@ -296,17 +296,17 @@ To see more information and additional examples of how you might configure your 
 
 [1]: https://opentracing.io/docs/
 [2]: https://opentelemetry.io/docs/
-[3]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/datadogexporter
+[3]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter
 [4]: https://opentelemetry.io/docs/collector/getting-started/#deployment
 [5]: https://opentelemetry.io/docs/collector/configuration/
 [6]: https://app.datadoghq.com/account/settings#api
-[7]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/master/exporter/datadogexporter/example/config.yaml
-[8]: https://github.com/open-telemetry/opentelemetry-collector/blob/master/docs/design.md#pipelines
-[9]: https://github.com/open-telemetry/opentelemetry-collector/tree/master/examples
-[10]: https://github.com/open-telemetry/opentelemetry-collector/tree/master/processor/batchprocessor#batch-processor
+[7]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/example/config.yaml
+[8]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/design.md#pipelines
+[9]: https://github.com/open-telemetry/opentelemetry-collector/tree/main/examples
+[10]: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor#batch-processor
 [11]: https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/latest
 [12]: https://hub.docker.com/r/otel/opentelemetry-collector-contrib/tags
-[13]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/master/exporter/datadogexporter/example/example_k8s_manifest.yaml
-[14]: https://github.com/open-telemetry/opentelemetry-collector/blob/master/docs/design.md#running-as-an-agent
-[15]: https://github.com/open-telemetry/opentelemetry-collector/blob/master/docs/design.md#running-as-a-standalone-collector
-[16]: https://github.com/open-telemetry/opentelemetry-collector/blob/master/docs/images/opentelemetry-service-deployment-models.png
+[13]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/example/example_k8s_manifest.yaml
+[14]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/design.md#running-as-an-agent
+[15]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/design.md#running-as-a-standalone-collector
+[16]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/images/opentelemetry-service-deployment-models.png

--- a/content/en/tracing/setup_overview/open_standards/python.md
+++ b/content/en/tracing/setup_overview/open_standards/python.md
@@ -137,6 +137,6 @@ Tags that are set directly on individual spans supersede conflicting tags define
 - See [github][2], [opentelemetry examples][3], or [readthedocs][4] for more OpenTelemetry Python Datadog Exporter usage.
 
 [1]: https://opentracing.io/guides/python/
-[2]: https://github.com/open-telemetry/opentelemetry-python/tree/master/ext/opentelemetry-ext-datadog
-[3]: https://github.com/open-telemetry/opentelemetry-python/tree/master/docs/examples/datadog_exporter
+[2]: https://github.com/open-telemetry/opentelemetry-python/tree/main/ext/opentelemetry-ext-datadog
+[3]: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples/datadog_exporter
 [4]: https://opentelemetry-python.readthedocs.io/en/stable/ext/datadog/datadog.html

--- a/content/fr/tracing/custom_instrumentation/python.md
+++ b/content/fr/tracing/custom_instrumentation/python.md
@@ -345,6 +345,6 @@ Les tags qui sont définis directement sur des spans spécifiques remplacement l
 [1]: /fr/tracing/compatibility_requirements/python
 [2]: /fr/tracing/security
 [3]: https://opentracing.io/guides/python/
-[4]: https://github.com/open-telemetry/opentelemetry-python/tree/master/ext/opentelemetry-ext-datadog
-[5]: https://github.com/open-telemetry/opentelemetry-python/tree/master/docs/examples/datadog_exporter
+[4]: https://github.com/open-telemetry/opentelemetry-python/tree/main/ext/opentelemetry-ext-datadog
+[5]: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples/datadog_exporter
 [6]: https://opentelemetry-python.readthedocs.io/en/stable/ext/datadog/datadog.html

--- a/content/fr/tracing/setup_overview/open_standards/python.md
+++ b/content/fr/tracing/setup_overview/open_standards/python.md
@@ -137,6 +137,6 @@ Les tags qui sont définis directement sur des spans spécifiques remplacement l
 - Consultez [Github][2], les [exemples OpenTelemetry][3] ou [readthedocs][4] pour en savoir plus sur l'utilisation de l'exportateur Datadog pour OpenTelemetry dans une application Python.
 
 [1]: https://opentracing.io/guides/python/
-[2]: https://github.com/open-telemetry/opentelemetry-python/tree/master/ext/opentelemetry-ext-datadog
-[3]: https://github.com/open-telemetry/opentelemetry-python/tree/master/docs/examples/datadog_exporter
+[2]: https://github.com/open-telemetry/opentelemetry-python/tree/main/ext/opentelemetry-ext-datadog
+[3]: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples/datadog_exporter
 [4]: https://opentelemetry-python.readthedocs.io/en/stable/ext/datadog/datadog.html

--- a/content/ja/integrations/otel.md
+++ b/content/ja/integrations/otel.md
@@ -127,6 +127,6 @@ OpenTelemetry コレクターには、イベントは含まれません。
 [1]: https://opentelemetry.io/docs/collector/getting-started/
 [2]: https://app.datadoghq.com/account/settings#api
 [3]: https://docs.datadoghq.com/ja/tracing/setup_overview/open_standards/#opentelemetry-collector-datadog-exporter
-[4]: https://github.com/open-telemetry/opentelemetry-collector/tree/master/receiver/hostmetricsreceiver
-[5]: https://github.com/DataDog/integrations-core/blob/master/opentelemetry/metadata.csv
+[4]: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/hostmetricsreceiver
+[5]: https://github.com/DataDog/integrations-core/blob/main/opentelemetry/metadata.csv
 [6]: https://docs.datadoghq.com/ja/help/

--- a/content/ja/tracing/custom_instrumentation/python.md
+++ b/content/ja/tracing/custom_instrumentation/python.md
@@ -345,6 +345,6 @@ exporter = DatadogSpanExporter(
 [1]: /ja/tracing/compatibility_requirements/python
 [2]: /ja/tracing/security
 [3]: https://opentracing.io/guides/python/
-[4]: https://github.com/open-telemetry/opentelemetry-python/tree/master/ext/opentelemetry-ext-datadog
-[5]: https://github.com/open-telemetry/opentelemetry-python/tree/master/docs/examples/datadog_exporter
+[4]: https://github.com/open-telemetry/opentelemetry-python/tree/main/ext/opentelemetry-ext-datadog
+[5]: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples/datadog_exporter
 [6]: https://opentelemetry-python.readthedocs.io/en/stable/ext/datadog/datadog.html

--- a/content/ja/tracing/setup_overview/open_standards/python.md
+++ b/content/ja/tracing/setup_overview/open_standards/python.md
@@ -137,6 +137,6 @@ exporter = DatadogSpanExporter(
 - OpenTelemetry Python Datadog Exporter の使用法については、[github][2]、[opentelemetry の例][3]、または [readthedocs][4] を参照してください。
 
 [1]: https://opentracing.io/guides/python/
-[2]: https://github.com/open-telemetry/opentelemetry-python/tree/master/ext/opentelemetry-ext-datadog
-[3]: https://github.com/open-telemetry/opentelemetry-python/tree/master/docs/examples/datadog_exporter
+[2]: https://github.com/open-telemetry/opentelemetry-python/tree/main/ext/opentelemetry-ext-datadog
+[3]: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples/datadog_exporter
 [4]: https://opentelemetry-python.readthedocs.io/en/stable/ext/datadog/datadog.html


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Good News Everyone! The OpenTelemetry Project has updated their branch from master to main (yay!), and in the process, broken most our links to docs from that project (oh no!). So, I have updated them. I also noticed a few dead links to renamed in-doc headers that i've updated.

### Motivation
<!-- What inspired you to submit this pull request?-->

Links working > links not working

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ericmustin/otel_update_links/tracing/setup_overview/open_standards/


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
