### PR TITLE
api: add instructions to run examples

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -23,13 +23,13 @@ code_languages:
     extension: rb
     name: ruby
     syntax: ruby
-    command: ruby
+    command: rb
     example_file: example.rb
   'rbbeta':
     extension: rbbeta
     name: ruby-beta
     syntax: ruby
-    command: ruby
+    command: rb
     example_file: example.rb
   'sh':
     extension: sh

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -11,18 +11,22 @@ code_languages:
     extension: py
     name: python
     syntax: python
+    command: python example.py
   'pybeta':
     extension: py
     name: python-beta
     syntax: python
+    command: python3 example.py
   'rb':
     extension: rb
     name: ruby
     syntax: ruby
+    command: ruby example.rb
   'rbbeta':
     extension: rbbeta
     name: ruby-beta
     syntax: ruby
+    command: ruby example.rb
   'sh':
     extension: sh
     name: curl
@@ -31,10 +35,12 @@ code_languages:
     extension: go
     name: go
     syntax: go
+    command: go main.go
   'java':
     extension: java
     name: java
     syntax: java
+    command: java Example.java
   'cs':
     extension: cs
     name: csharp

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -11,22 +11,26 @@ code_languages:
     extension: py
     name: python
     syntax: python
-    command: python example.py
+    command: python
+    example_file: example.py
   'pybeta':
     extension: py
     name: python-beta
     syntax: python
-    command: python3 example.py
+    command: python3
+    example_file: example.py
   'rb':
     extension: rb
     name: ruby
     syntax: ruby
-    command: ruby example.rb
+    command: ruby
+    example_file: example.rb
   'rbbeta':
     extension: rbbeta
     name: ruby-beta
     syntax: ruby
-    command: ruby example.rb
+    command: ruby
+    example_file: example.rb
   'sh':
     extension: sh
     name: curl
@@ -35,12 +39,14 @@ code_languages:
     extension: go
     name: go
     syntax: go
-    command: go main.go
+    command: go
+    example_file: main.go
   'java':
     extension: java
     name: java
     syntax: java
-    command: java Example.java
+    command: java
+    example_file: Example.java
   'cs':
     extension: cs
     name: csharp

--- a/content/en/api/_index.md
+++ b/content/en/api/_index.md
@@ -76,7 +76,7 @@ Maven `pom.xml` for running examples:
       <scope>compile</scope>
     </dependency>
   </dependencies>
-</project
+</project>
 ```
 Make sure that `CLASSPATH` variable contains all dependencies.
 

--- a/content/en/api/_index.md
+++ b/content/en/api/_index.md
@@ -31,6 +31,7 @@ By default, the Datadog API Docs show examples in cURL. Select one of our offici
 {{< programming-lang-wrapper langs="java,python,python-beta,ruby,ruby-beta,go" >}}
 
 {{< programming-lang lang="java" >}}
+#### Installation
 Maven - Add this dependency to your project's POM:
 ```java
 <dependency>
@@ -46,55 +47,70 @@ Gradle - Add this dependency to your project's build file:
 compile "com.datadoghq:datadog-api-client:1.0.0"
 ```
 
-Make sure that `CLASSPATH` variable contains all dependencies.
+#### Usage
 
+Make sure that `CLASSPATH` variable contains all dependencies.
+```java
+import com.datadog.api.<VERSION>.client.ApiClient;
+import com.datadog.api.<VERSION>.client.ApiException;
+import com.datadog.api.<VERSION>.client.Configuration;
+import com.datadog.api.v2.client.auth.*;
+import com.datadog.api.v2.client.model.*;
+import com.datadog.api.<VERSION>.client.api.*;
+```
+**Note**: Replace `<VERSION>` with v1 or v2, depending on which endpoints you want to use.
 {{< /programming-lang >}}
 
 {{< programming-lang lang="python" >}}
-```console
-$ pip install datadog
+#### Installation
+```sh
+pip install datadog
 ```
-
+#### Usage
 ```python
 import datadog
 ```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="python-beta" >}}
+#### Installation
 ```console
-$ pip3 install datadog-api-client --pre
+pip3 install datadog-api-client --pre
 ```
-
+#### Usage
 ```python
 import datadog_api_client
 ```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="ruby" >}}
-```console
-$ gem install dogapi
+#### Installation
+```sh
+gem install dogapi
 ```
-
+#### Usage
 ```ruby
 require 'dogapi'
 ```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="ruby-beta" >}}
-```console
-$ gem install datadog_api_client -v 1.0.0.beta.2 --pre
+#### Installation
+```sh
+gem install datadog_api_client -v 1.0.0.beta.2 --pre
 ```
-
+#### Usage
 ```ruby
 require 'datadog_api_client'
 ```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="go" >}}
-```console
-$ go get github.com/DataDog/datadog-api-client-go
+#### Installation
+```sh
+go get github.com/DataDog/datadog-api-client-go
 ```
-
+#### Usage
 ```go
 import "github.com/DataDog/datadog-api-client-go/api/<VERSION>/datadog"
 ```

--- a/content/en/api/_index.md
+++ b/content/en/api/_index.md
@@ -33,7 +33,7 @@ By default, the Datadog API Docs show examples in cURL. Select one of our offici
 {{< programming-lang lang="java" >}}
 #### Installation
 Maven - Add this dependency to your project's POM:
-```java
+```xml
 <dependency>
   <groupId>com.datadoghq</groupId>
   <artifactId>datadog-api-client</artifactId>
@@ -43,13 +43,12 @@ Maven - Add this dependency to your project's POM:
 ```
 
 Gradle - Add this dependency to your project's build file:
-```java
+```gradle
 compile "com.datadoghq:datadog-api-client:1.0.0"
 ```
 
 #### Usage
 
-Make sure that `CLASSPATH` variable contains all dependencies.
 ```java
 import com.datadog.api.<VERSION>.client.ApiClient;
 import com.datadog.api.<VERSION>.client.ApiException;
@@ -59,6 +58,53 @@ import com.datadog.api.v2.client.model.*;
 import com.datadog.api.<VERSION>.client.api.*;
 ```
 **Note**: Replace `<VERSION>` with v1 or v2, depending on which endpoints you want to use.
+
+#### Examples
+
+Maven `pom.xml` for running examples:
+```xml
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>example</artifactId>
+  <version>1</version>
+  <dependencies>
+    <dependency>
+      <groupId>com.datadoghq</groupId>
+      <artifactId>datadog-api-client</artifactId>
+      <version>1.0.0-beta.2</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project
+```
+Make sure that `CLASSPATH` variable contains all dependencies.
+
+```sh
+export CLASSPATH=$(mvn -q exec:exec -Dexec.executable=echo -Dexec.args="%classpath")
+```
+
+Gradle `build.gradle` for running examples:
+```gradle
+plugins {
+    id 'java'
+    id 'application'
+}
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    implementation 'com.datadoghq:datadog-api-client:1.0.0-beta.2'
+}
+
+application {
+    mainClassName = 'Example.java'
+}
+```
+Execute example by running `gradle run` command.
+
 {{< /programming-lang >}}
 
 {{< programming-lang lang="python" >}}

--- a/content/en/api/_index.md
+++ b/content/en/api/_index.md
@@ -28,7 +28,7 @@ To try out the API [![Run in Postman][3]](https://app.getpostman.com/run-collect
 
 By default, the Datadog API Docs show examples in cURL. Select one of our official [client libraries][6] languages in each endpoint to see code examples from that library. To install each library:
 
-{{< programming-lang-wrapper langs="java,python,ruby,go" >}}
+{{< programming-lang-wrapper langs="java,python,python-beta,ruby,ruby-beta,go" >}}
 
 {{< programming-lang lang="java" >}}
 Maven - Add this dependency to your project's POM:
@@ -46,6 +46,8 @@ Maven - Add this dependency to your project's POM:
 compile "com.datadoghq:datadog-api-client:1.0.0"
  ```
 
+Make sure that `CLASSPATH` variable contains all dependencies.
+
 {{< /programming-lang >}}
 
 {{< programming-lang lang="python" >}}
@@ -55,9 +57,22 @@ pip install datadog
 
 {{< /programming-lang >}}
 
+{{< programming-lang lang="python-beta" >}}
+ ```python
+pip install datadog-api-client --pre
+ ```
+
+{{< /programming-lang >}}
+
 {{< programming-lang lang="ruby" >}}
  ```ruby
 gem install dogapi
+ ```
+{{< /programming-lang >}}
+
+{{< programming-lang lang="ruby-beta" >}}
+ ```ruby
+gem install datadog_api_client -v 1.0.0.beta.2 --pre
  ```
 {{< /programming-lang >}}
 
@@ -72,7 +87,7 @@ import "github.com/DataDog/datadog-api-client-go/api/<VERSION>/datadog"
 
 Or check out the libraries directly:
 
-{{< partial name="api/sdk-languages.html" >}} 
+{{< partial name="api/sdk-languages.html" >}}
 </br>
 Trying to get started with the application instead? Check out our general [Getting Started docs][7].
 

--- a/content/en/api/_index.md
+++ b/content/en/api/_index.md
@@ -32,54 +32,72 @@ By default, the Datadog API Docs show examples in cURL. Select one of our offici
 
 {{< programming-lang lang="java" >}}
 Maven - Add this dependency to your project's POM:
- ```java
+```java
 <dependency>
   <groupId>com.datadoghq</groupId>
   <artifactId>datadog-api-client</artifactId>
   <version>1.0.0</version>
   <scope>compile</scope>
 </dependency>
- ```
+```
 
- Gradle - Add this dependency to your project's build file:
- ```java
+Gradle - Add this dependency to your project's build file:
+```java
 compile "com.datadoghq:datadog-api-client:1.0.0"
- ```
+```
 
 Make sure that `CLASSPATH` variable contains all dependencies.
 
 {{< /programming-lang >}}
 
 {{< programming-lang lang="python" >}}
- ```python
-pip install datadog
- ```
+```console
+$ pip install datadog
+```
 
+```python
+import datadog
+```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="python-beta" >}}
- ```python
-pip install datadog-api-client --pre
- ```
+```console
+$ pip3 install datadog-api-client --pre
+```
 
+```python
+import datadog_api_client
+```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="ruby" >}}
- ```ruby
-gem install dogapi
- ```
+```console
+$ gem install dogapi
+```
+
+```ruby
+require 'dogapi'
+```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="ruby-beta" >}}
- ```ruby
-gem install datadog_api_client -v 1.0.0.beta.2 --pre
- ```
+```console
+$ gem install datadog_api_client -v 1.0.0.beta.2 --pre
+```
+
+```ruby
+require 'datadog_api_client'
+```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="go" >}}
- ```go
+```console
+$ go get github.com/DataDog/datadog-api-client-go
+```
+
+```go
 import "github.com/DataDog/datadog-api-client-go/api/<VERSION>/datadog"
- ```
+```
  **Note**: Replace `<VERSION>` with v1 or v2, depending on which endpoints you want to use.
 {{< /programming-lang >}}
 

--- a/content/en/api/v1/_index.md
+++ b/content/en/api/v1/_index.md
@@ -76,7 +76,7 @@ Maven `pom.xml` for running examples:
       <scope>compile</scope>
     </dependency>
   </dependencies>
-</project
+</project>
 ```
 Make sure that `CLASSPATH` variable contains all dependencies.
 

--- a/content/en/api/v1/_index.md
+++ b/content/en/api/v1/_index.md
@@ -31,6 +31,7 @@ By default, the Datadog API Docs show examples in cURL. Select one of our offici
 {{< programming-lang-wrapper langs="java,python,python-beta,ruby,ruby-beta,go" >}}
 
 {{< programming-lang lang="java" >}}
+#### Installation
 Maven - Add this dependency to your project's POM:
 ```java
 <dependency>
@@ -46,55 +47,70 @@ Gradle - Add this dependency to your project's build file:
 compile "com.datadoghq:datadog-api-client:1.0.0"
 ```
 
-Make sure that `CLASSPATH` variable contains all dependencies.
+#### Usage
 
+Make sure that `CLASSPATH` variable contains all dependencies.
+```java
+import com.datadog.api.<VERSION>.client.ApiClient;
+import com.datadog.api.<VERSION>.client.ApiException;
+import com.datadog.api.<VERSION>.client.Configuration;
+import com.datadog.api.v2.client.auth.*;
+import com.datadog.api.v2.client.model.*;
+import com.datadog.api.<VERSION>.client.api.*;
+```
+**Note**: Replace `<VERSION>` with v1 or v2, depending on which endpoints you want to use.
 {{< /programming-lang >}}
 
 {{< programming-lang lang="python" >}}
-```console
-$ pip install datadog
+#### Installation
+```sh
+pip install datadog
 ```
-
+#### Usage
 ```python
 import datadog
 ```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="python-beta" >}}
+#### Installation
 ```console
-$ pip3 install datadog-api-client --pre
+pip3 install datadog-api-client --pre
 ```
-
+#### Usage
 ```python
 import datadog_api_client
 ```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="ruby" >}}
-```console
-$ gem install dogapi
+#### Installation
+```sh
+gem install dogapi
 ```
-
+#### Usage
 ```ruby
 require 'dogapi'
 ```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="ruby-beta" >}}
-```console
-$ gem install datadog_api_client -v 1.0.0.beta.2 --pre
+#### Installation
+```sh
+gem install datadog_api_client -v 1.0.0.beta.2 --pre
 ```
-
+#### Usage
 ```ruby
 require 'datadog_api_client'
 ```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="go" >}}
-```console
-$ go get github.com/DataDog/datadog-api-client-go
+#### Installation
+```sh
+go get github.com/DataDog/datadog-api-client-go
 ```
-
+#### Usage
 ```go
 import "github.com/DataDog/datadog-api-client-go/api/<VERSION>/datadog"
 ```

--- a/content/en/api/v1/_index.md
+++ b/content/en/api/v1/_index.md
@@ -33,7 +33,7 @@ By default, the Datadog API Docs show examples in cURL. Select one of our offici
 {{< programming-lang lang="java" >}}
 #### Installation
 Maven - Add this dependency to your project's POM:
-```java
+```xml
 <dependency>
   <groupId>com.datadoghq</groupId>
   <artifactId>datadog-api-client</artifactId>
@@ -43,13 +43,12 @@ Maven - Add this dependency to your project's POM:
 ```
 
 Gradle - Add this dependency to your project's build file:
-```java
+```gradle
 compile "com.datadoghq:datadog-api-client:1.0.0"
 ```
 
 #### Usage
 
-Make sure that `CLASSPATH` variable contains all dependencies.
 ```java
 import com.datadog.api.<VERSION>.client.ApiClient;
 import com.datadog.api.<VERSION>.client.ApiException;
@@ -59,6 +58,53 @@ import com.datadog.api.v2.client.model.*;
 import com.datadog.api.<VERSION>.client.api.*;
 ```
 **Note**: Replace `<VERSION>` with v1 or v2, depending on which endpoints you want to use.
+
+#### Examples
+
+Maven `pom.xml` for running examples:
+```xml
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>example</artifactId>
+  <version>1</version>
+  <dependencies>
+    <dependency>
+      <groupId>com.datadoghq</groupId>
+      <artifactId>datadog-api-client</artifactId>
+      <version>1.0.0-beta.2</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project
+```
+Make sure that `CLASSPATH` variable contains all dependencies.
+
+```sh
+export CLASSPATH=$(mvn -q exec:exec -Dexec.executable=echo -Dexec.args="%classpath")
+```
+
+Gradle `build.gradle` for running examples:
+```gradle
+plugins {
+    id 'java'
+    id 'application'
+}
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    implementation 'com.datadoghq:datadog-api-client:1.0.0-beta.2'
+}
+
+application {
+    mainClassName = 'Example.java'
+}
+```
+Execute example by running `gradle run` command.
+
 {{< /programming-lang >}}
 
 {{< programming-lang lang="python" >}}

--- a/content/en/api/v1/_index.md
+++ b/content/en/api/v1/_index.md
@@ -32,54 +32,72 @@ By default, the Datadog API Docs show examples in cURL. Select one of our offici
 
 {{< programming-lang lang="java" >}}
 Maven - Add this dependency to your project's POM:
- ```java
+```java
 <dependency>
   <groupId>com.datadoghq</groupId>
   <artifactId>datadog-api-client</artifactId>
   <version>1.0.0</version>
   <scope>compile</scope>
 </dependency>
- ```
+```
 
- Gradle - Add this dependency to your project's build file:
- ```java
+Gradle - Add this dependency to your project's build file:
+```java
 compile "com.datadoghq:datadog-api-client:1.0.0"
- ```
+```
 
 Make sure that `CLASSPATH` variable contains all dependencies.
 
 {{< /programming-lang >}}
 
 {{< programming-lang lang="python" >}}
- ```python
-pip install datadog
- ```
+```console
+$ pip install datadog
+```
 
+```python
+import datadog
+```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="python-beta" >}}
- ```python
-pip install datadog-api-client --pre
- ```
+```console
+$ pip3 install datadog-api-client --pre
+```
 
+```python
+import datadog_api_client
+```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="ruby" >}}
- ```ruby
-gem install dogapi
- ```
+```console
+$ gem install dogapi
+```
+
+```ruby
+require 'dogapi'
+```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="ruby-beta" >}}
- ```ruby
-gem install datadog_api_client -v 1.0.0.beta.2 --pre
- ```
+```console
+$ gem install datadog_api_client -v 1.0.0.beta.2 --pre
+```
+
+```ruby
+require 'datadog_api_client'
+```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="go" >}}
- ```go
+```console
+$ go get github.com/DataDog/datadog-api-client-go
+```
+
+```go
 import "github.com/DataDog/datadog-api-client-go/api/<VERSION>/datadog"
- ```
+```
  **Note**: Replace `<VERSION>` with v1 or v2, depending on which endpoints you want to use.
 {{< /programming-lang >}}
 

--- a/content/en/api/v1/_index.md
+++ b/content/en/api/v1/_index.md
@@ -28,7 +28,7 @@ To try out the API [![Run in Postman][3]](https://app.getpostman.com/run-collect
 
 By default, the Datadog API Docs show examples in cURL. Select one of our official [client libraries][6] languages in each endpoint to see code examples from that library. To install each library:
 
-{{< programming-lang-wrapper langs="java,python,ruby,go" >}}
+{{< programming-lang-wrapper langs="java,python,python-beta,ruby,ruby-beta,go" >}}
 
 {{< programming-lang lang="java" >}}
 Maven - Add this dependency to your project's POM:
@@ -46,6 +46,8 @@ Maven - Add this dependency to your project's POM:
 compile "com.datadoghq:datadog-api-client:1.0.0"
  ```
 
+Make sure that `CLASSPATH` variable contains all dependencies.
+
 {{< /programming-lang >}}
 
 {{< programming-lang lang="python" >}}
@@ -55,9 +57,22 @@ pip install datadog
 
 {{< /programming-lang >}}
 
+{{< programming-lang lang="python-beta" >}}
+ ```python
+pip install datadog-api-client --pre
+ ```
+
+{{< /programming-lang >}}
+
 {{< programming-lang lang="ruby" >}}
  ```ruby
 gem install dogapi
+ ```
+{{< /programming-lang >}}
+
+{{< programming-lang lang="ruby-beta" >}}
+ ```ruby
+gem install datadog_api_client -v 1.0.0.beta.2 --pre
  ```
 {{< /programming-lang >}}
 
@@ -72,7 +87,7 @@ import "github.com/DataDog/datadog-api-client-go/api/<VERSION>/datadog"
 
 Or check out the libraries directly:
 
-{{< partial name="api/sdk-languages.html" >}} 
+{{< partial name="api/sdk-languages.html" >}}
 </br>
 Trying to get started with the application instead? Check out our general [Getting Started docs][7].
 
@@ -86,4 +101,4 @@ Trying to get started with the application instead? Check out our general [Getti
 [4]: /api/v1/using-the-api/
 [5]: https://brew.sh
 [6]: https://docs.datadoghq.com/developers/libraries/
-[7]: /getting_started/application/ß
+[7]: /getting_started/application/

--- a/content/en/api/v2/_index.md
+++ b/content/en/api/v2/_index.md
@@ -76,7 +76,7 @@ Maven `pom.xml` for running examples:
       <scope>compile</scope>
     </dependency>
   </dependencies>
-</project
+</project>
 ```
 Make sure that `CLASSPATH` variable contains all dependencies.
 

--- a/content/en/api/v2/_index.md
+++ b/content/en/api/v2/_index.md
@@ -31,6 +31,7 @@ By default, the Datadog API Docs show examples in cURL. Select one of our offici
 {{< programming-lang-wrapper langs="java,python,python-beta,ruby,ruby-beta,go" >}}
 
 {{< programming-lang lang="java" >}}
+#### Installation
 Maven - Add this dependency to your project's POM:
 ```java
 <dependency>
@@ -46,55 +47,70 @@ Gradle - Add this dependency to your project's build file:
 compile "com.datadoghq:datadog-api-client:1.0.0"
 ```
 
-Make sure that `CLASSPATH` variable contains all dependencies.
+#### Usage
 
+Make sure that `CLASSPATH` variable contains all dependencies.
+```java
+import com.datadog.api.<VERSION>.client.ApiClient;
+import com.datadog.api.<VERSION>.client.ApiException;
+import com.datadog.api.<VERSION>.client.Configuration;
+import com.datadog.api.v2.client.auth.*;
+import com.datadog.api.v2.client.model.*;
+import com.datadog.api.<VERSION>.client.api.*;
+```
+**Note**: Replace `<VERSION>` with v1 or v2, depending on which endpoints you want to use.
 {{< /programming-lang >}}
 
 {{< programming-lang lang="python" >}}
-```console
-$ pip install datadog
+#### Installation
+```sh
+pip install datadog
 ```
-
+#### Usage
 ```python
 import datadog
 ```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="python-beta" >}}
+#### Installation
 ```console
-$ pip3 install datadog-api-client --pre
+pip3 install datadog-api-client --pre
 ```
-
+#### Usage
 ```python
 import datadog_api_client
 ```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="ruby" >}}
-```console
-$ gem install dogapi
+#### Installation
+```sh
+gem install dogapi
 ```
-
+#### Usage
 ```ruby
 require 'dogapi'
 ```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="ruby-beta" >}}
-```console
-$ gem install datadog_api_client -v 1.0.0.beta.2 --pre
+#### Installation
+```sh
+gem install datadog_api_client -v 1.0.0.beta.2 --pre
 ```
-
+#### Usage
 ```ruby
 require 'datadog_api_client'
 ```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="go" >}}
-```console
-$ go get github.com/DataDog/datadog-api-client-go
+#### Installation
+```sh
+go get github.com/DataDog/datadog-api-client-go
 ```
-
+#### Usage
 ```go
 import "github.com/DataDog/datadog-api-client-go/api/<VERSION>/datadog"
 ```

--- a/content/en/api/v2/_index.md
+++ b/content/en/api/v2/_index.md
@@ -33,7 +33,7 @@ By default, the Datadog API Docs show examples in cURL. Select one of our offici
 {{< programming-lang lang="java" >}}
 #### Installation
 Maven - Add this dependency to your project's POM:
-```java
+```xml
 <dependency>
   <groupId>com.datadoghq</groupId>
   <artifactId>datadog-api-client</artifactId>
@@ -43,13 +43,12 @@ Maven - Add this dependency to your project's POM:
 ```
 
 Gradle - Add this dependency to your project's build file:
-```java
+```gradle
 compile "com.datadoghq:datadog-api-client:1.0.0"
 ```
 
 #### Usage
 
-Make sure that `CLASSPATH` variable contains all dependencies.
 ```java
 import com.datadog.api.<VERSION>.client.ApiClient;
 import com.datadog.api.<VERSION>.client.ApiException;
@@ -59,6 +58,53 @@ import com.datadog.api.v2.client.model.*;
 import com.datadog.api.<VERSION>.client.api.*;
 ```
 **Note**: Replace `<VERSION>` with v1 or v2, depending on which endpoints you want to use.
+
+#### Examples
+
+Maven `pom.xml` for running examples:
+```xml
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>example</artifactId>
+  <version>1</version>
+  <dependencies>
+    <dependency>
+      <groupId>com.datadoghq</groupId>
+      <artifactId>datadog-api-client</artifactId>
+      <version>1.0.0-beta.2</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project
+```
+Make sure that `CLASSPATH` variable contains all dependencies.
+
+```sh
+export CLASSPATH=$(mvn -q exec:exec -Dexec.executable=echo -Dexec.args="%classpath")
+```
+
+Gradle `build.gradle` for running examples:
+```gradle
+plugins {
+    id 'java'
+    id 'application'
+}
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    implementation 'com.datadoghq:datadog-api-client:1.0.0-beta.2'
+}
+
+application {
+    mainClassName = 'Example.java'
+}
+```
+Execute example by running `gradle run` command.
+
 {{< /programming-lang >}}
 
 {{< programming-lang lang="python" >}}

--- a/content/en/api/v2/_index.md
+++ b/content/en/api/v2/_index.md
@@ -28,7 +28,7 @@ To try out the API [![Run in Postman][3]](https://app.getpostman.com/run-collect
 
 By default, the Datadog API Docs show examples in cURL. Select one of our official [client libraries][6] languages in each endpoint to see code examples from that library. To install each library:
 
-{{< programming-lang-wrapper langs="java,python,ruby,go" >}}
+{{< programming-lang-wrapper langs="java,python,python-beta,ruby,ruby-beta,go" >}}
 
 {{< programming-lang lang="java" >}}
 Maven - Add this dependency to your project's POM:
@@ -46,6 +46,8 @@ Maven - Add this dependency to your project's POM:
 compile "com.datadoghq:datadog-api-client:1.0.0"
  ```
 
+Make sure that `CLASSPATH` variable contains all dependencies.
+
 {{< /programming-lang >}}
 
 {{< programming-lang lang="python" >}}
@@ -55,9 +57,22 @@ pip install datadog
 
 {{< /programming-lang >}}
 
+{{< programming-lang lang="python-beta" >}}
+ ```python
+pip install datadog-api-client --pre
+ ```
+
+{{< /programming-lang >}}
+
 {{< programming-lang lang="ruby" >}}
  ```ruby
 gem install dogapi
+ ```
+{{< /programming-lang >}}
+
+{{< programming-lang lang="ruby-beta" >}}
+ ```ruby
+gem install datadog_api_client -v 1.0.0.beta.2 --pre
  ```
 {{< /programming-lang >}}
 
@@ -72,7 +87,7 @@ import "github.com/DataDog/datadog-api-client-go/api/<VERSION>/datadog"
 
 Or check out the libraries directly:
 
-{{< partial name="api/sdk-languages.html" >}} 
+{{< partial name="api/sdk-languages.html" >}}
 </br>
 Trying to get started with the application instead? Check out our general [Getting Started docs][7].
 

--- a/content/en/api/v2/_index.md
+++ b/content/en/api/v2/_index.md
@@ -32,54 +32,72 @@ By default, the Datadog API Docs show examples in cURL. Select one of our offici
 
 {{< programming-lang lang="java" >}}
 Maven - Add this dependency to your project's POM:
- ```java
+```java
 <dependency>
   <groupId>com.datadoghq</groupId>
   <artifactId>datadog-api-client</artifactId>
   <version>1.0.0</version>
   <scope>compile</scope>
 </dependency>
- ```
+```
 
- Gradle - Add this dependency to your project's build file:
- ```java
+Gradle - Add this dependency to your project's build file:
+```java
 compile "com.datadoghq:datadog-api-client:1.0.0"
- ```
+```
 
 Make sure that `CLASSPATH` variable contains all dependencies.
 
 {{< /programming-lang >}}
 
 {{< programming-lang lang="python" >}}
- ```python
-pip install datadog
- ```
+```console
+$ pip install datadog
+```
 
+```python
+import datadog
+```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="python-beta" >}}
- ```python
-pip install datadog-api-client --pre
- ```
+```console
+$ pip3 install datadog-api-client --pre
+```
 
+```python
+import datadog_api_client
+```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="ruby" >}}
- ```ruby
-gem install dogapi
- ```
+```console
+$ gem install dogapi
+```
+
+```ruby
+require 'dogapi'
+```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="ruby-beta" >}}
- ```ruby
-gem install datadog_api_client -v 1.0.0.beta.2 --pre
- ```
+```console
+$ gem install datadog_api_client -v 1.0.0.beta.2 --pre
+```
+
+```ruby
+require 'datadog_api_client'
+```
 {{< /programming-lang >}}
 
 {{< programming-lang lang="go" >}}
- ```go
+```console
+$ go get github.com/DataDog/datadog-api-client-go
+```
+
+```go
 import "github.com/DataDog/datadog-api-client-go/api/<VERSION>/datadog"
- ```
+```
  **Note**: Replace `<VERSION>` with v1 or v2, depending on which endpoints you want to use.
 {{< /programming-lang >}}
 

--- a/data/libraries.yaml
+++ b/data/libraries.yaml
@@ -65,7 +65,7 @@ Classic:
     - name: dogstatsde
       link: https://github.com/waisbrot/dogstatsde
       dogstatsd: true
-      authors: waisbrot    
+      authors: waisbrot
   - Go:
     - name: datadog-go
       link: https://github.com/DataDog/datadog-go
@@ -202,6 +202,11 @@ Classic:
   - Ruby:
     - name: DogApi
       link: https://github.com/DataDog/dogapi-rb
+      official: true
+      api: true
+      authors: Datadog
+    - name: datadog_api_client
+      link: https://github.com/DataDog/datadog-api-client-ruby
       official: true
       api: true
       authors: Datadog

--- a/layouts/partials/api/code-example.html
+++ b/layouts/partials/api/code-example.html
@@ -80,10 +80,11 @@
             </div>
 
             <h4>Instructions</h4>
+            <p>Save example to <code>{{ $lang.example_file }}</code> and run following commands.</p>
 
             <pre class="chroma">
               <code class="language-fallback" data-lang="sh"><div class="code-snippet"><span class="kn">export</span> <span class="n">DD_SITE</span><span class="o">=</span><span class="s1">"{{ range $region, $url := $endpoint.regions }}{{ if ne $region "local" }}<span class="kn d-none" data-region="{{ $region }}">{{ $url }}</span>{{ else }}{{ $url }}</span>{{ end }}{{ end }}"</span>
-<span class="n">{{ $lang.command }}</span></div></code></pre>
+<span class="n">{{ $lang.command }}</span> <span class="s1">"{{ $lang.example_file }}"</span></div></code></pre>
 
           </div>
           {{ $count = add $count 1 }}

--- a/layouts/partials/api/code-example.html
+++ b/layouts/partials/api/code-example.html
@@ -80,7 +80,7 @@
             </div>
 
             <h4>Instructions</h4>
-            <p>Save the example to <code>{{ $lang.example_file }}</code> and run following commands:</p>
+            <p>First <a href="{{ "api/" | absLangURL }}?code-lang={{ $lang.name }}">install the library and its dependencies</a> and then save the example to <code>{{ $lang.example_file }}</code> and run following commands:</p>
 
             <pre class="chroma">
               <code class="language-fallback" data-lang="sh"><div class="code-snippet"><span class="kn">export</span> <span class="n">DD_SITE</span><span class="o">=</span><span class="s1">"{{ range $region, $url := $endpoint.regions }}{{ if ne $region "local" }}<span class="kn d-none" data-region="{{ $region }}">{{ $url }}</span>{{ else }}{{ $url }}</span>{{ end }}{{ end }}"</span>

--- a/layouts/partials/api/code-example.html
+++ b/layouts/partials/api/code-example.html
@@ -72,12 +72,19 @@
 
         {{ if ne $file_extension "sh"}}
           <div class="code-snippet-wrapper js-code-block" data-code-lang-block="{{ $lang.name }}">
-              <div class="code-snippet">
+            <div class="code-snippet">
               <div class="code-button-wrapper position-absolute">
                   <button class="btn text-primary js-copy-button">{{ i18n "copy" }}</button>
               </div>
               {{ highlight $file_content $lang.syntax "" }}
-          </div>
+            </div>
+
+            <h4>Instructions</h4>
+
+            <pre class="chroma">
+              <code class="language-fallback" data-lang="sh"><div class="code-snippet"><span class="kn">export</span> <span class="n">DD_SITE</span><span class="o">=</span><span class="s1">"{{ range $region, $url := $endpoint.regions }}{{ if ne $region "local" }}<span class="kn d-none" data-region="{{ $region }}">{{ $url }}</span>{{ else }}{{ $url }}</span>{{ end }}{{ end }}"</span>
+<span class="n">{{ $lang.command }}</span></div></code></pre>
+
           </div>
           {{ $count = add $count 1 }}
         {{ end }}

--- a/layouts/partials/api/code-example.html
+++ b/layouts/partials/api/code-example.html
@@ -80,7 +80,7 @@
             </div>
 
             <h4>Instructions</h4>
-            <p>Save example to <code>{{ $lang.example_file }}</code> and run following commands.</p>
+            <p>Save the example to <code>{{ $lang.example_file }}</code> and run following commands:</p>
 
             <pre class="chroma">
               <code class="language-fallback" data-lang="sh"><div class="code-snippet"><span class="kn">export</span> <span class="n">DD_SITE</span><span class="o">=</span><span class="s1">"{{ range $region, $url := $endpoint.regions }}{{ if ne $region "local" }}<span class="kn d-none" data-region="{{ $region }}">{{ $url }}</span>{{ else }}{{ $url }}</span>{{ end }}{{ end }}"</span>

--- a/layouts/partials/api/code-example.html
+++ b/layouts/partials/api/code-example.html
@@ -80,7 +80,7 @@
             </div>
 
             <h4>Instructions</h4>
-            <p>First <a href="{{ "api/" | absLangURL }}?code-lang={{ $lang.name }}">install the library and its dependencies</a> and then save the example to <code>{{ $lang.example_file }}</code> and run following commands:</p>
+            <p>First <a href="{{ "api/latest/" | absLangURL }}?code-lang={{ $lang.name }}">install the library and its dependencies</a> and then save the example to <code>{{ $lang.example_file }}</code> and run following commands:</p>
 
             <pre class="chroma">
               <code class="language-fallback" data-lang="sh"><div class="code-snippet"><span class="kn">export</span> <span class="n">DD_SITE</span><span class="o">=</span><span class="s1">"{{ range $region, $url := $endpoint.regions }}{{ if ne $region "local" }}<span class="kn d-none" data-region="{{ $region }}">{{ $url }}</span>{{ else }}{{ $url }}</span>{{ end }}{{ end }}"</span>

--- a/layouts/shortcodes/programming-lang-wrapper.html
+++ b/layouts/shortcodes/programming-lang-wrapper.html
@@ -8,4 +8,4 @@
 
     {{ partial "code-lang-tabs" (dict "context" . "codeLangs" $codeLangs ) }}
     {{ .Inner }}
-</div> 
+</div>


### PR DESCRIPTION
### What does this PR do?

Adds instructions how to run API code examples.

### Motivation

- `DD_SITE` needs to be exported
- command and file name might not be obvious

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jirikuncar/dd-site/api/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
