### PR TITLE
Precision on the timerange saved for a Log Management Saved View

### DIFF
--- a/content/en/logs/explorer/saved_views.md
+++ b/content/en/logs/explorer/saved_views.md
@@ -21,7 +21,7 @@ Troubleshooting is highly contextual, and Saved Views enable you and your teamma
 
 Technically, a Saved View keeps track of:
 
-- A [search query][3]
+- A [search query][3] along with its timerange. Note that the Saved View is meant to track live timeranges (past hour, past week...) and fixed timeranges are converted as such on save. 
 - A customized default visualization ([log stream][4], [log patterns][5], or [log analytics][6] along with their specific visualization properties)
 - A [selected subset of facets][1] to be displayed in the facet list
 

--- a/content/en/logs/explorer/saved_views.md
+++ b/content/en/logs/explorer/saved_views.md
@@ -21,9 +21,9 @@ Troubleshooting is highly contextual, and Saved Views enable you and your teamma
 
 Technically, a Saved View keeps track of:
 
-- A [search query][3] along with its timerange. Note that the Saved View is meant to track live timeranges (past hour, past week...) and fixed timeranges are converted as such on save. 
-- A customized default visualization ([log stream][4], [log patterns][5], or [log analytics][6] along with their specific visualization properties)
-- A [selected subset of facets][1] to be displayed in the facet list
+- A [search query][3] along with its time range. **Note**: Saved View is meant to track live time ranges (such as past hour, or past week) and fixed time ranges are converted as such on save. 
+- A customized default visualization ([log stream][4], [log patterns][5], or [log analytics][6] along with their specific visualization properties).
+- A [selected subset of facets][1] to be displayed in the facet list.
 
 ## Default view
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/pcarioufr/saved_view_timeranges//logs/explorer/saved_views/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
