### PR TITLE
dogstatsd: document API changes that will soon be released with DogStatsd-ruby v5.x

### DIFF
--- a/content/en/developers/dogstatsd/high_throughput.md
+++ b/content/en/developers/dogstatsd/high_throughput.md
@@ -81,17 +81,18 @@ with DogStatsd(host="127.0.0.1", port=8125, max_buffer_size=25) as batch:
 {{< /programming-lang >}}
 {{< programming-lang lang="ruby" >}}
 
-By using Datadog's official Ruby library [dogstatsd-ruby][1], the example below creates a buffered DogStatsD client instance that sends metrics in one packet when the block completes:
+By using Datadog's official Ruby library [dogstatsd-ruby][1], the example below creates a buffered DogStatsD client instance that sends metrics in one packet when the flush is triggered:
 
 ```ruby
 require 'datadog/statsd'
 
 statsd = Datadog::Statsd.new('127.0.0.1', 8125)
 
-statsd.batch do |s|
-  s.increment('example_metric.increment', tags: ['environment:dev'])
-  s.gauge('example_metric.gauge', 123, tags: ['environment:dev'])
-end
+statsd.increment('example_metric.increment', tags: ['environment:dev'])
+statsd.gauge('example_metric.gauge', 123, tags: ['environment:dev'])
+
+# synchronous flush
+statsd.flush(sync: true)
 ```
 
 

--- a/content/fr/developers/dogstatsd/high_throughput.md
+++ b/content/fr/developers/dogstatsd/high_throughput.md
@@ -87,10 +87,11 @@ require 'datadog/statsd'
 
 statsd = Datadog::Statsd.new('127.0.0.1', 8125)
 
-statsd.batch do |s|
-  s.increment('exemple_métrique.increment', tags: ['environment:dev'])
-  s.gauge('exemple_métrique.gauge', 123, tags: ['environment:dev'])
-end
+statsd.increment('exemple_metric.increment', tags: ['environment:dev'])
+statsd.gauge('exemple_metric.gauge', 123, tags: ['environment:dev'])
+
+# flush synchrone
+statsd.flush(sync: true)
 ```
 
 

--- a/content/fr/developers/dogstatsd/high_throughput.md
+++ b/content/fr/developers/dogstatsd/high_throughput.md
@@ -15,7 +15,7 @@ further_reading:
 ---
 DogStatsD transmet des métriques générées à partir de votre application à l'[Agent][1] via un protocole de transport, à savoir UDP (User Datagram Protocol) ou UDS (Unix Domain Socket).
 
-Lorsque DogStatsD est utilisé pour transmettre un volume important de métriques à un seul Agent, si vous ne prenez pas les mesures appropriées, il est courant de rencontrer les problèmes suivants :
+Lorsque DogStatsD est utilisé pour transmettre un volume important de métriques à un seul Agent, si vous ne prenez pas les mesures appropriées, il est courant de rencontrer les problèmes suivants :
 
 - Utilisation intensive du processeur par l'Agent
 - Datagrammes/métriques perdus
@@ -33,7 +33,7 @@ Nous vous conseillons d'utiliser la dernière version des [clients DogStatsD off
 
 Certaines clients StatsD et DogStatsD envoient par défaut une métrique par datagramme. Cela ajoute une charge importante au niveau du client, du système d'exploitation et de l'Agent. Si votre client prend en charge la mise en mémoire tampon de plusieurs métriques dans un datagramme, activez cette option pour réduire considérablement les volumes d'échange.
 
-Voici quelques exemples de [clients DogStatsD officiels pris en charge][3] :
+Voici quelques exemples de [clients DogStatsD officiels pris en charge][3] :
 
 {{< tabs >}}
 {{% tab "Go" %}}
@@ -64,7 +64,7 @@ func main() {
 
 {{% tab "Python" %}}
 
-À l'aide de la bibliothèque Python officielle de Datadog, [datadogpy][1], l'exemple ci-dessous crée une instance du client DogStatsD en mémoire tampon qui envoie jusqu'à 25 métriques au sein d'un paquet à la fin du bloc :
+À l'aide de la bibliothèque Python officielle de Datadog, [datadogpy][1], l'exemple ci-dessous crée une instance du client DogStatsD en mémoire tampon qui envoie jusqu'à 25 métriques au sein d'un paquet à la fin du bloc :
 
 ```python
 from datadog import DogStatsd
@@ -80,7 +80,7 @@ with DogStatsd(host="127.0.0.1", port=8125, max_buffer_size=25) as batch:
 
 {{% tab "Ruby" %}}
 
-À l'aide de la bibliothèque Ruby officielle de Datadog, [dogstatsd-ruby][1], l'exemple ci-dessous crée une instance du client DogStatsD en mémoire tampon qui envoie des métriques au sein d'un paquet à la fin du bloc :
+À l'aide de la bibliothèque Ruby officielle de Datadog, [dogstatsd-ruby][1], l'exemple ci-dessous crée une instance du client DogStatsD et les métriques sont envoyées en une fois lors du flush :
 
 ```ruby
 require 'datadog/statsd'
@@ -100,7 +100,7 @@ statsd.flush(sync: true)
 
 {{% tab "Java" %}}
 
-À l'aide de la bibliothèque Java officielle de Datadog, [java-dogstatsd-client][1], l'exemple ci-dessous crée une instance du client DogStatsD en mémoire tampon avec une taille de paquet maximale de 1 500 octets. Ainsi, toutes les métriques envoyées depuis cette instance du client sont mises en mémoire tampon et envoyées en paquets d'une taille maximale de `1500` octets :
+À l'aide de la bibliothèque Java officielle de Datadog, [java-dogstatsd-client][1], l'exemple ci-dessous crée une instance du client DogStatsD en mémoire tampon avec une taille de paquet maximale de 1 500 octets. Ainsi, toutes les métriques envoyées depuis cette instance du client sont mises en mémoire tampon et envoyées en paquets d'une taille maximale de `1500` octets :
 
 ```java
 import com.timgroup.statsd.NonBlockingStatsDClient;
@@ -128,7 +128,7 @@ public class DogStatsdClient {
 [1]: https://github.com/DataDog/java-dogstatsd-client
 {{% /tab %}}
 {{% tab ".NET" %}}
-À l'aide de la bibliothèque C# officielle de Datadog, [dogstatsd-csharp-client][1], l'exemple ci-dessous crée un client DogStatsD avec le transport UDP :
+À l'aide de la bibliothèque C# officielle de Datadog, [dogstatsd-csharp-client][1], l'exemple ci-dessous crée un client DogStatsD avec le transport UDP :
 
 ```csharp
 using StatsdClient;
@@ -160,7 +160,7 @@ public class DogStatsdClient
 {{% /tab %}}
 {{% tab "PHP" %}}
 
-À l'aide de la bibliothèque PHP officielle de Datadog, [php-datadogstatsd][1], l'exemple ci-dessous crée une instance du client DogStatsD en mémoire tampon qui envoie des métriques au sein d'un paquet à la fin du bloc :
+À l'aide de la bibliothèque PHP officielle de Datadog, [php-datadogstatsd][1], l'exemple ci-dessous crée une instance du client DogStatsD en mémoire tampon qui envoie des métriques au sein d'un paquet à la fin du bloc :
 
 ```php
 <?php
@@ -186,7 +186,7 @@ $client->increment('exemple_métrique.increment', $sampleRate->0.5 , array('envi
 
 ### Échantillonner vos métriques
 
-Vous pouvez réduire le trafic depuis votre client DogStatsD vers l'Agent en définissant une valeur de taux d'échantillonnage pour votre client. Par exemple, un taux d'échantillonnage de `0.5` réduit de moitié le nombre de paquets UDP transmis. Cette solution constitue un compromis acceptable : vous réduisez le trafic, mais perdez légèrement en précision et en granularité.
+Vous pouvez réduire le trafic depuis votre client DogStatsD vers l'Agent en définissant une valeur de taux d'échantillonnage pour votre client. Par exemple, un taux d'échantillonnage de `0.5` réduit de moitié le nombre de paquets UDP transmis. Cette solution constitue un compromis acceptable : vous réduisez le trafic, mais perdez légèrement en précision et en granularité.
 
 Pour en savoir plus et obtenir des exemples de code, consultez le paragraphe [Sample Rate de la page DogStatsD][4].
 
@@ -196,32 +196,32 @@ UDS est un protocole de communication inter-processus utilisé pour [transporter
 
 ## Buffers kernel des systèmes d'opération
 
-La plupart des systèmes d'exploitation ajoutent des datagrammes UDP et UDS entrants, qui contiennent vos métriques, dans une mémoire tampon avec une taille limitée. Une fois cette limite atteinte, les datagrammes comprenant vos métriques sont perdues. Vous pouvez ajuster certaines valeurs afin d'accorder davantage de temps à l'Agent pour le traitement des métriques entrantes :
+La plupart des systèmes d'exploitation ajoutent des datagrammes UDP et UDS entrants, qui contiennent vos métriques, dans une mémoire tampon avec une taille limitée. Une fois cette limite atteinte, les datagrammes comprenant vos métriques sont perdues. Vous pouvez ajuster certaines valeurs afin d'accorder davantage de temps à l'Agent pour le traitement des métriques entrantes :
 
 ### Via UDP (User Datagram Protocol)
 
 #### Linux
 
-Sur la plupart des distributions Linux, la taille maximale de la mémoire tampon du kernel est par défaut définie sur `212992` (208 KiB). Pour vous en assurer, utilisez la commande suivante :
+Sur la plupart des distributions Linux, la taille maximale de la mémoire tampon du kernel est par défaut définie sur `212992` (208 KiB). Pour vous en assurer, utilisez la commande suivante :
 
 ```bash
 $ sysctl net.core.rmem_max
 net.core.rmem_max = 212992
 ```
 
-Pour définir la taille maximale de la mémoire tampon du socket DogStatsD sur 25 MiB, exécutez :
+Pour définir la taille maximale de la mémoire tampon du socket DogStatsD sur 25 MiB, exécutez :
 
 ```bash
 sysctl -w net.core.rmem_max=26214400
 ```
 
-Ajoutez la configuration suivante à `/etc/sysctl.conf` pour appliquer de façon permanente ce changement :
+Ajoutez la configuration suivante à `/etc/sysctl.conf` pour appliquer de façon permanente ce changement :
 
 ```conf
 net.core.rmem_max = 26214400
 ```
 
-Définissez ensuite l'option de configuration `dogstatsd_so_rcvbuf` de l'Agent sur le même nombre dans `datadog.yaml` :
+Définissez ensuite l'option de configuration `dogstatsd_so_rcvbuf` de l'Agent sur le même nombre dans `datadog.yaml` :
 
 ```yaml
 dogstatsd_so_rcvbuf: 26214400
@@ -233,31 +233,31 @@ Consultez la section [Remarque sur sysctl dans Kubernetes][5] si vous déployez 
 
 #### Linux
 
-Pour les sockets UDS, Linux met en interne les datagrammes dans une file d'attente en mémoire tampon si le lecteur est plus lent que l'enregistreur. La taille de cette file d'attente représente le nombre maximal de datagrammes que Linux met en mémoire tampon par socket. Cette valeur peut être obtenue avec la commande suivante :
+Pour les sockets UDS, Linux met en interne les datagrammes dans une file d'attente en mémoire tampon si le lecteur est plus lent que l'enregistreur. La taille de cette file d'attente représente le nombre maximal de datagrammes que Linux met en mémoire tampon par socket. Cette valeur peut être obtenue avec la commande suivante :
 
 ```bash
 sysctl net.unix.max_dgram_qlen
 ```
 
-Si la valeur est inférieure à 512, vous pouvez l'augmenter en la définissant sur 512 ou sur un nombre supérieur à l'aide de cette commande :
+Si la valeur est inférieure à 512, vous pouvez l'augmenter en la définissant sur 512 ou sur un nombre supérieur à l'aide de cette commande :
 
 ```bash
 sysctl -w net.unix.max_dgram_qlen=512
 ```
 
-Ajoutez la configuration suivante à `/etc/sysctl.conf` pour appliquer de façon permanente ce changement :
+Ajoutez la configuration suivante à `/etc/sysctl.conf` pour appliquer de façon permanente ce changement :
 
 ```conf
 net.unix.max_dgram_qlen = 512
 ```
 
-De la même manière, le paramètre `net.core.wmem_max` peut atteindre jusqu'à 4 MiB afin d'améliorer les performances d'écriture du client :
+De la même manière, le paramètre `net.core.wmem_max` peut atteindre jusqu'à 4 MiB afin d'améliorer les performances d'écriture du client :
 
 ```conf
 net.core.wmem_max = 4194304
 ```
 
-Définissez ensuite l'option de configuration `dogstatsd_so_rcvbuf` de l'Agent sur le même nombre dans `datadog.yaml` :
+Définissez ensuite l'option de configuration `dogstatsd_so_rcvbuf` de l'Agent sur le même nombre dans `datadog.yaml` :
 
 ```yaml
 dogstatsd_so_rcvbuf: 4194304
@@ -277,9 +277,9 @@ Si les paquets envoyés sont trop petits, l'Agent Datadog en regroupe plusieurs 
 
 Pour optimiser les performances de l'Agent, les clients DogStatsD doivent envoyer des paquets d'une taille correspondant à `dogstatsd_buffer_size`. La taille des paquets ne doit pas dépasser celle du buffer. Le cas contraire, l'Agent ne peut pas les charger entièrement dans le buffer, ce qui entraîne des anomalies pour certaines métriques. Utilisez le champ de configuration correspondant dans vos clients DogStatsD.
 
-Remarque pour le protocole UDP : étant donné que les paquets UDP passent généralement par la couche Ethernet et IP, évitez de fragmenter les paquets IP en limitant la taille des paquets à une valeur inférieure à une seule trame Ethernet sur votre réseau. La plupart du temps, les réseaux IPv4 sont configurés avec une MTU de 1 500 octets. Dans ce cas, la taille des paquets envoyés ne doit pas dépasser 1 472 octets.
+Remarque pour le protocole UDP : étant donné que les paquets UDP passent généralement par la couche Ethernet et IP, évitez de fragmenter les paquets IP en limitant la taille des paquets à une valeur inférieure à une seule trame Ethernet sur votre réseau. La plupart du temps, les réseaux IPv4 sont configurés avec une MTU de 1 500 octets. Dans ce cas, la taille des paquets envoyés ne doit pas dépasser 1 472 octets.
 
-Remarque pour le protocole UDS : pour maximiser les performances, les paquets UDS doivent avoir une taille de 8 192 octets.
+Remarque pour le protocole UDS : pour maximiser les performances, les paquets UDS doivent avoir une taille de 8 192 octets.
 
 ### Limiter l'utilisation maximale de la mémoire de l'Agent
 
@@ -287,11 +287,11 @@ Pour pouvoir traiter l'avalanche de métriques envoyées par les clients DogStat
 
 Pour éviter que l'Agent Datadog atteigne son seuil d'utilisation de la mémoire, répartissez les envois de métriques pour votre application.
 
-Pour limiter l'utilisation maximale de la mémoire, pensez également à réduire la mise en mémoire tampon. Le buffer principal du serveur DogStatsD dans l'Agent peut être configuré avec le champ `dogstatsd_queue_size` (depuis l'Agent Datadog 6.1.0). Sa valeur par défaut `1024` limite l'utilisation maximale de la mémoire à environ 768 Mo.
+Pour limiter l'utilisation maximale de la mémoire, pensez également à réduire la mise en mémoire tampon. Le buffer principal du serveur DogStatsD dans l'Agent peut être configuré avec le champ `dogstatsd_queue_size` (depuis l'Agent Datadog 6.1.0). Sa valeur par défaut `1024` limite l'utilisation maximale de la mémoire à environ 768 Mo.
 
-**Remarque** : la réduction de ce buffer peut entraîner une augmentation du nombre de paquets perdus.
+**Remarque** : la réduction de ce buffer peut entraîner une augmentation du nombre de paquets perdus.
 
-Cet exemple réduit l'utilisation maximale de la mémoire de DogStatsD à environ 384 Mo :
+Cet exemple réduit l'utilisation maximale de la mémoire de DogStatsD à environ 384 Mo :
 
 ```yaml
 dogstatsd_queue_size: 512
@@ -303,9 +303,9 @@ Consultez la section suivante dédiée à la détection des salves pour découvr
 
 DogStatsD possède un mode statistique qui permet de savoir quelles métriques sont les plus traitées.
 
-**Remarque** : l'activation de ce mode peut nuire aux performances de DogStatsD.
+**Remarque** : l'activation de ce mode peut nuire aux performances de DogStatsD.
 
-Pour activer le mode statistique, vous pouvez :
+Pour activer le mode statistique, vous pouvez :
 
 - Définir `dogstatsd_stats_enable` sur `true` dans votre fichier de configuration
 - Définir la variable d'environnement `DD_DOGSTATSD_STATS_ENABLE` sur `true`
@@ -313,7 +313,7 @@ Pour activer le mode statistique, vous pouvez :
 
 Lorsque ce mode est activé, exécutez la commande `datadog-agent dogstatsd-stats`. Cela envoie la liste des métriques traitées. Les métriques les plus reçues apparaissent en premier.
 
-Lors de l'exécution de ce mode, le serveur DogStatsD utilise un mécanisme de détection de salves. Si une salve est détectée, un log d'avertissement est généré. Par exemple :
+Lors de l'exécution de ce mode, le serveur DogStatsD utilise un mécanisme de détection de salves. Si une salve est détectée, un log d'avertissement est généré. Par exemple :
 
 ```text
 A burst of metrics has been detected by DogStatSd: here is the last 5 seconds count of metrics: [250 230 93899 233 218]
@@ -331,7 +331,7 @@ Chaque client partage un ensemble de tags communs.
 | `client_version`   | La version du client.                         | `client_version:1.2.3` |
 | `client_transport` | Le protocole de transport utilisé par le client (`udp` ou `uds`). | `client_transport:uds` |
 
-**Remarque** : lorsque vous utilisez le protocole UDP, le client ne peut pas détecter les erreurs réseau et les métriques correspondantes ne tiennent pas compte des octets/paquets perdus.
+**Remarque** : lorsque vous utilisez le protocole UDP, le client ne peut pas détecter les erreurs réseau et les métriques correspondantes ne tiennent pas compte des octets/paquets perdus.
 
 {{< tabs >}}
 {{% tab "Python" %}}
@@ -348,7 +348,7 @@ La télémétrie a été ajoutée avec la version `0.34.0` du client Python.
 | `datadog.dogstatsd.client.packets_sent`    | count       | Le nombre de datagrammes envoyés à l'Agent.                                     |
 | `datadog.dogstatsd.client.packets_dropped` | count       | Le nombre de datagrammes perdus par le client DogStatsD.                                    |
 
-Pour désactiver la télémétrie, utilisez la méthode `disable_telemetry` :
+Pour désactiver la télémétrie, utilisez la méthode `disable_telemetry` :
 
 ```python
 statsd.disable_telemetry()
@@ -373,7 +373,7 @@ La télémétrie a été ajoutée avec la version `4.6.0` du client Ruby.
 | `datadog.dogstatsd.client.packets_sent`    | count       | Le nombre de datagrammes envoyés à l'Agent.                                     |
 | `datadog.dogstatsd.client.packets_dropped` | count       | Le nombre de datagrammes perdus par le client DogStatsD.                                    |
 
-Pour désactiver la télémétrie, définissez le paramètre `disable_telemetry` sur `true` :
+Pour désactiver la télémétrie, définissez le paramètre `disable_telemetry` sur `true` :
 
 ```ruby
 Datadog::Statsd.new('localhost', 8125, disable_telemetry: true)
@@ -401,9 +401,9 @@ La télémétrie a été ajoutée avec la version `3.4.0` du client Go.
 | `datadog.dogstatsd.client.packets_dropped`           | count       | Le nombre de datagrammes perdus par le client DogStatsD.                                                                                                            |
 | `datadog.dogstatsd.client.packets_dropped_queue`     | count       | Le nombre de datagrammes perdus, car la liste d'attente du client DogStatsD était pleine.                                                                                        |
 | `datadog.dogstatsd.client.packets_dropped_writer`    | count       | Le nombre de datagrammes perdus en raison d'une erreur lors de l'écriture sur Datadog.                                                                                       |
-| `datadog.dogstatsd.client.metric_dropped_on_receive` | count       | Le nombre de métriques perdues, car le canal de réception interne était plein (uniquement lors de l'utilisation de `WithChannelMode()`). Métrique disponible à partir de la version `3.6.0` du client Go. |
+| `datadog.dogstatsd.client.metric_dropped_on_receive` | count       | Le nombre de métriques perdues, car le canal de réception interne était plein (uniquement lors de l'utilisation de `WithChannelMode()`). Métrique disponible à partir de la version `3.6.0` du client Go. |
 
-Pour désactiver la télémétrie, utilisez le paramètre `WithoutTelemetry` :
+Pour désactiver la télémétrie, utilisez le paramètre `WithoutTelemetry` :
 
 ```go
 statsd, err: = statsd.New("127.0.0.1:8125", statsd.WithoutTelemetry())
@@ -429,7 +429,7 @@ La télémétrie a été ajoutée avec la version `2.10.0` du client Java.
 | `datadog.dogstatsd.client.packets_dropped`       | count       | Le nombre de datagrammes perdus par le client DogStatsD.                                    |
 | `datadog.dogstatsd.client.packets_dropped_queue` | count       | Le nombre de datagrammes perdus, car la liste d'attente du client DogStatsD était pleine.                |
 
-Pour désactiver la télémétrie, utilisez l'option builder `enableTelemetry(false)` :
+Pour désactiver la télémétrie, utilisez l'option builder `enableTelemetry(false)` :
 
 ```java
 StatsDClient client = new NonBlockingStatsDClientBuilder()
@@ -446,7 +446,7 @@ Consultez le référentiel [DataDog/java-dogstatsd-client][1] pour en savoir plu
 {{% /tab %}}
 {{% tab "PHP" %}}
 
-Depuis la version `1.5.0` du client PHP, la télémétrie est activée par défaut pour le client `BatchedDogStatsd` et désactivée par défaut pour le client `DogStatsd`.
+Depuis la version `1.5.0` du client PHP, la télémétrie est activée par défaut pour le client `BatchedDogStatsd` et désactivée par défaut pour le client `DogStatsd`.
 
 
 | Nom de la métrique                               | Type de métrique | Description                                                                                 |
@@ -461,7 +461,7 @@ Depuis la version `1.5.0` du client PHP, la télémétrie est activée par déf
 
 Pour activer ou désactiver la télémétrie, utilisez l'argument `disable_telemetry`. Cependant, sachez que l'utilisation de la télémétrie avec le client `DogStatsd` entraîne une augmentation considérable de l'utilisation du réseau. Il est recommandé d'utiliser `BatchedDogStatsd` lors de l'utilisation de la télémétrie.
 
-Pour l'activer sur le client `DogStatsd` :
+Pour l'activer sur le client `DogStatsd` :
 
 ```php
 use DataDog\DogStatsd;
@@ -474,7 +474,7 @@ $statsd = new DogStatsd(
   );
 ```
 
-Pour désactiver la télémétrie sur le client `BatchedDogStatsd` :
+Pour désactiver la télémétrie sur le client `BatchedDogStatsd` :
 
 ```php
 use DataDog\BatchedDogStatsd;
@@ -506,7 +506,7 @@ La télémétrie a été ajoutée avec la version `5.0.0` du client .NET.
 | `datadog.dogstatsd.client.packets_dropped`           | count       | Le nombre de datagrammes perdus par le client DogStatsD.                                                                                                            |
 | `datadog.dogstatsd.client.packets_dropped_queue`     | count       | Le nombre de datagrammes perdus, car la liste d'attente du client DogStatsD était pleine.                                                                                        |
 
-Pour désactiver la télémétrie, définissez `TelemetryFlushInterval` sur `null` :
+Pour désactiver la télémétrie, définissez `TelemetryFlushInterval` sur `null` :
 
 ```csharp
 var dogstatsdConfig = new StatsdConfig

--- a/content/fr/integrations/sidekiq.md
+++ b/content/fr/integrations/sidekiq.md
@@ -55,7 +55,7 @@ Vous n'avez donc rien d'autre à installer sur votre serveur.
 1. Installez la [gem][3] `dogstatsd-ruby` :
 
    ```
-    gem install dogstatsd-ruby
+    gem install dogstatsd-ruby --version '~> 4'
    ```
 
 2. Pour activer la collecte de métriques de Sidekiq Pro, ajoutez le code suivant à votre initialiseur. Pour un déploiement conteneurisé, remplacez `localhost` par l'adresse du conteneur de votre Agent.

--- a/content/ja/developers/dogstatsd/high_throughput.md
+++ b/content/ja/developers/dogstatsd/high_throughput.md
@@ -87,10 +87,10 @@ require 'datadog/statsd'
 
 statsd = Datadog::Statsd.new('127.0.0.1', 8125)
 
-statsd.batch do |s|
-  s.increment('example_metric.increment', tags: ['environment:dev'])
-  s.gauge('example_metric.gauge', 123, tags: ['environment:dev'])
-end
+statsd.increment('example_metric.increment', tags: ['environment:dev'])
+statsd.gauge('example_metric.gauge', 123, tags: ['environment:dev'])
+
+statsd.flush(sync: true)
 ```
 
 

--- a/content/ja/integrations/sidekiq.md
+++ b/content/ja/integrations/sidekiq.md
@@ -55,7 +55,7 @@ Sidekiq インテグレーションは [Datadog Agent][4] にパッケージ化�
 1. `dogstatsd-ruby` [gem][3] をインストールします。
 
    ```
-    gem install dogstatsd-ruby
+    gem install dogstatsd-ruby --version '~> 4'
    ```
 
 2. これをイニシャライザに含めることにより、Sidekiq Pro メトリクス収集を有効にします。


### PR DESCRIPTION

### What does this PR do?

Official DogStatsD-ruby client library will have some API breaking changes when its version 5.0 will be released.
This PR is adapting the code snippets to be compatible with this new release.

### Preview

https://docs-staging.datadoghq.com/remeh/dogstatsd-ruby-v5/developers/dogstatsd/high_throughput/

### Additional Notes

**It should not be merged before the release of dogstatsd-ruby 5.0.0**

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
