### PR TITLE
Add NDM guides to search config

### DIFF
--- a/local/etc/algolia/docs_datadoghq.json
+++ b/local/etc/algolia/docs_datadoghq.json
@@ -45,6 +45,7 @@
                     "real_user_monitoring",
                     "serverless",
                     "synthetics",
+                    "network_monitoring/devices",
                     "developers"
                 ],
                 "localisation": ["", "/fr", "/ja"]

--- a/local/etc/algolia/docs_datadoghq_preview.json
+++ b/local/etc/algolia/docs_datadoghq_preview.json
@@ -43,6 +43,7 @@
                     "tracing",
                     "logs",
                     "synthetics",
+                    "network_monitoring/devices",
                     "serverless",
                     "real_user_monitoring",
                     "developers"


### PR DESCRIPTION
### What does this PR do?
Gets the pages under Network Monitoring > Devices > Guides to show up in search results.

### Motivation
Report in documentation slack

### Preview
https://docs-staging.datadoghq.com/kari/ndm-search/ and search for `NDM cluster`. Ensure `/network_monitoring/devices/guide/cluster-agent` page comes up in results.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
