### PR TITLE
Remove note on DSD mapper not effective for metrics with existing tags

### DIFF
--- a/content/en/developers/dogstatsd/dogstatsd_mapper.md
+++ b/content/en/developers/dogstatsd/dogstatsd_mapper.md
@@ -77,8 +77,6 @@ dogstatsd_mapper_profiles:
 
 It would send the metric `custom_metric.process` to Datadog with the tags `tag_key_1:value_1` and `tag_key_2:value_2`.
 
-**Note**: If the incoming metric have already at least one tag, no mapping is applied.
-
 ## Regex match pattern
 
 The regex match pattern matches metric names using regex patterns. Compared to the wildcard match pattern, it allows to define captured groups that contain `.`. Groups extracted can then be expanded with the `$n` format e.g. `$1`, `$2`, `$3`... or the `${n}` format e.g. `${1}`, `${2}`, `${3}`, ...
@@ -99,8 +97,6 @@ dogstatsd_mapper_profiles:
 ```
 
 It would send the metric `custom_metric.process` to Datadog with the tags `tag_key_1:value_1` and `tag_key_2:value.with.dots._2`.
-
-**Note**: If the incoming metric have already at least one tag, no mapping is applied.
 
 ## Expand group in metric name
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Remove note on DSD mapper not effective for metrics with existing tags

### Motivation

This not is not accurate anymore. DSD Mapper can now be applied to metrics that already have tags since this PR: https://github.com/DataDog/datadog-agent/pull/5984/files#diff-d16366ed2d59b497efea1f3bde3296e2944634354e4a4d6adf96078256740393R422

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
