### PR TITLE
update to add traces

### DIFF
--- a/content/en/logs/guide/how-to-set-up-only-logs.md
+++ b/content/en/logs/guide/how-to-set-up-only-logs.md
@@ -1,5 +1,5 @@
 ---
-title: Use the Datadog Agent for Log/Trace Collection Only
+title: Use the Datadog Agent for Log or Trace Collection Only
 aliases:
   - /logs/faq/how-to-set-up-only-logs
 kind: documentation

--- a/content/en/logs/guide/how-to-set-up-only-logs.md
+++ b/content/en/logs/guide/how-to-set-up-only-logs.md
@@ -1,12 +1,12 @@
 ---
-title: Use the Datadog Agent for Log Collection Only
+title: Use the Datadog Agent for Log/Trace Collection Only
 aliases:
   - /logs/faq/how-to-set-up-only-logs
 kind: documentation
 ---
 
 <div class="alert alert-danger">
-To setup Log collection without metrics, you have to disable certain payloads. This results in the potential loss of metadata and tags on the logs you are collecting. Datadog does not recommend this. For more information about the impact of this configuration, contact <a href="/help/">Datadog Support</a>.
+To setup Log/Trace collection without metrics, you have to disable certain payloads. This results in the potential loss of metadata and tags on the logs and/or traces you are collecting. Datadog does not recommend this. For more information about the impact of this configuration, contact <a href="/help/">Datadog Support</a>.
 </div>
 
 To disable payloads, you must be running Agent v6.4+. This disables metric data submission so that hosts stop showing up in Datadog. Follow these steps:

--- a/content/en/logs/guide/how-to-set-up-only-logs.md
+++ b/content/en/logs/guide/how-to-set-up-only-logs.md
@@ -6,7 +6,7 @@ kind: documentation
 ---
 
 <div class="alert alert-danger">
-To setup Log/Trace collection without metrics, you have to disable certain payloads. This results in the potential loss of metadata and tags on the logs and/or traces you are collecting. Datadog does not recommend this. For more information about the impact of this configuration, contact <a href="/help/">Datadog Support</a>.
+To setup log or trace collection (or both) without metrics, you have to disable certain payloads. This results in the potential loss of metadata and tags on the logs and traces you are collecting. Datadog does not recommend this. For more information about the impact of this configuration, contact <a href="/help/">Datadog Support</a>.
 </div>
 
 To disable payloads, you must be running Agent v6.4+. This disables metric data submission so that hosts stop showing up in Datadog. Follow these steps:


### PR DESCRIPTION
### What does this PR do?
Update the "Use the Datadog Agent for Log Collection Only" to include traces. That's because following the instructions in the doc won't block off traces. See links in the motivation section.

### Motivation
In [this ticket](https://datadog.zendesk.com/agent/tickets/449221), the customer asked about enabling only traces and logs. I was referred to [this internal doc](https://datadoghq.atlassian.net/wiki/spaces/TS/pages/328664868/How+to+get+only+Logs+collection+from+a+Datadog+agent) which says that it doesn't limit the agent to logs; it just disables certain metrics.

Other link: https://datadoghq.atlassian.net/wiki/spaces/TS/pages/357696364/How+to+get+only+APM+metrics+and+traces+from+a+Datadog+agent

### Preview
https://docs-staging.datadoghq.com/technopig-patch-1/content/en/logs/guide/how-to-set-up-only-logs.md

^ That should be the link, but it's not working for me for some reason.

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
