### PR TITLE
[agent] Update k8s manifests based on helm chart 2.9.11

### DIFF
--- a/static/resources/yaml/datadog-agent-aks.yaml
+++ b/static/resources/yaml/datadog-agent-aks.yaml
@@ -421,8 +421,6 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
-        - name: s6-run
-          emptyDir: {}
         - hostPath:
             path: /etc/passwd
           name: passwd

--- a/static/resources/yaml/datadog-agent-aks.yaml
+++ b/static/resources/yaml/datadog-agent-aks.yaml
@@ -1,5 +1,15 @@
-# Source: datadog/templates/secrets.yaml
-# API Key
+# Source: datadog/templates/cluster-agent-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: "datadog-agent"
+    chart: "datadog-2.9.11"
+    heritage: "Helm"
+    release: "datadog-agent"
+  name: datadog-agent-cluster-agent
+---
+# Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,8 +18,16 @@ metadata:
 type: Opaque
 data:
   api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
-
-# APP Key
+---
+# Source: datadog/templates/secret-cluster-agent-token.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: datadog-agent-cluster-agent
+  labels: {}
+type: Opaque
+data:
+  token: PUT_A_BASE64_ENCODED_RANDOM_STRING_HERE
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -18,7 +36,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
+    checksum/install_info: 092f34522792579934b4afae83bc34fc9fa2ea9d89ab29459dd8594579a3c8fa
 data:
   install_info: |
     ---
@@ -26,6 +44,144 @@ data:
       tool: kubernetes sample manifests
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
+---
+# Source: datadog/templates/cluster-agent-rbac.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: ClusterRole
+metadata:
+  labels: {}
+  name: datadog-agent-cluster-agent
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+      - nodes
+      - namespaces
+      - componentstatuses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+  - apiGroups: ["quota.openshift.io"]
+    resources:
+      - clusterresourcequotas
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - "autoscaling"
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - datadogtoken # Kubernetes event collection state
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - datadog-leader-election # Leader election token
+    verbs:
+      - get
+      - update
+  - apiGroups: # To create the leader election token and hpa events
+      - ""
+    resources:
+      - configmaps
+      - events
+    verbs:
+      - create
+  - nonResourceURLs:
+      - "/version"
+      - "/healthz"
+    verbs:
+      - get
+  - apiGroups: # to get the kube-system namespace UID and generate a cluster ID
+      - ""
+    resources:
+      - namespaces
+    resourceNames:
+      - "kube-system"
+    verbs:
+      - get
+  - apiGroups: # To create the cluster-id configmap
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - "datadog-cluster-id"
+    verbs:
+      - create
+      - get
+      - update
+  - apiGroups:
+      - "apps"
+    resources:
+      - deployments
+      - replicasets
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+    resourceNames:
+      - datadog-agent-cluster-agent
+---
+# Source: datadog/templates/cluster-agent-rbac.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: ClusterRoleBinding
+metadata:
+  labels: {}
+  name: datadog-agent-cluster-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-agent-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-agent-cluster-agent
+    namespace: default
+---
+# Source: datadog/templates/agent-services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: datadog-agent-cluster-agent
+  labels: {}
+spec:
+  type: ClusterIP
+  selector:
+    app: datadog-agent-cluster-agent
+  ports:
+    - port: 5005
+      name: agentport
+      protocol: TCP
 ---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
@@ -46,7 +202,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -72,6 +228,17 @@ spec:
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
               value: "8125"
+            - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "true"
+            - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+              value: datadog-agent-cluster-agent
+            - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: datadog-agent-cluster-agent
+                  key: token
             - name: DD_APM_ENABLED
               value: "false"
             - name: DD_LOGS_ENABLED
@@ -82,6 +249,8 @@ spec:
               value: "true"
             - name: DD_HEALTH_PORT
               value: "5555"
+            - name: DD_EXTRA_CONFIG_PROVIDERS
+              value: "clusterchecks endpointschecks"
             - name: DD_KUBELET_CLIENT_CA
               value: /etc/kubernetes/certs/kubeletserver.crt
           volumeMounts:
@@ -89,6 +258,9 @@ spec:
               subPath: install_info
               mountPath: /etc/datadog-agent/install_info
               readOnly: true
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false
             - name: config
               mountPath: /etc/datadog-agent
             - name: runtimesocketdir
@@ -127,7 +299,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -145,10 +317,26 @@ spec:
               value: "yes"
             - name: DOCKER_HOST
               value: unix:///host/var/run/docker.sock
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "true"
+            - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+              value: datadog-agent-cluster-agent
+            - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: datadog-agent-cluster-agent
+                  key: token
             - name: DD_LOG_LEVEL
               value: "INFO"
-            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+            - name: DD_SYSTEM_PROBE_ENABLED
               value: "false"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "true"
+            - name: DD_ORCHESTRATOR_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-cluster-id
+                  key: id
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
@@ -156,12 +344,16 @@ spec:
               mountPath: /host/var/run
               mountPropagation: None
               readOnly: true
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               readOnly: true
             - name: passwd
               mountPath: /etc/passwd
+              readOnly: true
             - name: procdir
               mountPath: /host/proc
               mountPropagation: None
@@ -171,7 +363,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -181,7 +373,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -221,6 +413,8 @@ spec:
         - hostPath:
             path: /var/run
           name: runtimesocketdir
+        - name: tmpdir
+          emptyDir: {}
         - hostPath:
             path: /proc
           name: procdir
@@ -244,7 +438,117 @@ spec:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
-
-# Source: datadog/templates/containers-common-env.yaml
-# The purpose of this template is to define a minimal set of environment
-# variables required to operate dedicated containers in the daemonset
+---
+# Source: datadog/templates/cluster-agent-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: datadog-agent-cluster-agent
+  labels: {}
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: datadog-agent-cluster-agent
+  template:
+    metadata:
+      labels:
+        app: datadog-agent-cluster-agent
+      name: datadog-agent-cluster-agent
+      annotations:
+        ad.datadoghq.com/cluster-agent.check_names: '["prometheus"]'
+        ad.datadoghq.com/cluster-agent.init_configs: '[{}]'
+        ad.datadoghq.com/cluster-agent.instances: |
+          [{
+            "prometheus_url": "http://%%host%%:5000/metrics",
+            "namespace": "datadog.cluster_agent",
+            "metrics": [
+              "go_goroutines", "go_memstats_*", "process_*",
+              "api_requests",
+              "datadog_requests", "external_metrics", "rate_limit_queries_*",
+              "cluster_checks_*"
+            ]
+          }]
+    spec:
+      serviceAccountName: datadog-agent-cluster-agent
+      containers:
+        - name: cluster-agent
+          image: "gcr.io/datadoghq/cluster-agent:1.11.0"
+          imagePullPolicy: IfNotPresent
+          resources: {}
+          ports:
+            - containerPort: 5005
+              name: agentport
+              protocol: TCP
+          env:
+            - name: DD_HEALTH_PORT
+              value: "5555"
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+                  optional: true
+            - name: DD_CLUSTER_CHECKS_ENABLED
+              value: "true"
+            - name: DD_EXTRA_CONFIG_PROVIDERS
+              value: "kube_endpoints kube_services"
+            - name: DD_EXTRA_LISTENERS
+              value: "kube_endpoints kube_services"
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_LEADER_ELECTION
+              value: "true"
+            - name: DD_LEADER_LEASE_DURATION
+              value: "15"
+            - name: DD_COLLECT_KUBERNETES_EVENTS
+              value: "true"
+            - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+              value: datadog-agent-cluster-agent
+            - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: datadog-agent-cluster-agent
+                  key: token
+            - name: DD_KUBE_RESOURCES_NAMESPACE
+              value: default
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "true"
+            - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
+              value: "true"
+          livenessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /live
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /ready
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: installinfo
+              subPath: install_info
+              mountPath: /etc/datadog-agent/install_info
+              readOnly: true
+      volumes:
+        - name: installinfo
+          configMap:
+            name: datadog-agent-installinfo
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/static/resources/yaml/datadog-agent-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-all-features.yaml
@@ -1,5 +1,15 @@
-# Source: datadog/templates/secrets.yaml
-# API Key
+# Source: datadog/templates/cluster-agent-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: "datadog-agent"
+    chart: "datadog-2.9.11"
+    heritage: "Helm"
+    release: "datadog-agent"
+  name: datadog-agent-cluster-agent
+---
+# Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,8 +18,16 @@ metadata:
 type: Opaque
 data:
   api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
-
-# APP Key
+---
+# Source: datadog/templates/secret-cluster-agent-token.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: datadog-agent-cluster-agent
+  labels: {}
+type: Opaque
+data:
+  token: PUT_A_BASE64_ENCODED_RANDOM_STRING_HERE
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -18,7 +36,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
+    checksum/install_info: 092f34522792579934b4afae83bc34fc9fa2ea9d89ab29459dd8594579a3c8fa
 data:
   install_info: |
     ---
@@ -44,9 +62,13 @@ data:
       bpf_debug: false
       enable_tcp_queue_length: false
       enable_oom_kill: false
-      collect_dns_stats: true
+      collect_dns_stats: false
+      max_tracked_connections: 65536
+      conntrack_max_state_size: 131072
+    network_config:
+      enabled: true
     runtime_security_config:
-      enabled: false
+      enabled: true
       debug: false
       socket: /var/run/sysprobe/runtime-security.sock
       policies:
@@ -243,6 +265,172 @@ data:
       ]
     }
 ---
+# Source: datadog/templates/cluster-agent-rbac.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: ClusterRole
+metadata:
+  labels: {}
+  name: datadog-agent-cluster-agent
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+      - nodes
+      - namespaces
+      - componentstatuses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+  - apiGroups: ["quota.openshift.io"]
+    resources:
+      - clusterresourcequotas
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - "autoscaling"
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - datadogtoken # Kubernetes event collection state
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - datadog-leader-election # Leader election token
+    verbs:
+      - get
+      - update
+  - apiGroups: # To create the leader election token and hpa events
+      - ""
+    resources:
+      - configmaps
+      - events
+    verbs:
+      - create
+  - nonResourceURLs:
+      - "/version"
+      - "/healthz"
+    verbs:
+      - get
+  - apiGroups: # to get the kube-system namespace UID and generate a cluster ID
+      - ""
+    resources:
+      - namespaces
+    resourceNames:
+      - "kube-system"
+    verbs:
+      - get
+  - apiGroups: # To create the cluster-id configmap
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - "datadog-cluster-id"
+    verbs:
+      - create
+      - get
+      - update
+  - apiGroups:
+      - "apps"
+    resources:
+      - deployments
+      - replicasets
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+      - namespaces
+    verbs:
+      - list
+  - apiGroups:
+      - "policy"
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - rolebindings
+    verbs:
+      - list
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - list
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+    resourceNames:
+      - datadog-agent-cluster-agent
+---
+# Source: datadog/templates/cluster-agent-rbac.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: ClusterRoleBinding
+metadata:
+  labels: {}
+  name: datadog-agent-cluster-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-agent-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-agent-cluster-agent
+    namespace: default
+---
+# Source: datadog/templates/agent-services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: datadog-agent-cluster-agent
+  labels: {}
+spec:
+  type: ClusterIP
+  selector:
+    app: datadog-agent-cluster-agent
+  ports:
+    - port: 5005
+      name: agentport
+      protocol: TCP
+---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
@@ -262,9 +450,10 @@ spec:
         container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
         container.seccomp.security.alpha.kubernetes.io/system-probe: localhost/system-probe
     spec:
+      hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -290,6 +479,17 @@ spec:
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
               value: "8125"
+            - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "true"
+            - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+              value: datadog-agent-cluster-agent
+            - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: datadog-agent-cluster-agent
+                  key: token
             - name: DD_APM_ENABLED
               value: "false"
             - name: DD_LOGS_ENABLED
@@ -300,23 +500,22 @@ spec:
               value: "true"
             - name: DD_HEALTH_PORT
               value: "5555"
+            - name: DD_EXTRA_CONFIG_PROVIDERS
+              value: "clusterchecks endpointschecks"
           volumeMounts:
             - name: installinfo
               subPath: install_info
               mountPath: /etc/datadog-agent/install_info
               readOnly: true
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false
             - name: config
               mountPath: /etc/datadog-agent
             - name: runtimesocketdir
               mountPath: /host/var/run
               mountPropagation: None
               readOnly: true
-            - name: sysprobe-socket-dir
-              mountPath: /var/run/sysprobe
-              readOnly: true
-            - name: sysprobe-config
-              mountPath: /etc/datadog-agent/system-probe.yaml
-              subPath: system-probe.yaml
             - name: procdir
               mountPath: /host/proc
               mountPropagation: None
@@ -357,7 +556,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -380,6 +579,15 @@ spec:
               value: "yes"
             - name: DOCKER_HOST
               value: unix:///host/var/run/docker.sock
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "true"
+            - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+              value: datadog-agent-cluster-agent
+            - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: datadog-agent-cluster-agent
+                  key: token
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_APM_ENABLED
@@ -391,6 +599,9 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false
             - name: runtimesocketdir
               mountPath: /host/var/run
               mountPropagation: None
@@ -402,7 +613,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -420,14 +631,30 @@ spec:
               value: "yes"
             - name: DOCKER_HOST
               value: unix:///host/var/run/docker.sock
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "true"
+            - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+              value: datadog-agent-cluster-agent
+            - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: datadog-agent-cluster-agent
+                  key: token
             - name: DD_PROCESS_AGENT_ENABLED
               value: "true"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_SYSTEM_PROBE_ENABLED
               value: "true"
+            - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
+              value: "true"
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_ORCHESTRATOR_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-cluster-id
+                  key: id
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
@@ -435,12 +662,16 @@ spec:
               mountPath: /host/var/run
               mountPropagation: None
               readOnly: true
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               readOnly: true
             - name: passwd
               mountPath: /etc/passwd
+              readOnly: true
             - name: procdir
               mountPath: /host/proc
               mountPropagation: None
@@ -452,11 +683,19 @@ spec:
               mountPath: /etc/datadog-agent/system-probe.yaml
               subPath: system-probe.yaml
         - name: system-probe
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
-              add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "IPC_LOCK"]
+              add:
+                - SYS_ADMIN
+                - SYS_RESOURCE
+                - SYS_PTRACE
+                - NET_ADMIN
+                - NET_BROADCAST
+                - NET_RAW
+                - IPC_LOCK
+            privileged: false
           command: ["/opt/datadog-agent/embedded/bin/system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
           env:
             - name: DD_API_KEY
@@ -476,9 +715,14 @@ spec:
               value: "INFO"
           resources: {}
           volumeMounts:
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false
             - name: debugfs
               mountPath: /sys/kernel/debug
               mountPropagation: None
+            - name: config
+              mountPath: /etc/datadog-agent
             - name: sysprobe-config
               mountPath: /etc/datadog-agent/system-probe.yaml
               subPath: system-probe.yaml
@@ -488,9 +732,89 @@ spec:
               mountPath: /host/proc
               mountPropagation: None
               readOnly: true
+        - name: security-agent
+          image: "gcr.io/datadoghq/agent:7.26.0"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              add: ["AUDIT_CONTROL", "AUDIT_READ"]
+          command: ["security-agent", "start", "-c=/etc/datadog-agent/datadog.yaml"]
+          resources: {}
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBERNETES
+              value: "yes"
+            - name: DOCKER_HOST
+              value: unix:///host/var/run/docker.sock
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_COMPLIANCE_CONFIG_ENABLED
+              value: "true"
+            - name: DD_COMPLIANCE_CONFIG_CHECK_INTERVAL
+              value: "20m"
+            - name: HOST_ROOT
+              value: /host/root
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "true"
+            - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+              value: datadog-agent-cluster-agent
+            - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: datadog-agent-cluster-agent
+                  key: token
+            - name: DD_RUNTIME_SECURITY_CONFIG_ENABLED
+              value: "true"
+            - name: DD_RUNTIME_SECURITY_CONFIG_POLICIES_DIR
+              value: "/etc/datadog-agent/runtime-security.d"
+            - name: DD_RUNTIME_SECURITY_CONFIG_SOCKET
+              value: /var/run/sysprobe/runtime-security.sock
+            - name: DD_RUNTIME_SECURITY_CONFIG_SYSCALL_MONITOR_ENABLED
+              value: "false"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              readOnly: true
+            - name: cgroups
+              mountPath: /host/sys/fs/cgroup
+              readOnly: true
+            - name: passwd
+              mountPath: /etc/passwd
+              readOnly: true
+            - name: group
+              mountPath: /etc/group
+              readOnly: true
+            - name: hostroot
+              mountPath: /host/root
+              readOnly: true
+            - name: runtimesocketdir
+              mountPath: /host/root/var/run
+              readOnly: true
+            - name: procdir
+              mountPath: /host/proc
+              readOnly: true
+            - name: sysprobe-socket-dir
+              mountPath: /var/run/sysprobe
+              readOnly: true
+            - name: sysprobe-config
+              mountPath: /etc/datadog-agent/system-probe.yaml
+              subPath: system-probe.yaml
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -500,7 +824,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -535,7 +859,7 @@ spec:
               value: unix:///host/var/run/docker.sock
           resources: {}
         - name: seccomp-setup
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           command:
             - cp
             - /etc/config/system-probe-seccomp.json
@@ -556,6 +880,8 @@ spec:
         - hostPath:
             path: /var/run
           name: runtimesocketdir
+        - name: tmpdir
+          emptyDir: {}
         - hostPath:
             path: /proc
           name: procdir
@@ -582,7 +908,13 @@ spec:
             path: /etc/passwd
           name: passwd
         - hostPath:
-            path: "/var/lib/datadog-agent/logs"
+            path: /etc/group
+          name: group
+        - hostPath:
+            path: /
+          name: hostroot
+        - hostPath:
+            path: /var/lib/datadog-agent/logs
           name: pointerdir
         - hostPath:
             path: /var/log/pods
@@ -599,7 +931,121 @@ spec:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
-
-# Source: datadog/templates/containers-common-env.yaml
-# The purpose of this template is to define a minimal set of environment
-# variables required to operate dedicated containers in the daemonset
+---
+# Source: datadog/templates/cluster-agent-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: datadog-agent-cluster-agent
+  labels: {}
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: datadog-agent-cluster-agent
+  template:
+    metadata:
+      labels:
+        app: datadog-agent-cluster-agent
+      name: datadog-agent-cluster-agent
+      annotations:
+        ad.datadoghq.com/cluster-agent.check_names: '["prometheus"]'
+        ad.datadoghq.com/cluster-agent.init_configs: '[{}]'
+        ad.datadoghq.com/cluster-agent.instances: |
+          [{
+            "prometheus_url": "http://%%host%%:5000/metrics",
+            "namespace": "datadog.cluster_agent",
+            "metrics": [
+              "go_goroutines", "go_memstats_*", "process_*",
+              "api_requests",
+              "datadog_requests", "external_metrics", "rate_limit_queries_*",
+              "cluster_checks_*"
+            ]
+          }]
+    spec:
+      serviceAccountName: datadog-agent-cluster-agent
+      containers:
+        - name: cluster-agent
+          image: "gcr.io/datadoghq/cluster-agent:1.11.0"
+          imagePullPolicy: IfNotPresent
+          resources: {}
+          ports:
+            - containerPort: 5005
+              name: agentport
+              protocol: TCP
+          env:
+            - name: DD_HEALTH_PORT
+              value: "5555"
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+                  optional: true
+            - name: DD_CLUSTER_CHECKS_ENABLED
+              value: "true"
+            - name: DD_EXTRA_CONFIG_PROVIDERS
+              value: "kube_endpoints kube_services"
+            - name: DD_EXTRA_LISTENERS
+              value: "kube_endpoints kube_services"
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_LEADER_ELECTION
+              value: "true"
+            - name: DD_LEADER_LEASE_DURATION
+              value: "15"
+            - name: DD_COLLECT_KUBERNETES_EVENTS
+              value: "true"
+            - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+              value: datadog-agent-cluster-agent
+            - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: datadog-agent-cluster-agent
+                  key: token
+            - name: DD_KUBE_RESOURCES_NAMESPACE
+              value: default
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "true"
+            - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
+              value: "true"
+            - name: DD_COMPLIANCE_CONFIG_ENABLED
+              value: "true"
+            - name: DD_COMPLIANCE_CONFIG_CHECK_INTERVAL
+              value: "20m"
+          livenessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /live
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /ready
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: installinfo
+              subPath: install_info
+              mountPath: /etc/datadog-agent/install_info
+              readOnly: true
+      volumes:
+        - name: installinfo
+          configMap:
+            name: datadog-agent-installinfo
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/static/resources/yaml/datadog-agent-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-all-features.yaml
@@ -888,8 +888,6 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
-        - name: s6-run
-          emptyDir: {}
         - name: sysprobe-config
           configMap:
             name: datadog-agent-system-probe-config

--- a/static/resources/yaml/datadog-agent-all-features_values.yaml
+++ b/static/resources/yaml/datadog-agent-all-features_values.yaml
@@ -8,8 +8,13 @@ datadog:
   processAgent:
     enabled: true
     processCollection: true
-  systemProbe:
+  networkMonitoring:
     enabled: true
+  securityAgent:
+    compliance:
+      enabled: true
+    runtime:
+      enabled: true
 agents:
   rbac:
     create: false

--- a/static/resources/yaml/datadog-agent-apm.yaml
+++ b/static/resources/yaml/datadog-agent-apm.yaml
@@ -287,8 +287,6 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
-        - name: s6-run
-          emptyDir: {}
         - hostPath:
             path: /etc/passwd
           name: passwd

--- a/static/resources/yaml/datadog-agent-apm.yaml
+++ b/static/resources/yaml/datadog-agent-apm.yaml
@@ -1,5 +1,4 @@
-# Source: datadog/templates/secrets.yaml
-# API Key
+# Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,8 +7,6 @@ metadata:
 type: Opaque
 data:
   api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
-
-# APP Key
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -18,7 +15,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
+    checksum/install_info: 092f34522792579934b4afae83bc34fc9fa2ea9d89ab29459dd8594579a3c8fa
 data:
   install_info: |
     ---
@@ -46,7 +43,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -72,6 +69,12 @@ spec:
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
               value: "8125"
+            - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_LEADER_ELECTION
+              value: "true"
+            - name: DD_COLLECT_KUBERNETES_EVENTS
+              value: "true"
             - name: DD_APM_ENABLED
               value: "false"
             - name: DD_LOGS_ENABLED
@@ -87,6 +90,9 @@ spec:
               subPath: install_info
               mountPath: /etc/datadog-agent/install_info
               readOnly: true
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false
             - name: config
               mountPath: /etc/datadog-agent
             - name: runtimesocketdir
@@ -122,7 +128,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -145,6 +151,8 @@ spec:
               value: "yes"
             - name: DOCKER_HOST
               value: unix:///host/var/run/docker.sock
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_APM_ENABLED
@@ -156,6 +164,9 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false
             - name: runtimesocketdir
               mountPath: /host/var/run
               mountPropagation: None
@@ -167,7 +178,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -185,8 +196,12 @@ spec:
               value: "yes"
             - name: DOCKER_HOST
               value: unix:///host/var/run/docker.sock
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
+            - name: DD_SYSTEM_PROBE_ENABLED
+              value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "false"
           volumeMounts:
@@ -196,19 +211,23 @@ spec:
               mountPath: /host/var/run
               mountPropagation: None
               readOnly: true
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               readOnly: true
             - name: passwd
               mountPath: /etc/passwd
+              readOnly: true
             - name: procdir
               mountPath: /host/proc
               mountPropagation: None
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -218,7 +237,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -248,6 +267,8 @@ spec:
               value: "yes"
             - name: DOCKER_HOST
               value: unix:///host/var/run/docker.sock
+            - name: DD_LEADER_ELECTION
+              value: "true"
           resources: {}
       volumes:
         - name: installinfo
@@ -258,6 +279,8 @@ spec:
         - hostPath:
             path: /var/run
           name: runtimesocketdir
+        - name: tmpdir
+          emptyDir: {}
         - hostPath:
             path: /proc
           name: procdir
@@ -278,7 +301,3 @@ spec:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
-
-# Source: datadog/templates/containers-common-env.yaml
-# The purpose of this template is to define a minimal set of environment
-# variables required to operate dedicated containers in the daemonset

--- a/static/resources/yaml/datadog-agent-apm_values.yaml
+++ b/static/resources/yaml/datadog-agent-apm_values.yaml
@@ -2,7 +2,11 @@ datadog:
   kubeStateMetricsEnabled: false
   apm:
     enabled: true
+  orchestratorExplorer:
+    enabled: false
 agents:
   rbac:
     create: false
     serviceAccountName: datadog-agent
+clusterAgent:
+  enabled: false

--- a/static/resources/yaml/datadog-agent-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-logs-apm.yaml
@@ -1,5 +1,4 @@
-# Source: datadog/templates/secrets.yaml
-# API Key
+# Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,8 +7,6 @@ metadata:
 type: Opaque
 data:
   api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
-
-# APP Key
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -18,7 +15,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
+    checksum/install_info: 092f34522792579934b4afae83bc34fc9fa2ea9d89ab29459dd8594579a3c8fa
 data:
   install_info: |
     ---
@@ -46,7 +43,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -74,6 +71,8 @@ spec:
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
               value: "8125"
+            - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
+              value: "true"
             - name: DD_LEADER_ELECTION
               value: "true"
             - name: DD_COLLECT_KUBERNETES_EVENTS
@@ -93,6 +92,9 @@ spec:
               subPath: install_info
               mountPath: /etc/datadog-agent/install_info
               readOnly: true
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false
             - name: config
               mountPath: /etc/datadog-agent
             - name: runtimesocketdir
@@ -139,7 +141,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -164,6 +166,8 @@ spec:
               value: "name:datadog-agent"
             - name: DOCKER_HOST
               value: unix:///host/var/run/docker.sock
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_APM_ENABLED
@@ -175,6 +179,9 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false
             - name: runtimesocketdir
               mountPath: /host/var/run
               mountPropagation: None
@@ -186,7 +193,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -206,8 +213,12 @@ spec:
               value: "name:datadog-agent"
             - name: DOCKER_HOST
               value: unix:///host/var/run/docker.sock
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
+            - name: DD_SYSTEM_PROBE_ENABLED
+              value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "false"
           volumeMounts:
@@ -217,19 +228,23 @@ spec:
               mountPath: /host/var/run
               mountPropagation: None
               readOnly: true
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               readOnly: true
             - name: passwd
               mountPath: /etc/passwd
+              readOnly: true
             - name: procdir
               mountPath: /host/proc
               mountPropagation: None
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -239,7 +254,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -283,6 +298,8 @@ spec:
         - hostPath:
             path: /var/run
           name: runtimesocketdir
+        - name: tmpdir
+          emptyDir: {}
         - hostPath:
             path: /proc
           name: procdir
@@ -295,7 +312,7 @@ spec:
             path: /etc/passwd
           name: passwd
         - hostPath:
-            path: "/var/lib/datadog-agent/logs"
+            path: /var/lib/datadog-agent/logs
           name: pointerdir
         - hostPath:
             path: /var/log/pods
@@ -312,7 +329,3 @@ spec:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
-
-# Source: datadog/templates/containers-common-env.yaml
-# The purpose of this template is to define a minimal set of environment
-# variables required to operate dedicated containers in the daemonset

--- a/static/resources/yaml/datadog-agent-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-logs-apm.yaml
@@ -306,8 +306,6 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
-        - name: s6-run
-          emptyDir: {}
         - hostPath:
             path: /etc/passwd
           name: passwd

--- a/static/resources/yaml/datadog-agent-logs-apm_values.yaml
+++ b/static/resources/yaml/datadog-agent-logs-apm_values.yaml
@@ -8,7 +8,11 @@ datadog:
   acExclude: "name:datadog-agent"
   apm:
     enabled: true
+  orchestratorExplorer:
+    enabled: false
 agents:
   rbac:
     create: false
     serviceAccountName: datadog-agent
+clusterAgent:
+  enabled: false

--- a/static/resources/yaml/datadog-agent-logs.yaml
+++ b/static/resources/yaml/datadog-agent-logs.yaml
@@ -254,8 +254,6 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
-        - name: s6-run
-          emptyDir: {}
         - hostPath:
             path: /etc/passwd
           name: passwd

--- a/static/resources/yaml/datadog-agent-logs.yaml
+++ b/static/resources/yaml/datadog-agent-logs.yaml
@@ -1,5 +1,4 @@
-# Source: datadog/templates/secrets.yaml
-# API Key
+# Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,8 +7,6 @@ metadata:
 type: Opaque
 data:
   api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
-
-# APP Key
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -18,7 +15,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
+    checksum/install_info: 092f34522792579934b4afae83bc34fc9fa2ea9d89ab29459dd8594579a3c8fa
 data:
   install_info: |
     ---
@@ -46,7 +43,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -74,6 +71,8 @@ spec:
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
               value: "8125"
+            - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
+              value: "true"
             - name: DD_LEADER_ELECTION
               value: "true"
             - name: DD_COLLECT_KUBERNETES_EVENTS
@@ -93,6 +92,9 @@ spec:
               subPath: install_info
               mountPath: /etc/datadog-agent/install_info
               readOnly: true
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false
             - name: config
               mountPath: /etc/datadog-agent
             - name: runtimesocketdir
@@ -139,7 +141,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -159,8 +161,12 @@ spec:
               value: "name:datadog-agent"
             - name: DOCKER_HOST
               value: unix:///host/var/run/docker.sock
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
+            - name: DD_SYSTEM_PROBE_ENABLED
+              value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "false"
           volumeMounts:
@@ -170,19 +176,23 @@ spec:
               mountPath: /host/var/run
               mountPropagation: None
               readOnly: true
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               readOnly: true
             - name: passwd
               mountPath: /etc/passwd
+              readOnly: true
             - name: procdir
               mountPath: /host/proc
               mountPropagation: None
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -192,7 +202,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -236,6 +246,8 @@ spec:
         - hostPath:
             path: /var/run
           name: runtimesocketdir
+        - name: tmpdir
+          emptyDir: {}
         - hostPath:
             path: /proc
           name: procdir
@@ -248,7 +260,7 @@ spec:
             path: /etc/passwd
           name: passwd
         - hostPath:
-            path: "/var/lib/datadog-agent/logs"
+            path: /var/lib/datadog-agent/logs
           name: pointerdir
         - hostPath:
             path: /var/log/pods
@@ -265,7 +277,3 @@ spec:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
-
-# Source: datadog/templates/containers-common-env.yaml
-# The purpose of this template is to define a minimal set of environment
-# variables required to operate dedicated containers in the daemonset

--- a/static/resources/yaml/datadog-agent-logs_values.yaml
+++ b/static/resources/yaml/datadog-agent-logs_values.yaml
@@ -6,7 +6,11 @@ datadog:
     enabled: true
     containerCollectAll: true
   acExclude: "name:datadog-agent"
+  orchestratorExplorer:
+    enabled: false
 agents:
   rbac:
     create: false
     serviceAccountName: datadog-agent
+clusterAgent:
+  enabled: false

--- a/static/resources/yaml/datadog-agent-npm.yaml
+++ b/static/resources/yaml/datadog-agent-npm.yaml
@@ -1,5 +1,4 @@
-# Source: datadog/templates/secrets.yaml
-# API Key
+# Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,8 +7,6 @@ metadata:
 type: Opaque
 data:
   api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
-
-# APP Key
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -18,7 +15,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
+    checksum/install_info: 092f34522792579934b4afae83bc34fc9fa2ea9d89ab29459dd8594579a3c8fa
 data:
   install_info: |
     ---
@@ -44,7 +41,11 @@ data:
       bpf_debug: false
       enable_tcp_queue_length: false
       enable_oom_kill: false
-      collect_dns_stats: true
+      collect_dns_stats: false
+      max_tracked_connections: 65536
+      conntrack_max_state_size: 131072
+    network_config:
+      enabled: true
     runtime_security_config:
       enabled: false
       debug: false
@@ -264,7 +265,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -290,6 +291,12 @@ spec:
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
               value: "8125"
+            - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_LEADER_ELECTION
+              value: "true"
+            - name: DD_COLLECT_KUBERNETES_EVENTS
+              value: "true"
             - name: DD_APM_ENABLED
               value: "false"
             - name: DD_LOGS_ENABLED
@@ -305,18 +312,15 @@ spec:
               subPath: install_info
               mountPath: /etc/datadog-agent/install_info
               readOnly: true
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false
             - name: config
               mountPath: /etc/datadog-agent
             - name: runtimesocketdir
               mountPath: /host/var/run
               mountPropagation: None
               readOnly: true
-            - name: sysprobe-socket-dir
-              mountPath: /var/run/sysprobe
-              readOnly: true
-            - name: sysprobe-config
-              mountPath: /etc/datadog-agent/system-probe.yaml
-              subPath: system-probe.yaml
             - name: procdir
               mountPath: /host/proc
               mountPropagation: None
@@ -346,7 +350,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -364,9 +368,13 @@ spec:
               value: "yes"
             - name: DOCKER_HOST
               value: unix:///host/var/run/docker.sock
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_SYSTEM_PROBE_ENABLED
+              value: "true"
+            - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "false"
@@ -377,12 +385,16 @@ spec:
               mountPath: /host/var/run
               mountPropagation: None
               readOnly: true
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               readOnly: true
             - name: passwd
               mountPath: /etc/passwd
+              readOnly: true
             - name: procdir
               mountPath: /host/proc
               mountPropagation: None
@@ -394,11 +406,19 @@ spec:
               mountPath: /etc/datadog-agent/system-probe.yaml
               subPath: system-probe.yaml
         - name: system-probe
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
-              add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "IPC_LOCK"]
+              add:
+                - SYS_ADMIN
+                - SYS_RESOURCE
+                - SYS_PTRACE
+                - NET_ADMIN
+                - NET_BROADCAST
+                - NET_RAW
+                - IPC_LOCK
+            privileged: false
           command: ["/opt/datadog-agent/embedded/bin/system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
           env:
             - name: DD_API_KEY
@@ -418,9 +438,14 @@ spec:
               value: "INFO"
           resources: {}
           volumeMounts:
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false
             - name: debugfs
               mountPath: /sys/kernel/debug
               mountPropagation: None
+            - name: config
+              mountPath: /etc/datadog-agent
             - name: sysprobe-config
               mountPath: /etc/datadog-agent/system-probe.yaml
               subPath: system-probe.yaml
@@ -432,7 +457,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -442,7 +467,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -475,9 +500,11 @@ spec:
               value: "yes"
             - name: DOCKER_HOST
               value: unix:///host/var/run/docker.sock
+            - name: DD_LEADER_ELECTION
+              value: "true"
           resources: {}
         - name: seccomp-setup
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           command:
             - cp
             - /etc/config/system-probe-seccomp.json
@@ -498,12 +525,16 @@ spec:
         - hostPath:
             path: /var/run
           name: runtimesocketdir
+        - name: tmpdir
+          emptyDir: {}
         - hostPath:
             path: /proc
           name: procdir
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
+        - name: s6-run
+          emptyDir: {}
         - name: sysprobe-config
           configMap:
             name: datadog-agent-system-probe-config
@@ -530,7 +561,3 @@ spec:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
-
-# Source: datadog/templates/containers-common-env.yaml
-# The purpose of this template is to define a minimal set of environment
-# variables required to operate dedicated containers in the daemonset

--- a/static/resources/yaml/datadog-agent-npm.yaml
+++ b/static/resources/yaml/datadog-agent-npm.yaml
@@ -533,8 +533,6 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
-        - name: s6-run
-          emptyDir: {}
         - name: sysprobe-config
           configMap:
             name: datadog-agent-system-probe-config

--- a/static/resources/yaml/datadog-agent-npm_values.yaml
+++ b/static/resources/yaml/datadog-agent-npm_values.yaml
@@ -2,9 +2,13 @@ datadog:
   kubeStateMetricsEnabled: false
   processAgent:
     enabled: true
-  systemProbe:
+  networkMonitoring:
     enabled: true
+  orchestratorExplorer:
+    enabled: false
 agents:
   rbac:
     create: false
     serviceAccountName: datadog-agent
+clusterAgent:
+  enabled: false

--- a/static/resources/yaml/datadog-agent-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-vanilla.yaml
@@ -1,5 +1,4 @@
-# Source: datadog/templates/secrets.yaml
-# API Key
+# Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,8 +7,6 @@ metadata:
 type: Opaque
 data:
   api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
-
-# APP Key
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -18,7 +15,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
+    checksum/install_info: 092f34522792579934b4afae83bc34fc9fa2ea9d89ab29459dd8594579a3c8fa
 data:
   install_info: |
     ---
@@ -46,7 +43,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -72,6 +69,12 @@ spec:
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
               value: "8125"
+            - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_LEADER_ELECTION
+              value: "true"
+            - name: DD_COLLECT_KUBERNETES_EVENTS
+              value: "true"
             - name: DD_APM_ENABLED
               value: "false"
             - name: DD_LOGS_ENABLED
@@ -87,6 +90,9 @@ spec:
               subPath: install_info
               mountPath: /etc/datadog-agent/install_info
               readOnly: true
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false
             - name: config
               mountPath: /etc/datadog-agent
             - name: runtimesocketdir
@@ -122,7 +128,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -140,8 +146,12 @@ spec:
               value: "yes"
             - name: DOCKER_HOST
               value: unix:///host/var/run/docker.sock
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
+            - name: DD_SYSTEM_PROBE_ENABLED
+              value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "false"
           volumeMounts:
@@ -151,19 +161,23 @@ spec:
               mountPath: /host/var/run
               mountPropagation: None
               readOnly: true
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               readOnly: true
             - name: passwd
               mountPath: /etc/passwd
+              readOnly: true
             - name: procdir
               mountPath: /host/proc
               mountPropagation: None
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -173,7 +187,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -203,6 +217,8 @@ spec:
               value: "yes"
             - name: DOCKER_HOST
               value: unix:///host/var/run/docker.sock
+            - name: DD_LEADER_ELECTION
+              value: "true"
           resources: {}
       volumes:
         - name: installinfo
@@ -213,6 +229,8 @@ spec:
         - hostPath:
             path: /var/run
           name: runtimesocketdir
+        - name: tmpdir
+          emptyDir: {}
         - hostPath:
             path: /proc
           name: procdir
@@ -233,7 +251,3 @@ spec:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
-
-# Source: datadog/templates/containers-common-env.yaml
-# The purpose of this template is to define a minimal set of environment
-# variables required to operate dedicated containers in the daemonset

--- a/static/resources/yaml/datadog-agent-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-vanilla.yaml
@@ -237,8 +237,6 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
-        - name: s6-run
-          emptyDir: {}
         - hostPath:
             path: /etc/passwd
           name: passwd

--- a/static/resources/yaml/datadog-agent-vanilla_values.yaml
+++ b/static/resources/yaml/datadog-agent-vanilla_values.yaml
@@ -1,6 +1,10 @@
 datadog:
   kubeStateMetricsEnabled: false
+  orchestratorExplorer:
+    enabled: false
 agents:
   rbac:
     create: false
     serviceAccountName: datadog-agent
+clusterAgent:
+  enabled: false

--- a/static/resources/yaml/datadog-agent-windows-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-windows-all-features.yaml
@@ -1,5 +1,15 @@
-# Source: datadog/templates/secrets.yaml
-# API Key
+# Source: datadog/templates/cluster-agent-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: "datadog-agent"
+    chart: "datadog-2.9.11"
+    heritage: "Helm"
+    release: "datadog-agent"
+  name: datadog-agent-cluster-agent
+---
+# Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,8 +18,16 @@ metadata:
 type: Opaque
 data:
   api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
-
-# APP Key
+---
+# Source: datadog/templates/secret-cluster-agent-token.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: datadog-agent-cluster-agent
+  labels: {}
+type: Opaque
+data:
+  token: PUT_A_BASE64_ENCODED_RANDOM_STRING_HERE
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -18,7 +36,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
+    checksum/install_info: 092f34522792579934b4afae83bc34fc9fa2ea9d89ab29459dd8594579a3c8fa
 data:
   install_info: |
     ---
@@ -26,6 +44,144 @@ data:
       tool: kubernetes sample manifests
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
+---
+# Source: datadog/templates/cluster-agent-rbac.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: ClusterRole
+metadata:
+  labels: {}
+  name: datadog-agent-cluster-agent
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+      - nodes
+      - namespaces
+      - componentstatuses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+  - apiGroups: ["quota.openshift.io"]
+    resources:
+      - clusterresourcequotas
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - "autoscaling"
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - datadogtoken # Kubernetes event collection state
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - datadog-leader-election # Leader election token
+    verbs:
+      - get
+      - update
+  - apiGroups: # To create the leader election token and hpa events
+      - ""
+    resources:
+      - configmaps
+      - events
+    verbs:
+      - create
+  - nonResourceURLs:
+      - "/version"
+      - "/healthz"
+    verbs:
+      - get
+  - apiGroups: # to get the kube-system namespace UID and generate a cluster ID
+      - ""
+    resources:
+      - namespaces
+    resourceNames:
+      - "kube-system"
+    verbs:
+      - get
+  - apiGroups: # To create the cluster-id configmap
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - "datadog-cluster-id"
+    verbs:
+      - create
+      - get
+      - update
+  - apiGroups:
+      - "apps"
+    resources:
+      - deployments
+      - replicasets
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+    resourceNames:
+      - datadog-agent-cluster-agent
+---
+# Source: datadog/templates/cluster-agent-rbac.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: ClusterRoleBinding
+metadata:
+  labels: {}
+  name: datadog-agent-cluster-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-agent-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-agent-cluster-agent
+    namespace: default
+---
+# Source: datadog/templates/agent-services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: datadog-agent-cluster-agent
+  labels: {}
+spec:
+  type: ClusterIP
+  selector:
+    app: datadog-agent-cluster-agent
+  ports:
+    - port: 5005
+      name: agentport
+      protocol: TCP
 ---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
@@ -46,7 +202,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -74,10 +230,17 @@ spec:
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-            - name: DD_LEADER_ELECTION
+            - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
               value: "true"
-            - name: DD_COLLECT_KUBERNETES_EVENTS
+            - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
+            - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+              value: datadog-agent-cluster-agent
+            - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: datadog-agent-cluster-agent
+                  key: token
             - name: DD_APM_ENABLED
               value: "false"
             - name: DD_LOGS_ENABLED
@@ -88,6 +251,8 @@ spec:
               value: "true"
             - name: DD_HEALTH_PORT
               value: "5555"
+            - name: DD_EXTRA_CONFIG_PROVIDERS
+              value: "clusterchecks endpointschecks"
           volumeMounts:
             - name: config
               mountPath: C:/ProgramData/Datadog
@@ -122,7 +287,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -147,6 +312,15 @@ spec:
               value: "name:datadog-agent"
             - name: DOCKER_HOST
               value: npipe:////./pipe/docker_engine
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "true"
+            - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+              value: datadog-agent-cluster-agent
+            - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: datadog-agent-cluster-agent
+                  key: token
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_APM_ENABLED
@@ -167,7 +341,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -187,12 +361,28 @@ spec:
               value: "name:datadog-agent"
             - name: DOCKER_HOST
               value: npipe:////./pipe/docker_engine
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "true"
+            - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+              value: datadog-agent-cluster-agent
+            - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: datadog-agent-cluster-agent
+                  key: token
             - name: DD_PROCESS_AGENT_ENABLED
               value: "true"
             - name: DD_LOG_LEVEL
               value: "INFO"
-            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+            - name: DD_SYSTEM_PROBE_ENABLED
               value: "false"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "true"
+            - name: DD_ORCHESTRATOR_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-cluster-id
+                  key: id
           volumeMounts:
             - name: config
               mountPath: C:/ProgramData/Datadog
@@ -200,7 +390,7 @@ spec:
               mountPath: \\.\pipe\docker_engine
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -214,7 +404,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -272,7 +462,117 @@ spec:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
-
-# Source: datadog/templates/containers-common-env.yaml
-# The purpose of this template is to define a minimal set of environment
-# variables required to operate dedicated containers in the daemonset
+---
+# Source: datadog/templates/cluster-agent-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: datadog-agent-cluster-agent
+  labels: {}
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: datadog-agent-cluster-agent
+  template:
+    metadata:
+      labels:
+        app: datadog-agent-cluster-agent
+      name: datadog-agent-cluster-agent
+      annotations:
+        ad.datadoghq.com/cluster-agent.check_names: '["prometheus"]'
+        ad.datadoghq.com/cluster-agent.init_configs: '[{}]'
+        ad.datadoghq.com/cluster-agent.instances: |
+          [{
+            "prometheus_url": "http://%%host%%:5000/metrics",
+            "namespace": "datadog.cluster_agent",
+            "metrics": [
+              "go_goroutines", "go_memstats_*", "process_*",
+              "api_requests",
+              "datadog_requests", "external_metrics", "rate_limit_queries_*",
+              "cluster_checks_*"
+            ]
+          }]
+    spec:
+      serviceAccountName: datadog-agent-cluster-agent
+      containers:
+        - name: cluster-agent
+          image: "gcr.io/datadoghq/cluster-agent:1.11.0"
+          imagePullPolicy: IfNotPresent
+          resources: {}
+          ports:
+            - containerPort: 5005
+              name: agentport
+              protocol: TCP
+          env:
+            - name: DD_HEALTH_PORT
+              value: "5555"
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog-agent"
+                  key: api-key
+                  optional: true
+            - name: DD_CLUSTER_CHECKS_ENABLED
+              value: "true"
+            - name: DD_EXTRA_CONFIG_PROVIDERS
+              value: "kube_endpoints kube_services"
+            - name: DD_EXTRA_LISTENERS
+              value: "kube_endpoints kube_services"
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_LEADER_ELECTION
+              value: "true"
+            - name: DD_LEADER_LEASE_DURATION
+              value: "15"
+            - name: DD_COLLECT_KUBERNETES_EVENTS
+              value: "true"
+            - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+              value: datadog-agent-cluster-agent
+            - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: datadog-agent-cluster-agent
+                  key: token
+            - name: DD_KUBE_RESOURCES_NAMESPACE
+              value: default
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "true"
+            - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
+              value: "true"
+          livenessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /live
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /ready
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: installinfo
+              subPath: install_info
+              mountPath: C:/ProgramData/Datadog/install_info
+              readOnly: true
+      volumes:
+        - name: installinfo
+          configMap:
+            name: datadog-agent-installinfo
+      nodeSelector:
+        kubernetes.io/os: windows

--- a/static/resources/yaml/datadog-agent-windows-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-apm.yaml
@@ -1,5 +1,4 @@
-# Source: datadog/templates/secrets.yaml
-# API Key
+# Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,8 +7,6 @@ metadata:
 type: Opaque
 data:
   api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
-
-# APP Key
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -18,7 +15,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
+    checksum/install_info: 092f34522792579934b4afae83bc34fc9fa2ea9d89ab29459dd8594579a3c8fa
 data:
   install_info: |
     ---
@@ -46,7 +43,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -72,6 +69,12 @@ spec:
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
               value: "8125"
+            - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_LEADER_ELECTION
+              value: "true"
+            - name: DD_COLLECT_KUBERNETES_EVENTS
+              value: "true"
             - name: DD_APM_ENABLED
               value: "false"
             - name: DD_LOGS_ENABLED
@@ -108,7 +111,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -131,6 +134,8 @@ spec:
               value: "yes"
             - name: DOCKER_HOST
               value: npipe:////./pipe/docker_engine
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_APM_ENABLED
@@ -152,7 +157,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -166,7 +171,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -213,7 +218,3 @@ spec:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
-
-# Source: datadog/templates/containers-common-env.yaml
-# The purpose of this template is to define a minimal set of environment
-# variables required to operate dedicated containers in the daemonset

--- a/static/resources/yaml/datadog-agent-windows-apm_values.yaml
+++ b/static/resources/yaml/datadog-agent-windows-apm_values.yaml
@@ -5,7 +5,11 @@ datadog:
     enabled: true
   processAgent:
     enabled: false
+  orchestratorExplorer:
+    enabled: false
 agents:
   rbac:
     create: false
     serviceAccountName: datadog-agent
+clusterAgent:
+  enabled: false

--- a/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
@@ -1,5 +1,4 @@
-# Source: datadog/templates/secrets.yaml
-# API Key
+# Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,8 +7,6 @@ metadata:
 type: Opaque
 data:
   api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
-
-# APP Key
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -18,7 +15,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
+    checksum/install_info: 092f34522792579934b4afae83bc34fc9fa2ea9d89ab29459dd8594579a3c8fa
 data:
   install_info: |
     ---
@@ -46,7 +43,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -74,6 +71,8 @@ spec:
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
               value: "8125"
+            - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
+              value: "true"
             - name: DD_LEADER_ELECTION
               value: "true"
             - name: DD_COLLECT_KUBERNETES_EVENTS
@@ -122,7 +121,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -147,6 +146,8 @@ spec:
               value: "name:datadog-agent"
             - name: DOCKER_HOST
               value: npipe:////./pipe/docker_engine
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_APM_ENABLED
@@ -168,7 +169,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -182,7 +183,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -240,7 +241,3 @@ spec:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
-
-# Source: datadog/templates/containers-common-env.yaml
-# The purpose of this template is to define a minimal set of environment
-# variables required to operate dedicated containers in the daemonset

--- a/static/resources/yaml/datadog-agent-windows-logs-apm_values.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs-apm_values.yaml
@@ -11,7 +11,11 @@ datadog:
     enabled: true
   processAgent:
     enabled: false
+  orchestratorExplorer:
+    enabled: false
 agents:
   rbac:
     create: false
     serviceAccountName: datadog-agent
+clusterAgent:
+  enabled: false

--- a/static/resources/yaml/datadog-agent-windows-logs.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs.yaml
@@ -1,5 +1,4 @@
-# Source: datadog/templates/secrets.yaml
-# API Key
+# Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,8 +7,6 @@ metadata:
 type: Opaque
 data:
   api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
-
-# APP Key
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -18,7 +15,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
+    checksum/install_info: 092f34522792579934b4afae83bc34fc9fa2ea9d89ab29459dd8594579a3c8fa
 data:
   install_info: |
     ---
@@ -46,7 +43,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -74,6 +71,8 @@ spec:
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
               value: "8125"
+            - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
+              value: "true"
             - name: DD_LEADER_ELECTION
               value: "true"
             - name: DD_COLLECT_KUBERNETES_EVENTS
@@ -123,7 +122,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -137,7 +136,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -195,7 +194,3 @@ spec:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
-
-# Source: datadog/templates/containers-common-env.yaml
-# The purpose of this template is to define a minimal set of environment
-# variables required to operate dedicated containers in the daemonset

--- a/static/resources/yaml/datadog-agent-windows-logs_values.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs_values.yaml
@@ -9,7 +9,11 @@ datadog:
   acExclude: "name:datadog-agent"
   processAgent:
     enabled: false
+  orchestratorExplorer:
+    enabled: false
 agents:
   rbac:
     create: false
     serviceAccountName: datadog-agent
+clusterAgent:
+  enabled: false

--- a/static/resources/yaml/datadog-agent-windows-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-windows-vanilla.yaml
@@ -1,5 +1,4 @@
-# Source: datadog/templates/secrets.yaml
-# API Key
+# Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,8 +7,6 @@ metadata:
 type: Opaque
 data:
   api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
-
-# APP Key
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -18,7 +15,7 @@ metadata:
   name: datadog-agent-installinfo
   labels: {}
   annotations:
-    checksum/install_info: 9f58f4fe71f1b79dfabae5311eb8f5373bd03072d4636e248cd3f581f8752627
+    checksum/install_info: 092f34522792579934b4afae83bc34fc9fa2ea9d89ab29459dd8594579a3c8fa
 data:
   install_info: |
     ---
@@ -46,7 +43,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -72,6 +69,12 @@ spec:
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
               value: "8125"
+            - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_LEADER_ELECTION
+              value: "true"
+            - name: DD_COLLECT_KUBERNETES_EVENTS
+              value: "true"
             - name: DD_APM_ENABLED
               value: "false"
             - name: DD_LOGS_ENABLED
@@ -109,7 +112,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -123,7 +126,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.23.1"
+          image: "gcr.io/datadoghq/agent:7.26.0"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -170,7 +173,3 @@ spec:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
-
-# Source: datadog/templates/containers-common-env.yaml
-# The purpose of this template is to define a minimal set of environment
-# variables required to operate dedicated containers in the daemonset

--- a/static/resources/yaml/datadog-agent-windows-vanilla_values.yaml
+++ b/static/resources/yaml/datadog-agent-windows-vanilla_values.yaml
@@ -3,7 +3,11 @@ datadog:
   kubeStateMetricsEnabled: false
   processAgent:
     enabled: false
+  orchestratorExplorer:
+    enabled: false
 agents:
   rbac:
     create: false
     serviceAccountName: datadog-agent
+clusterAgent:
+  enabled: false


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Update the agent k8s manifests to be aligned with the latest helm chart

### Motivation

Follow-up on https://github.com/DataDog/datadog-agent/pull/7461

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
