### PR TITLE
Add instructions for Lambda Extension for functions deployed as container images

### DIFF
--- a/content/en/serverless/datadog_lambda_library/extension.md
+++ b/content/en/serverless/datadog_lambda_library/extension.md
@@ -52,7 +52,7 @@ Then, add the Datadog Lambda Extension to your container image by adding the fol
 COPY --from=datadog/lambda-extension:<TAG> /opt/extensions/ /opt/extensions
 ```
 
-Replace `<TAG>` with either a specific version number (e.g. `6`) or with `latest`. You can see a complete list of possible tags in the [Dockerhub repository][11]. 
+Replace `<TAG>` with either a specific version number (for example, `6`) or with `latest`. You can see a complete list of possible tags in the [Dockerhub repository][11]. 
 
 ## Log collection
 

--- a/content/en/serverless/datadog_lambda_library/extension.md
+++ b/content/en/serverless/datadog_lambda_library/extension.md
@@ -32,7 +32,7 @@ The Datadog Lambda Extension is distributed as its own Lambda Layer (separate fr
     ```
 
     Replace the placeholder values in the ARN as follows:
-    - Replace `AWS_REGION` with be the same AWS region as your Lambda Function, e.g. `us-east-1`.
+    - Replace `AWS_REGION` with the same AWS region as your Lambda Function, e.g. `us-east-1`.
     - Replace `VERSION_NUMBER` with the version of the Datadog Lambda Extension you would like to use, e.g. `6`. You can identify the current version by viewing the newest tags in the [Dockerhub repository][11].
     
     **Note**: This Layer is separate from the Datadog Lambda Library. If you installed the Datadog Lambda Library as a Lambda Layer,

--- a/content/en/serverless/datadog_lambda_library/extension.md
+++ b/content/en/serverless/datadog_lambda_library/extension.md
@@ -35,7 +35,7 @@ The Datadog Lambda Extension is distributed as its own Lambda Layer (separate fr
     - Replace `AWS_REGION` with be the same AWS region as your Lambda Function, e.g. `us-east-1`.
     - Replace `VERSION_NUMBER` with the version of the Datadog Lambda Extension you would like to use, e.g. `6`. You can identify the current version by viewing the newest tags in the [Dockerhub repository][11].
     
-    Note that this Layer is separate from the Datadog Lambda Library. If you installed the Datadog Lambda Library as a Lambda Layer,
+    **Note**: This Layer is separate from the Datadog Lambda Library. If you installed the Datadog Lambda Library as a Lambda Layer,
     your function should now have two Lambda Layers attached.
 
 3. Reference the [sample code][10] to submit a custom metric.

--- a/content/en/serverless/datadog_lambda_library/extension.md
+++ b/content/en/serverless/datadog_lambda_library/extension.md
@@ -47,8 +47,7 @@ First, install the Datadog Lambda Library by following the installation instruct
 Then, add the Datadog Lambda Extension to your container image by adding the following to your Dockerfile:
 
 ```
-WORKDIR /opt/extensions
-COPY --from=datadog/lambda-extension:6 /opt/extensions/ .
+COPY --from=datadog/lambda-extension:6 /opt/extensions/ /opt/extensions
 ```
 
 ## Log collection

--- a/content/en/serverless/datadog_lambda_library/extension.md
+++ b/content/en/serverless/datadog_lambda_library/extension.md
@@ -25,13 +25,15 @@ The Datadog Lambda Extension is distributed as its own Lambda Layer (separate fr
 
 1. Instrument your [Python][4] or [Node.js][5] application by installing the Datadog Lambda Library.
 
-2. Add the Lambda Layer for the Datadog Extension to your AWS Lambda function:
+2. Add the Lambda Layer for the Datadog Extension to your AWS Lambda function with the following ARN:
 
     ```
-    arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:6
+    arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:<VERSION_NUMBER>
     ```
 
-    Replace the placeholder `AWS_REGION` in the Lambda Layer ARN with appropriate values.
+    Replace the placeholder values in the ARN as follows:
+    - Replace `AWS_REGION` with be the same AWS region as your Lambda Function, e.g. `us-east-1`.
+    - Replace `VERSION_NUMBER` with the version of the Datadog Lambda Extension you would like to use, e.g. `6`. You can identify the current version by viewing the newest tags in the [Dockerhub repository][11].
     
     Note that this Layer is separate from the Datadog Lambda Library. If you installed the Datadog Lambda Library as a Lambda Layer,
     your function should now have two Lambda Layers attached.
@@ -47,8 +49,10 @@ First, install the Datadog Lambda Library by following the installation instruct
 Then, add the Datadog Lambda Extension to your container image by adding the following to your Dockerfile:
 
 ```
-COPY --from=datadog/lambda-extension:6 /opt/extensions/ /opt/extensions
+COPY --from=datadog/lambda-extension:<TAG> /opt/extensions/ /opt/extensions
 ```
+
+Replace `<TAG>` with either a specific version number (e.g. `6`) or with `latest`. You can see a complete list of possible tags in the [Dockerhub repository][11]. 
 
 ## Log collection
 
@@ -68,3 +72,4 @@ To submit your AWS Lambda logs to Datadog using the Extension, set the env varia
 [8]: https://github.com/DataDog/datadog-lambda-js/releases
 [9]: https://github.com/DataDog/datadog-lambda-python/releases
 [10]: /serverless/custom_metrics#custom-metrics-sample-code
+[11]: https://hub.docker.com/repository/docker/datadog/lambda-extension/tags

--- a/content/en/serverless/datadog_lambda_library/extension.md
+++ b/content/en/serverless/datadog_lambda_library/extension.md
@@ -33,7 +33,7 @@ The Datadog Lambda Extension is distributed as its own Lambda Layer (separate fr
 
     Replace the placeholder values in the ARN as follows:
     - Replace `<AWS_REGION>` with the same AWS region as your Lambda Function, for example, `us-east-1`.
-    - Replace `<VERSION_NUMBER>` with the version of the Datadog Lambda Extension you would like to use, for example `6`. You can identify the current version by viewing the newest tags in the [Dockerhub repository][11].
+    - Replace `<VERSION_NUMBER>` with the version of the Datadog Lambda Extension you would like to use, for example `6`. You can identify the current version by viewing the newest image tags in the [Amazon ECR repository][11].
     
     **Note**: This Layer is separate from the Datadog Lambda Library. If you installed the Datadog Lambda Library as a Lambda Layer,
     your function should now have two Lambda Layers attached.
@@ -49,10 +49,10 @@ First, install the Datadog Lambda Library by following the installation instruct
 Then, add the Datadog Lambda Extension to your container image by adding the following to your Dockerfile:
 
 ```
-COPY --from=datadog/lambda-extension:<TAG> /opt/extensions/ /opt/extensions
+COPY --from=public.ecr.aws/datadog/lambda-extension:<TAG> /opt/extensions/ /opt/extensions
 ```
 
-Replace `<TAG>` with either a specific version number (for example, `6`) or with `latest`. You can see a complete list of possible tags in the [Dockerhub repository][11]. 
+Replace `<TAG>` with either a specific version number (for example, `6`) or with `latest`. You can see a complete list of possible tags in the [Amazon ECR repository][11]. 
 
 ## Log collection
 
@@ -72,4 +72,4 @@ To submit your AWS Lambda logs to Datadog using the extension, set the env varia
 [8]: https://github.com/DataDog/datadog-lambda-js/releases
 [9]: https://github.com/DataDog/datadog-lambda-python/releases
 [10]: /serverless/custom_metrics#custom-metrics-sample-code
-[11]: https://hub.docker.com/repository/docker/datadog/lambda-extension/tags
+[11]: https://gallery.ecr.aws/datadog/lambda-extension

--- a/content/en/serverless/datadog_lambda_library/extension.md
+++ b/content/en/serverless/datadog_lambda_library/extension.md
@@ -56,7 +56,7 @@ Replace `<TAG>` with either a specific version number (e.g. `6`) or with `latest
 
 ## Log collection
 
-To submit your AWS Lambda logs to Datadog using the Extension, set the env variable `DD_LOGS_ENABLED` to `true` in your function.
+To submit your AWS Lambda logs to Datadog using the extension, set the env variable `DD_LOGS_ENABLED` to `true` in your function.
 
 ## Further Reading
 

--- a/content/en/serverless/datadog_lambda_library/extension.md
+++ b/content/en/serverless/datadog_lambda_library/extension.md
@@ -44,7 +44,7 @@ The Datadog Lambda Extension is distributed as its own Lambda Layer (separate fr
 
 If your function is deployed as a container image, you cannot add Lambda Layers to your function. Instead, you must directly install the Datadog Lambda Library and the Datadog Lambda Extension in your function's image.
 
-First, install the Datadog Lambda Library by following the installation instructions for [Node.js][5] or [Python][4]. Be sure to use the installation instructions specifically for functions deployed as container images.
+First, install the Datadog Lambda Library by following the installation instructions for [Node.js][5] or [Python][4]. Use the installation instructions specifically for functions deployed as container images.
 
 Then, add the Datadog Lambda Extension to your container image by adding the following to your Dockerfile:
 

--- a/content/en/serverless/datadog_lambda_library/extension.md
+++ b/content/en/serverless/datadog_lambda_library/extension.md
@@ -32,8 +32,8 @@ The Datadog Lambda Extension is distributed as its own Lambda Layer (separate fr
     ```
 
     Replace the placeholder values in the ARN as follows:
-    - Replace `AWS_REGION` with the same AWS region as your Lambda Function, e.g. `us-east-1`.
-    - Replace `VERSION_NUMBER` with the version of the Datadog Lambda Extension you would like to use, e.g. `6`. You can identify the current version by viewing the newest tags in the [Dockerhub repository][11].
+    - Replace `<AWS_REGION>` with the same AWS region as your Lambda Function, e.g. `us-east-1`.
+    - Replace `<VERSION_NUMBER>` with the version of the Datadog Lambda Extension you would like to use, e.g. `6`. You can identify the current version by viewing the newest tags in the [Dockerhub repository][11].
     
     **Note**: This Layer is separate from the Datadog Lambda Library. If you installed the Datadog Lambda Library as a Lambda Layer,
     your function should now have two Lambda Layers attached.

--- a/content/en/serverless/datadog_lambda_library/extension.md
+++ b/content/en/serverless/datadog_lambda_library/extension.md
@@ -11,15 +11,19 @@ further_reading:
 
 <div class="alert alert-warning"> The Datadog AWS Lambda Extension is in public preview. If you have any feedback, contact <a href="/help">Datadog support</a>.</div>
 
-AWS Lambda Extensions are companion processes that augment your Lambda functions. They run within the Lambda execution environment, alongside your Lambda function code. The Datadog Extension is a lightweight version of the Datadog agent built to run alongside your code with minimal performance overhead.
+AWS Lambda Extensions are companion processes that augment your Lambda functions. They run within the Lambda execution environment, alongside your Lambda function code. The Datadog Extension is a lightweight version of the Datadog Agent built to run alongside your code with minimal performance overhead.
 
 The Datadog Extension supports submitting custom metrics and logs [synchronously][1] while your AWS Lambda function executes. This means that you can submit some of your telemetry data without the [Datadog Forwarder][2]. **Note**: The Datadog Forwarder is still required to submit traces to Datadog.
 
 ## Setup
 
-The Datadog Extension is distributed as its own Lambda Layer (separate from the [Datadog Lambda Library][3]) and supports Node.js and Python runtimes.
+The Datadog Extension currently supports Node.js and Python runtimes.
 
-1. Instrument your [Python][4] or [Node.js][5] application.
+### As a Lambda Layer
+
+The Datadog Lambda Extension is distributed as its own Lambda Layer (separate from the [Datadog Lambda Library][3]).
+
+1. Instrument your [Python][4] or [Node.js][5] application by installing the Datadog Lambda Library.
 
 2. Add the Lambda Layer for the Datadog Extension to your AWS Lambda function:
 
@@ -28,20 +32,28 @@ The Datadog Extension is distributed as its own Lambda Layer (separate from the 
     ```
 
     Replace the placeholder `AWS_REGION` in the Lambda Layer ARN with appropriate values.
+    
+    Note that this Layer is separate from the Datadog Lambda Library. If you installed the Datadog Lambda Library as a Lambda Layer,
+    your function should now have two Lambda Layers attached.
 
-3. If you are using Node.js or Python, add the Lambda Layer for the [Datadog Library][7] to your AWS Lambda function:
+3. Reference the [sample code][10] to submit a custom metric.
 
-    ```
-    arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:<VERSION>
-    ```
+### As a container image
 
-    The available `RUNTIME` options are `Node10-x`, `Node12-x`, `Python37`, and `Python38`. For `VERSION`, see the latest release for [Node.js][8] or [Python][9].
+If your function is deployed as a container image, you cannot add Lambda Layers to your function. Instead, you must directly install the Datadog Lambda Library and the Datadog Lambda Extension in your function's image.
 
-4. Reference the [sample code][10] to submit a custom metric.
+First, install the Datadog Lambda Library by following the installation instructions for [Node.js][5] or [Python][4]. Be sure to use the installation instructions specifically for functions deployed as container images.
 
-### Log collection
+Then, add the Datadog Lambda Extension to your container image by adding the following to your Dockerfile:
 
-To submit your AWS Lambda logs to Datadog using the Extension, set the env variable `DD_LOGS_ENABLED` to `true` in your function. Additionally, this generates Datadog's [enhanced metrics][11].
+```
+WORKDIR /opt/extensions
+COPY --from=datadog/lambda-extension:6 /opt/extensions/ .
+```
+
+## Log collection
+
+To submit your AWS Lambda logs to Datadog using the Extension, set the env variable `DD_LOGS_ENABLED` to `true` in your function.
 
 ## Further Reading
 
@@ -57,4 +69,3 @@ To submit your AWS Lambda logs to Datadog using the Extension, set the env varia
 [8]: https://github.com/DataDog/datadog-lambda-js/releases
 [9]: https://github.com/DataDog/datadog-lambda-python/releases
 [10]: /serverless/custom_metrics#custom-metrics-sample-code
-[11]: /serverless/enhanced_lambda_metrics

--- a/content/en/serverless/datadog_lambda_library/extension.md
+++ b/content/en/serverless/datadog_lambda_library/extension.md
@@ -32,8 +32,8 @@ The Datadog Lambda Extension is distributed as its own Lambda Layer (separate fr
     ```
 
     Replace the placeholder values in the ARN as follows:
-    - Replace `<AWS_REGION>` with the same AWS region as your Lambda Function, e.g. `us-east-1`.
-    - Replace `<VERSION_NUMBER>` with the version of the Datadog Lambda Extension you would like to use, e.g. `6`. You can identify the current version by viewing the newest tags in the [Dockerhub repository][11].
+    - Replace `<AWS_REGION>` with the same AWS region as your Lambda Function, for example, `us-east-1`.
+    - Replace `<VERSION_NUMBER>` with the version of the Datadog Lambda Extension you would like to use, for example `6`. You can identify the current version by viewing the newest tags in the [Dockerhub repository][11].
     
     **Note**: This Layer is separate from the Datadog Lambda Library. If you installed the Datadog Lambda Library as a Lambda Layer,
     your function should now have two Lambda Layers attached.


### PR DESCRIPTION
### What does this PR do?
Document how to install the Datadog Lambda Extension for functions deployed as container images.

### Preview
https://docs-staging.datadoghq.com/serverless/datadog_lambda_library/extension.md

### Additional Notes
~~Do not merge before the `datadog/lambda-extension` repository in Dockerhub has been made public. Until that happens, these instructions won't work.~~ The repository has been made public, so this is ready to merge.

I also made one other small correction. Enabling logs is no longer required to enable enhanced metrics as of [this PR](https://github.com/DataDog/datadog-agent/pull/7529).

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
