### PR TITLE
[WEB-1295] Adds description list markdown support for table displays

### DIFF
--- a/content/en/agent/kubernetes/operator_configuration.md
+++ b/content/en/agent/kubernetes/operator_configuration.md
@@ -23,16 +23,38 @@ spec:
     image:
       name: "gcr.io/datadoghq/agent:latest"
 ```
-<p>Testing description list element:</p>
-
 agent.additionalAnnotations
 : `AdditionalAnnotations` provide annotations that will be added to the Agent Pods.
 
-agent.config.securityContext.allowPrivilegeEscalation
-: Controls whether a process can gain more privileges than its parent process. This Boolean directly controls if the no_new_privs flag will be set on the container process. `AllowPrivilegeEscalation` is true always when the container is both run as Privileged, and has CAP_SYS_ADMIN.
+agent.additionalLabels
+: `AdditionalLabels` provide labels that will be added to the cluster checks runner pods.
+
+agent.apm.enabled
+: Enable this to enable APM and tracing on port 8126. See the [Datadog Docker documentation][1]
+
+agent.apm.env
+: The Datadog Agent supports many [environment variables][2]
 
 agent.apm.hostPort
 : Number of the port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If `HostNetwork` is specified, this must match `ContainerPort`. Most containers do not need this.
+
+agent.apm.resources.limits
+: Limits describes the maximum amount of compute resources allowed. For more info, [see the Kubernetes documentation][3]
+
+agent.apm.resources.requests
+: `Requests` describes the minimum amount of compute resources required. If `requests` is omitted for a container, it defaults to `limits` if that is explicitly specified. Otherwise, it defaults to an implementation-defined value. For more info, [see the Kubernetes documentation][3]
+
+agent.config.checksd.configMapName
+: Name of a ConfigMap used to mount a directory.
+
+agent.config.collectEvents
+: Enables starting event collection from the Kubernetes API. [See the Event Collection documentation][4]
+
+agent.config.confd.configMapName 
+: Name of a ConfigMap used to mount a directory.
+
+agent.config.criSocket.criSocketPath 
+: Path to the container runtime socket (if different from Docker). This is supported starting from Agent 6.6.0.  
 
 
 {{< table table-type="break-word" >}}

--- a/content/en/agent/kubernetes/operator_configuration.md
+++ b/content/en/agent/kubernetes/operator_configuration.md
@@ -23,6 +23,17 @@ spec:
     image:
       name: "gcr.io/datadoghq/agent:latest"
 ```
+<p>Testing description list element:</p>
+
+agent.additionalAnnotations
+: `AdditionalAnnotations` provide annotations that will be added to the Agent Pods.
+
+agent.config.securityContext.allowPrivilegeEscalation
+: Controls whether a process can gain more privileges than its parent process. This Boolean directly controls if the no_new_privs flag will be set on the container process. `AllowPrivilegeEscalation` is true always when the container is both run as Privileged, and has CAP_SYS_ADMIN.
+
+agent.apm.hostPort
+: Number of the port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If `HostNetwork` is specified, this must match `ContainerPort`. Most containers do not need this.
+
 
 {{< table table-type="break-word" >}}
 | Parameter                                                                                                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |

--- a/content/en/agent/kubernetes/operator_configuration.md
+++ b/content/en/agent/kubernetes/operator_configuration.md
@@ -23,39 +23,6 @@ spec:
     image:
       name: "gcr.io/datadoghq/agent:latest"
 ```
-agent.additionalAnnotations
-: `AdditionalAnnotations` provide annotations that will be added to the Agent Pods.
-
-agent.additionalLabels
-: `AdditionalLabels` provide labels that will be added to the cluster checks runner pods.
-
-agent.apm.enabled
-: Enable this to enable APM and tracing on port 8126. See the [Datadog Docker documentation][1]
-
-agent.apm.env
-: The Datadog Agent supports many [environment variables][2]
-
-agent.apm.hostPort
-: Number of the port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If `HostNetwork` is specified, this must match `ContainerPort`. Most containers do not need this.
-
-agent.apm.resources.limits
-: Limits describes the maximum amount of compute resources allowed. For more info, [see the Kubernetes documentation][3]
-
-agent.apm.resources.requests
-: `Requests` describes the minimum amount of compute resources required. If `requests` is omitted for a container, it defaults to `limits` if that is explicitly specified. Otherwise, it defaults to an implementation-defined value. For more info, [see the Kubernetes documentation][3]
-
-agent.config.checksd.configMapName
-: Name of a ConfigMap used to mount a directory.
-
-agent.config.collectEvents
-: Enables starting event collection from the Kubernetes API. [See the Event Collection documentation][4]
-
-agent.config.confd.configMapName 
-: Name of a ConfigMap used to mount a directory.
-
-agent.config.criSocket.criSocketPath 
-: Path to the container runtime socket (if different from Docker). This is supported starting from Agent 6.6.0.  
-
 
 {{< table table-type="break-word" >}}
 | Parameter                                                                                                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |

--- a/layouts/shortcodes/table.html
+++ b/layouts/shortcodes/table.html
@@ -1,1 +1,9 @@
-<div class="{{- if .Get "responsive" -}}table-responsive{{- end -}}{{ with .Get "table-type"}}{{.}}{{ end }}{{- if .Get "wide" -}}table-wide{{- end -}} {{- if .Get "vertical-mobile" -}}table-vertical-mobile{{- end -}}">{{- if .Get "responsive" -}}<div class="table-scroll">{{- .Inner -}}</div>{{- else -}}{{- .Inner | markdownify -}}{{- end -}}</div>
+<div class="{{- if .Get "responsive" -}}table-responsive{{- end -}}{{ with .Get "table-type"}}{{.}}{{ end }}{{- if .Get "wide" -}}table-wide{{- end -}} {{- if .Get "vertical-mobile" -}}table-vertical-mobile{{- end -}}">
+  {{- if .Get "responsive" -}}
+    <div class="table-scroll">
+      {{- .Inner -}}
+    </div>
+  {{- else -}}
+    {{- .Inner | markdownify -}}
+  {{- end -}}
+</div>

--- a/src/styles/pages/_global.scss
+++ b/src/styles/pages/_global.scss
@@ -786,6 +786,29 @@ table,
     }
 }
 
+dl {
+    border: 1px solid #d6d6d6;
+
+    dd,
+    dt {
+        padding-left: 0.75rem;
+    }
+
+    dt {
+        padding-top: 0.75rem;
+        padding-bottom: 0.25rem;
+    }
+
+    dd {
+        border-bottom: 1px solid #d6d6d6;
+        padding-bottom: 1.25rem;
+
+        &:last-of-type {
+            border-bottom: none;
+        }
+    }
+}
+
 // external link logos
 
 .link-logo {
@@ -941,28 +964,6 @@ table,
 
     .wide-parent {
         width: 100%;
-    }
-}
-
-dl {
-    border: 1px solid #d6d6d6;
-
-    dd,
-    dt {
-        padding-left: 0.75rem;
-    }
-
-    dt {
-        padding-top: 0.75rem;
-    }
-
-    dd {
-        border-bottom: 1px solid #d6d6d6;
-        padding-bottom: 0.75rem;
-
-        &:last-of-type {
-            border-bottom: none;
-        }
     }
 }
   

--- a/src/styles/pages/_global.scss
+++ b/src/styles/pages/_global.scss
@@ -943,3 +943,27 @@ table,
         width: 100%;
     }
 }
+
+dl {
+    border: 1px solid #d6d6d6;
+
+    dd,
+    dt {
+        padding-left: 0.75rem;
+    }
+
+    dt {
+        padding-top: 0.75rem;
+    }
+
+    dd {
+        border-bottom: 1px solid #d6d6d6;
+        padding-bottom: 0.75rem;
+
+        &:last-of-type {
+            border-bottom: none;
+        }
+    }
+}
+  
+  

--- a/src/styles/pages/_global.scss
+++ b/src/styles/pages/_global.scss
@@ -789,6 +789,10 @@ table,
 dl {
     border: 1px solid $ddgray;
 
+    a {
+        border-bottom: 1px solid;
+    }
+
     dt {
         padding: 0.75rem 0.75rem 0.25rem;
     }

--- a/src/styles/pages/_global.scss
+++ b/src/styles/pages/_global.scss
@@ -787,7 +787,7 @@ table,
 }
 
 dl {
-    border: 1px solid #d6d6d6;
+    border: 1px solid $ddgray;
 
     dd,
     dt {
@@ -800,7 +800,7 @@ dl {
     }
 
     dd {
-        border-bottom: 1px solid #d6d6d6;
+        border-bottom: 1px solid $ddgray;
         padding-bottom: 1.25rem;
 
         &:last-of-type {

--- a/src/styles/pages/_global.scss
+++ b/src/styles/pages/_global.scss
@@ -789,28 +789,20 @@ table,
 dl {
     border: 1px solid $ddgray;
 
-    dd,
     dt {
-        padding-left: 0.75rem;
-    }
-
-    dt {
-        padding-top: 0.75rem;
-        padding-bottom: 0.25rem;
+        padding: 0.75rem 0.75rem 0.25rem;
     }
 
     dd {
-        border-bottom: 1px solid $ddgray;
-        padding-bottom: 1.25rem;
+        padding: 0 0.75rem 1rem 1.75rem;
 
         &:last-of-type {
-            border-bottom: none;
+            padding-bottom: 0.5rem;
         }
     }
 }
 
 // external link logos
-
 .link-logo {
     transform: translateY(-1px);
     margin-right: -1px;


### PR DESCRIPTION
### What does this PR do?
Provides an alternative solution for tables that either overlap with the sidebar/TOC, or have difficult to read parameters.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1295

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/table-display/

This provides the styling framework to create organized content using the [HTML description list](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl) element.  To test, pull down this branch locally, add some markdown using the guide below, and start your local server.  The output should be rendered as a description list, and should look good at all screen sizes.

Description list markdown usage:

```
agent.additionalAnnotations
: `AdditionalAnnotations` provide annotations that will be added to the Agent Pods.

agent.additionalLabels
: `AdditionalLabels` provide labels that will be added to the cluster checks runner pods.

agent.apm.enabled
: Enable this to enable APM and tracing on port 8126. See the [Datadog Docker documentation][1]
```

https://www.markdownguide.org/extended-syntax/#definition-lists

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
