### PR TITLE
alibaba should be h3 not h2

### DIFF
--- a/content/en/integrations/faq/cloud-metric-delay.md
+++ b/content/en/integrations/faq/cloud-metric-delay.md
@@ -28,7 +28,7 @@ When using any Datadog cloud integration (AWS, Azure, GCP, etc.), metrics are pu
 
 These are specifics related to particular cloud providers.
 
-## Alibaba
+### Alibaba
 
 Alibaba emits metrics with one-minute granularity. Therefore, expect metric delays of ~7-8 minutes.
 


### PR DESCRIPTION
### What does this PR do?
Fixes `alibaba` header to be h3 not h2

### Motivation
https://dd.slack.com/archives/C3CT8QA11/p1613399715102100

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/cloud-metric-delay-fix/integrations/faq/cloud-metric-delay/#cloud-providers

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
