### PR TITLE
note Lambda names follow DD tagging format

### DIFF
--- a/content/en/serverless/serverless_tagging/_index.md
+++ b/content/en/serverless/serverless_tagging/_index.md
@@ -24,7 +24,7 @@ With these tags, you can:
 
 To tag your serverless application with `env`, `service` and `version`, see the [unified service tagging documentation][1].
 
-Also note that Lambda function names should adhere to [Datadog's tagging convention][4]. This allows us to tie all of your function's traces, logs and metrics together seamlessly.
+**Note**: Lambda function names should adhere to [Datadog's tagging convention][4]. This ties all of your function's traces, logs and metrics together seamlessly.
 
 ### The env tag
 

--- a/content/en/serverless/serverless_tagging/_index.md
+++ b/content/en/serverless/serverless_tagging/_index.md
@@ -24,6 +24,8 @@ With these tags, you can:
 
 To tag your serverless application with `env`, `service` and `version`, see the [unified service tagging documentation][1].
 
+Also note that Lambda function names should adhere to [Datadog's tagging convention][4]. This allows us to tie all of your function's traces, logs and metrics together seamlessly.
+
 ### The env tag
 
 Use `env` to separate out your staging, development, and production environments. This works for any kind of infrastructure, not just for your serverless functions. As an example, you could tag your production EU Lambda functions with `env:prod-eu`.
@@ -56,3 +58,4 @@ The [Service Map][3] groups services into maps by the `env` tag, and uses the `s
 [1]: /getting_started/tagging/unified_service_tagging/#aws-lambda-functions
 [2]: /tracing/deployment_tracking/
 [3]: /tracing/visualization/services_map/
+[4]: /developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags/#rules-and-best-practices-for-naming-tags


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Makes a note that Lambda function names will adhere to our tagging rules.

### Motivation
<!-- What inspired you to submit this pull request?-->
From a support case where a user used contiguous underscores for their function name, breaking the link between their function and its traces and logs. Related to https://github.com/DataDog/documentation/pull/10072

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/dylan/function-name-tagging/serverless/serverless_tagging

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
