### PR TITLE
Allows multiple regions per site-region shortcode

### DIFF
--- a/src/scripts/region-redirects.js
+++ b/src/scripts/region-redirects.js
@@ -68,10 +68,16 @@ function regionOnChangeHandler(region) {
 function showRegionSnippet(newSiteRegion) {
     const regionSnippets = document.querySelectorAll('[data-region]');
     const regionParams = document.querySelectorAll('[data-region-param]');
-    const externalLinks = document.querySelectorAll(
-        '#mainContent a[href*="app.datadoghq."]'
-    );
+    
+    // build list of external app links using config 
+    let externalLinksQuery = '';
+    Object.entries(config.dd_full_site).forEach(e => {
+        externalLinksQuery += `#mainContent a[href*="${e[1]}"],`
+    })
 
+    // query selector for all app links, removing trailing comma
+    const externalLinks = document.querySelectorAll(externalLinksQuery.slice(0, -1));
+    
     regionSnippets.forEach(regionSnippet => {
         const { region } = regionSnippet.dataset;
 

--- a/src/scripts/region-redirects.js
+++ b/src/scripts/region-redirects.js
@@ -75,7 +75,7 @@ function showRegionSnippet(newSiteRegion) {
     regionSnippets.forEach(regionSnippet => {
         const { region } = regionSnippet.dataset;
 
-        if (region !== newSiteRegion) {
+        if (region.split(',').indexOf(newSiteRegion) === -1) {
             regionSnippet.classList.add('d-none');
         } else {
             regionSnippet.classList.remove('d-none');


### PR DESCRIPTION
### What does this PR do?
Allow multiple regions and perform an exact match on string 
Proposed fix for: https://github.com/DataDog/documentation/pull/10024

### Motivation
Fix for bug introduced in above referenced PR 

### Preview

Confirm functionality of current Region selector hasn't changed
 
https://docs-staging.datadoghq.com/nsollecito/multi-region-shortcode/api/latest/logs/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
