### PR TITLE
Fix spelling mistake?

### DIFF
--- a/content/en/tracing/profiler/getting_started.md
+++ b/content/en/tracing/profiler/getting_started.md
@@ -116,7 +116,7 @@ To automatically profile your code, set the `DD_PROFILING_ENABLED` environment v
     DD_ENV=prod \
     DD_SERVICE=my-web-app \
     DD_VERSION=1.0.3 \
-    dd-trace-run python app.py
+    ddtrace-run python app.py
 
 It is strongly recommended that you add tags like `service` or `version`, as they provide the ability to slice and dice your profiles across these dimensions. See [Configuration][#configuration] below.
 


### PR DESCRIPTION
I believe it is supposed to be `ddtrace-run` not `dd-trace-run`

https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtrace-run

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- Fixes a possible spelling mistake

### Motivation
- I blindly copy and pasted some code and it didn't work

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/mustyoshi:patch-1/tracing/profiler/getting_started/?tab=python

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
