### PR TITLE
adding link to dns_tests and fixing order

### DIFF
--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -27,7 +27,7 @@ HTTP tests can be run from [**managed**][1] and [**private locations**][2] depen
 
 ## Configuration
 
-After choosing the type of test you want to create ([`HTTP`][3], [`SSL`][4], [`TCP`][5], [`DNS`][6], or [`ICMP` test][7]), you can define your test's request.
+After choosing the type of test you want to create ([`HTTP`][4], [`SSL`][5], [`TCP`][6], [`DNS`][17], or [`ICMP` test][7]), you can define your test's request.
 
 ### Define request
 
@@ -203,3 +203,4 @@ A test is considered `FAILED` if it does not satisfy one or several assertions o
 [14]: /monitors/notifications/?tab=is_recoveryis_alert_recovery#conditional-variables
 [15]: /synthetics/settings/#global-variables
 [16]: /synthetics/api_tests/errors/#ssl-errors
+[17]: /synthetics/api_tests/dns_tests


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fixing the links for the synthetics test and adding missing link to dns_tests

### Motivation
<!-- What inspired you to submit this pull request?-->
synthetics tests links were wrong

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
