### PR TITLE
Fix profiler get started partial

### DIFF
--- a/layouts/partials/profiling/profiling-languages.html
+++ b/layouts/partials/profiling/profiling-languages.html
@@ -2,17 +2,17 @@
 <div class="profiling-languages">
   <div class="container cards-dd">
     <div class="card-deck">
-      <a class="card" href="/tracing/profiler/getting_started/?tab=java">
+      <a class="card" href="/tracing/profiler/getting_started/?code-lang=java">
         <div class="card-body text-center py-2 px-1">
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/java.png" "class" "img-fluid" "alt" "Java" "width" "400") }}
         </div>
       </a>
-      <a class="card" href="/tracing/profiler/getting_started/?tab=python">
+      <a class="card" href="/tracing/profiler/getting_started/?code-lang=python">
         <div class="card-body text-center py-2 px-1">
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}
         </div>
       </a>
-      <a class="card" href="/tracing/profiler/getting_started/?tab=go">
+      <a class="card" href="/tracing/profiler/getting_started/?code-lang=go">
         <div class="card-body text-center py-2 px-1">
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/golang.png" "class" "img-fluid" "alt" "Go" "width" "400") }}
         </div>


### PR DESCRIPTION
### What does this PR do?
Fixes links on Profiler partial to language-specific tabs on getting started page.

### Motivation
report of weird tab behavior in #documenation 

### Preview

https://docs-staging.datadoghq.com/kari/profiler-gs-links/tracing/profiler/


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
