### PR TITLE
Fix for beanstalk config

### DIFF
--- a/static/config/99datadog-amazon-linux-2.config
+++ b/static/config/99datadog-amazon-linux-2.config
@@ -14,7 +14,7 @@ files:
         content: |
             #!/bin/bash
             sed 's/api_key:.*/api_key: '$DD_API_KEY'/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
-            sed 's/datadoghq.com/datadoghq.eu'
+            sed -i 's/datadoghq.com/datadoghq.eu/' /etc/datadog-agent/datadog.yaml
 
     "/datadog/datadog.repo":
         mode: "000644"

--- a/static/config/99datadog.config
+++ b/static/config/99datadog.config
@@ -17,7 +17,7 @@ files:
             DD_KEY="$(/opt/elasticbeanstalk/bin/get-config environment -k DD_API_KEY)"
 
             sed 's/api_key:.*/api_key: '$DD_KEY'/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
-            sed 's/datadoghq.com/datadoghq.eu'
+            sed -i 's/datadoghq.com/datadoghq.eu/' /etc/datadog-agent/datadog.yaml
 
     "/datadog/datadog.repo":
         mode: "000644"


### PR DESCRIPTION
### What does this PR do?
Updates the sed command as it was previously missing a flag and file path

### Motivation
Jira request

### Preview
https://docs-staging.datadoghq.com/sarina/beanstalk-fix/integrations/amazon_elasticbeanstalk/?tab=nocontainers#configuration

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
