### PR TITLE
Fix typo for "HIPAA"

### DIFF
--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -27,7 +27,7 @@ further_reading:
   - [Live Containers][2] data is `process.`{{< region-param key="dd_site" code="true" >}}
   - [Logs][3] data includes `agent-intake.logs.`{{< region-param key="dd_site" code="true" >}} for TCP traffic, `agent-http-intake.logs.`{{< region-param key="dd_site" code="true" >}} in HTTP, and several others. Review the complete list of [logs endpoints][4] for more information.
   - [Orchestrator Resources][5] data is `orchestrator.`{{< region-param key="dd_site" code="true" >}}.
-  - [HIPPA logs][6] data is the same as for all [Logs][3], but also the following legacy endpoints are supported:
+  - [HIPAA logs][6] data is the same as for all [Logs][3], but also the following legacy endpoints are supported:
     - `tcp-encrypted-intake.logs.`{{< region-param key="dd_site" code="true" >}}
     - `lambda-tcp-encrypted-intake.logs.`{{< region-param key="dd_site" code="true" >}}
     - `gcp-encrypted-intake.logs.`{{< region-param key="dd_site" code="true" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fix a typo in [Network Traffic](https://docs.datadoghq.com/agent/guide/network/?tab=agentv6v7) page

### Motivation
<!-- What inspired you to submit this pull request?-->
The correct accronym is HIPPA, not HIPPA: https://www.hhs.gov/hipaa/index.html

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/agent/guide/network/?tab=agentv6v7

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
