### PR TITLE
[WEB-1207] Style support for html disclosure element

### DIFF
--- a/content/en/dashboards/_index.md
+++ b/content/en/dashboards/_index.md
@@ -31,6 +31,19 @@ further_reading:
   text: "Add Dashboard widgets to your clipboard"
 ---
 
+## Content Toggle Test
+Some test content here.
+
+<details>
+  <summary>
+    {{< h3 >}}Manual{{< /h3 >}}
+  </summary>
+
+  1. Test
+  2. Another Test
+  3. Third Test
+</details>
+
 ## Overview
 
 A dashboard is Datadog's tool for visually tracking, analyzing, and displaying key performance metrics, which enable you to monitor the health of your infrastructure.

--- a/content/en/dashboards/_index.md
+++ b/content/en/dashboards/_index.md
@@ -36,7 +36,7 @@ Some test content here.
 
 <details>
   <summary>
-    {{< h3 >}}Manual{{< /h3 >}}
+    <h3>Manual</h3>
   </summary>
 
   1. Test

--- a/content/en/dashboards/_index.md
+++ b/content/en/dashboards/_index.md
@@ -31,19 +31,6 @@ further_reading:
   text: "Add Dashboard widgets to your clipboard"
 ---
 
-## Content Toggle Test
-Some test content here.
-
-<details>
-  <summary>
-    <h3>Manual</h3>
-  </summary>
-
-  1. Test
-  2. Another Test
-  3. Third Test
-</details>
-
 ## Overview
 
 A dashboard is Datadog's tool for visually tracking, analyzing, and displaying key performance metrics, which enable you to monitor the health of your infrastructure.

--- a/layouts/shortcodes/h3.html
+++ b/layouts/shortcodes/h3.html
@@ -1,0 +1,5 @@
+{{ $anchorized := anchorize .Inner }}
+
+<h3 id="{{ $anchorized }}">
+  {{ .Inner }}
+</h3>

--- a/src/styles/pages/_global.scss
+++ b/src/styles/pages/_global.scss
@@ -179,6 +179,20 @@ code + code.region-param {
     border-bottom-left-radius: 0;
 }
 
+details {
+    margin-bottom: 1.5rem;
+
+    summary {
+        h3 {
+            display: inline-block;
+        }
+
+        &:focus {
+            outline: none;
+        }
+    }
+}
+
 .programming-lang-wrapper {
     .code-snippet-wrapper {
         display: none;

--- a/src/styles/pages/_global.scss
+++ b/src/styles/pages/_global.scss
@@ -183,7 +183,11 @@ details {
     margin-bottom: 1.5rem;
 
     summary {
-        h3 {
+        h1,
+        h2,
+        h3,
+        h4,
+        h5 {
             display: inline-block;
         }
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds style support for HTML disclosure element: `<details><summary></summary></details>`

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1207

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/dropdown-css/

To test, pull down this branch locally and add some html to a markdown file:

```
<details>
  <summary>
    <h3>Title</h3>
  </summary>
     Test content here
</details>
```

### Additional Notes
I didn't end up using the `h3` shortcode, but decided to keep it around in case we need it in the future.   I can remove if there are concerns.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
