### PR TITLE
IoT is GA!

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -543,178 +543,183 @@ main:
     parent: agent_kubernetes
     identifier: agent_kubernetes_operator_configuration
     weight: 307
-  - name: Amazon ECS
+    - name: IoT
+    url: agent/iot/
+    parent: agent
+    identifier: agent_iot
+    weight: 4
+    - name: Amazon ECS
     url: agent/amazon_ecs/
     parent: agent
     identifier: agent_amazon_ecs
-    weight: 4
+    weight: 5
   - name: Log collection
     url: agent/amazon_ecs/logs/
     parent: agent_amazon_ecs
     identifier: agent_amazon_ecs_logs
-    weight: 401
+    weight: 501
   - name: APM
     url: agent/amazon_ecs/apm/
     parent: agent_amazon_ecs
     identifier: agent_amazon_ecs_apm
-    weight: 402
+    weight: 502
   - name: Tag extraction
     url: agent/amazon_ecs/tags/
     parent: agent_amazon_ecs
     identifier: agent_amazon_ecs_tags
-    weight: 403
+    weight: 503
   - name: Data collected
     url: agent/amazon_ecs/data_collected/
     parent: agent_amazon_ecs
     identifier: agent_amazon_ecs_data_collected
-    weight: 404
+    weight: 504
   - name: Cluster Agent
     url: agent/cluster_agent/
     parent: agent
     identifier: agent_cluster
-    weight: 5
+    weight: 6
   - name: Setup
     url: agent/cluster_agent/setup/
     parent: agent_cluster
     identifier: cluster_agent_setup
-    weight: 501
+    weight: 601
   - name: Event Collection
     url: agent/cluster_agent/event_collection/
     parent: agent_cluster
     identifier: cluster_agent_event_collection
-    weight: 502
+    weight: 602
   - name: Custom & External Metrics
     url: agent/cluster_agent/external_metrics/
     parent: agent_cluster
     identifier: cluster_agent_external_metrics
-    weight: 503
+    weight: 603
   - name: Cluster Checks
     url: agent/cluster_agent/clusterchecks/
     parent: agent_cluster
-    weight: 504
+    weight: 604
   - name: Endpoints Checks
     url: agent/cluster_agent/endpointschecks/
     parent: agent_cluster
-    weight: 505
+    weight: 605
   - name: Admission Controller
     url: agent/cluster_agent/admission_controller/
     parent: agent_cluster
-    weight: 506
+    weight: 606
   - name: Commands & Options
     url: agent/cluster_agent/commands/
     identifier: cluster_agent_commands
     parent: agent_cluster
-    weight: 507
+    weight: 607
   - name: Cluster metadata provider
     url: agent/cluster_agent/metadata_provider/
     identifier: cluster_agent_metadata_provider
     parent: agent_cluster
-    weight: 508
+    weight: 608
   - name: Build
     url: agent/cluster_agent/build/
     identifier: cluster_agent_build
     parent: agent_cluster
-    weight: 509
+    weight: 609
   - name: Cluster Checks Runner
     url: agent/cluster_agent/clusterchecksrunner
     identifier: cluster_agent_clcr
     parent: agent_cluster
-    weight: 510
+    weight: 610
   - name: Troubleshooting
     url: agent/cluster_agent/troubleshooting/
     identifier: cluster_agent_troubleshooting
     parent: agent_cluster
-    weight: 511
+    weight: 611
   - name: Log Collection
     url: agent/logs/
     identifier: agent_logs
     parent: agent
-    weight: 6
+    weight: 7
   - name: Advanced Log Collection
     url: agent/logs/advanced_log_collection
     parent: agent_logs
-    weight: 601
+    weight: 701
   - name: Proxy
     url: agent/logs/proxy
     parent: agent_logs
-    weight: 602
+    weight: 702
   - name: Transport
     url: agent/logs/log_transport
     parent: agent_logs
-    weight: 603
+    weight: 703
   - name: Proxy
     url: agent/proxy/
     parent: agent
     identifier: agent_proxy
-    weight: 7
+    weight: 8
   - name: Versions
     url: agent/versions
     parent: agent
     identifier: agent_versions
-    weight: 8
+    weight: 9
   - name: Upgrade to Agent v7
     url: agent/versions/upgrade_to_agent_v7/
     parent: agent_versions
-    weight: 801
+    weight: 901
   - name: Upgrade to Agent v6
     url: agent/versions/upgrade_to_agent_v6/
     parent: agent_versions
-    weight: 802
+    weight: 902
   - name: Troubleshooting
     url: agent/troubleshooting/
     parent: agent
-    weight: 9
+    weight: 10
     identifier: agent_troubleshooting
   - name: Debug Mode
     url: agent/troubleshooting/debug_mode/
     parent: agent_troubleshooting
-    weight: 901
+    weight: 1001
   - name: Agent Flare
     url: agent/troubleshooting/send_a_flare/
     parent: agent_troubleshooting
-    weight: 902
+    weight: 1002
   - name: Agent Check Status
     url: agent/troubleshooting/agent_check_status/
     parent: agent_troubleshooting
-    weight: 903
+    weight: 1003
   - name: NTP Issues
     url: agent/troubleshooting/ntp/
     parent: agent_troubleshooting
-    weight: 904
+    weight: 1004
   - name: Permission Issues
     url: agent/troubleshooting/permissions/
     parent: agent_troubleshooting
-    weight: 905
+    weight: 1005
   - name: Integrations Issues
     url: agent/troubleshooting/integrations/
     parent: agent_troubleshooting
-    weight: 906
+    weight: 1006
   - name: Site Issues
     url: agent/troubleshooting/site/
     parent: agent_troubleshooting
-    weight: 907
+    weight: 1007
   - name: Autodiscovery Issues
     url: agent/troubleshooting/autodiscovery/
     parent: agent_troubleshooting
-    weight: 908
+    weight: 1008
   - name: Windows Container Issues
     url: agent/troubleshooting/windows_containers
-    weight: 909
+    weight: 1009
     parent: agent_troubleshooting
   - name: Agent Runtime Configuration
     url: agent/troubleshooting/config
-    weight: 910
+    weight: 1010
     parent: agent_troubleshooting
   - name: Guides
     url: agent/guide/
     identifier: agent_guides
     parent: agent
-    weight: 10
+    weight: 11
   - name: Security
     identifier: agent_security
     url: security/agent/
     parent: agent
-    weight: 11
+    weight: 12
   - name: Integrations
     url: integrations/
     identifier: integrations_top_level
@@ -1007,28 +1012,24 @@ main:
     identifier: metrics_top_level
     pre: nav_metrics
     weight: 110000
-  - name: Introduction
-    url: metrics/introduction/
-    parent: metrics_top_level
-    weight: 901
   - name: Advanced Filtering
     url: metrics/advanced-filtering/
     parent: metrics_top_level
     identifier: metrics_advanced_filtering
-    weight: 902
+    weight: 901
   - name: Explorer
     url: metrics/explorer/
     parent: metrics_top_level
-    weight: 903
+    weight: 902
   - name: Summary
     url: metrics/summary/
     parent: metrics_top_level
-    weight: 904
+    weight: 903
   - name: Distributions
     url: metrics/distributions/
     parent: metrics_top_level
     identifier: metrics_distributions
-    weight: 905
+    weight: 904
   - name: Notebooks
     url: notebooks/
     identifier: notebooks

--- a/content/en/account_management/billing/_index.md
+++ b/content/en/account_management/billing/_index.md
@@ -29,15 +29,21 @@ Pro and Enterprise plans include 150,000 Indexed Spans and 5 custom metrics per 
 
 For more information, see the [Serverless billing page][5] and the [Datadog Pricing page][6].
 
+### IoT
+
+Datadog meters the count of IoT devices hourly. The billable count of IoT devices is calculated at the end of the month using the maximum count (high-water mark) of the lower 99 percent of usage for those hours. We exclude the top 1% to reduce the impact of spikes in usage on your bill.
+
+For more information about IoT billing, see the [Datadog Pricing page][7].
+
 ## Invoicing
 
-If you pay by credit card, receipts are available to [Administrators][7] for previous months under [Billing History][8].
+If you pay by credit card, receipts are available to [Administrators][8] for previous months under [Billing History][9].
 
-If you pay by check or wire, invoices are emailed to the billing email addresses when due. If you need an additional copy, email [Datadog billing][9].
+If you pay by check or wire, invoices are emailed to the billing email addresses when due. If you need an additional copy, email [Datadog billing][10].
 
 ### Billing emails
 
-You can set specific email addresses to receive invoices on the [Plan][10] page under **Manage Billing Emails**:
+You can set specific email addresses to receive invoices on the [Plan][11] page under **Manage Billing Emails**:
 
 {{< img src="account_management/billing/billing01.png" alt="Manage Billing Emails" >}}
 
@@ -72,7 +78,8 @@ You can set specific email addresses to receive invoices on the [Plan][10] page 
 [4]: https://docs.datadoghq.com/account_management/billing/pricing/#apm
 [5]: https://docs.datadoghq.com/account_management/billing/serverless
 [6]: https://www.datadoghq.com/pricing/#included_serverless_functions-d
-[7]: /account_management/users/default_roles/
-[8]: https://app.datadoghq.com/account/billing_history
-[9]: mailto:billing@datadoghq.com
-[10]: https://app.datadoghq.com/account/billing
+[7]: https://www.datadoghq.com/pricing/
+[8]: /account_management/users/default_roles/
+[9]: https://app.datadoghq.com/account/billing_history
+[10]: mailto:billing@datadoghq.com
+[11]: https://app.datadoghq.com/account/billing

--- a/content/en/agent/iot/_index.md
+++ b/content/en/agent/iot/_index.md
@@ -1,7 +1,6 @@
 ---
 title: IoT Agent
 kind: documentation
-beta: true
 further_reading:
   - link: "/getting_started/agent/"
     tag: "Documentation"
@@ -11,10 +10,6 @@ further_reading:
 ## Overview
 
 The Datadog IoT Agent is a version of the Agent optimized for monitoring IoT devices and embedded applications. Customers use the IoT Agent to monitor a wide variety of devices from digital displays to security devices running image detection algorithms.
-
-<div class="alert alert-warning">
-The IoT Agent is currently available for private beta. Request access by completing the <a href="https://docs.google.com/forms/d/e/1FAIpQLSfaoqr9Pgievq7f2WE6wcQMF1YjsOwiXHbmO2FehUlQwmNu0A/viewform?usp=sf_link">form</a>.
-</div>
 
 ## Capabilities
 


### PR DESCRIPTION
### What does this PR do?
Adding in IoT as GA and also a random metrics menu fix I noticed while I was working on this.

Iot updates:
- https://docs-staging.datadoghq.com/kaylyn/iot/agent/iot/ - should now be in the menu and not have a beta message
- https://docs-staging.datadoghq.com/kaylyn/iot/account_management/billing/#iot - billing page update

Metrics update:
https://docs-staging.datadoghq.com/kaylyn/iot/metrics/introduction/ - this page should no longer be showing up in the menu and should redirect to https://docs-staging.datadoghq.com/kaylyn/iot/metrics/

(bug is that it is currently the same page in both places - https://docs.datadoghq.com/metrics/ (correct) - https://docs.datadoghq.com/metrics/introduction/ (duplicate)

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
