### PR TITLE
update to 48H for monitors

### DIFF
--- a/content/en/monitors/monitor_types/apm.md
+++ b/content/en/monitors/monitor_types/apm.md
@@ -77,7 +77,7 @@ An alert is triggered whenever a metric deviates from an expected pattern.
 ### Select alert conditions
 
 * Trigger when the metric is `above` or `above or equal to`
-* the threshold during the last `5 minutes`, `15 minutes`, `1 hour`, etc. or `custom` to set a value between 5 minutes and 24 hours.
+* the threshold during the last `5 minutes`, `15 minutes`, `1 hour`, etc. or `custom` to set a value between 5 minutes and 48 hours.
 * Alert threshold: `<NUMBER>`
 * Warning threshold: `<NUMBER>`
 

--- a/content/en/monitors/monitor_types/log.md
+++ b/content/en/monitors/monitor_types/log.md
@@ -37,7 +37,7 @@ As you define the search query, the graph above the search fields updates.
 ### Set alert conditions
 
 * Trigger when the metric is `above`, `above or equal to`, `below`, or `below or equal to`
-* the threshold during the last `5 minutes`, `15 minutes`, `1 hour`, etc. or `custom` to set a value between 5 minutes and 24 hours.
+* the threshold during the last `5 minutes`, `15 minutes`, `1 hour`, etc. or `custom` to set a value between 5 minutes and 48 hours.
 * Alert threshold `<NUMBER>`
 * Warning threshold `<NUMBER>`
 

--- a/content/en/monitors/monitor_types/real_user_monitoring.md
+++ b/content/en/monitors/monitor_types/real_user_monitoring.md
@@ -37,7 +37,7 @@ As you define the search query, the graph above the search fields updates.
 ### Set alert conditions
 
 * Trigger when the metric is `above`, `above or equal to`, `below`, or `below or equal to`
-* the threshold during the last `5 minutes`, `15 minutes`, `1 hour`, etc. or `custom` to set a value between 5 minutes and 24 hours.
+* the threshold during the last `5 minutes`, `15 minutes`, `1 hour`, etc. or `custom` to set a value between 5 minutes and 48 hours.
 * Alert threshold `<NUMBER>`
 * Warning threshold `<NUMBER>`
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Edit the log, trace analytics and rum monitor maximum timeframe

### Motivation
maximum timeframe was changed

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/48h-monitor/monitors/monitor_types/real_user_monitoring/#define-the-search-query

https://docs-staging.datadoghq.com/nils/48h-monitor/monitors/monitor_types/log/#overview

https://docs-staging.datadoghq.com/nils/48h-monitor/monitors/monitor_types/real_user_monitoring/#define-the-search-query

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
