### PR TITLE
Add windows/NPM docs

### DIFF
--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -89,7 +89,7 @@ Each configuration item is added as a property to the command line. The followin
 | `DDAGENTUSER_PASSWORD`     | String | Override the cryptographically secure password generated for the `ddagentuser` user during Agent installation _(v6.11.0+)_. Must be provided for installs on domain servers. [Learn more about the Datadog Windows Agent User][3].  |
 | `APPLICATIONDATADIRECTORY` | Path   | Override the directory to use for the configuration file directory tree. May only be provided on initial install; not valid for upgrades. Default: `C:\ProgramData\Datadog`. _(v6.11.0+)_                                           |
 | `PROJECTLOCATION`          | Path   | Override the directory to use for the binary file directory tree. May only be provided on initial install; not valid for upgrades. Default: `%PROGRAMFILES%\Datadog\Datadog Agent`. _(v6.11.0+)_                                    |
-| `NPM`                      | Boolean| Enable the driver component for [Network Performance Monitoring][4]                                                                                                                                                                 |
+| `ADDLOCAL`                 | String | Enable additional agent component. Setting to `"NPM"` causes the driver component for [Network Performance Monitoring][4] to be installed.                                                                                          |
 
 **Note**: If a valid `datadog.yaml` is found and has an API key configured, that file takes precedence over all specified command line options.
 

--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -89,13 +89,14 @@ Each configuration item is added as a property to the command line. The followin
 | `DDAGENTUSER_PASSWORD`     | String | Override the cryptographically secure password generated for the `ddagentuser` user during Agent installation _(v6.11.0+)_. Must be provided for installs on domain servers. [Learn more about the Datadog Windows Agent User][3].  |
 | `APPLICATIONDATADIRECTORY` | Path   | Override the directory to use for the configuration file directory tree. May only be provided on initial install; not valid for upgrades. Default: `C:\ProgramData\Datadog`. _(v6.11.0+)_                                           |
 | `PROJECTLOCATION`          | Path   | Override the directory to use for the binary file directory tree. May only be provided on initial install; not valid for upgrades. Default: `%PROGRAMFILES%\Datadog\Datadog Agent`. _(v6.11.0+)_                                    |
+| `NPM`                      | Boolean| Enable the driver component for [Network Performance Monitoring][4]                                                                                                                                                                 |
 
 **Note**: If a valid `datadog.yaml` is found and has an API key configured, that file takes precedence over all specified command line options.
-
 
 [1]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi
 [2]: /agent/proxy/
 [3]: /agent/faq/windows-agent-ddagent-user/
+[4]: /network_monitoring/performance
 {{% /tab %}}
 {{% tab "Upgrading" %}}
 
@@ -127,7 +128,7 @@ The execution of the Agent is controlled by the Windows Service Control Manager.
 	- Agent versions <= 6.11: `"C:\Program Files\Datadog\Datadog Agent\embedded\agent.exe"`
 	- Agent versions >= 6.12: `"C:\Program Files\Datadog\Datadog Agent\bin\agent.exe"`
 * The configuration GUI is a browser-based configuration application (for Windows 64-bit only).
-* Commands can be run from the an **elevated(run as Admin)** command line (PowerShell or Command Prompt) using the syntax `<PATH_TO_AGENT.EXE> <COMMAND>`. 
+* Commands can be run from the an **elevated(run as Admin)** command line (PowerShell or Command Prompt) using the syntax `<PATH_TO_AGENT.EXE> <COMMAND>`.
 * Command-line options are below:
 
 | Command         | Description                                                                      |

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -183,7 +183,7 @@ To enable network performance monitoring for Windows hosts:
 
 1. Install the [Datadog Agent][1] (version 7.27.0 or above) with the network driver component enabled.
 
-   During installation pass `NPM=true` to the `msiexec` command, or select "Network Performance Monitoring" when running the agent installation through the GUI.
+   During installation pass `ADDLOCAL=NPM` to the `msiexec` command, or select "Network Performance Monitoring" when running the agent installation through the GUI.
 
 1. Edit `C:\ProgramData\Datadog\system-probe.yaml` to set the enabled flag to `true`:
 

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -16,7 +16,7 @@ further_reading:
       text: 'Network Widget'
 ---
 
-Datadog Network Performance Monitoring (NPM) gives you visibility into your network traffic between services, containers, availability zones, and any other tag in Datadog so you can: 
+Datadog Network Performance Monitoring (NPM) gives you visibility into your network traffic between services, containers, availability zones, and any other tag in Datadog so you can:
 
 - Pinpoint unexpected or latent service dependencies.
 - Optimize costly cross-regional or multi-cloud communication.
@@ -25,7 +25,7 @@ Datadog Network Performance Monitoring (NPM) gives you visibility into your netw
 
 Network performance monitoring requires [Datadog Agent v6.14+][1].
 
-## Supported Platforms 
+## Supported Platforms
 
 ### Operating Systems
 
@@ -41,12 +41,11 @@ Data collection is done using eBPF, so Datadog minimally requires platforms that
 - Amazon Linux 2
 - CentOS/RHEL 7.6+
 
-
-**Note:** The [DNS Resolution][4] feature is not supported on [CentOS/RHEL 7.6][3], but is supported on CentOS/RHEL 8+.
+**Note:** There is an exception to the 4.4.0+ kernel requirement for [CentOS/RHEL 7.6+][2]. The [DNS Resolution][3] feature is not supported on CentOS/RHEL 7.6.
 
 #### Windows OS
 
-Data collection is done using a device driver, and support is available in [public beta for Windows Server 2016 or later][4]. 
+Data collection is done using a device driver, and support is available as of Datadog agent version 7.27.0, for Windows versions 2012 and up.
 
 #### macOS
 
@@ -54,15 +53,16 @@ Datadog Network Performance Monitoring does not currently support macOS platform
 
 ### Container Setups
 
-NPM helps you visualize the architecture and performance of your containerized and orchestrated environments, with support for [Docker][5], [Kubernetes][6], [ECS][7], and other container technologies. Datadog’s container integrations enable you to aggregate traffic by meaningful entities -- such as containers, tasks, pods, clusters, and deployments -- with out-of-the -box tags (such as `container_name`, `task_name`, `kube_service`). 
+NPM helps you visualize the architecture and performance of your containerized and orchestrated environments, with support for [Docker][4], [Kubernetes][5], [ECS][6], and other container technologies. Datadog’s container integrations enable you to aggregate traffic by meaningful entities -- such as containers, tasks, pods, clusters, and deployments -- with out-of-the -box tags (such as `container_name`, `task_name`, `kube_service`).
 
 ### Network Routing Tools
 
-#### Istio 
+#### Istio
 
-With NPM, you can map network communication between containers, pods, and services over the Istio service mesh.  
+With NPM, you can map network communication between containers, pods, and services over the Istio service mesh.
 
 Datadog monitors every aspect of your Istio environment, so you can also:
+
 - Assess the health of Envoy and the Istio control plane with [logs][8].
 - Break down the performance of your service mesh with request, bandwidth, and resource consumption [metrics][8].
 - Drill into distributed traces for applications transacting over the mesh with [APM][9].
@@ -71,15 +71,15 @@ NPM supports Istio v1.6.4+ with [Datadog Agent v7.24.1+][1].
 
 To learn more about monitoring your Istio environment with Datadog, [see the Istio blog][10].
 
-#### Cilium 
+#### Cilium
 
 Network Performance Monitoring is compatible with **Cilium** installations, provided the following requirements are met:
 1) Cilium version 1.6 and above, and
 2) Kernel version 5.1.16 and above, or 4.19.57 and above for 4.19.x kernels
 
-### Provisioning Systems 
+### Provisioning Systems
 
-Network Performance Monitoring supports use of the following provisioning systems: 
+Network Performance Monitoring supports use of the following provisioning systems:
 
 - Daemonset / Helm 1.38.11+: See the [Datadog Helm chart][11]
 - Chef 12.7+: See the [Datadog Chef recipe][12]
@@ -170,31 +170,28 @@ If these utilities do not exist in your distribution, follow the same procedure 
 
 ### Windows systems
 
-Data collection for Windows systems is available in public beta for Windows Server versions 2016 or later.
+[1]: /infrastructure/process/?tab=linuxwindows#installation
+[2]: /agent/guide/agent-commands/#restart-the-agent
+[3]: https://github.com/DataDog/datadog-agent/blob/master/cmd/agent/selinux/system_probe_policy.te
+{{% /tab %}}
+{{% tab "Agent (Windows)" %}}
+Data collection for Windows relies on a privileged filter driver for collecting network data.
+
 **Note**: NPM currently monitors Windows hosts only, and not Windows containers. DNS metric collection is not supported for Windows systems.
 
 To enable network performance monitoring for Windows hosts:
 
-1. Install [this custom build][4] of the Datadog Agent.
-2. Edit `C:\ProgramData\Datadog\system-probe.yaml` to set the enable flag to `true`:
+1. Install the [Datadog Agent][1] (version 7.27.0 or above) with the network driver component enabled.
+
+   During installation pass `NPM=true` to the `msiexec` command, or select "Network Performance Monitoring" when running the agent installation through the GUI.
+
+1. Edit `C:\ProgramData\Datadog\system-probe.yaml` to set the enabled flag to `true`:
 
     ```yaml
-    system_probe_config:
-        ## @param enabled - boolean - optional - default: false
-        ## Set to true to enable the System Probe.
-        #
+    network_config:
         enabled: true
     ```
-3. Edit `C:\ProgramData\Datadog\datadog.yaml` to set the enable flag to `true`:
-
-    ```yaml
-    process_config:
-        ## @param enabled - boolean - optional - default: false
-        ## Set to true to enable the System Probe.
-        #
-        enabled: true
-    ```
-4. [Restart the Agent][2].
+3. [Restart the Agent][2].
 
     For PowerShell (`powershell.exe`):
     ```shell
@@ -205,10 +202,9 @@ To enable network performance monitoring for Windows hosts:
     net /y stop datadogagent && net start datadogagent
     ```
 
-[1]: /infrastructure/process/?tab=linuxwindows#installation
+
+[1]: /agent/basic_agent_usage/windows/?tab=commandline
 [2]: /agent/guide/agent-commands/#restart-the-agent
-[3]: https://github.com/DataDog/datadog-agent/blob/master/cmd/agent/selinux/system_probe_policy.te
-[4]: https://s3.amazonaws.com/ddagent-windows-unstable/datadog-agent-7.23.2-beta1-1-x86_64.msi
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 
@@ -428,3 +424,4 @@ To set up on AWS ECS, see the [AWS ECS][1] documentation page.
 [12]: https://github.com/DataDog/chef-datadog
 [13]: https://github.com/DataDog/ansible-datadog/blob/master/README.md#system-probe
 [14]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
+

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -92,7 +92,7 @@ To enable Network Performance Monitoring, configure it in your [Agent's main con
 Given this tool's focus and strength is in analyzing traffic _between_ network endpoints and mapping network dependencies, it is recommended to install it on a meaningful subset of your infrastructure and a **_minimum of 2 hosts_** to maximize value.
 
 {{< tabs >}}
-{{% tab "Agent" %}}
+{{% tab "Agent (Linux)" %}}
 
 To enable network performance monitoring with the Datadog Agent, use the following configurations:
 
@@ -175,9 +175,7 @@ If these utilities do not exist in your distribution, follow the same procedure 
 [3]: https://github.com/DataDog/datadog-agent/blob/master/cmd/agent/selinux/system_probe_policy.te
 {{% /tab %}}
 {{% tab "Agent (Windows)" %}}
-Data collection for Windows relies on a privileged filter driver for collecting network data.
-
-**Note**: NPM currently monitors Windows hosts only, and not Windows containers. DNS metric collection is not supported for Windows systems.
+Data collection for Windows relies on a filter driver for collecting network data.
 
 To enable network performance monitoring for Windows hosts:
 
@@ -201,7 +199,7 @@ To enable network performance monitoring for Windows hosts:
     ```shell
     net /y stop datadogagent && net start datadogagent
     ```
-
+**Note**: NPM currently monitors Windows hosts only, and not Windows containers. DNS metric collection is not supported for Windows systems.
 
 [1]: /agent/basic_agent_usage/windows/?tab=commandline
 [2]: /agent/guide/agent-commands/#restart-the-agent


### PR DESCRIPTION
### What does this PR do?

Adds docs for the planned release of NPM for windows in agent 7.27. 

The main change here is a new tab for windows specific installation for windows.

There are also minor changes to the windows/agent installation page.

I also moved around some links which made the diff rather large. 

### Motivation

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/lee.avital/agent_windows
https://docs-staging.datadoghq.com/lee.avital/agent_windows/network_monitoring/performance/setup/?tab=agent

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
