### PR TITLE
Revert "Change X to ✓ on manifest template table"

### DIFF
--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -155,12 +155,12 @@ To install the Datadog Agent on your Kubernetes cluster:
 
     | Metrics | Logs | APM | Process | NPM | Linux                  | Windows                 |
     |---------|------|-----|---------|-----|------------------------|-------------------------|
-    | {{< X >}}       | {{< X >}}    | {{< X >}}   | {{< X >}}       |     | [Manifest template][3] | [Manifest template][4] |
-    | {{< X >}}       | {{< X >}}    | {{< X >}}   |         |     | [Manifest template][5] | [Manifest template][6] |
-    | {{< X >}}       | {{< X >}}    |     |         |     | [Manifest template][7] | [Manifest template][8] |
-    | {{< X >}}       |      | {{< X >}}   |         |     | [Manifest template][9] | [Manifest template][10] |
-    |         |      |     |         | {{< X >}}   | [Manifest template][11] | no template             |
-    | {{< X >}}       |      |     |         |     | [Manifest template][12] | [Manifest template][13] |
+    | X       | X    | X   | X       |     | [Manifest template][3] | [Manifest template][4] |
+    | X       | X    | X   |         |     | [Manifest template][5] | [Manifest template][6] |
+    | X       | X    |     |         |     | [Manifest template][7] | [Manifest template][8] |
+    | X       |      | X   |         |     | [Manifest template][9] | [Manifest template][10] |
+    |         |      |     |         | X   | [Manifest template][11] | no template             |
+    | X       |      |     |         |     | [Manifest template][12] | [Manifest template][13] |
 
      To enable trace collection completely, [extra steps are required on your application Pod configuration][14]. Refer also to the [logs][15], [APM][16], [processes][17], and [Network Performance Monitoring][18] documentation pages to learn how to enable each feature individually.
 


### PR DESCRIPTION
Reverts DataDog/documentation#9934

Table borked because of shortcode