### PR TITLE
update snmp v3 instructions so vars are all camelCase

### DIFF
--- a/content/en/network_monitoring/devices/setup.md
+++ b/content/en/network_monitoring/devices/setup.md
@@ -47,7 +47,7 @@ To monitor individual devices:
 {{% /tab %}}
 {{% tab "SNMPv3" %}}
 
-- For SNMPv3, configure an instance specifying the IP address and SNMPv3 credentials of the device (as appropriate), for example: `user`, `auth_protocol`, `auth_key`, `priv_protocol`, and `priv_key`:
+- For SNMPv3, configure an instance specifying the IP address and SNMPv3 credentials of the device (as appropriate), for example: `user`, `authProtocol`, `authKey`, `privProtocol`, and `privKey`:
 
     ```yaml
     instances:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

The current docs listed the snmp v3 settings lower w/ underscores.  The settings should be camelCase.

### Motivation
<!-- What inspired you to submit this pull request?-->

There was a mismatch in syntax and was confusing to users.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
