### PR TITLE
profiler/getting_started: improve go snippet

### DIFF
--- a/content/en/tracing/profiler/getting_started.md
+++ b/content/en/tracing/profiler/getting_started.md
@@ -223,12 +223,14 @@ The Datadog Profiler requires Go 1.12+. To begin profiling applications:
 
 **Note**:
 
+- By default only the CPU and Heap profile are enabled. Use [profiler.WithProfileTypes][4] to enable additional [profile types][5].
+
 - You can set profiler parameters in code with these functions:
 
 | Function | Type          | Description                                                                                                  |
 | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------ |
-|  WithService     | String        | The Datadog [service][4] name, for example `my-web-app`.             |
-|  WithEnv         | String        | The Datadog [environment][5] name, for example, `production`.         |
+|  WithService     | String        | The Datadog [service][6] name, for example `my-web-app`.             |
+|  WithEnv         | String        | The Datadog [environment][7] name, for example, `production`.         |
 |  WithVersion     | String        | The version of your application.                                                                             |
 |  WithTags        | String        | The tags to apply to an uploaded profile. Must be a list of in the format `<KEY1>:<VALUE1>,<KEY2>:<VALUE2>`. |
 
@@ -236,16 +238,18 @@ The Datadog Profiler requires Go 1.12+. To begin profiling applications:
 
 | Environment variable                             | Type          | Description                                                                                      |
 | ------------------------------------------------ | ------------- | ------------------------------------------------------------------------------------------------ |
-| `DD_SERVICE`                                     | String        | The Datadog [service][4] name.     |
-| `DD_ENV`                                         | String        | The Datadog [environment][5] name, for example, `production`. |
+| `DD_SERVICE`                                     | String        | The Datadog [service][6] name.     |
+| `DD_ENV`                                         | String        | The Datadog [environment][7] name, for example, `production`. |
 | `DD_VERSION`                                     | String        | The version of your application.                             |
 | `DD_TAGS`                                        | String        | Tags to apply to an uploaded profile. Must be a list of `<key>:<value>` separated by commas such as: `layer:api,team:intake`.   |
 
 [1]: https://app.datadoghq.com/account/settings#agent/overview
 [2]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/profiler#pkg-constants
 [3]: https://app.datadoghq.com/profiling
-[4]: /tracing/visualization/#services
-[5]: /tracing/guide/setting_primary_tags_to_scope/#environment
+[4]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/profiler#WithProfileTypes
+[5]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/profiler#ProfileType
+[6]: /tracing/visualization/#services
+[7]: /tracing/guide/setting_primary_tags_to_scope/#environment
 {{< /programming-lang >}}
 {{< /programming-lang-wrapper >}}
 

--- a/content/en/tracing/profiler/getting_started.md
+++ b/content/en/tracing/profiler/getting_started.md
@@ -207,6 +207,7 @@ The Datadog Profiler requires Go 1.12+. To begin profiling applications:
           profiler.HeapProfile,
           // The profiles below are disabled by default to keep overhead
           // low, but can be enabled as needed.
+
           // profiler.BlockProfile,
           // profiler.MutexProfile,
           // profiler.GoroutineProfile,

--- a/content/en/tracing/profiler/getting_started.md
+++ b/content/en/tracing/profiler/getting_started.md
@@ -202,6 +202,15 @@ The Datadog Profiler requires Go 1.12+. To begin profiling applications:
         profiler.WithEnv("<ENVIRONMENT>"),
         profiler.WithVersion("<APPLICATION_VERSION>"),
         profiler.WithTags("<KEY1>:<VALUE1>,<KEY2>:<VALUE2>"),
+        profiler.WithProfileTypes(
+          profiler.CPUProfile,
+          profiler.HeapProfile,
+          // The profiles below are disabled by default to keep overhead
+          // low, but can be enabled as needed.
+          // profiler.BlockProfile,
+          // profiler.MutexProfile,
+          // profiler.GoroutineProfile,
+        ),
     )
     if err != nil {
         log.Fatal(err)
@@ -213,14 +222,12 @@ The Datadog Profiler requires Go 1.12+. To begin profiling applications:
 
 **Note**:
 
-- By default only the CPU and Heap profile are enabled. Use [profiler.WithProfileTypes][4] to enable additional [profile types][5].
-
 - You can set profiler parameters in code with these functions:
 
 | Function | Type          | Description                                                                                                  |
 | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------ |
-|  WithService     | String        | The Datadog [service][6] name, for example `my-web-app`.             |
-|  WithEnv         | String        | The Datadog [environment][7] name, for example, `production`.         |
+|  WithService     | String        | The Datadog [service][4] name, for example `my-web-app`.             |
+|  WithEnv         | String        | The Datadog [environment][5] name, for example, `production`.         |
 |  WithVersion     | String        | The version of your application.                                                                             |
 |  WithTags        | String        | The tags to apply to an uploaded profile. Must be a list of in the format `<KEY1>:<VALUE1>,<KEY2>:<VALUE2>`. |
 
@@ -228,18 +235,16 @@ The Datadog Profiler requires Go 1.12+. To begin profiling applications:
 
 | Environment variable                             | Type          | Description                                                                                      |
 | ------------------------------------------------ | ------------- | ------------------------------------------------------------------------------------------------ |
-| `DD_SERVICE`                                     | String        | The Datadog [service][6] name.     |
-| `DD_ENV`                                         | String        | The Datadog [environment][7] name, for example, `production`. |
+| `DD_SERVICE`                                     | String        | The Datadog [service][4] name.     |
+| `DD_ENV`                                         | String        | The Datadog [environment][5] name, for example, `production`. |
 | `DD_VERSION`                                     | String        | The version of your application.                             |
 | `DD_TAGS`                                        | String        | Tags to apply to an uploaded profile. Must be a list of `<key>:<value>` separated by commas such as: `layer:api,team:intake`.   |
 
 [1]: https://app.datadoghq.com/account/settings#agent/overview
 [2]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/profiler#pkg-constants
 [3]: https://app.datadoghq.com/profiling
-[4]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/profiler#WithProfileTypes
-[5]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/profiler#ProfileType
-[6]: /tracing/visualization/#services
-[7]: /tracing/guide/setting_primary_tags_to_scope/#environment
+[4]: /tracing/visualization/#services
+[5]: /tracing/guide/setting_primary_tags_to_scope/#environment
 {{< /programming-lang >}}
 {{< /programming-lang-wrapper >}}
 


### PR DESCRIPTION
This came up in a customer call, they hadn't noticed the text added in ee9cb474f889c760a08a8fe694b6bfb390077c4e and suggested to directly include the hint about it in the code snippet.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/felix.geisendoerfer/improve-go-profiler-code-snippet/tracing/profiler/getting_started/?tab=go

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
