### PR TITLE
[Doc Change]-adding-enter-after-div

### DIFF
--- a/content/en/real_user_monitoring/browser/monitoring_page_performance.md
+++ b/content/en/real_user_monitoring/browser/monitoring_page_performance.md
@@ -31,6 +31,7 @@ RUM view events collect extensive performance metrics for every single page view
 <div class="alert alert-warning"> 
   <strong>Note:</strong> The Core Web Vitals metrics are available in Datadog from <a href="https://github.com/DataDog/browser-sdk">@datadog/browser-rum</a> package version 2.0.0 and newer.
 </div>
+
 [Google's Core Web Vitals][4] are a set of three metrics designed to monitor a site's user experience. These metrics focus on giving you a view of load performance, interactivity, and visual stability. Each metric comes with guidance on the range of values that translate to good user experience. Datadog recommends monitoring the 75th percentile for these metrics.
 
 {{< img src="real_user_monitoring/browser/core-web-vitals.png" alt="Core Web Vitals summary visualization"  >}}


### PR DESCRIPTION
### What does this PR do?
I'm adding an enter after the div that was added in this PR https://github.com/DataDog/documentation/pull/10361

### Motivation
There was a link in next paragraph that was not showing correctly https://a.cl.ly/o0u6GjKO 

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
