### PR TITLE
[WEB-1250] - bug fix multi-code-lang 3rd attempt

### DIFF
--- a/src/scripts/components/async-loading.js
+++ b/src/scripts/components/async-loading.js
@@ -5,7 +5,7 @@ import { initializeIntegrations } from './integrations';
 import { initializeSecurityRules } from './security-rules';
 import {updateMainContentAnchors, reloadWistiaVidScripts, gtag, getCookieByName } from '../helpers/helpers';
 import configDocs from '../config/config-docs';
-import {redirectCodeLang, addCodeTabEventListeners, activateCodeLangNav} from './code-languages'; // eslint-disable-line import/no-cycle
+import {redirectCodeLang, addCodeTabEventListeners, activateCodeLangNav, toggleMultiCodeLangNav} from './code-languages'; // eslint-disable-line import/no-cycle
 
 const { env } = document.documentElement.dataset;
 const { gaTag } = configDocs[env];
@@ -199,7 +199,7 @@ function loadPage(newUrl) {
             addCodeTabEventListeners();
             activateCodeLangNav(pageCodeLang)
             redirectCodeLang();
-            // toggleMultiCodeLangNav(pageCodeLang);
+            toggleMultiCodeLangNav(pageCodeLang);
 
             // Gtag virtual pageview
             gtag('config', gaTag, { page_path: pathName });

--- a/src/scripts/components/code-languages.js
+++ b/src/scripts/components/code-languages.js
@@ -89,7 +89,7 @@ function activateCodeLangNav(activeLang) {
 
 function toggleCodeBlocks(activeLang) {
     activateCodeLangNav(activeLang);
-    // toggleMultiCodeLangNav(activeLang);
+    toggleMultiCodeLangNav(activeLang);
 
     // non-api page code blocks
     const codeWrappers = document.querySelectorAll('body:not(.api) [class*=js-code-snippet-wrapper]');
@@ -179,6 +179,6 @@ function toggleMultiCodeLangNav(codeLang) {
   }
 }
 
-// toggleMultiCodeLangNav(Cookies.get('code-lang') || '');
+toggleMultiCodeLangNav(Cookies.get('code-lang') || '');
 
 export { redirectCodeLang, addCodeTabEventListeners, activateCodeLangNav, toggleMultiCodeLangNav };


### PR DESCRIPTION
### What does this PR do?

The second attempt still had issues in #10294 so I left the code in production commented out.
This PR enables the functionality again.

The reason for the failures is that as an optimization in prod we automatically split chunks of js out into seperate files. One of those files was coming through as `0.js`. As this filename has no hash we would quite often still load a cached version in prod. 

In the previous releases the `0.js` file would get some code split into it that is required however we would never load it because we are grabbing a cached version and in turn get errors in various places.

This is resolved in #10319 by hashing and naming `0.js` appropriately.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview

https://docs-staging.datadoghq.com/david.jones/code-lang-bug3/

Some pages to test
https://docs-staging.datadoghq.com/david.jones/code-lang-bug3/tracing/setup_overview/setup/python
https://docs-staging.datadoghq.com/david.jones/code-lang-bug3/tracing/legacy_app_analytics/
https://docs-staging.datadoghq.com/david.jones/code-lang-bug3/tracing/troubleshooting/tracer_startup_logs
https://docs-staging.datadoghq.com/david.jones/code-lang-bug3/developers/dogstatsd/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
