### PR TITLE
[WEB-1364] Integrations page fixes

### DIFF
--- a/src/scripts/components/integrations.js
+++ b/src/scripts/components/integrations.js
@@ -268,6 +268,8 @@ export function initializeIntegrations() {
 
             updateData(searchQueryParameter, true);
 
+            search.value = searchQueryParameter;
+
             if (window._DATADOG_SYNTHETICS_BROWSER === undefined) {
                 window.DD_LOGS.logger.log(
                     'Integrations Search',

--- a/src/scripts/components/integrations.js
+++ b/src/scripts/components/integrations.js
@@ -263,6 +263,11 @@ export function initializeIntegrations() {
         const searchQueryParameter = getQueryParameterByName('q', window.location.href);
 
         if (searchQueryParameter) {
+            // Search query parameter should take priority if both param & category hash are present in URL.
+            if (window.location.hash) {
+                window.location.hash = '#all';
+            }
+
             updateData(searchQueryParameter, true);
 
             if (window._DATADOG_SYNTHETICS_BROWSER === undefined) {

--- a/src/scripts/components/integrations.js
+++ b/src/scripts/components/integrations.js
@@ -2,6 +2,7 @@
 
 import Mousetrap from 'mousetrap';
 import mixitup from 'mixitup';
+import { getQueryParameterByName } from '../helpers/helpers';
 
 export function initializeIntegrations() {
     let finderState = 0; // closed
@@ -257,12 +258,37 @@ export function initializeIntegrations() {
         }
     }
 
+    // Handle search query param filtering on page load.
+    const handleQueryParamFilter = () => {
+        const searchQueryParameter = getQueryParameterByName('q', window.location.href);
+
+        if (searchQueryParameter) {
+            updateData(searchQueryParameter, true);
+
+            if (window._DATADOG_SYNTHETICS_BROWSER === undefined) {
+                window.DD_LOGS.logger.log(
+                    'Integrations Search',
+                    {
+                        browser: {
+                            integrations: {
+                                search: searchQueryParameter.toLowerCase()
+                            }
+                        }
+                    },
+                    'info'
+                );
+            }
+        }
+    }
+
     // Set controls the active controls on startup
     activateButton(controls.querySelector('[data-filter="all"]'), filters);
     activateButton(
         mobilecontrols.querySelector('[data-filter="all"]'),
         mobilefilters
     );
+
+    handleQueryParamFilter();
 
     $(window).on('hashchange', function() {
         let currentCat = '';

--- a/src/scripts/components/integrations.js
+++ b/src/scripts/components/integrations.js
@@ -87,14 +87,15 @@ export function initializeIntegrations() {
 
     mobilecontrols.addEventListener('click', function(e) {
         e.stopPropagation();
-        // e.preventDefault();
         handleButtonClick(e.target, mobilefilters);
+
         // trigger same active on desktop
         const desktopBtn = controls.querySelector(
             `[data-filter="${e.target.getAttribute('data-filter')}"]`
         );
+
         activateButton(desktopBtn, filters);
-        // return false;
+
         pop.style.display = 'none';
         $(window).scrollTop(0);
     });
@@ -225,7 +226,6 @@ export function initializeIntegrations() {
                         (isSearch && !filter)
                     ) {
                         domitem.classList.remove('grayscale');
-                        // show.push(item);
                     } else {
                         const name = item.name ? item.name.toLowerCase() : '';
                         const publicTitle = item.public_title
@@ -241,10 +241,8 @@ export function initializeIntegrations() {
                                 item.tags.indexOf(filter.substr(1)) !== -1)
                         ) {
                             domitem.classList.remove('grayscale');
-                            // show.push(item);
                         } else {
                             domitem.classList.add('grayscale');
-                            // hide.push(item);
                         }
                     }
                 }

--- a/src/scripts/components/integrations.js
+++ b/src/scripts/components/integrations.js
@@ -2,7 +2,7 @@
 
 import Mousetrap from 'mousetrap';
 import mixitup from 'mixitup';
-import { getQueryParameterByName } from '../helpers/helpers';
+import { updateQueryParameter, deleteQueryParameter, getQueryParameterByName } from '../helpers/browser';
 
 export function initializeIntegrations() {
     let finderState = 0; // closed
@@ -74,15 +74,17 @@ export function initializeIntegrations() {
     const mixer = mixitup(container, config);
 
     controls.addEventListener('click', function(e) {
-        // e.preventDefault();
         handleButtonClick(e.target, filters);
+
+        if (e.target.dataset.filter && e.target.dataset.filter !== 'all') {
+            deleteQueryParameter('q');
+        }
+
         // trigger same active on mobile
-        // $('.integrations-select').val('#'+e.target.getAttribute('href').substr(1));
         const mobileBtn = controls.querySelector(
             `[data-filter="${e.target.getAttribute('data-filter')}"]`
         );
         activateButton(mobileBtn, mobilefilters);
-        // return false;
     });
 
     mobilecontrols.addEventListener('click', function(e) {
@@ -110,6 +112,12 @@ export function initializeIntegrations() {
         searchTimer = setTimeout(function() {
             activateButton(allBtn, filters);
             updateData(e.target.value.toLowerCase(), true);
+
+            if (window.location.hash && window.location.hash !== 'all') {
+                window.location.hash = '#all';
+            }
+
+            updateQueryParameter('q', e.target.value.toLowerCase());
 
             if (
                 e.target.value.length > 0 &&
@@ -176,6 +184,7 @@ export function initializeIntegrations() {
     function updateData(filter, isSearch) {
         const show = [];
         const hide = [];
+
         for (let i = 0; i < window.integrations.length; i++) {
             const item = window.integrations[i];
             const domitem = document.getElementById(`mixid_${item.id}`);

--- a/src/scripts/datadog-docs.js
+++ b/src/scripts/datadog-docs.js
@@ -589,8 +589,14 @@ $(document).ready(function () {
     onScroll();
 
     // TODO: move integrations code to own file after webpack update
-    initializeIntegrations();
-    initializeSecurityRules();
+
+    if (document.body.classList.value.includes('security_platform')) {
+        initializeSecurityRules();
+    }
+
+    if (document.body.classList.value.includes('integrations')) {
+        initializeIntegrations();
+    }
 });
 
 

--- a/src/scripts/helpers/browser.js
+++ b/src/scripts/helpers/browser.js
@@ -1,0 +1,37 @@
+export const updateQueryParameter = (queryParameterName, newQueryParameterValue) => {
+  let historyReplaceUrl =  `?${queryParameterName}=${newQueryParameterValue}`;
+
+  if (window.location.hash) {
+    historyReplaceUrl = `${historyReplaceUrl}${window.location.hash}`;
+  }
+
+  window.history.replaceState(null, '', historyReplaceUrl);
+}
+
+export const deleteQueryParameter = (queryParameterName) => {
+  if (queryParameterName) {
+    const url = new URL(window.location.href);
+    const urlSearchParams = new URLSearchParams(url.search);
+    urlSearchParams.delete(queryParameterName);
+  
+    let historyReplaceUrl = `${window.location.pathname}${urlSearchParams.toString()}`;
+  
+    if (window.location.hash) {
+      historyReplaceUrl = `${historyReplaceUrl}${window.location.hash}`;
+    }
+  
+    window.history.replaceState(null, '', historyReplaceUrl);
+  }
+}
+
+export const getQueryParameterByName = (name, currentURL) => {
+  const queryParameterName = name.replace(/[`[\]]/g, '\\$&');
+  const url = !currentURL ? window.location.href : currentURL;
+  const regex = new RegExp(`[?&]${queryParameterName}(=([^&#]*)|&|#|$)`);
+  const results = regex.exec(url);
+
+  if (!results) return null;
+  if (!results[2]) return '';
+
+  return decodeURIComponent(results[2].replace(/\+/g, ' '));
+}

--- a/src/scripts/helpers/browser.js
+++ b/src/scripts/helpers/browser.js
@@ -1,3 +1,4 @@
+// Note this works when the URL has one query parameter only.  To do: Update this function to work when multiple query params are present in URL.
 export const updateQueryParameter = (queryParameterName, newQueryParameterValue) => {
   let historyReplaceUrl =  `?${queryParameterName}=${newQueryParameterValue}`;
 

--- a/src/scripts/helpers/helpers.js
+++ b/src/scripts/helpers/helpers.js
@@ -52,5 +52,17 @@ const getCookieByName = (name) => {
     return value;
 }
 
+const getQueryParameterByName = (name, currentURL) => {
+    const queryParameterName = name.replace(/[`[\]]/g, '\\$&');
+    const url = !currentURL ? window.location.href : currentURL;
+    const regex = new RegExp(`[?&]${queryParameterName}(=([^&#]*)|&|#|$)`);
+    const results = regex.exec(url);
 
-export {updateMainContentAnchors, reloadWistiaVidScripts, gtag, getCookieByName}
+    if (!results) return null;
+    if (!results[2]) return '';
+
+    return decodeURIComponent(results[2].replace(/\+/g, ' '));
+}
+
+
+export {updateMainContentAnchors, reloadWistiaVidScripts, gtag, getCookieByName, getQueryParameterByName}

--- a/src/scripts/helpers/helpers.js
+++ b/src/scripts/helpers/helpers.js
@@ -52,17 +52,4 @@ const getCookieByName = (name) => {
     return value;
 }
 
-const getQueryParameterByName = (name, currentURL) => {
-    const queryParameterName = name.replace(/[`[\]]/g, '\\$&');
-    const url = !currentURL ? window.location.href : currentURL;
-    const regex = new RegExp(`[?&]${queryParameterName}(=([^&#]*)|&|#|$)`);
-    const results = regex.exec(url);
-
-    if (!results) return null;
-    if (!results[2]) return '';
-
-    return decodeURIComponent(results[2].replace(/\+/g, ' '));
-}
-
-
-export {updateMainContentAnchors, reloadWistiaVidScripts, gtag, getCookieByName, getQueryParameterByName}
+export {updateMainContentAnchors, reloadWistiaVidScripts, gtag, getCookieByName}

--- a/src/scripts/tests/browser.test.js
+++ b/src/scripts/tests/browser.test.js
@@ -1,0 +1,33 @@
+import { getQueryParameterByName, updateQueryParameter, deleteQueryParameter } from '../helpers/browser';
+
+describe(`URL helpers work as expected`, () => {
+  it(`Correctly gets query parameter by name`, () => {
+    const parameterName = 'foo';
+    const testUrl = 'datadoghq.com/?q=test&foo=bar';
+    const result = getQueryParameterByName(parameterName, testUrl);
+
+    expect(result).toEqual('bar');
+  })
+
+  it (`Updates the URL query parameter as expected`, () => {
+    window.history.pushState(null, '', 'datadoghq.com/integrations/?q=foo/#test');
+
+    const parameterName = 'q';
+    const newParameterValue = 'bar';
+
+    updateQueryParameter(parameterName, newParameterValue);
+
+    expect(window.location.href).toContain('?q=bar#test');
+  })
+
+  it (`Deletes query parameter as expected`, () => {
+    window.history.pushState(null, '', 'datadoghq.com/integrations/?foo=bar/#test');
+
+    const parameterName = 'foo';
+
+    deleteQueryParameter(parameterName);
+
+    expect(window.location.href).not.toContain('foo=bar');
+    expect(window.location.href).toContain('#test');
+  })
+})


### PR DESCRIPTION
### What does this PR do?
Integrations page front end fixes
- `All` category filter should be highlighted if there is no category filter in the URL hash, or if the hash is `#all`.
- Filtering works when there is a valid query parameter present in the URL (i.e. `/?q=azure`)

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1364

### Preview
- https://docs-staging.datadoghq.com/brian.deutsch/integrations-query-param/integrations/?q=mesos
  - Filtering based on query parameter should work correctly.

- https://docs-staging.datadoghq.com/brian.deutsch/integrations-query-param/integrations/?q=azure#cat-messaging
  - When both query param and category hash are present, filtering should be based on query param.  Category filter falls back to `#all`.

- https://docs-staging.datadoghq.com/brian.deutsch/integrations-query-param/integrations/#cat-marketplace
  - Filtering with a category hash in the URL still works as expected.

- Integrations page should otherwise work as expected.

- Synthetics: https://dd-corpsite.datadoghq.com/synthetics/details/5zm-7b4-ifw

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
