### PR TITLE
disable version button when latest

### DIFF
--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -78,7 +78,7 @@
             {{ range $versionIndex, $versionNum := $menuChild.Params.versions }}
               {{ $endpointVisibility := partial "api/endpoint-visibility.html" (dict "versionCount" $versionCount "versionNum" $versionNum "menuChild" $menuChild) }}
               <li class="nav-item">
-                <a class="nav-link mr-1 {{ if $endpointVisibility.isVisibleVersion }}active{{ end }}" data-toggle="tab" href="#{{ (print $anchorStr "-" $versionNum) | anchorize }}">{{ $versionNum }} ({{ $endpointVisibility.label }})</a>
+                <a class="nav-link mr-1 {{ if and ($endpointVisibility.isVisibleVersion) (gt (len $menuChild.Params.versions) 1) }}active{{ end }} {{ if eq (len $menuChild.Params.versions) 1 }}disabled{{ end }}" data-toggle="tab" href="#{{ (print $anchorStr "-" $versionNum) | anchorize }}">{{ $versionNum }} ({{ $endpointVisibility.label }})</a>
               </li>
             {{ end }}
           </ul>


### PR DESCRIPTION
### What does this PR do?
When there is only one api version button make it disabled/stand out less as clicking it has no effect.

### Motivation
slack

### Preview
https://docs-staging.datadoghq.com/david.jones/api-btn-disable/api/latest/ip-ranges/

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
