### PR TITLE
Add aliases in /dashboards/screenboards.md

### DIFF
--- a/content/en/dashboards/screenboards.md
+++ b/content/en/dashboards/screenboards.md
@@ -5,6 +5,8 @@ aliases:
     - /graphing/dashboards/screenboards/
     - /graphing/dashboards/screenboard/
     - /dashboards/screenboard/
+    - /screenboards/
+    - /screenboard/
 further_reading:
 - link: "/dashboards/template_variables/"
   tag: "Documentation"


### PR DESCRIPTION

### What does this PR do?
Adds some aliases that seem to be coming up a lot as 404s

### Motivation
On-call, looking at 404 dashboard. Seeing a lot of people trying to find /screenboards/ and getting 404s

### Preview
These should redirect to /dashboards/screenboards.

https://docs-staging.datadoghq.com/kari/alias-screenbds/screenboards/
https://docs-staging.datadoghq.com/kari/alias-screenbds/screenboard/


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
