### PR TITLE
Add note to 'Wildcard filtered metrics'

### DIFF
--- a/content/en/metrics/advanced-filtering.md
+++ b/content/en/metrics/advanced-filtering.md
@@ -65,7 +65,7 @@ Tag value prefix and suffix wildcard matching is supported:
 -  `pod_name: web-*` 
 -  `cluster:*-trace`.
 
-Please note that prefix and suffix wildcard matching in the same filter is not supported.
+**Note**: Prefix and suffix wildcard matching in the same filter is not supported.
 
 
 #### Wildcard filtered query examples

--- a/content/en/metrics/advanced-filtering.md
+++ b/content/en/metrics/advanced-filtering.md
@@ -65,6 +65,9 @@ Tag value prefix and suffix wildcard matching is supported:
 -  `pod_name: web-*` 
 -  `cluster:*-trace`.
 
+Please note that prefix and suffix wildcard matching in the same filter is not supported.
+
+
 #### Wildcard filtered query examples
 
 ```


### PR DESCRIPTION
Prefix and suffix wildcard matching in the same filter are not supported.

### What does this PR do?

Add a note to avoid confusion/assumptions.

### Motivation

I wasn't aware of this limitation and only found out after talking to Datadog's support.


### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
