### PR TITLE
[logs] fix a typo in serverless tab.

### DIFF
--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -74,7 +74,7 @@ Choose your environment below to get dedicated log collection instructions:
 
 {{% /tab %}}
 
-{{% tab "Severless" %}}
+{{% tab "Serverless" %}}
 
 Datadog collects logs from AWS Lambda. To enable this, refer to the [serverless monitoring documentation][17].
 


### PR DESCRIPTION
### What does this PR do?

Fix a typo in the Serverless tab header.

Note that it is changing an URL (`/logs/log_collection/?tab=severless` -> `/logs/log_collection/?tab=serverless` ) and I don't know what impact could it have (seo, external links, ...)

### Preview

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/remeh/typoserverless/logs/log_collection/

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
