### PR TITLE
Configure algolia docsearch for APM and serverless

### DIFF
--- a/local/etc/algolia/docs_datadoghq.json
+++ b/local/etc/algolia/docs_datadoghq.json
@@ -43,6 +43,7 @@
                     "tracing",
                     "logs",
                     "real_user_monitoring",
+                    "serverless",
                     "synthetics",
                     "developers"
                 ],
@@ -99,9 +100,9 @@
                     "real_user_monitoring",
                     "security",
                     "security_monitoring",
-                    "serverless",
                     "synthetics",
                     "tracing",
+                    "serverless",
                     "watchdog"
                 ]
             },


### PR DESCRIPTION

### What does this PR do?
Ensures APM terms appear in search results in the correct order relative to Serverless hits

### Motivation
PM request, DOCS-1696

### Preview
Already tested in staging at:
https://docs-staging.datadoghq.com/kari/apm-search-results

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
