### PR TITLE
Fix instructions for jfr-template-overrides

### DIFF
--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -20,7 +20,7 @@ If the default setup overhead is not acceptable, you can use the profiler with m
 - Increases sampling threshold to 500ms for `ThreadSleep`, `ThreadPark`, and `JavaMonitorWait` events compared to 100ms default
 - Disables `ObjectAllocationInNewTLAB`, `ObjectAllocationOutsideTLAB`, `ExceptionSample`, `ExceptionCount` events
 
-To use the minimal configuration ensure you have `dd-trace-java` version `0.70.0` then change your service invocation to the following:
+To use the minimal configuration ensure you have `dd-java-agent` version `0.70.0` then change your service invocation to the following:
 
 ```
 java -javaagent:dd-java-agent.jar -Ddd.profiling.enabled=true -Ddd.profiling.jfr-template-override-file=minimal -jar <YOUR_SERVICE>.jar <YOUR_SERVICE_FLAGS>


### PR DESCRIPTION
### What does this PR do?

This fixes the  instructions for jfr-template-overrides.

### Motivation

The `jfr` template overrides are part of the agent, not `dd-trace-java`.

[`dd-trace-java`](https://search.maven.org/artifact/com.datadoghq/dd-trace-java) seems to have been an earlier version of the agent or something else, but has not been updated since 2017.

### Preview

~~Replace the branch name and add the complete path: https://docs-staging.datadoghq.com/BRANCH_NAME/PATH~~

Does not apply, as I don't work at Datadog.  The affected page on the website would be <https://docs.datadoghq.com/tracing/profiler/profiler_troubleshooting>.

### Additional Notes

No, it should be a simple documentation change

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
