### PR TITLE
[WEB-1079] Site & Language Selectors UX overhaul

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -7,5 +7,5 @@ aliases:
   - /faq/
   - /docs/
   - /guides/overview/
-disable_toc: true
+disable_sidebar: true
 ---

--- a/content/en/agent/faq/_index.md
+++ b/content/en/agent/faq/_index.md
@@ -2,7 +2,7 @@
 title: Agent FAQ
 kind: faq
 private: true
-disable_toc: true
+disable_sidebar: true
 aliases:
 - /agent/faq/agent-5-vs-agent-6-for-docker-kubernetes
 ---

--- a/content/en/developers/faq/data-collection-resolution-retention.md
+++ b/content/en/developers/faq/data-collection-resolution-retention.md
@@ -1,7 +1,7 @@
 ---
 title: Datadog Data Collection, Resolution, and Retention
 kind: faq
-disable_toc: true
+disable_sidebar: true
 ---
 
 Find below a summary of Datadog data collection, resolution, and retention:

--- a/content/en/getting_started/_index.md
+++ b/content/en/getting_started/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Getting started
 kind: documentation
-disable_toc: true
+disable_sidebar: true
 aliases:
     - /overview
     - /getting_started/faq/

--- a/content/en/integrations/_index.md
+++ b/content/en/integrations/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Integrations
 kind: documentation
-disable_toc: true
+disable_sidebar: true
 aliases:
     - /integrations/verisign_openhybrid/
     - /integrations/tcp_queue_length/

--- a/content/en/logs/_index.md
+++ b/content/en/logs/_index.md
@@ -2,7 +2,7 @@
 title: Log Management
 kind: Documentation
 description: "Configure your Datadog Agent to gather logs from your host, containers & services."
-disable_toc: true
+disable_sidebar: true
 aliases:
     - /guides/logs/
     - /logs/logging_without_limits

--- a/content/en/metrics/_index.md
+++ b/content/en/metrics/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Metrics
 kind: documentation
-disable_toc: true
+disable_sidebar: true
 aliases:
   - /graphing/metrics/
   - /metrics/introduction/
@@ -113,7 +113,7 @@ There are four aggregations that can be applied when using space aggregation: _s
 
 ### What metric types can I submit to Datadog?
 
-Datadog supports several different metric types that serve distinct use cases: count, gauge, rate, histogram, and distribution. Metric types determine which graphs and functions are available to use with the metric in the app. 
+Datadog supports several different metric types that serve distinct use cases: count, gauge, rate, histogram, and distribution. Metric types determine which graphs and functions are available to use with the metric in the app.
 
 ### What’s the difference between each metric type?
 

--- a/content/en/monitors/_index.md
+++ b/content/en/monitors/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Alerting
 kind: documentation
-disable_toc: true
+disable_sidebar: true
 aliases:
     - /guides/monitors/
     - /guides/monitoring/

--- a/content/en/monitors/guide/_index.md
+++ b/content/en/monitors/guide/_index.md
@@ -2,7 +2,7 @@
 title: Monitor Guides
 kind: guide
 private: true
-disable_toc: true
+disable_sidebar: true
 ---
 
 {{< whatsnext desc="General Guides:" >}}

--- a/content/en/network_monitoring/_index.md
+++ b/content/en/network_monitoring/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Network Monitoring
 kind: documentation
-disable_toc: true
+disable_sidebar: true
 description: Explore Datadog Network Monitoring Products
 further_reading:
   - link: "https://www.datadoghq.com/blog/network-performance-monitoring"

--- a/content/en/network_monitoring/devices/_index.md
+++ b/content/en/network_monitoring/devices/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Network Device Monitoring
 kind: documentation
-disable_toc: true
+disable_sidebar: true
 description: Gain visibility into your network-connected devices, such as routers, switches, servers, and firewalls.
 aliases:
     - /network_performance_monitoring/devices/

--- a/content/en/network_monitoring/devices/guide/_index.md
+++ b/content/en/network_monitoring/devices/guide/_index.md
@@ -2,7 +2,7 @@
 title: NDM Guides
 kind: guide
 private: true
-disable_toc: true
+disable_sidebar: true
 aliases:
     - /network_performance_monitoring/devices/guide/
 further_reading:

--- a/content/en/network_monitoring/performance/guide/_index.md
+++ b/content/en/network_monitoring/performance/guide/_index.md
@@ -4,7 +4,7 @@ kind: guide
 aliases:
     - /network_performance_monitoring/guide/
 private: true
-disable_toc: true
+disable_sidebar: true
 ---
 
 {{< whatsnext desc="General Guides:" >}}

--- a/content/en/real_user_monitoring/_index.md
+++ b/content/en/real_user_monitoring/_index.md
@@ -2,7 +2,7 @@
 title: Real User Monitoring
 kind: documentation
 description: "Visualize and analyze the performance of your front end applications as seen by your users."
-disable_toc: true
+disable_sidebar: true
 aliases:
   - /real_user_monitoring/installation
 further_reading:

--- a/content/en/search.md
+++ b/content/en/search.md
@@ -1,7 +1,7 @@
 ---
 title: Search Results
 kind: search
-disable_toc: true
+disable_sidebar: true
 ---
 
 <div id="tipue_search_content">

--- a/content/en/security_monitoring/default_rules/_index.md
+++ b/content/en/security_monitoring/default_rules/_index.md
@@ -3,7 +3,7 @@ title: Default Threat Detection Rules
 kind: documentation
 type: security_rules
 description: "Datadog Security Detection Rules"
-disable_toc: true
+disable_sidebar: true
 ---
 
 [Detection rules][1] define conditional logic that is applied to all ingested logs. When at least one case defined in a detection rule is matched over a given period of time, Datadog generates a security signal.

--- a/content/en/synthetics/_index.md
+++ b/content/en/synthetics/_index.md
@@ -2,7 +2,7 @@
 title: Synthetic Monitoring
 kind: documentation
 description: "Use automated testing to ensure the most critical parts of your systems and applications are up and running from various locations around the world."
-disable_toc: true
+disable_sidebar: true
 aliases:
   - /integrations/synthetics/
 further_reading:

--- a/content/fr/_index.md
+++ b/content/fr/_index.md
@@ -7,5 +7,5 @@ aliases:
   - /fr/faq/
   - /fr/docs/
   - /fr/guides/overview/
-disable_toc: true
+disable_sidebar: true
 ---

--- a/content/fr/integrations/_index.md
+++ b/content/fr/integrations/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Intégrations
 kind: documentation
-disable_toc: true
+disable_sidebar: true
 aliases:
   - /fr/integrations/verisign_openhybrid/
 description: 'Rassembler des données de tous vos systèmes, toutes vos applications et tous vos services'

--- a/content/fr/logs/_index.md
+++ b/content/fr/logs/_index.md
@@ -2,7 +2,7 @@
 title: Log Management
 kind: Documentation
 description: 'Configurez votre Agent Datadog pour rassembler les logs de votre host, de vos conteneurs et de vos services.'
-disable_toc: true
+disable_sidebar: true
 aliases:
   - /fr/guides/logs/
   - /fr/logs/logging_without_limits

--- a/content/fr/metrics/_index.md
+++ b/content/fr/metrics/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Métriques
 kind: documentation
-disable_toc: true
+disable_sidebar: true
 aliases:
   - /fr/graphing/metrics/
   - /fr/metrics/introduction/
@@ -22,7 +22,7 @@ Les métriques vous aident également à ajuster la taille de votre environnemen
 
 Dans l'application Datadog, vous pouvez visualiser vos métriques et créer des graphiques depuis le [Metrics Explorer][3], les [dashboards][4] ou les [notebooks][5].
 
-Voici un exemple de visualisation représentant une série temporelle : 
+Voici un exemple de visualisation représentant une série temporelle :
 
 {{< img src="metrics/introduction/timeseries_example.png" alt="Exemple de série temporelle" >}}
 

--- a/content/fr/monitors/_index.md
+++ b/content/fr/monitors/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Alertes
 kind: documentation
-disable_toc: true
+disable_sidebar: true
 aliases:
   - /fr/guides/monitors/
   - /fr/guides/monitoring/

--- a/content/fr/monitors/guide/_index.md
+++ b/content/fr/monitors/guide/_index.md
@@ -2,7 +2,7 @@
 title: Guides sur les monitors
 kind: guide
 private: true
-disable_toc: true
+disable_sidebar: true
 ---
 
 {{< whatsnext desc="Guides généraux :" >}}

--- a/content/fr/monitors/incident_management.md
+++ b/content/fr/monitors/incident_management.md
@@ -1,7 +1,7 @@
 ---
 title: Gestion des incidents
 kind: documentation
-disable_toc: true
+disable_sidebar: true
 description: Créer et gérer des incidents
 ---
 {{< img src="monitors/incidents/incidents-top-1.png" alt="Gestion des incidents"  style="width:80%;">}}
@@ -74,7 +74,7 @@ Pour les clients non européens qui utilisent Slack, [demandez à accéder à la
 
 #### 4. Mise à jour de l'incident
 
-Mettez à jour l'incident à mesure que la situation évolue. Définissez le statut sur `Stable` pour indiquer que le problème a été atténué, et remplissez le champ concernant l'impact sur les clients afin que votre organisation sache dans quelle mesure le problème a affecté les clients. Ensuite, définissez le statut sur `Resolved` une fois que l'incident a été complètement résolu. Il existe un quatrième statut facultatif, `Completed`, qui peut être utilisé pour indiquer que toutes les étapes de remédiation ont été réalisées. Ce statut peut être activé dans les [Paramètres d'incident][2]. 
+Mettez à jour l'incident à mesure que la situation évolue. Définissez le statut sur `Stable` pour indiquer que le problème a été atténué, et remplissez le champ concernant l'impact sur les clients afin que votre organisation sache dans quelle mesure le problème a affecté les clients. Ensuite, définissez le statut sur `Resolved` une fois que l'incident a été complètement résolu. Il existe un quatrième statut facultatif, `Completed`, qui peut être utilisé pour indiquer que toutes les étapes de remédiation ont été réalisées. Ce statut peut être activé dans les [Paramètres d'incident][2].
 
 {{< img src="monitors/incidents/workflow-4-update-2.png" alt="Mise à jour de l'incident"  style="width:60%;">}}
 

--- a/content/fr/monitors/incident_management/datadog_clipboard.md
+++ b/content/fr/monitors/incident_management/datadog_clipboard.md
@@ -1,7 +1,7 @@
 ---
 title: Presse-papiers Datadog
 kind: documentation
-disable_toc: true
+disable_sidebar: true
 description: Créer et gérer des incidents
 ---
 **Le presse-papiers Datadog est actuellement disponible en version bêta.**

--- a/content/fr/network_performance_monitoring/devices/_index.md
+++ b/content/fr/network_performance_monitoring/devices/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Network Device Monitoring
 kind: documentation
-disable_toc: true
+disable_sidebar: true
 further_reading:
   - link: 'https://www.datadoghq.com/blog/monitor-snmp-with-datadog/'
     tag: Blog

--- a/content/fr/real_user_monitoring/_index.md
+++ b/content/fr/real_user_monitoring/_index.md
@@ -2,7 +2,7 @@
 title: Real User Monitoring
 kind: documentation
 description: 'Visualisez et analysez les performances de vos applications frontend, telles qu''elles sont perçues par vos utilisateurs.'
-disable_toc: true
+disable_sidebar: true
 aliases:
   - /fr/real_user_monitoring/installation
 further_reading:

--- a/content/fr/search.md
+++ b/content/fr/search.md
@@ -1,7 +1,7 @@
 ---
 title: Résultats de la recherche
 kind: search
-disable_toc: true
+disable_sidebar: true
 ---
 
 <div id="tipue_search_content">

--- a/content/fr/security_monitoring/default_rules/_index.md
+++ b/content/fr/security_monitoring/default_rules/_index.md
@@ -3,7 +3,7 @@ title: Règles de détection des menaces par défaut
 kind: documentation
 type: security_rules
 description: "Règles sécuritaires de détection Datadog"
-disable_toc: true
+disable_sidebar: true
 ---
 
 Les [règles de détection][1] définissent la logique conditionnelle appliquée à l'ensemble des logs ingérés. Lorsque les conditions d'une règle sont remplies pendant un intervalle donné, Datadog génère un signal de sécurité.

--- a/content/fr/synthetics/_index.md
+++ b/content/fr/synthetics/_index.md
@@ -2,7 +2,7 @@
 title: Surveillance Synthetic
 kind: documentation
 description: Utilisez des tests automatisés pour vous assurer que les aspects les plus importants de vos systèmes et applications fonctionnent correctement à différents endroits du monde.
-disable_toc: true
+disable_sidebar: true
 aliases:
   - /fr/integrations/synthetics/
 further_reading:

--- a/content/fr/tracing/setup/_index.md
+++ b/content/fr/tracing/setup/_index.md
@@ -4,7 +4,7 @@ kind: documentation
 aliases:
   - /fr/tracing/languages
   - /fr/tracing/proxies
-disable_toc: true
+disable_sidebar: true
 ---
 Après avoir [activé la collecte de traces][1], configurez votre application pour envoyer des [traces][2] en utilisant l'une des bibliothèques de tracing Datadog officielles suivantes :
 

--- a/content/fr/videos/_index.md
+++ b/content/fr/videos/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Vidéos
 kind: Documentation
-disable_toc: true
+disable_sidebar: true
 private: true
 aliases:
   - /fr/videos/tipsandtricks-k8s-autodiscovery/

--- a/content/ja/_index.md
+++ b/content/ja/_index.md
@@ -7,5 +7,5 @@ aliases:
   - /ja/faq/
   - /ja/docs/
   - /ja/guides/overview/
-disable_toc: true
+disable_sidebar: true
 ---

--- a/content/ja/getting_started/_index.md
+++ b/content/ja/getting_started/_index.md
@@ -1,7 +1,7 @@
 ---
 title: はじめに
 kind: documentation
-disable_toc: true
+disable_sidebar: true
 aliases:
   - /ja/overview
   - /ja/getting_started/faq/

--- a/content/ja/integrations/_index.md
+++ b/content/ja/integrations/_index.md
@@ -1,7 +1,7 @@
 ---
 title: インテグレーション
 kind: documentation
-disable_toc: true
+disable_sidebar: true
 aliases:
   - /ja/integrations/verisign_openhybrid/
   - /ja/integrations/tcp_queue_length/

--- a/content/ja/logs/_index.md
+++ b/content/ja/logs/_index.md
@@ -2,7 +2,7 @@
 title: ログ管理
 kind: Documentation
 description: Datadog Agent を設定して、ホスト、コンテナー、およびサービスからログを収集します。
-disable_toc: true
+disable_sidebar: true
 aliases:
   - /ja/guides/logs/
   - /ja/logs/logging_without_limits

--- a/content/ja/metrics/_index.md
+++ b/content/ja/metrics/_index.md
@@ -1,7 +1,7 @@
 ---
 title: メトリクス
 kind: documentation
-disable_toc: true
+disable_sidebar: true
 aliases:
   - /ja/graphing/metrics/
   - /ja/metrics/introduction/

--- a/content/ja/monitors/_index.md
+++ b/content/ja/monitors/_index.md
@@ -1,7 +1,7 @@
 ---
 title: アラート設定
 kind: documentation
-disable_toc: true
+disable_sidebar: true
 aliases:
   - /ja/guides/monitors/
   - /ja/guides/monitoring/

--- a/content/ja/monitors/guide/_index.md
+++ b/content/ja/monitors/guide/_index.md
@@ -2,7 +2,7 @@
 title: モニターガイド
 kind: ガイド
 private: true
-disable_toc: true
+disable_sidebar: true
 ---
 
 {{< whatsnext desc="全般ガイド:" >}}

--- a/content/ja/monitors/incident_management.md
+++ b/content/ja/monitors/incident_management.md
@@ -1,7 +1,7 @@
 ---
 title: インシデント管理
 kind: ドキュメント
-disable_toc: true
+disable_sidebar: true
 description: インシデントの作成と管理
 ---
 {{< img src="monitors/incidents/incidents-top-1.png" alt="インシデント管理"  style="width:80%;">}}

--- a/content/ja/network_performance_monitoring/devices/_index.md
+++ b/content/ja/network_performance_monitoring/devices/_index.md
@@ -1,7 +1,7 @@
 ---
 title: ネットワークデバイスモニタリング
 kind: ドキュメント
-disable_toc: true
+disable_sidebar: true
 further_reading:
   - link: 'https://www.datadoghq.com/blog/monitor-snmp-with-datadog/'
     tag: ブログ

--- a/content/ja/network_performance_monitoring/devices/guide/_index.md
+++ b/content/ja/network_performance_monitoring/devices/guide/_index.md
@@ -2,7 +2,7 @@
 title: NDM ガイド
 kind: ガイド
 private: true
-disable_toc: true
+disable_sidebar: true
 further_reading:
 - link: "https://www.datadoghq.com/blog/monitor-snmp-with-datadog/"
   tag: ブログ
@@ -13,7 +13,7 @@ further_reading:
 ---
 
 {{< whatsnext desc="一般的なガイド:" >}}
-    {{< nextlink href="network_performance_monitoring/devices/guide/cluster-agent" >}}Cluster Agent を使用した NDM{{< /nextlink >}} 
+    {{< nextlink href="network_performance_monitoring/devices/guide/cluster-agent" >}}Cluster Agent を使用した NDM{{< /nextlink >}}
    {{< nextlink href="network_performance_monitoring/devices/guide/build-ndm-profile" >}}NDM プロファイルを構築{{< /nextlink >}}
 {{< /whatsnext >}}
 

--- a/content/ja/real_user_monitoring/_index.md
+++ b/content/ja/real_user_monitoring/_index.md
@@ -2,7 +2,7 @@
 title: リアルユーザーモニタリング
 kind: documentation
 description: ユーザーから見たフロントエンドアプリケーションのパフォーマンスを視覚化して分析します。
-disable_toc: true
+disable_sidebar: true
 aliases:
   - /ja/real_user_monitoring/installation
 further_reading:
@@ -27,7 +27,7 @@ Datadog のリアルユーザーモニタリング (RUM) は、個々のユー�
 
 {{< whatsnext desc="RUM の概要:">}}
   {{< nextlink href="/real_user_monitoring/browser">}}<u>ブラウザの監視</u>: ブラウザ SDK を構成してアプリケーションを作成します。{{< /nextlink >}}
-  {{< nextlink href="/real_user_monitoring/android">}}<u>Android の監視</u>: Android SDK を構成してアプリケーションを作成します。{{< /nextlink >}} 
+  {{< nextlink href="/real_user_monitoring/android">}}<u>Android の監視</u>: Android SDK を構成してアプリケーションを作成します。{{< /nextlink >}}
   {{< nextlink href="/real_user_monitoring/dashboards">}}<u>ダッシュボード</u>: すぐに使用できるダッシュボード内で収集されたすべてのデータを利用開始後すぐに発見します。{{< /nextlink >}}
 {{< /whatsnext >}}
 {{< whatsnext desc="RUM イベントを探索する:">}}

--- a/content/ja/real_user_monitoring/error_tracking/_index.md
+++ b/content/ja/real_user_monitoring/error_tracking/_index.md
@@ -2,6 +2,7 @@
 title: RUM エラー追跡
 kind: ドキュメント
 beta: true
+disable_sidebar: true
 further_reading:
   - link: /real_user_monitoring/error_tracking/explorer
     tag: Documentation

--- a/content/ja/search.md
+++ b/content/ja/search.md
@@ -1,7 +1,7 @@
 ---
 title: 結果
 kind: search
-disable_toc: true
+disable_sidebar: true
 ---
 
 <div id="tipue_search_content">

--- a/content/ja/security_monitoring/default_rules/_index.md
+++ b/content/ja/security_monitoring/default_rules/_index.md
@@ -3,7 +3,7 @@ title: デフォルトの脅威検出ルール
 kind: ドキュメント
 type: security_rules
 description: "Datadog セキュリティ検出ルール"
-disable_toc: true
+disable_sidebar: true
 ---
 
 [検出ルール][1]は、取り込んだすべてのログに適用される条件付きロジックを定義します。対象期間内において、検出ルールで定義された少なくとも 1 つのケースが一致した場合に Datadog でセキュリティシグナルが生成されます。

--- a/content/ja/synthetics/_index.md
+++ b/content/ja/synthetics/_index.md
@@ -2,7 +2,7 @@
 title: Synthetic の監視
 kind: documentation
 description: 自動テストを使用して、システムとアプリケーションの最も重要な部分が世界各地で正常に稼働していることを確認します。
-disable_toc: true
+disable_sidebar: true
 aliases:
   - /ja/integrations/synthetics/
 further_reading:

--- a/content/ja/tracing/setup/_index.md
+++ b/content/ja/tracing/setup/_index.md
@@ -4,7 +4,7 @@ kind: documentation
 aliases:
   - /ja/tracing/languages
   - /ja/tracing/proxies
-disable_toc: true
+disable_sidebar: true
 ---
 [Datadog Agent を構成][1]したら、次の公式 Datadog トレースライブラリのいずれかを使用して[トレース][2]を送信するようにアプリケーションを構成します。
 

--- a/content/ja/videos/_index.md
+++ b/content/ja/videos/_index.md
@@ -1,7 +1,7 @@
 ---
 title: ビデオ
 kind: Documentation
-disable_toc: true
+disable_sidebar: true
 private: true
 aliases:
   - /ja/videos/tipsandtricks-k8s-autodiscovery/

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -65,16 +65,6 @@
         </div>
       </div>
 
-      <div class="region-selector-container">
-        <select class="js-region-selector d-none" placeholder="Site">
-          <option value="" disabled>Site</option>
-          {{ range sort .Site.Params.allowedRegions ".weight" "asc" }}
-              <option value="{{ .value }}">{{ .name }}</option>
-          {{ end }}
-        </select>
-      </div>
-      {{ partial "table-of-contents/table-of-contents.html" . }}
-
       {{ if ne .Params.disable_sidebar true }}
         <aside class="sidebar col-lg-2">
           {{ partial "language-region-select.html" . }}
@@ -84,10 +74,8 @@
           {{ end }}
         </aside>
       {{ end }}
-
     </div>
   </div>
-
 
   {{ partial "footer/footer.html" . }}
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -52,7 +52,7 @@
   {{ partial "header/header.html" . }}
 
   <div class="container h-100 pt-1">
-    <div class="row h-100 position-relative">
+    <div class="row h-100 position-relative js-content-container">
       <div class="d-none d-lg-flex col-12 col-sm-3 side">
         {{ partial "sidenav/main-sidenav.html" . }}
       </div>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -57,7 +57,7 @@
         {{ partial "sidenav/main-sidenav.html" . }}
       </div>
 
-      <div class="mainContent-wrapper order-2 order-lg-0 col-12 {{ if eq .Params.disable_toc true}} col-lg-9 {{ else }} col-lg-7 {{end}} main">
+      <div class="mainContent-wrapper order-2 order-lg-0 col-12 {{ if eq .Params.disable_sidebar true }}col-lg-9{{ else }}col-lg-7{{ end }} main">
         <div class="{{ if and (eq $.Section "integrations") (eq $.Kind "page") }}integrations-single{{ end }}"
           id="mainContent">
           {{ block "main" . }}{{ end }}
@@ -74,6 +74,16 @@
         </select>
       </div>
       {{ partial "table-of-contents/table-of-contents.html" . }}
+
+      {{ if ne .Params.disable_sidebar true }}
+        <aside class="sidebar col-lg-2">
+          {{ partial "language-region-select.html" . }}
+
+          {{ if ne .Params.disable_toc true }}
+            {{ partial "table-of-contents/table-of-contents.html" . }}
+          {{ end }}
+        </aside>
+      {{ end }}
 
     </div>
   </div>

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -1,7 +1,7 @@
 {{ define "api-main" }}
 
     {{ with .Content}}
-        <div class="col-12 col-lg-9">
+        <div class="col-12 col-lg-9 pl-0">
             {{ . }}
         </div>
     {{ end }}

--- a/layouts/partials/api/api-toolbar.html
+++ b/layouts/partials/api/api-toolbar.html
@@ -1,20 +1,14 @@
 {{ $url := replace .Permalink ( printf "%s" .Site.BaseURL) "" }}
 {{ $.Scratch.Add "path" .Site.BaseURL }}
 
+<div class="api-toolbar pt-2 mb-lg-1 d-lg-flex justify-content-between">
+    <div id="breadcrumbs">
+        <a class="text-uppercase text-gray-darkish" href="{{ .Page.Parent.RelPermalink }}">{{ .Page.Parent.Title }}</a>&nbsp;>&nbsp;
 
-<div class="bg-white row align-items-center mb-0 mb-lg-2 api-toolbar">
-    <div class="col-12">
-
-        <div class="row align-items-center">
-            <div class="col-12 col-lg-6 pt-2 pt-lg-0">
-                <div id="breadcrumbs">
-                    <a class="text-uppercase text-gray-darkish" href="/">Docs</a>
-                    &nbsp;>&nbsp;
-
-                    {{ if .Page.Parent }}
-                        <a class="text-uppercase text-gray-darkish" href="{{ .Page.Parent.RelPermalink }}">{{ .Page.Parent.Title }}</a>
-                        &nbsp;>&nbsp;
-                    {{ end }}
+        {{ if .Page.Parent }}
+            <a class="text-uppercase text-gray-darkish" href="{{ .Page.Parent.RelPermalink }}">{{ .Page.Parent.Title }}</a>
+            &nbsp;>&nbsp;
+        {{ end }}
 
                     <a class="text-primary text-uppercase" href="{{ .Page.RelPermalink }}">{{ .Page.Title }}</a>
 
@@ -41,8 +35,5 @@
                         </div>
                     </div>
 
-                </div>
-            </div>
-        </div>
-    </div>
+    {{ partial "language-region-select.html" . }}
 </div>

--- a/layouts/partials/api/api-toolbar.html
+++ b/layouts/partials/api/api-toolbar.html
@@ -10,30 +10,8 @@
             &nbsp;>&nbsp;
         {{ end }}
 
-                    <a class="text-primary text-uppercase" href="{{ .Page.RelPermalink }}">{{ .Page.Title }}</a>
-
-                    {{/* range $index, $element := split $url "/" }}
-                    {{ $.Scratch.Add "path" $element }}
-                        {{ if ne $element "" }}
-                        > <a href='{{ $.Scratch.Get "path" }}'>{{ . }}</a>
-                        {{ $.Scratch.Add "path" "/" }}
-                        {{ end }}
-                    {{ end */}}
-                </div>
-            </div>
-            <div class="col-12 col-lg-6 px-lg-0">
-                <div class="row justify-content-start justify-content-lg-end">
-
-                    <div class="col-5 col-lg-4 px-lg-0">
-                        <div class="d-flex justify-content-start justify-content-lg-end">
-                            <select class="js-region-selector d-none" placeholder="Site">
-                                <option value="" disabled>Site</option>
-                                {{ range sort .Site.Params.allowedRegions ".weight" "asc" }}
-                                    <option value="{{ .value }}">{{ .name }}</option>
-                                {{ end }}
-                              </select>
-                        </div>
-                    </div>
+        <a class="text-primary text-uppercase" href="{{ .Page.RelPermalink }}">{{ .Page.Title }}</a>
+    </div>
 
     {{ partial "language-region-select.html" . }}
 </div>

--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -14,7 +14,7 @@
 {{ end }}
 {{ $datafile := ($.Scratch.Get "data") }}
 
-<footer class="pt-3">
+<footer class="pt-3 position-relative">
     <div class="container">
         <div class="row pt-3 pb-0 pb-lg-6">
             <div class="col-12 col-lg-9">

--- a/layouts/partials/language-region-select.html
+++ b/layouts/partials/language-region-select.html
@@ -1,0 +1,40 @@
+<div class="language-region-select-container d-flex flex-lg-column">
+  <div class="language-select-container">
+    <p class="text-uppercase">Language</p>
+    <div class="dropdown bootstrap-dropdown-custom">
+      <button class="btn d-flex align-items-center justify-content-between" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        {{ .Language.LanguageName }}
+        <div class="chevron chevron-down"></div>
+        <div class="chevron chevron-up d-none"></div>
+      </button>
+      <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+        <a class="dropdown-item" href="{{ .Permalink }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
+
+        <!-- Manually adding English option to non-English sites -->
+        {{ if ne .Sites.First .Site }}
+          <a class="dropdown-item" href="{{ replace .Permalink (printf "/%s/" .Language.Lang) "/" }}?lang_pref=en">English</a>
+        {{ end }}
+
+        {{ range where .Translations "Language.Lang" "!=" "en" }}
+          <a class="dropdown-item" href="{{ .Permalink }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
+        {{ end }}
+      </div>
+    </div>
+  </div>
+
+  <div class="region-select-container">
+    <p class="text-uppercase">Site</p>
+    <div class="dropdown bootstrap-dropdown-custom js-region-select">
+      <button class="btn d-flex align-items-center justify-content-between" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <span class="btn-inner"></span>
+        <div class="chevron chevron-down"></div>
+        <div class="chevron chevron-up d-none"></div>
+      </button>
+      <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+        {{ range sort .Site.Params.allowedRegions ".weight" "asc" }}
+          <a class="dropdown-item" data-value="{{ .value }}">{{ .name }}</a>
+        {{ end }}
+      </div>
+    </div>
+  </div>
+</div>

--- a/layouts/partials/table-of-contents/table-of-contents.html
+++ b/layouts/partials/table-of-contents/table-of-contents.html
@@ -1,21 +1,14 @@
 {{ $ctx := . }}
 
-
-<div class="col-4 col-lg-2 js-toc-container toc-container ">
-
-    
-    <div class="sticky toc">
-
+<div class="js-toc-container toc-container">
+    <div class="toc">
         <div class="js-toc {{ if .Params.disable_toc }} d-none {{ else }} {{ end }}">
-            {{ if eq .Params.disable_edit true }} 
-            {{ else }}
+            {{ if ne .Params.disable_edit true }}
                 {{ partial "page-edit.html" (dict "ctx" $ctx "type" "edit") }}
             {{ end }}
             <p class="text-uppercase text-gray-darkish font-semibold mb-2 toc-title js-toc-title {{ if .Params.disable_toc }} d-none {{ else }} {{ end }}">{{ i18n "table_of_contents_heading"}}</p>
             {{ if ne .Params.disable_toc true }}{{ .TableOfContents }}{{ end }}
-
         </div>
-        
     </div>
 </div>
 

--- a/src/scripts/components/async-loading.js
+++ b/src/scripts/components/async-loading.js
@@ -163,14 +163,22 @@ function loadPage(newUrl) {
             }
 
             // Ensure sidebar is displayed or hidden properly based on HTTP response.  I'm certain we can implement a better strategy for what's happening in this script, but this should hold us over until then.
-            if (newSidebar && !currentSidebar) {              
+            if (newSidebar && !currentSidebar) {            
                 const jsContentContainer = document.querySelector('.js-content-container');
                 jsContentContainer.appendChild(newSidebar);
             }
 
             if (!newSidebar && currentSidebar) {
                 const sidebar = document.querySelector('.sidebar');
-                sidebar.style.display = 'none';
+                sidebar.classList.add('d-none');
+            }
+
+            if (newSidebar && currentSidebar) {
+                const sidebar = document.querySelector('.sidebar');
+
+                if (sidebar.classList.value.includes('d-none')) {
+                    sidebar.classList.remove('d-none');
+                }
             }
 
             const pathName = new URL(newUrl).pathname;

--- a/src/scripts/components/async-loading.js
+++ b/src/scripts/components/async-loading.js
@@ -3,7 +3,7 @@ import codeTabs from './codetabs';
 import { redirectToRegion } from '../region-redirects';
 import { initializeIntegrations } from './integrations';
 import { initializeSecurityRules } from './security-rules';
-import {updateMainContentAnchors, reloadWistiaVidScripts, gtag } from '../helpers/helpers';
+import {updateMainContentAnchors, reloadWistiaVidScripts, gtag, getCookieByName } from '../helpers/helpers';
 import configDocs from '../config/config-docs';
 import {redirectCodeLang, addCodeTabEventListeners, activateCodeLangNav} from './code-languages'; // eslint-disable-line import/no-cycle
 
@@ -103,7 +103,7 @@ function loadPage(newUrl) {
             // update data-relPermalink
             document.documentElement.dataset.relpermalink =
                 newDocument.documentElement.dataset.relpermalink;
-            
+
             // update data-type
             document.documentElement.dataset.type =
                 newDocument.documentElement.dataset.type;
@@ -165,9 +165,11 @@ function loadPage(newUrl) {
 
             codeTabs();
 
-            const regionSelector = document.querySelector('.js-region-selector');
+            const regionSelector = document.querySelector('.js-region-select');
+
             if (regionSelector) {
-                redirectToRegion(regionSelector.value);
+                const region = getCookieByName('site');
+                redirectToRegion(region);
             }
 
             const {pageCodeLang} = document.documentElement.dataset;

--- a/src/scripts/components/async-loading.js
+++ b/src/scripts/components/async-loading.js
@@ -51,6 +51,9 @@ function loadPage(newUrl) {
                 '.js-toc-container'
             );
 
+            const currentSidebar = document.querySelector('.sidebar'); 
+            const newSidebar = httpRequest.responseXML.querySelector('.sidebar');
+
             if (newContent === null) {
                 return;
             }
@@ -142,7 +145,7 @@ function loadPage(newUrl) {
             initializeSecurityRules();
 
             // if newly requested TOC is NOT disabled
-            if (newTOC.querySelector('#TableOfContents')) {
+            if (newTOC.querySelector('#TableOfContents') && currentTOC) {
                 currentTOC.replaceWith(newTOC);
                 buildTOCMap();
                 updateTOC();
@@ -157,6 +160,14 @@ function loadPage(newUrl) {
                     .querySelector('.js-toc-container #TableOfContents')
                     .remove();
                 updateTOC();
+            }
+
+            // If there wasn't a sidebar on the previous page, but a sidebar element exists in the response from the HTTP request,
+            // we need to manually append it to the DOM.   I'm certain we can implement a better strategy for much of the logic in here,
+            // but this should hold us over until then.
+            if (newSidebar && !currentSidebar) {                
+                const jsContentContainer = document.querySelector('.js-content-container');
+                jsContentContainer.appendChild(newSidebar);
             }
 
             const pathName = new URL(newUrl).pathname;

--- a/src/scripts/components/async-loading.js
+++ b/src/scripts/components/async-loading.js
@@ -145,7 +145,7 @@ function loadPage(newUrl) {
             initializeSecurityRules();
 
             // if newly requested TOC is NOT disabled
-            if (newTOC.querySelector('#TableOfContents') && currentTOC) {
+            if (newTOC && newTOC.querySelector('#TableOfContents') && currentTOC) {
                 currentTOC.replaceWith(newTOC);
                 buildTOCMap();
                 updateTOC();
@@ -162,12 +162,15 @@ function loadPage(newUrl) {
                 updateTOC();
             }
 
-            // If there wasn't a sidebar on the previous page, but a sidebar element exists in the response from the HTTP request,
-            // we need to manually append it to the DOM.   I'm certain we can implement a better strategy for much of the logic in here,
-            // but this should hold us over until then.
-            if (newSidebar && !currentSidebar) {                
+            // Ensure sidebar is displayed or hidden properly based on HTTP response.  I'm certain we can implement a better strategy for what's happening in this script, but this should hold us over until then.
+            if (newSidebar && !currentSidebar) {              
                 const jsContentContainer = document.querySelector('.js-content-container');
                 jsContentContainer.appendChild(newSidebar);
+            }
+
+            if (!newSidebar && currentSidebar) {
+                const sidebar = document.querySelector('.sidebar');
+                sidebar.style.display = 'none';
             }
 
             const pathName = new URL(newUrl).pathname;

--- a/src/scripts/components/bootstrap-dropdown-custom.js
+++ b/src/scripts/components/bootstrap-dropdown-custom.js
@@ -1,0 +1,35 @@
+const bootstrapCustomDropdownNodeList = document.querySelectorAll('.bootstrap-dropdown-custom');
+const bootstrapCustomDropdownBtnNodeList = document.querySelectorAll('.bootstrap-dropdown-custom > .btn');
+
+const toggleChevronArrowIcon = (dropdownBtnElement) => {
+  const chevronUp = dropdownBtnElement.querySelector('.chevron-up');
+  const chevronDown = dropdownBtnElement.querySelector('.chevron-down');
+
+  if (chevronUp.classList.contains('d-none')) {
+    chevronUp.classList.remove('d-none');
+    chevronDown.classList.add('d-none');
+  } else {
+    chevronUp.classList.add('d-none');
+    chevronDown.classList.remove('d-none');
+  }
+}
+
+const initBootstrapCustomDropdowns = () => {
+  bootstrapCustomDropdownBtnNodeList.forEach(dropdown => {
+    dropdown.addEventListener('click', (event) => {
+      toggleChevronArrowIcon(event.target);
+    })
+  })
+
+  document.body.addEventListener('click', () => {
+    bootstrapCustomDropdownNodeList.forEach(dropdown => {
+      const dropdownMenu = dropdown.querySelector('.dropdown-menu');
+
+      if (dropdownMenu.classList.contains('show')) {
+        toggleChevronArrowIcon(dropdown);
+      }
+    })
+  })
+}
+
+document.addEventListener('DOMContentLoaded', initBootstrapCustomDropdowns);

--- a/src/scripts/components/bootstrap-dropdown-custom.js
+++ b/src/scripts/components/bootstrap-dropdown-custom.js
@@ -17,7 +17,9 @@ const toggleChevronArrowIcon = (dropdownBtnElement) => {
 const initBootstrapCustomDropdowns = () => {
   bootstrapCustomDropdownBtnNodeList.forEach(dropdown => {
     dropdown.addEventListener('click', (event) => {
-      toggleChevronArrowIcon(event.target);
+      const targetClassList = event.target.classList.value;
+      const dropdownBtnElement = targetClassList.includes('chevron') ? event.target.closest('button') : event.target;
+      toggleChevronArrowIcon(dropdownBtnElement);
     })
   })
 

--- a/src/scripts/helpers/helpers.js
+++ b/src/scripts/helpers/helpers.js
@@ -40,5 +40,17 @@ function gtag(...args) {
     dataLayer.push(args);
 }
 
+const getCookieByName = (name) => {
+    let value = '';
+    const cookie = document.cookie.split('; ').find(row => row.startsWith(name));
 
-export {updateMainContentAnchors, reloadWistiaVidScripts, gtag}
+    if (cookie) {
+        // eslint-disable-next-line prefer-destructuring
+        value = cookie.split('=')[1];
+    }
+
+    return value;
+}
+
+
+export {updateMainContentAnchors, reloadWistiaVidScripts, gtag, getCookieByName}

--- a/src/scripts/main-dd-js.js
+++ b/src/scripts/main-dd-js.js
@@ -11,6 +11,7 @@ import './components/algolia';
 import './components/api';
 import './components/code-languages';
 import './components/language-select';
+import './components/bootstrap-dropdown-custom';
 
 // TODO: split up code from datadog-docs.js into modules after webpack migration
 // import './components/sidenav';

--- a/src/scripts/region-redirects.js
+++ b/src/scripts/region-redirects.js
@@ -18,7 +18,7 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 function replaceButtonInnerText(value) {
-    const selectedRegion = value === 'gov' ? 'US1-FED' : value.toUpperCase();
+    const selectedRegion = config.dd_datacenter[value];
     const regionSelector = document.querySelector('.js-region-select');
     const buttonInner = regionSelector.querySelector('.btn-inner');
     buttonInner.innerText = selectedRegion;

--- a/src/scripts/region-redirects.js
+++ b/src/scripts/region-redirects.js
@@ -3,14 +3,28 @@ import config from '../../regions.config';
 
 // need to wait for DOM since this script is loaded in the <head>
 document.addEventListener('DOMContentLoaded', () => {
-    const regionSelector = document.querySelector('.js-region-selector');
+    const regionSelector = document.querySelector('.js-region-select');
 
     if (regionSelector) {
-        regionSelector.addEventListener('change', regionOnChangeHandler);
+        const options = regionSelector.querySelectorAll('.dropdown-item');
+
+        options.forEach(option => {
+            option.addEventListener('click', () => {
+                const region = option.dataset.value;
+                regionOnChangeHandler(region)
+            })
+        })
     }
 });
 
-function isReferrerEU(){
+function replaceButtonInnerText(value) {
+    const selectedRegion = value === 'gov' ? 'US1-FED' : value.toUpperCase();
+    const regionSelector = document.querySelector('.js-region-select');
+    const buttonInner = regionSelector.querySelector('.btn-inner');
+    buttonInner.innerText = selectedRegion;
+}
+
+function isReferrerEU() {
     if (window.document.referrer.includes('datadoghq.eu') &&
     window.document.referrer.indexOf(
         `${window.location.protocol}//${window.location.host}` // check referrer is not from own domain
@@ -21,32 +35,33 @@ function isReferrerEU(){
     return false;
 }
 
-function regionOnChangeHandler(event) {
+function regionOnChangeHandler(region) {
     const queryParams = new URLSearchParams(window.location.search);
-    let siteRegion = '';
 
-    siteRegion = event.target.value;
     // on change, if query param exists, update the param
     if (config.allowedRegions.includes(queryParams.get('site'))) {
-        queryParams.set('site', siteRegion);
+        queryParams.set('site', region);
 
         window.history.replaceState(
             {},
             '',
             `${window.location.pathname}?${queryParams}`
         );
-        showRegionSnippet(siteRegion);
-        Cookies.set('site', siteRegion, { path: '/' });
-    } else if (isReferrerEU()){
+
+        showRegionSnippet(region);
+        replaceButtonInnerText(region);
+        Cookies.set('site', region, { path: '/' });
+    } else if (isReferrerEU()) {
         // need to reload the page if referrer is from EU to reset window.document.referrer
-        Cookies.set('site', siteRegion, { path: '/' });
+        Cookies.set('site', region, { path: '/' });
         window.location.reload();
     }
-    else if (config.allowedRegions.includes(siteRegion)){
-        showRegionSnippet(siteRegion);
-        Cookies.set('site', siteRegion, { path: '/' });
+    else if (config.allowedRegions.includes(region)){
+        showRegionSnippet(region);
+        replaceButtonInnerText(region);
+        Cookies.set('site', region, { path: '/' });
     } else {
-        redirectToRegion(siteRegion);
+        redirectToRegion(region);
     }
 }
 
@@ -96,8 +111,7 @@ function showRegionSnippet(newSiteRegion) {
 
 // have option to pass new site region to function.
 function redirectToRegion(region = '') {
-    const regionSelector = document.querySelector('.js-region-selector');
-
+    const regionSelector = document.querySelector('.js-region-select');
     const queryParams = new URLSearchParams(window.location.search);
 
     let newSiteRegion = region;
@@ -144,7 +158,7 @@ function redirectToRegion(region = '') {
     }
 
     if (regionSelector) {
-        regionSelector.value = newSiteRegion;
+        replaceButtonInnerText(newSiteRegion);
     }
 }
 

--- a/src/scripts/tests/region-redirects.test.js
+++ b/src/scripts/tests/region-redirects.test.js
@@ -1,14 +1,12 @@
 import { redirectToRegion } from '../region-redirects';
 
-let regionSelector;
 let regionUSSnippet;
 let regionEUSnippet;
+let regionGOVSnippet;
 let regionParam;
 let regionAppLink;
 
 describe(`On main page load (not home or api pages, nor loaded via async)`, () => {
-
-
     beforeEach(() => {
         Object.defineProperty(window.document, 'cookie', {
             writable: true,
@@ -24,12 +22,6 @@ describe(`On main page load (not home or api pages, nor loaded via async)`, () =
         window.location = {
             href: 'http://localhost:1313/getting_started/logs/'
         };
-
-        const selectOption = `<select id="region-select" class="js-region-selector">
-            <option disabled="" selected="" value="">--</option>
-            <option value="us">US</option>
-            <option value="eu">EU</option>
-        </select>`;
 
         const testUSRegionShortcodeHtml = `
         <div class="d-none" data-region="us">
@@ -49,22 +41,25 @@ describe(`On main page load (not home or api pages, nor loaded via async)`, () =
         <code class="js-region-param" data-region-param="dd_site"></code>
         `;
 
-        const testParamHtml = `<code class="js-region-param" data-region-param="dd_site"></code>`;
+        const testGovRegionShortcodeHtml = `
+        <div class="d-none" data-region="gov">
+        <code class="js-region-param" data-region-param="dd_site"></code>
+        `;
 
+        const testParamHtml = `<code class="js-region-param" data-region-param="dd_site"></code>`;
         const testAppLink = `<div id="mainContent"><a class="test-link" href="https://app.datadoghq.com/logs">Logs</a></div>`;
 
-        document.body.innerHTML = selectOption;
         document.body.innerHTML += testUSRegionShortcodeHtml;
         document.body.innerHTML += testEURegionShortcodeHtml;
+        document.body.innerHTML += testGovRegionShortcodeHtml;
         document.body.innerHTML += testParamHtml;
         document.body.innerHTML += testAppLink;
 
-        regionSelector = document.querySelector('.js-region-selector');
         regionUSSnippet = document.querySelector('[data-region=us]');
         regionEUSnippet = document.querySelector('[data-region=eu]');
+        regionGOVSnippet = document.querySelector('[data-region=gov]');
         regionParam = document.querySelector('[data-region-param]');
         regionAppLink = document.querySelector('.test-link');
-       
     });
 
     describe(`No Cookie Set`, () => {
@@ -73,7 +68,6 @@ describe(`On main page load (not home or api pages, nor loaded via async)`, () =
                 redirectToRegion();
 
                 expect(window.document.cookie).toContain('site=us');
-                expect(regionSelector.value).toEqual('us');
                 expect(regionEUSnippet.classList).toContain('d-none')
                 expect(regionUSSnippet.classList).not.toContain('d-none')
                 expect(regionParam.innerHTML).toEqual('datadoghq.com')
@@ -87,10 +81,7 @@ describe(`On main page load (not home or api pages, nor loaded via async)`, () =
 
                 redirectToRegion();
 
-                // console.log('regionAppLink.href: ', regionAppLink.href);
-
                 expect(window.document.cookie).toContain('site=eu');
-                expect(regionSelector.value).toEqual('eu');
                 expect(regionEUSnippet.classList).not.toContain('d-none')
                 expect(regionUSSnippet.classList).toContain('d-none')
                 expect(regionParam.innerHTML).toEqual('datadoghq.eu')
@@ -105,7 +96,6 @@ describe(`On main page load (not home or api pages, nor loaded via async)`, () =
                 redirectToRegion();
 
                 expect(window.document.cookie).toContain('site=us');
-                expect(regionSelector.value).toEqual('us');
                 expect(regionUSSnippet.classList).not.toContain('d-none')
                 expect(regionEUSnippet.classList).toContain('d-none')
                 expect(regionParam.innerHTML).toEqual('datadoghq.com')
@@ -120,7 +110,6 @@ describe(`On main page load (not home or api pages, nor loaded via async)`, () =
                 redirectToRegion();
 
                 expect(window.document.cookie).toContain('site=eu');
-                expect(regionSelector.value).toEqual('eu');
                 expect(regionUSSnippet.classList).toContain('d-none')
                 expect(regionEUSnippet.classList).not.toContain('d-none')
                 expect(regionParam.innerHTML).toEqual('datadoghq.eu')
@@ -142,10 +131,9 @@ describe(`On main page load (not home or api pages, nor loaded via async)`, () =
                 redirectToRegion();
 
                 expect(window.document.cookie).toContain('site=eu');
-                expect(regionSelector.value).toEqual('eu');
-                expect(regionUSSnippet.classList).toContain('d-none')
-                expect(regionEUSnippet.classList).not.toContain('d-none')
-                expect(regionParam.innerHTML).toEqual('datadoghq.eu')
+                expect(regionUSSnippet.classList).toContain('d-none');
+                expect(regionEUSnippet.classList).not.toContain('d-none');
+                expect(regionParam.innerHTML).toEqual('datadoghq.eu');
                 expect(regionAppLink.href).toEqual('https://app.datadoghq.eu/logs');
             });
         });
@@ -157,10 +145,9 @@ describe(`On main page load (not home or api pages, nor loaded via async)`, () =
                 redirectToRegion();
 
                 expect(window.document.cookie).toContain('site=eu');
-                expect(regionSelector.value).toEqual('eu');
-                expect(regionUSSnippet.classList).toContain('d-none')
-                expect(regionEUSnippet.classList).not.toContain('d-none')
-                expect(regionParam.innerHTML).toEqual('datadoghq.eu')
+                expect(regionUSSnippet.classList).toContain('d-none');
+                expect(regionEUSnippet.classList).not.toContain('d-none');
+                expect(regionParam.innerHTML).toEqual('datadoghq.eu');
                 expect(regionAppLink.href).toEqual('https://app.datadoghq.eu/logs');
             });
         });
@@ -172,7 +159,6 @@ describe(`On main page load (not home or api pages, nor loaded via async)`, () =
                 redirectToRegion();
 
                 expect(window.document.cookie).toContain('site=eu');
-                expect(regionSelector.value).toEqual('eu');
                 expect(regionUSSnippet.classList).toContain('d-none')
                 expect(regionEUSnippet.classList).not.toContain('d-none')
                 expect(regionParam.innerHTML).toEqual('datadoghq.eu')
@@ -187,7 +173,6 @@ describe(`On main page load (not home or api pages, nor loaded via async)`, () =
                 redirectToRegion();
 
                 expect(window.document.cookie).toContain('site=us');
-                expect(regionSelector.value).toEqual('us');
                 expect(regionUSSnippet.classList).not.toContain('d-none')
                 expect(regionEUSnippet.classList).toContain('d-none')
                 expect(regionParam.innerHTML).toEqual('datadoghq.com')
@@ -196,4 +181,65 @@ describe(`On main page load (not home or api pages, nor loaded via async)`, () =
         });
     });
 
+    describe(`Cookie is Set to "gov"`, () => {
+        beforeEach(() => {
+            Object.defineProperty(window.document, 'cookie', {
+                writable: true,
+                value: 'site=gov'
+            });
+        });
+        describe('no site param set', () => {
+            it('should set cookie value "site" to region "gov"', () => {
+                redirectToRegion();
+
+                expect(window.document.cookie).toContain('site=gov');
+                expect(regionUSSnippet.classList).toContain('d-none');
+                expect(regionEUSnippet.classList).toContain('d-none');
+                expect(regionGOVSnippet.classList).not.toContain('d-none');
+                expect(regionAppLink.href).toEqual('https://app.ddog-gov.com/logs');
+            });
+        });
+
+        describe('set region param in url', () => {
+            it('should set cookie value "site" to region from query param "gov"', () => {
+                window.location.search = 'site=gov';
+
+                redirectToRegion();
+
+                expect(window.document.cookie).toContain('site=gov');
+                expect(regionUSSnippet.classList).toContain('d-none');
+                expect(regionEUSnippet.classList).toContain('d-none');
+                expect(regionGOVSnippet.classList).not.toContain('d-none');
+                expect(regionAppLink.href).toEqual('https://app.ddog-gov.com/logs');
+            });
+        });
+
+        describe('invalid site param', () => {
+            it('should set cookie value "site" to region from query param "gov", and disregard invalid param value', () => {
+                window.location.search = 'site=fs';
+
+                redirectToRegion();
+
+                expect(window.document.cookie).toContain('site=gov');
+                expect(regionUSSnippet.classList).toContain('d-none');
+                expect(regionEUSnippet.classList).toContain('d-none');
+                expect(regionGOVSnippet.classList).not.toContain('d-none');
+                expect(regionAppLink.href).toEqual('https://app.ddog-gov.com/logs');
+            });
+        });
+
+        describe('referrer coming from app.ddog-gov.com', () => {
+            it('should set cookie value "site" to region "gov" from document referrer', () => {
+                window.document.referrer = "https://app.ddog-gov.com/";
+
+                redirectToRegion();
+
+                expect(window.document.cookie).toContain('site=gov');
+                expect(regionUSSnippet.classList).toContain('d-none');
+                expect(regionEUSnippet.classList).toContain('d-none');
+                expect(regionGOVSnippet.classList).not.toContain('d-none');
+                expect(regionAppLink.href).toEqual('https://app.ddog-gov.com/logs');
+            });
+        });
+    });
 });

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -1,3 +1,20 @@
+.chevron {
+  width: 8px;
+  height: 8px;
+  border: 2px solid $brand-primary;
+  display: inline-block;
+  border-top: none;
+  border-left: none;
+}
+
+.chevron-down {
+  transform: rotate(45deg);
+}
+
+.chevron-up {
+  transform: rotate(-135deg);
+  margin-top: 5px;
+}
 
 // Detect lightness
 @function detectLightness($color) {
@@ -197,10 +214,10 @@ $responsive-breakpoint: 768px
       border: none;
       z-index: 999;
       max-width: 100% !important;
-      
+
       @include layout-width($layout-width);
       box-shadow: 0px 1px 0px rgba(30, 5, 36, 0.16), 0px 23px 32px -8px rgba(0, 0, 0, 0.26);
-      
+
       // Arrow
       &:before {
         display: none;

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -9,6 +9,10 @@
 
 .chevron-down {
   transform: rotate(45deg);
+
+  &:lang(ja) {
+    margin-top: -1px;
+  }
 }
 
 .chevron-up {

--- a/src/styles/components/_integrations.scss
+++ b/src/styles/components/_integrations.scss
@@ -18,6 +18,14 @@ $ddpurple:    #632CA6;
     border-radius: 2px 0px 0px 2px;
     padding: 0.375rem 1rem;
   }
+
+  .sidebar {
+    display: none;
+
+    @include media-breakpoint-up(xl) {
+      display: flex;
+    }
+  }
 }
 
 .integrations-single {

--- a/src/styles/components/_language-region-select.scss
+++ b/src/styles/components/_language-region-select.scss
@@ -1,0 +1,111 @@
+// API pages-specific styles
+.api {
+  .language-region-select-container {
+    padding: 1.5rem 0;
+
+    .language-select-container,
+    .region-select-container {
+      display: flex;
+      align-items: baseline;
+
+      p {
+        margin-right: 10px;
+      }
+    }
+
+    .region-select-container {
+      margin-left: 30px;
+    }
+
+    @include media-breakpoint-up(lg) {
+      flex-direction: row !important;
+      padding: 0;
+
+      .region-select-container {
+        margin-top: 0;
+      }
+    }
+  }
+}
+// End API pages-specific styles
+
+aside.sidebar {
+  padding-left: 0;
+
+  @include media-breakpoint-up(lg) {
+    position: sticky;
+    top: 50px;
+    height: 100vh;
+    margin-bottom: 100px;
+  }
+}
+
+.language-region-select-container {
+  padding: 1.75rem 1rem;
+
+  p {
+    font-size: 14px;
+    line-height: 18px;
+    color: black !important;
+    margin-bottom: 10px;
+    font-weight: 400;
+  }
+
+  @include media-breakpoint-up(lg) {
+    padding: 4.05rem 1rem 1.4rem;
+  }
+
+  .region-select-container {
+    margin-left: 15px;
+
+    @include media-breakpoint-up(lg) {
+      margin-left: 0;
+      margin-top: 20px;
+    }
+  }
+
+  .btn {
+    border: 1px solid $gray-light;
+    background: $gray-lightest;
+    border-radius: 4px;
+    height: 31px;
+    padding: 0rem 0.6rem;
+    color: $brand-primary;
+    width: 100px;
+    font-size: 16px;
+    line-height: 20px;
+  }
+
+  .dropdown {
+    @include media-breakpoint-down(lg) {
+      z-index: 2;
+    }
+  }
+
+  .dropdown-menu {
+    padding: 0;
+    border-radius: 6px;
+    border: none;
+    box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.25);
+    min-width: 0rem;
+    width: 100px;
+    top: 6px !important;
+
+    .dropdown-item {
+      font-size: 16px;
+      line-height: 20px;
+      padding-left: 10px;
+      padding-bottom: 8px;
+    }
+
+    a {
+      color: #212529;
+
+      &:hover {
+        background: $gray-lighter;
+        color: $brand-primary;
+        cursor: pointer;
+      }
+    }
+  }
+}

--- a/src/styles/components/_language-region-select.scss
+++ b/src/styles/components/_language-region-select.scss
@@ -69,7 +69,7 @@ aside.sidebar {
     background: $gray-lightest;
     border-radius: 4px;
     height: 31px;
-    padding: 0rem 0.6rem;
+    padding: 0rem 0.6rem 0.1rem;
     color: $brand-primary;
     width: 100px;
     font-size: 16px;

--- a/src/styles/components/_language-region-select.scss
+++ b/src/styles/components/_language-region-select.scss
@@ -10,6 +10,14 @@
 
       p {
         margin-right: 10px;
+
+        @-moz-document url-prefix() {
+          margin-top: 8px;
+        }
+      }
+
+      @-moz-document url-prefix() {
+        align-items: center;
       }
     }
 

--- a/src/styles/components/_language-region-select.scss
+++ b/src/styles/components/_language-region-select.scss
@@ -127,6 +127,8 @@ aside.sidebar {
   }
 
   &:lang(ja) {
-    padding-left: 15px;
+    @include media-breakpoint-up(lg) {
+      padding-left: 15px;
+    }
   }
 }

--- a/src/styles/components/_language-region-select.scss
+++ b/src/styles/components/_language-region-select.scss
@@ -44,7 +44,7 @@ aside.sidebar {
   padding: 1.75rem 1rem;
 
   p {
-    font-size: 14px;
+    font-size: 14px !important;
     line-height: 18px;
     color: black !important;
     margin-bottom: 10px;
@@ -74,6 +74,11 @@ aside.sidebar {
     width: 100px;
     font-size: 16px;
     line-height: 20px;
+    z-index: 3;
+
+    &:lang(ja) {
+      font-size: 14px;
+    }
   }
 
   .dropdown {
@@ -96,6 +101,10 @@ aside.sidebar {
       line-height: 20px;
       padding-left: 10px;
       padding-bottom: 8px;
+
+      &:lang(ja) {
+        font-size: 15px;
+      }
     }
 
     a {
@@ -107,5 +116,9 @@ aside.sidebar {
         cursor: pointer;
       }
     }
+  }
+
+  &:lang(ja) {
+    padding-left: 15px;
   }
 }

--- a/src/styles/components/_schema-table.scss
+++ b/src/styles/components/_schema-table.scss
@@ -62,7 +62,7 @@
         margin-right: -180px;
     }
     @media (min-width: 1200px) {
-        margin-right: -220px;
+        margin-right: -216px;
     }
     p {
         margin: 4px 0;

--- a/src/styles/components/_table-of-contents.scss
+++ b/src/styles/components/_table-of-contents.scss
@@ -184,6 +184,7 @@ body > header.scrolled ~ .container .mobile-toc-toggle {
     }
     @media (min-width: 992px) {
         display: block;
+        padding: 0 1rem;
     }
 }
 

--- a/src/styles/components/_table-of-contents.scss
+++ b/src/styles/components/_table-of-contents.scss
@@ -204,13 +204,16 @@ body > header.scrolled ~ .container .mobile-toc-toggle {
     a {
         font-size: 18px;
         &:lang(ja) {
-            font-size: 14px;
+            font-size: 16px;
+
+            .toc-edit-btn img {
+                width: 35px;
+            }
         }
     }
 }
 
 // Mobile TOC
-
 .announcement_banner.open ~ .container .toc-container-mobile .toc {
     padding-top: 90px;
 }

--- a/src/styles/components/_table-of-contents.scss
+++ b/src/styles/components/_table-of-contents.scss
@@ -64,10 +64,8 @@ body > header.scrolled ~ .container .mobile-toc-toggle {
 // Desktop TOC
 .toc-container {
     display: none;
-    &:lang(ja) {
-        padding-left: 30px;
-    }
     padding-top: 95px;
+    
     &.mobile-open {
         top: 60px;
         position: sticky;

--- a/src/styles/pages/_api.scss
+++ b/src/styles/pages/_api.scss
@@ -57,7 +57,7 @@ $ddpurple: #632ca6;
             margin-right: -180px;
         }
         @media (min-width: 1200px) {
-            margin-right: -220px;
+            margin-right: -216px;
         }
     }
 
@@ -94,32 +94,44 @@ $ddpurple: #632ca6;
 }
 
 .api {
+    // These are temporary fixes until we refactor the announcement banner.
     .announcement_banner.open ~ .container {
         padding-top: 40px;
-        @media (min-width: 992px) {
+
+        @include media-breakpoint-up(lg) {
+            padding-top: 0px;
+            margin-top: -20px;
+        }
+
+        @include media-breakpoint-up(xl) {
             padding-top: 30px;
+            margin-top: 0;
         }
     }
 
     .announcement_banner ~ .container {
         padding-top: 20px;
+
         @media (min-width: 992px) {
             padding-top: 0px;
         }
     }
 
     .api-toolbar {
-        height: auto;
-        // position: sticky;
-        // z-index: 1;
-        // top: 105px;
         font-weight: 600;
-        @media (min-width: 992px) {
-            top: 95px;
-            height: 51px;
-        }
+        height: auto;
+
         a {
             border-bottom: none;
+        }
+
+        @include media-breakpoint-up(lg) {
+            align-items: baseline;
+            background: white;
+            position: sticky;
+            z-index: 1;
+            top: 95px;
+            height: 65px;
         }
     }
 

--- a/src/styles/pages/_api.scss
+++ b/src/styles/pages/_api.scss
@@ -137,7 +137,6 @@ $ddpurple: #632ca6;
         #breadcrumbs {
             &:lang(ja) {
                 font-size: 15px;
-                padding-left: 15px;
             }
         }
     }

--- a/src/styles/pages/_api.scss
+++ b/src/styles/pages/_api.scss
@@ -133,6 +133,13 @@ $ddpurple: #632ca6;
             top: 95px;
             height: 65px;
         }
+
+        #breadcrumbs {
+            &:lang(ja) {
+                font-size: 15px;
+                padding-left: 15px;
+            }
+        }
     }
 
     .api-content {

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -43,6 +43,7 @@
 @import "components/platforms";
 @import "components/preview_banner";
 @import "components/questions";
+@import "components/language-region-select";
 @import "components/sidenav";
 @import "components/support";
 @import "components/table-of-contents";


### PR DESCRIPTION
### What does this PR do?
Design/UX overhaul for the `Site` and `Language` dropdowns

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1079

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/site-lang-toggle2/
https://docs-staging.datadoghq.com/brian.deutsch/site-lang-toggle2/api/

### Additional Notes
This PR introduces one new frontmatter param and a change to an existing param:
- `disable_sidebar`: This removes the sidebar (containing `Site` + `Language` dropdowns, `Edit` button, and TOC) entirely.  Main content will expand to occupy the 2 columns reserved for the sidebar.
- `disable_toc`: This removes _only_ the TOC + `Edit` button, leaving the `Site` + `Language` dropdowns.

Related synthetics (Note these are not scheduled and have only been run ad-hoc.  If there are no results try broadening the search time range):
- Region selector (US/GOV): https://dd-corpsite.datadoghq.com/synthetics/details/yq3-qs9-b8k
- Region selector(EU): https://dd-corpsite.datadoghq.com/synthetics/details/3cj-f8n-a3y
- Language selector: https://dd-corpsite.datadoghq.com/synthetics/details/4rx-amr-pnv

There are also Jest unit tests.   Pull down this branch and from the `documentation` root: `jest src/scripts/tests/region-redirects.test.js` to run.   There is some duplication amongst the synthetics and jest tests, which will be addressed at a later time.

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
