### PR TITLE
fix link to office hours zoom

### DIFF
--- a/content/en/developers/office_hours.md
+++ b/content/en/developers/office_hours.md
@@ -30,6 +30,6 @@ Discover the full list of [Datadog open-source projects at GitHub][5].
 
 [1]: https://datadoghq.slack.com
 [2]: http://chat.datadoghq.com
-[3]: https://datadog.zoom.us/j/312430886
+[3]: https://datadog.zoom.us/j/312430886?pwd=SkJxaks5QzRWdXBCN3A5aVFPdjBHQT09
 [4]: /help/
 [5]: https://github.com/DataDog

--- a/content/fr/developers/office_hours.md
+++ b/content/fr/developers/office_hours.md
@@ -29,6 +29,6 @@ Découvrez la liste complète des [projets Datadog open source sur GitHub][5].
 
 [1]: https://datadoghq.slack.com
 [2]: http://chat.datadoghq.com
-[3]: https://datadog.zoom.us/j/312430886
+[3]: https://datadog.zoom.us/j/312430886?pwd=SkJxaks5QzRWdXBCN3A5aVFPdjBHQT09
 [4]: /fr/help/
 [5]: https://github.com/DataDog

--- a/content/ja/developers/office_hours.md
+++ b/content/ja/developers/office_hours.md
@@ -29,6 +29,6 @@ Datadog では、Datadog [オープンソースプロジェクト](#オープン
 
 [1]: https://datadoghq.slack.com
 [2]: http://chat.datadoghq.com
-[3]: https://datadog.zoom.us/j/312430886
+[3]: https://datadog.zoom.us/j/312430886?pwd=SkJxaks5QzRWdXBCN3A5aVFPdjBHQT09
 [4]: /ja/help/
 [5]: https://github.com/DataDog


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes the link to the Office Hours Zoom meeting.

### Motivation
Fixing the link to the Office Hours Zoom Meeting.

### Preview
It's a URL change. There is nothing to preview.

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
