### PR TITLE
Monitor add note multi group for metrics without all tags

### DIFF
--- a/content/en/monitors/monitor_types/metric.md
+++ b/content/en/monitors/monitor_types/metric.md
@@ -96,7 +96,8 @@ Alerts are grouped automatically based on your selection of the `group by` step 
 
 Simple alerts aggregate over all reporting sources. You receive one alert when the aggregated value meets the set conditions. This works best to monitor a metric from a single host or the sum of a metric across many hosts.
 
-Multi alerts apply the alert to each source according to your group parameters. You receive an alert for each group that meets the set conditions. For example, you could group `system.disk.in_use` by `host` and `device` to receive a separate alert for each host device that is running out of space.
+Multi alerts apply the alert to each source according to your group parameters. You receive an alert for each group that meets the set conditions. For example, you could group `system.disk.in_use` by `host` and `device` to receive a separate alert for each host device that is running out of space. 
+Note that if your metric is only reporting by `host` with no `device` tag, it would not be detected by a monitor group by both `host` and `device`.
 
 ### Set alert conditions
 


### PR DESCRIPTION


### What does this PR do?
Add a note for multi alert monitors in case a tag is missing, to reflect that it won't be detected by the monitor. All tags from the group by have to be present.

### Motivation
Dashboards reflect those with N/A while monitors do not because they only alert on what is present and ignore those that are missing. 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/monitor-multi-group-missing-tags/monitors/monitor_types/metric/?tab=threshold#alert-grouping

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
