### PR TITLE
Remove non-applicable resources

### DIFF
--- a/content/en/infrastructure/livecontainers.md
+++ b/content/en/infrastructure/livecontainers.md
@@ -86,10 +86,6 @@ documentation][2]. But if they are missing, ensure they are added (after
             resources:
             - deployments
             - replicasets
-            # Below are in case RBAC was not setup from the above linked "Cluster Agent Setup documentation"
-            - pods 
-            - nodes
-            - services
             verbs:
             - list
             - get


### PR DESCRIPTION
### What does this PR do?
Fix docs.

These resources are not in the "apps" api group.
They are also not present in the referred to file: https://github.com/DataDog/datadog-agent/blob/21d4d959405419bb826c36b2ca1ed158afae756f/Dockerfiles/manifests/cluster-agent/cluster-agent-rbac.yaml#L104-L112

### Motivation
The result was broken.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
