### PR TITLE
Update send_a_flare.md

### DIFF
--- a/content/en/agent/troubleshooting/send_a_flare.md
+++ b/content/en/agent/troubleshooting/send_a_flare.md
@@ -71,8 +71,10 @@ kubectl exec -it <AGENT_POD_NAME> -c trace-agent -- agent flare <CASE_ID> --loca
   
 ### System probe
 
+The system-probe container cannot send a flare so get container logs instead:
+
 ```bash
-kubectl exec -it <AGENT_POD_NAME> -c system-probe -- agent flare <CASE_ID> --local
+kubectl logs <AGENT_POD_NAME> -c system-probe > system-probe.log
 ```
 
 [1]: /agent/basic_agent_usage/#gui


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
The system-probe cannot send a flare so I changed it to a command that takes the container logs instead.

### Motivation
Correcting our docs.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
