### PR TITLE
fix empty categories on integrations

### DIFF
--- a/layouts/shortcodes/integrations.html
+++ b/layouts/shortcodes/integrations.html
@@ -11,8 +11,10 @@
 {{ $.Scratch.Set "filters" (slice)}}
 {{ range $index, $element := $integration_list }}
     {{ range $e := $element.Params.categories }}
-        {{ if not (in ($.Scratch.Get "filters") ($e | lower)) }}
-            {{ $.Scratch.Add "filters" ($e | lower) }}
+        {{ with $e }}
+          {{ if not (in ($.Scratch.Get "filters") (. | lower)) }}
+              {{ $.Scratch.Add "filters" (. | lower) }}
+          {{ end }}
         {{ end }}
     {{ end }}
 {{ end }}


### PR DESCRIPTION
### What does this PR do?

fixes an empty categories filter pill displaying on integrations page

### Motivation

slack

### Preview

https://docs-staging.datadoghq.com/david.jones/empty-cat/integrations/

### Additional Notes



---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
