### PR TITLE
Update the parameter name of the sample code to adjust to the caller method

### DIFF
--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -71,7 +71,7 @@ dependencies {
     ```java
     public class Handler implements RequestHandler<APIGatewayV2ProxyRequestEvent, APIGatewayV2ProxyResponseEvent> {
         public Integer handleRequest(APIGatewayV2ProxyRequestEvent request, Context context){
-            DDLambda dd = new DDLambda(request, lambda);
+            DDLambda dd = new DDLambda(request, context);
         }
     }
     ```
@@ -99,7 +99,7 @@ If you would like to submit a custom metric, see the sample code below:
 ```java
 public class Handler implements RequestHandler<APIGatewayV2ProxyRequestEvent, APIGatewayV2ProxyResponseEvent> {
     public Integer handleRequest(APIGatewayV2ProxyRequestEvent request, Context context){
-        DDLambda dd = new DDLambda(request, lambda);
+        DDLambda dd = new DDLambda(request, context);
 
         Map<String,String> myTags = new HashMap<String, String>();
             myTags.put("product", "latte");


### PR DESCRIPTION
Replace the DDLambda() parameter name `lambda` with `context` to adjust handlerRequest() parameter name.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
