### PR TITLE
Refine requisites for Java code hotspots under JDK 8.

### DIFF
--- a/content/en/tracing/profiler/connect_traces_and_profiles.md
+++ b/content/en/tracing/profiler/connect_traces_and_profiles.md
@@ -35,8 +35,8 @@ try (final Scope scope = tracer.activateSpan(span)) { // mandatory for Datadog c
 ```
 
 Requires:
-- tracing library version 0.65.0 or greater
-- OpenJDK 8u282 or greater
+- OpenJDK11 or greater and tracing library version 0.65.0 or greater
+- (alternatively if on OpenJDK8) OpenJDK 8u282 or greater and tracing library version 0.77.0 or greater
 
 
 [1]: /tracing/profiler/getting_started

--- a/content/en/tracing/profiler/connect_traces_and_profiles.md
+++ b/content/en/tracing/profiler/connect_traces_and_profiles.md
@@ -35,8 +35,8 @@ try (final Scope scope = tracer.activateSpan(span)) { // mandatory for Datadog c
 ```
 
 Requires:
-- OpenJDK11 or greater and tracing library version 0.65.0 or greater
-- (alternatively if on OpenJDK8) OpenJDK 8u282 or greater and tracing library version 0.77.0 or greater
+- OpenJDK 11 or greater and tracing library version 0.65.0 or greater; or
+- If on OpenJDK 8: 8u282 or greater and tracing library version 0.77.0 or greater.
 
 
 [1]: /tracing/profiler/getting_started


### PR DESCRIPTION
### What does this PR do?
Update requirements for Java Code hotspots

### Motivation
Java Code hotspots on OpenJDK 8 requires a minimum JDK build of 282 AND minimum tracing library version 0.77.0.


### Preview

https://docs-staging.datadoghq.com/alexjf/hotspots-jdk8-requirements-clarification/tracing/profiler/connect_traces_and_profiles/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
