### PR TITLE
[WEB-1305] Fixes display issue with algolia widget + code lang tabs

### DIFF
--- a/src/styles/pages/_global.scss
+++ b/src/styles/pages/_global.scss
@@ -273,7 +273,7 @@ details {
     margin-bottom: 20px;
     &.nav-tabs {
         .nav-item {
-            z-index: 3;
+            z-index: 1;
             
             &:before {
                 content: none;


### PR DESCRIPTION
### What does this PR do?
Adjust `z-index` property on code lang tabs so they don't render on top of algolia autocomplete widget.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1305

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/algolia-widget-z-index/api/latest/monitors/ - type in a search to open algolia widget.   with widget open, scroll down the page.   the widget should remain on top of all content including the programming language tabs.

https://docs-staging.datadoghq.com/brian.deutsch/algolia-widget-z-index/ - site wide review, making sure programming language tabs have no display issues (especially when scrolling), and are always clickable.  

to make sure the bug in this PR: https://github.com/DataDog/documentation/pull/9863 doesn't resurface, pull down the branch and add a markdown heading inside a `programming-lang` tab.   all of the language tabs should still be clickable and functional.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
