### PR TITLE
[EN] Update the `logs_public_config_api` section

### DIFF
--- a/content/en/account_management/rbac/permissions.md
+++ b/content/en/account_management/rbac/permissions.md
@@ -232,13 +232,13 @@ For `service:ci-cd` logs that are rehydrated from the `Prod Archive`, note the f
 
 #### `logs_public_config_api`
 
-Grants the ability to view, create or modify log configuration through the Datadog API:
+Grants the ability to view, create, or modify log configuration through the Datadog API:
 
-* View and Configure [Archives][15] through the API
-* View and Configure [Indexes][16] through the API
-* View and Configure [Pipelines][17] through the API
-* View and Configure [Restriction Queries][18] through the API
-* View and Configure [Metrics Generated from Logs][20] through the API
+* View and configure [archives][15] through the API
+* View and configure [indexes][16] through the API
+* View and configure [pipelines][17] through the API
+* View and configure [restriction queries][18] through the API
+* View and configure [metrics generated from logs][20] through the API
 
 The Log Public Configuration API permission only grants the permission to operate actions through API. For instance, a user without [Log Write Exclusion Filter Permission](#logs-write-exclusion-filters) cannot update sampling rate through API, even if granted The Log Public Configuration API permission.
 

--- a/content/en/account_management/rbac/permissions.md
+++ b/content/en/account_management/rbac/permissions.md
@@ -232,12 +232,13 @@ For `service:ci-cd` logs that are rehydrated from the `Prod Archive`, note the f
 
 #### `logs_public_config_api`
 
-Grants the ability to create or modify log configuration through the Datadog API:
+Grants the ability to view, create or modify log configuration through the Datadog API:
 
-* Configure [Archives][15] through the API
-* Configure [Indexes][16] through the API
-* Configure [Pipelines][17] through the API
-* Configure [Restriction Queries][18] through the API
+* View and Configure [Archives][15] through the API
+* View and Configure [Indexes][16] through the API
+* View and Configure [Pipelines][17] through the API
+* View and Configure [Restriction Queries][18] through the API
+* View and Configure [Metrics Generated from Logs][20] through the API
 
 The Log Public Configuration API permission only grants the permission to operate actions through API. For instance, a user without [Log Write Exclusion Filter Permission](#logs-write-exclusion-filters) cannot update sampling rate through API, even if granted The Log Public Configuration API permission.
 
@@ -409,3 +410,4 @@ This permission is global, and grants access to the livetail irregardless of [Lo
 [17]: /api/v1/logs-pipelines/
 [18]: /api/v2/logs-restriction-queries/
 [19]: /logs/explorer/live_tail/
+[20]: /api/v2/logs-metrics/


### PR DESCRIPTION
### What does this PR do?
The `logs_public_config_api` is inaccurate. The permissions set limits access to all actions on the `log/config` API path.
From an internal investigation we determined that it limits Get and Post access on the API path `log/config`.

### Motivation
Users have reported being unable to get Read Access to certain features they can access over the UI.

### Preview
https://docs-staging.datadoghq.com/theraffoul/logs-public-config-api/account_management/rbac/permissions/?tab=ui#logs_public_config_api

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
