### PR TITLE
Add DATADOG_RPM_KEY_CURRENT.public key to EBS sample config

### DIFF
--- a/static/config/99datadog-amazon-linux-2.config
+++ b/static/config/99datadog-amazon-linux-2.config
@@ -25,7 +25,8 @@ files:
             baseurl = https://yum.datadoghq.com/stable/7/x86_64/
             enabled=1
             gpgcheck=1
-            gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+            gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+                   https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
                    https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
             
     "/start_datadog.sh":


### PR DESCRIPTION
### What does this PR do?
Adds the CURRENT key file, which is updated when we rotate the key.

### Motivation
Future-proofing our customer's setup.
