### PR TITLE
[doc] Fix broken link to Docker Log Collection page

### DIFF
--- a/content/en/logs/faq/how-to-tail-logs-from-host-using-a-container-agent.md
+++ b/content/en/logs/faq/how-to-tail-logs-from-host-using-a-container-agent.md
@@ -5,7 +5,7 @@ further_reading:
 - link: "/docker/log"
   tag: "Documentation"
   text: "Logging with Docker"
-- link: "/agent/kubernetes/log"
+- link: "https://docs.datadoghq.com/agent/docker/log/?tab=containerinstallation"
   tag: "Documentation"
   text: "Logging with Kubernetes"
 - link: "https://www.datadoghq.com/blog/docker-logging/"

--- a/content/en/logs/faq/how-to-tail-logs-from-host-using-a-container-agent.md
+++ b/content/en/logs/faq/how-to-tail-logs-from-host-using-a-container-agent.md
@@ -5,7 +5,7 @@ further_reading:
 - link: "/docker/log"
   tag: "Documentation"
   text: "Logging with Docker"
-- link: "https://docs.datadoghq.com/agent/docker/log/?tab=containerinstallation"
+- link: "/agent/docker/log/?tab=containerinstallation"
   tag: "Documentation"
   text: "Logging with Kubernetes"
 - link: "https://www.datadoghq.com/blog/docker-logging/"


### PR DESCRIPTION
### What does this PR do?
Quick fix to a broken link that was 404'ing but should redirect to the Docker Log Collection page

### Motivation
Was just reviewing docs and came across this broken link at the bottom.

### Preview


### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
