### PR TITLE
[WEB-1050] - skip install job for translation prs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,6 +64,9 @@ install_dependencies:
   only:
     changes:
       - yarn.lock
+  except:
+    # skip on automated translation prs
+    - /^guacbot\/translation-[0-9]+$
 
 # ================== preview ================== #
 # If the branch has a name of <slack-user>/<feature-name> then ci builds a preview site


### PR DESCRIPTION
### What does this PR do?

This PR will skip the `install_dependencies` job for automated translation prs. 
These prs shouldn't change node dependencies so there is no need to run them. 
It should also hopefully trigger the `interruptible: true` causing the first translation pipeline to cancel and the second to run (the one we care about). This currently isn't happening because we can't label install_dependencies as something to interrupt.

### Motivation

https://datadoghq.atlassian.net/browse/WEB-1050

### Preview

https://docs-staging.datadoghq.com/david.jones/skip-job-translations/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
