### PR TITLE
apm/php: release 0.59.0

### DIFF
--- a/content/en/tracing/setup_overview/compatibility_requirements/php.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/php.md
@@ -102,7 +102,7 @@ To request support for additional CLI libraries, contact our awesome [support te
 | MongoDB - via [mongo][3] extension                                      | 1.4.x                      | Fully Supported |
 | MySQLi                                                                  | *(Any Supported PHP)*      | Fully Supported |
 | PDO (MySQL, PostgreSQL, MariaDB)                                        | *(Any Supported PHP)*      | Fully Supported |
-| PhpRedis                                                                | 3, 4, 5                    | Fully Supported |
+| PhpRedis                                                                | 3, 4, 5                    | PHP 7           |
 | Predis                                                                  | 1.1                        | Fully Supported |
 
 To request support for additional datastores, contact our awesome [support team][2].
@@ -119,15 +119,17 @@ To request support for additional libraries, contact our awesome [support team][
 
 #### Deep call stacks on PHP 5
 
-The call stack is limited on PHP 5. See the [deep call stack troubleshooting page][5] for more details.
+The call stack is limited on PHP 5. See the [deep call stack troubleshooting page][4] for more details.
 
 ### Generators
 
-Instrumenting [generators][6] is not supported on PHP 5 and PHP 7.
+Instrumenting [generators][5] is not supported on PHP 5 and PHP 7.
 
 ### PCNTL
 
-We currently do not offer support for [PCNTL][7] (Process control). Tracing applications that use functions such as `pcntl_fork` may result in unpredictable results.
+We currently do not offer support for tracing processes forked via [pcntl][6]. When a call to `pcntl_fork` is detected, we disable tracing in the forked process. The main process will still be traced. We plan to provide support for `pcntl` in the future.
+
+If the application invokes `pcntl_unshare(CLONE_NEWUSER);` and the tracer is installed, the application will fatally crash. This happens because `unshare` with `CLONE_NEWUSER` requires the process [not to be threaded][7], while the PHP tracer uses a separate thread to send traces to the Datadog agent without blocking the main process.
 
 ## Further Reading
 
@@ -136,7 +138,7 @@ We currently do not offer support for [PCNTL][7] (Process control). Tracing appl
 [1]: https://github.com/DataDog/dd-trace-php
 [2]: /help
 [3]: https://pecl.php.net/package/mongo
-[4]: https://pecl.php.net/package/mongodb
-[5]: /tracing/troubleshooting/php_5_deep_call_stacks
-[6]: https://www.php.net/manual/en/language.generators.overview.php
-[7]: https://www.php.net/manual/en/book.pcntl.php
+[4]: /tracing/troubleshooting/php_5_deep_call_stacks
+[5]: https://www.php.net/manual/en/language.generators.overview.php
+[6]: https://www.php.net/manual/en/book.pcntl.php
+[7]: https://man7.org/linux/man-pages/man2/unshare.2.html

--- a/content/en/tracing/setup_overview/compatibility_requirements/php.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/php.md
@@ -127,9 +127,9 @@ Instrumenting [generators][5] is not supported on PHP 5 and PHP 7.
 
 ### PCNTL
 
-We currently do not offer support for tracing processes forked via [pcntl][6]. When a call to `pcntl_fork` is detected, we disable tracing in the forked process. The main process will still be traced. We plan to provide support for `pcntl` in the future.
+We do not offer support for tracing processes forked using [pcntl][6]. When a call to `pcntl_fork` is detected, we disable tracing in the forked process. The main process is still be traced.
 
-If the application invokes `pcntl_unshare(CLONE_NEWUSER);` and the tracer is installed, the application will fatally crash. This happens because `unshare` with `CLONE_NEWUSER` requires the process [not to be threaded][7], while the PHP tracer uses a separate thread to send traces to the Datadog agent without blocking the main process.
+If the application invokes `pcntl_unshare(CLONE_NEWUSER);` and the tracer is installed, the application will fatally crash. This happens because `unshare` with `CLONE_NEWUSER` requires the process [not to be threaded][7], while the PHP tracer uses a separate thread to send traces to the Datadog Agent without blocking the main process.
 
 ## Further Reading
 


### PR DESCRIPTION
### What does this PR do?

Docs update for APM PHP 0.59.0 release.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/apm/php/0.59.0/tracing/setup_overview/compatibility_requirements/php/#datastore-compatibility

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
