### PR TITLE
[doc] Adding release version for Core Web Vitals

### DIFF
--- a/content/en/real_user_monitoring/browser/monitoring_page_performance.md
+++ b/content/en/real_user_monitoring/browser/monitoring_page_performance.md
@@ -28,7 +28,9 @@ RUM view events collect extensive performance metrics for every single page view
 - **RUM waterfall**: accessible for every single RUM view event in the [RUM Explorer][3], it lets you troubleshoot the performance of a specific page view. It shows how your website assets and resources, long tasks, and frontend errors affect performance for your end users, at the page level.
 
 ### Core Web Vitals
-
+<div class="alert alert-warning"> 
+  <strong>Note:</strong> The Core Web Vitals metrics have been introduced in Datadog since [`@datadog/browser-rum`](https://github.com/DataDog/browser-sdk) package version 2.0.0
+</div>
 [Google's Core Web Vitals][4] are a set of three metrics designed to monitor a site's user experience. These metrics focus on giving you a view of load performance, interactivity, and visual stability. Each metric comes with guidance on the range of values that translate to good user experience. Datadog recommends monitoring the 75th percentile for these metrics.
 
 {{< img src="real_user_monitoring/browser/core-web-vitals.png" alt="Core Web Vitals summary visualization"  >}}

--- a/content/en/real_user_monitoring/browser/monitoring_page_performance.md
+++ b/content/en/real_user_monitoring/browser/monitoring_page_performance.md
@@ -29,7 +29,7 @@ RUM view events collect extensive performance metrics for every single page view
 
 ### Core Web Vitals
 <div class="alert alert-warning"> 
-  <strong>Note:</strong> The Core Web Vitals metrics have been introduced in Datadog since [`@datadog/browser-rum`](https://github.com/DataDog/browser-sdk) package version 2.0.0
+  <strong>Note:</strong> The Core Web Vitals metrics are available in Datadog from <a href="https://github.com/DataDog/browser-sdk">@datadog/browser-rum</a> package version 2.0.0 and newer.
 </div>
 [Google's Core Web Vitals][4] are a set of three metrics designed to monitor a site's user experience. These metrics focus on giving you a view of load performance, interactivity, and visual stability. Each metric comes with guidance on the range of values that translate to good user experience. Datadog recommends monitoring the 75th percentile for these metrics.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR adds information on when the Core Web Vitals metrics were introduced into Datadog. This is for v2.0.0+ of the @datadog/browser-rum package.

### Motivation
 I believe this is important since support tickets are being open just asking why these metrics are missing in their platform, while having older versions of the previously mentioned package.  Example: https://datadog.zendesk.com/agent/tickets/469354 


### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
