### PR TITLE
update logs include_at_match docs

### DIFF
--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -147,6 +147,36 @@ logs:
       pattern: \w+@datadoghq.com
 ```
 
+**Note**: If multiple `include_at_match` rules are defined, all rules patterns must match in order for the log to be included. If you want to match one or more patterns you must define them in a single expression:
+
+```yaml
+logs:
+  - type: file
+    path: /my/test/file.log
+    service: cardpayment
+    source: java
+    log_processing_rules:
+    - type: include_at_match
+      name: include_datadoghq_users
+      pattern: abc|123
+```
+
+If the patterns are too long to fit legibly on a single line you can break them into multiple lines:
+
+```yaml
+logs:
+  - type: file
+    path: /my/test/file.log
+    service: cardpayment
+    source: java
+    log_processing_rules:
+    - type: include_at_match
+      name: include_datadoghq_users
+      pattern: "abc\
+|123\
+|\\w+@datadoghq.com"
+```
+
 {{% /tab %}}
 {{% tab "Docker" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Clarify the behavior of logs agent `include_at_match` when the user desires to use multiple patterns. 

### Motivation
This is frequently used incorrectly and can confuse users. 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/brian/include_at_match-clarify/agent/logs/advanced_log_collection

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
