### PR TITLE
Fix broken image

### DIFF
--- a/content/en/metrics/advanced-filtering.md
+++ b/content/en/metrics/advanced-filtering.md
@@ -67,7 +67,7 @@ avg:system.disk.in_use{!device:/dev/loop*} by {device}
 sum:kubernetes.pods.running{service:*-canary} by {service}
 ```
 
-{{< img src="metrics/advanced-filtering/wildcards2.png" alt="Example 2"  style="width:80%;" >}}
+{{< img src="metrics/advanced-filtering/wildcards2.jpg" alt="Example 2"  style="width:80%;" >}}
 
 ## Further Reading
 


### PR DESCRIPTION
The file extension being referenced prior to this commit is a PNG but in reality this file is a JPG.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes the last example image that's broken on https://docs.datadoghq.com/metrics/advanced-filtering/

### Motivation
broken image = sadness

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jorie/fix-image/metrics/advanced-filtering/
### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
