### PR TITLE
Update api-app-keys.md

### DIFF
--- a/content/en/account_management/api-app-keys.md
+++ b/content/en/account_management/api-app-keys.md
@@ -31,7 +31,7 @@ To add a Datadog API key or client token, navigate to [Integration -> APIs][1], 
 
 **Note**:
 
-* Your org must have at least one API key and at most five API keys.
+* Your org must have at least one API key and at most 50 API keys.
 * Key names must be unique across your org.
 
 ## Remove API keys or client tokens
@@ -62,7 +62,7 @@ Consider setting up multiple API keys for your organization. For example, use di
 
 Using multiple API keys lets you rotate keys as part of your security practice, or revoke a specific key if it's inadvertently exposed or if you want to stop using the service it's associated with. 
 
-If your organization needs more than the built-in limit of five API keys, contact [Support][6] to ask about increasing your limit.
+If your organization needs more than the built-in limit of 50 API keys, contact [Support][6] to ask about increasing your limit.
 
 ## Disabling a user account
 


### PR DESCRIPTION
### What does this PR do?
Limit of 5 api keys was raised to 50. I update all mentions of 5 -> 50

### Motivation
https://trello.com/c/M6nFV2m7/3749-api-key-limit-is-now-default-50-from-aaa-with-%F0%9F%92%9C
https://github.com/DataDog/consul-config/pull/72716 

### Preview
Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ na/api-key-limit-increase/account_management/api-app-keys/#using-multiple-api-keys

