### PR TITLE
Add rotation timeout + default port HTTP in logs agent

### DIFF
--- a/content/en/agent/logs/log_transport.md
+++ b/content/en/agent/logs/log_transport.md
@@ -57,6 +57,7 @@ To send logs with environment variables, configure the following:
 * `DD_LOGS_ENABLED=true`
 * `DD_LOGS_CONFIG_USE_HTTP=true`
 
+By default, the Datadog Agent uses the port `443` to send its logs to Datadog over HTTPS.
 
 [1]: /agent/guide/agent-configuration-files/
 {{% /tab %}}

--- a/content/en/logs/faq/log-collection-is-the-datadog-agent-losing-logs.md
+++ b/content/en/logs/faq/log-collection-is-the-datadog-agent-losing-logs.md
@@ -15,7 +15,7 @@ further_reading:
 ## Log rotate
 
 When a file is rotated, the Agent keeps tailing the old file while starting to tail the newly created file in parallel.
-Althought the agent continues to tail the old file, a 60 seconds timeout after the log rotation is set to ensure the agent is using its ressources to tail the most up-to-date files.
+Although the Agent continues to tail the old file, a 60-second timeout after the log rotation is set to ensure the agent is using its ressources to tail the most up-to-date files.
 
 ## Network issues
 

--- a/content/en/logs/faq/log-collection-is-the-datadog-agent-losing-logs.md
+++ b/content/en/logs/faq/log-collection-is-the-datadog-agent-losing-logs.md
@@ -14,7 +14,8 @@ further_reading:
 
 ## Log rotate
 
-When a file is rotated, the Agent keeps tailing the old file until its end before starting to look at the newly created file.
+When a file is rotated, the Agent keeps tailing the old file while starting to tail the newly created file in parallel.
+Althought the agent continues to tail the old file, a 60 seconds timeout after the log rotation is set to ensure the agent is using its ressources to tail the most up-to-date files.
 
 ## Network issues
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
* Add a clarification on the default port used in the logs agent over HTTP
* Add 60s timeout in the logs agent after a log rotation

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
