### PR TITLE
Update send-aws-services-logs-with-the-datadog-kinesis-firehose-desti…

### DIFF
--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
@@ -66,8 +66,8 @@ Alternatively, customize this CloudFormation template and install it from the AW
 
 ## Send AWS logs to your Kinesis stream
 
-1. Check the `Subscriptions` column on the [log groups index page][1] to see current subscriptions to your relevant log groups. Because CloudWatch Log groups can only have one subscription, delete any existing subscriptions to the log groups before adding the new Kinesis stream as a subscriber.
-  * **Note**: If you have something else you want to subscribe to, you can subscribe to the new Kinesis stream after completing this setup.
+1. Check the `Subscriptions` column on the [log groups index page][1] to see current subscriptions to your relevant log groups. Add the new Kinesis stream as a subscriber. Note: CloudWatch Log groups can only have two subscriptions each.
+  * **Note**: If you have more than 2 sources you want to subscribe to, you can subscribe to the new Kinesis stream after completing this setup.
 2. Subscribe your new Kinesis stream to the CloudWatch log groups you want to ingest into Datadog. Refer to [this CloudWatch Logs documentation section][2] (step 3 to 6) to:
   a. Use the `aws iam create-role` command to create the IAM role that gives CloudWatch Logs permission to put logs data into the Kinesis stream.
   b. Create a permissions policy allowing the `firehose:PutRecord` `firehose:PutRecordBatch`, `kinesis:PutRecord` and `kinesis:PutRecordBatch` actions.

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
@@ -67,7 +67,7 @@ Alternatively, customize this CloudFormation template and install it from the AW
 ## Send AWS logs to your Kinesis stream
 
 1. Check the `Subscriptions` column on the [log groups index page][1] to see current subscriptions to your relevant log groups. Add the new Kinesis stream as a subscriber. Note: CloudWatch Log groups can only have two subscriptions each.
-  * **Note**: If you have more than 2 sources you want to subscribe to, you can subscribe to the new Kinesis stream after completing this setup.
+  * **Note**: If you have more than two sources you want to subscribe to, you can subscribe to the new Kinesis stream after completing this setup.
 2. Subscribe your new Kinesis stream to the CloudWatch log groups you want to ingest into Datadog. Refer to [this CloudWatch Logs documentation section][2] (step 3 to 6) to:
   a. Use the `aws iam create-role` command to create the IAM role that gives CloudWatch Logs permission to put logs data into the Kinesis stream.
   b. Create a permissions policy allowing the `firehose:PutRecord` `firehose:PutRecordBatch`, `kinesis:PutRecord` and `kinesis:PutRecordBatch` actions.


### PR DESCRIPTION
…nation.md

Cloudwatch log groups now support 2 subscriptions each.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
