### PR TITLE
[kubernetes] Add tolerate unready pod annotation

### DIFF
--- a/content/en/agent/kubernetes/integrations.md
+++ b/content/en/agent/kubernetes/integrations.md
@@ -105,6 +105,22 @@ If you define your Kubernetes pods directly with `kind: Pod`, add each pod's ann
 
 
 [1]: /getting_started/tagging/unified_service_tagging
+
+### Tolerate unready pods
+
+By default, `unready` pods are ignored when the Datadog Agent schedules checks, so metrics, service checks and logs are not collected from these pods. However, the annotation `ad.datadoghq.com/tolerate-unready` overrides this behavior. For example: 
+
+```yaml
+apiVersion: v1
+kind: Pod
+# (...)
+metadata:
+  name: '<POD_NAME>'
+  annotations:
+    ad.datadoghq.com/tolerate-unready: "true"
+  ...
+```
+
 {{% /tab %}}
 {{% tab "File" %}}
 
@@ -223,6 +239,9 @@ With the key-value store enabled as a template source, the Agent looks for templ
 [2]: /agent/guide/agent-commands/
 {{% /tab %}}
 {{< /tabs >}}
+
+
+
 
 ## Examples
 

--- a/content/en/agent/kubernetes/integrations.md
+++ b/content/en/agent/kubernetes/integrations.md
@@ -104,11 +104,9 @@ If you define your Kubernetes pods directly with `kind: Pod`, add each pod's ann
 **Note:** As a best practice in containerized environments, Datadog recommends using unified service tagging when assigning tags. Unified service tagging ties Datadog telemetry together through the use of three standard tags: `env`, `service`, and `version`. To learn how to configure your environment with unified tagging, refer to the dedicated [unified service tagging][1] documentation.
 
 
-[1]: /getting_started/tagging/unified_service_tagging
-
 ### Tolerate unready pods
 
-By default, `unready` pods are ignored when the Datadog Agent schedules checks, so metrics, service checks, and logs are not collected from these pods. However, the annotation `ad.datadoghq.com/tolerate-unready` overrides this behavior. For example:
+By default, `unready` pods are ignored when the Datadog Agent schedules checks, so metrics, service checks, and logs are not collected from these pods. To override this behavior, set the annotation `ad.datadoghq.com/tolerate-unready` to `"true"`. For example:
 
 ```yaml
 apiVersion: v1
@@ -120,6 +118,8 @@ metadata:
     ad.datadoghq.com/tolerate-unready: "true"
   ...
 ```
+
+[1]: /getting_started/tagging/unified_service_tagging
 
 {{% /tab %}}
 {{% tab "File" %}}

--- a/content/en/agent/kubernetes/integrations.md
+++ b/content/en/agent/kubernetes/integrations.md
@@ -108,7 +108,7 @@ If you define your Kubernetes pods directly with `kind: Pod`, add each pod's ann
 
 ### Tolerate unready pods
 
-By default, `unready` pods are ignored when the Datadog Agent schedules checks, so metrics, service checks and logs are not collected from these pods. However, the annotation `ad.datadoghq.com/tolerate-unready` overrides this behavior. For example: 
+By default, `unready` pods are ignored when the Datadog Agent schedules checks, so metrics, service checks, and logs are not collected from these pods. However, the annotation `ad.datadoghq.com/tolerate-unready` overrides this behavior. For example:
 
 ```yaml
 apiVersion: v1
@@ -239,9 +239,6 @@ With the key-value store enabled as a template source, the Agent looks for templ
 [2]: /agent/guide/agent-commands/
 {{% /tab %}}
 {{< /tabs >}}
-
-
-
 
 ## Examples
 


### PR DESCRIPTION
### What does this PR do?
Document Kubernetes pod annotation to be used to monitor `unready` pods

### Motivation
Better user experience

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/celene/tolerate_unready/agent/kubernetes/integrations/?tab=kubernetes

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
