### PR TITLE
update deploy for rum js config so that we have no caching

### DIFF
--- a/config/live/config.yaml
+++ b/config/live/config.yaml
@@ -23,7 +23,7 @@ deployment:
 
     matchers:
       # dont cache rum/logs config
-      - pattern: "^assets/dd-browser-logs-rum.js$"
+      - pattern: "^static/dd-browser-logs-rum.js$"
         cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
         gzip: true
       - pattern: "^.+\\.(js|css|svg)$"

--- a/config/live/config.yaml
+++ b/config/live/config.yaml
@@ -22,6 +22,10 @@ deployment:
       include: "**.{jpg,jpeg,png,gif,mp4,svg,json}"
 
     matchers:
+      # dont cache rum/logs config
+      - pattern: "^assets/dd-browser-logs-rum.js$"
+        cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
+        gzip: true
       - pattern: "^.+\\.(js|css|svg)$"
         cacheControl: "max-age=31536000, no-transform, public"
         gzip: true

--- a/config/preview/config.yaml
+++ b/config/preview/config.yaml
@@ -23,7 +23,7 @@ deployment:
 
     matchers:
       # dont cache rum/logs config
-      - pattern: "^assets/dd-browser-logs-rum.js$"
+      - pattern: "^static/dd-browser-logs-rum.js$"
         cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
         gzip: true
       - pattern: "^.+\\.(js|css|svg)$"

--- a/config/preview/config.yaml
+++ b/config/preview/config.yaml
@@ -22,6 +22,10 @@ deployment:
       include: "**.{jpg,jpeg,png,gif,mp4,svg,json}"
 
     matchers:
+      # dont cache rum/logs config
+      - pattern: "^assets/dd-browser-logs-rum.js$"
+        cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
+        gzip: true
       - pattern: "^.+\\.(js|css|svg)$"
         cacheControl: "max-age=31536000, no-transform, public"
         gzip: true


### PR DESCRIPTION
### What does this PR do?

In an attempt to imrove the stack traces in rum error tracking this PR:

- Sets cache control header for rum config file so that it must revalidate every time.
- removing the cache should improve sourcemap to rum version matchups so we get better stack traces


### Motivation

deploy version improvement

### Preview
https://docs-staging.datadoghq.com/david.jones/rum-js-cache/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
