### PR TITLE
[serverless] bump aws lambda extension version to v6

### DIFF
--- a/content/en/serverless/datadog_lambda_library/extension.md
+++ b/content/en/serverless/datadog_lambda_library/extension.md
@@ -24,7 +24,7 @@ The Datadog Extension is distributed as its own Lambda Layer (separate from the 
 2. Add the Lambda Layer for the Datadog Extension to your AWS Lambda function:
 
     ```
-    arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:5
+    arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:6
     ```
 
     Replace the placeholder `AWS_REGION` in the Lambda Layer ARN with appropriate values.
@@ -46,7 +46,6 @@ To submit your AWS Lambda logs to Datadog using the Extension, set the env varia
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
-
 
 [1]: /serverless/custom_metrics?tab=python#synchronous-vs-asynchronous-custom-metrics
 [2]: /serverless/forwarder

--- a/content/fr/serverless/datadog_lambda_library/extension.md
+++ b/content/fr/serverless/datadog_lambda_library/extension.md
@@ -2,10 +2,11 @@
 title: Extension Lambda Datadog (en préversion)
 kind: documentation
 further_reading:
-  - link: serverless/custom_metrics
-    tag: Documentation
-    text: Envoyer des métriques custom à partir d'AWS Lambda
+    - link: serverless/custom_metrics
+      tag: Documentation
+      text: Envoyer des métriques custom à partir d'AWS Lambda
 ---
+
 ## Présentation
 
 <div class="alert alert-warning"> L'extension AWS Lambda Datadog est disponible sous forme de préversion publique. Si vous souhaitez nous faire part de vos remarques, contactez l'<a href="/help">assistance Datadog</a>.</div>
@@ -23,7 +24,7 @@ L'extension Datadog est distribuée sous forme de couche Lambda autonome (distin
 2. Ajoutez la couche Lambda pour l'extension Datadog à votre fonction AWS Lambda :
 
     ```
-    arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:5
+    arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:6
     ```
 
     Remplacez le paramètre fictif `AWS_REGION` dans l'ARN de la couche Lambda par les valeurs adéquates.
@@ -45,7 +46,6 @@ Pour envoyer vos logs Lambda AWS à Datadog à l'aide de l'extension, définisse
 ## Pour aller plus loin
 
 {{< partial name="whats-next/whats-next.html" >}}
-
 
 [1]: /fr/serverless/custom_metrics?tab=python#synchronous-vs-asynchronous-custom-metrics
 [2]: /fr/serverless/forwarder

--- a/content/ja/serverless/datadog_lambda_library/extension.md
+++ b/content/ja/serverless/datadog_lambda_library/extension.md
@@ -2,10 +2,11 @@
 title: Datadog Lambda 拡張機能 (プレビュー)
 kind: ドキュメント
 further_reading:
-  - link: serverless/custom_metrics
-    tag: Documentation
-    text: AWS Lambda からのカスタムメトリクスの送信
+    - link: serverless/custom_metrics
+      tag: Documentation
+      text: AWS Lambda からのカスタムメトリクスの送信
 ---
+
 ## 概要
 
 <div class="alert alert-warning">Datadog AWS Lambda 拡張機能は公開プレビューです。フィードバックがございましたら、<a href="/help">Datadog サポートチーム</a>までお寄せください。</div>
@@ -23,7 +24,7 @@ Datadog 拡張機能は、独自の Lambda レイヤー ([Datadog Lambda ライ�
 2. Datadog 拡張機能用 Lambda レイヤーを AWS Lambda 関数に追加します。
 
     ```
-    arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:5
+    arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:6
     ```
 
     Lambda レイヤー ARN のプレイスホルダー `AWS_REGION` を適切な値に置き換えます。
@@ -45,7 +46,6 @@ Extension を使用して AWS Lambda ログを Datadog に送信するには、�
 ## その他の参考資料
 
 {{< partial name="whats-next/whats-next.html" >}}
-
 
 [1]: /ja/serverless/custom_metrics?tab=python#synchronous-vs-asynchronous-custom-metrics
 [2]: /ja/serverless/forwarder


### PR DESCRIPTION
### What does this PR do?
Bumps the version referenced in the AWS Lambda Extension documentation to v6. Eventually we want to move this to a link to the releases tab on github.

### Motivation

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/darcy.rayner/bump-lambda-extension-6/content/en/serverless/datadog_lambda_library/extension.md 

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
