### PR TITLE
[WEB-950] - compare on ident instead of title for consistency

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -99,112 +99,134 @@ main_left:
     name: Solutions
     url: '#'
     weight: -460
-  - name: Financial Services
+  - identifier: industry-financial
+    name: Financial Services
     parent: solutions
     title: industry
     url: 'https://www.datadoghq.com/solutions/financial-services/'
     weight: -460
-  - name: Manufacturing & Logistics
+  - identifier: industry-manufacturing
+    name: Manufacturing & Logistics
     parent: solutions
     title: industry
     url: 'https://www.datadoghq.com/solutions/manufacturing-logistics/'
     weight: -459
-  - name: Healthcare/Life Sciences
+  - identifier: industry-healthcare
+    name: Healthcare/Life Sciences
     parent: solutions
     title: industry
     url: 'https://www.datadoghq.com/solutions/healthcare/'
     weight: -458
-  - name: Retail/E-Commerce
+  - identifier: industry-retail
+    name: Retail/E-Commerce
     parent: solutions
     title: industry
     url: 'https://www.datadoghq.com/solutions/retail-ecommerce/'
     weight: -457
-  - name: Public Sector
+  - identifier: industry-public
+    name: Public Sector
     parent: solutions
     title: industry
     url: 'https://www.datadoghq.com/solutions/public-sector/'
     weight: -456
-  - name: Media & Entertainment
+  - identifier: industry-media
+    name: Media & Entertainment
     parent: solutions
     title: industry
     url: 'https://www.datadoghq.com/solutions/media-entertainment/'
     weight: -455
-  - name: Technology
+  - identifier: industry-technology
+    name: Technology
     parent: solutions
     title: industry
     url: 'https://www.datadoghq.com/solutions/technology/'
     weight: -454
-  - name: Gaming
+  - identifier: industry-gaming
+    name: Gaming
     parent: solutions
     title: industry
     url: 'https://www.datadoghq.com/solutions/gaming/'
     weight: -453
-  - name: Amazon Web Services
+  - identifier: technology-aws
+    name: Amazon Web Services
     parent: solutions
     title: technology
     url: 'https://www.datadoghq.com/solutions/aws/'
     weight: -452
-  - name: Azure
+  - identifier: technology-azure
+    name: Azure
     parent: solutions
     title: technology
     url: 'https://www.datadoghq.com/solutions/azure/'
     weight: -451
-  - name: Google Cloud Platform
+  - identifier: technology-gcp
+    name: Google Cloud Platform
     parent: solutions
     title: technology
     url: 'https://www.datadoghq.com/solutions/gcp/'
     weight: -450
-  - name: Kubernetes
+  - identifier: technology-kubernetes
+    name: Kubernetes
     parent: solutions
     title: technology
     url: 'https://www.datadoghq.com/solutions/kubernetes/'
     weight: -449
-  - name: Red Hat OpenShift
+  - identifier: technology-openshift
+    name: Red Hat OpenShift
     parent: solutions
     title: technology
     url: 'https://www.datadoghq.com/solutions/openshift/'
     weight: -448
-  - name: Cloud Migration
+  - identifier: usecase-migration
+    name: Cloud Migration
     parent: solutions
     title: usecase
     url: 'https://www.datadoghq.com/solutions/cloud-migration/'
     weight: -447
-  - name: Monitoring Consolidation
+  - identifier: usecase-consolidate
+    name: Monitoring Consolidation
     parent: solutions
     title: usecase
     url: 'https://www.datadoghq.com/solutions/monitoring-consolidation/'
     weight: -446
-  - name: DevOps
+  - identifier: usecase-devops
+    name: DevOps
     parent: solutions
     title: usecase
     url: 'https://www.datadoghq.com/solutions/devops/'
     weight: -445
-  - name: Security Analytics
+  - identifier: usecase-security
+    name: Security Analytics
     parent: solutions
     title: usecase
     url: 'https://www.datadoghq.com/solutions/security-analytics/'
     weight: -444
-  - name: Hybrid Cloud Monitoring
+  - identifier: usecase-hybrid
+    name: Hybrid Cloud Monitoring
     parent: solutions
     title: usecase
     url: 'https://www.datadoghq.com/solutions/hybrid-cloud-monitoring/'
     weight: -443
-  - name: IoT Monitoring
+  - identifier: usecase-iot
+    name: IoT Monitoring
     parent: solutions
     title: usecase
     url: 'https://www.datadoghq.com/solutions/iot-monitoring/'
     weight: -442
-  - name: Machine Learning
+  - identifier: usecase-machine
+    name: Machine Learning
     parent: solutions
     title: usecase
     url: 'https://www.datadoghq.com/solutions/machine-learning/'
     weight: -441
-  - name: Real-Time BI
+  - identifier: usecase-analytics
+    name: Real-Time BI
     parent: solutions
     title: usecase
     url: 'https://www.datadoghq.com/solutions/business-analytics/'
     weight: -440
-  - name: On-Premises Monitoring
+  - identifier: usecase-onprem
+    name: On-Premises Monitoring
     parent: solutions
     title: usecase
     url: 'https://www.datadoghq.com/solutions/on-premises-monitoring/'

--- a/config/_default/menus/menus.fr.yaml
+++ b/config/_default/menus/menus.fr.yaml
@@ -99,112 +99,134 @@ main_left:
     name: Solutions
     url: '#'
     weight: -460
-  - name: Services financiers
+  - identifier: industry-financial
+    name: Services financiers
     parent: solutions
     title: industry
     url: 'https://www.datadoghq.com/solutions/financial-services/'
     weight: -460
-  - name: Production et logistique
+  - identifier: industry-manufacturing
+    name: Production et logistique
     parent: solutions
     title: industry
     url: 'https://www.datadoghq.com/solutions/manufacturing-logistics/'
     weight: -459
-  - name: Santé et sciences de la vie
+  - identifier: industry-healthcare
+    name: Santé et sciences de la vie
     parent: solutions
     title: industry
     url: 'https://www.datadoghq.com/solutions/healthcare/'
     weight: -458
-  - name: Commerce de détail et électronique
+  - identifier: industry-retail
+    name: Commerce de détail et électronique
     parent: solutions
     title: industry
     url: 'https://www.datadoghq.com/solutions/retail-ecommerce/'
     weight: -457
-  - name: Secteur public
+  - identifier: industry-public
+    name: Secteur public
     parent: solutions
     title: industry
     url: 'https://www.datadoghq.com/solutions/public-sector/'
     weight: -456
-  - name: Médias et divertissement
+  - identifier: industry-media
+    name: Médias et divertissement
     parent: solutions
     title: industry
     url: 'https://www.datadoghq.com/solutions/media-entertainment/'
     weight: -455
-  - name: Technologies
+  - identifier: industry-technology
+    name: Technologies
     parent: solutions
     title: industry
     url: 'https://www.datadoghq.com/solutions/technology/'
     weight: -454
-  - name: Jeux vidéo
+  - identifier: industry-gaming
+    name: Jeux vidéo
     parent: solutions
     title: industry
     url: 'https://www.datadoghq.com/solutions/gaming/'
     weight: -453
-  - name: "Amazon\_Web\_Services"
+  - identifier: technology-aws
+    name: "Amazon\_Web\_Services"
     parent: solutions
     title: technology
     url: 'https://www.datadoghq.com/solutions/aws/'
     weight: -452
-  - name: Azure
+  - identifier: technology-azure
+    name: Azure
     parent: solutions
     title: technology
     url: 'https://www.datadoghq.com/solutions/azure/'
     weight: -451
-  - name: "Google\_Cloud\_Platform"
+  - identifier: technology-gcp
+    name: "Google\_Cloud\_Platform"
     parent: solutions
     title: technology
     url: 'https://www.datadoghq.com/solutions/gcp/'
     weight: -450
-  - name: Kubernetes
+  - identifier: technology-kubernetes
+    name: Kubernetes
     parent: solutions
     title: technology
     url: 'https://www.datadoghq.com/solutions/kubernetes/'
     weight: -449
-  - name: Red Hat OpenShift
+  - identifier: technology-openshift
+    name: Red Hat OpenShift
     parent: solutions
     title: technology
     url: 'https://www.datadoghq.com/solutions/openshift/'
     weight: -448
-  - name: Migration vers le cloud
+  - identifier: usecase-migration
+    name: Migration vers le cloud
     parent: solutions
     title: usecase
     url: 'https://www.datadoghq.com/solutions/cloud-migration/'
     weight: -447
-  - name: Unification de la surveillance
+  - identifier: usecase-consolidate
+    name: Unification de la surveillance
     parent: solutions
     title: usecase
     url: 'https://www.datadoghq.com/solutions/monitoring-consolidation/'
     weight: -446
-  - name: DevOps
+  - identifier: usecase-devops
+    name: DevOps
     parent: solutions
     title: usecase
     url: 'https://www.datadoghq.com/solutions/devops/'
     weight: -445
-  - name: Analyse de la sécurité
+  - identifier: usecase-security
+    name: Analyse de la sécurité
     parent: solutions
     title: usecase
     url: 'https://www.datadoghq.com/solutions/security-analytics/'
     weight: -444
-  - name: Surveillance Cloud hybride
+  - identifier: usecase-hybrid
+    name: Surveillance Cloud hybride
     parent: solutions
     title: usecase
     url: 'https://www.datadoghq.com/solutions/hybrid-cloud-monitoring/'
     weight: -443
-  - name: Surveillance IoT
+  - identifier: usecase-iot
+    name: Surveillance IoT
     parent: solutions
     title: usecase
     url: 'https://www.datadoghq.com/solutions/iot-monitoring/'
     weight: -442
-  - name: Apprentissage automatique
+  - identifier: usecase-machine
+    name: Apprentissage automatique
     parent: solutions
     title: usecase
     url: 'https://www.datadoghq.com/solutions/machine-learning/'
     weight: -441
-  - name: BI en temps réel
+  - identifier: usecase-analytics
+    name: BI en temps réel
     parent: solutions
     title: usecase
     url: 'https://www.datadoghq.com/solutions/business-analytics/'
     weight: -440
-  - name: Surveillance sur site
+  - identifier: usecase-onprem
+    name: Surveillance sur site
     parent: solutions
     title: usecase
     url: 'https://www.datadoghq.com/solutions/on-premises-monitoring/'

--- a/config/_default/menus/menus.ja.yaml
+++ b/config/_default/menus/menus.ja.yaml
@@ -99,112 +99,134 @@ main_left:
     name: ソリューション
     url: '#'
     weight: -460
-  - name: 金融サービス
+  - identifier: industry-financial
+    name: 金融サービス
     parent: solutions
     title: 業種
     url: 'https://www.datadoghq.com/ja/solutions/financial-services/'
     weight: -460
-  - name: 製造 / 物流
+  - identifier: industry-manufacturing
+    name: 製造 / 物流
     parent: solutions
     title: 業種
     url: 'https://www.datadoghq.com/ja/solutions/manufacturing-logistics/'
     weight: -459
-  - name: 医療 / ライフサイエンス
+  - identifier: industry-healthcare
+    name: 医療 / ライフサイエンス
     parent: solutions
     title: 業種
     url: 'https://www.datadoghq.com/ja/solutions/healthcare/'
     weight: -458
-  - name: 小売業 / e コマース
+  - identifier: industry-retail
+    name: 小売業 / e コマース
     parent: solutions
     title: 業種
     url: 'https://www.datadoghq.com/ja/solutions/retail-ecommerce/'
     weight: -457
-  - name: 官業
+  - identifier: industry-public
+    name: 官業
     parent: solutions
     title: 業種
     url: 'https://www.datadoghq.com/solutions/public-sector/'
     weight: -456
-  - name: メディア / エンターテインメント
+  - identifier: industry-media
+    name: メディア / エンターテインメント
     parent: solutions
     title: 業種
     url: 'https://www.datadoghq.com/ja/solutions/media-entertainment/'
     weight: -455
-  - name: テクノロジー
+  - identifier: industry-technology
+    name: テクノロジー
     parent: solutions
     title: 業種
     url: 'https://www.datadoghq.com/solutions/technology/'
     weight: -454
-  - name: ゲーム業界
+  - identifier: industry-gaming
+    name: ゲーム業界
     parent: solutions
     title: 業種
     url: 'https://www.datadoghq.com/ja/solutions/gaming/'
     weight: -453
-  - name: Amazon Web Services
+  - identifier: technology-aws
+    name: Amazon Web Services
     parent: solutions
     title: テクノロジー
     url: 'https://www.datadoghq.com/solutions/aws/'
     weight: -452
-  - name: Azure
+  - identifier: technology-azure
+    name: Azure
     parent: solutions
     title: テクノロジー
     url: 'https://www.datadoghq.com/solutions/azure/'
     weight: -451
-  - name: Google Cloud Platform
+  - identifier: technology-gcp
+    name: Google Cloud Platform
     parent: solutions
     title: テクノロジー
     url: 'https://www.datadoghq.com/solutions/gcp/'
     weight: -450
-  - name: Kubernetes
+  - identifier: technology-kubernetes
+    name: Kubernetes
     parent: solutions
     title: テクノロジー
     url: 'https://www.datadoghq.com/solutions/kubernetes/'
     weight: -449
-  - name: Red Hat OpenShift
+  - identifier: technology-openshift
+    name: Red Hat OpenShift
     parent: solutions
     title: テクノロジー
     url: 'https://www.datadoghq.com/solutions/openshift/'
     weight: -448
-  - name: クラウド移行
+  - identifier: usecase-migration
+    name: クラウド移行
     parent: solutions
     title: ユースケース
     url: 'https://www.datadoghq.com/ja/solutions/cloud-migration/'
     weight: -447
-  - name: 統合監視
+  - identifier: usecase-consolidate
+    name: 統合監視
     parent: solutions
     title: ユースケース
     url: 'https://www.datadoghq.com/ja/solutions/monitoring-consolidation/'
     weight: -446
-  - name: DevOps
+  - identifier: usecase-devops
+    name: DevOps
     parent: solutions
     title: ユースケース
     url: 'https://www.datadoghq.com/ja/solutions/devops/'
     weight: -445
-  - name: セキュリティ分析
+  - identifier: usecase-security
+    name: セキュリティ分析
     parent: solutions
     title: ユースケース
     url: 'https://www.datadoghq.com/solutions/security-analytics/'
     weight: -444
-  - name: ハイブリッドクラウドモニタリング
+  - identifier: usecase-hybrid
+    name: ハイブリッドクラウドモニタリング
     parent: solutions
     title: ユースケース
     url: 'https://www.datadoghq.com/solutions/hybrid-cloud-monitoring/'
     weight: -443
-  - name: IoT モニタリング
+  - identifier: usecase-iot
+    name: IoT モニタリング
     parent: solutions
     title: ユースケース
     url: 'https://www.datadoghq.com/solutions/iot-monitoring/'
     weight: -442
-  - name: 機械学習
+  - identifier: usecase-machine
+    name: 機械学習
     parent: solutions
     title: ユースケース
     url: 'https://www.datadoghq.com/solutions/machine-learning/'
     weight: -441
-  - name: リアルタイム BI
+  - identifier: usecase-analytics
+    name: リアルタイム BI
     parent: solutions
     title: ユースケース
     url: 'https://www.datadoghq.com/solutions/business-analytics/'
     weight: -440
-  - name: オンプレミスモニタリング
+  - identifier: usecase-onprem
+    name: オンプレミスモニタリング
     parent: solutions
     title: ユースケース
     url: 'https://www.datadoghq.com/solutions/on-premises-monitoring/'

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -24,7 +24,7 @@
                               <div class="col-4">
                                 <p class="text-gray-dark small text-uppercase font-weight-bold no-event">Industry</p>
                                 {{ range .Children }}
-                                  {{ if in (slice "業種" "industry") .Title }}
+                                  {{ if hasPrefix .Identifier "industry-" }}
                                     <li class="nav-item">
                                         <a class="d-block " href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}"><span class="menu-text">{{ .Name | safeHTML }}</span></a>
                                     </li>
@@ -34,7 +34,7 @@
                               <div class="col-4">
                                 <p class="text-gray-dark small text-uppercase font-weight-bold no-event">Technology</p>
                                 {{ range .Children }}
-                                  {{ if in (slice "テクノロジー" "technology") .Title }}
+                                  {{ if hasPrefix .Identifier "technology-" }}
                                     <li class="nav-item">
                                         <a class="d-block " href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}"><span class="menu-text">{{ .Name | safeHTML }}</span></a>
                                     </li>
@@ -44,7 +44,7 @@
                               <div class="col-4">
                                 <p class="text-gray-dark small text-uppercase font-weight-bold no-event">Use-Case</p>
                                 {{ range .Children }}
-                                  {{ if in (slice "ユースケース" "usecase") .Title }}
+                                  {{ if hasPrefix .Identifier "usecase-" }}
                                     <li class="nav-item">
                                         <a class="d-block " href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}"><span class="menu-text">{{ .Name | safeHTML }}</span></a>
                                     </li>


### PR DESCRIPTION
### What does this PR do?

cleanup of #9057

We shouldn't rely on the title for display logic as translations can change and language additions can occur. 
This PR instead uses an identitfier that shouldn't change between localized menus

### Motivation

https://datadoghq.atlassian.net/browse/WEB-950

### Preview

check the header solutions menu still has the split of columns industry, technology, usecase
https://docs-staging.datadoghq.com/david.jones/menu-refactor/
https://docs-staging.datadoghq.com/david.jones/menu-refactor/fr/
https://docs-staging.datadoghq.com/david.jones/menu-refactor/ja/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
