### PR TITLE
Add sed command

### DIFF
--- a/static/config/99datadog-amazon-linux-2.config
+++ b/static/config/99datadog-amazon-linux-2.config
@@ -14,6 +14,7 @@ files:
         content: |
             #!/bin/bash
             sed 's/api_key:.*/api_key: '$DD_API_KEY'/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+            sed 's/datadoghq.com/datadoghq.eu'
 
     "/datadog/datadog.repo":
         mode: "000644"
@@ -28,7 +29,7 @@ files:
             gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
                    https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
                    https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-            
+
     "/start_datadog.sh":
         mode: "000700"
         owner: root

--- a/static/config/99datadog.config
+++ b/static/config/99datadog.config
@@ -17,6 +17,7 @@ files:
             DD_KEY="$(/opt/elasticbeanstalk/bin/get-config environment -k DD_API_KEY)"
 
             sed 's/api_key:.*/api_key: '$DD_KEY'/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+            sed 's/datadoghq.com/datadoghq.eu'
 
     "/datadog/datadog.repo":
         mode: "000644"


### PR DESCRIPTION
### What does this PR do?
Adds site sed command for AWS Elastic Beanstalk docs

### Motivation
Jira request

### Preview
https://docs-staging.datadoghq.com/sarina/99datadog-config/integrations/amazon_elasticbeanstalk/?tab=singlecontainer

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
