### PR TITLE
Use built-in function for site-level access

### DIFF
--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,11 +1,11 @@
 {
-  "@babel/polyfill.js": "static/@babel/polyfill.7fa72.js",
-  "api-redirect.js": "static/api-redirect.23eb5.js",
-  "dd-browser-logs-rum.js": "static/dd-browser-logs-rum.0e4b7.js",
-  "lang-redirects.js": "static/lang-redirects.a7e61.js",
-  "main-dd-css.css": "static/main-dd-css.587f0.css",
-  "main-dd-css.js": "static/main-dd-css.b60d0.js",
-  "main-dd-js.js": "static/main-dd-js.16f3b.js",
-  "region-redirects.js": "static/region-redirects.f2c91.js",
-  "vendor.js": "static/vendor.ad790.js"
+  "@babel/polyfill.js": "static/@babel/polyfill.js",
+  "api-redirect.js": "static/api-redirect.js",
+  "dd-browser-logs-rum.js": "static/dd-browser-logs-rum.js",
+  "lang-redirects.js": "static/lang-redirects.js",
+  "main-dd-css.css": "static/main-dd-css.css",
+  "main-dd-css.js": "static/main-dd-css.js",
+  "main-dd-js.js": "static/main-dd-js.js",
+  "region-redirects.js": "static/region-redirects.js",
+  "vendor.js": "static/vendor.js"
 }

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,11 +1,11 @@
 {
-  "@babel/polyfill.js": "static/@babel/polyfill.js",
-  "api-redirect.js": "static/api-redirect.js",
-  "dd-browser-logs-rum.js": "static/dd-browser-logs-rum.js",
-  "lang-redirects.js": "static/lang-redirects.js",
-  "main-dd-css.css": "static/main-dd-css.css",
-  "main-dd-css.js": "static/main-dd-css.js",
-  "main-dd-js.js": "static/main-dd-js.js",
-  "region-redirects.js": "static/region-redirects.js",
-  "vendor.js": "static/vendor.js"
+  "@babel/polyfill.js": "static/@babel/polyfill.7fa72.js",
+  "api-redirect.js": "static/api-redirect.23eb5.js",
+  "dd-browser-logs-rum.js": "static/dd-browser-logs-rum.0e4b7.js",
+  "lang-redirects.js": "static/lang-redirects.a7e61.js",
+  "main-dd-css.css": "static/main-dd-css.587f0.css",
+  "main-dd-css.js": "static/main-dd-css.b60d0.js",
+  "main-dd-js.js": "static/main-dd-js.16f3b.js",
+  "region-redirects.js": "static/region-redirects.f2c91.js",
+  "vendor.js": "static/vendor.ad790.js"
 }

--- a/layouts/_default/404-baseof.html
+++ b/layouts/_default/404-baseof.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}"
-  data-env="{{.Site.Params.environment}}" data-commit-ref="{{ .Site.Params.branch }}" style="opacity:0"
-  class="{{ if or $.Site.Params.announcement_banner.link $.Site.Params.announcement_banner.desktop_message }}banner{{ end }}">
+<html lang="{{ site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}"
+  data-env="{{site.Params.environment}}" data-commit-ref="{{ site.Params.branch }}" style="opacity:0"
+  class="{{ if or site.Params.announcement_banner.link site.Params.announcement_banner.desktop_message }}banner{{ end }}">
 
 <head>
   {{ partial "header-scripts.html" . }}
@@ -11,7 +11,7 @@
   {{ $dd_logs := resources.Get "node_modules/datadog-logs.js" }}
   {{ $dd_libs_js := slice $dd_rum $dd_logs | resources.Concat "js/dd-libs.js" }}
   <script>{{ $dd_libs_js.Content | safeJS }}</script>
-  <script src="{{ (index $.Site.Data.manifest "dd-browser-logs-rum.js") | relURL }}"></script>
+  <script src="{{ (index site.Data.manifest "dd-browser-logs-rum.js") | relURL }}"></script>
 
   <meta charset="utf-8">
   {{ partial "prefetch.html" . }}
@@ -24,7 +24,7 @@
   {{- partial "hreflang.html" . -}}
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <link rel="icon" type="image/png" href="https://docs.datadoghq.com/favicon.ico">
-  <link rel="stylesheet" href="{{ (index $.Site.Data.manifest "main-dd-css.css") | relURL }}">
+  <link rel="stylesheet" href="{{ (index site.Data.manifest "main-dd-css.css") | relURL }}">
 
   {{- if ne $.Params.disable_opengraph_meta_tags true -}}
   {{- partial "meta.html" . -}}
@@ -34,7 +34,7 @@
 {{- $bodyClass := $.Scratch.Get "bodyClass" -}}
 
 <body
-  class="{{ .Site.Language.Lang }} {{ if .Kind }}kind-{{.Kind}}{{ end }} {{ if .IsPage }} {{ replace $.Type "/" "-" }} {{ else }} {{ .Section }} {{ end }} {{ $bodyClass }}">
+  class="{{ site.Language.Lang }} {{ if .Kind }}kind-{{.Kind}}{{ end }} {{ if .IsPage }} {{ replace $.Type "/" "-" }} {{ else }} {{ .Section }} {{ end }} {{ $bodyClass }}">
 
   <div class="greyside">
     <div class="container h-100">
@@ -59,8 +59,8 @@
 
   {{ partial "footer/footer.html" . }}
 
-  <script src="{{ (index $.Site.Data.manifest "vendor.js") | relURL}}"></script>
-  <script src="{{ (index $.Site.Data.manifest "main-dd-js.js") | relURL}}"></script>
+  <script src="{{ (index site.Data.manifest "vendor.js") | relURL}}"></script>
+  <script src="{{ (index site.Data.manifest "main-dd-js.js") | relURL}}"></script>
 
   {{ partial "footer-scripts.html" . }}
   {{ partial "footer-js-dd-docs-methods" . }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.Language.Lang }}" data-base-url="{{ .Site.BaseURL }}" data-type="{{.Type}}" data-page-code-lang="{{ .Params.code_lang }}" data-current-section="{{ strings.TrimLeft "/" .CurrentSection.RelPermalink}}" data-relpermalink="{{.RelPermalink}}"
-  data-env="{{.Site.Params.environment}}" data-commit-ref="{{ .Site.Params.branch }}" style="opacity:0"
-  class="{{ if or $.Site.Params.announcement_banner.link $.Site.Params.announcement_banner.desktop_message }}banner{{ end }}">
+<html lang="{{ site.Language.Lang }}" data-base-url="{{ site.BaseURL }}" data-type="{{.Type}}" data-page-code-lang="{{ .Params.code_lang }}" data-current-section="{{ strings.TrimLeft "/" .CurrentSection.RelPermalink}}" data-relpermalink="{{.RelPermalink}}"
+  data-env="{{site.Params.environment}}" data-commit-ref="{{ site.Params.branch }}" style="opacity:0"
+  class="{{ if or site.Params.announcement_banner.link site.Params.announcement_banner.desktop_message }}banner{{ end }}">
 
 <head>
 
@@ -12,7 +12,7 @@
   {{ $dd_logs := resources.Get "node_modules/datadog-logs.js" }}
   {{ $dd_libs_js := slice $dd_rum $dd_logs | resources.Concat "js/dd-libs.js" }}
   <script>{{ $dd_libs_js.Content | safeJS }}</script>
-  <script src="{{ (index $.Site.Data.manifest "dd-browser-logs-rum.js") | relURL }}"></script>
+  <script src="{{ (index site.Data.manifest "dd-browser-logs-rum.js") | relURL }}"></script>
 
   <meta charset="utf-8">
   {{ partial "prefetch.html" . }}
@@ -26,20 +26,20 @@
   {{- partial "hreflang.html" . -}}
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <link rel="icon" type="image/png" href="https://docs.datadoghq.com/favicon.ico">
-  <link rel="stylesheet" href="{{ (index $.Site.Data.manifest "main-dd-css.css") | relURL }}">
+  <link rel="stylesheet" href="{{ (index site.Data.manifest "main-dd-css.css") | relURL }}">
   {{- if ne $.Params.disable_opengraph_meta_tags true -}}
   {{- partial "meta.html" . -}}
   {{- end -}}
 
-  <script src="{{ (index $.Site.Data.manifest "lang-redirects.js") | relURL }}"></script>
-  <script src="{{ (index $.Site.Data.manifest "region-redirects.js") | relURL }}"></script>
+  <script src="{{ (index site.Data.manifest "lang-redirects.js") | relURL }}"></script>
+  <script src="{{ (index site.Data.manifest "region-redirects.js") | relURL }}"></script>
 </head>
 {{- $bodyClass := $.Scratch.Get "bodyClass" -}}
 {{- $customClass := $.Params.customclass -}}
 {{ $ctx := . }}
 
 <body
-  class="{{ .Site.Language.Lang }} {{ if .Kind }}kind-{{.Kind}}{{ end }} {{ if .IsPage }} {{ replace $.Type "/" "-" }} {{ else }} {{ .Section }} {{ end }} {{ $bodyClass }} {{ $customClass }}">
+  class="{{ site.Language.Lang }} {{ if .Kind }}kind-{{.Kind}}{{ end }} {{ if .IsPage }} {{ replace $.Type "/" "-" }} {{ else }} {{ .Section }} {{ end }} {{ $bodyClass }} {{ $customClass }}">
 
   <div class="greyside">
     <div class="container h-100">
@@ -79,8 +79,8 @@
 
   {{ partial "footer/footer.html" . }}
 
-  <script src="{{ (index $.Site.Data.manifest "vendor.js") | relURL}}"></script>
-  <script src="{{ (index $.Site.Data.manifest "main-dd-js.js") | relURL}}"></script>
+  <script src="{{ (index site.Data.manifest "vendor.js") | relURL}}"></script>
+  <script src="{{ (index site.Data.manifest "main-dd-js.js") | relURL}}"></script>
 
   {{ partial "footer-scripts.html" . }}
 

--- a/layouts/api/baseof.html
+++ b/layouts/api/baseof.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}"
-  data-env="{{.Site.Params.environment}}" data-commit-ref="{{ .Site.Params.branch }}" style="opacity:0">
+<html lang="{{ site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}"
+  data-env="{{site.Params.environment}}" data-commit-ref="{{ site.Params.branch }}" style="opacity:0">
 
 <head>
 
@@ -11,8 +11,8 @@
   {{ $dd_logs := resources.Get "node_modules/datadog-logs.js" }}
   {{ $dd_libs_js := slice $dd_rum $dd_logs | resources.Concat "js/dd-libs.js" }}
   <script>{{ $dd_libs_js.Content | safeJS }}</script>
-  <script src="{{ (index $.Site.Data.manifest "dd-browser-logs-rum.js") | relURL }}"></script>
-  <script src="{{ (index $.Site.Data.manifest "api-redirect.js") | relURL }}"></script>
+  <script src="{{ (index site.Data.manifest "dd-browser-logs-rum.js") | relURL }}"></script>
+  <script src="{{ (index site.Data.manifest "api-redirect.js") | relURL }}"></script>
 
   <meta charset="utf-8">
   {{ partial "prefetch.html" . }}
@@ -25,18 +25,18 @@
   {{- partial "hreflang.html" . -}}
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <link rel="icon" type="image/png" href="https://docs.datadoghq.com/favicon.ico">
-  <link rel="stylesheet" href="{{ (index $.Site.Data.manifest "main-dd-css.css") | relURL}}">
+  <link rel="stylesheet" href="{{ (index site.Data.manifest "main-dd-css.css") | relURL}}">
   {{- if ne $.Params.disable_opengraph_meta_tags true -}}
   {{- partial "meta.html" . -}}
   {{- end -}}
 
-  <script src="{{ (index $.Site.Data.manifest "lang-redirects.js") | relURL }}"></script>
+  <script src="{{ (index site.Data.manifest "lang-redirects.js") | relURL }}"></script>
 </head>
 {{- $bodyClass := $.Scratch.Get "bodyClass" -}}
 
 <body
 data-spy="scroll" data-target="#navbar-example2" data-offset="5"
-  class="{{ .Site.Language.Lang }} {{ if .IsPage }} {{ replace $.Type "/" "-" }} {{ else }} {{ .Section }} {{ end }} {{ $bodyClass }}">
+  class="{{ site.Language.Lang }} {{ if .IsPage }} {{ replace $.Type "/" "-" }} {{ else }} {{ .Section }} {{ end }} {{ $bodyClass }}">
 
   {{ partial "header/header.html" . }}
 
@@ -54,8 +54,8 @@ data-spy="scroll" data-target="#navbar-example2" data-offset="5"
 
   {{ partial "footer/footer.html" . }}
 
-  <script src="{{ (index $.Site.Data.manifest "vendor.js") | relURL}}"></script>
-  <script src="{{ (index $.Site.Data.manifest "main-dd-js.js") | relURL}}"></script>
+  <script src="{{ (index site.Data.manifest "vendor.js") | relURL}}"></script>
+  <script src="{{ (index site.Data.manifest "main-dd-js.js") | relURL}}"></script>
 
   {{ partial "footer-scripts.html" . }}
   {{ partial "footer-js-dd-docs-methods" . }}

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -26,8 +26,8 @@
     {{ end }}
     {{ $ParamTitleEn := ($.Scratch.Get "ParamTitleEn") }}
 
-    {{ $d := index $dot.Site.Data.api.v1 "full_spec_deref" }}
-    {{ $d2 := index $dot.Site.Data.api.v2 "full_spec_deref" }}
+    {{ $d := index site.Data.api.v1 "full_spec_deref" }}
+    {{ $d2 := index site.Data.api.v2 "full_spec_deref" }}
 
     <!-- get lang specific data file -->
     {{ $tagSlug := path.Base .File.Dir }}
@@ -35,20 +35,20 @@
     {{ $.Scratch.Set "translate_actions" (dict) }}
     {{ if ne $.Page.Lang "en"}}
         {{ if (fileExists (print "data/api/" $apiVersion "/translate_tags." $.Page.Lang ".json")) }}
-          {{ $.Scratch.Set "translate_tags" (index (index $.Site.Data.api $apiVersion) (print "translate_tags." $.Page.Lang)) }}
+          {{ $.Scratch.Set "translate_tags" (index (index site.Data.api $apiVersion) (print "translate_tags." $.Page.Lang)) }}
         {{ end }}
         {{ if (fileExists (print "data/api/" $apiVersion "/translate_actions." $.Page.Lang ".json")) }}
-          {{ $.Scratch.Set "translate_actions" (index (index $.Site.Data.api $apiVersion) (print "translate_actions." $.Page.Lang)) }}
+          {{ $.Scratch.Set "translate_actions" (index (index site.Data.api $apiVersion) (print "translate_actions." $.Page.Lang)) }}
         {{ end }}
     {{ end }}
     {{ $translate_tags := ($.Scratch.Get "translate_tags") }}
     {{ $translate_actions := ($.Scratch.Get "translate_actions") }}
 
 <!-- if no api menu in other languages fallback to english -->
-{{ with index .Site.Menus "api" }}
+{{ with index site.Menus "api" }}
   {{ $dot.Scratch.Set "menu" . }}
 {{ else }}
-  {{ $dot.Scratch.Set "menu" (index .Sites.First.Menus "api") }}
+  {{ $dot.Scratch.Set "menu" (index site.First.Menus "api") }}
 {{ end }}
 {{ $menu := .Scratch.Get "menu" }}
 
@@ -56,7 +56,7 @@
 {{ $translate_tag := (index $translate_tags $tagSlug) | default (dict) }}
 
 <!-- lets show the intro text, shall we use v1 or v2 text. Lets try v1 for now.. -->
-{{ partial "api/intro.html" (dict "tags" $dot.Site.Data.api.v1.full_spec_deref.tags "title" $ParamTitleEn "translate_tag" $translate_tag) }}
+{{ partial "api/intro.html" (dict "tags" site.Data.api.v1.full_spec_deref.tags "title" $ParamTitleEn "translate_tag" $translate_tag) }}
 
 <!-- Loop over the menu to determine what to pull in -->
 {{ range (where .Sites.First.Menus.api ".Name" "==" $ParamTitleEn) }}
@@ -91,14 +91,14 @@
     {{ range $versionIndex, $versionNum := .Params.versions }}
       {{ $endpointVisibility := partial "api/endpoint-visibility.html" (dict "versionCount" $versionCount "versionNum" $versionNum "menuChild" $menuChild) }}
       <div id="{{ (print $anchorStr "-" $versionNum) | anchorize }}" class="tab-pane {{ if $endpointVisibility.isVisibleVersion }}active{{ end }}" role="tabpanel">
-      {{ $adat := (index (index $dot.Site.Data.api $versionNum) "full_spec_deref") }}
+      {{ $adat := (index (index site.Data.api $versionNum) "full_spec_deref") }}
 
       <!-- Get the general API server url for this version -->
       {{ $generalRegions := partial "api/regions.html" (dict "servers" $adat.servers) }}
       {{ $dot.Scratch.Set "regions" $generalRegions }}
 
       <!-- for accessing v1/v2 resources from latest -->
-      {{ $resourcePage := $dot.Site.GetPage (print "/api/" $versionNum "/" (path.Base $dot.File.Dir) "") }}
+      {{ $resourcePage := site.GetPage (print "/api/" $versionNum "/" (path.Base $dot.File.Dir) "") }}
 
       {{ range $tag := (first 1 (where $adat.tags ".name" "==" $ParamTitleEn)) }}
 

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -48,7 +48,7 @@
 {{ with index site.Menus "api" }}
   {{ $dot.Scratch.Set "menu" . }}
 {{ else }}
-  {{ $dot.Scratch.Set "menu" (index site.First.Menus "api") }}
+  {{ $dot.Scratch.Set "menu" (index .Sites.First.Menus "api") }}
 {{ end }}
 {{ $menu := .Scratch.Get "menu" }}
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}" data-env="{{.Site.Params.environment}}" data-commit-ref="{{ .Site.Params.branch }}" style="opacity:0" class="{{ if or $.Site.Params.announcement_banner.link $.Site.Params.announcement_banner.desktop_message }}banner{{ end }}">
+<html lang="{{ site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}" data-env="{{site.Params.environment}}" data-commit-ref="{{ site.Params.branch }}" style="opacity:0" class="{{ if or site.Params.announcement_banner.link site.Params.announcement_banner.desktop_message }}banner{{ end }}">
 
 <head>
         {{ partial "header-scripts.html" . }}
@@ -9,7 +9,7 @@
         {{ $dd_logs := resources.Get "node_modules/datadog-logs.js" }}
         {{ $dd_libs_js := slice $dd_rum $dd_logs | resources.Concat "js/dd-libs.js" }}
         <script>{{ $dd_libs_js.Content | safeJS }}</script>
-        <script src="{{ (index $.Site.Data.manifest "dd-browser-logs-rum.js") | relURL }}"></script>
+        <script src="{{ (index site.Data.manifest "dd-browser-logs-rum.js") | relURL }}"></script>
 
         <meta charset="utf-8">
         {{ partial "prefetch.html" . }}
@@ -23,12 +23,12 @@
         {{- partial "hreflang.html" . -}}
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <link rel="icon" type="image/png" href="https://docs.datadoghq.com/favicon.ico">
-        <link rel="stylesheet" href="{{ (index $.Site.Data.manifest "main-dd-css.css") | relURL }}">
+        <link rel="stylesheet" href="{{ (index site.Data.manifest "main-dd-css.css") | relURL }}">
         {{- if ne $.Params.disable_opengraph_meta_tags true -}}
         {{- partial "meta.html" . -}}
         {{- end -}}
 
-        <script src="{{ (index $.Site.Data.manifest "lang-redirects.js") | relURL }}"></script>
+        <script src="{{ (index site.Data.manifest "lang-redirects.js") | relURL }}"></script>
 </head>
 
 {{ $dot := . }}
@@ -37,12 +37,12 @@
 {{ $.Scratch.Set "data" "" }}
 {{ if ne $dot.Page.Lang "en"}}
     {{ if (fileExists (print "data/partials/home." $dot.Page.Lang ".yaml")) }}
-      {{ $.Scratch.Set "data" (index $dot.Page.Site.Data.partials (print "home." $dot.Page.Lang)) }}
+      {{ $.Scratch.Set "data" (index site.Data.partials (print "home." $dot.Page.Lang)) }}
     {{ else }}
-      {{ $.Scratch.Set "data" $dot.Page.Site.Data.partials.home }}
+      {{ $.Scratch.Set "data" site.Data.partials.home }}
     {{ end }}
 {{ else }}
-    {{ $.Scratch.Set "data" $dot.Page.Site.Data.partials.home }}
+    {{ $.Scratch.Set "data" site.Data.partials.home }}
 {{ end }}
 {{ $datafile := ($.Scratch.Get "data") }}
 
@@ -50,7 +50,7 @@
 
 {{- $bodyClass := $.Scratch.Get "bodyClass" -}}
 {{- $customClass := $.Params.customclass -}}
-<body class="{{ .Site.Language.Lang }} {{ if .Kind }}kind-{{.Kind}}{{ end }} {{ if .IsPage }} {{ replace $.Type "/" "-" }} {{ else }} {{ .Section }} {{ end }} {{ $bodyClass }} {{ $customClass }}">
+<body class="{{ site.Language.Lang }} {{ if .Kind }}kind-{{.Kind}}{{ end }} {{ if .IsPage }} {{ replace $.Type "/" "-" }} {{ else }} {{ .Section }} {{ end }} {{ $bodyClass }} {{ $customClass }}">
 
 
     {{ partial "header/header.html" . }}
@@ -122,8 +122,8 @@
 
     {{ partial "footer/footer.html" . }}
 
-    <script src="{{ (index $.Site.Data.manifest "vendor.js") | relURL}}"></script>
-    <script src="{{ (index $.Site.Data.manifest "main-dd-js.js") | relURL}}"></script>
+    <script src="{{ (index site.Data.manifest "vendor.js") | relURL}}"></script>
+    <script src="{{ (index site.Data.manifest "main-dd-js.js") | relURL}}"></script>
 
     {{ partial "footer-scripts.html" . }}
 

--- a/layouts/partials/announcement_banner/announcement_banner.html
+++ b/layouts/partials/announcement_banner/announcement_banner.html
@@ -1,4 +1,4 @@
-{{ $announce := .Site.Params.announcement_banner }}
+{{ $announce := site.Params.announcement_banner }}
 {{ if not (in (slice "dg" "landing-page" "tshirt" "apm" "legal" "event" "webinar" "summit") .Type) }}
 <div class="announcement_banner open text-center">
 <!-- default announcement banner -->

--- a/layouts/partials/api/api-toolbar.html
+++ b/layouts/partials/api/api-toolbar.html
@@ -1,5 +1,5 @@
-{{ $url := replace .Permalink ( printf "%s" .Site.BaseURL) "" }}
-{{ $.Scratch.Add "path" .Site.BaseURL }}
+{{ $url := replace .Permalink ( printf "%s" site.BaseURL) "" }}
+{{ $.Scratch.Add "path" site.BaseURL }}
 
 <div class="api-toolbar pt-2 mb-lg-1 d-lg-flex justify-content-between">
     <div id="breadcrumbs">

--- a/layouts/partials/api/code-example.html
+++ b/layouts/partials/api/code-example.html
@@ -14,7 +14,7 @@
 {{ with $resourcePage.Resources.Match (printf "%s%s" $operationid ".*" ) }}
     {{ range . }}
       {{ $file_extension := index (split (path.Ext .) ".") 1 }}
-      {{ $lang := index $context.Page.Site.Params.code_languages $file_extension }}
+      {{ $lang := index site.Params.code_languages $file_extension }}
       {{ $codeLangs = $codeLangs | append $lang.name }}
     {{ end }}
 {{ end }}
@@ -23,7 +23,7 @@
 
 {{ $count := 0 }}
 {{ $file_extension := "sh" }}
-{{ $lang := index $context.Site.Params.code_languages "sh" }}
+{{ $lang := index site.Params.code_languages "sh" }}
 <div class="code-snippet-wrapper js-code-block" data-code-lang-block="{{ $lang.name }}" >
     <div class="code-snippet">
       <div class="code-button-wrapper position-absolute">
@@ -68,7 +68,7 @@
     {{ range . }}
         {{ $file_content := .Content }}
         {{ $file_extension := index (split (path.Ext .) ".") 1 }}
-        {{ $lang := index $context.Site.Params.code_languages $file_extension }}
+        {{ $lang := index site.Params.code_languages $file_extension }}
 
         {{ if ne $file_extension "sh"}}
           <div class="code-snippet-wrapper js-code-block" data-code-lang-block="{{ $lang.name }}">
@@ -83,7 +83,7 @@
             <p>First <a href="{{ "api/latest/" | absLangURL }}?code-lang={{ $lang.name }}">install the library and its dependencies</a> and then save the example to <code>{{ $lang.example_file }}</code> and run following commands:</p>
 
             <pre class="chroma">
-              <code class="language-fallback" data-lang="sh"><div class="code-snippet"><span class="kn">export</span> <span class="n">DD_SITE</span><span class="o">=</span><span class="s1">"{{- range $context.Site.Params.allowedRegions -}}
+              <code class="language-fallback" data-lang="sh"><div class="code-snippet"><span class="kn">export</span> <span class="n">DD_SITE</span><span class="o">=</span><span class="s1">"{{- range site.Params.allowedRegions -}}
                 {{- if not (index ($endpoint.regions) .value) -}}
                   <span class="d-none" data-region="{{ .value }}">Not supported in the {{ .name }} region</span>
                 {{- else -}}

--- a/layouts/partials/code-lang-tabs.html
+++ b/layouts/partials/code-lang-tabs.html
@@ -6,9 +6,9 @@
 
     {{ range .codeLangs }}
         <li class="nav-item" style="margin-bottom: 6px;">
-            <a class="nav-link mr-1 js-code-example-link" data-code-lang-trigger="{{ . }}" href="#">{{ index $.context.Site.Params.code_language_ids . }}</a>
+            <a class="nav-link mr-1 js-code-example-link" data-code-lang-trigger="{{ . }}" href="#">{{ index site.Params.code_language_ids . }}</a>
         </li>
         {{ $count = add $count 1 }}
     {{ end}}
 
-</ul>  
+</ul>

--- a/layouts/partials/footer-scripts.html
+++ b/layouts/partials/footer-scripts.html
@@ -18,7 +18,7 @@
 
 {{ $dot := . }}
 
-{{ range $k, $v := .Site.Params.footer_scripts }}
+{{ range $k, $v := site.Params.footer_scripts }}
 
     {{ range $i, $tag := $v }}
 

--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -5,12 +5,12 @@
 {{ $.Scratch.Set "data" "" }}
 {{ if ne $dot.Page.Lang "en"}}
     {{ if (fileExists (print "data/partials/footer." $dot.Page.Lang ".yaml")) }}
-      {{ $.Scratch.Set "data" (index $dot.Page.Site.Data.partials (print "footer." $dot.Page.Lang)) }}
+      {{ $.Scratch.Set "data" (index site.Data.partials (print "footer." $dot.Page.Lang)) }}
     {{ else }}
-      {{ $.Scratch.Set "data" $dot.Page.Site.Data.partials.footer }}
+      {{ $.Scratch.Set "data" site.Data.partials.footer }}
     {{ end }}
 {{ else }}
-    {{ $.Scratch.Set "data" $dot.Page.Site.Data.partials.footer }}
+    {{ $.Scratch.Set "data" site.Data.partials.footer }}
 {{ end }}
 {{ $datafile := ($.Scratch.Get "data") }}
 
@@ -35,38 +35,38 @@
                     {{ end}}
                 </a>
                 <p class="font-weight-semibold text-center text-lg-left mb-0">Download mobile app</p>
-                
+
                 <div class="d-flex d-lg-none justify-content-center ">
                     <a href="https://apps.apple.com/app/datadog/id1391380318" class="mr-1" aria-label="Apple Store Link">
                         {{ partial "svg" (dict "context" $dot "src" "app-store-badge.svg" )}}
-                    </a>             
+                    </a>
                     <a href="https://play.google.com/store/apps/details?id=com.datadog.app" aria-label="Google Play Store Link">
-                        {{ partial "svg" (dict "context" $dot "src" "google-play-badge.svg" )}}  
+                        {{ partial "svg" (dict "context" $dot "src" "google-play-badge.svg" )}}
                     </a>
                 </div>
 
                 <div class="d-none d-lg-flex justify-content-lg-start">
                     <a href="https://apps.apple.com/app/datadog/id1391380318" class="mr-2" aria-label="Apple Store Link">
                         {{ partial "svg" (dict "context" $dot "src" "apple.svg" )}}
-                    </a>             
+                    </a>
                     <a href="https://play.google.com/store/apps/details?id=com.datadog.app" aria-label="Google Play Store Link">
-                        {{ partial "svg" (dict "context" $dot "src" "google-play.svg" )}}  
+                        {{ partial "svg" (dict "context" $dot "src" "google-play.svg" )}}
                     </a>
                 </div>
             </div>
             <div class="col-12 col-lg-6  mt-3 mt-lg-0">
                 <p class="border-bottom border-gray mb-0">{{ i18n "product" }}</p>
 
-                {{ $lenFooterProduct := len .Site.Menus.footer_product }}
+                {{ $lenFooterProduct := len site.Menus.footer_product }}
                 {{ $secondHalfFooterProduct := div $lenFooterProduct 2 }}
                 {{ $firstHalfFooterProduct := sub $lenFooterProduct  $secondHalfFooterProduct }}
 
                 <div class="row">
                     <div class="col-6 col-lg-4">
                         <ul class="footer-menu mt-1">
-                            {{ range first $firstHalfFooterProduct .Site.Menus.footer_product }}
+                            {{ range first $firstHalfFooterProduct site.Menus.footer_product }}
                                 <li>
-                                    {{ if eq $.Site.Params.full_translation true }}
+                                    {{ if eq site.Params.full_translation true }}
                                         {{ partial "footer_link" (dict "footer_link" . "base_url" ( .URL | absLangURL) ) }}
                                     {{ else }}
                                         {{ partial "footer_link" (dict "footer_link" . "base_url" ( .URL | absURL) ) }}
@@ -77,9 +77,9 @@
                     </div>
                     <div class="col-6 col-lg-4">
                         <ul class="footer-menu mt-1">
-                            {{ range last $secondHalfFooterProduct .Site.Menus.footer_product }}
+                            {{ range last $secondHalfFooterProduct site.Menus.footer_product }}
                                 <li>
-                                    {{ if eq $.Site.Params.full_translation true }}
+                                    {{ if eq site.Params.full_translation true }}
                                         {{ partial "footer_link" (dict "footer_link" . "base_url" ( .URL | absLangURL) ) }}
                                     {{ else }}
                                         {{ partial "footer_link" (dict "footer_link" . "base_url" ( .URL | absURL) ) }}
@@ -94,9 +94,9 @@
 
                     <div class="d-none d-lg-block col-lg-4 ">
                         <ul class="footer-menu mt-1">
-                            {{ range .Site.Menus.footer_product_three }}
+                            {{ range site.Menus.footer_product_three }}
                             <li>
-                                {{ if eq $.Site.Params.full_translation true }}
+                                {{ if eq site.Params.full_translation true }}
                                     {{ partial "footer_link" (dict "footer_link" . "base_url" ( .URL | absLangURL) ) }}
                                 {{ else }}
                                     {{ partial "footer_link" (dict "footer_link" . "base_url" ( .URL | absURL) ) }}
@@ -105,12 +105,12 @@
                             {{end}}
                         </ul>
                     </div>
-                    
+
                     <div class="col-6 d-lg-none">
                         <ul class="footer-menu mt-1">
-                            {{ range first 3 .Site.Menus.footer_product_three }}
+                            {{ range first 3 site.Menus.footer_product_three }}
                             <li>
-                                {{ if eq $.Site.Params.full_translation true }}
+                                {{ if eq site.Params.full_translation true }}
                                     {{ partial "footer_link" (dict "footer_link" . "base_url" ( .URL | absLangURL) ) }}
                                 {{ else }}
                                     {{ partial "footer_link" (dict "footer_link" . "base_url" ( .URL | absURL) ) }}
@@ -121,9 +121,9 @@
                     </div>
                     <div class="col-6 d-lg-none">
                         <ul class="footer-menu mt-1">
-                            {{ range last 2 .Site.Menus.footer_product_three }}
+                            {{ range last 2 site.Menus.footer_product_three }}
                             <li>
-                                {{ if eq $.Site.Params.full_translation true }}
+                                {{ if eq site.Params.full_translation true }}
                                     {{ partial "footer_link" (dict "footer_link" . "base_url" ( .URL | absLangURL) ) }}
                                 {{ else }}
                                     {{ partial "footer_link" (dict "footer_link" . "base_url" ( .URL | absURL) ) }}
@@ -132,7 +132,7 @@
                             {{end}}
                         </ul>
                     </div>
-                   
+
                 </div>
             </div>
             <div class="col-12 col-lg-3 mt-3 mt-lg-0">
@@ -140,9 +140,9 @@
                     <div class="col-6 col-lg-8">
                         <p class="border-bottom border-gray">{{ i18n "about" }}</p>
                         <ul class="footer-menu mt-1">
-                            {{ range .Site.Menus.footer_about }}
+                            {{ range site.Menus.footer_about }}
                             <li>
-                                {{ if eq $.Site.Params.full_translation true }}
+                                {{ if eq site.Params.full_translation true }}
                                     {{ partial "footer_link" (dict "footer_link" . "base_url" ( .URL | absLangURL) ) }}
                                 {{ else }}
                                     {{ partial "footer_link" (dict "footer_link" . "base_url" ( .URL | absURL) ) }}
@@ -154,18 +154,18 @@
                     <div class="col-6 col-lg-4">
                         <p class="border-bottom border-gray">{{ i18n "blog" }}</p>
                         <ul class="footer-menu mt-1">
-                            {{ range .Site.Menus.footer_blog }}
+                            {{ range site.Menus.footer_blog }}
                             <li>
                                 {{ if eq (substr .URL 0 1) "/" }}
                                     <!-- to specifig lang page e.g /es/blog -->
-                                    {{ if $.Site.Params.branch }}
-                                        {{ $.Scratch.Set "flink" ( (print "/" $.Site.Params.branch .URL) | absURL) }}
+                                    {{ if site.Params.branch }}
+                                        {{ $.Scratch.Set "flink" ( (print "/" site.Params.branch .URL) | absURL) }}
                                     {{ else }}
                                         {{ $.Scratch.Set "flink" ( .URL | absURL) }}
                                     {{ end }}
                                     {{ partial "footer_link" (dict "footer_link" . "base_url" ($.Scratch.Get "flink") ) }}
                                 {{ else }}
-                                    {{ if eq $.Site.Params.full_translation true }}
+                                    {{ if eq site.Params.full_translation true }}
                                         {{ partial "footer_link" (dict "footer_link" . "base_url" ( .URL | absLangURL) ) }}
                                     {{ else }}
                                         {{ partial "footer_link" (dict "footer_link" . "base_url" ( .URL | absURL) ) }}
@@ -175,7 +175,7 @@
                             {{end}}
                         </ul>
                     </div>
-                    
+
                 </div>
 
             </div>
@@ -226,8 +226,8 @@
                         </div>
                         <div class="col-6 col-lg-2 mb-1 mb-lg-0 d-flex justify-content-lg-end">
                             <ul class="footer-menu d-flex  align-items-center">
-                                {{ range $index, $value := .Site.Menus.footer_social }}
-                                <li class="d-flex align-items-center {{ if ne $index ( sub (len $.Site.Menus.footer_social) 1 ) }} mr-2 mr-lg-1 mr-xl-2 {{end}}">
+                                {{ range $index, $value := site.Menus.footer_social }}
+                                <li class="d-flex align-items-center {{ if ne $index ( sub (len site.Menus.footer_social) 1 ) }} mr-2 mr-lg-1 mr-xl-2 {{end}}">
                                     <a class="d-flex align-items-center" href="{{ .URL }}" aria-label="{{ .Name }} link">{{ partial "svg" (dict "context" $dot "src" .Pre  )}}  </a>
                                 </li>
                                 {{end}}
@@ -236,12 +236,12 @@
                         <div class="col-12 col-lg-6 order-lg-first d-flex align-items-center" style="transform: translateY(-2px);">
                             <span class="copyright">&copy; Datadog {{ $date := now }} {{ $date.Format "2006"}} &nbsp;</span>
                             <ul class="footer-menu d-flex align-items-center">
-                                {{ range $index, $v := .Site.Menus.footer_sub }}
+                                {{ range $index, $v := site.Menus.footer_sub }}
                                     <li class="d-flex align-items-center">
-                                        {{ if eq $.Site.Params.full_translation true }}
-                                            <a href="{{ "" | absLangURL }}{{.URL}}">{{$v.Name}}</a>{{ if ne $index ( sub (len $.Site.Menus.footer_sub) 1 ) }}<span style="font-size: 16px; transform: translateY(-1px);">&nbsp;|&nbsp;</span>{{end}}
+                                        {{ if eq site.Params.full_translation true }}
+                                            <a href="{{ "" | absLangURL }}{{.URL}}">{{$v.Name}}</a>{{ if ne $index ( sub (len site.Menus.footer_sub) 1 ) }}<span style="font-size: 16px; transform: translateY(-1px);">&nbsp;|&nbsp;</span>{{end}}
                                         {{ else }}
-                                            <a href="{{ "" | absURL }}{{.URL}}">{{$v.Name}}</a>{{ if ne $index ( sub (len $.Site.Menus.footer_sub) 1 ) }}<span style="font-size: 16px; transform: translateY(-1px);">&nbsp;|&nbsp;</span>{{end}}
+                                            <a href="{{ "" | absURL }}{{.URL}}">{{$v.Name}}</a>{{ if ne $index ( sub (len site.Menus.footer_sub) 1 ) }}<span style="font-size: 16px; transform: translateY(-1px);">&nbsp;|&nbsp;</span>{{end}}
                                         {{ end }}
                                     </li>
                                 {{ end }}
@@ -251,8 +251,8 @@
                 </div>
             </div>
         </div>
-        
-        
+
+
     </div>
 </footer>
 

--- a/layouts/partials/head_scripts/google-site-tag.html
+++ b/layouts/partials/head_scripts/google-site-tag.html
@@ -1,10 +1,10 @@
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.Params.ga }}"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.Params.ga }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag() { dataLayer.push(arguments); }
   gtag('js', new Date());
 
-  gtag('config', '{{ .Site.Params.ga }}');
+  gtag('config', '{{ site.Params.ga }}');
 </script>
 <!-- END -->

--- a/layouts/partials/head_scripts/hotjar.html
+++ b/layouts/partials/head_scripts/hotjar.html
@@ -2,7 +2,7 @@
 <script>
   (function (h, o, t, j, a, r) {
     h.hj = h.hj || function () { (h.hj.q = h.hj.q || []).push(arguments) };
-    h._hjSettings = { hjid: {{ $.Site.Params.hotjar.id }}, hjsv: 6 };
+    h._hjSettings = { hjid: {{ site.Params.hotjar.id }}, hjsv: 6 };
     a = o.getElementsByTagName('head')[0];
     r = o.createElement('script'); r.async = 1;
     r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;

--- a/layouts/partials/header-scripts.html
+++ b/layouts/partials/header-scripts.html
@@ -18,7 +18,7 @@
 
 {{ $dot := . }}
 
-{{ range $k, $v := .Site.Params.header_scripts }}
+{{ range $k, $v := site.Params.header_scripts }}
 
     {{ range $i, $tag := $v }}
 

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -1,8 +1,8 @@
 {{ $dot := . }}
 {{ $base := "" | absLangURL }}
-{{ $announce := .Site.Params.announcement_banner }}
+{{ $announce := site.Params.announcement_banner }}
 {{ $btnClass := "btn btn-gradient knockout-around js-cta-topRight" }}
-{{ $SignUpClass := .Site.Params.SignUpClass }}
+{{ $SignUpClass := site.Params.SignUpClass }}
 {{ if $announce }}
     {{ partial "announcement_banner/announcement_banner.html" . }}
 {{ end }}
@@ -12,7 +12,7 @@
         <div class="mainnav d-none d-xl-flex row align-items-center no-gutters">
             <div class="col">
                 <ul class="nav navbar-left">
-                    {{ range .Site.Menus.main_left   }}
+                    {{ range site.Menus.main_left   }}
                     {{ if .HasChildren }}
                     <li class="dropdown {{ .Identifier }}-dropdown nav-item">
                         <a href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}" class="nav-link dropdown {{ if eq .Name "Solutions" }} solutions{{ end }}">{{.Name}}</a>
@@ -88,8 +88,8 @@
             <div class="col-1 text-center">
                 {{ $allowedLangs := (slice "ja") }}
                 {{ .Scratch.Set "logoURL" "https://www.datadoghq.com/" }}
-                {{ if in $allowedLangs .Site.Language.Lang }}
-                  {{ .Scratch.Set "logoURL" (print "https://www.datadoghq.com/" .Site.Language.Lang "/") }}
+                {{ if in $allowedLangs site.Language.Lang }}
+                  {{ .Scratch.Set "logoURL" (print "https://www.datadoghq.com/" site.Language.Lang "/") }}
                 {{ end }}
                 {{ $logoURL := .Scratch.Get "logoURL" }}
                 <a href="{{ $logoURL }}" id="logo">
@@ -100,7 +100,7 @@
             <div class="col">
                 <!-- Menu: Right menu items -->
 <ul class="nav justify-content-end">
-  {{ range .Site.Menus.main_right }}
+  {{ range site.Menus.main_right }}
   {{ if .HasChildren }}
       <li class="dropdown nav-item">
         <a href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}" class="dropdown nav-link">{{.Name}}</a>

--- a/layouts/partials/home-header.html
+++ b/layouts/partials/home-header.html
@@ -4,12 +4,12 @@
 {{ $.Scratch.Set "data" "" }}
 {{ if ne $dot.Page.Lang "en"}}
     {{ if (fileExists (print "data/partials/home." $dot.Page.Lang ".yaml")) }}
-      {{ $.Scratch.Set "data" (index $dot.Page.Site.Data.partials (print "home." $dot.Page.Lang)) }}
+      {{ $.Scratch.Set "data" (index site.Data.partials (print "home." $dot.Page.Lang)) }}
     {{ else }}
-      {{ $.Scratch.Set "data" $dot.Page.Site.Data.partials.home }}
+      {{ $.Scratch.Set "data" site.Data.partials.home }}
     {{ end }}
 {{ else }}
-    {{ $.Scratch.Set "data" $dot.Page.Site.Data.partials.home }}
+    {{ $.Scratch.Set "data" site.Data.partials.home }}
 {{ end }}
 {{ $datafile := ($.Scratch.Get "data") }}
 
@@ -33,7 +33,7 @@
                         </form>
                 </div>
                 <p class="smaller text-white text-center font-semibold popular-search">
-                    Popular searches: 
+                    Popular searches:
                     {{ $lenList := (len $datafile.popular_searches)}}
                     {{ range $index, $popular_search := (sort $datafile.popular_searches "weight" "asc") }}
                         <a href="{{ $popular_search.link | absLangURL }}">{{ $popular_search.title }}</a>{{ if eq (sub $lenList 2) $index }}, and{{ else if eq (sub $lenList 1) $index }}{{ else }},{{ end}}

--- a/layouts/partials/img-resource.html
+++ b/layouts/partials/img-resource.html
@@ -1,1 +1,1 @@
-{{- $dot := .context -}}{{- with resources.Get .src  -}}{{- $perm := ( . | resources.Fingerprint "md5").RelPermalink -}}{{- print (strings.TrimRight "/" $dot.Site.Params.img_url) $perm -}}{{- end -}}
+{{- $dot := .context -}}{{- with resources.Get .src  -}}{{- $perm := ( . | resources.Fingerprint "md5").RelPermalink -}}{{- print (strings.TrimRight "/" site.Params.img_url) $perm -}}{{- end -}}

--- a/layouts/partials/img.html
+++ b/layouts/partials/img.html
@@ -5,7 +5,7 @@
 {{ end }}
 {{ $img_param := .root.Scratch.Get "img_param" }}
 
-{{ $url := (print (.root.Site.Params.img_url) (printf "%s/%s" "images" .src)  ($img_param)) | safeURL }}
+{{ $url := (print (site.Params.img_url) (printf "%s/%s" "images" .src)  ($img_param)) | safeURL }}
 
 {{ $image_type_arr := split .src "." }}
 {{ $image_ext := index $image_type_arr 1 }}

--- a/layouts/partials/imgurl.html
+++ b/layouts/partials/imgurl.html
@@ -1,1 +1,1 @@
-{{ $.Site.Params.img_url }}images/{{  .src  }}
+{{ site.Params.img_url }}images/{{  .src  }}

--- a/layouts/partials/language-region-select.html
+++ b/layouts/partials/language-region-select.html
@@ -26,7 +26,7 @@
     <div class="d-flex">
       <p class="text-uppercase">Site</p>
       <a href="/getting_started/site/" class="{{ if ne .Page.Type "api" }}ml-1{{ else }}mr-1{{ end }} d-inline-flex">
-        <img src="{{ .Site.Params.img_url }}images/icons/help-druids.svg" height="18" width="18" />
+        <img src="{{ site.Params.img_url }}images/icons/help-druids.svg" height="18" width="18" />
       </a>
     </div>
     <div class="dropdown bootstrap-dropdown-custom js-region-select">
@@ -36,7 +36,7 @@
         <div class="chevron chevron-up d-none"></div>
       </button>
       <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-        {{ range sort .Site.Params.allowedRegions ".weight" "asc" }}
+        {{ range sort site.Params.allowedRegions ".weight" "asc" }}
           <a class="dropdown-item" data-value="{{ .value }}">{{ .name }}</a>
         {{ end }}
       </div>

--- a/layouts/partials/menulink.html
+++ b/layouts/partials/menulink.html
@@ -1,6 +1,6 @@
 {{- $dot := (index $ 3) -}}
 {{- $no_base_urls := ( slice "documentation" "login" "enterprise_cta" "api") -}}
-{{- if eq $dot.Site.Params.full_translation true -}}
+{{- if eq site.Params.full_translation true -}}
     {{- $dot.Scratch.Set "url" ((index $ 1) | absLangURL) -}}
 {{- else -}}
     {{- $dot.Scratch.Set "url" ((index $ 1) | absURL) -}}

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -7,7 +7,7 @@
 {{ else if $.Params.title }}
     {{ $.Scratch.Add "meta_title" $.Params.title }}
 {{ else }}
-    {{ $.Scratch.Add "meta_title" .Site.Params.meta_title }}
+    {{ $.Scratch.Add "meta_title" site.Params.meta_title }}
 {{ end }}
 {{ $meta_title := $.Scratch.Get "meta_title" }}
 
@@ -16,7 +16,7 @@
 {{ else if $.Params.Description }}
     {{ $.Scratch.Add "meta_desc" $.Params.description }}
 {{ else }}
-    {{ $.Scratch.Add "meta_desc" .Site.Params.meta_description }}
+    {{ $.Scratch.Add "meta_desc" site.Params.meta_description }}
 {{ end }}
 {{ $meta_desc := $.Scratch.Get "meta_desc" }}
 
@@ -26,21 +26,21 @@
 <meta itemprop="description" content="{{ $meta_desc | safeHTML }}">
 
 <!-- Twitter Card data -->
-{{ if $meta_image}}<meta name="twitter:card" content="{{.Site.Params.img_url}}images{{ $meta_image }}">{{ end }}
+{{ if $meta_image}}<meta name="twitter:card" content="{{site.Params.img_url}}images{{ $meta_image }}">{{ end }}
 <meta name="twitter:site" content="@datadoghq">
 <meta name="twitter:title" content="{{ $meta_title | safeHTML }}">
 <meta name="twitter:description" content="{{ $meta_desc | safeHTML }}">
 <meta name="twitter:creator" content="@datadoghq">
 <!-- Twitter summary card with large image must be at least 280x150px -->
-{{ if $meta_image}}<meta name="twitter:image:src" content="{{.Site.Params.img_url}}images{{ $meta_image }}">{{ end }}
+{{ if $meta_image}}<meta name="twitter:image:src" content="{{site.Params.img_url}}images{{ $meta_image }}">{{ end }}
 
 <!-- Open Graph data -->
 <meta property="og:title" content="{{ $meta_title }}"/>
 <meta property="og:type" content="article"/>
 <meta property="og:url" content="{{ $.Permalink }}"/>
-{{ if $meta_image}}<meta property="og:image" content="{{.Site.Params.img_url}}images{{ $meta_image }}"/>{{ else }}<meta property="og:image" content="{{.Site.Params.img_url}}{{- partial "imgurl.html" (dict "root" $dot "src" "dd-docs-meta-image.png" ) -}}"/>{{ end }}
+{{ if $meta_image}}<meta property="og:image" content="{{site.Params.img_url}}images{{ $meta_image }}"/>{{ else }}<meta property="og:image" content="{{site.Params.img_url}}{{- partial "imgurl.html" (dict "root" $dot "src" "dd-docs-meta-image.png" ) -}}"/>{{ end }}
 <meta property="og:description" content="{{ $meta_desc }}"/>
-<meta property="og:site_name" content="{{ .Site.Params.site_name }}"/>
+<meta property="og:site_name" content="{{ site.Params.site_name }}"/>
 <meta property="article:author" content="Datadog"/>
 
 <!-- Address Bar Matches Brand Colors -->

--- a/layouts/partials/nav/api-main-menu.html
+++ b/layouts/partials/nav/api-main-menu.html
@@ -3,10 +3,10 @@
 {{ $apiMenu := "api" }}
 
 <!-- if no api menu in other languages fallback to english -->
-{{ with index .Site.Menus $apiMenu }}
+{{ with index site.Menus $apiMenu }}
   {{ $dot.Scratch.Set "menu" . }}
 {{ else }}
-  {{ $dot.Scratch.Set "menu" (index .Sites.First.Menus $apiMenu) }}
+  {{ $dot.Scratch.Set "menu" (index site.First.Menus $apiMenu) }}
 {{ end }}
 {{ $menu := .Scratch.Get "menu" }}
 

--- a/layouts/partials/nav/api-main-menu.html
+++ b/layouts/partials/nav/api-main-menu.html
@@ -6,7 +6,7 @@
 {{ with index site.Menus $apiMenu }}
   {{ $dot.Scratch.Set "menu" . }}
 {{ else }}
-  {{ $dot.Scratch.Set "menu" (index site.First.Menus $apiMenu) }}
+  {{ $dot.Scratch.Set "menu" (index .Sites.First.Menus $apiMenu) }}
 {{ end }}
 {{ $menu := .Scratch.Get "menu" }}
 

--- a/layouts/partials/nav/main-menu.html
+++ b/layouts/partials/nav/main-menu.html
@@ -1,13 +1,13 @@
 {{ $dot := . }}
 {{ $ctx := . }}
-{{ $menu := .Site.Menus.main }}
+{{ $menu := site.Menus.main }}
 {{/* Menu identifiers to apply class to */}}
 {{ $excludeAsyc := (slice "api" "dev_tools_metrics_api" "dev_tools_events_api" "integrations_top_level" "tracing api" "watchdog_top_level" "glossary_top_level" "video_top_level" "help_top_level" "other_integrations") }}
 
-{{ $path := (printf "%s/" $.Site.Params.branch) }}
+{{ $path := (printf "%s/" site.Params.branch) }}
 
 {{/* account for branch name in preview site for data-path */}}
-{{ if eq $.Site.Params.environment "preview"}}          
+{{ if eq site.Params.environment "preview"}}
     {{ $.Scratch.Set "branch_path" $path }}
 {{ else }}
     {{ $.Scratch.Set "branch_path" "" }}
@@ -17,7 +17,7 @@
 
 <ul class="list-unstyled">
     {{ $currentPage := . }}
-    {{ range .Site.Menus.main }}
+    {{ range site.Menus.main }}
         {{ if .HasChildren }}
             <li class="nav-top-level {{ if (not (in $excludeAsyc .Identifier)) }} js-load {{ end }}
             {{ if $currentPage.HasMenuCurrent "main" . }}active{{ end }}">

--- a/layouts/partials/platforms/platforms.html
+++ b/layouts/partials/platforms/platforms.html
@@ -4,12 +4,12 @@
 {{ $.Scratch.Set "data" "" }}
 {{ if ne $dot.Page.Lang "en"}}
     {{ if (fileExists (print "data/partials/platforms." $dot.Page.Lang ".yaml")) }}
-      {{ $.Scratch.Set "data" (index $dot.Page.Site.Data.partials (print "platforms." $dot.Page.Lang)) }}
+      {{ $.Scratch.Set "data" (index site.Data.partials (print "platforms." $dot.Page.Lang)) }}
     {{ else }}
-      {{ $.Scratch.Set "data" $dot.Page.Site.Data.partials.platforms }}
+      {{ $.Scratch.Set "data" site.Data.partials.platforms }}
     {{ end }}
 {{ else }}
-    {{ $.Scratch.Set "data" $dot.Page.Site.Data.partials.platforms }}
+    {{ $.Scratch.Set "data" site.Data.partials.platforms }}
 {{ end }}
 {{ $datafile := ($.Scratch.Get "data") }}
 
@@ -52,7 +52,7 @@
               <a class="card" href="{{ .link | absLangURL }}">
                   <div class="card-body text-center">
                       {{ $src := (print "icons/" .image)}}
-                      {{ $url := (print ($dot.Site.Params.img_url) "images/" $src "?ch=Width,DPR&fit=max&auto=format") | safeURL }}
+                      {{ $url := (print (site.Params.img_url) "images/" $src "?ch=Width,DPR&fit=max&auto=format") | safeURL }}
                       <picture class="mx-auto">
                           <source srcset="{{ $url }}&w=138 1x, {{ $url }}&w=138&dpr=2 2x" media="(min-width: 1200px)">
                           <source srcset="{{ $url }}&w=108 1x, {{ $url }}&w=108&dpr=2 2x" media="(min-width: 992px)">

--- a/layouts/partials/preload.html
+++ b/layouts/partials/preload.html
@@ -1,7 +1,7 @@
-<link rel="preload" as="font" type="font/woff2" href="{{ .Site.BaseURL }}fonts/NationalWeb-Light.woff2" crossorigin="anonymous">
-<link rel="preload" as="font" type="font/woff2" href="{{ .Site.BaseURL }}fonts/NationalWeb-Semibold.woff2" crossorigin="anonymous">
+<link rel="preload" as="font" type="font/woff2" href="{{ site.BaseURL }}fonts/NationalWeb-Light.woff2" crossorigin="anonymous">
+<link rel="preload" as="font" type="font/woff2" href="{{ site.BaseURL }}fonts/NationalWeb-Semibold.woff2" crossorigin="anonymous">
 
-{{ if eq .Site.Language.Lang "ja" }}
-    <link rel="preload" as="font" type="font/woff2" href="{{ .Site.BaseURL }}fonts/web-fonts/noto-sans-jp-v24-latin-300.woff2" crossorigin="anonymous">
-    <link rel="preload" as="font" type="font/woff2" href="{{ .Site.BaseURL }}fonts/web-fonts/noto-sans-jp-v24-latin-700.woff2" crossorigin="anonymous">
+{{ if eq site.Language.Lang "ja" }}
+    <link rel="preload" as="font" type="font/woff2" href="{{ site.BaseURL }}fonts/web-fonts/noto-sans-jp-v24-latin-300.woff2" crossorigin="anonymous">
+    <link rel="preload" as="font" type="font/woff2" href="{{ site.BaseURL }}fonts/web-fonts/noto-sans-jp-v24-latin-700.woff2" crossorigin="anonymous">
 {{ end }}

--- a/layouts/partials/preview_banner/preview_banner.html
+++ b/layouts/partials/preview_banner/preview_banner.html
@@ -1,5 +1,5 @@
-{{ if eq .Site.Params.environment "preview" }}
+{{ if eq site.Params.environment "preview" }}
 <div class="preview-banner">
-    PREVIEWING: <a class="no-check" href="https://github.com/DataDog/documentation/tree/{{ .Site.Params.branch }}"> {{ .Site.Params.branch }} </a>
+    PREVIEWING: <a class="no-check" href="https://github.com/DataDog/documentation/tree/{{ site.Params.branch }}"> {{ site.Params.branch }} </a>
 </div>
 {{ end }}

--- a/layouts/partials/questions/questions.html
+++ b/layouts/partials/questions/questions.html
@@ -4,12 +4,12 @@
 {{ $.Scratch.Set "data" "" }}
 {{ if ne $dot.Page.Lang "en"}}
     {{ if (fileExists (print "data/partials/questions." $dot.Page.Lang ".yaml")) }}
-      {{ $.Scratch.Set "data" (index $dot.Page.Site.Data.partials (print "questions." $dot.Page.Lang)) }}
+      {{ $.Scratch.Set "data" (index site.Data.partials (print "questions." $dot.Page.Lang)) }}
     {{ else }}
-      {{ $.Scratch.Set "data" $dot.Page.Site.Data.partials.questions }}
+      {{ $.Scratch.Set "data" site.Data.partials.questions }}
     {{ end }}
 {{ else }}
-    {{ $.Scratch.Set "data" $dot.Page.Site.Data.partials.questions }}
+    {{ $.Scratch.Set "data" site.Data.partials.questions }}
 {{ end }}
 {{ $datafile := ($.Scratch.Get "data") }}
 

--- a/layouts/partials/security-rule-map.html
+++ b/layouts/partials/security-rule-map.html
@@ -1,8 +1,8 @@
 {{ $dot := . }}
-{{ $data := $dot.ctx.Site.Data.security_monitoring.data }}
+{{ $data := site.Data.security_monitoring.data }}
 {{ $img_map := $data.image_map }}
 {{ $img_path := "images/integrations_logos/" }}
-{{ $img_url := printf "%s%s" $dot.ctx.Site.Params.img_url $img_path }}
+{{ $img_url := printf "%s%s" site.Params.img_url $img_path }}
 {{ $source := .source }}
 {{ $scope := .scope }}
 
@@ -20,7 +20,7 @@
             {{ else }}
                 {{ $src_img = printf "%s" .image }}
             {{ end }}
-            
+
             {{ if .link }}
                 {{ $src_link = printf "integrations/%s" .link }}
             {{ else }}

--- a/layouts/partials/translate_status_banner/translate_status_banner.html
+++ b/layouts/partials/translate_status_banner/translate_status_banner.html
@@ -11,7 +11,7 @@
   {{ $outdated := $dot.Scratch.Get "outdated" }}
 
   {{ if (and $outdated (not .Params.placeholder)) }}
-    {{ $text := .Site.Params.translate_status_banner | default "" }}
+    {{ $text := site.Params.translate_status_banner | default "" }}
     <div class="translate_status_banner text-left">
       <a href="{{ range where $dot.Page.Translations "Lang" "en"}}{{ .Permalink }}{{ end }}?lang_pref=en">
         <div class='alert alert-info'>{{ $text }}</div>

--- a/layouts/section/videos.html
+++ b/layouts/section/videos.html
@@ -4,7 +4,7 @@
 <section>
     <ul>
         {{ $data := .Data }}
-        {{ range $key, $value := index .Site.Taxonomies "video-categories" }}
+        {{ range $key, $value := index site.Taxonomies "video-categories" }}
         {{ $link := absLangURL (print "video-categories/" ($key | urlize) "/") }}
         <li><a href="{{ $link }}">{{ $key }}</a> - ({{ len $value }})</li>
         {{ end }}

--- a/layouts/security_rules/single.html
+++ b/layouts/security_rules/single.html
@@ -46,7 +46,7 @@
 	</div>
 
 	{{ if isset .Params "source" }}
-		{{ with .Site.GetPage (print "/" $meta_image.rellink) }}
+		{{ with site.GetPage (print "/" $meta_image.rellink) }}
 			<p>Set up the <a href="{{ $meta_image.link }}">{{ $dot.Params.source }}</a> integration.</p>
 		{{ end }}
 	{{ end }}

--- a/layouts/shortcodes/classic-libraries-table.html
+++ b/layouts/shortcodes/classic-libraries-table.html
@@ -2,12 +2,12 @@
 {{ $.Scratch.Set "data" "" }}
 {{ if ne $.Page.Lang "en"}}
     {{ if (fileExists (print "data/libraries." $.Page.Lang ".yaml")) }}
-      {{ $.Scratch.Set "data" (index $.Site.Data (print "libraries." $.Page.Lang)) }}
+      {{ $.Scratch.Set "data" (index site.Data (print "libraries." $.Page.Lang)) }}
     {{ else }}
-      {{ $.Scratch.Set "data" $.Site.Data.libraries }}
+      {{ $.Scratch.Set "data" site.Data.libraries }}
     {{ end }}
 {{ else }}
-    {{ $.Scratch.Set "data" $.Site.Data.libraries }}
+    {{ $.Scratch.Set "data" site.Data.libraries }}
 {{ end }}
 {{ $datafile := ($.Scratch.Get "data") }}
 

--- a/layouts/shortcodes/dashboards-widgets-api.html
+++ b/layouts/shortcodes/dashboards-widgets-api.html
@@ -2,7 +2,7 @@
 {{ $widget_type := .Page.Params.widget_type | default .Page.File.TranslationBaseName }}
 {{ $dot.Scratch.Set "json" "" }}
 {{ $dot.Scratch.Set "html" "" }}
-{{ with .Site.GetPage "/api/v1/dashboards/_index.md" }}
+{{ with site.GetPage "/api/v1/dashboards/_index.md" }}
   {{ with .Resources.Match "widgets.json" }}
     {{ range . }}
         {{ $data := . | unmarshal }}

--- a/layouts/shortcodes/dashboards-widgets-list.html
+++ b/layouts/shortcodes/dashboards-widgets-list.html
@@ -6,7 +6,7 @@
 </style>
 <div class="whatsnext">
     <ul class="list-group">
-        {{ range $dot.Site.Data.api.v1.full_spec_deref.components.schemas.WidgetDefinition.oneOf }}
+        {{ range site.Data.api.v1.full_spec_deref.components.schemas.WidgetDefinition.oneOf }}
           {{ $s := .properties.type.default }}
           {{ $pageExists := false }}
           {{ $filename := (lower (replace (humanize $s) " " "_" )) }}

--- a/layouts/shortcodes/detection-rules.html
+++ b/layouts/shortcodes/detection-rules.html
@@ -1,9 +1,9 @@
 {{ $dot := . }}
 
-{{ printf "%s" .Site.GetPage "/security_monitoring/default_rules" }}
+{{ printf "%s" site.GetPage "/security_monitoring/default_rules" }}
 
 {{/* Comment */}}
-{{ $rules := .Site.GetPage "/security_monitoring/default_rules/cloudtrail-aws-cloudtrail-configuration-modified.json" }}
+{{ $rules := site.GetPage "/security_monitoring/default_rules/cloudtrail-aws-cloudtrail-configuration-modified.json" }}
 
 {{/*  {{ range $rules }}
     <h2>{{ .name }}</h2>

--- a/layouts/shortcodes/get-metrics-from-git.html
+++ b/layouts/shortcodes/get-metrics-from-git.html
@@ -14,18 +14,18 @@
 
 {{ $integration := $.Scratch.Get "integration" }}
 
-{{ if or (not (eq $.Page.Site.Params.environment "development")) ($.Page.Site.Data.integrations) }}
+{{ if or (not (eq site.Params.environment "development")) (site.Data.integrations) }}
 
   <!-- get lang specific data file -->
   {{ $.Scratch.Set "data" "" }}
   {{ if ne $.Page.Lang "en"}}
       {{ if (fileExists (print "data/integrations/" $integration "." $.Page.Lang ".yaml")) }}
-        {{ $.Scratch.Set "data" (index $.Page.Site.Data.integrations (print $integration "." $.Page.Lang)) }}
+        {{ $.Scratch.Set "data" (index site.Data.integrations (print $integration "." $.Page.Lang)) }}
       {{ else }}
-        {{ $.Scratch.Set "data" (index $.Page.Site.Data.integrations $integration) }}
+        {{ $.Scratch.Set "data" (index site.Data.integrations $integration) }}
       {{ end }}
   {{ else }}
-      {{ $.Scratch.Set "data" (index $.Page.Site.Data.integrations $integration) }}
+      {{ $.Scratch.Set "data" (index site.Data.integrations $integration) }}
   {{ end }}
   {{ $data := ($.Scratch.Get "data") }}
 

--- a/layouts/shortcodes/get-service-checks-from-git.html
+++ b/layouts/shortcodes/get-service-checks-from-git.html
@@ -14,18 +14,18 @@
 
 {{ $integration := $.Scratch.Get "integration" }}
 
-{{ if or (not (eq $.Page.Site.Params.environment "development")) ($.Page.Site.Data.service_checks) }}
+{{ if or (not (eq site.Params.environment "development")) (site.Data.service_checks) }}
 
   <!-- get lang specific data file -->
   {{ $.Scratch.Set "data" "" }}
   {{ if ne $.Page.Lang "en"}}
       {{ if (fileExists (print "data/service_checks/" $integration "." $.Page.Lang ".json")) }}
-        {{ $.Scratch.Set "data" (index $.Page.Site.Data.service_checks (print $integration "." $.Page.Lang)) }}
+        {{ $.Scratch.Set "data" (index site.Data.service_checks (print $integration "." $.Page.Lang)) }}
       {{ else }}
-        {{ $.Scratch.Set "data" (index $.Page.Site.Data.service_checks $integration) }}
+        {{ $.Scratch.Set "data" (index site.Data.service_checks $integration) }}
       {{ end }}
   {{ else }}
-      {{ $.Scratch.Set "data" (index $.Page.Site.Data.service_checks $integration) }}
+      {{ $.Scratch.Set "data" (index site.Data.service_checks $integration) }}
   {{ end }}
   {{ $data := ($.Scratch.Get "data") }}
 

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -12,7 +12,7 @@
 {{- $wide :=  .Get "wide" -}}
 {{- $video :=  .Get "video" -}}
 {{- $src := (.Get "src") -}}
-{{- $img := (print .Site.Params.img_url "images/" $src) -}}
+{{- $img := (print site.Params.img_url "images/" $src) -}}
 
 {{- $img_resource := partial "img-resource.html" (dict "context" . "src" (print "images/" $src)) -}}
 

--- a/layouts/shortcodes/integration-items.html
+++ b/layouts/shortcodes/integration-items.html
@@ -1,4 +1,4 @@
-{{ $integrations := where (where .Site.Pages "Params.kind" "=" "integration") ".Params.beta" "!=" "true" }}
+{{ $integrations := where (where site.Pages "Params.kind" "=" "integration") ".Params.beta" "!=" "true" }}
 
 {{ $lower := sort $integrations "Params.integration_title" }}
 

--- a/layouts/shortcodes/integrations.html
+++ b/layouts/shortcodes/integrations.html
@@ -2,10 +2,10 @@
 
 <!-- From data file -->
 {{ $kind := "integration" }}
-{{ if eq .Site.Language.Lang "ja"}}
+{{ if eq site.Language.Lang "ja"}}
     {{ $kind = "インテグレーション"}}
 {{ end }}
-{{ $integration_list := sort (where (where (where .Site.Pages "Params.kind" "=" $kind) ".Params.beta" "!=" "true") ".Params.is_public" "=" true) ".File.BaseFileName" }}
+{{ $integration_list := sort (where (where (where site.Pages "Params.kind" "=" $kind) ".Params.beta" "!=" "true") ".Params.is_public" "=" true) ".File.BaseFileName" }}
 
 <!-- build filters -->
 {{ $.Scratch.Set "filters" (slice)}}
@@ -98,9 +98,9 @@
                     <a class="card-img" href="{{ (print "integrations/" ($urlname | lower)) | absLangURL }}">
                         {{ $.Scratch.Set "url" ""}}
                         {{ if $indx }}
-                            {{ $.Scratch.Set "url" (print (.Site.Params.img_url) $indx "?auto=format") | safeURL }}
+                            {{ $.Scratch.Set "url" (print (site.Params.img_url) $indx "?auto=format") | safeURL }}
                         {{ else }}
-                            {{ $.Scratch.Set "url" (print (.Site.Params.img_url) "integrations_logos/dd-noimage.png" "?auto=format") | safeURL }}
+                            {{ $.Scratch.Set "url" (print (site.Params.img_url) "integrations_logos/dd-noimage.png" "?auto=format") | safeURL }}
                         {{ end }}
                         {{ $url := $.Scratch.Get "url" }}
                         <picture class="mx-auto">

--- a/layouts/shortcodes/log-libraries-table.html
+++ b/layouts/shortcodes/log-libraries-table.html
@@ -2,12 +2,12 @@
 {{ $.Scratch.Set "data" "" }}
 {{ if ne $.Page.Lang "en"}}
     {{ if (fileExists (print "data/libraries." $.Page.Lang ".yaml")) }}
-      {{ $.Scratch.Set "data" (index $.Site.Data (print "libraries." $.Page.Lang)) }}
+      {{ $.Scratch.Set "data" (index site.Data (print "libraries." $.Page.Lang)) }}
     {{ else }}
-      {{ $.Scratch.Set "data" $.Site.Data.libraries }}
+      {{ $.Scratch.Set "data" site.Data.libraries }}
     {{ end }}
 {{ else }}
-    {{ $.Scratch.Set "data" $.Site.Data.libraries }}
+    {{ $.Scratch.Set "data" site.Data.libraries }}
 {{ end }}
 {{ $datafile := ($.Scratch.Get "data") }}
 

--- a/layouts/shortcodes/permissions.html
+++ b/layouts/shortcodes/permissions.html
@@ -1,4 +1,4 @@
-{{ $permissions_data := $.Site.Data.permissions }}
+{{ $permissions_data := site.Data.permissions }}
 {{ $single_permission_group := .Get "group" }}
 
 {{/* Passing a single permission group name allows us to render one set of permissions at a time.   Currently this is used to separate General from Advanced Permissions on the account_management/rbac/permissions page, but could be re-used elsewhere in the future. */}}

--- a/layouts/shortcodes/serverless-libraries-table.html
+++ b/layouts/shortcodes/serverless-libraries-table.html
@@ -2,12 +2,12 @@
 {{ $.Scratch.Set "data" "" }}
 {{ if ne $.Page.Lang "en"}}
     {{ if (fileExists (print "data/libraries." $.Page.Lang ".yaml")) }}
-      {{ $.Scratch.Set "data" (index $.Site.Data (print "libraries." $.Page.Lang)) }}
+      {{ $.Scratch.Set "data" (index site.Data (print "libraries." $.Page.Lang)) }}
     {{ else }}
-      {{ $.Scratch.Set "data" $.Site.Data.libraries }}
+      {{ $.Scratch.Set "data" site.Data.libraries }}
     {{ end }}
 {{ else }}
-    {{ $.Scratch.Set "data" $.Site.Data.libraries }}
+    {{ $.Scratch.Set "data" site.Data.libraries }}
 {{ end }}
 {{ $datafile := ($.Scratch.Get "data") }}
 

--- a/layouts/shortcodes/tag-set-examples.html
+++ b/layouts/shortcodes/tag-set-examples.html
@@ -1,6 +1,6 @@
 <section id="menu">
     <ul>
-        {{ range $key, $taxonomy := .Site.Taxonomies.examples }}
+        {{ range $key, $taxonomy := site.Taxonomies.examples }}
 
           {{ $examples := where ($taxonomy.Pages) "Section" "examples" }}
 

--- a/layouts/shortcodes/tile-nav.html
+++ b/layouts/shortcodes/tile-nav.html
@@ -2,7 +2,7 @@
     <div class="card-deck">
         <a class="card agent" href="{{ "agent/" | absLangURL }}">
             <div class="card-body text-center">
-                {{ $url := (print (.Site.Params.img_url) "images/icons/agent.png"  "?ch=Width,DPR&fit=max&auto=format") | safeURL }}
+                {{ $url := (print (site.Params.img_url) "images/icons/agent.png"  "?ch=Width,DPR&fit=max&auto=format") | safeURL }}
                 <picture class="mx-auto">
                     <source srcset="{{ $url }}&w=80 1x, {{ $url }}&w=80&dpr=2 2x" media="(min-width: 576px)">
                     <source srcset="{{ $url }}&w=47 1x, {{ $url }}&w=47&dpr=2 2x" media="(min-width: 0px)">
@@ -14,7 +14,7 @@
         </a>
         <a class="card integrations" href="{{ "integrations/" | absLangURL }}">
             <div class="card-body text-center">
-                {{ $url := (print (.Site.Params.img_url)  "images/icons/integrations.png"  "?ch=Width,DPR&fit=max&auto=format") | safeURL }}
+                {{ $url := (print (site.Params.img_url)  "images/icons/integrations.png"  "?ch=Width,DPR&fit=max&auto=format") | safeURL }}
                 <picture class="mx-auto">
                     <source srcset="{{ $url }}&w=80 1x, {{ $url }}&w=80&dpr=2 2x" media="(min-width: 576px)">
                     <source srcset="{{ $url }}&w=47 1x, {{ $url }}&w=47&dpr=2 2x" media="(min-width: 0px)">
@@ -27,7 +27,7 @@
         <div class="w-100 d-none d-sm-block d-md-none"><!-- wrap every 2 on sm--></div>
         <a class="card graphing" href="{{ "graphing/" | absLangURL }}">
             <div class="card-body text-center">
-                {{ $url := (print (.Site.Params.img_url) "images/icons/graphing.png"  "?ch=Width,DPR&fit=max&auto=format") | safeURL }}
+                {{ $url := (print (site.Params.img_url) "images/icons/graphing.png"  "?ch=Width,DPR&fit=max&auto=format") | safeURL }}
                 <picture class="mx-auto">
                     <source srcset="{{ $url }}&w=80 1x, {{ $url }}&w=80&dpr=2 2x" media="(min-width: 576px)">
                     <source srcset="{{ $url }}&w=47 1x, {{ $url }}&w=47&dpr=2 2x" media="(min-width: 0px)">
@@ -42,7 +42,7 @@
         <div class="w-100 d-none d-xl-block"><!-- wrap every 3 on xl--></div>
         <a class="card alerting" href="{{ "monitoring/" | absLangURL }}">
             <div class="card-body text-center">
-                {{ $url := (print (.Site.Params.img_url) "images/icons/alerting.png"  "?ch=Width,DPR&fit=max&auto=format") | safeURL }}
+                {{ $url := (print (site.Params.img_url) "images/icons/alerting.png"  "?ch=Width,DPR&fit=max&auto=format") | safeURL }}
                 <picture class="mx-auto">
                     <source srcset="{{ $url }}&w=80 1x, {{ $url }}&w=80&dpr=2 2x" media="(min-width: 576px)">
                     <source srcset="{{ $url }}&w=47 1x, {{ $url }}&w=47&dpr=2 2x" media="(min-width: 0px)">
@@ -55,7 +55,7 @@
         <div class="w-100 d-none d-sm-block d-md-none"><!-- wrap every 2 on sm--></div>
         <a class="card tracing" href="{{ "tracing/" | absLangURL }}">
             <div class="card-body text-center">
-                {{ $url := (print (.Site.Params.img_url) "images/icons/tracing_apm.png"  "?ch=Width,DPR&fit=max&auto=format") | safeURL }}
+                {{ $url := (print (site.Params.img_url) "images/icons/tracing_apm.png"  "?ch=Width,DPR&fit=max&auto=format") | safeURL }}
                 <picture class="mx-auto">
                     <source srcset="{{ $url }}&w=80 1x, {{ $url }}&w=80&dpr=2 2x" media="(min-width: 576px)">
                     <source srcset="{{ $url }}&w=47 1x, {{ $url }}&w=47&dpr=2 2x" media="(min-width: 0px)">
@@ -67,7 +67,7 @@
         </a>
         <a class="card developers" href="{{ "developers/" | absLangURL }}">
             <div class="card-body text-center">
-                {{ $url := (print (.Site.Params.img_url) "images/icons/developers.png"  "?ch=Width,DPR&fit=max&auto=format") | safeURL }}
+                {{ $url := (print (site.Params.img_url) "images/icons/developers.png"  "?ch=Width,DPR&fit=max&auto=format") | safeURL }}
                 <picture class="mx-auto">
                     <source srcset="{{ $url }}&w=80 1x, {{ $url }}&w=80&dpr=2 2x" media="(min-width: 576px)">
                     <source srcset="{{ $url }}&w=47 1x, {{ $url }}&w=47&dpr=2 2x" media="(min-width: 0px)">

--- a/layouts/shortcodes/tracing-libraries-table.html
+++ b/layouts/shortcodes/tracing-libraries-table.html
@@ -2,12 +2,12 @@
 {{ $.Scratch.Set "data" "" }}
 {{ if ne $.Page.Lang "en"}}
     {{ if (fileExists (print "data/libraries." $.Page.Lang ".yaml")) }}
-      {{ $.Scratch.Set "data" (index $.Site.Data (print "libraries." $.Page.Lang)) }}
+      {{ $.Scratch.Set "data" (index site.Data (print "libraries." $.Page.Lang)) }}
     {{ else }}
-      {{ $.Scratch.Set "data" $.Site.Data.libraries }}
+      {{ $.Scratch.Set "data" site.Data.libraries }}
     {{ end }}
 {{ else }}
-    {{ $.Scratch.Set "data" $.Site.Data.libraries }}
+    {{ $.Scratch.Set "data" site.Data.libraries }}
 {{ end }}
 {{ $datafile := ($.Scratch.Get "data") }}
 

--- a/layouts/shortcodes/translate.html
+++ b/layouts/shortcodes/translate.html
@@ -3,7 +3,7 @@
 <!-- attempts to load a data file at the same path/filename as md file e.g content/foo/bar.md will try look for data/foo/bar.yaml -->
 {{ $.Scratch.Set "data" "" }}
 {{ if (fileExists (print "data/" $dot.Page.Lang "/" $dot.Page.File.Dir (replace $dot.Page.File.TranslationBaseName "-" "_") ".yaml")) }}
-    {{ $.Scratch.Set "data" (index $dot.Page.Site.Data $dot.Page.Lang) }}
+    {{ $.Scratch.Set "data" (index site.Data $dot.Page.Lang) }}
     {{ range $k, $v := (split $dot.Page.File.Dir "/") }}
         {{ if ne $v "/"}}
             {{ if ne $v ""}}

--- a/layouts/taxonomy/video-category.html
+++ b/layouts/taxonomy/video-category.html
@@ -18,7 +18,7 @@
       <br><br>
   {{ end }}
 </div>
-<p>{{ partial "return-to-group-link" (dict "lang" .Site.Language.Lang "taxonomy" .Data) }}</p>
+<p>{{ partial "return-to-group-link" (dict "lang" site.Language.Lang "taxonomy" .Data) }}</p>
 </section>
 
 


### PR DESCRIPTION
### What does this PR do?

Replaces all invocations of `.Site` with `site`.

### Motivation

Hugo's `site` function is available everywhere, irrespective of context, and thus enables you to access site-level variables without needing to use `.Page.Site`, `$.Page.Site`, `$ctx.Page.Site`, etc. The benefits are largely cognitive/ergonomic but I suspect this may slightly improve build times as well.

### Preview

https://docs-staging.datadoghq.com/lucperkins/site-variable

### Reviewer checklist
- [x] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
