### PR TITLE
Agent-side data buffering on network unavailability

### DIFF
--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -145,6 +145,19 @@ Open the following ports in order to benefit from all the Agent functionalities:
 
 For a detailed configuration guide on proxy setup, see [Agent Proxy Configuration][8].
 
+## Agent-side data buffering on network unavailability
+
+When the network becomes unavailable, the Agent stores the traffic in the memory.
+The maximum memory usage for storing the traffic is defined by the configuration `forwarder_retry_queue_payloads_max_size`. When this limit is reached, the traffic is dropped.
+
+The Agent `7.27.0` and above can store the traffic on the disk when the memory limit is reached.
+This feature is enabled by setting `forwarder_storage_max_size_in_bytes` to a positive value.
+`forwarder_storage_max_size_in_bytes` defines the maximum amount of storage space the Agent can use to store the traffic on the disk.
+
+The traffic is stored in the folder defined by `forwarder_storage_path` which is by default `/opt/datadog-agent/run/transactions_to_retry` on Unix systems and `C:\ProgramData\Datadog\run\transactions_to_retry` on Windows.
+
+Note: In order to avoid running out of storage space, the Agent can store the traffic on the disk only if the total storage space used is less than 95%. This limit is defined by `forwarder_storage_max_disk_ratio`.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -148,7 +148,7 @@ For a detailed configuration guide on proxy setup, see [Agent Proxy Configuratio
 ## Agent-side data buffering on network unavailability
 
 If the network becomes unavailable, the Agent stores traffic in memory.
-The maximum memory usage for storing the traffic is defined by the configuration `forwarder_retry_queue_payloads_max_size`. When this limit is reached, the traffic is dropped.
+The maximum memory usage for storing traffic is defined by the `forwarder_retry_queue_payloads_max_size` configuration setting. When this limit is reached, the traffic is dropped.
 
 The Agent `7.27.0` and above can store the traffic on the disk when the memory limit is reached.
 This feature is enabled by setting `forwarder_storage_max_size_in_bytes` to a positive value.

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -150,7 +150,7 @@ For a detailed configuration guide on proxy setup, see [Agent Proxy Configuratio
 If the network becomes unavailable, the Agent stores traffic in memory.
 The maximum memory usage for storing traffic is defined by the `forwarder_retry_queue_payloads_max_size` configuration setting. When this limit is reached, the traffic is dropped.
 
-The Agent `7.27.0` and above can store the traffic on the disk when the memory limit is reached.
+Agent version 7.27.0 and above can store traffic on disk when the memory limit is reached.
 This feature is enabled by setting `forwarder_storage_max_size_in_bytes` to a positive value.
 `forwarder_storage_max_size_in_bytes` defines the maximum amount of storage space the Agent can use to store the traffic on the disk.
 

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -153,7 +153,7 @@ The maximum memory usage for storing traffic is defined by the `forwarder_retry_
 Agent version 7.27.0 and above can store traffic on disk when the memory limit is reached.
 Enable this capability by setting `forwarder_storage_max_size_in_bytes` to a positive value indicating the maximum amount of storage space, in bytes, that the Agent can use to store traffic on disk.
 
-The traffic is stored in the folder defined by `forwarder_storage_path` which is by default `/opt/datadog-agent/run/transactions_to_retry` on Unix systems and `C:\ProgramData\Datadog\run\transactions_to_retry` on Windows.
+The traffic is stored in the folder defined by the `forwarder_storage_path` setting, which is by default `/opt/datadog-agent/run/transactions_to_retry` on Unix systems and `C:\ProgramData\Datadog\run\transactions_to_retry` on Windows.
 
 Note: In order to avoid running out of storage space, the Agent can store the traffic on the disk only if the total storage space used is less than 95%. This limit is defined by `forwarder_storage_max_disk_ratio`.
 

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -151,8 +151,7 @@ If the network becomes unavailable, the Agent stores traffic in memory.
 The maximum memory usage for storing traffic is defined by the `forwarder_retry_queue_payloads_max_size` configuration setting. When this limit is reached, the traffic is dropped.
 
 Agent version 7.27.0 and above can store traffic on disk when the memory limit is reached.
-This feature is enabled by setting `forwarder_storage_max_size_in_bytes` to a positive value.
-`forwarder_storage_max_size_in_bytes` defines the maximum amount of storage space the Agent can use to store the traffic on the disk.
+Enable this capability by setting `forwarder_storage_max_size_in_bytes` to a positive value indicating the maximum amount of storage space, in bytes, that the Agent can use to store traffic on disk.
 
 The traffic is stored in the folder defined by `forwarder_storage_path` which is by default `/opt/datadog-agent/run/transactions_to_retry` on Unix systems and `C:\ProgramData\Datadog\run\transactions_to_retry` on Windows.
 

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -155,7 +155,7 @@ Enable this capability by setting `forwarder_storage_max_size_in_bytes` to a pos
 
 The traffic is stored in the folder defined by the `forwarder_storage_path` setting, which is by default `/opt/datadog-agent/run/transactions_to_retry` on Unix systems and `C:\ProgramData\Datadog\run\transactions_to_retry` on Windows.
 
-Note: In order to avoid running out of storage space, the Agent can store the traffic on the disk only if the total storage space used is less than 95%. This limit is defined by `forwarder_storage_max_disk_ratio`.
+To avoid running out of storage space, the Agent stores traffic on disk only if the total storage space used is less than 95 percent. This limit is defined by `forwarder_storage_max_disk_ratio` setting.
 
 ## Further Reading
 

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -147,7 +147,7 @@ For a detailed configuration guide on proxy setup, see [Agent Proxy Configuratio
 
 ## Agent-side data buffering on network unavailability
 
-When the network becomes unavailable, the Agent stores the traffic in the memory.
+If the network becomes unavailable, the Agent stores traffic in memory.
 The maximum memory usage for storing the traffic is defined by the configuration `forwarder_retry_queue_payloads_max_size`. When this limit is reached, the traffic is dropped.
 
 The Agent `7.27.0` and above can store the traffic on the disk when the memory limit is reached.

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -147,15 +147,15 @@ For a detailed configuration guide on proxy setup, see [Agent Proxy Configuratio
 
 ## Agent-side data buffering on network unavailability
 
-If the network becomes unavailable, the Agent stores traffic in memory.
-The maximum memory usage for storing traffic is defined by the `forwarder_retry_queue_payloads_max_size` configuration setting. When this limit is reached, the traffic is dropped.
+If the network becomes unavailable, the Agent stores the metrics in memory.
+The maximum memory usage for storing the metrics is defined by the `forwarder_retry_queue_payloads_max_size` configuration setting. When this limit is reached, the metrics are dropped.
 
-Agent version 7.27.0 and above can store traffic on disk when the memory limit is reached.
-Enable this capability by setting `forwarder_storage_max_size_in_bytes` to a positive value indicating the maximum amount of storage space, in bytes, that the Agent can use to store traffic on disk.
+Agent version 7.27.0 and above can store the metrics on disk when the memory limit is reached.
+Enable this capability by setting `forwarder_storage_max_size_in_bytes` to a positive value indicating the maximum amount of storage space, in bytes, that the Agent can use to store the metrics on disk.
 
-The traffic is stored in the folder defined by the `forwarder_storage_path` setting, which is by default `/opt/datadog-agent/run/transactions_to_retry` on Unix systems and `C:\ProgramData\Datadog\run\transactions_to_retry` on Windows.
+The metrics are stored in the folder defined by the `forwarder_storage_path` setting, which is by default `/opt/datadog-agent/run/transactions_to_retry` on Unix systems and `C:\ProgramData\Datadog\run\transactions_to_retry` on Windows.
 
-To avoid running out of storage space, the Agent stores traffic on disk only if the total storage space used is less than 95 percent. This limit is defined by `forwarder_storage_max_disk_ratio` setting.
+To avoid running out of storage space, the Agent stores the metrics on disk only if the total storage space used is less than 95 percent. This limit is defined by `forwarder_storage_max_disk_ratio` setting.
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR adds the section `Agent-side data buffering on network unavailability`

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/olivierg/agent-data-buffering/content/en/agent/guide/network.md

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
