### PR TITLE
APM > .NET > Add DD_LOGGING_RATE to Tracer Debug Logs section

### DIFF
--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -351,7 +351,7 @@ YYYY/MM/DD 16:06:35 Datadog Tracer <version> DEBUG: Sending payload: size: <size
 
 {{< programming-lang lang=".NET" >}}
 
-For performance reasons, the tracer writes each unique log message at most once in a 30 second period. For more visibility during debugging, disable rate limiting by setting the environment variable `DD_TRACE_LOGGING_RATE=0`.
+For performance reasons, the tracer writes each unique log message at most once in a 60 second period. For more visibility during debugging, disable rate limiting by setting the environment variable `DD_TRACE_LOGGING_RATE=0`.
 
 **Logs from native code:**
 

--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -351,7 +351,7 @@ YYYY/MM/DD 16:06:35 Datadog Tracer <version> DEBUG: Sending payload: size: <size
 
 {{< programming-lang lang=".NET" >}}
 
-For performance reasons, the tracer writes each unique log message at most once in a 30 second period. For more visibility during debugging, disable rate limiting by setting the environment variable `DD_LOGGING_RATE=0`.
+For performance reasons, the tracer writes each unique log message at most once in a 30 second period. For more visibility during debugging, disable rate limiting by setting the environment variable `DD_TRACE_LOGGING_RATE=0`.
 
 **Logs from native code:**
 

--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -351,6 +351,7 @@ YYYY/MM/DD 16:06:35 Datadog Tracer <version> DEBUG: Sending payload: size: <size
 
 {{< programming-lang lang=".NET" >}}
 
+For performance reasons, the tracer writes each unique log message at most once in a 30 second period. For more visibility during debugging, disable rate limiting by setting the environment variable `DD_LOGGING_RATE=0`.
 
 **Logs from native code:**
 


### PR DESCRIPTION
### What does this PR do?
Documents a new setting for debugging issues in the .NET Tracer : `DD_TRACE_LOGGING_RATE`.

### Motivation
We want to document the latest features of the .NET Tracer. Added in this section as this is where the Python tracer documents a similar settings

### Preview
https://docs-staging.datadoghq.com/andrewlock/apm-dotnet/log-rate-limit/tracing/troubleshooting/tracer_debug_logs/?tab=.NET#review-tracer-debug-logs

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
