### PR TITLE
Update rsyslog.md

### DIFF
--- a/content/en/integrations/rsyslog.md
+++ b/content/en/integrations/rsyslog.md
@@ -43,7 +43,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
 
     ```conf
     ## For each file to send
-    input(type="imfile" ruleset="infiles" Tag="<APP_NAME_OF_FILE1>" File="<PATH_TO_FILE1>" StateFile="<UNIQUE_FILE_ID>")
+    input(type="imfile" ruleset="infiles" Tag="<APP_NAME_OF_FILE1>" File="<PATH_TO_FILE1>")
 
     ## Set the Datadog Format to send the logs
     $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - - %msg%\n"


### PR DESCRIPTION
Remove StateFile=" argument as this is deprecated.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update the rsyslog documentation 

### Motivation
<!-- What inspired you to submit this pull request?-->
Errors in the rsyslog file like this:
Mar  1 16:12:30 gcp-deb-canary01 rsyslogd: error during parsing file /etc/rsyslog.d/datadog.conf, on or before line 4: parameter 'statefile' deprecated but accepted, consider removing or replacing it [v8.1901.0 try https://www.rsyslog.com/e/2207 ]

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
