### PR TITLE
Add signup sheet to Azure App Service Extension docs

### DIFF
--- a/content/en/serverless/azure_app_services.md
+++ b/content/en/serverless/azure_app_services.md
@@ -43,9 +43,9 @@ The Datadog extension for Azure App Services provides additional monitoring capa
 
 2. The extension only supports Azure App Service Web Apps. **Function Apps are not supported**.
 
-<div class="alert alert-warning">To get notified when a private beta is available for Function Apps or additional runtimes, [sign up here][9].</div>
+<div class="alert alert-warning">To get notified when a private beta is available for Function Apps or additional runtimes, <a href="https://forms.gle/n4nQcxEyLqDBMCDA7”>sign up here</a>.</div>
 
-3. The Datadog .NET APM extension supports the following .NET runtimes in both x64 and x86 architectures when running on Windows instances (AAS does not yet support extensions on Linux). For more details about automatically instrumented libraries, see the [Tracer documentation][10].
+3. The Datadog .NET APM extension supports the following .NET runtimes in both x64 and x86 architectures when running on Windows instances (AAS does not yet support extensions on Linux). For more details about automatically instrumented libraries, see the [Tracer documentation][9].
 
     - .NET Framework 4.5 and later
     - .NET Core 2.1
@@ -62,18 +62,18 @@ The Datadog extension for Azure App Services provides additional monitoring capa
 
 1. Configure the Azure integration to monitor your web app and verify it is configured correctly by ensuring that you see an `azure.app_service.count` metric tagged with the name of your web application. **Note**: This step is critical for metric/trace correlation, functional trace panel views in the Datadog portal, and accurate billing.
 
-2. Open the [Azure Portal][11] and navigate to the dashboard for the Azure App Services instance you wish to instrument with Datadog.
+2. Open the [Azure Portal][10] and navigate to the dashboard for the Azure App Services instance you wish to instrument with Datadog.
 
 3. Go to the Application settings tab of the Configuration page.
     {{< img src="infrastructure/serverless/azure_app_services/config.png" alt="configuration page" >}}
-4. Add your Datadog API key as an application setting called `DD_API_KEY` and a value of your [Datadog API Key][12].
+4. Add your Datadog API key as an application setting called `DD_API_KEY` and a value of your [Datadog API Key][11].
     {{< img src="infrastructure/serverless/azure_app_services/api_key.png" alt="api key page" >}}
 5. Configure optional application settings:
     - Set the `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (defaults to `datadoghq.com`).
     - Set `DD_ENV` to group your traces and custom statistics.
     - Set `DD_SERVICE` to specify a service name (defaults to your web app name).
     - Set `DD_LOGS_INJECTION:true` for correlation with application logs from your web app.
-    - See a full list of [optional configuration variables][13].
+    - See a full list of [optional configuration variables][12].
 6. Click **Save** (this restarts your application).
 7. <div class="alert alert-warning">[REQUIRED] Stop your application by clicking <u>Stop</u>.</div>
 8. Go to the Azure extensions page and select the Datadog APM extension.
@@ -88,7 +88,7 @@ Sending logs from your application in Azure App Services to Datadog requires the
 
 **Note**: Since this occurs inside your application, any Azure Platform logs you submit with diagnostic settings does not include the trace ID.
 
-See documentation on [setting up agentless logging with Serilog][14] for detailed instructions.
+See documentation on [setting up agentless logging with Serilog][13] for detailed instructions.
 
 ## Custom metrics with DogStatsD
 
@@ -96,12 +96,12 @@ The App Services extension includes an instance of [DogStatsD][7] (Datadog's met
 
 Writing custom metrics and checks in your web app is similar to the process for doing so with an application on a host running the Datadog Agent. To submit custom metrics to Datadog from Azure App Services using the extension:
 
-1. Add the [DogStatsD NuGet package][15] to your Visual Studio project.
+1. Add the [DogStatsD NuGet package][14] to your Visual Studio project.
 2. Initialize DogStatdD and write custom metrics in your application.
 3. Deploy your code to a supported Azure .NET web app.
 4. Install the Datadog App Service extension.
 
-**Note**: Unlike the [standard DogStatsD config process][16], there is no need to set ports or a server name when initializing the DogStatsD configuration. There are ambient environment variables in Azure App Service that determine how the metrics are sent (requires v6.0.0+ of the DogStatsD client).
+**Note**: Unlike the [standard DogStatsD config process][15], there is no need to set ports or a server name when initializing the DogStatsD configuration. There are ambient environment variables in Azure App Service that determine how the metrics are sent (requires v6.0.0+ of the DogStatsD client).
 
 To send metrics use this code:
 
@@ -123,7 +123,7 @@ Console.WriteLine(ex);
 DogStatsd.Increment("sample.startup");
 ```
 
-Learn more about [custom metrics][17].
+Learn more about [custom metrics][16].
 
 ## Troubleshooting
 
@@ -132,7 +132,7 @@ To start troubleshooting your application, try these steps:
 1. Verify you've set `DD_SITE` and `DD_API_KEY` correctly.
 2. Do a full stop and start of your application.
 3. If not resolved, try uninstalling the extension and re-installing (this also ensures you are running the latest version).
-4. Still need help? Contact [Datadog support][18].
+4. Still need help? Contact [Datadog support][17].
 
 **Note**: To expedite the process of investigating application errors with the support team, set `DD_TRACE_DEBUG:true` and add the content of the Datadog logs directory (`%AzureAppServiceHomeDirectory%\LogFiles\datadog`) to your email.
 
@@ -149,13 +149,12 @@ To start troubleshooting your application, try these steps:
 [6]: https://azure.microsoft.com/en-us/services/app-service/web/
 [7]: /developers/dogstatsd
 [8]: /integrations/azure
-[9]: https://forms.gle/n4nQcxEyLqDBMCDA7
-[10]: /tracing/setup/dotnet/
-[11]: https://portal.azure.com
-[12]: https://app.datadoghq.com/account/settings#api
-[13]: /tracing/setup_overview/setup/dotnet-framework/#additional-optional-configuration
-[14]: /logs/log_collection/csharp/?tab=serilog#agentless-logging
-[15]: https://www.nuget.org/packages/DogStatsD-CSharp-Client
-[16]: /developers/dogstatsd/?tab=net#code
-[17]: /developers/metrics/
-[18]: /help
+[9]: /tracing/setup/dotnet/
+[10]: https://portal.azure.com
+[11]: https://app.datadoghq.com/account/settings#api
+[12]: /tracing/setup_overview/setup/dotnet-framework/#additional-optional-configuration
+[13]: /logs/log_collection/csharp/?tab=serilog#agentless-logging
+[14]: https://www.nuget.org/packages/DogStatsD-CSharp-Client
+[15]: /developers/dogstatsd/?tab=net#code
+[16]: /developers/metrics/
+[17]: /help

--- a/content/en/serverless/azure_app_services.md
+++ b/content/en/serverless/azure_app_services.md
@@ -43,7 +43,9 @@ The Datadog extension for Azure App Services provides additional monitoring capa
 
 2. The extension only supports Azure App Service Web Apps. **Function Apps are not supported**.
 
-3. The Datadog .NET APM extension supports the following .NET runtimes in both x64 and x86 architectures when running on Windows instances (AAS does not yet support extensions on Linux). For more details about automatically instrumented libraries, see the [Tracer documentation][9].
+<div class="alert alert-warning">To get notified when a private beta is available for Function Apps or additional runtimes, [sign up here][9].</div>
+
+3. The Datadog .NET APM extension supports the following .NET runtimes in both x64 and x86 architectures when running on Windows instances (AAS does not yet support extensions on Linux). For more details about automatically instrumented libraries, see the [Tracer documentation][10].
 
     - .NET Framework 4.5 and later
     - .NET Core 2.1
@@ -60,18 +62,18 @@ The Datadog extension for Azure App Services provides additional monitoring capa
 
 1. Configure the Azure integration to monitor your web app and verify it is configured correctly by ensuring that you see an `azure.app_service.count` metric tagged with the name of your web application. **Note**: This step is critical for metric/trace correlation, functional trace panel views in the Datadog portal, and accurate billing.
 
-2. Open the [Azure Portal][10] and navigate to the dashboard for the Azure App Services instance you wish to instrument with Datadog.
+2. Open the [Azure Portal][11] and navigate to the dashboard for the Azure App Services instance you wish to instrument with Datadog.
 
 3. Go to the Application settings tab of the Configuration page.
     {{< img src="infrastructure/serverless/azure_app_services/config.png" alt="configuration page" >}}
-4. Add your Datadog API key as an application setting called `DD_API_KEY` and a value of your [Datadog API Key][11].
+4. Add your Datadog API key as an application setting called `DD_API_KEY` and a value of your [Datadog API Key][12].
     {{< img src="infrastructure/serverless/azure_app_services/api_key.png" alt="api key page" >}}
 5. Configure optional application settings:
     - Set the `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (defaults to `datadoghq.com`).
     - Set `DD_ENV` to group your traces and custom statistics.
     - Set `DD_SERVICE` to specify a service name (defaults to your web app name).
     - Set `DD_LOGS_INJECTION:true` for correlation with application logs from your web app.
-    - See a full list of [optional configuration variables][12].
+    - See a full list of [optional configuration variables][13].
 6. Click **Save** (this restarts your application).
 7. <div class="alert alert-warning">[REQUIRED] Stop your application by clicking <u>Stop</u>.</div>
 8. Go to the Azure extensions page and select the Datadog APM extension.
@@ -86,7 +88,7 @@ Sending logs from your application in Azure App Services to Datadog requires the
 
 **Note**: Since this occurs inside your application, any Azure Platform logs you submit with diagnostic settings does not include the trace ID.
 
-See documentation on [setting up agentless logging with Serilog][13] for detailed instructions.
+See documentation on [setting up agentless logging with Serilog][14] for detailed instructions.
 
 ## Custom metrics with DogStatsD
 
@@ -94,12 +96,12 @@ The App Services extension includes an instance of [DogStatsD][7] (Datadog's met
 
 Writing custom metrics and checks in your web app is similar to the process for doing so with an application on a host running the Datadog Agent. To submit custom metrics to Datadog from Azure App Services using the extension:
 
-1. Add the [DogStatsD NuGet package][14] to your Visual Studio project.
+1. Add the [DogStatsD NuGet package][15] to your Visual Studio project.
 2. Initialize DogStatdD and write custom metrics in your application.
 3. Deploy your code to a supported Azure .NET web app.
 4. Install the Datadog App Service extension.
 
-**Note**: Unlike the [standard DogStatsD config process][15], there is no need to set ports or a server name when initializing the DogStatsD configuration. There are ambient environment variables in Azure App Service that determine how the metrics are sent (requires v6.0.0+ of the DogStatsD client).
+**Note**: Unlike the [standard DogStatsD config process][16], there is no need to set ports or a server name when initializing the DogStatsD configuration. There are ambient environment variables in Azure App Service that determine how the metrics are sent (requires v6.0.0+ of the DogStatsD client).
 
 To send metrics use this code:
 
@@ -121,7 +123,7 @@ Console.WriteLine(ex);
 DogStatsd.Increment("sample.startup");
 ```
 
-Learn more about [custom metrics][16].
+Learn more about [custom metrics][17].
 
 ## Troubleshooting
 
@@ -130,7 +132,7 @@ To start troubleshooting your application, try these steps:
 1. Verify you've set `DD_SITE` and `DD_API_KEY` correctly.
 2. Do a full stop and start of your application.
 3. If not resolved, try uninstalling the extension and re-installing (this also ensures you are running the latest version).
-4. Still need help? Contact [Datadog support][17].
+4. Still need help? Contact [Datadog support][18].
 
 **Note**: To expedite the process of investigating application errors with the support team, set `DD_TRACE_DEBUG:true` and add the content of the Datadog logs directory (`%AzureAppServiceHomeDirectory%\LogFiles\datadog`) to your email.
 
@@ -147,12 +149,13 @@ To start troubleshooting your application, try these steps:
 [6]: https://azure.microsoft.com/en-us/services/app-service/web/
 [7]: /developers/dogstatsd
 [8]: /integrations/azure
-[9]: /tracing/setup/dotnet/
-[10]: https://portal.azure.com
-[11]: https://app.datadoghq.com/account/settings#api
-[12]: /tracing/setup_overview/setup/dotnet-framework/#additional-optional-configuration
-[13]: /logs/log_collection/csharp/?tab=serilog#agentless-logging
-[14]: https://www.nuget.org/packages/DogStatsD-CSharp-Client
-[15]: /developers/dogstatsd/?tab=net#code
-[16]: /developers/metrics/
-[17]: /help
+[9]: https://forms.gle/n4nQcxEyLqDBMCDA7
+[10]: /tracing/setup/dotnet/
+[11]: https://portal.azure.com
+[12]: https://app.datadoghq.com/account/settings#api
+[13]: /tracing/setup_overview/setup/dotnet-framework/#additional-optional-configuration
+[14]: /logs/log_collection/csharp/?tab=serilog#agentless-logging
+[15]: https://www.nuget.org/packages/DogStatsD-CSharp-Client
+[16]: /developers/dogstatsd/?tab=net#code
+[17]: /developers/metrics/
+[18]: /help

--- a/content/en/serverless/azure_app_services.md
+++ b/content/en/serverless/azure_app_services.md
@@ -43,7 +43,7 @@ The Datadog extension for Azure App Services provides additional monitoring capa
 
 2. The extension only supports Azure App Service Web Apps. **Function Apps are not supported**.
 
-<div class="alert alert-warning">To get notified when a private beta is available for Function Apps or additional runtimes, <a href="https://forms.gle/n4nQcxEyLqDBMCDA7”>sign up here</a>.</div>
+<div class="alert alert-warning">To be notified when a private beta is available for Function Apps or additional runtimes, <a href="https://forms.gle/n4nQcxEyLqDBMCDA7">sign up here</a>.</div>
 
 3. The Datadog .NET APM extension supports the following .NET runtimes in both x64 and x86 architectures when running on Windows instances (AAS does not yet support extensions on Linux). For more details about automatically instrumented libraries, see the [Tracer documentation][9].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a link to a form where customers can sign up for their interest in future betas for functions and other runtimes.

### Motivation
We want a better way to track customer requests and interest.

### Preview
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/steveharrington1-patch-1/content/en/serverless/azure_app_services.md

(maybe?)


### Additional Notes
<!-- Anything else we should know when reviewing?-->

Please don't merge until confirmed with Steve Harrington slack @steveh - I want to make sure the form is fully ready. Thanks!
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
