### PR TITLE
kristinbarr/add-comma-to-java-APM-config

### DIFF
--- a/content/en/tracing/setup_overview/setup/java.md
+++ b/content/en/tracing/setup_overview/setup/java.md
@@ -67,7 +67,7 @@ Install and configure the Datadog Agent to receive traces from your now instrume
 {{< partial name="apm/apm-containers.html" >}}
 </br>
 
-3. After having instrumented your application, the tracing client sends traces to `localhost:8126` by default.  If this is not the correct host and port change it by setting the below env variables:
+3. After having instrumented your application, the tracing client sends traces to `localhost:8126` by default.  If this is not the correct host and port, change it by setting the below env variables:
 
 `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a comma to the sentence: 
> If this is not the correct host and port change it by setting the below env variables:

The comma is added between "port" and "change".

### Motivation
I was researching for a ticket and reading this sentence didn't make sense to me and I think there should be a natural pause with a comma at this point.

### Preview
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/tracing/setup_overview/setup/java?tab=containers#configure-the-datadog-agent-for-apm

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
