### PR TITLE
Removing the EU tab for alert reports as it's not supported

### DIFF
--- a/content/en/monitors/faq/how-can-i-export-alert-history.md
+++ b/content/en/monitors/faq/how-can-i-export-alert-history.md
@@ -3,14 +3,16 @@ title: Export Monitor Alerts to CSV
 kind: faq
 ---
 
-Download a history of monitor alerts through the [hourly monitor data][1], which generates a CSV for the past 6 months (182 days). This CSV is **not** live; it is updated once a week on Monday at 11:59AM UTC. 
+Download a history of monitor alerts through the [hourly monitor data][1], which generates a CSV for the past 6 months (182 days). This CSV is **not** live; it is updated once a week on Monday at 11:59AM UTC.
 
-**Note**: You need to be an administrator of your organization to access the CSV file.
+**Notes**:
+
+- This feature is US only.
+- You need to be an administrator of your organization to access the CSV file.
+
+{{< site-region region="us" >}}
 
 To fetch the CSV using curl, use the following:
-
-{{< tabs >}}
-{{% tab "US" %}}
 
 ```shell
 api_key=<DATADOG_API_KEY>
@@ -22,14 +24,30 @@ curl -G \
     -d "application_key=${app_key}" \
 ```
 
-{{% /tab %}}
-{{< /tabs >}}
-
 Example response:
 
 ```text
 org_id,hour,source_type_name,alert_type,priority,event_object,host_name,device_name,alert_name,user,cnt
 <org_id_integer>, 2018-06-07 17,monitor alert,error,1,<event_object_string>,test.example.eu,"Host name: {{host.name}} Name name: {{name.name}}",<user_email>,1
 ```
+{{< /site-region >}}
+
+{{< site-region region="eu" >}}
+
+This feature is not supported.
+
+{{< /site-region >}}
+
+{{< site-region region="gov" >}}
+
+This feature is not supported.
+
+{{< /site-region >}}
+
+{{< site-region region="us3" >}}
+
+This feature is not supported.
+
+{{< /site-region >}}
 
 [1]: https://app.datadoghq.com/report/hourly_data/monitor

--- a/content/en/monitors/faq/how-can-i-export-alert-history.md
+++ b/content/en/monitors/faq/how-can-i-export-alert-history.md
@@ -23,19 +23,6 @@ curl -G \
 ```
 
 {{% /tab %}}
-{{% tab "EU" %}}
-
-```shell
-api_key=<DATADOG_API_KEY>
-app_key = <DATADOG_APPLICATION_KEY>
-
-curl -G \
-    "https://app.datadoghq.eu/report/hourly_data/monitor" \
-    -d "api_key=${api_key}" \
-    -d "application_key=${app_key}" \
-```
-
-{{% /tab %}}
 {{< /tabs >}}
 
 Example response:

--- a/content/en/monitors/faq/how-can-i-export-alert-history.md
+++ b/content/en/monitors/faq/how-can-i-export-alert-history.md
@@ -7,7 +7,7 @@ Download a history of monitor alerts through the [hourly monitor data][1], which
 
 **Notes**:
 
-- This feature is US only.
+- This feature is only supported for the Datadog US site.
 - You need to be an administrator of your organization to access the CSV file.
 
 {{< site-region region="us" >}}


### PR DESCRIPTION
### What does this PR do?
Remove the reference to EU in the article as this endpoint is not supported and some customers were wondering why it was returning a 500.

### Motivation
Avoid user confusion.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/alert-export-eu-removal/monitors/faq/how-can-i-export-alert-history

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
