### PR TITLE
Update to canonical hostname selection hierarchy

### DIFF
--- a/content/en/agent/faq/how-datadog-agent-determines-the-hostname.md
+++ b/content/en/agent/faq/how-datadog-agent-determines-the-hostname.md
@@ -27,7 +27,7 @@ From these names, a canonical name is chosen for the host. The Agent uses this n
 
 The canonical hostname is chosen according to the following rules. The first match is selected.
 
-1. **agent-hostname**: A hostname explicitly set in the [Agent configuration file][2].
+1. **agent-hostname**: A hostname explicitly set in the [Agent configuration file][2] if it does not start with ip or domu.
 2. **hostname** (`hostname -f` on Linux): If the DNS hostname is not an EC2 default (e.g. ip-192-0-0-1).
 3. **instance-id**: If the Agent can reach the EC2 metadata endpoint from the host.
 4. **hostname**: Fall back on the DNS hostname even if it is an EC2 default.


### PR DESCRIPTION
Hostnames that start with ip or domu are automatically skipped in favor of other hostnames even if they're set in the datadog.yaml or DD_HOSTNAME environment variable.  

https://github.com/DataDog/datadog-agent/blob/master/docs/agent/hostname_force_config_as_canonical.md

### What does this PR do?
Add a small caveat to the logic that the agent uses to decide on a canonical hostname

### Motivation
An escalation pointed that the logic was flawed and that names with ip-* was getting passed over even though they were manually set.

### Preview
https://docs.datadoghq.com/agent/faq/how-datadog-agent-determines-the-hostname/?tab=agentv6v7#potential-host-names

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
