### PR TITLE
[agent/logs] Additional multiline regexp example

### DIFF
--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -398,7 +398,7 @@ spec:
 {{% /tab %}}
 {{< /tabs >}}
 
-**Very important note**: Regex patterns for multi-line logs must start at the **beginning** of a log. Patterns cannot be matched mid-line. A never matching pattern may cause log line losses.
+**Very important note**: Regex patterns for multi-line logs must start at the **beginning** of a log. Patterns cannot be matched mid-line. *A never matching pattern may cause log line losses*.
 
 More examples:
 

--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -398,6 +398,8 @@ spec:
 {{% /tab %}}
 {{< /tabs >}}
 
+**Very important note**: Regex patterns for multi-line logs must start at the **beginning** of a log. Patterns cannot be matched mid-line. A never matching pattern may cause log line losses.
+
 More examples:
 
 | **Raw string**           | **Pattern**                                   |
@@ -407,8 +409,7 @@ More examples:
 | Thu Jun 16 08:29:03 2016 | `\w{3}\s+\w{3}\s+\d{2}\s\d{2}:\d{2}:\d{2}`    |
 | 20180228                 | `\d{8}`                                       |
 | 2020-10-27 05:10:49.657  | `\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}` |
-
-**Note**: Regex patterns for multi-line logs must start at the **beginning** of a log. Patterns cannot be matched mid-line.
+| {"date": "2018-01-02"    | `\{"date": "\d{4}-\d{2}-\d{2}`                |
 
 ## Commonly used log processing rules
 

--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -398,7 +398,7 @@ spec:
 {{% /tab %}}
 {{< /tabs >}}
 
-**Very important note**: Regex patterns for multi-line logs must start at the **beginning** of a log. Patterns cannot be matched mid-line. *A never matching pattern may cause log line losses*.
+<div class="alert alert-warning"><strong>Important!</strong> Regex patterns for multi-line logs must start at the <em>beginning</em> of a log. Patterns cannot be matched mid-line. <em>A never matching pattern may cause log line losses.</em></div>
 
 More examples:
 


### PR DESCRIPTION
### What does this PR do?
Add an additional example to the multiline regex sample table.

### Motivation
Emphase that regex matching is only from the beginning of a log line, no matter (like json formatting) what.
Highlight possible log losses.

### Preview

https://docs-staging.datadoghq.com/prognant/agent-multiline-regex-additional-example/agent/logs/advanced_log_collection/

### Additional Notes
N/A
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
