### PR TITLE
Fixing link issue

### DIFF
--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -92,7 +92,7 @@ Tests can be only recorded from **[Google Chrome][9]**. To record your test, dow
 4. In addition to the automatically recorded steps, you can also use the [steps][11] available in the upper left corner to enrich your scenario:
     {{< img src="synthetics/browser_tests/manual_steps.png" alt="Browser Test steps"  style="width:80%;">}}
 
-    **Note**: You should always make to **end your browser test with an [assertion][12]** to confirm the journey executed by the browser test resulted in the expected state.
+    **Note**: You should always make sure to **end your browser test with an [assertion][12]** to confirm the journey executed by the browser test resulted in the expected state.
 5. Once you have finished your scenario, click on **Save and Launch Test**.
 
 ## Further Reading
@@ -110,3 +110,4 @@ Tests can be only recorded from **[Google Chrome][9]**. To record your test, dow
 [9]: https://www.google.com/chrome
 [10]: https://chrome.google.com/webstore/detail/datadog-test-recorder/kkbncfpddhdmkfmalecgnphegacgejoa
 [11]: /synthetics/browser_tests/actions/
+[12]: /synthetics/browser_tests/actions/#assertion


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR fixes a broken link.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/margot.lepizzera/fix_link/synthetics/browser_tests/#record-your-steps
### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
