### PR TITLE
Minor clarifications for Lambdas deployed as container images

### DIFF
--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -235,7 +235,7 @@ Note that the minor version of the `datadog-lambda-js` package always matches th
 
 ### Configure the function
 
-1. Set your image's `CMD` value to `node_modules/datadog-lambda-js/dist/handler.handler`. You can set this in AWS or directly in your Dockerfile.
+1. Set your image's `CMD` value to `node_modules/datadog-lambda-js/dist/handler.handler`. You can set this in AWS or directly in your Dockerfile. Note that the value set in AWS overrides the value in the Dockerfile if you set both.
 2. Set the following environment variables in AWS:
   - Set `DD_LAMBDA_HANDLER` to your original handler, for example, `myfunc.handler`.
   - Set `DD_TRACE_ENABLED` to `true`.

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -216,7 +216,7 @@ More information and additional parameters can be found in the [CLI documentatio
 
 ### Install the Datadog Lambda Library
 
-If you are deploying your Lambda function as a container image, you cannot use the Datadog Lambda Library as a layer. Instead, you must install the Datadog Lambda Library directly within the image. If you are using Datadog tracing, you must also install `dd-trace`.
+If you are deploying your Lambda function as a container image, you cannot use the Datadog Lambda Library as a layer. Instead, you must install the Datadog Lambda Library as a dependency of your function within the image. If you are using Datadog tracing, you must also install `dd-trace`.
 
 **NPM**:
 
@@ -235,11 +235,12 @@ Note that the minor version of the `datadog-lambda-js` package always matches th
 
 ### Configure the function
 
-1. Set your image's `CMD` value to `node_modules/datadog-lambda-js/dist/handler.handler`. You can either set this directly in your Dockerfile or override the value using AWS.
-2. Set the environment variable `DD_LAMBDA_HANDLER` to your original handler, for example, `myfunc.handler`.
-3. Set the environment variable `DD_TRACE_ENABLED` to `true`.
-4. Set the environment variable `DD_FLUSH_TO_LOG` to `true`.
-5. Optionally add a `service` and `env` tag with appropriate values to your function.
+1. Set your image's `CMD` value to `node_modules/datadog-lambda-js/dist/handler.handler`. You can set this in AWS or directly in your Dockerfile.
+2. Set the following environment variables in AWS:
+  - Set `DD_LAMBDA_HANDLER` to your original handler, for example, `myfunc.handler`.
+  - Set `DD_TRACE_ENABLED` to `true`.
+  - Set `DD_FLUSH_TO_LOG` to `true`.
+3. Optionally add `service` and `env` tags with appropriate values to your function.
 
 ### Subscribe the Datadog Forwarder to the log groups
 

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -308,7 +308,7 @@ Note that the minor version of the `datadog-lambda` package always matches the l
 
 ### Configure the function
 
-1. Set your image's `CMD` value to `datadog_lambda.handler.handler`. You can set this in AWS or directly in your Dockerfile.
+1. Set your image's `CMD` value to `datadog_lambda.handler.handler`. You can set this in AWS or directly in your Dockerfile. Note that the value set in AWS overrides the value in the Dockerfile if you set both.
 2. Set the following environment variables in AWS:
   - Set `DD_LAMBDA_HANDLER` to your original handler, for example, `myfunc.handler`.
   - Set `DD_TRACE_ENABLED` to `true`.

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -297,7 +297,7 @@ More information and additional parameters can be found in the [CLI documentatio
 
 ### Install the Datadog Lambda Library
 
-If you are deploying your Lambda function as a container image, you cannot use the Datadog Lambda library as a layer. Instead, you must install the Datadog Lambda library directly within the image.
+If you are deploying your Lambda function as a container image, you cannot use the Datadog Lambda library as a layer. Instead, you must install the Datadog Lambda library as a dependency of your function within the image.
 
 
 ```sh
@@ -308,11 +308,12 @@ Note that the minor version of the `datadog-lambda` package always matches the l
 
 ### Configure the function
 
-1. Set your image's `CMD` value to `datadog_lambda.handler.handler`. You can either set this directly in your Dockerfile or override the value using AWS.
-2. Set the environment variable `DD_LAMBDA_HANDLER` to your original handler, for example, `myfunc.handler`.
-3. Set the environment variable `DD_TRACE_ENABLED` to `true`.
-4. Set the environment variable `DD_FLUSH_TO_LOG` to `true`.
-5. Optionally add a `service` and `env` tag with appropriate values to your function.
+1. Set your image's `CMD` value to `datadog_lambda.handler.handler`. You can set this in AWS or directly in your Dockerfile.
+2. Set the following environment variables in AWS:
+  - Set `DD_LAMBDA_HANDLER` to your original handler, for example, `myfunc.handler`.
+  - Set `DD_TRACE_ENABLED` to `true`.
+  - Set `DD_FLUSH_TO_LOG` to `true`.
+3. Optionally add `service` and `env` tags with appropriate values to your function.
 
 ### Subscribe the Datadog Forwarder to the log groups
 


### PR DESCRIPTION
### What does this PR do?
Makes some minor changes to the instructions for instrumenting Lambdas deployed as container images.
- Clarify that the `CMD` value set in AWS overrides the value in the Dockerfile.
- Clarify that environment variables are intended to be set in AWS, not in the Dockerfile.

### Motivation
Some customers are having trouble setting this up.

### Preview
- https://docs-staging.datadoghq.com/clarify-lambda-oci/serverless/installation/python
- https://docs-staging.datadoghq.com/clarify-lambda-oci/serverless/installation/nodejs

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
