### PR TITLE
[rum] document event dismissal in browser sdk

### DIFF
--- a/content/en/real_user_monitoring/browser/advanced_configuration.md
+++ b/content/en/real_user_monitoring/browser/advanced_configuration.md
@@ -18,14 +18,12 @@ further_reading:
       text: 'Tracking custom user actions'
 ---
 
-## Initialization
-
-Find below the different initialization options available with the [Datadog Browser SDK][1].
-
-### Scrub sensitive data from your RUM data
-If your RUM data contains sensitive information that need redacting, configure the Browser SDK to scrub sensitive sequences by using the `beforeSend` callback when you initialize RUM.
+## Scrub sensitive data from your RUM data
+If your RUM data contains sensitive information that need redacting, configure the Browser SDK to scrub sensitive sequences, or to dismiss selected RUM events, by using the `beforeSend` callback when you initialize RUM.
 
 This callback function gives you access to every event collected by the RUM SDK before they get sent to Datadog.
+
+### Modify the content of a RUM event
 
 For example, redact email addresses from your web application URLs:
 
@@ -89,9 +87,67 @@ You can update the following event properties:
 |   `error.resource.url`  |   String  |   The resource URL that triggered the error.                                                        |
 |   `resource.url`        |   String  |   The resource URL.                                                                                 |
 
-**Note**: The RUM SDK will ignore modifications made to event properties not listed above. Find out about all event properties on the [Browser SDK repository][2].
+**Note**: The RUM SDK will ignore modifications made to event properties not listed above. Find out about all event properties on the [Browser SDK repository][1].
 
-### Identify user sessions
+### Dismiss a RUM event
+
+With the `beforeSend` API, dismiss a RUM event by returning `false`:
+
+{{< tabs >}}
+{{% tab "NPM" %}}
+
+```javascript
+import { datadogRum } from '@datadog/browser-rum';
+
+datadogRum.init({
+    ...,
+    beforeSend: (event) => {
+        if (shouldDismiss(event)) {
+            return false
+        }
+        ...
+    },
+    ...
+});
+```
+
+{{% /tab %}}
+{{% tab "CDN async" %}}
+```javascript
+DD_RUM.onReady(function() {
+    DD_RUM.init({
+        ...,
+        beforeSend: (event) => {
+            if (shouldDismiss(event)) {
+                return false
+            },
+            ...
+        },
+        ...
+    })
+})
+```
+{{% /tab %}}
+{{% tab "CDN sync" %}}
+
+```javascript
+window.DD_RUM &&
+    window.DD_RUM.init({
+        ...,
+        beforeSend: (event) => {
+            if (shouldDismiss(event)) {
+                return false
+            }
+            ...
+        },
+        ...
+    });
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## Identify user sessions
 Adding user information to your RUM sessions makes it easy to:
 * Follow the journey of a given user
 * Know which users are the most impacted by errors
@@ -144,7 +200,7 @@ window.DD_RUM && window.DD_RUM.setUser({
 {{% /tab %}}
 {{< /tabs >}}
 
-### Sampling
+## Sampling
 
 By default, no sampling is applied on the number of collected sessions. To apply a relative sampling (in percent) to the number of sessions collected, use the `sampleRate` parameter when initializing RUM. The following example collects only 90% of all sessions on a given RUM application:
 
@@ -197,10 +253,9 @@ window.DD_RUM &&
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note**: For a sampled out session, all page views and associated telemetry for that session aren't collected.
+**Note**: For a sampled out session, all page views and associated telemetry for that session are not collected.
 
-## API available
-
+## Global context
 ### Add global context
 
 Once Real User Monitoring (RUM) is initialized, add extra context to all RUM events collected from your application with the `addRumGlobalContext(key: string, value: any)` API:
@@ -251,7 +306,7 @@ window.DD_RUM && window.DD_RUM.addRumGlobalContext('activity', {
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note**: Follow the [Datadog naming convention][3] for a better correlation of your data across the product.
+**Note**: Follow the [Datadog naming convention][2] for a better correlation of your data across the product.
 
 ### Replace global context
 
@@ -302,7 +357,7 @@ window.DD_RUM &&
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note**: Follow the [Datadog naming convention][3] for a better correlation of your data across the product.
+**Note**: Follow the [Datadog naming convention][2] for a better correlation of your data across the product.
 
 ### Read global context
 
@@ -341,6 +396,5 @@ var context = window.DD_RUM && DD_RUM.getRumGlobalContext();
 {{< partial name="whats-next/whats-next.html" >}}
 
 
-[1]: https://github.com/DataDog/browser-sdk
-[2]: https://github.com/DataDog/browser-sdk/blob/master/packages/rum-core/src/rumEvent.types.ts
-[3]: /logs/processing/attributes_naming_convention/#user-related-attributes
+[1]: https://github.com/DataDog/browser-sdk/blob/master/packages/rum-core/src/rumEvent.types.ts
+[2]: /logs/processing/attributes_naming_convention/#user-related-attributes


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add the ability to dismiss Browser RUM events as part of the `beforeSend` API.

### Motivation
<!-- What inspired you to submit this pull request?-->
New feature.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hdelaby/dismiss-events/real_user_monitoring/browser/advanced_configuration/?tab=npm#dismiss-a-rum-event

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
