### PR TITLE
DOCS-1726 [otel]: add opentelemetry trace log correlation docs

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1288,7 +1288,7 @@ main:
     parent: tracing_setup_overview_setup
     identifier: tracing_setup_overview_setup_dotnet_framework
     weight: 109
-  - name: OpenTracing and OpenTelemetry
+  - name: OpenTelemetry and OpenTracing
     url: tracing/setup_overview/open_standards/
     parent: tracing_setup_overview
     identifier: tracing_open_standards_open_standards

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1465,7 +1465,7 @@ main:
     url: tracing/connect_logs_and_traces/opentelemetry
     parent: tracing_connect_logs_and_traces
     identifier: tracing_connect_logs_and_traces_opentelemetry
-    weight: 807
+    weight: 808
   - name: Connect Synthetic Tests and Traces
     url: synthetics/apm
     parent: tracing

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1461,6 +1461,11 @@ main:
     parent: tracing_connect_logs_and_traces
     identifier: tracing_connect_logs_and_traces_dotnet
     weight: 807
+  - name: OpenTelemetry
+    url: tracing/connect_logs_and_traces/opentelemetry
+    parent: tracing_connect_logs_and_traces
+    identifier: tracing_connect_logs_and_traces_opentelemetry
+    weight: 807
   - name: Connect Synthetic Tests and Traces
     url: synthetics/apm
     parent: tracing

--- a/content/en/tracing/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/connect_logs_and_traces/opentelemetry.md
@@ -1,0 +1,242 @@
+### Connect OpenTelemetry Traces and Logs
+
+Connecting OpenTelemetry Language SDK's Logs and Traces within Datadog is similar to connecting [Datadog SDK Logs and Traces][1]. However, two main differences exist.  First, OpenTelemetry `TraceId` and `SpanId` properties differ from Datadog conventions. Therefore it's necessary to translate `TraceId` and `SpanId` from their OpenTelemetry formats [(a 128bit unsigned int and 64bit unsigned int represented as a 32-hex-character and 16-hex-character lowercase string, respectively)][2] into their Datadog Formats[(a 64bit unsigned int)][3]. Second, most OpenTelemetry Language SDK's lack the automatic trace/log correlation that Datadog SDKs offer, so it's necessary to manually patch your particular logging module or library with a processor that adds the aforementioned translated `TraceId` and `SpanId` as Log attributes marked `dd.trace_id` and `dd.span_id`, respectively. Lastly, it's suggested to ensure your logs are either sent as JSON, as your language level logs must be turned into Datadog attributes in order for traces and logs correlation to work.
+
+Below are Language specific examples of how to correlate your OpenTelemetry traces and logs.
+
+#### Python
+
+To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The below example uses the [structlog logging library][4], however for other Logging libraries, it may be more appropriate to [modify the Datadog SDKs examples][5]. You can also find [an example OpenTelemetry instrumented python application with trace and log correlation][6] in our trace-examples repository.
+
+```python
+# ########## injection.py
+from opentelemetry import trace
+
+class CustomDatadogLogProcessor(object):
+    def __call__(self, logger, method_name, event_dict):
+        # An example of adding datadog formatted trace context to logs
+        # from: https://github.com/open-telemetry/opentelemetry-python-contrib/blob/b53b9a012f76c4fc883c3c245fddc29142706d0d/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/propagator.py#L122-L129 
+        current_span = trace.get_current_span()
+
+        if current_span is not None:
+            event_dict['dd.trace_id'] = str(current_span.context.trace_id & 0xFFFFFFFFFFFFFFFF)
+            event_dict['dd.span_id'] = str(current_span.context.span_id)
+
+        return event_dict        
+# ##########
+
+# ########## app.py
+import .injection
+import logging
+import structlog
+# Add custom formatting to inject datadog formatted trace ids into logs
+structlog.configure(
+    processors=[
+        injection.CustomDatadogLogProcessor(),
+        structlog.processors.JSONRenderer(sort_keys=True)
+    ],
+)
+
+log = structlog.getLogger()
+
+log.info("There is as yet insufficient data for a meaningful answer")
+```
+
+#### Node
+
+To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The below example uses the [winston logging library][7], however for other Logging libraries, it may be more appropriate to [modify the Datadog SDKs examples][8]. You can also find [an example OpenTelemetry instrumented NodeJS application with trace and log correlation][9] in our trace-examples repository.
+
+```js
+// ########## logger.js
+
+// convert to dd with:
+// https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/id.js
+const opentelemetry = require('@opentelemetry/api');
+const winston = require('winston')
+const UINT_MAX = 4294967296
+
+// Convert a buffer to a numerical string.
+function toNumberString (buffer, radix) {
+  let high = readInt32(buffer, 0)
+  let low = readInt32(buffer, 4)
+  let str = ''
+
+  radix = radix || 10
+
+  while (1) {
+    const mod = (high % radix) * UINT_MAX + low
+
+    high = Math.floor(high / radix)
+    low = Math.floor(mod / radix)
+    str = (mod % radix).toString(radix) + str
+
+    if (!high && !low) break
+  }
+
+  return str
+}
+
+// Convert a numerical string to a buffer using the specified radix.
+function fromString (str, raddix) {
+  const buffer = new Uint8Array(8)
+  const len = str.length
+
+  let pos = 0
+  let high = 0
+  let low = 0
+
+  if (str[0] === '-') pos++
+
+  const sign = pos
+
+  while (pos < len) {
+    const chr = parseInt(str[pos++], raddix)
+
+    if (!(chr >= 0)) break // NaN
+
+    low = low * raddix + chr
+    high = high * raddix + Math.floor(low / UINT_MAX)
+    low %= UINT_MAX
+  }
+
+  if (sign) {
+    high = ~high
+
+    if (low) {
+      low = UINT_MAX - low
+    } else {
+      high++
+    }
+  }
+
+  writeUInt32BE(buffer, high, 0)
+  writeUInt32BE(buffer, low, 4)
+
+  return buffer
+}
+
+// Write unsigned integer bytes to a buffer.
+function writeUInt32BE (buffer, value, offset) {
+  buffer[3 + offset] = value & 255
+  value = value >> 8
+  buffer[2 + offset] = value & 255
+  value = value >> 8
+  buffer[1 + offset] = value & 255
+  value = value >> 8
+  buffer[0 + offset] = value & 255
+}
+
+// Read a buffer to unsigned integer bytes.
+function readInt32 (buffer, offset) {
+  return (buffer[offset + 0] * 16777216) +
+    (buffer[offset + 1] << 16) +
+    (buffer[offset + 2] << 8) +
+    buffer[offset + 3]
+}
+
+const tracingFormat = function () {
+  return winston.format(info => {
+    const span = opentelemetry.getSpan(opentelemetry.context.active());
+    if (span) {
+      const context = span.context();
+      const traceIdEnd = context.traceId.slice(context.traceId.length / 2)
+      info['dd.trace_id'] = toNumberString(fromString(traceIdEnd,16))
+      info['dd.span_id'] = toNumberString(fromString(context.spanId,16))
+    }
+    return info;
+  })();
+}
+
+module.exports = winston.createLogger({
+  transports: [new winston.transports.Console],
+  format: winston.format.combine(tracingFormat(), winston.format.json())
+});
+
+// ##########
+
+// ########## index.js
+//
+// ...
+// initialize your tracer
+// ...
+// 
+const logger = require('./logger') 
+//
+// use the logger in your application
+logger.info("There is as yet insufficient data for a meaningful answer")
+```
+
+#### Ruby
+
+To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The below example uses the [Ruby Standard Logging Library][10], however for Rails Applications or other Logging Libraries, it may be more appropriate to [modify the Datadog SDKs examples][11]. 
+
+You can also find [an example OpenTelemetry instrumented Ruby application with trace and log correlation][12] in our trace-examples repository.
+
+```ruby
+logger = Logger.new(STDOUT)
+logger.progname = 'multivac'
+original_formatter = Logger::Formatter.new
+logger.formatter  = proc do |severity, datetime, progname, msg|
+  current_span = OpenTelemetry::Trace.current_span(OpenTelemetry::Context.current).context
+  
+  dd_trace_id = current_span.trace_id.unpack1('H*')[16, 16].to_i(16).to_s
+  dd_span_id = current_span.span_id.unpack1('H*').to_i(16).to_s
+  
+  if current_span
+    "#{{datetime: datetime, progname: progname, severity: severity, msg: msg, 'dd.trace_id': dd_trace_id, 'dd.span_id': dd_span_id}.to_json}\n"
+  else
+    "#{{datetime: datetime, progname: progname, severity: severity, msg: msg}.to_json}\n"
+  end
+end
+
+logger.info("There is as yet insufficient data for a meaningful answer")
+```
+
+#### Java
+
+To manually correlate your traces with your logs, first enable the [openTelemetry-java-instrumentation Logger MDC Instrumentation][13]. Then, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The below example uses [Spring Boot and Logback][14], however for other Logging Libraries, it may be more appropriate to [modify the Datadog SDKs examples][15]. 
+
+```java
+String traceIdValue = Span.current().getSpanContext().getTraceIdAsHexString()
+String traceIdHexString = traceIdValue.substring(traceIdValue.length() - 16 );
+long datadogTraceId = Long.parseUnsignedLong(traceIdHexString, 16);
+String datadogTraceIdString = Long.toUnsignedString(datadogTraceId)
+
+logging.pattern.console = %d{yyyy-MM-dd HH:mm:ss} - %logger{36} - %msg dd.trace_id=%X{datadogTraceIdString} dd.span_id=%X{spanId} %n
+```
+
+#### PHP
+
+For Trace and Log Correlation in PHP, it may be possible to modify the [Datadog SDK PHP examples][16] according to the [steps above][#connect-opentelemetry-traces-and-logs]. Please [contact Datadog support][17] with any questions.
+
+#### Go
+
+For Trace and Log Correlation in Go, it may be possible to modify the [Datadog SDK Go examples][18] according to the [steps above][#connect-opentelemetry-traces-and-logs]. Please [contact Datadog support][17] with any questions.
+
+#### .NET
+
+For Trace and Log Correlation in .NET, it may be possible to modify the [Datadog SDK .NET examples][19] according to the [steps above][#connect-opentelemetry-traces-and-logs]. Please [contact Datadog support][17] with any questions.
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://docs.datadoghq.com/tracing/connect_logs_and_traces/
+[2]: https://github.com/open-telemetry/opentelemetry-specification/blob/eeef21259a12d61100804eff2e12ba06523821c3/specification/trace/api.md#retrieving-the-traceid-and-spanid
+[3]: https://docs.datadoghq.com/api/latest/tracing/#send-traces
+[4]: https://www.structlog.org/en/stable/standard-library.html
+[5]: https://docs.datadoghq.com/tracing/connect_logs_and_traces/python/#manually-inject-trace-and-span-ids
+[6]: https://github.com/DataDog/trace-examples/blob/98626d924f82666de60d6b2d6a65d87eebebdff1/opentelemetry/python-microservice/ddlogging/injection.py#L3
+[7]: https://github.com/winstonjs/winston
+[8]: https://docs.datadoghq.com/tracing/connect_logs_and_traces/nodejs/#manually-inject-trace-and-span-ids
+[9]: https://github.com/DataDog/trace-examples/blob/98626d924f82666de60d6b2d6a65d87eebebdff1/opentelemetry/node-microservice/logger.js#L86
+[10]: https://ruby-doc.org/stdlib-3.0.0/libdoc/logger/rdoc/index.html 
+[11]: https://docs.datadoghq.com/tracing/connect_logs_and_traces/ruby/#manually-inject-trace-and-span-ids
+[12]: https://github.com/DataDog/trace-examples/blob/98626d924f82666de60d6b2d6a65d87eebebdff1/opentelemetry/ruby-microservice/app.rb#L21-L35
+[13]: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/logger-mdc-instrumentation.md
+[14]: https://docs.spring.io/spring-boot/docs/2.1.18.RELEASE/reference/html/boot-features-logging.html
+[15]: https://docs.datadoghq.com/tracing/connect_logs_and_traces/java/?tab=log4j2#manually-inject-trace-and-span-ids
+[16]: https://docs.datadoghq.com/tracing/connect_logs_and_traces/php/
+[17]: https://docs.datadoghq.com/help/
+[18]: https://docs.datadoghq.com/tracing/connect_logs_and_traces/go/
+[19]: https://docs.datadoghq.com/tracing/connect_logs_and_traces/dotnet/

--- a/content/en/tracing/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/connect_logs_and_traces/opentelemetry.md
@@ -14,19 +14,21 @@ further_reading:
   text: "Datadog's partnership with OpenTelemetry"
 ---
 
-Connecting OpenTelemetry Language SDKs Logs and Traces within Datadog is similar to connecting [Datadog SDK Logs and Traces][1], with a few caveats:
+Connecting OpenTelemetry Language SDKs Logs and Traces within Datadog is similar to connecting [Datadog SDK Logs and Traces][1], with a few additional steps:
 
-First, OpenTelemetry `TraceId` and `SpanId` properties differ from Datadog conventions. Therefore it's necessary to translate `TraceId` and `SpanId` from their OpenTelemetry formats ([a 128bit unsigned int and 64bit unsigned int represented as a 32-hex-character and 16-hex-character lowercase string, respectively][2]) into their Datadog Formats([a 64bit unsigned int][3]). 
+1. OpenTelemetry `TraceId` and `SpanId` properties differ from Datadog conventions. Therefore it's necessary to translate `TraceId` and `SpanId` from their OpenTelemetry formats ([a 128bit unsigned int and 64bit unsigned int represented as a 32-hex-character and 16-hex-character lowercase string, respectively][2]) into their Datadog Formats([a 64bit unsigned int][3]). 
 
-Second, most OpenTelemetry Language SDKs lack the automatic trace-log correlation that Datadog SDKs offer, so it's necessary to manually patch your particular logging module or library with a processor that adds the aforementioned translated `TraceId` and `SpanId` as Log attributes marked `dd.trace_id` and `dd.span_id`, respectively. 
+2. OpenTelemetry Language SDKs lack the automatic trace-log correlation that Datadog SDKs offer, so it's necessary to manually patch your particular logging module or library with a processor that adds the aforementioned translated `TraceId` and `SpanId` as Log attributes marked `dd.trace_id` and `dd.span_id`, respectively. 
 
-Last, ensure your logs are sent as JSON, because your language level logs must be turned into Datadog attributes for trace-log correlation to work.
+3. Ensure your logs are sent as JSON, because your language level logs must be turned into Datadog attributes for trace-log correlation to work.
 
-Below are language-specific examples of how to correlate your OpenTelemetry traces and logs.
+See the following examples for language-specific information about how to correlate your OpenTelemetry traces and logs.
 
-#### Python
+{{< programming-lang-wrapper langs="python,nodejs,ruby,java,php,go,dotnet" >}}
 
-To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The below example uses the [structlog logging library][4], however for other Logging libraries, it may be more appropriate to [modify the Datadog SDKs examples][5]. You can also find [an example OpenTelemetry instrumented python application with trace and log correlation][6] in our trace-examples repository.
+{{< programming-lang lang="python" >}}
+
+To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The following example uses the [structlog logging library][1]. For other logging libraries, it may be more appropriate to [modify the Datadog SDKs examples][2]. You can also find [an example OpenTelemetry instrumented Python application with trace and log correlation][3] in the `trace-examples` GitHub repository.
 
 ```python
 # ########## injection.py
@@ -62,9 +64,15 @@ log = structlog.getLogger()
 log.info("There is as yet insufficient data for a meaningful answer")
 ```
 
-#### Node
 
-To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The below example uses the [winston logging library][7], however for other Logging libraries, it may be more appropriate to [modify the Datadog SDKs examples][8]. You can also find [an example OpenTelemetry instrumented NodeJS application with trace and log correlation][9] in our trace-examples repository.
+[1]: https://www.structlog.org/en/stable/standard-library.html
+[2]: /tracing/connect_logs_and_traces/python/#manually-inject-trace-and-span-ids
+[3]: https://github.com/DataDog/trace-examples/blob/98626d924f82666de60d6b2d6a65d87eebebdff1/opentelemetry/python-microservice/ddlogging/injection.py#L3
+{{< /programming-lang >}}
+
+{{< programming-lang lang="nodejs" >}}
+
+To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The following example uses the [winston logging library][1]. For other logging libraries, it may be more appropriate to [modify the Datadog SDKs examples][2]. You can also find [an example OpenTelemetry instrumented NodeJS application with trace and log correlation][3] in the `trace-examples` GitHub repository.
 
 ```js
 // ########## logger.js
@@ -186,11 +194,15 @@ const logger = require('./logger')
 logger.info("There is as yet insufficient data for a meaningful answer")
 ```
 
-#### Ruby
 
-To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The below example uses the [Ruby Standard Logging Library][10], however for Rails Applications or other Logging Libraries, it may be more appropriate to [modify the Datadog SDKs examples][11]. 
+[1]: https://github.com/winstonjs/winston
+[2]: /tracing/connect_logs_and_traces/nodejs/#manually-inject-trace-and-span-ids
+[3]: https://github.com/DataDog/trace-examples/blob/98626d924f82666de60d6b2d6a65d87eebebdff1/opentelemetry/node-microservice/logger.js#L86
+{{< /programming-lang >}}
 
-You can also find [an example OpenTelemetry instrumented Ruby application with trace and log correlation][12] in our trace-examples repository.
+{{< programming-lang lang="ruby" >}}
+
+To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The following example uses the [Ruby Standard Logging Library][1]. For Rails applications or other logging libraries, it may be more appropriate to [modify the Datadog SDKs examples][12]. You can also find [an example OpenTelemetry instrumented Ruby application with trace and log correlation][13] in the `trace-examples` GitHub repository.
 
 ```ruby
 logger = Logger.new(STDOUT)
@@ -212,9 +224,13 @@ end
 logger.info("There is as yet insufficient data for a meaningful answer")
 ```
 
-#### Java
 
-To manually correlate your traces with your logs, first enable the [openTelemetry-java-instrumentation Logger MDC Instrumentation][13]. Then, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The below example uses [Spring Boot and Logback][14], however for other Logging Libraries, it may be more appropriate to [modify the Datadog SDKs examples][15]. 
+[1]: https://ruby-doc.org/stdlib-3.0.0/libdoc/logger/rdoc/index.html
+{{< /programming-lang >}}
+
+{{< programming-lang lang="java" >}}
+
+To manually correlate your traces with your logs, first enable the [openTelemetry-java-instrumentation Logger MDC Instrumentation][1]. Then, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The following example uses [Spring Boot and Logback][2]. For other logging libraries, it may be more appropriate to [modify the Datadog SDKs examples][3]. 
 
 ```java
 String traceIdValue = Span.current().getSpanContext().getTraceIdAsHexString()
@@ -225,38 +241,45 @@ String datadogTraceIdString = Long.toUnsignedString(datadogTraceId)
 logging.pattern.console = %d{yyyy-MM-dd HH:mm:ss} - %logger{36} - %msg dd.trace_id=%X{datadogTraceIdString} dd.span_id=%X{spanId} %n
 ```
 
-#### PHP
+[1]: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/logger-mdc-instrumentation.md
+[2]: https://docs.spring.io/spring-boot/docs/2.1.18.RELEASE/reference/html/boot-features-logging.html
+[3]: /tracing/connect_logs_and_traces/java/?tab=log4j2#manually-inject-trace-and-span-ids
+{{< /programming-lang >}}
 
-For Trace and Log Correlation in PHP, it may be possible to modify the [Datadog SDK PHP examples][16] according to the [steps above][#connect-opentelemetry-traces-and-logs]. Please [contact Datadog support][17] with any questions.
+{{< programming-lang lang="php" >}}
 
-#### Go
+For trace and log correlation in PHP, modify the [Datadog SDK PHP examples][1] to include the additional steps discussed above. [Contact Datadog support][2] with any questions.
 
-For Trace and Log Correlation in Go, it may be possible to modify the [Datadog SDK Go examples][18] according to the [steps above][#connect-opentelemetry-traces-and-logs]. Please [contact Datadog support][17] with any questions.
 
-#### .NET
+[1]: /tracing/connect_logs_and_traces/php/
+[2]: /help/
+{{< /programming-lang >}}
 
-For Trace and Log Correlation in .NET, it may be possible to modify the [Datadog SDK .NET examples][19] according to the [steps above][#connect-opentelemetry-traces-and-logs]. Please [contact Datadog support][17] with any questions.
+{{< programming-lang lang="go" >}}
+
+For trace and log correlation in Go, modify the [Datadog SDK Go examples][1] to include the additional steps discussed above.[Contact Datadog support][2] with any questions.
+
+
+[1]: /tracing/connect_logs_and_traces/go/
+[2]: /help/
+{{< /programming-lang >}}
+
+{{< programming-lang lang="dotnet" >}}
+
+For trace and log correlation in .NET, modify the [Datadog SDK .NET examples][1] to include the additional steps discussed above. [Contact Datadog support][2] with any questions.
+
+
+[1]: /tracing/connect_logs_and_traces/dotnet/
+[2]: /help/
+{{< /programming-lang >}}
+
+{{< /programming-lang-wrapper >}}
+
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://docs.datadoghq.com/tracing/connect_logs_and_traces/
+[1]: /tracing/connect_logs_and_traces/
 [2]: https://github.com/open-telemetry/opentelemetry-specification/blob/eeef21259a12d61100804eff2e12ba06523821c3/specification/trace/api.md#retrieving-the-traceid-and-spanid
-[3]: https://docs.datadoghq.com/api/latest/tracing/#send-traces
-[4]: https://www.structlog.org/en/stable/standard-library.html
-[5]: https://docs.datadoghq.com/tracing/connect_logs_and_traces/python/#manually-inject-trace-and-span-ids
-[6]: https://github.com/DataDog/trace-examples/blob/98626d924f82666de60d6b2d6a65d87eebebdff1/opentelemetry/python-microservice/ddlogging/injection.py#L3
-[7]: https://github.com/winstonjs/winston
-[8]: https://docs.datadoghq.com/tracing/connect_logs_and_traces/nodejs/#manually-inject-trace-and-span-ids
-[9]: https://github.com/DataDog/trace-examples/blob/98626d924f82666de60d6b2d6a65d87eebebdff1/opentelemetry/node-microservice/logger.js#L86
-[10]: https://ruby-doc.org/stdlib-3.0.0/libdoc/logger/rdoc/index.html
-[11]: https://docs.datadoghq.com/tracing/connect_logs_and_traces/ruby/#manually-inject-trace-and-span-ids
-[12]: https://github.com/DataDog/trace-examples/blob/98626d924f82666de60d6b2d6a65d87eebebdff1/opentelemetry/ruby-microservice/app.rb#L21-L35
-[13]: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/logger-mdc-instrumentation.md
-[14]: https://docs.spring.io/spring-boot/docs/2.1.18.RELEASE/reference/html/boot-features-logging.html
-[15]: https://docs.datadoghq.com/tracing/connect_logs_and_traces/java/?tab=log4j2#manually-inject-trace-and-span-ids
-[16]: https://docs.datadoghq.com/tracing/connect_logs_and_traces/php/
-[17]: https://docs.datadoghq.com/help/
-[18]: https://docs.datadoghq.com/tracing/connect_logs_and_traces/go/
-[19]: https://docs.datadoghq.com/tracing/connect_logs_and_traces/dotnet/
+[3]: /api/latest/tracing/#send-traces

--- a/content/en/tracing/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/connect_logs_and_traces/opentelemetry.md
@@ -248,7 +248,10 @@ logging.pattern.console = %d{yyyy-MM-dd HH:mm:ss} - %logger{36} - %msg dd.trace_
 
 {{< programming-lang lang="php" >}}
 
-For trace and log correlation in PHP, modify the [Datadog SDK PHP examples][1] to include the additional steps discussed above. [Contact Datadog support][2] with any questions.
+For trace and log correlation in PHP, modify the [Datadog SDK PHP examples][1] to include the additional steps discussed above.
+
+[Contact Datadog support][2] with any questions.
+
 
 
 [1]: /tracing/connect_logs_and_traces/php/
@@ -257,7 +260,9 @@ For trace and log correlation in PHP, modify the [Datadog SDK PHP examples][1] t
 
 {{< programming-lang lang="go" >}}
 
-For trace and log correlation in Go, modify the [Datadog SDK Go examples][1] to include the additional steps discussed above.[Contact Datadog support][2] with any questions.
+For trace and log correlation in Go, modify the [Datadog SDK Go examples][1] to include the additional steps discussed above.
+
+[Contact Datadog support][2] with any questions.
 
 
 [1]: /tracing/connect_logs_and_traces/go/
@@ -266,7 +271,9 @@ For trace and log correlation in Go, modify the [Datadog SDK Go examples][1] to 
 
 {{< programming-lang lang="dotnet" >}}
 
-For trace and log correlation in .NET, modify the [Datadog SDK .NET examples][1] to include the additional steps discussed above. [Contact Datadog support][2] with any questions.
+For trace and log correlation in .NET, modify the [Datadog SDK .NET examples][1] to include the additional steps discussed above. 
+
+[Contact Datadog support][2] with any questions.
 
 
 [1]: /tracing/connect_logs_and_traces/dotnet/

--- a/content/en/tracing/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/connect_logs_and_traces/opentelemetry.md
@@ -1,8 +1,28 @@
-### Connect OpenTelemetry Traces and Logs
+---
+title: Connect OpenTelemetry Traces and Logs
+kind: documentation
+description: 'Connect your application logs and OpenTelemetry traces to correlate them in Datadog'
+further_reading:
+- link: "/tracing/setup_overview/openstandards/"
+  tag: "Documentation"
+  text: "Send OpenTelemetry Traces to Datadog"
+- link: "https://opentelemetry.io/docs/collector/"
+  tag: "OpenTelemetry"
+  text: "Collector documentation"
+- link: "https://www.datadoghq.com/blog/opentelemetry-instrumentation/"
+  tag: "Blog"
+  text: "Datadog's partnership with OpenTelemetry"
+---
 
-Connecting OpenTelemetry Language SDK's Logs and Traces within Datadog is similar to connecting [Datadog SDK Logs and Traces][1]. However, two main differences exist.  First, OpenTelemetry `TraceId` and `SpanId` properties differ from Datadog conventions. Therefore it's necessary to translate `TraceId` and `SpanId` from their OpenTelemetry formats [(a 128bit unsigned int and 64bit unsigned int represented as a 32-hex-character and 16-hex-character lowercase string, respectively)][2] into their Datadog Formats[(a 64bit unsigned int)][3]. Second, most OpenTelemetry Language SDK's lack the automatic trace/log correlation that Datadog SDKs offer, so it's necessary to manually patch your particular logging module or library with a processor that adds the aforementioned translated `TraceId` and `SpanId` as Log attributes marked `dd.trace_id` and `dd.span_id`, respectively. Lastly, it's suggested to ensure your logs are either sent as JSON, as your language level logs must be turned into Datadog attributes in order for traces and logs correlation to work.
+Connecting OpenTelemetry Language SDKs Logs and Traces within Datadog is similar to connecting [Datadog SDK Logs and Traces][1], with a few caveats:
 
-Below are Language specific examples of how to correlate your OpenTelemetry traces and logs.
+First, OpenTelemetry `TraceId` and `SpanId` properties differ from Datadog conventions. Therefore it's necessary to translate `TraceId` and `SpanId` from their OpenTelemetry formats ([a 128bit unsigned int and 64bit unsigned int represented as a 32-hex-character and 16-hex-character lowercase string, respectively][2]) into their Datadog Formats([a 64bit unsigned int][3]). 
+
+Second, most OpenTelemetry Language SDKs lack the automatic trace-log correlation that Datadog SDKs offer, so it's necessary to manually patch your particular logging module or library with a processor that adds the aforementioned translated `TraceId` and `SpanId` as Log attributes marked `dd.trace_id` and `dd.span_id`, respectively. 
+
+Last, ensure your logs are sent as JSON, because your language level logs must be turned into Datadog attributes for trace-log correlation to work.
+
+Below are language-specific examples of how to correlate your OpenTelemetry traces and logs.
 
 #### Python
 
@@ -230,7 +250,7 @@ For Trace and Log Correlation in .NET, it may be possible to modify the [Datadog
 [7]: https://github.com/winstonjs/winston
 [8]: https://docs.datadoghq.com/tracing/connect_logs_and_traces/nodejs/#manually-inject-trace-and-span-ids
 [9]: https://github.com/DataDog/trace-examples/blob/98626d924f82666de60d6b2d6a65d87eebebdff1/opentelemetry/node-microservice/logger.js#L86
-[10]: https://ruby-doc.org/stdlib-3.0.0/libdoc/logger/rdoc/index.html 
+[10]: https://ruby-doc.org/stdlib-3.0.0/libdoc/logger/rdoc/index.html
 [11]: https://docs.datadoghq.com/tracing/connect_logs_and_traces/ruby/#manually-inject-trace-and-span-ids
 [12]: https://github.com/DataDog/trace-examples/blob/98626d924f82666de60d6b2d6a65d87eebebdff1/opentelemetry/ruby-microservice/app.rb#L21-L35
 [13]: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/logger-mdc-instrumentation.md

--- a/content/en/tracing/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/connect_logs_and_traces/opentelemetry.md
@@ -14,7 +14,7 @@ further_reading:
   text: "Datadog's partnership with OpenTelemetry"
 ---
 
-Connecting OpenTelemetry Language SDKs Logs and Traces within Datadog is similar to connecting [Datadog SDK Logs and Traces][1], with a few additional steps:
+Connecting OpenTelemetry language SDK logs and traces within Datadog is similar to connecting [Datadog SDK logs and traces][1], with a few additional steps:
 
 1. OpenTelemetry `TraceId` and `SpanId` properties differ from Datadog conventions. Therefore it's necessary to translate `TraceId` and `SpanId` from their OpenTelemetry formats ([a 128bit unsigned int and 64bit unsigned int represented as a 32-hex-character and 16-hex-character lowercase string, respectively][2]) into their Datadog Formats([a 64bit unsigned int][3]). 
 
@@ -28,7 +28,7 @@ See the following examples for language-specific information about how to correl
 
 {{< programming-lang lang="python" >}}
 
-To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The following example uses the [structlog logging library][1]. For other logging libraries, it may be more appropriate to [modify the Datadog SDKs examples][2]. You can also find [an example OpenTelemetry instrumented Python application with trace and log correlation][3] in the `trace-examples` GitHub repository.
+To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The following example uses the [structlog logging library][1]. For other logging libraries, it may be more appropriate to [modify the Datadog SDK examples][2]. You can also find [an example OpenTelemetry instrumented Python application with trace and log correlation][3] in the `trace-examples` GitHub repository.
 
 ```python
 # ########## injection.py
@@ -61,7 +61,7 @@ structlog.configure(
 
 log = structlog.getLogger()
 
-log.info("There is as yet insufficient data for a meaningful answer")
+log.info("Example log line with trace correlation info")
 ```
 
 
@@ -72,7 +72,7 @@ log.info("There is as yet insufficient data for a meaningful answer")
 
 {{< programming-lang lang="nodejs" >}}
 
-To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The following example uses the [winston logging library][1]. For other logging libraries, it may be more appropriate to [modify the Datadog SDKs examples][2]. You can also find [an example OpenTelemetry instrumented NodeJS application with trace and log correlation][3] in the `trace-examples` GitHub repository.
+To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The following example uses the [winston logging library][1]. For other logging libraries, it may be more appropriate to [modify the Datadog SDK examples][2]. You can also find [an example OpenTelemetry instrumented NodeJS application with trace and log correlation][3] in the `trace-examples` GitHub repository.
 
 ```js
 // ########## logger.js
@@ -191,7 +191,7 @@ module.exports = winston.createLogger({
 const logger = require('./logger') 
 //
 // use the logger in your application
-logger.info("There is as yet insufficient data for a meaningful answer")
+logger.info("Example log line with trace correlation info")
 ```
 
 
@@ -202,7 +202,7 @@ logger.info("There is as yet insufficient data for a meaningful answer")
 
 {{< programming-lang lang="ruby" >}}
 
-To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The following example uses the [Ruby Standard Logging Library][1]. For Rails applications or other logging libraries, it may be more appropriate to [modify the Datadog SDKs examples][12]. You can also find [an example OpenTelemetry instrumented Ruby application with trace and log correlation][13] in the `trace-examples` GitHub repository.
+To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The following example uses the [Ruby Standard Logging Library][1]. For Rails applications or other logging libraries, it may be more appropriate to [modify the Datadog SDK examples][2]. You can also find [an example OpenTelemetry instrumented Ruby application with trace and log correlation][3] in the `trace-examples` GitHub repository.
 
 ```ruby
 logger = Logger.new(STDOUT)
@@ -221,16 +221,19 @@ logger.formatter  = proc do |severity, datetime, progname, msg|
   end
 end
 
-logger.info("There is as yet insufficient data for a meaningful answer")
+logger.info("Example log line with trace correlation info")
 ```
 
 
+
 [1]: https://ruby-doc.org/stdlib-3.0.0/libdoc/logger/rdoc/index.html
+[2]: /tracing/connect_logs_and_traces/ruby/#manually-inject-trace-and-span-ids
+[3]: https://github.com/DataDog/trace-examples/blob/98626d924f82666de60d6b2d6a65d87eebebdff1/opentelemetry/ruby-microservice/app.rb#L21-L35
 {{< /programming-lang >}}
 
 {{< programming-lang lang="java" >}}
 
-To manually correlate your traces with your logs, first enable the [openTelemetry-java-instrumentation Logger MDC Instrumentation][1]. Then, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The following example uses [Spring Boot and Logback][2]. For other logging libraries, it may be more appropriate to [modify the Datadog SDKs examples][3]. 
+To manually correlate your traces with your logs, first enable the [openTelemetry-java-instrumentation Logger MDC Instrumentation][1]. Then, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The following example uses [Spring Boot and Logback][2]. For other logging libraries, it may be more appropriate to [modify the Datadog SDK examples][3]. 
 
 ```java
 String traceIdValue = Span.current().getSpanContext().getTraceIdAsHexString()

--- a/content/en/tracing/setup_overview/open_standards/_index.md
+++ b/content/en/tracing/setup_overview/open_standards/_index.md
@@ -9,6 +9,9 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/opentelemetry-instrumentation/"
   tag: "Blog"
   text: "Datadog's partnership with OpenTelemetry"
+- link: "/tracing/connect_logs_and_traces/opentelemetry"
+  tag: "Documentation"
+  text: "Connect OpenTelemetry Traces and Logs"
 aliases:
 
 

--- a/content/en/tracing/setup_overview/open_standards/_index.md
+++ b/content/en/tracing/setup_overview/open_standards/_index.md
@@ -13,9 +13,9 @@ aliases:
 
 
 ---
-Datadog supports a variety of open standards, including [OpenTracing][1] and [OpenTelemetry][2]. Each of the following languages has support for sending Open Tracing data to Datadog. They all also have support for sending OpenTelemetry data to Datadog via the [OpenTelemetry Collector Datadog exporter](#opentelemetry-collector-datadog-exporter). Additionally, Python, Ruby, and NodeJS have dedicated OpenTelemetry Datadog span exporters, which export traces from OpenTelemetry tracing clients to a Datadog Agent. 
+Datadog supports a variety of open standards, including [OpenTracing][1] and [OpenTelemetry][2]. Each of the following languages has support for sending Open Tracing data to Datadog. They all also have support for sending OpenTelemetry data to Datadog via the [OpenTelemetry Collector Datadog exporter](#opentelemetry-collector-datadog-exporter), as well as [connecting OpenTelemetry Traces with Logs from the Application](#connect-opentelemetry-traces-and-logs). It's recommended to use the OpenTelemetry Collector Datadog exporter in conjunction with OpenTelemetry tracing clients. However, Python, Ruby, and NodeJS also have dedicated OpenTelemetry Datadog span exporters, which export traces directly from OpenTelemetry tracing clients to a Datadog Agent.
 
-Click your language to see instructions for setting up OpenTracing or language-specific OpenTelemetry exporters. See below for setting up the [OpenTelemetry Collector Datadog exporter](#opentelemetry-collector-datadog-exporter):
+Click your language to see instructions for setting up OpenTracing or language-specific OpenTelemetry exporters. See below for setting up the [OpenTelemetry Collector Datadog exporter](#opentelemetry-collector-datadog-exporter) as well as [connecting traces and logs](#connect-opentelemetry-traces-and-logs):
 
 {{< partial name="apm/apm-opentracing.html" >}}
 
@@ -290,6 +290,10 @@ spec:
 
 To see more information and additional examples of how you might configure your collector, see [the OpenTelemetry Collector configuration documentation][5].
 
+## Connect OpenTelemetry Traces and Logs
+
+To connect OpenTelemetry Traces and Logs, refer to the [OpenTelemetry language specific documentation for example code snippets and instructions][17].
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -310,3 +314,4 @@ To see more information and additional examples of how you might configure your 
 [14]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/design.md#running-as-an-agent
 [15]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/design.md#running-as-a-standalone-collector
 [16]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/images/opentelemetry-service-deployment-models.png
+[17]: tracing/connect_logs_and_traces/opentelemetry

--- a/content/en/tracing/setup_overview/open_standards/_index.md
+++ b/content/en/tracing/setup_overview/open_standards/_index.md
@@ -1,5 +1,5 @@
 ---
-title: OpenTracing and OpenTelemetry
+title: OpenTelemetry and OpenTracing
 kind: documentation
 description: 'Use open standards to generate your application traces'
 further_reading:
@@ -13,19 +13,13 @@ aliases:
 
 
 ---
-Datadog supports a variety of open standards, including [OpenTracing][1] and [OpenTelemetry][2]. Each of the following languages has support for sending Open Tracing data to Datadog. They all also have support for sending OpenTelemetry data to Datadog via the [OpenTelemetry Collector Datadog exporter](#opentelemetry-collector-datadog-exporter), as well as [connecting OpenTelemetry Traces with Logs from the Application](#connect-opentelemetry-traces-and-logs). It's recommended to use the OpenTelemetry Collector Datadog exporter in conjunction with OpenTelemetry tracing clients. However, Python, Ruby, and NodeJS also have dedicated OpenTelemetry Datadog span exporters, which export traces directly from OpenTelemetry tracing clients to a Datadog Agent.
-
-Click your language to see instructions for setting up OpenTracing or language-specific OpenTelemetry exporters. See below for setting up the [OpenTelemetry Collector Datadog exporter](#opentelemetry-collector-datadog-exporter) as well as [connecting traces and logs](#connect-opentelemetry-traces-and-logs):
-
-{{< partial name="apm/apm-opentracing.html" >}}
-
-<br>
+Datadog supports a variety of open standards, including [OpenTelemetry][1] and [OpenTracing][2].
 
 ## OpenTelemetry Collector Datadog exporter
 
-The OpenTelemetry Collector is a vendor-agnostic separate agent process for collecting and exporting telemetry data emitted by many processes. Datadog has [an exporter available within the OpenTelemetry Collector][3] to receive traces and metrics data from the OpenTelemetry SDKs, and to forward the data on to Datadog (without the Datadog Agent). It works with all supported languages. 
+The OpenTelemetry Collector is a vendor-agnostic separate agent process for collecting and exporting telemetry data emitted by many processes. Datadog has [an exporter available within the OpenTelemetry Collector][3] to receive traces and metrics data from the OpenTelemetry SDKs, and to forward the data on to Datadog (without the Datadog Agent). It works with all supported languages, and you can [connect those OpenTelemetry trace data with application logs](#connect-opentelemetry-traces-and-logs).
 
-You can [deploy the OpenTelemetry Collector via any of the supported methods][4], and configure it by adding a `datadog` exporter to your [OpenTelemetry configuration YAML file][5] along with your [Datadog API key][6]:
+You can [deploy the OpenTelemetry Collector using any of the supported methods][4], and configure it by adding a `datadog` exporter to your [OpenTelemetry configuration YAML file][5] along with your [Datadog API key][6]:
 
 ```
 datadog:
@@ -40,7 +34,7 @@ datadog:
     site: datadoghq.eu
 ```
 
-On each OpenTelemetry-instrumented application, set the resource attributes `development.environment`, `service.name`, and `service.version` using [the language's SDK][2]. As a fall-back, you can also configure hostname (optionally), environment, service name, and service version at the collector level for unified service tagging by following the [example configuration file][7]. If you don't specify the hostname explicitly, the exporter attempts to get an automatic default by checking the following sources in order, falling back to the next one if the current one is unavailable or invalid:
+On each OpenTelemetry-instrumented application, set the resource attributes `development.environment`, `service.name`, and `service.version` using [the language's SDK][1]. As a fall-back, you can also configure hostname (optionally), environment, service name, and service version at the collector level for unified service tagging by following the [example configuration file][7]. If you don't specify the hostname explicitly, the exporter attempts to get an automatic default by checking the following sources in order, falling back to the next one if the current one is unavailable or invalid:
 
 <!--- 1. Hostname set by another OpenTelemetry component -->
 1. Manually set hostname in configuration
@@ -290,16 +284,24 @@ spec:
 
 To see more information and additional examples of how you might configure your collector, see [the OpenTelemetry Collector configuration documentation][5].
 
-## Connect OpenTelemetry Traces and Logs
+## Connect OpenTelemetry traces and logs
 
-To connect OpenTelemetry Traces and Logs, refer to the [OpenTelemetry language specific documentation for example code snippets and instructions][17].
+To connect OpenTelemetry traces and logs so that your application logs monitoring and analysis has the additional context provided by the OpenTelemetry traces, see [Connect OpenTelemetry Traces and Logs][17] for language specific instructions and example code.
+
+## Alternatives to the OpenTelemetry Collector Datadog exporter
+
+Datadog recommends you use the OpenTelemetry Collector Datadog exporter in conjunction with OpenTelemetry tracing clients. However, if that doesn't work for you:
+
+  - Each of the supported languages also has support for [sending OpenTracing data to Datadog][18].
+
+  - [Python][19], [Ruby][20], and [NodeJS][21] also have language-specific OpenTelemetry Datadog span exporters, which export traces directly from OpenTelemetry tracing clients to a Datadog Agent. 
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://opentracing.io/docs/
-[2]: https://opentelemetry.io/docs/
+[1]: https://opentelemetry.io/docs/
+[2]: https://opentracing.io/docs/
 [3]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter
 [4]: https://opentelemetry.io/docs/collector/getting-started/#deployment
 [5]: https://opentelemetry.io/docs/collector/configuration/
@@ -314,4 +316,8 @@ To connect OpenTelemetry Traces and Logs, refer to the [OpenTelemetry language s
 [14]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/design.md#running-as-an-agent
 [15]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/design.md#running-as-a-standalone-collector
 [16]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/images/opentelemetry-service-deployment-models.png
-[17]: tracing/connect_logs_and_traces/opentelemetry
+[17]: /tracing/connect_logs_and_traces/opentelemetry
+[18]: /tracing/setup_overview/open_standards/java
+[19]: /tracing/setup_overview/open_standards/python#opentelemetry
+[20]: /tracing/setup_overview/open_standards/ruby#opentelemetry
+[21]: /tracing/setup_overview/open_standards/nodejs#opentelemetry

--- a/layouts/partials/apm/apm-connect-logs-and-traces.html
+++ b/layouts/partials/apm/apm-connect-logs-and-traces.html
@@ -40,6 +40,11 @@
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/php.png" "class" "img-fluid" "alt" "PHP" "width" "400") }}
         </div>
       </a>
+      <a class="card" href="opentelemetry" style="width: 25%" >
+        <div class="card-body text-center py-2 px-1">
+          {{ partial "img.html" (dict "root" . "src" "integrations_logos/otel.png" "class" "img-fluid" "alt" "OpenTelemetry" "width" "400") }}
+        </div>
+      </a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Hello friends. This PR adds documentation for how to connect traces and logs in OpenTelemetry.

#### _Background_

 Connecting Traces and Logs is one of the strongest Platform APM features Datadog offers, but is much more complex in OpenTelemetry Tracing SDKs than Datadog Tracing SDKs.
 
With Datadog Tracing Client SDKs, trace / log connection is trivial, since nearly all Datadog Tracing Clients have the feature and code built into the SDK itself, and all users need to do is add an environment variable to enable it. Hooray.

Unfortunately, while OpenTelemetry offers the same underpinnings and APIs that _could_ make this possible, the OpenTelemtry SDKs largely do not have these feature built in by default, and certainly nothing configurable via env var. So a considerable amount of documentation is needed.

#### Details

I've done 3 things in this PR to accomplish the above.

- Document the general steps and approach needed to connect logs and traces in opentelemetry. There are basically two language agnostic steps needed to accomplish this, so I have an overview section explaining what these steps are and why they exist. I also attempted to treat `OpenTelemetry` as a 1st Class Citizen in our Log/Trace Connection Documentation, linking to it and referencing it wherever log/trace correlation for specific languages was noted in our docs.  It could be argued that OpenTelemetry is merely a _subset_ of individual language setups, but given how vastly different the setup is, I believe treating this as almost it's "own language"/having a dedicated page (instead of lots of small examples sprinkled throughout other language specific pages) is appropriate. It's possible I've missed some places where trace/log correlation is referenced, so please let me know if I should add links somewhere.

- I created language specific sections detailing an example code snippet and setup that has been demonstrated to work in that language. The trouble here is that code snippets will vary depending on the specifics of the customers application, logging library, and so on. So I've chosen a common or popular library that can be modified for user's with other setups. Additionally, where Appropriate I've linked to a real-world example application that has OpenTelemetry Log / Trace correlation enabled, so users can see how the setup would work in a practical sense. 

  At present, I've only been able to create working code snippets for Python, Node, Ruby, and Java, and practical application examples for Python, Ruby, and Node. PHP/.NET/Go should technically be possible to accomplish as well but the time commitment required to get these working are going to be a blocker here, so what I've done is added the standard `contact support` language for PHP/.NET/Go, and can try to prioritize those languages as user requests dictate.

  tl;dr doing polygot stuff is hard but i tried my best.

- Last, I created a sample microservices application with 1 step setup instructions for docker and kubernetes that demonstrate these code examples for Ruby, Python, and Node. This lives in our `trace-examples` repository, and hopefully will help be a resource for folks trying to get setup. I chose this approach so that our in-doc code examples could be as small as possible while still representing a meaningful example of how to do trace / log correlation, while leaving the nuts and bolts application plumbing(which is still important and useful but extremely verbose) to the `trace-examples` repo.

#### Misc

I also made some smol edits to the Otel docs to try to subtley highlight the preferred onboarding path for OpenTelemetry (we'd like folks to use the collector-exporter if possible, not the lang specific exporters).

### Motivation
<!-- What inspired you to submit this pull request?-->

Customers want to correlate their OpenTelemetry Traces and Logs, just like they do in Datadog. However this is much harder to do in OpenTelemetry for a variety of reasons. So, we need to document it.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ericmustin/add_otel_log_traceid_correlation/tracing/connect_logs_and_traces/opentelemetry/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

Example Output of OpenTelemetry Trace / Log Correlation using docs in this PR and the sample application in `trace-examples`:

![look ma, my traces iz connet to lergs](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/Jru1n422/f3fe04fd-e1b8-4060-ba16-8a6f6340e10b.png?v=edc0b68802eb5baa4ed28fddeff67e14)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
