### PR TITLE
Add doc for PL helm chart

### DIFF
--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -168,7 +168,7 @@ docker-compose -f docker-compose.yml up
 
 {{% /tab %}}
 
-{{% tab "Kubernetes" %}}
+{{% tab "Kubernetes Deployment" %}}
 
 1. Create a Kubernetes ConfigMap with the previously created JSON file by executing the following:
 
@@ -216,6 +216,28 @@ docker-compose -f docker-compose.yml up
     ```
 
 [1]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+
+{{% /tab %}}
+
+{{% tab "Helm Chart" %}}
+
+1. Add the [Datadog Synthetics Private Location][1] to your Helm repositories:
+
+    ```shell
+    helm repo add datadog https://helm.datadoghq.com 
+    helm repo update
+    ```
+
+2. Install the chart with the release name `<RELEASE_NAME>`, using the previously created JSON file by executing the following:
+
+    ```shell
+    helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file configFile=<MY_WORKER_CONFIG_FILE_NAME>.json
+    ```
+
+    **Note:** If you blocked reserved IPs, make sure to add the `NET_ADMIN` [Linux capabilities][2] to your private location container.
+
+[1]: https://github.com/DataDog/helm-charts/tree/master/charts/synthetics-private-location
+[2]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 
 {{% /tab %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR adds documentation for private location deployment using helm charts

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/margot.lepizzera/pl_helmcharts/synthetics/private_locations?tab=helmchart 

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
