### PR TITLE
Remove autogenerated rules header

### DIFF
--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -17,8 +17,6 @@ TEMPLATE = """\
 {front_matter}
 ---
 
-## Overview
-
 {content}
 """
 


### PR DESCRIPTION
### What does this PR do?
Removes the `overview` header from the rules script as rules don't have an overview section (they follow CIS Benchmark/description format).

### Motivation
It's creating an unnecessary header / looks like a section is missing. 😬 

### Preview
https://docs-staging.datadoghq.com/sarina/sec-rules-overview-script/security_monitoring/default_rules

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
