### PR TITLE
dotnet log-trace-injection updates

### DIFF
--- a/content/en/developers/events/email.md
+++ b/content/en/developers/events/email.md
@@ -59,7 +59,7 @@ With a plain text formatted email, the following fields are controllable:
 |----------------------|----------|---------------------------------|
 | Sender email address | Yes      | The email address of the sender |
 | Subject              | Yes      | The subject of the email        |
-| Body                 | No       | The body of the email           |
+| Body                 | Yes      | The body of the email           |
 
 For example, the email below is a valid submission:
 

--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -105,7 +105,7 @@ For NLog version 4.5:
     <attribute name="exception" layout="${exception:format=ToString}" />
   </layout>
 ```
-For additional examples, see the automatic trace ID injection projects [for NLog45][1] or [for NLog46][2] on GitHub.
+For additional examples, see the automatic trace ID injection projects using [NLog 4.5][1] or [NLog 4.6][2] on GitHub.
 
 
 [1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/NLog45Example/NLog.config

--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -31,16 +31,14 @@ The .NET Tracer supports:
 
 ### Getting started
 
-1. In the .NET Tracer’s environment variables, enable  `DD_LOGS_INJECTION=true`. For alternative ways to configure the .NET Tracer, see [Configuring the .NET Tracer][5].
-
-2. Configure the .NET Tracer with the following tracer settings:
+1. Configure the .NET Tracer with the following tracer settings:
     - `DD_ENV`
     - `DD_SERVICE`
     - `DD_VERSION`
 
-3. In the [logs Agent configuration][6] for the specified files to tail, set `source: csharp` so that log pipelines can parse the log files.
+2. In the [logs Agent configuration][6] for the specified files to tail, set `source: csharp` so that log pipelines can parse the log files.
 
-4. Update the logging configuration based on the logging library:
+3. Update the logging configuration based on the logging library:
 
 Examples:
 
@@ -115,6 +113,7 @@ For additional examples, see the automatic trace ID injection projects using [NL
 {{% /tab %}}
 {{< /tabs >}}
 
+4. In the .NET Tracer’s environment variables, enable  `DD_LOGS_INJECTION=true`. For alternative ways to configure the .NET Tracer, see [Configuring the .NET Tracer][5].
 
 ## Manually inject trace and span IDs
 
@@ -122,9 +121,12 @@ For additional examples, see the automatic trace ID injection projects using [NL
 
 To manually correlate your [APM traces][9] with application logs:
 
-1. Reference the [`Datadog.Trace` NuGet package][10] in your project.
+1. Configure the .NET Tracer with the following tracer settings:
+    - `DD_ENV`
+    - `DD_SERVICE`
+    - `DD_VERSION`
 
-2. Use the `CorrelationIdentifier` API to retrieve correlation identifiers and add them to the log context while a span is active.
+2. In the [logs Agent configuration][6] for the specified files to tail, set `source: csharp` so that log pipelines can parse the log files.
 
 3. Update the logging configuration based on the logging library:
 
@@ -199,7 +201,9 @@ For additional examples, see the automatic trace ID injection projects using [NL
 {{% /tab %}}
 {{< /tabs >}}
 
-4. Add the correlation identifiers to the log context based on the logging library:
+4. Reference the [`Datadog.Trace` NuGet package][10] in your project.
+
+5. Use the `CorrelationIdentifier` API to retrieve correlation identifiers and add them to the log context while a span is active.
 
 Examples:
 

--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -106,11 +106,12 @@ For NLog version 4.5:
     <attribute name="exception" layout="${exception:format=ToString}" />
   </layout>
 ```
-For additional examples, see the automatic trace ID injection projects using [NLog 4.5][1] or [NLog 4.6][2] on GitHub.
+For additional examples, see the automatic trace ID injection projects using [NLog 4.0][1], [NLog 4.5][2], or [NLog 4.6][3] on GitHub.
 
 
-[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/NLog45Example/NLog.config
-[2]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/NLog46Example/NLog.config
+[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/NLog40Example/NLog.config
+[2]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/NLog45Example/NLog.config
+[3]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/NLog46Example/NLog.config
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -17,21 +17,34 @@ further_reading:
       text: 'Correlate request logs with traces automatically'
 ---
 
-## Automatically Inject Trace and Span IDs
+## Automatically inject trace and span IDs
 
-The .NET Tracer can automatically inject trace IDs, span IDs, `env`, `service`, and `version` into your application logs. If you haven't done so already, Datadog recommends configuring the .NET tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This provides the best experience when adding `env`, `service`, and `version` (see [Unified Service Tagging][3] for more details).
+<div class="alert alert-info"><strong>Note:</strong> Automatic injection works only for logs formatted as JSON. Otherwise, use manual injection.</div>
 
-The .NET Tracer supports [Serilog][4], [NLog][5] (version 4.0+), or [log4net][6]. Automatic injection only displays in the application logs after enabling `LogContext` enrichment in your `Serilog` logger or `Mapped Diagnostics Context` in your `NLog` or `log4net` logger.
+The .NET Tracer can automatically inject trace IDs and span IDs into your application logs. Configure the .NET Tracer with [Unified Service Tagging][1] for the best experience and helpful context when correlating application traces and logs.
 
-**Note**: Automatic injection only works for logs formatted as JSON.
+The .NET Tracer supports:
+- [Serilog][2]
+- [log4net][3]
+- [NLog][4] (version 4.0+)
 
-**To enable, follow these two steps:**
 
-1. Enable injection in the .NET Tracer’s [configuration][1] by setting `DD_LOGS_INJECTION=true` through environment variables or the configuration files.
-2. Update the logging configuration based on the logging library:
+### Getting started
+
+1. In the .NET Tracer’s environment variables, enable  `DD_LOGS_INJECTION=true`. For alternative ways to configure the .NET Tracer, see [Configuring the .NET Tracer][5].
+
+2. Configure the .NET Tracer with the following tracer settings:
+    - `DD_ENV`
+    - `DD_SERVICE`
+    - `DD_VERSION`
+
+3. In the [logs Agent configuration][6] for the specified files to tail, set `source: csharp` so that log pipelines can parse the log files.
+
+4. Update the logging configuration based on the logging library:
 
 {{< tabs >}}
 {{% tab "Serilog" %}}
+Trace and span IDs are injected into application logs only after you enable log context enrichment, as shown in the following example code: 
 
 ```csharp
 var log = new LoggerConfiguration()
@@ -40,9 +53,13 @@ var log = new LoggerConfiguration()
     .WriteTo.File(new JsonFormatter(), "log.json")
     .CreateLogger();
 ```
+For additional examples, see [the Serilog automatic trace ID injection project][1] on GitHub.
 
+
+[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/SerilogExample/Program.cs
 {{% /tab %}}
 {{% tab "log4net" %}}
+Trace and span IDs are injected into application logs only after you enable mapped diagnostic context (MDC), as shown in the following example code:
 
 ```xml
   <layout type="log4net.Layout.SerializedLayout, log4net.Ext.Json">
@@ -50,23 +67,25 @@ var log = new LoggerConfiguration()
     <default />
     <!--explicit default members-->
     <remove value="ndc" />
-    <remove value="message" />
     <!--remove the default preformatted message member-->
-    <member value="message:messageobject" />
+    <remove value="message" />
     <!--add raw message-->
-
+    <member value="message:messageobject" />
     <!-- Add value='properties' to emit Datadog properties -->
     <member value='properties'/>
   </layout>
 ```
+For additional examples, see [the log4net automatic trace ID injection project][1] on GitHub.
 
+
+[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/Log4NetExample/log4net.config
 {{% /tab %}}
 {{% tab "NLog" %}}
 
-For NLog version 4.6+:
+Trace and span IDs are injected into application logs only after you enable mapped diagnostic context (MDC), as shown in the following example code for NLog version 4.6+:
 
 ```xml
-  <!-- Add includeMdlc="true" to emit Datadog properties -->
+ <!-- Add includeMdlc="true" to emit MDC properties -->
   <layout xsi:type="JsonLayout" includeMdlc="true">
     <attribute name="date" layout="${longdate}" />
     <attribute name="level" layout="${level:upperCase=true}"/>
@@ -75,61 +94,52 @@ For NLog version 4.6+:
   </layout>
 ```
 
-For NLog version 4.0 - 4.5:
+For NLog version 4.5:
 
 ```xml
-  <!-- If using version 4.4.10+, you may add includeMdc="true" to emit Datadog properties -->
+ <!-- Add includeMdc="true" to emit MDC properties -->
   <layout xsi:type="JsonLayout" includeMdc="true">
     <attribute name="date" layout="${longdate}" />
     <attribute name="level" layout="${level:upperCase=true}"/>
     <attribute name="message" layout="${message}" />
     <attribute name="exception" layout="${exception:format=ToString}" />
   </layout>
-
-  <!-- If using version below 4.4.10, you must extract the Datadog properties individually by adding <attribute> nodes -->
-  <layout xsi:type="JsonLayout">
-    <attribute name="date" layout="${longdate}" />
-    <attribute name="level" layout="${level:upperCase=true}"/>
-    <attribute name="message" layout="${message}" />
-    <attribute name="exception" layout="${exception:format=ToString}" />
-
-    <attribute name="dd.env" layout="${mdc:item=dd.env}"/>
-    <attribute name="dd.service" layout="${mdc:item=dd.service}"/>
-    <attribute name="dd.version" layout="${mdc:item=dd.version}"/>
-    <attribute name="dd.trace_id" layout="${mdc:item=dd.trace_id}"/>
-    <attribute name="dd.span_id" layout="${mdc:item=dd.span_id}"/>
-  </layout>
 ```
+For additional examples, see the automatic trace ID injection projects [for NLog45][1] or [for NLog46][2] on GitHub.
 
-For NLog version lower than 4.0, there is no built-in JSON layout.
 
+[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/NLog45Example/NLog.config
+[2]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/NLog46Example/NLog.config
 {{% /tab %}}
 {{< /tabs >}}
 
 
-## Manually Inject Trace and Span IDs
+## Manually inject trace and span IDs
 
-If you prefer to manually correlate your [traces][7] with your logs and tie together data for your service,
-leverage the Datadog API to retrieve correlation identifiers:
+**Note:** If you are not using a [Datadog Log Integration][7] to parse your logs, custom log parsing rules must parse `dd.trace_id` and `dd.span_id` as strings. For information, see the [FAQ on this topic][8].
 
-- Use `CorrelationIdentifier.<FIELD>` API methods to inject identifiers at the beginning and end of each [span][8] to log (see examples below).
-- Configure MDC to use the injected keys:
+To manually correlate your [APM traces][9] with application logs:
 
-    - `dd.env` Globally configured `env` for the tracer (defaults to `""` if not set)
-    - `dd.service` Globally configured root service name (defaults to the name of the application or IIS site name if not set)
-    - `dd.version` Globally configured `version` for the service (defaults to `""` if not set)
-    - `dd.trace_id` Active Trace ID during the log statement (defaults to `0` if no trace)
-    - `dd.span_id` Active Span ID during the log statement (defaults to `0` if no trace)
+1. Reference the [`Datadog.Trace` NuGet package][10] in your project.
+
+2. Use the `CorrelationIdentifier` API to retrieve correlation identifiers and add them to the log context while a span is active.
+
+3. Configure mapped diagnostic context (MDC) to use the following injected keys:
+
+    | Required key   | Description                                  |
+    | -------------- | -------------------------------------------- |
+    | `dd.env`       | Globally configures the `env` for the tracer. Defaults to `""` if not set. |
+    | `dd.service`   | Globally configures the root service name. Ddefaults to the name of the application or IIS site name if not set.  |
+    | `dd.version`   | Globally configures `version` for the service. Defaults to `""` if not set.  |
+    | `dd.trace_id`  | Active trace ID during the log statement. Defaults to `0` if no trace.  |
+    | `dd.span_id`   | Active span ID during the log statement. Default to 0 if no trace. |
+
+Examples of adding correlation identifiers to the log context:
 
 {{< tabs >}}
 {{% tab "Serilog" %}}
 
-**Note**: The Serilog library requires message property names to be valid C# identifiers, so the property names must be:
-- `dd_env`
-- `dd_service`
-- `dd_version`
-- `dd_trace_id`
-- `dd_span_id`
+**Note**: The Serilog library requires message property names to be valid C# identifiers. The required property names are: `dd_env`, `dd_service`, `dd_version`, `dd_trace_id`, and `dd_span_id`.
 
 ```csharp
 using Datadog.Trace;
@@ -147,7 +157,7 @@ using (LogContext.PushProperty("dd_span_id", CorrelationIdentifier.SpanId.ToStri
 ```
 
 {{% /tab %}}
-{{% tab "Log4net" %}}
+{{% tab "log4net" %}}
 
 ```csharp
 using Datadog.Trace;
@@ -196,19 +206,18 @@ using (MappedDiagnosticsLogicalContext.SetScoped("dd.span_id", CorrelationIdenti
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note**: If you are not using a [Datadog Log Integration][9] to parse your logs, custom log parsing rules need to ensure that `dd.trace_id` and `dd.span_id` are being parsed as strings. More information can be found in the [FAQ on this topic][10].
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/setup/dotnet/#configuration
-[2]: https://github.com/damianh/LibLog
-[3]: /getting_started/tagging/unified_service_tagging
-[4]: http://serilog.net
-[5]: http://nlog-project.org
-[6]: https://logging.apache.org/log4net
-[7]: /tracing/visualization/#trace
-[8]: /tracing/visualization/#spans
-[9]: /logs/log_collection/csharp/#configure-your-logger
-[10]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/?tab=custom
+[1]: /getting_started/tagging/unified_service_tagging
+[2]: http://serilog.net
+[3]: https://logging.apache.org/log4net
+[4]: http://nlog-project.org
+[5]: /tracing/setup_overview/setup/dotnet-core/?tab=windows#configuring-the-net-tracer
+[6]: /logs/log_collection/csharp/?tab=serilog#configure-your-datadog-agent
+[7]: /logs/log_collection/csharp/#configure-your-logger
+[8]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/?tab=custom
+[9]: /tracing/visualization/#trace
+[10]: https://www.nuget.org/packages/Datadog.Trace/

--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -42,6 +42,16 @@ The .NET Tracer supports:
 
 4. Update the logging configuration based on the logging library:
 
+    | Required key   | Description                                  |
+    | -------------- | -------------------------------------------- |
+    | `dd.env`       | Globally configures the `env` for the tracer. Defaults to `""` if not set. |
+    | `dd.service`   | Globally configures the root service name. Defaults to the name of the application or IIS site name if not set.  |
+    | `dd.version`   | Globally configures `version` for the service. Defaults to `""` if not set.  |
+    | `dd.trace_id`  | Active trace ID during the log statement. Defaults to `0` if no trace.  |
+    | `dd.span_id`   | Active span ID during the log statement. Defaults to `0` if no trace. |
+
+Examples:
+
 {{< tabs >}}
 {{% tab "Serilog" %}}
 Trace and span IDs are injected into application logs only after you enable log context enrichment, as shown in the following example code: 
@@ -124,7 +134,7 @@ To manually correlate your [APM traces][9] with application logs:
 
 2. Use the `CorrelationIdentifier` API to retrieve correlation identifiers and add them to the log context while a span is active.
 
-3. Configure mapped diagnostic context (MDC) to use the following injected keys:
+3. Update the logging configuration based on the logging library:
 
     | Required key   | Description                                  |
     | -------------- | -------------------------------------------- |

--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -27,6 +27,9 @@ further_reading:
   - link: "https://github.com/DataDog/dd-trace-dotnet/tree/master/samples"
     tag: "GitHub"
     text: "Examples of Custom Instrumentation"
+  - link: "/tracing/connect_logs_and_traces/dotnet/"
+    tag: "Documentation"
+    text: "Connect .NET application logs to traces"
 ---
 
 ## Compatibility requirements

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -29,6 +29,9 @@ further_reading:
     - link: "https://github.com/DataDog/dd-trace-dotnet/tree/master/samples"
       tag: "GitHub"
       text: "Examples of Custom Instrumentation"
+  - link: "/tracing/connect_logs_and_traces/dotnet/"
+    tag: "Documentation"
+    text: "Connect .NET application logs to traces"
 ---
 ## Compatibility requirements
 

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -29,9 +29,9 @@ further_reading:
     - link: "https://github.com/DataDog/dd-trace-dotnet/tree/master/samples"
       tag: "GitHub"
       text: "Examples of Custom Instrumentation"
-  - link: "/tracing/connect_logs_and_traces/dotnet/"
-    tag: "Documentation"
-    text: "Connect .NET application logs to traces"
+    - link: "/tracing/connect_logs_and_traces/dotnet/"
+      tag: "Documentation"
+      text: "Connect .NET application logs to traces"
 ---
 ## Compatibility requirements
 


### PR DESCRIPTION
### What does this PR do?
Updates docs "Connect Logs and Traces" for .NET 

### Motivation
Googledoc from PM

### Preview
https://docs-staging.datadoghq.com/kari/dotnet-logs-traces-update/tracing/connect_logs_and_traces/dotnet

Added Further Reading link to updated page:

- https://docs-staging.datadoghq.com/kari/dotnet-logs-traces-update/tracing/setup_overview/setup/dotnet-core?tab=windows#further-reading
- https://docs-staging.datadoghq.com/kari/dotnet-logs-traces-update/tracing/setup_overview/setup/dotnet-framework?tab=environmentvariables#further-reading

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
