### PR TITLE
[DOCS-1604] adding privatelink instructions for kubernetes

### DIFF
--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -213,9 +213,15 @@ To forward your Kubernetes resources to Datadog using this new VPC endpoint, con
     dd_url: orchestrator-pvtlink.datadoghq.com
     ```
 
-2. [Restart your Agent][2] to send Kubernetes resources to Datadog through AWS PrivateLink.
+   For the container Agent, set the following environment variable instead:
 
-**Note**: If you are using the container Agent, set the environment variable instead: `DD_DD_URL="https://orchestrator-pvtlink.datadoghq.com"`. Configure this environment variable on _both_ the Cluster Agent & Node Agent if using the Cluster Agent to monitor a Kubernetes environment.
+   ```
+   DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_DD_URL="orchestrator-pvtlink.datadoghq.com"
+   ```
+
+   Set this for the process Agent as well. If you are using the Cluster Agent to monitor a Kubernetes environment, also configure this environment variable for the Cluster Agent and the node Agent.
+
+2. [Restart your Agent][2] to send Kubernetes resources to Datadog through AWS PrivateLink.
 
 
 [1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file

--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -72,6 +72,13 @@ The overall process consists of configuring an internal endpoint in your VPC tha
 | `com.amazonaws.vpce.us-east-1.vpce-svc-07672d13af0033c24` |
 
 {{% /tab %}}
+{{% tab "Kubernetes Resources" %}}
+
+| Datadog Kubernetes Explorer Service Name                  |
+| --------------------------------------------------------- |
+| `com.amazonaws.vpce.us-east-1.vpce-svc-0b03d6756bf6c2ec3` |
+
+{{% /tab %}}
 {{< /tabs >}}
 
 4. Hit the _verify_ button. If it does not return _Service name found_, reach out to the [Datadog support team][2].
@@ -191,6 +198,24 @@ To forward your trace metrics to Datadog using this new VPC endpoint, configure 
 2. [Restart your Agent][2] to send traces to Datadog through AWS PrivateLink.
 
 **Note**: If you are using the container Agent, set the environment variable instead: `DD_APM_DD_URL="https://trace-pvtlink.agent.datadoghq.com"`. Configure this environment variable on _both_ the Cluster Agent & Node Agent if using the Cluster Agent to monitor a Kubernetes environment.
+
+
+[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
+[2]: /agent/guide/agent-commands/#restart-the-agent
+{{% /tab %}}
+{{% tab "Kubernetes Resources" %}}
+
+To forward your Kubernetes resources to Datadog using this new VPC endpoint, configure `orchestrator-pvtlink.datadoghq.com` as your new orchestrator data destination:
+
+1. Update the `dd_url` parameter in the [Agent `datadog.yaml` configuration file][1]:
+
+    ```yaml
+    dd_url: orchestrator-pvtlink.datadoghq.com
+    ```
+
+2. [Restart your Agent][2] to send Kubernetes resources to Datadog through AWS PrivateLink.
+
+**Note**: If you are using the container Agent, set the environment variable instead: `DD_DD_URL="https://orchestrator-pvtlink.datadoghq.com"`. Configure this environment variable on _both_ the Cluster Agent & Node Agent if using the Cluster Agent to monitor a Kubernetes environment.
 
 
 [1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/cswatt/k8s-privatelink/agent/guide/private-link/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
