### PR TITLE
adds Azure mapping attributes to the docs

### DIFF
--- a/content/en/account_management/saml/_index.md
+++ b/content/en/account_management/saml/_index.md
@@ -59,6 +59,12 @@ Users with the Access Management permission can assign or remove Datadog roles b
 3. Specify the SAML identity provider key-value pair that you want to associate with an existing Datadog role (either default or custom). For example, if you want all users whose `member_of` attribute has a value of `Development` to be assigned to a custom Datadog role called `Devs`: 
 
     {{< img src="account_management/saml/create_mapping.png" alt="Creating a SAML mapping to Datadog Role"  >}}
+    
+    <div class="alert alert-info">
+      <strong>Azure users:</strong> The mapping attributes will be similar to the following:
+        Attribute key: `http://schemas.microsoft.com/ws/2008/06/identity/claims/groups`
+        Attribute value: `[group id]`
+    </div>
 
 4. If you have not already done so, enable mappings by clicking **Enable Mappings**. 
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

adds a note for azure users about what Azure specific attributes to enter in the DD role mappings.

### Motivation
client request, ZD ticket:https://datadog.zendesk.com/agent/tickets/440816

### Preview
https://docs.datadoghq.com/account_management/saml/#mapping-saml-attributes-to-datadog-roles

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
I'm not exactly sure what the display would be for the alert-info box will be, I assume it's blue. Please feel free to edit if there is a better format to describe how azure enters the role mappings.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
