### PR TITLE
[Agent 6/7] Fix NPM driver installation option

### DIFF
--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -89,7 +89,7 @@ Each configuration item is added as a property to the command line. The followin
 | `DDAGENTUSER_PASSWORD`     | String | Override the cryptographically secure password generated for the `ddagentuser` user during Agent installation _(v6.11.0+)_. Must be provided for installs on domain servers. [Learn more about the Datadog Windows Agent User][3].  |
 | `APPLICATIONDATADIRECTORY` | Path   | Override the directory to use for the configuration file directory tree. May only be provided on initial install; not valid for upgrades. Default: `C:\ProgramData\Datadog`. _(v6.11.0+)_                                           |
 | `PROJECTLOCATION`          | Path   | Override the directory to use for the binary file directory tree. May only be provided on initial install; not valid for upgrades. Default: `%PROGRAMFILES%\Datadog\Datadog Agent`. _(v6.11.0+)_                                    |
-| `ADDLOCAL`                 | String | Enable additional agent component. Setting to `"NPM"` causes the driver component for [Network Performance Monitoring][4] to be installed.                                                                                          |
+| `ADDLOCAL`                 | String | Enable additional agent component. Setting to `"MainApplication,NPM"` causes the driver component for [Network Performance Monitoring][4] to be installed.                                                                                          |
 
 **Note**: If a valid `datadog.yaml` is found and has an API key configured, that file takes precedence over all specified command line options.
 

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -181,7 +181,7 @@ To enable network performance monitoring for Windows hosts:
 
 1. Install the [Datadog Agent][1] (version 7.27.0 or above) with the network driver component enabled.
 
-   During installation pass `ADDLOCAL=NPM` to the `msiexec` command, or select "Network Performance Monitoring" when running the agent installation through the GUI.
+   During installation pass `ADDLOCAL="MainApplication,NPM"` to the `msiexec` command, or select "Network Performance Monitoring" when running the agent installation through the GUI.
 
 1. Edit `C:\ProgramData\Datadog\system-probe.yaml` to set the enabled flag to `true`:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Updates the `ADDLOCAL` option used to install the optional NPM driver component for the Windows Agent.

### Motivation

Setting `ADDLOCAL="NPM"` causes install failures or broken installs.

### Preview

[Windows install page](https://docs-staging.datadoghq.com/kylian.serrania/fix-npm-driver-docs/agent/basic_agent_usage/windows/?tab=commandline)
[NPM setup page](https://docs-staging.datadoghq.com/kylian.serrania/fix-npm-driver-docs/network_monitoring/performance/setup/?tab=agentwindows#setup)

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
