### PR TITLE
Add official Datadog Swift SDK to libraries list

### DIFF
--- a/data/libraries.yaml
+++ b/data/libraries.yaml
@@ -226,6 +226,12 @@ Classic:
       authors: NomadBlacky
       notes: Datadog API client for Scala.
   - Swift:
+    - name: DatadogSDK
+      link: https://github.com/DataDog/dd-sdk-ios
+      api: true
+      official: true
+      authors: Datadog
+  - Swift:
     - name: SwiftDog
       link: https://github.com/jaronoff97/SwiftDog
       api: true


### PR DESCRIPTION
### What does this PR do?

This references the official Datadog iOS SDK.

### Motivation

The official SDK is not listed on the documentation page. 

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
