### PR TITLE
[DOCS 1753] noting env vars for fargate private location

### DIFF
--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -316,7 +316,11 @@ Create a new Fargate task definition matching the below. Make sure to replace ea
 }
 ```
 
-**Note:** The private location firewall option is not supported on AWS Fargate - the `enableDefaultBlockedIpRanges` parameter can consequently not be set to `true`.
+**Notes:** 
+
+If you wish to use environment variables in your task definition, note that Fargate Private Location deployment uses different environment variables than other parts of Datadog. For Fargate, use the following environment variables: `DATADOG_API_KEY`, `DATADOG_ACCESS_KEY`, `DATADOG_SECRET_ACCESS_KEY`, `DATADOG_PRIVATE_KEY`.
+
+The private location firewall option is not supported on AWS Fargate—the `enableDefaultBlockedIpRanges` parameter can consequently not be set to `true`.
 
 {{% /tab %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fargate PL uses different envvars than other parts of datadog, this update makes note of them.

### Motivation
support request

### Preview

https://docs-staging.datadoghq.com/cswatt/pl-fargate/synthetics/private_locations?tab=fargate#install-your-private-location

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
