### PR TITLE
Add links to Azure App Service docs from .NET tracing setup docs

### DIFF
--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -30,6 +30,9 @@ further_reading:
   - link: "/tracing/connect_logs_and_traces/dotnet/"
     tag: "Documentation"
     text: "Connect .NET application logs to traces"
+  - link: "/serverless/azure_app_services/"
+    tag: "Documentation"
+    text: "Microsoft Azure App Services Extension"
 ---
 
 ## Compatibility requirements

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -32,6 +32,9 @@ further_reading:
     - link: "/tracing/connect_logs_and_traces/dotnet/"
       tag: "Documentation"
       text: "Connect .NET application logs to traces"
+    - link: "/serverless/azure_app_services/"
+      tag: "Documentation"
+      text: "Microsoft Azure App Services Extension"
 ---
 ## Compatibility requirements
 


### PR DESCRIPTION

### What does this PR do?
Adds Azure App Service links in Further reading section of .NET Core and Framework tracing setup pages

### Motivation
PM request

### Preview

https://docs-staging.datadoghq.com/kari/add-azure-links/tracing/setup_overview/setup/dotnet-core
https://docs-staging.datadoghq.com/kari/add-azure-links/tracing/setup_overview/setup/dotnet-framework

