### PR TITLE
Remove stale anchor link

### DIFF
--- a/content/en/agent/amazon_ecs/_index.md
+++ b/content/en/agent/amazon_ecs/_index.md
@@ -63,7 +63,7 @@ Configure the task using either the [AWS CLI tools][12] or using the Amazon Web 
 
 1. For Linux containers, download [datadog-agent-ecs.json][1] ([datadog-agent-ecs1.json][2] if you are using an original Amazon Linux 1 AMI). For Windows, download [datadog-agent-ecs-win.json][3].
 2. Edit `datadog-agent-ecs.json` and set `<YOUR_DATADOG_API_KEY>` with the [Datadog API key][4] for your account.
-3. Optionally - Add an [Agent health check](#agent-health-check).
+3. Optionally - Add an Agent health check.
 
     Add the following to your ECS task definition to create an Agent health check:
 


### PR DESCRIPTION
### What does this PR do?
Removes an anchor link that was going nowhere

### Motivation
Slack report

### Preview

https://docs-staging.datadoghq.com/kari/remove-anchor-link/agent/amazon_ecs/?tab=awscli

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
