### PR TITLE
[prod] kim-oehmichen/typo in https://docs.datadoghq.com/logs/processing/processors/?tab=ui#remapper 

### DIFF
--- a/content/en/logs/processing/processors.md
+++ b/content/en/logs/processing/processors.md
@@ -267,7 +267,7 @@ Use the [Datadog Log Pipeline API endpoint][1] with the following log message re
 
 ## Remapper
 
-The remapper processor remaps any source attribute(s) or tag to another target attribute or tag. It can transforms this log:
+The remapper processor remaps any source attribute(s) or tag to another target attribute or tag. It can transform this log:
 
 {{< img src="logs/processing/processors/attribute_pre_remapping.png" alt="attribute pre remapping "  style="width:40%;">}}
 

--- a/content/en/logs/processing/processors.md
+++ b/content/en/logs/processing/processors.md
@@ -267,7 +267,7 @@ Use the [Datadog Log Pipeline API endpoint][1] with the following log message re
 
 ## Remapper
 
-The remapper processor remaps any source attribute(s) or tag to another target attribute or tag. It can transform this log:
+The remapper processor remaps any source attribute(s) or tag to another target attribute or tag. It transforms this log:
 
 {{< img src="logs/processing/processors/attribute_pre_remapping.png" alt="attribute pre remapping "  style="width:40%;">}}
 


### PR DESCRIPTION
old: transforms -- It can transforms this log:
new: transform -- It can transform this log:

https://docs.datadoghq.com/logs/processing/processors/?tab=ui#remapper 


### What does this PR do?
correct typo in external doc.
https://docs.datadoghq.com/logs/processing/processors/?tab=ui#remapper 

### Motivation
Correcting a typo in external doc, visible to customers.

### Preview
https://docs.datadoghq.com/logs/processing/processors/?tab=ui#remapper 


Replace the branch name and add the complete path: -->
Kim: Not sure what I need to do there...
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
