### PR TITLE
api: fix DD_SITE value for generated clients

### DIFF
--- a/layouts/partials/api/code-example.html
+++ b/layouts/partials/api/code-example.html
@@ -83,7 +83,13 @@
             <p>First <a href="{{ "api/latest/" | absLangURL }}?code-lang={{ $lang.name }}">install the library and its dependencies</a> and then save the example to <code>{{ $lang.example_file }}</code> and run following commands:</p>
 
             <pre class="chroma">
-              <code class="language-fallback" data-lang="sh"><div class="code-snippet"><span class="kn">export</span> <span class="n">DD_SITE</span><span class="o">=</span><span class="s1">"{{ range $context.Site.Params.allowedRegions }}<span class="d-none" data-region="{{ .value }}">{{ .domain }}</span>{{ end }}"</span>
+              <code class="language-fallback" data-lang="sh"><div class="code-snippet"><span class="kn">export</span> <span class="n">DD_SITE</span><span class="o">=</span><span class="s1">"{{- range $context.Site.Params.allowedRegions -}}
+                {{- if not (index ($endpoint.regions) .value) -}}
+                  <span class="d-none" data-region="{{ .value }}">Not supported in the {{ .name }} region</span>
+                {{- else -}}
+                  <span class="d-none" data-region="{{ .value }}">{{ .domain }}</span>
+                {{- end -}}
+            {{- end -}}"</span>
 <span class="n">{{ $lang.command }}</span> <span class="s1">"{{ $lang.example_file }}"</span></div></code></pre>
 
           </div>

--- a/layouts/partials/api/code-example.html
+++ b/layouts/partials/api/code-example.html
@@ -83,7 +83,7 @@
             <p>First <a href="{{ "api/latest/" | absLangURL }}?code-lang={{ $lang.name }}">install the library and its dependencies</a> and then save the example to <code>{{ $lang.example_file }}</code> and run following commands:</p>
 
             <pre class="chroma">
-              <code class="language-fallback" data-lang="sh"><div class="code-snippet"><span class="kn">export</span> <span class="n">DD_SITE</span><span class="o">=</span><span class="s1">"{{ range $region, $url := $endpoint.regions }}{{ if ne $region "local" }}<span class="kn d-none" data-region="{{ $region }}">{{ $url }}</span>{{ else }}{{ $url }}</span>{{ end }}{{ end }}"</span>
+              <code class="language-fallback" data-lang="sh"><div class="code-snippet"><span class="kn">export</span> <span class="n">DD_SITE</span><span class="o">=</span><span class="s1">"{{ range $context.Site.Params.allowedRegions }}<span class="d-none" data-region="{{ .value }}">{{ .domain }}</span>{{ end }}"</span>
 <span class="n">{{ $lang.command }}</span> <span class="s1">"{{ $lang.example_file }}"</span></div></code></pre>
 
           </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

The `DD_SITE` variable must not contain a subdomain.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jirikuncar/dd-site-examples-fix/api/latest/ip-ranges/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
