### PR TITLE
provide default for undefined language

### DIFF
--- a/content/en/tracing/setup_overview/compatibility_requirements/_index.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/_index.md
@@ -9,6 +9,7 @@ further_reading:
 aliases:
   - /tracing/compatibility
   - /tracing/compatibility_requirements
+  - /tracing/setup_overview/compatibility_requirements/undefined
 ---
 
 Choose your language to see the compatibility requirements and supported integrations for Datadog APM.

--- a/content/en/tracing/setup_overview/custom_instrumentation/_index.md
+++ b/content/en/tracing/setup_overview/custom_instrumentation/_index.md
@@ -13,6 +13,7 @@ aliases:
     - /tracing/guide/adding_metadata_to_spans
     - /tracing/advanced/adding_metadata_to_spans/
     - /tracing/custom_instrumentation
+    - /tracing/setup_overview/custom_instrumentation/undefined
 further_reading:
     - link: 'tracing/guide/instrument_custom_method'
       text: 'Instrument a custom method to get deep visibility into your business logic'

--- a/content/en/tracing/setup_overview/setup/_index.md
+++ b/content/en/tracing/setup_overview/setup/_index.md
@@ -4,6 +4,7 @@ kind: documentation
 type: multi-code-lang
 aliases:
     - /tracing/languages
+    - /tracing/setup_overview/setup/undefined
 ---
 
 Set up your application to send [traces][1] using one of the following official Datadog tracing libraries:


### PR DESCRIPTION

### What does this PR do?
Had reports of 404s to `/tracing/setup_overview/setup/undefined` presumably caused by someone with an undefined programming language cookie? Providing a place for those to land.

### Motivation
Slack convo with Ruth

### Preview

These should go to a real page (with the language tiles on it), not 404:

https://docs-staging.datadoghq.com/kari/aliasfordefault/tracing/setup_overview/setup/undefined
https://docs-staging.datadoghq.com/kari/aliasfordefault/tracing/setup_overview/compatibility_requirements/undefined
https://docs-staging.datadoghq.com/kari/aliasfordefault/tracing/setup_overview/custom_instrumentation/undefined


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
