### PR TITLE
Fixed broken log4j translator hyperlink

### DIFF
--- a/content/en/logs/log_collection/java.md
+++ b/content/en/logs/log_collection/java.md
@@ -326,7 +326,7 @@ Use the SLF4J module [log4j-over-slf4j][1] with Logback to send logs to another 
 
 
 [1]: http://www.slf4j.org/legacy.html#log4j-over-slf4j
-[2]: http://logback.qos.ch/translator
+[2]: http://logback.qos.ch/translator/
 {{% /tab %}}
 
 {{% tab "Log4j 2" %}}


### PR DESCRIPTION
### What does this PR do?
Adds a forward slash to the log4j translator hyperlink, changing:

`logback.qos.ch/translator` to `logback.qos.ch/translator`

### Motivation
The former hyperlink above led to a 404.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/slazien-patch-1/logs/log_collection/java/?tab=log4j#bridge-from-java-logging-libraries-to-logback

### Additional Notes
N/A
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
