### PR TITLE
Remove deprecated syslog param

### DIFF
--- a/content/fr/integrations/rsyslog.md
+++ b/content/fr/integrations/rsyslog.md
@@ -42,7 +42,7 @@ Configurez Rsyslog pour rassembler les logs de votre host, de vos conteneurs et 
 
     ```conf
     ## For each file to send
-    input(type="imfile" ruleset="infiles" Tag="<APP_NAME_OF_FILE1>" File="<PATH_TO_FILE1>" StateFile="<UNIQUE_FILE_ID>")
+    input(type="imfile" ruleset="infiles" Tag="<APP_NAME_OF_FILE1>" File="<PATH_TO_FILE1>")
 
     ## Set the Datadog Format to send the logs
     $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - - %msg%\n"

--- a/content/ja/integrations/rsyslog.md
+++ b/content/ja/integrations/rsyslog.md
@@ -26,7 +26,7 @@ Rsyslog を構成して、ホスト、コンテナ、サービスからログを
 
 ### ログの収集
 
-#### Rsyslog バージョン 8 以上 
+#### Rsyslog バージョン 8 以上
 
 {{< tabs >}}
 {{% tab "Datadog US site" %}}
@@ -42,7 +42,7 @@ Rsyslog を構成して、ホスト、コンテナ、サービスからログを
 
     ```conf
     ## For each file to send
-    input(type="imfile" ruleset="infiles" Tag="<APP_NAME_OF_FILE1>" File="<PATH_TO_FILE1>" StateFile="<UNIQUE_FILE_ID>")
+    input(type="imfile" ruleset="infiles" Tag="<APP_NAME_OF_FILE1>" File="<PATH_TO_FILE1>")
 
     ## Set the Datadog Format to send the logs
     $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - - %msg%\n"


### PR DESCRIPTION
### What does this PR do?
Removing deprecated syslog param as it's not recommended for [newly created configs](https://www.rsyslog.com/doc/v8-stable/configuration/modules/imfile.html#deprecated-parameters)

### Motivation
#9897 has the US file, just removing from JA/FR as the content should be removed

### Preview
https://docs-staging.datadoghq.com/sarina/ryslog-statefile/integrations/ryslog

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
