### PR TITLE
changing the .net image

### DIFF
--- a/layouts/partials/apm/apm-compatibility.html
+++ b/layouts/partials/apm/apm-compatibility.html
@@ -40,7 +40,7 @@
     <div class="card-deck">
       <a class="card" href="dotnet-framework">
         <div class="card-body text-center py-2 px-1">
-          {{ partial "img.html" (dict "root" . "src" "integrations_logos/net.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
+          {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
         </div>
       </a>
       <a class="card" href="dotnet-core">


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/cswatt/net-apm-img/tracing

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
