### PR TITLE
Add mulesoft to java compatibility docs

### DIFF
--- a/content/en/tracing/setup_overview/compatibility_requirements/java.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/java.md
@@ -40,8 +40,8 @@ Beta integrations are disabled by default but can be enabled individually:
 | ----------------------- | ---------- | --------------- | ---------------------------------------------- |
 | Akka-Http Server        | 10.0+      | Fully Supported | `akka-http`, `akka-http-server`                |
 | Finatra Web             | 2.9+       | Fully Supported | `finatra`                                      |
-| Grizzly                 | 2.0+       | [Beta][2]       | `grizzly`                                      |
-| Grizzly-HTTP            | 2.3.20+    | [Beta][2]       | `grizzly-filterchain`                          |
+| Grizzly                 | 2.0+       | Fully Supported | `grizzly`                                      |
+| Grizzly-HTTP            | 2.3.20+    | Fully Supported | `grizzly-filterchain`                          |
 | Java Servlet Compatible | 2.3+, 3.0+ | Fully Supported | `servlet`, `servlet-2`, `servlet-3`            |
 | Jax-RS Annotations      | JSR311-API | Fully Supported | `jax-rs`, `jaxrs`, `jax-rs-annotations`, `jax-rs-filter` |
 | Jetty                   | 7.0-9.x    | Fully Supported | `jetty`                                        |
@@ -57,10 +57,15 @@ Beta integrations are disabled by default but can be enabled individually:
 **Note**: Many application servers are Servlet compatible and are automatically covered by that instrumentation, such as Tomcat, Jetty, Websphere, Weblogic, and JBoss.
 Also, frameworks like Spring Boot inherently work because it usually uses a supported embedded application server (Tomcat/Jetty/Netty).
 
-The Mulesoft Instrumentation is off by default, to enable add the following settings:
--Ddd.integration.grizzly-filterchain.enabled=true
--Ddd.integration.grizzly-client.enabled=true
--Ddd.integration.mule.enabled=true
+**Integrations Disabled By Default**
+
+The following instrumentation is off by default and can be enabled with the following settings:
+
+| Instrumentation         | To Enable 									  |
+| ----------------------- |---------------------------------------------- |
+| Mulesoft		          | `-Ddd.integration.mule.enabled=true`, `-Ddd.integration.grizzly-client.enabled=true`, `-Ddd.integration.grizzly-filterchain.enabled=true`|
+| Grizzly                 | `-Ddd.integration.grizzly-client.enabled=true`|
+| Grizzly-HTTP            | `-Ddd.integration.grizzly-filterchain.enabled=true`|
 
 Don't see your desired web frameworks? Datadog is continually adding additional support. Contact [Datadog support][2] if you need help.
 
@@ -127,6 +132,9 @@ Don't see your desired networking framework? Datadog is continually adding addit
 | MongoDB                 | 3.0-4.0+ | Fully Supported | `mongo`                                                                                  |
 | RediScala               | 1.5+     | Fully Supported | `rediscala`, `redis`                                                                     |
 | SpyMemcached            | 2.12+    | Fully Supported | `spymemcached`                                                                           |
+| Vert.x Cassandra Client | 3.9		 | Fully Supported | `cassandra`																			  |
+| Vert.x Redis Client     | 3.9      | Fully Supported | `vertx-redis-client`                                                                     |
+| Vert.x MySQL Client     | 3.9      | Fully Supported | `vertx-sql-client`																		  |
 
 `dd-java-agent` is also compatible with common JDBC drivers including:
 
@@ -141,6 +149,14 @@ Don't see your desired networking framework? Datadog is continually adding addit
 - Oracle
 - Postgres SQL
 - ScalikeJDBC
+
+**Integrations Disabled By Default**
+
+The following instrumentation is off by default and can be enabled with the following settings:
+
+| Instrumentation         | To Enable 									  |
+| ----------------------- |---------------------------------------------- |
+| JDBC-Datasource		  | `-Ddd.integration.jdbc-datasource.enabled=true` |
 
 Don't see your desired datastores? Datadog is continually adding additional support. Contact [Datadog support][2] if you need help.
 

--- a/content/en/tracing/setup_overview/compatibility_requirements/java.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/java.md
@@ -152,7 +152,7 @@ Don't see your desired networking framework? Datadog is continually adding addit
 
 **Integrations Disabled By Default**
 
-The following instrumentation is off by default and can be enabled with the following settings:
+The following instrumentations are disabled by default and can be enabled with the following settings:
 
 | Instrumentation         | To Enable 									  |
 | ----------------------- |---------------------------------------------- |

--- a/content/en/tracing/setup_overview/compatibility_requirements/java.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/java.md
@@ -59,7 +59,7 @@ Also, frameworks like Spring Boot inherently work because it usually uses a supp
 
 **Integrations Disabled By Default**
 
-The following instrumentation is off by default and can be enabled with the following settings:
+The following instrumentations are disabled by default and can be enabled with the following settings:
 
 | Instrumentation         | To Enable 									  |
 | ----------------------- |---------------------------------------------- |

--- a/content/en/tracing/setup_overview/compatibility_requirements/java.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/java.md
@@ -45,6 +45,7 @@ Beta integrations are disabled by default but can be enabled individually:
 | Java Servlet Compatible | 2.3+, 3.0+ | Fully Supported | `servlet`, `servlet-2`, `servlet-3`            |
 | Jax-RS Annotations      | JSR311-API | Fully Supported | `jax-rs`, `jaxrs`, `jax-rs-annotations`, `jax-rs-filter` |
 | Jetty                   | 7.0-9.x    | Fully Supported | `jetty`                                        |
+| Mulesoft                | 4          | Fully Supported | `mule`                                         |
 | Netty HTTP Server       | 3.8+       | Fully Supported | `netty`, `netty-3.8`, `netty-4.0`, `netty-4.1` |
 | Play                    | 2.3-2.8    | Fully Supported | `play`, `play-action`                          |
 | Ratpack                 | 1.5+       | Fully Supported | `ratpack`                                      |
@@ -55,6 +56,11 @@ Beta integrations are disabled by default but can be enabled individually:
 
 **Note**: Many application servers are Servlet compatible and are automatically covered by that instrumentation, such as Tomcat, Jetty, Websphere, Weblogic, and JBoss.
 Also, frameworks like Spring Boot inherently work because it usually uses a supported embedded application server (Tomcat/Jetty/Netty).
+
+The Mulesoft Instrumentation is off by default, to enable add the following settings:
+-Ddd.integration.grizzly-filterchain.enabled=true
+-Ddd.integration.grizzly-client.enabled=true
+-Ddd.integration.mule.enabled=true
 
 Don't see your desired web frameworks? Datadog is continually adding additional support. Contact [Datadog support][2] if you need help.
 
@@ -149,7 +155,7 @@ Don't see your desired datastores? Datadog is continually adding additional supp
 | Hibernate         | 3.5+     | Fully Supported | `hibernate`, `hibernate-core`                  |
 | Hystrix           | 1.4+     | Fully Supported | `hystrix`                                      |
 | JSP Rendering     | 2.3+     | Fully Supported | `jsp`, `jsp-render`, `jsp-compile`             |
-| JUnit             | 4.1+, 5.3+ | Fully Supported | `junit`, `junit-4`, `junit-5`                 |
+| JUnit             | 4.1+, 5.3+ | Fully Supported | `junit`, `junit-4`, `junit-5`                 |       
 | Project Reactor   | 3.1+     | Fully Supported | `reactor-core`                                 |
 | RxJava            | 2.x      | Fully Supported | `rxjava`                                       |
 | Spring Data       | 1.8+     | Fully Supported | `spring-data`                                  |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Added compatibility note on Mulesoft, and db clients:
- Vert.x Cassandra Client
- Vert.x Redis client
- Vert.x MySQL client

Also adds a "to disabled by default" section which should clarify the previous beta listing.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/andrewsouthard1-patch-1/tracing/setup_overview/compatibility_requirements/java

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
