### PR TITLE
Update link to dd-trace-java latest version

### DIFF
--- a/content/en/tracing/profiler/getting_started.md
+++ b/content/en/tracing/profiler/getting_started.md
@@ -32,7 +32,7 @@ The Datadog Profiler requires [JDK Flight Recorder][1]. The Datadog Profiler lib
 2. Download `dd-java-agent.jar`, which contains the Java Agent class files:
 
     ```shell
-    wget -O dd-java-agent.jar 'https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.datadoghq&a=dd-java-agent&v=LATEST'
+    wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
     ```
 
      **Note**: Profiler is available in the `dd-java-agent.jar` library in versions 0.55+.


### PR DESCRIPTION
### What does this PR do?
Update dd-trace-java download link to ensure parity between the Getting Started docs for the Java tracer and profiler.

### Motivation
On the Java tracer Getting Started page we use a [short link to the latest version of dd-trace-java](https://docs.datadoghq.com/tracing/setup_overview/setup/java/?tab=containers#java-installation-steps). It makes sense to the do same for the Getting Started doc for the profiler.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/codyborders-update-tracer-download-link/tracing/profiler/getting_started/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
