### PR TITLE
[agent/logs] Document file tailing from annotation

### DIFF
--- a/content/en/agent/docker/log.md
+++ b/content/en/agent/docker/log.md
@@ -231,7 +231,7 @@ See the [multi-line processing rule documentation][1] to get more pattern exampl
 {{% /tab %}}
 {{% tab "From file" %}}
 
-The Agent v7.25.0+/6.25.0+ can directly collect logs from a file based on a container Autodiscovery label. To collect these logs, use the `com.datadoghq.ad.logs` label as shown below on your containers to collect `/logs/app.log`:
+The Agent v7.25.0+/6.25.0+ can directly collect logs from a file based on a container Autodiscovery label. To collect these logs, use the `com.datadoghq.ad.logs` label as shown below on your containers to collect `/logs/app/prod.log`:
 
 ```yaml
 labels:
@@ -251,7 +251,7 @@ labels:
     com.datadoghq.ad.logs: '[{"type":"file", "source": "java", "service": "app", "path": "/logs/app/prod.log"}, {"type": "docker", "source": "app_container", "service": "app"}]'
 ```
 
-- When using this kind of combination, `source` and `service` have no default value and should be explicitly set in the Autodiscovery label.   
+- When using this kind of combination, `source` and `service` have no default value and should be explicitly set in the Autodiscovery label.
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/agent/kubernetes/log.md
+++ b/content/en/agent/kubernetes/log.md
@@ -449,6 +449,38 @@ Unlike auto-conf files, **key-value stores may use the short OR long image name 
 {{% /tab %}}
 {{< /tabs >}}
 
+### Examples - Log collection from file configured in an annotation
+
+The Agent v7.26.0+/6.26.0+ can directly collect logs from a file based on an annotation. To collect these logs, use the `ad.datadoghq.com/<CONTAINER_IDENTIFIER>.logs` with a file type configuration. Logs collected from file with such an annotation will automatically be tagged with same set of tags that logs coming from the container itself.
+
+So to collect logs from `/logs/app/prod.log` from a container named `webapp` inside a Kubernetes pod, the pod definition would have to be:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: webapp
+  annotations:
+    ad.datadoghq.com/webapp.logs: '[{"type":"file", "source": "webapp", "service": "backend-prod", "path": "/logs/app/prod.log"}]'
+  labels:
+    name: webapp
+spec:
+  containers:
+    - name: webapp
+      image: webapp:latest
+```
+
+**Notes**:
+
+- The file path is **relative** to the Agent, so the directory containing the file should be shared between the container running the application and the Agent container. For example, if the container mounts `/logs` each container logging to file may mount a volume such as `/logs/app` where the log file is written. Please check Kubernetes documentation for further detail on sharing volumes between pods/containers.
+
+- When using this kind of annotation on for a container, its ouptut logs are not collected automatically. If collection from both the container and a file are needed it should be explicity enabled in the annotation, for example:
+```yaml
+    ad.datadoghq.com/<CONTAINER_IDENTIFIER>.logs: '[{"type":"file", "source": "webapp", "service": "backend-prod", "path": "/logs/app/prod.log"}, {"source": "container", "service": "app"}]'
+```
+
+- When using this kind of combination, `source` and `service` have no default value for log collected from a file and should be explicitly set in the annotation.
+
 
 ## Advanced log collection
 

--- a/content/en/agent/kubernetes/log.md
+++ b/content/en/agent/kubernetes/log.md
@@ -472,7 +472,7 @@ spec:
 
 **Notes**:
 
-- The file path is **relative** to the Agent, so the directory containing the file should be shared between the container running the application and the Agent container. For example, if the container mounts `/logs` each container logging to file may mount a volume such as `/logs/app` where the log file is written. Please check Kubernetes documentation for further detail on sharing volumes between pods/containers.
+- The file path is **relative** to the Agent, so the directory containing the file should be shared between the container running the application and the Agent container. For example, if the container mounts `/logs` each container logging to a file may mount a volume such as `/logs/app`, where the log file is written. Please check Kubernetes documentation for further detail on sharing volumes between pods/containers.
 
 - When using this kind of annotation on for a container, its ouptut logs are not collected automatically. If collection from both the container and a file are needed it should be explicity enabled in the annotation, for example:
 ```yaml

--- a/content/en/agent/kubernetes/log.md
+++ b/content/en/agent/kubernetes/log.md
@@ -451,7 +451,7 @@ Unlike auto-conf files, **key-value stores may use the short OR long image name 
 
 ### Examples - Log collection from file configured in an annotation
 
-The Agent v7.26.0+/6.26.0+ can directly collect logs from a file based on an annotation. To collect these logs, use the `ad.datadoghq.com/<CONTAINER_IDENTIFIER>.logs` with a file type configuration. Logs collected from file with such an annotation will automatically be tagged with same set of tags that logs coming from the container itself.
+The Agent v7.26.0+/6.26.0+ can directly collect logs from a file based on an annotation. To collect these logs, use `ad.datadoghq.com/<CONTAINER_IDENTIFIER>.logs` with a file type configuration. Logs collected from files with such an annotation are automatically tagged with the same set of tags as logs coming from the container itself.
 
 For example, to collect logs from `/logs/app/prod.log` from a container named `webapp` inside a Kubernetes pod, the pod definition would be:
 
@@ -474,12 +474,12 @@ spec:
 
 - The file path is **relative** to the Agent, so the directory containing the file should be shared between the container running the application and the Agent container. For example, if the container mounts `/logs` each container logging to a file may mount a volume such as `/logs/app`, where the log file is written. Please check Kubernetes documentation for further detail on sharing volumes between pods/containers.
 
-- When using this kind of annotation on for a container, its ouptut logs are not collected automatically. If collection from both the container and a file are needed it should be explicity enabled in the annotation, for example:
+- When using this kind of annotation with a container, output logs are not collected automatically. If collection from both the container and a file are needed it should be explicitly enabled in the annotation, for example:
 ```yaml
     ad.datadoghq.com/<CONTAINER_IDENTIFIER>.logs: '[{"type":"file", "source": "webapp", "service": "backend-prod", "path": "/logs/app/prod.log"}, {"source": "container", "service": "app"}]'
 ```
 
-- When using this kind of combination, `source` and `service` have no default value for log collected from a file and should be explicitly set in the annotation.
+- When using this kind of combination, `source` and `service` have no default value for logs collected from a file and should be explicitly set in the annotation.
 
 
 ## Advanced log collection

--- a/content/en/agent/kubernetes/log.md
+++ b/content/en/agent/kubernetes/log.md
@@ -453,7 +453,7 @@ Unlike auto-conf files, **key-value stores may use the short OR long image name 
 
 The Agent v7.26.0+/6.26.0+ can directly collect logs from a file based on an annotation. To collect these logs, use the `ad.datadoghq.com/<CONTAINER_IDENTIFIER>.logs` with a file type configuration. Logs collected from file with such an annotation will automatically be tagged with same set of tags that logs coming from the container itself.
 
-So to collect logs from `/logs/app/prod.log` from a container named `webapp` inside a Kubernetes pod, the pod definition would have to be:
+For example, to collect logs from `/logs/app/prod.log` from a container named `webapp` inside a Kubernetes pod, the pod definition would be:
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
### What does this PR do?
Document new logs agent feature coming with the next release.
Slight harmonisation for the related feature on docker.

### Motivation
Keep doc up to date.

### Preview


https://docs-staging.datadoghq.com/prognant/file-tailine-from-k8s-annotation/agent/kubernetes/log

### Additional Notes

~Do not merge before agent 7.26.0 is released.~ [Agent v7.26.0 has been released 
](https://github.com/DataDog/datadog-agent/releases/tag/7.26.0)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.