### PR TITLE
Fix broken Auth0 SAML configuration link

### DIFF
--- a/content/en/account_management/saml/auth0.md
+++ b/content/en/account_management/saml/auth0.md
@@ -57,5 +57,5 @@ The `user_metadata` section of the user profile is used to specify additional us
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://auth0.com/docs/protocols/saml/saml2webapp-tutorial
-[2]: https://auth0.com/docs/protocols/saml/saml-apps/datadog
+[2]: https://auth0.com/docs/protocols/saml-protocol/saml-configuration-options/configure-auth0-as-identity-provider-for-datadog
 [3]: https://auth0.com/docs/users/normalized/auth0#normalized-user-profile-schema


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fixes broken URL pointing to auth0's SAML documenation

### Motivation
<!-- What inspired you to submit this pull request?-->
Support ticket

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
