### PR TITLE
fix link to slack app

### DIFF
--- a/content/en/monitors/incident_management/_index.md
+++ b/content/en/monitors/incident_management/_index.md
@@ -188,3 +188,4 @@ Link to a postmortem document, look back on exactly what went wrong, and add fol
 [5]: /tracing/#2-instrument-your-application
 [6]: https://app.datadoghq.com/incidents/ddslackapp
 [7]: https://app.datadoghq.com/notebook/list
+[8]: https://docs.datadoghq.com/integrations/slack/?tab=slackapplicationus


### PR DESCRIPTION
### What does this PR do?
Quick fix to a broken link on this page.

### Motivation
Just noticed the broken link.

### Preview
https://docs-staging.datadoghq.com/samcip/fix-link/monitors/incident_management/


### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
