### PR TITLE
Removed quotes around DD_API_KEY

### DIFF
--- a/content/en/agent/docker/apm.md
+++ b/content/en/agent/docker/apm.md
@@ -44,7 +44,7 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /proc/:/host/proc/:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
               -p 127.0.0.1:8126:8126/tcp \
-              -e DD_API_KEY="<DATADOG_API_KEY>" \
+              -e DD_API_KEY=<DATADOG_API_KEY> \
               -e DD_APM_ENABLED=true \
               gcr.io/datadoghq/agent:latest
 ```
@@ -54,7 +54,7 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
 
 ```shell
 docker run -d -p 127.0.0.1:8126:8126/tcp \
-              -e DD_API_KEY="<DATADOG_API_KEY>" \
+              -e DD_API_KEY=<DATADOG_API_KEY> \
               -e DD_APM_ENABLED=true \
               gcr.io/datadoghq/agent:latest
 ```
@@ -127,7 +127,7 @@ docker run -d --name app \
 # Datadog Agent
 docker run -d --name datadog-agent \
               --network "<NETWORK_NAME>" \
-              -e DD_API_KEY="<DATADOG_API_KEY>" \
+              -e DD_API_KEY=<DATADOG_API_KEY> \
               -e DD_APM_ENABLED=true \
               -e DD_APM_NON_LOCAL_TRAFFIC=true \
               gcr.io/datadoghq/agent:latest


### PR DESCRIPTION
Current public documentation implies there should be quotes around API key environment variable.

### What does this PR do?
Remove quotes around DD_API_KEY as these are unnecessary 

### Motivation
This is a very subtle issue with no error message
https://datadog.zendesk.com/agent/tickets/445886

### Preview
https://docs-staging.datadoghq.com/alisha/update_tracing_docker_public_doc/agent/docker/apm/?tab=windows 

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
