### PR TITLE
Add note about PL logs

### DIFF
--- a/content/en/synthetics/private_locations/configuration.md
+++ b/content/en/synthetics/private_locations/configuration.md
@@ -90,6 +90,8 @@ You can upload custom root certificates to your private locations to have your A
 | `dumpFullConfig` | Boolean | `none` | Display full worker configuration parameters. |
 | `help` | Boolean | `none` | Show help. |
 
+**Note**: Private Location containers output logs to stdout/stderr without saving them within the container.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/fr/synthetics/private_locations/configuration.md
+++ b/content/fr/synthetics/private_locations/configuration.md
@@ -89,6 +89,9 @@ Vous pouvez importer des certificats racine privés dans vos emplacements privé
 | `dumpFullConfig` | Booléen | `none` | Afficher les paramètres de configuration du worker complets. |
 | `help` | Booléen | `none` | Afficher les informations d'aide. |
 
+**Remarque** : Pour les conteneurs des Emplacements Privés, les logs sortants sont écrits sur stdout/stderr et ne sont pas sauvegardés au sein des conteneurs. 
+
+
 ## Pour aller plus loin
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/ja/synthetics/private_locations/configuration.md
+++ b/content/ja/synthetics/private_locations/configuration.md
@@ -89,6 +89,8 @@ docker run --rm -v $PWD/<MY_WORKER_CONFIG_FILE_NAME>.json:/etc/datadog/synthetic
 | `dumpFullConfig` | Boolean | `none` | 完全なワーカーコンフィギュレーションパラメーターを表示します。 |
 | `help` | Boolean | `none` | ヘルプを表示します。 |
 
+**注**: プライベートロケーションコンテナログはコンテナ内に保存されず、stdout/stderrに出力されます。
+
 ## その他の参考資料
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add a small note to the Synthetics Private Locations configuration page (en/fr/jp) to explain where logs are being output.

### Motivation
Customer enquiries, zendesk tickets.

### Preview
https://docs-staging.datadoghq.com/homere.faivre/private_locations/synthetics/private_locations/configuration/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
