### PR TITLE
Add section to terraformer docs for upgrading terraformer 0.12 resources to 0.13+

### DIFF
--- a/content/en/integrations/faq/how-to-import-datadog-resources-into-terraform.md
+++ b/content/en/integrations/faq/how-to-import-datadog-resources-into-terraform.md
@@ -77,6 +77,21 @@ All example commands require the `--api-key` and `--app-key` flags.
 * Import all monitors and dashboards: `terraformer import datadog --resources=monitor,dashboard`
 * Import monitor with id 1234 and dashboard with id abc-def-ghi: `terraformer import datadog --resources=monitor,dashboard --filter=monitor=1234,dashboard=abc-def-ghi`
 
+## Generating resources with Terraform v0.13+
+
+Terraformer currently generates `tf`/`json` and `tfstate` files using Terraform `v0.12.29`. To ensure compatibility, run the upgrade command `terraform 0.13upgrade .` using Terraform version `0.13.x`. Additionally, see [official Terraform docs][4] for upgrading.
+
+##### Upgrading the generated files for Terraform v0.13+:
+
+1. Import resource using terraformer.
+
+2. Using Terraform `v0.13.x`, CD into the generated resource directory and run `terraform 0.13upgrade .`.
+
+3. Run `terraform init` to re-run the provider installer.
+
+4. Run `terraform apply` to apply upgrades to Terraform state files.
+
 [1]: https://www.terraform.io/docs/import/index.html
 [2]: https://github.com/GoogleCloudPlatform/terraformer
 [3]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs
+[4]: https://www.terraform.io/upgrade-guides/0-13.html


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR adds section for upgrading terraformer generated resources to use with Terraform v0.13+

### Motivation
<!-- What inspired you to submit this pull request?-->
Terraformer currently generates resources utilizing Terraform 0.12.29. Additional steps are required for compatibility with 0.13+

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/sherz/terraformer-docs-update/integrations/faq/how-to-import-datadog-resources-into-terraform/#terraformer

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
