### PR TITLE
fix the runner tag on datadoc

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -305,7 +305,7 @@ index_internal_doc:
   only:
     - master
   except: [ tags, schedules ]
-  tags: [ "runner:docker", "size:2xlarge" ]
+  tags: [ "runner:main", "size:2xlarge" ]
   script:
     - INDEXING_SERVICE=https://datadoc.ddbuild.io index-repository hugo https://docs.datadoghq.com/ "Datadog" "Public Documentation" --source_folder=content/en --tags="team:Documentation,source:hugo-website,visibility:public,github-repository:documentation"
 


### PR DESCRIPTION
### What does this PR do?

Updated the tag to be main instead of docker to fix a bug where it won't find a runner.

### Motivation

bug introduced from a previous pr

### Preview

shouldn't change anything in preview
https://docs-staging.datadoghq.com/david.jones/fix-runner-tag/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
