### PR TITLE
Add note about excluding every container in AD

### DIFF
--- a/content/en/agent/guide/autodiscovery-management.md
+++ b/content/en/agent/guide/autodiscovery-management.md
@@ -22,7 +22,7 @@ Exclude containers from the Agent Autodiscovery perimeter with an exclude rule b
 
 **Note**: Exclude rules support regexes, which are defined as a list of comma-separated strings.
 
-**Note**: In order to exclude every container `name:.*`, `image:.*` or `kube_namespace:.*` can be used. Note that configuring `.*` without a `name:`, `image:` or `kube_namespace:` prefix will not work.
+**Note**: To exclude every container, you can use `name:.*`, `image:.*`, or `kube_namespace:.*`. Note that configuring `.*` without a `name:`, `image:`, or `kube_namespace:` prefix will not work.
 
 {{< tabs >}}
 {{% tab "Containerized Agent" %}}

--- a/content/en/agent/guide/autodiscovery-management.md
+++ b/content/en/agent/guide/autodiscovery-management.md
@@ -22,6 +22,8 @@ Exclude containers from the Agent Autodiscovery perimeter with an exclude rule b
 
 **Note**: Exclude rules support regexes, which are defined as a list of comma-separated strings.
 
+**Note**: In order to exclude every container `name:.*`, `image:.*` or `kube_namespace:.*` can be used. Note that configuring `.*` without a `name:`, `image:` or `kube_namespace:` prefix will not work.
+
 {{< tabs >}}
 {{% tab "Containerized Agent" %}}
 


### PR DESCRIPTION
### What does this PR do?
Add a note about excluding containers

### Motivation
https://github.com/DataDog/helm-charts/issues/191

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ahmed/ad-exclude-note/agent/guide/autodiscovery-management/?tab=containerizedagent#include-containers

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
