### PR TITLE
integrations links lowercase

### DIFF
--- a/layouts/shortcodes/integrations.html
+++ b/layouts/shortcodes/integrations.html
@@ -35,7 +35,7 @@
   {{- $s.SetInMap $path "id" $k -}}
   {{- $s.SetInMap $path "name" ($v.Params.name | default ($v.File.TranslationBaseName | lower))  -}}
   {{- $s.SetInMap $path "item_class" "" -}}
-  {{- $s.SetInMap $path "redirect" (print "integrations/" ($v.Params.name | default ($v.File.TranslationBaseName | lower)) "/") -}}
+  {{- $s.SetInMap $path "redirect" (print "integrations/" (($v.Params.name | lower) | default ($v.File.TranslationBaseName | lower)) "/") -}}
   {{- $s.SetInMap $path "blurb" $v.Params.short_description -}}
   {{- $s.SetInMap $path "public_title" $v.Params.public_title -}}
   {{- $s.SetInMap $path "integration_title" $v.Params.integration_title -}}


### PR DESCRIPTION
### What does this PR do?

- links should be lowercase to integrations pages

### Motivation

slack

### Preview

check apache and appkeeper and others
https://docs-staging.datadoghq.com/david.jones/fix-int-link/integrations/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
