### PR TITLE
Update documentation around RPM GPG keys

### DIFF
--- a/content/en/agent/faq/agent-downgrade-major.md
+++ b/content/en/agent/faq/agent-downgrade-major.md
@@ -125,7 +125,7 @@ This guide assumes you upgraded to the Agent v6 using the [upgrade guide][1]. If
 
     ```shell
     rm /etc/yum.repos.d/datadog-beta.repo
-    [ ! -f /etc/yum.repos.d/datadog.repo ] && echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/rpm/x86_64/   \nenabled=1\ngpgcheck=1\nrepo_gpgcheck=0\npriority=1\ngpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public\n       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public\n       https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public' | sudo tee /etc/yum.repos.d/datadog.repo
+    [ ! -f /etc/yum.repos.d/datadog.repo ] && echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/rpm/x86_64/   \nenabled=1\ngpgcheck=1\nrepo_gpgcheck=0\npriority=1\ngpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public\n       https://keys.datadoghq.com/DATADOG_RPM_KEY.public\n       https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public\n       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public' | sudo tee /etc/yum.repos.d/datadog.repo
     ```
 
 2. Update your local yum cache and downgrade the Agent

--- a/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
+++ b/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
@@ -39,21 +39,25 @@ Otherwise, the command returns a non-0 exit code and the following output:
 package gpg-pubkey-e09422b3 is not installed
 ```
 
-## Trust the GPG key
+## Trust the GPG keys
 
-This step is not required if hosts already trust the key or if a recent version of an official installation method is used.
+This step is not required if hosts already trust the keys or if a recent version of an official installation method is used.
 
 ### Import command
 
 Run the following commands on the host:
 
 ```bash
-$ curl -o /tmp/DATADOG_RPM_KEY_E09422B3.public https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+$ curl -o /tmp/DATADOG_RPM_KEY_CURRENT.public https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+$ curl -o /tmp/DATADOG_RPM_KEY_FD4BF915.public https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+$ curl -o /tmp/DATADOG_RPM_KEY_E09422B3.public https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
 
+$ rpm --import /tmp/DATADOG_RPM_KEY_CURRENT.public
+$ rpm --import /tmp/DATADOG_RPM_KEY_FD4BF915.public
 $ rpm --import /tmp/DATADOG_RPM_KEY_E09422B3.public
 ```
 
-Then check if the key is trusted by following the steps in [Check if a host trusts the GPG key](#check-if-a-host-trusts-the-gpg-key).
+Then check if the keys are trusted by following the steps in [Check if a host trusts the GPG key](#check-if-a-host-trusts-the-gpg-key).
 
 ### Yum repository file update
 
@@ -68,8 +72,9 @@ name = Datadog, Inc.
 baseurl = https://yum.datadoghq.com/stable/7/x86_64/
 enabled=1
 gpgcheck=1
-gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
 ```
 
 {{% /tab %}}
@@ -81,8 +86,10 @@ name = Datadog, Inc.
 baseurl = https://yum.datadoghq.com/stable/6/x86_64/
 enabled=1
 gpgcheck=1
-gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY.public
 ```
 
 {{% /tab %}}

--- a/content/en/agent/iot/_index.md
+++ b/content/en/agent/iot/_index.md
@@ -108,8 +108,9 @@ To manually install the IoT Agent on RPM-based operating systems, run the follow
     baseurl = https://yum.datadoghq.com/stable/7/<HOST_ARCHITECTURE>
     enabled=1
     gpgcheck=1
-    gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+    gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
     ```
 
     The `baseurl` is dependent on your host OS:

--- a/content/en/agent/versions/upgrade_to_agent_v6.md
+++ b/content/en/agent/versions/upgrade_to_agent_v6.md
@@ -76,9 +76,10 @@ Find below the manual upgrade instructions for:
     baseurl=https://yum.datadoghq.com/stable/6/x86_64/
     enabled=1
     gpgcheck=1
-    gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+    gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY.public
     ```
 
 2. Update your local Yum repo and install the Agent:
@@ -118,9 +119,10 @@ Find below the manual upgrade instructions for:
     baseurl=https://yum.datadoghq.com/stable/6/x86_64/
     enabled=1
     gpgcheck=1
-    gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+    gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY.public
     ```
 
 2. Update your local Yum repo and install the Agent:
@@ -199,9 +201,10 @@ Find below the manual upgrade instructions for:
     baseurl=https://yum.datadoghq.com/stable/6/x86_64/
     enabled=1
     gpgcheck=1
-    gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+    gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY.public
     ```
 
 2. Update your local Yum repo and install the Agent:
@@ -235,9 +238,10 @@ Find below the manual upgrade instructions for:
     baseurl=https://yum.datadoghq.com/stable/6/x86_64/
     enabled=1
     gpgcheck=1
-    gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+    gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY.public
     ```
 
 2. Update your local Yum repo and install the Agent:
@@ -325,17 +329,19 @@ Find below the manual upgrade instructions for:
   type=rpm-md
   gpgcheck=1
   repo_gpgcheck=0
-  gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-         https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-         https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+  gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+         https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+         https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+         https://keys.datadoghq.com/DATADOG_RPM_KEY.public
   ```
 
 2. Update your local Zypper repo and install the Agent:
   ```
   sudo zypper refresh
-  sudo rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-  sudo rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-  sudo rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+  sudo rpm --import https://keys.datadoghq.com/DATADOG_RPM_KEY.public
+  sudo rpm --import https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+  sudo rpm --import https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+  sudo rpm --import https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
   sudo zypper install datadog-agent
   ```
 

--- a/content/en/security/agent.md
+++ b/content/en/security/agent.md
@@ -79,9 +79,9 @@ For more information, see the [Secrets Management][20] documentation.
 [3]: /api/
 [4]: https://keyserver.ubuntu.com/pks/lookup?op=hget&search=d1402d39517b9f8888abfc98d6936dab
 [5]: https://keyserver.ubuntu.com/pks/lookup?op=hget&search=3e8510ce571008616b42bd67916e83f8
-[6]: https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
-[7]: https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-[8]: https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+[6]: https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+[7]: https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+[8]: https://keys.datadoghq.com/DATADOG_RPM_KEY.public
 [9]: /agent/faq/network/
 [10]: /agent/proxy/
 [11]: /agent/troubleshooting/

--- a/content/fr/agent/iot/_index.md
+++ b/content/fr/agent/iot/_index.md
@@ -107,8 +107,9 @@ Pour installer manuellement l'Agent IoT sur les systèmes d'exploitation basés 
     baseurl = https://yum.datadoghq.com/stable/7/<HOST_ARCHITECTURE>
     enabled=1
     gpgcheck=1
-    gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+    gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
     ```
 
    `baseurl` dépend du système d'exploitation de votre host :

--- a/content/fr/agent/versions/upgrade_to_agent_v6.md
+++ b/content/fr/agent/versions/upgrade_to_agent_v6.md
@@ -75,9 +75,10 @@ Vous trouverez ci-dessous les instructions d'installation manuelle pour :
     baseurl=https://yum.datadoghq.com/stable/6/x86_64/
     enabled=1
     gpgcheck=1
-    gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+    gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY.public
     ```
 
 2. Mettez à jour votre référentiel Yum local et installez l'Agent :
@@ -117,9 +118,10 @@ Vous trouverez ci-dessous les instructions d'installation manuelle pour :
     baseurl=https://yum.datadoghq.com/stable/6/x86_64/
     enabled=1
     gpgcheck=1
-    gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+    gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY.public
     ```
 
 2. Mettez à jour votre référentiel Yum local et installez l'Agent :
@@ -198,9 +200,10 @@ Vous trouverez ci-dessous les instructions d'installation manuelle pour :
     baseurl=https://yum.datadoghq.com/stable/6/x86_64/
     enabled=1
     gpgcheck=1
-    gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+    gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY.public
     ```
 
 2. Mettez à jour votre référentiel Yum local et installez l'Agent :
@@ -234,9 +237,10 @@ Vous trouverez ci-dessous les instructions d'installation manuelle pour :
     baseurl=https://yum.datadoghq.com/stable/6/x86_64/
     enabled=1
     gpgcheck=1
-    gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+    gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY.public
     ```
 
 2. Mettez à jour votre référentiel Yum local et installez l'Agent :
@@ -324,17 +328,19 @@ Vous trouverez ci-dessous les instructions d'installation manuelle pour :
   type=rpm-md
   gpgcheck=1
   repo_gpgcheck=0
-  gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-         https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-         https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+  gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+         https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+         https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+         https://keys.datadoghq.com/DATADOG_RPM_KEY.public
   ```
 
 2. Mettez à jour votre référentiel Zypper local et installez l'Agent :
   ```
   sudo zypper refresh
-  sudo rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-  sudo rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-  sudo rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+  sudo rpm --import https://keys.datadoghq.com/DATADOG_RPM_KEY.public
+  sudo rpm --import https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+  sudo rpm --import https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+  sudo rpm --import https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
   sudo zypper install datadog-agent
   ```
 

--- a/content/ja/agent/iot/_index.md
+++ b/content/ja/agent/iot/_index.md
@@ -107,8 +107,9 @@ RPM ベースのオペレーティングシステムに IoT Agent を手動で�
     baseurl = https://yum.datadoghq.com/stable/7/<HOST_ARCHITECTURE>
     enabled=1
     gpgcheck=1
-    gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+    gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
     ```
 
     `baseurl` は、ホスト OS に依存します。

--- a/content/ja/agent/versions/upgrade_to_agent_v6.md
+++ b/content/ja/agent/versions/upgrade_to_agent_v6.md
@@ -75,9 +75,10 @@ DD_UPGRADE=true bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/ins
     baseurl=https://yum.datadoghq.com/stable/6/x86_64/
     enabled=1
     gpgcheck=1
-    gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+    gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY.public
     ```
 
 2. ローカルの Yum リポジトリを更新し、Agent をインストールします。
@@ -117,9 +118,10 @@ DD_UPGRADE=true bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/ins
     baseurl=https://yum.datadoghq.com/stable/6/x86_64/
     enabled=1
     gpgcheck=1
-    gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+    gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY.public
     ```
 
 2. ローカルの Yum リポジトリを更新し、Agent をインストールします。
@@ -198,9 +200,10 @@ DD_UPGRADE=true bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/ins
     baseurl=https://yum.datadoghq.com/stable/6/x86_64/
     enabled=1
     gpgcheck=1
-    gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+    gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY.public
     ```
 
 2. ローカルの Yum リポジトリを更新し、Agent をインストールします。
@@ -234,9 +237,10 @@ DD_UPGRADE=true bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/ins
     baseurl=https://yum.datadoghq.com/stable/6/x86_64/
     enabled=1
     gpgcheck=1
-    gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-           https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+    gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY.public
     ```
 
 2. ローカルの Yum リポジトリを更新し、Agent をインストールします。
@@ -324,17 +328,19 @@ DD_UPGRADE=true bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/ins
   type=rpm-md
   gpgcheck=1
   repo_gpgcheck=0
-  gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-         https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-         https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+  gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+         https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+         https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+         https://keys.datadoghq.com/DATADOG_RPM_KEY.public
   ```
 
 2. ローカルの Zypper リポジトリを更新し、Agent をインストールします。
   ```
   sudo zypper refresh
-  sudo rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-  sudo rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-  sudo rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+  sudo rpm --import https://keys.datadoghq.com/DATADOG_RPM_KEY.public
+  sudo rpm --import https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+  sudo rpm --import https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+  sudo rpm --import https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
   sudo zypper install datadog-agent
   ```
 

--- a/content/ja/security/agent.md
+++ b/content/ja/security/agent.md
@@ -78,9 +78,9 @@ Agent の構成ファイルに機密情報がプレーンテキストで格納�
 [3]: /ja/api/
 [4]: https://keyserver.ubuntu.com/pks/lookup?op=hget&search=d1402d39517b9f8888abfc98d6936dab
 [5]: https://keyserver.ubuntu.com/pks/lookup?op=hget&search=3e8510ce571008616b42bd67916e83f8
-[6]: https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
-[7]: https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-[8]: https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+[6]: https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+[7]: https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+[8]: https://keys.datadoghq.com/DATADOG_RPM_KEY.public
 [9]: /ja/agent/faq/network/
 [10]: /ja/agent/proxy/
 [11]: /ja/agent/troubleshooting/

--- a/static/config/99datadog-amazon-linux-2.config
+++ b/static/config/99datadog-amazon-linux-2.config
@@ -25,9 +25,9 @@ files:
             baseurl = https://yum.datadoghq.com/stable/7/x86_64/
             enabled=1
             gpgcheck=1
-            gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
-                   https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-                   https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+            gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+                   https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+                   https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
             
     "/start_datadog.sh":
         mode: "000700"

--- a/static/config/99datadog.config
+++ b/static/config/99datadog.config
@@ -28,8 +28,9 @@ files:
             baseurl = https://yum.datadoghq.com/stable/7/x86_64/
             enabled=1
             gpgcheck=1
-            gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-                   https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+            gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+                   https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+                   https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
 
     "/datadog/hooks/99start_datadog.sh":
         mode: "000755"


### PR DESCRIPTION
### What does this PR do?

This PR updates the documentation around RPM GPG keys, addressing these

* Get keys from keys.datadoghq.com
* Add the CURRENT key entry to all relevant places

Note: As I don't speak French or Japanese, it's possible that there is some text around the changed files that might need to get updated.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
