### PR TITLE
APM > Logs and Traces -> .NET automatic instrumentation docs update

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -21,7 +21,7 @@ further_reading:
 
 The .NET Tracer can automatically inject trace IDs, span IDs, `env`, `service`, and `version` into your application logs. If you haven't done so already, Datadog recommends configuring the .NET tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This provides the best experience when adding `env`, `service`, and `version` (see [Unified Service Tagging][3] for more details).
 
-We support [Serilog][4], [NLog][5] (version 4.0+), or [log4net][6]. Automatic injection only displays in the application logs after enabling `LogContext` enrichment in your `Serilog` logger or `Mapped Diagnostics Context` in your `NLog` or `log4net` logger.
+The .NET Tracer supports [Serilog][4], [NLog][5] (version 4.0+), or [log4net][6]. Automatic injection only displays in the application logs after enabling `LogContext` enrichment in your `Serilog` logger or `Mapped Diagnostics Context` in your `NLog` or `log4net` logger.
 
 **Note**: Automatic injection only works for logs formatted as JSON.
 

--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -21,7 +21,7 @@ further_reading:
 
 The .NET Tracer can automatically inject trace IDs, span IDs, `env`, `service`, and `version` into your application logs. If you haven't done so already, Datadog recommends configuring the .NET tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This provides the best experience when adding `env`, `service`, and `version` (see [Unified Service Tagging][3] for more details).
 
-We support [Serilog][4], [NLog][5] (version 2.0.0.2000+), or [log4net][6]. Automatic injection only displays in the application logs after enabling `LogContext` enrichment in your `Serilog` logger or `Mapped Diagnostics Context` in your `NLog` or `log4net` logger.
+We support [Serilog][4], [NLog][5] (version 4.0+), or [log4net][6]. Automatic injection only displays in the application logs after enabling `LogContext` enrichment in your `Serilog` logger or `Mapped Diagnostics Context` in your `NLog` or `log4net` logger.
 
 **Note**: Automatic injection only works for logs formatted as JSON.
 
@@ -75,17 +75,30 @@ For NLog version 4.6+:
   </layout>
 ```
 
-For NLog version 4.5:
+For NLog version 4.0 - 4.5:
 
 ```xml
-  <!-- Add includeMdc="true" to emit MDC properties -->
+  <!-- If using version 4.4.10+, you may add includeMdc="true" to emit MDC properties -->
   <layout xsi:type="JsonLayout" includeMdc="true">
     <attribute name="date" layout="${longdate}" />
     <attribute name="level" layout="${level:upperCase=true}"/>
     <attribute name="message" layout="${message}" />
     <attribute name="exception" layout="${exception:format=ToString}" />
   </layout>
+
+  <!-- If using version below 4.4.10, you must explicitly extract the 'dd.trace_id' and 'dd.span_id' values using new <attribute> nodes -->
+  <layout xsi:type="JsonLayout">
+    <attribute name="date" layout="${longdate}" />
+    <attribute name="level" layout="${level:upperCase=true}"/>
+    <attribute name="message" layout="${message}" />
+    <attribute name="exception" layout="${exception:format=ToString}" />
+
+    <attribute name="dd.trace_id" layout="${mdc:item=dd.trace_id}"/>
+    <attribute name="dd.span_id" layout="${mdc:item=dd.span_id}"/>
+  </layout>
 ```
+
+For NLog version lower than 4.0, there is no built-in JSON layout.
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -35,7 +35,7 @@ We support [Serilog][4], [NLog][5] (version 4.0+), or [log4net][6]. Automatic in
 
 ```csharp
 var log = new LoggerConfiguration()
-    // Add Enrich.FromLogContext to emit MDC properties
+    // Add Enrich.FromLogContext to emit Datadog properties
     .Enrich.FromLogContext()
     .WriteTo.File(new JsonFormatter(), "log.json")
     .CreateLogger();
@@ -55,7 +55,7 @@ var log = new LoggerConfiguration()
     <member value="message:messageobject" />
     <!--add raw message-->
 
-    <!-- Add value='properties' to emit MDC properties -->
+    <!-- Add value='properties' to emit Datadog properties -->
     <member value='properties'/>
   </layout>
 ```
@@ -66,7 +66,7 @@ var log = new LoggerConfiguration()
 For NLog version 4.6+:
 
 ```xml
-  <!-- Add includeMdlc="true" to emit MDC properties -->
+  <!-- Add includeMdlc="true" to emit Datadog properties -->
   <layout xsi:type="JsonLayout" includeMdlc="true">
     <attribute name="date" layout="${longdate}" />
     <attribute name="level" layout="${level:upperCase=true}"/>
@@ -78,7 +78,7 @@ For NLog version 4.6+:
 For NLog version 4.0 - 4.5:
 
 ```xml
-  <!-- If using version 4.4.10+, you may add includeMdc="true" to emit MDC properties -->
+  <!-- If using version 4.4.10+, you may add includeMdc="true" to emit Datadog properties -->
   <layout xsi:type="JsonLayout" includeMdc="true">
     <attribute name="date" layout="${longdate}" />
     <attribute name="level" layout="${level:upperCase=true}"/>
@@ -86,13 +86,16 @@ For NLog version 4.0 - 4.5:
     <attribute name="exception" layout="${exception:format=ToString}" />
   </layout>
 
-  <!-- If using version below 4.4.10, you must explicitly extract the 'dd.trace_id' and 'dd.span_id' values using new <attribute> nodes -->
+  <!-- If using version below 4.4.10, you must extract the Datadog properties individually by adding <attribute> nodes -->
   <layout xsi:type="JsonLayout">
     <attribute name="date" layout="${longdate}" />
     <attribute name="level" layout="${level:upperCase=true}"/>
     <attribute name="message" layout="${message}" />
     <attribute name="exception" layout="${exception:format=ToString}" />
 
+    <attribute name="dd.env" layout="${mdc:item=dd.env}"/>
+    <attribute name="dd.service" layout="${mdc:item=dd.service}"/>
+    <attribute name="dd.version" layout="${mdc:item=dd.version}"/>
     <attribute name="dd.trace_id" layout="${mdc:item=dd.trace_id}"/>
     <attribute name="dd.span_id" layout="${mdc:item=dd.span_id}"/>
   </layout>


### PR DESCRIPTION
### What does this PR do?
Revise NLog support for .NET automatic logs injection and show setup for applications using NLog versions below 4.5

### Motivation
Customer using a version of NLog below 4.5

### Preview
https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-logs-injection-setup/tracing/connect_logs_and_traces/dotnet/?tab=nlog

### Additional Notes
N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
