### PR TITLE
Correct links to datadog-operator repo with new main branch

### DIFF
--- a/content/en/agent/cluster_agent/clusterchecksrunner.md
+++ b/content/en/agent/cluster_agent/clusterchecksrunner.md
@@ -52,7 +52,7 @@ datadogagent.datadoghq.com/datadog created
 See the [Datadog Operator repo][2] for more information about the Datadog Operator.
 
 
-[1]: https://github.com/DataDog/datadog-operator/blob/master/examples/datadog-agent-with-dca-clusterchecksrunner.yaml
+[1]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-with-dca-clusterchecksrunner.yaml
 [2]: https://github.com/DataDog/datadog-operator
 {{% /tab %}}
 {{% tab "Helm" %}}

--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -304,7 +304,7 @@ where `<USER_ID>` is the UID to run the agent and `<DOCKER_GROUP_ID>` is the gro
 [5]: https://github.com/DataDog/datadog-operator/releases/latest/download/datadog-agent-with-operator.tar.gz
 [6]: https://app.datadoghq.com/account/settings#api
 [7]: /agent/guide/operator-advanced
-[8]: https://github.com/DataDog/datadog-operator/blob/master/docs/configuration.md
+[8]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.md
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/agent/kubernetes/log.md
+++ b/content/en/agent/kubernetes/log.md
@@ -181,7 +181,7 @@ agent:
 
 where `<USER_ID>` is the UID to run the agent and `<DOCKER_GROUP_ID>` is the group ID owning the docker or containerd socket.
 
-[1]: https://github.com/DataDog/datadog-operator/blob/master/examples/datadog-agent-logs.yaml
+[1]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-logs.yaml
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates other links to the datadog-operator repo that used to use "master" and now uses "main" branch name. Github is properly redirecting for the branch, but they've also added another directory for some of the examples and that's ultimately what causes the 404s for these links.

### Motivation
broken links

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
