### PR TITLE
remove subdomain sentence on saml okta

### DIFF
--- a/content/en/account_management/saml/okta.md
+++ b/content/en/account_management/saml/okta.md
@@ -48,7 +48,7 @@ It's recommended that you set up Datadog as an Okta application manually, as opp
 * **sn**: user.lastName
 * **givenName**: user.firstName
 
-Additional information on configuring SAML for your Datadog account is available on the [SAML documentation page][2]. If you are using the custom sub-domain feature, your specific details are also available there.
+Additional information on configuring SAML for your Datadog account is available on the [SAML documentation page][2].
 
 In the event that you need to upload an `IDP.XML` file to Datadog before being able to fully configure the application in Okta, see [acquiring the idp.xml metadata file for a SAML template App article][3] for field placeholder instructions.
 


### PR DESCRIPTION
flagged by transifex. specific details on the custom sub-domain feature are not, in fact, available on the linked saml documentation page

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
