### PR TITLE
Fix gap on api pages on banner close

### DIFF
--- a/src/scripts/components/announcement_banner.js
+++ b/src/scripts/components/announcement_banner.js
@@ -1,7 +1,21 @@
+const handleApiToolbar = () => {
+    const banner = document.querySelector('.announcement_banner');
+    const toolbar = document.querySelector('.api-toolbar');
+
+    if (!banner.classList.value.includes('open')) {
+        if (toolbar) {
+            toolbar.style.top = '64px';
+        }
+    }
+}
+
 $(document).ready(function () {
+    handleApiToolbar();
+
     $('.announcement_banner .icon').on('click', function () {
         sessionStorage.setItem('announcement_banner', 'closed');
         $('.announcement_banner').removeClass('open');
+        handleApiToolbar();
         $('html').removeClass('banner');
         $(window).trigger('scroll');
     });

--- a/src/styles/pages/_api.scss
+++ b/src/styles/pages/_api.scss
@@ -130,7 +130,7 @@ $ddpurple: #632ca6;
             background: white;
             position: sticky;
             z-index: 1;
-            top: 95px;
+            top: 94px;
             height: 65px;
         }
 


### PR DESCRIPTION
### What does this PR do?
Fixes noticeable gap that exists on API pages when users close the announcement banner

### Motivation
https://dd.slack.com/archives/C0DESMBQU/p1612959438320200

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/selectors-banner-closed-fix/api/
There shouldn't be a gap between the breadcrumbs + site/region selectors and nav when closing the announcement banner

### Additional Notes


### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
