### PR TITLE
[doc] Correct "pod" reference to "node"

### DIFF
--- a/content/en/agent/kubernetes/log.md
+++ b/content/en/agent/kubernetes/log.md
@@ -24,7 +24,7 @@ The Agent has two ways to collect logs: from the [Docker socket][1], and from th
 * Docker is not the runtime, **or**
 * More than 10 containers are used on each node
 
-The Docker API is optimized to get logs from one container at a time, when there are many containers in the same pod, collecting logs through the Docker socket might be consuming much more resources than going through the Kubernetes log files logic.
+The Docker API is optimized to get logs from one container at a time; when there are many containers in the same node, collecting logs through the Docker socket might be consuming much more resources than going through the Kubernetes log files logic.
 
 ## Log collection
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR corrects the reference to "pod" and changes it to "node". Also changes the comma to a semicolon for readability.
Changes: "The Docker API is optimized to get logs from one container at a time, when there are many containers in the same pod, collecting logs through the Docker socket might be consuming much more resources..."
To: "The Docker API is optimized to get logs from one container at a time; when there are many containers in the same node, collecting logs through the Docker socket might be consuming much more resources"

### Motivation
Customer reached out about this discrepancy, and considering the doc references the node instead of pod directly above in the same doc, and after reviewing the [doc for Docker socket](https://docs.datadoghq.com/agent/faq/log-collection-with-docker-socket/?tab=daemonset), the term here should be "node" instead of "pod".

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/corey.ferland/kubernetes-log-doc-update/agent/kubernetes/log/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
