### PR TITLE
clarify agent advanced log collection include at match docs

### DIFF
--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -128,7 +128,7 @@ spec:
 
 | Parameter          | Description                                                                       |
 |--------------------|-----------------------------------------------------------------------------------|
-| `include_at_match` | Only logs with a message that includes the specified pattern are sent to Datadog. |
+| `include_at_match` | Only logs with a message that includes the specified pattern are sent to Datadog. If multiple `include_at_match` rules are defined, all rules patterns must match in order for the log to be included. |
 
 
 For example, to **filter IN** logs that contain a Datadog email address, use the following `log_processing_rules`:
@@ -149,7 +149,7 @@ logs_config:
       pattern: \w+@datadoghq.com
 ```
 
-**Note**: If multiple `include_at_match` rules are defined, all rules patterns must match in order for the log to be included. If you want to match one or more patterns you must define them in a single expression:
+If you want to match one or more patterns you must define them in a single expression:
 
 ```yaml
 logs_config:


### PR DESCRIPTION
### What does this PR do?
Move include at match details to the main `include_at_match` description so it is clear this behavior applies to Docker and K8's configurations as well. 

### Motivation
Team feedback.

### Preview
<!-- Impacted pages preview links-->

https://docs-staging.datadoghq.com/brian/clarify-include-at-match-docs/agent/logs/advanced_log_collection/?tab=configurationfile#include-at-match

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
