### PR TITLE
List out AWS logs supported for auto trigger configuration

### DIFF
--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -33,13 +33,16 @@ There are two options when configuring triggers on the Datadog Forwarder Lambda 
 
 ### Automatically set up triggers
 
-Datadog can automatically configure triggers on the Datadog Forwarder Lambda function to collect the following logs:
-- S3 Access Logs
-- Classic ELB Access Logs
-- Application ELB Access Logs
-- CloudFront Access Logs
-- Redshift Logs
-- Lambda CloudWatch Logs
+Datadog can automatically configure triggers on the Datadog Forwarder Lambda function to collect AWS logs from the following sources and locations:
+
+| Source                          | Location       |
+| ------------------------------- | ---------------|
+| S3 Access Logs                  | S3             |
+| Classic ELB Access Logs         | S3             |
+| Application ELB Access Logs     | S3             |
+| CloudFront Access Logs          | S3             |
+| Redshift Logs                   | S3             |
+| Lambda Logs                     | CloudWatch     |
 
 1. If you haven't already, set up the [Datadog log collection AWS Lambda function][1].
 2. Ensure the policy of the IAM role used for [Datadog-AWS integration][3] has the following permissions. Information on how these permissions are used can be found in the descriptions below:

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -33,7 +33,13 @@ There are two options when configuring triggers on the Datadog Forwarder Lambda 
 
 ### Automatically set up triggers
 
-If you are storing logs in many S3 buckets or CloudWatch Log groups, Datadog can automatically manage triggers for you.
+Datadog can automatically configure triggers on the Datadog Forwarder Lambda function to collect the following logs:
+- S3 Access Logs
+- Classic ELB Access Logs
+- Application ELB Access Logs
+- CloudFront Access Logs
+- Redshift Logs
+- Lambda CloudWatch Logs
 
 1. If you haven't already, set up the [Datadog log collection AWS Lambda function][1].
 2. Ensure the policy of the IAM role used for [Datadog-AWS integration][3] has the following permissions. Information on how these permissions are used can be found in the descriptions below:


### PR DESCRIPTION
### What does this PR do?

List out AWS logs supported for auto trigger configuration.

### Motivation

Customer expected the auto trigger configuration feature to work for non-supported AWS logs. While we expand the support coverage, we should list out the supported logs.

### Preview

https://docs-staging.datadoghq.com/tian.chu/list-supported-aws-logs-for-auto-trigger-configuration/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#automatically-set-up-triggers

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
