### PR TITLE
Correct the description of avg in histograms

### DIFF
--- a/content/en/developers/metrics/dogstatsd_metrics_submission.md
+++ b/content/en/developers/metrics/dogstatsd_metrics_submission.md
@@ -663,7 +663,7 @@ The above instrumentation produces the following metrics:
 | Metric                                  | Description                             |
 |-----------------------------------------|-----------------------------------------|
 | `example_metric.histogram.count`        | Number of times this metric was sampled |
-| `example_metric.histogram.avg`          | Average time of the sampled values      |
+| `example_metric.histogram.avg`          | Average of the sampled values           |
 | `example_metric.histogram.median`       | Median sampled value                    |
 | `example_metric.histogram.max`          | Maximum sampled value                   |
 | `example_metric.histogram.95percentile` | 95th percentile sampled value           |
@@ -769,7 +769,7 @@ As DogStatsD receives the timer metric data, it calculates the statistical distr
 | Metric                              | Description                             |
 |-------------------------------------|-----------------------------------------|
 | `example_metric.timer.count`        | Number of times this metric was sampled |
-| `example_metric.timer.avg`          | Average time of the sampled values      |
+| `example_metric.timer.avg`          | Average of the sampled values           |
 | `example_metric.timer.median`       | Median sampled value                    |
 | `example_metric.timer.max`          | Maximum sampled value                   |
 | `example_metric.timer.95percentile` | 95th percentile sampled value           |

--- a/content/en/developers/metrics/dogstatsd_metrics_submission.md
+++ b/content/en/developers/metrics/dogstatsd_metrics_submission.md
@@ -769,7 +769,7 @@ As DogStatsD receives the timer metric data, it calculates the statistical distr
 | Metric                              | Description                             |
 |-------------------------------------|-----------------------------------------|
 | `example_metric.timer.count`        | Number of times this metric was sampled |
-| `example_metric.timer.avg`          | Average of the sampled values           |
+| `example_metric.timer.avg`          | Average time of the sampled values      |
 | `example_metric.timer.median`       | Median sampled value                    |
 | `example_metric.timer.max`          | Maximum sampled value                   |
 | `example_metric.timer.95percentile` | 95th percentile sampled value           |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Correct the description of avg in histograms. We define histograms below and .avg is the average of sampled values, not "average time".
https://docs.datadoghq.com/developers/metrics/types/?tab=histogram#metric-types

### Motivation
<!-- What inspired you to submit this pull request?-->
Docs is incorrect/misleading.

### Preview
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/developers/metrics/dogstatsd_metrics_submission/
<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/mecsantos-patch-1/developers/metrics/dogstatsd_metrics_submission/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
