### PR TITLE
Note Golang regexp syntax for rule patterns

### DIFF
--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -30,6 +30,8 @@ Apply log processing rules to a specific log collection configurations to:
 
 **Note**: If you set up multiple processing rules, they are applied sequentially and each rule is applied on the result of the previous one.
 
+**Note**: Processing rule patterns must conform to [Golang regexp syntax](https://golang.org/pkg/regexp/syntax/).
+
 To apply a processing rule to all logs collected by a Datadog Agent, see the [Global processing rules](#global-processing-rules) section.
 
 ## Filter logs


### PR DESCRIPTION
### What does this PR do?
Adds a note that processing rule patterns must conform to Golang regex syntax.

### Motivation
We created a processing rule pattern that was not supported by Golang regex syntax and this information would have saved us time.

### Preview

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.