### PR TITLE
Update how-do-i-uninstall-the-agent.md

### DIFF
--- a/content/en/agent/faq/how-do-i-uninstall-the-agent.md
+++ b/content/en/agent/faq/how-do-i-uninstall-the-agent.md
@@ -134,6 +134,7 @@ sudo rm -rf /opt/datadog-agent
 sudo rm -rf /usr/local/bin/datadog-agent
 sudo rm -rf ~/.datadog-agent/**​ #to remove broken symlinks
 launchctl remove com.datadoghq.agent
+sudo rm -rf /var/log/datadog
 ```
 
 Then, reboot your machine for changes to take effect.


### PR DESCRIPTION
/var/log/datadog is the folder or symlink where all the agent / install logs are stored. This folder should also be removed on uninstall.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
