### PR TITLE
Remove rogue period in wildcard syntax

### DIFF
--- a/content/en/metrics/advanced-filtering.md
+++ b/content/en/metrics/advanced-filtering.md
@@ -63,7 +63,7 @@ avg:system.cpu.user{env:prod AND location NOT IN (atlanta,seattle,las-vegas)}
 
 Tag value prefix and suffix wildcard matching is supported: 
 -  `pod_name: web-*` 
--  `cluster:*-trace`.
+-  `cluster:*-trace`
 
 **Note**: Prefix and suffix wildcard matching in the same filter is not supported.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes a random period from the wildcard matching syntax list

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
