### PR TITLE
Change X to ✓ on manifest template table

### DIFF
--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -155,12 +155,12 @@ To install the Datadog Agent on your Kubernetes cluster:
 
     | Metrics | Logs | APM | Process | NPM | Linux                  | Windows                 |
     |---------|------|-----|---------|-----|------------------------|-------------------------|
-    | X       | X    | X   | X       |     | [Manifest template][3] | [Manifest template][4] |
-    | X       | X    | X   |         |     | [Manifest template][5] | [Manifest template][6] |
-    | X       | X    |     |         |     | [Manifest template][7] | [Manifest template][8] |
-    | X       |      | X   |         |     | [Manifest template][9] | [Manifest template][10] |
-    |         |      |     |         | X   | [Manifest template][11] | no template             |
-    | X       |      |     |         |     | [Manifest template][12] | [Manifest template][13] |
+    | {{< X >}}       | {{< X >}}    | {{< X >}}   | {{< X >}}       |     | [Manifest template][3] | [Manifest template][4] |
+    | {{< X >}}       | {{< X >}}    | {{< X >}}   |         |     | [Manifest template][5] | [Manifest template][6] |
+    | {{< X >}}       | {{< X >}}    |     |         |     | [Manifest template][7] | [Manifest template][8] |
+    | {{< X >}}       |      | {{< X >}}   |         |     | [Manifest template][9] | [Manifest template][10] |
+    |         |      |     |         | {{< X >}}   | [Manifest template][11] | no template             |
+    | {{< X >}}       |      |     |         |     | [Manifest template][12] | [Manifest template][13] |
 
      To enable trace collection completely, [extra steps are required on your application Pod configuration][14]. Refer also to the [logs][15], [APM][16], [processes][17], and [Network Performance Monitoring][18] documentation pages to learn how to enable each feature individually.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates the K8s manifest template tables to use ✓s instead of Xs. Xs can be confusing (indicating don't want).

### Motivation
Working with a prospect. They used the NPM template and was wondering why every other feature was not working.

### Preview
<!-- Impacted pages preview links-->
#### Before
![image](https://user-images.githubusercontent.com/19462912/109897939-697f7500-7cce-11eb-87d4-0d76c8ecb726.png)
#### After
![image](https://user-images.githubusercontent.com/19462912/109897962-6edcbf80-7cce-11eb-9426-781375e8adbe.png)


<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/greg/update-k8-manifest-template-table/agent/kubernetes/?tab=daemonset

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
