### PR TITLE
Update group retention for host monitors

### DIFF
--- a/content/en/monitors/faq/why-did-my-monitor-settings-change-not-take-effect.md
+++ b/content/en/monitors/faq/why-did-my-monitor-settings-change-not-take-effect.md
@@ -4,7 +4,7 @@ kind: faq
 
 ---
 
-Datadog keeps monitor groups available in the UI for 24 hours.  If you do not have *No Data* alert settings enabled and your group for a metric monitor stops reporting data, it will persist on the monitor status page until it ages out, though that group will stop being evaluated after a short absence (specific timing depends on your settings).
+Datadog keeps monitor groups available in the UI for 24 hours (48h for host monitors).  If you do not have *No Data* alert settings enabled and your group for a metric monitor stops reporting data, it will persist on the monitor status page until it ages out, though that group will stop being evaluated after a short absence (specific timing depends on your settings).
 
 For event monitors, however, Datadog also keeps groups for evaluations for at least 24 hours. This means that if a monitor is updated and the groups are changed in the query, some old groups may persist. If you must change the group settings on your event monitor, you may want clone or create a new monitor to reflect your new groups.  Alternatively, you can mute them if you would like to maintain the monitor but silence any alerts that would result from the changes.
 


### PR DESCRIPTION
### What does this PR do?
Update this FAQ article to better reflect the group retention for host monitors

### Motivation
A lot of users refer to this article for group retention. Until we add a page in the official documentation, we needed to add this update to better reflect group retention for host monitors. 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/monitors-group-retention/monitors/faq/why-did-my-monitor-settings-change-not-take-effect/#pagetitle

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
