### PR TITLE
Fix scroll position on API page anchors

### DIFF
--- a/src/styles/pages/_api.scss
+++ b/src/styles/pages/_api.scss
@@ -21,6 +21,7 @@ $ddpurple: #632ca6;
     h2 {
         margin-top: -80px;
         padding-top: 80px;
+        scroll-margin-top: 95px;
         pointer-events: none;
         background-clip: content-box;
         margin-right: 0;
@@ -39,8 +40,6 @@ $ddpurple: #632ca6;
         top: 2px;
         font-size: 16px;
     }
-
-
 
     a {
         color: #4a4a4a;

--- a/src/styles/pages/_api.scss
+++ b/src/styles/pages/_api.scss
@@ -6,8 +6,8 @@ $ddpurple: #632ca6;
 }
 
 .announcement_banner.open ~ .container .main-api h2 {
-    margin-top: -110px;
-    padding-top: 110px;
+    margin-top: -175px;
+    padding-top: 175px;
 }
 
 .main-api {
@@ -19,9 +19,8 @@ $ddpurple: #632ca6;
     }
 
     h2 {
-        margin-top: -80px;
-        padding-top: 80px;
-        scroll-margin-top: 95px;
+        margin-top: -145px;
+        padding-top: 145px;
         pointer-events: none;
         background-clip: content-box;
         margin-right: 0;


### PR DESCRIPTION
### What does this PR do?
Fixes bug on API pages where the header and api version selectors are being hidden by the breadcrumbs/language selector sticky div.  Here's a screen capture demonstrating the issue in live: https://a.cl.ly/8LukrO2Y

### Motivation
Slack - https://dd.slack.com/archives/C0DESMBQU/p1612979293326900?thread_ts=1612977582.325900&cid=C0DESMBQU

### Preview
- https://docs-staging.datadoghq.com/brian.deutsch/async-scroll-pos-fix/api/
- using the left side nav, users should be able to click the nested anchors for each endpoint on a page and clearly see the title and api version selector(s).  


### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
