### PR TITLE
adjust search results apm v serverless

### DIFF
--- a/local/etc/algolia/docs_datadoghq_preview.json
+++ b/local/etc/algolia/docs_datadoghq_preview.json
@@ -43,6 +43,7 @@
                     "tracing",
                     "logs",
                     "synthetics",
+                    "serverless",
                     "real_user_monitoring",
                     "developers"
                 ],
@@ -99,9 +100,9 @@
                     "real_user_monitoring",
                     "security",
                     "security_monitoring",
-                    "serverless",
                     "synthetics",
                     "tracing",
+                    "serverless",
                     "watchdog"
                 ]
             },


### PR DESCRIPTION
### What does this PR do?
On preview/staging, adjusts relative placement of APM v Serverless in search results

### Motivation
DOCS-1696 Trying to get APM results for basic terms like "java tracing" to be returned above Serverless hits.

### Preview
https://docs-staging.datadoghq.com/kari/apm-search-results/

### Additional Notes
This is just step 1 in addressing this. Kari to test thoroughly before updating prod search also.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
