### PR TITLE
Fix link to kafka integration documentation

### DIFF
--- a/content/en/agent/guide/autodiscovery-with-jmx.md
+++ b/content/en/agent/guide/autodiscovery-with-jmx.md
@@ -140,7 +140,7 @@ If your Agent is running in your cluster and you want to autodiscover your conta
     | [confluent_platform][7] | [metrics.yaml][8]  | [conf.yaml.example][9] |
     | [hive][10]              | [metrics.yaml][11] | [conf.yaml.example][12] |
     | [jboss_wildfly][13]     | [metrics.yaml][14] | [conf.yaml.example][15] |
-    | [kafka][16]             | [metrics.yaml][17] | [conf.yaml.example][18] |
+    | [kafka][29]             | [metrics.yaml][17] | [conf.yaml.example][18] |
     | [solr][19]              | [metrics.yaml][20] | [conf.yaml.example][21] |
     | [presto][22]            | [metrics.yaml][23] | [conf.yaml.example][24] |
     | [tomcat][16]            | [metrics.yaml][25] | [conf.yaml.example][26] |
@@ -227,6 +227,7 @@ If your Agent is running in your cluster and you want to autodiscover your conta
 [26]: https://github.com/DataDog/integrations-core/blob/master/tomcat/datadog_checks/tomcat/data/conf.yaml.example
 [27]: /agent/faq/template_variables/
 [28]: /agent/guide/ad_identifiers/#short-image-container-identifiers
+[29]: /integrations/kafka/
 {{% /tab %}}
 {{% tab "Host Agent" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
I added a new link to the kafka integration page and corrected the link reference number, because previously the kafka link lead to the tomcat documentation page.

### Motivation
<!-- What inspired you to submit this pull request?-->
Previously the link labeled for the kafka integration actually lead to the tomcat page. 

```html
<a href="https://docs.datadoghq.com/integrations/tomcat/">kafka</a>
```

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
