### PR TITLE
Group retention log monitor update

### DIFF
--- a/content/en/monitors/faq/why-did-my-monitor-settings-change-not-take-effect.md
+++ b/content/en/monitors/faq/why-did-my-monitor-settings-change-not-take-effect.md
@@ -7,5 +7,3 @@ kind: faq
 Datadog keeps monitor groups available in the UI for 24 hours (48h for host monitors).  If you do not have *No Data* alert settings enabled and your group for a metric monitor stops reporting data, it will persist on the monitor status page until it ages out, though that group will stop being evaluated after a short absence (specific timing depends on your settings).
 
 For event monitors, however, Datadog also keeps groups for evaluations for at least 24 hours. This means that if a monitor is updated and the groups are changed in the query, some old groups may persist. If you must change the group settings on your event monitor, you may want clone or create a new monitor to reflect your new groups.  Alternatively, you can mute them if you would like to maintain the monitor but silence any alerts that would result from the changes.
-
-For log monitors, Datadog keeps monitor groups available in the UI for 4 hours.


### PR DESCRIPTION
### What does this PR do?
Remove the reference to 4h for log group retention

### Motivation
Log group retention is now 24h like all other monitors.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/monitor-group-retention-update/monitors/faq/why-did-my-monitor-settings-change-not-take-effect/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
