### PR TITLE
Add tracer versions to the unified service tagging doc

### DIFF
--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -33,7 +33,7 @@ With these three tags you can:
 - Unified service tagging requires a tracer version that supports new configurations of the [reserved tags][1]. More information can be found per language in the [setup instructions][3].
 
 
-| Language         | Versions |
+| Language         | Minimum Tracer Version |
 |--------------|------------|
 | .NET    |  1.17.0+       |
 | C++    |  1.1.4+       |

--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -32,6 +32,18 @@ With these three tags you can:
 
 - Unified service tagging requires a tracer version that supports new configurations of the [reserved tags][1]. More information can be found per language in the [setup instructions][3].
 
+
+| Language         | Versions |
+|--------------|------------|
+| .NET    |  1.17.0+       |
+| C++    |  1.1.4+       |
+| Go         |  1.24.0+       |
+| Java   |  0.50.0+      |
+| Node    |  0.20.3+       |
+| PHP  |  0.47.0+      |
+| Python  |  0.38.0+      |
+| Ruby  |  0.34.0+      |
+
 - Unified service tagging requires knowledge of configuring tags. If you are unsure of how to configure tags, read the [Getting Started with Tagging][4] and [Assigning Tags][5] documentation before proceeding to configuration.
 
 ## Configuration


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This update explains what version of the tracers support unified service tagging.

### Motivation
<!-- What inspired you to submit this pull request?-->

The current documentation just tells you to use a version that supports this configuration. For convenience, the relevant tracer versions have been listed.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/wantsui/unified-service-tagging-tracer-versions/getting_started/tagging/unified_service_tagging/?tab=kubernetes#overview

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
