### PR TITLE
[prod]garrett-young/update AWS EKS pause containers doc

### DIFF
--- a/content/en/account_management/billing/containers.md
+++ b/content/en/account_management/billing/containers.md
@@ -11,7 +11,7 @@ Additional containers are billed at an [additional cost][1] per container per ho
 
 ### Kubernetes
 
-Kubernetes creates pause containers to acquire the respective pod’s IP address and set up the network namespace for all other containers that join that pod. Datadog excludes all pause containers from your quota and does not charge for them (requires Agent 5.8+ & Agent 7.20+ for AWS EKS pause container exclusion). 
+Kubernetes creates pause containers (requires Agent v5.8+) to acquire the respective pod’s IP address and set up the network namespace for all other containers that join that pod. Datadog excludes all pause containers from your quota and does not charge for them (requires Agent v7.20+ for AWS EKS pause container exclusion). 
 
 ### Fargate
 

--- a/content/en/account_management/billing/containers.md
+++ b/content/en/account_management/billing/containers.md
@@ -11,7 +11,7 @@ Additional containers are billed at an [additional cost][1] per container per ho
 
 ### Kubernetes
 
-Kubernetes creates pause containers to acquire the respective pod’s IP address and set up the network namespace for all other containers that join that pod. Datadog excludes all pause containers from your quota and does not charge for them (requires Agent 5.8+).
+Kubernetes creates pause containers to acquire the respective pod’s IP address and set up the network namespace for all other containers that join that pod. Datadog excludes all pause containers from your quota and does not charge for them (requires Agent 5.8+ & Agent 7.20+ for AWS EKS pause container exclusion). 
 
 ### Fargate
 


### PR DESCRIPTION
zd: https://datadog.zendesk.com/agent/tickets/471244

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Excluding pause containers for EKS setups is introduced in agent 7.20

### Motivation
<!-- What inspired you to submit this pull request?-->
zd: https://datadog.zendesk.com/agent/tickets/471244 
### Preview
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/account_management/billing/containers/#kubernetes
<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
