### PR TITLE
[WEB-1250] - bug fix multi-code-lang 2nd attempt

### DIFF
--- a/layouts/partials/nav/main-menu.html
+++ b/layouts/partials/nav/main-menu.html
@@ -34,7 +34,7 @@
                             <ul class="list-unstyled sub-menu">
                             {{ range .Children }}
                                 <li class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }} {{ if (not (in $excludeAsyc .Identifier)) }} js-load {{- end -}}" >
-                                    <a href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print .URL) | relLangURL)) "/" }}">
+                                    <a href="{{ .URL | relLangURL }}" data-type="{{- with site.GetPage .URL -}}{{- .Type -}}{{- end -}}" data-path="{{ trim (print $branchPath ((print .URL) | relLangURL)) "/" }}">
                                         {{ if .Pre }}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}{{ end }} <span>{{ .Name }}</span>
                                     </a>
                                     {{/*  4th level, hide  */}}
@@ -42,7 +42,7 @@
                                         <ul class="list-unstyled sub-menu d-none">
                                         {{ range .Children }}
                                             <li class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }} {{ if (not (in $excludeAsyc .Identifier)) }} js-load {{- end -}}" >
-                                                <a href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print .URL) | relLangURL)) "/" }}">
+                                                <a data-name="{{- delimit (last 1 (split (strings.TrimSuffix "/" .URL) "/")) "" -}}" href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print .URL) | relLangURL)) "/" }}">
                                                     {{ if .Pre }}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}{{ end }} <span>{{ .Name }}</span>
                                                 </a>
                                             </li>

--- a/src/scripts/components/async-loading.js
+++ b/src/scripts/components/async-loading.js
@@ -5,7 +5,7 @@ import { initializeIntegrations } from './integrations';
 import { initializeSecurityRules } from './security-rules';
 import {updateMainContentAnchors, reloadWistiaVidScripts, gtag, getCookieByName } from '../helpers/helpers';
 import configDocs from '../config/config-docs';
-import {redirectCodeLang, addCodeTabEventListeners, activateCodeLangNav} from './code-languages'; // eslint-disable-line import/no-cycle
+import {redirectCodeLang, addCodeTabEventListeners, activateCodeLangNav, toggleMultiCodeLangNav} from './code-languages'; // eslint-disable-line import/no-cycle
 
 const { env } = document.documentElement.dataset;
 const { gaTag } = configDocs[env];
@@ -51,7 +51,7 @@ function loadPage(newUrl) {
                 '.js-toc-container'
             );
 
-            const currentSidebar = document.querySelector('.sidebar'); 
+            const currentSidebar = document.querySelector('.sidebar');
             const newSidebar = httpRequest.responseXML.querySelector('.sidebar');
 
             if (newContent === null) {
@@ -163,7 +163,7 @@ function loadPage(newUrl) {
             }
 
             // Ensure sidebar is displayed or hidden properly based on HTTP response.  I'm certain we can implement a better strategy for what's happening in this script, but this should hold us over until then.
-            if (newSidebar && !currentSidebar) {            
+            if (newSidebar && !currentSidebar) {
                 const jsContentContainer = document.querySelector('.js-content-container');
                 jsContentContainer.appendChild(newSidebar);
             }
@@ -199,6 +199,7 @@ function loadPage(newUrl) {
             addCodeTabEventListeners();
             activateCodeLangNav(pageCodeLang)
             redirectCodeLang();
+            toggleMultiCodeLangNav(pageCodeLang);
 
             // Gtag virtual pageview
             gtag('config', gaTag, { page_path: pathName });

--- a/src/scripts/components/code-languages.js
+++ b/src/scripts/components/code-languages.js
@@ -89,6 +89,7 @@ function activateCodeLangNav(activeLang) {
 
 function toggleCodeBlocks(activeLang) {
     activateCodeLangNav(activeLang);
+    toggleMultiCodeLangNav(activeLang);
 
     // non-api page code blocks
     const codeWrappers = document.querySelectorAll('body:not(.api) [class*=js-code-snippet-wrapper]');
@@ -158,4 +159,26 @@ function toggleCodeBlocks(activeLang) {
     }
 }
 
-export { redirectCodeLang, addCodeTabEventListeners, activateCodeLangNav };
+function toggleMultiCodeLangNav(codeLang) {
+  /*
+  - Find any nav entries with type multi-code-lang
+  - Look for child entry that has data-name matching the current code lang
+  - Switch that url into the parent url, so its the appropriate language version
+   */
+  if(typeof(codeLang) === 'string' && codeLang.length > 0) {
+    const items = document.querySelectorAll('a[data-type="multi-code-lang"]');
+    if(items) {
+      items.forEach((item) => {
+        const li = item.closest('li');
+        const a = (li) ? li.querySelector(`a[data-name="${codeLang}"]`) : null;
+        if (a) {
+          item.setAttribute('href', a.getAttribute('href'));
+        }
+      });
+    }
+  }
+}
+
+toggleMultiCodeLangNav(Cookies.get('code-lang') || '');
+
+export { redirectCodeLang, addCodeTabEventListeners, activateCodeLangNav, toggleMultiCodeLangNav };


### PR DESCRIPTION
### What does this PR do?

This PR brings back the changes from [WEB-1250] fixing multi code lang navigation bugfix where we reverted due to issues. 

(revert pr) #10215 
(original pr) #10145

### Motivation

https://datadoghq.atlassian.net/browse/WEB-1250

### Preview

Some pages that had the issue when live
https://docs-staging.datadoghq.com/david.jones/code-lang-bug2/tracing/legacy_app_analytics/
https://docs-staging.datadoghq.com/david.jones/code-lang-bug2/tracing/troubleshooting/tracer_startup_logs
https://docs-staging.datadoghq.com/david.jones/code-lang-bug2/developers/dogstatsd/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[WEB-1250]: https://datadoghq.atlassian.net/browse/WEB-1250