### PR TITLE
Add http-intake shortcode

### DIFF
--- a/content/en/integrations/carbon_black.md
+++ b/content/en/integrations/carbon_black.md
@@ -30,9 +30,6 @@ First, install and setup the [Carbon Black Defense log shipper][1].
 
 The configuration file below enables your Carbon Black Defense shipper to forward your logs to Datadog:
 
-{{< tabs >}}
-{{% tab "Datadog US Site" %}}
-
 ```conf
 [general]
 
@@ -40,7 +37,7 @@ template = {{source}}|{{version}}|{{vendor}}|{{product}}|{{dev_version}}|{{signa
 policy_action_severity = 4
 output_format=json
 output_type=http
-http_out=https://http-intake.logs.datadoghq.com/v1/input/<DATADOG_API_KEY>?ddsource=cbdefense
+http_out={{< region-param key="http_endpoint" code="true" >}}<DATADOG_API_KEY>?ddsource=cbdefense
 http_headers={"content-type": "application/json"}
 https_ssl_verify=True
 
@@ -49,29 +46,6 @@ server_url = <CB_DEFENSE_SERVER_URL>
 siem_connector_id=<CB_DEFENSE_API_ID>
 siem_api_key=<CB_DEFENSE_API_SECRET_KEY>
 ```
-
-{{% /tab %}}
-{{% tab "Datadog EU Site" %}}
-
-```conf
-[general]
-
-template = {{source}}|{{version}}|{{vendor}}|{{product}}|{{dev_version}}|{{signature}}|{{name}}|{{severity}}|{{extension}}
-policy_action_severity = 4
-output_format=json
-output_type=http
-http_out=https://http-intake.logs.datadoghq.eu/v1/input/<DATADOG_API_KEY>?ddsource=cbdefense
-http_headers={"content-type": "application/json"}
-https_ssl_verify=True
-
-[cbdefense1]
-server_url = <CB_DEFENSE_SERVER_URL>
-siem_connector_id=<CB_DEFENSE_API_ID>
-siem_api_key=<CB_DEFENSE_API_SECRET_KEY>
-```
-
-{{% /tab %}}
-{{< /tabs >}}
 
 Replace the `<DATADOG_API_KEY>`, `<CB_DEFENSE_API_SECRET_KEY>`, `<CB_DEFENSE_API_ID>`, and `<CB_DEFENSE_SERVER_URL>` placeholders to complete your configuration.
 

--- a/content/en/integrations/fluentbit.md
+++ b/content/en/integrations/fluentbit.md
@@ -39,7 +39,7 @@ Before you begin, you need to have a [Datadog account][3], a [Datadog API key][4
 
 | Key            | Description                                                                                                              | Default                                                                     |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
-| Host           | _Required_ - The Datadog server where you are sending your logs.                                                         | US - `http-intake.logs.datadoghq.com`, EU - `http-intake.logs.datadoghq.eu` |
+| Host           | _Required_ - The Datadog server where you are sending your logs.                                                         | {{< region-param key="http_endpoint" code="true" >}} |
 | TLS            | _Required_ - End-to-end security communications security protocol. Datadog recommends setting this to `on`.              | `off`                                                                       |
 | apikey         | _Required_ - Your [Datadog API key][4].                                                                                  |                                                                             |
 | compress       | _Recommended_ - compresses the payload in GZIP format, Datadog supports and recommends setting this to `gzip`.           |                                                                             |


### PR DESCRIPTION
### What does this PR do?
Add `http-intake` shortcode to fluentbit and carbon black integrations

### Motivation
Jira request

### Preview
https://docs-staging.datadoghq.com/sarina/intg-shortcode/integrations/carbon_black
https://docs-staging.datadoghq.com/sarina/intg-shortcode/integrations/fluentbit

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
