### PR TITLE
add redirect from /logs/live_tail

### DIFF
--- a/content/en/logs/explorer/live_tail.md
+++ b/content/en/logs/explorer/live_tail.md
@@ -4,6 +4,7 @@ kind: documentation
 description: 'Search through all of your logs and perform Log Analytics'
 aliases:
     - /logs/explore/livetail
+    - /logs/live_tail
 further_reading:
     - link: 'logs/processing'
       tag: 'Documentation'


### PR DESCRIPTION

### What does this PR do?
adds a redirect from `/logs/live_tail/` to `/logs/explorer/live_tail`

### Motivation
404 toplist on Docs dashboard - on call tasks

### Preview

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/kari/livetailredirect/logs/live_tail/ should go to a real page, not 404


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
