### PR TITLE
Lint headings for Account Management

### DIFF
--- a/.github/styles/Datadog/headings.yml
+++ b/.github/styles/Datadog/headings.yml
@@ -77,6 +77,7 @@ exceptions:
   - Notebook List
   - npm
   - OkHttp
+  - OneLogin
   - OpenMetrics
   - openSUSE
   - OpenTelemetry

--- a/content/en/account_management/rbac/permissions.md
+++ b/content/en/account_management/rbac/permissions.md
@@ -59,20 +59,19 @@ More details about these permissions below.
 
 ### Log configuration access
 
-#### logs_generate_metrics
+#### `logs_generate_metrics`
 
 Grants a role the ability to use the [Generate Metrics][3] feature.
 
 This permission is global and enables both the creation of new metrics, and the edition or deletion of existing ones.
 
-#### logs_write_facets
+#### `logs_write_facets`
 
 Grants a role the ability to use the [Create, Edit, and Delete facets][4].
 
 This permission is global and enables both the creation of new facets, and the edition or deletion of existing ones.
 
-
-#### logs_modify_indexes
+#### `logs_modify_indexes`
 
 Grants a role the ability to create and modify [log indexes][5]. This includes:
 
@@ -85,7 +84,7 @@ This permission is global and enables both the creation of new indexes, and the 
 **Note**: This permission also grants [Logs Read Index Data](#logs-read-index-data) and [Logs Write Exlcusion Filters](#logs-write-exclusion-filters) permissions behind the scenes.
 
 
-#### logs_write_exclusion_filters
+#### `logs_write_exclusion_filters`
 
 Grants a role the ability to create or modify [exclusion filters][8] within an index.
 
@@ -110,7 +109,7 @@ This configuration is only supported through the UI.
 {{< /tabs >}}
 
 
-#### logs_write_pipelines
+#### `logs_write_pipelines`
 
 Grants a role the ability to create and modify [log processing pipelines][9]. This includes:
 
@@ -123,7 +122,7 @@ Grants a role the ability to create and modify [log processing pipelines][9]. Th
 **Note**: This permission also grants [Logs Write Processors](#logs-write-processors) (for all processors on all pipelines) permissions behind the scenes.
 
 
-#### logs_write_processors
+#### `logs_write_processors`
 
 Grants a role the ability to create, edit or delete processors and nested pipelines[12].
 
@@ -165,7 +164,7 @@ curl -X POST \
 {{% /tab %}}
 {{< /tabs >}}
 
-#### logs_write_archives
+#### `logs_write_archives`
 
 Grants the ability to create, edit or delete [Log Archives][13]. This includes:
 
@@ -176,7 +175,7 @@ Grants the ability to create, edit or delete [Log Archives][13]. This includes:
 
 This permission is global and enables the creation of new archives, and the edition and deletion of existing ones.
 
-#### logs_read_archives
+#### `logs_read_archives`
 
 Grants the ability to access the details of the archive configuration. In conjunction with [Logs Write Historical Views](#logs-write-historical-view), this permission also grants the ability to trigger a [Rehydration][14] from Archives.
 
@@ -208,7 +207,7 @@ Use the Logs Archive API either to [assign][1] or [revoke][2] a role from a give
 {{% /tab %}}
 {{< /tabs >}}
 
-#### logs_write_historical_views
+#### `logs_write_historical_views`
 
 Grants the ability to write historical views, meaning to trigger a [Log Rehydration*][14].
 
@@ -231,7 +230,7 @@ For `service:ci-cd` logs that are rehydrated from the `Prod Archive`, note the f
 * If you **do** use the [Log Read Index Data](#logs-read-index-data) legacy permission, these logs are not accessible for `CI-CD` role members, as the resulting historical view is restricted to `PROD` and `ADMIN` role members.
 
 
-#### logs_public_config_api
+#### `logs_public_config_api`
 
 Grants the ability to create or modify log configuration through the Datadog API:
 
@@ -249,7 +248,7 @@ Grant the following permissions to manage read access on subsets of log data:
 * [Logs Read Data](#logs-read-data) (Recommended) offers finer grained access control by restricting a role's access to logs matching a log restriction queries.
 * [Logs Read Index Data](#logs-read-index-data) is the legacy approach to restrict data access to indexed log data on a per-index basis (it is still required to have this permission enabled to access indexed data).
 
-#### logs_read_data
+#### `logs_read_data`
 
 Read access to log data. If granted, other restrictions then apply such as `logs_read_index_data` or with [restriction query][18].
 
@@ -335,7 +334,7 @@ These permissions are globally enabled by default for all users.
 * If this user has [livetail](#logs-livetail) permission, this users sees only sees `service:api` logs in the livetail.
 
 
-#### logs_read_index_data
+#### `logs_read_index_data`
 
 Grants a role read access on some number of log indexes. Can be set either globally or limited to a subset of log indexes.
 
@@ -378,7 +377,7 @@ curl -X POST \
 {{% /tab %}}
 {{< /tabs >}}
 
-#### logs_live_tail
+#### `logs_live_tail`
 
 Grants a role the ability to use the [Live Tail][19] feature.
 

--- a/content/en/account_management/saml/mobile-idp-login.md
+++ b/content/en/account_management/saml/mobile-idp-login.md
@@ -1,5 +1,5 @@
 ---
-title: Logging Into the Mobile App When Using IdP-Initiated SAML
+title: The Datadog Mobile App with IdP Initiated SAML
 kind: documentation
 is_public: true
 aliases:
@@ -13,35 +13,36 @@ further_reading:
   text: "Configuring Teams & Organizations with Multiple Accounts"
 ---
 
-## Using the Datadog Mobile App with your IdP-Initiated SAML (SSO) Provider
+## Setup
 
 <div class="alert alert-warning">
-Logging into the Datadog mobile app with IdP-initiated SAML is an opt-in feature. Reach out to <a href="https://docs.datadoghq.com/help/">Support</a> to have the feature enabled for your account before you alter your SAML configuration.
+Logging into the Datadog mobile app with IdP-initiated SAML is an opt-in feature. Reach out to <a href="https://docs.datadoghq.com/help/">Datadog support</a> to have the feature enabled for your account before you alter your SAML configuration.
 </div>
 
-In order to use the Datadog Mobile App with Identity Provider (IdP) Initiated SAML, you need to pass an additional Relay State through to Datadog to trigger the mobile app landing page on login. Once enabled, all sign ins from SAML for that particular app land on a the interstitial page before proceeding.
+In order to use the Datadog mobile app with Identity Provider (IdP) Initiated SAML, you need to pass an additional Relay State through to Datadog to trigger the mobile app landing page on login. Once enabled, all sign ins from SAML for that particular app land on a the interstitial page before proceeding.
 
 - On mobile devices with the Datadog mobile app installed, the app will automatically capture the request and continue to sign in from the app.
-- On Desktop devices or devices where the App is not installed the user will need to click "Use the Datadog Website" to proceed.
+- On Desktop devices or devices where the app is not installed the user will need to click "Use the Datadog Website" to proceed.
 
 {{< img src="account_management/saml/datadog-mobile-idp-saml-landing-page.png" alt="Datadog Mobile SAML Interstitial" >}}
 
+## Providers
 ### OneLogin
 
-When configuring your OneLogin App, set the Relay State value on the **Application Details** page to `dd_m_idp`.
+When configuring your OneLogin app, set the Relay State value on the **Application Details** page to `dd_m_idp`.
 {{< img src="account_management/saml/one-login-mobile-idp-relay-state.png" alt="One Login's Application Details Page" >}}
 
 ### Okta
 
-When configuring your Okta App, set the Default RelayState value on the **Configure SAML** page to `dd_m_idp`.
+When configuring your Okta app, set the Default RelayState value on the **Configure SAML** page to `dd_m_idp`.
 {{< img src="account_management/saml/okta-mobile-idp-relay-state.png" alt="Okta's Application Details Page" >}}
 
 ### Google
 
-When configuring your Google App for Work SAML App, set the **Start URL** under the Service Provider Details to `dd_m_idp`.
+When configuring your Google app for Work SAML app, set the **Start URL** under the Service Provider Details to `dd_m_idp`.
 {{< img src="account_management/saml/google-mobile-idp-relay-state.png" alt="Google's Service Provider Details Page" >}}
 
-#### Troubleshooting
+## Troubleshooting
 
 If you see a `403 Forbidden` error on login after configuring the Relay State, contact [Support][1] to ensure that the feature has been enabled for your organization.
 


### PR DESCRIPTION
### What does this PR do?
Lint headings for the Account Management section, mistakes found using:

```
vale content/en//account_management/*
```

### Motivation
Docs hackathon

### Preview
https://docs-staging.datadoghq.com/ruth/docs-lint-am/account_management/

### Additional Notes
N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
