### PR TITLE
Add log monitors as supported for test notification

### DIFF
--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -318,7 +318,7 @@ To notify your dev team if a triggering host has the name `production`, use the 
 
 ## Test notifications
 
-Test notifications are supported for the [monitor types][1]: host, metric, anomaly, outlier, forecast, integration (check only), process (check only), network (check only), custom check, event, and composite.
+Test notifications are supported for the [monitor types][1]: host, metric, anomaly, outlier, forecast, logs, integration (check only), process (check only), network (check only), custom check, event, and composite.
 
 ### Run the test
 

--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -318,7 +318,7 @@ To notify your dev team if a triggering host has the name `production`, use the 
 
 ## Test notifications
 
-Test notifications are supported for the [monitor types][1]: host, metric, anomaly, outlier, forecast, logs, integration (check only), process (check only), network (check only), custom check, event, and composite.
+Test notifications are supported for the [monitor types][1]: host, metric, anomaly, outlier, forecast, logs, rum, apm, integration (check only), process (check only), network (check only), custom check, event, and composite.
 
 ### Run the test
 


### PR DESCRIPTION
### What does this PR do?
Add log to the list of supported monitors for test notifications

### Motivation
Support for those has been added.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/log-monitor-test-notification/monitors/notifications/?tab=is_alert#test-notifications

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
