### PR TITLE
integrations sidebar css fix

### DIFF
--- a/src/styles/components/_integrations.scss
+++ b/src/styles/components/_integrations.scss
@@ -18,14 +18,6 @@ $ddpurple:    #632CA6;
     border-radius: 2px 0px 0px 2px;
     padding: 0.375rem 1rem;
   }
-
-  .sidebar {
-    display: none;
-
-    @include media-breakpoint-up(xl) {
-      display: flex;
-    }
-  }
 }
 
 .integrations-single {


### PR DESCRIPTION
### What does this PR do?
Fixes sidebar/TOC styles for Integrations details pages in live.

### Motivation
Slack - https://dd.slack.com/archives/C3CT8QA11/p1612971674087000?thread_ts=1612968866.086200&cid=C3CT8QA11

### Preview
- Integrations list page should not have a sidebar/TOC at all: https://docs-staging.datadoghq.com/brian.deutsch/toc-fix/integrations
- Integrations detail pages should have the correct sidebar/TOC single column layout: https://docs-staging.datadoghq.com/brian.deutsch/toc-fix/integrations/disk/ compared to live currently: https://docs.datadoghq.com/integrations/disk/.

### Additional Notes
- Navigating around using the left side nav, the sidebar/TOC section should always follow the single column layout (for non-API pages).

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
