### PR TITLE
Clarify supported Agent architectures

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -128,31 +128,32 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 
 3. For security reasons, the GUI can **only** be accessed from the local network interface (`localhost`/`127.0.0.1`), therefore you must be on the same host that the Agent is running. That is, you can't run the Agent on a VM or a container and access it from the host machine.
 
-## Supported OS versions
+## Supported platforms
 
 {{< tabs >}}
 {{% tab "Agent v6 & v7" %}}
 
-| OS                                              | Supported versions                                        |
-|-------------------------------------------------|-----------------------------------------------------------|
-| [Amazon][1]                                     | Amazon Linux 2                                            |
-| [Debian x86_64][2] with systemd                 | Debian 7 (wheezy)+                                        |
-| [Debian x86_64][2] with SysVinit                | Debian 7 (wheezy)+ in Agent 6.6.0+                        |
-| [Ubuntu x86_64][3]                              | Ubuntu 14.04+                                             |
-| [RedHat/CentOS x86_64][4]                       | RedHat/CentOS 6+                                          |
-| [Docker][5]                                     | Version 1.12+                                             |
-| [Kubernetes][6]                                 | Version 1.3+                                              |
-| [SUSE Enterprise Linux x86_64][7] with systemd  | SUSE 11 SP4+                                              |
-| [SUSE Enterprise Linux x86_64][7] with SysVinit | SUSE 11 SP4 in Agent 7.16.0+                              |
-| [Fedora x86_64][8]                              | Fedora 26+                                                |
-| [macOS][9]                                      | macOS 10.12+                                              |
-| [Windows Server 64-bit][10]                     | Windows Server 2008 R2+ and Server Core (not Nano Server) |
-| [Windows 64-bit][10]                            | Windows 7+                                                |
-| [Windows Azure Stack HCI OS][10]                | All Versions                                              |
+| Platform                                 | Supported versions                                        |
+|------------------------------------------|-----------------------------------------------------------|
+| [Amazon Linux][1]                        | Amazon Linux 2                                            |
+| [Debian][2] with systemd                 | Debian 7 (wheezy)+                                        |
+| [Debian][2] with SysVinit                | Debian 7 (wheezy)+ in Agent 6.6.0+                        |
+| [Ubuntu][3]                              | Ubuntu 14.04+                                             |
+| [RedHat/CentOS][4]                       | RedHat/CentOS 6+                                          |
+| [Docker][5]                              | Version 1.12+                                             |
+| [Kubernetes][6]                          | Version 1.3+                                              |
+| [SUSE Enterprise Linux][7] with systemd  | SUSE 11 SP4+                                              |
+| [SUSE Enterprise Linux][7] with SysVinit | SUSE 11 SP4 in Agent 7.16.0+                              |
+| [Fedora][8]                              | Fedora 26+                                                |
+| [macOS][9]                               | macOS 10.12+                                              |
+| [Windows Server][10]                     | Windows Server 2008 R2+ and Server Core (not Nano Server) |
+| [Windows][10]                            | Windows 7+                                                |
+| [Windows Azure Stack HCI OS][10]         | All Versions                                              |
 
 **Notes**: 
+- 64-bit x86 packages are available for all platforms on the list. Arm v8 packages are available for all platforms except Windows and MacOS.
 - [Source][11] install may work on operating systems not listed here and is supported on a best effort basis.
-- Datadog Agent v7+ supports Windows Server 2008 R2 with the most recent Windows updates installed. There is also a [known issue with clock drift and Go][12] that affects Windows Server 2008 R2.
+- Datadog Agent v6+ supports Windows Server 2008 R2 with the most recent Windows updates installed. There is also a [known issue with clock drift and Go][12] that affects Windows Server 2008 R2.
 
 [1]: /agent/basic_agent_usage/amazonlinux/
 [2]: /agent/basic_agent_usage/deb/
@@ -169,25 +170,23 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 {{% /tab %}}
 {{% tab "Agent v5" %}}
 
-| OS                                | Supported versions     |
-|-----------------------------------|------------------------|
-| [Amazon][1]                       | Amazon Linux 2         |
-| [Debian x86_64][2]                | Debian 7 (wheezy)+     |
-| [Ubuntu x86_64][3]                | Ubuntu 12.04+          |
-| [RedHat/CentOS x86_64][4]         | RedHat/CentOS 5+       |
-| [Docker][5]                       | Version 1.12+          |
-| [Kubernetes][6]                   | Version 1.3 to 1.8     |
-| [SUSE Enterprise Linux x86_64][7] | SUSE 11 SP4+           |
-| [Fedora x86_64][8]                | Fedora 26+             |
-| [MacOS][9]                        | macOS 10.10+           |
-| [Windows server 64-bit][10]       | Windows Server 2008r2+ |
-| [Windows 64-bit][10]              | Windows 7+             |
+| Platform                   | Supported versions     |
+|----------------------------|------------------------|
+| [Amazon Linux][1]          | Amazon Linux 2         |
+| [Debian][2]                | Debian 7 (wheezy)+     |
+| [Ubuntu][3]                | Ubuntu 12.04+          |
+| [RedHat/CentOS][4]         | RedHat/CentOS 5+       |
+| [Docker][5]                | Version 1.12+          |
+| [Kubernetes][6]            | Version 1.3 to 1.8     |
+| [SUSE Enterprise Linux][7] | SUSE 11 SP4+           |
+| [Fedora][8]                | Fedora 26+             |
+| [MacOS][9]                 | macOS 10.10+           |
+| [Windows Server][10]       | Windows Server 2008r2+ |
+| [Windows][10]              | Windows 7+             |
 
 **Notes**:
 
 - [Source][11] install may work on operating systems not listed here and is supported on a best effort basis.
-
-- Windows Server 2008 R2 is supported, but there is a [known issue with clock drift and Go][12] that affects Windows Server 2008 R2.
 
 [1]: /agent/basic_agent_usage/amazonlinux/?tab=agentv5
 [2]: /agent/basic_agent_usage/deb/
@@ -204,7 +203,7 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 {{% /tab %}}
 {{% tab "Unix Agent" %}}
 
-| OS       | Supported versions                        |
+| Platform | Supported versions                        |
 |----------|-------------------------------------------|
 | [AIX][1] | AIX 6.1 TL9 SP6, 7.1 TL5 SP3, 7.2 TL3 SP0 |
 

--- a/content/en/agent/basic_agent_usage/centos.md
+++ b/content/en/agent/basic_agent_usage/centos.md
@@ -20,6 +20,8 @@ further_reading:
 
 This page outlines the basic features of the Datadog Agent for CentOS. To install the Datadog Agent, follow the [Agent Installation Instructions][1] for CentOs.
 
+Packages are available for 64-bit x86 and Arm v8 architectures. For other architectures, use the source install.
+
 **Note**: CentOS 6 and above are supported.
 
 ## Commands

--- a/content/en/agent/basic_agent_usage/fedora.md
+++ b/content/en/agent/basic_agent_usage/fedora.md
@@ -20,6 +20,8 @@ further_reading:
 
 This page outlines the basic features of the Datadog Agent for Fedora. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
+Packages are available for 64-bit x86 and Arm v8 architectures. For other architectures, use the source install.
+
 **Note**: Fedora 26 and above are supported.
 
 ## Commands

--- a/content/en/agent/basic_agent_usage/redhat.md
+++ b/content/en/agent/basic_agent_usage/redhat.md
@@ -20,6 +20,8 @@ further_reading:
 
 This page outlines the basic features of the Datadog Agent for Red Hat. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
+Packages are available for 64-bit x86 and Arm v8 architectures. For other architectures, use the source install.
+
 **Note**: RedHat 6 and above are supported.
 
 ## Commands

--- a/content/en/agent/basic_agent_usage/suse.md
+++ b/content/en/agent/basic_agent_usage/suse.md
@@ -20,6 +20,8 @@ further_reading:
 
 This page outlines the basic features of the Datadog Agent for SUSE. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
+Packages are available for 64-bit x86 and Arm v8 architectures. For other architectures, use the source install.
+
 **Note**: SUSE 11 SP4 and above are supported.
 
 ## Commands


### PR DESCRIPTION
### What does this PR do?
- Mention Arm v8 support on some places where it was missing.
- Rename OS -> Platform, since we list things like k8s which aren't OSes.
- Remove note about clock drift on A5, since the problem only affects Go.
- Remove "x64" next to some OS names, since it was inconsistent and we also support Arm.
- Add a note about Arm v8 support.
- Change Windows 2008 support text so it mentions Agent v6+ and not v7+.

### Preview
https://docs-staging.datadoghq.com/albertvaka/agent-arm-arch-missing-places/agent/basic_agent_usage

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
