### PR TITLE
[WEB-1182] required label incorrectly output

### DIFF
--- a/layouts/partials/api/arguments.html
+++ b/layouts/partials/api/arguments.html
@@ -25,7 +25,7 @@
                         <div class="col-12 first-column">
                         <div class="row first-row ">
                             <div class="col-4 column">
-                                <p>{{- .name -}}{{- cond (eq .required false) "" "&nbsp;[<em>required</em>]" | safeHTML -}}</em></p>
+                                <p>{{- .name -}}{{- with .required -}}{{- cond (eq . false) "" "&nbsp;[<em>required</em>]" | safeHTML -}}{{- end -}}</p>
                             </div>
                             <div class="col-2 column">
                                 <p>{{ .schema.type }}</p>
@@ -61,7 +61,7 @@
                         <div class="col-12 first-column">
                         <div class="row first-row ">
                             <div class="col-4 column">
-                                <p>{{- .name -}}{{- cond (eq .required false) "" "&nbsp;[<em>required</em>]" | safeHTML -}}</em></p>
+                                <p>{{- .name -}}{{- with .required -}}{{- cond (eq . false) "" "&nbsp;[<em>required</em>]" | safeHTML -}}{{- end -}}</p>
                             </div>
                             <div class="col-2 column">
                                 <p>{{ .schema.type }}</p>
@@ -97,7 +97,7 @@
                         <div class="col-12 first-column">
                         <div class="row first-row ">
                             <div class="col-4 column">
-                                <p>{{- .name -}}{{- cond (eq .required false) "" "&nbsp;[<em>required</em>]" | safeHTML -}}</em></p>
+                                <p>{{- .name -}}{{- with .required -}}{{- cond (eq . false) "" "&nbsp;[<em>required</em>]" | safeHTML -}}{{- end -}}</p>
                             </div>
                             <div class="col-2 column">
                                 <p>{{ .schema.type }}</p>


### PR DESCRIPTION
### What does this PR do?

The api path, query and header params table is outputting the required label incorrectly.
The reason is that In some instances the required setting didn't exist in the spec and comparing this nil value against false would cause the required label to output when it shouldn't.

This PR fixes this by only running the label logic when the required spec setting exists.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1182

### Preview

see the query params table here vs prod
The impact is that scope and end will no longer have required labels next to them
https://docs-staging.datadoghq.com/david.jones/required-label-arguments/api/latest/monitors/#mute-a-monitor

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
