### PR TITLE
Added Helm instructions for enabled NPM with kubernetes

### DIFF
--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -216,7 +216,7 @@ To enable Network Performance Monitoring with Kubernetes using Helm, add:
   networkMonitoring:
       enabled: true
   ```
-to your values.yaml. See the [Datadog Helm Chart][4] for further information.
+to your values.yaml. Helm chart version 2.4.39 or higher is required. See the [Datadog Helm Chart][4] for further information.
 
 If you are not using Helm, you can enable Network Performance Monitoring with Kubernetes from scratch:
 

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -210,7 +210,15 @@ To enable network performance monitoring for Windows hosts:
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 
-To enable Network Performance Monitoring with Kubernetes from scratch:
+To enable Network Performance Monitoring with Kubernetes using Helm, add:
+
+  ```yaml
+  networkMonitoring:
+      enabled: true
+  ```
+to your values.yaml. See the [Datadog Helm Chart][9] for further information.
+
+If you are not using Helm, you can enable Network Performance Monitoring with Kubernetes from scratch:
 
 1. Download the [datadog-agent.yaml manifest][1] template.
 2. Replace `<DATADOG_API_KEY>` with your [Datadog API key][2].

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -216,7 +216,7 @@ To enable Network Performance Monitoring with Kubernetes using Helm, add:
   networkMonitoring:
       enabled: true
   ```
-to your values.yaml. See the [Datadog Helm Chart][9] for further information.
+to your values.yaml. See the [Datadog Helm Chart][4] for further information.
 
 If you are not using Helm, you can enable Network Performance Monitoring with Kubernetes from scratch:
 
@@ -347,6 +347,7 @@ If you already have the [Agent running with a manifest][3]:
 [1]: /resources/yaml/datadog-agent-npm.yaml
 [2]: https://app.datadoghq.com/account/settings#api
 [3]: /agent/kubernetes/
+[4]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/README.md#enabling-system-probe-collection
 {{% /tab %}}
 {{% tab "Docker" %}}
 


### PR DESCRIPTION
### What does this PR do?
Explains how to enable NPM with the Helm chart, but retains the old instructions for those that don't use Helm.

### Motivation
<!-- What inspired you to submit this pull request?-->
Enabling NPM in Kubernetes now uses Helm as the default, as with the core Agent

### Preview
https://docs-staging.datadoghq.com/ron.hay/agent-npm-helm-install/network_monitoring/performance/setup/?tab=kubernetes

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
