### PR TITLE
Document that system-probe and security-agent run as root

### DIFF
--- a/content/en/security/agent.md
+++ b/content/en/security/agent.md
@@ -62,7 +62,7 @@ If you believe you've discovered a bug in Datadog's security, get in touch at [s
 
 ## Running as an unprivileged user
 
-By default, the Agent runs as the `dd-agent` user on Linux and as the `ddagentuser` account on [Windows][18].
+By default, the Agent runs as the `dd-agent` user on Linux and as the `ddagentuser` account on [Windows][18]. Note the `system-probe` and `security-agent` services are an exception to this, and still need to run as `root` on Linux and `LOCAL_SYSTEM` on Windows.
 
 ## Secrets management
 


### PR DESCRIPTION
### What does this PR do?
Mention that there are two services that don't run as an unprivileged user. 
