### PR TITLE
Add blog link to serverless trace prop page

### DIFF
--- a/content/en/serverless/distributed_tracing/serverless_trace_propagation.md
+++ b/content/en/serverless/distributed_tracing/serverless_trace_propagation.md
@@ -8,6 +8,9 @@ further_reading:
 - link: "/tracing/trace_search_and_analytics/#live-search-for-15-minutes"
   tag: "Documentation"
   text: "Live Search"
+- link: "https://www.datadoghq.com/blog/aws-serverless-tracing-datadog-apm/"
+  tag: "Blog"
+  text: "Trace AWS event-driven serverless applications with Datadog APM"
 ---
 
 
@@ -254,6 +257,10 @@ exports.eventBridge = (event, context) => {
 
 {{% /tab %}}
 {{< /tabs >}}
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /serverless/installation
 [2]: /serverless/distributed_tracing


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a blog link to the serverless trace propagation page

### Motivation
On call checklist

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jorie/add-blog-link-serverless/serverless/distributed_tracing/serverless_trace_propagation/
### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
