### PR TITLE
Update nginx module referenced in docs

### DIFF
--- a/content/en/tracing/setup_overview/proxy_setup/_index.md
+++ b/content/en/tracing/setup_overview/proxy_setup/_index.md
@@ -249,7 +249,7 @@ A workaround for this is to run NGINX from a Docker container. An example Docker
 
 The following plugins must be installed:
 
-- NGINX plugin for OpenTracing - [linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz][3] - installed in `/usr/lib/nginx/modules`
+- NGINX plugin for OpenTracing - [linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz][3] - installed in `/usr/lib/nginx/modules`
 - Datadog OpenTracing C++ Plugin - [linux-amd64-libdd_opentracing_plugin.so.gz][4] - installed somewhere accessible to NGINX, eg `/usr/local/lib`
 
 Commands to download and install these modules:
@@ -265,8 +265,8 @@ NGINX_VERSION=1.17.3
 OPENTRACING_NGINX_VERSION="$(get_latest_release opentracing-contrib/nginx-opentracing)"
 DD_OPENTRACING_CPP_VERSION="$(get_latest_release DataDog/dd-opentracing-cpp)"
 # Install NGINX plugin for OpenTracing
-wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/${OPENTRACING_NGINX_VERSION}/linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz
-tar zxf linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz -C /usr/lib/nginx/modules
+wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/${OPENTRACING_NGINX_VERSION}/linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz
+tar zxf linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz -C /usr/lib/nginx/modules
 # Install Datadog Opentracing C++ Plugin
 wget https://github.com/DataDog/dd-opentracing-cpp/releases/download/${DD_OPENTRACING_CPP_VERSION}/linux-amd64-libdd_opentracing_plugin.so.gz
 gunzip linux-amd64-libdd_opentracing_plugin.so.gz -c > /usr/local/lib/libdd_opentracing_plugin.so

--- a/content/fr/tracing/setup/nginx.md
+++ b/content/fr/tracing/setup/nginx.md
@@ -33,7 +33,7 @@ Une solution consiste à exécuter NGINX à partir d'un conteneur Docker. Un exe
 
 Les plug-ins suivants doivent être installés :
 
-- Plug-in NGINX pour OpenTracing - [linux-amd64-nginx-${VERSION_NGINX}-ngx_http_module.so.tgz][3] : installé dans `/usr/lib/nginx/modules`
+- Plug-in NGINX pour OpenTracing - [linux-amd64-nginx-${VERSION_NGINX}-ot16-ngx_http_module.so.tgz][3] : installé dans `/usr/lib/nginx/modules`
 - Plug-in Datadog OpenTracing C++ - [linux-amd64-libdd_opentracing_plugin.so.gz][4] : installé à un emplacement accessible pour NGINX, p. ex. `/usr/local/lib`
 
 Commandes pour télécharger et installer ces modules :
@@ -49,8 +49,8 @@ NGINX_VERSION=1.17.3
 OPENTRACING_NGINX_VERSION="$(get_latest_release opentracing-contrib/nginx-opentracing)"
 DD_OPENTRACING_CPP_VERSION="$(get_latest_release DataDog/dd-opentracing-cpp)"
 # Installer le plug-in NGINX pour OpenTracing
-wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/${OPENTRACING_NGINX_VERSION}/linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz
-tar zxf linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz -C /usr/lib/nginx/modules
+wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/${OPENTRACING_NGINX_VERSION}/linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz
+tar zxf linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz -C /usr/lib/nginx/modules
 # Installer le plug-in C++ Datadog pour Opentracing
 wget https://github.com/DataDog/dd-opentracing-cpp/releases/download/${DD_OPENTRACING_CPP_VERSION}/linux-amd64-libdd_opentracing_plugin.so.gz
 gunzip linux-amd64-libdd_opentracing_plugin.so.gz -c > /usr/local/lib/libdd_opentracing_plugin.so

--- a/content/fr/tracing/setup_overview/proxy_setup/_index.md
+++ b/content/fr/tracing/setup_overview/proxy_setup/_index.md
@@ -248,7 +248,7 @@ Une solution consiste à exécuter NGINX à partir d'un conteneur Docker. Un exe
 
 Les plug-ins suivants doivent être installés :
 
-- Plug-in NGINX pour OpenTracing - [linux-amd64-nginx-${VERSION_NGINX}-ngx_http_module.so.tgz][3] : installé dans `/usr/lib/nginx/modules`
+- Plug-in NGINX pour OpenTracing - [linux-amd64-nginx-${VERSION_NGINX}-ot16-ngx_http_module.so.tgz][3] : installé dans `/usr/lib/nginx/modules`
 - Plug-in Datadog OpenTracing C++ - [linux-amd64-libdd_opentracing_plugin.so.gz][4] : installé à un emplacement accessible pour NGINX, p. ex. `/usr/local/lib`
 
 Commandes pour télécharger et installer ces modules :
@@ -264,8 +264,8 @@ NGINX_VERSION=1.17.3
 OPENTRACING_NGINX_VERSION="$(get_latest_release opentracing-contrib/nginx-opentracing)"
 DD_OPENTRACING_CPP_VERSION="$(get_latest_release DataDog/dd-opentracing-cpp)"
 # Installer le plug-in NGINX pour OpenTracing
-wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/${OPENTRACING_NGINX_VERSION}/linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz
-tar zxf linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz -C /usr/lib/nginx/modules
+wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/${OPENTRACING_NGINX_VERSION}/linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz
+tar zxf linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz -C /usr/lib/nginx/modules
 # Installer le plug-in C++ Datadog pour Opentracing
 wget https://github.com/DataDog/dd-opentracing-cpp/releases/download/${DD_OPENTRACING_CPP_VERSION}/linux-amd64-libdd_opentracing_plugin.so.gz
 gunzip linux-amd64-libdd_opentracing_plugin.so.gz -c > /usr/local/lib/libdd_opentracing_plugin.so

--- a/content/ja/tracing/setup/nginx.md
+++ b/content/ja/tracing/setup/nginx.md
@@ -33,7 +33,7 @@ aliases:
 
 次のプラグインをインストールする必要があります。
 
-- OpenTracing 対応 NGINX プラグイン - [linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz][3] - `/usr/lib/nginx/modules` にインストール
+- OpenTracing 対応 NGINX プラグイン - [linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz][3] - `/usr/lib/nginx/modules` にインストール
 - Datadog OpenTracing C++ プラグイン - [linux-amd64-libdd_opentracing_plugin.so.gz][4] - `/usr/local/lib` など、NGINX にアクセス可能な場所にインストール
 
 次のコマンドを使用してモジュールをダウンロードしてインストールします。
@@ -49,8 +49,8 @@ NGINX_VERSION=1.17.3
 OPENTRACING_NGINX_VERSION="$(get_latest_release opentracing-contrib/nginx-opentracing)"
 DD_OPENTRACING_CPP_VERSION="$(get_latest_release DataDog/dd-opentracing-cpp)"
 # OpenTracing 用の NGINX プラグインをインストールします
-wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/${OPENTRACING_NGINX_VERSION}/linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz
-tar zxf linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz -C /usr/lib/nginx/modules
+wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/${OPENTRACING_NGINX_VERSION}/linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz
+tar zxf linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz -C /usr/lib/nginx/modules
 # Datadog Opentracing C++ プラグインをインストールします
 wget https://github.com/DataDog/dd-opentracing-cpp/releases/download/${DD_OPENTRACING_CPP_VERSION}/linux-amd64-libdd_opentracing_plugin.so.gz
 gunzip linux-amd64-libdd_opentracing_plugin.so.gz -c > /usr/local/lib/libdd_opentracing_plugin.so

--- a/content/ja/tracing/setup_overview/proxy_setup/_index.md
+++ b/content/ja/tracing/setup_overview/proxy_setup/_index.md
@@ -248,7 +248,7 @@ stats_config:
 
 次のプラグインをインストールする必要があります。
 
-- OpenTracing 対応 NGINX プラグイン - [linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz][3] - `/usr/lib/nginx/modules` にインストール
+- OpenTracing 対応 NGINX プラグイン - [linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz][3] - `/usr/lib/nginx/modules` にインストール
 - Datadog OpenTracing C++ プラグイン - [linux-amd64-libdd_opentracing_plugin.so.gz][4] - `/usr/local/lib` など、NGINX にアクセス可能な場所にインストール
 
 次のコマンドを使用してモジュールをダウンロードしてインストールします。
@@ -264,8 +264,8 @@ NGINX_VERSION=1.17.3
 OPENTRACING_NGINX_VERSION="$(get_latest_release opentracing-contrib/nginx-opentracing)"
 DD_OPENTRACING_CPP_VERSION="$(get_latest_release DataDog/dd-opentracing-cpp)"
 # OpenTracing 用の NGINX プラグインをインストールします
-wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/${OPENTRACING_NGINX_VERSION}/linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz
-tar zxf linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz -C /usr/lib/nginx/modules
+wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/${OPENTRACING_NGINX_VERSION}/linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz
+tar zxf linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz -C /usr/lib/nginx/modules
 # Datadog Opentracing C++ プラグインをインストールします
 wget https://github.com/DataDog/dd-opentracing-cpp/releases/download/${DD_OPENTRACING_CPP_VERSION}/linux-amd64-libdd_opentracing_plugin.so.gz
 gunzip linux-amd64-libdd_opentracing_plugin.so.gz -c > /usr/local/lib/libdd_opentracing_plugin.so


### PR DESCRIPTION
### What does this PR do?
Fixes the instructions for installing the nginx-opentracing module for the datadog tracer.

### Motivation
It is affecting current and potential users. 

### Preview
https://docs-staging.datadoghq.com/cgilmour/update-ngx-module/tracing/setup_overview/proxy_setup/?tab=nginx

### Additional Notes
The fr and jp translations for `/tracing/setup/nginx.md` might need removing? There is no `en` equivalent
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
