### PR TITLE
remove SHA from pull config

### DIFF
--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -320,7 +320,6 @@
     contents:
     - action: pull-and-push-file
       branch: master
-      sha: 473c1776
       globs:
       - 'docs/rum_getting_started.md'
       options:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -320,7 +320,6 @@
     contents:
     - action: pull-and-push-file
       branch: master
-      sha: 473c1776
       globs:
       - 'docs/rum_getting_started.md'
       options:


### PR DESCRIPTION
### What does this PR do?
David had fixed the RUM Android getting started page to point to a particular SHA while we were making updates. Need to remove that (preview and prod)

