### PR TITLE
remove non public mds

### DIFF
--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -622,14 +622,16 @@ class Integrations:
         )
 
         if not exist_already and no_integration_issue:
-            with open(self.content_integrations_dir + new_file_name, "w", ) as out:
-                out.write(result)
+            # lets only write out file.md if its going to be public
+            if manifest_json.get("is_public", False):
+                with open(self.content_integrations_dir + new_file_name, "w", ) as out:
+                    out.write(result)
 
-            ## Reformating all links now that all processing is done
-            if tab_logic:
-                final_text = format_link_file(self.content_integrations_dir + new_file_name,regex_skip_sections_start,regex_skip_sections_end)
-                with open(self.content_integrations_dir + new_file_name, 'w') as final_file:
-                    final_file.write(final_text)
+                ## Reformating all links now that all processing is done
+                if tab_logic:
+                    final_text = format_link_file(self.content_integrations_dir + new_file_name,regex_skip_sections_start,regex_skip_sections_end)
+                    with open(self.content_integrations_dir + new_file_name, 'w') as final_file:
+                        final_file.write(final_text)
 
     def add_integration_frontmatter(
         self, file_name, content, dependencies=[]


### PR DESCRIPTION
### What does this PR do?

We were still building `is_public:false` integrations which tests like trademark checker were failing on.
This PR stops building the files any more.

### Motivation
Issues with trademark checker failing on files that we don't care about

### Preview

https://docs-staging.datadoghq.com/david.jones/rm-ispublic-mds/integrations/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
