### PR TITLE
[WEB-1250] fixing multi code lang navigation bug

### DIFF
--- a/layouts/partials/nav/main-menu.html
+++ b/layouts/partials/nav/main-menu.html
@@ -7,7 +7,7 @@
 {{ $path := (printf "%s/" $.Site.Params.branch) }}
 
 {{/* account for branch name in preview site for data-path */}}
-{{ if eq $.Site.Params.environment "preview"}}          
+{{ if eq $.Site.Params.environment "preview"}}
     {{ $.Scratch.Set "branch_path" $path }}
 {{ else }}
     {{ $.Scratch.Set "branch_path" "" }}
@@ -33,8 +33,10 @@
                         {{ if .HasChildren }}
                             <ul class="list-unstyled sub-menu">
                             {{ range .Children }}
+                                {{ $type := "" }}
+                                {{ with site.GetPage .URL }}{{ $type = .Type }}{{ end }}
                                 <li class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }} {{ if (not (in $excludeAsyc .Identifier)) }} js-load {{- end -}}" >
-                                    <a href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print .URL) | relLangURL)) "/" }}">
+                                    <a href="{{ .URL | relLangURL }}" data-type="{{- $type -}}" data-path="{{ trim (print $branchPath ((print .URL) | relLangURL)) "/" }}">
                                         {{ if .Pre }}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}{{ end }} <span>{{ .Name }}</span>
                                     </a>
                                     {{/*  4th level, hide  */}}

--- a/layouts/partials/nav/main-menu.html
+++ b/layouts/partials/nav/main-menu.html
@@ -44,7 +44,7 @@
                                         <ul class="list-unstyled sub-menu d-none">
                                         {{ range .Children }}
                                             <li class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }} {{ if (not (in $excludeAsyc .Identifier)) }} js-load {{- end -}}" >
-                                                <a href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print .URL) | relLangURL)) "/" }}">
+                                                <a data-name="{{- delimit (last 1 (split (strings.TrimSuffix "/" .URL) "/")) "" -}}" href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print .URL) | relLangURL)) "/" }}">
                                                     {{ if .Pre }}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}{{ end }} <span>{{ .Name }}</span>
                                                 </a>
                                             </li>

--- a/src/scripts/components/async-loading.js
+++ b/src/scripts/components/async-loading.js
@@ -1,4 +1,3 @@
-import Cookies from "js-cookie";
 import { updateTOC, buildTOCMap } from './table-of-contents';
 import codeTabs from './codetabs';
 import { redirectToRegion } from '../region-redirects';
@@ -113,16 +112,8 @@ function loadPage(newUrl) {
                 newDocument.documentElement.dataset.type;
 
             // update data-code-lang
-            if (document.documentElement.dataset.type === 'multi-code-lang') {
-              // if we are navigating to a multi-code-lang page
-              // we should try load the existing lang if possible
-              document.documentElement.dataset.pageCodeLang = Cookies.get('code-lang');
-              const replacedUrl = newUrl.replace(`/${newDocument.documentElement.dataset.pageCodeLang}`, `/${document.documentElement.dataset.pageCodeLang}`);
-              window.history.replaceState({}, '', replacedUrl);
-            } else {
-              document.documentElement.dataset.pageCodeLang =
-                newDocument.documentElement.dataset.pageCodeLang;
-            }
+            document.documentElement.dataset.pageCodeLang =
+            newDocument.documentElement.dataset.pageCodeLang;
 
             // update data-current-section
             document.documentElement.dataset.currentSection =

--- a/src/scripts/components/async-loading.js
+++ b/src/scripts/components/async-loading.js
@@ -5,7 +5,7 @@ import { initializeIntegrations } from './integrations';
 import { initializeSecurityRules } from './security-rules';
 import {updateMainContentAnchors, reloadWistiaVidScripts, gtag, getCookieByName } from '../helpers/helpers';
 import configDocs from '../config/config-docs';
-import {redirectCodeLang, addCodeTabEventListeners, activateCodeLangNav} from './code-languages'; // eslint-disable-line import/no-cycle
+import {redirectCodeLang, addCodeTabEventListeners, activateCodeLangNav, toggleMultiCodeLangNav} from './code-languages'; // eslint-disable-line import/no-cycle
 
 const { env } = document.documentElement.dataset;
 const { gaTag } = configDocs[env];
@@ -199,6 +199,7 @@ function loadPage(newUrl) {
             addCodeTabEventListeners();
             activateCodeLangNav(pageCodeLang)
             redirectCodeLang();
+            toggleMultiCodeLangNav(pageCodeLang);
 
             // Gtag virtual pageview
             gtag('config', gaTag, { page_path: pathName });

--- a/src/scripts/components/async-loading.js
+++ b/src/scripts/components/async-loading.js
@@ -1,3 +1,4 @@
+import Cookies from "js-cookie";
 import { updateTOC, buildTOCMap } from './table-of-contents';
 import codeTabs from './codetabs';
 import { redirectToRegion } from '../region-redirects';
@@ -51,7 +52,7 @@ function loadPage(newUrl) {
                 '.js-toc-container'
             );
 
-            const currentSidebar = document.querySelector('.sidebar'); 
+            const currentSidebar = document.querySelector('.sidebar');
             const newSidebar = httpRequest.responseXML.querySelector('.sidebar');
 
             if (newContent === null) {
@@ -171,7 +172,7 @@ function loadPage(newUrl) {
             }
 
             // Ensure sidebar is displayed or hidden properly based on HTTP response.  I'm certain we can implement a better strategy for what's happening in this script, but this should hold us over until then.
-            if (newSidebar && !currentSidebar) {            
+            if (newSidebar && !currentSidebar) {
                 const jsContentContainer = document.querySelector('.js-content-container');
                 jsContentContainer.appendChild(newSidebar);
             }

--- a/src/scripts/components/async-loading.js
+++ b/src/scripts/components/async-loading.js
@@ -112,8 +112,16 @@ function loadPage(newUrl) {
                 newDocument.documentElement.dataset.type;
 
             // update data-code-lang
-            document.documentElement.dataset.pageCodeLang =
-            newDocument.documentElement.dataset.pageCodeLang;
+            if (document.documentElement.dataset.type === 'multi-code-lang') {
+              // if we are navigating to a multi-code-lang page
+              // we should try load the existing lang if possible
+              document.documentElement.dataset.pageCodeLang = Cookies.get('code-lang');
+              const replacedUrl = newUrl.replace(`/${newDocument.documentElement.dataset.pageCodeLang}`, `/${document.documentElement.dataset.pageCodeLang}`);
+              window.history.replaceState({}, '', replacedUrl);
+            } else {
+              document.documentElement.dataset.pageCodeLang =
+                newDocument.documentElement.dataset.pageCodeLang;
+            }
 
             // update data-current-section
             document.documentElement.dataset.currentSection =

--- a/src/scripts/components/code-languages.js
+++ b/src/scripts/components/code-languages.js
@@ -89,6 +89,7 @@ function activateCodeLangNav(activeLang) {
 
 function toggleCodeBlocks(activeLang) {
     activateCodeLangNav(activeLang);
+    toggleMultiCodeLangNav(activeLang);
 
     // non-api page code blocks
     const codeWrappers = document.querySelectorAll('body:not(.api) [class*=js-code-snippet-wrapper]');

--- a/src/scripts/components/code-languages.js
+++ b/src/scripts/components/code-languages.js
@@ -158,4 +158,23 @@ function toggleCodeBlocks(activeLang) {
     }
 }
 
-export { redirectCodeLang, addCodeTabEventListeners, activateCodeLangNav };
+function toggleMultiCodeLangNav(codeLang) {
+  /*
+  - Find any nav entries with type multi-code-lang
+  - Look for child entry that has data-name matching the current code lang
+  - Switch that url into the parent url, so its the appropriate language version
+   */
+  if(codeLang.length) {
+    const items = document.querySelectorAll('a[data-type="multi-code-lang"]');
+    items.forEach((item) => {
+      const a = item.closest('li').querySelector(`a[data-name="${codeLang}"]`);
+      if (a) {
+        item.setAttribute('href', a.getAttribute('href'));
+      }
+    });
+  }
+}
+
+toggleMultiCodeLangNav(Cookies.get('code-lang') || '');
+
+export { redirectCodeLang, addCodeTabEventListeners, activateCodeLangNav, toggleMultiCodeLangNav };

--- a/src/scripts/datadog-docs.js
+++ b/src/scripts/datadog-docs.js
@@ -1,4 +1,3 @@
-import Cookies from 'js-cookie';
 import Stickyfill from 'stickyfilljs';
 import algoliasearch from 'algoliasearch';
 import Choices from 'choices.js';

--- a/src/scripts/datadog-docs.js
+++ b/src/scripts/datadog-docs.js
@@ -840,16 +840,6 @@ function navClickEventHandler(event) {
 
     newUrl = event.target.closest('li').querySelector('a').href;
 
-    /*
-    If this is a multi code lang page we are clicking on
-    lets check if we have a lang already and load that url
-    */
-    const type = event.target.closest('li').querySelector('a').dataset.type;
-    if(type === 'multi-code-lang') {
-      const codeLang = Cookies.get('code-lang') || document.documentElement.dataset.pageCodeLang || 'python';
-      newUrl = newUrl.replace(/\/[^\/]*$/, `/${codeLang}`)
-    }
-
     const domain = window.location.origin;
 
     if (typeof domain !== 'string' || newUrl.search(domain) !== 0) {

--- a/src/scripts/datadog-docs.js
+++ b/src/scripts/datadog-docs.js
@@ -1,3 +1,4 @@
+import Cookies from 'js-cookie';
 import Stickyfill from 'stickyfilljs';
 import algoliasearch from 'algoliasearch';
 import Choices from 'choices.js';
@@ -129,7 +130,7 @@ $(document).ready(function () {
         const results = new RegExp('[?&]' + 's' + '=([^&#]*)').exec(
             window.location.href
         );
-        
+
         let query = '';
         try {
             query = results[1];
@@ -560,7 +561,7 @@ $(document).ready(function () {
             );
         });
     }
-    
+
 
     updateMainContentAnchors();
 
@@ -657,7 +658,7 @@ function getPathElement() {
      if (path.includes('agent/guide')) {
         aPath = document.querySelector('.side [data-path*="agent/guide"]');
         maPath = document.querySelector('header [data-path*="agent/guide"]');
-    } 
+    }
 
 
     if (path.includes('tracing/guide')) {
@@ -716,7 +717,7 @@ function getPathElement() {
             'header .nav-top-level > [data-path*="integrations"]'
         );
     }
-    
+
     if (aPath) {
         aPath.classList.add('active');
         hasParentLi(aPath);
@@ -777,7 +778,7 @@ function updateSidebar(event) {
                 }
             }
         })
-        
+
     } else {
         if (event.target.closest('li').querySelector('a')) {
             event.target
@@ -839,6 +840,16 @@ function navClickEventHandler(event) {
 
     newUrl = event.target.closest('li').querySelector('a').href;
 
+    /*
+    If this is a multi code lang page we are clicking on
+    lets check if we have a lang already and load that url
+    */
+    const type = event.target.closest('li').querySelector('a').dataset.type;
+    if(type === 'multi-code-lang') {
+      const codeLang = Cookies.get('code-lang') || document.documentElement.dataset.pageCodeLang || 'python';
+      newUrl = newUrl.replace(/\/[^\/]*$/, `/${codeLang}`)
+    }
+
     const domain = window.location.origin;
 
     if (typeof domain !== 'string' || newUrl.search(domain) !== 0) {
@@ -881,7 +892,7 @@ function rulesListClickHandler(event, pathString) {
     if (event.target.matches('#rules .list-group .js-group a.js-page')) {
         event.preventDefault();
         const targetURL = event.target.href;
-        
+
         if (targetURL.includes(pathString)) {
             loadPage(targetURL);
             window.history.pushState({}, '' /* title */, targetURL);


### PR DESCRIPTION
### What does this PR do?

Fixes a bug with persisting the users selected code lang and navigating the site

### Motivation

https://datadoghq.atlassian.net/browse/WEB-1250

### Preview

If, for example, they're on /tracing/setup_overview/setup/python, and they click "Compatibility" via the sidebar TOC or a link, it should set the code-lang cookie to Python and take them to /tracing/setup_overview/compatibility_requirements/python (not java).

https://docs-staging.datadoghq.com/david.jones/code-lang-tabfix/tracing/setup_overview/setup/python

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
