### PR TITLE
[WEB-1257] Hides Hotjar feedback button on small screen sizes

### DIFF
--- a/src/styles/pages/_global.scss
+++ b/src/styles/pages/_global.scss
@@ -874,6 +874,15 @@ table,
     opacity: 0.3;
 }
 
+// hotjar feedback button
+._hj_feedback_container {
+    display: none;
+
+    @include media-breakpoint-up(md) {
+        display: block;
+    }
+}
+
 // all external links show an icon
 /*a {
   &:not([href*='localhost']):not([href*='datadoghq.com']):not([href*='datadog.com']):not( [href^='#'] ):not( [href^='/'] ):after {

--- a/src/styles/pages/_global.scss
+++ b/src/styles/pages/_global.scss
@@ -878,7 +878,7 @@ table,
 ._hj_feedback_container {
     display: none;
 
-    @include media-breakpoint-up(md) {
+    @include media-breakpoint-up(lg) {
         display: block;
     }
 }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Hides Hotjar feedback button on small screen sizes

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1257

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/hotjar-hide/

### Additional Notes
Hotjar feedback button is hidden when the screen size is < 991px

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
