### PR TITLE
Update agent-log-files.md - Agent Install Log Location

### DIFF
--- a/content/en/agent/guide/agent-log-files.md
+++ b/content/en/agent/guide/agent-log-files.md
@@ -74,7 +74,7 @@ The Datadog Agent does a logs rollover every 10MB. When a rollover occurs, one b
 
 | Platform                             | Location and file name        |
 |--------------------------------------|-------------------------------|
-| Linux                                | `/tmp/dd_agent.log`           |
+| Linux                                | `$pwd/ddagent-install.log`    |
 | macOS                                | `/tmp/dd_agent.log`           |
 | Windows                              | `%TEMP%\MSI*.LOG`             |
 


### PR DESCRIPTION
the Agent Install Logs are stored in the $PWD at the time the Agent was installed.  
If the Agent Install command was run from /tmp, the Install Log will be /tmp/ddagent-install.log
If the Agent Install command was run from ~ the Install Log will be ~/ddagent-install.log

https://datadoghq.atlassian.net/browse/DOCS-1750

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
