### PR TITLE
api: fix command to run go examples

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -39,7 +39,7 @@ code_languages:
     extension: go
     name: go
     syntax: go
-    command: go
+    command: go run
     example_file: main.go
   'java':
     extension: java


### PR DESCRIPTION
### What does this PR do?

```console
$ go run main.go
```

### Motivation

It slipped when refactoring templates.

### Preview
https://docs-staging.datadoghq.com/jirikuncar/go-run/api/ip-ranges/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
