### PR TITLE
Patch logs monitor notification

### DIFF
--- a/content/en/monitors/monitor_types/log.md
+++ b/content/en/monitors/monitor_types/log.md
@@ -58,14 +58,14 @@ When splitting the monitor by any dimension (tag or facet) and using a `below` c
 
 For detailed instructions on the **Say what's happening** and **Notify your team** sections, see the [Notifications][5] page.
 
-#### Log samples
+#### Log samples and breaching values toplist
 
-By default, when a logs monitor is triggered, samples or values are added to the notification message.
+When a logs monitor is triggered, samples or values can be added to the notification message.
 
-| Monitor over     | Added to notification message                                                                            |
+| Monitor over     | Can be added to notification message                                                                     |
 |------------------|----------------------------------------------------------------------------------------------------------|
 | Log count        | Grouped: The top 10 breaching values and their corresponding counts.<br>Ungrouped: Up to 10 log samples. |
-| Facet or measure | The top 10 facet or measure values.                                                                      |
+| Facet or measure | Grouped: The top 10 facet or measure values.<br>Ungrouped: The top 10 facet or measure values.           |
 
 These are available for notifications sent to Slack, Jira, webhooks, Microsoft Teams, Pagerduty, and email. **Note**: Samples are not displayed for recovery notifications.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->
"By default" denomination can be confusing and can lead to think that every monitors can benefit from samples and toplists. For example a facet monitor cannot have log samples.
### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/gturbat/patch-logs-monitor-notification/monitors/monitor_types/log/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
