### PR TITLE
Updating Syn authentication guide

### DIFF
--- a/content/en/synthetics/guide/_index.md
+++ b/content/en/synthetics/guide/_index.md
@@ -12,6 +12,6 @@ private: true
 {{< whatsnext desc="Browser Tests:" >}}
     {{< nextlink href="synthetics/guide/email-validation" >}}Email validation with browser tests{{< /nextlink >}}
     {{< nextlink href="synthetics/guide/testing-file-upload-and-download/" >}}Test file upload and download{{< /nextlink >}}
-    {{< nextlink href="synthetics/guide/app-that-requires-login/" >}}Monitor an application that requires a login{{< /nextlink >}}
+    {{< nextlink href="synthetics/guide/app-that-requires-login/" >}}Monitor an application that requires authentication{{< /nextlink >}}
     {{< nextlink href="synthetics/guide/manually-adding-chrome-extension/" >}}Manually adding the Browser Test Chrome Extension{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/synthetics/guide/app-that-requires-login.md
+++ b/content/en/synthetics/guide/app-that-requires-login.md
@@ -1,5 +1,5 @@
 ---
-title: Using Synthetic tests to monitor an application that requires a login
+title: Running tests on an application that requires authentication
 kind: guide
 further_reading:
     - link: 'synthetics/browser_tests'
@@ -63,7 +63,7 @@ The second way to ensure that your Datadog Browser tests can login into your app
 
 - Specific headers
 - Cookies
-- Basic, Digest or NTLM credentials
+- Basic, Digest, Bearer or NTLM credentials
 
 These are set at every test execution and consequently allow you to start the recording of your steps directly post login. 
 


### PR DESCRIPTION
- Changing title to include authentication rather than login
- Include bearer support

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/margot.lepizzera/guide_auth/synthetics/guide/app-that-requires-login/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
