### PR TITLE
bugfix dont add the filter if its an integration tile we are hiding

### DIFF
--- a/layouts/shortcodes/integrations.html
+++ b/layouts/shortcodes/integrations.html
@@ -10,10 +10,15 @@
 <!-- build filters -->
 {{ $.Scratch.Set "filters" (slice)}}
 {{ range $index, $element := $integration_list }}
+    {{ $urlname := $element.File.TranslationBaseName }}
+    {{ $src := (print "images/integrations_logos/" ($urlname | lower) ".png")}}
+    {{ $indx :=  $src }}
     {{ range $e := $element.Params.categories }}
-        {{ with $e }}
-          {{ if not (in ($.Scratch.Get "filters") (. | lower)) }}
-              {{ $.Scratch.Add "filters" (. | lower) }}
+        {{ if and $indx (fileExists (print "static/" $src)) }}
+          {{ with $e }}
+            {{ if not (in ($.Scratch.Get "filters") (. | lower)) }}
+                {{ $.Scratch.Add "filters" (. | lower) }}
+            {{ end }}
           {{ end }}
         {{ end }}
     {{ end }}


### PR DESCRIPTION
### What does this PR do?

A filter is showing on the integrations (`TESTING`) and displays no results when clicking it.
This PR doesn't add the filter to the list if the tile in the loop isn't showing.

### Motivation

Discovered during testing

### Preview

Testing category should be gone
https://docs-staging.datadoghq.com/david.jones/int-filters/integrations/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
