### PR TITLE
Add note on graphing multiple metrics for metrics

### DIFF
--- a/content/en/dashboards/querying/_index.md
+++ b/content/en/dashboards/querying/_index.md
@@ -95,6 +95,8 @@ Datadog also supports the ability to graph your metrics with various arithmetic 
 
 To graph metrics separately, use the comma (`,`). For example, `a, b, c`.
 
+**Note**: Queries using commas are only supported in visualisations, they do not work on monitors. Use [boolean operators][12] or arithmetic operations to combine multiple metrics in a monitor.
+
 #### Metric arithmetic using an integer
 
 Modify the displayed value of a metric on a graph by performing an arithmetic operation. For example, to visualize the double of a specific metric, click the **Advanced...** link in the graph editor. Then enter your arithmetic in the `Formula` box, in this case: `a * 2`:
@@ -165,3 +167,4 @@ View event correlations by using the **Event Overlays** section in the graphing 
 [9]: /dashboards/functions/#apply-functions-optional
 [10]: /events/#event-query-language
 [11]: /metrics/advanced-filtering/
+[12]: /metrics/advanced-filtering/#boolean-filtered-queries


### PR DESCRIPTION
### What does this PR do?
Add a note to the part where we explain how to add multiple metrics on a single graph to reference that this only work for visualisation but not for monitors.

### Motivation
Users were trying to monitor multiple metrics within the same monitor which is not supported and the confusion was always coming from this part as users believed it is working everywhere. 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/monitos-multiple-metric-note/dashboards/querying/#advanced-graphing

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
