### PR TITLE
Clarify deploying the agent with Operator instructions

### DIFF
--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -254,14 +254,14 @@ Here are the steps:
    helm install my-datadog-operator datadog/datadog-operator
    ```
 
-2. Create a Kubernetes secret with your API and APP keys
+2. Create a Kubernetes secret with your API and app keys
 
    ```shell
    kubectl create secret generic datadog-secret --from-literal api-key=<DATADOG_API_KEY> --from-literal app-key=<DATADOG_APP_KEY>
    ```
    Replace `<DATADOG_API_KEY>` and `<DATADOG_APP_KEY>` with your [Datadog API and application keys][6]
 
-2. Create a file with the spec of your DatadogAgent deployment configuration. The simplest configuration is:
+2. Create a file with the spec of your Datadog Agent deployment configuration. The simplest configuration is:
 
    ```yaml
    apiVersion: datadoghq.com/v1alpha1
@@ -284,7 +284,7 @@ Here are the steps:
          name: "gcr.io/datadoghq/cluster-agent:latest"
    ```
 
-3. Deploy the Datadog agent with the above configuration file:
+3. Deploy the Datadog Agent with the above configuration file:
    ```shell
    kubectl apply -f agent_spec=/path/to/your/datadog-agent.yaml
    ```

--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -247,28 +247,46 @@ Using the Datadog Operator requires the following prerequisites:
 To deploy a Datadog Agent with the Operator in the minimum number of steps, use the [`datadog-agent-with-operator`][4] Helm chart.
 Here are the steps:
 
-1. [Download the chart][5]:
+1. Install the [Datadog Operator][5]:
 
    ```shell
-   curl -Lo datadog-agent-with-operator.tar.gz https://github.com/DataDog/datadog-operator/releases/latest/download/datadog-agent-with-operator.tar.gz
+   helm repo add datadog https://helm.datadoghq.com
+   helm install my-datadog-operator datadog/datadog-operator
    ```
 
-2. Create a file with the spec of your Agent. The simplest configuration is:
+2. Create a Kubernetes secret with your API and APP keys
 
-   ```yaml
-   credentials:
-     apiKey: <DATADOG_API_KEY>
-     appKey: <DATADOG_APP_KEY>
-   agent:
-     image:
-       name: "gcr.io/datadoghq/agent:latest"
+   ```shell
+   kubectl create secret generic datadog-secret --from-literal api-key=<DATADOG_API_KEY> --from-literal app-key=<DATADOG_APP_KEY>
    ```
-
    Replace `<DATADOG_API_KEY>` and `<DATADOG_APP_KEY>` with your [Datadog API and application keys][6]
 
-3. Deploy the Datadog Agent with the above configuration file:
+2. Create a file with the spec of your DatadogAgent deployment configuration. The simplest configuration is:
+
+   ```yaml
+   apiVersion: datadoghq.com/v1alpha1
+   kind: DatadogAgent
+   metadata:
+     name: datadog
+   spec:
+     credentials:
+       apiSecret:
+         secretName: datadog-secret
+         keyName: api-key
+       appSecret:
+         secretName: datadog-secret
+         keyName: app-key
+     agent:
+       image:
+         name: "gcr.io/datadoghq/agent:latest"
+     clusterAgent:
+       image:
+         name: "gcr.io/datadoghq/cluster-agent:latest"
+   ```
+
+3. Deploy the Datadog agent with the above configuration file:
    ```shell
-   helm install --set-file agent_spec=/path/to/your/datadog-agent.yaml datadog datadog-agent-with-operator.tar.gz
+   kubectl apply -f agent_spec=/path/to/your/datadog-agent.yaml
    ```
 
 ## Cleanup
@@ -277,7 +295,7 @@ The following command deletes all the Kubernetes resources created by the above 
 
 ```shell
 kubectl delete datadogagent datadog
-helm delete datadog
+helm delete my-datadog-operator
 ```
 
 For further details on setting up Operator, including information about using tolerations, refer to the [Datadog Operator advanced setup guide][7].
@@ -301,7 +319,7 @@ where `<USER_ID>` is the UID to run the agent and `<DOCKER_GROUP_ID>` is the gro
 [2]: https://helm.sh
 [3]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [4]: https://github.com/DataDog/datadog-operator/tree/master/chart/datadog-agent-with-operator
-[5]: https://github.com/DataDog/datadog-operator/releases/latest/download/datadog-agent-with-operator.tar.gz
+[5]: https://artifacthub.io/packages/helm/datadog/datadog-operator
 [6]: https://app.datadoghq.com/account/settings#api
 [7]: /agent/guide/operator-advanced
 [8]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.md


### PR DESCRIPTION
The Operator pattern is popular within the Kubernetes community and it is based on extending the Kubernetes API with new objects to configure a deployment or maintenance tasks for a piece of software.

I think people expects that to deploy the agent once you have the Operator installed you will need to create a `DatadogAgent` object. I think that hiding this with some Helm magic might confuse people.

This PR extends a bit the number of steps, but I think it will be easier to understand for Kubernetes users.

### Preview
<!-- Impacted pages preview links-->

https://docs-staging.datadoghq.com/ara.pulido/fix_agent_deploy_with_operator/agent/kubernetes/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
