### PR TITLE
Plugging profiler intro guide where relevant

### DIFF
--- a/content/en/tracing/profiler/_index.md
+++ b/content/en/tracing/profiler/_index.md
@@ -46,7 +46,7 @@ To get notified when a private beta is available for the **Node**, **Ruby**, **P
 
 ## Guide to using the profiler
 
-Check out this [Intro to Profiling][2] which explains profiling and shows you how to use Continuous Profiler to understand and fix a sample service that has a performance problem.
+[Intro to Profiling][2] guide takes a sample service with a performance problem and shows you how to use Continuous Profiler to understand and fix the problem.
 
 ## Explore Datadog Profiler
 

--- a/content/en/tracing/profiler/_index.md
+++ b/content/en/tracing/profiler/_index.md
@@ -36,7 +36,7 @@ Continuous profiler is designed to run in production across all services by leve
 
 Profiling your service to visualize all your stack traces in one place takes just minutes.
 
-### 1. Instrument Your Application
+### Instrument Your Application
 
 Add a profiler library to your application to start sending profiles to the Datadog Agent.
 
@@ -44,14 +44,13 @@ To get notified when a private beta is available for the **Node**, **Ruby**, **P
 
 {{< partial name="profiling/profiling-languages.html" >}}
 
+## Guide to using the profiler
+
+Check out this [Intro to Profiling][2] which explains profiling and shows you how to use Continuous Profiler to understand and fix a sample service that has a performance problem.
+
 ## Explore Datadog Profiler
 
-Now that you've configured your application to send profiles to Datadog, start getting insights into your code performance:
-
-### Simple guide to using the profiler
-
-Explore the profiler with a [simple guide][2] where we'll explain profiling and show you how we can use Continuous Profiler to understand and fix a sample service that has a performance problem.
-
+After you've configured your application to send profiles to Datadog, start getting insights into your code performance:
 
 ### Search profiles by tags
 

--- a/content/en/tracing/profiler/_index.md
+++ b/content/en/tracing/profiler/_index.md
@@ -46,7 +46,7 @@ To get notified when a private beta is available for the **Node**, **Ruby**, **P
 
 ## Guide to using the profiler
 
-[Intro to Profiling][2] guide takes a sample service with a performance problem and shows you how to use Continuous Profiler to understand and fix the problem.
+The [Intro to Profiling][2] guide takes a sample service with a performance problem and shows you how to use Continuous Profiler to understand and fix the problem.
 
 ## Explore Datadog Profiler
 

--- a/content/en/tracing/profiler/_index.md
+++ b/content/en/tracing/profiler/_index.md
@@ -48,9 +48,14 @@ To get notified when a private beta is available for the **Node**, **Ruby**, **P
 
 Now that you've configured your application to send profiles to Datadog, start getting insights into your code performance:
 
+### Simple guide to using the profiler
+
+Explore the profiler with a [simple guide][2] where we'll explain profiling and show you how we can use Continuous Profiler to understand and fix a sample service that has a performance problem.
+
+
 ### Search profiles by tags
 
-[Use tags to search profiles][2] across any dimension—whether it’s a specific host, service, version, or any combination.
+[Use tags to search profiles][3] across any dimension—whether it’s a specific host, service, version, or any combination.
 
 {{< img src="tracing/profiling/search_profiles.gif" alt="Search profiles by tags">}}
 
@@ -62,7 +67,7 @@ Obtain key profiling metrics from services such as top CPU usage by method, top 
 
 ### Connect traces to profiling data
 
-Application processes that have both [APM distributed tracing][3] and continuous profiler enabled are automatically linked, so you can move directly from span information to profiling data on the [Code Hotspots tab][4] to find specific lines of code related to performance issues.
+Application processes that have both [APM distributed tracing][4] and continuous profiler enabled are automatically linked, so you can move directly from span information to profiling data on the [Code Hotspots tab][5] to find specific lines of code related to performance issues.
 
 {{< img src="tracing/profiling/code_hotspots_tab.gif" alt="Code Hotspots tab shows profiling information for a APM trace span">}}
 
@@ -71,6 +76,7 @@ Application processes that have both [APM distributed tracing][3] and continuous
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://docs.google.com/forms/d/e/1FAIpQLScb9GKmKfSoY6YNV2Wa5P8IzUn02tA7afCahk7S0XHfakjYQw/viewform
-[2]: /tracing/profiling/search_profiles
-[3]: /tracing/
-[4]: /tracing/profiler/connect_traces_and_profiles/
+[2]: /tracing/profiler/intro_to_profiling/
+[3]: /tracing/profiling/search_profiles
+[4]: /tracing/
+[5]: /tracing/profiler/connect_traces_and_profiles/

--- a/content/en/tracing/profiler/getting_started.md
+++ b/content/en/tracing/profiler/getting_started.md
@@ -67,12 +67,15 @@ The Datadog Profiler requires [JDK Flight Recorder][1]. The Datadog Profiler lib
 | `DD_VERSION`                                     | String        | The version of your service.                             |
 | `DD_TAGS`                                        | String        | Tags to apply to an uploaded profile. Must be a list of `<key>:<value>` separated by commas such as: `layer:api, team:intake`.  |
 
+- Don't know where to start? Explore the profiler with a [simple guide][7] where we'll explain profiling and show you how we can use Continuous Profiler to understand and fix a sample service that has a performance problem.
+
 [1]: https://docs.oracle.com/javacomponents/jmc-5-4/jfr-runtime-guide/about.htm
 [2]: /tracing/profiler/profiler_troubleshooting/#java-8-support
 [3]: https://app.datadoghq.com/account/settings#agent/overview
 [4]: https://app.datadoghq.com/profiling
 [5]: https://docs.oracle.com/javase/7/docs/technotes/tools/solaris/java.html
 [6]: /tracing/guide/setting_primary_tags_to_scope/#environment
+[7]: /tracing/profiler/intro_to_profiling/
 {{< /programming-lang >}}
 {{< programming-lang lang="python" >}}
 
@@ -168,10 +171,16 @@ You can configure the profiler using the following environment variables:
 | `DD_VERSION`            | `version`                      | String                     | The version of your application.                                    |
 | `DD_TAGS`               | `tags`                         | String / Dictionary        | Tags to apply to an uploaded profile. If set with an environment variable, it must be a list of `<key>:<value>` separated by commas such as: `layer:api,team:intake`. If set with keyword argument, it must be a dictionary where keys are tag names and values are tag values such as:`{"layer": "api", "team": "intake"}`.  |
 
+
+**Simple guide to using the profiler**
+
+Don't know where to start? Explore the profiler with a [simple guide][5] where we'll explain profiling and show you how we can use Continuous Profiler to understand and fix a sample service that has a performance problem.
+
 [1]: https://app.datadoghq.com/account/settings#agent/overview
 [2]: https://app.datadoghq.com/profiling
 [3]: /tracing/visualization/#services
 [4]: /tracing/guide/setting_primary_tags_to_scope/#environment
+[5]: /tracing/profiler/intro_to_profiling/
 {{< /programming-lang >}}
 {{< programming-lang lang="go" >}}
 
@@ -242,6 +251,8 @@ The Datadog Profiler requires Go 1.12+. To begin profiling applications:
 | `DD_ENV`                                         | String        | The Datadog [environment][7] name, for example, `production`. |
 | `DD_VERSION`                                     | String        | The version of your application.                             |
 | `DD_TAGS`                                        | String        | Tags to apply to an uploaded profile. Must be a list of `<key>:<value>` separated by commas such as: `layer:api,team:intake`.   |
+
+- Don't know where to start? Explore the profiler with a [simple guide][5] where we'll explain profiling and show you how we can use Continuous Profiler to understand and fix a sample service that has a performance problem.
 
 [1]: https://app.datadoghq.com/account/settings#agent/overview
 [2]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/profiler#pkg-constants

--- a/content/en/tracing/profiler/getting_started.md
+++ b/content/en/tracing/profiler/getting_started.md
@@ -260,7 +260,7 @@ The Datadog Profiler requires Go 1.12+. To begin profiling applications:
 
 ## Not sure what to do next?
 
-[Intro to Profiling][2] guide takes a sample service with a performance problem and shows you how to use Continuous Profiler to understand and fix the problem.
+The [Intro to Profiling][2] guide takes a sample service with a performance problem and shows you how to use Continuous Profiler to understand and fix the problem.
 
 ## Further Reading
 

--- a/content/en/tracing/profiler/getting_started.md
+++ b/content/en/tracing/profiler/getting_started.md
@@ -260,7 +260,7 @@ The Datadog Profiler requires Go 1.12+. To begin profiling applications:
 
 ## Not sure what to do next?
 
-Check out this [Intro to Profiling][2] which explains profiling and shows you how to use Continuous Profiler to understand and fix a sample service that has a performance problem.
+[Intro to Profiling][2] guide takes a sample service with a performance problem and shows you how to use Continuous Profiler to understand and fix the problem.
 
 ## Further Reading
 

--- a/content/en/tracing/profiler/getting_started.md
+++ b/content/en/tracing/profiler/getting_started.md
@@ -67,7 +67,6 @@ The Datadog Profiler requires [JDK Flight Recorder][1]. The Datadog Profiler lib
 | `DD_VERSION`                                     | String        | The version of your service.                             |
 | `DD_TAGS`                                        | String        | Tags to apply to an uploaded profile. Must be a list of `<key>:<value>` separated by commas such as: `layer:api, team:intake`.  |
 
-- Don't know where to start? Explore the profiler with a [simple guide][7] where we'll explain profiling and show you how we can use Continuous Profiler to understand and fix a sample service that has a performance problem.
 
 [1]: https://docs.oracle.com/javacomponents/jmc-5-4/jfr-runtime-guide/about.htm
 [2]: /tracing/profiler/profiler_troubleshooting/#java-8-support
@@ -75,7 +74,6 @@ The Datadog Profiler requires [JDK Flight Recorder][1]. The Datadog Profiler lib
 [4]: https://app.datadoghq.com/profiling
 [5]: https://docs.oracle.com/javase/7/docs/technotes/tools/solaris/java.html
 [6]: /tracing/guide/setting_primary_tags_to_scope/#environment
-[7]: /tracing/profiler/intro_to_profiling/
 {{< /programming-lang >}}
 {{< programming-lang lang="python" >}}
 
@@ -172,15 +170,11 @@ You can configure the profiler using the following environment variables:
 | `DD_TAGS`               | `tags`                         | String / Dictionary        | Tags to apply to an uploaded profile. If set with an environment variable, it must be a list of `<key>:<value>` separated by commas such as: `layer:api,team:intake`. If set with keyword argument, it must be a dictionary where keys are tag names and values are tag values such as:`{"layer": "api", "team": "intake"}`.  |
 
 
-**Simple guide to using the profiler**
-
-Don't know where to start? Explore the profiler with a [simple guide][5] where we'll explain profiling and show you how we can use Continuous Profiler to understand and fix a sample service that has a performance problem.
 
 [1]: https://app.datadoghq.com/account/settings#agent/overview
 [2]: https://app.datadoghq.com/profiling
 [3]: /tracing/visualization/#services
 [4]: /tracing/guide/setting_primary_tags_to_scope/#environment
-[5]: /tracing/profiler/intro_to_profiling/
 {{< /programming-lang >}}
 {{< programming-lang lang="go" >}}
 
@@ -252,7 +246,7 @@ The Datadog Profiler requires Go 1.12+. To begin profiling applications:
 | `DD_VERSION`                                     | String        | The version of your application.                             |
 | `DD_TAGS`                                        | String        | Tags to apply to an uploaded profile. Must be a list of `<key>:<value>` separated by commas such as: `layer:api,team:intake`.   |
 
-- Don't know where to start? Explore the profiler with a [simple guide][5] where we'll explain profiling and show you how we can use Continuous Profiler to understand and fix a sample service that has a performance problem.
+
 
 [1]: https://app.datadoghq.com/account/settings#agent/overview
 [2]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/profiler#pkg-constants
@@ -264,10 +258,13 @@ The Datadog Profiler requires Go 1.12+. To begin profiling applications:
 {{< /programming-lang >}}
 {{< /programming-lang-wrapper >}}
 
+## Not sure what to do next?
 
+Check out this [Intro to Profiling][2] which explains profiling and shows you how to use Continuous Profiler to understand and fix a sample service that has a performance problem.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://docs.google.com/forms/d/e/1FAIpQLScb9GKmKfSoY6YNV2Wa5P8IzUn02tA7afCahk7S0XHfakjYQw/viewform
+[2]: /tracing/profiler/intro_to_profiling/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Increasing profiler guide's discoverability.

### Motivation
<!-- What inspired you to submit this pull request?-->

Currently the profiler guide is not very discoverable for users.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/gaurab/intro-expansion/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
