### PR TITLE
Update dogstatsd.md

### DIFF
--- a/content/en/developers/events/dogstatsd.md
+++ b/content/en/developers/events/dogstatsd.md
@@ -28,7 +28,7 @@ event(<TITLE>, <TEXT>, <TIMESTAMP>, <HOSTNAME>, <AGGREGATION_KEY>, <PRIORITY>, <
 |----------------------|-----------------|----------|--------------------------------------------------------------------------------------------|
 | `<TITLE>`            | String          | Yes      | The title of the event                                                                     |
 | `<TEXT>`             | String          | Yes      | The text body of the event                                                                 |
-| `<TIMESTAMP>`        | Integer         | Yes      | The epoch timestamp for the event (defaults to the current time from the DogStatsD server) |
+| `<TIMESTAMP>`        | Integer         | No       | The epoch timestamp for the event (defaults to the current time from the DogStatsD server) |
 | `<HOSTNAME>`         | String          | No       | The name of the host                                                                       |
 | `<AGGREGATION_KEY>`  | String          | No       | A key to use for aggregating events                                                        |
 | `<PRIORITY>`         | String          | No       | Specifies the priority of the event (`normal` or `low`).                                   |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fix `event` definitions: parameter `<TIMESTAMP>` is not required if we take a look at the listed examples. Also, the description contains a fact that this parameter defaults to the current time from the DogStatsD server.

### Motivation
To eliminate confusion in the documentation for DataDog events.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
