### PR TITLE
[WEB-1202] Allows multiple regions per site-region shortcode

### DIFF
--- a/content/en/account_management/_index.md
+++ b/content/en/account_management/_index.md
@@ -6,8 +6,20 @@ aliases:
     - /guides/billing
     - /account_management/settings
 ---
+{{< site-region region="us,us3,eu" >}}
+<div class="alert alert-warning">Testing multiple regions in the site-region partial.</div>
+{{< /site-region >}}
+
 {{< site-region region="gov" >}}
 <div class="alert alert-warning">The Datadog for Government site only supports SAML login.</div>
+{{< /site-region >}}
+
+{{< site-region region="us,us3" >}}
+<h3>This text should only show up for us or us3.</h3>
+{{< /site-region >}}
+
+{{< site-region region="eu,gov" >}}
+<h3>This text should only show up for eu or gov.</h3>
 {{< /site-region >}}
 
 ## Account settings

--- a/content/en/account_management/_index.md
+++ b/content/en/account_management/_index.md
@@ -6,20 +6,8 @@ aliases:
     - /guides/billing
     - /account_management/settings
 ---
-{{< site-region region="us,us3,eu" >}}
-<div class="alert alert-warning">Testing multiple regions in the site-region partial.</div>
-{{< /site-region >}}
-
 {{< site-region region="gov" >}}
 <div class="alert alert-warning">The Datadog for Government site only supports SAML login.</div>
-{{< /site-region >}}
-
-{{< site-region region="us,us3" >}}
-<h3>This text should only show up for us or us3.</h3>
-{{< /site-region >}}
-
-{{< site-region region="eu,gov" >}}
-<h3>This text should only show up for eu or gov.</h3>
 {{< /site-region >}}
 
 ## Account settings

--- a/src/scripts/region-redirects.js
+++ b/src/scripts/region-redirects.js
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
         options.forEach(option => {
             option.addEventListener('click', () => {
                 const region = option.dataset.value;
-                regionOnChangeHandler(region)
+                regionOnChangeHandler(region);
             })
         })
     }
@@ -75,8 +75,7 @@ function showRegionSnippet(newSiteRegion) {
     regionSnippets.forEach(regionSnippet => {
         const { region } = regionSnippet.dataset;
 
-        // hide snippet if not active region
-        if (region !== newSiteRegion) {
+        if (!region.includes(newSiteRegion)) {
             regionSnippet.classList.add('d-none');
         } else {
             regionSnippet.classList.remove('d-none');


### PR DESCRIPTION
### What does this PR do?
Allows for multiple regions to be specified per one `site-region` shortcode.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1202

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/multiple-regions/

**Usage**
The `site-region` shortcode can now accept a comma separated list of region codes like so:

`{{< site-region region=”us,us3,eu” >}} Content here {{< /site-region >}}`

Changing the region selector dropdown will show the appropriate `site-region` partial if the selected value is found within the comma separated `region` string.   All existing functionality should still work as expected, including query params: `?site=us3`.

There are no examples of this functionality on the preview site currently.   To properly test this change, pull down the branch locally and update a markdown file according to the usage above.  This should cut down on the repetition needed when multiple regions have the same content on a page.  If there are any questions feel free to Slack me.   thanks!

### Additional Notes
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
