### PR TITLE
Remove <type>pom</type> option from sample pom.xml

### DIFF
--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -44,7 +44,6 @@ Include the following dependency in your `pom.xml`:
   <groupId>com.datadoghq</groupId>
   <artifactId>datadog-lambda-java</artifactId>
   <version>n.n.n</version>
-  <type>pom</type>
 </dependency>
 ```
 


### PR DESCRIPTION
Remove <type>pom</type> option.
Jar file is not downloaded with this option, it result in unresolved dependency.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
