### PR TITLE
[WEB-1227] Site & Language Selector style fixes

### DIFF
--- a/src/styles/components/_language-region-select.scss
+++ b/src/styles/components/_language-region-select.scss
@@ -97,8 +97,10 @@ aside.sidebar {
   }
 
   .dropdown {
-    @include media-breakpoint-down(lg) {
-      z-index: 2;
+    z-index: 2;
+
+    @include media-breakpoint-up(lg) {
+      z-index: unset;
     }
   }
 

--- a/src/styles/pages/_api.scss
+++ b/src/styles/pages/_api.scss
@@ -127,7 +127,7 @@ $ddpurple: #632ca6;
             align-items: baseline;
             background: white;
             position: sticky;
-            z-index: 1;
+            z-index: 5;
             top: 94px;
             height: 65px;
         }


### PR DESCRIPTION
### What does this PR do?
Fixes two style bugs in site & language selectors

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1227
https://dd.slack.com/archives/C3CT8QA11/p1615234380056000
https://dd.slack.com/archives/C3CT8QA11/p1615234440057300

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/site-lang-selector-style-fix/dashboards/
- There should be no style bug when opening the `Language` selector.   In live this bug can be reproduced only between 991 and 1200px screen width.  Both selectors should function and look correct at all screen sizes.   Originally reported in the Jira ticket linked above.

https://docs-staging.datadoghq.com/brian.deutsch/site-lang-selector-style-fix/api/latest/synthetics/
- Buttons from API examples, programming lang selectors, copy code function, etc should all be hidden under the sticky header (with breadcrumbs/site & lang selectors) as the user scrolls down the page.  In live this bug is found across API pages.  Originally reported in #Websites channel via the Slack links above.

### Additional Notes
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
