### PR TITLE
fix issue where previous params leaking to other endpoints

### DIFF
--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -153,7 +153,7 @@
                     <p>{{ $translate_action.description | default $endpoint.action.description | markdownify }}</p>
 
                     <!-- querystring, path params, header params -->
-                    {{ partial "api/arguments.html" (dict "context" $dot "parameters" $endpoint.action.parameters) }}
+                    {{ partial "api/arguments.html" (dict "context" $dot "endpoint" $endpoint) }}
 
                     <!-- request body -->
                     {{ partial "api/request-body.html" (dict "context" $dot "body" $endpoint.action.requestBody "resourcePage" $resourcePage "operationid" $endpoint.action.operationId "translate_action" $translate_action) }}

--- a/layouts/partials/api/arguments-data.html
+++ b/layouts/partials/api/arguments-data.html
@@ -1,0 +1,17 @@
+{{- $endpoint := .endpoint -}}
+{{- $queryStrings := slice -}}
+{{- $pathParams := slice -}}
+{{- $headerParams := slice -}}
+{{- with $endpoint.action.parameters -}}
+    {{- range . -}}
+        {{- if eq .in "query" -}}
+            {{- $queryStrings = $queryStrings | append . -}}
+        {{- else if eq .in "path" -}}
+            {{- $pathParams = $pathParams | append . -}}
+        {{- else if eq .in "header" -}}
+            {{- $headerParams = $headerParams | append . -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+{{- $exists := (or (gt (len $queryStrings) 0) (gt (len $pathParams) 0) (gt (len $headerParams) 0)) -}}
+{{- return (dict "isExists" $exists "queryStrings" $queryStrings "pathParams" $pathParams "headerParams" $headerParams) -}}

--- a/layouts/partials/api/arguments.html
+++ b/layouts/partials/api/arguments.html
@@ -1,32 +1,11 @@
 {{ $context := .context }}
-{{ $s := newScratch }}
-{{ $parameters := .parameters }}
-{{ $s.Set "queryStrings" slice }}
-{{ $s.Set "pathParams" slice }}
-{{ $s.Set "headerParams" slice }}
+{{ $endpoint := .endpoint }}
+{{ $parameters := partial "api/arguments-data.html" (dict "endpoint" $endpoint) }}
 
-{{ with $parameters }}
+{{ with $parameters.isExists }}
     <h3 class="mb-2">{{ i18n "arguments" }}</h3>
 
-    {{ range . }}
-        {{ if eq .in "query"}}
-            {{ $s.Add "queryStrings" .  }}
-        {{ else if eq .in "path"}}
-            {{ $s.Add "pathParams" .  }}
-        {{ else if eq .in "header"}}
-            {{ $s.Add "headerParams" .  }}
-        {{ end }}
-    {{ end }}
-
-    {{ $queryStrings := $s.Get "queryStrings" }}
-    {{ $pathParams := $s.Get "pathParams" }}
-    {{ $headerParams := $s.Get "headerParams" }}
-    <!-- Set for curl to use via dollarscratch -->
-    {{ $context.Scratch.Set "queryStrings" $queryStrings }}
-    {{ $context.Scratch.Set "pathParams" $pathParams }}
-    {{ $context.Scratch.Set "headerParams" $headerParams }}
-
-    {{ with $pathParams }}
+    {{ with $parameters.pathParams }}
         <h4 class="text-capitalize">{{ i18n "path_parameters" }}</h4>
         <div class=" schema-table row">
             <div class="col-12">
@@ -62,7 +41,7 @@
         </div>
     {{ end }}
 
-    {{ with $queryStrings }}
+    {{ with $parameters.queryStrings }}
         <h4 class="text-capitalize">{{ i18n "query_strings" }}</h4>
         <div class=" schema-table row">
             <div class="col-12">
@@ -98,8 +77,7 @@
         </div>
     {{ end }}
 
-
-    {{ with $headerParams }}
+    {{ with $parameters.headerParams }}
         <h4 class="text-capitalize">{{ i18n "header_parameters" }}</h4>
         <div class=" schema-table row">
             <div class="col-12">

--- a/layouts/partials/api/curl.html
+++ b/layouts/partials/api/curl.html
@@ -1,18 +1,17 @@
 {{- $securitySchemes := .securitySchemes -}}
 {{- $dollarScratch := .dollarScratch }}
-{{- $pathParams := $dollarScratch.Get "pathParams" -}}
-{{- $queryStrings := $dollarScratch.Get "queryStrings" -}}
 {{- $endpoint := .endpoint }}
+{{- $parameters := partial "api/arguments-data.html" (dict "endpoint" $endpoint) -}}
 {{- $count := 0 -}}
 
-{{- with $pathParams -}}
+{{- with $parameters.pathParams -}}
     <span class="c1"># Path parameters</span><br/>
     {{- range . -}}
         <span class="kn">export</span> <span class="n">{{ .name }}</span><span class="o">=</span><span class="s1">"{{ .example | default (.schema.example | default "CHANGE_ME") }}"</span><br/>
     {{- end -}}
 {{- end -}}
 
-{{- with $queryStrings -}}
+{{- with $parameters.queryStrings -}}
     {{- $i := 0 -}}
     {{- range . -}}
         {{- if eq .required true -}}
@@ -36,7 +35,7 @@
 
 <span class="c1"># Curl command</span>
 <span class="n">curl</span> <span class="o">-X</span> <span class="s1">{{ $endpoint.actionType | upper }}</span> {{ range $region, $url := $endpoint.regions }}{{ if ne $region "local" }}<span class="kn d-none" data-region="{{ $region }}">"{{ $url }}</span>{{ else }}<span class="kn">"{{ $url }}</span>{{ end }}{{ end }}<span class="kn">{{ replace $endpoint.pathKey "{" "${" }}</span>
-{{- range $qi, $q := $queryStrings -}}
+{{- range $qi, $q := $parameters.queryStrings -}}
     {{- if eq .required true -}}
         <span class="kn">{{ cond (gt $qi 0) "&" "?" }}</span><span class="kn">{{ $q.name }}</span><span class="kn">=</span><span class="kn">${ {{- $q.name -}} }</span>
     {{- end -}}


### PR DESCRIPTION
### What does this PR do?

This PR seperates the collection of parameters for endpoints into one location to fix an issue where previous params for an endpoint were leaking through to subsequent ones.

e.g  this would appear when it wasn't needed
```bash
# Path parameters
export location_id="CHANGE_ME"
```

### Motivation
slack

### Preview

compared to live
https://docs-staging.datadoghq.com/david.jones/curl-params/api/latest/synthetics/#delete-tests
https://docs-staging.datadoghq.com/david.jones/curl-params/api/latest/synthetics/#get-all-locations-public-and-private

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
