### PR TITLE
improvements

### DIFF
--- a/.github/styles/Datadog/Trademarks.yml
+++ b/.github/styles/Datadog/Trademarks.yml
@@ -1,0 +1,19 @@
+extends: existence
+message: Missing ™ on phrase '%s'
+link: https://www.datadoghq.com
+ignorecase: true
+level: error
+nonword: true
+
+# phrases that don't start with * and don't end with tm or \* should be fixed
+# this covers
+# \*Logging without Limits is a trademark of Datadog, Inc.
+# *Logging without Limits is a trademark of Datadog, Inc.
+# Logging without Limits*
+# Logging without Limits\*
+# Logging without Limits™
+tokens:
+  - '(?<!\*)Logging without Limits(?!\s*(\™|\\\*|\*))'
+  - '(?<!\*)Traces without Limits(?!\s*(\™|\\\*|\*))'
+  - '(?<!\*)Metrics without Limits(?!\s*(\™|\\\*|\*))'
+  - '(?<!\*)Log Rehydration(?!\s*(\™|\\\*|\*))'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,6 +93,8 @@ build_preview:
     # remove service_checks json as we don't need to s3 push that..
     - rm -rf data/service_checks
     - in-isolation deploy_preview
+    # remove static images so we can skip from artifact passed in gitlab
+    - remove_static_from_repo
     - notify_slack "<https://github.com/DataDog/documentation/commit/${CI_COMMIT_SHA}|${CI_COMMIT_REF_NAME}> is ready for preview. <${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}| checks running>." "#31b834"
   artifacts:
     paths:
@@ -172,7 +174,7 @@ missing_tms_preview:
     - build_preview
   script:
     # remove dirs we don't need to scan
-    - rm -rf ./images ./public/fr ./public/ja ./public/api/v1/ ./public/api/v2/
+    - rm -rf ./public/fr ./public/ja ./public/api/v1/ ./public/api/v2/
     - GOMAXPROCS=$(nproc --all) vale --glob='*.{html}' ./public
   only:
     - /.+?\/[a-zA-Z0-9_-]+/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,9 @@ variables:
   DATADOG_SUBDOMAIN: 'dd-corpsite'
   FORCE_COLOR: '1'
   GIT_DEPTH: 50
+  # gitlab checkout
+  DOCS_REPO_NAME: documentation
+  REPO_URL: "https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/${DOCS_REPO_NAME}.git"
 
 # ================== copy scripts =============== #
 before_script:
@@ -32,10 +35,10 @@ cache: &cache
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:david.jones_update-git
   tags:
     - "runner:main"
-    - "size:large"
+    - "size:2xlarge"
   except:
     - tags
   only:
@@ -47,8 +50,17 @@ install_dependencies:
   stage: bootstrap
   cache:
     <<: *cache
+  variables:
+    GIT_STRATEGY: none
   script:
-    - yarn install --frozen-lockfile
+    - git version
+    - git clone --branch $CI_COMMIT_REF_NAME --depth 1 --filter=blob:none --no-checkout $REPO_URL sparse-docs
+    - cd sparse-docs && git sparse-checkout init --cone && git sparse-checkout set local && git checkout $CI_COMMIT_REF_NAME && cd ..
+    - mkdir -p ./local/bin/sh && cp --remove-destination ./sparse-docs/local/bin/sh/preinstall.sh ./local/bin/sh/preinstall.sh
+    - cp --remove-destination ./sparse-docs/package.json ./package.json
+    - cp --remove-destination ./sparse-docs/yarn.lock ./yarn.lock
+    - yarn install --link-duplicates --frozen-lockfile --cache-folder .yarn
+    - rm -rf ./sparse-docs # cleanup runner
   only:
     changes:
       - yarn.lock
@@ -86,6 +98,8 @@ build_preview:
     paths:
       - ${ARTIFACT_RESOURCE}
       - ./integrations_data
+      - .github/
+      - .vale.ini
   only:
     - /.+?\/[a-zA-Z0-9_-]+/
   interruptible: true
@@ -145,7 +159,10 @@ link_checks_preview:
   interruptible: true
 
 missing_tms_preview:
-  <<: *base_template
+  image:
+    name: 486234852809.dkr.ecr.us-east-1.amazonaws.com/vale:v4036929-ee9929a-2.9.1
+    entrypoint: [ "" ]
+  tags: ["runner:main", "size:2xlarge"]
   stage: post-deploy
   cache: {}
   environment: "preview"
@@ -154,7 +171,9 @@ missing_tms_preview:
   dependencies:
     - build_preview
   script:
-    - check_missing_tms
+    # remove dirs we don't need to scan
+    - rm -rf ./images ./public/fr ./public/ja ./public/api/v1/ ./public/api/v2/
+    - GOMAXPROCS=$(nproc --all) vale --glob='*.{html}' ./public
   only:
     - /.+?\/[a-zA-Z0-9_-]+/
   interruptible: true
@@ -163,7 +182,7 @@ index_algolia_preview:
   image:
     name: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docsearch-scraper:v2978988-4692ed5-0.8
     entrypoint: [""] # force an empty entrypoint (see https://gitlab.com/gitlab-org/gitlab-runner/issues/2692)
-  tags: [ "runner:main","size:large" ]
+  tags: [ "runner:main","size:2xlarge" ]
   stage: post-deploy
   cache:
     <<: *cache
@@ -284,7 +303,7 @@ index_internal_doc:
   only:
     - master
   except: [ tags, schedules ]
-  tags: [ "runner:docker", "size:large" ]
+  tags: [ "runner:docker", "size:2xlarge" ]
   script:
     - INDEXING_SERVICE=https://datadoc.ddbuild.io index-repository hugo https://docs.datadoghq.com/ "Datadog" "Public Documentation" --source_folder=content/en --tags="team:Documentation,source:hugo-website,visibility:public,github-repository:documentation"
 
@@ -308,7 +327,7 @@ index_algolia:
   image:
     name: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docsearch-scraper:v2978988-4692ed5-0.8
     entrypoint: [ "" ] # force an empty entrypoint (see https://gitlab.com/gitlab-org/gitlab-runner/issues/2692)
-  tags: ["runner:main","size:large"]
+  tags: ["runner:main","size:2xlarge"]
   stage: post-deploy
   cache:
     <<: *cache

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,7 +1,12 @@
-StylesPath = .github/styles
-MinAlertLevel = suggestion
+StylesPath = ".github/styles"
+#MinAlertLevel = suggestion
 
-[*.md]
+;[*.md]
+;BasedOnStyles = Datadog
+;Datadog.Trademarks = NO
+;BlockIgnores = (?s) *({{< ?code-block [^>]* >}}.*?{{< ?/ ?code-block >}})
+
+[*.html]
 BasedOnStyles = Datadog
-
-BlockIgnores = (?s) *({{< ?code-block [^>]* >}}.*?{{< ?/ ?code-block >}})
+Datadog.headings = NO
+Datadog.Trademarks = YES

--- a/content/en/metrics/faq/metrics-without-limits.md
+++ b/content/en/metrics/faq/metrics-without-limits.md
@@ -1,5 +1,5 @@
 ---
-title: Metrics without Limits FAQ
+title: Metrics without Limits™ FAQ
 kind: faq
 is_beta: true
 further_reading:
@@ -8,7 +8,7 @@ further_reading:
   text: "How to Send Logs to Datadog via External Log Shippers?"
 ---
 
-## What is Metrics without Limits\*? 
+## What is Metrics without Limits\*?
 
 Metrics without Limits\* provides you with the ability to customize tagging on all metric types in-app without having to redeploy or change any code. With Metrics without Limits\*, you’ll be able to customize tagging to drop in-app host-level tags attached to application-level or business metrics. This functionality will be located in the [Metrics Summary][1] page.
 
@@ -17,7 +17,7 @@ Click on any metric name to open its details sidepanel. Then click on the **Mana
 
 {{< img src="metrics/faq/managetags.gif" alt="Configuration of Tags">}}
 
-## What is the pricing of Metrics without Limits?
+## What is the pricing of Metrics without Limits\*?
 
 Configuring your tags gives you control over what custom metrics can be queried -- ultimately reducing your billable count of custom metrics. Given this new functionality, your contract for custom metrics will include:
 - **Ingested custom metrics**: custom metrics you send to Datadog in code
@@ -25,6 +25,6 @@ Configuring your tags gives you control over what custom metrics can be queried 
 
 Please reach out to your Customer Support Manager if you're interested in this private beta and for further pricing details of this feature.
 
-[1]: https://app.datadoghq.com/metric/summary
 
 \*Metrics without Limits is a trademark of Datadog, Inc.
+[1]: https://app.datadoghq.com/metric/summary

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -9,9 +9,11 @@ const common = require('./webpack.common.js');
 const prodConfig = (env) => merge(common(env), {
 	mode: 'production',
 
-	output: {
-		filename: '[name].[contenthash:5].js'
-	},
+  output: {
+      filename: ({ chunk: { name } }) => {
+          return name === 'dd-browser-logs-rum' ? '[name].js' : '[name].[contenthash:5].js';
+      }
+  },
 
 	optimization: {
 		minimizer: [


### PR DESCRIPTION
### What does this PR do?

- upadte `install_dependencies` preview job so that its faster by checkout out less. roughly 2min 30 down to 1min
- update `missing_tms_preview` preview job to use vale on built html with custom config which is faster. 7min down to 4min
- update runner size throughout for more cores which has some improvement on hugo build.
- update rum logs script so that it doesn't use a hashed filename. Helps with deploying only files that have content changes.
- delete the static files from gitlab passed artifact, imrpoves job speed slightly, less to download/upload.

### Motivation

Similar improvements on corp

### Preview

https://docs-staging.datadoghq.com/david.jones/improvements/

Latest Job run:
(Note its showing a failure until a spec pr is merged)
https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/58238523

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
