### PR TITLE
update code examples to use region urls

### DIFF
--- a/layouts/partials/api/code-example.html
+++ b/layouts/partials/api/code-example.html
@@ -76,7 +76,20 @@
               <div class="code-button-wrapper position-absolute">
                   <button class="btn text-primary js-copy-button">{{ i18n "copy" }}</button>
               </div>
-              {{ highlight $file_content $lang.syntax "" }}
+              {{ $highlightedContent := highlight $file_content $lang.syntax "" }}
+
+              <!-- replace "https://api.datadoghq.com" -->
+              {{ $old := (print "\"https://api.datadoghq.com\"") | htmlEscape }}
+              {{ $new := "\"https://api.<span class=\"js-region-param region-param\" data-region-param=\"dd_site\"></span>\"" }}
+              {{ $highlightedContent = (replace $highlightedContent $old $new) }}
+
+              <!-- replace 'https://api.datadoghq.com' -->
+              {{ $old = (print "'https://api.datadoghq.com'") | htmlEscape }}
+              {{ $new = "'https://api.<span class=\"js-region-param region-param\" data-region-param=\"dd_site\"></span>'" }}
+              {{ $highlightedContent := (replace $highlightedContent $old $new) }}
+
+              <!-- run through safehtml to output correctly -->
+              {{ $highlightedContent | safeHTML }}
           </div>
           </div>
           {{ $count = add $count 1 }}


### PR DESCRIPTION
### What does this PR do?

This PR attempts to replace code snippets that have the api endpoint with region switching html. So that when a user switches region the code example will also switch.

### Motivation

Api docs sync discussions

### Preview

view code examples on api endpoints (except curl this already had region switching)
https://docs-staging.datadoghq.com/david.jones/code-example-regions/api/

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
