### PR TITLE
Raise CPU limit to 0.5 CPUs in our ECS example

### DIFF
--- a/static/resources/json/datadog-agent-ecs-win.json
+++ b/static/resources/json/datadog-agent-ecs-win.json
@@ -3,7 +3,7 @@
     {
       "name": "datadog-agent",
       "image": "datadog/agent:latest",
-      "cpu": 100,
+      "cpu": 512,
       "memory": 512,
       "essential": true,
       "mountPoints": [


### PR DESCRIPTION
### What does this PR do?
Update our sample ECS config file with a higher CPU limit.

### Motivation
100 cpu units (~0.1 CPUs) are not enough for the Agent to start, we time out.

### Additional Notes
On ECS, 1024 units = 1 CPU
