### PR TITLE
moving PR 9641 to fresh branch

### DIFF
--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
@@ -19,8 +19,12 @@ further_reading:
 ## Compatibility
 
 - The .NET Tracer supports all .NET-based languages (for example, C#, F#, Visual Basic).
-
-- The .NET Tracer supports automatic instrumentation on .NET 5, .NET Core 3.1, and .NET Core 2.1. It also supports [.NET Framework][1].
+ 
+- The .NET Tracer supports instrumentation on:
+  - .NET 5
+  - .NET Core 3.1
+  - .NET Core 2.1. 
+  It also supports [.NET Framework][1].
 
 - The .NET Tracer library for Datadog is open-source. For more information see the [tracer Github repository][2].
 

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
@@ -18,9 +18,11 @@ further_reading:
 
 ## Compatibility
 
-- The .NET Tracer library for Datadog is open-source. For more information see the [tracer Github repository][1].
+- The .NET Tracer supports all .NET-based languages (for example, C#, F#, Visual Basic).
 
-- For both automatic and custom instrumentation, the .NET Datadog Tracer supports .NET Framework 4.5 and above. 
+- The .NET Tracer supports instrumentation on .NET Framework 4.5 and above. It also supports [.NET Core][1].
+
+- The .NET Tracer library for Datadog is open-source. For more information see the [tracer Github repository][2].
 
 <div class="alert alert-warning"> 
   <strong>Notes:</strong><br><ul><li>Datadog automatic instrumentation relies on the .NET CLR Profiling API. This API allows only one subscriber (for example, APM). To ensure maximum visibility, run only one APM solution within your application environment.</li><li> If you are using both automatic and custom instrumentation, it is important to keep the package versions (for example, MSI and NuGet) in sync.</li></ul>
@@ -52,11 +54,12 @@ The .NET Tracer can instrument the following libraries automatically:
 <strong>Note:</strong> The ADO.NET integration instruments calls made through the <code>DbCommand</code> abstract class or the <code>IDbCommand</code> interface, regardless of the underlying implementation. It also instruments direct calls to <code>SqlCommand</code> and <code>NpgsqlCommand</code>.
 </div>
 
-Don’t see your desired libraries? Datadog is continually adding additional support. [Check with the Datadog team][2] for help.
+Don’t see your desired libraries? Datadog is continually adding additional support. [Check with the Datadog team][3] for help.
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/DataDog/dd-trace-dotnet
-[2]: /help/
+[1]: /tracing/compatibility_requirements/dotnet-core/
+[2]: https://github.com/DataDog/dd-trace-dotnet
+[3]: /help/

--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -29,24 +29,20 @@ further_reading:
     text: "Examples of Custom Instrumentation"
 ---
 
-## Compatibility Requirements
+## Compatibility requirements
 
-The .NET Tracer supports automatic instrumentation on .NET 5, .NET Core 3.1, and .NET Core 2.1. It also supports [.NET Framework][1]. For a full list of supported libraries, visit the [Compatibility Requirements][2] page.
+The .NET Tracer supports instrumentation on:
+  - .NET 5
+  - .NET Core 3.1
+  - .NET Core 2.1. 
 
-## Getting started
+For a full list of supported libraries, visit the [Compatibility Requirements][1] page.
 
-**Note**: The .NET Tracer supports all .NET-based languages (C#, F#, Visual Basic, etc).
+## Automatic instrumentation
 
-## Automatic Instrumentation
-
-Automatic instrumentation can collect performance data about your application with zero code changes and minimal configuration. The .NET Tracer automatically instruments all [supported libraries][2] out of the box.
-
-Automatic instrumentation captures:
-
-- Execution time of instrumented calls
-- Relevant trace data, such as URL and status response codes for web requests or SQL queries for database access
-- Unhandled exceptions, including stacktraces if available
-- A total count of traces (e.g. web requests) flowing through the system
+<div class="alert alert-warning"> 
+  <strong>Note:</strong>  If you are using both automatic and custom instrumentation, it is important to keep the package versions (for example, MSI and NuGet) in sync.
+</div>
 
 ### Installation
 
@@ -54,112 +50,113 @@ Automatic instrumentation captures:
 
 {{% tab "Windows" %}}
 
-To begin tracing applications written in any language, first [install and configure the Datadog Agent][1]. The .NET Tracer runs in-process to instrument your applications and sends traces from your application to the Agent.
+1. [Install and configure the Windows Datadog Agent][1].
 
-To use automatic instrumentation on Windows, install the .NET Tracer on the host by running the [MSI installer for Windows][2] as administrator. Choose the installer for the architecture that matches the operating system (x64 or x86).
+2. Download the [.NET Tracer MSI installer][2]. Select the MSI installer for the architecture that matches the operating system (x64 or x86).
 
-After installing the .NET Tracer, restart applications so they can read the new environment variables. To restart IIS, run the following commands as administrator:
+3. Run the .NET Tracer MSI installer with administrator privileges.
 
-```cmd
-net stop /y was
-net start w3svc
-```
+4. Restart IIS by running the following commands as an administrator:
+    ```cmd
+    net stop /y was
+    net start w3svc
+    ```
 
-**Update:** Starting with .NET Tracer version `1.8.0`, the `Datadog.Trace.ClrProfiler.Managed` NuGet package is no longer required for automatic instrumentation in .NET Core. Remove it from your application when you update the .NET Tracer.
+5. Create application load.
+
+6. Visit [APM Live Traces][3].
 
 
-[1]: https://docs.datadoghq.com/agent/basic_agent_usage/windows/?tab=gui
+
+[1]: /agent/basic_agent_usage/windows/?tab=gui
 [2]: https://github.com/DataDog/dd-trace-dotnet/releases
+[3]: https://app.datadoghq.com/apm/traces
 {{% /tab %}}
 
 {{% tab "Linux" %}}
 
-To use automatic instrumentation on Linux, follow these three steps:
+1. [Install and configure a Linux Datadog Agent][1].
+2. Download and install the .NET Tracer into the application environment:
+    - **Debian or Ubuntu** - Download and install the Debian package:
+      ```bash
+      curl -LO https://github.com/DataDog/dd-trace-dotnet/releases/download/v<TRACER_VERSION>/datadog-dotnet-apm_<TRACER_VERSION>_amd64.deb
+      sudo dpkg -i ./datadog-dotnet-apm_<TRACER_VERSION>_amd64.deb
+      ```
+    - **CentOS or Fedora** - Download and install the RPM package:
+      ```bash
+      curl -LO https://github.com/DataDog/dd-trace-dotnet/releases/download/v<TRACER_VERSION>/datadog-dotnet-apm-<TRACER_VERSION>-1.x86_64.rpm
+      sudo rpm -Uvh datadog-dotnet-apm-<TRACER_VERSION>-1.x86_64.rpm
+      ```
+    - **Alpine or other [musl-based distributions][2]** - Download the tar archive with the musl-linked binary:
+      ```bash
+      sudo mkdir -p /opt/datadog
+      curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v<TRACER_VERSION>/datadog-dotnet-apm-<TRACER_VERSION>-musl.tar.gz \
+      | sudo tar xzf - -C /opt/datadog
+      ```
+    - **Other distributions** - Download the tar archive with the glibc-linked binary:
+      ```bash
+      sudo mkdir -p /opt/datadog
+      curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v<TRACER_VERSION>/datadog-dotnet-apm-<TRACER_VERSION>.tar.gz \
+      | sudo tar xzf - -C /opt/datadog
+      ```
+3. Add the [required environment variables](#required-environment-variables).
 
-1. Install the .NET Tracer in the environment where your application is running using one of the packages available from the `dd-trace-dotnet` [releases page][1].
+4. Run the `/opt/datadog/createLogPath.sh` script, which creates a directory for the log files and sets appropriate directory permissions. The default directory for log files is `/var/log/datadog/dotnet`.
 
-2. Create the required environment variables. See [Required Environment Variables](#required-environment-variables) below for details.
+5. Create application load.
 
-3. Run the `/opt/datadog/createLogPath.sh` script, which creates a directory for the log files and sets appropriate directory permissions. The default directory for log files is `/var/log/datadog/dotnet`.
-
-**Update:** Starting with .NET Tracer version `1.8.0`, the `Datadog.Trace.ClrProfiler.Managed` NuGet package is no longer required for automatic instrumentation in .NET Core and is deprecated. Remove it from your application when you update the .NET Tracer and add the new environment variable, `DD_DOTNET_TRACER_HOME`. See [Required Environment Variables](#required-environment-variables) below for details.
-
-**Update:** .NET Tracer version `1.13.0` adds support for Alpine and other [Musl-based distributions][2].
-
-For Debian or Ubuntu, download and install the Debian package:
-
-```bash
-curl -LO https://github.com/DataDog/dd-trace-dotnet/releases/download/v<TRACER_VERSION>/datadog-dotnet-apm_<TRACER_VERSION>_amd64.deb
-sudo dpkg -i ./datadog-dotnet-apm_<TRACER_VERSION>_amd64.deb
-```
-
-For CentOS or Fedora, download and install the RPM package:
-
-```bash
-curl -LO https://github.com/DataDog/dd-trace-dotnet/releases/download/v<TRACER_VERSION>/datadog-dotnet-apm-<TRACER_VERSION>-1.x86_64.rpm
-sudo rpm -Uvh datadog-dotnet-apm-<TRACER_VERSION>-1.x86_64.rpm
-```
-
-For Alpine or other [Musl-based distributions][2], download the tar archive with the musl-linked binary:
-
-```bash
-sudo mkdir -p /opt/datadog
-curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v<TRACER_VERSION>/datadog-dotnet-apm-<TRACER_VERSION>-musl.tar.gz \
-| sudo tar xzf - -C /opt/datadog
-```
-
-For other distributions, download the tar archive with the glibc-linked binary:
-
-```bash
-sudo mkdir -p /opt/datadog
-curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v<TRACER_VERSION>/datadog-dotnet-apm-<TRACER_VERSION>.tar.gz \
-| sudo tar xzf - -C /opt/datadog
-```
+6. Visit [APM Live Traces][3].
 
 
-[1]: https://github.com/DataDog/dd-trace-dotnet/releases
+[1]: /agent/basic_agent_usage/
 [2]: https://en.wikipedia.org/wiki/Musl
+[3]: https://app.datadoghq.com/apm/traces
 {{% /tab %}}
 
 {{< /tabs >}}
 
-### Required Environment Variables
+
+### Required environment variables
 
 {{< tabs >}}
 
 {{% tab "Windows" %}}
 
-If your application runs in IIS, skip the rest of this section.
+#### Applications not hosted in IIS
 
-For Windows applications **not** running in IIS, set these two environment variables before starting your application to enable automatic instrumentation:
-
-**Note:** The .NET runtime tries to load a profiler into _any_ .NET process that is started with these environment variables set. You should limit instrumentation only to the applications that need to be traced. **We do not recommend setting these environment variables globally as this causes _all_ .NET processes on the host to load the profiler.**
+To enable automatic instrumentation for Windows applications not hosted in IIS, you must set two environment variables before starting your application:
 
 Name                       | Value
 ---------------------------|------
 `CORECLR_ENABLE_PROFILING` | `1`
 `CORECLR_PROFILER`         | `{846F5F1C-F9AE-4B07-969E-05C26BC060D8}`
 
-#### Windows Services
+<div class="alert alert-warning"> 
+  <strong>Note:</strong> The .NET runtime tries to load a profiler into any .NET process started with these environment variables set. You should limit instrumentation only to the applications that need to be traced. Don't set these environment variables globally because this causes all .NET processes on the host to load the profiler.
+</div>
 
-To automatically instrument a Windows Service, set the environment variables for that Service in the Windows Registry. Create a multi-string value called `Environment` in the `HKLM\System\CurrentControlSet\Services\<SERVICE NAME>` key. Then set the key's data to the values in the table:
-```text
-CORECLR_ENABLE_PROFILING=1
-CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
-```
+##### Windows services
 
-This can be done either through the Registry Editor as in the image below, or through a PowerShell snippet:
+To automatically instrument a Windows service, set the `CORECLR_ENABLE_PROFILING` and `CORECLR_PROFILER` environment variables: 
 
-{{< img src="tracing/setup/dotnet/RegistryEditorCore.png" alt="Registry Editor"  >}}
+1. In the Windows Registry Editor, create a multi-string value called `Environment` in the `HKLM\System\CurrentControlSet\Services\<SERVICE NAME>` key. 
+2. Set the value data to:
+    ```text
+    CORECLR_ENABLE_PROFILING=1
+    CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+    ```
+    {{< img src="tracing/setup/dotnet/RegistryEditorCore.png" alt="Creating the environment variables for instrumenting a service in the Registry Editor" >}}
+
+Alternatively, you can set the environment variables by using the following PowerShell snippet:
 
 ```powershell
 [String[]] $v = @("CORECLR_ENABLE_PROFILING=1", "CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}")
 Set-ItemProperty HKLM:SYSTEM\CurrentControlSet\Services\<NAME> -Name Environment -Value $v
 ```
 
-#### Console Apps
+##### Console applications
 
-Set the environment variables from a batch file before starting your application:
+To automatically instrument a console application, set the `CORECLR_ENABLE_PROFILING` and `CORECLR_PROFILER` environment variables from a batch file before starting your application:
 
 ```bat
 rem Set environment variables
@@ -174,30 +171,35 @@ dotnet.exe example.dll
 
 {{% tab "Linux" %}}
 
-1. Set `apm_non_local_traffic: true` in your main [`datadog.yaml` configuration file][1]
+1. If the Agent is running on a different host or container, set `apm_non_local_traffic: true` in your main [`datadog.yaml` configuration file][1]
 
 2. See the specific setup instructions to ensure that the Agent is configured to receive traces in a containerized environment:
 
 {{< partial name="apm/apm-containers.html" >}}
 </br>
 
-3. After having instrumented your application, the tracing client sends traces to `localhost:8126` by default.  If this is not the correct host and port change it by setting the below env variables:
+3. While it is instrumenting your application, the tracing client sends traces to `localhost:8126` by default.  If this is not the correct host and port, change it by setting these environment variables:
 
-`DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`.
+    - `DD_AGENT_HOST`
+    - `DD_TRACE_AGENT_PORT`
 
-4. On Linux, the following environment variables are required to enable automatic instrumentation:
+4. The following environment variables are required to enable automatic instrumentation on Linux:
 
-Name                       | Value
----------------------------|------
-`CORECLR_ENABLE_PROFILING` | `1`
-`CORECLR_PROFILER`         | `{846F5F1C-F9AE-4B07-969E-05C26BC060D8}`
-`CORECLR_PROFILER_PATH`    | `/opt/datadog/Datadog.Trace.ClrProfiler.Native.so`
-`DD_INTEGRATIONS`          | `/opt/datadog/integrations.json`
-`DD_DOTNET_TRACER_HOME`    | `/opt/datadog`
+    <div class="alert alert-info"> 
+      <strong>Note:</strong> If the .NET Tracer is installed into a path other than the default <code>/opt/datadog</code> path, ensure the paths are changed to match.
+    </div>
 
-**Note:** You must change the paths above if you install the .NET Tracer into a non-default path.
+    Name                       | Value
+    ---------------------------|------
+    `CORECLR_ENABLE_PROFILING` | `1`
+    `CORECLR_PROFILER`         | `{846F5F1C-F9AE-4B07-969E-05C26BC060D8}`
+    `CORECLR_PROFILER_PATH`    | `/opt/datadog/Datadog.Trace.ClrProfiler.Native.so`
+    `DD_INTEGRATIONS`          | `/opt/datadog/integrations.json`
+    `DD_DOTNET_TRACER_HOME`    | `/opt/datadog`
 
-For example, to set the environment variables them from a bash file before starting your application:
+#### Set the environment variables by bash script
+
+To set the required environment variables from a bash file before starting your application:
 
 ```bash
 # Set environment variables
@@ -211,97 +213,105 @@ export DD_DOTNET_TRACER_HOME=/opt/datadog
 dotnet example.dll
 ```
 
-To set the environment variables on a Linux Docker container, use [`ENV`][2]:
+#### Linux Docker container
 
-```docker
-# Set environment variables
-ENV CORECLR_ENABLE_PROFILING=1
-ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
-ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
-ENV DD_INTEGRATIONS=/opt/datadog/integrations.json
-ENV DD_DOTNET_TRACER_HOME=/opt/datadog
+To set the required environment variables on a Linux Docker container:
 
-# Start your application
-CMD ["dotnet", "example.dll"]
-```
+    ```docker
+    # Set environment variables
+    ENV CORECLR_ENABLE_PROFILING=1
+    ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+    ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
+    ENV DD_INTEGRATIONS=/opt/datadog/integrations.json
+    ENV DD_DOTNET_TRACER_HOME=/opt/datadog
 
+    # Start your application
+    CMD ["dotnet", "example.dll"]
+    ```
 
-#### Systemctl (Per Service)
+#### SystemCTL (per service)
 
 When using `systemctl` to run .NET applications as a service, you can add the required environment variables to be loaded for a specific service.
 
-Create a file called `environment.env` containing:
+1. Create a file called `environment.env` containing:
 
-```bat
-CORECLR_ENABLE_PROFILING=1
-CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
-CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
-DD_INTEGRATIONS=/opt/datadog/integrations.json
-DD_DOTNET_TRACER_HOME=/opt/datadog
-# any other environment variable used by the application
-```
+    ```bat
+    CORECLR_ENABLE_PROFILING=1
+    CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+    CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
+    DD_INTEGRATIONS=/opt/datadog/integrations.json
+    DD_DOTNET_TRACER_HOME=/opt/datadog
+    # any other environment variable used by the application
+    ```
+2. In the service's configuration file, reference this as an [`EnvironmentFile`][2] in the service block:
 
-In the service configuration file, reference this as an [`EnvironmentFile`][3] in the service block:
+    ```bat
+    [Service]
+    EnvironmentFile=/path/to/environment.env
+    ExecStart=<command used to start the application>
+    ```
+3. Restart the .NET service for the environment variable settings to take effect.
 
-```bat
-[Service]
-EnvironmentFile=/path/to/environment.env
-ExecStart=<command used to start the application>
-```
-After setting these variables, restart the .NET service for the environment variables to take effect.
+#### SystemCTL (all services)
 
-#### Systemctl (All Services)
+<div class="alert alert-warning"> 
+  <strong>Note:</strong> The .NET runtime tries to load a profiler into <em>any</em> .NET process that is started with these environment variables set. You should limit instrumentation to only the applications that need to be traced. <strong>Don't set these environment variables globally as this causes <em>all</em> .NET processes on the host to load the profiler.</strong>
+</div>
 
-When using `systemctl` to run .NET applications as a service, you can also set environment variables to be loaded for all services ran via `systemctl`. To confirm these variables have been set, use [`systemctl show-environment`][3]. Before using this approach, see the note below about this instrumenting all .NET processes.
+When using `systemctl` to run .NET applications as a service, you can also set environment variables to be loaded for all services run by `systemctl`. 
 
-```bat
-systemctl set-environment CORECLR_ENABLE_PROFILING=1
-systemctl set-environment CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
-systemctl set-environment CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
-systemctl set-environment DD_INTEGRATIONS=/opt/datadog/integrations.json
-systemctl set-environment DD_DOTNET_TRACER_HOME=/opt/datadog
-```
+1. Set the required environment variables by running [`systemctl set-environment`][2]:
 
-Once this is set, verify that the environment variables were set with `systemctl show-environment`.
+    ```bat
+    systemctl set-environment CORECLR_ENABLE_PROFILING=1
+    systemctl set-environment CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+    systemctl set-environment CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
+    systemctl set-environment DD_INTEGRATIONS=/opt/datadog/integrations.json
+    systemctl set-environment DD_DOTNET_TRACER_HOME=/opt/datadog
+    ```
+2. Verify that the environment variables were set by running `systemctl show-environment`.
+
+3. Restart the .NET service for the environment variables to take effect.
 
 [1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
-[2]: https://docs.docker.com/engine/reference/builder/#env
-[3]: https://www.freedesktop.org/software/systemd/man/systemd.exec.html#EnvironmentFile=
+[2]: https://www.freedesktop.org/software/systemd/man/systemctl.html#set-environment%20VARIABLE=VALUE%E2%80%A6
 {{% /tab %}}
 
 {{< /tabs >}}
 
-**Note:** The .NET runtime tries to load a profiler into _any_ .NET process that is started with these environment variables set. You should limit instrumentation only to the applications that need to be traced. **We do not recommend setting these environment variables globally as this causes _all_ .NET processes on the host to load the profiler.**
-
 ### Configure the Datadog Agent for APM
 
-Install and configure the Datadog Agent to receive traces from your instrumented application. By default the Datadog Agent is enabled in your `datadog.yaml` file under `apm_enabled: true` and listens for trace traffic at `localhost:8126`. For containerized environments, follow the in-app [Quickstart instructions][3] to enable trace collection within the Datadog Agent.
+Install and configure the Datadog Agent to receive traces from your instrumented application. By default the Datadog Agent is enabled in your `datadog.yaml` file under `apm_enabled: true` and listens for trace traffic at `localhost:8126`. For containerized environments, follow the in-app [Quickstart instructions][2] to enable trace collection within the Datadog Agent.
 
-## Manual Instrumentation
+## Custom Instrumentation
 
-To manually instrument your code, add the `Datadog.Trace` [NuGet package][4] to your application. In your code, access the global tracer through the `Datadog.Trace.Tracer.Instance` property to create new spans.
+<div class="alert alert-warning"> 
+  <strong>Note:</strong>  If you are using both automatic and custom instrumentation, it is important to keep the package versions (for example, MSI and NuGet) in sync.
+</div>
 
-For more details on manual instrumentation and custom tagging, see [Manual instrumentation documentation][5].
+To use custom instrumentation in your .NET application:
+1. Add the `Datadog.Trace` [NuGet package][2] to your application. 
+2. In your application code, access the global tracer through the `Datadog.Trace.Tracer.Instance` property to create new spans.
 
-Manual instrumentation is supported on .NET Framework 4.5 and above on Windows, on .NET Core 2.0 and above on Windows and Linux, and on .NET 5 on Windows and Linux.
+For more details on custom instrumentation and custom tagging, see [.NET Custom Instrumentation documentation][3].
 
-**Note:**  If you are using both automatic and custom instrumentation, it is important to keep the package versions (for example, MSI and NuGet) in sync.
+## Configuring the .NET Tracer
 
-## Configuration
+The .NET Tracer has configuration settings that can be set by any of these methods:
 
-There are multiple ways to configure the .NET Tracer:
-
-* setting environment variables
-* in .NET code
-* creating a `datadog.json` file
+* Environment variables.
+* In the .NET application code.
+* Using a `datadog.json` file.
 
 {{< tabs >}}
 
 {{% tab "Environment variables" %}}
 
-To configure the Tracer using environment variables, set the variables before launching the instrumented application.
+To configure the tracer using environment variables, set the variables before launching the instrumented application.
 
-For example, on Windows:
+#### Windows
+
+**Note:** To set environment variables for a Windows Service, use the multi-string key `HKLM\System\CurrentControlSet\Services\{service name}\Environment` in the Windows Registry, as described above.
 
 ```cmd
 rem Set environment variables
@@ -314,9 +324,7 @@ rem Launch application
 example.exe
 ```
 
-**Note:** To set environment variables for a Windows Service, use the multi-string key `HKLM\System\CurrentControlSet\Services\{service name}\Environment` in the Windows Registry.
-
-On Linux:
+#### Linux
 
 ```bash
 # Set environment variables
@@ -334,6 +342,10 @@ dotnet example.dll
 {{% tab "Code" %}}
 
 To configure the Tracer in application code, create a `TracerSettings` from the default configuration sources. Set properties on this `TracerSettings` instance before passing it to a `Tracer` constructor. For example:
+
+<div class="alert alert-warning"> 
+  <strong>Note:</strong> Settings must be set on <code>TracerSettings</code> <em>before</em> creating the <code>Tracer</code>. Changes made to <code>TracerSettings</code> properties after the <code>Tracer</code> is created are ignored.
+</div>
 
 ```csharp
 using Datadog.Trace;
@@ -358,13 +370,11 @@ var tracer = new Tracer(settings);
 Tracer.Instance = tracer;
 ```
 
-**Note:** Settings must be set on `TracerSettings` _before_ creating the `Tracer`. Changes made to `TracerSettings` properies after the `Tracer` is created are ignored.
-
 {{% /tab %}}
 
 {{% tab "JSON file" %}}
 
-To configure the Tracer using a JSON file, create `datadog.json` in the instrumented application's directory. The root JSON object must be a hash with a key/value pair for each setting. For example:
+To configure the Tracer using a JSON file, create `datadog.json` in the instrumented application's directory. The root JSON object must be an object with a key/value pair for each setting. For example:
 
 ```json
 {
@@ -379,63 +389,70 @@ To configure the Tracer using a JSON file, create `datadog.json` in the instrume
 
 {{< /tabs >}}
 
-### Configuration Variables
+### Configuration settings
+
+<div class="alert alert-info"> 
+  <strong>Note:</strong> On Linux, the names of environment variables are case-sensitive.
+</div>
 
 Using the methods described above, customize your tracing configuration with the variables in the following tables. Use the first name (for example, `DD_TRACE_AGENT_URL`) when setting environment variables or configuration files. The second name (for example, `AgentUri`), indicates the name for the `TracerSettings` property to use when changing settings in code.
 
 #### Unified Service Tagging
 
-| Setting Name                                        | Description                                                                                                                                                                                                       |
-|-----------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DD_ENV`<br/><br/>`Environment`                     | If specified, adds the `env` tag with the specified value to all generated spans. See [Agent configuration][8] for more details about the `env` tag.  Available for versions 1.17.0+.                                                            |
-| `DD_SERVICE`<br/><br/>`ServiceName`            | If specified, sets the service name. Otherwise, the .NET Tracer tries to determine service name automatically from application name (e.g. IIS application name, process entry assembly, or process name). Available for versions 1.17.0+  |
-| `DD_VERSION`<br/><br/>`ServiceVersion`            | If specified, sets the version of the service. Available for versions 1.17.0+
-| `DD_TAGS`<br/><br/>`GlobalTags`       | If specified, adds all of the specified tags to all generated spans (e.g., `layer:api,team:intake`). Available for versions 1.17.0+                                                                                                                                              |
-
-We highly recommend using `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` to set `env`, `service`, and `version` for your services.
-Check out the [Unified Service Tagging][6] documentation for recommendations on how to configure these environment variables.
-
-#### Instrumentation
-
-The following table below lists configuration variables that are available for both automatic and manual instrumentation.
+To use [Unified Service Tagging][4], configure the following settings for your services:
 
 | Setting Name                                        | Description                                                                                                                                                                                                       |
 |-----------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DD_TRACE_AGENT_URL`<br/><br/>`AgentUri`            | Sets the URL endpoint where traces are sent. Overrides `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` if set. Default value is `http://<DD_AGENT_HOST>:<DD_TRACE_AGENT_PORT>`.                                         |
-| `DD_AGENT_HOST`                                     | Sets the host where traces are sent (the host running the Agent). Can be a hostname or an IP address. Ignored if `DD_TRACE_AGENT_URL` is set. Default is value `localhost`.                                       |
-| `DD_TRACE_AGENT_PORT`                               | Sets the port where traces are sent (the port where the Agent is listening for connections). Ignored if `DD_TRACE_AGENT_URL` is set. Default value is `8126`.                                                     |
-| `DD_LOGS_INJECTION`<br/><br/>`LogsInjectionEnabled` | Enables or disables automatic injection of correlation identifiers into application logs.                                                                                                                         |
+| `DD_ENV`<br/><br/>`Environment`                     | If specified, adds the `env` tag with the specified value to all generated spans. Added in version 1.17.0.                                                            |
+| `DD_SERVICE`<br/><br/>`ServiceName`            | If specified, sets the service name. Otherwise, the .NET Tracer tries to determine service name automatically from application name (the IIS application name, process entry assembly, or process name). Added in version 1.17.0.  |
+| `DD_VERSION`<br/><br/>`ServiceVersion`            | If specified, sets the version of the service. Added in version 1.17.0. |
+
+
+#### Additional optional configuration
+
+The following table below lists configuration variables that are available for both automatic and custom instrumentation.
+
+| Setting Name                                        | Description                                                                                                                                                                                                       |
+|-----------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DD_TRACE_AGENT_URL`<br/><br/>`AgentUri`            | Sets the URL endpoint where traces are sent. Overrides `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` if set. Default value is `http://<DD_AGENT_HOST>:<DD_TRACE_AGENT_PORT>`.       |
+| `DD_AGENT_HOST`                                     | Sets the host where traces are sent (the host running the Agent). Can be a hostname or an IP address. Ignored if `DD_TRACE_AGENT_URL` is set. Default value is `localhost`.                 |
+| `DD_TRACE_AGENT_PORT`                               | Sets the port where traces are sent (the port where the Agent is listening for connections). Ignored if `DD_TRACE_AGENT_URL` is set. Default value is `8126`.                     |
+| `DD_LOGS_INJECTION`<br/><br/>`LogsInjectionEnabled` | Enables or disables automatic injection of correlation identifiers into application logs.                                                                                               |
 | `DD_TRACE_GLOBAL_TAGS`<br/><br/>`GlobalTags`        | If specified, adds all of the specified tags to all generated spans.                                                                                                                                              |
-| `DD_TRACE_DEBUG`                                    | Enables or disables debug logging. Valid values are: `true` or `false` (default).                                                                                                                                 |
-| `DD_TRACE_HEADER_TAGS`                              | Accepts a map of case-insensitive header keys to tag names and automatically applies matching header values as tags on root spans. (e.g. : `CASE-insensitive-Header:my-tag-name,User-ID:userId`). Available for version 1.18.3+  |
+| `DD_TRACE_DEBUG` <br/><br/>`DebugEnabled`           | Enables or disables debug logging. Valid values are: `true` or `false` (default).                                                                          |
+| `DD_TRACE_HEADER_TAGS`                              | Accepts a map of case-insensitive header keys to tag names and automatically applies matching header values as tags on root spans. Example: `CASE-insensitive-Header:my-tag-name,User-ID:userId`. Added in version 1.18.3.  |
+| `DD_TRACE_LOG_DIRECTORY`                            | Sets the directory for .NET Tracer logs.<br/><br/>Default: `%ProgramData%\Datadog .NET Tracer\logs\`      |
+| `DD_TRACE_LOG_PATH`                                 | Sets the path for the automatic instrumentation log file and determines the directory of all other .NET Tracer log files. Ignored if `DD_TRACE_LOG_DIRECTORY` is set.             |
 | `DD_TRACE_SERVICE_MAPPING`                          | Rename services using configuration. Accepts a map of service name keys to rename, and the name to use instead, in the format `[from-key]:[to-name]`. For example: `mysql:main-mysql-db, mongodb:offsite-mongodb-service`. `from-key` is specific to the integration type, and should exclude the application name prefix. For example, to rename `my-application-sql-server` to `main-db`, use `sql-server:main-db`. Added in version 1.23.0 |
+| `DD_TAGS`<br/><br/>`GlobalTags`       | If specified, adds all of the specified tags to all generated spans Example: `layer:api,team:intake`. Added in version 1.17.0.                                                           |
 
-The following table lists configuration variables that are available only when using automatic instrumentation.
+#### Automatic instrumentation optional configuration
+
+The following table lists configuration variables that are available **only** when using automatic instrumentation.
 
 | Setting Name                                                   | Description                                                                                                                                                                                                                                                                              |
 |----------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `DD_TRACE_ENABLED`<br/><br/>`TraceEnabled`                      | Enables or disables all automatic instrumentation. Setting the environment variable to `false` completely disables the CLR profiler. For other configuration methods, the CLR profiler is still loaded, but traces will not be generated. Valid values are: `true` (default) or `false`. |
-| `DD_TRACE_DEBUG`                                                | Enables or disables debug logs in the Tracer. Valid values are: `true` or `false` (default). Setting this as an environment variable also enabled debug logs in the CLR Profiler.                                                                                                        |
-| `DD_TRACE_LOG_DIRECTORY`                                        | Sets the directory for .NET Tracer logs.<br/><br/>Windows default: `%ProgramData%\Datadog .NET Tracer\logs\`<br/><br/>Linux default: `/var/log/datadog/dotnet/`                                                                                                                                                                                     |
-| `DD_TRACE_LOG_PATH`                                             | Sets the path for the automatic instrumentation log file and determines the directory of all other .NET Tracer log files. Ignored if `DD_TRACE_LOG_DIRECTORY` is set.                                                                              |
-| `DD_DISABLED_INTEGRATIONS`<br/><br/>`DisabledIntegrationNames`  | Sets a list of integrations to disable. All other integrations remain enabled. If not set, all integrations are enabled. Supports multiple values separated with semicolons. Valid values are the integration names listed in the [Integrations][2] section.           |
+| `DD_DISABLED_INTEGRATIONS`<br/><br/>`DisabledIntegrationNames`  | Sets a list of integrations to disable. All other integrations remain enabled. If not set, all integrations are enabled. Supports multiple values separated with semicolons. Valid values are the integration names listed in the [Integrations][5] section.           |
 | `DD_HTTP_CLIENT_ERROR_STATUSES`                                 | Sets status code ranges that will cause HTTP client spans to be marked as errors. Default value is `400-499`. |
 | `DD_HTTP_SERVER_ERROR_STATUSES`                                 | Sets status code ranges that will cause HTTP server spans to be marked as errors. Default value is `500-599`. |
 | `DD_TRACE_ADONET_EXCLUDED_TYPES`<br/><br/>`AdoNetExcludedTypes` | Sets a list of `AdoNet` types (for example, `System.Data.SqlClient.SqlCommand`) that will be excluded from automatic instrumentation. |
 
-The following table lists configuration variables that are available only when using automatic instrumentation and can be set for each integration. Use the first name (e.g. `DD_<INTEGRATION>_ENABLED`) when setting environment variables or configuration files. The second name (e.g. `Enabled`), indicates the name the `IntegrationSettings` property to use when changing settings in the code. Access these properties through the `TracerSettings.Integrations[]` indexer. Integration names are listed in the [Integrations][2] section. **Note:** On Linux, the names of environment variables are case-sensitive.
+
+#### Disable integration configuration
+
+The following table lists the configuration variables that are available **only** when automatic instrumentation can be set for each integration. 
 
 | Setting Name                                                                  | Description                                                                                                           |
 |-------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| `DD_TRACE_<INTEGRATION>_ENABLED`<br/><br/>`Enabled`                           | Enables or disables a specific integration. Valid values are: `true` (default) or `false`.                            |
+| `DD_TRACE_<INTEGRATION_NAME>_ENABLED`<br/><br/>`Integrations[<INTEGRATION_NAME>].Enabled`            | Enables or disables a specific integration. Valid values are: `true` (default) or `false`.  Integration names are listed in the [Integrations][5] section.                          |
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/setup_overview/setup/dotnet-framework
-[2]: /tracing/compatibility_requirements/dotnet-core
-[3]: https://app.datadoghq.com/apm/docs
-[4]: https://www.nuget.org/packages/Datadog.Trace
-[5]: /tracing/custom_instrumentation/dotnet/
-[6]: /getting_started/tagging/unified_service_tagging/
+[1]: /tracing/setup_overview/compatibility_requirements/dotnet-core
+[2]: https://www.nuget.org/packages/Datadog.Trace
+[3]: /tracing/setup_overview/custom_instrumentation/dotnet/
+[4]: /getting_started/tagging/unified_service_tagging/
+[5]: /tracing/setup_overview/compatibility_requirements/dotnet-core#integrations

--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -178,7 +178,7 @@ dotnet.exe example.dll
 {{< partial name="apm/apm-containers.html" >}}
 </br>
 
-3. While it is instrumenting your application, the tracing client sends traces to `localhost:8126` by default.  If this is not the correct host and port, change it by setting these environment variables:
+3. While it is instrumenting your application, the tracing client sends traces to `localhost:8126` by default. If this is not the correct host and port, change it by setting these environment variables:
 
     - `DD_AGENT_HOST`
     - `DD_TRACE_AGENT_PORT`
@@ -286,7 +286,7 @@ Install and configure the Datadog Agent to receive traces from your instrumented
 ## Custom Instrumentation
 
 <div class="alert alert-warning"> 
-  <strong>Note:</strong>  If you are using both automatic and custom instrumentation, it is important to keep the package versions (for example, MSI and NuGet) in sync.
+  <strong>Note:</strong> If you are using both automatic and custom instrumentation, it is important to keep the package versions (for example, MSI and NuGet) in sync.
 </div>
 
 To use custom instrumentation in your .NET application:
@@ -445,7 +445,7 @@ The following table lists the configuration variables that are available **only*
 
 | Setting Name                                                                  | Description                                                                                                           |
 |-------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| `DD_TRACE_<INTEGRATION_NAME>_ENABLED`<br/><br/>`Integrations[<INTEGRATION_NAME>].Enabled`            | Enables or disables a specific integration. Valid values are: `true` (default) or `false`.  Integration names are listed in the [Integrations][5] section.                          |
+| `DD_TRACE_<INTEGRATION_NAME>_ENABLED`<br/><br/>`Integrations[<INTEGRATION_NAME>].Enabled`            | Enables or disables a specific integration. Valid values are: `true` (default) or `false`. Integration names are listed in the [Integrations][5] section.                          |
 
 ## Further reading
 

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -166,6 +166,10 @@ example.exe
 
 To configure the Tracer in application code, create a `TracerSettings` instance from the default configuration sources. Set properties on this `TracerSettings` instance before passing it to a `Tracer` constructor. For example:
 
+<div class="alert alert-warning"> 
+  <strong>Note:</strong> Settings must be set on <code>TracerSettings</code> <em>before</em> creating the <code>Tracer</code>. Changes made to <code>TracerSettings</code> properties after the <code>Tracer</code> is created are ignored.
+</div>
+
 ```csharp
 using Datadog.Trace;
 using Datadog.Trace.Configuration;
@@ -186,9 +190,6 @@ var tracer = new Tracer(settings);
 Tracer.Instance = tracer;
 ```
 
-<div class="alert alert-warning"> 
-<strong>Note:</strong> Settings must be set on <code>TracerSettings</code> <em>before</em> creating the <code>Tracer</code>. Changes made to <code>TracerSettings</code> properies after the <code>Tracer</code> is created are ignored.
-</div>
 {{% /tab %}}
 
 {{% tab "web.config" %}}


### PR DESCRIPTION

### What does this PR do?

Recreates [PR9641](https://github.com/DataDog/documentation/pull/9641) on a new branch without unintentional link-changes to other files.

### Motivation
The mess on 9641

### Preview

Most of the changes here:
https://docs-staging.datadoghq.com/kari/update-dotnet-core2/tracing/setup_overview/setup/dotnet-core/

A few minor ones here:
https://docs-staging.datadoghq.com/kari/update-dotnet-core2/tracing/setup_overview/compatibility_requirements/dotnet-core/
https://docs-staging.datadoghq.com/kari/update-dotnet-core2/tracing/setup_overview/compatibility_requirements/dotnet-framework/
https://docs-staging.datadoghq.com/kari/update-dotnet-core2/tracing/setup_overview/setup/dotnet-framework/

### Additional Notes
Changes tech and PM reviewed on 9641

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
