### PR TITLE
Add advanced openmetrics AD config

### DIFF
--- a/content/en/agent/kubernetes/prometheus.md
+++ b/content/en/agent/kubernetes/prometheus.md
@@ -137,7 +137,7 @@ With Prometheus Autodiscovery, the Datadog Agent is able to detect native Promet
 
 ### Requirements
 
-- Datadog Agent v7 or v6.27+ (for Pod checks)
+- Datadog Agent v7.27+ or v6.27+ (for Pod checks)
 - Datadog Cluster Agent v1.11+ (for service and endpoint checks)
 
 ### Configuration

--- a/content/en/agent/kubernetes/prometheus.md
+++ b/content/en/agent/kubernetes/prometheus.md
@@ -179,7 +179,7 @@ The autodiscovery configuration can be based on container names or kubernetes an
 
 `kubernetes_annotations` contains two maps of labels to define the discovery rules: `include` and `exclude`.
 
-**Note:** The default value of `kubernetes_annotations` in the Datadog Agent configuration is the following
+**Note:** The default value of `kubernetes_annotations` in the Datadog Agent configuration is the following:
 
 ```
 kubernetes_annotations:

--- a/content/en/agent/kubernetes/prometheus.md
+++ b/content/en/agent/kubernetes/prometheus.md
@@ -137,10 +137,12 @@ With Prometheus Autodiscovery, the Datadog Agent is able to detect native Promet
 
 ### Requirements
 
-- Datadog Agent v7 or v6.26+ (for Pod checks)
+- Datadog Agent v7 or v6.27+ (for Pod checks)
 - Datadog Cluster Agent v1.11+ (for service and endpoint checks)
 
 ### Configuration
+
+#### Basic configuration
 
 In your Helm `values.yaml`, add the following:
 
@@ -163,6 +165,51 @@ It also instructs the Datadog Cluster Agent (if enabled) to detect the services 
 
 This configuration generates a check that collects all metrics exposed using the default configuration of the [OpenMetrics integration][1].
 
+#### Advanced configuration
+
+It is possible to define advanced Openmetrics check configuration or custom Autodiscovery rules other than native Prometheus annotations thanks the `additionalConfigs` configuration field in `values.yaml`.
+
+`additionalConfigs` is a list of structures containing Openmetrics check configurations and Autodiscovery rules.
+
+Every [configuration field][15] supported by the Openmetrics check can be passed in the configurations list.
+
+The autodiscovery configuration can be based on container names or kubernetes annotations or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it’s an AND (both rules must match).
+
+`kubernetes_container_names` is a list of container names to target, it supports the `*` wildcard.
+
+`kubernetes_annotations` contains two maps of labels to define the discovery rules: `include` and `exclude`.
+
+**Note:** The default value of `kubernetes_annotations` in the Datadog Agent configuration is the following
+
+```
+kubernetes_annotations:
+  include:
+    - prometheus.io/scrape: "true"
+  exclude:
+    - prometheus.io/scrape: "false"
+```
+
+**Example:**
+
+In this example we're defining an advanced configuration targeting a container named `my-app` running in a pod labeled `app=my-app`. We're customising the Openmetrics check configuration as well, by enabling the `send_distribution_buckets` option and defining a custom timeout of 5 seconds.
+
+```
+datadog:
+...
+  prometheusScrape:
+    enabled: true
+    additionalConfigs:
+      -
+        configurations:
+        - timeout: 5
+          send_distribution_buckets: true
+        autodiscovery:
+          kubernetes_container_names:
+            - my-app
+          kubernetes_annotations:
+            include:
+              app: my-app
+```
 
 ## From custom to official integration
 
@@ -188,3 +235,4 @@ Official integrations have their own dedicated directories. There's a default in
 [12]: https://app.datadoghq.com/metric/summary
 [13]: /agent/faq/template_variables/
 [14]: https://github.com/DataDog/integrations-core/tree/master/kube_proxy
+[15]: https://github.com/DataDog/integrations-core/blob/7.27.x/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example

--- a/content/en/agent/kubernetes/prometheus.md
+++ b/content/en/agent/kubernetes/prometheus.md
@@ -167,7 +167,7 @@ This configuration generates a check that collects all metrics exposed using the
 
 #### Advanced configuration
 
-It is possible to define advanced Openmetrics check configuration or custom Autodiscovery rules other than native Prometheus annotations thanks the `additionalConfigs` configuration field in `values.yaml`.
+You can define advanced Openmetrics check configurations or custom Autodiscovery rules other than native Prometheus annotations with the `additionalConfigs` configuration field in `values.yaml`.
 
 `additionalConfigs` is a list of structures containing Openmetrics check configurations and Autodiscovery rules.
 

--- a/content/en/agent/kubernetes/prometheus.md
+++ b/content/en/agent/kubernetes/prometheus.md
@@ -173,7 +173,7 @@ You can define advanced Openmetrics check configurations or custom Autodiscovery
 
 Every [configuration field][15] supported by the Openmetrics check can be passed in the configurations list.
 
-The autodiscovery configuration can be based on container names or kubernetes annotations or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it’s an AND (both rules must match).
+The autodiscovery configuration can be based on container names or kubernetes annotations or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it uses AND logic (both rules must match).
 
 `kubernetes_container_names` is a list of container names to target, it supports the `*` wildcard.
 

--- a/content/en/agent/kubernetes/prometheus.md
+++ b/content/en/agent/kubernetes/prometheus.md
@@ -191,7 +191,7 @@ kubernetes_annotations:
 
 **Example:**
 
-In this example we're defining an advanced configuration targeting a container named `my-app` running in a pod labeled `app=my-app`. We're customising the Openmetrics check configuration as well, by enabling the `send_distribution_buckets` option and defining a custom timeout of 5 seconds.
+In this example we're defining an advanced configuration targeting a container named `my-app` running in a pod labeled `app=my-app`. We're customizing the Openmetrics check configuration as well, by enabling the `send_distribution_buckets` option and defining a custom timeout of 5 seconds.
 
 ```
 datadog:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Document how to add advanced `prometheusScrape` configurations in the agent.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ahmed/prom-advanced-config/agent/kubernetes/prometheus/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
