### PR TITLE
Note contiguous underscores get deduped

### DIFF
--- a/content/en/developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags.md
+++ b/content/en/developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags.md
@@ -33,6 +33,7 @@ As a best practice, Datadog recommends using unified service tagging when assign
 * Tags must start with a letter.
 * May contain alphanumerics, underscores, minuses, colons, periods, and slashes. Other characters are converted to underscores.
 * Any trailing underscore will get removed, whether if it originated from a converted character or if it was in the original tag value.
+* Contiguous underscores will be reduced to a single underscore.
 * Tags can be up to 200 characters long and support Unicode.
 * Tags are converted to lowercase.
 * For optimal functionality, it is recommended to use the `key:value` syntax.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds a note about the deduplication of contiguous underscores.

### Motivation
<!-- What inspired you to submit this pull request?-->
Originated from a support case for serverless ([SLES-474](https://datadoghq.atlassian.net/browse/SLES-474)). Function names in DD adhere to the same tagging conventions and we're working on making that clear to avoid any further pitfalls.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/dylan/tag-underscores/developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags/#rules-and-best-practices-for-naming-tags

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
