### PR TITLE
Update profiling migration page with new url for java lib

### DIFF
--- a/content/en/tracing/faq/profiling_migration.md
+++ b/content/en/tracing/faq/profiling_migration.md
@@ -25,7 +25,7 @@ Perform the following steps to migrate your service to send profiles directly th
 2. Upgrade the tracing library to [version 0.55][2]+ or run the following command to get the latest tracer version:
 
     ```shell
-    wget -O dd-java-agent.jar 'https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.datadoghq&a=dd-java-agent&v=LATEST'
+    wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
     ```
 
 3. Clear the `DD_PROFILING_API_KEY_FILE`, `DD_PROFILING_API_KEY`, `DD_API_KEY_FILE` or `DD_API_KEY` environment variables or equivalent system property flags. The API key files are deprecated as of version 0.55.


### PR DESCRIPTION
### Motivation
The tracer version of this link was updated in https://github.com/DataDog/documentation/pull/7909 and profiling getting started in https://github.com/DataDog/documentation/pull/10360. This fixes one more place.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
